### PR TITLE
Don't show fractional ticks for y axis if it contains only integer values

### DIFF
--- a/charts/LineChartTransform.ts
+++ b/charts/LineChartTransform.ts
@@ -205,6 +205,11 @@ export class LineChartTransform extends ChartTransform {
         }
     }
 
+    @computed get yAxisHideFractionalTicks(): boolean {
+        // all y axis points are integral, don't show fractional ticks in that case
+        return this.allValues.every(val => val.y % 1 === 0)
+    }
+
     @computed get yAxis(): AxisSpec {
         const { chart, yDomain, yScaleType, yTickFormat, isRelativeMode } = this
         return {
@@ -215,7 +220,7 @@ export class LineChartTransform extends ChartTransform {
             scaleTypeOptions: isRelativeMode
                 ? ["linear"]
                 : chart.yAxis.scaleTypeOptions,
-            hideFractionalTicks: this.yDimensionFirst?.numDecimalPlaces === 0
+            hideFractionalTicks: this.yAxisHideFractionalTicks
         }
     }
 

--- a/charts/LineChartTransform.ts
+++ b/charts/LineChartTransform.ts
@@ -214,7 +214,8 @@ export class LineChartTransform extends ChartTransform {
             scaleType: yScaleType,
             scaleTypeOptions: isRelativeMode
                 ? ["linear"]
-                : chart.yAxis.scaleTypeOptions
+                : chart.yAxis.scaleTypeOptions,
+            hideFractionalTicks: this.yDimensionFirst?.numDecimalPlaces === 0
         }
     }
 


### PR DESCRIPTION
fixes https://owid.slack.com/archives/C46U9LXRR/p1590491812001400.

Maybe we should also do the same for other chart types?