### PR TITLE
Add sandbox to folder baking

### DIFF
--- a/public/sandbox/bakeSandbox.ts
+++ b/public/sandbox/bakeSandbox.ts
@@ -1,10 +1,12 @@
 #!/usr/bin/env ts-node
 
 import * as fs from "fs-extra"
-import * as http from "http"
 
 const bakeSandbox = async (outputPath: string) => {
-    console.log(`Baking sandbox to ${outputPath}`)
+    outputPath = outputPath.replace(/\/$/, "") + "/"
+    console.log(
+        `Baking sandbox to "${outputPath}". Be sure to run 'yarn build' first to build needed bundles.`
+    )
 
     const assets = `http://localhost:8090/css/commons.css
 http://localhost:8090/css/owid.css
@@ -16,9 +18,12 @@ http://localhost:8090/js/commons.js`.split("\n")
     assets.forEach(url => {
         const parts = url.split("/")
         const filename = parts[parts.length - 1]
+        const extension = filename.split(".").pop()
+        fs.copy(
+            `${__dirname}/../../dist/webpack/${extension}/${filename}`,
+            outputPath + filename
+        )
         indexPage = indexPage.replace(url, filename)
-        const stream = fs.createWriteStream(outputPath + filename)
-        http.get(url, response => response.pipe(stream))
     })
     fs.writeFileSync(outputPath + "index.html", indexPage, "utf8")
     fs.writeFileSync(
@@ -28,4 +33,6 @@ http://localhost:8090/js/commons.js`.split("\n")
     )
 }
 
-bakeSandbox(process.argv[2])
+const destination = process.argv[2]
+if (!destination) throw new Error("No destination folder provided")
+bakeSandbox(destination)

--- a/public/sandbox/bakeSandbox.ts
+++ b/public/sandbox/bakeSandbox.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env ts-node
+
+import * as fs from "fs-extra"
+import * as http from "http"
+
+const bakeSandbox = async (outputPath: string) => {
+    console.log(`Baking sandbox to ${outputPath}`)
+
+    const assets = `http://localhost:8090/css/commons.css
+http://localhost:8090/css/owid.css
+http://localhost:8090/js/owid.js
+http://localhost:8090/js/commons.js`.split("\n")
+
+    await fs.mkdirp(outputPath)
+    let indexPage = fs.readFileSync(__dirname + "/index.html", "utf8")
+    assets.forEach(url => {
+        const parts = url.split("/")
+        const filename = parts[parts.length - 1]
+        indexPage = indexPage.replace(url, filename)
+        const stream = fs.createWriteStream(outputPath + filename)
+        http.get(url, response => response.pipe(stream))
+    })
+    fs.writeFileSync(outputPath + "index.html", indexPage, "utf8")
+    fs.writeFileSync(
+        outputPath + "chart.js",
+        fs.readFileSync(__dirname + "/chart.js", "utf8"),
+        "utf8"
+    )
+}
+
+bakeSandbox(process.argv[2])

--- a/public/sandbox/index.html
+++ b/public/sandbox/index.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta charset="UTF-8" />
         <title>OWID GCharts</title>
         <link
             href="https://fonts.googleapis.com/css?family=Lato:300,400,400i,700,700i|Playfair+Display:400,700"

--- a/public/sandbox/readme.md
+++ b/public/sandbox/readme.md
@@ -1,0 +1,19 @@
+# Grapher Sandbox
+
+The Grapher Sandbox provides a minimal HTML/JS environment for debugging and prototyping Grapher charts.
+
+Use it:
+
+1. When you want to try code changes against a production chart without syncing the production database.
+2. When you want to share an interactive demo of a new Grapher feature with the team without deploying a full branch.
+
+## How to load a production chart against your local branch
+
+1. Copy the JSON for the chart from the Debug textarea in the bottom of the Admin->Revisions panel
+2. Paste the JSON into `sandbox/chart.js`. Prefix the JSON with `const sandboxChart =`. You can also see the example `chart.sample.js`.
+3. Open `sandbox/index.html`
+
+## How to bundle your current branch into a folder for distribution
+
+1. After you've made code changes to your Grapher charts and your chart.js file and want to share, run `yarn build`
+2. Then run `./sandbox/bakeSandbox.ts ~/some-output-folder` to copy all dependencies into that folder and get a standalone bundle.


### PR DESCRIPTION
This allows you to bake a current chart in the sandbox along with your local development version of Grapher charts to a self-contained folder in order to share interactive development prototypes with the rest of the team for feedback.

How to use:

1. Go to the admin for any chart on prod and copy/paste the debug version into sandbox/chart.js (paste it with `const sandboxChart =`—see chart.sample.js for a sample).
2. Run "ts-node bakeSandbox.ts /some/destionation/folder
