### PR TITLE
Fix broken hrefs in optimized svgs

### DIFF
--- a/settings.ts
+++ b/settings.ts
@@ -75,3 +75,8 @@ export const PUBLIC_TAG_PARENT_IDS: number[] = [
 export const EXPLORER: boolean = process.env.EXPLORER
     ? parseBool(process.env.EXPLORER)
     : false
+
+// Settings for optimizations that are applied in the baking step
+export const OPTIMIZE_SVG_EXPORTS = process.env.OPTIMIZE_SVG_EXPORTS
+    ? parseBool(process.env.OPTIMIZE_SVG_EXPORTS)
+    : false

--- a/site/server/SiteBaker.tsx
+++ b/site/server/SiteBaker.tsx
@@ -11,7 +11,7 @@ import * as settings from "settings"
 import { formatPost, extractFormattingOptions } from "./formatting"
 import { LongFormPage } from "./views/LongFormPage"
 import { BASE_DIR, BAKED_SITE_DIR, WORDPRESS_DIR } from "serverSettings"
-const { BLOG_POSTS_PER_PAGE } = settings
+const { BLOG_POSTS_PER_PAGE, OPTIMIZE_SVG_EXPORTS } = settings
 import {
     renderToHtmlPage,
     renderFrontPage,
@@ -414,7 +414,8 @@ export class SiteBaker {
                 await bakeImageExports(
                     `${BAKED_SITE_DIR}/grapher/exports`,
                     chart,
-                    vardata
+                    vardata,
+                    OPTIMIZE_SVG_EXPORTS
                 )
                 this.stage(svgPath)
                 this.stage(pngPath)

--- a/site/server/svgPngExport.tsx
+++ b/site/server/svgPngExport.tsx
@@ -10,8 +10,13 @@ global.App = { isEditor: false }
 import { ChartConfig, ChartConfigProps } from "charts/ChartConfig"
 
 const svgoConfig: svgo.Options = {
-    floatPrecision: 1,
-    plugins: [{ collapseGroups: false }, { removeViewBox: false }]
+    floatPrecision: 2,
+    plugins: [
+        { collapseGroups: false }, // breaks the "Our World in Data" logo in the upper right
+        { removeUnknownsAndDefaults: false }, // would remove hrefs from links (<a>)
+        { removeViewBox: false },
+        { removeXMLNS: false }
+    ]
 }
 
 const svgoInstance = new svgo(svgoConfig)


### PR DESCRIPTION
This fixes broken hrefs mentioned in https://github.com/owid/owid-grapher/pull/370#issuecomment-607054294, and also introduces a new flag `OPTIMIZE_SVG_EXPORTS` in `settings.ts` (which can be overridden in `.env`) to quickly enable and disable the feature.