### PR TITLE
show timeline for slope charts

### DIFF
--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -338,7 +338,7 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
         this.props.chart.map.targetYear = targetStartYear
     }
 
-    @action.bound onScatterTargetChange({
+    @action.bound onChartTargetChange({
         targetStartYear,
         targetEndYear
     }: {
@@ -390,7 +390,7 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
             return (
                 <Timeline
                     years={years}
-                    onTargetChange={this.onScatterTargetChange}
+                    onTargetChange={this.onChartTargetChange}
                     startYear={chart.scatter.startYear}
                     endYear={chart.scatter.endYear}
                     onStartDrag={this.onTimelineStart}
@@ -403,7 +403,7 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
             return (
                 <Timeline
                     years={years}
-                    onTargetChange={this.onScatterTargetChange}
+                    onTargetChange={this.onChartTargetChange}
                     startYear={chart.lineChart.startYear}
                     endYear={chart.lineChart.endYear}
                     onStartDrag={this.onTimelineStart}
@@ -417,7 +417,7 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
             return (
                 <Timeline
                     years={years}
-                    onTargetChange={this.onScatterTargetChange}
+                    onTargetChange={this.onChartTargetChange}
                     startYear={chart.slopeChart.startYear}
                     endYear={chart.slopeChart.endYear}
                     onStartDrag={this.onTimelineStart}
@@ -431,7 +431,7 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
             return (
                 <Timeline
                     years={years}
-                    onTargetChange={this.onScatterTargetChange}
+                    onTargetChange={this.onChartTargetChange}
                     startYear={chart.lineChart.startYear}
                     endYear={chart.lineChart.endYear}
                     onStartDrag={this.onTimelineStart}

--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -411,6 +411,20 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
                     singleYearPlay={true}
                 />
             )
+        } else if (chart.isSlopeChart) {
+            const years = this.boundedYears(chart.slopeChart.timelineYears)
+            if (years.length === 0) return null
+            return (
+                <Timeline
+                    years={years}
+                    onTargetChange={this.onScatterTargetChange}
+                    startYear={chart.slopeChart.startYear}
+                    endYear={chart.slopeChart.endYear}
+                    onStartDrag={this.onTimelineStart}
+                    onStopDrag={this.onTimelineStop}
+                    singleYearPlay={false}
+                />
+            )
         } else {
             const years = this.boundedYears(chart.lineChart.timelineYears)
             if (years.length === 0) return null
@@ -462,6 +476,8 @@ export class Controls {
             return true
         else if (chart.tab === "chart" && chart.isLineChart)
             return !chart.props.hideTimeline
+        else if (chart.tab === "chart" && chart.isSlopeChart)
+            return chart.slopeChart.hasTimeline
         else return false
     }
 

--- a/charts/SlopeChartTransform.ts
+++ b/charts/SlopeChartTransform.ts
@@ -66,6 +66,14 @@ export class SlopeChartTransform implements IChartTransform {
         return defaultTo(max(this.timelineYears), 2000)
     }
 
+    @computed get hasTimeline(): boolean {
+        return (
+            this.minTimelineYear !== this.maxTimelineYear &&
+            this.timelineYears.length > 2 &&
+            !this.chart.props.hideTimeline
+        )
+    }
+
     @computed get startYear(): number {
         const minYear = defaultWith(
             this.chart.timeDomain[0],


### PR DESCRIPTION
Hello 👋

It has been a while :) I had some free time and decided to check back in on one of my favorite github projects.

This is a very simple PR to get interactive timeline for slope charts as requested here: https://github.com/owid/owid-grapher/issues/256

It works for the most part. Except playing a video starts with a view of no data which can definitely be improved. Let me know and I can make that improvement in this PR. 

Note that all current slope charts will start showing timeline control by default.

Example screenshot:

<img width="953" alt="Screenshot 2020-01-25 16 23 53" src="https://user-images.githubusercontent.com/4923428/73129016-17c6d000-3f8f-11ea-8611-f1640345cc90.png">


