### PR TITLE
Better touch support for line & area charts

### DIFF
--- a/charts/Lines.tsx
+++ b/charts/Lines.tsx
@@ -188,6 +188,7 @@ export class Lines extends React.Component<LinesProps> {
         this.container.addEventListener("touchstart", this.onCursorMove)
         this.container.addEventListener("touchmove", this.onCursorMove)
         this.container.addEventListener("touchend", this.onCursorLeave)
+        this.container.addEventListener("touchcancel", this.onCursorLeave)
     }
 
     componentWillUnmount() {
@@ -197,6 +198,10 @@ export class Lines extends React.Component<LinesProps> {
             this.container.removeEventListener("touchstart", this.onCursorMove)
             this.container.removeEventListener("touchmove", this.onCursorMove)
             this.container.removeEventListener("touchend", this.onCursorLeave)
+            this.container.removeEventListener(
+                "touchcancel",
+                this.onCursorLeave
+            )
         }
     }
 

--- a/charts/Lines.tsx
+++ b/charts/Lines.tsx
@@ -95,9 +95,8 @@ export class Lines extends React.Component<LinesProps> {
         )
     }
 
-    @action.bound onMouseMove(ev: MouseEvent) {
-        // const {axisBox, data} = this.props
-        const { axisBox, xScale, yScale } = this.props
+    @action.bound onCursorMove(ev: MouseEvent | TouchEvent) {
+        const { axisBox, xScale } = this.props
 
         const mouse = getRelativeMouse(this.base.current, ev)
 
@@ -110,6 +109,10 @@ export class Lines extends React.Component<LinesProps> {
         }
 
         this.props.onHover(hoverX)
+    }
+
+    @action.bound onCursorLeave(ev: MouseEvent | TouchEvent) {
+        this.props.onHover(undefined)
     }
 
     @computed get bounds() {
@@ -180,14 +183,20 @@ export class Lines extends React.Component<LinesProps> {
         const base = this.base.current as SVGGElement
         this.container = base.closest("svg") as SVGElement
 
-        this.container.addEventListener("mousemove", this.onMouseMove)
-        this.container.addEventListener("mouseleave", this.onMouseMove)
+        this.container.addEventListener("mousemove", this.onCursorMove)
+        this.container.addEventListener("mouseleave", this.onCursorLeave)
+        this.container.addEventListener("touchstart", this.onCursorMove)
+        this.container.addEventListener("touchmove", this.onCursorMove)
+        this.container.addEventListener("touchend", this.onCursorLeave)
     }
 
     componentWillUnmount() {
         if (this.container) {
-            this.container.removeEventListener("mousemove", this.onMouseMove)
-            this.container.removeEventListener("mouseleave", this.onMouseMove)
+            this.container.removeEventListener("mousemove", this.onCursorMove)
+            this.container.removeEventListener("mouseleave", this.onCursorLeave)
+            this.container.removeEventListener("touchstart", this.onCursorMove)
+            this.container.removeEventListener("touchmove", this.onCursorMove)
+            this.container.removeEventListener("touchend", this.onCursorLeave)
         }
     }
 

--- a/charts/StackedArea.tsx
+++ b/charts/StackedArea.tsx
@@ -154,6 +154,7 @@ export class Areas extends React.Component<AreasProps> {
                 onTouchStart={this.onCursorMove}
                 onTouchMove={this.onCursorMove}
                 onTouchEnd={this.onCursorLeave}
+                onTouchCancel={this.onCursorLeave}
             >
                 <rect
                     x={xScale.range[0]}

--- a/charts/StackedArea.tsx
+++ b/charts/StackedArea.tsx
@@ -47,7 +47,9 @@ export class Areas extends React.Component<AreasProps> {
 
     @observable hoverIndex?: number
 
-    @action.bound onMouseMove(ev: React.MouseEvent<SVGGElement>) {
+    @action.bound onCursorMove(
+        ev: React.MouseEvent<SVGGElement> | React.TouchEvent<SVGElement>
+    ) {
         const { axisBox, data } = this.props
 
         const mouse = getRelativeMouse(this.base.current, ev.nativeEvent)
@@ -62,6 +64,13 @@ export class Areas extends React.Component<AreasProps> {
             this.hoverIndex = undefined
         }
 
+        this.props.onHover(this.hoverIndex)
+    }
+
+    @action.bound onCursorLeave(
+        ev: React.MouseEvent<SVGGElement> | React.TouchEvent<SVGElement>
+    ) {
+        this.hoverIndex = undefined
         this.props.onHover(this.hoverIndex)
     }
 
@@ -140,8 +149,11 @@ export class Areas extends React.Component<AreasProps> {
             <g
                 ref={this.base}
                 className="Areas"
-                onMouseMove={this.onMouseMove}
-                onMouseLeave={this.onMouseMove}
+                onMouseMove={this.onCursorMove}
+                onMouseLeave={this.onCursorLeave}
+                onTouchStart={this.onCursorMove}
+                onTouchMove={this.onCursorMove}
+                onTouchEnd={this.onCursorLeave}
             >
                 <rect
                     x={xScale.range[0]}


### PR DESCRIPTION
Fixes #369.

I've changed it so the tooltip follows the finger, and is only visible while the finger is held down (on mobile).
The desktop behavior is still the same.