### PR TITLE
Add Halos to text labels on scatterplots

### DIFF
--- a/charts/Bounds.ts
+++ b/charts/Bounds.ts
@@ -70,11 +70,13 @@ export class Bounds {
         {
             x = 0,
             y = 0,
-            fontSize = 16
+            fontSize = 16,
+            fontWeight = 400
         }: {
             x?: number
             y?: number
             fontSize?: number
+            fontWeight?: number
             fontFamily?: string
         } = {}
     ): Bounds {
@@ -89,7 +91,11 @@ export class Bounds {
 
         if (str === "") bounds = Bounds.empty()
         else {
-            const width = pixelWidth(str, { font: "Arial", size: fontSize })
+            const width = pixelWidth(str, {
+                font: "Arial",
+                size: fontSize,
+                bold: fontWeight >= 600
+            })
             const height = fontSize
             bounds = new Bounds(x, y - height, width, height)
         }

--- a/charts/ComparisonLine.tsx
+++ b/charts/ComparisonLine.tsx
@@ -7,6 +7,7 @@ import { AxisBox } from "./AxisBox"
 import { generateComparisonLinePoints } from "./ComparisonLineGenerator"
 import { Bounds } from "./Bounds"
 import { Vector2 } from "./Vector2"
+import { getElementWithHalo } from "./Halos"
 
 export interface ComparisonLineConfig {
     label?: string
@@ -111,25 +112,15 @@ export class ComparisonLine extends React.Component<{
                         }}
                         clipPath={`url(#axisBounds-${renderUid})`}
                     >
-                        <textPath
-                            baselineShift="-0.2rem"
-                            href={`#path-${renderUid}`}
-                            startOffset="90%"
-                            style={{
-                                stroke: "white",
-                                strokeWidth: "0.3em"
-                            }}
-                            dy="-0.33em"
-                        >
-                            {placedLabel.text}
-                        </textPath>
-                        <textPath
-                            baselineShift="-0.2rem"
-                            href={`#path-${renderUid}`}
-                            startOffset="90%"
-                        >
-                            {placedLabel.text}
-                        </textPath>
+                        {getElementWithHalo(
+                            <textPath
+                                baselineShift="-0.2rem"
+                                href={`#path-${renderUid}`}
+                                startOffset="90%"
+                            >
+                                {placedLabel.text}
+                            </textPath>
+                        )}
                     </text>
                 )}
             </g>

--- a/charts/Halos.tsx
+++ b/charts/Halos.tsx
@@ -5,7 +5,7 @@ const HaloStyle: React.CSSProperties = {
     stroke: "#fff",
     strokeLinecap: "round",
     strokeLinejoin: "round",
-    strokeWidth: ".2em"
+    strokeWidth: ".25em"
 }
 
 export const getElementWithHalo = (element: React.ReactElement) => {

--- a/charts/Halos.tsx
+++ b/charts/Halos.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+
+const HaloStyle: React.CSSProperties = {
+    fill: "#fff",
+    stroke: "#fff",
+    strokeLinecap: "round",
+    strokeLinejoin: "round",
+    strokeWidth: ".2em"
+}
+
+export const getElementWithHalo = (element: React.ReactElement) => {
+    const halo = React.cloneElement(element, {
+        key: `${element.props.key}Halo`,
+        style: HaloStyle
+    })
+    return (
+        <React.Fragment>
+            {halo}
+            {element}
+        </React.Fragment>
+    )
+}

--- a/charts/PointsWithLabels.tsx
+++ b/charts/PointsWithLabels.tsx
@@ -595,9 +595,9 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                 if (lowerPriorityLabel.isHidden) continue
 
                 if (
-                    higherPriorityLabel.bounds.intersects(
-                        lowerPriorityLabel.bounds
-                    )
+                    higherPriorityLabel.bounds
+                        .pad(-5)
+                        .intersects(lowerPriorityLabel.bounds)
                 ) {
                     lowerPriorityLabel.isHidden = true
                 }

--- a/charts/PointsWithLabels.tsx
+++ b/charts/PointsWithLabels.tsx
@@ -732,7 +732,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                                     )}
                                     fontSize={l.fontSize.toFixed(2)}
                                     fontWeight={l.fontWeight}
-                                    fill={l.series.color}
+                                    fill={isLayerMode ? "#aaa" : l.series.color}
                                 >
                                     {l.text}
                                 </text>

--- a/charts/PointsWithLabels.tsx
+++ b/charts/PointsWithLabels.tsx
@@ -33,6 +33,7 @@ import { getRelativeMouse, makeSafeForCSS, intersection } from "./Util"
 import { Vector2 } from "./Vector2"
 import { Triangle } from "./Marks"
 import { select } from "d3-selection"
+import { getElementWithHalo } from "./Halos"
 
 export interface ScatterSeries {
     color: string
@@ -108,27 +109,6 @@ interface ScatterLabel {
     isStart?: boolean
     isMid?: boolean
     isEnd?: boolean
-}
-
-const HaloStyle: React.CSSProperties = {
-    fill: "#fff",
-    stroke: "#fff",
-    strokeLinecap: "round",
-    strokeLinejoin: "round",
-    strokeWidth: ".2em"
-}
-
-const getElementWithHalo = (element: React.ReactElement) => {
-    const halo = React.cloneElement(element, {
-        key: `${element.props.key}Halo`,
-        style: HaloStyle
-    })
-    return (
-        <React.Fragment>
-            {halo}
-            {element}
-        </React.Fragment>
-    )
 }
 
 // When there's only a single point in a group (e.g. single year mode)

--- a/charts/PointsWithLabels.tsx
+++ b/charts/PointsWithLabels.tsx
@@ -103,6 +103,7 @@ interface ScatterRenderSeries {
 interface ScatterLabel {
     text: string
     fontSize: number
+    fontWeight: number
     bounds: Bounds
     series: ScatterRenderSeries
     isHidden?: boolean
@@ -396,6 +397,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
         return {
             text: firstValue.label,
             fontSize: fontSize,
+            fontWeight: 400,
             bounds: bounds,
             series: series,
             isStart: true
@@ -417,6 +419,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                 ? 8
                 : 9
             : 7
+        const fontWeight = 400
         const { labelFontFamily } = this
 
         return series.values.slice(1, -1).map((v, i) => {
@@ -447,6 +450,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                 x: pos.x,
                 y: pos.y,
                 fontSize: fontSize,
+                fontWeight: fontWeight,
                 fontFamily: labelFontFamily
             })
             if (pos.x < v.position.x)
@@ -467,6 +471,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
             return {
                 text: v.label,
                 fontSize: fontSize,
+                fontWeight: fontWeight,
                 bounds: bounds,
                 series: series,
                 isMid: true
@@ -491,6 +496,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                 : 7
             : lastValue.fontSize *
               (series.isForeground ? (isSubtleForeground ? 1.2 : 1.3) : 1.1)
+        const fontWeight = series.isForeground ? 700 : 400
 
         let offsetVector = Vector2.up
         if (series.values.length > 1) {
@@ -528,6 +534,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                     ? lastValue.label
                     : series.text,
             fontSize: fontSize,
+            fontWeight: fontWeight,
             bounds: labelBounds,
             series: series,
             isEnd: true
@@ -724,6 +731,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                                         2
                                     )}
                                     fontSize={l.fontSize.toFixed(2)}
+                                    fontWeight={l.fontWeight}
                                 >
                                     {l.text}
                                 </text>
@@ -839,6 +847,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                             fontSize={l.fontSize}
                             fontFamily={labelFontFamily}
                             fill="#333"
+                            fontWeight={l.fontWeight}
                         >
                             {l.text}
                         </text>

--- a/charts/PointsWithLabels.tsx
+++ b/charts/PointsWithLabels.tsx
@@ -110,6 +110,27 @@ interface ScatterLabel {
     isEnd?: boolean
 }
 
+const HaloStyle: React.CSSProperties = {
+    fill: "#fff",
+    stroke: "#fff",
+    strokeLinecap: "round",
+    strokeLinejoin: "round",
+    strokeWidth: ".2em"
+}
+
+const getElementWithHalo = (element: React.ReactElement) => {
+    const halo = React.cloneElement(element, {
+        key: `${element.props.key}Halo`,
+        style: HaloStyle
+    })
+    return (
+        <React.Fragment>
+            {halo}
+            {element}
+        </React.Fragment>
+    )
+}
+
 // When there's only a single point in a group (e.g. single year mode)
 @observer
 class ScatterGroupSingle extends React.Component<{
@@ -688,7 +709,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
         return this.renderData.filter(group => !!group.isForeground)
     }
 
-    renderBackgroundGroups() {
+    private renderBackgroundGroups() {
         const { backgroundGroups, isLayerMode, isConnected, hideLines } = this
 
         return hideLines
@@ -703,17 +724,19 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
               ))
     }
 
-    renderBackgroundLabels() {
+    private renderBackgroundLabels() {
         const { backgroundGroups, isLayerMode } = this
+
         return (
             <g
                 className="backgroundLabels"
                 fill={!isLayerMode ? "#333" : "#aaa"}
             >
                 {backgroundGroups.map(series => {
-                    return series.allLabels.map(
-                        l =>
-                            !l.isHidden && (
+                    return series.allLabels
+                        .filter(l => !l.isHidden)
+                        .map(l =>
+                            getElementWithHalo(
                                 <text
                                     key={series.displayKey + "-endLabel"}
                                     x={l.bounds.x.toFixed(2)}
@@ -725,7 +748,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                                     {l.text}
                                 </text>
                             )
-                    )
+                        )
                 })}
             </g>
         )
@@ -735,7 +758,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
         return guid()
     }
 
-    renderForegroundGroups() {
+    private renderForegroundGroups() {
         const {
             foregroundGroups,
             isSubtleForeground,
@@ -822,12 +845,13 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
         })
     }
 
-    renderForegroundLabels() {
+    private renderForegroundLabels() {
         const { foregroundGroups, labelFontFamily } = this
         return foregroundGroups.map(series => {
-            return series.allLabels.map(
-                (l, i) =>
-                    !l.isHidden && (
+            return series.allLabels
+                .filter(l => !l.isHidden)
+                .map((l, i) =>
+                    getElementWithHalo(
                         <text
                             key={`${series.displayKey}-label-${i}`}
                             x={l.bounds.x.toFixed(2)}
@@ -839,7 +863,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                             {l.text}
                         </text>
                     )
-            )
+                )
         })
     }
 

--- a/charts/PointsWithLabels.tsx
+++ b/charts/PointsWithLabels.tsx
@@ -732,6 +732,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                                     )}
                                     fontSize={l.fontSize.toFixed(2)}
                                     fontWeight={l.fontWeight}
+                                    fill={l.series.color}
                                 >
                                     {l.text}
                                 </text>
@@ -846,8 +847,8 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                             y={(l.bounds.y + l.bounds.height).toFixed(2)}
                             fontSize={l.fontSize}
                             fontFamily={labelFontFamily}
-                            fill="#333"
                             fontWeight={l.fontWeight}
+                            fill={l.series.color}
                         >
                             {l.text}
                         </text>


### PR DESCRIPTION
Before & afters:
![Screen Shot 2020-04-09 at 1 15 21 PM](https://user-images.githubusercontent.com/74692/78948992-e45ff180-7a65-11ea-85bc-ac5961c69a9b.png)
![Screen Shot 2020-04-09 at 1 17 14 PM](https://user-images.githubusercontent.com/74692/78948998-e6c24b80-7a65-11ea-9f98-12ae82b4058e.png)
![Screen Shot 2020-04-09 at 1 15 16 PM](https://user-images.githubusercontent.com/74692/78948999-e75ae200-7a65-11ea-8cd1-e37ed7b52d62.png)
