### PR TITLE
Support navigator.share API in share menu

### DIFF
--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -132,6 +132,21 @@ class ShareMenu extends React.Component<{
         }
     }
 
+    @action.bound async onNavigatorShare() {
+        if (this.canonicalUrl && navigator.share) {
+            const shareData = {
+                title: this.title,
+                url: this.canonicalUrl
+            }
+
+            try {
+                await navigator.share(shareData)
+            } catch (err) {
+                console.error("couldn't share using navigator.share", err)
+            }
+        }
+    }
+
     @computed get twitterHref(): string {
         let href =
             "https://twitter.com/intent/tweet/?text=" +
@@ -181,6 +196,15 @@ class ShareMenu extends React.Component<{
                 >
                     <FontAwesomeIcon icon={faCode} /> Embed
                 </a>
+                {"share" in navigator && (
+                    <a
+                        className="btn"
+                        title="Share this visualization with an app on your device"
+                        onClick={this.onNavigatorShare}
+                    >
+                        <FontAwesomeIcon icon={faShareAlt} /> Share via&hellip;
+                    </a>
+                )}
                 {editUrl && (
                     <a
                         className="btn"

--- a/charts/client/chart.scss
+++ b/charts/client/chart.scss
@@ -498,29 +498,23 @@ figure[data-grapher-src]:empty:after,
     }
 
     .ShareMenu .btn {
-        display: block;
+        display: flex;
+        align-items: center;
         padding: 1em 1.5em;
-        padding-right: 3em;
         text-align: left;
         color: #333;
         text-decoration: none;
     }
 
-    .ShareMenu .btn > i {
-        background-color: #333;
-        color: white;
-        text-align: center;
+    .ShareMenu .btn > svg {
         font-size: 1em;
-        width: 1.8em;
-        height: 1.8em;
-        line-height: 1.8em;
-        margin-right: 2px;
-        border-radius: 2px;
+        width: 1.5em;
+        height: 1.5em;
+        margin-right: 8px;
         position: relative;
     }
 
     .ShareMenu .btn:hover {
-        text-decoration: none;
         background-color: #eee;
     }
 

--- a/charts/global.d.ts
+++ b/charts/global.d.ts
@@ -1,0 +1,12 @@
+// navigator.share API: taken from https://github.com/Microsoft/TypeScript/issues/18642#issuecomment-576763015
+type ShareData = {
+    title?: string
+    text?: string
+    url?: string
+    files?: ReadonlyArray<File>
+}
+
+interface Navigator {
+    share?: (data?: ShareData) => Promise<void>
+    canShare?: (data?: ShareData) => boolean
+}


### PR DESCRIPTION
Resolves #326.

As mentioned over there, the `navigator.share` API allows a website to interact with the operating systems' share functionality, especially on iOS and Android. It has good browser compatibility on mobile.

The additional menu entry ("Share via...", [akin to Twitter mobile](https://user-images.githubusercontent.com/2641501/77945355-d3beb700-72c0-11ea-965e-182db3e4d8a6.jpg)) is only shown if the API is supported, so you won't see any difference on a normal desktop browser.

This is what this looks like on Android 10:
<img src="https://user-images.githubusercontent.com/2641501/77944932-116f1000-72c0-11ea-8389-1e2bc475acb1.jpg" height=400 />
<img src="https://user-images.githubusercontent.com/2641501/77945229-99551a00-72c0-11ea-8301-240eb360931f.jpg" height=400 />