### PR TITLE
Explore URL binding

### DIFF
--- a/charts/ChartUrl.ts
+++ b/charts/ChartUrl.ts
@@ -18,6 +18,7 @@ import {
 } from "utils/client/url"
 import { MapProjection } from "./MapProjection"
 import { BAKED_GRAPHER_URL } from "settings"
+import { ObservableUrl } from "./UrlBinding"
 
 interface ChartQueryParams {
     tab?: string
@@ -35,7 +36,7 @@ interface ChartQueryParams {
 
 declare const App: any
 
-export class ChartUrl {
+export class ChartUrl implements ObservableUrl {
     chart: ChartConfig
     origChartProps: ChartConfigProps
     chartQueryStr: string = "?"
@@ -62,7 +63,7 @@ export class ChartUrl {
 
     // Autocomputed url params to reflect difference between current chart state
     // and original config state
-    @computed.struct get params(): ChartQueryParams {
+    @computed.struct get params(): QueryParams {
         const params: ChartQueryParams = {}
         const { chart, origChart } = this
 
@@ -98,11 +99,11 @@ export class ChartUrl {
         )
             params.region = chart.props.map.projection
 
-        return params
+        return params as QueryParams
     }
 
     @computed get queryStr(): string {
-        return queryParamsToStr(this.params as QueryParams)
+        return queryParamsToStr(this.params)
     }
 
     @computed get baseUrl(): string | undefined {

--- a/charts/ChartUrl.ts
+++ b/charts/ChartUrl.ts
@@ -20,7 +20,7 @@ import { MapProjection } from "./MapProjection"
 import { BAKED_GRAPHER_URL } from "settings"
 import { ObservableUrl } from "./UrlBinding"
 
-interface ChartQueryParams {
+export interface ChartQueryParams {
     tab?: string
     overlay?: string
     stackMode?: string

--- a/charts/ExploreModel.ts
+++ b/charts/ExploreModel.ts
@@ -1,0 +1,13 @@
+import { observable } from "mobx"
+import { ChartType, ChartTypeType } from "./ChartType"
+
+export type ExplorerChartType = ChartTypeType | "WorldMap"
+
+export class ExploreModel {
+    static defaultChartType: ExplorerChartType = ChartType.LineChart
+
+    // This is different from the chart's concept of chart type because it includes "WorldMap" as
+    // an option, and doesn't include certain chart types we don't support right now, such as
+    // scatter plots
+    @observable chartType: ExplorerChartType = ExploreModel.defaultChartType
+}

--- a/charts/ExploreUrl.ts
+++ b/charts/ExploreUrl.ts
@@ -1,0 +1,55 @@
+import { computed } from "mobx"
+
+import { ObservableUrl } from "./UrlBinding"
+import { ExploreModel, ExplorerChartType } from "./ExploreModel"
+import { ChartUrl, ChartQueryParams } from "./ChartUrl"
+import { QueryParams, strToQueryParams } from "utils/client/url"
+import { omit, extend } from "./Util"
+
+type ExploreQueryParams = Omit<ChartQueryParams, "tab"> & {
+    type?: string
+}
+
+export class ExploreUrl implements ObservableUrl {
+    model: ExploreModel
+    chartUrl: ChartUrl
+
+    constructor(model: ExploreModel, chartUrl: ChartUrl) {
+        this.model = model
+        this.chartUrl = chartUrl
+    }
+
+    @computed get params(): QueryParams {
+        const params: ExploreQueryParams = {}
+        const { model } = this
+
+        extend(params, omit(this.chartUrl.params, "tab"))
+
+        params.type =
+            model.chartType === ExploreModel.defaultChartType
+                ? undefined
+                : model.chartType
+
+        return params as QueryParams
+    }
+
+    @computed get debounceMode(): boolean {
+        return this.chartUrl.debounceMode
+    }
+
+    populateFromQueryStr(queryStr?: string) {
+        if (queryStr === undefined) return
+        this.populateFromQueryParams(strToQueryParams(queryStr))
+    }
+
+    populateFromQueryParams(params: ExploreQueryParams) {
+        const { model } = this
+
+        const chartType = params.type
+        if (chartType) {
+            model.chartType = chartType as ExplorerChartType
+        }
+
+        this.chartUrl.populateFromQueryParams(params)
+    }
+}

--- a/charts/ExploreView.tsx
+++ b/charts/ExploreView.tsx
@@ -15,6 +15,7 @@ import { ChartView } from "./ChartView"
 import { ChartConfig, ChartConfigProps } from "./ChartConfig"
 import { ChartType, ChartTypeType } from "./ChartType"
 import * as urlBinding from "charts/UrlBinding"
+import { ExploreModel, ExplorerChartType } from "./ExploreModel"
 
 // Hardcoding some dummy config for now so we can display a chart.
 // There will eventually be a list of these, downloaded from a static JSON file.
@@ -31,8 +32,6 @@ const DUMMY_JSON_CONFIG = {
 }
 
 const WorldMap = "WorldMap"
-
-type ExplorerChartType = ChartTypeType | "WorldMap"
 
 const AVAILABLE_CHART_TYPES: ExplorerChartType[] = [
     ChartType.LineChart,
@@ -86,11 +85,7 @@ export class ExploreView extends React.Component<ExploreProps> {
         return view
     }
 
-    // This is different from the chart's concept of chart type because it includes "WorldMap" as
-    // an option, and doesn't include certain chart types we don't support right now, such as
-    // scatter plots
-    @observable chartType: ExplorerChartType = ChartType.LineChart
-
+    model: ExploreModel
     chart: ChartConfig
 
     dispose!: IReactionDisposer
@@ -102,6 +97,8 @@ export class ExploreView extends React.Component<ExploreProps> {
         const chartProps = new ChartConfigProps()
         extend(chartProps, DUMMY_JSON_CONFIG)
         this.chart = new ChartConfig(chartProps, { queryStr })
+
+        this.model = new ExploreModel()
 
         // We need these updates in an autorun because the chart config objects aren't really meant
         // to be recreated all the time. They aren't pure value objects and have behaviors on
@@ -125,7 +122,7 @@ export class ExploreView extends React.Component<ExploreProps> {
     }
 
     @computed get isMap() {
-        return this.chartType === "WorldMap"
+        return this.model.chartType === "WorldMap"
     }
 
     @computed get tab() {
@@ -138,11 +135,11 @@ export class ExploreView extends React.Component<ExploreProps> {
     @computed get configChartType(): ChartTypeType {
         return this.isMap
             ? ChartType.LineChart
-            : (this.chartType as ChartTypeType)
+            : (this.model.chartType as ChartTypeType)
     }
 
     renderChartTypeButton(type: ExplorerChartType) {
-        const isSelected = type === this.chartType
+        const isSelected = type === this.model.chartType
         const display = CHART_TYPE_DISPLAY[type]
         return (
             <button
@@ -150,7 +147,7 @@ export class ExploreView extends React.Component<ExploreProps> {
                 data-type={type}
                 className={`chart-type-button ${isSelected ? "selected" : ""}`}
                 onClick={() => {
-                    this.chartType = type
+                    this.model.chartType = type
                 }}
             >
                 <FontAwesomeIcon icon={display.icon} />

--- a/charts/ExploreView.tsx
+++ b/charts/ExploreView.tsx
@@ -15,6 +15,7 @@ import { ChartView } from "./ChartView"
 import { ChartConfig, ChartConfigProps } from "./ChartConfig"
 import { ChartType, ChartTypeType } from "./ChartType"
 import * as urlBinding from "charts/UrlBinding"
+import { ExploreUrl } from "./ExploreUrl"
 import { ExploreModel, ExplorerChartType } from "./ExploreModel"
 
 // Hardcoding some dummy config for now so we can display a chart.
@@ -87,18 +88,21 @@ export class ExploreView extends React.Component<ExploreProps> {
 
     model: ExploreModel
     chart: ChartConfig
+    url: ExploreUrl
 
     dispose!: IReactionDisposer
 
     constructor(props: ExploreProps) {
         super(props)
 
-        const { queryStr } = this.props
         const chartProps = new ChartConfigProps()
         extend(chartProps, DUMMY_JSON_CONFIG)
-        this.chart = new ChartConfig(chartProps, { queryStr })
+        this.chart = new ChartConfig(chartProps)
 
         this.model = new ExploreModel()
+
+        this.url = new ExploreUrl(this.model, this.chart.url)
+        this.url.populateFromQueryStr(this.props.queryStr)
 
         // We need these updates in an autorun because the chart config objects aren't really meant
         // to be recreated all the time. They aren't pure value objects and have behaviors on
@@ -176,7 +180,7 @@ export class ExploreView extends React.Component<ExploreProps> {
     }
 
     bindToWindow() {
-        urlBinding.bindUrlToWindow(this.chart.url)
+        urlBinding.bindUrlToWindow(this.url)
         autorun(() => (document.title = this.chart.data.currentTitle))
     }
 }

--- a/charts/ExploreView.tsx
+++ b/charts/ExploreView.tsx
@@ -14,6 +14,7 @@ import { Bounds } from "./Bounds"
 import { ChartView } from "./ChartView"
 import { ChartConfig, ChartConfigProps } from "./ChartConfig"
 import { ChartType, ChartTypeType } from "./ChartType"
+import * as urlBinding from "charts/UrlBinding"
 
 // Hardcoding some dummy config for now so we can display a chart.
 // There will eventually be a list of these, downloaded from a static JSON file.
@@ -64,14 +65,25 @@ const CHART_TYPE_DISPLAY: {
 
 interface ExploreProps {
     bounds: Bounds
+    queryStr?: string
 }
 
 @observer
 export class ExploreView extends React.Component<ExploreProps> {
-    static bootstrap({ containerNode }: { containerNode: HTMLElement }) {
+    static bootstrap({
+        containerNode,
+        queryStr
+    }: {
+        containerNode: HTMLElement
+        queryStr?: string
+    }) {
         const rect = containerNode.getBoundingClientRect()
         const bounds = Bounds.fromRect(rect)
-        return ReactDOM.render(<ExploreView bounds={bounds} />, containerNode)
+        const view = ReactDOM.render(
+            <ExploreView bounds={bounds} queryStr={queryStr} />,
+            containerNode
+        )
+        return view
     }
 
     // This is different from the chart's concept of chart type because it includes "WorldMap" as
@@ -86,9 +98,10 @@ export class ExploreView extends React.Component<ExploreProps> {
     constructor(props: ExploreProps) {
         super(props)
 
+        const { queryStr } = this.props
         const chartProps = new ChartConfigProps()
         extend(chartProps, DUMMY_JSON_CONFIG)
-        this.chart = new ChartConfig(chartProps)
+        this.chart = new ChartConfig(chartProps, { queryStr })
 
         // We need these updates in an autorun because the chart config objects aren't really meant
         // to be recreated all the time. They aren't pure value objects and have behaviors on
@@ -163,5 +176,10 @@ export class ExploreView extends React.Component<ExploreProps> {
                 <ChartView chart={this.chart} bounds={this.bounds} />
             </div>
         )
+    }
+
+    bindToWindow() {
+        urlBinding.bindUrlToWindow(this.chart.url)
+        autorun(() => (document.title = this.chart.data.currentTitle))
     }
 }

--- a/charts/UrlBinding.ts
+++ b/charts/UrlBinding.ts
@@ -8,13 +8,16 @@ import {
 } from "utils/client/url"
 
 import { debounce } from "./Util"
-import { ChartUrl } from "./ChartUrl"
 
-export function bindUrlToWindow(url: ChartUrl) {
+export interface ObservableUrl {
+    params: QueryParams
+    debounceMode: boolean
+}
+
+export function bindUrlToWindow(url: ObservableUrl) {
     // There is a surprisingly considerable performance overhead to updating the url
     // while animating, so we debounce to allow e.g. smoother timelines
-    const pushParams = () =>
-        setWindowQueryStr(queryParamsToStr(url.params as QueryParams))
+    const pushParams = () => setWindowQueryStr(queryParamsToStr(url.params))
     const debouncedPushParams = debounce(pushParams, 100)
 
     reaction(

--- a/charts/__tests__/ExploreView.test.tsx
+++ b/charts/__tests__/ExploreView.test.tsx
@@ -38,12 +38,22 @@ describe(ExploreView, () => {
         beforeAll(() => xhrMock.setup())
         afterAll(() => xhrMock.teardown())
 
-        it("applies the params to the chart", async () => {
+        async function renderWithQueryStr(queryStr: string) {
             mockDataResponse()
             const view = mount(
-                <ExploreView bounds={bounds} queryStr={"time=1965..2005"} />
+                <ExploreView bounds={bounds} queryStr={queryStr} />
             )
             await updateViewWhenReady(view)
+            return view
+        }
+
+        it("applies the chart type", async () => {
+            const view = await renderWithQueryStr("type=WorldMap")
+            expect(view.find(ChoroplethMap)).toHaveLength(1)
+        })
+
+        it("applies the time params to the chart", async () => {
+            const view = await renderWithQueryStr("time=1960..2005")
             const style: any = view.find(".slider .interval").prop("style")
             expect(parseFloat(style.left)).toBeGreaterThan(0)
             expect(parseFloat(style.right)).toBeGreaterThan(0)

--- a/site/server/views/ExplorePage.tsx
+++ b/site/server/views/ExplorePage.tsx
@@ -18,7 +18,8 @@ import { SiteFooter } from "./SiteFooter"
 export const ExplorePage = () => {
     const script = `
         var div = document.getElementById('explore');
-        window.ExploreView.bootstrap({ containerNode: div });
+        var view = window.ExploreView.bootstrap({ containerNode: div, queryStr: window.location.search });
+        view.bindToWindow();
     `
 
     return (


### PR DESCRIPTION
Make URL binding work on the Explore page, including both the Chart params and the chart type managed by the Explore view itself.

* Refactor the UrlBinding utility to take an abstract ObservableUrl
* Add a simple ExploreModel that just wraps chartType for now
* Add an ExploreUrl that wraps ChartUrl and handles URL params
* Update ExploreView to use these to accomplish URL binding

Note that the chart types show up in the URL params with names like `StackedArea` and `WorldMap`. Not sure if that's what we want; we may want to rename them to simply `area`, `map`, etc.

I would like to do more refactoring on this. In particular, I'm not happy with the ExploreView taking the queryStr on its props and creating its model. The model itself should be passed in as a prop, similar to ChartView. Also, the ExploreModel should wrap the ChartConfig. But I'd rather get this merged then probably do this code improvement after @danielgavrilov's changes.