### PR TITLE
Memoize the result of fetchECDCData

### DIFF
--- a/charts/Util.ts
+++ b/charts/Util.ts
@@ -61,6 +61,7 @@ import range from "lodash/range"
 import findIndex from "lodash/findIndex"
 import fromPairs from "lodash/fromPairs"
 import mapKeys from "lodash/mapKeys"
+import memoize from "lodash/memoize"
 
 export {
     isEqual,
@@ -123,7 +124,8 @@ export {
     range,
     findIndex,
     fromPairs,
-    mapKeys
+    mapKeys,
+    memoize
 }
 
 import moment = require("moment")

--- a/site/client/covid/CovidFetch.ts
+++ b/site/client/covid/CovidFetch.ts
@@ -2,11 +2,11 @@ import { csvParse } from "d3"
 import moment from "moment"
 
 import { CovidSeries } from "./CovidTypes"
-import { fetchText, retryPromise } from "charts/Util"
+import { fetchText, retryPromise, memoize } from "charts/Util"
 import { ECDC_DATA_URL, TESTS_DATA_URL } from "./CovidConstants"
 import { parseIntOrUndefined } from "./CovidUtils"
 
-export async function fetchECDCData(): Promise<CovidSeries> {
+async function _fetchECDCData(): Promise<CovidSeries> {
     const responseText = await retryPromise(() => fetchText(ECDC_DATA_URL))
     const rows: CovidSeries = csvParse(responseText).map(row => {
         return {
@@ -20,6 +20,10 @@ export async function fetchECDCData(): Promise<CovidSeries> {
     })
     return rows
 }
+
+// We want to memoize (cache) the return value of that fetch, so we don't need to load
+// the file multiple times if we request the data more than once
+export const fetchECDCData = memoize(_fetchECDCData)
 
 //      'Entity string'
 //      'OWID country'


### PR DESCRIPTION
Further looking into how we can reduce the amount of resources loaded on https://ourworldindata.org/coronavirus, I noticed that `full_data.csv` is being loaded twice:
![image](https://user-images.githubusercontent.com/2641501/78412788-f0d2ed00-7614-11ea-8faa-c46a38ea0c3b.png)

This stems from the fact that both the "deaths" and "cases" tables call `fetchECDCData` for themselves (and at roughly the same time, so the browser can't access a cached version quite yet).

While the file is only about 50KB gzipped, it's still an unnecessary request that we can prevent quite easily and nicely. And lodash's memoize seems to do a good job of saving the Promise. I'm open to other solutions, though.