### PR TITLE
Fix broken blog post paging

### DIFF
--- a/settings.ts
+++ b/settings.ts
@@ -39,7 +39,7 @@ export const GIT_DEFAULT_USERNAME: string =
 export const GIT_DEFAULT_EMAIL: string =
     process.env.GIT_DEFAULT_EMAIL || "info@ourworldindata.org"
 
-export const BLOG_POSTS_PER_PAGE: number = 21
+export const BLOG_POSTS_PER_PAGE: number = 20
 
 export const ALGOLIA_ID: string = process.env.ALGOLIA_ID || ""
 export const ALGOLIA_SEARCH_KEY: string = process.env.ALGOLIA_SEARCH_KEY || ""

--- a/site/server/siteBaking.tsx
+++ b/site/server/siteBaking.tsx
@@ -27,6 +27,7 @@ import { ChartConfigProps } from "charts/ChartConfig"
 import { FeedbackPage } from "./views/FeedbackPage"
 import { isExplorable, FORCE_EXPLORABLE_CHART_IDS } from "utils/charts"
 import { Indicator } from "charts/Indicator"
+import { BLOG_POSTS_PER_PAGE } from "settings"
 
 // Wrap ReactDOMServer to stick the doctype on
 export function renderToHtmlPage(element: any) {
@@ -182,14 +183,12 @@ export async function renderSubscribePage() {
 }
 
 export async function renderBlogByPageNum(pageNum: number) {
-    const postsPerPage = 20
-
     const allPosts = await wpdb.getBlogIndex()
 
-    const numPages = Math.ceil(allPosts.length / postsPerPage)
+    const numPages = Math.ceil(allPosts.length / BLOG_POSTS_PER_PAGE)
     const posts = allPosts.slice(
-        (pageNum - 1) * postsPerPage,
-        pageNum * postsPerPage
+        (pageNum - 1) * BLOG_POSTS_PER_PAGE,
+        pageNum * BLOG_POSTS_PER_PAGE
     )
 
     return renderToHtmlPage(


### PR DESCRIPTION
Currently, the last page https://ourworldindata.org/blog/page/11 is not baked, even though a eleventh page should exist. This happens because two different values of `postsPerPage` are being used, https://github.com/owid/owid-grapher/blob/fa47a6237cbdc252e50758723bd1980983b24317/site/server/SiteBaker.tsx#L318-L320 (using `BLOG_POSTS_PER_PAGE = 21`) and https://github.com/owid/owid-grapher/blob/fa47a6237cbdc252e50758723bd1980983b24317/site/server/siteBaking.tsx#L184-L185.

I have now changed it so both files use `BLOG_POSTS_PER_PAGE`, which is now set to a default value of 20.

This is not an issue when running `yarn dev` bc in that case, `renderBlogByPageNum` is called unconditionally.

I couldn't test this because I don't have a local `wpdb`, but I guess this will work.

This was broken in https://github.com/owid/owid-grapher/commit/dab487e2e338f565352ff29237a62ea542f8a3a9#diff-8cbf5c187bf82a29dce1101cf4afbb4b.
cc @mlbrgl 