### PR TITLE
Add Zoom to selection toggle to scatterplots

### DIFF
--- a/admin/client/EditorScatterTab.tsx
+++ b/admin/client/EditorScatterTab.tsx
@@ -52,7 +52,7 @@ export class EditorScatterTab extends React.Component<{ chart: ChartConfig }> {
     }
 
     @computed get excludedEntityChoices(): string[] {
-        return this.props.chart.scatter.entitiesToShow
+        return this.props.chart.scatter.getEntitiesToShow()
     }
 
     @action.bound onExcludeEntity(entity: string) {

--- a/charts/AxisScale.ts
+++ b/charts/AxisScale.ts
@@ -55,11 +55,11 @@ export class AxisScale {
         this.hideGridlines = hideGridlines
     }
 
-    @computed get d3_scaleConstructor(): any {
+    @computed private get d3_scaleConstructor(): any {
         return this.scaleType === "log" ? scaleLog : scaleLinear
     }
 
-    @computed get d3_scale():
+    @computed private get d3_scale():
         | ScaleLinear<number, number>
         | ScaleLogarithmic<number, number> {
         return this.d3_scaleConstructor()

--- a/charts/Bounds.ts
+++ b/charts/Bounds.ts
@@ -350,7 +350,7 @@ export class Bounds {
 
     // Calculate squared distance between a given point and the closest border of the bounds
     // If the point is within the bounds, returns 0
-    distanceToPointSq(p: Vector2) {
+    private distanceToPointSq(p: Vector2) {
         if (this.contains(p)) return 0
 
         const cx = Math.max(Math.min(p.x, this.x + this.width), this.x)

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -194,6 +194,7 @@ export class ChartConfigProps {
     @observable.ref entityType?: string = undefined
     @observable.ref entityTypePlural?: string = undefined
     @observable.ref hideTimeline?: true = undefined
+    @observable.ref zoomToSelection?: true = undefined
 
     // Always show year in labels for bar charts
     @observable.ref showYearLabels?: boolean = undefined

--- a/charts/ChartData.ts
+++ b/charts/ChartData.ts
@@ -261,6 +261,10 @@ export class ChartData {
         return keyBy(this.filledDimensions, "property")
     }
 
+    @computed get hasSelection() {
+        return this.chart.props.selectedData.length > 0
+    }
+
     @computed private get selectionData(): Array<{
         key: EntityDimensionKey
         color?: Color

--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -3,7 +3,7 @@ import { observable, computed, action } from "mobx"
 import { observer } from "mobx-react"
 import * as Cookies from "js-cookie"
 
-import { ChartConfig } from "./ChartConfig"
+import { ChartConfig, ChartConfigProps } from "./ChartConfig"
 import { getQueryParams, getWindowQueryParams } from "utils/client/url"
 import { ChartView } from "./ChartView"
 import { HighlightToggleConfig } from "./ChartConfig"
@@ -322,6 +322,32 @@ class AbsRelToggle extends React.Component<{ chart: ChartConfig }> {
                     onChange={this.onToggle}
                     disabled={!supported}
                     data-track-note="chart-abs-rel-toggle"
+                />{" "}
+                {label}
+            </label>
+        )
+    }
+}
+
+@observer
+class ZoomToggle extends React.Component<{
+    chart: ChartConfigProps
+}> {
+    @action.bound onToggle() {
+        this.props.chart.zoomToSelection = this.props.chart.zoomToSelection
+            ? undefined
+            : true
+    }
+
+    render() {
+        const label = "Zoom to selection"
+        return (
+            <label className="clickable">
+                <input
+                    type="checkbox"
+                    checked={this.props.chart.zoomToSelection}
+                    onChange={this.onToggle}
+                    data-track-note="chart-zoom-to-selection"
                 />{" "}
                 {label}
             </label>
@@ -833,6 +859,10 @@ export class ControlsFooterView extends React.Component<{
                 {chart.isScatter && chart.scatter.canToggleRelative && (
                     <AbsRelToggle chart={chart} />
                 )}
+                {chart.isScatter && chart.data.hasSelection && (
+                    <ZoomToggle chart={chart.props}></ZoomToggle>
+                )}
+
                 {chart.isLineChart && chart.lineChart.canToggleRelative && (
                     <AbsRelToggle chart={chart} />
                 )}


### PR DESCRIPTION
This adds a toggle to zoom instead of the auto zoom behavior on selection change:
![2020-04-07 19 38 13](https://user-images.githubusercontent.com/74692/78748304-67b70100-7907-11ea-9e9d-176f2666d924.gif)

We could make the button pop more but it doesn't do much in certain situations so I found a more subtle placement in the controls area to be relatively straightforward. We could try this and iterate later.

There remain opportunities to clean up the scatter transform code to make this work better on some of the existing scatterplots. It works pretty well on connected scatters but in certain situations it has little effect (or no effect) due to various sorts of filters in the Scatter transform.