### PR TITLE
Executable test files

### DIFF
--- a/charts/__tests__/ChartConfig.test.ts
+++ b/charts/__tests__/ChartConfig.test.ts
@@ -1,3 +1,5 @@
+#! /usr/bin/env jest
+
 import { ChartConfig, ChartConfigProps } from "charts/ChartConfig"
 
 function createConfig(props: Partial<ChartConfigProps>) {

--- a/charts/__tests__/DataTable.test.tsx
+++ b/charts/__tests__/DataTable.test.tsx
@@ -1,3 +1,5 @@
+#! /usr/bin/env jest
+
 import * as React from "react"
 import { shallow, ShallowWrapper } from "enzyme"
 

--- a/charts/__tests__/ExploreModel.test.ts
+++ b/charts/__tests__/ExploreModel.test.ts
@@ -1,3 +1,5 @@
+#! /usr/bin/env jest
+
 import { ExploreModel } from "../ExploreModel"
 import { ChartType } from "../ChartType"
 import { RootStore } from "charts/Store"

--- a/charts/__tests__/ExploreView.test.tsx
+++ b/charts/__tests__/ExploreView.test.tsx
@@ -1,3 +1,5 @@
+#! /usr/bin/env jest
+
 import * as React from "react"
 import { shallow, mount, ReactWrapper } from "enzyme"
 import { observe } from "mobx"

--- a/charts/__tests__/Store.test.ts
+++ b/charts/__tests__/Store.test.ts
@@ -1,3 +1,5 @@
+#! /usr/bin/env jest
+
 import { observe } from "mobx"
 
 import { RootStore, IndicatorStore } from "charts/Store"

--- a/charts/__tests__/TextWrap.test.ts
+++ b/charts/__tests__/TextWrap.test.ts
@@ -1,3 +1,5 @@
+#! /usr/bin/env jest
+
 import { TextWrap } from "../TextWrap"
 import { Bounds } from "../Bounds"
 

--- a/charts/__tests__/Util.test.ts
+++ b/charts/__tests__/Util.test.ts
@@ -1,3 +1,5 @@
+#! /usr/bin/env jest
+
 import { findClosestYear, getStartEndValues, DataValue } from "../Util"
 
 function iteratorFromArray<T>(array: T[]): Iterable<T> {

--- a/site/server/views/__tests__/ChartPage.test.tsx
+++ b/site/server/views/__tests__/ChartPage.test.tsx
@@ -1,3 +1,5 @@
+#! /usr/bin/env jest
+
 import * as React from "react"
 import { shallow, ShallowWrapper } from "enzyme"
 

--- a/site/server/views/__tests__/ExplorePage.test.tsx
+++ b/site/server/views/__tests__/ExplorePage.test.tsx
@@ -1,3 +1,5 @@
+#! /usr/bin/env jest
+
 import * as React from "react"
 import { shallow } from "enzyme"
 

--- a/test/admin/serverUtil.test.ts
+++ b/test/admin/serverUtil.test.ts
@@ -1,3 +1,5 @@
+#! /usr/bin/env jest
+
 const { exec } = require("utils/server/serverUtil")
 
 describe("serverUtil", () => {

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -5,7 +5,7 @@ import { ChartConfigProps } from "charts/ChartConfig"
 import { DataForChart } from "charts/VariableData"
 
 export function readBuffer(fixture: string) {
-    return fs.readFileSync(`test/fixtures/${fixture}.json`)
+    return fs.readFileSync(__dirname + `/${fixture}.json`)
 }
 
 function readObj(fixture: string) {

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -1,3 +1,5 @@
+#! /usr/bin/env jest
+
 import { chunkParagraphs } from "utils/search"
 import { htmlToPlaintext } from "utils/string"
 


### PR DESCRIPTION
I forget where I learned this habit, but it is a minor dev UX pattern that I like: making each test file executable with a shebang so you can just open the command line and type "/foobar.test.tsx" to run that particular test file, or hit a keyboard shortcut in your editor to execute the file.

It does require running "yarn global add jest" once.

I know it seems trivial as you can currently do "jest filepath", but I've found I run tests so much that often a quick copy/paste of the filename or the editor keyboard shortcut can shave off a couple seconds on test runs and make testing a little more fun.

Posting this as a "Draft" Pull Request to see what you all think. 