### PR TITLE
Show necessary decimal places to differentiate axis ticks

### DIFF
--- a/charts/AxisScale.ts
+++ b/charts/AxisScale.ts
@@ -12,13 +12,6 @@ import { observable, computed, toJS } from "mobx"
 
 export type ScaleType = "linear" | "log"
 
-export interface AxisConfig {
-    scaleType: ScaleType
-    scaleTypeOptions: ScaleType[]
-    tickFormat: (v: number) => string
-    domain: [number, number]
-    label: string
-}
 
 export class AxisScale {
     @observable scaleType: ScaleType

--- a/charts/AxisScale.ts
+++ b/charts/AxisScale.ts
@@ -99,9 +99,31 @@ export class AxisScale {
     }
 
     getTickFormattingOptions(): TickFormattingOptions {
+        // The chart's tick formatting function is used by default to format axis ticks. This means
+        // that the chart's `numDecimalPlaces` is also used by default to format the axis ticks.
+        //
+        // However, the author-specified decimal places are not always appropriate for rendering
+        // ticks, because:
+        // 1. Subsets of the data may require higher fidelity, e.g. users can use the timeline to
+        //    end up in a subset of the dataset where values happen to be much lower than usual.
+        // 2. Ticks may be rendered at granularities that may not exist in the data, e.g. the data
+        //    may only contain 0 and 1, but we may show ticks in between those values.
+        //
+        // Therefore, when formatting ticks, we determine the `numDecimalPlaces` automatically, by
+        // finding the smallest difference between any pair of ticks and making sure that we have
+        // sufficient decimal places to express the difference to the first significant figure (the
+        // first non-zero digit).
+        //
+        // One significant figure is sufficient because we use D3's ticks() and that creates
+        // "uniformly-spaced, nicely-rounded values [...] where each value is a power of ten
+        // multiplied by 1, 2 or 5"
+        // See: https://github.com/d3/d3-array/blob/master/README.md#ticks
+        //
+        // -@danielgavrilov, 2020-05-27
         const tickValues = this.getTickValues()
         const minDist = min(rollingMap(tickValues, (a, b) => Math.abs(a - b)))
         if (minDist !== undefined) {
+            // Find the decimal places required to reach the first non-zero digit
             const dp = Math.ceil(-Math.log10(minDist))
             if (isFinite(dp) && dp >= 0) return { numDecimalPlaces: dp }
         }

--- a/charts/HorizontalAxis.tsx
+++ b/charts/HorizontalAxis.tsx
@@ -79,9 +79,12 @@ export class HorizontalAxis {
     @computed get tickPlacements() {
         const { scale, labelOffset } = this
         return this.baseTicks.map(tick => {
-            const bounds = Bounds.forText(scale.tickFormat(tick), {
-                fontSize: this.tickFontSize
-            })
+            const bounds = Bounds.forText(
+                scale.tickFormat(tick, this.tickFormattingOptions),
+                {
+                    fontSize: this.tickFontSize
+                }
+            )
             return {
                 tick: tick,
                 bounds: bounds.extend({
@@ -110,6 +113,10 @@ export class HorizontalAxis {
 
         return tickPlacements.filter(t => !t.isHidden).map(t => t.tick)
     }
+
+    @computed get tickFormattingOptions() {
+        return this.scale.getTickFormattingOptions()
+    }
 }
 
 export class HorizontalAxisView extends React.Component<{
@@ -127,7 +134,7 @@ export class HorizontalAxisView extends React.Component<{
             axisPosition,
             showTickMarks
         } = this.props
-        const { scale, ticks, label, labelOffset } = axis
+        const { scale, ticks, label, labelOffset, tickFormattingOptions } = axis
         const textColor = "#666"
 
         const tickMarks = showTickMarks ? (
@@ -149,7 +156,7 @@ export class HorizontalAxisView extends React.Component<{
                     )}
                 {tickMarks}
                 {ticks.map((tick, i) => {
-                    const label = scale.tickFormat(tick)
+                    const label = scale.tickFormat(tick, tickFormattingOptions)
                     const rawXPosition = scale.place(tick)
                     // Ensure the first label does not exceed the chart viewing area
                     const xPosition =

--- a/charts/Util.ts
+++ b/charts/Util.ts
@@ -795,3 +795,12 @@ export function scrollIntoViewIfNeeded(
         scrollTo(containerEl, Math.max(focusedEl.offsetTop - overScroll, 0))
     }
 }
+
+export function rollingMap<T, U>(array: T[], mapper: (a: T, b: T) => U) {
+    const result: U[] = []
+    if (array.length <= 1) return result
+    for (let i = 0; i < array.length - 1; i++) {
+        result.push(mapper(array[i], array[i + 1]))
+    }
+    return result
+}

--- a/charts/VerticalAxis.tsx
+++ b/charts/VerticalAxis.tsx
@@ -63,6 +63,10 @@ export class VerticalAxis {
     @computed get ticks(): number[] {
         return this.scale.getTickValues()
     }
+
+    @computed get tickFormattingOptions() {
+        return this.scale.getTickFormattingOptions()
+    }
 }
 
 @observer
@@ -73,7 +77,7 @@ export class VerticalAxisView extends React.Component<{
 }> {
     render() {
         const { bounds, axis, onScaleTypeChange } = this.props
-        const { scale, ticks, label } = axis
+        const { scale, ticks, label, tickFormattingOptions } = axis
         const textColor = "#666"
 
         return (
@@ -94,7 +98,7 @@ export class VerticalAxisView extends React.Component<{
                         textAnchor="end"
                         fontSize={axis.tickFontSize}
                     >
-                        {scale.tickFormat(tick)}
+                        {scale.tickFormat(tick, tickFormattingOptions)}
                     </text>
                 ))}
                 {scale.scaleTypeOptions.length > 1 && onScaleTypeChange && (

--- a/charts/__tests__/Util.test.ts
+++ b/charts/__tests__/Util.test.ts
@@ -9,7 +9,8 @@ import {
     formatDay,
     retryPromise,
     computeRollingAverage,
-    insertMissingValuePlaceholders
+    insertMissingValuePlaceholders,
+    rollingMap
 } from "../Util"
 
 describe(findClosestYear, () => {
@@ -202,5 +203,17 @@ describe(retryPromise, () => {
     it("rejects when promise doesn't succeed within retry limit", async () => {
         const promiseGetter = resolveAfterNthRetry(3, "success")
         expect(retryPromise(promiseGetter, 3)).rejects.toBeUndefined()
+    })
+})
+
+describe(rollingMap, () => {
+    it("handles empty arrays", () => {
+        expect(rollingMap([], () => undefined).length).toEqual(0)
+    })
+    it("handles 1 element arrays", () => {
+        expect(rollingMap([1], (a, b) => a + b).length).toEqual(0)
+    })
+    it("handles 1 element arrays", () => {
+        expect(rollingMap([1, 2, 4, 8], (a, b) => b - a)).toEqual([1, 2, 4])
     })
 })

--- a/charts/__tests__/Util.test.ts
+++ b/charts/__tests__/Util.test.ts
@@ -210,10 +210,10 @@ describe(rollingMap, () => {
     it("handles empty arrays", () => {
         expect(rollingMap([], () => undefined).length).toEqual(0)
     })
-    it("handles 1 element arrays", () => {
+    it("handles arrays with 1 element", () => {
         expect(rollingMap([1], (a, b) => a + b).length).toEqual(0)
     })
-    it("handles 1 element arrays", () => {
+    it("handles arrays with multiple elements", () => {
         expect(rollingMap([1, 2, 4, 8], (a, b) => b - a)).toEqual([1, 2, 4])
     })
 })


### PR DESCRIPTION
As we [discussed with @MarcelGerber](https://owid.slack.com/archives/C46U9LXRR/p1590491812001400).

# Y axis

URL: https://ourworldindata.org/coronavirus-data-explorer?zoomToSelection=true&deathsMetric=true&dailyFreq=true&perCapita=true&smoothing=7&country=AGO~

### Before

![coronavirus-data-explorer (2)](https://user-images.githubusercontent.com/1308115/82960586-cf5a0600-9fb2-11ea-8df8-b323efd517bf.png)

### After

![coronavirus-data-explorer (3)](https://user-images.githubusercontent.com/1308115/82960599-d719aa80-9fb2-11ea-9565-2c8ed0f0988c.png)

# X axis

URL: https://ourworldindata.org/coronavirus-data-explorer?yScale=log&zoomToSelection=true&time=2020-05-23&deathsMetric=true&dailyFreq=true&perCapita=true&smoothing=7&country=DEU~GBR~ITA~AUT~USA~MKD~FRA~AUS~CHE~IRL~BEL~NLD~IRN~DNK~ECU~CAN~SRB~CHN

### Before

![coronavirus-data-explorer](https://user-images.githubusercontent.com/1308115/82959961-fe6f7800-9fb0-11ea-9235-78da93b802d3.png)

### After

![coronavirus-data-explorer (1)](https://user-images.githubusercontent.com/1308115/82959986-0cbd9400-9fb1-11ea-98e2-7491be7c7311.png)