### PR TITLE
Give clear success message when feedback is successfully sent

### DIFF
--- a/site/client/Feedback.tsx
+++ b/site/client/Feedback.tsx
@@ -119,17 +119,13 @@ export class FeedbackForm extends React.Component<{ onClose?: () => void }> {
         return (
             <React.Fragment>
                 <div className="header">Leave us feedback</div>
+                <div className="notice">
+                    <p>
+                        We read and consider all feedback, but due to a high
+                        volume of messages we are not able to reply to all.
+                    </p>
+                </div>
                 <div className="formBody">
-                    <div className="formSection">
-                        <div className="notice">
-                            <p className="title">We welcome your feedback.</p>
-                            <p>
-                                In the current situation we read and consider
-                                all feedback, but can not promise to reply to
-                                all.
-                            </p>
-                        </div>
-                    </div>
                     <div className="formSection">
                         <label htmlFor="feedback.name">Your name</label>
                         <input

--- a/site/client/owid.scss
+++ b/site/client/owid.scss
@@ -1370,6 +1370,21 @@ html:not(.js) {
             margin: 0;
         }
     }
+
+    .doneMessage {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        padding: 1rem;
+
+        .icon {
+            font-size: 3rem;
+            color: rgba($primary-color, 0.6);
+        }
+    }
 }
 
 .CountryProfilePage {

--- a/site/client/owid.scss
+++ b/site/client/owid.scss
@@ -1344,18 +1344,18 @@ html:not(.js) {
             flex: 1;
             resize: none;
         }
+    }
 
-        .notice {
-            @include info;
-            margin-top: $vertical-spacing;
-            padding: 1rem;
-            background-color: $tertiary-color;
-            color: $primary-color;
-            .title {
-                font-weight: bold;
-                margin: 0 0 0.5rem;
-                font-size: inherit;
-            }
+    .notice {
+        @include info;
+        margin-top: 0;
+        padding: 1rem;
+        background-color: $tertiary-color;
+        color: $primary-color;
+        .title {
+            font-weight: bold;
+            margin: 0 0 0.5rem;
+            font-size: inherit;
         }
     }
 
@@ -1380,9 +1380,17 @@ html:not(.js) {
         text-align: center;
         padding: 1rem;
 
+        h3 {
+            margin: 1rem 0;
+        }
+
+        p {
+            margin: 1rem 0;
+        }
+
         .icon {
             font-size: 3rem;
-            color: rgba($primary-color, 0.6);
+            color: rgba($primary-color, 0.45);
         }
     }
 }


### PR DESCRIPTION
We currently don't clear the form after feedback is successfully sent.

This is a quick fix that shows an unavoidable message – hopefully it decreases the duplication of messages.

<img width="404" alt="Screenshot 2020-03-30 at 20 51 31" src="https://user-images.githubusercontent.com/1308115/77955553-47b08d80-72c8-11ea-91b3-bca63161ce3f.png">
