### PR TITLE
Lazy-loading images

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "@types/mysql": "^2.15.6",
         "@types/nodemailer": "^6.2.0",
         "@types/randomstring": "^1.1.6",
-        "@types/react": "^16.8.19",
+        "@types/react": "^16.9.34",
         "@types/react-dom": "^16.8.4",
         "@types/react-recaptcha": "^2.3.3",
         "@types/react-router-dom": "^4.3.3",

--- a/site/server/formatting.tsx
+++ b/site/server/formatting.tsx
@@ -221,7 +221,7 @@ export async function formatWordpressPost(
                 const output = `
                 <figure data-grapher-src="${src}" class="${GRAPHER_PREVIEW_CLASS}">
                     <a href="${src}" target="_blank">
-                        <div><img src="${chart.svgUrl}" width="${chart.width}" height="${chart.height}" /></div>
+                        <div><img src="${chart.svgUrl}" width="${chart.width}" height="${chart.height}" loading="lazy" /></div>
                         <div class="interactionNotice">
                             <span class="icon">${INTERACTIVE_ICON_SVG}</span>
                             <span class="label">Click to open interactive version</span>

--- a/site/server/formatting.tsx
+++ b/site/server/formatting.tsx
@@ -332,6 +332,11 @@ export async function formatWordpressPost(
                 originalFilename.replace(/[-_]/g, " ")
             )
         }
+
+        // Lazy load all images, unless they already have a "loading" attribute.
+        if (!el.attribs["loading"]) {
+            el.attribs["loading"] = "lazy"
+        }
     }
 
     // Table of contents and deep links

--- a/site/server/views/FrontPage.tsx
+++ b/site/server/views/FrontPage.tsx
@@ -449,6 +449,7 @@ export const FrontPage = (props: {
                                     <img
                                         src={`${settings.BAKED_BASE_URL}/sdg-wheel.png`}
                                         alt="SDG Tracker logo"
+                                        loading="lazy"
                                     />
                                 </div>
                                 <div className="content">
@@ -473,6 +474,7 @@ export const FrontPage = (props: {
                                     <img
                                         src={`${settings.BAKED_BASE_URL}/teaching-hub.svg`}
                                         alt="Teaching Hub logo"
+                                        loading="lazy"
                                     />
                                 </div>
                                 <div className="content">

--- a/site/server/views/SiteFooter.tsx
+++ b/site/server/views/SiteFooter.tsx
@@ -175,6 +175,7 @@ export const SiteFooter = ({
                                     <img
                                         src={`${BAKED_BASE_URL}/oms-logo.svg`}
                                         alt="Oxford Martin School logo"
+                                        loading="lazy"
                                     />
                                 </a>
                                 <a
@@ -185,6 +186,7 @@ export const SiteFooter = ({
                                     <img
                                         src={`${BAKED_BASE_URL}/yc-logo.png`}
                                         alt="Y Combinator logo"
+                                        loading="lazy"
                                     />
                                 </a>
                             </div>
@@ -216,6 +218,7 @@ export const SiteFooter = ({
                                         <img
                                             src={`${BAKED_BASE_URL}/gcdl-logo-narrow.png`}
                                             alt="Global Change Data Lab logo"
+                                            loading="lazy"
                                         />
                                     </a>
                                     Our World In Data is a project of the{" "}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2794,15 +2794,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "16.8.19"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.19.tgz#629154ef05e2e1985cdde94477deefd823ad9be3"
-  integrity sha512-QzEzjrd1zFzY9cDlbIiFvdr+YUmefuuRYrPxmkwG0UQv5XF35gFIi7a95m1bNVcFU0VimxSZ5QVGSiBmlggQXQ==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
-
-"@types/react@^16.9.34":
+"@types/react@*", "@types/react@^16.9.34":
   version "16.9.34"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.34.tgz#f7d5e331c468f53affed17a8a4d488cd44ea9349"
   integrity sha512-8AJlYMOfPe1KGLKyHpflCg5z46n0b5DbRfqDksxBLBTUpB75ypDBAO9eCUcjNwE6LCUslwTz00yyG/X9gaVtow==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2794,10 +2794,18 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.8.19":
+"@types/react@*":
   version "16.8.19"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.19.tgz#629154ef05e2e1985cdde94477deefd823ad9be3"
   integrity sha512-QzEzjrd1zFzY9cDlbIiFvdr+YUmefuuRYrPxmkwG0UQv5XF35gFIi7a95m1bNVcFU0VimxSZ5QVGSiBmlggQXQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
+"@types/react@^16.9.34":
+  version "16.9.34"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.34.tgz#f7d5e331c468f53affed17a8a4d488cd44ea9349"
+  integrity sha512-8AJlYMOfPe1KGLKyHpflCg5z46n0b5DbRfqDksxBLBTUpB75ypDBAO9eCUcjNwE6LCUslwTz00yyG/X9gaVtow==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"


### PR DESCRIPTION
We load a lot of images.
For example, upon visiting https://ourworldindata.org/coronavirus, a whopping 1MB of just svg graphics are loaded, many of which are either immediately replaced by an interactive chart or are simply never displayed because the user navigates away before she reaches them.
That's unnecessary traffic for us and unnecessary bandwidth towards the data caps of visitors.

That's why I suggest we lazy-load some of them, meaning they are only loaded once the user is _close_ to reaching them. This is now natively possible in [many browsers](https://caniuse.com/#feat=loading-lazy-attr) using the `<img loading="lazy">` attribute: https://web.dev/native-lazy-loading/
When exactly the image is loaded is a decision the browser makes, depending on the connection speed, whether data saver mode is enabled and how "close" the user is to the image. In my (short) testing, all images were already there when I reached them.
For browsers that don't support the attribute the images are just loaded normally.

Note, though, that this PR only introduces the attribute to "chart placeholders" and a few other places, and there are other images that might arguably benefit even more:
* "Lightbox" images. For https://ourworldindata.org/child-mortality for example, 3.6MB of `.png` graphics are loaded.
  I can't change those since these are coming directly from Wordpress, and would probably need to be included in `formatting.tsx` somewhere.
* The same goes for the "Related charts" links which include a preview of the chart they are linking to.
* The post images under "Latest publications" on the homepage. Currently those are 1.2MB, and at least on mobile I don't think the lower ones are often seen.
  I haven't changed these yet [since they are loaded using `background-image`](https://github.com/owid/owid-grapher/blob/2f56e8a6cd5bf0d73d5068328d510541063a335a/site/server/views/FrontPage.tsx#L326-L330).
* iframes can also have a `loading="lazy"` attribute, and that might make sense in some places, too.
  The WHO dashboard in the coronavirus entry (https://ourworldindata.org/coronavirus#who-data-on-covid-19) is probably not being looked at much since it's so far down the page, but comes with around 4MB of data nonetheless. While that's not traffic we have to pay for, the user may have to.

note: I had to update `@types/react` [to use the `loading` attribute without errors](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38390)