### PR TITLE
fix issue when chosen input format does not have an entry 

### DIFF
--- a/js/admin/CountryStandardizerPage.tsx
+++ b/js/admin/CountryStandardizerPage.tsx
@@ -225,6 +225,7 @@ export default class CountryStandardizerPage extends React.Component {
 
         const countryMap: { [key: string]: string} = {}
         results.countries.forEach((countryFormat: any) => {
+            if (countryFormat.input === null) return
             countryMap[countryFormat.input.toLowerCase()] = countryFormat.output
         })
         runInAction(() => {
@@ -383,8 +384,8 @@ export default class CountryStandardizerPage extends React.Component {
                             <tr>
                                 <th>Original Name</th>
                                 <th>Standardized Name</th>
-                                <th>Potential Candidates</th>
-                                <th>Custom Name</th>
+                                <th>Potential Candidates (select below)</th>
+                                <th>Or enter a Custom Name</th>
                             </tr>
                         </thead>
                         <tbody>

--- a/js/admin/CountryStandardizerPage.tsx
+++ b/js/admin/CountryStandardizerPage.tsx
@@ -74,7 +74,7 @@ class CSV {
             const outputCountry = mapCountriesInputToOutput[country.toLowerCase()]
             let approximatedMatches: FuzzyMatch[] = []
 
-            if (outputCountry === undefined) {
+            if (outputCountry === undefined || outputCountry === null) {
                 approximatedMatches = fuzzysort.go(country, targetValues)
             } else {
                 autoMatched += 1
@@ -122,13 +122,13 @@ export class CountryEntryRowRenderer extends React.Component<{ entry: CountryEnt
         if (entry.standardizedName === null) {
             console.log(entry)
         }
-        if (entry.standardizedName !== undefined && entry.standardizedName.length > 0) {
+        if (entry.standardizedName !== undefined && ((typeof(entry.standardizedName) === "number") || (entry.standardizedName.length > 0))) {
             return true
         }
-        if (entry.selectedMatch !== undefined && entry.selectedMatch.length > 0) {
+        if (entry.selectedMatch !== undefined && ((typeof(entry.selectedMatch) === "number") || (entry.selectedMatch.length > 0))) {
             return true
         }
-        if (entry.customName !== undefined && entry.customName.length > 0) {
+        if (entry.customName !== undefined && ((typeof(entry.customName) === "number") || (entry.customName.length > 0))) {
             return true
         }
         return false
@@ -219,7 +219,6 @@ export default class CountryStandardizerPage extends React.Component {
         if (inputFormat === undefined || outputFormat === undefined)
             return
 
-        console.log("fetch input -> output country mapping")
         const { admin }  = this.context
         const results = await admin.getJSON(`/api/countries.json?input=` + inputFormat + `&output=` + outputFormat)
 


### PR DESCRIPTION
Certain OWID country names (like Rest of the World, World) do not have a corresponding entry for formats like ISO alpha 2 code. This fix will prevent the tool from breaking when those input formats are chosen.

cc @mispy 