### PR TITLE
Node version pinning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
-node_js:
-    - "12.13.1"
 services:
     - mysql
 dist: xenial

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
     "private": true,
     "version": "2.0.0",
+    "engines": {
+        "node": "12.13.1"
+    },
     "scripts": {
         "tsn": "ts-node --transpile-only -r tsconfig-paths/register -r dotenv/config",
         "tsnd": "ts-node-dev --transpileOnly --respawn --no-notify --no-deps -r tsconfig-paths/register -r source-map-support/register -r dotenv/config",


### PR DESCRIPTION
Travis defaults to using .nvmrc's node version if not specified. 
Confirmation here: https://travis-ci.org/owid/owid-grapher/builds/623120043#L171

Also pinning in package.json's engines as I think we benefit more from predictable builds across environments (including dev) than a wider and more flexible node version range.