### PR TITLE
Add notice to open interactive charts on mobile

### DIFF
--- a/charts/client/chart.scss
+++ b/charts/client/chart.scss
@@ -1,4 +1,5 @@
 $sans-serif-font-stack: Lato, "Helvetica Neue", Arial, sans-serif;
+$controls-color: #3F9EFF;
 
 figure[data-grapher-src]:empty {
     display: flex;
@@ -711,14 +712,14 @@ figure[data-grapher-src]:empty:after {
             width: 0.5em;
             border-radius: 0.2em;
             margin-left: -5px;
-            background: #3F9EFF;
+            background: $controls-color;
             position: absolute;
         }
 
         .interval {
             position: absolute;
             height: 0.6em;
-            background: #3F9EFF;
+            background: $controls-color;
         }
     }
 }
@@ -812,7 +813,7 @@ figure[data-grapher-src]:empty:after {
             top: 0;
             width: 16px;
             height: 16px;
-            background-color: #3f9eff;
+            background-color: $controls-color;
             border-radius: 100%;
             transform: scale(0);
             transform-origin: center;
@@ -828,7 +829,7 @@ figure[data-grapher-src]:empty:after {
 .ChartPlotArea:hover, .is-touch {
     .ControlsOverlay .addDataButton {
         transition: color 200ms cubic-bezier(0, 0, 0.4, 1);
-        color: #3f9eff;
+        color: $controls-color;
 
         .icon {
             path {

--- a/site/client/Grapher.ts
+++ b/site/client/Grapher.ts
@@ -18,7 +18,8 @@ export function readConfigFromHTML(html: string): any {
 // Determine whether this device is powerful enough to handle
 // loading a bunch of inline interactive charts
 export function shouldProgressiveEmbed() {
-    return !isMobile()
+    // 680px is also used in CSS – keep it in sync if you change this
+    return !isMobile() || window.screen.width > 680
 }
 
 export class MultiEmbedder {

--- a/site/client/owid.scss
+++ b/site/client/owid.scss
@@ -946,7 +946,38 @@ figure[data-grapher-src] {
 		padding: 0;
 		width: 100%;
 		max-width: 850px;
-	}
+    }
+
+    .interactionNotice {
+        font-size: 14px;
+        font-weight: 400;
+        line-height: 1.2;
+        color: rgba(black, .4);
+        display: none;
+        background-color: rgba(black, .03);
+        padding: 12px 30px;
+        position: relative;
+        text-decoration: none;
+
+        // Anything >680px will get the interactive graphics in-place.
+        // 680px is a breakpoint also used in the JavaScript code – keep it in sync.
+        @media screen and (max-device-width: 680px) {
+            display: block;
+        }
+
+        .icon {
+            font-size: 21px;
+            line-height: 28px;
+            margin-top: -15px;
+            position: absolute;
+            left: 10px;
+            top: 50%;
+        }
+
+        .label {
+            display: block;
+        }
+    }
 }
 
 figure[data-grapher-src].grapherPreview {

--- a/site/server/devServer.ts
+++ b/site/server/devServer.ts
@@ -5,7 +5,7 @@ import * as path from 'path'
 import {renderFrontPage, renderPageBySlug, renderChartsPage, renderMenuJson, renderSearchPage, renderDonatePage, entriesByYearPage, makeAtomFeed, pagePerVariable} from 'site/server/siteBaking'
 import {chartPage, chartDataJson} from 'site/server/chartBaking'
 import {BAKED_DEV_SERVER_PORT, BAKED_DEV_SERVER_HOST, BAKED_GRAPHER_URL} from 'settings'
-import {WORDPRESS_DIR, BASE_DIR} from 'serverSettings'
+import {WORDPRESS_DIR, BASE_DIR, BAKED_SITE_DIR} from 'serverSettings'
 import * as wpdb from 'db/wpdb'
 import * as db from 'db/db'
 import { expectInt, JsonError } from 'utils/server/serverUtil'
@@ -76,6 +76,9 @@ devServer.get('/headerMenu.json', async (req, res) => {
 })
 
 devServer.use('/uploads', express.static(path.join(WORDPRESS_DIR, 'wp-content/uploads')))
+devServer.use('/wp-content/uploads', express.static(path.join(WORDPRESS_DIR, 'wp-content/uploads')))
+
+devServer.use('/exports', express.static(path.join(BAKED_SITE_DIR, 'exports')))
 
 devServer.use('/', express.static(path.join(BASE_DIR, 'public')))
 

--- a/site/server/formatting.tsx
+++ b/site/server/formatting.tsx
@@ -14,6 +14,12 @@ import { htmlToPlaintext } from 'utils/string'
 
 const mjAPI = require("mathjax-node")
 
+// A modifed FontAwesome icon
+const INTERACTIVE_ICON_SVG = `<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="hand-pointer" class="svg-inline--fa fa-hand-pointer fa-w-14" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 617">
+    <path fill="currentColor" d="M448,344.59v96a40.36,40.36,0,0,1-1.06,9.16l-32,136A40,40,0,0,1,376,616.59H168a40,40,0,0,1-32.35-16.47l-128-176a40,40,0,0,1,64.7-47.06L104,420.58v-276a40,40,0,0,1,80,0v200h8v-40a40,40,0,1,1,80,0v40h8v-24a40,40,0,1,1,80,0v24h8a40,40,0,1,1,80,0Zm-256,80h-8v96h8Zm88,0h-8v96h8Zm88,0h-8v96h8Z" transform="translate(0 -0.41)"/>
+    <path fill="currentColor" opacity="0.6" d="M239.76,234.78A27.5,27.5,0,0,1,217,192a87.76,87.76,0,1,0-145.9,0A27.5,27.5,0,1,1,25.37,222.6,142.17,142.17,0,0,1,1.24,143.17C1.24,64.45,65.28.41,144,.41s142.76,64,142.76,142.76a142.17,142.17,0,0,1-24.13,79.43A27.47,27.47,0,0,1,239.76,234.78Z" transform="translate(0 -0.41)"/>
+</svg>`
+
 export interface Reference {
 
 }
@@ -154,7 +160,15 @@ export async function formatWordpressPost(post: FullPost, html: string, formatti
             const src = el.attribs['src']
             const chart = grapherExports.get(src)
             if (chart) {
-                const output = `<figure data-grapher-src="${src}" class="grapherPreview"><a href="${src}" target="_blank"><div><img src="${chart.svgUrl}"/></div></a></div>`
+                const output = `<figure data-grapher-src="${src}" class="grapherPreview">
+                    <a href="${src}" target="_blank">
+                        <div><img src="${chart.svgUrl}" width="${chart.width}" height="${chart.height}" /></div>
+                        <div class="interactionNotice">
+                            <span class="icon">${INTERACTIVE_ICON_SVG}</span>
+                            <span class="label">Click to open interactive version</span>
+                        </div>
+                    </a>
+                </div>`
                 const $p = $(el).closest('p')
                 $(el).remove()
                 $p.after(output)


### PR DESCRIPTION
Some things to note:
- The interactive charts will now load on any device whose screen is >680px wide (orientation independent) no matter whether it's mobile (e.g. tablet). They still won't load on mobile devices ≤680px.
- The `img` tags now have `width` and `height` attributes specified – I'm assuming these are always correct?