### PR TITLE
Fix TextWrap bounds calculations for HTML

### DIFF
--- a/charts/Bounds.ts
+++ b/charts/Bounds.ts
@@ -78,6 +78,8 @@ export class Bounds {
             fontFamily?: string
         } = {}
     ): Bounds {
+        // Collapse contiguous spaces into one
+        str = str.replace(/ +/g, " ")
         const key = `${str}-${fontSize}`
         let bounds = this.textBoundsCache[key]
         if (bounds) {

--- a/charts/TextWrap.tsx
+++ b/charts/TextWrap.tsx
@@ -1,4 +1,4 @@
-import { isEmpty, reduce, max } from "./Util"
+import { isEmpty, reduce, max, stripHTML } from "./Util"
 import { computed } from "mobx"
 import { FontSize } from "./FontSize"
 import { defaultTo } from "./Util"
@@ -58,7 +58,13 @@ export class TextWrap {
 
         words.forEach(word => {
             const nextLine = line.concat([word])
-            const nextBounds = Bounds.forText(nextLine.join(" "), {
+
+            // Strip HTML if a raw string is passed
+            const text = this.props.raw
+                ? stripHTML(nextLine.join(" "))
+                : nextLine.join(" ")
+
+            const nextBounds = Bounds.forText(text, {
                 fontSize: fontSize
             })
 

--- a/charts/Util.ts
+++ b/charts/Util.ts
@@ -113,6 +113,7 @@ export {
 
 import { format } from "d3-format"
 import { extent } from "d3-array"
+import * as striptags from "striptags"
 
 import { Vector2 } from "./Vector2"
 import { TickFormattingOptions } from "./TickFormattingOptions"
@@ -462,4 +463,8 @@ export async function fetchJSON(url: string): Promise<any> {
     // const response = await window.fetch(url)
     // const result = await response.json()
     // return result
+}
+
+export function stripHTML(html: string): string {
+    return striptags(html)
 }

--- a/charts/__tests__/TextWrap.test.ts
+++ b/charts/__tests__/TextWrap.test.ts
@@ -1,0 +1,49 @@
+import { TextWrap } from "../TextWrap"
+import { Bounds } from "../Bounds"
+
+const FONT_SIZE = 14
+
+describe(TextWrap, () => {
+    describe("width()", () => {
+        function stringWidth(text: string): number {
+            return Bounds.forText(text, { fontSize: FONT_SIZE }).width
+        }
+
+        function renderedWidth(text: string, raw?: true): number {
+            const textwrap = new TextWrap({
+                maxWidth: Infinity,
+                fontSize: FONT_SIZE,
+                text,
+                raw
+            })
+            return textwrap.width
+        }
+
+        it("correct for single line text", () => {
+            const text = "an example line"
+            expect(stringWidth(text)).toEqual(renderedWidth(text))
+        })
+
+        it("collapses congiguous spaces", () => {
+            const text = "an example    spaced   out text"
+            expect(stringWidth(text)).toEqual(renderedWidth(text))
+        })
+
+        it("strips HTML in raw strings", () => {
+            const html = "<b>an example</b> line, <i> hopefully </i> it works"
+            const text = "an example line, hopefully it works"
+            expect(stringWidth(text)).toEqual(renderedWidth(html, true))
+        })
+
+        it("strips HTML when the first word token is an HTML tag", () => {
+            const html = "<b>  test</b>"
+            const text = " test"
+            expect(stringWidth(text)).toEqual(renderedWidth(html, true))
+        })
+
+        it("doesn't naively strip '<' and '>' symbols", () => {
+            const text = "text that contains <  and  > symbols that aren't HTML"
+            expect(stringWidth(text)).toEqual(renderedWidth(text, true))
+        })
+    })
+})

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
         "smooth-scroll": "^16.1.0",
         "string-pixel-width": "^1.9.0",
         "stripe": "^7.1.0",
+        "striptags": "^3.1.1",
         "style-loader": "^0.23.1",
         "supertest": "^4.0.2",
         "timeago.js": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14983,6 +14983,11 @@ stripe@^7.1.0:
     safe-buffer "^5.1.1"
     uuid "^3.3.2"
 
+striptags@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/striptags/-/striptags-3.1.1.tgz#c8c3e7fdd6fb4bb3a32a3b752e5b5e3e38093ebd"
+  integrity sha1-yMPn/db7S7OjKjt1LltePjgJPr0=
+
 style-loader@^0.23.1:
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.23.1.tgz#cb9154606f3e771ab6c4ab637026a1049174d925"


### PR DESCRIPTION
I knew [this one](https://github.com/owid/owid-grapher/commit/5ef074a48380ff38a31af4d1630251cbefc0b635) was coming to bite me at some point.

I recently noticed that the license for the charts was aligned to the left and it used to be aligned to the right:

<img width="795" alt="Screenshot_2019-12-18_at_14_18_37" src="https://user-images.githubusercontent.com/1308115/71093741-b77b8c00-21a1-11ea-8fa7-e133dd2bed30.png">

This happens because **the text bounds calculation was done including the HTML content, so the text width calculation treated the HTML tags as renderable text.**

**This PR strips HTML before calculating the width.**

Maybe a useful note while on this topic:

We use `pixelWidth()` to calculate the rendered space used by text – it's just a library that contains the rough dimension of letters and sums them up. This is not bulletproof and the charts would break if the used font is not available on the client, or if the text rendering of the OS is very different from others (like some Linux distros).