### PR TITLE
Turn on Mobx enforceActions flag

### DIFF
--- a/admin/client/AdminLayout.tsx
+++ b/admin/client/AdminLayout.tsx
@@ -18,19 +18,23 @@ export class AdminLayout extends React.Component<{
     static contextType = AdminAppContext
     context!: AdminAppContextType
 
-    @observable isFAQ: boolean = false
-    @observable isSidebar: boolean = false
+    @observable private showFAQ: boolean = false
+    @observable private showSidebar: boolean = false
 
     @action.bound onToggleFAQ() {
-        this.isFAQ = !this.isFAQ
+        this.showFAQ = !this.showFAQ
     }
 
     @action.bound onToggleSidebar() {
-        this.isSidebar = !this.isSidebar
+        this.showSidebar = !this.showSidebar
+    }
+
+    @action.bound private setInitialSidebarState(value: boolean) {
+        this.showSidebar = value
     }
 
     componentDidMount() {
-        this.isSidebar = !this.props.noSidebar
+        this.setInitialSidebarState(!this.props.noSidebar)
         this.componentDidUpdate()
     }
 
@@ -52,10 +56,12 @@ export class AdminLayout extends React.Component<{
 
     render() {
         const { admin } = this.context
-        const { isFAQ, isSidebar, environmentSpan } = this
+        const { showFAQ: isFAQ, showSidebar, environmentSpan } = this
 
         return (
-            <div className={"AdminLayout" + (isSidebar ? " withSidebar" : "")}>
+            <div
+                className={"AdminLayout" + (showSidebar ? " withSidebar" : "")}
+            >
                 {isFAQ && <EditorFAQ onClose={this.onToggleFAQ} />}
                 <nav className="navbar navbar-dark bg-dark flex-row navbar-expand-lg">
                     <button
@@ -97,7 +103,7 @@ export class AdminLayout extends React.Component<{
                         </li>
                     </ul>
                 </nav>
-                {isSidebar && <AdminSidebar />}
+                {showSidebar && <AdminSidebar />}
                 {this.props.children}
             </div>
         )

--- a/admin/client/VariableSelector.tsx
+++ b/admin/client/VariableSelector.tsx
@@ -372,6 +372,10 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
                 )
         })
 
+        this.initChosenVariables()
+    }
+
+    @action.bound private initChosenVariables() {
         this.chosenVariables = this.props.slot.dimensionsWithData.map(d => ({
             name: d.displayName,
             id: d.variableId,

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -86,7 +86,8 @@ declare const App: any
 declare const window: any
 
 const IS_DEV = ENV === "development"
-if (IS_DEV) configure({ enforceActions: "observed" })
+const ENFORCE_ACTIONS = false
+if (IS_DEV && ENFORCE_ACTIONS) configure({ enforceActions: "observed" })
 
 // That node check is taken from the "detect-node" npm package: https://www.npmjs.com/package/detect-node
 const isNode: boolean =

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -569,7 +569,7 @@ export class ChartConfig {
             })
     }
 
-    ensureValidConfig() {
+    @action.bound ensureValidConfig() {
         const disposers = [
             autorun(() => {
                 if (!this.availableTabs.includes(this.props.tab)) {

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import * as ReactDOMServer from "react-dom/server"
 import {
+    configure,
     observable,
     computed,
     action,
@@ -59,7 +60,7 @@ import {
 import { TooltipProps } from "./Tooltip"
 import { LogoOption } from "./Logos"
 import { canBeExplorable } from "utils/charts"
-import { BAKED_GRAPHER_URL } from "settings"
+import { BAKED_GRAPHER_URL, ENV } from "settings"
 import {
     minTimeFromJSON,
     maxTimeFromJSON,
@@ -83,6 +84,9 @@ import { populationMap } from "./PopulationMap"
 
 declare const App: any
 declare const window: any
+
+const IS_DEV = ENV === "development"
+if (IS_DEV) configure({ enforceActions: "observed" })
 
 // That node check is taken from the "detect-node" npm package: https://www.npmjs.com/package/detect-node
 const isNode: boolean =

--- a/charts/ChartUrl.ts
+++ b/charts/ChartUrl.ts
@@ -5,7 +5,7 @@
  * the chart and url parameters, to enable nice linking support
  * for specific countries and years.
  */
-import { computed, when, runInAction, observable } from "mobx"
+import { computed, when, runInAction, observable, action } from "mobx"
 
 import { BAKED_GRAPHER_URL, EPOCH_DATE } from "settings"
 
@@ -302,7 +302,7 @@ export class ChartUrl implements ObservableUrl {
     /**
      * Applies query parameters to the chart config
      */
-    populateFromQueryParams(params: ChartQueryParams) {
+    @action.bound populateFromQueryParams(params: ChartQueryParams) {
         const { chart } = this
 
         // Set tab if specified

--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -812,8 +812,12 @@ export class ControlsOverlay extends React.Component<{
         this.context.chartView.overlays[this.props.id] = this
     }
 
-    componentWillUnmount() {
+    @action.bound deleteOverlay() {
         delete this.context.chartView.overlays[this.props.id]
+    }
+
+    componentWillUnmount() {
+        this.deleteOverlay()
     }
 
     render() {

--- a/charts/DownloadTab.tsx
+++ b/charts/DownloadTab.tsx
@@ -32,7 +32,7 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
     @observable pngBlob?: Blob
     @observable pngBlobUrl?: string
     @observable pngDataUri?: string
-    @observable isReady: boolean = false
+    @observable private isReady: boolean = false
     @action.bound export() {
         if (!HTMLCanvasElement.prototype.toBlob) {
             // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob#Polyfill
@@ -91,20 +91,24 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
                     canvas.toBlob(blob => {
                         this.pngBlob = blob as Blob
                         this.pngBlobUrl = URL.createObjectURL(blob)
-                        this.isReady = true
+                        this.markAsReady()
                     })
                 } catch (e) {
                     console.error(e)
-                    this.isReady = true
+                    this.markAsReady()
                 }
             }
             img.onerror = err => {
                 console.error(JSON.stringify(err))
-                this.isReady = true
+                this.markAsReady()
             }
             img.src = this.svgDataUri
         }
         reader.readAsDataURL(this.svgBlob as Blob)
+    }
+
+    @action.bound markAsReady() {
+        this.isReady = true
     }
 
     @computed get fallbackPngUrl() {

--- a/charts/ExploreModel.ts
+++ b/charts/ExploreModel.ts
@@ -1,4 +1,4 @@
-import { observable, computed, autorun, IReactionDisposer } from "mobx"
+import { observable, computed, autorun, IReactionDisposer, action } from "mobx"
 
 import { ChartType, ChartTypeType } from "./ChartType"
 import { ChartConfig, ChartConfigProps } from "./ChartConfig"
@@ -40,6 +40,22 @@ export class ExploreModel {
     store: RootStore
     disposers: IReactionDisposer[] = []
 
+    @action.bound setIndicatorId(id?: number) {
+        this.indicatorId = id
+    }
+
+    @action.bound setChartType(chartType: ExplorerChartType) {
+        this.chartType = chartType
+        this.updateChartFromExplorer()
+    }
+
+    @action.bound updateChartFromExplorer() {
+        this.chart.props.type = this.configChartType
+        this.chart.props.hasMapTab = this.isMap
+        this.chart.props.hasChartTab = !this.isMap
+        this.chart.tab = this.isMap ? "map" : "chart"
+    }
+
     constructor(store: RootStore) {
         this.store = store
         this.chart = new ChartConfig()
@@ -51,13 +67,6 @@ export class ExploreModel {
         // observable properties, and on this autorun block to connect them to the Explore controls.
         // -@jasoncrawford 2019-12-04
         this.disposers.push(
-            autorun(() => {
-                this.chart.props.type = this.configChartType
-                this.chart.props.hasMapTab = this.isMap
-                this.chart.props.hasChartTab = !this.isMap
-                this.chart.tab = this.isMap ? "map" : "chart"
-            }),
-
             autorun(() => {
                 if (this.indicatorEntry === null) {
                     this.chart.update({ dimensions: [] })

--- a/charts/ExploreUrl.ts
+++ b/charts/ExploreUrl.ts
@@ -1,4 +1,4 @@
-import { computed } from "mobx"
+import { computed, action } from "mobx"
 
 import { ObservableUrl } from "./UrlBinding"
 import { ExploreModel, ExplorerChartType } from "./ExploreModel"
@@ -47,17 +47,17 @@ export class ExploreUrl implements ObservableUrl {
         this.populateFromQueryParams(strToQueryParams(queryStr))
     }
 
-    populateFromQueryParams(params: ExploreQueryParams) {
+    @action.bound populateFromQueryParams(params: ExploreQueryParams) {
         const { model } = this
 
         const chartType = params.type
         if (chartType) {
-            model.chartType = chartType as ExplorerChartType
+            model.setChartType(chartType as ExplorerChartType)
         }
 
         if (params.indicator) {
             const id = parseInt(params.indicator)
-            model.indicatorId = isNaN(id) ? undefined : id
+            model.setIndicatorId(isNaN(id) ? undefined : id)
         }
 
         this.chartUrl.populateFromQueryParams(params)

--- a/charts/ExploreView.tsx
+++ b/charts/ExploreView.tsx
@@ -99,7 +99,7 @@ export class ExploreView extends React.Component<ExploreProps> {
                 data-type={button.type}
                 className={`chart-type-button ${isSelected ? "selected" : ""}`}
                 onClick={() => {
-                    this.model.chartType = button.type
+                    this.model.setChartType(button.type)
                 }}
             >
                 <FontAwesomeIcon icon={button.icon} />

--- a/charts/__tests__/ExploreModel.test.ts
+++ b/charts/__tests__/ExploreModel.test.ts
@@ -32,7 +32,7 @@ describe(ExploreModel, () => {
     describe("when you set an area type", () => {
         beforeAll(() => {
             model = new ExploreModel(store)
-            model.chartType = ChartType.StackedArea
+            model.setChartType(ChartType.StackedArea)
         })
 
         it("updates the chart type to area", () => {
@@ -55,7 +55,7 @@ describe(ExploreModel, () => {
     describe("when you set a map type", () => {
         beforeAll(() => {
             model = new ExploreModel(store)
-            model.chartType = ExploreModel.WorldMap
+            model.setChartType(ExploreModel.WorldMap)
         })
 
         it("updates the chart type to line", () => {

--- a/charts/__tests__/ExploreView.test.tsx
+++ b/charts/__tests__/ExploreView.test.tsx
@@ -29,7 +29,7 @@ function getStore() {
 
 function getDefaultModel() {
     const model = new ExploreModel(getStore())
-    model.indicatorId = indicator.id
+    model.setIndicatorId(indicator.id)
     return model
 }
 
@@ -77,7 +77,7 @@ describe(ExploreView, () => {
 
         it("applies the chart type", async () => {
             const model = getDefaultModel()
-            model.chartType = "WorldMap"
+            model.setChartType("WorldMap")
             const view = await renderWithModel(model)
             expect(view.find(ChoroplethMap)).toHaveLength(1)
         })
@@ -179,7 +179,7 @@ describe(ExploreView, () => {
             const view = mount(<ExploreView bounds={bounds} model={model} />)
             expect(view.find(ChartView)).toHaveLength(1)
 
-            model.indicatorId = indicator.id
+            model.setIndicatorId(indicator.id)
             await updateViewWhenReady(view)
             expect(view.find(".chart h1")).toHaveLength(1)
             expect(view.find(".chart h1").text()).toContain(indicator.title)


### PR DESCRIPTION
Often I hit runtime Mobx errors because observables are being changed by regular methods (or computeds). It seems it is recommended to enable the global 'enforceActions' (https://mobx.js.org/refguide/api.html#enforceactions) so an error is thrown if an observable is being updated not in a function with an `@action` decorator. My hope is that this will help make it easier to debug Mobx issues.

At first I tried the "always" setting, but that throws errors when default properties are initialized on object construction (https://github.com/mobxjs/mobx/issues/1702 if curious). So the "observed" setting makes more sense.