### PR TITLE
Always show footer timeline and additional controls on their own rows like on mobile

### DIFF
--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -497,10 +497,6 @@ export class Controls {
         return this.props.chart.tab === "map"
     }
 
-    @computed get widthIsGreaterThan700(): boolean {
-        return this.props.width > 700
-    }
-
     @computed get hasAddButton(): boolean {
         const { chart } = this.props
         return (
@@ -515,7 +511,6 @@ export class Controls {
         let numLines = 1
         if (this.hasTimeline) numLines += 1
         if (this.hasInlineControls) numLines += 1
-        if (this.widthIsGreaterThan700 && numLines > 1) numLines -= 1
         return numLines
     }
 
@@ -839,15 +834,25 @@ export class ControlsFooterView extends React.Component<{
             isShareMenuActive,
             isSettingsMenuActive,
             hasTimeline,
-            hasInlineControls,
-            widthIsGreaterThan700
+            hasInlineControls
         } = props.controls
         const { chart, chartView } = props.controls.props
 
-        const tabsElement = this._getTabsElement()
-        const timelineElement = hasTimeline && <TimelineControl chart={chart} />
-        const inlineControlsElement =
-            hasInlineControls && this._getInlineControlsElement()
+        const timelineElement = hasTimeline && (
+            <div className="footerRowSingle">
+                <TimelineControl chart={this.props.controls.props.chart} />
+            </div>
+        )
+
+        const inlineControlsElement = hasInlineControls && (
+            <div className="footerRowSingle">
+                {this._getInlineControlsElement()}
+            </div>
+        )
+
+        const tabsElement = (
+            <div className="footerRowSingle">{this._getTabsElement()}</div>
+        )
 
         const shareMenuElement = isShareMenuActive && (
             <ShareMenu
@@ -856,6 +861,7 @@ export class ControlsFooterView extends React.Component<{
                 onDismiss={this.onShareMenu}
             />
         )
+
         const settingsMenuElement = isSettingsMenuActive && (
             <SettingsMenu chart={chart} onDismiss={this.onSettingsMenu} />
         )
@@ -865,28 +871,9 @@ export class ControlsFooterView extends React.Component<{
                 className="ControlsFooter"
                 style={{ height: props.controls.footerHeight }}
             >
-                {hasTimeline &&
-                    (hasInlineControls || !widthIsGreaterThan700) && (
-                        <div className="footerRowSingle">{timelineElement}</div>
-                    )}
-                {hasInlineControls && !widthIsGreaterThan700 && (
-                    <div className="footerRowSingle">
-                        {inlineControlsElement}
-                    </div>
-                )}
-                {widthIsGreaterThan700 && (
-                    <div className="footerRowMulti">
-                        <div>
-                            {hasInlineControls
-                                ? inlineControlsElement
-                                : timelineElement}
-                        </div>
-                        {tabsElement}
-                    </div>
-                )}
-                {!widthIsGreaterThan700 && (
-                    <div className="footerRowSingle">{tabsElement}</div>
-                )}
+                {timelineElement}
+                {inlineControlsElement}
+                {tabsElement}
                 {shareMenuElement}
                 {settingsMenuElement}
             </div>

--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -497,7 +497,7 @@ export class Controls {
         return this.props.chart.tab === "map"
     }
 
-    @computed get hasSpace(): boolean {
+    @computed get widthIsGreaterThan700(): boolean {
         return this.props.width > 700
     }
 
@@ -515,7 +515,7 @@ export class Controls {
         let numLines = 1
         if (this.hasTimeline) numLines += 1
         if (this.hasInlineControls) numLines += 1
-        if (this.hasSpace && numLines > 1) numLines -= 1
+        if (this.widthIsGreaterThan700 && numLines > 1) numLines -= 1
         return numLines
     }
 
@@ -702,20 +702,11 @@ export class ControlsFooterView extends React.Component<{
         this.props.controls.props.chartView.isSelectingData = true
     }
 
-    render() {
+    private _getTabsElement() {
         const { props } = this
-        const {
-            isShareMenuActive,
-            isSettingsMenuActive,
-            hasSettingsMenu,
-            hasTimeline,
-            hasInlineControls,
-            hasAddButton,
-            hasSpace
-        } = props.controls
-        const { chart, chartView } = props.controls.props
-
-        const tabs = (
+        const { hasSettingsMenu } = props.controls
+        const { chart } = props.controls.props
+        return (
             <nav className="tabs">
                 <ul>
                     {chart.availableTabs.map(tabName => {
@@ -793,10 +784,13 @@ export class ControlsFooterView extends React.Component<{
                 </ul>
             </nav>
         )
+    }
 
-        const timeline = hasTimeline && <TimelineControl chart={chart} />
-
-        const extraControls = hasInlineControls && (
+    private _getInlineControlsElement() {
+        const { props } = this
+        const { hasAddButton } = props.controls
+        const { chart } = props.controls.props
+        return (
             <div className="extraControls">
                 {chart.data.canAddData && !hasAddButton && (
                     <button type="button" onClick={this.onDataSelect}>
@@ -837,40 +831,64 @@ export class ControlsFooterView extends React.Component<{
                 )}
             </div>
         )
+    }
+
+    render() {
+        const { props } = this
+        const {
+            isShareMenuActive,
+            isSettingsMenuActive,
+            hasTimeline,
+            hasInlineControls,
+            widthIsGreaterThan700
+        } = props.controls
+        const { chart, chartView } = props.controls.props
+
+        const tabsElement = this._getTabsElement()
+        const timelineElement = hasTimeline && <TimelineControl chart={chart} />
+        const inlineControlsElement =
+            hasInlineControls && this._getInlineControlsElement()
+
+        const shareMenuElement = isShareMenuActive && (
+            <ShareMenu
+                chartView={chartView}
+                chart={chart}
+                onDismiss={this.onShareMenu}
+            />
+        )
+        const settingsMenuElement = isSettingsMenuActive && (
+            <SettingsMenu chart={chart} onDismiss={this.onSettingsMenu} />
+        )
 
         return (
             <div
                 className="ControlsFooter"
                 style={{ height: props.controls.footerHeight }}
             >
-                {hasTimeline && (hasInlineControls || !hasSpace) && (
-                    <div className="footerRowSingle">{timeline}</div>
-                )}
-                {hasInlineControls && !hasSpace && (
-                    <div className="footerRowSingle">{extraControls}</div>
-                )}
-                {hasSpace && (
-                    <div className="footerRowMulti">
-                        <div>
-                            {hasInlineControls ? extraControls : timeline}
-                        </div>
-                        {tabs}
+                {hasTimeline &&
+                    (hasInlineControls || !widthIsGreaterThan700) && (
+                        <div className="footerRowSingle">{timelineElement}</div>
+                    )}
+                {hasInlineControls && !widthIsGreaterThan700 && (
+                    <div className="footerRowSingle">
+                        {inlineControlsElement}
                     </div>
                 )}
-                {!hasSpace && <div className="footerRowSingle">{tabs}</div>}
-                {isShareMenuActive && (
-                    <ShareMenu
-                        chartView={chartView}
-                        chart={chart}
-                        onDismiss={this.onShareMenu}
-                    />
+                {widthIsGreaterThan700 && (
+                    <div className="footerRowMulti">
+                        <div>
+                            {hasInlineControls
+                                ? inlineControlsElement
+                                : timelineElement}
+                        </div>
+                        {tabsElement}
+                    </div>
                 )}
-                {isSettingsMenuActive && (
-                    <SettingsMenu
-                        chart={chart}
-                        onDismiss={this.onSettingsMenu}
-                    />
+                {!widthIsGreaterThan700 && (
+                    <div className="footerRowSingle">{tabsElement}</div>
                 )}
+                {shareMenuElement}
+                {settingsMenuElement}
             </div>
         )
     }

--- a/charts/client/chart.scss
+++ b/charts/client/chart.scss
@@ -222,8 +222,7 @@ figure[data-grapher-src]:empty:after,
         z-index: $zindex-ControlsFooter;
         color: #777;
 
-        .footerRowSingle,
-        .footerRowMulti {
+        .footerRowSingle {
             border-top: 1px solid #e1e1e1;
             box-sizing: content-box;
             width: 100%;
@@ -234,23 +233,11 @@ figure[data-grapher-src]:empty:after,
             width: 100%;
         }
 
-        .footerRowMulti {
-            display: flex;
-
-            > * {
-                width: 50%;
-            }
-        }
-
         .extraControls {
             display: flex;
             height: 100%;
             align-items: center;
             font-size: 0.8em;
-        }
-
-        .footerRowMulti .extraControls {
-            padding-left: 0.5em;
         }
 
         .footerRowSingle .extraControls {


### PR DESCRIPTION
Working on the issue: "Display timeline slider on its own row for date-based charts"

After working with the code we currently have 8 different code paths:
(>700px?)*(inlineControls?)*(timelineControls?)

If we added (isDayBased?) we would have more to support.

Instead what if we just always present the chart as on the mobile device, with timelines and extra controls on their own lines?

I have another branch too where I try to cleanly implement all the existing paths with the addition of the new paths but thought I'd put this one for review first, since it removes a decent amount of complexity.