### PR TITLE
For non-interactive charts, don't open the preview in the lightbox

### DIFF
--- a/site/client/Lightbox.tsx
+++ b/site/client/Lightbox.tsx
@@ -137,31 +137,29 @@ export const runLightbox = () => {
             ".article-content .wp-block-column:nth-child(2) img, .article-content .wp-block-columns.is-style-side-by-side img"
         )
     ).forEach(img => {
-        // TODO/HACK: refactor with something more generic when more exceptions need to be made
-        if (!img.closest(".wp-block-owid-prominent-link")) {
-            img.classList.add("lightbox-enabled")
-            img.addEventListener("click", () => {
-                const imgSrc = img.getAttribute("data-high-res-src")
-                    ? img.getAttribute("data-high-res-src")
-                    : img.src
-                if (imgSrc) {
-                    ReactDOM.render(
-                        <Lightbox
-                            imgSrc={imgSrc}
-                            containerNode={lightboxContainer}
-                        >
-                            {(isLoaded: boolean, setIsLoaded: any) => (
-                                <Image
-                                    src={imgSrc}
-                                    isLoaded={isLoaded}
-                                    setIsLoaded={setIsLoaded}
-                                />
-                            )}
-                        </Lightbox>,
-                        lightboxContainer
-                    )
-                }
-            })
-        }
+        if (
+            img.closest(".wp-block-owid-prominent-link") ||
+            img.closest("[data-no-lightbox]")
+        )
+            return
+
+        img.classList.add("lightbox-enabled")
+        img.addEventListener("click", () => {
+            const imgSrc = img.getAttribute("data-high-res-src") ?? img.src
+            if (imgSrc) {
+                ReactDOM.render(
+                    <Lightbox imgSrc={imgSrc} containerNode={lightboxContainer}>
+                        {(isLoaded: boolean, setIsLoaded: any) => (
+                            <Image
+                                src={imgSrc}
+                                isLoaded={isLoaded}
+                                setIsLoaded={setIsLoaded}
+                            />
+                        )}
+                    </Lightbox>,
+                    lightboxContainer
+                )
+            }
+        })
     })
 }

--- a/site/server/formatting.tsx
+++ b/site/server/formatting.tsx
@@ -228,7 +228,7 @@ export async function formatWordpressPost(
                 const output = `
                 <figure data-grapher-src="${src}" class="${GRAPHER_PREVIEW_CLASS}">
                     <a href="${src}" target="_blank">
-                        <div><img src="${chart.svgUrl}" width="${chart.width}" height="${chart.height}" loading="lazy" /></div>
+                        <div><img src="${chart.svgUrl}" width="${chart.width}" height="${chart.height}" loading="lazy" data-no-lightbox /></div>
                         <div class="interactionNotice">
                             <span class="icon">${INTERACTIVE_ICON_SVG}</span>
                             <span class="label">Click to open interactive version</span>


### PR DESCRIPTION
Currently on mobile when you click the preview of a non-interactive chart, the interactive chart loads in a new tab _and_ the preview image shows up in the lightbox in the old tab.

This prevents the lightbox opening.

I went with the class `no-lightbox` to enable this, we could just as well go with a `data-` attribute if you want.