### PR TITLE
Selection issues fixes

### DIFF
--- a/charts/__tests__/CovidChartUrl.test.ts
+++ b/charts/__tests__/CovidChartUrl.test.ts
@@ -9,12 +9,16 @@ describe(CovidQueryParams, () => {
     })
 
     it("computes constrained params correctly", () => {
-        const params = new CovidQueryParams(`cfrMetric=true&dailyFreq=true`)
+        const params = new CovidQueryParams(
+            `cfrMetric=true&dailyFreq=true&smoothing=7`
+        )
         expect(params.dailyFreq).toEqual(true)
         expect(params.totalFreq).toEqual(false)
+        expect(params.smoothing).toEqual(7)
         const constrainedParams = params.constrainedParams
         expect(constrainedParams.dailyFreq).toEqual(false)
         expect(constrainedParams.totalFreq).toEqual(true)
+        expect(constrainedParams.smoothing).toEqual(0)
     })
 
     it("switches to 7-day smoothing param if on daily but daily is restricted", () => {

--- a/charts/__tests__/CovidExplorerTable.test.ts
+++ b/charts/__tests__/CovidExplorerTable.test.ts
@@ -125,6 +125,12 @@ describe("do not include unselected groups in aligned charts", () => {
         expect(dataTable.table.unfilteredEntities.has("World")).toBeTruthy()
         dataTable.addGroupFilterColumn()
         expect(dataTable.table.unfilteredEntities.has("World")).toBeFalsy()
+        dataTable.table.selectEntity("World")
+        expect(dataTable.table.unfilteredEntities.has("World")).toBeTruthy()
+        dataTable.table.deselectEntity("World")
+        expect(dataTable.table.unfilteredEntities.has("World")).toBeFalsy()
+        dataTable.table.setSelectedEntities(["World"])
+        expect(dataTable.table.unfilteredEntities.has("World")).toBeTruthy()
     })
 })
 

--- a/charts/__tests__/CovidExplorerTable.test.ts
+++ b/charts/__tests__/CovidExplorerTable.test.ts
@@ -42,8 +42,7 @@ describe("generateContinentRows", () => {
 })
 
 describe("build covid column", () => {
-    const parsedRows = getRows()
-    const dataTable = new CovidExplorerTable(new OwidTable([]), parsedRows)
+    const dataTable = new CovidExplorerTable(new OwidTable([]), getRows())
     dataTable.table.addRollingAverageColumn(
         { slug: "totalCasesSmoothed" },
         3,
@@ -69,8 +68,7 @@ describe("build covid column", () => {
 })
 
 describe("builds aligned tests column", () => {
-    const parsedRows = getRows()
-    const dataTable = new CovidExplorerTable(new OwidTable([]), parsedRows)
+    const dataTable = new CovidExplorerTable(new OwidTable([]), getRows())
 
     it("it has testing data", () => {
         expect(dataTable.table.columnSlugs.includes("tests-daily")).toEqual(
@@ -118,6 +116,15 @@ describe(getLeastUsedColor, () => {
         expect(
             getLeastUsedColor(["red", "green"], ["red", "green", "green"])
         ).toEqual("red")
+    })
+})
+
+describe("do not include unselected groups in aligned charts", () => {
+    const dataTable = new CovidExplorerTable(new OwidTable([]), getRows())
+    it("can filter rows without continent", () => {
+        expect(dataTable.table.unfilteredEntities.has("World")).toBeTruthy()
+        dataTable.addGroupFilterColumn()
+        expect(dataTable.table.unfilteredEntities.has("World")).toBeFalsy()
     })
 })
 

--- a/charts/covidDataExplorer/CovidChartUrl.ts
+++ b/charts/covidDataExplorer/CovidChartUrl.ts
@@ -123,10 +123,13 @@ export class CovidConstrainedQueryParams extends CovidQueryParams {
         if (this.allowEverything) return this
         const available = this.available
         const wasDaily = this.dailyFreq
+        const defaults = new CovidQueryParams("")
+
         Object.keys(available).forEach(key => {
             const typedKey = key as keyof typeof available
+            // If the key is not available, set it to the default value (generally is false, but for smoothing is 0)
             if (!available[typedKey] && (this as any)[key])
-                (this as any)[key] = false
+                (this as any)[key] = defaults[key as keyof CovidQueryParams]
         })
 
         // We always need either total or daily freq

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -563,20 +563,20 @@ export class CovidDataExplorer extends React.Component<{
     }
 
     @computed get selectedData() {
-        const countryCodeMap = this.countryCodeToEntityIdMap
+        const countryCodeMap = this.countryCodeToCountryOptionMap
         return Array.from(this.props.params.selectedCountryCodes).map(code => {
             return {
                 index: 0,
-                entityId: countryCodeMap.get(code)!,
+                entityId: countryCodeMap.get(code)!.entityId,
                 color: this.countryCodeToColorMap[code]
             }
         })
     }
 
-    @computed private get countryCodeToEntityIdMap() {
-        const countryCodeMap = new Map<entityCode, entityId>()
+    @computed private get countryCodeToCountryOptionMap() {
+        const countryCodeMap = new Map<entityCode, CountryOption>()
         this.countryOptions.forEach(country => {
-            countryCodeMap.set(country.code, country.entityId)
+            countryCodeMap.set(country.code, country)
         })
         return countryCodeMap
     }
@@ -686,6 +686,12 @@ export class CovidDataExplorer extends React.Component<{
         )
         chartProps.map.variableId = this.currentYVarId
         chartProps.map.colorScale.baseColorScheme = this.mapColorScheme
+
+        this.covidExplorerTable.table.setSelectedEntities(
+            Array.from(this.props.params.selectedCountryCodes.values()).map(
+                code => this.countryCodeToCountryOptionMap.get(code)!.name
+            )
+        )
 
         // Do not show unselected groups on scatterplots
         if (this.chartType === "ScatterPlot")

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -649,6 +649,7 @@ export class CovidDataExplorer extends React.Component<{
     private renderControlsThenUpdateChart() {
         // Updating the chart may take a second so render the Data Explorer controls immediately then the chart.
         setTimeout(() => {
+            this.selectionChangeFromBuilder = true
             this._updateChart()
         }, 1)
     }

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -94,7 +94,8 @@ export class CovidDataExplorer extends React.Component<{
 
     @action.bound clearSelectionCommand() {
         this.props.params.selectedCountryCodes.clear()
-        this.updateChart()
+        this.selectionChangeFromBuilder = true
+        this.renderControlsThenUpdateChart()
     }
 
     setTotalFrequencyCommand(option: TotalFrequencyOption) {
@@ -127,7 +128,7 @@ export class CovidDataExplorer extends React.Component<{
                 onChange: value => {
                     this.clearMetricsCommand()
                     this.props.params.casesMetric = true
-                    this.updateChart()
+                    this.renderControlsThenUpdateChart()
                 }
             },
             {
@@ -137,7 +138,7 @@ export class CovidDataExplorer extends React.Component<{
                 onChange: value => {
                     this.clearMetricsCommand()
                     this.props.params.deathsMetric = true
-                    this.updateChart()
+                    this.renderControlsThenUpdateChart()
                 }
             },
 
@@ -148,7 +149,7 @@ export class CovidDataExplorer extends React.Component<{
                 onChange: value => {
                     this.clearMetricsCommand()
                     this.props.params.cfrMetric = true
-                    this.updateChart()
+                    this.renderControlsThenUpdateChart()
                 }
             }
         ]
@@ -161,7 +162,7 @@ export class CovidDataExplorer extends React.Component<{
                 onChange: value => {
                     this.clearMetricsCommand()
                     this.props.params.testsMetric = true
-                    this.updateChart()
+                    this.renderControlsThenUpdateChart()
                 }
             },
             {
@@ -171,7 +172,7 @@ export class CovidDataExplorer extends React.Component<{
                 onChange: value => {
                     this.clearMetricsCommand()
                     this.props.params.testsPerCaseMetric = true
-                    this.updateChart()
+                    this.renderControlsThenUpdateChart()
                 }
             },
             {
@@ -181,7 +182,7 @@ export class CovidDataExplorer extends React.Component<{
                 onChange: value => {
                     this.clearMetricsCommand()
                     this.props.params.positiveTestRate = true
-                    this.updateChart()
+                    this.renderControlsThenUpdateChart()
                 }
             }
         ]
@@ -213,7 +214,7 @@ export class CovidDataExplorer extends React.Component<{
                     this.setDailyFrequencyCommand(false)
                     this.setSmoothingCommand(0)
 
-                    this.updateChart()
+                    this.renderControlsThenUpdateChart()
                 }
             },
             {
@@ -222,7 +223,7 @@ export class CovidDataExplorer extends React.Component<{
                 checked: this.constrainedParams.smoothing === 7,
                 onChange: () => {
                     this.setSmoothingCommand(7)
-                    this.updateChart()
+                    this.renderControlsThenUpdateChart()
                     this.setDailyFrequencyCommand(true)
                     this.setTotalFrequencyCommand(false)
                 }
@@ -238,7 +239,7 @@ export class CovidDataExplorer extends React.Component<{
                     this.setTotalFrequencyCommand(false)
                     this.setSmoothingCommand(0)
 
-                    this.updateChart()
+                    this.renderControlsThenUpdateChart()
                 }
             }
         ]
@@ -263,7 +264,7 @@ export class CovidDataExplorer extends React.Component<{
                 checked: this.constrainedParams.perCapita,
                 onChange: value => {
                     this.props.params.perCapita = value
-                    this.updateChart()
+                    this.renderControlsThenUpdateChart()
                 }
             }
         ]
@@ -284,7 +285,7 @@ export class CovidDataExplorer extends React.Component<{
                 checked: this.constrainedParams.aligned,
                 onChange: value => {
                     this.props.params.aligned = value
-                    this.updateChart()
+                    this.renderControlsThenUpdateChart()
                 }
             }
         ]
@@ -312,7 +313,8 @@ export class CovidDataExplorer extends React.Component<{
 
     @action.bound toggleSelectedCountryCommand(code: string, value?: boolean) {
         this.toggleSelectedCountry(code, value)
-        this.updateChart()
+        this.selectionChangeFromBuilder = true
+        this.renderControlsThenUpdateChart()
     }
 
     @computed get lastUpdated() {
@@ -644,10 +646,9 @@ export class CovidDataExplorer extends React.Component<{
     }
 
     private selectionChangeFromBuilder = false
-    updateChart() {
+    private renderControlsThenUpdateChart() {
         // Updating the chart may take a second so render the Data Explorer controls immediately then the chart.
         setTimeout(() => {
-            this.selectionChangeFromBuilder = true
             this._updateChart()
         }, 1)
     }
@@ -789,7 +790,6 @@ export class CovidDataExplorer extends React.Component<{
                 added.forEach(code => this.toggleSelectedCountry(code, true))
                 removed.forEach(code => this.toggleSelectedCountry(code, false))
                 // Trigger an update in order to apply color changes
-                console.log(newCodes.join(" "))
                 this._updateChart()
             })
         )
@@ -810,7 +810,7 @@ export class CovidDataExplorer extends React.Component<{
                             this.props.params.selectedCountryCodes = new Set(
                                 selectedEntities.map(entity => entity.code)
                             )
-                            this.updateChart()
+                            this.renderControlsThenUpdateChart()
                         }
                     },
                     { fireImmediately: true }

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -685,6 +685,11 @@ export class CovidDataExplorer extends React.Component<{
         chartProps.map.variableId = this.currentYVarId
         chartProps.map.colorScale.baseColorScheme = this.mapColorScheme
 
+        // Do not show unselected groups on scatterplots
+        if (this.chartType === "ScatterPlot")
+            this.covidExplorerTable.addGroupFilterColumn()
+        else this.covidExplorerTable.removeGroupFilterColumn()
+
         if (this.constrainedParams.testsPerCaseMetric)
             Object.assign(chartProps.map, this.mapConfigs.tests_per_case)
         if (this.constrainedParams.positiveTestRate)

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -562,12 +562,13 @@ export class CovidDataExplorer extends React.Component<{
         return ""
     }
 
-    @computed get selectedData() {
+    @computed private get selectedData() {
         const countryCodeMap = this.countryCodeToCountryOptionMap
         return Array.from(this.props.params.selectedCountryCodes).map(code => {
+            const countryOption = countryCodeMap.get(code)
             return {
                 index: 0,
-                entityId: countryCodeMap.get(code)!.entityId,
+                entityId: countryOption ? countryOption.entityId : 0,
                 color: this.countryCodeToColorMap[code]
             }
         })
@@ -662,6 +663,13 @@ export class CovidDataExplorer extends React.Component<{
         )
     }
 
+    private getSelectedEntityNames() {
+        return Array.from(this.props.params.selectedCountryCodes.values())
+            .map(code => this.countryCodeToCountryOptionMap.get(code))
+            .filter(i => i)
+            .map(option => option!.name)
+    }
+
     // We can't create a new chart object with every radio change because the Chart component itself
     // maintains state (for example, which tab is currently active). Temporary workaround is just to
     // manually update the chart when the chart builderselections change.
@@ -688,9 +696,7 @@ export class CovidDataExplorer extends React.Component<{
         chartProps.map.colorScale.baseColorScheme = this.mapColorScheme
 
         this.covidExplorerTable.table.setSelectedEntities(
-            Array.from(this.props.params.selectedCountryCodes.values()).map(
-                code => this.countryCodeToCountryOptionMap.get(code)!.name
-            )
+            this.getSelectedEntityNames()
         )
 
         // Do not show unselected groups on scatterplots

--- a/charts/covidDataExplorer/CovidExplorerTable.ts
+++ b/charts/covidDataExplorer/CovidExplorerTable.ts
@@ -113,7 +113,7 @@ export class CovidExplorerTable {
         return filtered.concat(continentRows, euRows)
     }
 
-    buildCovidVariableId(
+    private static buildCovidVariableId(
         name: MetricKind,
         perCapita: number,
         rollingAverage?: number,
@@ -180,7 +180,7 @@ export class CovidExplorerTable {
     ): ColumnSpec {
         const spec = cloneDeep(columnSpecs[name]) as ColumnSpec
         spec.slug = this.getColumnSlug(name, perCapita, daily, rollingAverage)
-        spec.owidVariableId = this.buildCovidVariableId(
+        spec.owidVariableId = CovidExplorerTable.buildCovidVariableId(
             name,
             perCapita,
             rollingAverage,
@@ -383,7 +383,11 @@ export class CovidExplorerTable {
 
     private groupFilterSlug = "group_filter"
     addGroupFilterColumn() {
-        this.table.addFilterColumn(this.groupFilterSlug, row => row.continent)
+        if (!this.table.columnsBySlug.has(this.groupFilterSlug))
+            this.table.addFilterColumn(
+                this.groupFilterSlug,
+                row => row.continent
+            )
     }
 
     removeGroupFilterColumn() {

--- a/charts/covidDataExplorer/CovidExplorerTable.ts
+++ b/charts/covidDataExplorer/CovidExplorerTable.ts
@@ -320,15 +320,8 @@ export class CovidExplorerTable {
     }
 
     initCfrColumn(params: CovidConstrainedQueryParams) {
-        if (params.dailyFreq)
-            this.initColumn(params, row =>
-                row.total_cases < 100
-                    ? undefined
-                    : row.new_cases && row.new_deaths
-                    ? (100 * row.new_deaths) / row.new_cases
-                    : 0
-            )
-        else if (params.totalFreq)
+        // We do not support daily freq for CFR
+        if (params.totalFreq)
             this.initColumn(params, row =>
                 row.total_cases < 100
                     ? undefined

--- a/charts/covidDataExplorer/CovidExplorerTable.ts
+++ b/charts/covidDataExplorer/CovidExplorerTable.ts
@@ -381,6 +381,15 @@ export class CovidExplorerTable {
         )
     }
 
+    private groupFilterSlug = "group_filter"
+    addGroupFilterColumn() {
+        this.table.addFilterColumn(this.groupFilterSlug, row => row.continent)
+    }
+
+    removeGroupFilterColumn() {
+        this.table.deleteColumnBySlug(this.groupFilterSlug)
+    }
+
     initRequestedColumns(params: CovidConstrainedQueryParams) {
         if (params.casesMetric) this.initCasesColumn(params)
         if (params.deathsMetric) this.initDeathsColumn(params)

--- a/charts/owidData/OwidTable.ts
+++ b/charts/owidData/OwidTable.ts
@@ -446,6 +446,10 @@ export class OwidTable extends AbstractTable<OwidRow> {
         return Array.from(new Set(this.rows.map(row => row.entityName)))
     }
 
+    @computed get unfilteredEntities() {
+        return new Set(this.unfilteredRows.map(row => row.entityName))
+    }
+
     // todo: can we remove at some point?
     @computed get entityIdToNameMap() {
         const map = new Map<entityId, entityName>()


### PR DESCRIPTION
This moves toward a new selection system and fixes a few issues.

On scatterplots, unselected groups (like World, EU, etc) are now filtered.

Before:
![Screen Shot 2020-07-06 at 2 03 23 PM](https://user-images.githubusercontent.com/74692/86671598-832aba00-bf91-11ea-9718-e8cd731e2551.png)

After:
![Screen Shot 2020-07-06 at 2 03 29 PM](https://user-images.githubusercontent.com/74692/86671583-7f973300-bf91-11ea-8f7a-abb72a7317e5.png)

Selection now also trumps filtering:

Viewing aligned and then selecting "World":
![Screen Shot 2020-07-06 at 2 05 16 PM](https://user-images.githubusercontent.com/74692/86671836-bd945700-bf91-11ea-9fe1-4d6de22a95f6.png)

Hiding small countries then selecting "Iceland":
![Screen Shot 2020-07-06 at 2 06 56 PM](https://user-images.githubusercontent.com/74692/86672051-f7fdf400-bf91-11ea-8f89-f79e1026d99d.png)


