### PR TITLE
Don't include Javascript libs on Chart, Explore, or Covid pages since they are already included in Footer. #324

### DIFF
--- a/site/server/views/ChartPage.tsx
+++ b/site/server/views/ChartPage.tsx
@@ -110,7 +110,6 @@ export const ChartPage = (props: {
                     </noscript>
                 </main>
                 <SiteFooter />
-                <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,fetch" />
                 <script dangerouslySetInnerHTML={{ __html: script }} />
             </body>
         </html>

--- a/site/server/views/ChartPage.tsx
+++ b/site/server/views/ChartPage.tsx
@@ -109,11 +109,9 @@ export const ChartPage = (props: {
                         <p>Interactive visualization requires JavaScript</p>
                     </noscript>
                 </main>
-                <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,fetch" />
-                <script src={webpack("commons.js")} />
-                <script src={webpack("owid.js")} />
-                <script dangerouslySetInnerHTML={{ __html: script }} />
                 <SiteFooter />
+                <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,fetch" />
+                <script dangerouslySetInnerHTML={{ __html: script }} />
             </body>
         </html>
     )

--- a/site/server/views/CovidPage.tsx
+++ b/site/server/views/CovidPage.tsx
@@ -155,8 +155,6 @@ export const CovidPage = () => {
                         </div>
                     </article>
                 </main>
-
-                <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,fetch" />
                 <SiteFooter />
             </body>
         </html>

--- a/site/server/views/CovidPage.tsx
+++ b/site/server/views/CovidPage.tsx
@@ -157,8 +157,6 @@ export const CovidPage = () => {
                 </main>
 
                 <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,fetch" />
-                <script src={webpack("commons.js")} />
-                <script src={webpack("owid.js")} />
                 <SiteFooter />
             </body>
         </html>

--- a/site/server/views/ExplorePage.tsx
+++ b/site/server/views/ExplorePage.tsx
@@ -35,11 +35,9 @@ export const ExplorePage = () => {
                 <main>
                     <div id="explore"></div>
                 </main>
-                <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,fetch" />
-                <script src={webpack("commons.js")} />
-                <script src={webpack("owid.js")} />
-                <script dangerouslySetInnerHTML={{ __html: script }} />
                 <SiteFooter />
+                <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,fetch" />
+                <script dangerouslySetInnerHTML={{ __html: script }} />
             </body>
         </html>
     )

--- a/site/server/views/ExplorePage.tsx
+++ b/site/server/views/ExplorePage.tsx
@@ -36,7 +36,6 @@ export const ExplorePage = () => {
                     <div id="explore"></div>
                 </main>
                 <SiteFooter />
-                <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,fetch" />
                 <script dangerouslySetInnerHTML={{ __html: script }} />
             </body>
         </html>

--- a/site/server/views/SiteFooter.tsx
+++ b/site/server/views/SiteFooter.tsx
@@ -248,6 +248,7 @@ export const SiteFooter = ({
                     </div>
                 </div>
                 <div className="site-tools" />
+                <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,fetch" />
                 <script src={webpack("commons.js", "site")} />
                 <script src={webpack("owid.js", "site")} />
                 <script


### PR DESCRIPTION
@MarcelGerber spotted the problem.