### PR TITLE
Namespace filter for test pages

### DIFF
--- a/src/admin/testPages.tsx
+++ b/src/admin/testPages.tsx
@@ -13,6 +13,8 @@ import * as querystring from 'querystring'
 import * as _ from 'lodash'
 import * as url from 'url'
 
+const IS_LIVE = NODE_BASE_URL === "https://owid.cloud"
+
 const testPages = Router()
 
 interface EmbedTestPageProps {
@@ -67,12 +69,12 @@ function EmbedTestPage(props: EmbedTestPageProps) {
         <body>
             <div className="row">
                 <h3>ourworldindata.org</h3>
-                {ENV === 'development' && <h3>{NODE_BASE_URL}</h3>}
+                {!IS_LIVE && <h3>{NODE_BASE_URL}</h3>}
             </div>
             {props.slugs.map(slug =>
                 <div className="row">
                     <iframe src={`https://ourworldindata.org/grapher/${slug}`}/>
-                    {ENV === 'development' && <figure data-grapher-src={`/grapher/${slug}`}/>}
+                    {!IS_LIVE && <figure data-grapher-src={`/grapher/${slug}`}/>}
                 </div>
             )}
             <nav className="pagination">

--- a/src/admin/testPages.tsx
+++ b/src/admin/testPages.tsx
@@ -7,7 +7,7 @@ import {renderToHtmlPage} from './serverUtil'
 import {chartToSVG} from '../svgPngExport'
 import OldChart, {Chart} from '../model/Chart'
 import * as db from '../db'
-import {ENV, NODE_BASE_URL} from '../settings'
+import {NODE_BASE_URL, BUILD_GRAPHER_URL} from '../settings'
 import {expectInt} from './serverUtil'
 import * as querystring from 'querystring'
 import * as _ from 'lodash'
@@ -96,7 +96,7 @@ function EmbedTestPage(props: EmbedTestPageProps) {
                     <div className="chart-id">{chart.id}</div>
                     <div className="side-by-side">
                         <iframe src={`https://ourworldindata.org/grapher/${chart.slug}`}/>
-                        {!IS_LIVE && <figure data-grapher-src={`/grapher/${chart.slug}`}/>}
+                        {!IS_LIVE && <figure data-grapher-src={`${BUILD_GRAPHER_URL}/${chart.slug}`}/>}
                     </div>
                 </div>
             )}

--- a/src/admin/testPages.tsx
+++ b/src/admin/testPages.tsx
@@ -15,7 +15,15 @@ import * as url from 'url'
 
 const testPages = Router()
 
-function EmbedTestPage(props: { prevPageUrl?: string, nextPageUrl?: string, slugs: string[] }) {
+interface EmbedTestPageProps {
+    prevPageUrl?: string,
+    nextPageUrl?: string,
+    currentPage?: number,
+    totalPages?: number,
+    slugs: string[]
+}
+
+function EmbedTestPage(props: EmbedTestPageProps) {
     const style = `
         html, body {
             height: 100%;
@@ -66,7 +74,11 @@ function EmbedTestPage(props: { prevPageUrl?: string, nextPageUrl?: string, slug
                 </div>
             )}
             <nav className="pagination">
-                {props.prevPageUrl && <a href={props.prevPageUrl}>&lt;&lt; Prev</a>} {props.nextPageUrl && <a href={props.nextPageUrl}>Next &gt;&gt;</a>}
+                {props.prevPageUrl && <a href={props.prevPageUrl}>&lt;&lt; Prev</a>}
+                {" "}
+                {props.currentPage != null && props.totalPages != null && `Page ${props.currentPage} of ${props.totalPages}`}
+                {" "}
+                {props.nextPageUrl && <a href={props.nextPageUrl}>Next &gt;&gt;</a>}
             </nav>
             <script src="/grapher/embedCharts.js"/>
         </body>
@@ -98,7 +110,7 @@ testPages.get('/embeds', async (req, res) => {
     const prevPageUrl = page > 1 ? (url.parse(req.originalUrl).pathname as string) + "?" + querystring.stringify(_.extend({}, req.query, { page: page-1 })) : undefined
     const nextPageUrl = page < numPages ? (url.parse(req.originalUrl).pathname as string) + "?" + querystring.stringify(_.extend({}, req.query, { page: page+1 })) : undefined
 
-    res.send(renderToHtmlPage(<EmbedTestPage prevPageUrl={prevPageUrl} nextPageUrl={nextPageUrl} slugs={slugs}/>))
+    res.send(renderToHtmlPage(<EmbedTestPage prevPageUrl={prevPageUrl} nextPageUrl={nextPageUrl} slugs={slugs} currentPage={page} totalPages={numPages} />))
 })
 
 function PreviewTestPage(props: { charts: any[] }) {

--- a/src/admin/testPages.tsx
+++ b/src/admin/testPages.tsx
@@ -28,6 +28,8 @@ function EmbedTestPage(props: EmbedTestPageProps) {
         html, body {
             height: 100%;
             margin: 0;
+            background-color: #f1f1f1;
+            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
         }
 
         figure, iframe {


### PR DESCRIPTION
~~**Not ready to merge**~~ Now ready to be reviewed.

Allows specifying a `namespace` query parameter in the test pages, e.g. http://localhost:3030/admin/test/embeds?namespace=wdi

...so that we can show charts from live and test grapher side-by-side:

<img width="1421" alt="screenshot 2018-11-27 at 22 27 57" src="https://user-images.githubusercontent.com/1308115/49115902-ef144f00-f293-11e8-9008-921cf19526ef.png">

(Something funny happening with the unit here! We should probably discuss separately.)

The purpose is to make it easier to go through the chart differences and flag up things that don't look right. 

Since the import will run on the test grapher first, there will be no (easy) way to fix anything at this point, except flag things. Do you think it's a good idea to show the chart IDs and ask the reviewer to put them in e.g. a spreadsheet? (Or is there some easier way?) We would then run the import on the live grapher and fix all the flagged charts before baking them. 🍪