### PR TITLE
Link tracking for header, footer & homepage

### DIFF
--- a/site/client/SiteHeaderMenus.tsx
+++ b/site/client/SiteHeaderMenus.tsx
@@ -92,7 +92,7 @@ export class Header extends React.Component<{ categories: CategoryWithEntries[] 
         return <React.Fragment>
             <div className="wrapper site-navigation-bar">
                 <div className="site-logo">
-                    <a href="/">
+                    <a href="/" data-track-click data-track-note="header-navigation">
                         Our World<br /> in Data
                     </a>
                 </div>
@@ -118,42 +118,42 @@ export class Header extends React.Component<{ categories: CategoryWithEntries[] 
                         <div className="site-primary-navigation">
                             <HeaderSearch/>
                             <ul className="site-primary-links">
-                                <li><a href="/blog">Blog</a></li>
-                                <li><a href="/about">About</a></li>
-                                <li><a href="/donate">Donate</a></li>
+                                <li><a href="/blog" data-track-click data-track-note="header-navigation">Blog</a></li>
+                                <li><a href="/about" data-track-click data-track-note="header-navigation">About</a></li>
+                                <li><a href="/donate" data-track-click data-track-note="header-navigation">Donate</a></li>
                             </ul>
                         </div>
                         <div className="site-secondary-navigation">
                             <ul className="site-secondary-links">
-                                <li><a href="/charts">All charts</a></li>
-                                <li><a href="/teaching">Teaching material</a></li>
-                                <li><a href="https://sdg-tracker.org">Sustainable Development Goals</a></li>
+                                <li><a href="/charts" data-track-click data-track-note="header-navigation">All charts</a></li>
+                                <li><a href="/teaching" data-track-click data-track-note="header-navigation">Teaching material</a></li>
+                                <li><a href="https://sdg-tracker.org" data-track-click data-track-note="header-navigation">Sustainable Development Goals</a></li>
                             </ul>
                         </div>
                     </div>
                 </nav>
                 <ul className="site-social-links lg-only">
                     <li>
-                        <a href="https://twitter.com/ourworldindata" target="_blank" rel="noopener noreferrer" title="Follow us on Twitter">
+                        <a href="https://twitter.com/ourworldindata" target="_blank" rel="noopener noreferrer" title="Follow us on Twitter" data-track-click data-track-note="header-navigation">
                             <FontAwesomeIcon icon={faTwitter} />
                         </a>
                     </li>
                     <li>
-                        <a href="https://www.facebook.com/OurWorldinData/" target="_blank" rel="noopener noreferrer" title="Subscribe to our Facebook page">
+                        <a href="https://www.facebook.com/OurWorldinData/" target="_blank" rel="noopener noreferrer" title="Subscribe to our Facebook page" data-track-click data-track-note="header-navigation">
                             <FontAwesomeIcon icon={faFacebook} />
                         </a>
                     </li>
                     <li>
-                        <a href="/subscribe" target="_blank" rel="noopener noreferrer" title="Subscribe to our newsletter">
+                        <a href="/subscribe" target="_blank" rel="noopener noreferrer" title="Subscribe to our newsletter" data-track-click data-track-note="header-navigation">
                             <FontAwesomeIcon icon={faEnvelope} />
                         </a>
                     </li>
                 </ul>
                 <div className="site-navigation sm-only">
-                    <button className="button" onClick={this.onToggleSearch}>
+                    <button className="button" onClick={this.onToggleSearch} data-track-click  data-track-note="mobile-search-button">
                         <FontAwesomeIcon icon={faSearch}/>
                     </button>
-                    <button className="button" onClick={this.onToggleCategories}>
+                    <button className="button" onClick={this.onToggleCategories} data-track-click  data-track-note="mobile-hamburger-button">
                         <FontAwesomeIcon icon={faBars}/>
                     </button>
                 </div>
@@ -220,14 +220,14 @@ export class DesktopTopicsMenu extends React.Component<{ categories: CategoryWit
                         </div>
                     )}
                     <hr />
-                    <a href="http://sdg-tracker.org" className="item" data-submenu-id>
+                    <a href="http://sdg-tracker.org" className="item" data-submenu-id data-track-click data-track-note="header-navigation">
                         <span className="label">Sustainable Development Goals</span>
                         <span className="icon">
                             <FontAwesomeIcon icon={faExternalLinkAlt} />
                         </span>
                     </a>
                     {/* An extra "Index" menu item, for when we have the Index page. */}
-                    {/* <a href="/index" className="item">
+                    {/* <a href="/index" className="item" data-track-click data-track-note="header-navigation">
                         <span className="label">Index of all topics</span>
                         <span className="icon">
                             <FontAwesomeIcon icon={faExternalLinkAlt} />
@@ -236,7 +236,7 @@ export class DesktopTopicsMenu extends React.Component<{ categories: CategoryWit
                 </AmazonMenu>
             </div>
             <div className="submenu" ref={this.submenuRef}>
-                {activeCategory && activeCategory.entries.map((entry) => <a key={entry.title} href={`/${entry.slug}`} className="item">
+                {activeCategory && activeCategory.entries.map((entry) => <a key={entry.title} href={`/${entry.slug}`} className="item" data-track-click data-track-note="header-navigation">
                     <span className="label">{entry.title}</span>
                 </a>)}
             </div>
@@ -275,19 +275,19 @@ export class MobileTopicsMenu extends React.Component<{ categories: CategoryWith
                             <ul>
                                 {category.entries.map(entry => {
                                     return <li key={entry.slug}>
-                                        <a href={`/${entry.slug}`}>{entry.title}</a>
+                                        <a href={`/${entry.slug}`} data-track-click data-track-note="header-navigation">{entry.title}</a>
                                     </li>
                                 })}
                             </ul>
                         </div>}
                     </li>
                 )}
-                <li className="end-link"><a href="/charts">Charts</a></li>
-                <li className="end-link"><a href="/teaching">Teaching material</a></li>
-                <li className="end-link"><a href="https://sdg-tracker.org">Sustainable Development Goals</a></li>
-                <li className="end-link"><a href="/blog">Blog</a></li>
-                <li className="end-link"><a href="/about">About</a></li>
-                <li className="end-link"><a href="/donate">Donate</a></li>
+                <li className="end-link"><a href="/charts" data-track-click data-track-note="header-navigation">Charts</a></li>
+                <li className="end-link"><a href="/teaching" data-track-click data-track-note="header-navigation">Teaching material</a></li>
+                <li className="end-link"><a href="https://sdg-tracker.org" data-track-click data-track-note="header-navigation">Sustainable Development Goals</a></li>
+                <li className="end-link"><a href="/blog" data-track-click data-track-note="header-navigation">Blog</a></li>
+                <li className="end-link"><a href="/about" data-track-click data-track-note="header-navigation">About</a></li>
+                <li className="end-link"><a href="/donate" data-track-click data-track-note="header-navigation">Donate</a></li>
             </ul>
         </div>
     }

--- a/site/client/css/footer.scss
+++ b/site/client/css/footer.scss
@@ -76,8 +76,14 @@
 
     .logos a {
         display: block;
-        transition: opacity 150ms ease;
-        &:hover { opacity: .8; }
+        transition: opacity 150ms ease, filter 150ms ease;
+        filter: grayscale(1);
+        opacity: .5;
+
+        &:hover {
+            filter: grayscale(0);
+            opacity: 1;
+        }
     }
 
     .logos img {

--- a/site/client/owid.entry.ts
+++ b/site/client/owid.entry.ts
@@ -56,9 +56,8 @@ if (trackedLinkExists) {
         const targetElement = ev.target as HTMLElement
         const trackedElement = getParent(targetElement, (el: HTMLElement) => el.getAttribute("data-track-click") != null)
         if (trackedElement) {
-            // In order for events to be send for all anchor tags, there needs
-            // to be a delay to send the event to amplitude before navigating
-            // away from the page.
+            // In order for events to be sent for anchor tags, there needs to be
+            // a delay before navigating away from the page.
             const href = trackedElement.getAttribute("href")
             const target = trackedElement.getAttribute("target")
             if (href && target !== "_blank") {

--- a/site/client/owid.entry.ts
+++ b/site/client/owid.entry.ts
@@ -39,7 +39,7 @@ if (search) {
 
 const trackedLinkExists: boolean = !!document.querySelector("[data-track-click]")
 
-function createFunctionWithTimeout(callback: () => void, timeout?: number) {
+function createFunctionWithTimeout(callback: () => void, timeout: number = 350) {
     let called = false
     function fn() {
         if (!called) {
@@ -47,7 +47,7 @@ function createFunctionWithTimeout(callback: () => void, timeout?: number) {
             callback()
         }
     }
-    setTimeout(fn, timeout || 350)
+    setTimeout(fn, timeout)
     return fn
 }
 

--- a/site/client/owid.entry.ts
+++ b/site/client/owid.entry.ts
@@ -47,7 +47,7 @@ function createFunctionWithTimeout(callback: () => void, timeout?: number) {
             callback()
         }
     }
-    setTimeout(fn, timeout || 500)
+    setTimeout(fn, timeout || 350)
     return fn
 }
 

--- a/site/client/owid.entry.ts
+++ b/site/client/owid.entry.ts
@@ -49,7 +49,8 @@ if (trackedLinkExists) {
             // To handle those we need to wait before navigating.
             Analytics.logEvent("OWID_SITE_CLICK", {
                 text: trackedElement.innerText,
-                href: trackedElement.getAttribute("href")
+                href: trackedElement.getAttribute("href"),
+                note: trackedElement.getAttribute("data-track-note")
             })
         }
     })

--- a/site/client/owid.entry.ts
+++ b/site/client/owid.entry.ts
@@ -37,7 +37,7 @@ if (search) {
     })
 }
 
-const trackedLinkExists: boolean = !!document.querySelector("a[data-track-click]")
+const trackedLinkExists: boolean = !!document.querySelector("[data-track-click]")
 
 if (trackedLinkExists) {
     document.addEventListener("click", (ev) => {

--- a/site/server/views/FrontPage.tsx
+++ b/site/server/views/FrontPage.tsx
@@ -73,7 +73,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                             <div className="owid-col owid-col--lg-auto owid-padding-bottom--sm-5">
                                 <section>
                                     <h3 className="align-center">Trusted in <strong>research and media</strong></h3>
-                                    <a href="/about/coverage#coverage" className="coverage-link">
+                                    <a href="/about/coverage#coverage" className="coverage-link" data-track-click data-track-note="trust-media">
                                         <img src="/media-logos.png" alt="Logos of the publications that have used our content" />
                                         <div className="hover-note">
                                             <p>Find out how our work is used by journalists and researchers</p>
@@ -82,7 +82,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                 </section>
                                 <section>
                                     <h3 className="align-center">Used in <strong>teaching</strong></h3>
-                                    <a href="/about/coverage#teaching" className="coverage-link">
+                                    <a href="/about/coverage#teaching" className="coverage-link" data-track-click data-track-note="trust-teaching">
                                         <img src="/university-logos.png" alt="Logos of the universities that have used our content" />
                                         <div className="hover-note">
                                             <p>Find out how our work is used in teaching</p>
@@ -106,7 +106,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                     </ul>
                                 </section>
                                 <section>
-                                    <h3>Based at University of Oxford</h3>
+                                    <h3>Based at the University of Oxford</h3>
                                     <img className="oxford-logo" src="/oxford-logo-rect.png" alt="University of Oxford logo" />
                                 </section>
                             </div>
@@ -122,7 +122,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                         <div className="owid-row owid-spacing--1">
                             <div className="owid-col owid-col--lg-auto">
                                 <div className="list">
-                                    <a href="/co2-and-other-greenhouse-gas-emissions" className="list-item">
+                                    <a href="/co2-and-other-greenhouse-gas-emissions" className="list-item" data-track-click data-track-note="popular-research">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faBook} />
                                         </div>
@@ -130,7 +130,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                             CO₂ and other Greenhouse Gas Emissions
                                         </div>
                                     </a>
-                                    <a href="/a-history-of-global-living-conditions-in-5-charts" className="list-item">
+                                    <a href="/a-history-of-global-living-conditions-in-5-charts" className="list-item" data-track-click data-track-note="popular-research">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faFileAlt} />
                                         </div>
@@ -138,7 +138,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                             The short history of global living conditions
                                         </div>
                                     </a>
-                                    <a href="/literacy" className="list-item">
+                                    <a href="/literacy" className="list-item" data-track-click data-track-note="popular-research">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faBook} />
                                         </div>
@@ -146,7 +146,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                             Literacy
                                         </div>
                                     </a>
-                                    <a href="/world-population-growth" className="list-item">
+                                    <a href="/world-population-growth" className="list-item" data-track-click data-track-note="popular-research">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faBook} />
                                         </div>
@@ -154,7 +154,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                             World Population Growth
                                         </div>
                                     </a>
-                                    <a href="/life-expectancy" className="list-item">
+                                    <a href="/life-expectancy" className="list-item" data-track-click data-track-note="popular-research">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faBook} />
                                         </div>
@@ -162,7 +162,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                             Life expectancy
                                         </div>
                                     </a>
-                                    <a href="/why-do-women-live-longer-than-men" className="list-item">
+                                    <a href="/why-do-women-live-longer-than-men" className="list-item" data-track-click data-track-note="popular-research">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faFileAlt} />
                                         </div>
@@ -174,7 +174,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                             </div>
                             <div className="owid-col owid-col--lg-auto">
                                 <div className="list">
-                                    <a href="/hunger-and-undernourishment" className="list-item">
+                                    <a href="/hunger-and-undernourishment" className="list-item" data-track-click data-track-note="popular-research">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faBook} />
                                         </div>
@@ -182,7 +182,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                             Hunger and undernourishment
                                         </div>
                                     </a>
-                                    <a href="/income-inequality" className="list-item">
+                                    <a href="/income-inequality" className="list-item" data-track-click data-track-note="popular-research">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faBook} />
                                         </div>
@@ -190,7 +190,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                             Income inequality
                                         </div>
                                     </a>
-                                    <a href="/faq-on-plastics" className="list-item">
+                                    <a href="/faq-on-plastics" className="list-item" data-track-click data-track-note="popular-research">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faFileAlt} />
                                         </div>
@@ -198,7 +198,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                             FAQs on plastics pollution
                                         </div>
                                     </a>
-                                    <a href="/global-rise-of-education" className="list-item">
+                                    <a href="/global-rise-of-education" className="list-item" data-track-click data-track-note="popular-research">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faBook} />
                                         </div>
@@ -206,7 +206,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                             Global rise of education
                                         </div>
                                     </a>
-                                    <a href="/much-better-awful-can-be-better" className="list-item">
+                                    <a href="/much-better-awful-can-be-better" className="list-item" data-track-click data-track-note="popular-research">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faFileAlt} />
                                         </div>
@@ -230,7 +230,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                     <h2>Short updates and facts</h2>
                                 </div>
                                 <div className="list">
-                                    {shortPosts.slice(0,5).map(post => <a key={post.slug} href={`/${post.slug}`} className="list-item">
+                                    {shortPosts.slice(0,5).map(post => <a key={post.slug} href={`/${post.slug}`} className="list-item" data-track-click data-track-note="short-post">
                                         <div className="thumbnail">
                                             <div className="cover-image" style={{ backgroundImage: post.imageUrl && `url(${post.imageUrl})` }} />
                                         </div>
@@ -240,7 +240,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                         </div>
                                     </a>)}
                                 </div>
-                                <a href="/blog" className="see-all">
+                                <a href="/blog" className="see-all" data-track-click data-track-note="see-all-short-posts">
                                     <div className="label">See all short updates and facts</div>
                                     <div className="icon"><FontAwesomeIcon icon={faAngleRight} /></div>
                                 </a>
@@ -256,7 +256,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                 </div>
                                 <div className="list">
                                     {explainerPosts.slice(0,6).map(post => <div key={post.slug} className="list-item-wrapper">
-                                        <a href={`/${post.slug}`} className="list-item">
+                                        <a href={`/${post.slug}`} className="list-item" data-track-click data-track-note="explainer">
                                             <div className="thumbnail">
                                                 <div className="cover-image" style={{ backgroundImage: post.imageUrl && `url(${post.imageUrl})` }} />
                                             </div>
@@ -266,7 +266,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                         </a>
                                     </div>)}
                                 </div>
-                                <a href="/blog" className="see-all">
+                                <a href="/blog" className="see-all" data-track-click data-track-note="see-all-explainers">
                                     <div className="label">See all explainers</div>
                                     <div className="icon"><FontAwesomeIcon icon={faAngleRight} /></div>
                                 </a>
@@ -346,7 +346,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
             <section className="homepage-projects">
                 <div className="wrapper">
                     <div className="list">
-                        <a href="https://sdg-tracker.org" className="list-item">
+                        <a href="https://sdg-tracker.org" className="list-item" data-track-click data-track-note="popular-research">
                             <div className="icon-left">
                                 <img src="/sdg-wheel.png" alt="SDG Tracker logo"/>
                             </div>
@@ -358,7 +358,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                 <FontAwesomeIcon icon={faExternalLinkAlt} />
                             </div>
                         </a>
-                        <a href="/teaching" className="list-item">
+                        <a href="/teaching" className="list-item" data-track-click data-track-note="popular-research">
                             <div className="icon-left">
                                 <img src="/teaching-hub.svg" alt="Teaching Hub logo"/>
                             </div>

--- a/site/server/views/FrontPage.tsx
+++ b/site/server/views/FrontPage.tsx
@@ -374,8 +374,6 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                 </div>
             </section>
 
-            <section className="homepage-about"></section>
-
             <section id="entries" className="homepage-entries">
                 <div className="wrapper">
                     <h2>All topics</h2>

--- a/site/server/views/FrontPage.tsx
+++ b/site/server/views/FrontPage.tsx
@@ -73,7 +73,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                             <div className="owid-col owid-col--lg-auto owid-padding-bottom--sm-5">
                                 <section>
                                     <h3 className="align-center">Trusted in <strong>research and media</strong></h3>
-                                    <a href="/about/coverage#coverage" className="coverage-link" data-track-click data-track-note="trust-media">
+                                    <a href="/about/coverage#coverage" className="coverage-link" data-track-click data-track-note="homepage-trust">
                                         <img src="/media-logos.png" alt="Logos of the publications that have used our content" />
                                         <div className="hover-note">
                                             <p>Find out how our work is used by journalists and researchers</p>
@@ -82,7 +82,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                 </section>
                                 <section>
                                     <h3 className="align-center">Used in <strong>teaching</strong></h3>
-                                    <a href="/about/coverage#teaching" className="coverage-link" data-track-click data-track-note="trust-teaching">
+                                    <a href="/about/coverage#teaching" className="coverage-link" data-track-click data-track-note="homepage-trust">
                                         <img src="/university-logos.png" alt="Logos of the universities that have used our content" />
                                         <div className="hover-note">
                                             <p>Find out how our work is used in teaching</p>
@@ -122,7 +122,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                         <div className="owid-row owid-spacing--1">
                             <div className="owid-col owid-col--lg-auto">
                                 <div className="list">
-                                    <a href="/co2-and-other-greenhouse-gas-emissions" className="list-item" data-track-click data-track-note="popular-research">
+                                    <a href="/co2-and-other-greenhouse-gas-emissions" className="list-item" data-track-click data-track-note="homepage-popular">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faBook} />
                                         </div>
@@ -130,7 +130,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                             CO₂ and other Greenhouse Gas Emissions
                                         </div>
                                     </a>
-                                    <a href="/a-history-of-global-living-conditions-in-5-charts" className="list-item" data-track-click data-track-note="popular-research">
+                                    <a href="/a-history-of-global-living-conditions-in-5-charts" className="list-item" data-track-click data-track-note="homepage-popular">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faFileAlt} />
                                         </div>
@@ -138,7 +138,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                             The short history of global living conditions
                                         </div>
                                     </a>
-                                    <a href="/literacy" className="list-item" data-track-click data-track-note="popular-research">
+                                    <a href="/literacy" className="list-item" data-track-click data-track-note="homepage-popular">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faBook} />
                                         </div>
@@ -146,7 +146,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                             Literacy
                                         </div>
                                     </a>
-                                    <a href="/world-population-growth" className="list-item" data-track-click data-track-note="popular-research">
+                                    <a href="/world-population-growth" className="list-item" data-track-click data-track-note="homepage-popular">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faBook} />
                                         </div>
@@ -154,7 +154,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                             World Population Growth
                                         </div>
                                     </a>
-                                    <a href="/life-expectancy" className="list-item" data-track-click data-track-note="popular-research">
+                                    <a href="/life-expectancy" className="list-item" data-track-click data-track-note="homepage-popular">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faBook} />
                                         </div>
@@ -162,7 +162,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                             Life expectancy
                                         </div>
                                     </a>
-                                    <a href="/why-do-women-live-longer-than-men" className="list-item" data-track-click data-track-note="popular-research">
+                                    <a href="/why-do-women-live-longer-than-men" className="list-item" data-track-click data-track-note="homepage-popular">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faFileAlt} />
                                         </div>
@@ -174,7 +174,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                             </div>
                             <div className="owid-col owid-col--lg-auto">
                                 <div className="list">
-                                    <a href="/hunger-and-undernourishment" className="list-item" data-track-click data-track-note="popular-research">
+                                    <a href="/hunger-and-undernourishment" className="list-item" data-track-click data-track-note="homepage-popular">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faBook} />
                                         </div>
@@ -182,7 +182,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                             Hunger and undernourishment
                                         </div>
                                     </a>
-                                    <a href="/income-inequality" className="list-item" data-track-click data-track-note="popular-research">
+                                    <a href="/income-inequality" className="list-item" data-track-click data-track-note="homepage-popular">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faBook} />
                                         </div>
@@ -190,7 +190,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                             Income inequality
                                         </div>
                                     </a>
-                                    <a href="/faq-on-plastics" className="list-item" data-track-click data-track-note="popular-research">
+                                    <a href="/faq-on-plastics" className="list-item" data-track-click data-track-note="homepage-popular">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faFileAlt} />
                                         </div>
@@ -198,7 +198,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                             FAQs on plastics pollution
                                         </div>
                                     </a>
-                                    <a href="/global-rise-of-education" className="list-item" data-track-click data-track-note="popular-research">
+                                    <a href="/global-rise-of-education" className="list-item" data-track-click data-track-note="homepage-popular">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faBook} />
                                         </div>
@@ -206,7 +206,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                             Global rise of education
                                         </div>
                                     </a>
-                                    <a href="/much-better-awful-can-be-better" className="list-item" data-track-click data-track-note="popular-research">
+                                    <a href="/much-better-awful-can-be-better" className="list-item" data-track-click data-track-note="homepage-popular">
                                         <div className="icon">
                                             <FontAwesomeIcon icon={faFileAlt} />
                                         </div>
@@ -230,7 +230,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                     <h2>Short updates and facts</h2>
                                 </div>
                                 <div className="list">
-                                    {shortPosts.slice(0,5).map(post => <a key={post.slug} href={`/${post.slug}`} className="list-item" data-track-click data-track-note="short-post">
+                                    {shortPosts.slice(0,5).map(post => <a key={post.slug} href={`/${post.slug}`} className="list-item" data-track-click data-track-note="homepage-short-post">
                                         <div className="thumbnail">
                                             <div className="cover-image" style={{ backgroundImage: post.imageUrl && `url(${post.imageUrl})` }} />
                                         </div>
@@ -240,7 +240,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                         </div>
                                     </a>)}
                                 </div>
-                                <a href="/blog" className="see-all" data-track-click data-track-note="see-all-short-posts">
+                                <a href="/blog" className="see-all" data-track-click data-track-note="homepage-see-all-short-posts">
                                     <div className="label">See all short updates and facts</div>
                                     <div className="icon"><FontAwesomeIcon icon={faAngleRight} /></div>
                                 </a>
@@ -256,7 +256,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                 </div>
                                 <div className="list">
                                     {explainerPosts.slice(0,6).map(post => <div key={post.slug} className="list-item-wrapper">
-                                        <a href={`/${post.slug}`} className="list-item" data-track-click data-track-note="explainer">
+                                        <a href={`/${post.slug}`} className="list-item" data-track-click data-track-note="homepage-explainer">
                                             <div className="thumbnail">
                                                 <div className="cover-image" style={{ backgroundImage: post.imageUrl && `url(${post.imageUrl})` }} />
                                             </div>
@@ -266,7 +266,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                         </a>
                                     </div>)}
                                 </div>
-                                <a href="/blog" className="see-all" data-track-click data-track-note="see-all-explainers">
+                                <a href="/blog" className="see-all" data-track-click data-track-note="homepage-see-all-explainers">
                                     <div className="label">See all explainers</div>
                                     <div className="icon"><FontAwesomeIcon icon={faAngleRight} /></div>
                                 </a>
@@ -317,19 +317,19 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                 <div className="shaded-box">
                                     <h2>Follow us</h2>
                                     <div className="list">
-                                        <a href="https://twitter.com/ourworldindata" className="list-item" title="Twitter">
+                                        <a href="https://twitter.com/ourworldindata" className="list-item" title="Twitter" target="_blank" rel="noopener noreferrer" data-track-click data-track-note="homepage-follow-us">
                                             <div className="icon">
                                                 <FontAwesomeIcon icon={faTwitter} />
                                             </div>
                                             <div className="label">Twitter</div>
                                         </a>
-                                        <a href="https://facebook.com/ourworldindata" className="list-item" title="Facebook">
+                                        <a href="https://facebook.com/ourworldindata" className="list-item" title="Facebook" target="_blank" rel="noopener noreferrer" data-track-click data-track-note="homepage-follow-us">
                                             <div className="icon">
                                                 <FontAwesomeIcon icon={faFacebook} />
                                             </div>
                                             <div className="label">Facebook</div>
                                         </a>
-                                        <a href="/feed" className="list-item" title="RSS">
+                                        <a href="/feed" className="list-item" title="RSS" target="_blank" data-track-click data-track-note="homepage-follow-us">
                                             <div className="icon">
                                                 <FontAwesomeIcon icon={faRss} />
                                             </div>
@@ -346,7 +346,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
             <section className="homepage-projects">
                 <div className="wrapper">
                     <div className="list">
-                        <a href="https://sdg-tracker.org" className="list-item" data-track-click data-track-note="popular-research">
+                        <a href="https://sdg-tracker.org" className="list-item" data-track-click data-track-note="homepage-projects">
                             <div className="icon-left">
                                 <img src="/sdg-wheel.png" alt="SDG Tracker logo"/>
                             </div>
@@ -358,7 +358,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                                 <FontAwesomeIcon icon={faExternalLinkAlt} />
                             </div>
                         </a>
-                        <a href="/teaching" className="list-item" data-track-click data-track-note="popular-research">
+                        <a href="/teaching" className="list-item" data-track-click data-track-note="homepage-projects">
                             <div className="icon-left">
                                 <img src="/teaching-hub.svg" alt="Teaching Hub logo"/>
                             </div>
@@ -384,7 +384,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                             <h3 id={category.slug}>{category.name}</h3>
                         </div>
                         <div className="category-entries">
-                            {category.entries.map(entry => <a key={entry.slug} href={`/${entry.slug}`} className={`entry ${category.slug}-color`}>
+                            {category.entries.map(entry => <a key={entry.slug} href={`/${entry.slug}`} className={`entry ${category.slug}-color`} data-track-click data-track-note="homepage-entries">
                                 <h4>{entry.title}</h4>
                             </a>)}
                         </div>

--- a/site/server/views/FrontPage.tsx
+++ b/site/server/views/FrontPage.tsx
@@ -36,7 +36,7 @@ export const FrontPage = (props: { entries: CategoryWithEntries[], posts: PostIn
                 <div className="wrapper">
                     <div className="homepage-masthead--main">
                         <h1 className="lg-only">Know the world you live in</h1>
-                        <div className="subheading">Understand the world's largest problems through research and interactive data visualizations</div>
+                        <div className="subheading">Research and interactive data visualizations to understand the world’s largest problems.</div>
                     </div>
                     <div className="homepage-masthead--search lg-only">
                         <form action="/search" method="get">

--- a/site/server/views/SiteFooter.tsx
+++ b/site/server/views/SiteFooter.tsx
@@ -7,35 +7,35 @@ export const SiteFooter = () => {
             <div className="owid-row">
                 <div className="owid-col owid-col--lg-1">
                     <ul>
-                        <li><a href="/about">About</a></li>
-                        <li><a href="/about#contact">Contact</a></li>
-                        <li><a href="/jobs">Jobs</a></li>
-                        <li><a href="/about#supporters">Supporters</a></li>
-                        <li><a href="/about/how-to-use-our-world-in-data">How to use</a></li>
-                        <li><a href="/donate">Donate</a></li>
+                        <li><a href="/about" data-track-click data-track-note="footer-navigation">About</a></li>
+                        <li><a href="/about#contact" data-track-click data-track-note="footer-navigation">Contact</a></li>
+                        <li><a href="/jobs" data-track-click data-track-note="footer-navigation">Jobs</a></li>
+                        <li><a href="/about#supporters" data-track-click data-track-note="footer-navigation">Supporters</a></li>
+                        <li><a href="/about/how-to-use-our-world-in-data" data-track-click data-track-note="footer-navigation">How to use</a></li>
+                        <li><a href="/donate" data-track-click data-track-note="footer-navigation">Donate</a></li>
                     </ul>
                 </div>
                 <div className="owid-col owid-col--lg-1">
                     <ul>
-                        <li><a href="/blog">Blog</a></li>
-                        <li><a href="/charts">All charts</a></li>
+                        <li><a href="/blog" data-track-click data-track-note="footer-navigation">Blog</a></li>
+                        <li><a href="/charts" data-track-click data-track-note="footer-navigation">All charts</a></li>
                     </ul>
                     <ul>
-                        <li><a href="https://twitter.com/OurWorldInData">Twitter</a></li>
-                        <li><a href="https://www.facebook.com/OurWorldinData">Facebook</a></li>
-                        <li><a href="https://github.com/owid">GitHub</a></li>
-                        <li><a href="/feed">RSS Feed</a></li>
+                        <li><a href="https://twitter.com/OurWorldInData" data-track-click data-track-note="footer-navigation">Twitter</a></li>
+                        <li><a href="https://www.facebook.com/OurWorldinData" data-track-click data-track-note="footer-navigation">Facebook</a></li>
+                        <li><a href="https://github.com/owid" data-track-click data-track-note="footer-navigation">GitHub</a></li>
+                        <li><a href="/feed" data-track-click data-track-note="footer-navigation">RSS Feed</a></li>
                     </ul>
                 </div>
                 <div className="owid-col owid-col--lg-1">
                     <div className="logos">
-                        <a href="https://www.oxfordmartin.ox.ac.uk/research/programmes/global-development" className="partner-logo">
+                        <a href="https://www.oxfordmartin.ox.ac.uk/research/programmes/global-development" className="partner-logo" data-track-click data-track-note="footer-navigation">
                             <img src="/oxford-logo-rect.png" alt="University of Oxford logo"/>
                         </a>
-                        <a href="https://global-change-data-lab.org/" className="partner-logo">
+                        <a href="https://global-change-data-lab.org/" className="partner-logo" data-track-click data-track-note="footer-navigation">
                             <img src="/gcdl-logo.png" alt="Global Change Data Lab logo"/>
                         </a>
-                        <a href="/owid-at-ycombinator" className="partner-logo">
+                        <a href="/owid-at-ycombinator" className="partner-logo" data-track-click data-track-note="footer-navigation">
                             <img src="/yc-logo.png" alt="Y Combinator logo"/>
                         </a>
                     </div>

--- a/site/server/views/SiteHeader.tsx
+++ b/site/server/views/SiteHeader.tsx
@@ -32,33 +32,33 @@ export const SiteHeader = () => {
                             </div>
                         </form>
                         <ul className="site-primary-links">
-                            <li><a href="/blog" data-track-click data-track-note="site-navigation">Blog</a></li>
-                            <li><a href="/about" data-track-click data-track-note="site-navigation">About</a></li>
-                            <li><a href="/donate" data-track-click data-track-note="site-navigation">Donate</a></li>
+                            <li><a href="/blog" data-track-click data-track-note="header-navigation">Blog</a></li>
+                            <li><a href="/about" data-track-click data-track-note="header-navigation">About</a></li>
+                            <li><a href="/donate" data-track-click data-track-note="header-navigation">Donate</a></li>
                         </ul>
                     </div>
                     <div className="site-secondary-navigation">
                         <ul className="site-secondary-links">
-                            <li><a href="/charts" data-track-click data-track-note="site-navigation">All charts</a></li>
-                            <li><a href="/teaching" data-track-click data-track-note="site-navigation">Teaching material</a></li>
-                            <li><a href="https://sdg-tracker.org" data-track-click data-track-note="site-navigation">Sustainable Development Goals</a></li>
+                            <li><a href="/charts" data-track-click data-track-note="header-navigation">All charts</a></li>
+                            <li><a href="/teaching" data-track-click data-track-note="header-navigation">Teaching material</a></li>
+                            <li><a href="https://sdg-tracker.org" data-track-click data-track-note="header-navigation">Sustainable Development Goals</a></li>
                         </ul>
                     </div>
                 </div>
             </nav>
             <ul className="site-social-links lg-only">
                 <li>
-                    <a href="https://twitter.com/ourworldindata" target="_blank" rel="noopener noreferrer" title="Follow us on Twitter" data-track-click data-track-note="site-navigation">
+                    <a href="https://twitter.com/ourworldindata" target="_blank" rel="noopener noreferrer" title="Follow us on Twitter" data-track-click data-track-note="header-navigation">
                         <FontAwesomeIcon icon={faTwitter} />
                     </a>
                 </li>
                 <li>
-                    <a href="https://www.facebook.com/OurWorldinData/" target="_blank" rel="noopener noreferrer" title="Subscribe to our Facebook page" data-track-click data-track-note="site-navigation">
+                    <a href="https://www.facebook.com/OurWorldinData/" target="_blank" rel="noopener noreferrer" title="Subscribe to our Facebook page" data-track-click data-track-note="header-navigation">
                         <FontAwesomeIcon icon={faFacebook} />
                     </a>
                 </li>
                 <li>
-                    <a href="/subscribe" target="_blank" rel="noopener noreferrer" title="Subscribe to our newsletter" data-track-click data-track-note="site-navigation">
+                    <a href="/subscribe" target="_blank" rel="noopener noreferrer" title="Subscribe to our newsletter" data-track-click data-track-note="header-navigation">
                         <FontAwesomeIcon icon={faEnvelope} />
                     </a>
                 </li>

--- a/site/server/views/SiteHeader.tsx
+++ b/site/server/views/SiteHeader.tsx
@@ -32,42 +32,42 @@ export const SiteHeader = () => {
                             </div>
                         </form>
                         <ul className="site-primary-links">
-                            <li><a href="/blog">Blog</a></li>
-                            <li><a href="/about">About</a></li>
-                            <li><a href="/donate">Donate</a></li>
+                            <li><a href="/blog" data-track-click data-track-note="site-navigation">Blog</a></li>
+                            <li><a href="/about" data-track-click data-track-note="site-navigation">About</a></li>
+                            <li><a href="/donate" data-track-click data-track-note="site-navigation">Donate</a></li>
                         </ul>
                     </div>
                     <div className="site-secondary-navigation">
                         <ul className="site-secondary-links">
-                            <li><a href="/charts">All charts</a></li>
-                            <li><a href="/teaching">Teaching material</a></li>
-                            <li><a href="https://sdg-tracker.org">Sustainable Development Goals</a></li>
+                            <li><a href="/charts" data-track-click data-track-note="site-navigation">All charts</a></li>
+                            <li><a href="/teaching" data-track-click data-track-note="site-navigation">Teaching material</a></li>
+                            <li><a href="https://sdg-tracker.org" data-track-click data-track-note="site-navigation">Sustainable Development Goals</a></li>
                         </ul>
                     </div>
                 </div>
             </nav>
             <ul className="site-social-links lg-only">
                 <li>
-                    <a href="https://twitter.com/ourworldindata" target="_blank" rel="noopener noreferrer" title="Follow us on Twitter">
+                    <a href="https://twitter.com/ourworldindata" target="_blank" rel="noopener noreferrer" title="Follow us on Twitter" data-track-click data-track-note="site-navigation">
                         <FontAwesomeIcon icon={faTwitter} />
                     </a>
                 </li>
                 <li>
-                    <a href="https://www.facebook.com/OurWorldinData/" target="_blank" rel="noopener noreferrer" title="Subscribe to our Facebook page">
+                    <a href="https://www.facebook.com/OurWorldinData/" target="_blank" rel="noopener noreferrer" title="Subscribe to our Facebook page" data-track-click data-track-note="site-navigation">
                         <FontAwesomeIcon icon={faFacebook} />
                     </a>
                 </li>
                 <li>
-                    <a href="/subscribe" target="_blank" rel="noopener noreferrer" title="Subscribe to our newsletter">
+                    <a href="/subscribe" target="_blank" rel="noopener noreferrer" title="Subscribe to our newsletter" data-track-click data-track-note="site-navigation">
                         <FontAwesomeIcon icon={faEnvelope} />
                     </a>
                 </li>
             </ul>
             <div className="site-navigation sm-only">
-                <button className="button">
+                <button className="button" data-track-click data-track-note="mobile-search-button">
                     <FontAwesomeIcon icon={faSearch}/>
                 </button>
-                <button className="button">
+                <button className="button" data-track-click data-track-note="mobile-hamburger-button">
                     <FontAwesomeIcon icon={faBars}/>
                 </button>
             </div>


### PR DESCRIPTION
It makes navigation slower but gives us more data about what people click on. For every link, there is up to a 350ms delay before navigating away from a page, in order to have time to send an event to Amplitude.

Google Analytics can tell us which pages were visited next, but since we have duplicate links in the header, footer and across the homepage, without this we don't know which link they clicked on. 