### PR TITLE
Allow inline controls in chart tabs row

### DIFF
--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -497,6 +497,10 @@ export class Controls {
         return this.props.chart.tab === "map"
     }
 
+    @computed get hasSpace(): boolean {
+        return this.props.width > 700
+    }
+
     @computed get hasAddButton(): boolean {
         const { chart } = this.props
         return (
@@ -511,6 +515,7 @@ export class Controls {
         let numLines = 1
         if (this.hasTimeline) numLines += 1
         if (this.hasInlineControls) numLines += 1
+        if (this.hasSpace && numLines > 1) numLines -= 1
         return numLines
     }
 
@@ -834,7 +839,8 @@ export class ControlsFooterView extends React.Component<{
             isShareMenuActive,
             isSettingsMenuActive,
             hasTimeline,
-            hasInlineControls
+            hasInlineControls,
+            hasSpace
         } = props.controls
         const { chart, chartView } = props.controls.props
 
@@ -844,14 +850,19 @@ export class ControlsFooterView extends React.Component<{
             </div>
         )
 
-        const inlineControlsElement = hasInlineControls && (
+        const inlineControlsElement = hasInlineControls && !hasSpace && (
             <div className="footerRowSingle">
                 {this._getInlineControlsElement()}
             </div>
         )
 
         const tabsElement = (
-            <div className="footerRowSingle">{this._getTabsElement()}</div>
+            <div className="footerRowMulti">
+                {hasInlineControls && hasSpace && (
+                    <div>{this._getInlineControlsElement()}</div>
+                )}
+                {this._getTabsElement()}
+            </div>
         )
 
         const shareMenuElement = isShareMenuActive && (

--- a/charts/client/chart.scss
+++ b/charts/client/chart.scss
@@ -222,7 +222,8 @@ figure[data-grapher-src]:empty:after,
         z-index: $zindex-ControlsFooter;
         color: #777;
 
-        .footerRowSingle {
+        .footerRowSingle,
+        .footerRowMulti {
             border-top: 1px solid #e1e1e1;
             box-sizing: content-box;
             width: 100%;
@@ -233,11 +234,23 @@ figure[data-grapher-src]:empty:after,
             width: 100%;
         }
 
+        .footerRowMulti {
+            display: flex;
+
+            > * {
+                width: 50%;
+            }
+        }
+
         .extraControls {
             display: flex;
             height: 100%;
             align-items: center;
             font-size: 0.8em;
+        }
+
+        .footerRowMulti .extraControls {
+            padding-left: 0.5em;
         }
 
         .footerRowSingle .extraControls {


### PR DESCRIPTION
I think it's good to have this back actually. I forgot about this case:

<img width="1440" alt="Screenshot 2020-03-14 at 12 15 42" src="https://user-images.githubusercontent.com/1308115/76682050-908df400-65f0-11ea-8904-cea236753166.png">

(current on left, this PR on right)