### PR TITLE
Discrete Bar: Use same color from ColorScheme for equal values

### DIFF
--- a/charts/DiscreteBarTransform.ts
+++ b/charts/DiscreteBarTransform.ts
@@ -105,7 +105,7 @@ export class DiscreteBarTransform implements IChartTransform {
                 if (
                     currentDatum &&
                     Math.abs(currentDatum.year - targetYear) <
-                    Math.abs(year - targetYear)
+                        Math.abs(year - targetYear)
                 )
                     continue
 


### PR DESCRIPTION
Solves #72, by de-duping the values and then creating a map value->color using the color scheme.

Note: I wasn't able to extensively test this locally because I only have a limited dataset on my machine. But it seems to work.

