### PR TITLE
Use shorter date format on x tick marks for all but last tick

### DIFF
--- a/charts/AxisBox.tsx
+++ b/charts/AxisBox.tsx
@@ -18,6 +18,7 @@ import { HorizontalAxis, HorizontalAxisView } from "./HorizontalAxis"
 import { AxisSpec } from "./AxisSpec"
 import { ScaleType } from "./ScaleType"
 import { extend } from "./Util"
+import { ChartConfig } from "./ChartConfig"
 
 interface AxisBoxProps {
     bounds: Bounds
@@ -245,6 +246,7 @@ export class AxisGridLines extends React.Component<AxisGridLinesProps> {
 
 export interface AxisBoxViewProps {
     axisBox: AxisBox
+    chart: ChartConfig
     onYScaleChange: (scaleType: ScaleType) => void
     onXScaleChange: (scaleType: ScaleType) => void
     highlightValue?: { x: number; y: number }
@@ -262,6 +264,7 @@ export class AxisBoxView extends React.Component<AxisBoxViewProps> {
             axisBox,
             onYScaleChange,
             onXScaleChange,
+            chart,
             showTickMarks
         } = this.props
         const { bounds, xScale, yScale, xAxis, yAxis, innerBounds } = axisBox
@@ -270,6 +273,7 @@ export class AxisBoxView extends React.Component<AxisBoxViewProps> {
             <g className="AxisBoxView">
                 <HorizontalAxisView
                     bounds={bounds}
+                    chart={chart}
                     axisPosition={innerBounds.bottom}
                     axis={xAxis}
                     onScaleTypeChange={onXScaleChange}

--- a/charts/DiscreteBarChart.tsx
+++ b/charts/DiscreteBarChart.tsx
@@ -275,6 +275,7 @@ export class DiscreteBarChart extends React.Component<{
                 />
                 <HorizontalAxisView
                     bounds={bounds}
+                    chart={this.chart}
                     axis={xAxis}
                     onScaleTypeChange={
                         this.chart.yAxis.canChangeScaleType

--- a/charts/HorizontalAxis.tsx
+++ b/charts/HorizontalAxis.tsx
@@ -161,16 +161,14 @@ export class HorizontalAxisView extends React.Component<{
                 {ticks.map((tick, index) => {
                     let label = scale.tickFormat(tick, tickFormattingOptions)
                     // On line charts, with dates on the x axis, display the dates sans year except for the final tick.
-                    // So we print something like:  `Mar 1     April 1    May 1 2020`
+                    // So we print something like:  `Mar 1     Apr 1    May 1 2020`
                     if (
                         chart.isLineChart &&
                         !chart.lineChart.isSingleYear &&
-                        chart.yearIsDayVar
+                        chart.yearIsDayVar &&
+                        index < ticks.length - 1
                     )
-                        label =
-                            index === ticks.length - 1
-                                ? scale.tickFormat(tick)
-                                : formatDay(tick, { format: "MMM D" })
+                        label = formatDay(tick, { format: "MMM D" })
 
                     const rawXPosition = scale.place(tick)
                     // Ensure the first label does not exceed the chart viewing area

--- a/charts/HorizontalAxis.tsx
+++ b/charts/HorizontalAxis.tsx
@@ -160,7 +160,8 @@ export class HorizontalAxisView extends React.Component<{
                 {tickMarks}
                 {ticks.map((tick, index) => {
                     let label = scale.tickFormat(tick, tickFormattingOptions)
-                    // On line charts with dates on the x axis format the dates without the year except for the final date.
+                    // On line charts, with dates on the x axis, display the dates sans year except for the final tick.
+                    // So we print something like:  `Mar 1     April 1    May 1 2020`
                     if (
                         chart.isLineChart &&
                         !chart.lineChart.isSingleYear &&

--- a/charts/ScatterPlot.tsx
+++ b/charts/ScatterPlot.tsx
@@ -331,6 +331,7 @@ export class ScatterPlot extends React.Component<{
             <g>
                 <AxisBoxView
                     axisBox={axisBox}
+                    chart={this.chart}
                     onXScaleChange={this.onXScaleChange}
                     onYScaleChange={this.onYScaleChange}
                     showTickMarks={false}

--- a/charts/StandardAxisBoxView.tsx
+++ b/charts/StandardAxisBoxView.tsx
@@ -30,6 +30,7 @@ export class StandardAxisBoxView extends React.Component<
         const { axisBox } = this.props
         return (
             <AxisBoxView
+                chart={this.props.chart}
                 axisBox={axisBox}
                 onXScaleChange={this.onXScaleChange}
                 onYScaleChange={this.onYScaleChange}

--- a/charts/TimeScatter.tsx
+++ b/charts/TimeScatter.tsx
@@ -646,6 +646,7 @@ export class TimeScatter extends React.Component<{
         return (
             <g>
                 <AxisBoxView
+                    chart={this.chart}
                     axisBox={axisBox}
                     onXScaleChange={this.onXScaleChange}
                     onYScaleChange={this.onYScaleChange}


### PR DESCRIPTION
 Before:
![Screen Shot 2020-05-27 at 4 40 30 PM](https://user-images.githubusercontent.com/74692/83092418-f65b1b00-a038-11ea-8b45-c35ed08799fb.png)


After:
![Screen Shot 2020-05-27 at 4 40 37 PM](https://user-images.githubusercontent.com/74692/83092423-f9eea200-a038-11ea-8d30-8f177e011f5e.png)

I'm not crazy about passing the ChartConfig all the way down to HorizontalAxis, but I also didn't like passing 2 format functions or 2 format strings down, particularly because I'm not sure if we would ever use that option. If this becomes a pattern where we often want to decorate the last tick mark differently, perhaps we could implement something like that.