### PR TITLE
New: color options, keyboard shortcuts, more dimension options

### DIFF
--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -313,6 +313,7 @@ export class ChartConfig {
     @observable.ref isNode: boolean
     @observable.ref isExporting?: boolean
     @observable.ref tooltip?: TooltipProps
+    @observable isPlaying: boolean = false
 
     // at startDrag, we want to show the full axis
     @observable.ref useTimelineDomains = false

--- a/charts/HTMLTimeline.tsx
+++ b/charts/HTMLTimeline.tsx
@@ -57,7 +57,6 @@ export class Timeline extends React.Component<TimelineProps> {
 
     disposers!: IReactionDisposer[]
 
-    @observable isPlaying: boolean = false
     @observable dragTarget?: string
 
     @computed get isDragging(): boolean {
@@ -84,6 +83,10 @@ export class Timeline extends React.Component<TimelineProps> {
         if (this.props.years.length === 0) {
             console.warn("invoking HTMLTimeline with empty years array")
         }
+    }
+
+    @computed get isPlaying() {
+        return this.context.chart.isPlaying
     }
 
     componentDidUpdate() {
@@ -166,7 +169,7 @@ export class Timeline extends React.Component<TimelineProps> {
                 const elapsed = time - lastTime
 
                 if (endYearUI >= maxYear) {
-                    this.isPlaying = false
+                    this.context.chart.isPlaying = false
                 } else {
                     const nextYear = years[years.indexOf(endYearUI) + 1]
                     const yearsToNext = nextYear - endYearUI
@@ -404,7 +407,7 @@ export class Timeline extends React.Component<TimelineProps> {
     }
 
     @action.bound onTogglePlay() {
-        this.isPlaying = !this.isPlaying
+        this.context.chart.isPlaying = !this.isPlaying
     }
 
     render() {

--- a/charts/Util.ts
+++ b/charts/Util.ts
@@ -358,6 +358,17 @@ export function lastOfNonEmptyArray<T>(arr: T[]): T {
     return last(arr) as T
 }
 
+export function next<T>(set: T[], current: T) {
+    let nextIndex = set.indexOf(current) + 1
+    nextIndex = nextIndex === -1 ? 0 : nextIndex
+    return set[nextIndex === set.length ? 0 : nextIndex]
+}
+
+export function previous<T>(set: T[], current: T) {
+    let nextIndex = set.indexOf(current) - 1
+    return set[nextIndex < 0 ? set.length - 1 : nextIndex]
+}
+
 // Calculate the extents of a set of numbers, with safeguards for log scales
 export function domainExtent(
     numValues: number[],

--- a/charts/__tests__/OwidTable.test.ts
+++ b/charts/__tests__/OwidTable.test.ts
@@ -29,7 +29,7 @@ describe(OwidTable, () => {
     })
 
     it("a column can be added", () => {
-        table.addComputedColumn({
+        table.addNumericComputedColumn({
             slug: "populationInMillions",
             fn: row => row.population / 1000000
         })
@@ -141,12 +141,12 @@ iceland,1`
     const rows = [{ country: "USA" }, { country: "Germany" }]
     const table = new BasicTable(rows)
     it("does not modify rows", () => {
-        table.addComputedColumn({
+        table.addNumericComputedColumn({
             slug: "firstLetter",
-            fn: row => row.country.substr(0, 1)
+            fn: row => row.country.length
         })
         expect(table.columnsBySlug.get("firstLetter")?.values.join("")).toEqual(
-            `UG`
+            `37`
         )
         expect((rows[0] as any).firstLetter).toEqual(undefined)
     })
@@ -184,7 +184,7 @@ describe("rolling averages", () => {
     it("a column can be added", () => {
         expect(table.rows.length).toEqual(rows.length)
         expect(Array.from(table.columnsByName.keys()).length).toEqual(colLength)
-        table.addComputedColumn({
+        table.addNumericComputedColumn({
             slug: "populationInMillions",
             fn: row => row.population / 1000000
         })

--- a/charts/__tests__/OwidTable.test.ts
+++ b/charts/__tests__/OwidTable.test.ts
@@ -62,7 +62,7 @@ hi,1,in millions,2000
 hi,1,,2001`
     const specs = new Map()
     const table = BasicTable.fromCsv(csv)
-    table.addColumnSpec({ slug: "pop", annotationsColumnSlug: "notes" })
+    table.addStringColumnSpec({ slug: "pop", annotationsColumnSlug: "notes" })
 
     it("can get annotations for a row", () => {
         const annotationsColumn = table.columnsBySlug.get("pop")

--- a/charts/__tests__/Util.test.ts
+++ b/charts/__tests__/Util.test.ts
@@ -12,7 +12,9 @@ import {
     insertMissingValuePlaceholders,
     rollingMap,
     groupMap,
-    mergeQueryStr
+    mergeQueryStr,
+    next,
+    previous
 } from "../Util"
 import { strToQueryParams } from "utils/client/url"
 
@@ -76,6 +78,49 @@ describe(getStartEndValues, () => {
         ]) as DataValue[]
         expect(extent[0].year).toEqual(2014)
         expect(extent[1].year).toEqual(2017)
+    })
+})
+
+describe(next, () => {
+    const scenarios = [
+        {
+            list: [55, 33, 22],
+            current: 33,
+            next: 22,
+            previous: 55
+        },
+        {
+            list: [55, 33, 22],
+            current: 44,
+            next: 55,
+            previous: 22
+        },
+        {
+            list: [55, 33, 22],
+            current: 22,
+            next: 55,
+            previous: 33
+        },
+        {
+            list: [55, 33, 22],
+            current: 55,
+            next: 33,
+            previous: 22
+        },
+        {
+            list: [55],
+            current: 55,
+            next: 55,
+            previous: 55
+        }
+    ]
+    it("iterates correctly", () => {
+        scenarios.forEach(scenario => {
+            expect(next(scenario.list, scenario.current)).toBe(scenario.next)
+            expect(previous(scenario.list, scenario.current)).toBe(
+                scenario.previous
+            )
+        })
     })
 })
 

--- a/charts/covidDataExplorer/CommandPalette.tsx
+++ b/charts/covidDataExplorer/CommandPalette.tsx
@@ -1,0 +1,47 @@
+import { observer } from "mobx-react"
+import React from "react"
+
+declare type keyboardCombo = string
+
+export interface Command {
+    combo: keyboardCombo
+    fn: () => any
+    title: string
+    category: string
+}
+
+@observer
+export class CommandPalette extends React.Component<{
+    commands: Command[]
+    display: "none" | "block"
+}> {
+    render() {
+        const style: any = {
+            display: this.props.display
+        }
+        let lastCat = ""
+        const commands = this.props.commands.map(command => {
+            let cat = undefined
+            if (command.category !== lastCat) {
+                lastCat = command.category
+                cat = <div className="commandCategory">{lastCat}</div>
+            }
+            return (
+                <>
+                    {cat}
+                    <div className="commandOption">
+                        <span className="commandCombo">{command.combo}</span>
+                        <a onClick={() => command.fn()}>{command.title}</a>
+                    </div>
+                </>
+            )
+        })
+
+        return (
+            <div className="CommandPalette" style={style}>
+                <div className="paletteTitle">Keyboard Shortcuts</div>
+                {commands}
+            </div>
+        )
+    }
+}

--- a/charts/covidDataExplorer/CommandPalette.tsx
+++ b/charts/covidDataExplorer/CommandPalette.tsx
@@ -20,20 +20,20 @@ export class CommandPalette extends React.Component<{
             display: this.props.display
         }
         let lastCat = ""
-        const commands = this.props.commands.map(command => {
+        const commands = this.props.commands.map((command, index) => {
             let cat = undefined
             if (command.category !== lastCat) {
                 lastCat = command.category
                 cat = <div className="commandCategory">{lastCat}</div>
             }
             return (
-                <>
+                <div key={`command${index}`}>
                     {cat}
                     <div className="commandOption">
                         <span className="commandCombo">{command.combo}</span>
                         <a onClick={() => command.fn()}>{command.title}</a>
                     </div>
-                </>
+                </div>
             )
         })
 

--- a/charts/covidDataExplorer/CovidChartUrl.ts
+++ b/charts/covidDataExplorer/CovidChartUrl.ts
@@ -113,8 +113,6 @@ export class CovidQueryParams {
                 params.country
             ).forEach(code => this.selectedCountryCodes.add(code))
         }
-        if (params.colorScale)
-            this.colorScale = params.colorScale as colorScaleOption
 
         if (params.pickerMetric) {
             const metric = oneOf<CountryPickerMetric | undefined>(
@@ -136,6 +134,7 @@ export class CovidQueryParams {
         this.yColumn = params.yColumn
         this.xColumn = params.xColumn
         this.sizeColumn = params.sizeColumn
+        this.colorScale = params.colorScale as colorScaleOption
     }
 
     constructor(queryString: string) {

--- a/charts/covidDataExplorer/CovidChartUrl.ts
+++ b/charts/covidDataExplorer/CovidChartUrl.ts
@@ -192,6 +192,16 @@ export class CovidQueryParams {
         return this.aligned ? "ScatterPlot" : "LineChart"
     }
 
+    @computed get colorStrategy(): colorScaleOption {
+        if (this.chartType !== "ScatterPlot") return "none"
+
+        if (this.colorScale) return this.colorScale
+
+        if (this.casesMetric || this.testsMetric) return "ptr"
+
+        return "continents"
+    }
+
     @computed get yColumnSlug() {
         if (this.yColumn) return this.yColumn
         return buildColumnSlug(

--- a/charts/covidDataExplorer/CovidChartUrl.ts
+++ b/charts/covidDataExplorer/CovidChartUrl.ts
@@ -195,9 +195,9 @@ export class CovidQueryParams {
     }
 
     @computed get colorStrategy(): colorScaleOption {
-        if (this.chartType !== "ScatterPlot") return "none"
-
         if (this.colorScale) return this.colorScale
+
+        if (this.chartType !== "ScatterPlot") return "none"
 
         if (this.casesMetric || this.testsMetric) return "ptr"
 

--- a/charts/covidDataExplorer/CovidChartUrl.ts
+++ b/charts/covidDataExplorer/CovidChartUrl.ts
@@ -33,6 +33,7 @@ export class CovidQueryParams {
 
     @observable yColumn?: string
     @observable xColumn?: string
+    @observable sizeColumn?: string
 
     @observable totalFreq: boolean = false
     @observable dailyFreq: boolean = false
@@ -134,6 +135,7 @@ export class CovidQueryParams {
 
         this.yColumn = params.yColumn
         this.xColumn = params.xColumn
+        this.sizeColumn = params.sizeColumn
     }
 
     constructor(queryString: string) {
@@ -162,6 +164,7 @@ export class CovidQueryParams {
         const params: any = {}
         params.xColumn = this.xColumn ? this.xColumn : undefined
         params.yColumn = this.yColumn ? this.yColumn : undefined
+        params.sizeColumn = this.sizeColumn ? this.sizeColumn : undefined
         params.testsMetric = this.testsMetric ? true : undefined
         params.deathsMetric = this.deathsMetric ? true : undefined
         params.casesMetric = this.casesMetric ? true : undefined

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -56,6 +56,7 @@ import {
 import { entityCode } from "charts/owidData/OwidTable"
 import { ColorScaleConfigProps } from "charts/ColorScaleConfig"
 import * as Mousetrap from "mousetrap"
+import { CommandPalette, Command } from "./CommandPalette"
 
 const abSeed = Math.random()
 
@@ -64,71 +65,6 @@ interface BootstrapProps {
     isEmbed?: boolean
     queryStr?: string
     globalEntitySelection?: GlobalEntitySelection
-}
-
-declare type keyboardCombo = string
-
-interface Command {
-    combo: keyboardCombo
-    fn: () => any
-    title: string
-    category: string
-}
-
-@observer
-export class CommandCenter extends React.Component<{ commands: Command[] }> {
-    render() {
-        const style: any = {
-            position: "fixed",
-            display: "none",
-            top: 100,
-            left: 100,
-            right: 100,
-            bottom: 100,
-            background: "white",
-            zIndex: 1000,
-            opacity: 0.7
-        }
-        let lastCat = ""
-        const commands = this.props.commands.map(command => {
-            let cat = undefined
-            if (command.category !== lastCat) {
-                lastCat = command.category
-                cat = (
-                    <tr>
-                        <td>
-                            <strong>{lastCat}</strong>
-                        </td>
-                        <td></td>
-                    </tr>
-                )
-            }
-            return (
-                <>
-                    {cat}
-                    <tr>
-                        <td>{command.combo}</td>
-                        <td>
-                            <a onClick={() => command.fn()}>{command.title}</a>
-                        </td>
-                    </tr>
-                </>
-            )
-        })
-
-        return (
-            <div id="keyboardHelp" style={style}>
-                <h3>Keyboard Shortcuts</h3>
-                <table>
-                    <thead>
-                        <th></th>
-                        <th></th>
-                    </thead>
-                    <tbody>{commands}</tbody>
-                </table>
-            </div>
-        )
-    }
 }
 
 @observer
@@ -521,7 +457,10 @@ export class CovidDataExplorer extends React.Component<{
     render() {
         return (
             <>
-                <CommandCenter commands={this.keyboardShortcuts} />
+                <CommandPalette
+                    commands={this.keyboardShortcuts}
+                    display="none"
+                />
                 <div
                     className={classnames({
                         CovidDataExplorer: true,
@@ -865,12 +804,13 @@ export class CovidDataExplorer extends React.Component<{
             },
             {
                 combo: "?",
-                fn: () =>
-                    (document.getElementById("keyboardHelp")!.style.display =
-                        document.getElementById("keyboardHelp")!.style
-                            .display === "none"
-                            ? "block"
-                            : "none"),
+                fn: () => {
+                    const element = document.getElementsByClassName(
+                        "CommandPalette"
+                    )[0] as HTMLElement
+                    element.style.display =
+                        element.style.display === "none" ? "block" : "none"
+                },
                 title: "Toggle Help",
                 category: "Navigation"
             },
@@ -925,26 +865,23 @@ export class CovidDataExplorer extends React.Component<{
                 category: "Chart"
             },
             {
-                combo: "x",
-                fn: () => this.toggleDimensionColumnCommand("x"),
-                title: "Next X Option",
-                category: "Chart"
-            },
-
-            {
                 combo: "shift+y",
                 fn: () => this.toggleDimensionColumnCommand("y", true),
                 title: "Previous Y Option",
                 category: "Chart"
             },
-
+            {
+                combo: "x",
+                fn: () => this.toggleDimensionColumnCommand("x"),
+                title: "Next X Option",
+                category: "Chart"
+            },
             {
                 combo: "shift+x",
                 fn: () => this.toggleDimensionColumnCommand("x", true),
                 title: "Previous X Option",
                 category: "Chart"
             },
-
             {
                 combo: "s",
                 fn: () => this.toggleDimensionColumnCommand("size"),

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -57,6 +57,7 @@ import { entityCode } from "charts/owidData/OwidTable"
 import { ColorScaleConfigProps } from "charts/ColorScaleConfig"
 import * as Mousetrap from "mousetrap"
 import { CommandPalette, Command } from "./CommandPalette"
+import { TimeBoundValue } from "charts/TimeBounds"
 
 const abSeed = Math.random()
 
@@ -778,18 +779,37 @@ export class CovidDataExplorer extends React.Component<{
         })
     }
 
+    playDefaultViewCommand() {
+        const props = this.chart.props
+        props.tab = "chart"
+        props.xAxis.scaleType = "linear"
+        props.yAxis.scaleType = "log"
+        this.chart.timeDomain = [
+            TimeBoundValue.unboundedLeft,
+            TimeBoundValue.unboundedRight
+        ]
+        this.props.params.setParamsFromQueryString(coronaDefaultView)
+        this.renderControlsThenUpdateChart()
+    }
+
     get keyboardShortcuts(): Command[] {
         return [
             {
+                combo: "h",
+                fn: () => this.playDefaultViewCommand(),
+                title: "Default view",
+                category: "Browse"
+            },
+            {
                 combo: "right",
                 fn: () => this.playIndex(++this.currentIndex),
-                title: "Play next",
+                title: "Show next",
                 category: "Browse"
             },
             {
                 combo: "left",
                 fn: () => this.playIndex(--this.currentIndex),
-                title: "Play previous",
+                title: "Show previous",
                 category: "Browse"
             },
             {
@@ -817,13 +837,13 @@ export class CovidDataExplorer extends React.Component<{
             {
                 combo: "esc",
                 fn: () => this.clearSelectionCommand(),
-                title: "Clear selected countries",
+                title: "Clear selection",
                 category: "Selection"
             },
             {
                 combo: "a",
                 fn: () => this.selectAllCommand(),
-                title: "Select all countries",
+                title: "Select all",
                 category: "Selection"
             },
             {

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -82,6 +82,7 @@ export class CovidDataExplorer extends React.Component<{
     queryStr?: string
     isEmbed?: boolean
     globalEntitySelection?: GlobalEntitySelection
+    enableKeyboardShortcuts?: boolean
 }> {
     static async bootstrap(props: BootstrapProps) {
         const [typedData, updated, covidMeta] = await Promise.all([
@@ -103,6 +104,7 @@ export class CovidDataExplorer extends React.Component<{
                 queryStr={queryStr}
                 isEmbed={props.isEmbed}
                 globalEntitySelection={props.globalEntitySelection}
+                enableKeyboardShortcuts={true}
             />,
             props.containerNode
         )
@@ -791,12 +793,16 @@ export class CovidDataExplorer extends React.Component<{
         this.chart.embedExplorerCheckbox = this.controlsToggleElement
         ;(window as any).covidDataExplorer = this
 
-        this.keyboardShortcuts.forEach(shortcut => {
-            Mousetrap.bind(shortcut.combo, () => {
-                shortcut.fn()
-                Analytics.logKeyboardShortcut(shortcut.title, shortcut.combo)
+        if (this.props.enableKeyboardShortcuts)
+            this.keyboardShortcuts.forEach(shortcut => {
+                Mousetrap.bind(shortcut.combo, () => {
+                    shortcut.fn()
+                    Analytics.logKeyboardShortcut(
+                        shortcut.title,
+                        shortcut.combo
+                    )
+                })
             })
-        })
     }
 
     playDefaultViewCommand() {

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -59,6 +59,7 @@ import * as Mousetrap from "mousetrap"
 import { CommandPalette, Command } from "./CommandPalette"
 import { TimeBoundValue } from "charts/TimeBounds"
 import { startCase } from "lodash"
+import { Analytics } from "site/client/Analytics"
 
 const abSeed = Math.random()
 
@@ -791,7 +792,10 @@ export class CovidDataExplorer extends React.Component<{
         ;(window as any).covidDataExplorer = this
 
         this.keyboardShortcuts.forEach(shortcut => {
-            Mousetrap.bind(shortcut.combo, shortcut.fn)
+            Mousetrap.bind(shortcut.combo, () => {
+                shortcut.fn()
+                Analytics.logKeyboardShortcut(shortcut.title, shortcut.combo)
+            })
         })
     }
 

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -829,13 +829,13 @@ export class CovidDataExplorer extends React.Component<{
             {
                 combo: "right",
                 fn: () => this.playIndex(++this.currentIndex),
-                title: "Show next",
+                title: "Next view",
                 category: "Browse"
             },
             {
                 combo: "left",
                 fn: () => this.playIndex(--this.currentIndex),
-                title: "Show previous",
+                title: "Previous view",
                 category: "Browse"
             },
             {
@@ -870,6 +870,18 @@ export class CovidDataExplorer extends React.Component<{
                 category: "Selection"
             },
             {
+                combo: "f",
+                fn: () => {
+                    this.chart.props.minPopulationFilter =
+                        this.chart.props.minPopulationFilter === 2e9
+                            ? undefined
+                            : 2e9
+                    this.renderControlsThenUpdateChart()
+                },
+                title: "Hide unselected",
+                category: "Selection"
+            },
+            {
                 combo: "c",
                 fn: () => {
                     this.props.params.colorScale = next(
@@ -892,67 +904,18 @@ export class CovidDataExplorer extends React.Component<{
                 category: "Chart"
             },
             {
-                combo: "shift+l",
-                fn: () =>
-                    (this.chart.props.xAxis.scaleType = next(
-                        ["linear", "log"],
-                        this.chart.props.xAxis.scaleType
-                    )),
-                title: "Toggle X log/linear",
-                category: "Chart"
-            },
-            {
-                combo: "y",
-                fn: () => this.toggleDimensionColumnCommand("y"),
-                title: "Next Y Option",
-                category: "Chart"
-            },
-            {
-                combo: "shift+y",
-                fn: () => this.toggleDimensionColumnCommand("y", true),
-                title: "Previous Y Option",
-                category: "Chart"
-            },
-            {
-                combo: "x",
-                fn: () => this.toggleDimensionColumnCommand("x"),
-                title: "Next X Option",
-                category: "Chart"
-            },
-            {
-                combo: "shift+x",
-                fn: () => this.toggleDimensionColumnCommand("x", true),
-                title: "Previous X Option",
-                category: "Chart"
-            },
-            {
-                combo: "s",
-                fn: () => this.toggleDimensionColumnCommand("size"),
-                title: "Next Size Option",
-                category: "Chart"
-            },
-            {
-                combo: "shift+s",
-                fn: () => this.toggleDimensionColumnCommand("size", true),
-                title: "Previous Size Option",
-                category: "Chart"
-            },
-            {
                 combo: "z",
                 fn: () => {
-                    this.chart.url.setTimeFromTimeQueryParam("latest")
+                    // Todo: add tests for this
+                    this.chart.url.setTimeFromTimeQueryParam(
+                        next(
+                            ["latest", "earliest", ".."],
+                            this.chart.url.timeParam!
+                        )
+                    )
                     this.renderControlsThenUpdateChart()
                 },
-                title: "Latest period",
-                category: "Timeline"
-            },
-            {
-                combo: "shift+z",
-                fn: () => {
-                    this.chart.url.setTimeFromTimeQueryParam("earliest")
-                    this.renderControlsThenUpdateChart()
-                },
-                title: "Earliest period",
+                title: "Latest/Earliest/All period",
                 category: "Timeline"
             },
             {

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -28,7 +28,7 @@ import {
     next,
     previous
 } from "charts/Util"
-import { CountryOption, CovidGrapherRow, colorScaleOption } from "./CovidTypes"
+import { CountryOption, CovidGrapherRow } from "./CovidTypes"
 import { ControlOption, ExplorerControl } from "./CovidExplorerControl"
 import { CountryPicker } from "./CovidCountryPicker"
 import { CovidQueryParams, CovidUrl } from "./CovidChartUrl"
@@ -688,6 +688,11 @@ export class CovidDataExplorer extends React.Component<{
         const params = this.constrainedParams
         const { covidExplorerTable } = this
         covidExplorerTable.initRequestedColumns(params)
+
+        // Init column for epi color strategy if needed
+        if (params.colorStrategy === "ptr")
+            this.covidExplorerTable.initAndGetShortTermPositivityRateVarId()!
+
         const chartProps = this.chart.props
         chartProps.title = this.chartTitle
         chartProps.subtitle = this.subtitle
@@ -1105,7 +1110,7 @@ export class CovidDataExplorer extends React.Component<{
         const variableId =
             this.constrainedParams.colorStrategy === "continents"
                 ? 123
-                : this.covidExplorerTable.getShortTermPositivityRateVarId()!
+                : this.covidExplorerTable.initAndGetShortTermPositivityRateVarId()!
 
         return {
             property: "color",

--- a/charts/covidDataExplorer/CovidExplorerTable.ts
+++ b/charts/covidDataExplorer/CovidExplorerTable.ts
@@ -413,7 +413,7 @@ export class CovidExplorerTable {
         )
     }
 
-    getShortTermPositivityRateVarId() {
+    initAndGetShortTermPositivityRateVarId() {
         // We init this column for the epi line colors on ScatterPlots
         const params = new CovidQueryParams("")
         params.smoothing = 7

--- a/charts/covidDataExplorer/CovidExplorerTable.ts
+++ b/charts/covidDataExplorer/CovidExplorerTable.ts
@@ -88,7 +88,7 @@ export class CovidExplorerTable {
         this.initColumnSpecs(owidVariableSpecs)
         this.table = table
         this.table.rows = data
-        this.table.addSpecs(this.getBaseSpecs(data[0]))
+        this.table.addSpecs(this.getBaseSpecs(data[0] || {}))
         this.table.columnsBySlug.forEach(col => {
             // Ensure all columns have a OwidVarId for now. Todo: rely on just column slug in Grapher.
             if (!col.spec.owidVariableId)
@@ -190,12 +190,17 @@ export class CovidExplorerTable {
         })
 
         // Todo: move to the grapher specs?
-        this.columnSpecs.positive_test_rate.display!.tableDisplay = {
-            hideRelativeChange: true
-        } as any
-        this.columnSpecs.case_fatality_rate.display!.tableDisplay = {
-            hideRelativeChange: true
-        } as any
+        const ptrDisplay = this.columnSpecs.positive_test_rate.display
+        if (ptrDisplay)
+            ptrDisplay.tableDisplay = {
+                hideRelativeChange: true
+            } as any
+
+        const cfrDisplay = this.columnSpecs.case_fatality_rate.display
+        if (cfrDisplay)
+            cfrDisplay.tableDisplay = {
+                hideRelativeChange: true
+            } as any
     }
 
     private addAnnotationColumns() {

--- a/charts/covidDataExplorer/CovidExplorerTable.ts
+++ b/charts/covidDataExplorer/CovidExplorerTable.ts
@@ -137,11 +137,7 @@ export class CovidExplorerTable {
                 ...owidVariableSpecs[sourceVariables.positive_test_rate],
                 isDailyMeasurement: true,
                 description:
-                    "The number of confirmed cases divided by the number of tests, expressed as a percentage. Tests may refer to the number of tests performed or the number of people tested – depending on which is reported by the particular country.",
-                display: {
-                    shortUnit: "%",
-                    tableDisplay: { hideRelativeChange: true }
-                }
+                    "The number of confirmed cases divided by the number of tests, expressed as a percentage. Tests may refer to the number of tests performed or the number of people tested – depending on which is reported by the particular country."
             },
             tests_per_case: {
                 ...owidVariableSpecs[sourceVariables.tests_per_case],
@@ -153,11 +149,7 @@ export class CovidExplorerTable {
                 ...owidVariableSpecs[sourceVariables.case_fatality_rate],
                 annotationsColumnSlug: "case_fatality_rate_annotations",
                 isDailyMeasurement: true,
-                description: `The Case Fatality Rate (CFR) is the ratio between confirmed deaths and confirmed cases. During an outbreak of a pandemic the CFR is a poor measure of the mortality risk of the disease. We explain this in detail at OurWorldInData.org/Coronavirus`,
-                display: {
-                    shortUnit: "%",
-                    tableDisplay: { hideRelativeChange: true }
-                }
+                description: `The Case Fatality Rate (CFR) is the ratio between confirmed deaths and confirmed cases. During an outbreak of a pandemic the CFR is a poor measure of the mortality risk of the disease. We explain this in detail at OurWorldInData.org/Coronavirus`
             },
             cases: {
                 ...owidVariableSpecs[sourceVariables.cases],
@@ -196,6 +188,14 @@ export class CovidExplorerTable {
         Object.keys(this.columnSpecs).forEach(key => {
             this.columnSpecs[key].owidVariableId = (sourceVariables as any)[key]
         })
+
+        // Todo: move to the grapher specs?
+        this.columnSpecs.positive_test_rate.display!.tableDisplay = {
+            hideRelativeChange: true
+        } as any
+        this.columnSpecs.case_fatality_rate.display!.tableDisplay = {
+            hideRelativeChange: true
+        } as any
     }
 
     private addAnnotationColumns() {

--- a/charts/covidDataExplorer/CovidExplorerTable.ts
+++ b/charts/covidDataExplorer/CovidExplorerTable.ts
@@ -30,7 +30,8 @@ import {
     RowToValueMapper,
     ColumnSpec,
     entityName,
-    columnSlug
+    columnSlug,
+    columnTypes
 } from "charts/owidData/OwidTable"
 import { CovidConstrainedQueryParams, CovidQueryParams } from "./CovidChartUrl"
 import { covidAnnotations } from "./CovidAnnotations"
@@ -101,7 +102,9 @@ export class CovidExplorerTable {
         return Object.keys(row).map(slug => {
             return {
                 slug,
-                type: stringColumnSlugs.has(slug) ? "String" : "Numeric"
+                type: stringColumnSlugs.has(slug)
+                    ? "String"
+                    : ("Numeric" as columnTypes)
             }
         })
     }

--- a/charts/covidDataExplorer/CovidTypes.ts
+++ b/charts/covidDataExplorer/CovidTypes.ts
@@ -7,7 +7,7 @@ export declare type TotalFrequencyOption = boolean
 
 export declare type countrySlug = string
 
-export declare type colorScaleOption = "continents" | "ptr"
+export declare type colorScaleOption = "continents" | "ptr" | "none"
 
 export declare type MetricKind =
     | "deaths"

--- a/charts/owidData/OwidTable.ts
+++ b/charts/owidData/OwidTable.ts
@@ -78,7 +78,7 @@ interface OwidRow extends Row {
     date?: string
 }
 
-declare type columnTypes =
+export declare type columnTypes =
     | "Numeric"
     | "String"
     | "Categorical"

--- a/site/client/Analytics.ts
+++ b/site/client/Analytics.ts
@@ -77,6 +77,10 @@ export class Analytics {
         this.logToGA("SiteClick", note || "unknown-category", text)
     }
 
+    static logKeyboardShortcut(shortcut: string, combo: string) {
+        this.logToGA("KeyboardShortcut", shortcut, combo)
+    }
+
     static logPageLoad() {
         this.logToAmplitude("OWID_PAGE_LOAD")
     }

--- a/site/client/css/pages/commandPalette.scss
+++ b/site/client/css/pages/commandPalette.scss
@@ -1,3 +1,5 @@
+$linkColor: #0645ad;
+
 .CommandPalette {
     position: fixed;
     top: 100;
@@ -29,5 +31,17 @@
     .commandCategory,
     .commandOption {
         line-height: 1.4em;
+    }
+
+    a {
+        color: $linkColor;
+
+        &:hover {
+            color: lighten($color: $linkColor, $amount: 20);
+        }
+
+        &:active {
+            color: lighten($color: $linkColor, $amount: 40);
+        }
     }
 }

--- a/site/client/css/pages/commandPalette.scss
+++ b/site/client/css/pages/commandPalette.scss
@@ -1,0 +1,33 @@
+.CommandPalette {
+    position: fixed;
+    top: 100;
+    left: 100;
+    font-size: 0.8em;
+    background: white;
+    z-index: 1000;
+    opacity: 0.95;
+    padding: 14px;
+    border-radius: 2px;
+    box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 2px 0px,
+        rgba(0, 0, 0, 0.25) 0px 2px 2px 0px;
+
+    .paletteTitle {
+        font-size: 1.2em;
+        font-weight: bold;
+    }
+
+    .commandCategory {
+        font-weight: bold;
+        margin-top: 1.4em;
+    }
+
+    .commandCombo {
+        width: 5em;
+        display: inline-block;
+    }
+
+    .commandCategory,
+    .commandOption {
+        line-height: 1.4em;
+    }
+}

--- a/site/client/owid.scss
+++ b/site/client/owid.scss
@@ -36,6 +36,7 @@
 @import "css/pages/homepage.scss";
 @import "css/pages/donate.scss";
 @import "css/pages/faq.scss";
+@import "css/pages/commandPalette.scss";
 @import "css/pages/covidDataExplorer.scss";
 @import "css/pages/covid.scss";
 @import "css/pages/chart.scss";

--- a/stories/index.stories.tsx
+++ b/stories/index.stories.tsx
@@ -19,7 +19,7 @@ storiesOf("FeedbackForm", module).add("normal", () => <FeedbackForm />)
 storiesOf("ChartStoryView", module).add("normal", () => <ChartStoryView />)
 
 storiesOf("CovidDataExplorer", module)
-    .add("single", () => {
+    .add("single with keyboard shortcuts", () => {
         const dummyMeta = {
             charts: {},
             variables: {}
@@ -30,6 +30,7 @@ storiesOf("CovidDataExplorer", module)
                 params={new CovidQueryParams("")}
                 covidChartAndVariableMeta={dummyMeta}
                 updated="2020-05-09T18:59:31"
+                enableKeyboardShortcuts={true}
             />
         )
     })

--- a/stories/index.stories.tsx
+++ b/stories/index.stories.tsx
@@ -9,6 +9,10 @@ import "charts/client/chart.scss"
 import { CovidDataExplorer } from "charts/covidDataExplorer/CovidDataExplorer"
 import { covidSampleRows } from "test/fixtures/CovidSampleRows"
 import { CovidQueryParams } from "charts/covidDataExplorer/CovidChartUrl"
+import {
+    CommandPalette,
+    Command
+} from "charts/covidDataExplorer/CommandPalette"
 
 storiesOf("FeedbackForm", module).add("normal", () => <FeedbackForm />)
 
@@ -51,6 +55,30 @@ storiesOf("CovidDataExplorer", module)
             </>
         )
     })
+
+storiesOf("CommandPalette", module).add("testCommands", () => {
+    const demoCommands: Command[] = [
+        {
+            combo: "ctrl+o",
+            fn: () => {},
+            title: "Open",
+            category: "File"
+        },
+        {
+            combo: "ctrl+s",
+            fn: () => {},
+            title: "Save",
+            category: "File"
+        },
+        {
+            combo: "ctrl+c",
+            fn: () => {},
+            title: "Copy",
+            category: "Edit"
+        }
+    ]
+    return <CommandPalette commands={demoCommands} display="block" />
+})
 
 // storiesOf('Button', module)
 //   .add('with text', () => <Button onClick={action('clicked')}>Hello Button</Button>)


### PR DESCRIPTION
This adds keyboard shortcuts and a clickable help menu (placeholder design for now).  Color schemes can be toggled and dimensions as well.

Shortcuts are not enabled on the baked pages.

I'm thinking of putting it behind some sort of feature flag and/or removing the dimension changing commands for now.