### PR TITLE
Consistent country colors on COVID Data Explorer

### DIFF
--- a/charts/Util.ts
+++ b/charts/Util.ts
@@ -81,6 +81,7 @@ export {
     every,
     min,
     max,
+    minBy,
     maxBy,
     compact,
     uniq,

--- a/charts/covidDataExplorer/CovidChartUrl.ts
+++ b/charts/covidDataExplorer/CovidChartUrl.ts
@@ -2,7 +2,7 @@ import { computed, observable } from "mobx"
 import { ObservableUrl } from "../UrlBinding"
 import { ChartUrl } from "../ChartUrl"
 import { QueryParams, strToQueryParams } from "utils/client/url"
-import { extend } from "../Util"
+import { omit } from "../Util"
 import { PerCapita, AlignedOption, SmoothingOption } from "./CovidTypes"
 
 export class CovidQueryParams {
@@ -61,6 +61,7 @@ export class CovidQueryParams {
         params.aligned = this.aligned ? true : undefined
         params.perCapita = this.perCapita ? true : undefined
         params.smoothing = this.smoothing
+        params.country = Array.from(this.selectedCountryCodes).join("+")
         return params as QueryParams
     }
 }
@@ -75,7 +76,10 @@ export class CovidUrl implements ObservableUrl {
     }
 
     @computed get params(): QueryParams {
-        return extend({}, this.chartUrl.params, this.covidQueryParams.toParams)
+        // Omit `country` from chart params, it will be managed by the explorer.
+        const chartParams = omit(this.chartUrl.params, "country")
+        const covidParams = this.covidQueryParams.toParams
+        return { ...chartParams, ...covidParams }
     }
 
     @computed get debounceMode(): boolean {

--- a/charts/covidDataExplorer/CovidCountryPicker.tsx
+++ b/charts/covidDataExplorer/CovidCountryPicker.tsx
@@ -238,7 +238,7 @@ export class CountryPicker extends React.Component<{
             <div className="CountryPicker" onKeyDown={this.onKeyDown}>
                 <CovidSearchInput
                     value={this.searchInput}
-                    onInput={query => (this.searchInput = query)}
+                    onChange={query => (this.searchInput = query)}
                     onFocus={this.onSearchFocus}
                 />
                 <div className="CountryList">
@@ -302,13 +302,13 @@ export class CountryPicker extends React.Component<{
 
 interface CovidSearchInputProps {
     value: string | undefined
-    onInput: (value: string) => void
+    onChange: (value: string) => void
     onFocus: () => void
 }
 
 class CovidSearchInput extends React.Component<CovidSearchInputProps> {
-    @bind onInput(event: React.FormEvent<HTMLInputElement>) {
-        this.props.onInput(event.currentTarget.value)
+    @bind onChange(event: React.FormEvent<HTMLInputElement>) {
+        this.props.onChange(event.currentTarget.value)
     }
 
     render() {
@@ -318,8 +318,8 @@ class CovidSearchInput extends React.Component<CovidSearchInputProps> {
                     className="input-field"
                     type="search"
                     placeholder="Type to add a country..."
-                    value={this.props.value}
-                    onInput={this.onInput}
+                    value={this.props.value ?? ""}
+                    onChange={this.onChange}
                     onFocus={this.props.onFocus}
                 />
                 <div className="search-icon">

--- a/charts/covidDataExplorer/CovidCountryPicker.tsx
+++ b/charts/covidDataExplorer/CovidCountryPicker.tsx
@@ -59,6 +59,10 @@ export class CountryPicker extends React.Component<{
         return this.props.covidDataExplorer.selectedCountryOptions
     }
 
+    @computed private get optionColorMap() {
+        return this.props.covidDataExplorer.countryCodeToColorMap
+    }
+
     @bind private isSelected(option: CountryOption) {
         return this.selectedOptions.includes(option)
     }
@@ -269,6 +273,7 @@ export class CountryPicker extends React.Component<{
                                     barScale={
                                         this.props.covidDataExplorer.barScale
                                     }
+                                    color={this.optionColorMap[option.code]}
                                     onChange={this.selectCountryCode}
                                     onHover={() => this.onHover(option, index)}
                                     isSelected={this.isSelected(option)}
@@ -339,6 +344,7 @@ interface CovidCountryOptionProps {
     isFocused?: boolean
     isSelected?: boolean
     barScale?: ScaleLinear<number, number>
+    color?: string
 }
 
 class CovidCountryOption extends React.Component<CovidCountryOptionProps> {
@@ -350,6 +356,7 @@ class CovidCountryOption extends React.Component<CovidCountryOptionProps> {
             isSelected,
             isFocused,
             highlight,
+            color,
             barScale
         } = this.props
         const testsPerCase = option.latestTotalTestsPerCase
@@ -388,6 +395,14 @@ class CovidCountryOption extends React.Component<CovidCountryOptionProps> {
                                 </div>
                             )} */}
                         </div>
+                        {isSelected && color && (
+                            <div className="color-container">
+                                <div
+                                    className="color"
+                                    style={{ backgroundColor: color }}
+                                />
+                            </div>
+                        )}
                         {/* Hide plot as it lacks labels to be understandable */}
                         {/* {barScale && testsPerCase ? (
                             <div className="plot">

--- a/charts/covidDataExplorer/CovidCountryPicker.tsx
+++ b/charts/covidDataExplorer/CovidCountryPicker.tsx
@@ -187,8 +187,14 @@ export class CountryPicker extends React.Component<{
                 }
                 return (
                     <React.Fragment>
-                        {tokens.map(token =>
-                            token.match ? <mark>{token.text}</mark> : token.text
+                        {tokens.map((token, i) =>
+                            token.match ? (
+                                <mark key={i}>{token.text}</mark>
+                            ) : (
+                                <React.Fragment key={i}>
+                                    {token.text}
+                                </React.Fragment>
+                            )
                         )}
                     </React.Fragment>
                 )

--- a/charts/covidDataExplorer/CovidCountryPicker.tsx
+++ b/charts/covidDataExplorer/CovidCountryPicker.tsx
@@ -396,9 +396,9 @@ class CovidCountryOption extends React.Component<CovidCountryOptionProps> {
                             )} */}
                         </div>
                         {isSelected && color && (
-                            <div className="color-container">
+                            <div className="color-marker-container">
                                 <div
-                                    className="color"
+                                    className="color-marker"
                                     style={{ backgroundColor: color }}
                                 />
                             </div>

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -290,12 +290,15 @@ export class CovidDataExplorer extends React.Component<{
     }
 
     toggleSelectedCountry(code: string, value?: boolean) {
-        if (value) this.props.params.selectedCountryCodes.add(code)
-        else if (value === false)
+        if (value) {
+            this.props.params.selectedCountryCodes.add(code)
+        } else if (value === false) {
             this.props.params.selectedCountryCodes.delete(code)
-        else if (this.props.params.selectedCountryCodes.has(code))
+        } else if (this.props.params.selectedCountryCodes.has(code)) {
             this.props.params.selectedCountryCodes.delete(code)
-        else this.props.params.selectedCountryCodes.add(code)
+        } else {
+            this.props.params.selectedCountryCodes.add(code)
+        }
     }
 
     @action.bound toggleSelectedCountryCommand(code: string, value?: boolean) {

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -749,6 +749,8 @@ export class CovidDataExplorer extends React.Component<{
                     removed.forEach(code =>
                         this.toggleSelectedCountry(code, false)
                     )
+                    // Trigger an update in order to apply color changes
+                    this.updateChart()
                 }
             })
         )

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -666,18 +666,19 @@ export class CovidDataExplorer extends React.Component<{
 
     componentDidMount() {
         this.bindToWindow()
+
         this.chart.hideEntityControls = true
         this.chart.externalCsvLink = covidDataPath
         this.chart.url.externalBaseUrl = `${BAKED_BASE_URL}/${covidDashboardSlug}`
         this._updateChart()
+
+        this.observeChartEntitySelection()
+
         const win = window as any
         win.covidDataExplorer = this
     }
 
-    bindToWindow() {
-        const url = new CovidUrl(this.chart.url, this.props.params)
-        urlBinding.bindUrlToWindow(url)
-
+    private observeChartEntitySelection() {
         this.disposers.push(
             observe(this.chart.data, "selectedEntityCodes", change => {
                 // Ignore the change if it was triggered by the chart builder,
@@ -705,6 +706,11 @@ export class CovidDataExplorer extends React.Component<{
                 }
             })
         )
+    }
+
+    bindToWindow() {
+        const url = new CovidUrl(this.chart.url, this.props.params)
+        urlBinding.bindUrlToWindow(url)
     }
 
     @computed get mapColorScheme() {

--- a/charts/covidDataExplorer/CovidDataUtils.ts
+++ b/charts/covidDataExplorer/CovidDataUtils.ts
@@ -7,7 +7,10 @@ import {
     map,
     groupBy,
     parseFloatOrUndefined,
-    insertMissingValuePlaceholders
+    insertMissingValuePlaceholders,
+    difference,
+    entries,
+    minBy
 } from "charts/Util"
 import moment from "moment"
 import { ParsedCovidRow, MetricKind, CountryOption } from "./CovidTypes"
@@ -293,4 +296,26 @@ const trajectoryOptions = {
             fn: (row: ParsedCovidRow) => row.new_deaths_per_million >= 0.1
         }
     }
+}
+
+export function getLeastUsedColor(
+    availableColors: string[],
+    usedColors: string[]
+): string {
+    // If there are unused colors, return the first available
+    const unusedColors = difference(availableColors, usedColors)
+    if (unusedColors.length > 0) {
+        return unusedColors[0]
+    }
+    // If all colors are used, we want to count the times each color is used, and use the most
+    // unused one.
+    const colorCounts = entries(groupBy(usedColors)).map(([color, arr]) => [
+        color,
+        arr.length
+    ])
+    const mostUnusedColor = minBy(colorCounts, ([, count]) => count) as [
+        string,
+        number
+    ]
+    return mostUnusedColor[0]
 }

--- a/site/client/css/pages/covidDataExplorer.scss
+++ b/site/client/css/pages/covidDataExplorer.scss
@@ -192,7 +192,7 @@ $placeholder-height: 800px;
         border-radius: 2px;
     }
 
-    .color-container {
+    .color-marker-container {
         position: absolute;
         top: 6px;
         right: 0;
@@ -201,7 +201,7 @@ $placeholder-height: 800px;
         align-items: center;
     }
 
-    .color {
+    .color-marker {
         width: 3px;
         height: 100%;
     }

--- a/site/client/css/pages/covidDataExplorer.scss
+++ b/site/client/css/pages/covidDataExplorer.scss
@@ -192,6 +192,20 @@ $placeholder-height: 800px;
         border-radius: 2px;
     }
 
+    .color-container {
+        position: absolute;
+        top: 6px;
+        right: 0;
+        bottom: 6px;
+        display: flex;
+        align-items: center;
+    }
+
+    .color {
+        width: 3px;
+        height: 100%;
+    }
+
     .metric {
         flex: 0;
         font-size: 14px;


### PR DESCRIPTION
Notion issue: https://www.notion.so/owid/Ensure-country-colors-don-t-change-as-you-select-countries-a0a033f788aa415d844a657fc2b839ce

- Assigns a color to a country on select. Uses that color for any chart, until the country is unselected.
- Adds a small, colored rectangle in the country list.

<img width="1217" alt="Screenshot 2020-05-12 at 16 31 24" src="https://user-images.githubusercontent.com/1308115/81713959-734d9880-946e-11ea-9809-bb2aa18d1b53.png">
