### PR TITLE
StackedArea: Reduce the legend width on mobile so there's more place for the chart itself

### DIFF
--- a/charts/StackedArea.tsx
+++ b/charts/StackedArea.tsx
@@ -254,7 +254,7 @@ export class StackedArea extends React.Component<{
         const that = this
         return new HeightedLegend({
             get maxWidth() {
-                return 150
+                return Math.min(150, that.bounds.width / 3)
             },
             get fontSize() {
                 return that.chart.baseFontSize


### PR DESCRIPTION
## Before:
<img src="https://user-images.githubusercontent.com/2641501/79022009-4b23fe80-7b7d-11ea-9c0d-11c5d56efb61.png" width="300" />

## After:
<img src="https://user-images.githubusercontent.com/2641501/79022019-51b27600-7b7d-11ea-84bb-b070f01e0c84.png" width="300" />

Now there's a _little_ more space for the chart itself.

The bigger issue here is the big padding on the right of the legend, but that's way harder to fix (it comes from the markers/indicators that _may_ be to the left of the labels).