### PR TITLE
fix(slope): show correct start/end year in chart title

### DIFF
--- a/charts/ChartConfig.tsx
+++ b/charts/ChartConfig.tsx
@@ -904,6 +904,7 @@ export class ChartConfig {
             return this.scatter.endYear
         else if (this.isDiscreteBar && !this.discreteBar.failMessage)
             return this.discreteBar.targetYear
+        else if (this.isSlopeChart) return this.slopeChart.endYear
         else return this.lineChart.endYear
     }
 
@@ -928,6 +929,7 @@ export class ChartConfig {
             return this.scatter.startYear
         else if (this.isDiscreteBar && !this.discreteBar.failMessage)
             return this.discreteBar.targetYear
+        else if (this.isSlopeChart) return this.slopeChart.startYear
         else return this.lineChart.startYear
     }
 


### PR DESCRIPTION
As reported by max (https://owid.slack.com/archives/C46U9LXRR/p1596443291092100)

## Before
![image](https://user-images.githubusercontent.com/2641501/89168965-e3575080-d57d-11ea-9573-a49d3885a91a.png)

## After
![image](https://user-images.githubusercontent.com/2641501/89169027-fa963e00-d57d-11ea-9fe0-98bfa002fc9b.png)
