### PR TITLE
Don't bundle html-to-text in production commons.js

### DIFF
--- a/scripts/indexToAlgolia.ts
+++ b/scripts/indexToAlgolia.ts
@@ -6,7 +6,7 @@ import { ALGOLIA_ID } from "settings"
 import { ALGOLIA_SECRET_KEY } from "serverSettings"
 import { formatPost, FormattedPost } from "site/server/formatting"
 import { chunkParagraphs } from "utils/search"
-import { htmlToPlaintext } from "utils/string"
+import { htmlToPlaintext } from "utils/htmlToString"
 import { countries } from "utils/countries"
 
 interface Tag {

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -1,7 +1,7 @@
 #! /usr/bin/env jest
 
 import { chunkParagraphs } from "utils/search"
-import { htmlToPlaintext } from "utils/string"
+import { htmlToPlaintext } from "utils/htmlToString"
 
 const CO2_TEXT = `The large growth in global CO₂ emissions has had a significant impact on the concentrations of CO₂ in Earth’s atmosphere. If we look at atmospheric concentrations over the past 2000 years (see the Data Quality and Measurement section in this entry for explanation on how we estimate historical emissions), we see that levels were fairly stable at 270-285 parts per million (ppm) until the 18th century. Since the Industrial Revolution, global CO₂ concentrations have been increasing rapidly.
 

--- a/utils/htmlToString.ts
+++ b/utils/htmlToString.ts
@@ -1,0 +1,11 @@
+import { fromString } from "html-to-text"
+
+export function htmlToPlaintext(html: string): string {
+    return fromString(html, {
+        tables: true,
+        ignoreHref: true,
+        wordwrap: false,
+        uppercaseHeadings: false,
+        ignoreImage: true
+    })
+}

--- a/utils/string.ts
+++ b/utils/string.ts
@@ -4,18 +4,6 @@ export function findUrlsInText(s: string): string[] {
     return s.match(URL_REGEX) || []
 }
 
-import { fromString } from "html-to-text"
-
-export function htmlToPlaintext(html: string): string {
-    return fromString(html, {
-        tables: true,
-        ignoreHref: true,
-        wordwrap: false,
-        uppercaseHeadings: false,
-        ignoreImage: true
-    })
-}
-
 export function parseBool(input: string): boolean {
     const normalized = input.trim().toLowerCase()
     return normalized === "true" || normalized === "1"


### PR DESCRIPTION
This is again working towards #367.

I've moved `htmlToPlaintext`, which requires the [big html-to-text](https://bundlephobia.com/result?p=html-to-text@5.1.1) library and is only used in scripts and texts, to its own file.

This decreases the size of `commons.js` by .2 MB yet again.