### PR TITLE
Hide tooltip when the cursor leaves the map, even in literal "edge" cases

### DIFF
--- a/charts/ChoroplethMap.tsx
+++ b/charts/ChoroplethMap.tsx
@@ -318,6 +318,7 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
                 className="ChoroplethMap"
                 clipPath={`url(#boundsClip-${uid})`}
                 onMouseMove={this.onMouseMove}
+                onMouseLeave={this.onMouseLeave}
                 onClick={this.onClick}
                 style={this.hoverFeature ? { cursor: "pointer" } : {}}
             >

--- a/charts/MapLegend.tsx
+++ b/charts/MapLegend.tsx
@@ -330,7 +330,7 @@ class NumericMapLegendView extends React.Component<{
                             />
                         )
                     }),
-                    r => r.props["stroke-width"]
+                    r => r.props["strokeWidth"]
                 )}
                 {numericLabels.map(label => (
                     <text


### PR DESCRIPTION
Fixes an issue where we could get into a state where a tooltip is shown on top of the Data or Sources tab:
![image](https://user-images.githubusercontent.com/2641501/72095818-83673700-3319-11ea-833d-904f98c4e652.png)

This happens whenever a country expands right up to the edge. For example when you leave towards the lower left corner in https://ourworldindata.org/grapher/fatalities-from-terrorism?region=Asia.