### PR TITLE
Fix skewed arrows

### DIFF
--- a/charts/Marks.tsx
+++ b/charts/Marks.tsx
@@ -19,7 +19,7 @@ export class Triangle extends React.Component<TriangleProps> {
         const x = cx - r,
             y = cy - r
         const points = [
-            [x, y + 4 * 2],
+            [x, y + r * 2],
             [x + (r * 2) / 2, y],
             [x + r * 2, y + r * 2]
         ]


### PR DESCRIPTION
https://www.notion.so/Fix-skewed-arrow-on-scatter-plot-929b156ae4ea4fad841c9468af950000

Well, this one was easy 😄 

Looked like this before:
![Anmerkung 2020-04-08 201154](https://user-images.githubusercontent.com/2641501/78818817-8b487d00-79d5-11ea-921d-6123697b1e11.jpg)

... now it doesn't anymore!