### PR TITLE
Session cookie hardening

### DIFF
--- a/admin/server/adminViews.tsx
+++ b/admin/server/adminViews.tsx
@@ -19,6 +19,7 @@ import { Dataset } from "db/model/Dataset"
 import { User } from "db/model/User"
 import { UserInvitation } from "db/model/UserInvitation"
 import { renderPageById } from "site/server/siteBaking"
+import { ENV } from "settings"
 
 const adminViews = Router()
 
@@ -44,7 +45,11 @@ adminViews.get("/login", async (req, res) => {
 adminViews.post("/login", async (req, res) => {
     try {
         const session = await tryLogin(req.body.username, req.body.password)
-        res.cookie("sessionid", session.id)
+        res.cookie("sessionid", session.id, {
+            httpOnly: true,
+            sameSite: "strict",
+            secure: ENV === "production"
+        })
         res.redirect(req.query.next || "/admin")
     } catch (err) {
         res.status(400).send(

--- a/settings.ts
+++ b/settings.ts
@@ -3,7 +3,7 @@ import { parseBool } from "utils/string"
 // All of this information is available to the client-side code
 // DO NOT retrieve sensitive information from the environment in here! :O
 
-export const ENV: string =
+export const ENV: "production" | "development" =
     process.env.ENV === "production" || process.env.NODE_ENV === "production"
         ? "production"
         : "development"


### PR DESCRIPTION
This enables browser security features for our session token:
* HttpOnly ensures the cookie cannot be read using `document.cookie`, so nefarious code on the client side cannot obtain the token.
* SameSite=Strict will never send the cookie with cross-site requests, and provides protection against cross-site request forgery attacks.
* Secure means the token will only ever be sent over encrypted connections.
  It is disabled in a development environment since most localhost connections are not running over https.

This is in line with the session cookie recommendations from OWASP: https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#cookies