### PR TITLE
Correctly align right labels and values for slope charts

### DIFF
--- a/charts/LabelledSlopes.tsx
+++ b/charts/LabelledSlopes.tsx
@@ -262,7 +262,6 @@ class Slope extends React.Component<SlopeProps> {
                     <Text
                         x={x2 + 8}
                         y={y2 - rightValueLabelBounds.height / 2}
-                        dominantBaseline="middle"
                         fontSize={labelFontSize}
                         fill={labelColor}
                         fontWeight={isFocused || isHovered ? "bold" : undefined}


### PR DESCRIPTION
This is an easy one.

## Before/After

![image](https://user-images.githubusercontent.com/2641501/79471684-30c9a500-8003-11ea-9453-6a6f7e3bd4a8.png)
