### PR TITLE
ControlsOverlay: Support padding in any direction

### DIFF
--- a/charts/ChartLayout.tsx
+++ b/charts/ChartLayout.tsx
@@ -135,25 +135,21 @@ export class ChartLayoutView extends React.Component<{
         return (
             <React.Fragment>
                 <HeaderHTML chart={layout.props.chart} header={layout.header} />
-                {/* The "chart plot area" div helps highlight the overlay controls on hover,
-                as we don't want to show them when the cursor is over the tabs */}
-                <div className="ChartPlotArea">
-                    <ControlsOverlayView
-                        chartView={this.context.chartView}
-                        controls={this.context.chartView.controls}
+                <ControlsOverlayView
+                    chartView={this.context.chartView}
+                    controls={this.context.chartView.controls}
+                >
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        version="1.1"
+                        style={this.svgStyle as any}
+                        width={layout.svgWidth}
+                        height={layout.svgHeight}
+                        viewBox={`0 0 ${layout.svgWidth} ${layout.svgHeight}`}
                     >
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            version="1.1"
-                            style={this.svgStyle as any}
-                            width={layout.svgWidth}
-                            height={layout.svgHeight}
-                            viewBox={`0 0 ${layout.svgWidth} ${layout.svgHeight}`}
-                        >
-                            {this.props.children}
-                        </svg>
-                    </ControlsOverlayView>
-                </div>
+                        {this.props.children}
+                    </svg>
+                </ControlsOverlayView>
                 <SourcesFooterHTML
                     chart={layout.props.chart}
                     footer={layout.footer}

--- a/charts/ChartLayout.tsx
+++ b/charts/ChartLayout.tsx
@@ -53,24 +53,39 @@ export class ChartLayout {
     }
 
     @computed get svgWidth() {
+        if (this.isHTML) {
+            const { overlayPadding } = this.props.chartView.controls
+            return (
+                this.props.bounds.width -
+                overlayPadding.left -
+                overlayPadding.right
+            )
+        }
         return this.props.bounds.width
     }
 
     @computed get svgHeight() {
-        return this.isHTML
-            ? this.props.bounds.height -
-                  this.header.height -
-                  this.footer.height -
-                  30
-            : this.props.bounds.height
+        if (this.isHTML) {
+            const { overlayPadding } = this.props.chartView.controls
+            return (
+                this.props.bounds.height -
+                this.header.height -
+                this.footer.height -
+                overlayPadding.top -
+                overlayPadding.bottom -
+                30
+            )
+        }
+        return this.props.bounds.height
     }
 
     @computed get innerBounds() {
-        return this.isHTML
-            ? new Bounds(0, 2, this.svgWidth, this.svgHeight).padWidth(15)
-            : this.paddedBounds
-                  .padTop(this.header.height)
-                  .padBottom(this.footer.height)
+        if (this.isHTML) {
+            return new Bounds(0, 0, this.svgWidth, this.svgHeight).padWidth(15)
+        }
+        return this.paddedBounds
+            .padTop(this.header.height)
+            .padBottom(this.footer.height)
     }
 }
 
@@ -126,17 +141,18 @@ export class ChartLayoutView extends React.Component<{
                     <ControlsOverlayView
                         chartView={this.context.chartView}
                         controls={this.context.chartView.controls}
-                    />
-                    <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        version="1.1"
-                        style={this.svgStyle as any}
-                        width={layout.svgWidth}
-                        height={layout.svgHeight}
-                        viewBox={`0 0 ${layout.svgWidth} ${layout.svgHeight}`}
                     >
-                        {this.props.children}
-                    </svg>
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            version="1.1"
+                            style={this.svgStyle as any}
+                            width={layout.svgWidth}
+                            height={layout.svgHeight}
+                            viewBox={`0 0 ${layout.svgWidth} ${layout.svgHeight}`}
+                        >
+                            {this.props.children}
+                        </svg>
+                    </ControlsOverlayView>
                 </div>
                 <SourcesFooterHTML
                     chart={layout.props.chart}

--- a/charts/ChartView.tsx
+++ b/charts/ChartView.tsx
@@ -234,9 +234,9 @@ export class ChartView extends React.Component<ChartViewProps> {
     }
 
     @computed get tabBounds() {
-        return new Bounds(0, 0, this.renderWidth, this.renderHeight)
-            .padTop(this.isExport ? 0 : this.controls.paddingTop)
-            .padBottom(this.isExport ? 0 : this.controls.footerHeight)
+        return new Bounds(0, 0, this.renderWidth, this.renderHeight).padBottom(
+            this.isExport ? 0 : this.controls.footerHeight
+        )
     }
 
     @observable.shallow overlays: { [id: string]: ControlsOverlay } = {}

--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -802,17 +802,22 @@ export class ControlsOverlayView extends React.Component<{
         const containerStyle: React.CSSProperties = {
             position: "relative",
             clear: "both",
-            marginTop: `${overlayPadding.top}px`,
-            marginRight: `${overlayPadding.right}px`,
-            marginBottom: `${overlayPadding.bottom}px`,
-            marginLeft: `${overlayPadding.left}px`
+            paddingTop: `${overlayPadding.top}px`,
+            paddingRight: `${overlayPadding.right}px`,
+            paddingBottom: `${overlayPadding.bottom}px`,
+            paddingLeft: `${overlayPadding.left}px`
         }
         const overlayStyle: React.CSSProperties = {
             position: "absolute",
-            top: "0px",
-            left: "0px",
-            width: "1px",
-            height: "1px"
+            // Overlays should be positioned relative to the same origin
+            // as the <svg>
+            top: `${overlayPadding.top}px`,
+            left: `${overlayPadding.left}px`,
+            // Create 0px element to avoid capturing events.
+            // Can achieve the same with `pointer-events: none`, but then control
+            // has to override `pointer-events` to capture events.
+            width: "0px",
+            height: "0px"
         }
         return (
             <div style={containerStyle}>

--- a/charts/HeightedLegend.tsx
+++ b/charts/HeightedLegend.tsx
@@ -471,18 +471,22 @@ export class HeightedLegendComponent extends React.Component<
     get addEntityButton() {
         if (!this.context.chart.showAddEntityControls) return undefined
 
+        const verticalAlign = "bottom"
+
         const leftOffset = this.needsLines
             ? this.props.legend.leftPadding
             : this.props.legend.width > 70
             ? 21
             : 5
-        const y = Math.max(
-            0,
-            defaultTo(min(this.placedMarks.map(mark => mark.bounds.top)), 0)
+
+        const topMarkY = defaultTo(
+            min(this.placedMarks.map(mark => mark.bounds.top)),
+            0
         )
+
         const paddingTop = AddEntityButton.calcPaddingTop(
-            y,
-            "bottom",
+            topMarkY,
+            verticalAlign,
             ADD_BUTTON_HEIGHT
         )
 
@@ -490,9 +494,9 @@ export class HeightedLegendComponent extends React.Component<
             <ControlsOverlay id="add-country" paddingTop={paddingTop}>
                 <AddEntityButton
                     x={this.props.x + leftOffset}
-                    y={y}
+                    y={topMarkY}
                     align="left"
-                    verticalAlign="bottom"
+                    verticalAlign={verticalAlign}
                     height={ADD_BUTTON_HEIGHT}
                     label={`Add ${this.context.chart.entityType}`}
                     onClick={this.onAddClick}

--- a/charts/HorizontalAxis.tsx
+++ b/charts/HorizontalAxis.tsx
@@ -191,7 +191,10 @@ export class HorizontalAxisView extends React.Component<{
                     return element
                 })}
                 {scale.scaleTypeOptions.length > 1 && onScaleTypeChange && (
-                    <ControlsOverlay id="horizontal-scale-selector">
+                    <ControlsOverlay
+                        id="horizontal-scale-selector"
+                        paddingBottom={10}
+                    >
                         <ScaleSelector
                             x={bounds.right}
                             y={bounds.bottom}

--- a/charts/LabelledSlopes.tsx
+++ b/charts/LabelledSlopes.tsx
@@ -762,8 +762,8 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
                 {yScaleTypeOptions.length > 1 && (
                     <ControlsOverlay id="slope-scale-selector" paddingTop={20}>
                         <ScaleSelector
-                            x={x1 + 5}
-                            y={y2 - 20}
+                            x={bounds.x}
+                            y={bounds.y - 35}
                             scaleType={yScaleType}
                             scaleTypeOptions={yScaleTypeOptions}
                             onChange={onScaleTypeChange}

--- a/charts/VerticalAxis.tsx
+++ b/charts/VerticalAxis.tsx
@@ -105,11 +105,11 @@ export class VerticalAxisView extends React.Component<{
                 {scale.scaleTypeOptions.length > 1 && onScaleTypeChange && (
                     <ControlsOverlay
                         id="vertical-scale-selector"
-                        paddingTop={18}
+                        paddingTop={10}
                     >
                         <ScaleSelector
                             x={bounds.left}
-                            y={bounds.top - 18}
+                            y={bounds.top - 25}
                             scaleType={scale.scaleType}
                             scaleTypeOptions={scale.scaleTypeOptions}
                             onChange={onScaleTypeChange}

--- a/charts/VerticalAxis.tsx
+++ b/charts/VerticalAxis.tsx
@@ -105,11 +105,11 @@ export class VerticalAxisView extends React.Component<{
                 {scale.scaleTypeOptions.length > 1 && onScaleTypeChange && (
                     <ControlsOverlay
                         id="vertical-scale-selector"
-                        paddingTop={10}
+                        paddingTop={18}
                     >
                         <ScaleSelector
                             x={bounds.left}
-                            y={bounds.top - 25}
+                            y={bounds.top - 34}
                             scaleType={scale.scaleType}
                             scaleTypeOptions={scale.scaleTypeOptions}
                             onChange={onScaleTypeChange}

--- a/charts/client/chart.scss
+++ b/charts/client/chart.scss
@@ -785,12 +785,6 @@ $zindex-IndicatorDropdown: 50;
     padding: 0 !important;
 }
 
-.ControlsOverlay {
-    position: relative;
-    clear: both;
-    width: 1px; /* This affects layout calculations for add entity button */
-}
-
 @keyframes appear {
     0% {
         opacity: 0;


### PR DESCRIPTION
Very fiddly implementation! I hope I never have to touch this code again. 😄 

The immediate thing this fixes is support for `paddingBottom` in order to fix [Log/lin toggle covers x-axis footnote sometimes](https://www.notion.so/owid/Log-lin-toggle-covers-x-axis-footnote-sometimes-6893edce6a30450f84adc9bbff6c12a5).

@breck7 It would be great if you can look through and let me know if you notice anything weird or anything that should be explained.

I drew this diagram to try to understand what is going on, but sadly we live in an era where code is written in plaintext so I can't embed it:

![IMG_1751](https://user-images.githubusercontent.com/1308115/84044800-eed43400-a99f-11ea-8be8-dcee2036e648.jpeg)
