### PR TITLE
"Related Charts" dynamic links

### DIFF
--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -79,7 +79,6 @@ import { countries } from "utils/countries"
 import { DataTableTransform } from "./DataTableTransform"
 import { getWindowQueryParams } from "utils/client/url"
 import { populationMap } from "./PopulationMap"
-import { EntityDimensionKey } from "./EntityDimensionKey"
 
 declare const App: any
 declare const window: any

--- a/charts/ChartUrl.ts
+++ b/charts/ChartUrl.ts
@@ -381,7 +381,12 @@ export class ChartUrl implements ObservableUrl {
 
         // Selected countries -- we can't actually look these up until we have the data
         const country = params.country
-        if (chart.props.useV2 || !country) return
+        if (
+            chart.props.useV2 ||
+            !country ||
+            chart.addCountryMode === "disabled"
+        )
+            return
         when(
             () => chart.isReady,
             () => {

--- a/charts/ChartUrl.ts
+++ b/charts/ChartUrl.ts
@@ -51,7 +51,7 @@ export class EntityUrlBuilder {
     private static v1Delimiter = "+"
     private static v2Delimiter = "~"
 
-    static entitiesToQueryParams(entities: entityCodeOrName[]) {
+    static entitiesToQueryParam(entities: entityCodeOrName[]) {
         // Always include a v2Delimiter in a v2 link. When decoding we will drop any empty strings.
         if (entities.length === 1)
             return encodeURIComponent(this.v2Delimiter + entities[0])
@@ -78,7 +78,7 @@ export class EntityUrlBuilder {
     }
 
     private static decodeV2Link(queryParam: string) {
-        // Faceboook turns %20 into +. v2 links will never contain a +, so we can safely replace all of them with %20.
+        // Facebook turns %20 into +. v2 links will never contain a +, so we can safely replace all of them with %20.
         return decodeURIComponent(queryParam.replace(/\+/g, "%20"))
             .split(this.v2Delimiter)
             .filter(item => item)
@@ -251,7 +251,7 @@ export class ChartUrl implements ObservableUrl {
             JSON.stringify(chart.props.selectedData) !==
                 JSON.stringify(origChartProps.selectedData)
         ) {
-            return EntityUrlBuilder.entitiesToQueryParams(
+            return EntityUrlBuilder.entitiesToQueryParam(
                 chart.data.selectedEntityCodes
             )
         } else {

--- a/charts/Util.ts
+++ b/charts/Util.ts
@@ -863,3 +863,10 @@ export const getErrorMessageRelatedQuestionUrl = (
               undefined
         : undefined
 }
+
+export function getAttributesOfHTMLElement(el: HTMLElement) {
+    const attributes: { [key: string]: string } = {}
+    each(el.attributes, attr => (attributes[attr.name] = attr.value))
+
+    return attributes
+}

--- a/charts/__tests__/ChartUrl.test.ts
+++ b/charts/__tests__/ChartUrl.test.ts
@@ -373,7 +373,7 @@ describe(EntityUrlBuilder, () => {
     encodeTests.forEach(testCase => {
         it(`correctly encodes url strings`, () => {
             expect(
-                EntityUrlBuilder.entitiesToQueryParams(testCase.entities)
+                EntityUrlBuilder.entitiesToQueryParam(testCase.entities)
             ).toEqual(testCase.queryString)
         })
 

--- a/charts/covidDataExplorer/CovidChartUrl.ts
+++ b/charts/covidDataExplorer/CovidChartUrl.ts
@@ -104,7 +104,7 @@ export class CovidQueryParams {
         params.hideControls = this.hideControls ? true : undefined
         params.perCapita = this.perCapita ? true : undefined
         params.smoothing = this.smoothing
-        params.country = EntityUrlBuilder.entitiesToQueryParams(
+        params.country = EntityUrlBuilder.entitiesToQueryParam(
             Array.from(this.selectedCountryCodes)
         )
         params.pickerMetric = this.countryPickerMetric

--- a/site/client/EmbedChart.tsx
+++ b/site/client/EmbedChart.tsx
@@ -10,13 +10,15 @@ import {
 } from "mobx"
 import { ChartConfig } from "charts/ChartConfig"
 import { ChartFigureView } from "./ChartFigureView"
+import { splitURLintoPathAndQueryString } from "utils/client/url"
+
 @observer
 export class EmbedChart extends React.Component<{ src: string }> {
     @computed get configUrl(): string {
-        return this.props.src.split(/\?/)[0]
+        return splitURLintoPathAndQueryString(this.props.src).path
     }
-    @computed get queryStr(): string {
-        return this.props.src.split(/\?/)[1]
+    @computed get queryStr(): string | undefined {
+        return splitURLintoPathAndQueryString(this.props.src).queryString
     }
     @observable chart?: ChartConfig
 

--- a/site/client/Lightbox.tsx
+++ b/site/client/Lightbox.tsx
@@ -9,6 +9,7 @@ import { faDownload } from "@fortawesome/free-solid-svg-icons/faDownload"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch"
 import { LoadingIndicator } from "site/client/LoadingIndicator"
+import { PROMINENT_LINK_CLASSNAME } from "./blocks/ProminentLink/ProminentLink"
 
 const Lightbox = ({
     children,
@@ -138,7 +139,7 @@ export const runLightbox = () => {
         document.querySelectorAll<HTMLImageElement>(".article-content img")
     ).forEach(img => {
         if (
-            img.closest(".wp-block-owid-prominent-link") ||
+            img.closest(`.${PROMINENT_LINK_CLASSNAME}`) ||
             img.closest("[data-no-lightbox]")
         )
             return

--- a/site/client/SearchResults.tsx
+++ b/site/client/SearchResults.tsx
@@ -28,7 +28,7 @@ class ChartResult extends React.Component<{
         else
             return (
                 hit.slug +
-                `?tab=chart&country=${EntityUrlBuilder.entitiesToQueryParams(
+                `?tab=chart&country=${EntityUrlBuilder.entitiesToQueryParam(
                     entities
                 )}`
             )
@@ -162,7 +162,7 @@ export class SearchResults extends React.Component<{
         else
             return (
                 bestChartHit.slug +
-                `?tab=chart&country=${EntityUrlBuilder.entitiesToQueryParams(
+                `?tab=chart&country=${EntityUrlBuilder.entitiesToQueryParam(
                     bestChartEntities
                 )}`
             )

--- a/site/client/blocks/ProminentLink/ProminentLink.tsx
+++ b/site/client/blocks/ProminentLink/ProminentLink.tsx
@@ -82,15 +82,10 @@ class ProminentLink extends React.Component<{
     }
 
     render() {
-        const updatedURL = this.originalURLPath.includes(
-            "total-covid-deaths-region"
-        )
-            ? this.props.originalURL
-            : this.updatedURL
         return (
             <a
                 dangerouslySetInnerHTML={{ __html: this.props.innerHTML ?? "" }}
-                href={updatedURL}
+                href={this.updatedURL}
             />
         )
     }

--- a/site/client/blocks/ProminentLink/ProminentLink.tsx
+++ b/site/client/blocks/ProminentLink/ProminentLink.tsx
@@ -23,12 +23,12 @@ class ProminentLink extends React.Component<{
         return splitURLintoPathAndQueryString(this.props.originalURL).path
     }
 
-    @computed get originalURLQueryString(): string | undefined {
+    @computed private get originalURLQueryString(): string | undefined {
         return splitURLintoPathAndQueryString(this.props.originalURL)
             .queryString
     }
 
-    @computed get originalURLQueryParams(): QueryParams | undefined {
+    @computed private get originalURLQueryParams(): QueryParams | undefined {
         const { originalURLQueryString } = this
 
         return originalURLQueryString
@@ -36,7 +36,7 @@ class ProminentLink extends React.Component<{
             : undefined
     }
 
-    @computed get originalURLEntityCodes(): string[] {
+    @computed private get originalURLEntityCodes(): string[] {
         const originalEntityQueryParam = this.originalURLQueryParams?.[
             "country"
         ]
@@ -50,13 +50,13 @@ class ProminentLink extends React.Component<{
             : []
     }
 
-    @computed get entitiesInGlobalEntitySelection(): string[] {
+    @computed private get entitiesInGlobalEntitySelection(): string[] {
         return Grapher.globalEntitySelection.selectedEntities.map(
             entity => entity.code
         )
     }
 
-    @computed get updatedEntityQueryParam(): string {
+    @computed private get updatedEntityQueryParam(): string {
         const newEntityList = union(
             this.originalURLEntityCodes,
             this.entitiesInGlobalEntitySelection
@@ -65,7 +65,7 @@ class ProminentLink extends React.Component<{
         return EntityUrlBuilder.entitiesToQueryParam(newEntityList)
     }
 
-    @computed get updatedURLParams(): QueryParams {
+    @computed private get updatedURLParams(): QueryParams {
         const { originalURLQueryParams, updatedEntityQueryParam } = this
 
         return {
@@ -76,7 +76,7 @@ class ProminentLink extends React.Component<{
         }
     }
 
-    @computed get updatedURL() {
+    @computed private get updatedURL() {
         return this.originalURLPath + queryParamsToStr(this.updatedURLParams)
     }
 

--- a/site/client/blocks/ProminentLink/ProminentLink.tsx
+++ b/site/client/blocks/ProminentLink/ProminentLink.tsx
@@ -23,12 +23,12 @@ class ProminentLink extends React.Component<{
         return splitURLintoPathAndQueryString(this.props.originalURL).path
     }
 
-    @computed get originalURLQueryString() {
+    @computed get originalURLQueryString(): string | undefined {
         return splitURLintoPathAndQueryString(this.props.originalURL)
             .queryString
     }
 
-    @computed get originalURLQueryParams() {
+    @computed get originalURLQueryParams(): QueryParams | undefined {
         const { originalURLQueryString } = this
 
         return originalURLQueryString
@@ -36,7 +36,7 @@ class ProminentLink extends React.Component<{
             : undefined
     }
 
-    @computed get originalURLEntityCodes() {
+    @computed get originalURLEntityCodes(): string[] {
         const originalEntityQueryParam = this.originalURLQueryParams?.[
             "country"
         ]
@@ -50,14 +50,14 @@ class ProminentLink extends React.Component<{
             : []
     }
 
-    @computed get entitiesInGlobalEntitySelection() {
+    @computed get entitiesInGlobalEntitySelection(): string[] {
         // return Grapher.globalEntitySelection.url?.params.country ?? ""
         return Grapher.globalEntitySelection.selectedEntities.map(
             entity => entity.code
         )
     }
 
-    @computed get updatedEntityQueryParam() {
+    @computed get updatedEntityQueryParam(): string {
         const newEntityList = union(
             this.originalURLEntityCodes,
             this.entitiesInGlobalEntitySelection

--- a/site/client/blocks/ProminentLink/ProminentLink.tsx
+++ b/site/client/blocks/ProminentLink/ProminentLink.tsx
@@ -12,7 +12,7 @@ import {
 import { EntityUrlBuilder } from "charts/ChartUrl"
 import { union, isEmpty } from "charts/Util"
 
-const PROMINENT_LINK_CLASSNAME = "wp-block-owid-prominent-link"
+export const PROMINENT_LINK_CLASSNAME = "wp-block-owid-prominent-link"
 
 @observer
 class ProminentLink extends React.Component<{

--- a/site/client/blocks/ProminentLink/ProminentLink.tsx
+++ b/site/client/blocks/ProminentLink/ProminentLink.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import ReactDOMServer from "react-dom/server"
+
+const PROMINENT_LINK_CLASSNAME = "wp-block-owid-prominent-link"
+
+const ProminentLink = ({ content }: { content: string | null }) => {
+    return (
+        <div className={PROMINENT_LINK_CLASSNAME}>
+            <a dangerouslySetInnerHTML={{ __html: content ?? "" }} href=""></a>
+        </div>
+    )
+}
+
+export const render = ($: CheerioStatic) => {
+    $(`.${PROMINENT_LINK_CLASSNAME}>a`).each((index, el) => {
+        const $block = $(el)
+        const innerHTML = $block.html()
+
+        const rendered = ReactDOMServer.renderToStaticMarkup(
+            <ProminentLink content={innerHTML} />
+        )
+
+        $block.after(rendered)
+        $block.remove()
+    })
+}

--- a/site/client/blocks/ProminentLink/ProminentLink.tsx
+++ b/site/client/blocks/ProminentLink/ProminentLink.tsx
@@ -10,22 +10,25 @@ import {
     QueryParams
 } from "utils/client/url"
 import { EntityUrlBuilder } from "charts/ChartUrl"
-import { union, isEmpty } from "charts/Util"
+import { union, isEmpty, getAttributesOfHTMLElement } from "charts/Util"
 
 export const PROMINENT_LINK_CLASSNAME = "wp-block-owid-prominent-link"
 
 @observer
 class ProminentLink extends React.Component<{
-    originalURL: string
+    originalAnchorAttributes: { [key: string]: string }
     innerHTML: string | null
 }> {
     @computed get originalURLPath() {
-        return splitURLintoPathAndQueryString(this.props.originalURL).path
+        return splitURLintoPathAndQueryString(
+            this.props.originalAnchorAttributes.href
+        ).path
     }
 
     @computed private get originalURLQueryString(): string | undefined {
-        return splitURLintoPathAndQueryString(this.props.originalURL)
-            .queryString
+        return splitURLintoPathAndQueryString(
+            this.props.originalAnchorAttributes.href
+        ).queryString
     }
 
     @computed private get originalURLQueryParams(): QueryParams | undefined {
@@ -84,6 +87,7 @@ class ProminentLink extends React.Component<{
         return (
             <a
                 dangerouslySetInnerHTML={{ __html: this.props.innerHTML ?? "" }}
+                {...this.props.originalAnchorAttributes}
                 href={this.updatedURL}
             />
         )
@@ -97,13 +101,12 @@ export const renderProminentLink = () => {
             const anchorTag = el.querySelector("a")
             if (!anchorTag) return
 
-            const originalUrl = anchorTag.href
-            const innerHTML = anchorTag.innerHTML
-
             const rendered = (
                 <ProminentLink
-                    originalURL={originalUrl}
-                    innerHTML={innerHTML}
+                    originalAnchorAttributes={getAttributesOfHTMLElement(
+                        anchorTag
+                    )}
+                    innerHTML={anchorTag.innerHTML}
                 />
             )
 

--- a/site/client/blocks/ProminentLink/ProminentLink.tsx
+++ b/site/client/blocks/ProminentLink/ProminentLink.tsx
@@ -90,7 +90,7 @@ class ProminentLink extends React.Component<{
     }
 }
 
-export const render = () => {
+export const renderProminentLink = () => {
     document
         .querySelectorAll<HTMLElement>(`.${PROMINENT_LINK_CLASSNAME}`)
         .forEach(el => {

--- a/site/client/blocks/ProminentLink/ProminentLink.tsx
+++ b/site/client/blocks/ProminentLink/ProminentLink.tsx
@@ -51,7 +51,6 @@ class ProminentLink extends React.Component<{
     }
 
     @computed get entitiesInGlobalEntitySelection(): string[] {
-        // return Grapher.globalEntitySelection.url?.params.country ?? ""
         return Grapher.globalEntitySelection.selectedEntities.map(
             entity => entity.code
         )

--- a/site/client/blocks/index.ts
+++ b/site/client/blocks/index.ts
@@ -3,7 +3,7 @@ import {
     render as renderAdditionalInformation
 } from "./AdditionalInformation/AdditionalInformation"
 import { render as renderHelp } from "./Help/Help"
-import { render as renderProminentLink } from "./ProminentLink/ProminentLink"
+import { renderProminentLink } from "./ProminentLink/ProminentLink"
 import { shouldProgressiveEmbed } from "../Grapher"
 
 export const renderBlocks = ($: CheerioStatic) => {

--- a/site/client/blocks/index.ts
+++ b/site/client/blocks/index.ts
@@ -3,11 +3,13 @@ import {
     render as renderAdditionalInformation
 } from "./AdditionalInformation/AdditionalInformation"
 import { render as renderHelp } from "./Help/Help"
+import { render as renderProminentLink } from "./ProminentLink/ProminentLink"
 import { shouldProgressiveEmbed } from "../Grapher"
 
 export const renderBlocks = ($: CheerioStatic) => {
     renderAdditionalInformation($)
     renderHelp($)
+    renderProminentLink($)
 }
 export const runBlocks = () => {
     if (!shouldProgressiveEmbed()) {

--- a/site/client/blocks/index.ts
+++ b/site/client/blocks/index.ts
@@ -9,7 +9,6 @@ import { shouldProgressiveEmbed } from "../Grapher"
 export const renderBlocks = ($: CheerioStatic) => {
     renderAdditionalInformation($)
     renderHelp($)
-    renderProminentLink($)
 }
 export const runBlocks = () => {
     if (!shouldProgressiveEmbed()) {
@@ -20,4 +19,5 @@ export const runBlocks = () => {
             .classList.add("is-not-chart-interactive")
     }
     hydrateAdditionalInformation()
+    renderProminentLink()
 }

--- a/site/client/figures/ChartFigure.ts
+++ b/site/client/figures/ChartFigure.ts
@@ -2,6 +2,7 @@ import { ChartView } from "charts/ChartView"
 import { excludeUndefined, fetchText } from "charts/Util"
 
 import { Figure, LoadProps } from "./Figure"
+import { splitURLintoPathAndQueryString } from "utils/client/url"
 
 /**
  * Given the HTML of a ChartPage, it extracts the chart's config as JSON
@@ -13,7 +14,7 @@ export function readConfigFromHTML(html: string): any {
 
 interface ChartFigureProps {
     configUrl: string
-    queryStr: string
+    queryStr?: string
     container: HTMLElement // TODO rename to container
 }
 
@@ -68,10 +69,12 @@ export class ChartFigure implements Figure {
             elements.map(element => {
                 const dataSrc = element.getAttribute("data-grapher-src")
                 if (!dataSrc) return undefined
-                const [configUrl, queryStr] = dataSrc.split(/\?/)
+                const { path, queryString } = splitURLintoPathAndQueryString(
+                    dataSrc
+                )
                 return new ChartFigure({
-                    configUrl,
-                    queryStr,
+                    configUrl: path,
+                    queryStr: queryString,
                     container: element
                 })
             })

--- a/site/client/figures/CovidExplorerFigure.ts
+++ b/site/client/figures/CovidExplorerFigure.ts
@@ -6,7 +6,7 @@ import { Figure, LoadProps } from "./Figure"
 import { splitURLintoPathAndQueryString } from "utils/client/url"
 
 interface CovidExplorerFigureProps {
-    queryStr: string
+    queryStr?: string
     container: HTMLElement
 }
 

--- a/site/client/figures/CovidExplorerFigure.ts
+++ b/site/client/figures/CovidExplorerFigure.ts
@@ -3,6 +3,7 @@ import { covidDashboardSlug } from "charts/covidDataExplorer/CovidConstants"
 import { excludeUndefined } from "charts/Util"
 
 import { Figure, LoadProps } from "./Figure"
+import { splitURLintoPathAndQueryString } from "utils/client/url"
 
 interface CovidExplorerFigureProps {
     queryStr: string
@@ -55,7 +56,10 @@ export class CovidExplorerFigure implements Figure {
             elements.map(element => {
                 const dataSrc = element.getAttribute("data-explorer-src")
                 if (!dataSrc) return undefined
-                const [explorerUrl, queryStr] = dataSrc.split(/\?/)
+                const {
+                    path: explorerUrl,
+                    queryString: queryStr
+                } = splitURLintoPathAndQueryString(dataSrc)
                 if (!explorerUrl.includes(covidDashboardSlug)) return undefined
                 return new CovidExplorerFigure({
                     queryStr,

--- a/site/client/global-entity/GlobalEntitySelectionUrl.ts
+++ b/site/client/global-entity/GlobalEntitySelectionUrl.ts
@@ -24,7 +24,7 @@ export class GlobalEntitySelectionUrl implements ObservableUrl {
         const entities = this.globalEntitySelection.selectedEntities
         // Do not add 'country' param unless at least one country is selected
         if (entities.length > 0) {
-            params.country = EntityUrlBuilder.entitiesToQueryParams(
+            params.country = EntityUrlBuilder.entitiesToQueryParam(
                 entities.map(entity => entity.code)
             )
         }

--- a/site/server/formatting.tsx
+++ b/site/server/formatting.tsx
@@ -22,6 +22,7 @@ import { Country } from "utils/countries"
 import { covidDefaultCountryPlaceholder } from "./covid/CovidConstants"
 import { covidDashboardSlug } from "charts/covidDataExplorer/CovidConstants"
 import { LoadingIndicator } from "site/client/LoadingIndicator"
+import { PROMINENT_LINK_CLASSNAME } from "site/client/blocks/ProminentLink/ProminentLink"
 
 // A modifed FontAwesome icon
 const INTERACTIVE_ICON_SVG = `<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="hand-pointer" class="svg-inline--fa fa-hand-pointer fa-w-14" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 617">
@@ -430,7 +431,7 @@ export async function formatWordpressPost(
                     tocHeadings.push(tocHeading)
                     parentHeading = tocHeading
                 } else if (
-                    $heading.closest(".wp-block-owid-prominent-link").length ===
+                    $heading.closest(`.${PROMINENT_LINK_CLASSNAME}`).length ===
                         0 &&
                     $heading.closest(".wp-block-owid-additional-information")
                         .length === 0
@@ -449,7 +450,7 @@ export async function formatWordpressPost(
         // Add deep link for headings not contained in <a> tags already
         // (e.g. within a prominent link block)
         if (
-            !$heading.closest(".wp-block-owid-prominent-link").length && // already wrapped in <a>
+            !$heading.closest(`.${PROMINENT_LINK_CLASSNAME}`).length && // already wrapped in <a>
             !$heading.closest(".wp-block-owid-additional-information").length && // prioritize clean SSR of AdditionalInformation
             !$heading.closest(".wp-block-help").length
         ) {
@@ -577,7 +578,7 @@ export async function formatWordpressPost(
                     // TODO: remove temporary support for pre-Gutenberg images and associated captions
                     el.name === "h6" ||
                     ($el.find("img").length !== 0 &&
-                        !$el.hasClass("wp-block-owid-prominent-link") &&
+                        !$el.hasClass(PROMINENT_LINK_CLASSNAME) &&
                         !$el.find(
                             ".wp-block-owid-additional-information[data-variation='merge-left']"
                         ))

--- a/utils/client/url.ts
+++ b/utils/client/url.ts
@@ -65,3 +65,10 @@ export function setWindowQueryStr(str: string) {
         window.location.pathname + str + window.location.hash
     )
 }
+
+export function splitURLintoPathAndQueryString(
+    url: string
+): { path: string; queryString: string | undefined } {
+    const [path, queryString] = url.split(/\?/)
+    return { path: path, queryString: queryString }
+}


### PR DESCRIPTION
This PR:
- syncs "Related Charts" links on pages with the floating country selector list of entities, adding to a link if the link already specifies entities on its own.
- renames `entitiesToQueryParams` to `entitiesToQueryParam` as the return value is a single query parameter
- creates a `splitURLintoPathAndQueryString` function
- makes Charts with disabled "Add country" buttons ignore entity query parameters

Check it out live at: https://nightingale-owid.netlify.app/covid-deaths

Note, we will eventually need to isolate out a `RelatedChartLink` component out of the `ProminentLink` component on the Wordpress, especially if the floating country selector expands to appear across the website.