### PR TITLE
Add analytics to Charts and additional site events

### DIFF
--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -729,7 +729,14 @@ export class ControlsFooterView extends React.Component<{
                                     }
                                     onClick={() => (chart.tab = tabName)}
                                 >
-                                    <a>{tabName}</a>
+                                    <a
+                                        data-track-click
+                                        data-track-note={
+                                            "chart-click-" + tabName
+                                        }
+                                    >
+                                        {tabName}
+                                    </a>
                                 </li>
                             )
                         )
@@ -739,6 +746,8 @@ export class ControlsFooterView extends React.Component<{
                             "tab clickable icon" +
                             (chart.tab === "download" ? " active" : "")
                         }
+                        data-track-click
+                        data-track-note="chart-click-download"
                         onClick={() => (chart.tab = "download")}
                         title="Download as .png or .svg"
                     >
@@ -747,13 +756,23 @@ export class ControlsFooterView extends React.Component<{
                         </a>
                     </li>
                     <li className="clickable icon">
-                        <a title="Share" onClick={this.onShareMenu}>
+                        <a
+                            title="Share"
+                            onClick={this.onShareMenu}
+                            data-track-click
+                            data-track-note="chart-click-share"
+                        >
                             <FontAwesomeIcon icon={faShareAlt} />
                         </a>
                     </li>
                     {hasSettingsMenu && (
                         <li className="clickable icon">
-                            <a title="Settings" onClick={this.onSettingsMenu}>
+                            <a
+                                title="Settings"
+                                onClick={this.onSettingsMenu}
+                                data-track-click
+                                data-track-note="chart-click-settings"
+                            >
                                 <FontAwesomeIcon icon={faCog} />
                             </a>
                         </li>
@@ -763,6 +782,8 @@ export class ControlsFooterView extends React.Component<{
                             <a
                                 title="Open chart in new tab"
                                 href={chart.url.canonicalUrl}
+                                data-track-click
+                                data-track-note="chart-click-newtab"
                                 target="_blank"
                             >
                                 <FontAwesomeIcon icon={faExpand} />

--- a/charts/DataTab.tsx
+++ b/charts/DataTab.tsx
@@ -101,6 +101,8 @@ export class DataTab extends React.Component<{
                         href={csvDataUri}
                         download={csvFilename}
                         className="btn btn-primary"
+                        data-track-click
+                        data-track-note="chart-download-csv"
                         onClick={this.onDownload}
                     >
                         <FontAwesomeIcon icon={faDownload} /> {csvFilename}

--- a/charts/DownloadTab.tsx
+++ b/charts/DownloadTab.tsx
@@ -187,6 +187,8 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
                 key="png"
                 href={pngDownloadUrl}
                 download={baseFilename + ".png"}
+                data-track-click
+                data-track-note="chart-download-png"
                 onClick={this.onPNGDownload}
             >
                 <div>
@@ -204,6 +206,8 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
                 key="svg"
                 href={svgDownloadUrl}
                 download={baseFilename + ".svg"}
+                data-track-click
+                data-track-note="chart-download-svg"
                 onClick={this.onSVGDownload}
             >
                 <div>

--- a/charts/HTMLTimeline.tsx
+++ b/charts/HTMLTimeline.tsx
@@ -3,6 +3,7 @@ import { first, last, sortBy, find } from "./Util"
 import * as React from "react"
 import { Bounds } from "./Bounds"
 import { getRelativeMouse, formatYear } from "./Util"
+import { Analytics } from "site/client/Analytics"
 import {
     observable,
     computed,
@@ -152,6 +153,8 @@ export class Timeline extends React.Component<TimelineProps> {
     animRequest?: number
 
     @action.bound onStartPlaying() {
+        Analytics.logEvent("CHART_TIMELINE_PLAY")
+
         let lastTime: number | undefined
         const ticksPerSec = 5
 

--- a/site/client/Analytics.ts
+++ b/site/client/Analytics.ts
@@ -18,6 +18,7 @@ export class Analytics {
             props
         )
 
+        // Todo: switch to async/await when AmplitudeSDK switches off callbacks
         return new Promise((resolve, reject) => {
             if (!window.amplitude) {
                 // console.log(name, props)

--- a/site/client/Feedback.tsx
+++ b/site/client/Feedback.tsx
@@ -183,6 +183,8 @@ class FeedbackPrompt extends React.Component {
                     ) : (
                         <button
                             className="FeedbackPrompt"
+                            data-track-click
+                            data-track-note="page-open-feedback"
                             onClick={this.toggleOpen}
                         >
                             <FontAwesomeIcon icon={faEnvelope} /> Feedback

--- a/site/client/owid.entry.ts
+++ b/site/client/owid.entry.ts
@@ -57,6 +57,7 @@ new SmoothScroll('a[href*="#"][data-smooth-scroll]', {
 
 const search = document.querySelector("form#search-nav") as HTMLFormElement
 if (search) {
+    // Todo: Not seeing this event in Amplitude. Can this be removed?
     const input = search.querySelector("input[type=search]") as HTMLInputElement
     search.addEventListener("submit", ev => {
         ev.preventDefault()

--- a/site/client/owid.entry.ts
+++ b/site/client/owid.entry.ts
@@ -55,51 +55,21 @@ new SmoothScroll('a[href*="#"][data-smooth-scroll]', {
     popstate: false
 })
 
-const search = document.querySelector("form#search-nav") as HTMLFormElement
-if (search) {
-    // Todo: Not seeing this event in Amplitude. Can this be removed?
-    const input = search.querySelector("input[type=search]") as HTMLInputElement
-    search.addEventListener("submit", ev => {
-        ev.preventDefault()
-        Analytics.logEvent("OWID_SITE_SEARCH", { query: input.value })
-            .then(() => search.submit())
-            .catch(() => search.submit())
-    })
-}
-
-const trackedLinkExists: boolean = !!document.querySelector(
-    "[data-track-click]"
-)
-
-function createFunctionWithTimeout(callback: () => void, timeout: number = 50) {
-    let called = false
-    function fn() {
-        if (!called) {
-            called = true
-            callback()
-        }
+document.addEventListener("click", async ev => {
+    const targetElement = ev.target as HTMLElement
+    const trackedElement = getParent(
+        targetElement,
+        (el: HTMLElement) => el.getAttribute("data-track-click") !== null
+    )
+    if (trackedElement) {
+        // Note that browsers will cancel all pending requests once a user
+        // navigates away from a page. An earlier implementation had a
+        // timeout to send the event before navigating, but it broke
+        // CMD+CLICK for opening a new tab.
+        Analytics.logEvent("OWID_SITE_CLICK", {
+            text: trackedElement.innerText,
+            href: trackedElement.getAttribute("href"),
+            note: trackedElement.getAttribute("data-track-note")
+        })
     }
-    setTimeout(fn, timeout)
-    return fn
-}
-
-if (trackedLinkExists) {
-    document.addEventListener("click", async ev => {
-        const targetElement = ev.target as HTMLElement
-        const trackedElement = getParent(
-            targetElement,
-            (el: HTMLElement) => el.getAttribute("data-track-click") != null
-        )
-        if (trackedElement) {
-            // Note that browsers will cancel all pending requests once a user
-            // navigates away from a page. An earlier implementation had a
-            // timeout to send the event before navigating, but it broke
-            // CMD+CLICK for opening a new tab.
-            Analytics.logEvent("OWID_SITE_CLICK", {
-                text: trackedElement.innerText,
-                href: trackedElement.getAttribute("href"),
-                note: trackedElement.getAttribute("data-track-note")
-            })
-        }
-    })
-}
+})


### PR DESCRIPTION
From the Notion issue, this adds tracking for the following:

- [ ]  Record current chart state (more context on this one?)
- [x]  Record user-initiated tab changes
- [x]  Record download SVG/PNG
- [x]  Record download data

I also added tracking to Feedback opens and Timeline plays. Once these are live I'll make a dashboard for chart events in Amplitude.

The existing code is simple enough and I just stuck with the patterns I found, though I guess there is room for marginal improvements. Most events currently have the type OWID_SITE_CLICK and then "note" is used for further bucketing, but some events use different types. At some point if someone is spending a lot of time in Amplitude it might be helpful to organize the analytics code a little better and standardize these event names. For now Amplitude has great querying capabilities so even with a few naming conventions it is easy to sort through the events.