### PR TITLE
Editor option to control DataTable column selection

### DIFF
--- a/admin/client/ChartEditor.ts
+++ b/admin/client/ChartEditor.ts
@@ -168,6 +168,8 @@ export class ChartEditor {
     async saveChart({ onError }: { onError?: () => void } = {}) {
         const { chart, isNewChart, currentChartJson } = this
 
+        debugger
+
         const targetUrl = isNewChart
             ? "/api/charts"
             : `/api/charts/${chart.props.id}`

--- a/admin/client/ChartEditor.ts
+++ b/admin/client/ChartEditor.ts
@@ -168,8 +168,6 @@ export class ChartEditor {
     async saveChart({ onError }: { onError?: () => void } = {}) {
         const { chart, isNewChart, currentChartJson } = this
 
-        debugger
-
         const targetUrl = isNewChart
             ? "/api/charts"
             : `/api/charts/${chart.props.id}`

--- a/admin/client/DimensionCard.tsx
+++ b/admin/client/DimensionCard.tsx
@@ -15,6 +15,10 @@ import { faChevronUp } from "@fortawesome/free-solid-svg-icons/faChevronUp"
 import { faExchangeAlt } from "@fortawesome/free-solid-svg-icons/faExchangeAlt"
 import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import {
+    OwidVariableDisplaySettings,
+    OwidVariableTableDisplaySettings
+} from "charts/owidData/OwidVariable"
 
 @observer
 export class DimensionCard extends React.Component<{
@@ -46,8 +50,11 @@ export class DimensionCard extends React.Component<{
     }
 
     @computed private get tableDisplaySettings() {
-        const { tableDisplay } = this.props.dimension.props.display
-        if (!tableDisplay) return
+        const { spec } = this.props.dimension.column
+        if (!spec.display) spec.display = new OwidVariableDisplaySettings()
+        if (!spec.display.tableDisplay)
+            spec.display.tableDisplay = new OwidVariableTableDisplaySettings()
+        const { tableDisplay } = spec.display
         return (
             <React.Fragment>
                 <hr className="ui divider" />

--- a/admin/client/DimensionCard.tsx
+++ b/admin/client/DimensionCard.tsx
@@ -53,14 +53,14 @@ export class DimensionCard extends React.Component<{
                 <hr className="ui divider" />
                 Table:
                 <Toggle
-                    label="Show absolute change column"
-                    value={tableDisplay.showAbsoluteChange}
-                    onValue={value => (tableDisplay.showAbsoluteChange = value)}
+                    label="Hide absolute change column"
+                    value={tableDisplay.hideAbsoluteChange}
+                    onValue={value => (tableDisplay.hideAbsoluteChange = value)}
                 />
                 <Toggle
-                    label="Show relative change column"
-                    value={tableDisplay.showRelativeChange}
-                    onValue={value => (tableDisplay.showRelativeChange = value)}
+                    label="Hide relative change column"
+                    value={tableDisplay.hideRelativeChange}
+                    onValue={value => (tableDisplay.hideRelativeChange = value)}
                 />
                 <hr className="ui divider" />
             </React.Fragment>

--- a/admin/client/DimensionCard.tsx
+++ b/admin/client/DimensionCard.tsx
@@ -15,10 +15,6 @@ import { faChevronUp } from "@fortawesome/free-solid-svg-icons/faChevronUp"
 import { faExchangeAlt } from "@fortawesome/free-solid-svg-icons/faExchangeAlt"
 import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import {
-    OwidVariableDisplaySettings,
-    OwidVariableTableDisplaySettings
-} from "charts/owidData/OwidVariable"
 
 @observer
 export class DimensionCard extends React.Component<{
@@ -49,12 +45,9 @@ export class DimensionCard extends React.Component<{
         this.props.dimension.props.saveToVariable = value || undefined
     }
 
-    @computed private get tableDisplaySettings() {
-        const { spec } = this.props.dimension.column
-        if (!spec.display) spec.display = new OwidVariableDisplaySettings()
-        if (!spec.display.tableDisplay)
-            spec.display.tableDisplay = new OwidVariableTableDisplaySettings()
-        const { tableDisplay } = spec.display
+    private get tableDisplaySettings() {
+        const { tableDisplay } = this.props.dimension.props.display
+        if (!tableDisplay) return
         return (
             <React.Fragment>
                 <hr className="ui divider" />

--- a/admin/client/DimensionCard.tsx
+++ b/admin/client/DimensionCard.tsx
@@ -45,6 +45,28 @@ export class DimensionCard extends React.Component<{
         this.props.dimension.props.saveToVariable = value || undefined
     }
 
+    @computed private get tableDisplaySettings() {
+        const { tableDisplay } = this.props.dimension.props.display
+        if (!tableDisplay) return
+        return (
+            <React.Fragment>
+                <hr className="ui divider" />
+                Table:
+                <Toggle
+                    label="Show absolute change column"
+                    value={tableDisplay.showAbsoluteChange}
+                    onValue={value => (tableDisplay.showAbsoluteChange = value)}
+                />
+                <Toggle
+                    label="Show relative change column"
+                    value={tableDisplay.showRelativeChange}
+                    onValue={value => (tableDisplay.showRelativeChange = value)}
+                />
+                <hr className="ui divider" />
+            </React.Fragment>
+        )
+    }
+
     render() {
         const { dimension, editor } = this.props
         const { chart } = editor
@@ -131,6 +153,7 @@ export class DimensionCard extends React.Component<{
                             auto={dimension.unitConversionFactor}
                             helpText={`Multiply all values by this amount`}
                         />
+                        {this.tableDisplaySettings}
                         {(chart.isScatter ||
                             chart.isDiscreteBar ||
                             chart.isLineChart) && (

--- a/charts/ChartDimension.ts
+++ b/charts/ChartDimension.ts
@@ -4,7 +4,10 @@
 import { observable } from "mobx"
 import { extend } from "./Util"
 import { Time } from "./TimeBounds"
-import { OwidVariableDisplaySettings } from "./owidData/OwidVariable"
+import {
+    OwidVariableDisplaySettings,
+    OwidVariableTableDisplaySettings
+} from "./owidData/OwidVariable"
 import { owidVariableId } from "./owidData/OwidTable"
 
 export declare type dimensionProperty = "y" | "x" | "size" | "color"
@@ -29,7 +32,8 @@ export class ChartDimension implements DimensionSpec {
         isProjection: undefined,
         conversionFactor: undefined,
         numDecimalPlaces: undefined,
-        tolerance: undefined
+        tolerance: undefined,
+        tableDisplay: new OwidVariableTableDisplaySettings()
     }
 
     // XXX move this somewhere else, it's only used for scatter x override

--- a/charts/ChartDimension.ts
+++ b/charts/ChartDimension.ts
@@ -32,7 +32,8 @@ export class ChartDimension implements DimensionSpec {
         isProjection: undefined,
         conversionFactor: undefined,
         numDecimalPlaces: undefined,
-        tolerance: undefined
+        tolerance: undefined,
+        tableDisplay: new OwidVariableTableDisplaySettings()
     }
 
     // XXX move this somewhere else, it's only used for scatter x override

--- a/charts/ChartDimension.ts
+++ b/charts/ChartDimension.ts
@@ -32,8 +32,7 @@ export class ChartDimension implements DimensionSpec {
         isProjection: undefined,
         conversionFactor: undefined,
         numDecimalPlaces: undefined,
-        tolerance: undefined,
-        tableDisplay: new OwidVariableTableDisplaySettings()
+        tolerance: undefined
     }
 
     // XXX move this somewhere else, it's only used for scatter x override

--- a/charts/DataTableTransform.ts
+++ b/charts/DataTableTransform.ts
@@ -228,16 +228,10 @@ export class DataTableTransform extends ChartTransform {
             // One column for absolute difference, another for % difference.
             const deltaColumns: DimensionColumn[] = []
             if (isRange) {
-                const tableDisplay = dim.props.display.tableDisplay
-                if (
-                    tableDisplay?.showAbsoluteChange === undefined ||
-                    tableDisplay.showAbsoluteChange
-                )
+                const { tableDisplay } = dim.props.display
+                if (!tableDisplay?.hideAbsoluteChange)
                     deltaColumns.push({ key: RangeValueKey.delta })
-                if (
-                    tableDisplay?.showRelativeChange === undefined ||
-                    tableDisplay.showRelativeChange
-                )
+                if (!tableDisplay?.hideRelativeChange)
                     deltaColumns.push({ key: RangeValueKey.deltaRatio })
             }
 

--- a/charts/DataTableTransform.ts
+++ b/charts/DataTableTransform.ts
@@ -226,12 +226,15 @@ export class DataTableTransform extends ChartTransform {
 
             // Inject delta columns if we have start & end values to compare in the table.
             // One column for absolute difference, another for % difference.
-            const deltaColumns: DimensionColumn[] = isRange
-                ? [
-                      { key: RangeValueKey.delta },
-                      { key: RangeValueKey.deltaRatio }
-                  ]
-                : []
+            const deltaColumns: DimensionColumn[] = []
+            if (isRange) {
+                const tableDisplay = dim.props.display.tableDisplay
+
+                tableDisplay?.showAbsoluteChange &&
+                    deltaColumns.push({ key: RangeValueKey.delta })
+                tableDisplay?.showRelativeChange &&
+                    deltaColumns.push({ key: RangeValueKey.deltaRatio })
+            }
 
             const columns: DimensionColumn[] = [
                 ...targetYears.map((targetYear, index) => ({

--- a/charts/DataTableTransform.ts
+++ b/charts/DataTableTransform.ts
@@ -228,7 +228,7 @@ export class DataTableTransform extends ChartTransform {
             // One column for absolute difference, another for % difference.
             const deltaColumns: DimensionColumn[] = []
             if (isRange) {
-                const tableDisplay = dim.column.spec.display?.tableDisplay
+                const tableDisplay = dim.props.display.tableDisplay
                 if (
                     tableDisplay?.showAbsoluteChange === undefined ||
                     tableDisplay.showAbsoluteChange

--- a/charts/DataTableTransform.ts
+++ b/charts/DataTableTransform.ts
@@ -228,11 +228,16 @@ export class DataTableTransform extends ChartTransform {
             // One column for absolute difference, another for % difference.
             const deltaColumns: DimensionColumn[] = []
             if (isRange) {
-                const tableDisplay = dim.props.display.tableDisplay
-
-                tableDisplay?.showAbsoluteChange &&
+                const tableDisplay = dim.column.spec.display?.tableDisplay
+                if (
+                    tableDisplay?.showAbsoluteChange === undefined ||
+                    tableDisplay.showAbsoluteChange
+                )
                     deltaColumns.push({ key: RangeValueKey.delta })
-                tableDisplay?.showRelativeChange &&
+                if (
+                    tableDisplay?.showRelativeChange === undefined ||
+                    tableDisplay.showRelativeChange
+                )
                     deltaColumns.push({ key: RangeValueKey.deltaRatio })
             }
 

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -150,7 +150,7 @@ export class CovidDataExplorer extends React.Component<{
                 available: true,
                 label: "Confirmed cases",
                 checked: this.constrainedParams.casesMetric,
-                onChange: value => {
+                onChange: () => {
                     params.setMetric("cases")
                     this.renderControlsThenUpdateChart()
                 }
@@ -159,7 +159,7 @@ export class CovidDataExplorer extends React.Component<{
                 available: true,
                 label: "Confirmed deaths",
                 checked: this.constrainedParams.deathsMetric,
-                onChange: value => {
+                onChange: () => {
                     params.setMetric("deaths")
                     this.renderControlsThenUpdateChart()
                 }
@@ -169,7 +169,7 @@ export class CovidDataExplorer extends React.Component<{
                 available: true,
                 label: "Case fatality rate",
                 checked: this.constrainedParams.cfrMetric,
-                onChange: value => {
+                onChange: () => {
                     params.setMetric("case_fatality_rate")
                     this.renderControlsThenUpdateChart()
                 }
@@ -181,7 +181,7 @@ export class CovidDataExplorer extends React.Component<{
                 available: true,
                 label: "Tests",
                 checked: this.constrainedParams.testsMetric,
-                onChange: value => {
+                onChange: () => {
                     params.setMetric("tests")
                     this.renderControlsThenUpdateChart()
                 }
@@ -190,7 +190,7 @@ export class CovidDataExplorer extends React.Component<{
                 available: true,
                 label: "Tests per confirmed case",
                 checked: this.constrainedParams.testsPerCaseMetric,
-                onChange: value => {
+                onChange: () => {
                     params.setMetric("tests_per_case")
                     this.renderControlsThenUpdateChart()
                 }
@@ -199,7 +199,7 @@ export class CovidDataExplorer extends React.Component<{
                 available: true,
                 label: "Share of positive tests",
                 checked: this.constrainedParams.positiveTestRate,
-                onChange: value => {
+                onChange: () => {
                     params.setMetric("positive_test_rate")
                     this.renderControlsThenUpdateChart()
                 }
@@ -892,7 +892,8 @@ export class CovidDataExplorer extends React.Component<{
                         // Allow ± 1 day difference in data plotted on bar charts
                         // This is what we use for charts on the Grapher too
                         tolerance: 1,
-                        name: this.chartTitle
+                        name: this.chartTitle,
+                        tableDisplay: yColumn.display.tableDisplay
                     }
                 }
             ]
@@ -904,14 +905,16 @@ export class CovidDataExplorer extends React.Component<{
                 property: "y",
                 variableId: yColumn.spec.owidVariableId!,
                 display: {
-                    name: this.chartTitle
+                    name: this.chartTitle,
+                    tableDisplay: yColumn.display.tableDisplay
                 }
             },
             {
                 property: "x",
                 variableId: xColumn.spec.owidVariableId!,
                 display: {
-                    name: xColumn.spec.name
+                    name: xColumn.spec.name,
+                    tableDisplay: xColumn.display.tableDisplay
                 }
             },
             {

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -714,7 +714,6 @@ export class CovidDataExplorer extends React.Component<{
 
         this._updateMap()
         this._updateColorScale()
-        this._updateTableDisplaySettings()
 
         chartProps.selectedData = this.selectedData
         this.chart.url.externallyProvidedParams = this.props.params.toParams
@@ -755,27 +754,6 @@ export class CovidDataExplorer extends React.Component<{
 
         chartProps.map.targetYear = undefined
         chartProps.map.variableId = this.yColumn.spec.owidVariableId
-    }
-
-    private _updateTableDisplaySettings() {
-        const tableDisplaySettingsByDimensionProperty: {
-            [dimensionProperty: string]:
-                | OwidVariableTableDisplaySettings
-                | undefined
-        } = {}
-
-        // get table display settings for every dimension on source chart
-        this.sourceChart?.dimensions.forEach(
-            dim =>
-                (tableDisplaySettingsByDimensionProperty[dim.property] =
-                    dim.display.tableDisplay)
-        )
-
-        this.chart.filledDimensions.forEach(dim => {
-            dim.props.display.tableDisplay =
-                tableDisplaySettingsByDimensionProperty[dim.property] ??
-                new OwidVariableTableDisplaySettings()
-        })
     }
 
     componentDidMount() {

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -54,8 +54,6 @@ import {
 import { entityCode } from "charts/owidData/OwidTable"
 import { ColorScaleConfigProps } from "charts/ColorScaleConfig"
 import * as Mousetrap from "mousetrap"
-import { OwidVariableTableDisplaySettings } from "charts/owidData/OwidVariable"
-
 const abSeed = Math.random()
 
 interface BootstrapProps {

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -54,6 +54,7 @@ import {
 import { entityCode } from "charts/owidData/OwidTable"
 import { ColorScaleConfigProps } from "charts/ColorScaleConfig"
 import * as Mousetrap from "mousetrap"
+
 const abSeed = Math.random()
 
 interface BootstrapProps {

--- a/charts/covidDataExplorer/CovidExplorerTable.ts
+++ b/charts/covidDataExplorer/CovidExplorerTable.ts
@@ -38,8 +38,7 @@ import {
     covidDataPath,
     covidLastUpdatedPath,
     covidChartAndVariableMetaPath,
-    sourceVariables,
-    trajectoryColumnSpecs
+    sourceVariables
 } from "./CovidConstants"
 
 type MetricKey = {

--- a/charts/covidDataExplorer/CovidExplorerTable.ts
+++ b/charts/covidDataExplorer/CovidExplorerTable.ts
@@ -120,8 +120,11 @@ export class CovidExplorerTable {
                 ...owidVariableSpecs[sourceVariables.positive_test_rate],
                 isDailyMeasurement: true,
                 description:
-                    "The number of confirmed cases divided by the number of tests, expressed as a percentage. Tests may refer to the number of tests performed or the number of people tested – depending on which is reported by the particular country."
-            } as any,
+                    "The number of confirmed cases divided by the number of tests, expressed as a percentage. Tests may refer to the number of tests performed or the number of people tested – depending on which is reported by the particular country.",
+                display: {
+                    tableDisplay: { showRelativeChange: false }
+                }
+            } as ColumnSpec,
             tests_per_case: {
                 ...owidVariableSpecs[sourceVariables.tests_per_case],
                 isDailyMeasurement: true,
@@ -132,7 +135,10 @@ export class CovidExplorerTable {
                 ...owidVariableSpecs[sourceVariables.case_fatality_rate],
                 annotationsColumnSlug: "case_fatality_rate_annotations",
                 isDailyMeasurement: true,
-                description: `The Case Fatality Rate (CFR) is the ratio between confirmed deaths and confirmed cases. During an outbreak of a pandemic the CFR is a poor measure of the mortality risk of the disease. We explain this in detail at OurWorldInData.org/Coronavirus`
+                description: `The Case Fatality Rate (CFR) is the ratio between confirmed deaths and confirmed cases. During an outbreak of a pandemic the CFR is a poor measure of the mortality risk of the disease. We explain this in detail at OurWorldInData.org/Coronavirus`,
+                display: {
+                    tableDisplay: { showRelativeChange: false }
+                }
             } as any,
             cases: {
                 ...owidVariableSpecs[sourceVariables.cases],

--- a/charts/covidDataExplorer/CovidExplorerTable.ts
+++ b/charts/covidDataExplorer/CovidExplorerTable.ts
@@ -122,57 +122,57 @@ export class CovidExplorerTable {
                 description:
                     "The number of confirmed cases divided by the number of tests, expressed as a percentage. Tests may refer to the number of tests performed or the number of people tested – depending on which is reported by the particular country.",
                 display: {
-                    tableDisplay: { showRelativeChange: false }
+                    tableDisplay: { hideRelativeChange: true }
                 }
-            } as ColumnSpec,
+            },
             tests_per_case: {
                 ...owidVariableSpecs[sourceVariables.tests_per_case],
                 isDailyMeasurement: true,
                 description:
                     "The number of tests divided by the number of confirmed cases. Not all countries report testing data on a daily basis."
-            } as any,
+            },
             case_fatality_rate: {
                 ...owidVariableSpecs[sourceVariables.case_fatality_rate],
                 annotationsColumnSlug: "case_fatality_rate_annotations",
                 isDailyMeasurement: true,
                 description: `The Case Fatality Rate (CFR) is the ratio between confirmed deaths and confirmed cases. During an outbreak of a pandemic the CFR is a poor measure of the mortality risk of the disease. We explain this in detail at OurWorldInData.org/Coronavirus`,
                 display: {
-                    tableDisplay: { showRelativeChange: false }
+                    tableDisplay: { hideRelativeChange: true }
                 }
-            } as any,
+            },
             cases: {
                 ...owidVariableSpecs[sourceVariables.cases],
                 isDailyMeasurement: true,
                 annotationsColumnSlug: "cases_annotations",
                 name: "Confirmed cases of COVID-19",
                 description: `The number of confirmed cases is lower than the number of actual cases; the main reason for that is limited testing.`
-            } as any,
+            },
             deaths: {
                 ...owidVariableSpecs[sourceVariables.deaths],
                 isDailyMeasurement: true,
                 annotationsColumnSlug: "deaths_annotations",
                 name: "Confirmed deaths due to COVID-19",
                 description: `Limited testing and challenges in the attribution of the cause of death means that the number of confirmed deaths may not be an accurate count of the true number of deaths from COVID-19.`
-            } as any,
+            },
             tests: {
                 ...owidVariableSpecs[sourceVariables.tests],
                 isDailyMeasurement: true,
                 description: "",
                 name: "tests",
                 annotationsColumnSlug: "tests_units"
-            } as any,
+            },
             days_since: {
                 ...owidVariableSpecs[sourceVariables.days_since],
                 isDailyMeasurement: true,
                 description: "",
                 name: "days_since"
-            } as any,
+            },
             continents: {
                 ...owidVariableSpecs[sourceVariables.continents],
                 description: "",
                 name: "continent",
                 slug: "continent"
-            } as any
+            }
         }
         Object.keys(this.columnSpecs).forEach(key => {
             this.columnSpecs[key].owidVariableId = (sourceVariables as any)[key]

--- a/charts/owidData/OwidVariable.ts
+++ b/charts/owidData/OwidVariable.ts
@@ -5,9 +5,10 @@ import { observable } from "mobx"
 import { OwidSource } from "./OwidSource"
 
 export class OwidVariableTableDisplaySettings {
-    @observable showRelativeChange: boolean = true
     @observable showAbsoluteChange: boolean = true
+    @observable showRelativeChange: boolean = true
 }
+
 export class OwidVariableDisplaySettings {
     @observable name?: string = undefined
     @observable unit?: string = undefined

--- a/charts/owidData/OwidVariable.ts
+++ b/charts/owidData/OwidVariable.ts
@@ -5,8 +5,8 @@ import { observable } from "mobx"
 import { OwidSource } from "./OwidSource"
 
 export class OwidVariableTableDisplaySettings {
-    @observable showAbsoluteChange: boolean = true
-    @observable showRelativeChange: boolean = true
+    @observable hideAbsoluteChange: boolean = false
+    @observable hideRelativeChange: boolean = false
 }
 
 export class OwidVariableDisplaySettings {

--- a/charts/owidData/OwidVariable.ts
+++ b/charts/owidData/OwidVariable.ts
@@ -4,6 +4,10 @@ import { extend } from "../Util"
 import { observable } from "mobx"
 import { OwidSource } from "./OwidSource"
 
+export class OwidVariableTableDisplaySettings {
+    @observable showRelativeChange: boolean = true
+    @observable showAbsoluteChange: boolean = true
+}
 export class OwidVariableDisplaySettings {
     @observable name?: string = undefined
     @observable unit?: string = undefined
@@ -16,6 +20,7 @@ export class OwidVariableDisplaySettings {
     @observable zeroDay?: string = undefined
     @observable entityAnnotationsMap?: string = undefined
     @observable includeInTable?: boolean = true
+    @observable tableDisplay?: OwidVariableTableDisplaySettings
 }
 
 export class OwidVariable {


### PR DESCRIPTION
This PR allows one to select whether a chart's DataTable should show Absolute and/or Relative columns for individual dimensions. This behavior extends to the source charts for the Data Explorer.

The controls can be found on the Basic tab under the individual dimension dropdowns.

![image](https://user-images.githubusercontent.com/11683872/87481952-798efb00-c5fe-11ea-969b-14169f7cb5a2.png)
