### PR TITLE
Add weekly, biweekly, and weekly/biweekly change options to Explorer

### DIFF
--- a/charts/__tests__/CovidChartUrl.test.ts
+++ b/charts/__tests__/CovidChartUrl.test.ts
@@ -27,12 +27,12 @@ describe(CovidQueryParams, () => {
         const params = new CovidQueryParams(
             `cfrMetric=true&dailyFreq=true&smoothing=7`
         )
-        expect(params.dailyFreq).toEqual(true)
-        expect(params.totalFreq).toEqual(false)
+        expect(params.isDailyOrSmoothed).toEqual(true)
+        expect(params.interval).toEqual("smoothed")
         expect(params.smoothing).toEqual(7)
-        const constrainedParams = params.constrainedParams
-        expect(constrainedParams.dailyFreq).toEqual(false)
-        expect(constrainedParams.totalFreq).toEqual(true)
+        const constrainedParams = params.toConstrainedParams()
+        expect(constrainedParams.interval).toEqual("total")
+        expect(constrainedParams.isDailyOrSmoothed).toEqual(false)
         expect(constrainedParams.smoothing).toEqual(0)
     })
 
@@ -40,12 +40,11 @@ describe(CovidQueryParams, () => {
         const params = new CovidQueryParams(
             `positiveTestRate=true&dailyFreq=true`
         )
-        expect(params.dailyFreq).toEqual(true)
-        expect(params.totalFreq).toEqual(false)
+        expect(params.isDailyOrSmoothed).toEqual(true)
+        expect(params.interval).toEqual("daily")
         const constrainedParams = params.constrainedParams
-        expect(constrainedParams.dailyFreq).toEqual(true)
+        expect(constrainedParams.interval).toEqual("smoothed")
         expect(constrainedParams.smoothing).toEqual(7)
-        expect(constrainedParams.totalFreq).toEqual(false)
     })
 
     it("computes the correct source chart key given current params", () => {

--- a/charts/covidDataExplorer/CovidChartUrl.ts
+++ b/charts/covidDataExplorer/CovidChartUrl.ts
@@ -320,9 +320,20 @@ export class CovidQueryParams {
         let interval: string = this.interval
         if (interval === "smoothed") interval = "daily"
         if (this.isWeekly || this.isBiweekly) interval = "weeklys"
-        return [this.metricName, interval, this.perCapita ? "per_capita" : ""]
+        return [
+            this.metricName,
+            interval,
+            this.perCapita ? "per_capita" : "",
+            this.intervalChange ? "change" : ""
+        ]
             .filter(i => i)
             .join("_")
+    }
+
+    get intervalChange() {
+        if (this.interval === "weeklyChange") return 7
+        else if (this.interval === "biweeklyChange") return 14
+        return undefined
     }
 }
 
@@ -380,12 +391,6 @@ export class CovidConstrainedQueryParams extends CovidQueryParams {
         if (this.isWeekly) return 7
         else if (this.isBiweekly) return 14
         return 1
-    }
-
-    get intervalChange() {
-        if (this.interval === "weeklyChange") return 7
-        else if (this.interval === "biweeklyChange") return 14
-        return undefined
     }
 
     get isWeeklyOrBiweeklyChange() {

--- a/charts/covidDataExplorer/CovidChartUrl.ts
+++ b/charts/covidDataExplorer/CovidChartUrl.ts
@@ -1,4 +1,4 @@
-import { computed, observable } from "mobx"
+import { computed, observable, action } from "mobx"
 import { ObservableUrl } from "../UrlBinding"
 import { ChartUrl, EntityUrlBuilder } from "../ChartUrl"
 import {
@@ -13,13 +13,28 @@ import {
     AlignedOption,
     SmoothingOption,
     colorScaleOption,
-    MetricKind
+    MetricKind,
+    IntervalOption,
+    intervalOptions
 } from "./CovidTypes"
 import { CountryPickerMetric } from "./CovidCountryPickerMetric"
 import { ChartTypeType } from "charts/ChartType"
 import { trajectoryColumnSpecs } from "./CovidConstants"
 import { buildColumnSlug } from "./CovidExplorerTable"
 import { uniq, intersection } from "lodash"
+
+// Previously the query string was a few booleans like dailyFreq=true. Now it is a single 'interval'.
+// This method is for backward compat.
+const legacyTimeToInterval = (
+    totalFreq: boolean,
+    dailyFreq: boolean,
+    smoothing: boolean
+): IntervalOption | undefined => {
+    if (totalFreq) return "total"
+    else if (smoothing) return "smoothed"
+    else if (dailyFreq) return "daily"
+    return undefined
+}
 
 export class CovidQueryParams {
     // Todo: in hindsight these 6 metrics should have been something like "yColumn". May want to switch to that and translate these
@@ -35,8 +50,6 @@ export class CovidQueryParams {
     @observable xColumn?: string
     @observable sizeColumn?: string
 
-    @observable totalFreq: boolean = false
-    @observable dailyFreq: boolean = false
     @observable perCapita: PerCapita = false
     @observable aligned: AlignedOption = false
     @observable hideControls: boolean = false
@@ -49,6 +62,8 @@ export class CovidQueryParams {
         CountryPickerMetric.location
     @observable countryPickerSort: SortOrder = SortOrder.asc
 
+    @observable interval: IntervalOption = "daily"
+
     allAvailableCombos(): string[] {
         const metrics = [
             "casesMetric",
@@ -58,20 +73,19 @@ export class CovidQueryParams {
             "testsPerCaseMetric",
             "positiveTestRate"
         ]
-        const timelines = ["totalFreq", 7, "dailyFreq"]
         const perCapita = [true, false]
         const aligned = [true, false]
         const yScale = ["log", "linear"] // todo
         const tab = ["map", "chart"] // todo
         const combos: any = []
         metrics.forEach(metric => {
-            timelines.forEach(timeline => {
+            intervalOptions.forEach(interval => {
                 perCapita.forEach(perCapita => {
                     aligned.forEach(aligned => {
                         const combo: any = {}
                         combo[metric] = true
-                        if (timeline !== 7) combo[timeline] = true
-                        else combo.smoothing = 7
+                        combo.interval = interval
+                        if (interval === "smoothed") combo.smoothing = 7
                         combo.perCapita = perCapita
                         combo.aligned = aligned
                         combos.push(combo)
@@ -82,23 +96,29 @@ export class CovidQueryParams {
 
         return uniq(
             combos.map((combo: any) =>
-                new CovidQueryParams(
-                    queryParamsToStr(combo)
-                ).constrainedParams.toString()
+                new CovidQueryParams(queryParamsToStr(combo))
+                    .toConstrainedParams()
+                    .toString()
             )
         )
     }
 
-    setParamsFromQueryString(queryString: string) {
+    @action.bound setParamsFromQueryString(queryString: string) {
         const params = strToQueryParams(queryString)
+        this.interval =
+            (params.interval as IntervalOption) ||
+            legacyTimeToInterval(
+                !!params.totalFreq,
+                !!params.dailyFreq,
+                !!params.smoothing
+            )
+
         this.casesMetric = params.casesMetric === "true"
-        this.totalFreq = params.totalFreq === "true"
         this.testsMetric = params.testsMetric === "true"
         this.testsPerCaseMetric = params.testsPerCaseMetric === "true"
         this.positiveTestRate = params.positiveTestRate === "true"
         this.deathsMetric = params.deathsMetric === "true"
         this.cfrMetric = params.cfrMetric === "true"
-        this.dailyFreq = params.dailyFreq === "true"
         this.perCapita = params.perCapita === "true"
         this.hideControls = params.hideControls === "true"
         this.aligned = params.aligned === "true"
@@ -159,6 +179,19 @@ export class CovidQueryParams {
         return "positive_test_rate"
     }
 
+    @computed get intervalTitle() {
+        const titles: { [K in IntervalOption]: string } = {
+            total: "Cumulative",
+            daily: "Daily new",
+            smoothed: "Daily new",
+            weekly: "Weekly",
+            biweekly: "Biweekly",
+            weeklyChange: "Week by week change of",
+            biweeklyChange: "Biweekly change of"
+        }
+        return titles[this.interval]
+    }
+
     @computed get toParams(): QueryParams {
         const params: any = {}
         params.xColumn = this.xColumn ? this.xColumn : undefined
@@ -170,8 +203,7 @@ export class CovidQueryParams {
         params.cfrMetric = this.cfrMetric ? true : undefined
         params.testsPerCaseMetric = this.testsPerCaseMetric ? true : undefined
         params.positiveTestRate = this.positiveTestRate ? true : undefined
-        params.dailyFreq = this.dailyFreq ? true : undefined
-        params.totalFreq = this.totalFreq ? true : undefined
+        params.interval = this.interval // or undefined?
         params.aligned = this.aligned ? true : undefined
         params.hideControls = this.hideControls ? true : undefined
         params.perCapita = this.perCapita ? true : undefined
@@ -209,9 +241,13 @@ export class CovidQueryParams {
         return buildColumnSlug(
             this.metricName,
             this.perCapitaDivisor,
-            this.dailyFreq,
+            this.interval,
             this.smoothing
         )
+    }
+
+    @computed get isDailyOrSmoothed() {
+        return this.interval === "daily" || this.interval === "smoothed"
     }
 
     @computed get xColumnSlug() {
@@ -227,14 +263,14 @@ export class CovidQueryParams {
             trajectoryColumnSpecs[key][
                 this.perCapita
                     ? "perCapita"
-                    : this.dailyFreq
+                    : this.isDailyOrSmoothed
                     ? "daily"
                     : "total"
             ]
         const sourceSlug = buildColumnSlug(
             key,
             this.perCapita ? 1e6 : 1,
-            this.dailyFreq,
+            this.interval,
             this.smoothing
         )
         return {
@@ -245,6 +281,10 @@ export class CovidQueryParams {
     }
 
     @computed get constrainedParams() {
+        return this.toConstrainedParams()
+    }
+
+    toConstrainedParams() {
         return new CovidConstrainedQueryParams(this.toString())
     }
 
@@ -257,27 +297,30 @@ export class CovidQueryParams {
         this.positiveTestRate = option === "positive_test_rate"
     }
 
-    setTimeline(option: "daily" | "total" | "smoothed") {
-        this.totalFreq = false
-        this.dailyFreq = false
-        this.smoothing = 0
-        if (option === "smoothed") {
-            this.smoothing = 7
-            this.dailyFreq = true
-        } else if (option === "daily") this.dailyFreq = true
-        else this.totalFreq = true
+    setTimeline(option: IntervalOption) {
+        this.interval = option
+        this.smoothing = option === "smoothed" ? 7 : 0
     }
 
     toString() {
         return queryParamsToStr(this.toParams)
     }
 
+    get isWeekly() {
+        return this.interval === "weekly" || this.interval === "weeklyChange"
+    }
+
+    get isBiweekly() {
+        return (
+            this.interval === "biweekly" || this.interval === "biweeklyChange"
+        )
+    }
+
     @computed get sourceChartKey() {
-        return [
-            this.metricName,
-            this.totalFreq ? "total" : "daily",
-            this.perCapita ? "per_capita" : ""
-        ]
+        let interval: string = this.interval
+        if (interval === "smoothed") interval = "daily"
+        if (this.isWeekly || this.isBiweekly) interval = "weeklys"
+        return [this.metricName, interval, this.perCapita ? "per_capita" : ""]
             .filter(i => i)
             .join("_")
     }
@@ -287,28 +330,35 @@ export class CovidConstrainedQueryParams extends CovidQueryParams {
     constructor(queryString: string) {
         super(queryString)
         if (this.allowEverything) return this
+
         const available = this.available
-        const defaults = new CovidQueryParams("")
-        const wasDaily = this.dailyFreq
 
-        Object.keys(available).forEach(key => {
-            const typedKey = key as keyof typeof available
-            // If the key is not available, set it to the default value (generally is false, but for smoothing is 0)
-            if (!available[typedKey] && (this as any)[key])
-                (this as any)[key] = defaults[key as keyof CovidQueryParams]
-        })
+        if (this.perCapita && !available.perCapita) this.perCapita = false
+        if (this.aligned && !available.aligned) this.aligned = false
 
-        // We always need either total or daily freq
-        if (!this.totalFreq && !this.dailyFreq) {
-            // If daily is not available, we need to set totalFreq to true
-            if (!available.dailyFreq && !available.smoothing)
-                this.totalFreq = true
-            // If it was daily, but only so that smoothing could happen, we need to set daily to true
-            else if ((wasDaily || this.smoothing) && available.smoothing) {
-                this.dailyFreq = true
-                this.smoothing = 7
-            } else this.totalFreq = true
+        if ((this.isWeekly || this.isBiweekly) && !available.weekly)
+            this.interval = "total"
+
+        if (this.smoothing && !available.smoothed) {
+            this.smoothing = 0
+            if (this.interval === "smoothed") this.interval = "total"
         }
+
+        if (this.interval === "daily" && !available.daily) {
+            if (available.smoothed) {
+                this.interval = "smoothed"
+                this.smoothing = 7
+            } else {
+                this.interval = "total"
+            }
+        }
+
+        if (!this.interval)
+            this.interval =
+                this.smoothing && available.smoothed ? "smoothed" : "total"
+
+        if (this.isWeekly) this.smoothing = 7
+        if (this.isBiweekly) this.smoothing = 14
 
         // Ensure there is always a metric
         const hasMetric = [
@@ -322,16 +372,38 @@ export class CovidConstrainedQueryParams extends CovidQueryParams {
         if (!hasMetric) this.casesMetric = true
     }
 
-    @computed get allowEverything() {
+    get allowEverything() {
         return false
     }
 
-    @computed get available() {
+    get rollingMultiplier() {
+        if (this.isWeekly) return 7
+        else if (this.isBiweekly) return 14
+        return 1
+    }
+
+    get intervalChange() {
+        if (this.interval === "weeklyChange") return 7
+        else if (this.interval === "biweeklyChange") return 14
+        return undefined
+    }
+
+    get isWeeklyOrBiweeklyChange() {
+        return (
+            this.interval === "biweeklyChange" ||
+            this.interval === "weeklyChange"
+        )
+    }
+
+    get available() {
+        const weekly = this.casesMetric || this.deathsMetric
+        const isWeekly = (this.isWeekly || this.isBiweekly) && weekly // If weekly is set AND available
         const constraints = {
-            perCapita: !this.isRate,
-            aligned: !this.isRate,
-            dailyFreq: !this.isRate,
-            smoothing: !this.cfrMetric
+            perCapita: !this.isRate && !isWeekly,
+            aligned: !this.isRate && !isWeekly,
+            daily: !this.isRate,
+            smoothed: !this.cfrMetric,
+            weekly
         }
 
         if (this.allowEverything) {
@@ -343,7 +415,7 @@ export class CovidConstrainedQueryParams extends CovidQueryParams {
         return constraints
     }
 
-    @computed private get isRate() {
+    private get isRate() {
         return (
             this.cfrMetric || this.testsPerCaseMetric || this.positiveTestRate
         )

--- a/charts/covidDataExplorer/CovidConstants.ts
+++ b/charts/covidDataExplorer/CovidConstants.ts
@@ -20,14 +20,14 @@ export const sourceCharts = {
     cases_total_per_capita: 4051,
     cases_daily_per_capita: 4028,
     cases_weeklys: 4195,
-    cases_weeklys_rates: 4194,
+    cases_weeklys_change: 4194,
 
     deaths_total: 4020,
     deaths_daily: 4021,
     deaths_total_per_capita: 4029,
     deaths_daily_per_capita: 4030,
     deaths_weeklys: 4196,
-    deaths_weeklys_rates: 4193,
+    deaths_weeklys_change: 4193,
 
     tests_total: 4191,
     tests_daily: 4307,

--- a/charts/covidDataExplorer/CovidConstants.ts
+++ b/charts/covidDataExplorer/CovidConstants.ts
@@ -19,11 +19,15 @@ export const sourceCharts = {
     cases_daily: 4019,
     cases_total_per_capita: 4051,
     cases_daily_per_capita: 4028,
+    cases_weeklys: 4195,
+    cases_weeklys_rates: 4194,
 
     deaths_total: 4020,
     deaths_daily: 4021,
     deaths_total_per_capita: 4029,
     deaths_daily_per_capita: 4030,
+    deaths_weeklys: 4196,
+    deaths_weeklys_rates: 4193,
 
     tests_total: 4191,
     tests_daily: 4307,

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -793,6 +793,8 @@ export class CovidDataExplorer extends React.Component<{
             }
         }
 
+        chartProps.yAxis.min = params.intervalChange ? undefined : 0
+
         // When dimensions changes, chart.variableIds change, which calls downloadData(), which reparses variableSet
         chartProps.dimensions = this.dimensionSpecs.map(
             spec => new ChartDimension(spec)
@@ -804,7 +806,8 @@ export class CovidDataExplorer extends React.Component<{
 
         if (
             (params.casesMetric || params.deathsMetric) &&
-            !(params.interval === "total")
+            !(params.interval === "total") &&
+            !params.intervalChange
         )
             covidExplorerTable.addNegativeFilterColumn(params.yColumnSlug)
         else covidExplorerTable.removeNegativeFilterColumn()

--- a/charts/covidDataExplorer/CovidExplorerControl.tsx
+++ b/charts/covidDataExplorer/CovidExplorerControl.tsx
@@ -85,19 +85,32 @@ export class ExplorerControl extends React.Component<{
                 }
             })
 
+        const styles = getStylesForTargetHeight(16, {
+            control: {
+                border /* Keep it subtle */: 0,
+                boxShadow:
+                    "none" /* Remove the outline style because text is too close to it */
+            },
+            singleValue: {
+                color: "#7a899e" /* Match the unselected text */,
+                marginLeft:
+                    "-3px" /* Shift the text left to align with header */
+            }
+        })
+
         return (
             <Select
                 className="intervalDropdown"
+                classNamePrefix="intervalDropdown"
                 options={options}
                 value={options.find(
                     option => option.value === this.props.value
                 )}
                 onChange={(option: any) => this.customOnChange(option.value)}
-                menuPlacement="bottom"
                 components={{
                     IndicatorSeparator: null
                 }}
-                styles={getStylesForTargetHeight(26)}
+                styles={styles}
                 isSearchable={false}
             />
         )

--- a/charts/covidDataExplorer/CovidExplorerControl.tsx
+++ b/charts/covidDataExplorer/CovidExplorerControl.tsx
@@ -102,6 +102,7 @@ export class ExplorerControl extends React.Component<{
             <Select
                 className="intervalDropdown"
                 classNamePrefix="intervalDropdown"
+                menuPlacement="auto"
                 options={options}
                 value={options.find(
                     option => option.value === this.props.value

--- a/charts/covidDataExplorer/CovidExplorerControl.tsx
+++ b/charts/covidDataExplorer/CovidExplorerControl.tsx
@@ -76,12 +76,14 @@ export class ExplorerControl extends React.Component<{
     }
 
     get renderDropdown() {
-        const options = this.props.dropdownOptions!.map(option => {
-            return {
-                label: option.label,
-                value: option.value
-            }
-        })
+        const options = this.props
+            .dropdownOptions!.filter(option => option.available)
+            .map(option => {
+                return {
+                    label: option.label,
+                    value: option.value
+                }
+            })
 
         return (
             <Select

--- a/charts/covidDataExplorer/CovidExplorerControl.tsx
+++ b/charts/covidDataExplorer/CovidExplorerControl.tsx
@@ -2,6 +2,8 @@ import React from "react"
 import { observer } from "mobx-react"
 import { action } from "mobx"
 import classNames from "classnames"
+import Select from "react-select"
+import { getStylesForTargetHeight } from "utils/client/react-select"
 
 export interface ControlOption {
     label: string
@@ -10,13 +12,22 @@ export interface ControlOption {
     available: boolean
 }
 
+export interface DropdownOption {
+    label: string
+    available: boolean
+    value: string
+}
+
 @observer
 export class ExplorerControl extends React.Component<{
     title: string
     name: string
+    value?: string
     options: ControlOption[]
+    dropdownOptions?: DropdownOption[]
     isCheckbox?: boolean
     comment?: string
+    onChange?: (value: string) => void
     hideTitle?: boolean
 }> {
     @action.bound onChange(ev: React.ChangeEvent<HTMLInputElement>) {
@@ -25,15 +36,83 @@ export class ExplorerControl extends React.Component<{
         )
     }
 
+    renderOption(option: ControlOption, index: number) {
+        const { title, name, comment, isCheckbox } = this.props
+        return (
+            <div key={index} className="ControlOption">
+                <label
+                    className={[
+                        option.checked ? "SelectedOption" : "Option",
+                        option.available
+                            ? "AvailableOption"
+                            : "UnavailableOption"
+                    ].join(" ")}
+                    data-track-note={`covid-click-${title.toLowerCase()}`}
+                >
+                    <input
+                        onChange={option.available ? this.onChange : undefined}
+                        type={isCheckbox ? "checkbox" : "radio"}
+                        disabled={!option.available}
+                        name={name}
+                        checked={option.available && option.checked}
+                        value={index}
+                    />{" "}
+                    {option.label}
+                    {comment && (
+                        <div
+                            className={[
+                                "comment",
+                                option.available
+                                    ? "AvailableOption"
+                                    : "UnavailableOption"
+                            ].join(" ")}
+                        >
+                            {comment}
+                        </div>
+                    )}
+                </label>
+            </div>
+        )
+    }
+
+    get renderDropdown() {
+        const options = this.props.dropdownOptions!.map(option => {
+            return {
+                label: option.label,
+                value: option.value
+            }
+        })
+
+        return (
+            <Select
+                className="intervalDropdown"
+                options={options}
+                value={options.find(
+                    option => option.value === this.props.value
+                )}
+                onChange={(option: any) => this.customOnChange(option.value)}
+                menuPlacement="bottom"
+                components={{
+                    IndicatorSeparator: null
+                }}
+                styles={getStylesForTargetHeight(26)}
+                isSearchable={false}
+            />
+        )
+    }
+
+    @action.bound customOnChange(value: string) {
+        this.props.onChange!(value)
+    }
+
+    get renderOptions() {
+        return this.props.options.map((option, index) =>
+            this.renderOption(option, index)
+        )
+    }
+
     render() {
-        const {
-            title,
-            name,
-            comment,
-            options,
-            isCheckbox,
-            hideTitle
-        } = this.props
+        const { title, hideTitle } = this.props
         return (
             <div className={classNames("CovidDataExplorerControl", name)}>
                 <div
@@ -44,43 +123,9 @@ export class ExplorerControl extends React.Component<{
                 >
                     {title}
                 </div>
-                {options.map((option, index) => (
-                    <div key={index} className="ControlOption">
-                        <label
-                            className={[
-                                option.checked ? "SelectedOption" : "Option",
-                                option.available
-                                    ? "AvailableOption"
-                                    : "UnavailableOption"
-                            ].join(" ")}
-                            data-track-note={`covid-click-${title.toLowerCase()}`}
-                        >
-                            <input
-                                onChange={
-                                    option.available ? this.onChange : undefined
-                                }
-                                type={isCheckbox ? "checkbox" : "radio"}
-                                disabled={!option.available}
-                                name={name}
-                                checked={option.available && option.checked}
-                                value={index}
-                            />{" "}
-                            {option.label}
-                            {comment && (
-                                <div
-                                    className={[
-                                        "comment",
-                                        option.available
-                                            ? "AvailableOption"
-                                            : "UnavailableOption"
-                                    ].join(" ")}
-                                >
-                                    {comment}
-                                </div>
-                            )}
-                        </label>
-                    </div>
-                ))}
+                {this.props.dropdownOptions?.length
+                    ? this.renderDropdown
+                    : this.renderOptions}
             </div>
         )
     }

--- a/charts/covidDataExplorer/CovidTypes.ts
+++ b/charts/covidDataExplorer/CovidTypes.ts
@@ -1,9 +1,25 @@
 export declare type PerCapita = boolean
 export declare type AlignedOption = boolean
-export declare type SmoothingOption = 0 | 3 | 7
+export declare type SmoothingOption = 0 | 3 | 7 | 14
 
-export declare type DailyFrequencyOption = boolean
-export declare type TotalFrequencyOption = boolean
+export declare type IntervalOption =
+    | "daily"
+    | "weekly"
+    | "total"
+    | "smoothed"
+    | "biweekly"
+    | "weeklyChange"
+    | "biweeklyChange"
+
+export const intervalOptions: IntervalOption[] = [
+    "daily",
+    "weekly",
+    "total",
+    "smoothed",
+    "biweekly",
+    "weeklyChange",
+    "biweeklyChange"
+]
 
 export declare type countrySlug = string
 

--- a/site/client/Analytics.ts
+++ b/site/client/Analytics.ts
@@ -89,6 +89,8 @@ export class Analytics {
         if (DEBUG && IS_DEV) {
             console.log("Analytics.logToAmplitude", name, props)
         }
+        if (!window.amplitude) return
+
         props = Object.assign(
             {},
             {
@@ -100,8 +102,7 @@ export class Analytics {
             },
             props
         )
-        if (window.amplitude)
-            window.amplitude.getInstance().logEvent(name, props)
+        window.amplitude.getInstance().logEvent(name, props)
     }
 
     private static logToGA(

--- a/site/client/css/pages/covidDataExplorer.scss
+++ b/site/client/css/pages/covidDataExplorer.scss
@@ -213,10 +213,11 @@ html.iframe .CovidDataExplorerFigure,
     }
 
     .intervalDropdown {
-        font-size: 14px;
-        font-weight: 700;
-        color: $primary-color;
+        font-size: 13px;
+        font-weight: 400;
+        // color: $primary-color;
         min-width: 120px;
+        border: 0;
     }
 
     &.mobile-explorer {

--- a/site/client/css/pages/covidDataExplorer.scss
+++ b/site/client/css/pages/covidDataExplorer.scss
@@ -215,7 +215,7 @@ html.iframe .CovidDataExplorerFigure,
     .intervalDropdown {
         font-size: 13px;
         font-weight: 400;
-        min-width: 120px;
+        min-width: 150px;
     }
 
     &.mobile-explorer {

--- a/site/client/css/pages/covidDataExplorer.scss
+++ b/site/client/css/pages/covidDataExplorer.scss
@@ -215,9 +215,7 @@ html.iframe .CovidDataExplorerFigure,
     .intervalDropdown {
         font-size: 13px;
         font-weight: 400;
-        // color: $primary-color;
         min-width: 120px;
-        border: 0;
     }
 
     &.mobile-explorer {

--- a/site/client/css/pages/covidDataExplorer.scss
+++ b/site/client/css/pages/covidDataExplorer.scss
@@ -212,6 +212,13 @@ html.iframe .CovidDataExplorerFigure,
         }
     }
 
+    .intervalDropdown {
+        font-size: 14px;
+        font-weight: 700;
+        color: $primary-color;
+        min-width: 120px;
+    }
+
     &.mobile-explorer {
         grid-template-columns: auto;
         grid-template-rows: 0fr 0fr 0fr 1fr;

--- a/utils/client/react-select.tsx
+++ b/utils/client/react-select.tsx
@@ -10,34 +10,61 @@ export function asArray<T>(value: ValueType<T>): T[] {
     else return [value]
 }
 
-export function getStylesForTargetHeight(targetHeight: number): StylesConfig {
+export function getStylesForTargetHeight(
+    targetHeight: number,
+    props: any = {}
+): StylesConfig {
     // Taken from https://github.com/JedWatson/react-select/issues/1322#issuecomment-591189551
+    const {
+        control,
+        valueContainer,
+        singleValue,
+        clearIndicator,
+        container,
+        dropdownIndicator,
+        option,
+        menu
+    } = props
     return {
+        container: (base: React.CSSProperties) => ({
+            ...base,
+            ...container
+        }),
         control: (base: React.CSSProperties) => ({
             ...base,
-            minHeight: "initial"
+            minHeight: "initial",
+            ...control
         }),
         valueContainer: (base: React.CSSProperties) => ({
             ...base,
             height: `${targetHeight - 1 - 1}px`,
-            padding: "0 4px"
+            padding: "0 4px",
+            ...valueContainer
+        }),
+        singleValue: (base: React.CSSProperties) => ({
+            ...base,
+            ...singleValue
         }),
         clearIndicator: (base: React.CSSProperties) => ({
             ...base,
-            padding: `${(targetHeight - 20 - 1 - 1) / 2}px`
+            padding: `${(targetHeight - 20 - 1 - 1) / 2}px`,
+            ...clearIndicator
         }),
         dropdownIndicator: (base: React.CSSProperties) => ({
             ...base,
-            padding: `${(targetHeight - 20 - 1 - 1) / 2}px`
+            padding: `${(targetHeight - 20 - 1 - 1) / 2}px`,
+            ...dropdownIndicator
         }),
         option: (base: React.CSSProperties) => ({
             ...base,
             paddingTop: "5px",
-            paddingBottom: "5px"
+            paddingBottom: "5px",
+            ...option
         }),
         menu: (base: React.CSSProperties) => ({
             ...base,
-            zIndex: 10000
+            zIndex: 10000,
+            ...menu
         })
     }
 }


### PR DESCRIPTION
This change adds 8 more chart views + 8 more map views to the Explorer.

It also changes the Interval control to a dropdown to accommodate the new options.

It changes the dailyFreq=true, totalFreq=true query param booleans to a single enum type instead.

New:
![Screen Shot 2020-07-28 at 1 17 47 PM](https://user-images.githubusercontent.com/74692/88737570-bd8d0000-d0d4-11ea-874d-a96e56663d9f.png)

