### PR TITLE
Bring back shelljs

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "save-svg-as-png": "^1.2.0",
     "sharp": "^0.18.4",
     "shell-quote": "^1.6.1",
+    "shelljs": "^0.8.3",
     "slugify": "^1.2.7",
     "string-pixel-width": "^1.4.0",
     "style-loader": "^0.20.3",

--- a/src/admin/serverUtil.tsx
+++ b/src/admin/serverUtil.tsx
@@ -6,22 +6,19 @@ import * as urljoin from 'url-join'
 import * as settings from '../settings'
 import * as util from 'util'
 import { exec as childExec } from 'child_process'
+import * as shell from 'shelljs'
 
-export const promisifiedExec = util.promisify(childExec)
+export const promisifiedExec = util.promisify(shell.exec)
 
-export async function exec(command: string): Promise<{ stdout: string, stderr: string }> {
-    return promisifiedExec(command, { maxBuffer: 1024 * 1024 * 10 })
+export async function exec(command: string): Promise<string> {
+    return promisifiedExec(command)
 }
 
-export async function tryExec(command: string): Promise<{ stdout: string, stderr: string, error?: any }> {
+export async function tryExec(command: string): Promise<string> {
     try {
         return await exec(command)
     } catch (error) {
-        return {
-            error,
-            stdout: error.stdout,
-            stderr: error.stderr
-        }
+        return error
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9958,6 +9958,15 @@ shelljs@^0.8.0:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
+shelljs@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
+  integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"


### PR DESCRIPTION
When I removed it, I wondered why shelljs was creating files for stderr, stdout and parameters... I now figured out that it's the most robust way to handle lots of data without hitting the maxBuffer limit.

`netlifyctl` in particular is pretty noisy and easily reaches the maxBuffer limit, which also means all deploys will fail with the existing code, which I think is not good?

Anyway, the return value is now changed to be the exit code as a string (but we don't use it anywhere anyway).