### PR TITLE
Attach Slack error reporting before catch-all middleware

### DIFF
--- a/src/admin/app.tsx
+++ b/src/admin/app.tsx
@@ -1,6 +1,7 @@
 import * as express from 'express'
 require('express-async-errors')
 const cookieParser = require('cookie-parser')
+const errorToSlack = require('express-error-slack')
 import "reflect-metadata"
 
 import AdminSPA from './AdminSPA'
@@ -10,7 +11,7 @@ import devServer from './devServer'
 import testPages from './testPages'
 import adminViews from './adminViews'
 import {renderToHtmlPage} from './serverUtil'
-import {BUILD_GRAPHER_URL} from '../settings'
+import {BUILD_GRAPHER_URL, SLACK_ERRORS_WEBHOOK_URL} from '../settings'
 
 import * as React from 'react'
 
@@ -37,6 +38,12 @@ app.use('/admin', adminViews)
 app.get('*', (req, res) => {
     res.send(renderToHtmlPage(<AdminSPA rootUrl={`${BUILD_GRAPHER_URL}`} username={res.locals.user.fullName}/>))
 })
+
+// Send errors to Slack
+// The middleware passes all errors onto the next error-handling middleware
+if (SLACK_ERRORS_WEBHOOK_URL) {
+    app.use(errorToSlack({ webhookUri: SLACK_ERRORS_WEBHOOK_URL }))
+}
 
 // Give full error messages, including in production
 app.use(async (err: any, req: any, res: express.Response, next: any) => {

--- a/src/admin/server.tsx
+++ b/src/admin/server.tsx
@@ -1,9 +1,8 @@
 
 // This import has side-effects to do with React import binding, keep it up here
-import {NODE_SERVER_PORT, NODE_SERVER_HOST, SLACK_ERRORS_WEBHOOK_URL} from '../settings'
+import {NODE_SERVER_PORT, NODE_SERVER_HOST} from '../settings'
 
 import app from './app'
-const errorToSlack = require('express-error-slack')
 
 import * as db from '../db'
 import * as wpdb from '../articles/wpdb'
@@ -14,8 +13,3 @@ wpdb.connect()
 app.listen(NODE_SERVER_PORT, NODE_SERVER_HOST, () => {
     console.log(`Express started on ${NODE_SERVER_HOST}:${NODE_SERVER_PORT}`)
 })
-
-// Send errors to slack
-if (SLACK_ERRORS_WEBHOOK_URL) {
-    app.use(errorToSlack({ webhookUri: SLACK_ERRORS_WEBHOOK_URL }))
-}


### PR DESCRIPTION
Should fix #101, but I haven't tested.

@mispy I was actually wondering:

1. Is there any way to test this?
2. Why are some imports (including this one & cookie parser) still using `require()`?