### PR TITLE
Fix disappearing chart while indicator is loading

### DIFF
--- a/charts/Bounds.ts
+++ b/charts/Bounds.ts
@@ -66,7 +66,7 @@ export class Bounds {
     }
 
     static forText(
-        str: string,
+        str: string = "",
         {
             x = 0,
             y = 0,

--- a/charts/ChartTab.tsx
+++ b/charts/ChartTab.tsx
@@ -12,6 +12,7 @@ import { DiscreteBarChart } from "./DiscreteBarChart"
 import { StackedBarChart } from "./StackedBarChart"
 import { ChartLayout, ChartLayoutView } from "./ChartLayout"
 import { TimeScatter } from "./TimeScatter"
+import { LoadingChart } from "./LoadingChart"
 
 @observer
 export class ChartTab extends React.Component<{
@@ -38,7 +39,8 @@ export class ChartTab extends React.Component<{
         const { chart, chartView } = this.props
         const bounds = this.layout.innerBounds
 
-        if (chart.isSlopeChart)
+        if (!chart.data.isReady) return <LoadingChart bounds={bounds} />
+        else if (chart.isSlopeChart)
             return <SlopeChart bounds={bounds.padTop(20)} chart={chart} />
         else if (chart.isScatter)
             return (

--- a/charts/ChartView.tsx
+++ b/charts/ChartView.tsx
@@ -233,7 +233,6 @@ export class ChartView extends React.Component<ChartViewProps> {
 
     @observable hasBeenVisible: boolean = false
     @observable hasError: boolean = false
-    @observable isInitialLoad: boolean = true
 
     // Resolved when this.chart.data.isReady becomes true; used for testing
     resolveReady: () => void = () => undefined
@@ -414,21 +413,16 @@ export class ChartView extends React.Component<ChartViewProps> {
     @action.bound onUpdate() {
         // handler always runs on resize and resets the base font size
         this.setBaseFontSize()
-        if (
-            this.chart.data.isReady &&
-            this.hasBeenVisible &&
-            this.isInitialLoad
-        ) {
+        if (this.chart.data.isReady && this.hasBeenVisible) {
             select(this.base.current!)
                 .selectAll(".chart > *")
                 .style("opacity", 0)
                 .transition()
                 .style("opacity", null)
-            this.isInitialLoad = false
         } else {
             this.checkVisibility()
         }
-        if (this.chart.data.isReady) {
+        if (this.hasBeenVisible && this.chart.data.isReady) {
             this.resolveReady()
         }
     }

--- a/charts/ChartView.tsx
+++ b/charts/ChartView.tsx
@@ -234,12 +234,6 @@ export class ChartView extends React.Component<ChartViewProps> {
     @observable hasBeenVisible: boolean = false
     @observable hasError: boolean = false
 
-    // Resolved when this.chart.data.isReady becomes true; used for testing
-    resolveReady: () => void = () => undefined
-    readyPromise: Promise<void> = new Promise<void>((resolve, reject) => {
-        this.resolveReady = resolve
-    })
-
     @computed get classNames(): string {
         const classNames = [
             "chart",
@@ -421,9 +415,6 @@ export class ChartView extends React.Component<ChartViewProps> {
                 .style("opacity", null)
         } else {
             this.checkVisibility()
-        }
-        if (this.hasBeenVisible && this.chart.data.isReady) {
-            this.resolveReady()
         }
     }
 

--- a/charts/ChartView.tsx
+++ b/charts/ChartView.tsx
@@ -33,6 +33,16 @@ interface ChartViewProps {
     isEmbed?: boolean
 }
 
+function isVisible(elm: HTMLElement | null) {
+    if (!elm || !elm.getBoundingClientRect) return false
+    const rect = elm.getBoundingClientRect()
+    const viewHeight = Math.max(
+        document.documentElement.clientHeight,
+        window.innerHeight
+    )
+    return !(rect.bottom < 0 || rect.top - viewHeight >= 0)
+}
+
 @observer
 export class ChartView extends React.Component<ChartViewProps> {
     static bootstrap({
@@ -397,17 +407,7 @@ export class ChartView extends React.Component<ChartViewProps> {
 
     // Chart should only render SVG when it's on the screen
     @action.bound checkVisibility() {
-        function checkVisible(elm: HTMLElement | null) {
-            if (!elm || !elm.getBoundingClientRect) return false
-            const rect = elm.getBoundingClientRect()
-            const viewHeight = Math.max(
-                document.documentElement.clientHeight,
-                window.innerHeight
-            )
-            return !(rect.bottom < 0 || rect.top - viewHeight >= 0)
-        }
-
-        if (!this.hasBeenVisible && checkVisible(this.base.current)) {
+        if (!this.hasBeenVisible && isVisible(this.base.current)) {
             this.hasBeenVisible = true
         }
     }

--- a/charts/ChartView.tsx
+++ b/charts/ChartView.tsx
@@ -333,6 +333,40 @@ export class ChartView extends React.Component<ChartViewProps> {
         )
     }
 
+    renderError() {
+        return (
+            <div
+                style={{
+                    width: "100%",
+                    height: "100%",
+                    position: "relative",
+                    display: "flex",
+                    flexDirection: "column",
+                    justifyContent: "center",
+                    textAlign: "center",
+                    lineHeight: 1.5,
+                    padding: "3rem"
+                }}
+            >
+                <p style={{ color: "#cc0000", fontWeight: 700 }}>
+                    <FontAwesomeIcon icon={faExclamationTriangle} /> There was a
+                    problem loading this chart
+                </p>
+                <p>
+                    We have been notified of this error, please check back later
+                    whether it's been fixed. If the error persists, get in touch
+                    with us at{" "}
+                    <a
+                        href={`mailto:info@ourworldindata.org?subject=Broken chart on page ${window.location.href}`}
+                    >
+                        info@ourworldindata.org
+                    </a>
+                    .
+                </p>
+            </div>
+        )
+    }
+
     renderMain() {
         // TODO how to handle errors in exports?
         // TODO tidy this up
@@ -347,53 +381,11 @@ export class ChartView extends React.Component<ChartViewProps> {
                 fontSize: this.chart.baseFontSize
             }
 
-            if (this.hasError) {
-                return (
-                    <div className={this.classNames} style={style}>
-                        <div
-                            style={{
-                                width: "100%",
-                                height: "100%",
-                                position: "relative",
-                                display: "flex",
-                                flexDirection: "column",
-                                justifyContent: "center",
-                                textAlign: "center",
-                                lineHeight: 1.5,
-                                padding: "3rem"
-                            }}
-                        >
-                            <p style={{ color: "#cc0000", fontWeight: 700 }}>
-                                <FontAwesomeIcon icon={faExclamationTriangle} />{" "}
-                                There was a problem loading this chart
-                            </p>
-                            <p>
-                                We have been notified of this error, please
-                                check back later whether it's been fixed. If the
-                                error persists, get in touch with us at{" "}
-                                <a
-                                    href={`mailto:info@ourworldindata.org?subject=Broken chart on page ${window.location.href}`}
-                                >
-                                    info@ourworldindata.org
-                                </a>
-                                .
-                            </p>
-                        </div>
-                    </div>
-                )
-            } else {
-                return (
-                    this.chart.data.isReady && (
-                        <div
-                            ref={this.base}
-                            className={this.classNames}
-                            style={style}
-                        >
-                            {this.renderReady()}
-                        </div>
-                    )
-                )
-            }
+            return (
+                <div ref={this.base} className={this.classNames} style={style}>
+                    {this.hasError ? this.renderError() : this.renderReady()}
+                </div>
+            )
         }
     }
 

--- a/charts/DiscreteBarChart.tsx
+++ b/charts/DiscreteBarChart.tsx
@@ -65,7 +65,11 @@ export class DiscreteBarChart extends React.Component<{
         const labels = this.currentData.map(d => d.label)
         if (this.hasAddButton)
             labels.push(` + ${this.context.chartView.controls.addButtonLabel}`)
-        const longestLabel = sortBy(labels, d => -d.length)[0]
+        // TypeScript assumes that indexes always return the array type, but it can also be undefined
+        // Issue: https://github.com/microsoft/TypeScript/issues/13778
+        const longestLabel = sortBy(labels, d => -d.length)[0] as
+            | string
+            | undefined
         return Bounds.forText(longestLabel, { fontSize: this.legendFontSize })
             .width
     }

--- a/charts/LoadingChart.tsx
+++ b/charts/LoadingChart.tsx
@@ -1,0 +1,38 @@
+import * as React from "react"
+import { Bounds } from "./Bounds"
+import { ControlsOverlay } from "./Controls"
+
+// For arcane reasons, the ControlsOverlay only allows passing React components as children, not
+// any HTML elements.
+class LoadingAnimation extends React.Component<{ bounds: Bounds }> {
+    render() {
+        const { bounds } = this.props
+        return (
+            <div
+                className="loading-chart"
+                style={{
+                    position: "absolute",
+                    top: bounds.top,
+                    left: bounds.left,
+                    width: bounds.width,
+                    height: bounds.height
+                }}
+            ></div>
+        )
+    }
+}
+
+export class LoadingChart extends React.Component<{ bounds: Bounds }> {
+    render() {
+        // The charts are rendered within an SVG element while the initial chart loading animation
+        // that we use for our charts is coded in HTML with CSS animations.
+        // In order to keep the animation consistent, we render HTML in an overlay (by using a React
+        // portal, ControlsOverlay).
+        // -@danielgavrilov, 2020-01-07
+        return (
+            <ControlsOverlay id="loading-chart">
+                <LoadingAnimation bounds={this.props.bounds} />
+            </ControlsOverlay>
+        )
+    }
+}

--- a/charts/MapTab.tsx
+++ b/charts/MapTab.tsx
@@ -17,12 +17,12 @@ import { MapConfig } from "./MapConfig"
 import { MapLegendBin } from "./MapData"
 import { MapProjection } from "./MapProjection"
 import { Tooltip } from "./Tooltip"
-import { NoData } from "./NoData"
 import { select } from "d3-selection"
 import { easeCubic } from "d3-ease"
 import { ChartViewContext, ChartViewContextType } from "./ChartViewContext"
 import { ChartLayout, ChartLayoutView } from "./ChartLayout"
 import { ChartView } from "./ChartView"
+import { LoadingChart } from "./LoadingChart"
 
 // TODO refactor to use transform pattern, bit too much info for a pure component
 
@@ -296,23 +296,25 @@ export class MapTab extends React.Component<MapTabProps> {
 
     render() {
         const { map } = this
-        if (!map.data.isReady) return <NoData bounds={this.props.bounds} />
-
         const { layout } = this
 
         return (
             <ChartLayoutView layout={this.layout}>
-                <MapWithLegend
-                    bounds={layout.innerBounds}
-                    choroplethData={map.data.choroplethData}
-                    years={map.data.timelineYears}
-                    inputYear={map.data.targetYear}
-                    legendData={map.data.legendData}
-                    legendTitle={map.data.legendTitle}
-                    projection={map.projection}
-                    defaultFill={map.noDataColor}
-                    mapToDataEntities={map.data.mapToDataEntities}
-                />
+                {this.props.chart.data.isReady ? (
+                    <MapWithLegend
+                        bounds={layout.innerBounds}
+                        choroplethData={map.data.choroplethData}
+                        years={map.data.timelineYears}
+                        inputYear={map.data.targetYear}
+                        legendData={map.data.legendData}
+                        legendTitle={map.data.legendTitle}
+                        projection={map.projection}
+                        defaultFill={map.noDataColor}
+                        mapToDataEntities={map.data.mapToDataEntities}
+                    />
+                ) : (
+                    <LoadingChart bounds={layout.innerBounds} />
+                )}
             </ChartLayoutView>
         )
     }

--- a/charts/__tests__/ExploreView.test.tsx
+++ b/charts/__tests__/ExploreView.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { shallow, mount, ReactWrapper } from "enzyme"
+import { observe } from "mobx"
 
 import { ExploreView } from "../ExploreView"
 import { Bounds } from "../Bounds"
@@ -39,9 +40,18 @@ function mockDataResponse() {
     apiMock.mockVariable(104402)
 }
 
+async function whenReady(chartView: ChartView): Promise<void> {
+    return new Promise(resolve => {
+        const data = chartView.chart.data
+        observe(data, "isReady", () => {
+            if (data.isReady) resolve()
+        })
+    })
+}
+
 async function updateViewWhenReady(exploreView: ReactWrapper) {
     const chartView = exploreView.find(ChartView).first()
-    await (chartView.instance() as ChartView).readyPromise
+    await whenReady(chartView.instance() as ChartView)
     exploreView.update()
 }
 

--- a/charts/__tests__/ExploreView.test.tsx
+++ b/charts/__tests__/ExploreView.test.tsx
@@ -176,7 +176,6 @@ describe(ExploreView, () => {
             const model = getEmptyModel()
             const view = mount(<ExploreView bounds={bounds} model={model} />)
             expect(view.find(ChartView)).toHaveLength(1)
-            expect(view.find(".chart h1")).toHaveLength(0)
 
             model.indicatorId = indicator.id
             await updateViewWhenReady(view)

--- a/charts/client/chart.scss
+++ b/charts/client/chart.scss
@@ -12,13 +12,15 @@ $zindex-Tooltip: 100;
 $zindex-DataSelector: 110;
 $zindex-IndicatorDropdown: 200;
 
-figure[data-grapher-src]:empty {
+figure[data-grapher-src]:empty,
+.loading-chart {
     display: flex;
     align-items: center;
     justify-content: center;
 }
 
-figure[data-grapher-src]:empty:after {
+figure[data-grapher-src]:empty:after,
+.loading-chart:after {
     content: "";
     border: 5px solid #333;
     border-radius: 30px;


### PR DESCRIPTION
It used to be the case that the chart view disappears (element is fully removed from the DOM tree) while the data is loading, e.g. when switching an indicator.

Changes:
- The ChartView is always shown, even while loading the data
- If available, the header and notes/sources of a chart are shown (indicator data)
- The chart plot is replaced with a loading indicator while the data is loading. This is the same loading indicator that appears