### PR TITLE
Increase `max-old-space-size` for baker scripts

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -131,7 +131,7 @@ fi
 
   # Static build to update the public frontend code
   cd $FINAL_TARGET
-  yarn tsn scripts/bakeSite.ts "$GIT_EMAIL" "$GIT_NAME"
+  yarn bake "$GIT_EMAIL" "$GIT_NAME"
 
   # Restart the deploy queue
   pm2 start $NAME-deploy-queue

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     },
     "scripts": {
         "tsn": "ts-node --transpile-only -r tsconfig-paths/register -r dotenv/config",
+        "tsnr": "node -r ts-node/register/transpile-only -r tsconfig-paths/register -r dotenv/config",
         "tsnd": "ts-node-dev --transpileOnly --respawn --no-notify --no-deps -r tsconfig-paths/register -r source-map-support/register -r dotenv/config",
         "dev-admin": "yarn tsnd admin/server/server.tsx",
         "dev-site": "yarn tsnd site/server/devServer.tsx",
@@ -29,8 +30,8 @@
         "testcheck": "yarn prettify:check && yarn typecheck && yarn test",
         "deploy": "./bin/deploy.sh",
         "serve": "yarn tsn admin/server/server.tsx",
-        "bake": "yarn tsn scripts/bakeSite.ts",
-        "deploy-queue": "yarn tsn deploy/watch.ts",
+        "bake": "yarn tsnr --max-old-space-size=4096 scripts/bakeSite.ts",
+        "deploy-queue": "yarn tsnr --max-old-space-size=4096 deploy/watch.ts",
         "storybook": "yarn tsn node_modules/.bin/start-storybook -p 6006",
         "build-storybook": "build-storybook",
         "bundlewatch": "ENV=production webpack -p && bundlewatch --config .bundlewatch.config.json",


### PR DESCRIPTION
Increases the maximum heap size limit from 2GB (the current default) to 4GB. The baker otherwise often runs out of memory.

Introduces the `tsnr` command (`tsn` with require) in order to be able to pass Node arguments through TS Node:

> **Note:** If you need to use advanced node.js CLI arguments (e.g. `--inspect`), use them with `node -r ts-node/register` instead of the `ts-node` CLI.

https://github.com/TypeStrong/ts-node#programmatic

---

To get the current limit (in bytes), you can run this in a Node script:

```js
v8.getHeapStatistics().heap_size_limit
```