### PR TITLE
Perf: remove cloneDeep from PointsWithLabels

### DIFF
--- a/charts/PointsWithLabels.tsx
+++ b/charts/PointsWithLabels.tsx
@@ -342,7 +342,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                     offsetVector: Vector2.zero
                 }
             }),
-            d => d.size
+            d => -d.size
         ) as any
     }
 
@@ -546,9 +546,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
 
     @computed private get renderData(): ScatterRenderSeries[] {
         // Draw the largest points first so that smaller ones can sit on top of them
-        const renderData = cloneDeep(
-            sortBy(this.initialRenderData, d => -d.size)
-        )
+        const renderData = this.initialRenderData
 
         for (const series of renderData) {
             series.isHover = this.hoverKeys.includes(series.entityDimensionKey)


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/74692/81020818-65ac6900-8e05-11ea-80bf-b2ff53184a38.png)

After:
![image](https://user-images.githubusercontent.com/74692/81020833-6fce6780-8e05-11ea-8fc5-123bb24b6291.png)


The current top perf hit in the Dashboard is a simple "cloneDeep". It looks like it was added in be1f0c6ce0dcd2bb473ceacbeb69cc1201d8e1ad to ensure we weren't repeatedly incrementing a memoized value on hover.

I looked at a large number of scatters and couldn't find one where we had `initialRenderData` not computed when `renderData` was called. So I think this is safe to not cloneDeep. In theory if there is a way to call `renderData` with a memoized `initialRenderData` and you hover/unhovered a series a number of times, maybe you would see a slight increase in the circle or line size, but couldn't repro that.