### PR TITLE
fix(jumpiness): do not set min axis domain to 0 during scale animation.

### DIFF
--- a/charts/AxisBox.tsx
+++ b/charts/AxisBox.tsx
@@ -50,8 +50,15 @@ export class AxisBox {
         const [prevMinY, prevMaxY] = this.prevYDomain
         const [targetMinY, targetMaxY] = this.targetYDomain
 
+        // If we have a log axis and are animating from linear to log do not set domain min to 0
+        const progress = this.animProgress
+            ? this.animProgress
+            : this.props.yAxis.scaleType === "log"
+            ? 0.01
+            : 0
+
         return [
-            prevMinY + (targetMinY - prevMinY) * this.animProgress,
+            prevMinY + (targetMinY - prevMinY) * progress,
             prevMaxY + (targetMaxY - prevMaxY) * this.animProgress
         ]
     }
@@ -62,8 +69,15 @@ export class AxisBox {
         const [prevMinX, prevMaxX] = this.prevXDomain
         const [targetMinX, targetMaxX] = this.targetXDomain
 
+        // If we have a log axis and are animating from linear to log do not set domain min to 0
+        const progress = this.animProgress
+            ? this.animProgress
+            : this.props.xAxis.scaleType === "log"
+            ? 0.01
+            : 0
+
         return [
-            prevMinX + (targetMinX - prevMinX) * this.animProgress,
+            prevMinX + (targetMinX - prevMinX) * progress,
             prevMaxX + (targetMaxX - prevMaxX) * this.animProgress
         ]
     }


### PR DESCRIPTION
Some of the "jumpiness" of the animations in log/linear switching happens when we go from a linear to a log scale and one of the domain mins is temporarily 0, which cascades until we get SVGs with lots of NaNs.

In LineCharts one of the intermediate renders looks like this:

![Screen Shot 2020-05-04 at 4 51 15 PM](https://user-images.githubusercontent.com/74692/81031300-85548900-8e27-11ea-8964-4a12ba8619b6.png)

In ScatterPlots:

![Screen Shot 2020-05-04 at 4 53 05 PM](https://user-images.githubusercontent.com/74692/81031371-c187e980-8e27-11ea-996a-7401ce1bdf6e.png)

This removes those invalid states and also removes some red in console.logs.

It's probably not worth it, but I wonder whether we could avoid the (logScale && domainContainsZero) runtime bugs by having an axis domain type to ensure there is code to handle zeroes in an axis domain.
