### PR TITLE
Default to variable name if there is no dimension displayName

### DIFF
--- a/js/charts/ChartData.ts
+++ b/js/charts/ChartData.ts
@@ -311,7 +311,7 @@ export default class ChartData {
                 if (isSingleVariable) {
                     label = entity
                 } else if (isSingleEntity) {
-                    label = `${dim.displayName}`
+                    label = `${dim.displayName || variable.name}`
                 }
 
                 keyData.set(key, {


### PR DESCRIPTION
When a chart is in single entity mode and the dimension has no `displayName`, the labels are empty strings e.g. https://ourworldindata.org/grapher/long-term-price-index-in-food-commodities-1850-2015:

![long-term-price-index-in-food-commodities-1850-2015](https://user-images.githubusercontent.com/1308115/48790458-44c28780-ece7-11e8-81d1-9a5d30edfa55.png)

This PR makes the label default to `variable.name` if there is no `displayName`, which works well for this chart, but not sure if it would work well in other cases?