### PR TITLE
Add tracking to determine how often broken entity names are happening

### DIFF
--- a/charts/ChartData.ts
+++ b/charts/ChartData.ts
@@ -21,7 +21,6 @@ import { EntityDimensionKey } from "./EntityDimensionKey"
 import { Color } from "./Color"
 import { ChartDimensionWithOwidVariable } from "./ChartDimensionWithOwidVariable"
 import { OwidSource } from "./owidData/OwidSource"
-import { Analytics } from "site/client/Analytics"
 
 export interface EntityDimensionInfo {
     entity: string
@@ -371,11 +370,7 @@ export class ChartData {
                     .some(item => item)
             })
         }
-        const notFoundEntities = Array.from(matchedEntities.keys()).filter(
-            key => !matchedEntities.get(key)
-        )
-        if (notFoundEntities.length)
-            Analytics.logEntitiesNotFoundError(notFoundEntities)
+        return matchedEntities
     }
 
     @action.bound resetSelectedEntities() {

--- a/charts/ChartUrl.ts
+++ b/charts/ChartUrl.ts
@@ -32,6 +32,7 @@ import {
     TimeBound,
     parseTimeBound
 } from "./TimeBounds"
+import { Analytics } from "site/client/Analytics"
 
 export interface ChartQueryParams {
     tab?: string
@@ -334,7 +335,14 @@ export class ChartUrl implements ObservableUrl {
                         const entityCodes = country
                             .split("+")
                             .map(decodeURIComponent)
-                        this.chart.data.setSelectedEntitiesByCode(entityCodes)
+                        const matchedEntities = this.chart.data.setSelectedEntitiesByCode(
+                            entityCodes
+                        )
+                        const notFoundEntities = Array.from(
+                            matchedEntities.keys()
+                        ).filter(key => !matchedEntities.get(key))
+                        if (notFoundEntities.length)
+                            Analytics.logEntitiesNotFoundError(notFoundEntities)
                     }
                 })
             }

--- a/site/client/Analytics.ts
+++ b/site/client/Analytics.ts
@@ -23,6 +23,11 @@ export class Analytics {
         this.logToGA("Errors", "Explore")
     }
 
+    static logEntitiesNotFoundError(entities: string[]) {
+        this.logToAmplitude("ENTITIES_NOT_FOUND", { entities })
+        this.logToGA("Errors", "ENTITIES_NOT_FOUND", JSON.stringify(entities))
+    }
+
     static logChartTimelinePlay(slug?: string) {
         this.logToAmplitude("CHART_TIMELINE_PLAY")
         this.logToGA("Chart", "TimelinePlay", slug)


### PR DESCRIPTION
Before I deploy the `~` fix, I thought it might make sense to see how often we are seeing broken country links coming in. Then hopefully this will go down to zero when we switch to `~`.

