### PR TITLE
Remove print(dim) in savechart() function

### DIFF
--- a/grapher_admin/views.py
+++ b/grapher_admin/views.py
@@ -223,7 +223,6 @@ def savechart(chart: Chart, data: Dict, user: User):
     chart.save()
 
     for dim in data["chart-dimensions"]:
-        print(dim)
         newdim = ChartDimension()
         newdim.order = i
         newdim.chartId = chart


### PR DESCRIPTION
A UnicodeError is appearing when saving some charts.