### PR TITLE
ShareMenu: Allow copying link to chart

### DIFF
--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -3,6 +3,7 @@ import { observable, computed, action } from "mobx"
 import { observer } from "mobx-react"
 import * as Cookies from "js-cookie"
 import Select, { ValueType, StylesConfig } from "react-select"
+import copy from "copy-to-clipboard"
 
 import { ChartConfig, ChartConfigProps } from "./ChartConfig"
 import { getQueryParams, getWindowQueryParams } from "utils/client/url"
@@ -15,6 +16,7 @@ import { ADMIN_BASE_URL, ENV } from "settings"
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faCode } from "@fortawesome/free-solid-svg-icons/faCode"
+import { faCopy } from "@fortawesome/free-solid-svg-icons/faCopy"
 import { faEdit } from "@fortawesome/free-solid-svg-icons/faEdit"
 import { faDownload } from "@fortawesome/free-solid-svg-icons/faDownload"
 import { faShareAlt } from "@fortawesome/free-solid-svg-icons/faShareAlt"
@@ -73,13 +75,27 @@ class EmbedMenu extends React.Component<{
     }
 }
 
-@observer
-class ShareMenu extends React.Component<{
+interface ShareMenuProps {
     chart: ChartConfig
     chartView: any
     onDismiss: () => void
-}> {
+}
+
+interface ShareMenuState {
+    copied: boolean
+}
+
+@observer
+class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
     dismissable = true
+
+    constructor(props: ShareMenuProps) {
+        super(props)
+
+        this.state = {
+            copied: false
+        }
+    }
 
     @computed get title(): string {
         return this.props.chart.data.currentTitle
@@ -151,6 +167,12 @@ class ShareMenu extends React.Component<{
         }
     }
 
+    @action.bound onCopy() {
+        if (this.canonicalUrl) {
+            if (copy(this.canonicalUrl)) this.setState({ copied: true })
+        }
+    }
+
     @computed get twitterHref(): string {
         let href =
             "https://twitter.com/intent/tweet/?text=" +
@@ -209,6 +231,14 @@ class ShareMenu extends React.Component<{
                         <FontAwesomeIcon icon={faShareAlt} /> Share via&hellip;
                     </a>
                 )}
+                <a
+                    className="btn"
+                    title="Copy link to clipboard"
+                    onClick={this.onCopy}
+                >
+                    <FontAwesomeIcon icon={faCopy} />
+                    {this.state.copied ? "Copied!" : "Copy link"}
+                </a>
                 {editUrl && (
                     <a
                         className="btn"

--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -115,10 +115,6 @@ class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
         return this.props.chart.url.canonicalUrl
     }
 
-    @observable isEmbedMenuActive: boolean = false
-
-    embedMenu: any
-
     @action.bound dismiss() {
         this.props.onDismiss()
     }

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
         "colorbrewer": "^1.3.0",
         "concurrently": "^4.1.0",
         "cookie-parser": "^1.4.4",
+        "copy-to-clipboard": "^3.3.1",
         "css-loader": "^3.5.2",
         "csv-parse": "^4.4.3",
         "d3": "^5.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5607,6 +5607,13 @@ copy-to-clipboard@^3.0.8:
   dependencies:
     toggle-selection "^1.0.6"
 
+copy-to-clipboard@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
+  integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==
+  dependencies:
+    toggle-selection "^1.0.6"
+
 core-js-compat@^3.0.0, core-js-compat@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.1.3.tgz#0cc3ba4c7f62928c2837e1cffbe8dc78b4f1ae14"


### PR DESCRIPTION
Fixes #258.

The share menu now looks like this:
![image](https://user-images.githubusercontent.com/2641501/79613619-2e4c7580-80ff-11ea-9194-14f1fedc6467.png)

As expected, the "Copy link" entry copies the full link to the clipboard. The text changes to "Copied!" afterwards.

I tested this in quite a few browsers, and all worked fine:
* Windows Chrome 83
* Windows Firefox 68
* iOS Safari 13.3 & 12.2
* macOS Safari 13 & 12
* Android Chrome 83

The library I'm using (`copy-to-clipboard`) will fallback to a `prompt()` window in case other methods don't work, but that shouldn't happen too often and has never happened in my testing.