### PR TITLE
Replace loading chart with static

### DIFF
--- a/charts/ChartTab.tsx
+++ b/charts/ChartTab.tsx
@@ -12,7 +12,7 @@ import { DiscreteBarChart } from "./DiscreteBarChart"
 import { StackedBarChart } from "./StackedBarChart"
 import { ChartLayout, ChartLayoutView } from "./ChartLayout"
 import { TimeScatter } from "./TimeScatter"
-import { LoadingChart } from "./LoadingChart"
+import { BAKED_GRAPHER_URL } from "settings"
 
 @observer
 export class ChartTab extends React.Component<{
@@ -38,12 +38,16 @@ export class ChartTab extends React.Component<{
     renderChart() {
         const { chart, chartView } = this.props
         const bounds = this.layout.innerBounds
-
-        if (!chart.data.isReady) {
-            return <LoadingChart bounds={bounds} />
-        } else if (chart.isSlopeChart) {
+        if (!chart.data.isReady)
+            return <a href={`${BAKED_GRAPHER_URL}/${chart.props.slug}`}>
+                <img
+                    src={`${BAKED_GRAPHER_URL}/exports/${chart.props.slug}.svg`}
+                    className="chartPreview"
+                />
+            </a>
+        else if (chart.isSlopeChart)
             return <SlopeChart bounds={bounds.padTop(20)} chart={chart} />
-        } else if (chart.isScatter) {
+        else if (chart.isScatter)
             return (
                 <ScatterPlot
                     bounds={bounds.padTop(20).padBottom(15)}
@@ -51,7 +55,7 @@ export class ChartTab extends React.Component<{
                     isStatic={chartView.isExport}
                 />
             )
-        } else if (chart.isTimeScatter) {
+        else if (chart.isTimeScatter)
             return (
                 <TimeScatter
                     bounds={bounds.padTop(20).padBottom(15)}
@@ -59,7 +63,7 @@ export class ChartTab extends React.Component<{
                     isStatic={chartView.isExport}
                 />
             )
-        } else if (chart.isLineChart) {
+        else if (chart.isLineChart)
             // Switch to bar chart if a single year is selected
             return chart.lineChart.isSingleYear ? (
                 <DiscreteBarChart
@@ -67,35 +71,33 @@ export class ChartTab extends React.Component<{
                     chart={chart}
                 />
             ) : (
-                <LineChart
-                    bounds={bounds.padTop(20).padBottom(15)}
-                    chart={chart}
-                />
-            )
-        } else if (chart.isStackedArea) {
+                    <LineChart
+                        bounds={bounds.padTop(20).padBottom(15)}
+                        chart={chart}
+                    />
+                )
+        else if (chart.isStackedArea)
             return (
                 <StackedArea
                     bounds={bounds.padTop(20).padBottom(15)}
                     chart={chart}
                 />
             )
-        } else if (chart.isDiscreteBar) {
+        else if (chart.isDiscreteBar)
             return (
                 <DiscreteBarChart
                     bounds={bounds.padTop(20).padBottom(15)}
                     chart={chart}
                 />
             )
-        } else if (chart.isStackedBar) {
+        else if (chart.isStackedBar)
             return (
                 <StackedBarChart
                     bounds={bounds.padTop(20).padBottom(15)}
                     chart={chart}
                 />
             )
-        } else {
-            return null
-        }
+        else return null
     }
 
     render() {

--- a/charts/ChartTab.tsx
+++ b/charts/ChartTab.tsx
@@ -38,16 +38,17 @@ export class ChartTab extends React.Component<{
     renderChart() {
         const { chart, chartView } = this.props
         const bounds = this.layout.innerBounds
-        if (!chart.data.isReady)
+
+        if (!chart.data.isReady) {
             return <a href={`${BAKED_GRAPHER_URL}/${chart.props.slug}`}>
                 <img
                     src={`${BAKED_GRAPHER_URL}/exports/${chart.props.slug}.svg`}
                     className="chartPreview"
                 />
             </a>
-        else if (chart.isSlopeChart)
+        } else if (chart.isSlopeChart) {
             return <SlopeChart bounds={bounds.padTop(20)} chart={chart} />
-        else if (chart.isScatter)
+        } else if (chart.isScatter) {
             return (
                 <ScatterPlot
                     bounds={bounds.padTop(20).padBottom(15)}
@@ -55,7 +56,7 @@ export class ChartTab extends React.Component<{
                     isStatic={chartView.isExport}
                 />
             )
-        else if (chart.isTimeScatter)
+        } else if (chart.isTimeScatter) {
             return (
                 <TimeScatter
                     bounds={bounds.padTop(20).padBottom(15)}
@@ -63,7 +64,7 @@ export class ChartTab extends React.Component<{
                     isStatic={chartView.isExport}
                 />
             )
-        else if (chart.isLineChart)
+        } else if (chart.isLineChart) {
             // Switch to bar chart if a single year is selected
             return chart.lineChart.isSingleYear ? (
                 <DiscreteBarChart
@@ -76,28 +77,30 @@ export class ChartTab extends React.Component<{
                         chart={chart}
                     />
                 )
-        else if (chart.isStackedArea)
+        } else if (chart.isStackedArea) {
             return (
                 <StackedArea
                     bounds={bounds.padTop(20).padBottom(15)}
                     chart={chart}
                 />
             )
-        else if (chart.isDiscreteBar)
+        } else if (chart.isDiscreteBar) {
             return (
                 <DiscreteBarChart
                     bounds={bounds.padTop(20).padBottom(15)}
                     chart={chart}
                 />
             )
-        else if (chart.isStackedBar)
+        } else if (chart.isStackedBar) {
             return (
                 <StackedBarChart
                     bounds={bounds.padTop(20).padBottom(15)}
                     chart={chart}
                 />
             )
-        else return null
+        } else {
+            return null
+        }
     }
 
     render() {

--- a/charts/ChartTab.tsx
+++ b/charts/ChartTab.tsx
@@ -72,11 +72,11 @@ export class ChartTab extends React.Component<{
                     chart={chart}
                 />
             ) : (
-                    <LineChart
-                        bounds={bounds.padTop(20).padBottom(15)}
-                        chart={chart}
-                    />
-                )
+                <LineChart
+                    bounds={bounds.padTop(20).padBottom(15)}
+                    chart={chart}
+                />
+            )
         } else if (chart.isStackedArea) {
             return (
                 <StackedArea

--- a/charts/ChartTab.tsx
+++ b/charts/ChartTab.tsx
@@ -40,12 +40,14 @@ export class ChartTab extends React.Component<{
         const bounds = this.layout.innerBounds
 
         if (!chart.data.isReady) {
-            return <a href={`${BAKED_GRAPHER_URL}/${chart.props.slug}`}>
-                <img
-                    src={`${BAKED_GRAPHER_URL}/exports/${chart.props.slug}.svg`}
-                    className="chartPreview"
-                />
-            </a>
+            return (
+                <a href={`${BAKED_GRAPHER_URL}/${chart.props.slug}`}>
+                    <img
+                        src={`${BAKED_GRAPHER_URL}/exports/${chart.props.slug}.svg`}
+                        className="chartPreview"
+                    />
+                </a>
+            )
         } else if (chart.isSlopeChart) {
             return <SlopeChart bounds={bounds.padTop(20)} chart={chart} />
         } else if (chart.isScatter) {


### PR DESCRIPTION
The goal of this change is to replace the loading chart with a static image of the chart when loading a specific interactive chart as requested in https://github.com/owid/owid-grapher/issues/257. Before, there would be two loading animations upon opening the page. One while the text, overview, and title of the chart loads, and another after this while the interactive chart loads. The changed code displays a static image of the chart instead of the "loading" animation during the second load, so the user only sees one loading wheel animation. 

During second load, before:
![Screen Shot 2020-04-14 at 2 36 26 PM](https://user-images.githubusercontent.com/43069697/79261150-692f7e80-7e5d-11ea-8184-a6dfd21466d1.png)

During second load, after:
![Screen Shot 2020-04-14 at 2 36 39 PM](https://user-images.githubusercontent.com/43069697/79261215-819f9900-7e5d-11ea-83ab-76b116446e3d.png)
In this image the chart is not interactive

I tested this by running it locally and with yarn test.

