### PR TITLE
Take annotation into account when computing legend width

### DIFF
--- a/charts/HeightedLegend.tsx
+++ b/charts/HeightedLegend.tsx
@@ -120,7 +120,12 @@ export class HeightedLegend {
                 item,
                 textWrap,
                 annotationTextWrap,
-                width: leftPadding + textWrap.width,
+                width:
+                    leftPadding +
+                    Math.max(
+                        textWrap.width,
+                        annotationTextWrap ? annotationTextWrap.width : 0
+                    ),
                 height:
                     textWrap.height +
                     (annotationTextWrap ? annotationTextWrap.height : 0)


### PR DESCRIPTION
### Before:

<img width="782" alt="Screenshot 2020-04-07 at 20 37 01" src="https://user-images.githubusercontent.com/1308115/78711972-c84a3c00-790f-11ea-8254-edbdb59dc392.png">

### After:

<img width="782" alt="Screenshot 2020-04-07 at 20 37 35" src="https://user-images.githubusercontent.com/1308115/78711983-cc765980-790f-11ea-96d2-d8da5e958bb5.png">

---

There is a bit too much padding? This could go out as it is, but that wide gap is kind of a bit much. 

I thought this would be a 2min fix and I've spend much longer, so I'm leaving this here to merge or for anyone to extend and fix that padding.

I think the problem is that when legend items get offset, they have lines on the left, and this padding is reserved for those lines. But the padding is reserved in `HeightedLegend`, before we even know whether we need those lines. So when the lines are unnecessary, we end up with unused space.