### PR TITLE
Timeline Methods Refactor

### DIFF
--- a/admin/client/EditorCustomizeTab.tsx
+++ b/admin/client/EditorCustomizeTab.tsx
@@ -82,13 +82,6 @@ class TimelineSection extends React.Component<{ editor: ChartEditor }> {
         return this.props.editor.chart
     }
 
-    @computed get minTime() {
-        return this.chart.props.minTime
-    }
-    @computed get maxTime() {
-        return this.chart.props.maxTime
-    }
-
     @computed get timelineMinTime() {
         return this.chart.props.timelineMinTime
     }
@@ -96,12 +89,12 @@ class TimelineSection extends React.Component<{ editor: ChartEditor }> {
         return this.chart.props.timelineMaxTime
     }
 
-    @action.bound onMinTime(value: number | undefined) {
-        this.chart.props.minTime = value
+    @action.bound setDefaultTimelineStartYear(value: number | undefined) {
+        this.chart.props.selectedTimelineStartYear = value
     }
 
-    @action.bound onMaxTime(value: number | undefined) {
-        this.chart.props.maxTime = value
+    @action.bound setDefaultTimelineEndYear(value: number | undefined) {
+        this.chart.props.selectedTimelineEndYear = value
     }
 
     @action.bound onTimelineMinTime(value: number | undefined) {
@@ -130,8 +123,8 @@ class TimelineSection extends React.Component<{ editor: ChartEditor }> {
                     {features.timeDomain && (
                         <NumberField
                             label="Selection start"
-                            value={chart.props.minTime}
-                            onValue={debounce(this.onMinTime)}
+                            value={chart.props.selectedTimelineStartYear}
+                            onValue={debounce(this.setDefaultTimelineStartYear)}
                             allowNegative
                         />
                     )}
@@ -141,8 +134,8 @@ class TimelineSection extends React.Component<{ editor: ChartEditor }> {
                                 ? "Selection end"
                                 : "Selected year"
                         }
-                        value={chart.props.maxTime}
-                        onValue={debounce(this.onMaxTime)}
+                        value={chart.props.selectedTimelineEndYear}
+                        onValue={debounce(this.setDefaultTimelineEndYear)}
                         allowNegative
                     />
                 </FieldsRow>

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -67,7 +67,8 @@ import {
     maxTimeToJSON,
     TimeBound,
     Time,
-    TimeBounds
+    TimeBounds,
+    TimeBoundValue
 } from "./TimeBounds"
 import {
     GlobalEntitySelection,

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -212,6 +212,11 @@ export class ChartConfigProps {
     useV2?: boolean = false
 
     @observable.ref selectedData: EntitySelection[] = []
+
+    // minTime === selectedTimelineStartYear, etc.
+    // Temporary hack until we migrate minTime in the JSON to selectedTimelineStartYear
+    private readonly minTime?: TimeBound = undefined
+    private readonly maxTime?: TimeBound = undefined
     @observable.ref selectedTimelineStartYear?: TimeBound = undefined
     @observable.ref selectedTimelineEndYear?: TimeBound = undefined
 
@@ -775,11 +780,12 @@ export class ChartConfig {
             this.props.slug = undefined
 
         // JSON doesn't support Infinity, so we use strings instead.
+        // minTime === selectedTimelineStartYear, etc.
         this.props.selectedTimelineStartYear = selectedTimelineStartYearFromJSON(
-            json.minTime
+            json.selectedTimelineStartYear ?? json.minTime
         )
         this.props.selectedTimelineEndYear = selectedTimelineEndYearFromJSON(
-            json.maxTime
+            json.selectedTimelineEndYear ?? json.maxTime
         )
 
         if (json.map) {
@@ -992,6 +998,7 @@ export class ChartConfig {
         }
 
         // JSON doesn't support Infinity, so we use strings instead.
+        // minTime === selectedTimelineStartYear, etc.
         json.minTime = minTimeToJSON(this.props.selectedTimelineStartYear)
         json.maxTime = maxTimeToJSON(this.props.selectedTimelineEndYear)
 

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -666,9 +666,13 @@ export class ChartConfig {
 
     @computed get selectedTimelineYears(): TimeBounds {
         return [
-            this.props.selectedTimelineStartYear ??
-                TimeBoundValue.unboundedLeft,
-            this.props.selectedTimelineEndYear ?? TimeBoundValue.unboundedRight
+            // this.props.selectedTimelineStartYear ??
+            //     TimeBoundValue.unboundedLeft,
+            // this.props.selectedTimelineEndYear ?? TimeBoundValue.unboundedRight
+            selectedTimelineStartYearFromJSON(
+                this.props.selectedTimelineStartYear
+            ),
+            selectedTimelineEndYearFromJSON(this.props.selectedTimelineEndYear)
         ]
     }
 

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -61,8 +61,8 @@ import { LogoOption } from "./Logos"
 import { canBeExplorable } from "utils/charts"
 import { BAKED_GRAPHER_URL } from "settings"
 import {
-    minTimeFromJSON,
-    maxTimeFromJSON,
+    selectedTimelineStartYearFromJSON,
+    selectedTimelineEndYearFromJSON,
     minTimeToJSON,
     maxTimeToJSON,
     TimeBound,
@@ -211,8 +211,8 @@ export class ChartConfigProps {
     useV2?: boolean = false
 
     @observable.ref selectedData: EntitySelection[] = []
-    @observable.ref minTime?: TimeBound = undefined
-    @observable.ref maxTime?: TimeBound = undefined
+    @observable.ref selectedTimelineStartYear?: TimeBound = undefined
+    @observable.ref selectedTimelineEndYear?: TimeBound = undefined
 
     @observable.ref timelineMinTime?: Time = undefined
     @observable.ref timelineMaxTime?: Time = undefined
@@ -663,17 +663,17 @@ export class ChartConfig {
         }
     }
 
-    @computed get timeDomain(): TimeBounds {
+    @computed get selectedTimelineYears(): TimeBounds {
         return [
-            // Handle `undefined` values in minTime/maxTime
-            minTimeFromJSON(this.props.minTime),
-            maxTimeFromJSON(this.props.maxTime)
+            this.props.selectedTimelineStartYear ??
+                TimeBoundValue.unboundedLeft,
+            this.props.selectedTimelineEndYear ?? TimeBoundValue.unboundedRight
         ]
     }
 
-    set timeDomain(value: TimeBounds) {
-        this.props.minTime = value[0]
-        this.props.maxTime = value[1]
+    set selectedTimelineYears(value: TimeBounds) {
+        this.props.selectedTimelineStartYear = value[0]
+        this.props.selectedTimelineEndYear = value[1]
     }
 
     @computed get xAxis() {
@@ -770,13 +770,17 @@ export class ChartConfig {
             this.props.slug = undefined
 
         // JSON doesn't support Infinity, so we use strings instead.
-        this.props.minTime = minTimeFromJSON(json.minTime)
-        this.props.maxTime = maxTimeFromJSON(json.maxTime)
+        this.props.selectedTimelineStartYear = selectedTimelineStartYearFromJSON(
+            json.minTime
+        )
+        this.props.selectedTimelineEndYear = selectedTimelineEndYearFromJSON(
+            json.maxTime
+        )
 
         if (json.map) {
             this.props.map = new MapConfigProps({
                 ...json.map,
-                targetYear: maxTimeFromJSON(json.map.targetYear)
+                targetYear: selectedTimelineEndYearFromJSON(json.map.targetYear)
             })
         }
 
@@ -983,8 +987,8 @@ export class ChartConfig {
         }
 
         // JSON doesn't support Infinity, so we use strings instead.
-        json.minTime = minTimeToJSON(this.props.minTime)
-        json.maxTime = maxTimeToJSON(this.props.maxTime)
+        json.minTime = minTimeToJSON(this.props.selectedTimelineStartYear)
+        json.maxTime = maxTimeToJSON(this.props.selectedTimelineEndYear)
 
         if (this.props.map) {
             json.map.targetYear = maxTimeToJSON(this.props.map.targetYear)

--- a/charts/ChartTransform.ts
+++ b/charts/ChartTransform.ts
@@ -75,33 +75,43 @@ export abstract class ChartTransform implements IChartTransform {
     }
 
     /**
-     * The minimum year that appears in the plotted data, after the raw data is filtered.
-     *
-     * Derived from the timeline selection start.
+     * Returns:
+     * - either the first year selected in the Timeline,
+     * - or, if the Timeline has an unbounded start, the earliest year in the data,
+     * - or, if no data exists, a hard-coded default minimum year
      */
     @computed get startYear(): Time {
-        const minYear = this.chart.timeDomain[0]
-        if (isUnboundedLeft(minYear)) {
+        const selectedTimelineYears = this.chart.selectedTimelineYears[0]
+        if (isUnboundedLeft(selectedTimelineYears)) {
             return this.minTimelineYear
-        } else if (isUnboundedRight(minYear)) {
+        } else if (isUnboundedRight(selectedTimelineYears)) {
             return this.maxTimelineYear
         }
-        return getClosestTime(this.timelineYears, minYear, this.minTimelineYear)
+        return getClosestTime(
+            this.timelineYears,
+            selectedTimelineYears,
+            this.minTimelineYear
+        )
     }
 
     /**
-     * The maximum year that appears in the plotted data, after the raw data is filtered.
-     *
-     * Derived from the timeline selection end.
+     * Returns:
+     * - either the last year selected in the Timeline,
+     * - or, if the Timeline has an unbounded end, the latest year in the data,
+     * - or, if no data exists, a hard-coded default maximum year
      */
     @computed get endYear(): Time {
-        const maxYear = this.chart.timeDomain[1]
-        if (isUnboundedLeft(maxYear)) {
+        const selectedTimelineYears = this.chart.selectedTimelineYears[1]
+        if (isUnboundedLeft(selectedTimelineYears)) {
             return this.minTimelineYear
-        } else if (isUnboundedRight(maxYear)) {
+        } else if (isUnboundedRight(selectedTimelineYears)) {
             return this.maxTimelineYear
         }
-        return getClosestTime(this.timelineYears, maxYear, this.maxTimelineYear)
+        return getClosestTime(
+            this.timelineYears,
+            selectedTimelineYears,
+            this.maxTimelineYear
+        )
     }
 
     @computed get hasTimeline(): boolean {

--- a/charts/ChartTransform.ts
+++ b/charts/ChartTransform.ts
@@ -81,15 +81,15 @@ export abstract class ChartTransform implements IChartTransform {
      * - or, if no data exists, a hard-coded default minimum year
      */
     @computed get startYear(): Time {
-        const selectedTimelineYears = this.chart.selectedTimelineYears[0]
-        if (isUnboundedLeft(selectedTimelineYears)) {
+        const selectedTimelineStartYear = this.chart.selectedTimelineYears[0]
+        if (isUnboundedLeft(selectedTimelineStartYear)) {
             return this.minTimelineYear
-        } else if (isUnboundedRight(selectedTimelineYears)) {
+        } else if (isUnboundedRight(selectedTimelineStartYear)) {
             return this.maxTimelineYear
         }
         return getClosestTime(
             this.timelineYears,
-            selectedTimelineYears,
+            selectedTimelineStartYear,
             this.minTimelineYear
         )
     }
@@ -101,15 +101,15 @@ export abstract class ChartTransform implements IChartTransform {
      * - or, if no data exists, a hard-coded default maximum year
      */
     @computed get endYear(): Time {
-        const selectedTimelineYears = this.chart.selectedTimelineYears[1]
-        if (isUnboundedLeft(selectedTimelineYears)) {
+        const selectedTimelineEndYear = this.chart.selectedTimelineYears[1]
+        if (isUnboundedLeft(selectedTimelineEndYear)) {
             return this.minTimelineYear
-        } else if (isUnboundedRight(selectedTimelineYears)) {
+        } else if (isUnboundedRight(selectedTimelineEndYear)) {
             return this.maxTimelineYear
         }
         return getClosestTime(
             this.timelineYears,
-            selectedTimelineYears,
+            selectedTimelineEndYear,
             this.maxTimelineYear
         )
     }

--- a/charts/ChartUrl.ts
+++ b/charts/ChartUrl.ts
@@ -219,25 +219,36 @@ export class ChartUrl implements ObservableUrl {
         const { chart, origChartProps } = this
 
         if (
-            chart.props.minTime !== origChartProps.minTime ||
-            chart.props.maxTime !== origChartProps.maxTime
+            chart.props.selectedTimelineStartYear !==
+                origChartProps.selectedTimelineStartYear ||
+            chart.props.selectedTimelineEndYear !==
+                origChartProps.selectedTimelineEndYear
         ) {
-            const [minTime, maxTime] = chart.timeDomain
-            if (minTime === maxTime)
+            const [
+                selectedTimelineStartYear,
+                selectedTimelineEndYear
+            ] = chart.selectedTimelineYears
+            if (selectedTimelineStartYear === selectedTimelineEndYear)
                 return formatTimeURIComponent(
-                    minTime,
+                    selectedTimelineStartYear,
                     !!chart.table.hasDayColumn
                 )
             // It's not possible to have an unbounded right minTime or an unbounded left maxTime,
             // because minTime <= maxTime and because the === case is addressed above.
             // So the direction of the unbounded is unambiguous, and we can format it as an empty
             // string.
-            const start = isUnbounded(minTime)
+            const start = isUnbounded(selectedTimelineStartYear)
                 ? ""
-                : formatTimeURIComponent(minTime, !!chart.table.hasDayColumn)
-            const end = isUnbounded(maxTime)
+                : formatTimeURIComponent(
+                      selectedTimelineStartYear,
+                      !!chart.table.hasDayColumn
+                  )
+            const end = isUnbounded(selectedTimelineEndYear)
                 ? ""
-                : formatTimeURIComponent(maxTime, !!chart.table.hasDayColumn)
+                : formatTimeURIComponent(
+                      selectedTimelineEndYear,
+                      !!chart.table.hasDayColumn
+                  )
             return `${start}..${end}`
         } else {
             return undefined
@@ -343,7 +354,7 @@ export class ChartUrl implements ObservableUrl {
             )
             if (reIntRange.test(time) || reDateRange.test(time)) {
                 const [start, end] = time.split("..")
-                chart.timeDomain = [
+                chart.selectedTimelineYears = [
                     parseTimeURIComponent(start, TimeBoundValue.unboundedLeft),
                     parseTimeURIComponent(end, TimeBoundValue.unboundedRight)
                 ]
@@ -352,7 +363,7 @@ export class ChartUrl implements ObservableUrl {
                     time,
                     TimeBoundValue.unboundedRight
                 )
-                chart.timeDomain = [t, t]
+                chart.selectedTimelineYears = [t, t]
             }
         }
 

--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -443,7 +443,10 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
         targetStartYear: TimeBound
         targetEndYear: TimeBound
     }) {
-        this.props.chart.timeDomain = [targetStartYear, targetEndYear]
+        this.props.chart.selectedTimelineYears = [
+            targetStartYear,
+            targetEndYear
+        ]
     }
 
     @action.bound onTimelineStart() {
@@ -465,8 +468,8 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
                 <Timeline
                     years={years}
                     onTargetChange={this.onChartTargetChange}
-                    startYear={chart.timeDomain[0]}
-                    endYear={chart.timeDomain[1]}
+                    startYear={chart.selectedTimelineYears[0]}
+                    endYear={chart.selectedTimelineYears[1]}
                     onStartDrag={this.onTimelineStart}
                     onStopDrag={this.onTimelineStop}
                 />
@@ -493,8 +496,8 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
                 <Timeline
                     years={years}
                     onTargetChange={this.onChartTargetChange}
-                    startYear={chart.timeDomain[0]}
-                    endYear={chart.timeDomain[1]}
+                    startYear={chart.selectedTimelineYears[0]}
+                    endYear={chart.selectedTimelineYears[1]}
                     onStartDrag={this.onTimelineStart}
                     onStopDrag={this.onTimelineStop}
                 />
@@ -506,8 +509,8 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
                 <Timeline
                     years={years}
                     onTargetChange={this.onChartTargetChange}
-                    startYear={chart.timeDomain[0]}
-                    endYear={chart.timeDomain[1]}
+                    startYear={chart.selectedTimelineYears[0]}
+                    endYear={chart.selectedTimelineYears[1]}
                     onStartDrag={this.onTimelineStart}
                     onStopDrag={this.onTimelineStop}
                     singleYearPlay={true}
@@ -520,8 +523,8 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
                 <Timeline
                     years={years}
                     onTargetChange={this.onChartTargetChange}
-                    startYear={chart.timeDomain[0]}
-                    endYear={chart.timeDomain[1]}
+                    startYear={chart.selectedTimelineYears[0]}
+                    endYear={chart.selectedTimelineYears[1]}
                     onStartDrag={this.onTimelineStart}
                     onStopDrag={this.onTimelineStop}
                     disablePlay={true}
@@ -534,8 +537,8 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
                 <Timeline
                     years={years}
                     onTargetChange={this.onChartTargetChange}
-                    startYear={chart.timeDomain[0]}
-                    endYear={chart.timeDomain[1]}
+                    startYear={chart.selectedTimelineYears[0]}
+                    endYear={chart.selectedTimelineYears[1]}
                     onStartDrag={this.onTimelineStart}
                     onStopDrag={this.onTimelineStop}
                 />

--- a/charts/DataTableTransform.ts
+++ b/charts/DataTableTransform.ts
@@ -162,7 +162,7 @@ export class DataTableTransform extends ChartTransform {
     // TODO move this logic to chart
     @computed get targetYears(): TargetYears {
         const mapTarget = this.chart.map.targetYear
-        const [startYear, endYear] = this.chart.timeDomain
+        const [startYear, endYear] = this.chart.selectedTimelineYears
         const timeRange: [Time, Time] = [this.minYear, this.maxYear]
         if (this.chart.tab === "map") {
             return [getTimeWithinTimeRange(timeRange, mapTarget)]

--- a/charts/ScatterPlot.tsx
+++ b/charts/ScatterPlot.tsx
@@ -71,7 +71,7 @@ export class ScatterPlot extends React.Component<{
         targetStartYear: TimeBound
         targetEndYear: TimeBound
     }) {
-        this.chart.timeDomain = [targetStartYear, targetEndYear]
+        this.chart.selectedTimelineYears = [targetStartYear, targetEndYear]
     }
 
     @action.bound onSelectEntity(key: EntityDimensionKey) {

--- a/charts/TimeBounds.ts
+++ b/charts/TimeBounds.ts
@@ -89,16 +89,16 @@ function toJSON(bound: TimeBound | undefined): string | number | undefined {
     return bound
 }
 
-export function minTimeFromJSON(
-    minTime: TimeBound | string | undefined
+export function selectedTimelineStartYearFromJSON(
+    selectedTimelineStartYear: TimeBound | string | undefined
 ): TimeBound {
-    return fromJSON(minTime, TimeBoundValue.unboundedLeft)
+    return fromJSON(selectedTimelineStartYear, TimeBoundValue.unboundedLeft)
 }
 
-export function maxTimeFromJSON(
-    maxTime: TimeBound | string | undefined
+export function selectedTimelineEndYearFromJSON(
+    selectedTimelineEndYear: TimeBound | string | undefined
 ): TimeBound {
-    return fromJSON(maxTime, TimeBoundValue.unboundedRight)
+    return fromJSON(selectedTimelineEndYear, TimeBoundValue.unboundedRight)
 }
 
 export const minTimeToJSON = toJSON

--- a/charts/TimeScatter.tsx
+++ b/charts/TimeScatter.tsx
@@ -594,7 +594,7 @@ export class TimeScatter extends React.Component<{
         targetStartYear: TimeBound
         targetEndYear: TimeBound
     }) {
-        this.chart.timeDomain = [targetStartYear, targetEndYear]
+        this.chart.selectedTimelineYears = [targetStartYear, targetEndYear]
     }
 
     @computed get axisBox() {

--- a/charts/__tests__/ChartUrl.test.ts
+++ b/charts/__tests__/ChartUrl.test.ts
@@ -18,8 +18,8 @@ function fromQueryParams(
 
 function toQueryParams(props?: Partial<ChartConfigProps>) {
     const chart = createConfig({
-        minTime: -5000,
-        maxTime: 5000,
+        selectedTimelineStartYear: -5000,
+        selectedTimelineEndYear: 5000,
         map: new MapConfigProps({ targetYear: 5000 })
     })
     chart.update(props)
@@ -92,8 +92,8 @@ describe(ChartUrl, () => {
                 })
                 it(`encode ${test.name}`, () => {
                     const params = toQueryParams({
-                        minTime: test.param[0],
-                        maxTime: test.param[1]
+                        selectedTimelineStartYear: test.param[0],
+                        selectedTimelineEndYear: test.param[1]
                     })
                     expect(params.time).toEqual(test.query)
                 })
@@ -102,7 +102,7 @@ describe(ChartUrl, () => {
             it("empty string doesn't change time", () => {
                 const chart = fromQueryParams(
                     { time: "" },
-                    { minTime: 0, maxTime: 5 }
+                    { selectedTimelineStartYear: 0, selectedTimelineEndYear: 5 }
                 )
                 const [start, end] = chart.selectedTimelineYears
                 expect(start).toEqual(0)
@@ -111,16 +111,16 @@ describe(ChartUrl, () => {
 
             it("doesn't include URL param if it's identical to original config", () => {
                 const chart = createConfig({
-                    minTime: 0,
-                    maxTime: 75
+                    selectedTimelineStartYear: 0,
+                    selectedTimelineEndYear: 75
                 })
                 expect(chart.url.params.time).toEqual(undefined)
             })
 
             it("doesn't include URL param if unbounded is encoded as `undefined`", () => {
                 const chart = createConfig({
-                    minTime: undefined,
-                    maxTime: 75
+                    selectedTimelineStartYear: undefined,
+                    selectedTimelineEndYear: 75
                 })
                 expect(chart.url.params.time).toEqual(undefined)
             })
@@ -219,8 +219,8 @@ describe(ChartUrl, () => {
                     it(`encode ${test.name}`, () => {
                         const chart = setupChart(4066, [142708])
                         chart.update({
-                            minTime: test.param[0],
-                            maxTime: test.param[1]
+                            selectedTimelineStartYear: test.param[0],
+                            selectedTimelineEndYear: test.param[1]
                         })
                         const params = chart.url.params
                         expect(params.time).toEqual(test.query)

--- a/charts/__tests__/ChartUrl.test.ts
+++ b/charts/__tests__/ChartUrl.test.ts
@@ -18,8 +18,8 @@ function fromQueryParams(
 
 function toQueryParams(props?: Partial<ChartConfigProps>) {
     const chart = createConfig({
-        minTime: -5000,
-        maxTime: 5000,
+        selectedTimelineStartYear: -5000,
+        selectedTimelineEndYear: 5000,
         map: new MapConfigProps({ targetYear: 5000 })
     })
     chart.update(props)
@@ -86,14 +86,14 @@ describe(ChartUrl, () => {
             for (const test of tests) {
                 it(`parse ${test.name}`, () => {
                     const chart = fromQueryParams({ time: test.query })
-                    const [start, end] = chart.timeDomain
+                    const [start, end] = chart.selectedTimelineYears
                     expect(start).toEqual(test.param[0])
                     expect(end).toEqual(test.param[1])
                 })
                 it(`encode ${test.name}`, () => {
                     const params = toQueryParams({
-                        minTime: test.param[0],
-                        maxTime: test.param[1]
+                        selectedTimelineStartYear: test.param[0],
+                        selectedTimelineEndYear: test.param[1]
                     })
                     expect(params.time).toEqual(test.query)
                 })
@@ -102,25 +102,25 @@ describe(ChartUrl, () => {
             it("empty string doesn't change time", () => {
                 const chart = fromQueryParams(
                     { time: "" },
-                    { minTime: 0, maxTime: 5 }
+                    { selectedTimelineStartYear: 0, selectedTimelineEndYear: 5 }
                 )
-                const [start, end] = chart.timeDomain
+                const [start, end] = chart.selectedTimelineYears
                 expect(start).toEqual(0)
                 expect(end).toEqual(5)
             })
 
             it("doesn't include URL param if it's identical to original config", () => {
                 const chart = createConfig({
-                    minTime: 0,
-                    maxTime: 75
+                    selectedTimelineStartYear: 0,
+                    selectedTimelineEndYear: 75
                 })
                 expect(chart.url.params.time).toEqual(undefined)
             })
 
             it("doesn't include URL param if unbounded is encoded as `undefined`", () => {
                 const chart = createConfig({
-                    minTime: undefined,
-                    maxTime: 75
+                    selectedTimelineStartYear: undefined,
+                    selectedTimelineEndYear: 75
                 })
                 expect(chart.url.params.time).toEqual(undefined)
             })
@@ -211,7 +211,7 @@ describe(ChartUrl, () => {
                 it(`parse ${test.name}`, () => {
                     const chart = setupChart(4066, [142708])
                     chart.url.populateFromQueryParams({ time: test.query })
-                    const [start, end] = chart.timeDomain
+                    const [start, end] = chart.selectedTimelineYears
                     expect(start).toEqual(test.param[0])
                     expect(end).toEqual(test.param[1])
                 })

--- a/charts/__tests__/ChartUrl.test.ts
+++ b/charts/__tests__/ChartUrl.test.ts
@@ -9,17 +9,17 @@ import { MapConfigProps } from "charts/MapConfig"
 
 function fromQueryParams(
     params: ChartQueryParams,
-    props?: Partial<ChartConfigProps>
+    props?: Partial<ChartConfigProps> | any
 ) {
     const chart = createConfig(props)
     chart.url.populateFromQueryParams(params)
     return chart
 }
 
-function toQueryParams(props?: Partial<ChartConfigProps>) {
+function toQueryParams(props?: Partial<ChartConfigProps> | any) {
     const chart = createConfig({
-        selectedTimelineStartYear: -5000,
-        selectedTimelineEndYear: 5000,
+        minTime: -5000,
+        maxTime: 5000,
         map: new MapConfigProps({ targetYear: 5000 })
     })
     chart.update(props)
@@ -92,8 +92,8 @@ describe(ChartUrl, () => {
                 })
                 it(`encode ${test.name}`, () => {
                     const params = toQueryParams({
-                        selectedTimelineStartYear: test.param[0],
-                        selectedTimelineEndYear: test.param[1]
+                        minTime: test.param[0],
+                        maxTime: test.param[1]
                     })
                     expect(params.time).toEqual(test.query)
                 })
@@ -102,7 +102,7 @@ describe(ChartUrl, () => {
             it("empty string doesn't change time", () => {
                 const chart = fromQueryParams(
                     { time: "" },
-                    { selectedTimelineStartYear: 0, selectedTimelineEndYear: 5 }
+                    { minTime: 0, maxTime: 5 }
                 )
                 const [start, end] = chart.selectedTimelineYears
                 expect(start).toEqual(0)
@@ -111,16 +111,16 @@ describe(ChartUrl, () => {
 
             it("doesn't include URL param if it's identical to original config", () => {
                 const chart = createConfig({
-                    selectedTimelineStartYear: 0,
-                    selectedTimelineEndYear: 75
+                    minTime: 0,
+                    maxTime: 75
                 })
                 expect(chart.url.params.time).toEqual(undefined)
             })
 
             it("doesn't include URL param if unbounded is encoded as `undefined`", () => {
                 const chart = createConfig({
-                    selectedTimelineStartYear: undefined,
-                    selectedTimelineEndYear: 75
+                    minTime: undefined,
+                    maxTime: 75
                 })
                 expect(chart.url.params.time).toEqual(undefined)
             })

--- a/charts/__tests__/ChartUrl.test.ts
+++ b/charts/__tests__/ChartUrl.test.ts
@@ -9,14 +9,14 @@ import { MapConfigProps } from "charts/MapConfig"
 
 function fromQueryParams(
     params: ChartQueryParams,
-    props?: Partial<ChartConfigProps> | any
+    props?: Partial<ChartConfigProps>
 ) {
     const chart = createConfig(props)
     chart.url.populateFromQueryParams(params)
     return chart
 }
 
-function toQueryParams(props?: Partial<ChartConfigProps> | any) {
+function toQueryParams(props?: Partial<ChartConfigProps>) {
     const chart = createConfig({
         minTime: -5000,
         maxTime: 5000,

--- a/charts/__tests__/DataTable.test.tsx
+++ b/charts/__tests__/DataTable.test.tsx
@@ -64,8 +64,8 @@ describe(DataTable, () => {
             const chart = setupChart(677, [104402], {
                 type: "LineChart",
                 tab: "chart",
-                minTime: 1990,
-                maxTime: 2017
+                selectedTimelineStartYear: 1990,
+                selectedTimelineEndYear: 2017
             })
             view = mount(<DataTable chart={chart} />)
         })

--- a/charts/__tests__/DataTable.test.tsx
+++ b/charts/__tests__/DataTable.test.tsx
@@ -64,8 +64,8 @@ describe(DataTable, () => {
             const chart = setupChart(677, [104402], {
                 type: "LineChart",
                 tab: "chart",
-                selectedTimelineStartYear: 1990,
-                selectedTimelineEndYear: 2017
+                minTime: 1990,
+                maxTime: 2017
             })
             view = mount(<DataTable chart={chart} />)
         })

--- a/charts/__tests__/ExploreModel.test.ts
+++ b/charts/__tests__/ExploreModel.test.ts
@@ -25,7 +25,7 @@ describe(ExploreModel, () => {
         })
 
         it("populates the chart params", () => {
-            expect(model.chart.timeDomain).toEqual([1960, 2000])
+            expect(model.chart.selectedTimelineYears).toEqual([1960, 2000])
         })
     })
 

--- a/charts/__tests__/ExploreView.test.tsx
+++ b/charts/__tests__/ExploreView.test.tsx
@@ -92,7 +92,7 @@ describe(ExploreView, () => {
         // -@danielgavrilov 2019-12-12
         it.skip("applies the time params to the chart", async () => {
             const model = getDefaultModel()
-            model.chart.timeDomain = [1960, 2005]
+            model.chart.selectedTimelineYears = [1960, 2005]
             const view = await renderWithModel(model)
             const style: any = view.find(".slider .interval").prop("style")
             expect(parseFloat(style.left)).toBeGreaterThan(0)

--- a/charts/__tests__/TimeBounds.ts
+++ b/charts/__tests__/TimeBounds.ts
@@ -2,57 +2,63 @@
 
 import {
     TimeBoundValue,
-    minTimeFromJSON,
-    maxTimeFromJSON,
+    selectedTimelineStartYearFromJSON,
+    selectedTimelineEndYearFromJSON,
     minTimeToJSON,
     maxTimeToJSON
 } from "charts/TimeBounds"
 
-describe(minTimeFromJSON, () => {
+describe(selectedTimelineStartYearFromJSON, () => {
     it("handles unbounded left", () => {
-        expect(minTimeFromJSON("earliest")).toEqual(
+        expect(selectedTimelineStartYearFromJSON("earliest")).toEqual(
             TimeBoundValue.unboundedLeft
         )
     })
     it("handles unbounded right", () => {
-        expect(minTimeFromJSON("latest")).toEqual(TimeBoundValue.unboundedRight)
+        expect(selectedTimelineStartYearFromJSON("latest")).toEqual(
+            TimeBoundValue.unboundedRight
+        )
     })
     it("handles undefined", () => {
-        expect(minTimeFromJSON(undefined)).toEqual(TimeBoundValue.unboundedLeft)
+        expect(selectedTimelineStartYearFromJSON(undefined)).toEqual(
+            TimeBoundValue.unboundedLeft
+        )
     })
     it("handles number", () => {
-        expect(minTimeFromJSON(1990)).toEqual(1990)
+        expect(selectedTimelineStartYearFromJSON(1990)).toEqual(1990)
     })
     it("handles negative number", () => {
-        expect(minTimeFromJSON(-1990)).toEqual(-1990)
+        expect(selectedTimelineStartYearFromJSON(-1990)).toEqual(-1990)
     })
     it("handles zero", () => {
-        expect(minTimeFromJSON(0)).toEqual(0)
+        expect(selectedTimelineStartYearFromJSON(0)).toEqual(0)
     })
 })
 
-describe(maxTimeFromJSON, () => {
+describe(selectedTimelineEndYearFromJSON, () => {
     it("handles unbounded left", () => {
-        expect(maxTimeFromJSON("earliest")).toEqual(
+        expect(selectedTimelineEndYearFromJSON("earliest")).toEqual(
             TimeBoundValue.unboundedLeft
         )
     })
     it("handles unbounded right", () => {
-        expect(maxTimeFromJSON("latest")).toEqual(TimeBoundValue.unboundedRight)
+        expect(selectedTimelineEndYearFromJSON("latest")).toEqual(
+            TimeBoundValue.unboundedRight
+        )
     })
     it("handles undefined", () => {
-        expect(maxTimeFromJSON(undefined)).toEqual(
+        expect(selectedTimelineEndYearFromJSON(undefined)).toEqual(
             TimeBoundValue.unboundedRight
         )
     })
     it("handles number", () => {
-        expect(maxTimeFromJSON(1990)).toEqual(1990)
+        expect(selectedTimelineEndYearFromJSON(1990)).toEqual(1990)
     })
     it("handles negative number", () => {
-        expect(maxTimeFromJSON(-1990)).toEqual(-1990)
+        expect(selectedTimelineEndYearFromJSON(-1990)).toEqual(-1990)
     })
     it("handles zero", () => {
-        expect(maxTimeFromJSON(0)).toEqual(0)
+        expect(selectedTimelineEndYearFromJSON(0)).toEqual(0)
     })
 })
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -3,7 +3,7 @@ import { ChartConfig, ChartConfigProps } from "charts/ChartConfig"
 import * as fixtures from "./fixtures"
 import { first } from "lodash"
 
-export function createConfig(props?: Partial<ChartConfigProps> | any) {
+export function createConfig(props?: Partial<ChartConfigProps>) {
     const config = new ChartConfig(new ChartConfigProps(props))
     // ensureValidConfig() is only run on non-node environments, so we have
     // to manually trigger it.
@@ -14,7 +14,7 @@ export function createConfig(props?: Partial<ChartConfigProps> | any) {
 export function setupChart(
     id: number,
     varIds: number[],
-    configOverrides?: Partial<ChartConfigProps> | any
+    configOverrides?: Partial<ChartConfigProps>
 ) {
     const variableSet =
         varIds.length > 1

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -3,7 +3,7 @@ import { ChartConfig, ChartConfigProps } from "charts/ChartConfig"
 import * as fixtures from "./fixtures"
 import { first } from "lodash"
 
-export function createConfig(props?: Partial<ChartConfigProps>) {
+export function createConfig(props?: Partial<ChartConfigProps> | any) {
     const config = new ChartConfig(new ChartConfigProps(props))
     // ensureValidConfig() is only run on non-node environments, so we have
     // to manually trigger it.
@@ -14,7 +14,7 @@ export function createConfig(props?: Partial<ChartConfigProps>) {
 export function setupChart(
     id: number,
     varIds: number[],
-    configOverrides?: Partial<ChartConfigProps>
+    configOverrides?: Partial<ChartConfigProps> | any
 ) {
     const variableSet =
         varIds.length > 1


### PR DESCRIPTION
I find myself spending a lot of time trying to remember the difference between `startYear()`, `minTime()`, `timeDomain[0]`, `timelineMinTime`, `minTimelineYear`, etc., etc. This _starts_ the process of separating these concepts into hopefully more clear names.

I've just renamed a few methods in this case to try it out, but I think we'd have to do some kind of database migration to change "minTime" and "maxTime" in the DB. Not sure how difficult this is -- I can also do some kind of live conversion in the code.

Leaving this as a draft PR until I know whether the DB migration can be done fairly easily. The code breaks as-is until we figure that out.