### PR TITLE
Use white background in lightbox

### DIFF
--- a/site/client/css/components/lightbox.scss
+++ b/site/client/css/components/lightbox.scss
@@ -28,6 +28,7 @@
         display: block; // prevent stretching large images on Safari
         & > * {
             max-height: 100vh; // prevent tall images from overflowing
+            background: white;
         }
     }
 


### PR DESCRIPTION
Fixes the issue with the Germany Covid post, mentioned here: https://owid.slack.com/archives/C46U9LXRR/p1593820854047200