### PR TITLE
Disable mathjax font caching to prevent unnecessary page updates

### DIFF
--- a/site/server/MathJax.ts
+++ b/site/server/MathJax.ts
@@ -10,7 +10,7 @@ export function initMathJax() {
     RegisterHTMLHandler(adaptor)
 
     const tex = new TeX({ packages: AllPackages })
-    const svg = new SVG({ fontCache: "local" })
+    const svg = new SVG({ fontCache: "none" })
     const doc = mathjax.document("", {
         InputJax: tex,
         OutputJax: svg


### PR DESCRIPTION
I just noticed that posts like `latex-maths` get a whole bunch of unnecessary updates (https://github.com/owid/owid-static/commits/master/latex-maths.html).
That's due to mathjax's font caching, which assigns ids in the order of rendering, which is not deterministic in our case. Disabling the font caching should resolve that without any side effects.