### PR TITLE
Trim iframe url when converting iframes to figures

### DIFF
--- a/site/server/SiteBaker.tsx
+++ b/site/server/SiteBaker.tsx
@@ -170,7 +170,7 @@ export class SiteBaker {
                     .filter(el =>
                         (el.attribs["src"] || "").match(/\/grapher\//)
                     )
-                    .map(el => el.attribs["src"])
+                    .map(el => el.attribs["src"].trim())
             )
         }
         grapherUrls = _.uniq(grapherUrls)

--- a/site/server/bakeChartsToImages.tsx
+++ b/site/server/bakeChartsToImages.tsx
@@ -48,13 +48,15 @@ export async function bakeChartsToImages(
         const slug = _.last(url.pathname.split("/")) as string
         const jsonConfig = chartsBySlug.get(slug)
         if (jsonConfig) {
-            const queryStr = url.query as any
+            // the type definition for url.query is wrong (bc we have query string parsing disabled),
+            // so we have to explicitly cast it
+            const queryStr = (url.query as unknown) as string
 
-            const chart = new ChartConfig(jsonConfig, { queryStr: queryStr })
+            const chart = new ChartConfig(jsonConfig, { queryStr })
             chart.isLocalExport = true
             const { width, height } = chart.idealBounds
             const outPath = `${outDir}/${slug}${
-                queryStr ? "-" + (md5(queryStr) as string) : ""
+                queryStr ? "-" + md5(queryStr) : ""
             }_v${jsonConfig.version}_${width}x${height}.svg`
             console.log(outPath)
 

--- a/site/server/formatting.tsx
+++ b/site/server/formatting.tsx
@@ -215,7 +215,7 @@ export async function formatWordpressPost(
             .filter(el => (el.attribs["src"] || "").match(/\/grapher\//))
         for (const el of grapherIframes) {
             const $el = $(el)
-            const src = el.attribs["src"]
+            const src = el.attribs["src"].trim()
             const chart = grapherExports.get(src)
             if (chart) {
                 const output = `

--- a/site/server/grapherUtil.ts
+++ b/site/server/grapherUtil.ts
@@ -27,7 +27,7 @@ interface ChartExportMeta {
 }
 
 export interface GrapherExports {
-    get: (grapherUrl: string) => ChartExportMeta
+    get: (grapherUrl: string) => ChartExportMeta | undefined
 }
 
 export async function mapSlugsToIds(): Promise<{ [slug: string]: number }> {
@@ -96,13 +96,11 @@ export async function bakeGrapherUrls(urls: string[]) {
     }
 }
 
-export async function getGrapherExportsByUrl(): Promise<{
-    get: (grapherUrl: string) => ChartExportMeta
-}> {
+export async function getGrapherExportsByUrl(): Promise<GrapherExports> {
     // Index the files to see what we have available, using the most recent version
     // if multiple exports exist
     const files = glob.sync(`${BAKED_SITE_DIR}/exports/*.svg`)
-    const exportsByKey = new Map()
+    const exportsByKey = new Map<string, ChartExportMeta>()
     for (const filepath of files) {
         const filename = path.basename(filepath)
         const [key, version, dims] = filename.split("_")

--- a/site/server/siteBaking.tsx
+++ b/site/server/siteBaking.tsx
@@ -149,7 +149,7 @@ async function renderPage(postApi: object) {
     const grapherUrls = $("iframe")
         .toArray()
         .filter(el => (el.attribs["src"] || "").match(/\/grapher\//))
-        .map(el => el.attribs["src"])
+        .map(el => el.attribs["src"].trim())
 
     // This can be slow if uncached!
     await bakeGrapherUrls(grapherUrls)


### PR DESCRIPTION
This should potentially fix case 2 of https://www.notion.so/Bug-iframe-full-embeds-58f7693f518c42d7aebe95f306a1e65b.

I've also included some other, minimal somewhat-related fixes I've come across.