### PR TITLE
Nit: added small tmux alternative to npm-run-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "dev-site:inspect": "yarn tsnd:inspect site/server/devServer.tsx",
         "dev-webpack": "webpack-dev-server -d",
         "dev": "npm-run-all --race --parallel dev-admin dev-site dev-webpack",
+        "dev-tmux": "tmex dev \"yarn dev-admin\" \"yarn dev-site\" \"yarn dev-webpack\"",
         "typeorm": "yarn tsn node_modules/.bin/typeorm",
         "knex": "yarn tsn node_modules/.bin/knex --knexfile knexfile.ts",
         "migrate": "yarn knex migrate:latest && yarn typeorm migration:run",


### PR DESCRIPTION
This is a very minor thing but I've found tmux to be helpful when you have to start multiple services to run a product.

The benefit of tmux versus "npm-run-all" is each process runs in it's own shell and logs stay separate, like in the screenshot below:

![Screen Shot 2020-03-10 at 3 14 47 PM](https://user-images.githubusercontent.com/74692/76372698-58ca3800-62e2-11ea-8e36-9d87b37bf9fd.png)

The downside is the tmux key bindings are a little obtuse. I also don't want to add two more dependencies, tmux and tmex (the latter is an npm package that provides a nice wrapper for launching tmux sessions). So I'm more posting this to share as tmux can be a handy tool to have on the toolbelt.

I think ideally it would be better to try and modularize the various packages and then you wouldn't need to start multiple services if you were only working on one at a time. In the cases where you did need to start multiple services you could just have a terminal tab for each separate one.