### PR TITLE
Increase exec() maxBuffer to 10MB

### DIFF
--- a/src/admin/serverUtil.tsx
+++ b/src/admin/serverUtil.tsx
@@ -10,18 +10,18 @@ import { exec as childExec } from 'child_process'
 export const promisifiedExec = util.promisify(childExec)
 
 export async function exec(command: string): Promise<{ stdout: string, stderr: string }> {
-    return await promisifiedExec(command);
+    return promisifiedExec(command, { maxBuffer: 1024 * 1024 * 10 })
 }
 
 export async function tryExec(command: string): Promise<{ stdout: string, stderr: string, error?: any }> {
     try {
-        return await exec(command);
+        return await exec(command)
     } catch (error) {
         return {
             error,
             stdout: error.stdout,
             stderr: error.stderr
-        };
+        }
     }
 }
 


### PR DESCRIPTION
The exec() call was reaching the maxBuffer limit on stdout in the chart baker (with a fresh setup). I think the default limit was 200KB.