### PR TITLE
Map color picker can be reset to default color

### DIFF
--- a/admin/client/Forms.tsx
+++ b/admin/client/Forms.tsx
@@ -466,7 +466,25 @@ export class ColorBox extends React.Component<{
         return (
             <Tippy
                 content={
-                    <Colorpicker color={color} onColor={this.props.onColor} />
+                    <>
+                        <Colorpicker
+                            color={color}
+                            onColor={this.props.onColor}
+                        />
+                        <div
+                            style={{
+                                display: "flex",
+                                alignItems: "center",
+                                flexDirection: "column"
+                            }}
+                        >
+                            <Button
+                                onClick={() => this.props.onColor(undefined)}
+                            >
+                                Reset to color scheme default
+                            </Button>
+                        </div>
+                    </>
                 }
                 placement="right"
                 interactive={true}

--- a/admin/client/admin.scss
+++ b/admin/client/admin.scss
@@ -510,6 +510,10 @@ body {
 .colorpicker-tooltip {
     .tippy-content {
         padding: 0;
+
+        .sketch-picker {
+            box-shadow: none !important;
+        }
     }
 }
 


### PR DESCRIPTION
As discussed in Slack (https://owid.slack.com/archives/C5BDCB2R3/p15906768430756009), since this was possible with the old one.

![image](https://user-images.githubusercontent.com/2641501/83306790-88168400-a203-11ea-97c0-7e62a57c3222.png)
