### PR TITLE
Fade out no-data countries as well

### DIFF
--- a/charts/ChoroplethMap.tsx
+++ b/charts/ChoroplethMap.tsx
@@ -360,7 +360,13 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
                         <g className="noDataFeatures">
                             {noDataFeatures.map(d => {
                                 const isFocus = this.hasFocus(d.id)
+                                const outOfFocusBracket =
+                                    !!this.focusBracket && !isFocus
                                 const stroke = isFocus ? focusColor : "#aaa"
+                                const fillOpacity = outOfFocusBracket ? 0.2 : 1
+                                const strokeOpacity = outOfFocusBracket
+                                    ? 0.5
+                                    : 1
                                 return (
                                     <path
                                         key={d.id}
@@ -370,8 +376,10 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
                                             viewportScale
                                         }
                                         stroke={stroke}
+                                        strokeOpacity={strokeOpacity}
                                         cursor="pointer"
                                         fill={defaultFill}
+                                        fillOpacity={fillOpacity}
                                         onClick={() =>
                                             this.props.onClick(d.geo)
                                         }


### PR DESCRIPTION
This is in addition to the recently-merged #301. It fades out countries without data, too.
I like it better this way, but this may be a matter of taste.

## Before (http://localhost:3099/grapher/fatalities-from-terrorism?region=Asia):
![image](https://user-images.githubusercontent.com/2641501/72095207-58301800-3318-11ea-9715-69554dfc9926.png)

---

## After:
![image](https://user-images.githubusercontent.com/2641501/72095224-5cf4cc00-3318-11ea-9f94-46456250cbfc.png)

