### PR TITLE
Fix some problems with the Country Standardizer

### DIFF
--- a/admin/client/CountryStandardizerPage.tsx
+++ b/admin/client/CountryStandardizerPage.tsx
@@ -381,7 +381,7 @@ export class CountryStandardizerPage extends React.Component {
     componentDidMount() {
         // Fetch mapping from server when the input or output format changes
         this.dispose = reaction(
-            () => this.inputFormat && this.outputFormat,
+            () => [this.inputFormat, this.outputFormat],
             () => this.fetchCountryMap()
         )
 
@@ -621,7 +621,7 @@ export class CountryStandardizerPage extends React.Component {
                         </div>
                         <SelectField
                             label="Input Format"
-                            value={CountryNameFormat.NonStandardCountryName}
+                            value={this.inputFormat}
                             onValue={this.onInputFormat}
                             options={allowedInputFormats.map(def => def.key)}
                             optionLabels={allowedInputFormats.map(
@@ -632,7 +632,7 @@ export class CountryStandardizerPage extends React.Component {
                         />
                         <SelectField
                             label="Output Format"
-                            value={CountryNameFormat.OurWorldInDataName}
+                            value={this.outputFormat}
                             onValue={this.onOutputFormat}
                             options={allowedOutputFormats.map(def => def.key)}
                             optionLabels={allowedOutputFormats.map(


### PR DESCRIPTION
Charlie had problems using the Country Standardizer tool and I'm seeing these too, so these should hopefully fix these.

The issues are as following:
* Upon selecting an input format, the `<select>` jumps back to "Non-default country name"
* Same for the output format ("Our World in Data Name")
* For this reason, it's also not possible to change back to the default after a value was changed
* For some reason, the mobx `reaction` that fetched the country name mapping didn't trigger when `inputFormat` changed, only for `outputFormat`