### PR TITLE
Add support for ourworldindata.org/x originUrl to "Here is all our research" link

### DIFF
--- a/site/server/views/ChartPage.tsx
+++ b/site/server/views/ChartPage.tsx
@@ -5,8 +5,6 @@ import { faArrowRight } from "@fortawesome/free-solid-svg-icons/faArrowRight"
 import * as React from "react"
 import urljoin = require("url-join")
 import * as _ from "lodash"
-
-import { webpack } from "utils/server/staticGen"
 import { ChartConfigProps } from "charts/ChartConfig"
 import { SiteHeader } from "./SiteHeader"
 import { SiteFooter } from "./SiteFooter"
@@ -92,7 +90,7 @@ export const ChartPage = (props: {
 
                     {post && (
                         <div className="originReference">
-                            <a href={chart.originUrl}>
+                            <a href={`/${post.slug}`}>
                                 Here is all our research and data on{" "}
                                 <strong>{post.title}</strong>.
                                 <FontAwesomeIcon icon={faArrowRight} />


### PR DESCRIPTION
Ex:
- http://localhost:3030/admin/charts/4060/edit
- http://localhost:3099/grapher/deaths-covid-19-vs-case-fatality-rate

"ourworldindata.org/malaria" in the `originUrl` field creates the following big blue button href:
- before: "ourworldindata.org/malaria", leading to "[HOST]/ourworldindata.org/malaria"
- after: "/malaria", leading to "[HOST]/malaria"