### PR TITLE
Reduce lodash bundle size

### DIFF
--- a/charts/LineChartTransform.ts
+++ b/charts/LineChartTransform.ts
@@ -20,7 +20,7 @@ import { AxisSpec } from "./AxisSpec"
 import { ColorSchemes, ColorScheme } from "./ColorSchemes"
 import { IChartTransform } from "./IChartTransform"
 import { DimensionWithData } from "./DimensionWithData"
-import { findIndex } from "lodash"
+import { findIndex } from "./Util"
 
 // Responsible for translating chart configuration into the form
 // of a line chart

--- a/charts/MapData.ts
+++ b/charts/MapData.ts
@@ -1,6 +1,5 @@
 import { computed, autorun, runInAction, reaction, toJS } from "mobx"
 import { mean, deviation } from "d3-array"
-import * as _ from "lodash"
 
 import { ChartConfig } from "./ChartConfig"
 import { ColorSchemes, ColorScheme } from "./ColorSchemes"
@@ -521,7 +520,7 @@ export class MapData {
         if (targetYear === undefined || !valueByEntityAndYear) return {}
 
         const { tolerance } = map
-        const entities = _.keys(this.knownMapEntities)
+        const entities = Object.keys(this.knownMapEntities)
 
         const result: { [key: string]: MapDataValue } = {}
 

--- a/charts/Util.ts
+++ b/charts/Util.ts
@@ -1,67 +1,67 @@
-import {
-    isEqual,
-    map,
-    sortBy,
-    orderBy,
-    each,
-    keys,
-    entries,
-    trim,
-    isNumber,
-    filter,
-    extend,
-    isEmpty,
-    isFinite,
-    some,
-    every,
-    min,
-    max,
-    minBy,
-    maxBy,
-    compact,
-    uniq,
-    cloneDeep,
-    sum,
-    sumBy,
-    find,
-    identity,
-    union,
-    debounce,
-    includes,
-    toString,
-    isString,
-    keyBy,
-    values,
-    flatten,
-    groupBy,
-    reverse,
-    clone,
-    reduce,
-    noop,
-    floor,
-    ceil,
-    round,
-    toArray,
-    throttle,
-    has,
-    intersection,
-    uniqWith,
-    without,
-    uniqBy,
-    capitalize,
-    sample,
-    sampleSize,
-    pick,
-    omit,
-    difference,
-    sortedUniq,
-    zip,
-    partition,
-    range,
-    findIndex,
-    fromPairs,
-    mapKeys
-} from "lodash"
+// We're importing every item on its own to enable webpack tree shaking
+import isEqual from "lodash/isEqual"
+import map from "lodash/map"
+import sortBy from "lodash/sortBy"
+import orderBy from "lodash/orderBy"
+import each from "lodash/each"
+import keys from "lodash/keys"
+import entries from "lodash/entries"
+import trim from "lodash/trim"
+import isNumber from "lodash/isNumber"
+import filter from "lodash/filter"
+import extend from "lodash/extend"
+import isEmpty from "lodash/isEmpty"
+import isFinite from "lodash/isFinite"
+import some from "lodash/some"
+import every from "lodash/every"
+import min from "lodash/min"
+import max from "lodash/max"
+import minBy from "lodash/minBy"
+import maxBy from "lodash/maxBy"
+import compact from "lodash/compact"
+import uniq from "lodash/uniq"
+import cloneDeep from "lodash/cloneDeep"
+import sum from "lodash/sum"
+import sumBy from "lodash/sumBy"
+import find from "lodash/find"
+import identity from "lodash/identity"
+import union from "lodash/union"
+import debounce from "lodash/debounce"
+import includes from "lodash/includes"
+import toString from "lodash/toString"
+import isString from "lodash/isString"
+import keyBy from "lodash/keyBy"
+import values from "lodash/values"
+import flatten from "lodash/flatten"
+import groupBy from "lodash/groupBy"
+import reverse from "lodash/reverse"
+import clone from "lodash/clone"
+import reduce from "lodash/reduce"
+import noop from "lodash/noop"
+import floor from "lodash/floor"
+import ceil from "lodash/ceil"
+import round from "lodash/round"
+import toArray from "lodash/toArray"
+import throttle from "lodash/throttle"
+import has from "lodash/has"
+import intersection from "lodash/intersection"
+import uniqWith from "lodash/uniqWith"
+import without from "lodash/without"
+import uniqBy from "lodash/uniqBy"
+import capitalize from "lodash/capitalize"
+import sample from "lodash/sample"
+import sampleSize from "lodash/sampleSize"
+import pick from "lodash/pick"
+import omit from "lodash/omit"
+import difference from "lodash/difference"
+import sortedUniq from "lodash/sortedUniq"
+import zip from "lodash/zip"
+import partition from "lodash/partition"
+import range from "lodash/range"
+import findIndex from "lodash/findIndex"
+import fromPairs from "lodash/fromPairs"
+import mapKeys from "lodash/mapKeys"
+
 export {
     isEqual,
     map,

--- a/charts/Util.ts
+++ b/charts/Util.ts
@@ -57,7 +57,10 @@ import {
     sortedUniq,
     zip,
     partition,
-    range
+    range,
+    findIndex,
+    fromPairs,
+    mapKeys
 } from "lodash"
 export {
     isEqual,
@@ -117,7 +120,10 @@ export {
     sortedUniq,
     zip,
     partition,
-    range
+    range,
+    findIndex,
+    fromPairs,
+    mapKeys
 }
 
 import moment = require("moment")

--- a/site/client/FullStory.ts
+++ b/site/client/FullStory.ts
@@ -1,4 +1,4 @@
-import { mapKeys } from "lodash"
+import { mapKeys } from "charts/Util"
 
 declare var window: any
 

--- a/site/client/SiteHeaderMenus.tsx
+++ b/site/client/SiteHeaderMenus.tsx
@@ -11,7 +11,7 @@ import { observer } from "mobx-react"
 import { HeaderSearch } from "./HeaderSearch"
 import { CategoryWithEntries, EntryMeta } from "db/wpdb"
 import classnames from "classnames"
-import { find } from "lodash"
+import { find } from "charts/Util"
 import { bind } from "decko"
 
 import { BAKED_BASE_URL } from "settings"

--- a/site/client/covid/CovidTable.tsx
+++ b/site/client/covid/CovidTable.tsx
@@ -3,7 +3,7 @@ import { observable, action, computed } from "mobx"
 import { observer } from "mobx-react"
 import classnames from "classnames"
 import { scaleLinear, schemeCategory10 } from "d3"
-import { fromPairs, uniq } from "lodash"
+import { fromPairs, uniq } from "charts/Util"
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faAngleDoubleDown } from "@fortawesome/free-solid-svg-icons/faAngleDoubleDown"

--- a/site/client/covid/CovidUtils.ts
+++ b/site/client/covid/CovidUtils.ts
@@ -1,4 +1,4 @@
-import { maxBy } from "lodash"
+import { maxBy } from "charts/Util"
 import { utcFormat } from "d3"
 
 import { TickFormattingOptions } from "charts/TickFormattingOptions"

--- a/site/client/runChartsIndexPage.ts
+++ b/site/client/runChartsIndexPage.ts
@@ -1,5 +1,5 @@
 const fuzzysort = require("fuzzysort")
-import * as _ from "lodash"
+import { keyBy } from "charts/Util"
 import { observable, computed, action, autorun } from "mobx"
 import { Analytics } from "./Analytics"
 interface ChartItem {
@@ -39,7 +39,7 @@ class ChartFilter {
     }
 
     @computed get resultsByTitle(): { [key: string]: SearchResult } {
-        return _.keyBy(this.searchResults, "target")
+        return keyBy(this.searchResults, "target")
     }
 
     constructor() {
@@ -57,7 +57,7 @@ class ChartFilter {
             li: li,
             ul: li.closest("ul") as HTMLUListElement
         }))
-        this.chartItemsByTitle = _.keyBy(this.chartItems, "title")
+        this.chartItemsByTitle = keyBy(this.chartItems, "title")
         this.strings = this.chartItems.map(c => fuzzysort.prepare(c.title))
     }
 

--- a/site/client/runCountryProfilePage.ts
+++ b/site/client/runCountryProfilePage.ts
@@ -1,5 +1,5 @@
 const fuzzysort = require("fuzzysort")
-import * as _ from "lodash"
+import { keyBy } from "charts/Util"
 import { observable, computed, action, autorun } from "mobx"
 import { Analytics } from "./Analytics"
 interface ChartItem {
@@ -39,7 +39,7 @@ class ChartFilter {
     }
 
     @computed get resultsByTitle(): { [key: string]: SearchResult } {
-        return _.keyBy(this.searchResults, "target")
+        return keyBy(this.searchResults, "target")
     }
 
     constructor() {
@@ -60,7 +60,7 @@ class ChartFilter {
             li: li,
             ul: li.closest("ul") as HTMLUListElement
         }))
-        this.chartItemsByTitle = _.keyBy(this.chartItems, "title")
+        this.chartItemsByTitle = keyBy(this.chartItems, "title")
         this.strings = this.chartItems.map(c => fuzzysort.prepare(c.title))
     }
 

--- a/utils/charts.ts
+++ b/utils/charts.ts
@@ -1,5 +1,3 @@
-import * as _ from "lodash"
-
 import { ChartConfigProps } from "charts/ChartConfig"
 import { ChartTypeType } from "charts/ChartType"
 import { EXPLORER } from "settings"
@@ -101,7 +99,8 @@ export function canBeExplorable(config: ChartConfigProps) {
 export function isExplorable(config: ChartConfigProps): boolean {
     return (
         (config.isExplorable ||
-            _.includes(FORCE_EXPLORABLE_CHART_IDS, config.id)) &&
+            (config.id !== undefined &&
+                FORCE_EXPLORABLE_CHART_IDS.includes(config.id))) &&
         canBeExplorable(config)
     )
 }

--- a/utils/search.ts
+++ b/utils/search.ts
@@ -1,4 +1,4 @@
-import * as _ from "lodash"
+import { flatten } from "charts/Util"
 
 const chunk = require("chunk-text")
 
@@ -10,7 +10,7 @@ export function chunkSentences(text: string, maxChunkLength: number): string[] {
     // See https://stackoverflow.com/a/25736082/1983739
     // Not perfect, just works in most cases
     const sentenceRegex = /(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\?|\n)\s/g
-    const sentences = _.flatten(
+    const sentences = flatten(
         text
             .split(sentenceRegex)
             .map(s =>
@@ -50,7 +50,7 @@ export function chunkParagraphs(
     text: string,
     maxChunkLength: number
 ): string[] {
-    const paragraphs = _.flatten(
+    const paragraphs = flatten(
         text
             .split("\n\n")
             .map(p =>


### PR DESCRIPTION
Working further towards #367, this makes sure we are only importing the lodash functions we need, and never `import * from lodash` (at least on the client side).

The savings are not huge: a mere 0.04MB less for `commons.js`. Well, I guess we're using quite a lot of lodash functions.

This would be easier with `lodash-es`, where the nicer destructuring imports are supported, but `ts-node` then complains about using ES6 modules directly, and I haven't really come up with a nice solution to that.

Note that admin code still uses `import *` imports, but we don't really care about its size. We could change those too, though.