### PR TITLE
Data Table Automatic Time Selection

### DIFF
--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -67,7 +67,8 @@ import {
     maxTimeToJSON,
     TimeBound,
     Time,
-    TimeBounds
+    TimeBounds,
+    TimeBoundValue
 } from "./TimeBounds"
 import {
     GlobalEntitySelection,
@@ -649,11 +650,27 @@ export class ChartConfig {
         return defaultTo(this.props.entityTypePlural, "countries")
     }
 
+    /** If the start year was autoselected in the DataTable, revert. */
+    @action
+    revertAutoSelectedStartYear() {
+        this.timeDomain = [
+            this.initialProps.minTime ?? TimeBoundValue.unboundedLeft,
+            this.timeDomain[1]
+        ]
+    }
+
     @computed get tab() {
         return this.props.overlay ? this.props.overlay : this.props.tab
     }
 
     set tab(value) {
+        if (
+            this.props.tab === "table" &&
+            value === "chart" &&
+            !this.userHasSetTimeline
+        )
+            this.revertAutoSelectedStartYear()
+
         if (value === "chart" || value === "map" || value === "table") {
             this.props.tab = value
             this.props.overlay = undefined

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -318,6 +318,8 @@ export class ChartConfig {
     // at startDrag, we want to show the full axis
     @observable.ref useTimelineDomains = false
 
+    @observable userHasSetTimeline: boolean = false
+
     @action.bound async downloadData() {
         if (this.props.useV2) return
 

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -471,8 +471,6 @@ export class ChartConfig {
     @observable hideEntityControls: boolean = false
     externalCsvLink = ""
 
-    @observable timelineLoaded: boolean = false
-
     @computed get hasOWIDLogo(): boolean {
         return (
             !this.props.hideLogo &&
@@ -677,6 +675,8 @@ export class ChartConfig {
     }
 
     set timeDomain(value: TimeBounds) {
+        console.log(`time to ${value}`)
+        debugger
         this.props.minTime = value[0]
         this.props.maxTime = value[1]
     }

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -471,7 +471,7 @@ export class ChartConfig {
     @observable hideEntityControls: boolean = false
     externalCsvLink = ""
 
-    @observable controlsLoaded: boolean = false
+    @observable timelineLoaded: boolean = false
 
     @computed get hasOWIDLogo(): boolean {
         return (

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -471,6 +471,8 @@ export class ChartConfig {
     @observable hideEntityControls: boolean = false
     externalCsvLink = ""
 
+    @observable controlsLoaded: boolean = false
+
     @computed get hasOWIDLogo(): boolean {
         return (
             !this.props.hideLogo &&

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -675,8 +675,6 @@ export class ChartConfig {
     }
 
     set timeDomain(value: TimeBounds) {
-        console.log(`time to ${value}`)
-        debugger
         this.props.minTime = value[0]
         this.props.maxTime = value[1]
     }

--- a/charts/ChartDimensionWithOwidVariable.ts
+++ b/charts/ChartDimensionWithOwidVariable.ts
@@ -18,6 +18,7 @@ import {
     owidVariableId,
     entityName
 } from "./owidData/OwidTable"
+import { Time } from "./TimeBounds"
 
 export class ChartDimensionWithOwidVariable {
     props: ChartDimension
@@ -160,7 +161,7 @@ export class ChartDimensionWithOwidVariable {
 
     // todo: remove unitConversionFactor concept? use computed columns instead?
     // note: unitConversionFactor is used >400 times in charts and >800 times in variables!!!
-    @computed get values() {
+    @computed get values(): (number | string)[] {
         const { unitConversionFactor } = this
         if (unitConversionFactor !== 1)
             return this.column.values.map(
@@ -177,7 +178,7 @@ export class ChartDimensionWithOwidVariable {
         return sortedUniq(this.years)
     }
 
-    get years() {
+    get years(): Time[] {
         return this.column.years
     }
 

--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -462,18 +462,14 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
             if (years.length === 0) {
                 return null
             }
-
-            if (dataTableTransform.autoSelectedStartYear)
-                chart.timeDomain = [
-                    dataTableTransform.autoSelectedStartYear,
-                    chart.timeDomain[1]
-                ]
-
             return (
                 <Timeline
                     years={years}
                     onTargetChange={this.onChartTargetChange}
-                    startYear={chart.timeDomain[0]}
+                    startYear={
+                        dataTableTransform.autoSelectedStartYear ??
+                        chart.timeDomain[0]
+                    }
                     endYear={chart.timeDomain[1]}
                     onStartDrag={this.onTimelineStart}
                     onStopDrag={this.onTimelineStop}

--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -462,14 +462,18 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
             if (years.length === 0) {
                 return null
             }
+
+            if (dataTableTransform.autoSelectedStartYear)
+                chart.timeDomain = [
+                    dataTableTransform.autoSelectedStartYear,
+                    chart.timeDomain[1]
+                ]
+
             return (
                 <Timeline
                     years={years}
                     onTargetChange={this.onChartTargetChange}
-                    startYear={
-                        dataTableTransform.autoSelectedStartYear ??
-                        chart.timeDomain[0]
-                    }
+                    startYear={chart.timeDomain[0]}
                     endYear={chart.timeDomain[1]}
                     onStartDrag={this.onTimelineStart}
                     onStopDrag={this.onTimelineStop}

--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -457,7 +457,8 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
     render() {
         const { chart } = this.props
         if (chart.props.tab === "table") {
-            const years = chart.dataTableTransform.timelineYears
+            const { dataTableTransform } = chart
+            const years = dataTableTransform.timelineYears
             if (years.length === 0) {
                 return null
             }
@@ -465,7 +466,10 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
                 <Timeline
                     years={years}
                     onTargetChange={this.onChartTargetChange}
-                    startYear={chart.timeDomain[0]}
+                    startYear={
+                        dataTableTransform.autoSelectedStartYear ??
+                        chart.timeDomain[0]
+                    }
                     endYear={chart.timeDomain[1]}
                     onStartDrag={this.onTimelineStart}
                     onStopDrag={this.onTimelineStop}

--- a/charts/DataTable.tsx
+++ b/charts/DataTable.tsx
@@ -24,7 +24,6 @@ import {
     SingleValueKey,
     Value
 } from "./DataTableTransform"
-import { TimeBoundValue } from "./TimeBounds"
 
 export interface DataTableProps {
     chart: ChartConfig
@@ -348,18 +347,6 @@ export class DataTable extends React.Component<DataTableProps> {
         return this.displayRows.map(row =>
             this.renderEntityRow(row, this.displayDimensions)
         )
-    }
-
-    @action
-    revertAutoSelectedStartYear() {
-        this.chart.timeDomain = [
-            this.chart.initialProps.minTime ?? TimeBoundValue.unboundedLeft,
-            this.transform.endYear
-        ]
-    }
-
-    componentWillUnmount() {
-        if (!this.chart.userHasSetTimeline) this.revertAutoSelectedStartYear()
     }
 
     render() {

--- a/charts/DataTable.tsx
+++ b/charts/DataTable.tsx
@@ -359,12 +359,7 @@ export class DataTable extends React.Component<DataTableProps> {
     }
 
     componentWillUnmount() {
-        // if current Timeline startYear is auto-selected and hasn't been changed by user, revert
-        if (
-            this.transform.autoSelectedStartYear &&
-            this.transform.autoSelectedStartYear == this.transform.startYear
-        )
-            this.revertAutoSelectedStartYear()
+        if (!this.chart.userHasSetTimeline) this.revertAutoSelectedStartYear()
     }
 
     render() {

--- a/charts/DataTableTransform.ts
+++ b/charts/DataTableTransform.ts
@@ -11,7 +11,7 @@ import {
 import { ChartConfig } from "./ChartConfig"
 import { ChartDimensionWithOwidVariable } from "./ChartDimensionWithOwidVariable"
 import { TickFormattingOptions } from "./TickFormattingOptions"
-import { getTimeWithinTimeRange, Time } from "./TimeBounds"
+import { isUnbounded, getTimeWithinTimeRange, Time } from "./TimeBounds"
 import { ChartTransform } from "./ChartTransform"
 
 // Target year modes
@@ -151,19 +151,16 @@ export class DataTableTransform extends ChartTransform {
         return TargetYearMode.point
     }
 
-    @computed get minYear(): Time {
-        return this.chart.minYear
+    @computed get initialTimelineStartYearSpecified(): boolean {
+        const initialMinTime = this.chart.initialProps.minTime
+        if (initialMinTime) return !isUnbounded(initialMinTime)
+        return false
     }
 
-    @computed get maxYear(): Time {
-        return this.chart.maxYear
-    }
-
-    // TODO move this logic to chart
     @computed get targetYears(): TargetYears {
         const mapTarget = this.chart.map.targetYear
         const [startYear, endYear] = this.chart.timeDomain
-        const timeRange: [Time, Time] = [this.minYear, this.maxYear]
+        const timeRange: [Time, Time] = [this.chart.minYear, this.chart.maxYear]
         if (this.chart.tab === "map") {
             return [getTimeWithinTimeRange(timeRange, mapTarget)]
         } else if (startYear === endYear) {
@@ -174,6 +171,9 @@ export class DataTableTransform extends ChartTransform {
                 getTimeWithinTimeRange(timeRange, endYear)
             ]
         }
+        // return this.startYear == this.endYear
+        //     ? [this.startYear]
+        //     : [this.startYear, this.endYear]
     }
 
     formatValue(

--- a/charts/DataTableTransform.ts
+++ b/charts/DataTableTransform.ts
@@ -1,4 +1,4 @@
-import { computed, observable } from "mobx"
+import { computed } from "mobx"
 
 import {
     valuesByEntityAtYears,
@@ -15,7 +15,6 @@ import { ChartDimensionWithOwidVariable } from "./ChartDimensionWithOwidVariable
 import { TickFormattingOptions } from "./TickFormattingOptions"
 import { isUnbounded, getTimeWithinTimeRange, Time } from "./TimeBounds"
 import { ChartTransform } from "./ChartTransform"
-import { observer } from "mobx-react"
 
 // Target year modes
 

--- a/charts/DataTableTransform.ts
+++ b/charts/DataTableTransform.ts
@@ -13,7 +13,7 @@ import {
 import { ChartConfig } from "./ChartConfig"
 import { ChartDimensionWithOwidVariable } from "./ChartDimensionWithOwidVariable"
 import { TickFormattingOptions } from "./TickFormattingOptions"
-import { isUnbounded, getTimeWithinTimeRange, Time } from "./TimeBounds"
+import { getTimeWithinTimeRange, Time, isUnboundedLeft } from "./TimeBounds"
 import { ChartTransform } from "./ChartTransform"
 
 // Target year modes
@@ -205,7 +205,7 @@ export class DataTableTransform extends ChartTransform {
 
     @computed get initialTimelineStartYearSpecified(): boolean {
         const initialMinTime = this.chart.initialProps.minTime
-        if (initialMinTime) return !isUnbounded(initialMinTime)
+        if (initialMinTime) return !isUnboundedLeft(initialMinTime)
         return false
     }
 

--- a/charts/HTMLTimeline.tsx
+++ b/charts/HTMLTimeline.tsx
@@ -361,10 +361,7 @@ export class Timeline extends React.Component<TimelineProps> {
             }),
             autorun(
                 () => {
-                    if (
-                        this.props.onTargetChange &&
-                        this.context.chart.userHasSetTimeline
-                    ) {
+                    if (this.props.onTargetChange) {
                         this.props.onTargetChange({
                             targetStartYear: this.startYearClosest,
                             targetEndYear: this.endYearClosest

--- a/charts/HTMLTimeline.tsx
+++ b/charts/HTMLTimeline.tsx
@@ -385,9 +385,6 @@ export class Timeline extends React.Component<TimelineProps> {
                         ]
                     })
                 }
-            }),
-            autorun(() => {
-                this.context.chart.timelineLoaded = true
             })
         ]
     }

--- a/charts/HTMLTimeline.tsx
+++ b/charts/HTMLTimeline.tsx
@@ -240,6 +240,7 @@ export class Timeline extends React.Component<TimelineProps> {
 
     @action.bound onDrag(inputYear: number) {
         const { props, dragTarget, minYear, maxYear } = this
+        if (!this.isPlaying) this.context.chart.userHasSetTimeline = true
 
         const clampedYear = this.getClampedYear(inputYear)
 

--- a/charts/HTMLTimeline.tsx
+++ b/charts/HTMLTimeline.tsx
@@ -389,7 +389,6 @@ export class Timeline extends React.Component<TimelineProps> {
                             this.startYearClosest,
                             this.endYearClosest
                         ]
-                        this.updateChartTimeDomain()
                     })
                 }
             })

--- a/charts/HTMLTimeline.tsx
+++ b/charts/HTMLTimeline.tsx
@@ -361,7 +361,10 @@ export class Timeline extends React.Component<TimelineProps> {
             }),
             autorun(
                 () => {
-                    if (this.props.onTargetChange) {
+                    if (
+                        this.props.onTargetChange &&
+                        this.context.chart.userHasSetTimeline
+                    ) {
                         this.props.onTargetChange({
                             targetStartYear: this.startYearClosest,
                             targetEndYear: this.endYearClosest

--- a/charts/HTMLTimeline.tsx
+++ b/charts/HTMLTimeline.tsx
@@ -95,6 +95,7 @@ export class Timeline extends React.Component<TimelineProps> {
             runInAction(() => {
                 this.startYearRaw = this.props.startYear
                 this.endYearRaw = this.props.endYear
+                this.updateChartTimeDomain()
             })
         }
     }
@@ -185,6 +186,8 @@ export class Timeline extends React.Component<TimelineProps> {
 
             lastTime = time
             this.animRequest = requestAnimationFrame(playFrame)
+
+            this.updateChartTimeDomain()
         })
 
         this.animRequest = requestAnimationFrame(playFrame)
@@ -323,10 +326,23 @@ export class Timeline extends React.Component<TimelineProps> {
         this.queuedAnimationFrame = requestAnimationFrame(() => {
             this.onDrag(this.getInputYearFromMouse(ev as any))
         })
+
+        this.updateChartTimeDomain()
     }
 
     @action.bound onMouseUp() {
         this.dragTarget = undefined
+
+        this.updateChartTimeDomain()
+    }
+
+    @action updateChartTimeDomain() {
+        if (this.props.onTargetChange) {
+            this.props.onTargetChange({
+                targetStartYear: this.startYearClosest,
+                targetEndYear: this.endYearClosest
+            })
+        }
     }
 
     // Allow proper dragging behavior even if mouse leaves timeline area
@@ -334,6 +350,7 @@ export class Timeline extends React.Component<TimelineProps> {
         runInAction(() => {
             this.startYearRaw = this.props.startYear
             this.endYearRaw = this.props.endYear
+            this.updateChartTimeDomain()
         })
 
         document.documentElement.addEventListener("mouseup", this.onMouseUp)
@@ -359,17 +376,6 @@ export class Timeline extends React.Component<TimelineProps> {
                     if (onStopDrag) onStopDrag()
                 }
             }),
-            autorun(
-                () => {
-                    if (this.props.onTargetChange) {
-                        this.props.onTargetChange({
-                            targetStartYear: this.startYearClosest,
-                            targetEndYear: this.endYearClosest
-                        })
-                    }
-                },
-                { delay: 0 }
-            ),
             autorun(() => {
                 // If we're not playing or dragging, lock the input to the closest year (no interpolation)
                 const { isPlaying, isDragging } = this
@@ -383,6 +389,7 @@ export class Timeline extends React.Component<TimelineProps> {
                             this.startYearClosest,
                             this.endYearClosest
                         ]
+                        this.updateChartTimeDomain()
                     })
                 }
             })

--- a/charts/HTMLTimeline.tsx
+++ b/charts/HTMLTimeline.tsx
@@ -385,6 +385,9 @@ export class Timeline extends React.Component<TimelineProps> {
                         ]
                     })
                 }
+            }),
+            autorun(() => {
+                this.context.chart.controlsLoaded = true
             })
         ]
     }

--- a/charts/HTMLTimeline.tsx
+++ b/charts/HTMLTimeline.tsx
@@ -387,7 +387,7 @@ export class Timeline extends React.Component<TimelineProps> {
                 }
             }),
             autorun(() => {
-                this.context.chart.controlsLoaded = true
+                this.context.chart.timelineLoaded = true
             })
         ]
     }

--- a/charts/Util.ts
+++ b/charts/Util.ts
@@ -59,6 +59,7 @@ import memoize from "lodash/memoize"
 import takeWhile from "lodash/takeWhile"
 import upperFirst from "lodash/upperFirst"
 import assign from "lodash/assign"
+import countBy from "lodash/countBy"
 
 export {
     isEqual,
@@ -119,7 +120,8 @@ export {
     mapKeys,
     memoize,
     takeWhile,
-    upperFirst
+    upperFirst,
+    countBy
 }
 
 import moment from "moment"


### PR DESCRIPTION
With this PR, DataTables automatically select a start year where x>=50% of the entities have values. This is intended to reduce tables with an initial view of sparse data. This auto-selection will not trigger if the user has modified the timeline, the authors have specified a default timeline start year, or if the start year is set to the "latest" data.

Live on [Nightingale](https://nightingale-owid.netlify.app/).

~~Note: the Covid Data Explorer already has some lag when switching tabs that is now slightly exacerbated (when Table->Chart) by this code. I'm adding this as an issue [here](https://www.notion.so/owid/Lag-when-switching-tabs-in-CDE-491b7e8577104fd6bc722d163160e208) that I think we should address separately.~~ Fixed.

**Before:**
![image](https://user-images.githubusercontent.com/11683872/88076139-b5b6e400-cb47-11ea-8a24-806a307a932e.png)


**After:**
![image](https://user-images.githubusercontent.com/11683872/88076183-c1a2a600-cb47-11ea-9a3c-f458f80381b2.png)
