### PR TITLE
Multimetric CDE DataTable

### DIFF
--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -742,10 +742,10 @@ export class ChartConfig {
         return validDimensions
     }
 
-    @observable tableOnlyDimensions: ChartDimensionWithOwidVariable[] = []
+    @observable dataTableOnlyDimensions: ChartDimensionWithOwidVariable[] = []
 
     @computed get multiMetricTableMode(): boolean {
-        return this.tableOnlyDimensions.length > 0
+        return this.dataTableOnlyDimensions.length > 0
     }
 
     @computed.struct get filledDimensions(): ChartDimensionWithOwidVariable[] {

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -742,6 +742,8 @@ export class ChartConfig {
         return validDimensions
     }
 
+    @observable tableOnlyDimensions: ChartDimensionWithOwidVariable[] = []
+
     @computed.struct get filledDimensions(): ChartDimensionWithOwidVariable[] {
         if (!this.isReady) return []
 

--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -744,6 +744,10 @@ export class ChartConfig {
 
     @observable tableOnlyDimensions: ChartDimensionWithOwidVariable[] = []
 
+    @computed get multiMetricTableMode(): boolean {
+        return this.tableOnlyDimensions.length > 0
+    }
+
     @computed.struct get filledDimensions(): ChartDimensionWithOwidVariable[] {
         if (!this.isReady) return []
 

--- a/charts/ChartDimension.ts
+++ b/charts/ChartDimension.ts
@@ -10,7 +10,7 @@ import {
 } from "./owidData/OwidVariable"
 import { owidVariableId } from "./owidData/OwidTable"
 
-export declare type dimensionProperty = "y" | "x" | "size" | "color" | "table"
+export declare type dimensionProperty = "y" | "x" | "size" | "color"
 
 export interface DimensionSpec {
     property: dimensionProperty

--- a/charts/ChartDimension.ts
+++ b/charts/ChartDimension.ts
@@ -10,7 +10,7 @@ import {
 } from "./owidData/OwidVariable"
 import { owidVariableId } from "./owidData/OwidTable"
 
-export declare type dimensionProperty = "y" | "x" | "size" | "color"
+export declare type dimensionProperty = "y" | "x" | "size" | "color" | "table"
 
 export interface DimensionSpec {
     property: dimensionProperty

--- a/charts/Controls.tsx
+++ b/charts/Controls.tsx
@@ -462,17 +462,22 @@ class TimelineControl extends React.Component<{ chart: ChartConfig }> {
             if (years.length === 0) {
                 return null
             }
+
+            const startYear =
+                dataTableTransform.autoSelectedStartYear ?? chart.timeDomain[0]
+            const endYear = chart.multiMetricTableMode
+                ? startYear
+                : chart.timeDomain[1]
+
             return (
                 <Timeline
                     years={years}
                     onTargetChange={this.onChartTargetChange}
-                    startYear={
-                        dataTableTransform.autoSelectedStartYear ??
-                        chart.timeDomain[0]
-                    }
-                    endYear={chart.timeDomain[1]}
+                    startYear={startYear}
+                    endYear={endYear}
                     onStartDrag={this.onTimelineStart}
                     onStopDrag={this.onTimelineStop}
+                    singleYearMode={chart.multiMetricTableMode}
                 />
             )
         } else if (chart.props.tab === "map") {

--- a/charts/DataTableTransform.ts
+++ b/charts/DataTableTransform.ts
@@ -278,8 +278,8 @@ export class DataTableTransform extends ChartTransform {
                           dim.tolerance
                       )
 
-            // const isRange = targetYears.length === 2
-            const isRange = this.targetYearMode === TargetYearMode.range
+            const isRange = targetYears.length === 2
+            // const isRange = this.targetYearMode === TargetYearMode.range
 
             // Inject delta columns if we have start & end values to compare in the table.
             // One column for absolute difference, another for % difference.

--- a/charts/DataTableTransform.ts
+++ b/charts/DataTableTransform.ts
@@ -15,6 +15,7 @@ import { ChartDimensionWithOwidVariable } from "./ChartDimensionWithOwidVariable
 import { TickFormattingOptions } from "./TickFormattingOptions"
 import { getTimeWithinTimeRange, Time, isUnboundedLeft } from "./TimeBounds"
 import { ChartTransform } from "./ChartTransform"
+import { union } from "lodash"
 
 // Target year modes
 
@@ -174,11 +175,16 @@ export class DataTableTransform extends ChartTransform {
     }
 
     @computed get dimensions() {
-        return this.chart.filledDimensions.filter(dim => dim.includeInTable)
+        return this.chart.tableOnlyDimensions.length
+            ? this.chart.tableOnlyDimensions
+            : this.chart.filledDimensions.filter(dim => dim.includeInTable)
     }
 
     @computed get entities() {
-        return this.chart.data.availableEntityNames
+        return union(
+            this.chart.data.availableEntityNames,
+            flatten(this.dimensions.map(dim => dim.entityNamesUniq))
+        )
     }
 
     // TODO move this logic to chart

--- a/charts/DataTableTransform.ts
+++ b/charts/DataTableTransform.ts
@@ -176,7 +176,7 @@ export class DataTableTransform extends ChartTransform {
 
     @computed get dimensions() {
         return this.chart.multiMetricTableMode
-            ? this.chart.tableOnlyDimensions
+            ? this.chart.dataTableOnlyDimensions
             : this.chart.filledDimensions.filter(dim => dim.includeInTable)
     }
 

--- a/charts/DataTableTransform.ts
+++ b/charts/DataTableTransform.ts
@@ -187,7 +187,7 @@ export class DataTableTransform extends ChartTransform {
     // TODO move this logic to chart
     @computed get targetYearMode(): TargetYearMode {
         const { tab } = this.chart
-        if (tab !== "map") {
+        if (tab === "chart") {
             if (this.chart.multiMetricTableMode) return TargetYearMode.point
             if (
                 (this.chart.isLineChart &&

--- a/charts/DataTableTransform.ts
+++ b/charts/DataTableTransform.ts
@@ -8,14 +8,14 @@ import {
     intersection,
     flatten,
     sortBy,
-    countBy
+    countBy,
+    union
 } from "./Util"
 import { ChartConfig } from "./ChartConfig"
 import { ChartDimensionWithOwidVariable } from "./ChartDimensionWithOwidVariable"
 import { TickFormattingOptions } from "./TickFormattingOptions"
 import { getTimeWithinTimeRange, Time, isUnboundedLeft } from "./TimeBounds"
 import { ChartTransform } from "./ChartTransform"
-import { union } from "lodash"
 
 // Target year modes
 

--- a/charts/DataTableTransform.ts
+++ b/charts/DataTableTransform.ts
@@ -181,10 +181,7 @@ export class DataTableTransform extends ChartTransform {
     }
 
     @computed get entities() {
-        return union(
-            this.chart.data.availableEntityNames,
-            flatten(this.dimensions.map(dim => dim.entityNamesUniq))
-        )
+        return union(...this.dimensions.map(dim => dim.entityNamesUniq))
     }
 
     // TODO move this logic to chart

--- a/charts/DataTableTransform.ts
+++ b/charts/DataTableTransform.ts
@@ -175,7 +175,7 @@ export class DataTableTransform extends ChartTransform {
     }
 
     @computed get dimensions() {
-        return this.chart.tableOnlyDimensions.length
+        return this.chart.multiMetricTableMode
             ? this.chart.tableOnlyDimensions
             : this.chart.filledDimensions.filter(dim => dim.includeInTable)
     }
@@ -187,7 +187,8 @@ export class DataTableTransform extends ChartTransform {
     // TODO move this logic to chart
     @computed get targetYearMode(): TargetYearMode {
         const { tab } = this.chart
-        if (tab === "chart") {
+        if (tab !== "map") {
+            if (this.chart.multiMetricTableMode) return TargetYearMode.point
             if (
                 (this.chart.isLineChart &&
                     !this.chart.lineChart.isSingleYear) ||
@@ -277,7 +278,8 @@ export class DataTableTransform extends ChartTransform {
                           dim.tolerance
                       )
 
-            const isRange = targetYears.length === 2
+            // const isRange = targetYears.length === 2
+            const isRange = this.targetYearMode === TargetYearMode.range
 
             // Inject delta columns if we have start & end values to compare in the table.
             // One column for absolute difference, another for % difference.

--- a/charts/DataTableTransform.ts
+++ b/charts/DataTableTransform.ts
@@ -279,7 +279,6 @@ export class DataTableTransform extends ChartTransform {
                       )
 
             const isRange = targetYears.length === 2
-            // const isRange = this.targetYearMode === TargetYearMode.range
 
             // Inject delta columns if we have start & end values to compare in the table.
             // One column for absolute difference, another for % difference.

--- a/charts/HTMLTimeline.tsx
+++ b/charts/HTMLTimeline.tsx
@@ -444,7 +444,7 @@ export class Timeline extends React.Component<TimelineProps> {
                     </div>
                 )}
                 <div className="date">
-                    {this.context.chart.formatYearFunction(minYear)}
+                    {this.context.chart.formatYearFunction(startYearUI)}
                 </div>
                 <div className="slider">
                     <div

--- a/charts/Util.ts
+++ b/charts/Util.ts
@@ -60,6 +60,7 @@ import takeWhile from "lodash/takeWhile"
 import upperFirst from "lodash/upperFirst"
 import assign from "lodash/assign"
 import countBy from "lodash/countBy"
+import startCase from "lodash/startCase"
 
 export {
     isEqual,
@@ -121,7 +122,8 @@ export {
     memoize,
     takeWhile,
     upperFirst,
-    countBy
+    countBy,
+    startCase
 }
 
 import moment from "moment"
@@ -367,7 +369,7 @@ export function next<T>(set: T[], current: T) {
 }
 
 export function previous<T>(set: T[], current: T) {
-    let nextIndex = set.indexOf(current) - 1
+    const nextIndex = set.indexOf(current) - 1
     return set[nextIndex < 0 ? set.length - 1 : nextIndex]
 }
 

--- a/charts/covidDataExplorer/CovidChartUrl.ts
+++ b/charts/covidDataExplorer/CovidChartUrl.ts
@@ -20,24 +20,6 @@ import { ChartTypeType } from "charts/ChartType"
 import { trajectoryColumnSpecs } from "./CovidConstants"
 import { buildColumnSlug } from "./CovidExplorerTable"
 
-export const metricMap: { [key: string]: MetricKind } = {
-    casesMetric: "cases",
-    deathsMetric: "deaths",
-    cfrMetric: "case_fatality_rate",
-    testsMetric: "tests",
-    testsPerCaseMetric: "tests_per_case",
-    positiveTestRate: "positive_test_rate"
-}
-
-export const metricMap2: { [key: string]: string } = {
-    cases: "casesMetric",
-    deaths: "deathsMetric",
-    case_fatality_rate: "cfrMetric",
-    tests: "testsMetric",
-    tests_per_case: "testsPerCaseMetric",
-    positive_test_rate: "positiveTestRate"
-}
-
 export class CovidQueryParams {
     // Todo: in hindsight these 6 metrics should have been something like "yColumn". May want to switch to that and translate these
     // for back compat.

--- a/charts/covidDataExplorer/CovidChartUrl.ts
+++ b/charts/covidDataExplorer/CovidChartUrl.ts
@@ -18,7 +18,7 @@ import {
 import { CountryPickerMetric } from "./CovidCountryPickerMetric"
 import { ChartTypeType } from "charts/ChartType"
 import { trajectoryColumnSpecs } from "./CovidConstants"
-import { buildColumnSlug, perCapitaDivisor } from "./CovidExplorerTable"
+import { buildColumnSlug, perCapitaDivisorByMetric } from "./CovidExplorerTable"
 
 export class CovidQueryParams {
     // Todo: in hindsight these 6 metrics should have been something like "yColumn". May want to switch to that and translate these
@@ -189,6 +189,11 @@ export class CovidQueryParams {
         return params as QueryParams
     }
 
+    /** If perCapita is enabled, will return size of divisor i.e. 1000, else 1 */
+    @computed get perCapitaAdjustment() {
+        return this.perCapita ? perCapitaDivisorByMetric(this.metricName) : 1
+    }
+
     // If someone selects "Align with..." we switch to a scatterplot chart type.
     @computed get chartType(): ChartTypeType {
         return this.aligned ? "ScatterPlot" : "LineChart"
@@ -208,7 +213,7 @@ export class CovidQueryParams {
         if (this.yColumn) return this.yColumn
         return buildColumnSlug(
             this.metricName,
-            this.perCapita ? perCapitaDivisor(this.metricName) : 1,
+            this.perCapitaAdjustment,
             this.dailyFreq,
             this.smoothing
         )

--- a/charts/covidDataExplorer/CovidChartUrl.ts
+++ b/charts/covidDataExplorer/CovidChartUrl.ts
@@ -18,7 +18,7 @@ import {
 import { CountryPickerMetric } from "./CovidCountryPickerMetric"
 import { ChartTypeType } from "charts/ChartType"
 import { trajectoryColumnSpecs } from "./CovidConstants"
-import { buildColumnSlug } from "./CovidExplorerTable"
+import { buildColumnSlug, perCapitaDivisor } from "./CovidExplorerTable"
 
 export class CovidQueryParams {
     // Todo: in hindsight these 6 metrics should have been something like "yColumn". May want to switch to that and translate these
@@ -189,10 +189,6 @@ export class CovidQueryParams {
         return params as QueryParams
     }
 
-    get perCapitaDivisor() {
-        return this.perCapita ? (this.testsMetric ? 1e3 : 1e6) : 1
-    }
-
     // If someone selects "Align with..." we switch to a scatterplot chart type.
     @computed get chartType(): ChartTypeType {
         return this.aligned ? "ScatterPlot" : "LineChart"
@@ -212,7 +208,7 @@ export class CovidQueryParams {
         if (this.yColumn) return this.yColumn
         return buildColumnSlug(
             this.metricName,
-            this.perCapitaDivisor,
+            this.perCapita ? perCapitaDivisor(this.metricName) : 1,
             this.dailyFreq,
             this.smoothing
         )

--- a/charts/covidDataExplorer/CovidChartUrl.ts
+++ b/charts/covidDataExplorer/CovidChartUrl.ts
@@ -252,22 +252,13 @@ export class CovidQueryParams {
         return new CovidConstrainedQueryParams(this.toString())
     }
 
-    setMetric(option: MetricKind, metricMode: "single" | "multi" = "single") {
-        if (metricMode === "single") {
-            this.casesMetric = false
-            this.testsMetric = false
-            this.deathsMetric = false
-            this.cfrMetric = false
-            this.testsPerCaseMetric = false
-            this.positiveTestRate = false
-        }
-
-        if (option === "cases") this.casesMetric = true
-        if (option === "tests") this.testsMetric = true
-        if (option === "deaths") this.deathsMetric = true
-        if (option === "case_fatality_rate") this.cfrMetric = true
-        if (option === "tests_per_case") this.testsPerCaseMetric = true
-        if (option === "positive_test_rate") this.positiveTestRate = true
+    setMetric(option: MetricKind) {
+        this.casesMetric = option === "cases"
+        this.testsMetric = option === "tests"
+        this.deathsMetric = option === "deaths"
+        this.cfrMetric = option === "case_fatality_rate"
+        this.testsPerCaseMetric = option === "tests_per_case"
+        this.positiveTestRate = option === "positive_test_rate"
     }
 
     setTimeline(option: "daily" | "total" | "smoothed") {

--- a/charts/covidDataExplorer/CovidConstants.ts
+++ b/charts/covidDataExplorer/CovidConstants.ts
@@ -1,3 +1,5 @@
+import { MetricKind } from "./CovidTypes"
+
 export const covidDashboardSlug = "coronavirus-data-explorer"
 export const coronaOpenGraphImagePath = "coronavirus-data-explorer.png"
 export const coronaWordpressElementAttribute = "data-coronavirus-data-explorer"
@@ -86,4 +88,13 @@ export const trajectoryColumnSpecs = {
             owidVariableId: 4566
         }
     }
+}
+
+export const metricLabels: { [key in MetricKind]: string } = {
+    cases: "Confirmed cases",
+    deaths: "Confirmed deaths",
+    tests: "Tests",
+    case_fatality_rate: "Case fatality rate",
+    tests_per_case: "Tests per confirmed case",
+    positive_test_rate: "Share of positive tests"
 }

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -45,7 +45,7 @@ import {
     CovidExplorerTable,
     fetchCovidChartAndVariableMeta,
     buildColumnSlug,
-    perCapitaDivisor
+    perCapitaDivisorByMetric
 } from "./CovidExplorerTable"
 import { BAKED_BASE_URL } from "settings"
 import moment from "moment"
@@ -547,7 +547,7 @@ export class CovidDataExplorer extends React.Component<{
     }
 
     @computed private get perCapitaDivisor() {
-        return perCapitaDivisor(this.constrainedParams.metricName)
+        return perCapitaDivisorByMetric(this.constrainedParams.metricName)
     }
 
     @computed private get perCapitaOptions() {
@@ -560,7 +560,7 @@ export class CovidDataExplorer extends React.Component<{
 
     private perCapitaTitle(metric: MetricKind) {
         return this.constrainedParams.perCapita
-            ? " " + this.perCapitaOptions[perCapitaDivisor(metric)]
+            ? " " + this.perCapitaOptions[perCapitaDivisorByMetric(metric)]
             : ""
     }
 
@@ -1099,7 +1099,7 @@ export class CovidDataExplorer extends React.Component<{
         const colSlug = buildColumnSlug(
             metric,
             this.constrainedParams.perCapita && isCountMetric(metric)
-                ? perCapitaDivisor(metric)
+                ? perCapitaDivisorByMetric(metric)
                 : 1,
             dailyFreq,
             0

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -721,13 +721,13 @@ export class CovidDataExplorer extends React.Component<{
         const { covidExplorerTable } = this
 
         if (this.constrainedParams.tableMetrics) {
-            const tableParams = new CovidConstrainedQueryParams(
+            const dataTableParams = new CovidConstrainedQueryParams(
                 params.toString()
             )
-            this.constrainedParams.tableMetrics.map(metric => {
-                tableParams.setMetric(metric, "multi")
+            this.constrainedParams.tableMetrics.forEach(metric => {
+                dataTableParams.setMetric(metric, "multi")
             })
-            covidExplorerTable.initRequestedColumns(tableParams)
+            covidExplorerTable.initRequestedColumns(dataTableParams)
         }
         covidExplorerTable.initRequestedColumns(params)
 

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -53,7 +53,8 @@ import {
     covidDashboardSlug,
     coronaDefaultView,
     covidDataPath,
-    sourceCharts
+    sourceCharts,
+    metricLabels
 } from "./CovidConstants"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { ColorScheme, ColorSchemes, continentColors } from "charts/ColorSchemes"
@@ -170,7 +171,7 @@ export class CovidDataExplorer extends React.Component<{
         const options: ControlOption[] = [
             {
                 available: true,
-                label: "Confirmed cases",
+                label: metricLabels.cases,
                 checked: this.constrainedParams.casesMetric,
                 onChange: () => {
                     params.setMetric("cases")
@@ -179,7 +180,7 @@ export class CovidDataExplorer extends React.Component<{
             },
             {
                 available: true,
-                label: "Confirmed deaths",
+                label: metricLabels.deaths,
                 checked: this.constrainedParams.deathsMetric,
                 onChange: () => {
                     params.setMetric("deaths")
@@ -189,7 +190,7 @@ export class CovidDataExplorer extends React.Component<{
 
             {
                 available: true,
-                label: "Case fatality rate",
+                label: metricLabels.case_fatality_rate,
                 checked: this.constrainedParams.cfrMetric,
                 onChange: () => {
                     params.setMetric("case_fatality_rate")
@@ -201,7 +202,7 @@ export class CovidDataExplorer extends React.Component<{
         const optionsColumn2: ControlOption[] = [
             {
                 available: true,
-                label: "Tests",
+                label: metricLabels.tests,
                 checked: this.constrainedParams.testsMetric,
                 onChange: () => {
                     params.setMetric("tests")
@@ -210,7 +211,7 @@ export class CovidDataExplorer extends React.Component<{
             },
             {
                 available: true,
-                label: "Tests per confirmed case",
+                label: metricLabels.tests_per_case,
                 checked: this.constrainedParams.testsPerCaseMetric,
                 onChange: () => {
                     params.setMetric("tests_per_case")
@@ -219,7 +220,7 @@ export class CovidDataExplorer extends React.Component<{
             },
             {
                 available: true,
-                label: "Share of positive tests",
+                label: metricLabels.positive_test_rate,
                 checked: this.constrainedParams.positiveTestRate,
                 onChange: () => {
                     params.setMetric("positive_test_rate")
@@ -1105,13 +1106,15 @@ export class CovidDataExplorer extends React.Component<{
         )
 
         const column = this.chart.table.columnsBySlug.get(colSlug)
-
         return {
             property: "table",
             variableId: column?.spec.owidVariableId,
             display: {
                 tolerance: 2,
-                name: this.metricLongName(metric, dailyFreq),
+                name:
+                    metricLabels[metric] +
+                    (isCountMetric(metric) ? this.perCapitaTitle(metric) : ""),
+                unit: dailyFreq ? "daily new" : "cumulative",
                 tableDisplay: column?.display.tableDisplay
             }
         } as DimensionSpec

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -28,7 +28,7 @@ import {
     next,
     previous
 } from "charts/Util"
-import { CountryOption, CovidGrapherRow } from "./CovidTypes"
+import { CountryOption, CovidGrapherRow, MetricKind } from "./CovidTypes"
 import { ControlOption, ExplorerControl } from "./CovidExplorerControl"
 import { CountryPicker } from "./CovidCountryPicker"
 import {
@@ -563,30 +563,36 @@ export class CovidDataExplorer extends React.Component<{
             : ""
     }
 
-    @computed private get chartTitle() {
-        let title = ""
+    private metricLongName(metric: MetricKind) {
+        let longName = ""
         const params = this.constrainedParams
 
+        const freq = params.dailyFreq ? "Daily new" : "Cumulative"
+        if (metric === "case_fatality_rate")
+            longName = `Case fatality rate of the ongoing COVID-19 pandemic`
+        else if (metric === "positive_test_rate")
+            longName = `The share of ${
+                params.dailyFreq ? "daily " : ""
+            }COVID-19 tests that are positive`
+        else if (metric === "tests_per_case")
+            longName = `${
+                params.totalFreq ? `Cumulative tests` : `Tests`
+            } conducted per confirmed case of COVID-19`
+        else if (metric === "tests") longName = `${freq} COVID-19 tests`
+        else if (metric === "deaths")
+            longName = `${freq} confirmed COVID-19 deaths`
+        else if (metric === "cases")
+            longName = `${freq} confirmed COVID-19 cases`
+
+        return longName + this.perCapitaTitle
+    }
+
+    @computed private get chartTitle() {
+        const params = this.constrainedParams
         if (params.yColumn || params.xColumn)
             return startCase(`${this.yColumn.name} by ${this.xColumn?.name}`)
 
-        const freq = params.dailyFreq ? "Daily new" : "Cumulative"
-        if (params.cfrMetric)
-            title = `Case fatality rate of the ongoing COVID-19 pandemic`
-        else if (params.positiveTestRate)
-            title = `The share of ${
-                params.dailyFreq ? "daily " : ""
-            }COVID-19 tests that are positive`
-        else if (params.testsPerCaseMetric)
-            title = `${
-                params.totalFreq ? `Cumulative tests` : `Tests`
-            } conducted per confirmed case of COVID-19`
-        else if (params.testsMetric) title = `${freq} COVID-19 tests`
-        else if (params.deathsMetric)
-            title = `${freq} confirmed COVID-19 deaths`
-        else if (params.casesMetric) title = `${freq} confirmed COVID-19 cases`
-
-        return title + this.perCapitaTitle
+        return this.metricLongName(this.constrainedParams.metricName)
     }
 
     @computed private get subtitle() {
@@ -1111,7 +1117,7 @@ export class CovidDataExplorer extends React.Component<{
                     variableId: column?.spec.owidVariableId,
                     display: {
                         tolerance: 1,
-                        name: column?.spec.name,
+                        name: this.metricLongName(metricName),
                         tableDisplay: column?.display.tableDisplay
                     }
                 } as DimensionSpec

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -1089,7 +1089,10 @@ export class CovidDataExplorer extends React.Component<{
             : undefined
     }
 
-    _buildTableOnlyDimensionSpec = (metric: MetricKind, dailyFreq: boolean) => {
+    private _buildTableOnlyDimensionSpec = (
+        metric: MetricKind,
+        dailyFreq: boolean
+    ) => {
         const params = this.constrainedParams
         const colSlug = buildColumnSlug(
             metric,
@@ -1111,7 +1114,7 @@ export class CovidDataExplorer extends React.Component<{
         } as DimensionSpec
     }
 
-    @computed get dataTableOnlyDimensions(): DimensionSpec[] {
+    @computed private get dataTableOnlyDimensions(): DimensionSpec[] {
         const params = this.constrainedParams
         return flatten(
             params.tableMetrics?.map(metric => {

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -564,40 +564,32 @@ export class CovidDataExplorer extends React.Component<{
             : ""
     }
 
-    private metricLongName(metric: MetricKind, dailyFreq: boolean) {
-        let longName = ""
-
-        const freq = dailyFreq ? "Daily new" : "Cumulative"
-        if (metric === "case_fatality_rate")
-            longName = `Case fatality rate of the ongoing COVID-19 pandemic`
-        else if (metric === "positive_test_rate")
-            longName = `The share of ${
-                dailyFreq ? "daily " : ""
-            }COVID-19 tests that are positive`
-        else if (metric === "tests_per_case")
-            longName = `${
-                !dailyFreq ? `Cumulative tests` : `Tests`
-            } conducted per confirmed case of COVID-19`
-        else if (metric === "tests") longName = `${freq} COVID-19 tests`
-        else if (metric === "deaths")
-            longName = `${freq} confirmed COVID-19 deaths`
-        else if (metric === "cases")
-            longName = `${freq} confirmed COVID-19 cases`
-
-        return isCountMetric(metric)
-            ? longName + this.perCapitaTitle(metric)
-            : longName
-    }
-
     @computed private get chartTitle() {
+        let title = ""
         const params = this.constrainedParams
+        const interval = params.interval
+
         if (params.yColumn || params.xColumn)
             return startCase(`${this.yColumn.name} by ${this.xColumn?.name}`)
 
-        return this.metricLongName(
-            this.constrainedParams.metricName,
-            params.dailyFreq
-        )
+        const isCumulative = interval === "total"
+        const freq = params.intervalTitle
+        if (params.cfrMetric)
+            title = `Case fatality rate of the ongoing COVID-19 pandemic`
+        else if (params.positiveTestRate)
+            title = `The share of ${
+                isCumulative ? "" : "daily "
+            }COVID-19 tests that are positive`
+        else if (params.testsPerCaseMetric)
+            title = `${
+                isCumulative ? `Cumulative tests` : `Tests`
+            } conducted per confirmed case of COVID-19`
+        else if (params.testsMetric) title = `${freq} COVID-19 tests`
+        else if (params.deathsMetric)
+            title = `${freq} confirmed COVID-19 deaths`
+        else if (params.casesMetric) title = `${freq} confirmed COVID-19 cases`
+
+        return title + this.perCapitaTitle(params.metricName)
     }
 
     @computed private get subtitle() {

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -34,7 +34,6 @@ import { CountryPicker } from "./CovidCountryPicker"
 import {
     CovidQueryParams,
     CovidUrl,
-    metricMap2,
     CovidConstrainedQueryParams
 } from "./CovidChartUrl"
 import {
@@ -64,7 +63,7 @@ import { ColorScaleConfigProps } from "charts/ColorScaleConfig"
 import * as Mousetrap from "mousetrap"
 import { CommandPalette, Command } from "./CommandPalette"
 import { TimeBoundValue } from "charts/TimeBounds"
-import { startCase, cloneDeep, clone, cloneDeepWith } from "lodash"
+import { startCase } from "lodash"
 import { Analytics } from "site/client/Analytics"
 import { ChartDimensionWithOwidVariable } from "charts/ChartDimensionWithOwidVariable"
 
@@ -1110,7 +1109,6 @@ export class CovidDataExplorer extends React.Component<{
                 )
 
                 const column = this.chart.table.columnsBySlug.get(columnSlug)
-                console.log(`looking for slug ${columnSlug}. Found ${column}`)
 
                 return {
                     property: "table",

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -26,7 +26,9 @@ import {
     capitalize,
     mergeQueryStr,
     next,
-    previous
+    previous,
+    startCase,
+    flatten
 } from "charts/Util"
 import { CountryOption, CovidGrapherRow, MetricKind } from "./CovidTypes"
 import { ControlOption, ExplorerControl } from "./CovidExplorerControl"
@@ -63,7 +65,6 @@ import { ColorScaleConfigProps } from "charts/ColorScaleConfig"
 import * as Mousetrap from "mousetrap"
 import { CommandPalette, Command } from "./CommandPalette"
 import { TimeBoundValue } from "charts/TimeBounds"
-import { startCase, flatten } from "lodash"
 import { Analytics } from "site/client/Analytics"
 import { ChartDimensionWithOwidVariable } from "charts/ChartDimensionWithOwidVariable"
 

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -1098,7 +1098,9 @@ export class CovidDataExplorer extends React.Component<{
     ) => {
         const colSlug = buildColumnSlug(
             metric,
-            this.constrainedParams.perCapita ? perCapitaDivisor(metric) : 1,
+            this.constrainedParams.perCapita && isCountMetric(metric)
+                ? perCapitaDivisor(metric)
+                : 1,
             dailyFreq,
             0
         )
@@ -1141,15 +1143,18 @@ export class CovidDataExplorer extends React.Component<{
         const { covidExplorerTable } = this
 
         const dataTableParams = new CovidConstrainedQueryParams("")
-        dataTableParams.perCapita = params.perCapita
 
         params.tableMetrics?.forEach(metric => {
             dataTableParams.setMetric(metric)
             dataTableParams.dailyFreq = false
+            dataTableParams.totalFreq = true
+            dataTableParams.perCapita = false
             if (isCountMetric(metric)) {
-                // generate daily columns too
+                dataTableParams.perCapita = params.perCapita
                 covidExplorerTable.initRequestedColumns(dataTableParams)
-                dataTableParams.dailyFreq = !dataTableParams.dailyFreq
+                // generate daily columns too
+                dataTableParams.dailyFreq = true
+                dataTableParams.totalFreq = false
             }
 
             covidExplorerTable.initRequestedColumns(dataTableParams)

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -68,6 +68,7 @@ import { CommandPalette, Command } from "./CommandPalette"
 import { TimeBoundValue } from "charts/TimeBounds"
 import { Analytics } from "site/client/Analytics"
 import { ChartDimensionWithOwidVariable } from "charts/ChartDimensionWithOwidVariable"
+import { emptyString } from "react-select/src/utils"
 
 const abSeed = Math.random()
 
@@ -297,11 +298,7 @@ export class CovidDataExplorer extends React.Component<{
         const options: ControlOption[] = [
             {
                 available: this.constrainedParams.available.perCapita,
-                label: capitalize(
-                    this.perCapitaOptions[
-                        perCapitaDivisor(this.constrainedParams.metricName)
-                    ]
-                ),
+                label: capitalize(this.perCapitaOptions[this.perCapitaDivisor]),
                 checked: this.constrainedParams.perCapita,
                 onChange: value => {
                     this.props.params.perCapita = value
@@ -587,8 +584,9 @@ export class CovidDataExplorer extends React.Component<{
         else if (metric === "cases")
             longName = `${freq} confirmed COVID-19 cases`
 
-        if (isCountMetric(metric)) return longName + this.perCapitaTitle(metric)
-        return longName
+        return isCountMetric(metric)
+            ? longName + this.perCapitaTitle(metric)
+            : longName
     }
 
     @computed private get chartTitle() {
@@ -1094,7 +1092,7 @@ export class CovidDataExplorer extends React.Component<{
             : undefined
     }
 
-    private _buildTableOnlyDimensionSpec = (
+    private _buildDataTableOnlyDimensionSpec = (
         metric: MetricKind,
         dailyFreq: boolean
     ) => {
@@ -1122,11 +1120,15 @@ export class CovidDataExplorer extends React.Component<{
         const params = this.constrainedParams
         return flatten(
             params.tableMetrics?.map(metric => {
-                const specs = [this._buildTableOnlyDimensionSpec(metric, false)]
+                const specs = [
+                    this._buildDataTableOnlyDimensionSpec(metric, false)
+                ]
 
                 if (isCountMetric(metric)) {
                     // add daily column
-                    specs.push(this._buildTableOnlyDimensionSpec(metric, true))
+                    specs.push(
+                        this._buildDataTableOnlyDimensionSpec(metric, true)
+                    )
                 }
 
                 return specs

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -68,7 +68,6 @@ import { CommandPalette, Command } from "./CommandPalette"
 import { TimeBoundValue } from "charts/TimeBounds"
 import { Analytics } from "site/client/Analytics"
 import { ChartDimensionWithOwidVariable } from "charts/ChartDimensionWithOwidVariable"
-import { emptyString } from "react-select/src/utils"
 
 const abSeed = Math.random()
 

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -753,7 +753,7 @@ export class CovidDataExplorer extends React.Component<{
         // multimetric table
         if (this.constrainedParams.tableMetrics) {
             this._generateDataTableColumnsInTable()
-            this._addDataTableOnlyDimensionsToChart
+            this._addDataTableOnlyDimensionsToChart()
         }
 
         covidExplorerTable.table.setSelectedEntities(

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -734,7 +734,8 @@ export class CovidDataExplorer extends React.Component<{
                     metric === "deaths" ||
                     metric === "cases" ||
                     metric === "tests"
-                ) { // generate daily columns too
+                ) {
+                    // generate daily columns too
                     covidExplorerTable.initRequestedColumns(dataTableParams)
                     dataTableParams.dailyFreq = !dataTableParams.dailyFreq
                 }
@@ -1123,7 +1124,6 @@ export class CovidDataExplorer extends React.Component<{
 
         const column = this.chart.table.columnsBySlug.get(colSlug)
 
-        if (!column) console.log(`failing column is ${colSlug}`)
         return {
             property: "table",
             variableId: column?.spec.owidVariableId,

--- a/charts/covidDataExplorer/CovidExplorerTable.ts
+++ b/charts/covidDataExplorer/CovidExplorerTable.ts
@@ -274,7 +274,7 @@ export class CovidExplorerTable {
             arbitraryStartingPrefix,
             names[params.metricName],
             intervalOptions.indexOf(params.interval),
-            params.perCapitaDivisor,
+            params.perCapitaAdjustment,
             params.smoothing
         ]
         return parseInt(parts.join(""))
@@ -282,7 +282,7 @@ export class CovidExplorerTable {
 
     buildColumnSpec(params: CovidQueryParams): ColumnSpec {
         const name = params.metricName
-        const perCapita = params.perCapitaDivisor
+        const perCapita = params.perCapitaAdjustment
         const interval = params.interval
         const rollingAverage = params.smoothing
 

--- a/charts/covidDataExplorer/CovidExplorerTable.ts
+++ b/charts/covidDataExplorer/CovidExplorerTable.ts
@@ -331,9 +331,7 @@ export class CovidExplorerTable {
         rowFn: RowToValueMapper
     ) {
         const columnName = params.metricName
-        const perCapita = params.perCapita
-            ? perCapitaDivisor(params.metricName)
-            : 1
+        const perCapita = params.perCapitaAdjustment
         const smoothing = params.smoothing
         const spec = this.buildColumnSpec(
             columnName,
@@ -788,6 +786,6 @@ export function getLeastUsedColor(
     return mostUnusedColor[0]
 }
 
-export function perCapitaDivisor(metric: MetricKind) {
+export function perCapitaDivisorByMetric(metric: MetricKind) {
     return metric === "tests" ? 1e3 : 1e6
 }

--- a/charts/covidDataExplorer/CovidExplorerTable.ts
+++ b/charts/covidDataExplorer/CovidExplorerTable.ts
@@ -332,7 +332,9 @@ export class CovidExplorerTable {
         rowFn: RowToValueMapper
     ) {
         const columnName = metricName
-        const perCapita = params.perCapitaDivisor
+        const perCapita = params.perCapita
+            ? perCapitaDivisor(params.metricName)
+            : 1
         const smoothing = params.smoothing
         const spec = this.buildColumnSpec(
             columnName,
@@ -787,4 +789,8 @@ export function getLeastUsedColor(
         number
     ]
     return mostUnusedColor[0]
+}
+
+export function perCapitaDivisor(metric: MetricKind) {
+    return metric === "tests" ? 1e3 : 1e6
 }

--- a/charts/covidDataExplorer/CovidExplorerTable.ts
+++ b/charts/covidDataExplorer/CovidExplorerTable.ts
@@ -487,7 +487,6 @@ export class CovidExplorerTable {
     }
 
     initDeathsColumn(params: CovidConstrainedQueryParams) {
-        console.log(`initing death`)
         this.initColumn(
             "deaths",
             params,

--- a/charts/covidDataExplorer/CovidExplorerTable.ts
+++ b/charts/covidDataExplorer/CovidExplorerTable.ts
@@ -327,11 +327,10 @@ export class CovidExplorerTable {
     }
 
     private initColumn(
-        metricName: MetricKind,
         params: CovidConstrainedQueryParams,
         rowFn: RowToValueMapper
     ) {
-        const columnName = metricName
+        const columnName = params.metricName
         const perCapita = params.perCapita
             ? perCapitaDivisor(params.metricName)
             : 1
@@ -384,19 +383,19 @@ export class CovidExplorerTable {
 
     initTestingColumn(params: CovidConstrainedQueryParams) {
         if (params.dailyFreq)
-            this.initColumn("tests", params, row => {
+            this.initColumn(params, row => {
                 return params.smoothing === 7
                     ? row.new_tests_smoothed
                     : row.new_tests
             })
         else if (params.totalFreq)
-            this.initColumn("tests", params, row => row.total_tests)
+            this.initColumn(params, row => row.total_tests)
     }
 
     initTestsPerCaseColumn(params: CovidConstrainedQueryParams) {
         if (params.dailyFreq && params.smoothing) {
             const casesSlug = this.addNewCasesSmoothedColumn(params.smoothing)
-            this.initColumn("tests_per_case", params, row => {
+            this.initColumn(params, row => {
                 if (
                     row.new_tests_smoothed === undefined ||
                     !(row as any)[casesSlug]
@@ -410,7 +409,7 @@ export class CovidExplorerTable {
                 return tpc >= 1 ? tpc : undefined
             })
         } else if (params.totalFreq)
-            this.initColumn("tests_per_case", params, row => {
+            this.initColumn(params, row => {
                 if (row.total_tests === undefined || !row.total_cases)
                     return undefined
 
@@ -425,7 +424,7 @@ export class CovidExplorerTable {
     initCfrColumn(params: CovidConstrainedQueryParams) {
         // We do not support daily freq for CFR
         if (params.totalFreq)
-            this.initColumn("case_fatality_rate", params, row =>
+            this.initColumn(params, row =>
                 row.total_cases < 100
                     ? undefined
                     : row.total_deaths && row.total_cases
@@ -436,7 +435,6 @@ export class CovidExplorerTable {
 
     initCasesColumn(params: CovidConstrainedQueryParams) {
         this.initColumn(
-            "cases",
             params,
             params.dailyFreq ? row => row.new_cases : row => row.total_cases
         )
@@ -456,7 +454,7 @@ export class CovidExplorerTable {
     initTestRateColumn(params: CovidConstrainedQueryParams) {
         if (params.dailyFreq) {
             const casesSlug = this.addNewCasesSmoothedColumn(params.smoothing)
-            return this.initColumn("positive_test_rate", params, row => {
+            return this.initColumn(params, row => {
                 const testCount =
                     params.smoothing === 7
                         ? row.new_tests_smoothed
@@ -476,7 +474,7 @@ export class CovidExplorerTable {
                 return rate >= 0 && rate <= 1 ? rate : undefined
             })
         }
-        return this.initColumn("positive_test_rate", params, row => {
+        return this.initColumn(params, row => {
             if (row.total_cases === undefined || !row.total_tests)
                 return undefined
 
@@ -490,7 +488,6 @@ export class CovidExplorerTable {
 
     initDeathsColumn(params: CovidConstrainedQueryParams) {
         this.initColumn(
-            "deaths",
             params,
             params.dailyFreq ? row => row.new_deaths : row => row.total_deaths
         )


### PR DESCRIPTION
This PR creates a multimetric DataTable in the CDE. To enable this, add `&tableMetrics=` to the URL followed by a MetricKind a la `deaths`, `cases`, etc. This will force the DataTable for the explorer to show only the metrics you specify, according to the following format:
- `deaths`, `cases`, and `tests` will show both cumulative and daily numbers
- `case_fatality_rate`, `tests_per_case`, and `positive_test_rate` will show only cumulative numbers

The only control that should affect the view is the `per capita` option. Otherwise, clicking "align outbreaks" will add continents to the table, but I didn't consider that necessarily worth changing as only the authors should be interacting with the controls anyways.

**You can see it live on Nightingale [here](https://nightingale-owid.netlify.app/coronavirus-data-explorer?tab=table&yScale=log&zoomToSelection=true&time=latest&casesMetric=true&dailyFreq=true&aligned=true&smoothing=7&country=USA~GBR~CAN~BRA~AUS~IND~DEU~MEX~ZAF~COL~KOR~NOR~UGA~NGA&pickerMetric=location&pickerSort=asc&tableMetrics=cases~deaths~tests~tests_per_case~case_fatality_rate~positive_test_rate) with all parameters enabled.**

**Note:** I think the default sorting behavior should be descending for the data columns, and will add that as a separate PR.