### PR TITLE
Replace old font-awesome <i> elements in admin with <FontAwesomeIcon/>

### DIFF
--- a/admin/client/CountryStandardizerPage.tsx
+++ b/admin/client/CountryStandardizerPage.tsx
@@ -11,6 +11,8 @@ import { SelectField, SelectGroupsField, SelectGroup } from './Forms'
 import { CountryNameFormat, CountryNameFormatDefs, CountryDefByKey } from 'admin/CountryNameFormat'
 import { uniq, toString, csvEscape, values, sortBy } from 'charts/Util'
 import { AdminAppContext } from './AdminAppContext'
+import { faDownload } from '@fortawesome/free-solid-svg-icons/faDownload'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 class CSV {
     @observable filename?: string
@@ -461,8 +463,10 @@ export class CountryStandardizerPage extends React.Component {
                     <SelectField label="Output Format" value={CountryNameFormat.OurWorldInDataName} onValue={this.onOutputFormat} options={allowedOutputFormats.map(def => def.key)} optionLabels={allowedOutputFormats.map(def => def.label)} helpText="Choose the desired format of the country names. If the chosen format is other than OWID name, the tool won't attempt to find similar countries when there is no exact match." />
                     <div className="topbar">
                         {showDownloadOption ?
-                            <a href={this.csvDataUri} download={this.csvFilename} className="btn btn-secondary" onClick={this.onDownload} title={this.downloadTooltip}><i className="fa fa-download"></i> Download {this.csvFilename}</a>
-                            : <button className="btn btn-secondary" disabled><i className="fa fa-download"></i> No file to download (upload a CSV to start)</button>
+                            <a href={this.csvDataUri} download={this.csvFilename} className="btn btn-secondary" onClick={this.onDownload} title={this.downloadTooltip}>
+                                <FontAwesomeIcon icon={faDownload}/> Download {this.csvFilename}
+                            </a>
+                            : <button className="btn btn-secondary" disabled><FontAwesomeIcon icon={faDownload}/> No file to download (upload a CSV to start)</button>
                         }
                         <label><input type="checkbox" checked={this.showAllRows} onChange={this.onToggleRows} /> Show All Rows</label>
                     </div>

--- a/admin/client/DimensionCard.tsx
+++ b/admin/client/DimensionCard.tsx
@@ -4,7 +4,12 @@ import { observer } from 'mobx-react'
 import { DimensionWithData } from 'charts/DimensionWithData'
 import { ChartEditor } from './ChartEditor'
 import { Toggle, EditableListItem, BindAutoString, BindAutoFloat } from './Forms'
-import { Link } from './Link';
+import { Link } from './Link'
+import { faChevronDown } from '@fortawesome/free-solid-svg-icons/faChevronDown'
+import { faChevronUp } from '@fortawesome/free-solid-svg-icons/faChevronUp'
+import { faExchangeAlt } from '@fortawesome/free-solid-svg-icons/faExchangeAlt'
+import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 @observer
 export class DimensionCard extends React.Component<{ dimension: DimensionWithData, editor: ChartEditor, onEdit?: () => void, onRemove?: () => void }> {
@@ -33,14 +38,14 @@ export class DimensionCard extends React.Component<{ dimension: DimensionWithDat
         return <EditableListItem className="DimensionCard">
             <header>
                 <div>
-                    {this.hasExpandedOptions && <span className="clickable" onClick={this.onToggleExpand}><i className={"fa fa-chevron-" + (this.isExpanded ? 'up' : 'down')} /></span>}
+                    {this.hasExpandedOptions && <span className="clickable" onClick={this.onToggleExpand}><FontAwesomeIcon icon={this.isExpanded ? faChevronUp : faChevronDown}/></span>}
                 </div>
                 <div>
                     <Link to={`/variables/${dimension.variableId}`} className="dimensionLink" target="_blank">{dimension.variable.name}</Link>
                 </div>
                 <div>
-                    {this.props.onEdit && <div className="clickable" onClick={this.props.onEdit}><i className="fa fa-exchange" /></div>}
-                    {this.props.onRemove && <div className="clickable" onClick={this.props.onRemove}><i className="fa fa-times" /></div>}
+                    {this.props.onEdit && <div className="clickable" onClick={this.props.onEdit}><FontAwesomeIcon icon={faExchangeAlt}/></div>}
+                    {this.props.onRemove && <div className="clickable" onClick={this.props.onRemove}><FontAwesomeIcon icon={faTimes}/></div>}
                 </div>
             </header>
             {this.isExpanded && <div>

--- a/admin/client/EditorCustomizeTab.tsx
+++ b/admin/client/EditorCustomizeTab.tsx
@@ -9,6 +9,9 @@ import { NumberField, SelectField, Toggle, FieldsRow, Section, BindAutoString, B
 import { debounce, keysOf } from 'charts/Util'
 import { ColorSchemes, ColorScheme } from 'charts/ColorSchemes'
 import { Color } from 'charts/Color'
+import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'
+import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 @observer
 class ColorSchemeSelector extends React.Component<{ chart: ChartConfig }> {
@@ -164,9 +167,9 @@ class ComparisonLineSection extends React.Component<{ editor: ChartEditor }> {
         return <Section name="Comparison line">
             <p>Overlay a line onto the chart for comparison. Supports basic <a href="https://github.com/silentmatt/expr-eval#expression-syntax">mathematical expressions</a>.</p>
 
-            <Button onClick={this.onAddComparisonLine}><i className="fa fa-plus"></i> Add comparison line</Button>
+            <Button onClick={this.onAddComparisonLine}><FontAwesomeIcon icon={faPlus}/> Add comparison line</Button>
             {comparisonLines.map((comparisonLine, i) => <div key={i}>
-                {`Line ${i+1}`} <Button onClick={() => this.onRemoveComparisonLine(i)}><i className="fa fa-remove"></i></Button>
+                {`Line ${i+1}`} <Button onClick={() => this.onRemoveComparisonLine(i)}><FontAwesomeIcon icon={faMinus}/></Button>
                 <TextField label={`y=`} placeholder="x" value={comparisonLine.yEquals} onValue={action((value: string) => { comparisonLine.yEquals = value||undefined })}/>
                 <TextField label="Label" value={comparisonLine.label} onValue={action((value: string) => { comparisonLine.label = value||undefined })}/>
             </div>)}

--- a/admin/client/EditorFAQ.tsx
+++ b/admin/client/EditorFAQ.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react'
 import { Modal } from './Forms'
+import { faLink } from '@fortawesome/free-solid-svg-icons/faLink'
+import { faUnlink } from '@fortawesome/free-solid-svg-icons/faUnlink'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 export class EditorFAQ extends React.Component<{ onClose: () => void }> {
     render() {
@@ -13,7 +16,7 @@ export class EditorFAQ extends React.Component<{ onClose: () => void }> {
                 <h6>What are "variables" and "entities"?</h6>
                 <p>They roughly correspond to columns and rows in a CSV file. For OWID, entities are usually but not always countries.</p>
                 <h6>What do the little icons mean?</h6>
-                <p>If you see the <i className="fa fa-link"/> link icon, it means a field is currently linked to the database and has its default value. By changing that field you break the link <i className="fa fa-unlink"/> and set manual input for this particular chart.</p>
+                <p>If you see the <FontAwesomeIcon icon={faLink}/> link icon, it means a field is currently linked to the database and has its default value. By changing that field you break the link <FontAwesomeIcon icon={faUnlink}/> and set manual input for this particular chart.</p>
                 <h6>When are charts updated?</h6>
                 <p>The version of the chart you see in the editor is always the most current version. When published, charts are bundled together in a static build process and sent to Netlify for distribution around the world. This means it may take a few minutes for the live version to be updated.</p>
                 <p>The public version of a chart is not (currently) updated automatically when new data is uploaded. You may need to click "update chart" to have data changes reflected publicly.</p>

--- a/admin/client/EditorMapTab.tsx
+++ b/admin/client/EditorMapTab.tsx
@@ -9,6 +9,9 @@ import { MapProjection } from 'charts/MapProjection'
 import { ColorSchemes } from 'charts/ColorSchemes'
 import { NumericBin, CategoricalBin } from 'charts/MapData'
 import { Color } from 'charts/Color'
+import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'
+import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 @observer
 class VariableSection extends React.Component<{ mapConfig: MapConfig }> {
@@ -114,10 +117,10 @@ class NumericBinView extends React.Component<{ mapConfig: MapConfig, bin: Numeri
         const { mapConfig, bin } = this.props
 
         return <EditableListItem className="numeric">
-            <div className="clickable" onClick={this.onAddAfter}><i className="fa fa-plus"/></div>
+            <div className="clickable" onClick={this.onAddAfter}><FontAwesomeIcon icon={faPlus}/></div>
             <ColorBox color={bin.color} onColor={this.onColor} />
             <NumberField value={bin.max} onValue={this.onMaximumValue}/>
-            {mapConfig.props.colorSchemeValues.length > 2 && <div className="clickable" onClick={this.onRemove}><i className="fa fa-remove"/></div>}
+            {mapConfig.props.colorSchemeValues.length > 2 && <div className="clickable" onClick={this.onRemove}><FontAwesomeIcon icon={faMinus}/></div>}
         </EditableListItem>
     }
 }

--- a/admin/client/EditorScatterTab.tsx
+++ b/admin/client/EditorScatterTab.tsx
@@ -5,6 +5,8 @@ import {observer} from 'mobx-react'
 import { ChartConfig, HighlightToggleConfig } from 'charts/ChartConfig'
 import {ComparisonLineConfig} from 'charts/ComparisonLine'
 import {Toggle, NumberField, SelectField, TextField, Section} from './Forms'
+import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 @observer
 export class EditorScatterTab extends React.Component<{ chart: ChartConfig }> {
@@ -86,7 +88,7 @@ export class EditorScatterTab extends React.Component<{ chart: ChartConfig }> {
                 <SelectField label="Exclude individual entities" placeholder="Select an entity to exclude" value={undefined} onValue={v => v && this.onExcludeEntity(v)} options={excludedEntityChoices}/>
                 {chart.scatter.excludedEntities && <ul className="excludedEntities">
                     {chart.scatter.excludedEntities.map(entity => <li key={entity}>
-                        <div className="clickable" onClick={() => this.onUnexcludeEntity(entity)}><i className="fa fa-remove"/></div>
+                        <div className="clickable" onClick={() => this.onUnexcludeEntity(entity)}><FontAwesomeIcon icon={faMinus}/></div>
                         {entity}
                     </li>)}
                 </ul>}

--- a/admin/client/Forms.tsx
+++ b/admin/client/Forms.tsx
@@ -12,6 +12,7 @@ import {observer} from 'mobx-react'
 
 import { extend, pick, capitalize } from 'charts/Util'
 import { Colorpicker } from './Colorpicker'
+import { faCog } from '@fortawesome/free-solid-svg-icons/faCog'
 import { faLink } from '@fortawesome/free-solid-svg-icons/faLink'
 import { faPaintBrush } from '@fortawesome/free-solid-svg-icons/faPaintBrush'
 import { faUnlink } from '@fortawesome/free-solid-svg-icons/faUnlink'
@@ -532,7 +533,7 @@ export class Modal extends React.Component<{ className?: string, onClose: () => 
 export class LoadingBlocker extends React.Component<{}> {
     render() {
         return <div className="LoadingBlocker">
-            <i className="fa fa-cog fa-spin fa-3x fa-fw"/>
+            <FontAwesomeIcon icon={faCog} spin fixedWidth size="3x"/>
         </div>
     }
 }

--- a/admin/client/Forms.tsx
+++ b/admin/client/Forms.tsx
@@ -12,6 +12,10 @@ import {observer} from 'mobx-react'
 
 import { extend, pick, capitalize } from 'charts/Util'
 import { Colorpicker } from './Colorpicker'
+import { faLink } from '@fortawesome/free-solid-svg-icons/faLink'
+import { faPaintBrush } from '@fortawesome/free-solid-svg-icons/faPaintBrush'
+import { faUnlink } from '@fortawesome/free-solid-svg-icons/faUnlink'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 export class FieldsRow extends React.Component<{}> {
     render() {
@@ -311,7 +315,7 @@ export class ColorBox extends React.Component<{ color: string|undefined, onColor
         const style = color !== undefined ? { backgroundColor: color } : undefined
 
         return <div className="ColorBox" style={style} onClick={this.onClick}>
-            {color === undefined && <i className="fa fa-paint-brush"/>}
+            {color === undefined && <FontAwesomeIcon icon={faPaintBrush}/>}
             {isChoosingColor && <Colorpicker color={color} onColor={this.props.onColor} onClose={() => this.isChoosingColor = false} />}
         </div>
     }
@@ -360,7 +364,10 @@ export class AutoTextField extends React.Component<AutoTextFieldProps> {
             <div className="input-group mb-2 mb-sm-0">
                 <input type="text" className="form-control" value={props.value} placeholder={props.placeholder} onChange={e => props.onValue(e.currentTarget.value)}/>
                 <div className="input-group-addon" onClick={() => props.onToggleAuto(!props.isAuto)} title={props.isAuto ? "Automatic default" : "Manual input"}>
-                    {props.isAuto ? <i className="fa fa-link"/> : <i className="fa fa-unlink"/>}
+                    {props.isAuto ?
+                        <FontAwesomeIcon icon={faLink}/>
+                        : <FontAwesomeIcon icon={faUnlink}/>
+                    }
                 </div>
             </div>
             {props.helpText && <small className="form-text text-muted">{props.helpText}</small>}

--- a/admin/client/ImportPage.tsx
+++ b/admin/client/ImportPage.tsx
@@ -11,6 +11,8 @@ import * as parse from 'csv-parse'
 import { BindString, NumericSelectField, FieldsRow } from './Forms'
 import { AdminLayout } from './AdminLayout'
 import { AdminAppContext } from './AdminAppContext'
+import { faSpinner } from '@fortawesome/free-solid-svg-icons/faSpinner'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 declare const App: any
 declare const window: any
@@ -509,7 +511,7 @@ class Importer extends React.Component<ImportPageData> {
                 {!existingDataset && <p>Your data will be validated and stored in the database for visualization. After creating the dataset, please fill out the metadata fields and then mark the dataset as "publishable" if it should be reused by others.</p>}
                 <BindString field="name" store={dataset} helpText={`Dataset name should include a basic description of the variables, followed by the source and year. For example: "Government Revenue Data – ICTD (2016)"`}/>
 
-                {dataset.isLoading && <i className="fa fa-spinner fa-spin"></i>}
+                {dataset.isLoading && <FontAwesomeIcon icon={faSpinner} spin/>}
                 {!dataset.isLoading && [
                     <EditVariables key="editVariables" dataset={dataset} />,
                     <input key="submit" type="submit" className="btn btn-success" value={existingDataset ? "Update dataset" : "Create dataset"} />

--- a/admin/client/admin.scss
+++ b/admin/client/admin.scss
@@ -468,6 +468,8 @@ html, body {
 .AutoTextField {
     .input-group-addon {
         cursor: pointer;
+        padding-left: 8px;
+        padding-top: 6px;
     }
 }
 

--- a/charts/DataTab.tsx
+++ b/charts/DataTab.tsx
@@ -4,6 +4,8 @@ import * as React from 'react'
 import { computed, action } from 'mobx'
 import { observer } from 'mobx-react'
 import { ChartConfig } from './ChartConfig'
+import { faDownload } from '@fortawesome/free-solid-svg-icons/faDownload'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 // Client-side data export from chart
 @observer
@@ -77,7 +79,7 @@ export class DataTab extends React.Component<{ bounds: Bounds, chart: ChartConfi
         return <div className="dataTab" style={extend(bounds.toCSS(), { position: 'absolute' })}>
             <div style={{maxWidth: "100%"}}>
                 <p>Download a CSV file containing all data used in this visualization:</p>
-                <a href={csvDataUri} download={csvFilename} className="btn btn-primary" onClick={this.onDownload}><i className="fa fa-download"></i> {csvFilename}</a>
+                <a href={csvDataUri} download={csvFilename} className="btn btn-primary" onClick={this.onDownload}><FontAwesomeIcon icon={faDownload}/> {csvFilename}</a>
             </div>
         </div>
     }

--- a/charts/SourcesTab.tsx
+++ b/charts/SourcesTab.tsx
@@ -7,6 +7,8 @@ import { ChartConfig } from './ChartConfig'
 import { SourceWithDimension } from './ChartData'
 import * as Cookies from 'js-cookie'
 import { ADMIN_BASE_URL } from 'settings'
+import { faPencilAlt } from '@fortawesome/free-solid-svg-icons/faPencilAlt'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 const linkifyHtml = require('linkifyjs/html')
 function linkify(s: string) {
@@ -29,7 +31,7 @@ export class SourcesTab extends React.Component<{ bounds: Bounds, chart: ChartCo
         const editUrl = Cookies.get('isAdmin') ? `${ADMIN_BASE_URL}/admin/datasets/${variable.datasetId}` : undefined
 
         return <div key={source.id} className="datasource-wrapper">
-            <h2>{variable.name} {editUrl && <a href={editUrl} target="_blank"><i className="fa fa-pencil"/></a>}</h2>
+            <h2>{variable.name} {editUrl && <a href={editUrl} target="_blank"><FontAwesomeIcon icon={faPencilAlt}/></a>}</h2>
             <table className="variable-desc">
                 <tbody>
                     {variable.description ? <tr><td>Variable description</td><td dangerouslySetInnerHTML={{__html: linkify(variable.description)}}/></tr> : null}


### PR DESCRIPTION
Fixes https://github.com/owid/owid-grapher/issues/146

- Replace usage of `<i class="fa fa-name"/>` to `<FontAwesomeIcon icon={faName}/>`.
- Check most of the UI and make sure it renders and looks fine / similar to previous one (there are slight changes due to different Font Awesome versions).
- Fix a minor padding issue with the link / unlink icon next to text fields.
- Could not find `faRemove` thus replaced with `faMinus`.