### PR TITLE
Sherin/mig audit

### DIFF
--- a/js/admin/ChartEditor.ts
+++ b/js/admin/ChartEditor.ts
@@ -27,6 +27,13 @@ export interface Dataset {
     isPrivate: boolean
 }
 
+export interface Log {
+    userId: number
+    userName: string
+    config: string
+    createdAt: string
+}
+
 // This contains the dataset/variable metadata for the entire database
 // Used for variable selector interface
 
@@ -47,6 +54,7 @@ export interface ChartEditorProps {
     admin: Admin
     chart: ChartConfig
     database: EditorDatabase
+    logs: Log[]
 }
 
 export default class ChartEditor {
@@ -83,11 +91,15 @@ export default class ChartEditor {
         return this.props.database
     }
 
+    @computed get logs(): Log[] {
+        return this.props.logs
+    }
+
     @computed get availableTabs(): EditorTab[] {
         if (!this.chart.activeTransform.isValidConfig) {
             return ['basic']
         } else {
-            const tabs: EditorTab[] = ['basic', 'data', 'text', 'customize']
+            const tabs: EditorTab[] = ['basic', 'data', 'text', 'customize', 'history']
             if (this.chart.hasMapTab) tabs.push('map')
             if (this.chart.isScatter) tabs.push('scatter')
             return tabs
@@ -100,6 +112,10 @@ export default class ChartEditor {
 
     @computed get features() {
         return new EditorFeatures(this)
+    }
+
+    async applyConfig(config: any) {
+        this.props.chart.update(JSON.parse(config))
     }
 
     // Load index of datasets and variables for the given namespace

--- a/js/admin/EditorHistoryTab.tsx
+++ b/js/admin/EditorHistoryTab.tsx
@@ -40,7 +40,7 @@ export class LogRenderer extends React.Component<{ log: Log, applyConfig: (confi
 
     render() {
         const { configToShow, title, truncate } = this
-        const log = this.props.log
+        const { log } = this.props
 
         return <div>
             <Section name={title}>

--- a/js/admin/EditorHistoryTab.tsx
+++ b/js/admin/EditorHistoryTab.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react'
+import { observer } from "mobx-react"
+import ChartEditor, { Log } from './ChartEditor'
+import { computed, action, observable } from 'mobx'
+import { Section } from './Forms'
+const timeago = require('timeago.js')()
+
+@observer
+export class LogRenderer extends React.Component<{ log: Log, applyConfig: (config: any) => void }> {
+    @observable truncate: boolean = true
+
+    @computed get configToShow() {
+        const { truncate, prettyConfig } = this
+
+        if (truncate) {
+            return prettyConfig.substring(0, 200) + "...\n}"
+        }
+        return prettyConfig
+    }
+
+    @computed get prettyConfig() {
+        const { log } = this.props
+        return JSON.stringify(JSON.parse(log.config), undefined, 2)
+    }
+
+    @computed get title() {
+        const { log } = this.props
+
+        const user = log.userName || log.userId.toString()
+        return "Invalidated " + timeago.format(log.createdAt) + " by " + user
+    }
+
+    @action.bound onExpand() {
+        this.truncate = false
+    }
+
+    @action.bound onCollapse() {
+        this.truncate = true
+    }
+
+    render() {
+        const { configToShow, title, truncate } = this
+        const log = this.props.log
+
+        return <div>
+            <Section name={title}>
+                <pre>{configToShow}</pre>
+                <button className="btn btn-danger" onClick={_ => this.props.applyConfig(log.config)}>Apply</button>
+                <button className="btn btn-secondary" onClick={truncate ? this.onExpand : this.onCollapse}>{truncate ? "Expand" : "Collapse"}</button>
+            </Section>
+        </div>
+    }
+}
+
+@observer
+export default class EditorHistoryTab extends React.Component<{ editor: ChartEditor}> {
+    @computed get logs() { return this.props.editor.logs || [] }
+
+    @action.bound async applyConfig(config: any) {
+        this.props.editor.applyConfig(config)
+    }
+
+    render() {
+        return <div>
+            {this.logs.length === 0 && <span>No history to show yet :(</span>}
+            {this.logs.map(log => {
+                return <LogRenderer log={log} applyConfig={this.applyConfig}></LogRenderer>
+            })}
+        </div>
+    }
+}

--- a/src/admin/api.ts
+++ b/src/admin/api.ts
@@ -86,7 +86,8 @@ async function getLogsByChartId(chartId: number): Promise<ChartLog[]> {
         FROM chart_logs l
         LEFT JOIN users u on u.id = userId
         WHERE chartId = ?
-        ORDER BY l.id DESC`, [chartId]))
+        ORDER BY l.id DESC
+        LIMIT 50`, [chartId]))
     return logs
 }
 

--- a/src/admin/api.ts
+++ b/src/admin/api.ts
@@ -21,6 +21,7 @@ import {Dataset} from '../model/Dataset'
 import {Tag} from '../model/Tag'
 import User from '../model/User'
 import { syncDatasetToGitRepo, removeDatasetFromGitRepo } from '../gitDataExport'
+import { createChartLog, ChartLog } from '../model/ChartLog'
 
 // Little wrapper to automatically send returned objects as JSON, makes
 // the API code a bit cleaner
@@ -80,6 +81,15 @@ async function getChartById(chartId: number): Promise<ChartConfigProps|undefined
     }
 }
 
+async function getLogsByChartId(chartId: number): Promise<ChartLog[]> {
+    const logs = (await db.query(`SELECT userId, config, fullName as userName, l.createdAt
+        FROM chart_logs l
+        LEFT JOIN users u on u.id = userId
+        WHERE chartId = ?
+        ORDER BY l.id DESC`, [chartId]))
+    return logs
+}
+
 async function expectChartById(chartId: any): Promise<ChartConfigProps> {
     const chart = await getChartById(expectInt(chartId))
 
@@ -132,6 +142,7 @@ async function saveChart(user: CurrentUser, newConfig: ChartConfigProps, existin
                 `UPDATE charts SET config=?, updatedAt=?, lastEditedAt=?, lastEditedByUserId=? WHERE id = ?`,
                 [JSON.stringify(newConfig), now, now, user.id, chartId]
             )
+            createChartLog(chartId, user.id, existingConfig)
         } else {
             const result = await t.execute(
                 `INSERT INTO charts (config, createdAt, updatedAt, lastEditedAt, lastEditedByUserId, starred) VALUES (?)`,
@@ -199,6 +210,13 @@ api.get('/editorData/namespaces.json', async (req: Request, res: Response) => {
 
     return {
         namespaces: rows.map(row => row.namespace)
+    }
+})
+
+api.get('/charts/:chartId.logs.json', async (req: Request, res: Response) => {
+    const logs = await getLogsByChartId(req.params.chartId)
+    return {
+        logs: logs
     }
 })
 
@@ -644,7 +662,7 @@ api.put('/datasets/:datasetId', async (req: Request, res: Response) => {
 
 api.router.put('/datasets/:datasetId/uploadZip', bodyParser.raw({ type: "application/zip", limit: "50mb" }), async (req: Request, res: Response) => {
     const datasetId = expectInt(req.params.datasetId)
- 
+
     await db.transaction(async t => {
         await t.execute(`DELETE FROM dataset_files WHERE datasetId=?`, [datasetId])
         await t.execute(`INSERT INTO dataset_files (datasetId, filename, file) VALUES (?, ?, ?)`, [datasetId, 'additional-material.zip', req.body])

--- a/src/migration/1542908319140-CreateChartLogs.ts
+++ b/src/migration/1542908319140-CreateChartLogs.ts
@@ -1,0 +1,13 @@
+import {MigrationInterface, QueryRunner} from "typeorm"
+
+export class CreateChartLogs1542908319140 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query("CREATE TABLE `chart_logs` (`id` bigint NOT NULL AUTO_INCREMENT, `chartId` int, `userId` int, `config` json, `createdAt` datetime, `updatedAt` datetime, PRIMARY KEY(`id`)) ENGINE=InnoDB")
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query("DROP TABLE IF EXISTS `chart_logs` ")
+    }
+
+}

--- a/src/migration/1543002209183-AddIndexToChartLogs.ts
+++ b/src/migration/1543002209183-AddIndexToChartLogs.ts
@@ -1,0 +1,12 @@
+import {MigrationInterface, QueryRunner} from "typeorm"
+
+export class AddIndexToChartLogs1543002209183 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query("CREATE INDEX `chartId` ON chart_logs(chartId)")
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+    }
+
+}

--- a/src/model/Chart.ts
+++ b/src/model/Chart.ts
@@ -1,10 +1,11 @@
 import * as _ from 'lodash'
-import {Entity, PrimaryGeneratedColumn, Column, BaseEntity, ManyToOne, JoinColumn} from "typeorm"
+import {Entity, PrimaryGeneratedColumn, Column, BaseEntity, ManyToOne, OneToMany, JoinColumn} from "typeorm"
 
 import * as db from '../db'
 import ChartConfig, { ChartConfigProps } from '../../js/charts/ChartConfig'
 import {getVariableData} from './Variable'
 import User from './User'
+import { ChartLog } from './ChartLog'
 
 @Entity("charts")
 export class Chart extends BaseEntity {
@@ -22,6 +23,8 @@ export class Chart extends BaseEntity {
     lastEditedByUser!: User
     @ManyToOne(type => User, user => user.publishedCharts)
     publishedByUser!: User
+    @OneToMany(type => ChartLog, log => log.chart)
+    logs!: ChartLog[]
 }
 
 // TODO integrate this old logic with typeorm

--- a/src/model/ChartLog.ts
+++ b/src/model/ChartLog.ts
@@ -1,0 +1,36 @@
+import {Entity, PrimaryGeneratedColumn, Column, BaseEntity, ManyToOne, JoinColumn} from "typeorm"
+
+import * as db from '../db'
+import { Chart } from './Chart'
+import User from './User'
+
+@Entity("chart_logs")
+export class ChartLog extends BaseEntity {
+    @PrimaryGeneratedColumn() id!: number
+    @Column() chartId!: number
+    @Column({ type: 'json' }) config: any
+    @Column() userId!: number
+
+    @Column() createdAt!: Date
+    @Column() updatedAt!: Date
+
+    @ManyToOne(type => User, user => user.editedCharts)
+    user!: User
+
+    @ManyToOne(type => Chart, chart => chart.logs)
+    chart!: Chart
+
+}
+
+export function createChartLog(chartId: number|undefined, userId: number, config: any) {
+    if (chartId === undefined) return
+
+    const log = new ChartLog()
+    log.chartId = chartId
+    log.userId = userId
+    log.config = config
+    // TODO: the orm needs to support this but it does not :(
+    log.createdAt = new Date()
+    log.updatedAt = new Date()
+    log.save()
+}

--- a/src/model/User.ts
+++ b/src/model/User.ts
@@ -1,6 +1,7 @@
 import {Entity, PrimaryGeneratedColumn, Column, BaseEntity, OneToMany} from "typeorm"
 import { Chart } from './Chart'
 import { Dataset } from './Dataset'
+import { ChartLog } from "./ChartLog"
 const hashers = require('node-django-hashers')
 
 @Entity("users")
@@ -21,6 +22,9 @@ export default class User extends BaseEntity {
 
     @OneToMany(type => Chart, chart => chart.publishedByUser)
     publishedCharts!: Chart[]
+
+    @OneToMany(type => ChartLog, log => log.user)
+    editedCharts!: ChartLog[]
 
     @OneToMany(type => Dataset, dataset => dataset.createdByUser)
     createdDatasets!: Dataset[]


### PR DESCRIPTION
Track configuration changes to charts as requested in https://github.com/owid/owid-grapher/issues/108

This adds a simple `chart_logs` table to track history of configs. I went back and forth on whether to save the current config being added or the config being replaced. I chose the latter since the History view will always show what was replaced (instead of current + history) and who replaced/invalidated it.

<img width="1364" alt="screenshot 2018-11-23 11 50 25" src="https://user-images.githubusercontent.com/4923428/48958756-1b3b7300-ef16-11e8-924b-9c2a52543a77.png">

Also, added an index. We may want to add pagination to do this at some point but for now it will only show the the last 50 config updates.

PS: HI Jaiden!! It is thanksgiving holidays out here so I am glad to have found time to relax with owid :)

