### PR TITLE
fix: remove host from assets URL

### DIFF
--- a/utils/server/staticGen.tsx
+++ b/utils/server/staticGen.tsx
@@ -14,7 +14,7 @@ export function webpack(assetName: string, context?: string) {
         }
         assetName = manifest[assetName]
 
-        return urljoin(BAKED_BASE_URL, '/assets', assetName)
+        return urljoin('/assets', assetName)
     } else {
         if (assetName.match(/\.js$/)) {
             assetName = `js/${assetName}`


### PR DESCRIPTION
Prevents past deploys' assets from being loaded from the production URL systematically