### PR TITLE
add `yarn live-commit` script to show information about deployed commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
         "storybook": "yarn tsn node_modules/.bin/start-storybook -p 6006",
         "build-storybook": "build-storybook",
         "bundlesize": "ENV=production webpack -p && bundlesize",
-        "bundlesize-json": "ENV=production webpack -p --json > dist/webpack-bundle-stats.json && bundlesize"
+        "bundlesize-json": "ENV=production webpack -p --json > dist/webpack-bundle-stats.json && bundlesize",
+        "live-commit": "yarn tsn scripts/liveCommit.ts"
     },
     "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.19",
@@ -205,6 +206,7 @@
         "@storybook/addons": "^5.1.3",
         "@storybook/react": "^5.1.11",
         "@types/jest": "^24.0.13",
+        "@types/opener": "^1.4.0",
         "@types/storybook__addon-actions": "^3.4.3",
         "@types/storybook__addon-links": "^3.3.5",
         "@types/storybook__react": "^4.0.2",
@@ -216,6 +218,7 @@
         "eslint-plugin-react": "^7.19.0",
         "jest": "^24.8.0",
         "npm-run-all": "^4.1.5",
+        "opener": "^1.5.1",
         "source-map-support": "^0.5.12",
         "ts-jest": "^24.0.2",
         "ts-node-dev": "^1.0.0-pre.40",

--- a/scripts/liveCommit.ts
+++ b/scripts/liveCommit.ts
@@ -19,7 +19,7 @@ import { promisifiedExec as exec } from "utils/server/serverUtil"
  *  If it still doesn't work, the live commit is not pushed to GitHub yet. That should only happen on a staging server, never on live.
  */
 
-const servers = ["live", "staging", "explorer", "hans", "playfair"]
+const servers = ["live", "staging", "explorer", "hans", "playfair", "jefferson"]
 
 const args = parseArgs(process.argv.slice(2))
 

--- a/scripts/liveCommit.ts
+++ b/scripts/liveCommit.ts
@@ -1,0 +1,53 @@
+import parseArgs from "minimist"
+import fetch from "node-fetch"
+import opener from "opener"
+import { promisifiedExec as exec } from "utils/server/serverUtil"
+
+/**
+ * Retrieves information about the deployed commit on a live or staging server.
+ * Usage examples:
+ * - `yarn live-commit` will retrieve the commit that's live on https://ourworldindata.org and opens it in GitHub
+ *   That's equivalent to `yarn live-commit live --open`
+ * - `yarn live-commit staging --show` will `git show` information about the commit deployed on https://staging-owid.netlify.app
+ * - `yarn live-commit --show --tree` will both show a git tree and a `git show` of the deployed commits on https://ourworldindata.org
+ *
+ * Note:
+ *  For the local git commands to work you need to have that commit on your machine. Run a `git fetch` if you're getting a git error message.
+ *  If it still doesn't work, the live commit is not pushed to GitHub yet. That should only happen on a staging server, never on live.
+ */
+
+const args = parseArgs(process.argv.slice(2))
+
+const showTree = args["tree"]
+const showCommit = args["show"]
+const openInBrowser = args["open"] || !(showCommit || showTree)
+
+let server = "https://ourworldindata.org"
+if (args._[0] && args._[0] !== "live") {
+    server = `https://${args._[0]}-owid.netlify.com`
+}
+
+fetch(`${server}/head.txt`)
+    .then(res => {
+        if (res.ok) return res
+        else throw Error(`Request rejected with status ${res.status}`)
+    })
+    .then(resp => resp.text())
+    .then(async headSha => {
+        if (showTree)
+            await exec(
+                `git log -10 --graph --oneline --decorate --color=always ${headSha}`
+            )
+
+        if (showTree && showCommit) console.log()
+
+        if (showCommit) await exec(`git show --stat --color=always ${headSha}`)
+
+        if (openInBrowser)
+            opener(`https://github.com/owid/owid-grapher/commit/${headSha}`)
+    })
+    .catch(err =>
+        console.error(
+            `Could not retrieve live commit information from ${server}. ${err}`
+        )
+    )

--- a/scripts/liveCommit.ts
+++ b/scripts/liveCommit.ts
@@ -1,4 +1,4 @@
-import { sortBy } from "lodash"
+import { keyBy, mapValues, sortBy } from "lodash"
 import parseArgs from "minimist"
 import fetch from "node-fetch"
 import opener from "opener"
@@ -132,5 +132,18 @@ if (args._[0]) {
         )
 } else {
     // fetch information for _all_ servers
-    fetchAll().then(console.table)
+    fetchAll().then(commitInformation =>
+        console.table(
+            mapValues(
+                keyBy(
+                    commitInformation,
+                    commitInformation => commitInformation.serverName
+                ),
+                commitInformation => {
+                    delete commitInformation.serverName
+                    return commitInformation
+                }
+            )
+        )
+    )
 }

--- a/scripts/liveCommit.ts
+++ b/scripts/liveCommit.ts
@@ -19,7 +19,7 @@ import { promisifiedExec as exec } from "utils/server/serverUtil"
  *  If it still doesn't work, the live commit is not pushed to GitHub yet. That should only happen on a staging server, never on live.
  */
 
-const servers = ["live", "staging", "explorer", "hans", "playfair", "jefferson"]
+const servers = ["live", "staging", "explorer", "hans", "playfair", "jefferson", "nightingale"]
 
 const args = parseArgs(process.argv.slice(2))
 

--- a/scripts/liveCommit.ts
+++ b/scripts/liveCommit.ts
@@ -19,7 +19,15 @@ import { promisifiedExec as exec } from "utils/server/serverUtil"
  *  If it still doesn't work, the live commit is not pushed to GitHub yet. That should only happen on a staging server, never on live.
  */
 
-const servers = ["live", "staging", "explorer", "hans", "playfair", "jefferson", "nightingale"]
+const servers = [
+    "live",
+    "staging",
+    "explorer",
+    "hans",
+    "playfair",
+    "jefferson",
+    "nightingale"
+]
 
 const args = parseArgs(process.argv.slice(2))
 
@@ -132,18 +140,27 @@ if (args._[0]) {
         )
 } else {
     // fetch information for _all_ servers
-    fetchAll().then(commitInformation =>
-        console.table(
-            mapValues(
-                keyBy(
-                    commitInformation,
-                    commitInformation => commitInformation.serverName
-                ),
-                commitInformation => {
-                    delete commitInformation.serverName
-                    return commitInformation
+    fetchAll().then(commitInformation => {
+        const data = mapValues(
+            keyBy(
+                commitInformation,
+                commitInformation => commitInformation.serverName
+            ),
+            commitInformation => {
+                delete commitInformation.serverName
+                return {
+                    ...commitInformation,
+                    commitMessage:
+                        // truncate to 60 characters
+                        commitInformation.commitMessage &&
+                        commitInformation.commitMessage.length > 60
+                            ? commitInformation.commitMessage?.substr(0, 60) +
+                              "…"
+                            : commitInformation?.commitMessage
                 }
-            )
+            }
         )
-    )
+
+        console.table(data)
+    })
 }

--- a/scripts/liveCommit.ts
+++ b/scripts/liveCommit.ts
@@ -1,12 +1,15 @@
+import { sortBy } from "lodash"
 import parseArgs from "minimist"
 import fetch from "node-fetch"
 import opener from "opener"
+import * as timeago from "timeago.js"
 import { promisifiedExec as exec } from "utils/server/serverUtil"
 
 /**
  * Retrieves information about the deployed commit on a live or staging server.
  * Usage examples:
- * - `yarn live-commit` will retrieve the commit that's live on https://ourworldindata.org and opens it in GitHub
+ * - `yarn live-commit` will retrieve information about the deployed commits for _all_ servers, and show a table
+ * - `yarn live-commit live` will retrieve the commit that's live on https://ourworldindata.org and opens it in GitHub
  *   That's equivalent to `yarn live-commit live --open`
  * - `yarn live-commit staging --show` will `git show` information about the commit deployed on https://staging-owid.netlify.app
  * - `yarn live-commit --show --tree` will both show a git tree and a `git show` of the deployed commits on https://ourworldindata.org
@@ -16,38 +19,113 @@ import { promisifiedExec as exec } from "utils/server/serverUtil"
  *  If it still doesn't work, the live commit is not pushed to GitHub yet. That should only happen on a staging server, never on live.
  */
 
+const servers = ["live", "staging", "explorer", "hans", "playfair"]
+
 const args = parseArgs(process.argv.slice(2))
 
 const showTree = args["tree"]
 const showCommit = args["show"]
 const openInBrowser = args["open"] || !(showCommit || showTree)
 
-let server = "https://ourworldindata.org"
-if (args._[0] && args._[0] !== "live") {
-    server = `https://${args._[0]}-owid.netlify.com`
+function getServerUrl(server: string): string {
+    if (server === "live") return "https://ourworldindata.org"
+    else return `https://${server}-owid.netlify.com`
 }
 
-fetch(`${server}/head.txt`)
-    .then(res => {
-        if (res.ok) return res
-        else throw Error(`Request rejected with status ${res.status}`)
-    })
-    .then(resp => resp.text())
-    .then(async headSha => {
-        if (showTree)
-            await exec(
-                `git log -10 --graph --oneline --decorate --color=always ${headSha}`
-            )
+async function fetchCommitSha(server: string): Promise<string> {
+    return fetch(`${getServerUrl(server)}/head.txt`)
+        .then(res => {
+            if (res.ok) return res
+            else throw Error(`Request rejected with status ${res.status}`)
+        })
+        .then(resp => resp.text())
+}
 
-        if (showTree && showCommit) console.log()
+interface ServerCommitInformation {
+    serverName: string
+    commitSha: string | undefined
+    commitDate: string | undefined
+    commitAuthor: string | undefined
+    commitMessage: string | undefined
+}
 
-        if (showCommit) await exec(`git show --stat --color=always ${headSha}`)
+async function fetchAll(): Promise<Array<ServerCommitInformation>> {
+    const commits = await Promise.all(
+        servers.map(async serverName => {
+            let commitSha = undefined
+            try {
+                commitSha = await fetchCommitSha(serverName)
+            } catch {
+                commitSha = undefined
+            }
 
-        if (openInBrowser)
-            opener(`https://github.com/owid/owid-grapher/commit/${headSha}`)
-    })
-    .catch(err =>
-        console.error(
-            `Could not retrieve live commit information from ${server}. ${err}`
-        )
+            return {
+                serverName,
+                commitSha,
+                commitDate: undefined,
+                commitAuthor: undefined,
+                commitMessage: undefined
+            }
+        })
     )
+
+    const commitsWithInformation = await Promise.all(
+        commits.map(async commit => {
+            if (!commit.commitSha) return commit
+
+            const apiResponse = (await fetch(
+                `https://api.github.com/repos/owid/owid-grapher/git/commits/${commit.commitSha}`
+            )) as any
+
+            const response = await apiResponse.json()
+
+            return {
+                ...commit,
+                commitSha: commit.commitSha.substr(0, 7),
+                commitDate:
+                    response?.author?.date && new Date(response?.author?.date),
+                commitAuthor: response?.author?.name,
+                commitMessage: response?.message?.split("\n")?.[0]
+            }
+        })
+    )
+
+    return sortBy(commitsWithInformation, c => c.commitDate ?? 0)
+        .reverse()
+        .map(commitInformation => ({
+            ...commitInformation,
+            commitDate:
+                commitInformation.commitDate &&
+                timeago.format(commitInformation.commitDate)
+        }))
+}
+
+if (args._[0]) {
+    // fetch information for one specific server
+    const server = args._[0]
+    fetchCommitSha(server)
+        .then(async headSha => {
+            if (showTree)
+                await exec(
+                    `git log -10 --graph --oneline --decorate --color=always ${headSha}`
+                )
+
+            if (showTree && showCommit) console.log()
+
+            if (showCommit)
+                await exec(`git show --stat --color=always ${headSha}`)
+
+            if (openInBrowser)
+                opener(`https://github.com/owid/owid-grapher/commit/${headSha}`)
+        })
+        .catch(err =>
+            console.error(
+                `Could not retrieve commit information from ${getServerUrl(
+                    server
+                )}. ${err}`
+            )
+        )
+} else {
+    // fetch information for _all_ servers
+    fetchAll().then(console.table)
+}

--- a/scripts/liveCommit.ts
+++ b/scripts/liveCommit.ts
@@ -74,7 +74,12 @@ async function fetchAll(): Promise<Array<ServerCommitInformation>> {
             if (!commit.commitSha) return commit
 
             const apiResponse = (await fetch(
-                `https://api.github.com/repos/owid/owid-grapher/git/commits/${commit.commitSha}`
+                `https://api.github.com/repos/owid/owid-grapher/git/commits/${commit.commitSha}`,
+                {
+                    headers: {
+                        Accept: "application/vnd.github.v3"
+                    }
+                }
             )) as any
 
             const response = await apiResponse.json()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2718,6 +2718,13 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/opener@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@types/opener/-/opener-1.4.0.tgz#7967fae45cfabfe1fa268512b1b304f5a2b1127f"
+  integrity sha1-eWf65Fz6v+H6JoUSsbME9aKxEn8=
+  dependencies:
+    "@types/node" "*"
+
 "@types/prop-types@*":
   version "15.7.1"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
@@ -12630,6 +12637,11 @@ open@^6.4.0:
   integrity sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==
   dependencies:
     is-wsl "^1.1.0"
+
+opener@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
+  integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
 
 opn@5.4.0:
   version "5.4.0"


### PR DESCRIPTION
This is based off Daniels comment here (https://owid.slack.com/archives/CQQUA2C2U/p1590083865004800), but expanded to also cover staging servers and viewing commit information locally (`--tree` and `--show`).

This is the output of `yarn live-commit playfair --show --tree`, for example:
![image](https://user-images.githubusercontent.com/2641501/82611380-b15e6100-9bc0-11ea-82f4-1e28524d2ea4.png)

`yarn live-commit` just opens the deployed commit on the live server on github, just like Daniels snippet did.


As for why I'm using `opener` instead of a simple `open`, I'll leave it to [opener](https://www.npmjs.com/package/opener#why):
> Because Windows has `start`, Macs have `open`, and *nix has `xdg-open`. At least [according to some guy on StackOverflow](http://stackoverflow.com/q/1480971/3191). And I like things that work on all three. Like Node.js. And Opener.

I'm running on a Linux/Windows combination, and would like it to work for me too :)