### PR TITLE
Ability to preview color schemes in the dropdown

### DIFF
--- a/admin/client/ColorSchemeDropdown.tsx
+++ b/admin/client/ColorSchemeDropdown.tsx
@@ -1,4 +1,4 @@
-import React = require("react")
+import * as React from "react"
 import { computed, action } from "mobx"
 import Select, { ValueType } from "react-select"
 import { ColorScheme, ColorSchemes } from "charts/ColorSchemes"

--- a/admin/client/ColorSchemeDropdown.tsx
+++ b/admin/client/ColorSchemeDropdown.tsx
@@ -3,6 +3,7 @@ import { computed, action } from "mobx"
 import Select, { ValueType } from "react-select"
 import { ColorScheme, ColorSchemes } from "charts/ColorSchemes"
 import { observer } from "mobx-react"
+import { bind } from "decko"
 
 export interface ColorSchemeOption {
     colorScheme?: ColorScheme
@@ -79,7 +80,7 @@ export class ColorSchemeDropdown extends React.Component<
         this.props.onChange(selected as ColorSchemeOption)
     }
 
-    @action.bound formatOptionLabel(option: ColorSchemeOption) {
+    @bind formatOptionLabel(option: ColorSchemeOption) {
         const { invertedColorScheme } = this.props
 
         return (

--- a/admin/client/ColorSchemeDropdown.tsx
+++ b/admin/client/ColorSchemeDropdown.tsx
@@ -131,6 +131,7 @@ export class ColorSchemeDropdown extends React.Component<
                         }
                     }
                 }}
+                menuPlacement="auto"
             />
         )
     }

--- a/admin/client/ColorSchemeDropdown.tsx
+++ b/admin/client/ColorSchemeDropdown.tsx
@@ -12,7 +12,7 @@ export interface ColorSchemeOption {
 }
 
 export interface ColorSchemeDropdownProps {
-    additionalColorSchemes: ColorSchemeOption[]
+    additionalOptions: ColorSchemeOption[]
     initialValue?: string
     gradientColorCount: number
     invertedColorScheme: boolean
@@ -24,35 +24,39 @@ export class ColorSchemeDropdown extends React.Component<
     ColorSchemeDropdownProps
 > {
     static defaultProps = {
-        additionalColorSchemes: [],
+        additionalOptions: [],
         gradientColorCount: 6,
         invertedColorScheme: false
     }
 
-    @computed get additionalColorSchemes() {
-        return this.props.additionalColorSchemes
+    @computed get additionalOptions() {
+        return this.props.additionalOptions
     }
 
     @computed get gradientColorCount() {
         return this.props.gradientColorCount
     }
 
-    @computed get availableColorSchemes() {
-        const { additionalColorSchemes, gradientColorCount } = this
-
-        return additionalColorSchemes.concat(
-            Object.entries(ColorSchemes).map(([key, scheme]) => {
+    @computed get colorSchemeOptions() {
+        return Object.entries(ColorSchemes)
+            .filter(([, v]) => v !== undefined)
+            .map(([key, scheme]) => {
                 return {
                     colorScheme: scheme as ColorScheme,
                     gradient: this.createLinearGradient(
                         scheme as ColorScheme,
-                        gradientColorCount
+                        this.gradientColorCount
                     ),
                     label: (scheme as ColorScheme).name,
                     value: key
                 }
             })
-        )
+    }
+
+    @computed get allOptions() {
+        const { additionalOptions } = this
+
+        return additionalOptions.concat(this.colorSchemeOptions)
     }
 
     createLinearGradient(colorScheme: ColorScheme, count: number) {
@@ -112,10 +116,10 @@ export class ColorSchemeDropdown extends React.Component<
 
         return (
             <Select
-                options={this.availableColorSchemes}
+                options={this.allOptions}
                 formatOptionLabel={this.formatOptionLabel}
                 onChange={this.onChange}
-                defaultValue={this.availableColorSchemes.find(
+                defaultValue={this.allOptions.find(
                     scheme => scheme.value === initialValue
                 )}
                 styles={{

--- a/admin/client/ColorSchemeDropdown.tsx
+++ b/admin/client/ColorSchemeDropdown.tsx
@@ -1,0 +1,125 @@
+import React = require("react")
+import { computed, action } from "mobx"
+import Select, { ValueType } from "react-select"
+import { ColorScheme, ColorSchemes } from "charts/ColorSchemes"
+
+export interface ColorSchemeOption {
+    colorScheme?: ColorScheme
+    gradient?: string
+    label: string
+    value: string
+}
+
+export interface ColorSchemeDropdownProps {
+    additionalColorSchemes: ColorSchemeOption[]
+    defaultValue?: string
+    gradientColorCount: number
+    invertedColorScheme: boolean
+    onChange: (selected: ColorSchemeOption) => void
+}
+
+export class ColorSchemeDropdown extends React.Component<
+    ColorSchemeDropdownProps
+> {
+    static defaultProps = {
+        additionalColorSchemes: [],
+        gradientColorCount: 6
+    }
+
+    @computed get availableColorSchemes() {
+        const { additionalColorSchemes, gradientColorCount } = this.props
+
+        return additionalColorSchemes.concat(
+            Object.entries(ColorSchemes).map(([key, scheme]) => {
+                return {
+                    colorScheme: scheme as ColorScheme,
+                    gradient: this.createLinearGradient(
+                        scheme as ColorScheme,
+                        gradientColorCount
+                    ),
+                    label: (scheme as ColorScheme).name,
+                    value: key
+                }
+            })
+        )
+    }
+
+    createLinearGradient(colorScheme: ColorScheme, count: number) {
+        const colors = colorScheme.getColors(count)
+
+        const step = 100 / count
+        const gradientEntries = colors.map(
+            (color, i) => `${color} ${i * step}%, ${color} ${(i + 1) * step}%`
+        )
+
+        return `linear-gradient(90deg, ${gradientEntries.join(", ")})`
+    }
+
+    @action.bound onChange(selected: ValueType<ColorSchemeOption>) {
+        // The onChange method can return an array of values (when multiple
+        // items can be selected) or a single value. Since we are certain that
+        // we are not using the multi-option select we can force the type to be
+        // a single value.
+
+        this.props.onChange(selected as ColorSchemeOption)
+    }
+
+    @action.bound formatOptionLabel(option: ColorSchemeOption) {
+        const { invertedColorScheme } = this.props
+
+        return (
+            <div
+                style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center"
+                }}
+            >
+                <div>{option.label}</div>
+                <span
+                    style={{
+                        backgroundImage: option.gradient,
+                        width: "6rem",
+                        height: "1.25rem",
+                        border: option.gradient ? "1px solid #aaa" : undefined,
+
+                        // Mirror the element if color schemes are inverted
+                        transform: invertedColorScheme
+                            ? "scaleX(-1)"
+                            : undefined
+                    }}
+                />
+            </div>
+        )
+    }
+
+    render() {
+        const { defaultValue } = this.props
+
+        return (
+            <Select
+                label="Color scheme"
+                options={this.availableColorSchemes}
+                formatOptionLabel={this.formatOptionLabel}
+                onChange={this.onChange}
+                defaultValue={this.availableColorSchemes.find(
+                    scheme => scheme.value === defaultValue
+                )}
+                styles={{
+                    singleValue: provided => {
+                        return {
+                            ...provided,
+                            width: "calc(100% - 10px)"
+                        }
+                    },
+                    indicatorSeparator: provided => {
+                        return {
+                            ...provided,
+                            visibility: "hidden"
+                        }
+                    }
+                }}
+            />
+        )
+    }
+}

--- a/admin/client/ColorSchemeDropdown.tsx
+++ b/admin/client/ColorSchemeDropdown.tsx
@@ -13,7 +13,7 @@ export interface ColorSchemeOption {
 
 export interface ColorSchemeDropdownProps {
     additionalColorSchemes: ColorSchemeOption[]
-    defaultValue?: string
+    initialValue?: string
     gradientColorCount: number
     invertedColorScheme: boolean
     onChange: (selected: ColorSchemeOption) => void
@@ -25,7 +25,8 @@ export class ColorSchemeDropdown extends React.Component<
 > {
     static defaultProps = {
         additionalColorSchemes: [],
-        gradientColorCount: 6
+        gradientColorCount: 6,
+        invertedColorScheme: false
     }
 
     @computed get additionalColorSchemes() {
@@ -107,7 +108,7 @@ export class ColorSchemeDropdown extends React.Component<
     }
 
     render() {
-        const { defaultValue } = this.props
+        const { initialValue } = this.props
 
         return (
             <Select
@@ -115,7 +116,7 @@ export class ColorSchemeDropdown extends React.Component<
                 formatOptionLabel={this.formatOptionLabel}
                 onChange={this.onChange}
                 defaultValue={this.availableColorSchemes.find(
-                    scheme => scheme.value === defaultValue
+                    scheme => scheme.value === initialValue
                 )}
                 styles={{
                     singleValue: provided => {

--- a/admin/client/ColorSchemeDropdown.tsx
+++ b/admin/client/ColorSchemeDropdown.tsx
@@ -28,8 +28,16 @@ export class ColorSchemeDropdown extends React.Component<
         gradientColorCount: 6
     }
 
+    @computed get additionalColorSchemes() {
+        return this.props.additionalColorSchemes
+    }
+
+    @computed get gradientColorCount() {
+        return this.props.gradientColorCount
+    }
+
     @computed get availableColorSchemes() {
-        const { additionalColorSchemes, gradientColorCount } = this.props
+        const { additionalColorSchemes, gradientColorCount } = this
 
         return additionalColorSchemes.concat(
             Object.entries(ColorSchemes).map(([key, scheme]) => {

--- a/admin/client/ColorSchemeDropdown.tsx
+++ b/admin/client/ColorSchemeDropdown.tsx
@@ -120,17 +120,14 @@ export class ColorSchemeDropdown extends React.Component<
                 value={this.allOptions.find(
                     scheme => scheme.value === this.props.value
                 )}
+                components={{
+                    IndicatorSeparator: null
+                }}
                 styles={{
                     singleValue: provided => {
                         return {
                             ...provided,
                             width: "calc(100% - 10px)"
-                        }
-                    },
-                    indicatorSeparator: provided => {
-                        return {
-                            ...provided,
-                            visibility: "hidden"
                         }
                     }
                 }}

--- a/admin/client/ColorSchemeDropdown.tsx
+++ b/admin/client/ColorSchemeDropdown.tsx
@@ -13,7 +13,7 @@ export interface ColorSchemeOption {
 
 export interface ColorSchemeDropdownProps {
     additionalOptions: ColorSchemeOption[]
-    initialValue?: string
+    value?: string
     gradientColorCount: number
     invertedColorScheme: boolean
     onChange: (selected: ColorSchemeOption) => void
@@ -112,15 +112,13 @@ export class ColorSchemeDropdown extends React.Component<
     }
 
     render() {
-        const { initialValue } = this.props
-
         return (
             <Select
                 options={this.allOptions}
                 formatOptionLabel={this.formatOptionLabel}
                 onChange={this.onChange}
-                defaultValue={this.allOptions.find(
-                    scheme => scheme.value === initialValue
+                value={this.allOptions.find(
+                    scheme => scheme.value === this.props.value
                 )}
                 styles={{
                     singleValue: provided => {

--- a/admin/client/ColorSchemeDropdown.tsx
+++ b/admin/client/ColorSchemeDropdown.tsx
@@ -76,19 +76,22 @@ export class ColorSchemeDropdown extends React.Component<
                 }}
             >
                 <div>{option.label}</div>
-                <span
-                    style={{
-                        backgroundImage: option.gradient,
-                        width: "6rem",
-                        height: "1.25rem",
-                        border: option.gradient ? "1px solid #aaa" : undefined,
 
-                        // Mirror the element if color schemes are inverted
-                        transform: invertedColorScheme
-                            ? "scaleX(-1)"
-                            : undefined
-                    }}
-                />
+                {option.gradient && (
+                    <span
+                        style={{
+                            backgroundImage: option.gradient,
+                            width: "6rem",
+                            height: "1.25rem",
+                            border: "1px solid #aaa",
+
+                            // Mirror the element if color schemes are inverted
+                            transform: invertedColorScheme
+                                ? "scaleX(-1)"
+                                : undefined
+                        }}
+                    />
+                )}
             </div>
         )
     }

--- a/admin/client/ColorSchemeDropdown.tsx
+++ b/admin/client/ColorSchemeDropdown.tsx
@@ -2,6 +2,7 @@ import React = require("react")
 import { computed, action } from "mobx"
 import Select, { ValueType } from "react-select"
 import { ColorScheme, ColorSchemes } from "charts/ColorSchemes"
+import { observer } from "mobx-react"
 
 export interface ColorSchemeOption {
     colorScheme?: ColorScheme
@@ -18,6 +19,7 @@ export interface ColorSchemeDropdownProps {
     onChange: (selected: ColorSchemeOption) => void
 }
 
+@observer
 export class ColorSchemeDropdown extends React.Component<
     ColorSchemeDropdownProps
 > {
@@ -101,7 +103,6 @@ export class ColorSchemeDropdown extends React.Component<
 
         return (
             <Select
-                label="Color scheme"
                 options={this.availableColorSchemes}
                 formatOptionLabel={this.formatOptionLabel}
                 onChange={this.onChange}

--- a/admin/client/EditorCustomizeTab.tsx
+++ b/admin/client/EditorCustomizeTab.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import Select, { ValueType } from "react-select"
+import Select, * as ReactSelect from "react-select"
 import { observable, computed, action } from "mobx"
 import { observer } from "mobx-react"
 import { ChartEditor } from "./ChartEditor"
@@ -27,31 +27,44 @@ import { faMinus } from "@fortawesome/free-solid-svg-icons/faMinus"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 
 interface ColorSchemeOption {
+    colorScheme?: ColorScheme
+    gradient?: string
     label: string
     value: string
-    colorScheme: ColorScheme
 }
 
-@observer
-class ColorSchemeSelector extends React.Component<{ chart: ChartConfig }> {
-    @action.bound onChange(selectedColorScheme: ValueType<ColorSchemeOption>) {
-        // The onChange method can return an array of values (when multiple
-        // items can be selected) or a single value. Since we are certain that
-        // we are not using the multi-option select we can force the type to be
-        // a single value.
+interface ColorSchemeDropdownProps {
+    additionalColorSchemes: ColorSchemeOption[]
+    gradientColorCount: number
+    invertedColorScheme: boolean
+    onChange: (selected: ColorSchemeOption) => void
+    preselectedColorScheme: string | undefined
+}
 
-        const value = (selectedColorScheme as ColorSchemeOption).value
-        this.props.chart.props.baseColorScheme =
-            value === "default" ? undefined : value
+class ColorSchemeDropdown extends React.Component<ColorSchemeDropdownProps> {
+    static defaultProps = {
+        gradientColorCount: 6
     }
 
-    @action.bound onInvertColorScheme(value: boolean) {
-        this.props.chart.props.invertColorScheme = value || undefined
+    @computed
+    get availableColorSchemes() {
+        return this.props.additionalColorSchemes.concat(
+            Object.entries(ColorSchemes).map(([key, scheme]) => {
+                return {
+                    value: key,
+                    label: (scheme as ColorScheme).name,
+                    colorScheme: scheme as ColorScheme,
+                    gradient: this.createLinearGradient(
+                        scheme as ColorScheme,
+                        this.props.gradientColorCount
+                    )
+                }
+            })
+        )
     }
 
     createLinearGradient(colorScheme: ColorScheme, count: number) {
-        let colors = colorScheme.getColors(count)
-        if (this.props.chart.props.invertColorScheme) colors = colors.reverse()
+        const colors = colorScheme.getColors(count)
 
         const step = 100 / count
         const gradientEntries = colors.map(
@@ -59,6 +72,15 @@ class ColorSchemeSelector extends React.Component<{ chart: ChartConfig }> {
         )
 
         return `linear-gradient(90deg, ${gradientEntries.join(", ")})`
+    }
+
+    @action.bound onChange(selected: ReactSelect.ValueType<ColorSchemeOption>) {
+        // The onChange method can return an array of values (when multiple
+        // items can be selected) or a single value. Since we are certain that
+        // we are not using the multi-option select we can force the type to be
+        // a single value.
+
+        this.props.onChange(selected as ColorSchemeOption)
     }
 
     @action.bound formatOptionLabel(option: ColorSchemeOption) {
@@ -73,13 +95,15 @@ class ColorSchemeSelector extends React.Component<{ chart: ChartConfig }> {
                 <div>{option.label}</div>
                 <span
                     style={{
-                        backgroundImage: this.createLinearGradient(
-                            option.colorScheme,
-                            6
-                        ),
+                        backgroundImage: option.gradient,
                         width: "6rem",
                         height: "1.25rem",
-                        border: "1px solid #aaa"
+                        border: option.gradient ? "1px solid #aaa" : undefined,
+
+                        // Mirror the element if color schemes are inverted
+                        transform: this.props.invertedColorScheme
+                            ? "scaleX(-1)"
+                            : undefined
                     }}
                 />
             </div>
@@ -87,56 +111,71 @@ class ColorSchemeSelector extends React.Component<{ chart: ChartConfig }> {
     }
 
     render() {
-        const { chart } = this.props
-
-        const defaultColorScheme = {
-            value: "default",
-            label: "Default",
-
-            // This is the default color in DiscreteBarTransform
-            colorScheme: new ColorScheme(
-                "DiscreteBarChart default",
-                [["#2e5778", "#2e5778", "#2e5778"]],
-                false
-            )
-        }
-
-        const availableColorSchemes = [defaultColorScheme].concat(
-            Object.entries(ColorSchemes).map(([key, scheme]) => {
-                return {
-                    value: key,
-                    label: (scheme as ColorScheme).name,
-                    colorScheme: scheme as ColorScheme
-                }
-            })
+        return (
+            <Select
+                defaultValue={this.availableColorSchemes.find(
+                    scheme => scheme.value === this.props.preselectedColorScheme
+                )}
+                label="Color scheme"
+                options={this.availableColorSchemes}
+                formatOptionLabel={this.formatOptionLabel}
+                styles={{
+                    singleValue: provided => {
+                        return {
+                            ...provided,
+                            width: "calc(100% - 10px)"
+                        }
+                    },
+                    indicatorSeparator: provided => {
+                        return {
+                            ...provided,
+                            visibility: "hidden"
+                        }
+                    }
+                }}
+                onChange={this.onChange}
+            />
         )
+    }
+}
+
+@observer
+class ColorSchemeSelector extends React.Component<{ chart: ChartConfig }> {
+    @action.bound onChange(selected: ColorSchemeOption) {
+        // The onChange method can return an array of values (when multiple
+        // items can be selected) or a single value. Since we are certain that
+        // we are not using the multi-option select we can force the type to be
+        // a single value.
+
+        this.props.chart.props.baseColorScheme =
+            selected.value === "default" ? undefined : selected.value
+    }
+
+    @action.bound onInvertColorScheme(value: boolean) {
+        this.props.chart.props.invertColorScheme = value || undefined
+    }
+
+    render() {
+        const { chart } = this.props
 
         return (
             <React.Fragment>
                 <FieldsRow>
-                    <Select
-                        defaultValue={
-                            availableColorSchemes.find(
-                                scheme => scheme.value === chart.baseColorScheme
-                            ) || defaultColorScheme
+                    <ColorSchemeDropdown
+                        preselectedColorScheme={
+                            chart.baseColorScheme || "default"
                         }
-                        label="Color scheme"
-                        options={availableColorSchemes}
                         onChange={this.onChange}
-                        formatOptionLabel={this.formatOptionLabel}
-                        styles={{
-                            singleValue: provided => {
-                                return {
-                                    ...provided,
-                                    width: "calc(100% - 10px)"
-                                }
-                            },
-                            indicatorSeparator: () => {
-                                return {
-                                    visibility: "hidden"
-                                }
+                        invertedColorScheme={!!chart.props.invertColorScheme}
+                        additionalColorSchemes={[
+                            {
+                                value: "default",
+                                label: "Default",
+                                colorScheme: undefined,
+                                gradient:
+                                    "linear-gradient(90deg, #2e5778 0%, #2e5778 100%)"
                             }
-                        }}
+                        ]}
                     />
                 </FieldsRow>
                 <FieldsRow>

--- a/admin/client/EditorCustomizeTab.tsx
+++ b/admin/client/EditorCustomizeTab.tsx
@@ -50,7 +50,7 @@ class ColorSchemeSelector extends React.Component<{ chart: ChartConfig }> {
                     <div className="form-group">
                         <label>Color scheme</label>
                         <ColorSchemeDropdown
-                            initialValue={chart.baseColorScheme || "default"}
+                            value={chart.baseColorScheme || "default"}
                             onChange={this.onChange}
                             invertedColorScheme={
                                 !!chart.props.invertColorScheme

--- a/admin/client/EditorCustomizeTab.tsx
+++ b/admin/client/EditorCustomizeTab.tsx
@@ -41,6 +41,17 @@ class ColorSchemeSelector extends React.Component<{ chart: ChartConfig }> {
         this.props.chart.props.invertColorScheme = value || undefined
     }
 
+    @computed get additionalColorSchemes() {
+        return [
+            {
+                colorScheme: undefined,
+                gradient: "linear-gradient(90deg, #2e5778 0%, #2e5778 100%)",
+                label: "Default",
+                value: "default"
+            }
+        ]
+    }
+
     render() {
         const { chart } = this.props
 
@@ -55,15 +66,7 @@ class ColorSchemeSelector extends React.Component<{ chart: ChartConfig }> {
                             invertedColorScheme={
                                 !!chart.props.invertColorScheme
                             }
-                            additionalColorSchemes={[
-                                {
-                                    colorScheme: undefined,
-                                    gradient:
-                                        "linear-gradient(90deg, #2e5778 0%, #2e5778 100%)",
-                                    label: "Default",
-                                    value: "default"
-                                }
-                            ]}
+                            additionalColorSchemes={this.additionalColorSchemes}
                         />
                     </div>
                 </FieldsRow>

--- a/admin/client/EditorCustomizeTab.tsx
+++ b/admin/client/EditorCustomizeTab.tsx
@@ -1,5 +1,4 @@
 import * as React from "react"
-import Select, { ValueType } from "react-select"
 import { observable, computed, action } from "mobx"
 import { observer } from "mobx-react"
 import { ChartEditor } from "./ChartEditor"
@@ -20,130 +19,11 @@ import {
     EditableList
 } from "./Forms"
 import { debounce } from "charts/Util"
-import { ColorSchemes, ColorScheme } from "charts/ColorSchemes"
 import { Color } from "charts/Color"
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus"
 import { faMinus } from "@fortawesome/free-solid-svg-icons/faMinus"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-
-interface ColorSchemeOption {
-    colorScheme?: ColorScheme
-    gradient?: string
-    label: string
-    value: string
-}
-
-interface ColorSchemeDropdownProps {
-    additionalColorSchemes: ColorSchemeOption[]
-    defaultValue?: string
-    gradientColorCount: number
-    invertedColorScheme: boolean
-    onChange: (selected: ColorSchemeOption) => void
-}
-
-class ColorSchemeDropdown extends React.Component<ColorSchemeDropdownProps> {
-    static defaultProps = {
-        additionalColorSchemes: [],
-        gradientColorCount: 6
-    }
-
-    @computed get availableColorSchemes() {
-        const { additionalColorSchemes, gradientColorCount } = this.props
-
-        return additionalColorSchemes.concat(
-            Object.entries(ColorSchemes).map(([key, scheme]) => {
-                return {
-                    colorScheme: scheme as ColorScheme,
-                    gradient: this.createLinearGradient(
-                        scheme as ColorScheme,
-                        gradientColorCount
-                    ),
-                    label: (scheme as ColorScheme).name,
-                    value: key
-                }
-            })
-        )
-    }
-
-    createLinearGradient(colorScheme: ColorScheme, count: number) {
-        const colors = colorScheme.getColors(count)
-
-        const step = 100 / count
-        const gradientEntries = colors.map(
-            (color, i) => `${color} ${i * step}%, ${color} ${(i + 1) * step}%`
-        )
-
-        return `linear-gradient(90deg, ${gradientEntries.join(", ")})`
-    }
-
-    @action.bound onChange(selected: ValueType<ColorSchemeOption>) {
-        // The onChange method can return an array of values (when multiple
-        // items can be selected) or a single value. Since we are certain that
-        // we are not using the multi-option select we can force the type to be
-        // a single value.
-
-        this.props.onChange(selected as ColorSchemeOption)
-    }
-
-    @action.bound formatOptionLabel(option: ColorSchemeOption) {
-        const { invertedColorScheme } = this.props
-
-        return (
-            <div
-                style={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "center"
-                }}
-            >
-                <div>{option.label}</div>
-                <span
-                    style={{
-                        backgroundImage: option.gradient,
-                        width: "6rem",
-                        height: "1.25rem",
-                        border: option.gradient ? "1px solid #aaa" : undefined,
-
-                        // Mirror the element if color schemes are inverted
-                        transform: invertedColorScheme
-                            ? "scaleX(-1)"
-                            : undefined
-                    }}
-                />
-            </div>
-        )
-    }
-
-    render() {
-        const { defaultValue } = this.props
-
-        return (
-            <Select
-                label="Color scheme"
-                options={this.availableColorSchemes}
-                formatOptionLabel={this.formatOptionLabel}
-                onChange={this.onChange}
-                defaultValue={this.availableColorSchemes.find(
-                    scheme => scheme.value === defaultValue
-                )}
-                styles={{
-                    singleValue: provided => {
-                        return {
-                            ...provided,
-                            width: "calc(100% - 10px)"
-                        }
-                    },
-                    indicatorSeparator: provided => {
-                        return {
-                            ...provided,
-                            visibility: "hidden"
-                        }
-                    }
-                }}
-            />
-        )
-    }
-}
+import { ColorSchemeDropdown, ColorSchemeOption } from "./ColorSchemeDropdown"
 
 @observer
 class ColorSchemeSelector extends React.Component<{ chart: ChartConfig }> {

--- a/admin/client/EditorCustomizeTab.tsx
+++ b/admin/client/EditorCustomizeTab.tsx
@@ -58,8 +58,7 @@ class ColorSchemeSelector extends React.Component<{ chart: ChartConfig }> {
                             additionalOptions={[
                                 {
                                     colorScheme: undefined,
-                                    gradient:
-                                        "linear-gradient(90deg, #2e5778 0%, #2e5778 100%)",
+                                    gradient: undefined,
                                     label: "Default",
                                     value: "default"
                                 }

--- a/admin/client/EditorCustomizeTab.tsx
+++ b/admin/client/EditorCustomizeTab.tsx
@@ -47,20 +47,25 @@ class ColorSchemeSelector extends React.Component<{ chart: ChartConfig }> {
         return (
             <React.Fragment>
                 <FieldsRow>
-                    <ColorSchemeDropdown
-                        defaultValue={chart.baseColorScheme || "default"}
-                        onChange={this.onChange}
-                        invertedColorScheme={!!chart.props.invertColorScheme}
-                        additionalColorSchemes={[
-                            {
-                                colorScheme: undefined,
-                                gradient:
-                                    "linear-gradient(90deg, #2e5778 0%, #2e5778 100%)",
-                                label: "Default",
-                                value: "default"
+                    <div className="form-group">
+                        <label>Color scheme</label>
+                        <ColorSchemeDropdown
+                            defaultValue={chart.baseColorScheme || "default"}
+                            onChange={this.onChange}
+                            invertedColorScheme={
+                                !!chart.props.invertColorScheme
                             }
-                        ]}
-                    />
+                            additionalColorSchemes={[
+                                {
+                                    colorScheme: undefined,
+                                    gradient:
+                                        "linear-gradient(90deg, #2e5778 0%, #2e5778 100%)",
+                                    label: "Default",
+                                    value: "default"
+                                }
+                            ]}
+                        />
+                    </div>
                 </FieldsRow>
                 <FieldsRow>
                     <Toggle

--- a/admin/client/EditorCustomizeTab.tsx
+++ b/admin/client/EditorCustomizeTab.tsx
@@ -41,17 +41,6 @@ class ColorSchemeSelector extends React.Component<{ chart: ChartConfig }> {
         this.props.chart.props.invertColorScheme = value || undefined
     }
 
-    @computed get additionalColorSchemes() {
-        return [
-            {
-                colorScheme: undefined,
-                gradient: "linear-gradient(90deg, #2e5778 0%, #2e5778 100%)",
-                label: "Default",
-                value: "default"
-            }
-        ]
-    }
-
     render() {
         const { chart } = this.props
 
@@ -66,7 +55,15 @@ class ColorSchemeSelector extends React.Component<{ chart: ChartConfig }> {
                             invertedColorScheme={
                                 !!chart.props.invertColorScheme
                             }
-                            additionalColorSchemes={this.additionalColorSchemes}
+                            additionalOptions={[
+                                {
+                                    colorScheme: undefined,
+                                    gradient:
+                                        "linear-gradient(90deg, #2e5778 0%, #2e5778 100%)",
+                                    label: "Default",
+                                    value: "default"
+                                }
+                            ]}
                         />
                     </div>
                 </FieldsRow>

--- a/admin/client/EditorCustomizeTab.tsx
+++ b/admin/client/EditorCustomizeTab.tsx
@@ -61,7 +61,7 @@ class ColorSchemeSelector extends React.Component<{ chart: ChartConfig }> {
                     <div className="form-group">
                         <label>Color scheme</label>
                         <ColorSchemeDropdown
-                            defaultValue={chart.baseColorScheme || "default"}
+                            initialValue={chart.baseColorScheme || "default"}
                             onChange={this.onChange}
                             invertedColorScheme={
                                 !!chart.props.invertColorScheme

--- a/admin/client/EditorMapTab.tsx
+++ b/admin/client/EditorMapTab.tsx
@@ -309,17 +309,6 @@ class ColorsSection extends React.Component<{ mapConfig: MapConfig }> {
             : true
     }
 
-    @computed get additionalColorSchemes() {
-        return [
-            {
-                colorScheme: undefined,
-                gradient: undefined,
-                label: "Custom",
-                value: "custom"
-            }
-        ]
-    }
-
     render() {
         const { mapConfig } = this.props
 
@@ -338,7 +327,14 @@ class ColorsSection extends React.Component<{ mapConfig: MapConfig }> {
                             invertedColorScheme={
                                 !!mapConfig.props.colorSchemeInvert
                             }
-                            additionalColorSchemes={this.additionalColorSchemes}
+                            additionalOptions={[
+                                {
+                                    colorScheme: undefined,
+                                    gradient: undefined,
+                                    label: "Custom",
+                                    value: "custom"
+                                }
+                            ]}
                         />
                     </div>
                 </FieldsRow>

--- a/admin/client/EditorMapTab.tsx
+++ b/admin/client/EditorMapTab.tsx
@@ -333,7 +333,7 @@ class ColorsSection extends React.Component<{ mapConfig: MapConfig }> {
                     <div className="form-group">
                         <label>Color scheme</label>
                         <ColorSchemeDropdown
-                            defaultValue={currentColorScheme}
+                            initialValue={currentColorScheme}
                             onChange={this.onColorScheme}
                             invertedColorScheme={
                                 !!mapConfig.props.colorSchemeInvert

--- a/admin/client/EditorMapTab.tsx
+++ b/admin/client/EditorMapTab.tsx
@@ -309,6 +309,17 @@ class ColorsSection extends React.Component<{ mapConfig: MapConfig }> {
             : true
     }
 
+    @computed get additionalColorSchemes() {
+        return [
+            {
+                colorScheme: undefined,
+                gradient: undefined,
+                label: "Custom",
+                value: "custom"
+            }
+        ]
+    }
+
     render() {
         const { mapConfig } = this.props
 
@@ -327,14 +338,7 @@ class ColorsSection extends React.Component<{ mapConfig: MapConfig }> {
                             invertedColorScheme={
                                 !!mapConfig.props.colorSchemeInvert
                             }
-                            additionalColorSchemes={[
-                                {
-                                    colorScheme: undefined,
-                                    gradient: undefined,
-                                    label: "Custom",
-                                    value: "custom"
-                                }
-                            ]}
+                            additionalColorSchemes={this.additionalColorSchemes}
                         />
                     </div>
                 </FieldsRow>

--- a/admin/client/EditorMapTab.tsx
+++ b/admin/client/EditorMapTab.tsx
@@ -309,12 +309,14 @@ class ColorsSection extends React.Component<{ mapConfig: MapConfig }> {
             : true
     }
 
-    render() {
+    @computed get currentColorScheme() {
         const { mapConfig } = this.props
 
-        const currentColorScheme = mapConfig.isCustomColors
-            ? "custom"
-            : mapConfig.baseColorScheme
+        return mapConfig.isCustomColors ? "custom" : mapConfig.baseColorScheme
+    }
+
+    render() {
+        const { mapConfig } = this.props
 
         return (
             <Section name="Colors">
@@ -322,7 +324,7 @@ class ColorsSection extends React.Component<{ mapConfig: MapConfig }> {
                     <div className="form-group">
                         <label>Color scheme</label>
                         <ColorSchemeDropdown
-                            initialValue={currentColorScheme}
+                            value={this.currentColorScheme}
                             onChange={this.onColorScheme}
                             invertedColorScheme={
                                 !!mapConfig.props.colorSchemeInvert

--- a/admin/client/EditorMapTab.tsx
+++ b/admin/client/EditorMapTab.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { clone, isEmpty, noop, extend, map } from "charts/Util"
+import { clone, isEmpty, noop, map } from "charts/Util"
 import { computed, action } from "mobx"
 import { observer } from "mobx-react"
 import { ChartEditor } from "./ChartEditor"
@@ -18,12 +18,12 @@ import {
 } from "./Forms"
 import { MapConfig } from "charts/MapConfig"
 import { MapProjection } from "charts/MapProjection"
-import { ColorSchemes } from "charts/ColorSchemes"
 import { NumericBin, CategoricalBin } from "charts/MapData"
 import { Color } from "charts/Color"
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus"
 import { faMinus } from "@fortawesome/free-solid-svg-icons/faMinus"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { ColorSchemeDropdown, ColorSchemeOption } from "./ColorSchemeDropdown"
 
 @observer
 class VariableSection extends React.Component<{ mapConfig: MapConfig }> {
@@ -288,12 +288,13 @@ class ColorSchemeEditor extends React.Component<{ map: MapConfig }> {
 
 @observer
 class ColorsSection extends React.Component<{ mapConfig: MapConfig }> {
-    @action.bound onColorScheme(schemeKey: string | undefined) {
+    @action.bound onColorScheme(selected: ColorSchemeOption) {
         const { mapConfig } = this.props
-        if (schemeKey === "custom") {
+
+        if (selected.value === "custom") {
             mapConfig.props.customColorsActive = true
         } else {
-            mapConfig.props.baseColorScheme = schemeKey
+            mapConfig.props.baseColorScheme = selected.value
             mapConfig.props.customColorsActive = undefined
         }
     }
@@ -310,9 +311,7 @@ class ColorsSection extends React.Component<{ mapConfig: MapConfig }> {
 
     render() {
         const { mapConfig } = this.props
-        const availableColorSchemes = map(ColorSchemes, (v: any, k: any) =>
-            extend({}, v, { key: k })
-        ).filter((v: any) => !!v.name)
+
         const currentColorScheme = mapConfig.isCustomColors
             ? "custom"
             : mapConfig.baseColorScheme
@@ -320,24 +319,28 @@ class ColorsSection extends React.Component<{ mapConfig: MapConfig }> {
         return (
             <Section name="Colors">
                 <FieldsRow>
-                    <SelectField
-                        label="Color scheme"
-                        value={currentColorScheme}
-                        options={availableColorSchemes
-                            .map(d => d.key)
-                            .concat(["custom"])}
-                        optionLabels={availableColorSchemes
-                            .map(d => d.name)
-                            .concat(["custom"])}
-                        onValue={this.onColorScheme}
+                    <ColorSchemeDropdown
+                        defaultValue={currentColorScheme}
+                        onChange={this.onColorScheme}
+                        invertedColorScheme={
+                            !!mapConfig.props.colorSchemeInvert
+                        }
+                        additionalColorSchemes={[
+                            {
+                                colorScheme: undefined,
+                                gradient: undefined,
+                                label: "Custom",
+                                value: "custom"
+                            }
+                        ]}
                     />
+                </FieldsRow>
+                <FieldsRow>
                     <Toggle
                         label="Invert colors"
                         value={mapConfig.props.colorSchemeInvert || false}
                         onValue={this.onInvert}
                     />
-                </FieldsRow>
-                <FieldsRow>
                     <Toggle
                         label="Automatic classification"
                         value={!mapConfig.props.isManualBuckets}

--- a/admin/client/EditorMapTab.tsx
+++ b/admin/client/EditorMapTab.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { clone, isEmpty, noop, map } from "charts/Util"
+import { clone, isEmpty, noop } from "charts/Util"
 import { computed, action } from "mobx"
 import { observer } from "mobx-react"
 import { ChartEditor } from "./ChartEditor"
@@ -319,21 +319,24 @@ class ColorsSection extends React.Component<{ mapConfig: MapConfig }> {
         return (
             <Section name="Colors">
                 <FieldsRow>
-                    <ColorSchemeDropdown
-                        defaultValue={currentColorScheme}
-                        onChange={this.onColorScheme}
-                        invertedColorScheme={
-                            !!mapConfig.props.colorSchemeInvert
-                        }
-                        additionalColorSchemes={[
-                            {
-                                colorScheme: undefined,
-                                gradient: undefined,
-                                label: "Custom",
-                                value: "custom"
+                    <div className="form-group">
+                        <label>Color scheme</label>
+                        <ColorSchemeDropdown
+                            defaultValue={currentColorScheme}
+                            onChange={this.onColorScheme}
+                            invertedColorScheme={
+                                !!mapConfig.props.colorSchemeInvert
                             }
-                        ]}
-                    />
+                            additionalColorSchemes={[
+                                {
+                                    colorScheme: undefined,
+                                    gradient: undefined,
+                                    label: "Custom",
+                                    value: "custom"
+                                }
+                            ]}
+                        />
+                    </div>
                 </FieldsRow>
                 <FieldsRow>
                     <Toggle

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
         "react-modal": "^3.8.1",
         "react-recaptcha": "^2.3.10",
         "react-router-dom": "^5.0.1",
-        "react-select": "^3.0.8",
+        "react-select": "3.0.3",
         "react-tag-autocomplete": "https://github.com/mispy/react-tags",
         "reflect-metadata": "^0.1.13",
         "sass-loader": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13195,7 +13195,7 @@ react-hotkeys@2.0.0-pre4:
   dependencies:
     prop-types "^15.6.1"
 
-react-input-autosize@^2.2.2:
+react-input-autosize@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.2.tgz#fcaa7020568ec206bc04be36f4eb68e647c4d8c2"
   integrity sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==
@@ -13301,18 +13301,20 @@ react-router@5.0.1:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-select@^3.0.8:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.0.8.tgz#06ff764e29db843bcec439ef13e196865242e0c1"
-  integrity sha512-v9LpOhckLlRmXN5A6/mGGEft4FMrfaBFTGAnuPHcUgVId7Je42kTq9y0Z+Ye5z8/j0XDT3zUqza8gaRaI1PZIg==
+react-select@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.0.3.tgz#f570b7b00e9b8b5bc938c3c834fdac0240e305d8"
+  integrity sha512-/WmzNDvATL2mFMLtZYlfUBHzg6YywglkmwJ52TCuvj2ALNu8gRKSlhkivPfKUWxxWKbolVCXSAh+xuwOQZJykg==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@emotion/cache" "^10.0.9"
     "@emotion/core" "^10.0.9"
     "@emotion/css" "^10.0.9"
+    classnames "^2.2.5"
     memoize-one "^5.0.0"
     prop-types "^15.6.0"
-    react-input-autosize "^2.2.2"
+    raf "^3.4.0"
+    react-input-autosize "^2.2.1"
     react-transition-group "^2.2.1"
 
 react-syntax-highlighter@^8.0.1:


### PR DESCRIPTION
As suggested in #137, color schemes are now previewed right in the dropdown:
![image](https://user-images.githubusercontent.com/2641501/73584811-980f9880-449b-11ea-93b3-3083c49710ea.png)

This is accomplished by making use of the `react-select` package that is being used elsewhere.

A custom `linear-gradient` is being created from each color scheme (it currently contains exactly 6 colors), which is displayed along with the color scheme name.