### PR TITLE
Don't include moment.js locales in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
         "mobx-react": "5",
         "module-alias": "^2.2.0",
         "moment": "^2.24.0",
+        "moment-locales-webpack-plugin": "^1.2.0",
         "mysql": "^2.17.1",
         "netlify-cli": "^2.15.0",
         "node-fetch": "^2.6.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require("path")
 const ExtractTextPlugin = require("extract-text-webpack-plugin")
 const ManifestPlugin = require("webpack-manifest-plugin")
+const MomentLocalesPlugin = require("moment-locales-webpack-plugin")
 const Dotenv = require("dotenv-webpack")
 
 module.exports = (env, argv) => {
@@ -95,6 +96,10 @@ module.exports = (env, argv) => {
 
             // Writes manifest.json which production code reads to know paths to asset files
             new ManifestPlugin(),
+
+            // Remove all moment locales except for "en"
+            // This way of doing so is recommended by Moment itself: https://momentjs.com/docs/#/use-it/webpack/
+            new MomentLocalesPlugin(),
 
             // This plugin loads settings from .env so we can import them
             // Note that this means the settings become part of the client-side JS at webpack build time, not at server run time

--- a/yarn.lock
+++ b/yarn.lock
@@ -11080,6 +11080,13 @@ module-definition@^3.1.0:
     ast-module-types "^2.4.0"
     node-source-walk "^4.0.0"
 
+moment-locales-webpack-plugin@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.2.0.tgz#9af83876a44053706b868ceece5119584d10d7aa"
+  integrity sha512-QAi5v0OlPUP7GXviKMtxnpBAo8WmTHrUNN7iciAhNOEAd9evCOvuN0g1N7ThIg3q11GLCkjY1zQ2saRcf/43nQ==
+  dependencies:
+    lodash.difference "^4.5.0"
+
 moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"


### PR DESCRIPTION
Working towards #367, this shaves 200KB off our `commons.js` bundle by removing all locales from moment. `en` is still available, even though we don't currently use it (but might do so in the future).