### PR TITLE
Ensure a git repo exists before attempting to deploy

### DIFF
--- a/src/ChartBaker.tsx
+++ b/src/ChartBaker.tsx
@@ -220,6 +220,9 @@ ${BUILD_GRAPHER_PATH}/*
     async deploy(commitMsg: string, authorEmail?: string, authorName?: string) {
         const {repoDir} = this.props
 
+        // Ensure there is a git repo in repoDir
+        await this.exec(`cd ${repoDir} && git init`)
+
         if (fs.existsSync(path.join(repoDir, "netlify.toml"))) {
             // Deploy directly to Netlify (faster than using the github hook)
             await this.exec(`cd ${repoDir} && netlifyctl deploy -b .`)


### PR DESCRIPTION
Fixes #105. 

`git init` is supposed to be safe to run in an existing repo. Pretty small change, but since it deals with deploys my confidence levels are very low. 