### PR TITLE
isExplorable chart field

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Finally, run `yarn dev` and head to `localhost:3030/admin`. If everything is goi
 
 ## Migrations
 
-If you need to make changes to the MySQL database structure, these are specified by [typeorm](http://typeorm.io/#/) migration files. Use `yarn typeorm migration:create -n MigrationName` and then populate the file with the SQL statements to alter the tables, using past migration files for reference if needed. Then run migrations with `yarn typeorm migration:run`.
+If you need to make changes to the MySQL database structure, these are specified by [typeorm](http://typeorm.io/#/) migration files. Use `yarn typeorm migration:create -n MigrationName` and then populate the file with the SQL statements to alter the tables, using past migration files for reference if needed. Then run migrations with `yarn migrate`.
 
 ## Architecture notes
 

--- a/admin/client/Admin.tsx
+++ b/admin/client/Admin.tsx
@@ -13,6 +13,7 @@ type HTTPMethod = "GET" | "PUT" | "POST" | "DELETE"
 interface ClientSettings {
     ENV: "development" | "production"
     GITHUB_USERNAME: string
+    EXPLORER: boolean
 }
 
 // Entry point for the grapher admin

--- a/admin/client/EditorBasicTab.tsx
+++ b/admin/client/EditorBasicTab.tsx
@@ -12,6 +12,7 @@ import { Toggle, SelectField, EditableList, FieldsRow, Section } from "./Forms"
 import { ChartEditor } from "./ChartEditor"
 import { VariableSelector } from "./VariableSelector"
 import { DimensionCard } from "./DimensionCard"
+import { canBeExplorable } from "utils/charts"
 
 @observer
 class DimensionSlotView extends React.Component<{
@@ -199,16 +200,30 @@ export class EditorBasicTab extends React.Component<{ editor: ChartEditor }> {
                         options={ChartTypeDefs.map(def => def.key)}
                         optionLabels={ChartTypeDefs.map(def => def.label)}
                     />
+                    {editor.features.explorer && (
+                        <FieldsRow>
+                            <Toggle
+                                label="Explorable chart"
+                                value={chart.props.isExplorable}
+                                onValue={value =>
+                                    (chart.props.isExplorable = value)
+                                }
+                                disabled={!canBeExplorable(chart.props)}
+                            />
+                        </FieldsRow>
+                    )}
                     <FieldsRow>
                         <Toggle
                             label="Chart tab"
                             value={chart.props.hasChartTab}
                             onValue={value => (chart.props.hasChartTab = value)}
+                            disabled={chart.props.isExplorable}
                         />
                         <Toggle
                             label="Map tab"
                             value={chart.props.hasMapTab}
                             onValue={value => (chart.props.hasMapTab = value)}
+                            disabled={chart.props.isExplorable}
                         />
                     </FieldsRow>
                 </Section>

--- a/admin/client/EditorFeatures.tsx
+++ b/admin/client/EditorFeatures.tsx
@@ -80,4 +80,8 @@ export class EditorFeatures {
     @computed get comparisonLine() {
         return this.chart.isLineChart || this.chart.isScatter
     }
+
+    @computed get explorer() {
+        return this.editor.props.admin.settings.EXPLORER
+    }
 }

--- a/admin/server/AdminSPA.tsx
+++ b/admin/server/AdminSPA.tsx
@@ -11,7 +11,7 @@ export function AdminSPA(props: { username: string; isSuperuser: boolean }) {
         window.admin = new Admin({ username: "${
             props.username
         }", isSuperuser: ${props.isSuperuser.toString()}, settings: ${JSON.stringify(
-        _.pick(settings, ["ENV", "GITHUB_USERNAME"])
+        _.pick(settings, ["ENV", "GITHUB_USERNAME", "EXPLORER"])
     )}})
         admin.start(document.querySelector("#app"))
 `

--- a/admin/server/api.ts
+++ b/admin/server/api.ts
@@ -35,6 +35,7 @@ import { denormalizeLatestCountryData } from "site/server/countryProfiles"
 import { BAKED_BASE_URL } from "settings"
 import { PostReference, ChartRedirect } from "admin/client/ChartEditor"
 import { enqueueDeploy } from "deploy/queue"
+import { isExplorable } from "utils/charts"
 
 // Little wrapper to automatically send returned objects as JSON, makes
 // the API code a bit cleaner
@@ -296,13 +297,30 @@ async function saveChart(
 
         if (existingConfig) {
             await t.query(
-                `UPDATE charts SET config=?, updatedAt=?, lastEditedAt=?, lastEditedByUserId=? WHERE id = ?`,
-                [newJsonConfig, now, now, user.id, chartId]
+                `UPDATE charts SET config=?, updatedAt=?, lastEditedAt=?, lastEditedByUserId=?, isExplorable=? WHERE id = ?`,
+                [
+                    newJsonConfig,
+                    now,
+                    now,
+                    user.id,
+                    isExplorable(newConfig),
+                    chartId
+                ]
             )
         } else {
             const result = await t.execute(
-                `INSERT INTO charts (config, createdAt, updatedAt, lastEditedAt, lastEditedByUserId, starred) VALUES (?)`,
-                [[newJsonConfig, now, now, now, user.id, false]]
+                `INSERT INTO charts (config, createdAt, updatedAt, lastEditedAt, lastEditedByUserId, starred, isExplorable) VALUES (?)`,
+                [
+                    [
+                        newJsonConfig,
+                        now,
+                        now,
+                        now,
+                        user.id,
+                        false,
+                        isExplorable(newConfig)
+                    ]
+                ]
             )
             chartId = result.insertId
         }

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -59,7 +59,6 @@ then
   cd $TMP_NEW
   yarn install --production
   yarn build
-  yarn typeorm migration:run
   yarn migrate
   yarn tsn scripts/configureAlgolia.ts
 

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -25,6 +25,7 @@ import { IChartTransform } from "./IChartTransform"
 import { ChartDimension } from "./ChartDimension"
 import { TooltipProps } from "./Tooltip"
 import { LogoOption } from "./Logos"
+import { canBeExplorable } from "utils/charts"
 
 declare const App: any
 declare const window: any
@@ -106,6 +107,7 @@ export class DimensionSlot {
 // under the same rendering conditions it ought to remain visually identical
 export class ChartConfigProps {
     @observable.ref type: ChartTypeType = "LineChart"
+    @observable.ref isExplorable: boolean = false
 
     @observable.ref id?: number = undefined
     @observable.ref createdAt?: Date = undefined
@@ -268,6 +270,17 @@ export class ChartConfig {
         autorun(() => {
             if (!isEqual(this.props.dimensions, this.validDimensions)) {
                 this.props.dimensions = this.validDimensions
+            }
+        })
+
+        autorun(() => {
+            if (this.props.isExplorable) {
+                if (canBeExplorable(this.props)) {
+                    this.props.hasChartTab = true
+                    this.props.hasMapTab = true
+                } else {
+                    this.props.isExplorable = false
+                }
             }
         })
     }

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -530,6 +530,10 @@ export class ChartConfig {
         return this.props.version.toString()
     }
 
+    @computed get isExplorable(): boolean {
+        return this.props.isExplorable
+    }
+
     receiveData(data: DataForChart) {
         this.vardata.receiveData(data)
     }

--- a/db/migration/1574953821471-AddExplorableCharts.ts
+++ b/db/migration/1574953821471-AddExplorableCharts.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddExplorableCharts1574953821471 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        queryRunner.query(
+            "ALTER TABLE charts ADD COLUMN isExplorable BOOLEAN NOT NULL DEFAULT FALSE"
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        queryRunner.query("ALTER TABLE charts DROP COLUMN isExplorable")
+    }
+}

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -26,6 +26,7 @@ export class Chart extends BaseEntity {
     @Column() createdAt!: Date
     @Column() updatedAt!: Date
     @Column() starred!: boolean
+    @Column() isExplorable!: boolean
 
     @ManyToOne(type => User, user => user.lastEditedCharts)
     lastEditedByUser!: User
@@ -139,7 +140,8 @@ export class OldChart {
         lastEditedByUser.fullName AS lastEditedBy,
         charts.publishedAt,
         charts.publishedByUserId,
-        publishedByUser.fullName AS publishedBy
+        publishedByUser.fullName AS publishedBy,
+        charts.isExplorable AS isExplorable
     `
 
     static async getBySlug(slug: string): Promise<OldChart> {

--- a/features.ts
+++ b/features.ts
@@ -1,5 +1,0 @@
-import { parseBool } from "utils/string"
-
-export const EXPLORER: boolean = process.env.FEATURE_FLAG_EXPLORER
-    ? parseBool(process.env.FEATURE_FLAG_EXPLORER)
-    : false

--- a/features.ts
+++ b/features.ts
@@ -1,0 +1,5 @@
+import { parseBool } from "utils/string"
+
+export const EXPLORER: boolean = process.env.FEATURE_FLAG_EXPLORER
+    ? parseBool(process.env.FEATURE_FLAG_EXPLORER)
+    : false

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
     preset: "ts-jest",
-    testEnvironment: "node",
+    testEnvironment: "jsdom",
     moduleNameMapper: {
         "^(admin|site|charts|utils|db|settings)/(.*)$": "<rootDir>/$1/$2",
         "^settings$": "<rootDir>/settings",

--- a/knexfile.ts
+++ b/knexfile.ts
@@ -1,13 +1,15 @@
 // Update with your config settings.
 
-import { DB_NAME, DB_USER, DB_PASS } from "serverSettings"
+import { DB_NAME, DB_USER, DB_PASS, DB_HOST, DB_PORT } from "serverSettings"
 
 const dbConfig = {
     client: "mysql",
     connection: {
         database: DB_NAME,
         user: DB_USER,
-        password: DB_PASS
+        password: DB_PASS,
+        host: DB_HOST,
+        port: DB_PORT
     },
     pool: {
         min: 2,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "dev": "npm-run-all --race --parallel dev-admin dev-site dev-webpack",
         "typeorm": "yarn tsn node_modules/.bin/typeorm",
         "knex": "yarn tsn node_modules/.bin/knex --knexfile knexfile.ts",
-        "migrate": "yarn knex migrate:latest",
+        "migrate": "yarn knex migrate:latest && yarn typeorm migration:run",
         "lint": "tslint --project . -t verbose",
         "prettify": "yarn prettier --write \"**/*.{tsx,ts,jsx,js,json,md,html,css}\"",
         "prettify:check": "yarn prettier --check \"**/*.{tsx,ts,jsx,js,json,md,html,css}\"",

--- a/settings.ts
+++ b/settings.ts
@@ -1,3 +1,5 @@
+import { parseBool } from "utils/string"
+
 // All of this information is available to the client-side code
 // DO NOT retrieve sensitive information from the environment in here! :O
 
@@ -69,3 +71,8 @@ export const PUBLIC_TAG_PARENT_IDS: number[] = [
     1512,
     1510
 ]
+
+// Feature flag for explorable charts
+export const EXPLORER: boolean = process.env.EXPLORER
+    ? parseBool(process.env.EXPLORER)
+    : false

--- a/site/server/SiteBaker.tsx
+++ b/site/server/SiteBaker.tsx
@@ -8,10 +8,11 @@ import * as cheerio from "cheerio"
 
 import * as wpdb from "db/wpdb"
 import * as db from "db/db"
+import * as features from "features"
+import * as settings from "settings"
 import { formatPost, extractFormattingOptions } from "./formatting"
 import { LongFormPage } from "./views/LongFormPage"
 import { BlogPostPage } from "./views/BlogPostPage"
-import * as settings from "settings"
 import { BASE_DIR, BAKED_SITE_DIR, WORDPRESS_DIR } from "serverSettings"
 const { BAKED_BASE_URL, BLOG_POSTS_PER_PAGE } = settings
 import {
@@ -269,11 +270,12 @@ export class SiteBaker {
             `${BAKED_SITE_DIR}/charts.html`,
             await renderChartsPage()
         )
-        // Leave this out of the production build for now while it is still a stub. -@jasoncrawford 27 Nov 2019
-        // await this.stageWrite(
-        //     `${BAKED_SITE_DIR}/explore.html`,
-        //     await renderExplorePage()
-        // )
+        if (features.EXPLORER) {
+            await this.stageWrite(
+                `${BAKED_SITE_DIR}/explore.html`,
+                await renderExplorePage()
+            )
+        }
         await this.stageWrite(
             `${BAKED_SITE_DIR}/search.html`,
             await renderSearchPage()

--- a/site/server/SiteBaker.tsx
+++ b/site/server/SiteBaker.tsx
@@ -8,7 +8,6 @@ import * as cheerio from "cheerio"
 
 import * as wpdb from "db/wpdb"
 import * as db from "db/db"
-import * as features from "features"
 import * as settings from "settings"
 import { formatPost, extractFormattingOptions } from "./formatting"
 import { LongFormPage } from "./views/LongFormPage"
@@ -270,7 +269,7 @@ export class SiteBaker {
             `${BAKED_SITE_DIR}/charts.html`,
             await renderChartsPage()
         )
-        if (features.EXPLORER) {
+        if (settings.EXPLORER) {
             await this.stageWrite(
                 `${BAKED_SITE_DIR}/explore.html`,
                 await renderExplorePage()

--- a/test/charts/ChartConfig.test.ts
+++ b/test/charts/ChartConfig.test.ts
@@ -1,0 +1,31 @@
+import { ChartConfig, ChartConfigProps } from "charts/ChartConfig"
+
+function createConfig(props: ChartConfigProps) {
+    const config = new ChartConfig(props)
+    // ensureValidConfig() is only run on non-node environments, so we have
+    // to manually trigger it.
+    config.ensureValidConfig()
+    return config
+}
+
+describe("ChartConfig", () => {
+    it("map & chart tabs are force enabled when an explorer", () => {
+        const props = new ChartConfigProps()
+        props.type = "LineChart"
+        props.hasChartTab = false
+        props.hasMapTab = false
+        props.isExplorable = true
+        const config = createConfig(props)
+        expect(config.hasMapTab).toBe(true)
+        expect(config.hasChartTab).toBe(true)
+    })
+
+    it("explorer not available for scatter plots", () => {
+        const props = new ChartConfigProps()
+        props.type = "ScatterPlot"
+        props.hasChartTab = true
+        props.isExplorable = true
+        const config = createConfig(props)
+        expect(config.isExplorable).toBe(false)
+    })
+})

--- a/utils/charts.ts
+++ b/utils/charts.ts
@@ -1,0 +1,17 @@
+import { ChartConfigProps } from "charts/ChartConfig"
+import { ChartTypeType } from "charts/ChartType"
+
+export const EXPLORABLE_CHART_TYPES: ChartTypeType[] = [
+    "LineChart",
+    "DiscreteBar"
+]
+
+// A centralized predicate to test whether a chart can be explorable.
+// Used for validation on both server & client.
+export function canBeExplorable(config: ChartConfigProps) {
+    return EXPLORABLE_CHART_TYPES.includes(config.type)
+}
+
+export function isExplorable(config: ChartConfigProps): boolean {
+    return config.isExplorable && canBeExplorable(config)
+}


### PR DESCRIPTION
- Adds an `EXPLORER` flag in settings (need to set `EXPLORER=true` in your local `.env`)
- An `isExplorer` column on `charts` table
- An "Explorable chart" checkbox in the Grapher admin
- Logic to ensure map & chart tab are force enabled for explorable charts
- Logic to ensure only `LineChart` and `DiscreteBar` can be made explorable (arbitrarily chosen, can change)

Notion: https://www.notion.so/owid/Boolean-is_explorable-on-Chart-310eafedc0924ad78afb616a718c8200