### PR TITLE
Add ability to run testcheck remotely

### DIFF
--- a/.rsync-ignore
+++ b/.rsync-ignore
@@ -10,7 +10,8 @@ logs/*
 datasetsExport
 tmp
 .tscache
-test
+/test
+__tests__
 dist
 .queue
 .pending

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -79,7 +79,7 @@ then
 
   # Install dependencies, build assets and migrate
   cd $TMP_NEW
-  yarn install --production
+  yarn install --production --frozen-lockfile
   yarn build
   yarn migrate
   yarn tsn scripts/configureAlgolia.ts

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,4 +1,6 @@
 #!/bin/bash -e
+
+USER="$(id -un)" # $USER empty in vscode terminal
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 RSYNC="rsync -havz --no-perms --progress --delete --delete-excluded --exclude-from=$DIR/.rsync-ignore"
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "test": "jest",
         "coverage": "jest --coverage=true --coverageProvider=v8 && open coverage/lcov-report/index.html",
         "cypress:open": "yarn cypress open --project ./test/e2e",
-        "testcheck": "yarn test && yarn typecheck && yarn prettify:check",
+        "testcheck": "yarn prettify:check && yarn typecheck && yarn test",
         "deploy": "./bin/deploy.sh",
         "serve": "yarn tsn admin/server/server.tsx",
         "bake": "yarn tsn scripts/bakeSite.ts",


### PR DESCRIPTION
Motivation: running tests locally is getting increasingly resource intensive.

This adds an "-r" option to the deploy command to run tests on the target server rather than locally. 

Given the size of the resulting node_modules folder, only one target test folder is created per staging server (as opposed to one per user). From preliminary tests, it looks like constantly overriding each other's changes in the target folder through rsync will be barely noticeable.

This PR also adds some more minor related improvements.