### PR TITLE
In the mobile menu, preview entry list for each category

### DIFF
--- a/charts/Util.ts
+++ b/charts/Util.ts
@@ -62,6 +62,7 @@ import findIndex from "lodash/findIndex"
 import fromPairs from "lodash/fromPairs"
 import mapKeys from "lodash/mapKeys"
 import memoize from "lodash/memoize"
+import flatMap from "lodash/flatMap"
 
 export {
     isEqual,
@@ -125,7 +126,8 @@ export {
     findIndex,
     fromPairs,
     mapKeys,
-    memoize
+    memoize,
+    flatMap
 }
 
 import moment = require("moment")

--- a/charts/Util.ts
+++ b/charts/Util.ts
@@ -62,7 +62,6 @@ import findIndex from "lodash/findIndex"
 import fromPairs from "lodash/fromPairs"
 import mapKeys from "lodash/mapKeys"
 import memoize from "lodash/memoize"
-import flatMap from "lodash/flatMap"
 
 export {
     isEqual,
@@ -126,8 +125,7 @@ export {
     findIndex,
     fromPairs,
     mapKeys,
-    memoize,
-    flatMap
+    memoize
 }
 
 import moment = require("moment")

--- a/site/client/SiteHeaderMenus.tsx
+++ b/site/client/SiteHeaderMenus.tsx
@@ -11,7 +11,7 @@ import { observer } from "mobx-react"
 import { HeaderSearch } from "./HeaderSearch"
 import { CategoryWithEntries, EntryMeta } from "db/wpdb"
 import classnames from "classnames"
-import { find, flatMap } from "charts/Util"
+import { find, flatten } from "charts/Util"
 import { bind } from "decko"
 
 import { BAKED_BASE_URL } from "settings"
@@ -306,6 +306,16 @@ const renderEntry = (entry: EntryMeta): JSX.Element => {
     )
 }
 
+const allEntries = (category: CategoryWithEntries): EntryMeta[] => {
+    // combine "direct" entries and those from subcategories
+    return [
+        ...category.entries,
+        ...flatten(
+            category.subcategories.map(subcategory => subcategory.entries)
+        )
+    ]
+}
+
 @observer
 export class DesktopTopicsMenu extends React.Component<{
     categories: CategoryWithEntries[]
@@ -426,14 +436,8 @@ export class DesktopTopicsMenu extends React.Component<{
                 </div>
                 <ul className="submenu" ref={this.submenuRef}>
                     {activeCategory &&
-                        activeCategory.entries.map(entry => renderEntry(entry))}
-                    {activeCategory &&
-                        activeCategory.subcategories.map(
-                            subcategory =>
-                                subcategory.entries &&
-                                subcategory.entries.map(entry =>
-                                    renderEntry(entry)
-                                )
+                        allEntries(activeCategory).map(entry =>
+                            renderEntry(entry)
                         )}
                 </ul>
             </div>
@@ -474,14 +478,7 @@ export class MobileTopicsMenu extends React.Component<{
                                         {category.name}
                                     </span>
                                     <span className="entries-muted">
-                                        {[
-                                            ...category.entries,
-                                            ...flatMap(
-                                                category.subcategories,
-                                                subcategory =>
-                                                    subcategory.entries
-                                            )
-                                        ]
+                                        {allEntries(category)
                                             .map(entry => entry.title)
                                             .join(", ")}
                                     </span>
@@ -499,15 +496,8 @@ export class MobileTopicsMenu extends React.Component<{
                             {activeCategory === category && (
                                 <div className="subcategory-menu">
                                     <ul>
-                                        {category.entries.map(entry =>
+                                        {allEntries(category).map(entry =>
                                             renderEntry(entry)
-                                        )}
-                                        {category.subcategories.map(
-                                            subcategory =>
-                                                subcategory.entries &&
-                                                subcategory.entries.map(entry =>
-                                                    renderEntry(entry)
-                                                )
                                         )}
                                     </ul>
                                 </div>

--- a/site/client/SiteHeaderMenus.tsx
+++ b/site/client/SiteHeaderMenus.tsx
@@ -11,7 +11,7 @@ import { observer } from "mobx-react"
 import { HeaderSearch } from "./HeaderSearch"
 import { CategoryWithEntries, EntryMeta } from "db/wpdb"
 import classnames from "classnames"
-import { find } from "charts/Util"
+import { find, flatMap } from "charts/Util"
 import { bind } from "decko"
 
 import { BAKED_BASE_URL } from "settings"
@@ -462,9 +462,30 @@ export class MobileTopicsMenu extends React.Component<{
                         <h2>Topics</h2>
                     </li>
                     {categories.map(category => (
-                        <li key={category.slug} className="category">
+                        <li
+                            key={category.slug}
+                            className={`category ${
+                                activeCategory === category ? "expanded" : ""
+                            }`}
+                        >
                             <a onClick={() => this.toggleCategory(category)}>
-                                <span className="label">{category.name}</span>
+                                <span className="label-wrapper">
+                                    <span className="label">
+                                        {category.name}
+                                    </span>
+                                    <span className="entries-muted">
+                                        {[
+                                            ...category.entries,
+                                            ...flatMap(
+                                                category.subcategories,
+                                                subcategory =>
+                                                    subcategory.entries
+                                            )
+                                        ]
+                                            .map(entry => entry.title)
+                                            .join(", ")}
+                                    </span>
+                                </span>
                                 <span className="icon">
                                     <FontAwesomeIcon
                                         icon={

--- a/site/client/css/header.scss
+++ b/site/client/css/header.scss
@@ -510,15 +510,16 @@
         }
 
         .entries-muted {
-            color: lightgray;
+            color: $primary-color-400;
             font-size: 0.7em;
+            font-weight: 400;
             overflow: hidden;
             white-space: nowrap;
             text-overflow: ellipsis;
             flex-basis: 0;
             flex-grow: 1;
             margin-left: 0.5rem;
-            margin-right: 0.25rem;
+            margin-right: 0.5rem;
         }
 
         &:hover {

--- a/site/client/css/header.scss
+++ b/site/client/css/header.scss
@@ -502,8 +502,33 @@
         display: block;
         text-align: center;
 
+        .label-wrapper {
+            display: flex;
+            align-items: baseline;
+            overflow: hidden;
+            flex-grow: 1;
+        }
+
+        .entries-muted {
+            color: lightgray;
+            font-size: 0.7em;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            flex-basis: 0;
+            flex-grow: 1;
+            margin-left: 0.5rem;
+            margin-right: 0.25rem;
+        }
+
         &:hover {
             background-color: $primary-color-100;
+        }
+    }
+
+    li.expanded a {
+        .entries-muted {
+            display: none;
         }
     }
 


### PR DESCRIPTION
https://www.notion.so/Fill-up-mobile-menu-empty-space-with-entry-list-1f816b7560864ffa85b70bc2459a6154

## Before:
![ourworldindata org_(iPhone X)](https://user-images.githubusercontent.com/2641501/78975478-73c3de00-7b14-11ea-91ab-d72e7728f364.png)

## After (iPhone X, iPad):
![localhost_3099_(iPhone X)](https://user-images.githubusercontent.com/2641501/78975489-7a525580-7b14-11ea-92e4-332d8f6c411a.png)
![localhost_3099_(iPad) (1)](https://user-images.githubusercontent.com/2641501/78975488-79212880-7b14-11ea-9b78-7da413953720.png)

These item previews will only be shown in the mobile menu, and only for categories that are not expanded. They are cutoff with "...".
