### PR TITLE
URL binding refactor

### DIFF
--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -26,6 +26,7 @@ import { ChartDimension } from "./ChartDimension"
 import { TooltipProps } from "./Tooltip"
 import { LogoOption } from "./Logos"
 import { canBeExplorable } from "utils/charts"
+import { getWindowQueryStr } from "utils/client/url"
 
 declare const App: any
 declare const window: any
@@ -258,7 +259,11 @@ export class ChartConfig {
         this.update(props || { yAxis: { min: 0 } })
         this.vardata = new VariableData(this)
         this.data = new ChartData(this)
-        this.url = new ChartUrl(this, options.queryStr)
+
+        const queryStr = this.isSinglePage
+            ? getWindowQueryStr()
+            : options.queryStr
+        this.url = new ChartUrl(this, queryStr)
 
         window.chart = this
         if (!this.isNode) this.ensureValidConfig()

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -256,7 +256,6 @@ export class ChartConfig {
         this.data = new ChartData(this)
         this.url = new ChartUrl(this, options.queryStr)
 
-        window.chart = this
         if (!this.isNode) this.ensureValidConfig()
     }
 

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -9,7 +9,7 @@ import { VariableData, DataForChart } from "./VariableData"
 import { ChartData } from "./ChartData"
 import { DimensionWithData } from "./DimensionWithData"
 import { MapConfig, MapConfigProps } from "./MapConfig"
-import { URLBinder } from "./URLBinder"
+import { ChartUrl } from "./ChartUrl"
 import { StackedBarTransform } from "./StackedBarTransform"
 import { DiscreteBarTransform } from "./DiscreteBarTransform"
 import { StackedAreaTransform } from "./StackedAreaTransform"
@@ -210,7 +210,7 @@ export class ChartConfig {
 
     vardata: VariableData
     data: ChartData
-    url: URLBinder
+    url: ChartUrl
 
     @computed get isIframe(): boolean {
         return window.self !== window.top
@@ -258,7 +258,7 @@ export class ChartConfig {
         this.update(props || { yAxis: { min: 0 } })
         this.vardata = new VariableData(this)
         this.data = new ChartData(this)
-        this.url = new URLBinder(this, options.queryStr)
+        this.url = new ChartUrl(this, options.queryStr)
 
         window.chart = this
         if (!this.isNode) this.ensureValidConfig()

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -225,10 +225,6 @@ export class ChartConfig {
         return this.isEmbed && !this.isIframe && !this.isLocalExport
     }
 
-    @computed get isSinglePage(): boolean {
-        return !this.isNode && !this.isEmbed
-    }
-
     @computed get hasOWIDLogo(): boolean {
         return (
             !this.props.hideLogo &&

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -26,7 +26,6 @@ import { ChartDimension } from "./ChartDimension"
 import { TooltipProps } from "./Tooltip"
 import { LogoOption } from "./Logos"
 import { canBeExplorable } from "utils/charts"
-import { getWindowQueryStr } from "utils/client/url"
 
 declare const App: any
 declare const window: any

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -259,11 +259,7 @@ export class ChartConfig {
         this.update(props || { yAxis: { min: 0 } })
         this.vardata = new VariableData(this)
         this.data = new ChartData(this)
-
-        const queryStr = this.isSinglePage
-            ? getWindowQueryStr()
-            : options.queryStr
-        this.url = new ChartUrl(this, queryStr)
+        this.url = new ChartUrl(this, options.queryStr)
 
         window.chart = this
         if (!this.isNode) this.ensureValidConfig()

--- a/charts/ChartUrl.ts
+++ b/charts/ChartUrl.ts
@@ -1,10 +1,9 @@
 /* ChartUrl.ts
  * ================
  *
- * This component is responsible for handling data binding between the
+ * This component is responsible for translating between the
  * the chart and url parameters, to enable nice linking support
  * for specific countries and years.
- *
  */
 
 import { isNumber, includes, filter, uniq, toString, isFinite } from "./Util"
@@ -15,7 +14,6 @@ import { ChartConfig, ChartConfigProps } from "./ChartConfig"
 import {
     queryParamsToStr,
     strToQueryParams,
-    getWindowQueryParams,
     QueryParams
 } from "utils/client/url"
 import { MapProjection } from "./MapProjection"
@@ -48,10 +46,7 @@ export class ChartUrl {
         this.chart = chart
         this.origChartProps = toJS(chart.props)
 
-        if (chart.isSinglePage) {
-            // Only work with the actual url if we're not an embed
-            this.populateFromURL(getWindowQueryParams())
-        } else if (queryStr !== undefined) {
+        if (queryStr !== undefined) {
             this.populateFromURL(strToQueryParams(queryStr))
         }
     }

--- a/charts/ChartUrl.ts
+++ b/charts/ChartUrl.ts
@@ -1,4 +1,4 @@
-/* URLBinder.ts
+/* ChartUrl.ts
  * ================
  *
  * This component is responsible for handling data binding between the
@@ -46,7 +46,7 @@ interface ChartQueryParams {
 
 declare const App: any
 
-export class URLBinder {
+export class ChartUrl {
     chart: ChartConfig
     origChartProps: ChartConfigProps
     chartQueryStr: string = "?"

--- a/charts/ChartUrl.ts
+++ b/charts/ChartUrl.ts
@@ -7,21 +7,12 @@
  *
  */
 
-import {
-    debounce,
-    isNumber,
-    includes,
-    filter,
-    uniq,
-    toString,
-    isFinite
-} from "./Util"
-import { computed, when, runInAction, reaction, toJS } from "mobx"
+import { isNumber, includes, filter, uniq, toString, isFinite } from "./Util"
+import { computed, when, runInAction, toJS } from "mobx"
 import { ChartTabOption } from "./ChartTabOption"
 import { defaultTo } from "./Util"
 import { ChartConfig, ChartConfigProps } from "./ChartConfig"
 import {
-    setWindowQueryStr,
     queryParamsToStr,
     strToQueryParams,
     getWindowQueryParams,
@@ -60,17 +51,6 @@ export class ChartUrl {
         if (chart.isSinglePage) {
             // Only work with the actual url if we're not an embed
             this.populateFromURL(getWindowQueryParams())
-
-            // There is a surprisingly considerable performance overhead to updating the url
-            // while animating, so we debounce to allow e.g. smoother timelines
-            const pushParams = () =>
-                setWindowQueryStr(queryParamsToStr(this.params as QueryParams))
-            const debouncedPushParams = debounce(pushParams, 100)
-
-            reaction(
-                () => this.params,
-                () => (this.debounceMode ? debouncedPushParams() : pushParams())
-            )
         } else if (queryStr !== undefined) {
             this.populateFromURL(strToQueryParams(queryStr))
         }

--- a/charts/ChartUrl.ts
+++ b/charts/ChartUrl.ts
@@ -47,7 +47,7 @@ export class ChartUrl {
         this.origChartProps = toJS(chart.props)
 
         if (queryStr !== undefined) {
-            this.populateFromURL(strToQueryParams(queryStr))
+            this.populateFromQueryParams(strToQueryParams(queryStr))
         }
     }
 
@@ -182,9 +182,9 @@ export class ChartUrl {
     }*/
 
     /**
-     * Apply any url parameters on chartView startup
+     * Applies query parameters to the chart config
      */
-    populateFromURL(params: ChartQueryParams) {
+    populateFromQueryParams(params: ChartQueryParams) {
         const { chart } = this
 
         // Set tab if specified

--- a/charts/ChartView.tsx
+++ b/charts/ChartView.tsx
@@ -85,7 +85,7 @@ export class ChartView extends React.Component<ChartViewProps> {
                 chart.props.hideConnectedScatterLines,
             compareEndPointsOnly_bool: chart.props.compareEndPointsOnly,
             entityType_str: chart.entityType,
-            isSinglePage_bool: chart.isSinglePage,
+            isEmbed_bool: chart.isEmbed,
             hasChartTab_bool: chart.hasChartTab,
             hasMapTab_bool: chart.hasMapTab,
             tab_str: chart.tab,

--- a/charts/ChartView.tsx
+++ b/charts/ChartView.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as ReactDOM from "react-dom"
-import { observable, computed, action } from "mobx"
+import { observable, computed, action, autorun } from "mobx"
 import { observer } from "mobx-react"
 import { select } from "d3-selection"
 import "d3-transition"
@@ -418,8 +418,11 @@ export class ChartView extends React.Component<ChartViewProps> {
         else if (this.renderWidth >= 1080) this.props.chart.baseFontSize = 18
     }
 
-    bindUrlToWindow() {
+    // Binds chart properties to global window title and URL. This should only
+    // ever be invoked from top-level JavaScript.
+    bindToWindow() {
         urlBinding.bindUrlToWindow(this.chart.url)
+        autorun(() => (document.title = this.chart.data.currentTitle))
     }
 
     componentDidMount() {

--- a/charts/ChartView.tsx
+++ b/charts/ChartView.tsx
@@ -421,12 +421,13 @@ export class ChartView extends React.Component<ChartViewProps> {
     // Binds chart properties to global window title and URL. This should only
     // ever be invoked from top-level JavaScript.
     bindToWindow() {
+        window.chartView = this
+        window.chart = this.chart
         urlBinding.bindUrlToWindow(this.chart.url)
         autorun(() => (document.title = this.chart.data.currentTitle))
     }
 
     componentDidMount() {
-        window.chartView = this
         window.addEventListener("scroll", this.checkVisibility)
     }
 

--- a/charts/ChartView.tsx
+++ b/charts/ChartView.tsx
@@ -70,7 +70,6 @@ export class ChartView extends React.Component<ChartViewProps> {
 
         render()
         window.addEventListener("resize", throttle(render))
-        urlBinding.bindUrlToWindow(chart.url)
 
         FullStory.event("Loaded chart v2", {
             chart_type_str: chart.props.type,
@@ -417,6 +416,10 @@ export class ChartView extends React.Component<ChartViewProps> {
         if (this.renderWidth <= 400) this.props.chart.baseFontSize = 14
         else if (this.renderWidth < 1080) this.props.chart.baseFontSize = 16
         else if (this.renderWidth >= 1080) this.props.chart.baseFontSize = 18
+    }
+
+    bindUrlToWindow() {
+        urlBinding.bindUrlToWindow(this.chart.url)
     }
 
     componentDidMount() {

--- a/charts/ChartView.tsx
+++ b/charts/ChartView.tsx
@@ -21,6 +21,7 @@ import { ChartViewContext } from "./ChartViewContext"
 import { TooltipView } from "./Tooltip"
 import { FullStory } from "site/client/FullStory"
 import { Analytics } from "site/client/Analytics"
+import * as urlBinding from "charts/UrlBinding"
 
 declare const window: any
 
@@ -69,6 +70,7 @@ export class ChartView extends React.Component<ChartViewProps> {
 
         render()
         window.addEventListener("resize", throttle(render))
+        urlBinding.bindUrlToWindow(chart.url)
 
         FullStory.event("Loaded chart v2", {
             chart_type_str: chart.props.type,

--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -4,7 +4,7 @@ import { observer } from "mobx-react"
 import * as Cookies from "js-cookie"
 
 import { ChartConfig } from "./ChartConfig"
-import { getQueryParams } from "utils/client/url"
+import { getQueryParams, getWindowQueryParams } from "utils/client/url"
 import { ChartView } from "./ChartView"
 import { HighlightToggleConfig } from "./ChartConfig"
 import { Timeline } from "./HTMLTimeline"
@@ -266,7 +266,7 @@ class HighlightToggle extends React.Component<{
 
     @action.bound onHighlightToggle(e: React.FormEvent<HTMLInputElement>) {
         if (e.currentTarget.checked) {
-            const params = getQueryParams()
+            const params = getWindowQueryParams()
             this.chart.url.populateFromURL(extend(params, this.highlightParams))
         } else {
             this.chart.data.selectedKeys = []
@@ -274,7 +274,7 @@ class HighlightToggle extends React.Component<{
     }
 
     get isHighlightActive() {
-        const params = getQueryParams()
+        const params = getWindowQueryParams()
         let isActive = true
         keys(this.highlightParams).forEach(key => {
             if (params[key] !== this.highlightParams[key]) isActive = false

--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -266,8 +266,8 @@ class HighlightToggle extends React.Component<{
 
     @action.bound onHighlightToggle(e: React.FormEvent<HTMLInputElement>) {
         if (e.currentTarget.checked) {
-            const params = getWindowQueryParams()
-            this.chart.url.populateFromURL(extend(params, this.highlightParams))
+            const params = extend(getWindowQueryParams(), this.highlightParams)
+            this.chart.url.populateFromQueryParams(params)
         } else {
             this.chart.data.selectedKeys = []
         }

--- a/charts/Header.tsx
+++ b/charts/Header.tsx
@@ -129,10 +129,8 @@ class HeaderView extends React.Component<{
 }> {
     render() {
         const { props } = this
-        const { title, titleText, logo, subtitle } = props.header
+        const { title, logo, subtitle } = props.header
         const { chart, maxWidth } = props.header.props
-
-        if (chart.isSinglePage) document.title = titleText
 
         if (chart.isMediaCard) return null
 

--- a/charts/URLBinder.ts
+++ b/charts/URLBinder.ts
@@ -21,9 +21,10 @@ import { ChartTabOption } from "./ChartTabOption"
 import { defaultTo } from "./Util"
 import { ChartConfig, ChartConfigProps } from "./ChartConfig"
 import {
-    getQueryParams,
-    setQueryStr,
+    setWindowQueryStr,
     queryParamsToStr,
+    strToQueryParams,
+    getWindowQueryParams,
     QueryParams
 } from "utils/client/url"
 import { MapProjection } from "./MapProjection"
@@ -58,12 +59,12 @@ export class URLBinder {
 
         if (chart.isSinglePage) {
             // Only work with the actual url if we're not an embed
-            this.populateFromURL(getQueryParams())
+            this.populateFromURL(getWindowQueryParams())
 
             // There is a surprisingly considerable performance overhead to updating the url
             // while animating, so we debounce to allow e.g. smoother timelines
             const pushParams = () =>
-                setQueryStr(queryParamsToStr(this.params as QueryParams))
+                setWindowQueryStr(queryParamsToStr(this.params as QueryParams))
             const debouncedPushParams = debounce(pushParams, 100)
 
             reaction(
@@ -71,7 +72,7 @@ export class URLBinder {
                 () => (this.debounceMode ? debouncedPushParams() : pushParams())
             )
         } else if (queryStr !== undefined) {
-            this.populateFromURL(getQueryParams(queryStr))
+            this.populateFromURL(strToQueryParams(queryStr))
         }
     }
 

--- a/charts/UrlBinding.ts
+++ b/charts/UrlBinding.ts
@@ -1,0 +1,24 @@
+// Static utilities to bind the global window URL to a ChartUrl object.
+
+import { reaction } from "mobx"
+import {
+    setWindowQueryStr,
+    queryParamsToStr,
+    QueryParams
+} from "utils/client/url"
+
+import { debounce } from "./Util"
+import { ChartUrl } from "./ChartUrl"
+
+export function bindUrlToWindow(url: ChartUrl) {
+    // There is a surprisingly considerable performance overhead to updating the url
+    // while animating, so we debounce to allow e.g. smoother timelines
+    const pushParams = () =>
+        setWindowQueryStr(queryParamsToStr(url.params as QueryParams))
+    const debouncedPushParams = debounce(pushParams, 100)
+
+    reaction(
+        () => url.params,
+        () => (url.debounceMode ? debouncedPushParams() : pushParams())
+    )
+}

--- a/site/client/SearchPageMain.tsx
+++ b/site/client/SearchPageMain.tsx
@@ -1,6 +1,6 @@
 import ReactDOM = require("react-dom")
 import React = require("react")
-import { getQueryParams, decodeQueryParam } from "utils/client/url"
+import { getWindowQueryParams, decodeQueryParam } from "utils/client/url"
 import { siteSearch, SiteSearchResults } from "site/siteSearch"
 import { SearchResults } from "site/client/SearchResults"
 import { observer } from "mobx-react"
@@ -16,7 +16,7 @@ import { faSearch } from "@fortawesome/free-solid-svg-icons/faSearch"
 
 @observer
 export class SearchPageMain extends React.Component {
-    @observable query: string = decodeQueryParam(getQueryParams().q || "")
+    @observable query: string = decodeQueryParam(getWindowQueryParams().q || "")
     lastQuery?: string
 
     @observable.ref results?: SiteSearchResults

--- a/site/server/views/ChartPage.tsx
+++ b/site/server/views/ChartPage.tsx
@@ -45,7 +45,7 @@ export const ChartPage = (props: {
                 containerNode: figure,
                 queryStr: window.location.search
             });
-            view.bindUrlToWindow();
+            view.bindToWindow();
         } catch (err) {
             figure.innerHTML = "<img src=\\"/grapher/exports/${
                 chart.slug

--- a/site/server/views/ChartPage.tsx
+++ b/site/server/views/ChartPage.tsx
@@ -40,7 +40,11 @@ export const ChartPage = (props: {
 
         try {
             window.App = {};
-            var view = window.ChartView.bootstrap({ jsonConfig: jsonConfig, containerNode: figure });
+            var view = window.ChartView.bootstrap({
+                jsonConfig: jsonConfig,
+                containerNode: figure,
+                queryStr: window.location.search
+            });
             view.bindUrlToWindow();
         } catch (err) {
             figure.innerHTML = "<img src=\\"/grapher/exports/${

--- a/site/server/views/ChartPage.tsx
+++ b/site/server/views/ChartPage.tsx
@@ -40,7 +40,8 @@ export const ChartPage = (props: {
 
         try {
             window.App = {};
-            window.ChartView.bootstrap({ jsonConfig: jsonConfig, containerNode: figure });
+            var view = window.ChartView.bootstrap({ jsonConfig: jsonConfig, containerNode: figure });
+            view.bindUrlToWindow();
         } catch (err) {
             figure.innerHTML = "<img src=\\"/grapher/exports/${
                 chart.slug

--- a/utils/client/url.ts
+++ b/utils/client/url.ts
@@ -7,11 +7,11 @@ export interface QueryParams {
 // Deprecated. Use getWindowQueryParams() to get the params from the global URL,
 // or strToQueryParams(str) to parse an arbtirary query string.
 export function getQueryParams(queryStr?: string): QueryParams {
-    return strToQueryParams(queryStr || window.location.search)
+    return strToQueryParams(queryStr || getWindowQueryStr())
 }
 
 export function getWindowQueryParams(): QueryParams {
-    return strToQueryParams(window.location.search)
+    return strToQueryParams(getWindowQueryStr())
 }
 
 export function strToQueryParams(queryStr: string): QueryParams {
@@ -52,6 +52,10 @@ export function setWindowQueryVariable(key: string, val: string | null) {
     }
 
     setWindowQueryStr(queryParamsToStr(params))
+}
+
+export function getWindowQueryStr() {
+    return window.location.search
 }
 
 export function setWindowQueryStr(str: string) {

--- a/utils/client/url.ts
+++ b/utils/client/url.ts
@@ -4,8 +4,17 @@ export interface QueryParams {
     [key: string]: string | undefined
 }
 
+// Deprecated. Use getWindowQueryParams() to get the params from the global URL,
+// or strToQueryParams(str) to parse an arbtirary query string.
 export function getQueryParams(queryStr?: string): QueryParams {
-    queryStr = queryStr || window.location.search
+    return strToQueryParams(queryStr || window.location.search)
+}
+
+export function getWindowQueryParams(): QueryParams {
+    return strToQueryParams(window.location.search)
+}
+
+export function strToQueryParams(queryStr: string): QueryParams {
     if (queryStr[0] === "?") queryStr = queryStr.substring(1)
 
     const querySplit = filter(queryStr.split("&"), s => !isEmpty(s))
@@ -33,8 +42,8 @@ export function queryParamsToStr(params: QueryParams) {
     return newQueryStr
 }
 
-export function setQueryVariable(key: string, val: string | null) {
-    const params = getQueryParams()
+export function setWindowQueryVariable(key: string, val: string | null) {
+    const params = getWindowQueryParams()
 
     if (val === null || val === "") {
         delete params[key]
@@ -42,10 +51,10 @@ export function setQueryVariable(key: string, val: string | null) {
         params[key] = val
     }
 
-    setQueryStr(queryParamsToStr(params))
+    setWindowQueryStr(queryParamsToStr(params))
 }
 
-export function setQueryStr(str: string) {
+export function setWindowQueryStr(str: string) {
     history.replaceState(
         null,
         document.title,


### PR DESCRIPTION
Ready for review.

For motivation/plan, see the notes on https://www.notion.so/owid/Chart-type-in-URL-params-4e7cd507297c48afabb6c0e66762e248. This is part 1, the refactor.

* Replace `URLBinder` with a `ChartUrl` object and a static utility, `UrlBinding`
* Move all manipulation of `window` and `document` into a method `bindToWindow` that is only ever invoked from top-level JavaScript
* Also move to the top level: grabbing the global window query string to configure the chart with
* Remove `isSinglePage` from ChartConfig
* Rename and refactor some methods for clarity, mostly in the URL utils