### PR TITLE
Improve fallback styles

### DIFF
--- a/site/client/css/pages/chart.scss
+++ b/site/client/css/pages/chart.scss
@@ -42,6 +42,16 @@
     }
 }
 
+#fallback {
+    // Override any sizing rules set by the above code, so the fallback chart never overlaps the
+    // site header or other site elements
+    height: auto !important;
+    max-width: none !important;
+    max-height: none !important;
+
+    margin-top: 25px;
+}
+
 #fallback > img {
     max-width: 100%;
     border: 1px solid #ccc;

--- a/site/server/views/ChartPage.tsx
+++ b/site/server/views/ChartPage.tsx
@@ -91,6 +91,12 @@ export const ChartPage = (props: {
                     <figure data-grapher-src={`/grapher/${chart.slug}`}>
                         <LoadingIndicator color="#333" />
                     </figure>
+                    <noscript id="fallback">
+                        <img
+                            src={`${BAKED_GRAPHER_URL}/exports/${chart.slug}.svg`}
+                        />
+                        <p>Interactive visualization requires JavaScript</p>
+                    </noscript>
 
                     {post && (
                         <div className="related-research-data">
@@ -122,14 +128,6 @@ export const ChartPage = (props: {
                             )}
                         </div>
                     )}
-                    <noscript id="fallback">
-                        <h1>{chart.title}</h1>
-                        <p>{chart.subtitle}</p>
-                        <img
-                            src={`${BAKED_GRAPHER_URL}/exports/${chart.slug}.svg`}
-                        />
-                        <p>Interactive visualization requires JavaScript</p>
-                    </noscript>
                 </main>
                 <SiteFooter />
                 <script dangerouslySetInnerHTML={{ __html: script }} />


### PR DESCRIPTION
This improves the styles for our fallbacks elements when JS is disabled (`<noscript>`) or fails.

## Before
| | |
| :--- | :--- |
| ![image](https://user-images.githubusercontent.com/2641501/85399664-7650a400-b557-11ea-9276-ede643e1b52c.png) | ![image](https://user-images.githubusercontent.com/2641501/85399884-d6dfe100-b557-11ea-8cd9-430f574b559d.png) |

## After
| | |
| :--- | :--- |
| ![image](https://user-images.githubusercontent.com/2641501/85400016-0bec3380-b558-11ea-8818-8c47431fde88.png) | ![image](https://user-images.githubusercontent.com/2641501/85400053-1ad2e600-b558-11ea-8d82-7d8556ffbaef.png) |
