### PR TITLE
New option to show custom label instead of numeric value in map tooltip

### DIFF
--- a/admin/client/EditorMapTab.tsx
+++ b/admin/client/EditorMapTab.tsx
@@ -453,6 +453,12 @@ class MapLegendSection extends React.Component<{ mapConfig: MapConfig }> {
         this.props.mapConfig.props.equalSizeBins = isEqual ? true : undefined
     }
 
+    @action.bound onTooltipUseCustomLabels(tooltipUseCustomLabels: boolean) {
+        this.props.mapConfig.props.tooltipUseCustomLabels = tooltipUseCustomLabels
+            ? true
+            : undefined
+    }
+
     render() {
         const { mapConfig } = this.props
         return (
@@ -462,6 +468,13 @@ class MapLegendSection extends React.Component<{ mapConfig: MapConfig }> {
                     label="Disable visual scaling of legend bins"
                     value={!!mapConfig.props.equalSizeBins}
                     onValue={this.onEqualSizeBins}
+                />
+                <Toggle
+                    label={
+                        "Show custom label in the tooltip, instead of the numeric value"
+                    }
+                    value={!!mapConfig.props.tooltipUseCustomLabels}
+                    onValue={this.onTooltipUseCustomLabels}
                 />
                 {mapConfig.props.isManualBuckets && (
                     <EditableList>

--- a/charts/MapConfig.ts
+++ b/charts/MapConfig.ts
@@ -29,6 +29,8 @@ export class MapConfigProps {
     // e.g. { 'foo' => '#c00' }
     @observable.ref customCategoryColors: { [key: string]: string } = {}
     @observable.ref customCategoryLabels: { [key: string]: string } = {}
+    // Show the label from colorSchemeLabels in the tooltip instead of the numeric value
+    @observable.ref tooltipUseCustomLabels?: true = undefined
 
     // Allow hiding categories from the legend
     @observable.ref customHiddenCategories: { [key: string]: true } = {}
@@ -41,7 +43,7 @@ export class MapConfigProps {
         if (json !== undefined) {
             for (const key in this) {
                 if (key in json) {
-                    ;(this as any)[key] = (json as any)[key]
+                    this[key] = (json as any)[key]
                 }
             }
         }
@@ -112,6 +114,10 @@ export class MapConfig {
 
     set targetYear(value: TimeBound) {
         this.props.targetYear = value
+    }
+
+    @computed get tooltipUseCustomLabels() {
+        return this.props.tooltipUseCustomLabels ?? false
     }
 
     constructor(chart: ChartConfig) {

--- a/charts/MapData.ts
+++ b/charts/MapData.ts
@@ -560,10 +560,13 @@ export class MapData extends ChartTransform {
 
     @computed get formatTooltipValue(): (d: number | string) => string {
         const formatValueLong = this.dimension && this.dimension.formatValueLong
+        const customLabels = this.map.tooltipUseCustomLabels
+            ? this.customBucketLabels
+            : []
         return formatValueLong
             ? (d: number | string) => {
                   if (isString(d)) return d
-                  else return formatValueLong(d)
+                  else return customLabels[d] ?? formatValueLong(d)
               }
             : () => ""
     }


### PR DESCRIPTION
I think for charts like https://ourworldindata.org/grapher/covid-19-testing-policy, or really any chart on https://ourworldindata.org/policy-responses-covid, it makes way more sense to display the label of the bin (i.e. "No testing policy", "symptoms & key groups", ...) rather than the numeric value (i.e. 1, 2, 3).

Therefore this is now an option, and the new things are highlighted in red in the screenshot below:
![image](https://user-images.githubusercontent.com/2641501/81443853-7b5bbe80-9176-11ea-86f4-a15bb5a09414.png)

I'm not 100% happy with the variable name & label for the toggle, so if you can come up with anything else feel free to suggest something else.