### PR TITLE
Add FullStory 'Loaded chart' event

### DIFF
--- a/charts/ChartView.tsx
+++ b/charts/ChartView.tsx
@@ -17,6 +17,7 @@ import { Bounds } from './Bounds'
 import { DataSelector } from './DataSelector'
 import { ChartViewContext } from './ChartViewContext'
 import { TooltipView } from './Tooltip'
+import { FullStory } from 'site/client/FullStory';
 
 declare const window: any
 
@@ -51,6 +52,27 @@ export class ChartView extends React.Component<ChartViewProps> {
 
         render()
         window.addEventListener('resize', throttle(render))
+
+        FullStory.event("Loaded chart", {
+            type_str: chart.props.type,
+            id_int: chart.props.id,
+            slug_str: chart.props.slug,
+            originUrl_str: chart.props.originUrl,
+            addCountryMode_str: chart.props.addCountryMode,
+            stackMode_str: chart.props.stackMode,
+            hideLegend_bool: chart.props.hideLegend,
+            hideRelativeToggle_bool: chart.props.hideRelativeToggle,
+            hideTimeline_bool: chart.props.hideTimeline,
+            hideConnectedScatterLines_bool: chart.props.hideConnectedScatterLines,
+            compareEndPointsOnly_bool: chart.props.compareEndPointsOnly,
+            entityType_str: chart.entityType,
+            isSinglePage_bool: chart.isSinglePage,
+            hasChartTab_bool: chart.hasChartTab,
+            hasMapTab_bool: chart.hasMapTab,
+            tab_str: chart.tab,
+            totalSelectedEntities: chart.props.selectedData.length
+        })
+
         return chartView
     }
 

--- a/site/client/FullStory.ts
+++ b/site/client/FullStory.ts
@@ -1,0 +1,55 @@
+import { mapKeys } from 'lodash'
+
+declare var window: any
+
+/*
+
+FullStory is a bit strict around typing. All keys must have type suffixes, e.g.
+"fullName_str" for string, "itemPrices_reals" for array of reals. Arrays can't
+have multiple types.
+
+Details: https://help.fullstory.com/develop-js/367098-fs-recording-client-api-requirements##search_query=
+
+*/
+
+const alreadyTyped = /_(strs?|ints?|reals?|dates?|bools?)$/
+
+type ValueType = "str" | "int" | "real" | "bool" | "date" | ""
+
+function getType(value: any): ValueType {
+    if (typeof value === "string") return "str"
+    if (typeof value === "number") return "real"
+    if (typeof value === "boolean") return "bool"
+    if (value instanceof Date) return "date"
+    else return "" // assume it's nested object
+}
+
+function getTypedKey(key: string, value: any): string {
+    if (alreadyTyped.test(key)) {
+        return key
+    } else if (Array.isArray(value)) {
+        const allTypes = value.map(getType)
+        if (allTypes.some(type => type !== allTypes[0])) {
+            throw new Error("All array items must be of same type")
+        } else {
+            if (allTypes[0]) return `${key}_${allTypes[0]}s`
+            else return key
+        }
+    } else {
+        const type = getType(value)
+        if (type) return `${key}_${type}`
+        else return key
+    }
+}
+
+// TODO support nested objects
+function annotateKeyTypes(obj: { [key: string]: any }) {
+    return mapKeys(obj, getTypedKey)
+}
+
+export class FullStory {
+    static event(name: string, props: { [key: string]: any }) {
+        if (!window.FS) return
+        window.FS.event(name, annotateKeyTypes(props))
+    }
+}

--- a/site/client/FullStory.ts
+++ b/site/client/FullStory.ts
@@ -50,6 +50,10 @@ function annotateKeyTypes(obj: { [key: string]: any }) {
 export class FullStory {
     static event(name: string, props: { [key: string]: any }) {
         if (!window.FS) return
-        window.FS.event(name, annotateKeyTypes(props))
+        try {
+            window.FS.event(name, annotateKeyTypes(props))
+        } catch (error) {
+            console.error(error)
+        }
     }
 }


### PR DESCRIPTION
These custom events are pretty cool – we'd be able to find sessions looking at specific chart types, with add country enabled/disabled... here's a GIF:

![](https://static.helpjuice.com/helpjuice_production/uploads/upload/image/2329/direct/1550608201673-1-12-128-75.gif)

Though I haven't tested whether this works yet. I think I might try it on the test server first. Leaving it here for next week...