### PR TITLE
Use dimension-specific formatYear where possible

### DIFF
--- a/charts/DimensionWithData.ts
+++ b/charts/DimensionWithData.ts
@@ -6,10 +6,13 @@ import {
     some,
     isString,
     sortBy,
-    isNumber
+    isNumber,
+    formatDay,
+    formatYear
 } from "./Util"
 import { ChartDimension } from "./ChartDimension"
 import { TickFormattingOptions } from "./TickFormattingOptions"
+import { formatDate } from "site/server/formatting"
 
 export class DimensionWithData {
     props: ChartDimension
@@ -136,6 +139,13 @@ export class DimensionWithData {
                     ...options
                 })
         }
+    }
+
+    @computed get formatYear(): (year: number) => string {
+        const { yearIsDay, zeroDay } = this.variable.display
+        return yearIsDay
+            ? (year: number) => formatDay(year, zeroDay)
+            : formatYear
     }
 
     @computed get values() {

--- a/charts/MapData.ts
+++ b/charts/MapData.ts
@@ -6,7 +6,7 @@ import { ChartConfig } from "./ChartConfig"
 import { ColorSchemes, ColorScheme } from "./ColorSchemes"
 import { Color } from "./Color"
 import { ChoroplethData } from "./ChoroplethMap"
-import { entityNameForMap } from "./Util"
+import { entityNameForMap, formatYear } from "./Util"
 import { DimensionWithData } from "./DimensionWithData"
 import { MapTopology } from "./MapTopology"
 
@@ -567,5 +567,9 @@ export class MapData {
                   else return formatValueLong(d)
               }
             : () => ""
+    }
+
+    @computed get formatYear(): (year: number) => string {
+        return this.dimension ? this.dimension.formatYear : formatYear
     }
 }

--- a/charts/MapTab.tsx
+++ b/charts/MapTab.tsx
@@ -31,6 +31,7 @@ interface MapWithLegendProps {
     choroplethData: ChoroplethData
     years: number[]
     inputYear?: number
+    formatYear: (year: number) => string
     legendData: MapLegendBin[]
     legendTitle: string
     projection: MapProjection
@@ -177,7 +178,8 @@ class MapWithLegend extends React.Component<MapWithLegendProps> {
             defaultFill,
             bounds,
             inputYear,
-            mapToDataEntities
+            mapToDataEntities,
+            formatYear
         } = this.props
         const {
             focusBracket,
@@ -235,7 +237,7 @@ class MapWithLegend extends React.Component<MapWithLegendProps> {
                                     ? this.context.chart.map.data.formatTooltipValue(
                                           tooltipDatum.value
                                       )
-                                    : `No data for ${this.context.chart.formatYearFunction(
+                                    : `No data for ${formatYear(
                                           inputYear as number
                                       )}`}
                             </span>
@@ -244,11 +246,7 @@ class MapWithLegend extends React.Component<MapWithLegendProps> {
                                 <div>
                                     in
                                     <br />
-                                    <span>
-                                        {this.context.chart.formatYearFunction(
-                                            tooltipDatum.year
-                                        )}
-                                    </span>
+                                    <span>{formatYear(tooltipDatum.year)}</span>
                                 </div>
                             )}
                         </div>
@@ -317,6 +315,7 @@ export class MapTab extends React.Component<MapTabProps> {
                         projection={map.projection}
                         defaultFill={map.noDataColor}
                         mapToDataEntities={map.data.mapToDataEntities}
+                        formatYear={map.data.formatYear}
                     />
                 ) : (
                     <LoadingChart bounds={layout.innerBounds} />

--- a/charts/ScatterPlot.tsx
+++ b/charts/ScatterPlot.tsx
@@ -283,7 +283,7 @@ export class ScatterPlot extends React.Component<{
     @computed private get scatterPointLabelFormatFunction() {
         const scatterPointLabelFormatFunctions = {
             year: (scatterValue: ScatterValue) =>
-                this.chart.formatYearFunction(scatterValue.time.y),
+                this.chart.formatYearFunction(scatterValue.year),
             y: (scatterValue: ScatterValue) =>
                 this.transform.yFormatTooltip(scatterValue.y),
             x: (scatterValue: ScatterValue) =>
@@ -381,7 +381,8 @@ export class ScatterPlot extends React.Component<{
                     <ScatterTooltip
                         formatY={transform.yFormatTooltip}
                         formatX={transform.xFormatTooltip}
-                        formatYearFunction={this.chart.formatYearFunction}
+                        formatYYear={transform.yFormatYear}
+                        formatXYear={transform.xFormatYear}
                         series={tooltipSeries}
                         maxWidth={sidebarWidth}
                         fontSize={this.chart.baseFontSize}
@@ -402,7 +403,8 @@ export class ScatterPlot extends React.Component<{
 interface ScatterTooltipProps {
     formatY: (value: number) => string
     formatX: (value: number) => string
-    formatYearFunction: (value: number) => string
+    formatYYear: (value: number) => string
+    formatXYear: (value: number) => string
     series: ScatterSeries
     maxWidth: number
     fontSize: number
@@ -421,7 +423,7 @@ class ScatterTooltip extends React.Component<ScatterTooltipProps> {
 
     formatValueX(value: ScatterValue) {
         let s = "X Axis: " + this.props.formatX(value.x)
-        const formatYear = this.props.formatYearFunction
+        const formatYear = this.props.formatXYear
         if (!value.time.span && value.time.y !== value.time.x)
             s += ` (data from ${formatYear(value.time.x)})`
         return s
@@ -450,7 +452,7 @@ class ScatterTooltip extends React.Component<ScatterTooltipProps> {
         elements.push(heading)
         offset += heading.wrap.height + lineHeight
 
-        const formatFunction = this.props.formatYearFunction
+        const { formatYYear } = this.props
 
         values.forEach(v => {
             const year = {
@@ -460,10 +462,10 @@ class ScatterTooltip extends React.Component<ScatterTooltipProps> {
                     maxWidth: maxWidth,
                     fontSize: 0.65 * fontSize,
                     text: v.time.span
-                        ? `${formatFunction(
-                              v.time.span[0]
-                          )} to ${formatFunction(v.time.span[1])}`
-                        : formatFunction(v.time.y)
+                        ? `${formatYYear(v.time.span[0])} to ${formatYYear(
+                              v.time.span[1]
+                          )}`
+                        : formatYYear(v.time.y)
                 })
             }
             offset += year.wrap.height

--- a/charts/ScatterTransform.ts
+++ b/charts/ScatterTransform.ts
@@ -16,7 +16,8 @@ import {
     firstOfNonEmptyArray,
     lastOfNonEmptyArray,
     uniq,
-    compact
+    compact,
+    formatYear
 } from "./Util"
 import { computed } from "mobx"
 import { defaultTo, defaultWith, first, last } from "./Util"
@@ -574,6 +575,14 @@ export class ScatterTransform implements IChartTransform {
         return this.isRelativeMode || !this.xDimension
             ? this.xAxis.tickFormat
             : this.xDimension.formatValueLong
+    }
+
+    @computed get yFormatYear(): (year: number) => string {
+        return this.yDimension ? this.yDimension.formatYear : formatYear
+    }
+
+    @computed get xFormatYear(): (year: number) => string {
+        return this.xDimension ? this.xDimension.formatYear : formatYear
     }
 
     @computed get currentData(): ScatterSeries[] {

--- a/charts/SourcesTab.tsx
+++ b/charts/SourcesTab.tsx
@@ -39,9 +39,9 @@ export class SourcesTab extends React.Component<{
         const maxYear = max(variable.years)
         let timespan = ""
         if (minYear !== undefined && maxYear !== undefined)
-            timespan = `${this.props.chart.formatYearFunction(
+            timespan = `${dimension.formatYear(
                 minYear
-            )} – ${this.props.chart.formatYearFunction(maxYear)}`
+            )} – ${dimension.formatYear(maxYear)}`
 
         return (
             <div key={source.id} className="datasource-wrapper">


### PR DESCRIPTION
In some cases, we may use different time formatting on different dimensions, e.g. a scatter plot where X axis has a years variable, and Y axis has a days variable: https://owid.cloud/admin/charts/4041/edit (Slack discussion: https://owid.slack.com/archives/CUQSW9STU/p1584912362004000?thread_ts=1584907551.000900&cid=CUQSW9STU)

![total-confirmed-cases-of-covid-19-per-million-people-vs-gdp-per-capita](https://user-images.githubusercontent.com/1308115/77310415-35e24f80-6cf6-11ea-943d-a260a6be74eb.png)

From an implementation point of view, this breaks the timespan logic (and probably more) and it isn't a good idea to combine variables with different time-bases. But authors are already creating these charts, and I imagine there will be more as we find interesting correlations between COVID-19 and various health/economics metrics.

Anyway, I thought we should try to use dimension-specific year formatting to address the problem as much as possible.

This PR fixes a problem here:

<img width="239" alt="Screenshot 2020-03-23 at 11 05 10" src="https://user-images.githubusercontent.com/1308115/77310486-50b4c400-6cf6-11ea-8189-f70014c15345.png">

And here: 

<img width="409" alt="Screenshot 2020-03-23 at 11 08 16" src="https://user-images.githubusercontent.com/1308115/77310681-a38e7b80-6cf6-11ea-8081-9995d212e906.png">