### PR TITLE
TypeScript: Enable esModuleInterop

### DIFF
--- a/admin/client/CountryStandardizerPage.tsx
+++ b/admin/client/CountryStandardizerPage.tsx
@@ -8,7 +8,7 @@ import {
     reaction,
     IReactionDisposer
 } from "mobx"
-import * as parse from "csv-parse"
+import parse from "csv-parse"
 
 const unidecode = require("unidecode")
 const FuzzySet = require("fuzzyset")

--- a/admin/client/DatasetEditPage.tsx
+++ b/admin/client/DatasetEditPage.tsx
@@ -11,7 +11,7 @@ import {
 } from "mobx"
 import * as _ from "lodash"
 import { Prompt, Redirect } from "react-router-dom"
-import * as filenamify from "filenamify"
+import filenamify from "filenamify"
 const timeago = require("timeago.js")()
 
 import { VariableDisplaySettings } from "charts/Variable"

--- a/admin/client/ImportPage.tsx
+++ b/admin/client/ImportPage.tsx
@@ -13,7 +13,7 @@ import {
 import { observer } from "mobx-react"
 import { Redirect } from "react-router-dom"
 
-import * as parse from "csv-parse"
+import parse from "csv-parse"
 import { BindString, NumericSelectField, FieldsRow } from "./Forms"
 import { AdminLayout } from "./AdminLayout"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext"

--- a/admin/server/adminViews.tsx
+++ b/admin/server/adminViews.tsx
@@ -1,6 +1,6 @@
 // Misc non-SPA views
 import { Router } from "express"
-import * as filenamify from "filenamify"
+import filenamify from "filenamify"
 import * as React from "react"
 import { getConnection } from "typeorm"
 

--- a/admin/server/app.tsx
+++ b/admin/server/app.tsx
@@ -1,4 +1,4 @@
-import * as express from "express"
+import express from "express"
 require("express-async-errors")
 const cookieParser = require("cookie-parser")
 const expressErrorSlack = require("express-error-slack")

--- a/charts/SourcesFooter.tsx
+++ b/charts/SourcesFooter.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { observable, computed, action } from "mobx"
 import { observer } from "mobx-react"
-import * as parseUrl from "url-parse"
+import parseUrl from "url-parse"
 
 import { TextWrap } from "./TextWrap"
 import { ChartConfig } from "./ChartConfig"

--- a/charts/Util.ts
+++ b/charts/Util.ts
@@ -123,8 +123,8 @@ export {
 import moment = require("moment")
 import { format } from "d3-format"
 import { extent } from "d3-array"
-import * as striptags from "striptags"
-import * as parseUrl from "url-parse"
+import striptags from "striptags"
+import parseUrl from "url-parse"
 
 import { Vector2 } from "./Vector2"
 import { TickFormattingOptions } from "./TickFormattingOptions"

--- a/db/db.ts
+++ b/db/db.ts
@@ -1,6 +1,6 @@
 import * as mysql from "mysql"
 import * as typeorm from "typeorm"
-import * as Knex from "knex"
+import Knex from "knex"
 import { DB_HOST, DB_USER, DB_PASS, DB_NAME, DB_PORT } from "serverSettings"
 import { registerExitHandler } from "./cleanup"
 let connection: typeorm.Connection

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -11,7 +11,7 @@ import {
 } from "serverSettings"
 import { WORDPRESS_URL, BAKED_BASE_URL } from "settings"
 import * as db from "db/db"
-import * as Knex from "knex"
+import Knex from "knex"
 import fetch from "node-fetch"
 const urlSlug = require("url-slug")
 

--- a/scripts/bakeSite.ts
+++ b/scripts/bakeSite.ts
@@ -1,4 +1,4 @@
-import * as parseArgs from "minimist"
+import parseArgs from "minimist"
 import { tryDeployAndTerminate } from "deploy/deploy"
 const argv = parseArgs(process.argv.slice(2))
 

--- a/scripts/configureAlgolia.ts
+++ b/scripts/configureAlgolia.ts
@@ -1,4 +1,4 @@
-import * as algoliasearch from "algoliasearch"
+import algoliasearch from "algoliasearch"
 
 import { ALGOLIA_ID } from "settings"
 import { ALGOLIA_SECRET_KEY } from "serverSettings"

--- a/scripts/exportChartData.ts
+++ b/scripts/exportChartData.ts
@@ -2,7 +2,7 @@
 
 import * as db from "db/db"
 import * as _ from "lodash"
-import * as parseArgs from "minimist"
+import parseArgs from "minimist"
 
 import { DB_NAME, DB_USER, DB_PASS, DB_HOST, DB_PORT } from "serverSettings"
 import { exec } from "utils/server/serverUtil"

--- a/scripts/exportMetadata.ts
+++ b/scripts/exportMetadata.ts
@@ -2,7 +2,7 @@
 
 import * as db from "db/db"
 import * as fs from "fs-extra"
-import * as parseArgs from "minimist"
+import parseArgs from "minimist"
 
 import { DB_NAME, DB_USER, DB_PASS, DB_HOST, DB_PORT } from "serverSettings"
 import { exec } from "utils/server/serverUtil"

--- a/scripts/exportStripeDonors.ts
+++ b/scripts/exportStripeDonors.ts
@@ -1,4 +1,4 @@
-import * as Stripe from "stripe"
+import Stripe from "stripe"
 import { groupBy, sum } from "lodash"
 
 import { STRIPE_SECRET_KEY } from "serverSettings"

--- a/scripts/indexChartsToAlgolia.ts
+++ b/scripts/indexChartsToAlgolia.ts
@@ -1,4 +1,4 @@
-import * as algoliasearch from "algoliasearch"
+import algoliasearch from "algoliasearch"
 import * as _ from "lodash"
 
 import * as db from "db/db"

--- a/scripts/indexToAlgolia.ts
+++ b/scripts/indexToAlgolia.ts
@@ -1,4 +1,4 @@
-import * as algoliasearch from "algoliasearch"
+import algoliasearch from "algoliasearch"
 
 import * as db from "db/db"
 import * as wpdb from "db/wpdb"

--- a/scripts/postUpdatedHook.ts
+++ b/scripts/postUpdatedHook.ts
@@ -1,5 +1,5 @@
 import { syncPostToGrapher } from "db/model/Post"
-import * as parseArgs from "minimist"
+import parseArgs from "minimist"
 import { BAKE_ON_CHANGE } from "serverSettings"
 import { enqueueDeploy } from "deploy/queue"
 import { exit } from "db/cleanup"

--- a/site/client/DonateForm.tsx
+++ b/site/client/DonateForm.tsx
@@ -4,7 +4,7 @@ import classnames from "classnames"
 import { observable, action, computed, runInAction } from "mobx"
 import { observer } from "mobx-react"
 import { bind } from "decko"
-import * as Recaptcha from "react-recaptcha"
+import Recaptcha from "react-recaptcha"
 import { DONATE_API_URL, BAKED_BASE_URL, RECAPTCHA_SITE_KEY } from "settings"
 
 import stripe from "./stripe"

--- a/site/client/covid/CovidFetch.ts
+++ b/site/client/covid/CovidFetch.ts
@@ -1,5 +1,5 @@
 import { csvParse } from "d3"
-import * as moment from "moment"
+import moment from "moment"
 
 import { CovidSeries } from "./CovidTypes"
 import { fetchText, retryPromise } from "charts/Util"

--- a/site/client/runCookieNotice.tsx
+++ b/site/client/runCookieNotice.tsx
@@ -1,7 +1,7 @@
 import ReactDOM = require("react-dom")
 import * as React from "react"
 import * as Cookies from "js-cookie"
-import * as classnames from "classnames"
+import classnames from "classnames"
 import { observable, action, runInAction } from "mobx"
 import { observer } from "mobx-react"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"

--- a/site/server/bakeChartsToImages.tsx
+++ b/site/server/bakeChartsToImages.tsx
@@ -1,7 +1,7 @@
 import * as _ from "lodash"
-import * as parseUrl from "url-parse"
+import parseUrl from "url-parse"
 import * as db from "db/db"
-import * as parseArgs from "minimist"
+import parseArgs from "minimist"
 const argv = parseArgs(process.argv.slice(2))
 import { getVariableData } from "db/model/Variable"
 import * as fs from "fs-extra"

--- a/site/server/devServer.tsx
+++ b/site/server/devServer.tsx
@@ -1,4 +1,4 @@
-import * as express from "express"
+import express from "express"
 require("express-async-errors")
 import * as path from "path"
 

--- a/site/server/grapherUtil.ts
+++ b/site/server/grapherUtil.ts
@@ -1,9 +1,9 @@
 import * as glob from "glob"
-import * as parseUrl from "url-parse"
+import parseUrl from "url-parse"
 const exec = require("child-process-promise").exec
 import * as path from "path"
 import * as _ from "lodash"
-import * as md5 from "md5"
+import md5 from "md5"
 
 import { BAKED_BASE_URL, OPTIMIZE_SVG_EXPORTS } from "settings"
 import { BAKED_SITE_DIR } from "serverSettings"

--- a/site/server/svgPngExport.tsx
+++ b/site/server/svgPngExport.tsx
@@ -1,7 +1,7 @@
 import * as fs from "fs-extra"
-import * as sharp from "sharp"
+import sharp from "sharp"
 import * as path from "path"
-import * as svgo from "svgo"
+import svgo from "svgo"
 
 declare var global: any
 global.window = { location: { search: "" } }

--- a/site/siteSearch.ts
+++ b/site/siteSearch.ts
@@ -1,4 +1,4 @@
-import * as algoliasearch from "algoliasearch"
+import algoliasearch from "algoliasearch"
 
 import { countries, Country } from "utils/countries"
 

--- a/test/enzymeSetup.ts
+++ b/test/enzymeSetup.ts
@@ -1,4 +1,4 @@
 import * as Enzyme from "enzyme"
-import * as Adapter from "enzyme-adapter-react-16"
+import Adapter from "enzyme-adapter-react-16"
 
 Enzyme.configure({ adapter: new Adapter() })

--- a/tsconfig.client.json
+++ b/tsconfig.client.json
@@ -15,7 +15,8 @@
         "lib": ["dom", "es7", "esnext.asynciterable"],
         "baseUrl": ".",
         "plugins": [],
-        "keyofStringsOnly": true
+        "keyofStringsOnly": true,
+        "esModuleInterop": true
     },
     "exclude": ["node_modules", "bakedSite"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
         "baseUrl": ".",
         "plugins": [],
         "keyofStringsOnly": true,
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        "esModuleInterop": true
     },
     "exclude": ["node_modules", "bakedSite"]
 }

--- a/utils/csv.ts
+++ b/utils/csv.ts
@@ -1,4 +1,4 @@
-import * as parse from "csv-parse"
+import parse from "csv-parse"
 import { ReadStream } from "fs"
 
 export async function parseCSV(csv: string): Promise<string[][]> {

--- a/utils/server/serverUtil.tsx
+++ b/utils/server/serverUtil.tsx
@@ -98,5 +98,5 @@ export const splitOnLastWord = (s: string) => {
     }
 }
 
-import * as filenamify from "filenamify"
+import filenamify from "filenamify"
 export { filenamify }


### PR DESCRIPTION
Working towards #367, I realized on the way that I need to enable the TypeScript option `esModuleInterop`.

The flag is explained here: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-from-commonjs-modules-with---esmoduleinterop

I just thought to open a separate PR for that, so the tree shaking one (currently at https://github.com/owid/owid-grapher/compare/tree-shaking-lodash) doesn't get too crowded. This here shouldn't be able to break anything.