### PR TITLE
Chart editor: Make Map color bins more clear

### DIFF
--- a/admin/client/EditorMapTab.tsx
+++ b/admin/client/EditorMapTab.tsx
@@ -186,12 +186,23 @@ class NumericBinView extends React.Component<{
                     <FontAwesomeIcon icon={faPlus} />
                 </div>
                 <ColorBox color={bin.color} onColor={this.onColor} />
-                <NumberField
-                    value={bin.max}
-                    onValue={this.onMaximumValue}
-                    allowNegative
-                    allowDecimal
-                />
+                <div className="range">
+                    <span>
+                        {bin.props.isOpenLeft
+                            ? "≤"
+                            : bin.props.isFirst
+                            ? "≥"
+                            : ">"}
+                        {bin.min} ⁠–⁠ {"≤"}
+                    </span>
+                    <NumberField
+                        value={bin.max}
+                        onValue={this.onMaximumValue}
+                        allowNegative
+                        allowDecimal
+                    />
+                    {bin.props.isOpenRight && <span>and above</span>}
+                </div>
                 {mapConfig.props.colorSchemeValues.length > 2 && (
                     <div className="clickable" onClick={this.onRemove}>
                         <FontAwesomeIcon icon={faMinus} />

--- a/admin/client/admin.scss
+++ b/admin/client/admin.scss
@@ -389,11 +389,26 @@ body {
             }
 
             > * {
-                margin-right: 12px;
+                margin-right: 8px;
+
+                &:last-child {
+                    margin-right: 0;
+                }
+            }
+
+            .range {
+                display: flex;
+                flex: 1 0;
+                align-items: center;
+
+                span {
+                    font-size: 0.85em;
+                    margin: 0 3px;
+                }
             }
 
             .form-group {
-                flex-grow: 1;
+                flex: 1 1;
                 margin-bottom: 0;
             }
         }

--- a/charts/MapData.ts
+++ b/charts/MapData.ts
@@ -89,6 +89,14 @@ export class NumericBin {
             return d.value >= this.min && d.value <= this.max
         else return d.value > this.min && d.value <= this.max
     }
+
+    equals(other: MapLegendBin): boolean {
+        return (
+            other instanceof NumericBin &&
+            this.min === other.min &&
+            this.max === other.max
+        )
+    }
 }
 
 export class CategoricalBin {
@@ -127,6 +135,10 @@ export class CategoricalBin {
             (d === null && this.value === "No data") ||
             (d !== null && d.value === this.value)
         )
+    }
+
+    equals(other: MapLegendBin): boolean {
+        return other instanceof CategoricalBin && this.index === other.index
     }
 }
 

--- a/charts/MapLegend.tsx
+++ b/charts/MapLegend.tsx
@@ -319,12 +319,7 @@ class NumericMapLegendView extends React.Component<{
                 {sortBy(
                     positionedBins.map((d, i) => {
                         const isFocus =
-                            focusBracket &&
-                            ((d.bin as NumericBin).min ===
-                                (focusBracket as NumericBin).min ||
-                                ((d.bin as CategoricalBin).value != null &&
-                                    (d.bin as CategoricalBin).value ===
-                                        (focusBracket as CategoricalBin).value))
+                            focusBracket && d.bin.equals(focusBracket)
                         return (
                             <rect
                                 key={i}


### PR DESCRIPTION
https://www.notion.so/Chart-editor-Make-Map-color-bins-more-clear-b2d7a990160e4b478243a5f8373a7676

This is for the discussion we had on Slack today about the confusing map legend bins.
I tried to make them a little clearer:
![image](https://user-images.githubusercontent.com/2641501/81207977-b4592f00-8fce-11ea-9429-f02128c8a7ab.png)


I'm not 100% sure if the operators are making the situation better or worse, so please feel free to chime in if they're confusing the hell out of you.