### PR TITLE
Change delimiter in country query parameter to support Facebook URLs

### DIFF
--- a/charts/ChartData.ts
+++ b/charts/ChartData.ts
@@ -378,11 +378,7 @@ export class ChartData {
     }
 
     @computed get selectedEntityCodes(): string[] {
-        return uniq(
-            this.selectedKeys
-                .map(k => this.lookupKey(k).shortCode)
-                .map(encodeURIComponent)
-        )
+        return uniq(this.selectedKeys.map(k => this.lookupKey(k).shortCode))
     }
 
     @computed get selectedKeys(): EntityDimensionKey[] {

--- a/charts/ChartUrl.ts
+++ b/charts/ChartUrl.ts
@@ -49,7 +49,7 @@ export interface ChartQueryParams {
     endpointsOnly?: string
 }
 
-// Todo: ensure entityCodeOrName never contain the delimiter "|"
+// Todo: ensure entityCodeOrName never contain the v2Delimiter
 declare type entityCodeOrName = string
 
 export class EntityUrlBuilder {
@@ -57,7 +57,7 @@ export class EntityUrlBuilder {
     private static v2Delimiter = "~"
 
     static entitiesToQueryParams(entities: entityCodeOrName[]) {
-        // Always include a | in a v2 link
+        // Always include a v2Delimiter in a v2 link. When decoding we will drop any empty strings.
         if (entities.length === 1)
             return encodeURIComponent(entities[0] + this.v2Delimiter)
 
@@ -66,7 +66,7 @@ export class EntityUrlBuilder {
 
     static queryParamToEntities(queryParam: string) {
         // First preserve handling of the old v1 country=USA+FRA style links. If a link does not
-        // include a | and includes a + we assume it's a v1 link. Unfortunately link sharing
+        // include a v2Delimiter and includes a + we assume it's a v1 link. Unfortunately link sharing
         // with v1 links did not work on Facebook because FB would replace %20 with "+".
         return this.isV1Link(queryParam)
             ? this.decodeV1Link(queryParam)
@@ -74,7 +74,7 @@ export class EntityUrlBuilder {
     }
 
     private static isV1Link(queryParam: string) {
-        // No entities currently have a "|" in their name so if a | is present we know it's a v2 link.
+        // No entities currently have a v2Delimiter in their name so if a v2Delimiter is present we know it's a v2 link.
         return !decodeURIComponent(queryParam).includes(this.v2Delimiter)
     }
 

--- a/charts/ChartUrl.ts
+++ b/charts/ChartUrl.ts
@@ -50,12 +50,36 @@ export interface ChartQueryParams {
 }
 
 export class EntityUrlBuilder {
-    static entitiesToQueryParams(countries: string[], delimiter: string = "+") {
-        return countries.map(encodeURIComponent).join(delimiter)
+    private static v1Delimiter = "+"
+    private static v2Delimiter = "|"
+
+    static entitiesToQueryParams(countries: string[]) {
+        return encodeURIComponent(countries.join(this.v2Delimiter))
     }
 
-    static queryParamToCountries(queryParam: string, delimiter: string = "+") {
-        return queryParam.split(delimiter).map(decodeURIComponent)
+    static queryParamToCountries(queryParam: string) {
+        // First preserve handling of the old v1 country=USA+FRA style links. If a link does not
+        // include a | and includes a + we assume it's a v1 link. Unfortunately link sharing
+        // with v1 links did not work on Facebook because FB would replace %20 with "+".
+        return this.isV1Link(queryParam)
+            ? this.decodeV1Link(queryParam)
+            : this.decodeV2Link(queryParam)
+    }
+
+    private static isV1Link(queryParam: string) {
+        // No entities currently have a "|" in their name so if a | is present we know it's a v2 link.
+        if (decodeURIComponent(queryParam).includes(this.v2Delimiter))
+            return false
+        // If there is no + then we can just let v2 parse
+        return queryParam.includes(this.v1Delimiter)
+    }
+
+    private static decodeV1Link(queryParam: string) {
+        return queryParam.split(this.v1Delimiter).map(decodeURIComponent)
+    }
+
+    private static decodeV2Link(queryParam: string) {
+        return decodeURIComponent(queryParam).split(this.v2Delimiter)
     }
 }
 

--- a/charts/ChartUrl.ts
+++ b/charts/ChartUrl.ts
@@ -54,7 +54,7 @@ declare type entityCodeOrName = string
 
 export class EntityUrlBuilder {
     private static v1Delimiter = "+"
-    private static v2Delimiter = "|"
+    private static v2Delimiter = "~"
 
     static entitiesToQueryParams(entities: entityCodeOrName[]) {
         // Always include a | in a v2 link

--- a/charts/ChartUrl.ts
+++ b/charts/ChartUrl.ts
@@ -49,6 +49,8 @@ export interface ChartQueryParams {
     endpointsOnly?: string
 }
 
+export const entityUrlDelimiter = "+"
+
 const reISODateComponent = new RegExp("\\d{4}-[01]\\d-[0-3]\\d")
 const reISODate = new RegExp(`^(${reISODateComponent.source})$`)
 
@@ -206,7 +208,7 @@ export class ChartUrl implements ObservableUrl {
             JSON.stringify(chart.props.selectedData) !==
                 JSON.stringify(origChartProps.selectedData)
         ) {
-            return chart.data.selectedEntityCodes.join("+")
+            return chart.data.selectedEntityCodes.join(entityUrlDelimiter)
         } else {
             return undefined
         }
@@ -333,7 +335,7 @@ export class ChartUrl implements ObservableUrl {
                 runInAction(() => {
                     if (country) {
                         const entityCodes = country
-                            .split("+")
+                            .split(entityUrlDelimiter)
                             .map(decodeURIComponent)
                         const matchedEntities = this.chart.data.setSelectedEntitiesByCode(
                             entityCodes

--- a/charts/ChartUrl.ts
+++ b/charts/ChartUrl.ts
@@ -49,7 +49,15 @@ export interface ChartQueryParams {
     endpointsOnly?: string
 }
 
-export const entityUrlDelimiter = "+"
+export class EntityUrlBuilder {
+    static entitiesToQueryParams(countries: string[], delimiter: string = "+") {
+        return countries.map(encodeURIComponent).join(delimiter)
+    }
+
+    static queryParamToCountries(queryParam: string, delimiter: string = "+") {
+        return queryParam.split(delimiter).map(decodeURIComponent)
+    }
+}
 
 const reISODateComponent = new RegExp("\\d{4}-[01]\\d-[0-3]\\d")
 const reISODate = new RegExp(`^(${reISODateComponent.source})$`)
@@ -201,14 +209,16 @@ export class ChartUrl implements ObservableUrl {
         }
     }
 
-    @computed get countryParam(): string | undefined {
+    @computed private get countryParam(): string | undefined {
         const { chart, origChartProps } = this
         if (
             chart.data.isReady &&
             JSON.stringify(chart.props.selectedData) !==
                 JSON.stringify(origChartProps.selectedData)
         ) {
-            return chart.data.selectedEntityCodes.join(entityUrlDelimiter)
+            return EntityUrlBuilder.entitiesToQueryParams(
+                chart.data.selectedEntityCodes
+            )
         } else {
             return undefined
         }
@@ -334,9 +344,9 @@ export class ChartUrl implements ObservableUrl {
             () => {
                 runInAction(() => {
                     if (country) {
-                        const entityCodes = country
-                            .split(entityUrlDelimiter)
-                            .map(decodeURIComponent)
+                        const entityCodes = EntityUrlBuilder.queryParamToCountries(
+                            country
+                        )
                         const matchedEntities = this.chart.data.setSelectedEntitiesByCode(
                             entityCodes
                         )

--- a/charts/__tests__/ChartUrl.test.ts
+++ b/charts/__tests__/ChartUrl.test.ts
@@ -4,7 +4,7 @@ import { ChartConfigProps } from "charts/ChartConfig"
 import { TimeBoundValue, TimeBound, TimeBounds } from "charts/TimeBounds"
 import { createConfig, setupChart } from "test/utils"
 
-import { ChartUrl, ChartQueryParams } from "../ChartUrl"
+import { ChartUrl, ChartQueryParams, EntityUrlBuilder } from "../ChartUrl"
 import { MapConfigProps } from "charts/MapConfig"
 
 function fromQueryParams(
@@ -327,6 +327,53 @@ describe(ChartUrl, () => {
                     })
                 }
             }
+        })
+    })
+})
+
+describe(EntityUrlBuilder, () => {
+    const encodeTests = [
+        { entities: ["USA", "GB"], queryString: "USA+GB" },
+        { entities: ["YouTube", "Google+"], queryString: "YouTube+Google%2B" },
+        {
+            entities: [
+                "Bogebakken (Denmark); 4300 - 3800 BCE",
+                "British Columbia (30 sites); 3500 BCE - 1674 CE",
+                "Brittany; 6000 BCE"
+            ],
+            delimiter: "|",
+            queryString:
+                "Bogebakken%20(Denmark)%3B%204300%20-%203800%20BCE|British%20Columbia%20(30%20sites)%3B%203500%20BCE%20-%201674%20CE|Brittany%3B%206000%20BCE"
+        },
+
+        {
+            delimiter: "|",
+            entities: [
+                "Men and Women Ages 65+",
+                "Australia & New Zealand + (Total)"
+            ],
+            queryString:
+                "Men%20and%20Women%20Ages%2065%2B|Australia%20%26%20New%20Zealand%20%2B%20(Total)"
+        }
+    ]
+
+    encodeTests.forEach(testCase => {
+        it(`correctly encodes url strings`, () => {
+            expect(
+                EntityUrlBuilder.entitiesToQueryParams(
+                    testCase.entities,
+                    testCase.delimiter
+                )
+            ).toEqual(testCase.queryString)
+        })
+
+        it(`correctly decodes url strings`, () => {
+            expect(
+                EntityUrlBuilder.queryParamToCountries(
+                    testCase.queryString,
+                    testCase.delimiter
+                )
+            ).toEqual(testCase.entities)
         })
     })
 })

--- a/charts/__tests__/ChartUrl.test.ts
+++ b/charts/__tests__/ChartUrl.test.ts
@@ -350,11 +350,11 @@ describe(EntityUrlBuilder, () => {
         {
             entities: ["British Columbia (30 sites); 3500 BCE - 1674 CE"],
             queryString:
-                "British%20Columbia%20(30%20sites)%3B%203500%20BCE%20-%201674%20CE"
+                "British%20Columbia%20(30%20sites)%3B%203500%20BCE%20-%201674%20CE%7C"
         },
         {
             entities: ["North America"],
-            queryString: "North%20America"
+            queryString: "North%20America%7C"
         },
         {
             entities: [
@@ -375,7 +375,7 @@ describe(EntityUrlBuilder, () => {
 
         it(`correctly decodes url strings`, () => {
             expect(
-                EntityUrlBuilder.queryParamToCountries(testCase.queryString)
+                EntityUrlBuilder.queryParamToEntities(testCase.queryString)
             ).toEqual(testCase.entities)
         })
     })
@@ -392,7 +392,22 @@ describe(EntityUrlBuilder, () => {
     legacyLinks.forEach(testCase => {
         it(`correctly decodes legacy url strings`, () => {
             expect(
-                EntityUrlBuilder.queryParamToCountries(testCase.queryString)
+                EntityUrlBuilder.queryParamToEntities(testCase.queryString)
+            ).toEqual(testCase.entities)
+        })
+    })
+
+    const facebookLinks = [
+        {
+            entities: ["Caribbean small states"],
+            queryString: "Caribbean+small+states%7C"
+        }
+    ]
+
+    facebookLinks.forEach(testCase => {
+        it(`correctly decodes Facebook altered links`, () => {
+            expect(
+                EntityUrlBuilder.queryParamToEntities(testCase.queryString)
             ).toEqual(testCase.entities)
         })
     })

--- a/charts/__tests__/ChartUrl.test.ts
+++ b/charts/__tests__/ChartUrl.test.ts
@@ -333,10 +333,10 @@ describe(ChartUrl, () => {
 
 describe(EntityUrlBuilder, () => {
     const encodeTests = [
-        { entities: ["USA", "GB"], queryString: "USA%7CGB" },
+        { entities: ["USA", "GB"], queryString: "USA~GB" },
         {
             entities: ["YouTube", "Google+"],
-            queryString: "YouTube%7CGoogle%2B"
+            queryString: "YouTube~Google%2B"
         },
         {
             entities: [
@@ -345,20 +345,20 @@ describe(EntityUrlBuilder, () => {
                 "Brittany; 6000 BCE"
             ],
             queryString:
-                "Bogebakken%20(Denmark)%3B%204300%20-%203800%20BCE%7CBritish%20Columbia%20(30%20sites)%3B%203500%20BCE%20-%201674%20CE%7CBrittany%3B%206000%20BCE"
+                "Bogebakken%20(Denmark)%3B%204300%20-%203800%20BCE~British%20Columbia%20(30%20sites)%3B%203500%20BCE%20-%201674%20CE~Brittany%3B%206000%20BCE"
         },
         {
             entities: ["British Columbia (30 sites); 3500 BCE - 1674 CE"],
             queryString:
-                "British%20Columbia%20(30%20sites)%3B%203500%20BCE%20-%201674%20CE%7C"
+                "British%20Columbia%20(30%20sites)%3B%203500%20BCE%20-%201674%20CE~"
         },
         {
             entities: ["Caribbean small states"],
-            queryString: "Caribbean%20small%20states%7C"
+            queryString: "Caribbean%20small%20states~"
         },
         {
             entities: ["North America"],
-            queryString: "North%20America%7C"
+            queryString: "North%20America~"
         },
         {
             entities: [
@@ -366,7 +366,7 @@ describe(EntityUrlBuilder, () => {
                 "Australia & New Zealand + (Total)"
             ],
             queryString:
-                "Men%20and%20Women%20Ages%2065%2B%7CAustralia%20%26%20New%20Zealand%20%2B%20(Total)"
+                "Men%20and%20Women%20Ages%2065%2B~Australia%20%26%20New%20Zealand%20%2B%20(Total)"
         }
     ]
 
@@ -404,7 +404,7 @@ describe(EntityUrlBuilder, () => {
     const facebookLinks = [
         {
             entities: ["Caribbean small states"],
-            queryString: "Caribbean+small+states%7C"
+            queryString: "Caribbean+small+states~"
         }
     ]
 

--- a/charts/__tests__/ChartUrl.test.ts
+++ b/charts/__tests__/ChartUrl.test.ts
@@ -353,6 +353,10 @@ describe(EntityUrlBuilder, () => {
                 "British%20Columbia%20(30%20sites)%3B%203500%20BCE%20-%201674%20CE%7C"
         },
         {
+            entities: ["Caribbean small states"],
+            queryString: "Caribbean%20small%20states%7C"
+        },
+        {
             entities: ["North America"],
             queryString: "North%20America%7C"
         },

--- a/charts/__tests__/ChartUrl.test.ts
+++ b/charts/__tests__/ChartUrl.test.ts
@@ -333,46 +333,66 @@ describe(ChartUrl, () => {
 
 describe(EntityUrlBuilder, () => {
     const encodeTests = [
-        { entities: ["USA", "GB"], queryString: "USA+GB" },
-        { entities: ["YouTube", "Google+"], queryString: "YouTube+Google%2B" },
+        { entities: ["USA", "GB"], queryString: "USA%7CGB" },
+        {
+            entities: ["YouTube", "Google+"],
+            queryString: "YouTube%7CGoogle%2B"
+        },
         {
             entities: [
                 "Bogebakken (Denmark); 4300 - 3800 BCE",
                 "British Columbia (30 sites); 3500 BCE - 1674 CE",
                 "Brittany; 6000 BCE"
             ],
-            delimiter: "|",
             queryString:
-                "Bogebakken%20(Denmark)%3B%204300%20-%203800%20BCE|British%20Columbia%20(30%20sites)%3B%203500%20BCE%20-%201674%20CE|Brittany%3B%206000%20BCE"
+                "Bogebakken%20(Denmark)%3B%204300%20-%203800%20BCE%7CBritish%20Columbia%20(30%20sites)%3B%203500%20BCE%20-%201674%20CE%7CBrittany%3B%206000%20BCE"
         },
-
         {
-            delimiter: "|",
+            entities: ["British Columbia (30 sites); 3500 BCE - 1674 CE"],
+            queryString:
+                "British%20Columbia%20(30%20sites)%3B%203500%20BCE%20-%201674%20CE"
+        },
+        {
+            entities: ["North America"],
+            queryString: "North%20America"
+        },
+        {
             entities: [
                 "Men and Women Ages 65+",
                 "Australia & New Zealand + (Total)"
             ],
             queryString:
-                "Men%20and%20Women%20Ages%2065%2B|Australia%20%26%20New%20Zealand%20%2B%20(Total)"
+                "Men%20and%20Women%20Ages%2065%2B%7CAustralia%20%26%20New%20Zealand%20%2B%20(Total)"
         }
     ]
 
     encodeTests.forEach(testCase => {
         it(`correctly encodes url strings`, () => {
             expect(
-                EntityUrlBuilder.entitiesToQueryParams(
-                    testCase.entities,
-                    testCase.delimiter
-                )
+                EntityUrlBuilder.entitiesToQueryParams(testCase.entities)
             ).toEqual(testCase.queryString)
         })
 
         it(`correctly decodes url strings`, () => {
             expect(
-                EntityUrlBuilder.queryParamToCountries(
-                    testCase.queryString,
-                    testCase.delimiter
-                )
+                EntityUrlBuilder.queryParamToCountries(testCase.queryString)
+            ).toEqual(testCase.entities)
+        })
+    })
+
+    const legacyLinks = [
+        {
+            entities: ["North America", "DOM"],
+            queryString: "North%20America+DOM"
+        },
+        { entities: ["USA", "GB"], queryString: "USA+GB" },
+        { entities: ["YouTube", "Google+"], queryString: "YouTube+Google%2B" }
+    ]
+
+    legacyLinks.forEach(testCase => {
+        it(`correctly decodes legacy url strings`, () => {
+            expect(
+                EntityUrlBuilder.queryParamToCountries(testCase.queryString)
             ).toEqual(testCase.entities)
         })
     })

--- a/charts/covidDataExplorer/CovidChartUrl.ts
+++ b/charts/covidDataExplorer/CovidChartUrl.ts
@@ -1,6 +1,6 @@
 import { computed, observable } from "mobx"
 import { ObservableUrl } from "../UrlBinding"
-import { ChartUrl, entityUrlDelimiter } from "../ChartUrl"
+import { ChartUrl, EntityUrlBuilder } from "../ChartUrl"
 import { QueryParams, strToQueryParams } from "utils/client/url"
 import { omit } from "../Util"
 import { PerCapita, AlignedOption, SmoothingOption } from "./CovidTypes"
@@ -36,9 +36,9 @@ export class CovidQueryParams {
     }
 
     setCountrySelectionFromChartUrl(chartCountries: string) {
-        chartCountries
-            .split(entityUrlDelimiter)
-            .forEach(code => this.selectedCountryCodes.add(code))
+        EntityUrlBuilder.queryParamToCountries(chartCountries).forEach(code =>
+            this.selectedCountryCodes.add(code)
+        )
     }
 
     private setDefaults() {
@@ -61,8 +61,8 @@ export class CovidQueryParams {
         params.aligned = this.aligned ? true : undefined
         params.perCapita = this.perCapita ? true : undefined
         params.smoothing = this.smoothing
-        params.country = Array.from(this.selectedCountryCodes).join(
-            entityUrlDelimiter
+        params.country = EntityUrlBuilder.entitiesToQueryParams(
+            Array.from(this.selectedCountryCodes)
         )
         return params as QueryParams
     }

--- a/charts/covidDataExplorer/CovidChartUrl.ts
+++ b/charts/covidDataExplorer/CovidChartUrl.ts
@@ -1,6 +1,6 @@
 import { computed, observable } from "mobx"
 import { ObservableUrl } from "../UrlBinding"
-import { ChartUrl } from "../ChartUrl"
+import { ChartUrl, entityUrlDelimiter } from "../ChartUrl"
 import { QueryParams, strToQueryParams } from "utils/client/url"
 import { omit } from "../Util"
 import { PerCapita, AlignedOption, SmoothingOption } from "./CovidTypes"
@@ -37,7 +37,7 @@ export class CovidQueryParams {
 
     setCountrySelectionFromChartUrl(chartCountries: string) {
         chartCountries
-            .split("+")
+            .split(entityUrlDelimiter)
             .forEach(code => this.selectedCountryCodes.add(code))
     }
 
@@ -46,8 +46,8 @@ export class CovidQueryParams {
         this.deathsMetric = false
         this.casesMetric = true
         this.totalFreq = true
-        "USA+GBR+CAN+BRA+AUS+IND+ESP+DEU+FRA"
-            .split("+")
+        "USA GBR CAN BRA AUS IND ESP DEU FRA"
+            .split(" ")
             .forEach(code => this.selectedCountryCodes.add(code))
     }
 
@@ -61,7 +61,9 @@ export class CovidQueryParams {
         params.aligned = this.aligned ? true : undefined
         params.perCapita = this.perCapita ? true : undefined
         params.smoothing = this.smoothing
-        params.country = Array.from(this.selectedCountryCodes).join("+")
+        params.country = Array.from(this.selectedCountryCodes).join(
+            entityUrlDelimiter
+        )
         return params as QueryParams
     }
 }

--- a/charts/covidDataExplorer/CovidChartUrl.ts
+++ b/charts/covidDataExplorer/CovidChartUrl.ts
@@ -36,7 +36,7 @@ export class CovidQueryParams {
     }
 
     setCountrySelectionFromChartUrl(chartCountries: string) {
-        EntityUrlBuilder.queryParamToCountries(chartCountries).forEach(code =>
+        EntityUrlBuilder.queryParamToEntities(chartCountries).forEach(code =>
             this.selectedCountryCodes.add(code)
         )
     }

--- a/site/client/Analytics.ts
+++ b/site/client/Analytics.ts
@@ -117,13 +117,16 @@ export class Analytics {
             eventValue
         }
         if (window.ga) {
-            const tracker = window.ga.getAll()[0]
-            // @types/google.analytics seems to suggest this usage is invalid but we know Google
-            // Analytics logs these events correctly.
-            // I have avoided changing the implementation for now, but we should look into this as
-            // we use Google Analytics more.
-            // -@danielgavrilov 2020-04-23
-            if (tracker) tracker.send(event as any)
+            // https://developers.google.com/analytics/devguides/collection/analyticsjs/ga-object-methods-reference
+            window.ga(function() {
+                const tracker = window.ga.getAll()[0]
+                // @types/google.analytics seems to suggest this usage is invalid but we know Google
+                // Analytics logs these events correctly.
+                // I have avoided changing the implementation for now, but we should look into this as
+                // we use Google Analytics more.
+                // -@danielgavrilov 2020-04-23
+                if (tracker) tracker.send(event as any)
+            })
         }
     }
 }

--- a/site/client/SearchPageMain.tsx
+++ b/site/client/SearchPageMain.tsx
@@ -1,6 +1,6 @@
 import ReactDOM from "react-dom"
 import React from "react"
-import { getWindowQueryParams, decodeQueryParam } from "utils/client/url"
+import { getWindowQueryParams } from "utils/client/url"
 import { siteSearch, SiteSearchResults } from "site/siteSearch"
 import { SearchResults } from "site/client/SearchResults"
 import { observer } from "mobx-react"
@@ -8,7 +8,9 @@ import { action, observable, runInAction } from "mobx"
 
 @observer
 export class SearchPageMain extends React.Component {
-    @observable query: string = decodeQueryParam(getWindowQueryParams().q || "")
+    @observable query: string = decodeURIComponent(
+        (getWindowQueryParams().q || "").replace(/\+/g, " ")
+    )
     lastQuery?: string
 
     @observable.ref results?: SiteSearchResults

--- a/site/client/SearchResults.tsx
+++ b/site/client/SearchResults.tsx
@@ -11,7 +11,7 @@ import { EmbedChart } from "./EmbedChart"
 import { BAKED_GRAPHER_URL } from "settings"
 import { uniq, capitalize } from "charts/Util"
 import { Country } from "utils/countries"
-import { entityUrlDelimiter } from "charts/ChartUrl"
+import { EntityUrlBuilder } from "charts/ChartUrl"
 
 class ChartResult extends React.Component<{
     hit: ChartHit
@@ -28,9 +28,9 @@ class ChartResult extends React.Component<{
         else
             return (
                 hit.slug +
-                `?tab=chart&country=${entities
-                    .map(e => encodeURIComponent(e))
-                    .join(entityUrlDelimiter)}`
+                `?tab=chart&country=${EntityUrlBuilder.entitiesToQueryParams(
+                    entities
+                )}`
             )
     }
 
@@ -162,9 +162,9 @@ export class SearchResults extends React.Component<{
         else
             return (
                 bestChartHit.slug +
-                `?tab=chart&country=${bestChartEntities
-                    .map(e => encodeURIComponent(e))
-                    .join(entityUrlDelimiter)}`
+                `?tab=chart&country=${EntityUrlBuilder.entitiesToQueryParams(
+                    bestChartEntities
+                )}`
             )
     }
 

--- a/site/client/SearchResults.tsx
+++ b/site/client/SearchResults.tsx
@@ -11,6 +11,7 @@ import { EmbedChart } from "./EmbedChart"
 import { BAKED_GRAPHER_URL } from "settings"
 import { uniq, capitalize } from "charts/Util"
 import { Country } from "utils/countries"
+import { entityUrlDelimiter } from "charts/ChartUrl"
 
 class ChartResult extends React.Component<{
     hit: ChartHit
@@ -29,7 +30,7 @@ class ChartResult extends React.Component<{
                 hit.slug +
                 `?tab=chart&country=${entities
                     .map(e => encodeURIComponent(e))
-                    .join("+")}`
+                    .join(entityUrlDelimiter)}`
             )
     }
 
@@ -163,7 +164,7 @@ export class SearchResults extends React.Component<{
                 bestChartHit.slug +
                 `?tab=chart&country=${bestChartEntities
                     .map(e => encodeURIComponent(e))
-                    .join("+")}`
+                    .join(entityUrlDelimiter)}`
             )
     }
 

--- a/site/client/global-entity/GlobalEntitySelectionUrl.ts
+++ b/site/client/global-entity/GlobalEntitySelectionUrl.ts
@@ -42,7 +42,7 @@ export class GlobalEntitySelectionUrl implements ObservableUrl {
 
     private populateFromQueryParams(params: QueryParams) {
         if (params.country) {
-            const countryCodes = EntityUrlBuilder.queryParamToCountries(
+            const countryCodes = EntityUrlBuilder.queryParamToEntities(
                 params.country
             )
             this.globalEntitySelection.mode =

--- a/site/client/global-entity/GlobalEntitySelectionUrl.ts
+++ b/site/client/global-entity/GlobalEntitySelectionUrl.ts
@@ -6,6 +6,7 @@ import {
     GlobalEntitySelection,
     GlobalEntitySelectionModes
 } from "./GlobalEntitySelection"
+import { entityUrlDelimiter } from "charts/ChartUrl"
 
 type GlobalEntitySelectionQueryParams = {
     country?: string
@@ -23,7 +24,9 @@ export class GlobalEntitySelectionUrl implements ObservableUrl {
         const entities = this.globalEntitySelection.selectedEntities
         // Do not add 'country' param unless at least one country is selected
         if (entities.length > 0) {
-            params.country = entities.map(entity => entity.code).join("+")
+            params.country = entities
+                .map(entity => entity.code)
+                .join(entityUrlDelimiter)
         }
         return params
     }
@@ -39,7 +42,7 @@ export class GlobalEntitySelectionUrl implements ObservableUrl {
 
     private populateFromQueryParams(params: QueryParams) {
         if (params.country) {
-            const countryCodes = params.country.split("+")
+            const countryCodes = params.country.split(entityUrlDelimiter)
             this.globalEntitySelection.mode =
                 GlobalEntitySelectionModes.override
             this.globalEntitySelection.selectByCountryCodes(countryCodes)

--- a/site/client/global-entity/GlobalEntitySelectionUrl.ts
+++ b/site/client/global-entity/GlobalEntitySelectionUrl.ts
@@ -6,7 +6,7 @@ import {
     GlobalEntitySelection,
     GlobalEntitySelectionModes
 } from "./GlobalEntitySelection"
-import { entityUrlDelimiter } from "charts/ChartUrl"
+import { EntityUrlBuilder } from "charts/ChartUrl"
 
 type GlobalEntitySelectionQueryParams = {
     country?: string
@@ -24,9 +24,9 @@ export class GlobalEntitySelectionUrl implements ObservableUrl {
         const entities = this.globalEntitySelection.selectedEntities
         // Do not add 'country' param unless at least one country is selected
         if (entities.length > 0) {
-            params.country = entities
-                .map(entity => entity.code)
-                .join(entityUrlDelimiter)
+            params.country = EntityUrlBuilder.entitiesToQueryParams(
+                entities.map(entity => entity.code)
+            )
         }
         return params
     }
@@ -42,7 +42,9 @@ export class GlobalEntitySelectionUrl implements ObservableUrl {
 
     private populateFromQueryParams(params: QueryParams) {
         if (params.country) {
-            const countryCodes = params.country.split(entityUrlDelimiter)
+            const countryCodes = EntityUrlBuilder.queryParamToCountries(
+                params.country
+            )
             this.globalEntitySelection.mode =
                 GlobalEntitySelectionModes.override
             this.globalEntitySelection.selectByCountryCodes(countryCodes)

--- a/utils/client/url.ts
+++ b/utils/client/url.ts
@@ -65,7 +65,3 @@ export function setWindowQueryStr(str: string) {
         window.location.pathname + str + window.location.hash
     )
 }
-
-export function decodeQueryParam(s: string) {
-    return decodeURIComponent(s.replace(/\+/g, " "))
-}


### PR DESCRIPTION
This addresses https://github.com/owid/owid-grapher/issues/397

It maintains backwards compatibility with the current URLs (called "v1"), while from here on out using a new schema ("v2"). v2 uses "|" as the delimiter, and concatenates the entities and then encodes the whole string. v2 always contain a "|", so if there is only 1 entity I append an extra "|" just to differentiate between v1 and v2.

The downside is the URLs are not as pretty, so very open to suggestions. Another potential tweak is to only use v2 style URLs for the Facebook share button (but then we'd have the problem if someone just copies/pastes the url into FB). Or we could use a different delimiter that doesn't have the Facebook problems (~ or _ perhaps). 