### PR TITLE
CovidDataExplorer: Show 1 decimal place is metric is rate

### DIFF
--- a/charts/covidDataExplorer/CovidDataUtils.ts
+++ b/charts/covidDataExplorer/CovidDataUtils.ts
@@ -457,7 +457,11 @@ const buildVariableMetadata = (
     // Show decimal places for rolling average & per capita variables
     if (perCapita > 1) {
         variable.display!.numDecimalPlaces = 2
-    } else if (rollingAverage && rollingAverage > 1) {
+    } else if (
+        name === "positive_test_rate" ||
+        name === "case_fatality_rate" ||
+        (rollingAverage && rollingAverage > 1)
+    ) {
         variable.display!.numDecimalPlaces = 1
     } else {
         variable.display!.numDecimalPlaces = 0


### PR DESCRIPTION
As [Max pointed out](https://owid.slack.com/archives/C5BDCB2R3/p1592864662018900):

https://ourworldindata.org/coronavirus-data-explorer?zoomToSelection=true&positiveTestRate=true&dailyFreq=true&perCapita=true&smoothing=7&country=~MYS

<img width="985" alt="Screen Shot 2020-06-22 at 23 24 12" src="https://user-images.githubusercontent.com/1308115/85341783-ea9c3080-b4e0-11ea-9787-831b05e25902.png">
