### PR TITLE
Add ability to use x or y values in point labels on ScatterPlots.

### DIFF
--- a/admin/client/EditorScatterTab.tsx
+++ b/admin/client/EditorScatterTab.tsx
@@ -2,7 +2,11 @@ import * as React from "react"
 import { extend, debounce } from "charts/Util"
 import { observable, computed, action, toJS } from "mobx"
 import { observer } from "mobx-react"
-import { ChartConfig, HighlightToggleConfig } from "charts/ChartConfig"
+import {
+    ChartConfig,
+    HighlightToggleConfig,
+    ScatterPointLabelStrategy
+} from "charts/ChartConfig"
 import { ComparisonLineConfig } from "charts/ComparisonLine"
 import { Toggle, NumberField, SelectField, TextField, Section } from "./Forms"
 import { faMinus } from "@fortawesome/free-solid-svg-icons/faMinus"
@@ -77,6 +81,10 @@ export class EditorScatterTab extends React.Component<{ chart: ChartConfig }> {
         chart.props.hideConnectedScatterLines = value
     }
 
+    @action.bound onChangeScatterPointLabelStrategy(value: string) {
+        this.props.chart.props.scatterPointLabelStrategy = value as ScatterPointLabelStrategy
+    }
+
     render() {
         const {
             hasHighlightToggle,
@@ -108,6 +116,13 @@ export class EditorScatterTab extends React.Component<{ chart: ChartConfig }> {
                         value={chart.scatter.xOverrideYear}
                         onValue={debounce(this.onXOverrideYear, 300)}
                         allowNegative
+                    />
+                </Section>
+                <Section name="Point Labels">
+                    <SelectField
+                        value={chart.props.scatterPointLabelStrategy}
+                        onValue={this.onChangeScatterPointLabelStrategy}
+                        options={["year", "y", "x"]}
                     />
                 </Section>
                 <Section name="Filtering">

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -44,6 +44,11 @@ export interface EntitySelection {
     color?: Color
 }
 
+// When a user hovers over a connected series line in a ScatterPlot we show
+// a label for each point. By default that value will be from the "year" column
+// but by changing this option the column used for the x or y axis could be used instead.
+export declare type ScatterPointLabelStrategy = "year" | "x" | "y"
+
 export class DimensionSlot {
     chart: ChartConfig
     property: string
@@ -184,6 +189,8 @@ export class ChartConfigProps {
 
     // Hides lines between points when timeline spans multiple years. Requested by core-econ for certain charts
     @observable hideConnectedScatterLines?: boolean = undefined
+    @observable
+    scatterPointLabelStrategy?: ScatterPointLabelStrategy = undefined
     @observable.ref compareEndPointsOnly?: true = undefined
     @observable.ref matchingEntitiesOnly?: true = undefined
     @observable excludedEntities?: number[] = undefined

--- a/charts/ScatterPlot.tsx
+++ b/charts/ScatterPlot.tsx
@@ -280,6 +280,20 @@ export class ScatterPlot extends React.Component<{
         return !!this.chart.props.hideConnectedScatterLines
     }
 
+    @computed private get scatterPointLabelFormatFunction() {
+        const scatterPointLabelFormatFunctions = {
+            year: (scatterValue: ScatterValue) =>
+                this.chart.formatYearFunction(scatterValue.time.y),
+            y: (scatterValue: ScatterValue) =>
+                this.transform.yFormatTooltip(scatterValue.y),
+            x: (scatterValue: ScatterValue) =>
+                this.transform.xFormatTooltip(scatterValue.x)
+        }
+
+        return scatterPointLabelFormatFunctions[
+            this.chart.props.scatterPointLabelStrategy || "year"
+        ]
+    }
     render() {
         if (this.transform.failMessage)
             return (
@@ -334,7 +348,7 @@ export class ScatterPlot extends React.Component<{
                     onMouseOver={this.onScatterMouseOver}
                     onMouseLeave={this.onScatterMouseLeave}
                     onClick={this.onScatterClick}
-                    formatLabel={d => this.chart.formatYearFunction(d.time.y)}
+                    formatLabel={this.scatterPointLabelFormatFunction}
                 />
                 <ScatterColorLegendView
                     legend={legend}


### PR DESCRIPTION
This adds a select option for admin users to specify a different source for the label values in the scatterplots.

Before:
![image](https://user-images.githubusercontent.com/74692/77206793-f1f40e00-6a9b-11ea-9e54-2aefa99699dd.png)

After:
![image](https://user-images.githubusercontent.com/74692/77206802-f91b1c00-6a9b-11ea-81a3-4248a79151a7.png)
