### PR TITLE
Timeline Years Reflect Selections

### DIFF
--- a/charts/HTMLTimeline.tsx
+++ b/charts/HTMLTimeline.tsx
@@ -57,7 +57,7 @@ export class Timeline extends React.Component<TimelineProps> {
 
     disposers!: IReactionDisposer[]
 
-    @observable dragTarget?: string
+    @observable dragTarget?: "start" | "end" | "both"
 
     @computed get isDragging(): boolean {
         return !!this.dragTarget
@@ -417,8 +417,19 @@ export class Timeline extends React.Component<TimelineProps> {
         this.context.chart.isPlaying = !this.isPlaying
     }
 
+    @computed get startYearDisplayed() {
+        return this.context.chart.minYear
+    }
+
+    @computed get endYearDisplayed(): number {
+        return this.startYearClosest === this.endYearClosest
+            ? this.maxYear
+            : this.context.chart.maxYear
+    }
+
     render() {
         const { minYear, maxYear, isPlaying, startYearUI, endYearUI } = this
+        const { chart } = this.context
 
         const startYearProgress = (startYearUI - minYear) / (maxYear - minYear)
         const endYearProgress = (endYearUI - minYear) / (maxYear - minYear)
@@ -444,7 +455,7 @@ export class Timeline extends React.Component<TimelineProps> {
                     </div>
                 )}
                 <div className="date">
-                    {this.context.chart.formatYearFunction(minYear)}
+                    {chart.formatYearFunction(this.startYearDisplayed)}
                 </div>
                 <div className="slider">
                     <div
@@ -464,7 +475,7 @@ export class Timeline extends React.Component<TimelineProps> {
                     />
                 </div>
                 <div className="date">
-                    {this.context.chart.formatYearFunction(maxYear)}
+                    {chart.formatYearFunction(this.endYearDisplayed)}
                 </div>
             </div>
         )


### PR DESCRIPTION
This PR makes the following changes to the Timeline:
- The date on the left of the timeline will always show the currently selected start year rather than the minimum year in the data.
- The date on the right of the timeline will show the currently selected end year rather than the maximum year in the data. If there is only one slider (i.e. start year == end year), then this date reflects the maximum year in the data (like before).

**View it live on Staging [here](https://staging-owid.netlify.app//grapher/broadband-penetration-by-country)**


**Before:**
![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/11683872/89236734-5e8d2680-d5bf-11ea-91a0-e7ee78979a7c.gif)


**After:**
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/11683872/89236593-02c29d80-d5bf-11ea-854b-345581415c89.gif)

