### PR TITLE
Add a min-height to the chart on wide screens so the chart doesn't un…

### DIFF
--- a/site/client/css/pages/chart.scss
+++ b/site/client/css/pages/chart.scss
@@ -10,6 +10,10 @@
     @include md-up {
         height: calc(100vh - 225px);
     }
+
+    @include lg-up {
+        min-height: 600px;
+    }
 }
 
 #fallback > img {


### PR DESCRIPTION
…necessarily spread the whole display width

Fixes #358.

This is my proposed fix for that issue, adding a min-height of 600px (which is the `authorWidth`) on large (`lg`) screens, so the chart doesn't spread the _width_ because of missing _height_.

This fixes the issue on my laptop.
I've also tested this change with the iPad and iPad Pro dimensions in Chrome, and confirmed that the site works the same way as before in those cases.