### PR TITLE
Covid data explorer label improvements

### DIFF
--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -240,6 +240,7 @@ export class CovidDataExplorer extends React.Component<{
                 name="timeline"
                 isCheckbox={true}
                 options={options}
+                comment={this.daysSinceOption.title}
             ></CovidInputControl>
         )
     }

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -24,7 +24,8 @@ import {
     difference,
     pick,
     lastOfNonEmptyArray,
-    throttle
+    throttle,
+    capitalize
 } from "charts/Util"
 import {
     SmoothingOption,
@@ -207,7 +208,7 @@ export class CovidDataExplorer extends React.Component<{
     @computed private get perCapitaPicker() {
         const options: InputOption[] = [
             {
-                label: "Per capita",
+                label: capitalize(this.perCapitaOptions[this.perCapitaDivisor]),
                 checked: this.props.params.perCapita,
                 onChange: value => {
                     this.props.params.perCapita = value
@@ -448,22 +449,27 @@ export class CovidDataExplorer extends React.Component<{
         return "Total"
     }
 
+    @computed get perCapitaDivisorIfEnabled() {
+        return this.props.params.perCapita ? this.perCapitaDivisor : 1
+    }
+
     @computed get perCapitaDivisor() {
         const { params } = this.props
-        if (!params.perCapita) return 1
         if (params.testsMetric && !params.deathsMetric && !params.casesMetric)
             return 1000
         return 1000000
     }
 
-    @computed get perCapitaTitle() {
-        const options = {
+    @computed get perCapitaOptions() {
+        return {
             1: "",
-            1000: " per thousand people",
-            1000000: " per million people"
+            1000: "per thousand people",
+            1000000: "per million people"
         }
+    }
 
-        return options[this.perCapitaDivisor]
+    @computed get perCapitaTitle() {
+        return " " + this.perCapitaOptions[this.perCapitaDivisor]
     }
 
     @computed get metricTitle() {
@@ -628,7 +634,7 @@ export class CovidDataExplorer extends React.Component<{
         ) => {
             const id = buildCovidVariableId(
                 columnName,
-                this.perCapitaDivisor,
+                this.perCapitaDivisorIfEnabled,
                 this.props.params.smoothing,
                 daily
             )
@@ -641,7 +647,7 @@ export class CovidDataExplorer extends React.Component<{
                     this.countryMap,
                     this.props.data,
                     rowFn,
-                    this.perCapitaDivisor,
+                    this.perCapitaDivisorIfEnabled,
                     this.props.params.smoothing,
                     daily,
                     columnName === "tests" ? "" : " - " + this.lastUpdated

--- a/charts/covidDataExplorer/CovidRadioControl.tsx
+++ b/charts/covidDataExplorer/CovidRadioControl.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { observer } from "mobx-react"
 import { action } from "mobx"
+import classNames from "classnames"
 
 export interface RadioOption {
     label: string
@@ -24,7 +25,12 @@ export class CovidRadioControl extends React.Component<{
     render() {
         const { name, comment } = this.props
         return (
-            <div className="CovidDataExplorerControl">
+            <div
+                className={classNames(
+                    "CovidDataExplorerControl",
+                    this.props.name
+                )}
+            >
                 <div className="ControlHeader">{this.props.name}</div>
                 {this.props.options.map((option, index) => (
                     <div key={index}>

--- a/charts/covidDataExplorer/CovidRadioControl.tsx
+++ b/charts/covidDataExplorer/CovidRadioControl.tsx
@@ -13,6 +13,7 @@ export class CovidRadioControl extends React.Component<{
     name: string
     isCheckbox?: boolean
     options: RadioOption[]
+    comment?: string
 }> {
     @action.bound onChange(ev: React.ChangeEvent<HTMLInputElement>) {
         this.props.options[parseInt(ev.currentTarget.value)].onChange(
@@ -21,7 +22,7 @@ export class CovidRadioControl extends React.Component<{
     }
 
     render() {
-        const name = this.props.name
+        const { name, comment } = this.props
         return (
             <div className="CovidDataExplorerControl">
                 <div className="ControlHeader">{this.props.name}</div>
@@ -43,6 +44,9 @@ export class CovidRadioControl extends React.Component<{
                                 value={index}
                             />{" "}
                             {option.label}
+                            {comment && (
+                                <div className="comment">{comment}</div>
+                            )}
                         </label>
                     </div>
                 ))}

--- a/site/client/css/pages/covidDataExplorer.scss
+++ b/site/client/css/pages/covidDataExplorer.scss
@@ -155,6 +155,10 @@ html.iframe {
                 line-height: normal;
                 color: $option-color;
             }
+
+            &.count {
+                width: 15%;
+            }
         }
     }
 
@@ -222,7 +226,11 @@ html.iframe {
         }
 
         .CovidDataExplorerControl {
-            max-width: inherit;
+            max-width: unset;
+
+            &.count {
+                width: unset;
+            }
         }
     }
 }

--- a/site/client/css/pages/covidDataExplorer.scss
+++ b/site/client/css/pages/covidDataExplorer.scss
@@ -133,6 +133,7 @@ html.iframe {
             font-size: 13px;
             color: #7a899e;
             line-height: 26px;
+            max-width: 25%;
 
             input {
                 margin-right: 5px;
@@ -145,6 +146,10 @@ html.iframe {
 
             .SelectedOption {
                 color: #243d60;
+            }
+
+            .comment {
+                line-height: normal;
             }
         }
     }

--- a/site/client/css/pages/covidDataExplorer.scss
+++ b/site/client/css/pages/covidDataExplorer.scss
@@ -120,6 +120,9 @@ html.iframe {
     }
 
     .CovidDataExplorerControlBar {
+        $option-color: #7a899e;
+        $selected-option-color: #243d60;
+
         display: flex;
         justify-content: space-between;
         background: white;
@@ -131,7 +134,7 @@ html.iframe {
             display: flex;
             flex-direction: column;
             font-size: 13px;
-            color: #7a899e;
+            color: $option-color;
             line-height: 26px;
             max-width: 22%;
 
@@ -145,11 +148,12 @@ html.iframe {
             }
 
             .SelectedOption {
-                color: #243d60;
+                color: $selected-option-color;
             }
 
             .comment {
                 line-height: normal;
+                color: $option-color;
             }
         }
     }

--- a/site/client/css/pages/covidDataExplorer.scss
+++ b/site/client/css/pages/covidDataExplorer.scss
@@ -133,7 +133,7 @@ html.iframe {
             font-size: 13px;
             color: #7a899e;
             line-height: 26px;
-            max-width: 25%;
+            max-width: 22%;
 
             input {
                 margin-right: 5px;
@@ -215,6 +215,10 @@ html.iframe {
 
         .CovidDataExplorerFigure {
             min-height: 480px;
+        }
+
+        .CovidDataExplorerControl {
+            max-width: inherit;
         }
     }
 }


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/11683872/82286158-0bfe7f80-996b-11ea-91c9-87efe94d7bf6.png)

**After:**
![image](https://user-images.githubusercontent.com/11683872/82286166-14ef5100-996b-11ea-87d6-c3222e8e0a91.png)


https://www.notion.so/owid/Additional-label-for-align-outbreaks-checkbox-e8a6d6187df041ee8c244943464c29dc
https://www.notion.so/owid/Per-capita-label-displays-x-axis-label-a7ad27d4855146829c1e97b16ba40091