### PR TITLE
Only show "Click for change over time" hint if that's actually possible

### DIFF
--- a/charts/MapTab.tsx
+++ b/charts/MapTab.tsx
@@ -73,17 +73,25 @@ class MapWithLegend extends React.Component<MapWithLegendProps> {
         this.tooltipTarget = undefined
     }
 
-    // Determine if we can go to line chart by clicking on a map entity
-    @computed get isEntityClickable() {
-        return (
-            this.context.chart.hasChartTab &&
-            this.context.chart.isLineChart &&
-            !this.context.chartView.isMobile
+    // Determine if we can go to line chart by clicking on a given map entity
+    isEntityClickable(featureId: string | number | undefined) {
+        if (
+            !this.context.chart.hasChartTab ||
+            !this.context.chart.isLineChart ||
+            this.context.chartView.isMobile ||
+            featureId === undefined
         )
+            return false
+
+        const { chart } = this.context
+        const entity = this.props.mapToDataEntities[featureId]
+        const datakeys = chart.data.availableKeysByEntity.get(entity)
+
+        return datakeys && datakeys.length
     }
 
     @action.bound onClick(d: GeoFeature) {
-        if (!this.isEntityClickable) return
+        if (!this.isEntityClickable(d.id)) return
 
         const { chart } = this.context
         const entity = this.props.mapToDataEntities[d.id as string]
@@ -268,7 +276,7 @@ class MapWithLegend extends React.Component<MapWithLegendProps> {
                                 </div>
                             )}
                         </div>
-                        {this.isEntityClickable && (
+                        {this.isEntityClickable(tooltipTarget.featureId) && (
                             <div>
                                 <p
                                     style={{


### PR DESCRIPTION
Currently, we show the hint "Click for change over time" for all countries on a map, even if there is no data available to show. That's confusing, since we encourage the user to click - and nothing happens.

One example of that would be Greenland here: https://ourworldindata.org/grapher/men-survival-to-age-65

This changes it so the hint is only shown if it's actually possible.