### PR TITLE
fix(recaptcha): use v2 URL params

### DIFF
--- a/site/server/views/DonatePage.tsx
+++ b/site/server/views/DonatePage.tsx
@@ -14,7 +14,7 @@ export const DonatePage = () => {
             >
                 <script src="https://js.stripe.com/v3/" />
                 <script
-                    src={`https://www.google.com/recaptcha/api.js?render=${settings.RECAPTCHA_SITE_KEY}`}
+                    src={`https://www.google.com/recaptcha/api.js?render=explicit`}
                 />
             </Head>
             <body>


### PR DESCRIPTION
The current API URL (api.js) seems to be for recaptcha v3, while the v2 flow is being used. 

For v2, accepted values for the `render` URL parameter are `explicit` or `load` (not the site key):
https://developers.google.com/recaptcha/docs/invisible#javascript_resource_apijs_parameters

Even in cases where v2 and v3 are concurrently used, the v3 key is being used in the URL:
https://developers.google.com/recaptcha/docs/faq#can-i-run-recaptcha-v2-and-v3-on-the-same-page
