### PR TITLE
Don't duplicate <a> element when hydrating footnotes

### DIFF
--- a/site/client/Footnote.tsx
+++ b/site/client/Footnote.tsx
@@ -5,15 +5,17 @@ import ReactDOM from "react-dom"
 
 export const Footnote = ({
     index,
-    href,
     htmlContent,
     triggerTarget
 }: {
     index: number
-    href: string
     htmlContent?: string
     triggerTarget?: Element
 }) => {
+    const onEvent = (instance: any, event: Event) => {
+        if (event.type === "click") event.preventDefault()
+    }
+
     return (
         <Tippy
             appendTo={() => document.body}
@@ -33,16 +35,10 @@ export const Footnote = ({
             theme="owid-footnote"
             trigger="mouseenter focus click"
             triggerTarget={triggerTarget}
+            onTrigger={onEvent}
+            onUntrigger={onEvent}
         >
-            <a
-                id={`ref-${index}`}
-                className="ref"
-                href={href}
-                // Prevent scrolling to footnotes section
-                onClick={e => e.preventDefault()}
-            >
-                <sup>{index}</sup>
-            </a>
+            <sup>{index}</sup>
         </Tippy>
     )
 }
@@ -75,7 +71,6 @@ export function runFootnotes() {
         ReactDOM.hydrate(
             <Footnote
                 index={footnoteContent.index}
-                href={footnoteContent.href}
                 htmlContent={footnoteContent.htmlContent}
                 triggerTarget={f}
             />,

--- a/site/server/formatting.tsx
+++ b/site/server/formatting.tsx
@@ -133,7 +133,9 @@ export async function formatWordpressPost(
             const href = `#note-${i}`
 
             return ReactDOMServer.renderToStaticMarkup(
-                <Footnote index={i} href={href} />
+                <a id={`ref-${i}`} className="ref" href={href}>
+                    <Footnote index={i} />
+                </a>
             )
         } else {
             return ""


### PR DESCRIPTION
Currently, `React.hydrate()` duplicates every `<a>` element we have, since it can only hydrate _into_ a wrapper element, not replace one:
![image](https://user-images.githubusercontent.com/2641501/83120762-bf851380-a0d1-11ea-80f4-b063078f4f61.png)

In fact I made the exact same mistake myself at some point, but didn't catch it when you @danielgavrilov pushed your changes.



The `onTrigger` and `onUntrigger` callbacks of Tippy together catch every `click` event on the link.