### PR TITLE
Netlify: add explicit ! to (implicit) forced redirects

### DIFF
--- a/site/server/SiteBaker.tsx
+++ b/site/server/SiteBaker.tsx
@@ -60,7 +60,7 @@ export class SiteBaker {
     async bakeRedirects() {
         const redirects = [
             // RSS feed
-            "/feed /atom.xml 302",
+            "/feed /atom.xml 302!",
 
             // Backwards compatibility-- admin urls
             "/wp-admin/* https://owid.cloud/wp/wp-admin/:splat 301",
@@ -107,7 +107,7 @@ export class SiteBaker {
                     `${row.url.replace(/__/g, "/")} ${row.action_data.replace(
                         /__/g,
                         "/"
-                    )} ${row.action_code}`
+                    )} ${row.action_code}!`
             )
         )
 
@@ -130,7 +130,7 @@ export class SiteBaker {
         for (const row of chartRedirectRows) {
             const trueSlug = JSON.parse(row.trueSlug)
             if (row.slug !== trueSlug) {
-                redirects.push(`/grapher/${row.slug} /grapher/${trueSlug} 302`)
+                redirects.push(`/grapher/${row.slug} /grapher/${trueSlug} 302!`)
             }
         }
 


### PR DESCRIPTION
On April 7th, 2020 Netlify will change the way they handle redirects. Currently, the default behaviour is to always assume redirects are forced – a path will be redirected even if the file exists.

This behaviour will change on April 7th, and we will need to explicitly mark our redirects with a trailing `!` in order to preserve the current behaviour.

More info: https://community.netlify.com/t/changed-behavior-in-redirects/10084