### PR TITLE
ScatterPlot: Use date formatting when labels are days instead of years

### DIFF
--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -1,4 +1,4 @@
-import { extend, map, filter, includes, uniqWith, isEqual } from "./Util"
+import { extend, map, filter, includes, uniqWith, isEqual, first } from "./Util"
 import { observable, computed, action, autorun, toJS, runInAction } from "mobx"
 import { ComparisonLineConfig } from "./ComparisonLine"
 import { AxisConfig, AxisConfigProps } from "./AxisConfig"
@@ -219,11 +219,12 @@ export class ChartConfig {
     }
 
     @computed get formatYearFunction() {
-        const firstVar = this.vardata.variables[0]
-        if (!firstVar) return formatYear
+        const yearIsDayVar = first(
+            this.vardata.variables.filter(v => v.display.yearIsDay)
+        )
 
-        return firstVar.display.yearIsDay
-            ? (day: number) => formatDay(day, firstVar.display.zeroDay)
+        return yearIsDayVar
+            ? (day: number) => formatDay(day, yearIsDayVar.display.zeroDay)
             : formatYear
     }
 

--- a/charts/PointsWithLabels.tsx
+++ b/charts/PointsWithLabels.tsx
@@ -68,12 +68,14 @@ interface PointsWithLabelsProps {
     onMouseLeave: () => void
     onClick: () => void
     hideLines: boolean
+    formatLabel: (v: ScatterValue) => string
 }
 
 interface ScatterRenderValue {
     position: Vector2
     size: number
     fontSize: number
+    label: string
     time: {
         x: number
         y: number
@@ -318,7 +320,8 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                         ),
                         size: Math.sqrt(area / Math.PI),
                         fontSize: fontScale(d.size || 1),
-                        time: v.time
+                        time: v.time,
+                        label: this.props.formatLabel(v)
                     }
                 })
 
@@ -366,7 +369,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
         const pos = firstValue.position.subtract(
             nextSegment.normalize().times(5)
         )
-        let bounds = Bounds.forText(firstValue.time.y.toString(), {
+        let bounds = Bounds.forText(firstValue.label, {
             x: pos.x,
             y: pos.y,
             fontSize: fontSize,
@@ -388,7 +391,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
             )
 
         return {
-            text: firstValue.time.y.toString(),
+            text: firstValue.label,
             fontSize: fontSize,
             bounds: bounds,
             series: series,
@@ -437,7 +440,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                 pos = v.position.subtract(nextSegment.normalize().times(5))
             }
 
-            let bounds = Bounds.forText(v.time.y.toString(), {
+            let bounds = Bounds.forText(v.label, {
                 x: pos.x,
                 y: pos.y,
                 fontSize: fontSize,
@@ -459,7 +462,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                 )
 
             return {
-                text: v.time.y.toString(),
+                text: v.label,
                 fontSize: fontSize,
                 bounds: bounds,
                 series: series,
@@ -519,7 +522,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
         return {
             text:
                 hideLines && series.isForeground
-                    ? lastValue.time.y.toString()
+                    ? lastValue.label
                     : series.text,
             fontSize: fontSize,
             bounds: labelBounds,

--- a/charts/ScatterPlot.tsx
+++ b/charts/ScatterPlot.tsx
@@ -333,6 +333,7 @@ export class ScatterPlot extends React.Component<{
                     onMouseOver={this.onScatterMouseOver}
                     onMouseLeave={this.onScatterMouseLeave}
                     onClick={this.onScatterClick}
+                    formatLabel={d => this.chart.formatYearFunction(d.time.y)}
                 />
                 <ScatterColorLegendView
                     legend={legend}


### PR DESCRIPTION
Notion issue: https://www.notion.so/owid/Show-axis-value-instead-of-year-on-ScatterPlot-points-d8069816d451406ab267b2c116ebc679

### To-do

- [x]  Format dates correctly on scatter plots
- [ ]  ~~Allow authors to change whether points are labeled with time, X, or Y value~~