### PR TITLE
Add Entity Annotations Feature to Line Charts

### DIFF
--- a/admin/client/EditorDataTab.tsx
+++ b/admin/client/EditorDataTab.tsx
@@ -3,7 +3,7 @@ import { clone, map } from "charts/Util"
 import { computed, action, observable } from "mobx"
 import { observer } from "mobx-react"
 import { ChartConfig } from "charts/ChartConfig"
-import { DataKey } from "charts/DataKey"
+import { EntityDimensionKey } from "charts/EntityDimensionKey"
 import {
     EditableList,
     EditableListItem,
@@ -19,7 +19,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 
 interface DataKeyItemProps extends EditableListItemProps {
     chart: ChartConfig
-    datakey: DataKey
+    datakey: EntityDimensionKey
 }
 
 @observer
@@ -43,7 +43,7 @@ class DataKeyItem extends React.Component<DataKeyItemProps> {
     render() {
         const { props, color } = this
         const { chart, datakey, ...rest } = props
-        const meta = chart.data.keyData.get(datakey)
+        const meta = chart.data.entityDimensionMap.get(datakey)
 
         return (
             <EditableListItem className="DataKeyItem" key={datakey} {...rest}>
@@ -64,13 +64,13 @@ class DataKeyItem extends React.Component<DataKeyItemProps> {
 
 @observer
 class KeysSection extends React.Component<{ chart: ChartConfig }> {
-    @observable.ref dragKey?: DataKey
+    @observable.ref dragKey?: EntityDimensionKey
 
     @action.bound onAddKey(key: string) {
         this.props.chart.data.selectKey(key)
     }
 
-    @action.bound onStartDrag(key: DataKey) {
+    @action.bound onStartDrag(key: EntityDimensionKey) {
         this.dragKey = key
 
         const onDrag = action(() => {
@@ -81,7 +81,7 @@ class KeysSection extends React.Component<{ chart: ChartConfig }> {
         window.addEventListener("mouseup", onDrag)
     }
 
-    @action.bound onMouseEnter(targetKey: DataKey) {
+    @action.bound onMouseEnter(targetKey: EntityDimensionKey) {
         if (!this.dragKey || targetKey === this.dragKey) return
 
         const selectedKeys = clone(this.props.chart.data.selectedKeys)

--- a/admin/client/VariableEditPage.tsx
+++ b/admin/client/VariableEditPage.tsx
@@ -40,6 +40,7 @@ class VariableEditable {
     @observable unit: string = ""
     @observable shortUnit: string = ""
     @observable description: string = ""
+    @observable entityAnnotationsMap: string = ""
     @observable display: VariableDisplaySettings = new VariableDisplaySettings()
 
     constructor(json: any) {
@@ -206,6 +207,13 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                     field="description"
                                     store={newVariable}
                                     label="Description"
+                                    textarea
+                                    disabled={isBulkImport}
+                                />
+                                <BindString
+                                    field="entityAnnotationsMap"
+                                    store={newVariable.display}
+                                    label="Entity Annotations"
                                     textarea
                                     disabled={isBulkImport}
                                 />

--- a/admin/client/VariableEditPage.tsx
+++ b/admin/client/VariableEditPage.tsx
@@ -212,10 +212,12 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                 />
                                 <BindString
                                     field="entityAnnotationsMap"
+                                    placeholder="Example:&#10;Japan:people tested&#10;France:units unclear"
                                     store={newVariable.display}
-                                    label="Entity Annotations"
+                                    label="Entity annotations"
                                     textarea
                                     disabled={isBulkImport}
+                                    helpText="Additional text to show next to entity labels."
                                 />
                             </section>
                             <input

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -169,6 +169,7 @@ export class ChartConfigProps {
 
     @observable.ref tabularData?: TabularDataset = undefined
     @observable.ref externalDataUrl?: string = undefined
+    @observable.ref owidDataset?: OwidDataset = undefined
 
     @observable.ref selectedData: EntitySelection[] = []
     @observable.ref minTime?: number = undefined
@@ -259,6 +260,11 @@ export class ChartConfig {
         if (this.props.externalDataUrl) {
             const json = await fetchJSON(this.props.externalDataUrl)
             this.receiveData(json)
+            return
+        }
+
+        if (this.props.owidDataset) {
+            this.receiveData(this.props.owidDataset)
             return
         }
 

--- a/charts/ChartData.ts
+++ b/charts/ChartData.ts
@@ -484,7 +484,6 @@ export class ChartData {
     }
 
     getAnnotationForKey(key: EntityDimensionKey): string {
-        console.log(this.lookupKey(key))
         return this.lookupKey(key).annotation || ""
     }
 

--- a/charts/ChartData.ts
+++ b/charts/ChartData.ts
@@ -18,11 +18,11 @@ import {
 } from "./Util"
 import { computed, toJS } from "mobx"
 import { ChartConfig } from "./ChartConfig"
-import { DataKey } from "./DataKey"
+import { EntityDimensionKey } from "./EntityDimensionKey"
 import { Color } from "./Color"
 import { DimensionWithData } from "./DimensionWithData"
 
-export interface DataKeyInfo {
+export interface EntityDimensionInfo {
     entity: string
     entityId: number
     dimension: DimensionWithData
@@ -30,6 +30,7 @@ export interface DataKeyInfo {
     key: string
     fullLabel: string
     label: string
+    annotation?: string
     shortCode: string
 }
 
@@ -81,7 +82,7 @@ export class ChartData {
         )
     }
 
-    @computed get defaultTitle(): string {
+    @computed private get defaultTitle(): string {
         if (this.chart.isScatter)
             return this.axisDimensions.map(d => d.displayName).join(" vs. ")
         else if (
@@ -192,7 +193,7 @@ export class ChartData {
         return text.trim()
     }
 
-    @computed get defaultSlug(): string {
+    @computed private get defaultSlug(): string {
         return slugify(this.title)
     }
 
@@ -206,7 +207,7 @@ export class ChartData {
         return url
     }
 
-    @computed get defaultSourcesLine(): string {
+    @computed private get defaultSourcesLine(): string {
         let sourceNames = this.sources.map(source => source.name)
 
         // Shorten automatic source names for certain major sources
@@ -237,7 +238,7 @@ export class ChartData {
         )
     }
 
-    @computed get isSingleVariable(): boolean {
+    @computed private get isSingleVariable(): boolean {
         return this.primaryDimensions.length === 1
     }
 
@@ -249,7 +250,10 @@ export class ChartData {
     }
 
     // Make a unique string key for an entity on a variable
-    keyFor(entity: string, dimensionIndex: number): DataKey {
+    makeEntityDimensionKey(
+        entity: string,
+        dimensionIndex: number
+    ): EntityDimensionKey {
         return `${entity}_${dimensionIndex}`
     }
 
@@ -257,7 +261,10 @@ export class ChartData {
         return keyBy(this.filledDimensions, "property")
     }
 
-    @computed get selectionData(): Array<{ key: DataKey; color?: Color }> {
+    @computed private get selectionData(): Array<{
+        key: EntityDimensionKey
+        color?: Color
+    }> {
         const { chart, primaryDimensions } = this
         let validSelections = chart.props.selectedData.filter(sel => {
             // Must be a dimension that's on the chart
@@ -290,7 +297,7 @@ export class ChartData {
 
         return map(validSelections, sel => {
             return {
-                key: this.keyFor(
+                key: this.makeEntityDimensionKey(
                     chart.entityMetaById[sel.entityId].name,
                     sel.index
                 ),
@@ -299,7 +306,7 @@ export class ChartData {
         })
     }
 
-    selectKey(key: DataKey) {
+    selectKey(key: EntityDimensionKey) {
         this.selectedKeys = this.selectedKeys.concat([key])
     }
 
@@ -311,7 +318,7 @@ export class ChartData {
         return keyColors
     }
 
-    setKeyColor(datakey: DataKey, color: Color | undefined) {
+    setKeyColor(datakey: EntityDimensionKey, color: Color | undefined) {
         const meta = this.lookupKey(datakey)
         const selectedData = cloneDeep(this.chart.props.selectedData)
         selectedData.forEach(d => {
@@ -349,12 +356,12 @@ export class ChartData {
         this.chart.props.selectedData = selectedData
     }
 
-    @computed get selectedKeys(): DataKey[] {
+    @computed get selectedKeys(): EntityDimensionKey[] {
         return this.selectionData.map(d => d.key)
     }
 
     // Map keys back to their components for storage
-    set selectedKeys(keys: DataKey[]) {
+    set selectedKeys(keys: EntityDimensionKey[]) {
         const { chart } = this
         if (!this.isReady) return
 
@@ -369,12 +376,15 @@ export class ChartData {
         chart.props.selectedData = selection
     }
 
-    @computed get selectedKeysByKey(): { [key: string]: DataKey } {
+    @computed get selectedKeysByKey(): { [key: string]: EntityDimensionKey } {
         return keyBy(this.selectedKeys)
     }
 
     // Calculate the available datakeys and their associated info
-    @computed get keyData(): Map<DataKey, DataKeyInfo> {
+    @computed get entityDimensionMap(): Map<
+        EntityDimensionKey,
+        EntityDimensionInfo
+    > {
         if (!this.isReady) return new Map()
         const {
             chart,
@@ -384,36 +394,42 @@ export class ChartData {
         } = this
 
         const keyData = new Map()
-        each(primaryDimensions, (dim, index) => {
-            const { variable } = dim
-            each(variable.entitiesUniq, entity => {
-                const entityMeta = chart.entityMetaByKey[entity]
-                const key = this.keyFor(entity, index)
+        primaryDimensions.forEach((dimension, dimensionIndex) => {
+            const annotationMap = dimension.variable.annotationMap
+            dimension.variable.entitiesUniq.forEach(entityName => {
+                const entityMeta = chart.entityMetaByKey[entityName]
+                const entityDimensionKey = this.makeEntityDimensionKey(
+                    entityName,
+                    dimensionIndex
+                )
 
                 // Full label completely represents the data in the key and is used in the editor
-                const fullLabel = `${entity} - ${dim.displayName}`
+                const fullLabel = `${entityName} - ${dimension.displayName}`
 
                 // The output label however is context-dependent
                 let label = fullLabel
                 if (isSingleVariable) {
-                    label = entity
+                    label = entityName
                 } else if (isSingleEntity) {
-                    label = `${dim.displayName}`
+                    label = `${dimension.displayName}`
                 }
 
-                keyData.set(key, {
-                    key: key,
+                const annotationKey = entityName
+
+                keyData.set(entityDimensionKey, {
+                    key: entityDimensionKey,
                     entityId: entityMeta.id,
-                    entity: entity,
-                    dimension: dim,
-                    index: index,
-                    fullLabel: fullLabel,
-                    label: label,
+                    entity: entityName,
+                    annotation: annotationMap.get(annotationKey),
+                    dimension,
+                    index: dimensionIndex,
+                    fullLabel,
+                    label,
                     shortCode:
                         primaryDimensions.length > 1 &&
                         chart.addCountryMode !== "change-country"
                             ? `${entityMeta.code || entityMeta.name}-${
-                                  dim.index
+                                  dimension.index
                               }`
                             : entityMeta.code || entityMeta.name
                 })
@@ -438,18 +454,18 @@ export class ChartData {
         )
     }
 
-    @computed.struct get availableKeys(): DataKey[] {
-        return sortBy([...Array.from(this.keyData.keys())])
+    @computed.struct get availableKeys(): EntityDimensionKey[] {
+        return sortBy([...Array.from(this.entityDimensionMap.keys())])
     }
 
-    @computed.struct get remainingKeys(): DataKey[] {
+    @computed.struct get remainingKeys(): EntityDimensionKey[] {
         const { availableKeys, selectedKeys } = this
         return without(availableKeys, ...selectedKeys)
     }
 
-    @computed get availableKeysByEntity(): Map<string, DataKey[]> {
+    @computed get availableKeysByEntity(): Map<string, EntityDimensionKey[]> {
         const keysByEntity = new Map()
-        this.keyData.forEach((info, key) => {
+        this.entityDimensionMap.forEach((info, key) => {
             const keys = keysByEntity.get(info.entity) || []
             keys.push(key)
             keysByEntity.set(info.entity, keys)
@@ -457,17 +473,22 @@ export class ChartData {
         return keysByEntity
     }
 
-    lookupKey(key: DataKey) {
-        const keyDatum = this.keyData.get(key)
+    lookupKey(key: EntityDimensionKey) {
+        const keyDatum = this.entityDimensionMap.get(key)
         if (keyDatum !== undefined) return keyDatum
         else throw new Error(`Unknown data key: ${key}`)
     }
 
-    formatKey(key: DataKey): string {
+    getLabelForKey(key: EntityDimensionKey): string {
         return this.lookupKey(key).label
     }
 
-    toggleKey(key: DataKey) {
+    getAnnotationForKey(key: EntityDimensionKey): string {
+        console.log(this.lookupKey(key))
+        return this.lookupKey(key).annotation || ""
+    }
+
+    toggleKey(key: EntityDimensionKey) {
         if (includes(this.selectedKeys, key)) {
             this.selectedKeys = this.selectedKeys.filter(k => k !== key)
         } else {

--- a/charts/DataKey.ts
+++ b/charts/DataKey.ts
@@ -1,1 +1,0 @@
-export type DataKey = string

--- a/charts/DataSelector.tsx
+++ b/charts/DataSelector.tsx
@@ -4,7 +4,7 @@ import { computed, action, observable } from "mobx"
 
 import { uniqBy, isTouchDevice } from "./Util"
 import { ChartConfig } from "./ChartConfig"
-import { DataKeyInfo } from "./ChartData"
+import { EntityDimensionInfo } from "./ChartData"
 import { ChartView } from "./ChartView"
 import { FuzzySearch } from "./FuzzySearch"
 import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes"
@@ -27,7 +27,7 @@ export class DataSelectorMulti extends React.Component<{
     base: React.RefObject<HTMLDivElement> = React.createRef()
     dismissable: boolean = true
 
-    @computed get availableData(): DataKeyInfo[] {
+    @computed get availableData(): EntityDimensionInfo[] {
         const { chart } = this.props
 
         const selectableKeys = chart.activeTransform.selectableKeys
@@ -41,11 +41,11 @@ export class DataSelectorMulti extends React.Component<{
         return this.availableData.filter(d => this.isSelectedKey(d.key))
     }
 
-    @computed get fuzzy(): FuzzySearch<DataKeyInfo> {
+    @computed get fuzzy(): FuzzySearch<EntityDimensionInfo> {
         return new FuzzySearch(this.availableData, "label")
     }
 
-    @computed get searchResults(): DataKeyInfo[] {
+    @computed get searchResults(): EntityDimensionInfo[] {
         return this.searchInput
             ? this.fuzzy.search(this.searchInput)
             : this.availableData
@@ -196,7 +196,7 @@ export class DataSelectorSingle extends React.Component<{
 
     @computed get availableItems() {
         const availableItems: { id: number; label: string }[] = []
-        this.props.chart.data.keyData.forEach(meta => {
+        this.props.chart.data.entityDimensionMap.forEach(meta => {
             availableItems.push({
                 id: meta.entityId,
                 label: meta.entity

--- a/charts/DiscreteBarTransform.ts
+++ b/charts/DiscreteBarTransform.ts
@@ -93,7 +93,10 @@ export class DiscreteBarTransform implements IChartTransform {
             for (let i = 0; i < dimension.years.length; i++) {
                 const year = dimension.years[i]
                 const entity = dimension.entities[i]
-                const datakey = chart.data.keyFor(entity, dimIndex)
+                const datakey = chart.data.makeEntityDimensionKey(
+                    entity,
+                    dimIndex
+                )
 
                 if (
                     year < targetYear - tolerance ||
@@ -115,7 +118,7 @@ export class DiscreteBarTransform implements IChartTransform {
                     key: datakey,
                     value: +dimension.values[i],
                     year: year,
-                    label: chart.data.formatKey(datakey),
+                    label: chart.data.getLabelForKey(datakey),
                     color: "#2E5778",
                     formatValue: dimension.formatValueShort
                 }
@@ -193,7 +196,10 @@ export class DiscreteBarTransform implements IChartTransform {
             for (let i = 0; i < dimension.years.length; i++) {
                 const year = dimension.years[i]
                 const entity = dimension.entities[i]
-                const datakey = chart.data.keyFor(entity, dimIndex)
+                const datakey = chart.data.makeEntityDimensionKey(
+                    entity,
+                    dimIndex
+                )
 
                 if (!selectedKeysByKey[datakey]) continue
 
@@ -201,7 +207,7 @@ export class DiscreteBarTransform implements IChartTransform {
                     key: datakey,
                     value: +dimension.values[i],
                     year: year,
-                    label: chart.data.formatKey(datakey),
+                    label: chart.data.getLabelForKey(datakey),
                     color: "#2E5778",
                     formatValue: dimension.formatValueShort
                 }

--- a/charts/EntityDimensionKey.ts
+++ b/charts/EntityDimensionKey.ts
@@ -1,0 +1,1 @@
+export type EntityDimensionKey = string

--- a/charts/HeightedLegend.tsx
+++ b/charts/HeightedLegend.tsx
@@ -108,7 +108,7 @@ export class HeightedLegend {
                 ? new TextWrap({
                       text: item.annotation,
                       maxWidth: maxTextWidth,
-                      fontSize: fontSize * 0.7
+                      fontSize: fontSize * 0.9
                   })
                 : undefined
             const textWrap = new TextWrap({
@@ -176,7 +176,7 @@ class PlacedMarkComponent extends React.Component<{
         const markerXMid = markerX1 + step + mark.level * step
         const lineColor = isFocus ? "#999" : "#eee"
         const textColor = isFocus ? mark.mark.item.color : "#ddd"
-        const annotationColor = isFocus ? "#999" : "#ddd"
+        const annotationColor = isFocus ? "#333" : "#ddd"
         return (
             <g
                 className="legendMark"
@@ -211,7 +211,11 @@ class PlacedMarkComponent extends React.Component<{
                     mark.mark.annotationTextWrap.render(
                         needsLines ? markerX2 + MARKER_MARGIN : markerX1,
                         mark.bounds.y + mark.mark.textWrap.height,
-                        { fill: annotationColor, className: "textAnnotation" }
+                        {
+                            fill: annotationColor,
+                            className: "textAnnotation",
+                            style: { fontWeight: "lighter" }
+                        }
                     )}
             </g>
         )

--- a/charts/HeightedLegend.tsx
+++ b/charts/HeightedLegend.tsx
@@ -24,7 +24,7 @@ import { AxisScale } from "./AxisScale"
 import { Bounds } from "./Bounds"
 import { ChartViewContextType, ChartViewContext } from "./ChartViewContext"
 import { ControlsOverlay, AddEntityButton } from "./Controls"
-import { DataKey } from "./DataKey"
+import { EntityDimensionKey } from "./EntityDimensionKey"
 
 // Minimum vertical space between two legend items
 const LEGEND_ITEM_MIN_SPACING = 2
@@ -35,23 +35,19 @@ const MARKER_HORIZONTAL_SEGMENT = 5
 // Need a constant button height which we can use in positioning calculations
 const ADD_BUTTON_HEIGHT = 30
 
-export interface HeightedLegendProps {
-    items: HeightedLegendItem[]
-    maxWidth?: number
-    fontSize: number
-}
-
 export interface HeightedLegendItem {
     key: string
     label: string
     color: string
     yValue: number
+    annotation?: string
     yRange?: [number, number]
 }
 
 interface HeightedLegendMark {
     item: HeightedLegendItem
     textWrap: TextWrap
+    annotationTextWrap?: TextWrap
     width: number
     height: number
 }
@@ -84,16 +80,22 @@ function stackGroupVertically(group: PlacedMark[], y: number) {
     return group
 }
 
+export interface HeightedLegendProps {
+    items: HeightedLegendItem[]
+    maxWidth?: number
+    fontSize: number
+}
+
 export class HeightedLegend {
     props: HeightedLegendProps
 
-    @computed get fontSize(): number {
+    @computed private get fontSize(): number {
         return 0.75 * this.props.fontSize
     }
     @computed get leftPadding(): number {
         return 35
     }
-    @computed get maxWidth() {
+    @computed private get maxWidth() {
         return defaultTo(this.props.maxWidth, Infinity)
     }
 
@@ -102,16 +104,26 @@ export class HeightedLegend {
         const maxTextWidth = maxWidth - leftPadding
 
         return this.props.items.map(item => {
+            const annotationTextWrap = item.annotation
+                ? new TextWrap({
+                      text: item.annotation,
+                      maxWidth: maxTextWidth,
+                      fontSize: fontSize * 0.7
+                  })
+                : undefined
             const textWrap = new TextWrap({
                 text: item.label,
                 maxWidth: maxTextWidth,
-                fontSize: fontSize
+                fontSize
             })
             return {
-                item: item,
-                textWrap: textWrap,
+                item,
+                textWrap,
+                annotationTextWrap,
                 width: leftPadding + textWrap.width,
-                height: textWrap.height
+                height:
+                    textWrap.height +
+                    (annotationTextWrap ? annotationTextWrap.height : 0)
             }
         })
     }
@@ -126,19 +138,19 @@ export class HeightedLegend {
     }
 }
 
-export interface HeightedLegendViewProps {
+export interface HeightedLegendComponentProps {
     x: number
     legend: HeightedLegend
     yScale: AxisScale
-    focusKeys: DataKey[]
-    clickableMarks: boolean
+    focusKeys: EntityDimensionKey[]
+    areMarksClickable: boolean
     onMouseOver?: (key: string) => void
     onClick?: (key: string) => void
     onMouseLeave?: () => void
 }
 
 @observer
-class PlacedMarkView extends React.Component<{
+class PlacedMarkComponent extends React.Component<{
     mark: PlacedMark
     legend: HeightedLegend
     isFocus?: boolean
@@ -164,6 +176,7 @@ class PlacedMarkView extends React.Component<{
         const markerXMid = markerX1 + step + mark.level * step
         const lineColor = isFocus ? "#999" : "#eee"
         const textColor = isFocus ? mark.mark.item.color : "#ddd"
+        const annotationColor = isFocus ? "#999" : "#ddd"
         return (
             <g
                 className="legendMark"
@@ -194,14 +207,20 @@ class PlacedMarkView extends React.Component<{
                     mark.bounds.y,
                     { fill: textColor }
                 )}
+                {mark.mark.annotationTextWrap &&
+                    mark.mark.annotationTextWrap.render(
+                        needsLines ? markerX2 + MARKER_MARGIN : markerX1,
+                        mark.bounds.y + mark.mark.textWrap.height,
+                        { fill: annotationColor }
+                    )}
             </g>
         )
     }
 }
 
 @observer
-export class HeightedLegendView extends React.Component<
-    HeightedLegendViewProps
+export class HeightedLegendComponent extends React.Component<
+    HeightedLegendComponentProps
 > {
     static contextType = ChartViewContext
     context!: ChartViewContextType
@@ -223,24 +242,30 @@ export class HeightedLegendView extends React.Component<
     }
 
     // Naive initial placement of each mark at the target height, before collision detection
-    @computed get initialMarks(): PlacedMark[] {
+    @computed private get initialMarks(): PlacedMark[] {
         const { legend, x, yScale } = this.props
 
         return sortBy(
-            legend.marks.map(m => {
+            legend.marks.map(mark => {
                 // place vertically centered at Y value
-                const initialY = yScale.place(m.item.yValue) - m.height / 2
-                const origBounds = new Bounds(x, initialY, m.width, m.height)
+                const initialY =
+                    yScale.place(mark.item.yValue) - mark.height / 2
+                const origBounds = new Bounds(
+                    x,
+                    initialY,
+                    mark.width,
+                    mark.height
+                )
 
                 // ensure label doesn't go beyond the top or bottom of the chart
                 const y = Math.min(
                     Math.max(initialY, yScale.rangeMin),
-                    yScale.rangeMax - m.height
+                    yScale.rangeMax - mark.height
                 )
-                const bounds = new Bounds(x, y, m.width, m.height)
+                const bounds = new Bounds(x, y, mark.width, mark.height)
 
                 return {
-                    mark: m,
+                    mark: mark,
                     y: y,
                     origBounds: origBounds,
                     bounds: bounds,
@@ -252,17 +277,16 @@ export class HeightedLegendView extends React.Component<
 
                 // Ensure list is sorted by the visual position in ascending order
             }),
-            m => yScale.place(m.mark.item.yValue)
+            mark => yScale.place(mark.mark.item.yValue)
         )
     }
 
     @computed get standardPlacement() {
-        const { initialMarks } = this
         const { yScale } = this.props
 
-        const groups: PlacedMark[][] = cloneDeep(initialMarks).map(mark => [
-            mark
-        ])
+        const groups: PlacedMark[][] = cloneDeep(
+            this.initialMarks
+        ).map(mark => [mark])
 
         let hasOverlap
 
@@ -365,7 +389,7 @@ export class HeightedLegendView extends React.Component<
         }
     }
 
-    @computed get backgroundMarks() {
+    @computed private get backgroundMarks() {
         const { focusKeys } = this.props
         const { isFocusMode } = this
         return this.placedMarks.filter(m =>
@@ -373,7 +397,7 @@ export class HeightedLegendView extends React.Component<
         )
     }
 
-    @computed get focusMarks() {
+    @computed private get focusMarks() {
         const { focusKeys } = this.props
         const { isFocusMode } = this
         return this.placedMarks.filter(m =>
@@ -381,6 +405,7 @@ export class HeightedLegendView extends React.Component<
         )
     }
 
+    // TODO: looks unused. Can we remove?
     @computed get numMovesNeeded() {
         return this.placedMarks.filter(
             m => m.isOverlap || !m.bounds.equals(m.origBounds)
@@ -388,20 +413,17 @@ export class HeightedLegendView extends React.Component<
     }
 
     // Does this placement need line markers or is the position of the labels already clear?
-    @computed get needsLines(): boolean {
+    @computed private get needsLines(): boolean {
         return this.placedMarks.some(mark => mark.totalLevels > 1)
     }
 
-    renderBackground() {
-        const { x, legend } = this.props
-        const { backgroundMarks, needsLines } = this
-
-        return backgroundMarks.map(mark => (
-            <PlacedMarkView
+    private renderBackground() {
+        return this.backgroundMarks.map(mark => (
+            <PlacedMarkComponent
                 key={mark.mark.item.key}
                 mark={mark}
-                legend={legend}
-                needsLines={needsLines}
+                legend={this.props.legend}
+                needsLines={this.needsLines}
                 onMouseOver={() => this.onMouseOver(mark.mark.item.key)}
                 onClick={() => this.onClick(mark.mark.item.key)}
             />
@@ -409,17 +431,14 @@ export class HeightedLegendView extends React.Component<
     }
 
     // All labels are focused by default, moved to background when mouseover of other label
-    renderFocus() {
-        const { legend } = this.props
-        const { focusMarks, needsLines } = this
-
-        return focusMarks.map(mark => (
-            <PlacedMarkView
+    private renderFocus() {
+        return this.focusMarks.map(mark => (
+            <PlacedMarkComponent
                 key={mark.mark.item.key}
                 mark={mark}
-                legend={legend}
+                legend={this.props.legend}
                 isFocus={true}
-                needsLines={needsLines}
+                needsLines={this.needsLines}
                 onMouseOver={() => this.onMouseOver(mark.mark.item.key)}
                 onClick={() => this.onClick(mark.mark.item.key)}
                 onMouseLeave={() => this.onMouseLeave(mark.mark.item.key)}
@@ -442,7 +461,7 @@ export class HeightedLegendView extends React.Component<
             <g
                 className="HeightedLegend"
                 style={{
-                    cursor: this.props.clickableMarks ? "pointer" : "default"
+                    cursor: this.props.areMarksClickable ? "pointer" : "default"
                 }}
             >
                 {this.renderBackground()}

--- a/charts/HeightedLegend.tsx
+++ b/charts/HeightedLegend.tsx
@@ -211,7 +211,7 @@ class PlacedMarkComponent extends React.Component<{
                     mark.mark.annotationTextWrap.render(
                         needsLines ? markerX2 + MARKER_MARGIN : markerX1,
                         mark.bounds.y + mark.mark.textWrap.height,
-                        { fill: annotationColor }
+                        { fill: annotationColor, className: "textAnnotation" }
                     )}
             </g>
         )

--- a/charts/LineChart.tsx
+++ b/charts/LineChart.tsx
@@ -207,6 +207,7 @@ export class LineChart extends React.Component<{
                                                     color: annotationColor
                                                 }}
                                             >
+                                                {" "}
                                                 {annotation}
                                             </span>
                                         )}

--- a/charts/LineChart.tsx
+++ b/charts/LineChart.tsx
@@ -174,7 +174,7 @@ export class LineChart extends React.Component<{
                             const isBlur =
                                 this.seriesIsBlur(series) || value === undefined
                             const textColor = isBlur ? "#ddd" : "#333"
-                            const annotationColor = isBlur ? "#ddd" : "#bbb"
+                            const annotationColor = isBlur ? "#ddd" : "#999"
                             const circleColor = isBlur
                                 ? BLUR_COLOR
                                 : series.color

--- a/charts/LineChart.tsx
+++ b/charts/LineChart.tsx
@@ -40,7 +40,6 @@ export interface LineChartSeries {
     values: LineChartValue[]
     classed?: string
     isProjection?: boolean
-    annotation?: string
     formatValue: (value: number) => string
 }
 
@@ -148,6 +147,10 @@ export class LineChart extends React.Component<{
                                 v => v.x === hoverX
                             )
 
+                            const annotation = chart.data.getAnnotationForKey(
+                                series.key
+                            )
+
                             // It sometimes happens that data is missing for some years for a particular
                             // entity. If the user hovers over these years, we want to show a "No data"
                             // notice. However, we only want to show this notice when we are in the middle
@@ -171,6 +174,7 @@ export class LineChart extends React.Component<{
                             const isBlur =
                                 this.seriesIsBlur(series) || value === undefined
                             const textColor = isBlur ? "#ddd" : "#333"
+                            const annotationColor = isBlur ? "#ddd" : "#bbb"
                             const circleColor = isBlur
                                 ? BLUR_COLOR
                                 : series.color
@@ -196,6 +200,16 @@ export class LineChart extends React.Component<{
                                             }}
                                         />{" "}
                                         {chart.data.getLabelForKey(series.key)}
+                                        {annotation && (
+                                            <span
+                                                className="tooltipAnnotation"
+                                                style={{
+                                                    color: annotationColor
+                                                }}
+                                            >
+                                                {annotation}
+                                            </span>
+                                        )}
                                     </td>
                                     <td style={{ textAlign: "right" }}>
                                         {!value

--- a/charts/LineChartTransform.ts
+++ b/charts/LineChartTransform.ts
@@ -14,7 +14,7 @@ import {
     formatValue
 } from "./Util"
 import { ChartConfig } from "./ChartConfig"
-import { DataKey } from "./DataKey"
+import { EntityDimensionKey } from "./EntityDimensionKey"
 import { LineChartSeries, LineChartValue } from "./LineChart"
 import { AxisSpec } from "./AxisSpec"
 import { ColorSchemes, ColorScheme } from "./ColorSchemes"
@@ -65,29 +65,32 @@ export class LineChartTransform implements IChartTransform {
         let chartData: LineChartSeries[] = []
 
         filledDimensions.forEach((dimension, dimIndex) => {
-            const seriesByKey = new Map<DataKey, LineChartSeries>()
+            const seriesByKey = new Map<EntityDimensionKey, LineChartSeries>()
 
             for (let i = 0; i < dimension.years.length; i++) {
                 const year = dimension.years[i]
                 const value = parseFloat(dimension.values[i] as string)
                 const entity = dimension.entities[i]
-                const datakey = chart.data.keyFor(entity, dimIndex)
-                let series = seriesByKey.get(datakey)
+                const entityDimensionKey = chart.data.makeEntityDimensionKey(
+                    entity,
+                    dimIndex
+                )
+                let series = seriesByKey.get(entityDimensionKey)
 
                 // Not a selected key, don't add any data for it
-                if (!selectedKeysByKey[datakey]) continue
+                if (!selectedKeysByKey[entityDimensionKey]) continue
                 // Can't have values <= 0 on log scale
                 if (value <= 0 && yAxis.scaleType === "log") continue
 
                 if (!series) {
                     series = {
                         values: [],
-                        key: datakey,
+                        key: entityDimensionKey,
                         isProjection: dimension.isProjection,
                         formatValue: dimension.formatValueLong,
                         color: "#000" // tmp
                     }
-                    seriesByKey.set(datakey, series)
+                    seriesByKey.set(entityDimensionKey, series)
                 }
 
                 series.values.push({ x: year, y: value, time: year })

--- a/charts/Lines.tsx
+++ b/charts/Lines.tsx
@@ -7,7 +7,7 @@ import { AxisScale } from "./AxisScale"
 import { Vector2 } from "./Vector2"
 import { getRelativeMouse, makeSafeForCSS, pointsToPath } from "./Util"
 import { Bounds } from "./Bounds"
-import { DataKey } from "./DataKey"
+import { EntityDimensionKey } from "./EntityDimensionKey"
 import { AxisBox } from "./AxisBox"
 
 export interface LinesProps {
@@ -15,7 +15,7 @@ export interface LinesProps {
     xScale: AxisScale
     yScale: AxisScale
     data: LineChartSeries[]
-    focusKeys: DataKey[]
+    focusKeys: EntityDimensionKey[]
     onHover: (hoverX: number | undefined) => void
 }
 

--- a/charts/ScatterTransform.ts
+++ b/charts/ScatterTransform.ts
@@ -605,11 +605,11 @@ export class ScatterTransform implements IChartTransform {
         // As needed, join the individual year data points together to create an "arrow chart"
         dataByEntityAndYear.forEach((dataByYear, entity) => {
             // Since scatterplots interrelate two variables via entity overlap, their datakeys are solely entity-based
-            const datakey = chart.data.keyFor(entity, 0)
+            const datakey = chart.data.makeEntityDimensionKey(entity, 0)
 
             const group = {
                 key: datakey,
-                label: chart.data.formatKey(datakey),
+                label: chart.data.getLabelForKey(datakey),
                 color: "#ffcb1f", // Default color
                 size: 0,
                 values: []

--- a/charts/SlopeChartTransform.ts
+++ b/charts/SlopeChartTransform.ts
@@ -195,7 +195,10 @@ export class SlopeChartTransform implements IChartTransform {
                 })
             }
 
-            const key = chart.data.keyFor(entity, yDimension.index)
+            const key = chart.data.makeEntityDimensionKey(
+                entity,
+                yDimension.index
+            )
             return {
                 key: key,
                 label: entityKey[entity].name,

--- a/charts/SourcesFooter.tsx
+++ b/charts/SourcesFooter.tsx
@@ -77,7 +77,7 @@ export class SourcesFooter {
         }
     }
 
-    @computed get licenseSvg(): string {
+    @computed private get licenseSvg(): string {
         const { finalUrl, finalUrlText } = this
         if (finalUrlText) {
             let licenseSvg = `*data-entry* • ${this.ccSvg}`
@@ -123,7 +123,7 @@ export class SourcesFooter {
             maxWidth: maxWidth * 3,
             fontSize: fontSize,
             text: licenseSvg,
-            raw: true
+            rawHtml: true
         })
     }
 

--- a/charts/StackedArea.tsx
+++ b/charts/StackedArea.tsx
@@ -7,14 +7,18 @@ import { Bounds } from "./Bounds"
 import { AxisBox } from "./AxisBox"
 import { StandardAxisBoxView } from "./StandardAxisBoxView"
 import { getRelativeMouse, makeSafeForCSS } from "./Util"
-import { HeightedLegend, HeightedLegendView } from "./HeightedLegend"
+import {
+    HeightedLegend,
+    HeightedLegendItem,
+    HeightedLegendComponent
+} from "./HeightedLegend"
 import { NoData } from "./NoData"
 import { Tooltip } from "./Tooltip"
 import { select } from "d3-selection"
 import { easeLinear } from "d3-ease"
 import { rgb } from "d3-color"
 import { ChartViewContext, ChartViewContextType } from "./ChartViewContext"
-import { DataKey } from "./DataKey"
+import { EntityDimensionKey } from "./EntityDimensionKey"
 
 export interface StackedAreaValue {
     x: number
@@ -35,7 +39,7 @@ export interface StackedAreaSeries {
 interface AreasProps extends React.SVGAttributes<SVGGElement> {
     axisBox: AxisBox
     data: StackedAreaSeries[]
-    focusKeys: DataKey[]
+    focusKeys: EntityDimensionKey[]
     onHover: (hoverIndex: number | undefined) => void
 }
 
@@ -218,20 +222,20 @@ export class StackedArea extends React.Component<{
         })
     }
 
-    @computed get legendItems() {
+    @computed get legendItems(): HeightedLegendItem[] {
         const { transform, midpoints } = this
         const items = transform.stackedData
             .map((d, i) => ({
                 color: d.color,
                 key: d.key,
-                label: this.chart.data.formatKey(d.key),
+                label: this.chart.data.getLabelForKey(d.key),
                 yValue: midpoints[i]
             }))
             .reverse()
         return items
     }
 
-    @computed get legend(): HeightedLegend | undefined {
+    @computed private get legend(): HeightedLegend | undefined {
         if (this.chart.hideLegend) return undefined
 
         const that = this
@@ -352,7 +356,7 @@ export class StackedArea extends React.Component<{
                                                 backgroundColor: blockColor
                                             }}
                                         />{" "}
-                                        {chart.data.formatKey(series.key)}
+                                        {chart.data.getLabelForKey(series.key)}
                                     </td>
                                     <td style={{ textAlign: "right" }}>
                                         {value.isFake
@@ -453,7 +457,7 @@ export class StackedArea extends React.Component<{
                 <StandardAxisBoxView axisBox={axisBox} chart={chart} />
                 <g clipPath={`url(#boundsClip-${renderUid})`}>
                     {legend && (
-                        <HeightedLegendView
+                        <HeightedLegendComponent
                             legend={legend}
                             x={bounds.right - legend.width}
                             yScale={axisBox.yScale}
@@ -461,7 +465,7 @@ export class StackedArea extends React.Component<{
                             onClick={this.onLegendClick}
                             onMouseOver={this.onLegendMouseOver}
                             onMouseLeave={this.onLegendMouseLeave}
-                            clickableMarks={this.chart.data.canAddData}
+                            areMarksClickable={this.chart.data.canAddData}
                         />
                     )}
                     <Areas

--- a/charts/StackedAreaTransform.ts
+++ b/charts/StackedAreaTransform.ts
@@ -16,7 +16,7 @@ import {
     findClosest
 } from "./Util"
 import { ChartConfig } from "./ChartConfig"
-import { DataKey } from "./DataKey"
+import { EntityDimensionKey } from "./EntityDimensionKey"
 import { StackedAreaSeries, StackedAreaValue } from "./StackedArea"
 import { AxisSpec } from "./AxisSpec"
 import { ColorSchemes, ColorScheme } from "./ColorSchemes"
@@ -57,17 +57,20 @@ export class StackedAreaTransform implements IChartTransform {
 
         // First, we populate the data as we would for a line chart (each series independently)
         filledDimensions.forEach((dimension, dimIndex) => {
-            const seriesByKey = new Map<DataKey, StackedAreaSeries>()
+            const seriesByKey = new Map<EntityDimensionKey, StackedAreaSeries>()
 
             for (let i = 0; i < dimension.years.length; i++) {
                 const year = dimension.years[i]
                 const value = +dimension.values[i]
                 const entity = dimension.entities[i]
-                const datakey = chart.data.keyFor(entity, dimIndex)
-                let series = seriesByKey.get(datakey)
+                const entityDimensionKey = chart.data.makeEntityDimensionKey(
+                    entity,
+                    dimIndex
+                )
+                let series = seriesByKey.get(entityDimensionKey)
 
                 // Not a selected key, don't add any data for it
-                if (!selectedKeysByKey[datakey]) continue
+                if (!selectedKeysByKey[entityDimensionKey]) continue
                 // Must be numeric
                 if (isNaN(value)) continue
                 // Stacked area chart can't go negative!
@@ -76,11 +79,11 @@ export class StackedAreaTransform implements IChartTransform {
                 if (!series) {
                     series = {
                         values: [],
-                        key: datakey,
+                        key: entityDimensionKey,
                         isProjection: dimension.isProjection,
                         color: "#fff" // tmp
                     }
-                    seriesByKey.set(datakey, series)
+                    seriesByKey.set(entityDimensionKey, series)
                 }
 
                 series.values.push({ x: year, y: value, time: year })

--- a/charts/StackedBarTransform.ts
+++ b/charts/StackedBarTransform.ts
@@ -18,7 +18,7 @@ import { StackedBarValue, StackedBarSeries } from "./StackedBarChart"
 import { AxisSpec } from "./AxisSpec"
 import { IChartTransform } from "./IChartTransform"
 import { DimensionWithData } from "./DimensionWithData"
-import { DataKey } from "./DataKey"
+import { EntityDimensionKey } from "./EntityDimensionKey"
 import { Colorizer, Colorable } from "./Colorizer"
 
 // Responsible for translating chart configuration into the form
@@ -185,17 +185,20 @@ export class StackedBarTransform implements IChartTransform {
         let groupedData: StackedBarSeries[] = []
 
         filledDimensions.forEach((dimension, dimIndex) => {
-            const seriesByKey = new Map<DataKey, StackedBarSeries>()
+            const seriesByKey = new Map<EntityDimensionKey, StackedBarSeries>()
 
             for (let i = 0; i <= dimension.years.length; i += 1) {
                 const year = dimension.years[i]
                 const entity = dimension.entities[i]
                 const value = +dimension.values[i]
-                const datakey = chart.data.keyFor(entity, dimIndex)
-                let series = seriesByKey.get(datakey)
+                const entityDimensionKey = chart.data.makeEntityDimensionKey(
+                    entity,
+                    dimIndex
+                )
+                let series = seriesByKey.get(entityDimensionKey)
 
                 // Not a selected key, don't add any data for it
-                if (!selectedKeysByKey[datakey]) continue
+                if (!selectedKeysByKey[entityDimensionKey]) continue
                 // Must be numeric
                 if (isNaN(value)) continue
                 // Stacked bar chart can't go negative!
@@ -205,12 +208,12 @@ export class StackedBarTransform implements IChartTransform {
 
                 if (!series) {
                     series = {
-                        key: datakey,
-                        label: chart.data.formatKey(datakey),
+                        key: entityDimensionKey,
+                        label: chart.data.getLabelForKey(entityDimensionKey),
                         values: [],
                         color: "#fff" // Temp
                     }
-                    seriesByKey.set(datakey, series)
+                    seriesByKey.set(entityDimensionKey, series)
                 }
                 series.values.push({
                     x: year,
@@ -276,7 +279,7 @@ export class StackedBarTransform implements IChartTransform {
                 return that.colorKeys
             },
             get labelFormat() {
-                return (key: string) => that.chart.data.formatKey(key)
+                return (key: string) => that.chart.data.getLabelForKey(key)
             },
             invert: true
         })

--- a/charts/TextWrap.tsx
+++ b/charts/TextWrap.tsx
@@ -10,7 +10,7 @@ export interface TextWrapProps {
     maxWidth: number
     lineHeight?: number
     fontSize: FontSize
-    raw?: true
+    rawHtml?: true
 }
 
 interface WrapLine {
@@ -60,7 +60,7 @@ export class TextWrap {
             const nextLine = line.concat([word])
 
             // Strip HTML if a raw string is passed
-            const text = this.props.raw
+            const text = this.props.rawHtml
                 ? stripHTML(nextLine.join(" "))
                 : nextLine.join(" ")
 
@@ -126,25 +126,22 @@ export class TextWrap {
 
         return (
             <React.Fragment>
-                {lines.map((line, i) => {
-                    if (props.raw)
-                        return (
-                            <React.Fragment key={i}>
-                                <span
-                                    dangerouslySetInnerHTML={{
-                                        __html: line.text
-                                    }}
-                                />
-                                <br />
-                            </React.Fragment>
-                        )
-                    else
-                        return (
-                            <React.Fragment key={i}>
-                                {line.text}
-                                <br />
-                            </React.Fragment>
-                        )
+                {lines.map((line, index) => {
+                    const content = props.rawHtml ? (
+                        <span
+                            dangerouslySetInnerHTML={{
+                                __html: line.text
+                            }}
+                        />
+                    ) : (
+                        line.text
+                    )
+                    return (
+                        <React.Fragment key={index}>
+                            {content}
+                            <br />
+                        </React.Fragment>
+                    )
                 })}
             </React.Fragment>
         )
@@ -165,7 +162,7 @@ export class TextWrap {
                 {...options}
             >
                 {lines.map((line, i) => {
-                    if (props.raw)
+                    if (props.rawHtml)
                         return (
                             <tspan
                                 key={i}

--- a/charts/Variable.ts
+++ b/charts/Variable.ts
@@ -21,6 +21,7 @@ export class VariableDisplaySettings {
     @observable tolerance?: number = undefined
     @observable yearIsDay?: boolean = undefined
     @observable zeroDay?: string = undefined
+    @observable entityAnnotationsMap?: string = undefined
 }
 
 export class Variable {
@@ -59,6 +60,17 @@ export class Variable {
                 }
             }
         }
+    }
+
+    @computed get annotationMap() {
+        const map = new Map()
+        if (!this.display.entityAnnotationsMap) return map
+        this.display.entityAnnotationsMap.split("\n").forEach(line => {
+            const words = line.split(":")
+            const key = words.shift()
+            map.set(key, words.join(" "))
+        })
+        return map
     }
 
     @computed get hasNumericValues(): boolean {

--- a/charts/Variable.ts
+++ b/charts/Variable.ts
@@ -67,8 +67,9 @@ export class Variable {
         if (!this.display.entityAnnotationsMap) return map
         const delimiter = ":"
         this.display.entityAnnotationsMap.split("\n").forEach(line => {
-            const words = line.split(delimiter)
-            const key = words.shift()
+            const [key, ...words] = line
+                .split(delimiter)
+                .map(word => word.trim())
             map.set(key, words.join(delimiter))
         })
         return map

--- a/charts/Variable.ts
+++ b/charts/Variable.ts
@@ -65,10 +65,11 @@ export class Variable {
     @computed get annotationMap() {
         const map = new Map()
         if (!this.display.entityAnnotationsMap) return map
+        const delimiter = ":"
         this.display.entityAnnotationsMap.split("\n").forEach(line => {
-            const words = line.split(":")
+            const words = line.split(delimiter)
             const key = words.shift()
-            map.set(key, words.join(" "))
+            map.set(key, words.join(delimiter))
         })
         return map
     }

--- a/charts/__tests__/TextWrap.test.ts
+++ b/charts/__tests__/TextWrap.test.ts
@@ -16,7 +16,7 @@ describe(TextWrap, () => {
                 maxWidth: Infinity,
                 fontSize: FONT_SIZE,
                 text,
-                raw
+                rawHtml: raw
             })
             return textwrap.width
         }


### PR DESCRIPTION
Before & After:
![Screen Shot 2020-04-03 at 5 44 48 PM](https://user-images.githubusercontent.com/74692/78417923-ea238600-75d2-11ea-839a-7eb7c65c1736.png)

![Screen Shot 2020-04-03 at 5 44 13 PM](https://user-images.githubusercontent.com/74692/78417926-ed1e7680-75d2-11ea-9b92-058c73fd141b.png)

This hopefully improves styling of those charts and will let us use standard entity names and get the Map view working. It requires researchers to paste in an entity-annotation map at the variable level. The preferred way would be to have an annotation column and I tried to implement that but was not able to come up with a good approach yet. If we get our data warehouse model refactored hopefully that will be easy to move, if we want to keep this annotations feature around.

I also tried to clean up a few things as I went like adding more privates and renaming the vague "DataKey" to "EntityDimensionKey". Not that the latter rolls off the tongue but I think it's slightly better to have wordy but more informative names. These are all nits and would be happy to separate those out into a separate commit.

Finally, I added the owidDataset property to ChartConfig so you can just load a full chart from 1 JSON file to ease debugging.

