### PR TITLE
Fade out non-highlighted countries on map

### DIFF
--- a/charts/ChoroplethMap.tsx
+++ b/charts/ChoroplethMap.tsx
@@ -388,9 +388,12 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
                     {sortBy(
                         dataFeatures.map(d => {
                             const isFocus = this.hasFocus(d.id)
+                            const outOfFocusBracket =
+                                !!this.focusBracket && !isFocus
                             const datum = choroplethData[d.id as string]
                             const stroke = isFocus ? focusColor : "#333"
                             const fill = datum ? datum.color : defaultFill
+                            const fillOpacity = outOfFocusBracket ? 0.4 : 1
 
                             return (
                                 <path
@@ -403,6 +406,7 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
                                     stroke={stroke}
                                     cursor="pointer"
                                     fill={fill}
+                                    fillOpacity={fillOpacity}
                                     onClick={() => this.props.onClick(d.geo)}
                                     onMouseEnter={ev =>
                                         this.onMouseEnter(d, ev)

--- a/charts/ChoroplethMap.tsx
+++ b/charts/ChoroplethMap.tsx
@@ -309,7 +309,7 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
             noDataFeatures,
             dataFeatures
         } = this
-        const focusColor = "#FFEC38"
+        const focusColor = "#111"
         const focusStrokeWidth = 2.5
 
         return (


### PR DESCRIPTION
For #268.

* The focussed countries now have a black border instead of a yellow one (the black tone is a little "blacker" than the one for non-focussed countries).
  * Note, though, that the legend still has a yellow border. I wasn't sure whether that color should be changed as well.
* When countries are focussed by hovering the legend (as opposed to hovering over a country itself), all other countries now get a `fill-opacity` of `.4`, fading them out.

It now looks like this:
![image](https://user-images.githubusercontent.com/2641501/71969341-bff63e00-3206-11ea-8017-92696882b06f.png)
