### PR TITLE
Ability to emulate vision deficiencies in the grapher admin

### DIFF
--- a/admin/client/ChartEditorPage.tsx
+++ b/admin/client/ChartEditorPage.tsx
@@ -39,10 +39,10 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faMobile } from "@fortawesome/free-solid-svg-icons/faMobile"
 import { faDesktop } from "@fortawesome/free-solid-svg-icons/faDesktop"
 import {
-    VisionDeficieny,
+    VisionDeficiency,
     VisionDeficiencySvgFilters,
-    VisionDeficienyDropdown,
-    VisionDeficienyEntity
+    VisionDeficiencyDropdown,
+    VisionDeficiencyEntity
 } from "./VisionDeficiencies"
 
 @observer
@@ -93,7 +93,7 @@ export class ChartEditorPage extends React.Component<{
     static contextType = AdminAppContext
     context!: AdminAppContextType
 
-    @observable simulateVisionDeficiency?: VisionDeficieny
+    @observable simulateVisionDeficiency?: VisionDeficiency
 
     async fetchChart() {
         const { chartId, chartConfig } = this.props
@@ -350,9 +350,9 @@ export class ChartEditorPage extends React.Component<{
                             style={{ width: 250, marginLeft: 15 }}
                         >
                             Emulate vision deficiency:{" "}
-                            <VisionDeficienyDropdown
+                            <VisionDeficiencyDropdown
                                 onChange={action(
-                                    (option: VisionDeficienyEntity) =>
+                                    (option: VisionDeficiencyEntity) =>
                                         (this.simulateVisionDeficiency =
                                             option.deficiency)
                                 )}

--- a/admin/client/ChartEditorPage.tsx
+++ b/admin/client/ChartEditorPage.tsx
@@ -38,6 +38,12 @@ import { AdminAppContext, AdminAppContextType } from "./AdminAppContext"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faMobile } from "@fortawesome/free-solid-svg-icons/faMobile"
 import { faDesktop } from "@fortawesome/free-solid-svg-icons/faDesktop"
+import {
+    VisionDeficieny,
+    VisionDeficiencySvgFilters,
+    VisionDeficienyDropdown,
+    VisionDeficienyEntity
+} from "./VisionDeficiencies"
 
 @observer
 class TabBinder extends React.Component<{ editor: ChartEditor }> {
@@ -86,6 +92,8 @@ export class ChartEditorPage extends React.Component<{
     @observable redirects?: ChartRedirect[]
     static contextType = AdminAppContext
     context!: AdminAppContextType
+
+    @observable simulateVisionDeficiency?: VisionDeficieny
 
     async fetchChart() {
         const { chartId, chartConfig } = this.props
@@ -275,7 +283,14 @@ export class ChartEditorPage extends React.Component<{
                     <SaveButtons editor={editor} />
                 </div>
                 <div className="chart-editor-view">
-                    <figure data-grapher-src>
+                    <figure
+                        data-grapher-src
+                        style={{
+                            filter:
+                                this.simulateVisionDeficiency &&
+                                `url(#${this.simulateVisionDeficiency.id})`
+                        }}
+                    >
                         {
                             <ChartView
                                 chart={chart}
@@ -286,50 +301,67 @@ export class ChartEditorPage extends React.Component<{
                                 }
                             />
                         }
-                        {/*<ChartView chart={chart} bounds={new Bounds(0, 0, 800, 600)}/>*/}
                     </figure>
-                    <div
-                        className="btn-group"
-                        data-toggle="buttons"
-                        style={{ whiteSpace: "nowrap" }}
-                    >
-                        <label
-                            className={
-                                "btn btn-light" +
-                                (previewMode === "mobile" ? " active" : "")
-                            }
-                            title="Mobile preview"
+                    <div>
+                        <div
+                            className="btn-group"
+                            data-toggle="buttons"
+                            style={{ whiteSpace: "nowrap" }}
                         >
-                            <input
-                                type="radio"
-                                onChange={action(
-                                    () => (editor.previewMode = "mobile")
-                                )}
-                                name="previewSize"
-                                id="mobile"
-                                checked={previewMode === "mobile"}
-                            />{" "}
-                            <FontAwesomeIcon icon={faMobile} />
-                        </label>
-                        <label
-                            className={
-                                "btn btn-light" +
-                                (previewMode === "desktop" ? " active" : "")
-                            }
-                            title="Desktop preview"
+                            <label
+                                className={
+                                    "btn btn-light" +
+                                    (previewMode === "mobile" ? " active" : "")
+                                }
+                                title="Mobile preview"
+                            >
+                                <input
+                                    type="radio"
+                                    onChange={action(
+                                        () => (editor.previewMode = "mobile")
+                                    )}
+                                    name="previewSize"
+                                    id="mobile"
+                                    checked={previewMode === "mobile"}
+                                />{" "}
+                                <FontAwesomeIcon icon={faMobile} />
+                            </label>
+                            <label
+                                className={
+                                    "btn btn-light" +
+                                    (previewMode === "desktop" ? " active" : "")
+                                }
+                                title="Desktop preview"
+                            >
+                                <input
+                                    onChange={action(
+                                        () => (editor.previewMode = "desktop")
+                                    )}
+                                    type="radio"
+                                    name="previewSize"
+                                    id="desktop"
+                                    checked={previewMode === "desktop"}
+                                />{" "}
+                                <FontAwesomeIcon icon={faDesktop} />
+                            </label>
+                        </div>
+                        <div
+                            className="form-group d-inline-block"
+                            style={{ width: 250, marginLeft: 15 }}
                         >
-                            <input
+                            Emulate vision deficiency:{" "}
+                            <VisionDeficienyDropdown
                                 onChange={action(
-                                    () => (editor.previewMode = "desktop")
+                                    (option: VisionDeficienyEntity) =>
+                                        (this.simulateVisionDeficiency =
+                                            option.deficiency)
                                 )}
-                                type="radio"
-                                name="previewSize"
-                                id="desktop"
-                                checked={previewMode === "desktop"}
-                            />{" "}
-                            <FontAwesomeIcon icon={faDesktop} />
-                        </label>
+                            />
+                        </div>
                     </div>
+
+                    {/* Include svg filters necessary for vision deficiency emulation */}
+                    <VisionDeficiencySvgFilters />
                 </div>
             </React.Fragment>
         )

--- a/admin/client/VisionDeficiencies.tsx
+++ b/admin/client/VisionDeficiencies.tsx
@@ -1,0 +1,226 @@
+import React from "react"
+import Select, {
+    components,
+    OptionProps,
+    GroupedOptionsType,
+    ValueType
+} from "react-select"
+import classNames from "classnames"
+import { observer } from "mobx-react"
+import { computed, action } from "mobx"
+import { groupBy, first } from "charts/Util"
+import { asArray, getStylesForTargetHeight } from "utils/client/react-select"
+
+// Transformation matrices taken from https://github.com/hail2u/color-blindness-emulation/blob/master/filters.svg?short_path=5708e81
+// "Affected" numbers from https://en.wikipedia.org/wiki/Color_blindness#Epidemiology
+
+export interface VisionDeficieny {
+    id: string
+    name: string
+    group: string
+    alternativeName: string
+    affected: string
+    transformationMatrix: string
+}
+
+export const visionDeficiencies: VisionDeficieny[] = [
+    // Color blindnesses first
+    {
+        id: "protanopia",
+        name: "Protanopia",
+        group: "Color blindness",
+        alternativeName: "red-blind",
+        affected: "1.3% male, 0.02% female",
+        transformationMatrix: `
+                0.567, 0.433, 0,     0, 0
+                0.558, 0.442, 0,     0, 0
+                0,     0.242, 0.758, 0, 0
+                0,     0,     0,     1, 0
+                `
+    },
+
+    {
+        id: "deuteranopia",
+        name: "Deuteranopia",
+        group: "Color blindness",
+        alternativeName: "green-blind",
+        affected: "1.2% male, 0.01% female",
+        transformationMatrix: `
+                0.625, 0.375, 0,   0, 0
+                0.7,   0.3,   0,   0, 0
+                0,     0.3,   0.7, 0, 0
+                0,     0,     0,   1, 0
+                `
+    },
+    {
+        id: "tritanopia",
+        name: "Tritanopia",
+        group: "Color blindness",
+        alternativeName: "blue-blind",
+        affected: "0.001% male, 0.03% female",
+        transformationMatrix: `
+                0.95, 0.05,  0,     0, 0
+                0,    0.433, 0.567, 0, 0
+                0,    0.475, 0.525, 0, 0
+                0,    0,     0,     1, 0
+                `
+    },
+    {
+        id: "achromatopsia",
+        name: "Achromatopsia",
+        group: "Color blindness",
+        alternativeName: "total color blindness",
+        affected: "0.003%",
+        transformationMatrix: `
+                0.299, 0.587, 0.114, 0, 0
+                0.299, 0.587, 0.114, 0, 0
+                0.299, 0.587, 0.114, 0, 0
+                0,     0,     0,     1, 0
+                `
+    },
+    // Then weaknesses
+    {
+        id: "protanomaly",
+        name: "Protanomaly",
+        group: "Reduced vision",
+        alternativeName: "red-weak",
+        affected: "1.3% male, 0.02% female",
+        transformationMatrix: `
+                0.817, 0.183, 0,     0, 0
+                0.333, 0.667, 0,     0, 0
+                0,     0.125, 0.875, 0, 0
+                0,     0,     0,     1, 0
+                `
+    },
+    {
+        id: "deuteranomaly",
+        name: "Deuteranomaly",
+        group: "Reduced vision",
+        alternativeName: "green-weak",
+        affected: "5.0% male, 0.35% female",
+        transformationMatrix: `
+                0.8,   0.2,   0,     0, 0
+                0.258, 0.742, 0,     0, 0
+                0,     0.142, 0.858, 0, 0
+                0,     0,     0,     1, 0
+                `
+    },
+    {
+        id: "tritanomaly",
+        name: "Tritanomaly",
+        group: "Reduced vision",
+        alternativeName: "blue-weak",
+        affected: "0.0001% male, 0.0001% female",
+        transformationMatrix: `
+                0.967, 0.033, 0,     0, 0
+                0,     0.733, 0.267, 0, 0
+                0,     0.183, 0.817, 0, 0
+                0,     0,     0,     1, 0
+                `
+    },
+    {
+        id: "achromatomaly",
+        name: "Achromatomaly",
+        group: "Reduced vision",
+        alternativeName: "weak color visibility",
+        affected: "",
+        transformationMatrix: `
+                0.618, 0.320, 0.062, 0, 0
+                0.163, 0.775, 0.062, 0, 0
+                0.163, 0.320, 0.516, 0, 0
+                0,     0,     0,     1, 0
+                `
+    }
+]
+
+export const VisionDeficiencySvgFilters = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="0">
+        <defs>
+            {visionDeficiencies.map(deficiency => (
+                <filter id={deficiency.id} key={deficiency.id}>
+                    <feColorMatrix
+                        in="SourceGraphic"
+                        type="matrix"
+                        values={deficiency.transformationMatrix}
+                    />
+                </filter>
+            ))}
+        </defs>
+    </svg>
+)
+
+interface VisionDeficiencyDropdownProps {
+    value?: string
+    onChange: (selected: VisionDeficienyEntity) => void
+}
+
+export interface VisionDeficienyEntity {
+    label: string
+    value: string
+    deficiency?: VisionDeficieny
+}
+
+const VisionDeficiencyOption = (props: OptionProps<VisionDeficienyEntity>) => (
+    <div style={{ fontSize: ".9em", lineHeight: 1 }}>
+        <components.Option {...props}>
+            <label>{props.label}</label>
+            {props.data.deficiency?.affected && (
+                <div
+                    className={classNames({ "text-muted": !props.isSelected })}
+                >
+                    <small>Affected: {props.data.deficiency.affected}</small>
+                </div>
+            )}
+        </components.Option>
+    </div>
+)
+
+@observer
+export class VisionDeficienyDropdown extends React.Component<
+    VisionDeficiencyDropdownProps
+> {
+    noDeficiencyOption = {
+        label: "No deficiencies",
+        value: "none"
+    }
+
+    @computed get options(): GroupedOptionsType<VisionDeficienyEntity> {
+        const options = visionDeficiencies.map(deficiency => ({
+            label: `${deficiency.name} (${deficiency.alternativeName})`,
+            value: deficiency.id,
+            deficiency
+        }))
+        const grouped = groupBy(options, option => option.deficiency.group)
+        const selectGroups = Object.entries(
+            grouped
+        ).map(([label, options]) => ({ label, options }))
+
+        return [
+            {
+                label: "No deficiencies",
+                options: [this.noDeficiencyOption]
+            },
+            ...selectGroups
+        ]
+    }
+
+    @action.bound onChange(selected: ValueType<VisionDeficienyEntity>) {
+        const value = first(asArray(selected))
+        if (value) this.props.onChange(value)
+    }
+
+    render() {
+        return (
+            <Select
+                options={this.options}
+                onChange={this.onChange}
+                defaultValue={this.noDeficiencyOption}
+                menuPlacement="top"
+                components={{
+                    Option: VisionDeficiencyOption
+                }}
+                styles={getStylesForTargetHeight(30)}
+            />
+        )
+    }
+}

--- a/admin/client/VisionDeficiencies.tsx
+++ b/admin/client/VisionDeficiencies.tsx
@@ -14,7 +14,7 @@ import { asArray, getStylesForTargetHeight } from "utils/client/react-select"
 // Transformation matrices taken from https://github.com/hail2u/color-blindness-emulation/blob/master/filters.svg?short_path=5708e81
 // "Affected" numbers from https://en.wikipedia.org/wiki/Color_blindness#Epidemiology
 
-export interface VisionDeficieny {
+export interface VisionDeficiency {
     id: string
     name: string
     group: string
@@ -23,7 +23,7 @@ export interface VisionDeficieny {
     transformationMatrix: string
 }
 
-export const visionDeficiencies: VisionDeficieny[] = [
+export const visionDeficiencies: VisionDeficiency[] = [
     // Color blindnesses first
     {
         id: "protanopia",
@@ -151,16 +151,16 @@ export const VisionDeficiencySvgFilters = () => (
 
 interface VisionDeficiencyDropdownProps {
     value?: string
-    onChange: (selected: VisionDeficienyEntity) => void
+    onChange: (selected: VisionDeficiencyEntity) => void
 }
 
-export interface VisionDeficienyEntity {
+export interface VisionDeficiencyEntity {
     label: string
     value: string
-    deficiency?: VisionDeficieny
+    deficiency?: VisionDeficiency
 }
 
-const VisionDeficiencyOption = (props: OptionProps<VisionDeficienyEntity>) => (
+const VisionDeficiencyOption = (props: OptionProps<VisionDeficiencyEntity>) => (
     <div style={{ fontSize: ".9em", lineHeight: 1 }}>
         <components.Option {...props}>
             <label>{props.label}</label>
@@ -176,7 +176,7 @@ const VisionDeficiencyOption = (props: OptionProps<VisionDeficienyEntity>) => (
 )
 
 @observer
-export class VisionDeficienyDropdown extends React.Component<
+export class VisionDeficiencyDropdown extends React.Component<
     VisionDeficiencyDropdownProps
 > {
     noDeficiencyOption = {
@@ -184,7 +184,7 @@ export class VisionDeficienyDropdown extends React.Component<
         value: "none"
     }
 
-    @computed get options(): GroupedOptionsType<VisionDeficienyEntity> {
+    @computed get options(): GroupedOptionsType<VisionDeficiencyEntity> {
         const options = visionDeficiencies.map(deficiency => ({
             label: `${deficiency.name} (${deficiency.alternativeName})`,
             value: deficiency.id,
@@ -204,7 +204,7 @@ export class VisionDeficienyDropdown extends React.Component<
         ]
     }
 
-    @action.bound onChange(selected: ValueType<VisionDeficienyEntity>) {
+    @action.bound onChange(selected: ValueType<VisionDeficiencyEntity>) {
         const value = first(asArray(selected))
         if (value) this.props.onChange(value)
     }


### PR DESCRIPTION
# How it looks

![image](https://user-images.githubusercontent.com/2641501/85174442-ad803600-b275-11ea-9af6-e77fd0573dcf.png)

# How it works
The effects work with SVG color filters, which are taken from here: https://github.com/hail2u/color-blindness-emulation/blob/master/filters.svg?short_path=5708e81
These filters can then be applied as CSS filters, using something like `filter: url(#deuteranopia)`.