### PR TITLE
VSCode: enable `formatOnSave` and set default formatter

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "esbenp.prettier-vscode",
+        "ms-vscode.vscode-typescript-tslint-plugin"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,6 @@
     "editor.codeActionsOnSave": {
         "source.fixAll.tslint": true
     },
-    "editor.formatOnSave": false
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
 }


### PR DESCRIPTION
Without having an identical `defaultFormatter`, our editors might produce different formatting on save.

### To-do

- [ ] Add README notice about VS Code plugins