### PR TITLE
Improve chart sizing on ChartPage

### DIFF
--- a/charts/ChartView.tsx
+++ b/charts/ChartView.tsx
@@ -170,13 +170,13 @@ export class ChartView extends React.Component<ChartViewProps> {
     // If we have a big screen to be in, we can define our own aspect ratio and sit in the center
     @computed get paddedWidth(): number {
         return this.isPortrait
-            ? this.containerBounds.width * 0.9
-            : this.containerBounds.width * 0.9
+            ? this.containerBounds.width * 0.95
+            : this.containerBounds.width * 0.95
     }
     @computed get paddedHeight(): number {
         return this.isPortrait
-            ? this.containerBounds.height * 0.9
-            : this.containerBounds.height * 0.9
+            ? this.containerBounds.height * 0.95
+            : this.containerBounds.height * 0.95
     }
     @computed get scaleToFitIdeal(): number {
         return Math.min(

--- a/charts/ChartView.tsx
+++ b/charts/ChartView.tsx
@@ -140,10 +140,10 @@ export class ChartView extends React.Component<ChartViewProps> {
     }
 
     @computed get authorWidth() {
-        return this.isPortrait ? 400 : 850
+        return this.isPortrait ? 400 : 680
     }
     @computed get authorHeight() {
-        return this.isPortrait ? 640 : 600
+        return this.isPortrait ? 640 : 480
     }
 
     // If the available space is very small, we use all of the space given to us

--- a/site/client/css/pages/chart.scss
+++ b/site/client/css/pages/chart.scss
@@ -4,12 +4,37 @@
     align-items: center;
     justify-content: center;
     flex-direction: column;
-    margin: 0;
+    margin: 0 auto;
     width: 100%;
+
+    // Defined in chart.authorWidth & chart.authorHeight (the landscape values)
+    $author-width: 680px;
+    $author-height: 480px;
+    $ideal-ratio: $author-width / $author-height;
+
+    $max-width: 1250px; // The rough max-width across all pages on the site
+    $max-height: $max-width / $ideal-ratio;
+
+    // On small viewports always use the full available height.
+    // We only leave space for the mobile header and fill the rest.
     height: calc(100vh - #{$mobile-header-height});
+
     @include md-up {
+        // On larger viewports, we want to leave more space at the bottom to make the entry link
+        // more visible. It doesn't need to be fully visible, just enough to pop out to the user.
         height: calc(100vh - 175px);
-        max-height: 950px;
+    }
+
+    // At this point, the ratio-preserving sizing kicks in, so we want to mirror that in the CSS
+    // to avoid using unnecessary space.
+    @media (min-width: $author-width) {
+        // We no longer use the full height
+        max-height: #{1 / $ideal-ratio * 100}vw;
+    }
+
+    @media (min-width: $max-width) {
+        max-width: $max-width;
+        max-height: $max-height;
     }
 }
 

--- a/site/client/css/pages/chart.scss
+++ b/site/client/css/pages/chart.scss
@@ -8,7 +8,8 @@
     width: 100%;
     height: calc(100vh - #{$mobile-header-height});
     @include md-up {
-        height: calc(100vh - 225px);
+        height: calc(100vh - 175px);
+        max-height: 950px;
     }
 }
 


### PR DESCRIPTION
**⚠️ This will possibly have an effect on external embeds.** 

Fixes #358, in an alternative and more involved way than #359.

Implements:
- Less empty space around chart
- Ideal-ratio-sizing at smaller dimensions, so that `fitBounds` doesn't apply on normal laptop screens (see #358)
- The (huge) entry link is now moved lower and isn't fully visible, but I think visible enough – the space is prioritized for the chart instead

@MarcelGerber I've tagged you to review if you have time, but no worries if you can't. I just saw that you've dug into how the chart sizing works and can let me know if you see some ways this could fail, or could be improved. 

I've avoided this issue for a long time because of how it ties up CSS & JS sizing. It's probably better to keep all logic in one place; this is supposed to be a "temporary" fix...