### PR TITLE
Make lookup of iframe url case-insensitive

### DIFF
--- a/site/server/grapherUtil.ts
+++ b/site/server/grapherUtil.ts
@@ -14,7 +14,7 @@ import { log } from "utils/server/log"
 export function grapherUrlToFilekey(grapherUrl: string) {
     const url = parseUrl(grapherUrl)
     const slug = _.last(url.pathname.split("/")) as string
-    const queryStr = url.query as any
+    const queryStr = (url.query as unknown) as string
     return `${slug}${queryStr ? "-" + md5(queryStr) : ""}`
 }
 
@@ -103,7 +103,7 @@ export async function getGrapherExportsByUrl(): Promise<GrapherExports> {
     const exportsByKey = new Map<string, ChartExportMeta>()
     for (const filepath of files) {
         const filename = path.basename(filepath)
-        const [key, version, dims] = filename.split("_")
+        const [key, version, dims] = filename.toLowerCase().split("_")
         const versionNumber = parseInt(version.split("v")[1])
         const [width, height] = dims.split("x")
 
@@ -121,7 +121,9 @@ export async function getGrapherExportsByUrl(): Promise<GrapherExports> {
 
     return {
         get(grapherUrl: string) {
-            return exportsByKey.get(grapherUrlToFilekey(grapherUrl))
+            return exportsByKey.get(
+                grapherUrlToFilekey(grapherUrl).toLowerCase()
+            )
         }
     }
 }


### PR DESCRIPTION
This hopefully fixes case 4 of https://www.notion.so/Bug-iframe-full-embeds-58f7693f518c42d7aebe95f306a1e65b.

I don't think there's anything that can go wrong here, but it's probably still better to test this somewhere before deploying because this would be one that either breaks nothing or everything 🙃