### PR TITLE
Fix typechecking on first() and last()

### DIFF
--- a/admin/client/Colorpicker.tsx
+++ b/admin/client/Colorpicker.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { last } from "charts/Util"
+import { lastOfNonEmptyArray } from "charts/Util"
 import { TextField } from "./Forms"
 import { ColorSchemes, ColorScheme } from "charts/ColorSchemes"
 import { action } from "mobx"
@@ -42,9 +42,8 @@ export class Colorpicker extends React.Component<ColorpickerProps> {
     }
 
     render() {
-        const availableColors: string[] = last(
-            (ColorSchemes["owid-distinct"] as ColorScheme).colorSets
-        )
+        const scheme = ColorSchemes["owid-distinct"] as ColorScheme
+        const availableColors: string[] = lastOfNonEmptyArray(scheme.colorSets)
 
         return (
             <div

--- a/charts/ColorSchemes.ts
+++ b/charts/ColorSchemes.ts
@@ -1,6 +1,6 @@
 import { rgb } from "d3-color"
 import { interpolate } from "d3-interpolate"
-import { clone, last } from "./Util"
+import { clone, lastOfNonEmptyArray } from "./Util"
 import * as colorbrewer from "colorbrewer"
 import { Color } from "./Color"
 
@@ -137,11 +137,13 @@ export class ColorScheme {
     getDistinctColors(numColors: number): Color[] {
         const { colorSets } = this
 
+        if (colorSets.length === 0) return []
         if (colorSets[numColors]) return clone(colorSets[numColors])
-        else if (numColors > colorSets.length - 1)
+        else if (numColors > colorSets.length - 1) {
             // If more colors are wanted than we have defined, have to improvise
-            return this.improviseGradientFromShorter(last(colorSets), numColors)
-        else {
+            const colorSet = lastOfNonEmptyArray(colorSets)
+            return this.improviseGradientFromShorter(colorSet, numColors)
+        } else {
             // We have enough colors but not a specific set for this number-- improvise from the closest longer set
             for (let i = numColors; i < colorSets.length; i++) {
                 if (colorSets[i]) {

--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -328,14 +328,6 @@ class AbsRelToggle extends React.Component<{ chart: ChartConfig }> {
     }
 }
 
-function boundRange(range: number[], start?: number, end?: number): number[] {
-    return range.filter(n => {
-        if (start !== undefined && n < start) return false
-        if (end !== undefined && n > end) return false
-        return true
-    })
-}
-
 @observer
 class TimelineControl extends React.Component<{ chart: ChartConfig }> {
     @action.bound onMapTargetChange({
@@ -364,19 +356,28 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
         this.props.chart.useTimelineDomains = false
     }
 
+    boundedYears(years: number[]) {
+        const chartProps = this.props.chart.props
+        const min = chartProps.timelineMinTime
+        const max = chartProps.timelineMaxTime
+        return years.filter(year => {
+            if (min !== undefined && year < min) return false
+            if (max !== undefined && year > max) return false
+            return true
+        })
+    }
+
     render() {
         const { chart } = this.props
-        const timelineMinTime = chart.props.timelineMinTime
-        const timelineMaxTime = chart.props.timelineMaxTime
         if (chart.props.tab === "map") {
             const { map } = chart
+            const years = this.boundedYears(map.data.timelineYears)
+            if (years.length === 0 || map.data.targetYear === undefined) {
+                return null
+            }
             return (
                 <Timeline
-                    years={boundRange(
-                        map.data.timelineYears,
-                        timelineMinTime,
-                        timelineMaxTime
-                    )}
+                    years={years}
                     onTargetChange={this.onMapTargetChange}
                     startYear={map.data.targetYear}
                     endYear={map.data.targetYear}
@@ -384,13 +385,11 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
                 />
             )
         } else if (chart.isScatter) {
+            const years = this.boundedYears(chart.scatter.timelineYears)
+            if (years.length === 0) return null
             return (
                 <Timeline
-                    years={boundRange(
-                        chart.scatter.timelineYears,
-                        timelineMinTime,
-                        timelineMaxTime
-                    )}
+                    years={years}
                     onTargetChange={this.onScatterTargetChange}
                     startYear={chart.scatter.startYear}
                     endYear={chart.scatter.endYear}
@@ -399,13 +398,11 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
                 />
             )
         } else if (chart.isLineChart) {
+            const years = this.boundedYears(chart.lineChart.timelineYears)
+            if (years.length === 0) return null
             return (
                 <Timeline
-                    years={boundRange(
-                        chart.lineChart.timelineYears,
-                        timelineMinTime,
-                        timelineMaxTime
-                    )}
+                    years={years}
                     onTargetChange={this.onScatterTargetChange}
                     startYear={chart.lineChart.startYear}
                     endYear={chart.lineChart.endYear}
@@ -415,13 +412,11 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
                 />
             )
         } else {
+            const years = this.boundedYears(chart.lineChart.timelineYears)
+            if (years.length === 0) return null
             return (
                 <Timeline
-                    years={boundRange(
-                        chart.lineChart.timelineYears,
-                        timelineMinTime,
-                        timelineMaxTime
-                    )}
+                    years={years}
                     onTargetChange={this.onScatterTargetChange}
                     startYear={chart.lineChart.startYear}
                     endYear={chart.lineChart.endYear}

--- a/charts/HTMLTimeline.tsx
+++ b/charts/HTMLTimeline.tsx
@@ -61,6 +61,14 @@ export class Timeline extends React.Component<TimelineProps> {
 
     constructor(props: TimelineProps) {
         super(props)
+
+        if (this.props.years.length === 0) {
+            // Lots of stuff in this class assumes the years array is non-empty,
+            // see e.g. minYear, maxYear, targetStartYear, targetEndYear. Should
+            // deal with this more gracefully -@jasoncrawford 2019-12-17
+            console.warn("invoking HTMLTimeline with empty years array")
+        }
+
         runInAction(() => {
             this.startYearInput = props.startYear
             this.endYearInput = props.endYear
@@ -82,10 +90,14 @@ export class Timeline extends React.Component<TimelineProps> {
     }
 
     @computed get minYear(): number {
+        // This cast is necessary because `years` might be empty. Should deal
+        // with an empty years array more gracefully -@jasoncrawford 2019-12-17
         return first(this.props.years) as number
     }
 
     @computed get maxYear(): number {
+        // This cast is necessary because `years` might be empty. Should deal
+        // with an empty years array more gracefully -@jasoncrawford 2019-12-17
         return last(this.props.years) as number
     }
 

--- a/charts/MapData.ts
+++ b/charts/MapData.ts
@@ -301,11 +301,12 @@ export class MapData {
         return !this.map.props.hideTimeline && this.timelineYears.length > 1
     }
 
-    @computed get targetYear(): number {
+    @computed get targetYear(): number | undefined {
         const targetYear = defaultTo(
             this.map.props.targetYear,
             last(this.timelineYears)
         )
+        if (targetYear === undefined) return undefined
         return defaultTo(
             findClosest(this.timelineYears, targetYear),
             last(this.timelineYears)
@@ -521,6 +522,7 @@ export class MapData {
     // Get values for the current year, without any color info yet
     @computed get valuesByEntity(): { [key: string]: MapDataValue } {
         const { map, mappableData, targetYear } = this
+        if (targetYear === undefined) return {}
 
         const { tolerance } = map
         const { years, values, entities } = mappableData

--- a/charts/MapTab.tsx
+++ b/charts/MapTab.tsx
@@ -32,7 +32,7 @@ interface MapWithLegendProps {
     bounds: Bounds
     choroplethData: ChoroplethData
     years: number[]
-    inputYear: number
+    inputYear?: number
     legendData: MapLegendBin[]
     legendTitle: string
     projection: MapProjection

--- a/charts/PointsWithLabels.tsx
+++ b/charts/PointsWithLabels.tsx
@@ -117,7 +117,9 @@ class ScatterGroupSingle extends React.Component<{
 }> {
     render() {
         const { group, isLayerMode, isConnected } = this.props
-        const value = first(group.values) as ScatterRenderValue
+        const value = first(group.values)
+        if (value === undefined) return null
+
         const color = group.isFocus || !isLayerMode ? group.color : "#e2e2e2"
 
         const isLabelled = group.allLabels.some(label => !label.isHidden)
@@ -170,8 +172,9 @@ class ScatterBackgroundLine extends React.Component<{
                 />
             )
         } else {
-            const firstValue = first(group.values) as ScatterRenderValue
-            const lastValue = last(group.values) as ScatterRenderValue
+            const firstValue = first(group.values)
+            const lastValue = last(group.values)
+            if (firstValue === undefined || lastValue === undefined) return null
             const color = !isLayerMode ? group.color : "#e2e2e2"
 
             let rotation = Vector2.angle(group.offsetVector, Vector2.up)

--- a/charts/ScatterPlot.tsx
+++ b/charts/ScatterPlot.tsx
@@ -10,7 +10,7 @@
 
 import * as React from "react"
 import { observable, computed, action } from "mobx"
-import { intersection, without, uniq } from "./Util"
+import { intersection, without, compact, uniq } from "./Util"
 import { observer } from "mobx-react"
 import { Bounds } from "./Bounds"
 import { ChartConfig } from "./ChartConfig"
@@ -413,8 +413,7 @@ class ScatterTooltip extends React.Component<ScatterTooltipProps> {
 
         const firstValue = first(series.values)
         const lastValue = last(series.values)
-        const values =
-            series.values.length === 1 ? [firstValue] : [firstValue, lastValue]
+        const values = compact(uniq([firstValue, lastValue]))
 
         const elements: Array<{ x: number; y: number; wrap: TextWrap }> = []
         let offset = 0

--- a/charts/Util.ts
+++ b/charts/Util.ts
@@ -16,6 +16,7 @@ import {
     every,
     min,
     max,
+    compact,
     uniq,
     cloneDeep,
     sum,
@@ -71,6 +72,7 @@ export {
     every,
     min,
     max,
+    compact,
     uniq,
     cloneDeep,
     sum,
@@ -287,11 +289,22 @@ export function defaultTo<T, K>(
     else return value
 }
 
-export function first<T>(arr: T[]) {
+export function first<T>(arr: T[]): T | undefined {
     return arr[0]
 }
-export function last<T>(arr: T[]) {
+
+export function last<T>(arr: T[]): T | undefined {
     return arr[arr.length - 1]
+}
+
+export function firstOfNonEmptyArray<T>(arr: T[]): T {
+    if (arr.length < 1) throw new Error("array is empty")
+    return first(arr) as T
+}
+
+export function lastOfNonEmptyArray<T>(arr: T[]): T {
+    if (arr.length < 1) throw new Error("array is empty")
+    return last(arr) as T
 }
 
 // Calculate the extents of a set of numbers, with safeguards for log scales


### PR DESCRIPTION
Our utils didn't acknowledge that these can return undefined when the
array is empty. One downstream consequence of this was a bunch of
console warnings about trying to format an invalid year of undefined.

The one thing I left in a funky state is Timeline, because it makes too
many assumptions. Instead, I tried not to render it if the years array
is empty, and I put a warning on the constructor if this is ever missed.
So far, no warnings in tests or on the console in dev.