### PR TITLE
Make LoadingIndicator more general and use it more consistently across owid

### DIFF
--- a/charts/DownloadTab.tsx
+++ b/charts/DownloadTab.tsx
@@ -4,8 +4,7 @@ import { observable, computed, action } from "mobx"
 import { observer } from "mobx-react"
 import { Bounds } from "./Bounds"
 import { ChartConfig } from "./ChartConfig"
-import { faSpinner } from "@fortawesome/free-solid-svg-icons/faSpinner"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { LoadingIndicator } from "site/client/LoadingIndicator"
 
 interface DownloadTabProps {
     bounds: Bounds
@@ -241,9 +240,7 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
                 {this.isReady ? (
                     this.renderReady()
                 ) : (
-                    <div className="loadingIcon">
-                        <FontAwesomeIcon icon={faSpinner} />
-                    </div>
+                    <LoadingIndicator color="#000" />
                 )}
             </div>
         )

--- a/charts/LoadingChart.tsx
+++ b/charts/LoadingChart.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { Bounds } from "./Bounds"
 import { ControlsOverlay } from "./Controls"
+import { LoadingIndicator } from "site/client/LoadingIndicator"
 
 export class LoadingChart extends React.Component<{ bounds: Bounds }> {
     render() {
@@ -9,19 +10,9 @@ export class LoadingChart extends React.Component<{ bounds: Bounds }> {
         // In order to keep the animation consistent, we render HTML in an overlay (by using a React
         // portal, ControlsOverlay).
         // -@danielgavrilov, 2020-01-07
-        const { bounds } = this.props
         return (
             <ControlsOverlay id="loading-chart">
-                <div
-                    className="loading-chart"
-                    style={{
-                        position: "absolute",
-                        top: bounds.top,
-                        left: bounds.left,
-                        width: bounds.width,
-                        height: bounds.height
-                    }}
-                ></div>
+                <LoadingIndicator bounds={this.props.bounds} color="#333" />
             </ControlsOverlay>
         )
     }

--- a/charts/client/chart.scss
+++ b/charts/client/chart.scss
@@ -14,15 +14,13 @@ $zindex-Tooltip: 20;
 $zindex-EntitySelector: 30;
 $zindex-IndicatorDropdown: 50;
 
-figure[data-grapher-src]:empty,
-.loading-chart {
+figure[data-grapher-src]:empty {
     display: flex;
     align-items: center;
     justify-content: center;
 }
 
-figure[data-grapher-src]:empty:after,
-.loading-chart:after {
+figure[data-grapher-src]:empty:after {
     content: "";
     border: 5px solid #333;
     border-radius: 30px;
@@ -310,19 +308,6 @@ figure[data-grapher-src]:empty:after,
         nav.tabs li.active > a {
             border-bottom-color: rgba(0, 33, 71, 0.9);
         }
-    }
-
-    /* The little loading icon on the download tab */
-    .loadingIcon {
-        position: absolute;
-        top: 0;
-        left: 0;
-        bottom: 0;
-        right: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 1.3em;
     }
 
     /* Axis Scale Selectors

--- a/charts/client/chart.scss
+++ b/charts/client/chart.scss
@@ -14,38 +14,6 @@ $zindex-Tooltip: 20;
 $zindex-EntitySelector: 30;
 $zindex-IndicatorDropdown: 50;
 
-figure[data-grapher-src]:empty {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-figure[data-grapher-src]:empty:after {
-    content: "";
-    border: 5px solid #333;
-    border-radius: 30px;
-    height: 30px;
-    width: 30px;
-    opacity: 0;
-
-    animation: pulsate 1s ease-out;
-    animation-iteration-count: infinite;
-}
-
-@keyframes pulsate {
-    0% {
-        transform: scale(0.1);
-        opacity: 0;
-    }
-    50% {
-        opacity: 1;
-    }
-    100% {
-        transform: scale(1.2);
-        opacity: 0;
-    }
-}
-
 .chart,
 .chart p,
 .chart ul,

--- a/site/client/Lightbox.tsx
+++ b/site/client/Lightbox.tsx
@@ -41,7 +41,9 @@ const Lightbox = ({
 
     return (
         <div className="container">
-            {!isLoaded && <LoadingIndicator color="#ccc" />}
+            {!isLoaded && (
+                <LoadingIndicator backgroundColor="#000" color="#ccc" />
+            )}
             <TransformWrapper doubleClick={{ mode: "reset" }}>
                 {({ zoomIn, zoomOut, resetTransform }: any) => (
                     <>

--- a/site/client/Lightbox.tsx
+++ b/site/client/Lightbox.tsx
@@ -41,7 +41,7 @@ const Lightbox = ({
 
     return (
         <div className="container">
-            {!isLoaded && <LoadingIndicator />}
+            {!isLoaded && <LoadingIndicator color="#ccc" />}
             <TransformWrapper doubleClick={{ mode: "reset" }}>
                 {({ zoomIn, zoomOut, resetTransform }: any) => (
                     <>

--- a/site/client/LoadingIndicator.tsx
+++ b/site/client/LoadingIndicator.tsx
@@ -1,9 +1,19 @@
 import * as React from "react"
 import { Bounds } from "charts/Bounds"
 
-export const LoadingIndicator = (props: { color: string; bounds?: Bounds }) => {
+export const LoadingIndicator = (props: {
+    backgroundColor?: string
+    bounds?: Bounds
+    color: string
+}) => {
     return (
-        <div className="loading-indicator" style={{ ...props.bounds?.toCSS() }}>
+        <div
+            className="loading-indicator"
+            style={{
+                backgroundColor: props.backgroundColor,
+                ...props.bounds?.toCSS()
+            }}
+        >
             <span
                 style={{
                     borderColor: props.color

--- a/site/client/LoadingIndicator.tsx
+++ b/site/client/LoadingIndicator.tsx
@@ -1,11 +1,14 @@
 import * as React from "react"
-import { faSpinner } from "@fortawesome/free-solid-svg-icons/faSpinner"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { Bounds } from "charts/Bounds"
 
-export const LoadingIndicator = () => {
+export const LoadingIndicator = (props: { color: string; bounds?: Bounds }) => {
     return (
-        <div className="loading-indicator">
-            <FontAwesomeIcon icon={faSpinner} spin />
+        <div className="loading-indicator" style={{ ...props.bounds?.toCSS() }}>
+            <span
+                style={{
+                    borderColor: props.color
+                }}
+            />
         </div>
     )
 }

--- a/site/client/css/components/loading-indicator.scss
+++ b/site/client/css/components/loading-indicator.scss
@@ -1,14 +1,40 @@
 .loading-indicator {
-    position: fixed;
+    position: absolute;
     display: flex;
     align-items: center;
     justify-content: center;
     top: 0;
     left: 0;
-    bottom: 0;
     right: 0;
-    background-color: black;
-    opacity: 0.5;
-    font-size: 1.2rem;
-    color: $white;
+    bottom: 0;
+}
+
+.loading-indicator span {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    border: 5px solid;
+    box-sizing: content-box;
+    border-radius: 30px;
+    height: 30px;
+    width: 30px;
+    opacity: 0;
+
+    animation: pulsate 1s ease-out;
+    animation-iteration-count: infinite;
+}
+
+@keyframes pulsate {
+    0% {
+        transform: scale(0.1);
+        opacity: 0;
+    }
+    50% {
+        opacity: 1;
+    }
+    100% {
+        transform: scale(1.2);
+        opacity: 0;
+    }
 }

--- a/site/server/views/ChartPage.tsx
+++ b/site/server/views/ChartPage.tsx
@@ -12,6 +12,7 @@ import { Head } from "./Head"
 import { Post } from "db/model/Post"
 import { RelatedChart } from "site/client/blocks/RelatedCharts/RelatedCharts"
 import { ChartListItemVariant } from "./ChartListItemVariant"
+import { LoadingIndicator } from "site/client/LoadingIndicator"
 
 export const ChartPage = (props: {
     chart: ChartConfigProps
@@ -87,9 +88,9 @@ export const ChartPage = (props: {
             <body className="ChartPage">
                 <SiteHeader />
                 <main>
-                    <figure
-                        data-grapher-src={`/grapher/${chart.slug}`}
-                    ></figure>
+                    <figure data-grapher-src={`/grapher/${chart.slug}`}>
+                        <LoadingIndicator color="#333" />
+                    </figure>
 
                     {post && (
                         <div className="related-research-data">


### PR DESCRIPTION
Currently, loading charts have "pulsating" loading indicator, while the lightbox and download tab use `fa-spinner`.

This changes `LoadingIndicator` to use the pulsating one and uses it for loading charts, the lightbox and the download tab.

## Before/After:
### Lightbox
![image](https://user-images.githubusercontent.com/2641501/80800269-59c46b00-8ba9-11ea-9ad2-af72829c0b65.png)
![image](https://user-images.githubusercontent.com/2641501/80800485-e3743880-8ba9-11ea-9ee6-ab7ac8224475.png)

### Download tab
![image](https://user-images.githubusercontent.com/2641501/80800620-3221d280-8baa-11ea-8ad4-8098ce453fa1.png)
![image](https://user-images.githubusercontent.com/2641501/80800601-27ffd400-8baa-11ea-8b34-9fdf6a839e10.png)

This also makes it easier to re-use the element in the future.
