### PR TITLE
Map: Don't show Tooltip for countries outside the projection

### DIFF
--- a/charts/ChoroplethMap.tsx
+++ b/charts/ChoroplethMap.tsx
@@ -250,13 +250,13 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
     @action.bound onMouseMove(ev: React.MouseEvent<SVGGElement>) {
         if (this.hoverEnterFeature) return
 
-        const { renderFeatures } = this
+        const { projectionFeatures } = this
         const mouse = getRelativeMouse(
             this.base.current!.querySelector(".subunits"),
             ev
         )
 
-        const featuresWithDistance = renderFeatures.map(d => {
+        const featuresWithDistance = projectionFeatures.map(d => {
             return { feature: d, distance: Vector2.distance(d.center, mouse) }
         })
 

--- a/charts/MapLegend.tsx
+++ b/charts/MapLegend.tsx
@@ -708,7 +708,6 @@ export class MapLegendView extends React.Component<MapLegendViewProps> {
                         onMouseLeave={onMouseLeave}
                     />
                 )}
-                />}
                 {mainLabel.render(
                     bounds.centerX - mainLabel.width / 2,
                     bounds.bottom - mainLabel.height


### PR DESCRIPTION
Until now, Grapher showed Tooltips for countries outside the current projection:
![image](https://user-images.githubusercontent.com/2641501/73126462-0c859b80-3fb3-11ea-8ddd-72bc57b2469a.png)

This is very inconsistent, for multiple reasons:
* The country for which the tooltip is shown is not even highlighted with a thicker border (the cursor changes to `pointer`, though).
* Tooltips were only shown using the "close to center" logic (`onMouseMove`), not the "inside country" logic (`onMouseEnter`). Therefore, a tooltip is not shown for large countries even if your cursor is inside it (Brazil with "Africa" projection is a good example).

This PR changes it so a tooltip is never shown for countries outside the current projection.

cc @danielgavrilov 