### PR TITLE
Explore model/view refactor

### DIFF
--- a/charts/ExploreModel.ts
+++ b/charts/ExploreModel.ts
@@ -1,5 +1,7 @@
 import { observable } from "mobx"
 import { ChartType, ChartTypeType } from "./ChartType"
+import { ChartConfig } from "./ChartConfig"
+import { ExploreUrl } from "./ExploreUrl"
 
 export type ExplorerChartType = ChartTypeType | "WorldMap"
 
@@ -12,4 +14,16 @@ export class ExploreModel {
     @observable chartType: ExplorerChartType = ExploreModel.defaultChartType
 
     @observable indicatorId?: number = undefined
+
+    chart: ChartConfig
+    url: ExploreUrl
+
+    constructor(chart?: ChartConfig) {
+        this.chart = chart || new ChartConfig()
+        this.url = new ExploreUrl(this, this.chart.url)
+    }
+
+    populateFromQueryStr(queryStr?: string) {
+        this.url.populateFromQueryStr(queryStr)
+    }
 }

--- a/charts/ExploreModel.ts
+++ b/charts/ExploreModel.ts
@@ -1,4 +1,5 @@
 import { observable } from "mobx"
+
 import { ChartType, ChartTypeType } from "./ChartType"
 import { ChartConfig } from "./ChartConfig"
 import { ExploreUrl } from "./ExploreUrl"
@@ -6,6 +7,7 @@ import { ExploreUrl } from "./ExploreUrl"
 export type ExplorerChartType = ChartTypeType | "WorldMap"
 
 export class ExploreModel {
+    static WorldMap: ExplorerChartType = "WorldMap"
     static defaultChartType: ExplorerChartType = ChartType.LineChart
 
     // This is different from the chart's concept of chart type because it includes "WorldMap" as

--- a/charts/ExploreView.tsx
+++ b/charts/ExploreView.tsx
@@ -133,6 +133,11 @@ export class ExploreView extends React.Component<ExploreProps> {
         return this.props.bounds
     }
 
+    get childContext() {
+        return {
+            store: this.props.store
+        }
+    }
     renderChartTypeButton(button: ChartTypeButton) {
         const isSelected = button.type === this.model.chartType
         return (
@@ -172,17 +177,6 @@ export class ExploreView extends React.Component<ExploreProps> {
         )
     }
 
-    get childContext() {
-        return {
-            store: this.props.store
-        }
-    }
-
-    bindToWindow() {
-        urlBinding.bindUrlToWindow(this.model.url)
-        autorun(() => (document.title = this.chart.data.currentTitle))
-    }
-
     render() {
         return (
             <ExplorerViewContext.Provider value={this.childContext}>
@@ -194,5 +188,10 @@ export class ExploreView extends React.Component<ExploreProps> {
                 </div>
             </ExplorerViewContext.Provider>
         )
+    }
+
+    bindToWindow() {
+        urlBinding.bindUrlToWindow(this.model.url)
+        autorun(() => (document.title = this.chart.data.currentTitle))
     }
 }

--- a/charts/ExploreView.tsx
+++ b/charts/ExploreView.tsx
@@ -101,21 +101,14 @@ export class ExploreView extends React.Component<ExploreProps> {
     }
 
     model: ExploreModel
-    chart: ChartConfig
-    url: ExploreUrl
 
     disposers: IReactionDisposer[]
 
     constructor(props: ExploreProps) {
         super(props)
 
-        const chartProps = new ChartConfigProps()
-        this.chart = new ChartConfig(chartProps)
-
         this.model = this.props.model
-
-        this.url = new ExploreUrl(this.model, this.chart.url)
-        this.url.populateFromQueryStr(this.props.queryStr)
+        this.model.populateFromQueryStr(this.props.queryStr)
 
         this.disposers = [
             // We need these updates in an autorun because the chart config objects aren't really meant
@@ -145,6 +138,10 @@ export class ExploreView extends React.Component<ExploreProps> {
 
     componentWillUnmount() {
         this.disposers.forEach(dispose => dispose())
+    }
+
+    @computed get chart() {
+        return this.model.chart
     }
 
     @computed get indicatorEntry(): StoreEntry<Indicator> | null {
@@ -221,7 +218,7 @@ export class ExploreView extends React.Component<ExploreProps> {
     }
 
     bindToWindow() {
-        urlBinding.bindUrlToWindow(this.url)
+        urlBinding.bindUrlToWindow(this.model.url)
         autorun(() => (document.title = this.chart.data.currentTitle))
     }
 

--- a/charts/ExploreView.tsx
+++ b/charts/ExploreView.tsx
@@ -73,7 +73,6 @@ interface ExploreProps {
     bounds: Bounds
     model: ExploreModel
     store: RootStore
-    queryStr?: string
 }
 
 @observer
@@ -89,13 +88,9 @@ export class ExploreView extends React.Component<ExploreProps> {
         const bounds = Bounds.fromRect(rect)
         const store = new RootStore()
         const model = new ExploreModel()
+        model.populateFromQueryStr(queryStr)
         return ReactDOM.render(
-            <ExploreView
-                bounds={bounds}
-                model={model}
-                store={store}
-                queryStr={queryStr}
-            />,
+            <ExploreView bounds={bounds} model={model} store={store} />,
             containerNode
         )
     }
@@ -108,7 +103,6 @@ export class ExploreView extends React.Component<ExploreProps> {
         super(props)
 
         this.model = this.props.model
-        this.model.populateFromQueryStr(this.props.queryStr)
 
         this.disposers = [
             // We need these updates in an autorun because the chart config objects aren't really meant

--- a/charts/ExploreView.tsx
+++ b/charts/ExploreView.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as ReactDOM from "react-dom"
-import { observable, computed, IReactionDisposer, autorun } from "mobx"
+import { computed, IReactionDisposer, autorun } from "mobx"
 import { observer } from "mobx-react"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { IconDefinition } from "@fortawesome/fontawesome-svg-core"
@@ -11,14 +11,13 @@ import { faMap } from "@fortawesome/free-solid-svg-icons/faMap"
 
 import { Bounds } from "./Bounds"
 import { ChartView } from "./ChartView"
-import { ChartConfig, ChartConfigProps } from "./ChartConfig"
+import { ChartConfigProps } from "./ChartConfig"
 import { ChartType, ChartTypeType } from "./ChartType"
 import { ExplorerViewContext } from "./ExplorerViewContext"
 import { IndicatorDropdown } from "./IndicatorDropdown"
 import { Indicator } from "./Indicator"
 import { RootStore, StoreEntry } from "./Store"
 import * as urlBinding from "charts/UrlBinding"
-import { ExploreUrl } from "./ExploreUrl"
 import { ExploreModel, ExplorerChartType } from "./ExploreModel"
 import { DataTable } from "./DataTable"
 
@@ -38,27 +37,20 @@ function chartConfigFromIndicator(
     }
 }
 
-const WorldMap = "WorldMap"
-
-const AVAILABLE_CHART_TYPES: ExplorerChartType[] = [
-    ChartType.LineChart,
-    ChartType.StackedArea,
-    ChartType.StackedBar,
-    ChartType.DiscreteBar,
-    ChartType.SlopeChart,
-    WorldMap
-]
-
-const CHART_TYPE_DISPLAY: {
-    [key: string]: { label: string; icon: IconDefinition }
-} = {
-    [ChartType.LineChart]: { label: "Line", icon: faChartLine },
-    [ChartType.StackedArea]: { label: "Area", icon: faChartArea },
-    [ChartType.StackedBar]: { label: "Stacked", icon: faChartBar },
-    [ChartType.DiscreteBar]: { label: "Bar", icon: faChartBar },
-    [ChartType.SlopeChart]: { label: "Slope", icon: faChartLine },
-    [WorldMap]: { label: "Map", icon: faMap }
+export interface ChartTypeButton {
+    type: ExplorerChartType
+    label: string
+    icon: IconDefinition
 }
+
+const CHART_TYPE_BUTTONS: ChartTypeButton[] = [
+    { type: ChartType.LineChart, label: "Line", icon: faChartLine },
+    { type: ChartType.StackedArea, label: "Area", icon: faChartArea },
+    { type: ChartType.StackedBar, label: "Stacked", icon: faChartBar },
+    { type: ChartType.DiscreteBar, label: "Bar", icon: faChartBar },
+    { type: ChartType.SlopeChart, label: "Slope", icon: faChartLine },
+    { type: ExploreModel.WorldMap, label: "Map", icon: faMap }
+]
 
 // This component was modeled after ChartView.
 //
@@ -165,20 +157,19 @@ export class ExploreView extends React.Component<ExploreProps> {
             : (this.model.chartType as ChartTypeType)
     }
 
-    renderChartTypeButton(type: ExplorerChartType) {
-        const isSelected = type === this.model.chartType
-        const display = CHART_TYPE_DISPLAY[type]
+    renderChartTypeButton(button: ChartTypeButton) {
+        const isSelected = button.type === this.model.chartType
         return (
             <button
-                key={type}
-                data-type={type}
+                key={button.type}
+                data-type={button.type}
                 className={`chart-type-button ${isSelected ? "selected" : ""}`}
                 onClick={() => {
-                    this.model.chartType = type
+                    this.model.chartType = button.type
                 }}
             >
-                <FontAwesomeIcon icon={display.icon} />
-                <div>{display.label}</div>
+                <FontAwesomeIcon icon={button.icon} />
+                <div>{button.label}</div>
             </button>
         )
     }
@@ -186,8 +177,8 @@ export class ExploreView extends React.Component<ExploreProps> {
     renderChartTypes() {
         return (
             <div className="chart-type-buttons">
-                {AVAILABLE_CHART_TYPES.map(type =>
-                    this.renderChartTypeButton(type)
+                {CHART_TYPE_BUTTONS.map(button =>
+                    this.renderChartTypeButton(button)
                 )}
             </div>
         )

--- a/charts/ExploreView.tsx
+++ b/charts/ExploreView.tsx
@@ -87,14 +87,10 @@ export class ExploreView extends React.Component<ExploreProps> {
         )
     }
 
-    model: ExploreModel
-
     disposers: IReactionDisposer[]
 
     constructor(props: ExploreProps) {
         super(props)
-
-        this.model = this.props.model
 
         this.disposers = [
             // We need these updates in an autorun because the chart config objects aren't really meant
@@ -124,6 +120,10 @@ export class ExploreView extends React.Component<ExploreProps> {
 
     componentWillUnmount() {
         this.disposers.forEach(dispose => dispose())
+    }
+
+    @computed get model() {
+        return this.props.model
     }
 
     @computed get chart() {

--- a/charts/ExploreView.tsx
+++ b/charts/ExploreView.tsx
@@ -144,6 +144,9 @@ export class ExploreView extends React.Component<ExploreProps> {
 
     bindToWindow() {
         urlBinding.bindUrlToWindow(this.model.url)
+
+        // We ignore the disposer here, because this reaction lasts for the
+        // lifetime of the window. -@jasoncrawford 2019-12-16
         autorun(() => (document.title = this.chart.data.currentTitle))
     }
 }

--- a/charts/ExploreView.tsx
+++ b/charts/ExploreView.tsx
@@ -87,24 +87,12 @@ export class ExploreView extends React.Component<ExploreProps> {
         )
     }
 
-    disposers: IReactionDisposer[]
+    disposers: IReactionDisposer[] = []
 
     constructor(props: ExploreProps) {
         super(props)
 
-        this.disposers = [
-            // We need these updates in an autorun because the chart config objects aren't really meant
-            // to be recreated all the time. They aren't pure value objects and have behaviors on
-            // instantiation that include fetching data over the network. Instead, we rely on their
-            // observable properties, and on this autorun block to connect them to the Explore controls.
-            // -@jasoncrawford 2019-12-04
-            autorun(() => {
-                this.chart.props.type = this.configChartType
-                this.chart.props.hasMapTab = this.isMap
-                this.chart.props.hasChartTab = !this.isMap
-                this.chart.tab = this.isMap ? "map" : "chart"
-            }),
-
+        this.disposers.push(
             autorun(() => {
                 if (this.indicatorEntry === null) {
                     this.chart.update({ dimensions: [] })
@@ -115,11 +103,12 @@ export class ExploreView extends React.Component<ExploreProps> {
                     }
                 }
             })
-        ]
+        )
     }
 
     componentWillUnmount() {
         this.disposers.forEach(dispose => dispose())
+        this.model.dispose()
     }
 
     @computed get model() {
@@ -142,19 +131,6 @@ export class ExploreView extends React.Component<ExploreProps> {
 
     @computed get bounds() {
         return this.props.bounds
-    }
-
-    @computed get isMap() {
-        return this.model.chartType === "WorldMap"
-    }
-
-    // Translates between the chart type chosen in the Explore UI, and the type we want to set on
-    // the ChartConfigProps. It's a pass-through unless map is chosen, in which case we tell the
-    // chart (arbitrarily) to be a line chart, and set the tab to map.
-    @computed get configChartType(): ChartTypeType {
-        return this.isMap
-            ? ChartType.LineChart
-            : (this.model.chartType as ChartTypeType)
     }
 
     renderChartTypeButton(button: ChartTypeButton) {

--- a/charts/UrlBinding.ts
+++ b/charts/UrlBinding.ts
@@ -20,6 +20,8 @@ export function bindUrlToWindow(url: ObservableUrl) {
     const pushParams = () => setWindowQueryStr(queryParamsToStr(url.params))
     const debouncedPushParams = debounce(pushParams, 100)
 
+    // We ignore the disposer here, because this reaction lasts for the
+    // lifetime of the window. -@jasoncrawford 2019-12-16
     reaction(
         () => url.params,
         () => (url.debounceMode ? debouncedPushParams() : pushParams())

--- a/charts/__tests__/ExploreModel.test.ts
+++ b/charts/__tests__/ExploreModel.test.ts
@@ -1,9 +1,10 @@
-import { ExploreModel } from "charts/ExploreModel"
+import { ExploreModel } from "../ExploreModel"
+import { ChartType } from "../ChartType"
 
 describe(ExploreModel, () => {
-    describe("when you give it a query string", () => {
-        let model: ExploreModel
+    let model: ExploreModel
 
+    describe("when you give it a query string", () => {
         beforeAll(() => {
             const queryStr = "indicator=488&time=1960..2000&type=WorldMap"
             model = new ExploreModel()
@@ -20,6 +21,52 @@ describe(ExploreModel, () => {
 
         it("populates the chart params", () => {
             expect(model.chart.timeDomain).toEqual([1960, 2000])
+        })
+    })
+
+    describe("when you set an area type", () => {
+        beforeAll(() => {
+            model = new ExploreModel()
+            model.chartType = ChartType.StackedArea
+        })
+
+        it("updates the chart type to area", () => {
+            expect(model.chart.props.type).toBe(ChartType.StackedArea)
+        })
+
+        it("has a chart tab", () => {
+            expect(model.chart.hasChartTab).toBe(true)
+        })
+
+        it("doesn't have a map tab", () => {
+            expect(model.chart.hasMapTab).toBe(false)
+        })
+
+        it("is on the chart tab", () => {
+            expect(model.chart.tab).toBe("chart")
+        })
+    })
+
+    describe("when you set a map type", () => {
+        beforeAll(() => {
+            model = new ExploreModel()
+            model.chartType = ExploreModel.WorldMap
+        })
+
+        it("updates the chart type to line", () => {
+            expect(model.chart.props.type).toBe(ChartType.LineChart)
+        })
+
+        it("has a map tab", () => {
+            expect(model.chart.hasMapTab).toBe(true)
+        })
+
+        it("doesn't have a chart tab", () => {
+            expect(model.chart.hasChartTab).toBe(false)
+        })
+
+        it("is on the map tab", () => {
+            expect(model.chart.tab).toBe("map")
         })
     })
 })

--- a/charts/__tests__/ExploreModel.test.ts
+++ b/charts/__tests__/ExploreModel.test.ts
@@ -1,0 +1,25 @@
+import { ExploreModel } from "charts/ExploreModel"
+
+describe(ExploreModel, () => {
+    describe("when you give it a query string", () => {
+        let model: ExploreModel
+
+        beforeAll(() => {
+            const queryStr = "indicator=488&time=1960..2000&type=WorldMap"
+            model = new ExploreModel()
+            model.populateFromQueryStr(queryStr)
+        })
+
+        it("populates the indicator id", () => {
+            expect(model.indicatorId).toBe(488)
+        })
+
+        it("populates the chart type", () => {
+            expect(model.chartType).toBe("WorldMap")
+        })
+
+        it("populates the chart params", () => {
+            expect(model.chart.timeDomain).toEqual([1960, 2000])
+        })
+    })
+})

--- a/charts/__tests__/ExploreModel.test.ts
+++ b/charts/__tests__/ExploreModel.test.ts
@@ -1,5 +1,8 @@
 import { ExploreModel } from "../ExploreModel"
 import { ChartType } from "../ChartType"
+import { RootStore } from "charts/Store"
+
+const store = new RootStore()
 
 describe(ExploreModel, () => {
     let model: ExploreModel
@@ -7,7 +10,7 @@ describe(ExploreModel, () => {
     describe("when you give it a query string", () => {
         beforeAll(() => {
             const queryStr = "indicator=488&time=1960..2000&type=WorldMap"
-            model = new ExploreModel()
+            model = new ExploreModel(store)
             model.populateFromQueryStr(queryStr)
         })
 
@@ -26,7 +29,7 @@ describe(ExploreModel, () => {
 
     describe("when you set an area type", () => {
         beforeAll(() => {
-            model = new ExploreModel()
+            model = new ExploreModel(store)
             model.chartType = ChartType.StackedArea
         })
 
@@ -49,7 +52,7 @@ describe(ExploreModel, () => {
 
     describe("when you set a map type", () => {
         beforeAll(() => {
-            model = new ExploreModel()
+            model = new ExploreModel(store)
             model.chartType = ExploreModel.WorldMap
         })
 

--- a/charts/__tests__/ExploreView.test.tsx
+++ b/charts/__tests__/ExploreView.test.tsx
@@ -57,13 +57,11 @@ describe(ExploreView, () => {
         expect(view.find(ChartView)).toHaveLength(1)
     })
 
-    describe("when you render with url params", () => {
+    describe("when you render with diferent model params", () => {
         apiMock.init()
 
-        async function renderWithQueryStr(queryStr: string) {
+        async function renderWithModel(model: ExploreModel) {
             mockDataResponse()
-            const model = getDefaultModel()
-            model.populateFromQueryStr(queryStr)
             const view = mount(
                 <ExploreView bounds={bounds} model={model} store={getStore()} />
             )
@@ -72,7 +70,9 @@ describe(ExploreView, () => {
         }
 
         it("applies the chart type", async () => {
-            const view = await renderWithQueryStr("type=WorldMap")
+            const model = getDefaultModel()
+            model.chartType = "WorldMap"
+            const view = await renderWithModel(model)
             expect(view.find(ChoroplethMap)).toHaveLength(1)
         })
 
@@ -85,15 +85,12 @@ describe(ExploreView, () => {
         //
         // -@danielgavrilov 2019-12-12
         it.skip("applies the time params to the chart", async () => {
-            const view = await renderWithQueryStr("time=1960..2005")
+            const model = getDefaultModel()
+            model.chart.timeDomain = [1960, 2005]
+            const view = await renderWithModel(model)
             const style: any = view.find(".slider .interval").prop("style")
             expect(parseFloat(style.left)).toBeGreaterThan(0)
             expect(parseFloat(style.right)).toBeGreaterThan(0)
-        })
-
-        it("applies the indicator", async () => {
-            const view = await renderWithQueryStr(`indicator=${indicator.id}`)
-            expect(view.find(".chart h1").text()).toContain(indicator.title)
         })
     })
 

--- a/charts/__tests__/ExploreView.test.tsx
+++ b/charts/__tests__/ExploreView.test.tsx
@@ -20,16 +20,18 @@ import * as fixtures from "test/fixtures"
 const bounds = new Bounds(0, 0, 800, 600)
 const indicator = fixtures.readIndicators().indicators[0]
 
-const store = new RootStore()
+function getStore() {
+    return new RootStore()
+}
 
 function getDefaultModel() {
-    const model = new ExploreModel(store)
+    const model = new ExploreModel(getStore())
     model.indicatorId = indicator.id
     return model
 }
 
 function getEmptyModel() {
-    return new ExploreModel(store)
+    return new ExploreModel(getStore())
 }
 
 function mockDataResponse() {

--- a/charts/__tests__/ExploreView.test.tsx
+++ b/charts/__tests__/ExploreView.test.tsx
@@ -20,18 +20,16 @@ import * as fixtures from "test/fixtures"
 const bounds = new Bounds(0, 0, 800, 600)
 const indicator = fixtures.readIndicators().indicators[0]
 
-function getStore() {
-    return new RootStore()
-}
+const store = new RootStore()
 
 function getDefaultModel() {
-    const model = new ExploreModel()
+    const model = new ExploreModel(store)
     model.indicatorId = indicator.id
     return model
 }
 
 function getEmptyModel() {
-    return new ExploreModel()
+    return new ExploreModel(store)
 }
 
 function mockDataResponse() {
@@ -48,23 +46,17 @@ async function updateViewWhenReady(exploreView: ReactWrapper) {
 describe(ExploreView, () => {
     it("renders an empty chart", () => {
         const view = shallow(
-            <ExploreView
-                bounds={bounds}
-                model={getEmptyModel()}
-                store={getStore()}
-            />
+            <ExploreView bounds={bounds} model={getEmptyModel()} />
         )
         expect(view.find(ChartView)).toHaveLength(1)
     })
 
     describe("when you render with diferent model params", () => {
         apiMock.init()
+        beforeAll(() => mockDataResponse())
 
         async function renderWithModel(model: ExploreModel) {
-            mockDataResponse()
-            const view = mount(
-                <ExploreView bounds={bounds} model={model} store={getStore()} />
-            )
+            const view = mount(<ExploreView bounds={bounds} model={model} />)
             await updateViewWhenReady(view)
             return view
         }
@@ -96,27 +88,18 @@ describe(ExploreView, () => {
 
     describe("chart types", () => {
         apiMock.init()
+        beforeAll(() => mockDataResponse())
 
         it("displays chart types", () => {
-            mockDataResponse()
             const view = mount(
-                <ExploreView
-                    bounds={bounds}
-                    model={getDefaultModel()}
-                    store={getStore()}
-                />
+                <ExploreView bounds={bounds} model={getDefaultModel()} />
             )
             expect(view.find(".chart-type-button")).toHaveLength(6)
         })
 
         it("defaults to line chart", async () => {
-            mockDataResponse()
             const view = mount(
-                <ExploreView
-                    bounds={bounds}
-                    model={getDefaultModel()}
-                    store={getStore()}
-                />
+                <ExploreView bounds={bounds} model={getDefaultModel()} />
             )
             await updateViewWhenReady(view)
             expect(view.find(LineChart)).toHaveLength(1)
@@ -136,12 +119,10 @@ describe(ExploreView, () => {
                 const button = `.chart-type-button[data-type="${type.key}"]`
 
                 beforeAll(async () => {
-                    mockDataResponse()
                     view = mount(
                         <ExploreView
                             bounds={bounds}
                             model={getDefaultModel()}
-                            store={getStore()}
                         />
                     )
                     await updateViewWhenReady(view)
@@ -161,26 +142,18 @@ describe(ExploreView, () => {
 
     describe("indicator switching", () => {
         apiMock.init()
+        beforeAll(() => mockDataResponse())
 
         it("loads an empty chart with no indicator", () => {
             const view = shallow(
-                <ExploreView
-                    bounds={bounds}
-                    model={getEmptyModel()}
-                    store={getStore()}
-                />
+                <ExploreView bounds={bounds} model={getEmptyModel()} />
             )
             expect(view.find(ChartView)).toHaveLength(1)
         })
 
         it("loads a chart with the initialized indicator", async () => {
-            mockDataResponse()
             const view = mount(
-                <ExploreView
-                    bounds={bounds}
-                    model={getDefaultModel()}
-                    store={getStore()}
-                />
+                <ExploreView bounds={bounds} model={getDefaultModel()} />
             )
             await updateViewWhenReady(view)
             expect(view.find(ChartView)).toHaveLength(1)
@@ -188,11 +161,8 @@ describe(ExploreView, () => {
         })
 
         it("loads the indicator when the indicatorId is changed", async () => {
-            mockDataResponse()
             const model = getEmptyModel()
-            const view = mount(
-                <ExploreView bounds={bounds} model={model} store={getStore()} />
-            )
+            const view = mount(<ExploreView bounds={bounds} model={model} />)
             expect(view.find(ChartView)).toHaveLength(1)
             expect(view.find(".chart h1")).toHaveLength(0)
 
@@ -203,13 +173,8 @@ describe(ExploreView, () => {
         })
 
         it("shows the loaded indicator in the dropdown", async () => {
-            mockDataResponse()
             const view = mount(
-                <ExploreView
-                    bounds={bounds}
-                    model={getDefaultModel()}
-                    store={getStore()}
-                />
+                <ExploreView bounds={bounds} model={getDefaultModel()} />
             )
             await updateViewWhenReady(view)
             expect(

--- a/charts/__tests__/ExploreView.test.tsx
+++ b/charts/__tests__/ExploreView.test.tsx
@@ -62,13 +62,10 @@ describe(ExploreView, () => {
 
         async function renderWithQueryStr(queryStr: string) {
             mockDataResponse()
+            const model = getDefaultModel()
+            model.populateFromQueryStr(queryStr)
             const view = mount(
-                <ExploreView
-                    bounds={bounds}
-                    model={getDefaultModel()}
-                    store={getStore()}
-                    queryStr={queryStr}
-                />
+                <ExploreView bounds={bounds} model={model} store={getStore()} />
             )
             await updateViewWhenReady(view)
             return view


### PR DESCRIPTION
Mostly move a bunch of model concerns out of the ExploreView, into the ExploreModel. Added tests for ExploreModel.

Note that the ExploreModel now takes a RootStore as a required param. I tend to think this is the way models should work.

If every view has a model, and every model has a store, then we don't need to create context providers to pass the store around. We can just pass the model down through the props (or if we don't want to do that, put the model itself in a context).

Also cleaned up the way the view was doing the chart type buttons.