### PR TITLE
Introduce asArray to react-select.tsx and use it instead of casts

### DIFF
--- a/admin/client/ColorSchemeDropdown.tsx
+++ b/admin/client/ColorSchemeDropdown.tsx
@@ -5,6 +5,8 @@ import { ColorScheme, ColorSchemes } from "charts/ColorSchemes"
 import { observer } from "mobx-react"
 import { bind } from "decko"
 
+import { asArray } from "utils/client/react-select"
+
 export interface ColorSchemeOption {
     colorScheme?: ColorScheme
     gradient?: string
@@ -72,12 +74,8 @@ export class ColorSchemeDropdown extends React.Component<
     }
 
     @action.bound onChange(selected: ValueType<ColorSchemeOption>) {
-        // The onChange method can return an array of values (when multiple
-        // items can be selected) or a single value. Since we are certain that
-        // we are not using the multi-option select we can force the type to be
-        // a single value.
-
-        this.props.onChange(selected as ColorSchemeOption)
+        const value = asArray(selected)[0]
+        this.props.onChange(value)
     }
 
     @bind formatOptionLabel(option: ColorSchemeOption) {

--- a/admin/client/ColorSchemeDropdown.tsx
+++ b/admin/client/ColorSchemeDropdown.tsx
@@ -6,6 +6,7 @@ import { observer } from "mobx-react"
 import { bind } from "decko"
 
 import { asArray } from "utils/client/react-select"
+import { first } from "charts/Util"
 
 export interface ColorSchemeOption {
     colorScheme?: ColorScheme
@@ -74,8 +75,8 @@ export class ColorSchemeDropdown extends React.Component<
     }
 
     @action.bound onChange(selected: ValueType<ColorSchemeOption>) {
-        const value = asArray(selected)[0]
-        this.props.onChange(value)
+        const value = first(asArray(selected))
+        if (value) this.props.onChange(value)
     }
 
     @bind formatOptionLabel(option: ColorSchemeOption) {

--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -31,7 +31,7 @@ import { ChartViewContext, ChartViewContextType } from "./ChartViewContext"
 import { TimeBound } from "./TimeBounds"
 import { Bounds } from "./Bounds"
 import { MapProjection } from "./MapProjection"
-import { getStylesForTargetHeight } from "utils/client/react-select"
+import { asArray, getStylesForTargetHeight } from "utils/client/react-select"
 
 @observer
 class EmbedMenu extends React.Component<{
@@ -687,7 +687,7 @@ export class ProjectionChooser extends React.Component<{
     onChange: (value: MapProjection) => void
 }> {
     @action.bound onChange(selected: ValueType<ProjectionChooserEntry>) {
-        const selectedValue = (selected as ProjectionChooserEntry)?.value
+        const selectedValue = asArray(selected)[0]?.value
         if (selectedValue) this.props.onChange(selectedValue)
     }
 

--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -32,6 +32,7 @@ import { TimeBound } from "./TimeBounds"
 import { Bounds } from "./Bounds"
 import { MapProjection } from "./MapProjection"
 import { asArray, getStylesForTargetHeight } from "utils/client/react-select"
+import { first } from "charts/Util"
 
 @observer
 class EmbedMenu extends React.Component<{
@@ -687,7 +688,7 @@ export class ProjectionChooser extends React.Component<{
     onChange: (value: MapProjection) => void
 }> {
     @action.bound onChange(selected: ValueType<ProjectionChooserEntry>) {
-        const selectedValue = asArray(selected)[0]?.value
+        const selectedValue = first(asArray(selected))?.value
         if (selectedValue) this.props.onChange(selectedValue)
     }
 

--- a/charts/IndicatorDropdown.tsx
+++ b/charts/IndicatorDropdown.tsx
@@ -11,6 +11,7 @@ import { Indicator } from "./Indicator"
 import { observer } from "mobx-react"
 import { StoreEntry } from "./Store"
 import { asArray } from "utils/client/react-select"
+import { first } from "./Util"
 
 export interface IndicatorDropdownProps {
     placeholder: string
@@ -28,7 +29,7 @@ export class IndicatorDropdown extends React.Component<IndicatorDropdownProps> {
     }
 
     @bind onChange(indicator: ValueType<Indicator>) {
-        const value = asArray(indicator)[0]?.id
+        const value = first(asArray(indicator))?.id
         if (value) this.props.onChangeId(value)
     }
 

--- a/charts/IndicatorDropdown.tsx
+++ b/charts/IndicatorDropdown.tsx
@@ -10,6 +10,7 @@ import {
 import { Indicator } from "./Indicator"
 import { observer } from "mobx-react"
 import { StoreEntry } from "./Store"
+import { asArray } from "utils/client/react-select"
 
 export interface IndicatorDropdownProps {
     placeholder: string
@@ -27,11 +28,8 @@ export class IndicatorDropdown extends React.Component<IndicatorDropdownProps> {
     }
 
     @bind onChange(indicator: ValueType<Indicator>) {
-        // The onChange method can return an array of values (when multiple
-        // items can be selected) or a single value. Since we are certain that
-        // we are not using the multi-option select we can force the type to be
-        // a single value.
-        this.props.onChangeId((indicator as Indicator).id)
+        const value = asArray(indicator)[0]?.id
+        if (value) this.props.onChangeId(value)
     }
 
     @bind async loadOptions(query: string): Promise<Indicator[]> {

--- a/site/client/global-entity/GlobalEntityControl.tsx
+++ b/site/client/global-entity/GlobalEntityControl.tsx
@@ -26,7 +26,7 @@ import {
     GlobalEntitySelection,
     GlobalEntitySelectionEntity
 } from "./GlobalEntitySelection"
-import { isMultiValue } from "utils/client/react-select"
+import { asArray } from "utils/client/react-select"
 import { Analytics } from "../Analytics"
 
 const allEntities = sortBy(countries, c => c.name)
@@ -236,13 +236,9 @@ export class GlobalEntityControl extends React.Component<
     @action.bound private onChange(
         newEntities: ValueType<GlobalEntitySelectionEntity>
     ) {
-        if (newEntities == null) return
+        const entities: GlobalEntitySelectionEntity[] = asArray(newEntities)
 
-        const entities: GlobalEntitySelectionEntity[] = isMultiValue(
-            newEntities
-        )
-            ? Array.from(newEntities)
-            : [newEntities]
+        if (entities.length === 0) return
 
         this.setSelectedEntities(entities)
 

--- a/site/client/global-entity/GlobalEntityControl.tsx
+++ b/site/client/global-entity/GlobalEntityControl.tsx
@@ -236,9 +236,7 @@ export class GlobalEntityControl extends React.Component<
     @action.bound private onChange(
         newEntities: ValueType<GlobalEntitySelectionEntity>
     ) {
-        const entities: GlobalEntitySelectionEntity[] = asArray(newEntities)
-
-        if (entities.length === 0) return
+        const entities = asArray(newEntities)
 
         this.setSelectedEntities(entities)
 

--- a/utils/client/react-select.tsx
+++ b/utils/client/react-select.tsx
@@ -4,6 +4,12 @@ export function isMultiValue<T>(value: ValueType<T>): value is OptionsType<T> {
     return Array.isArray(value)
 }
 
+export function asArray<T>(value: ValueType<T>): T[] {
+    if (value == null) return []
+    else if (isMultiValue(value)) return Array.from(value)
+    else return [value]
+}
+
 export function getStylesForTargetHeight(targetHeight: number): StylesConfig {
     // Taken from https://github.com/JedWatson/react-select/issues/1322#issuecomment-591189551
     return {


### PR DESCRIPTION
@danielgavrilov When looking at #420 I noticed you introduced the new `react-select` class, which is great.
I just find the new `isArray` function to be even more useful, since it allows us to get the values as an array every time without casting. Let me know what you think.