### PR TITLE
Line Chart - When legend is hidden, add some padding 

### DIFF
--- a/js/charts/LineChart.tsx
+++ b/js/charts/LineChart.tsx
@@ -109,7 +109,7 @@ export default class LineChart extends React.Component<{ bounds: Bounds, chart: 
     @computed get axisBox() {
         const that = this
         return new AxisBox({
-            get bounds() { return that.bounds.padRight(that.legend ? that.legend.width : 0) },
+            get bounds() { return that.bounds.padRight(that.legend ? that.legend.width : 20) },
             get fontSize() { return that.chart.baseFontSize },
             get yAxis() { return that.transform.yAxis },
             get xAxis() { return that.transform.xAxis }
@@ -158,7 +158,7 @@ export default class LineChart extends React.Component<{ bounds: Bounds, chart: 
         return <g className="LineChart">
             <defs>
                 <clipPath id={`boundsClip-${renderUid}`}>
-                    <rect x={axisBox.innerBounds.x - 10} y={0} width={bounds.width + 10} height={bounds.height * 2}></rect>
+                    <rect x={axisBox.innerBounds.x} y={0} width={bounds.width} height={bounds.height * 2}></rect>
                 </clipPath>
             </defs>
             <StandardAxisBoxView axisBox={axisBox} chart={chart} />


### PR DESCRIPTION
Hannah mentioned the following issue with the label crossing over the graph:

<img width="1011" alt="screenshot 2018-08-04 17 50 17" src="https://user-images.githubusercontent.com/4923428/43681651-06a0babc-980f-11e8-8b72-01a54127b199.png">


This change fixes it by adding standard padding as used in other charts when the legend is hidden.

<img width="1016" alt="screenshot 2018-08-04 17 52 55" src="https://user-images.githubusercontent.com/4923428/43681663-446090b6-980f-11e8-98f7-90130bdc5791.png">
