### PR TITLE
Dev: memory leak fix. Map projections was keeping a ref to all charts preventing GC

### DIFF
--- a/charts/MapProjections.ts
+++ b/charts/MapProjections.ts
@@ -1,88 +1,57 @@
 import {
     geoPath,
-    GeoPath,
     geoConicConformal,
     geoAzimuthalEqualArea,
     GeoProjection
 } from "d3-geo"
-import { computed } from "mobx"
 import { geoRobinson, geoPatterson } from "d3-geo-projection"
 
-class MapProjectionsKlass {
-    [key: string]: GeoPath<any, any>
+export const MapProjections = {
+    World: geoPath().projection(geoRobinson() as GeoProjection),
 
-    @computed get World(): GeoPath<any, any> {
-        const projection = geoRobinson() as GeoProjection
-        const path = geoPath().projection(projection)
-        return path
-    }
-
-    @computed get Africa(): GeoPath<any, any> {
-        //empiric
-        const projection = geoConicConformal()
+    Africa: geoPath().projection(
+        geoConicConformal()
             .rotate([-25, 0])
             .center([0, 0])
             .parallels([30, -20])
-        const path = geoPath().projection(projection)
-        return path
-    }
+    ),
 
-    @computed get NorthAmerica(): GeoPath<any, any> {
-        const projection = geoConicConformal()
+    NorthAmerica: geoPath().projection(
+        geoConicConformal()
             .rotate([98, 0])
             .center([0, 38])
             .parallels([29.5, 45.5])
-        const path = geoPath().projection(projection)
-        return path
-    }
+    ),
 
-    @computed get SouthAmerica(): GeoPath<any, any> {
-        //empiric
-        const projection = geoConicConformal()
+    SouthAmerica: geoPath().projection(
+        geoConicConformal()
             .rotate([68, 0])
             .center([0, -14])
             .parallels([10, -30])
-        const path = geoPath().projection(projection)
-        return path
-    }
+    ),
+
     // From http://bl.ocks.org/dhoboy/ff8448ace9d5d567390a
-    @computed get Asia(): GeoPath<any, any> {
-        const projection = geoPatterson()
+    Asia: geoPath().projection(
+        geoPatterson()
             .center([58, 54])
             .scale(150)
             .translate([0, 0])
             .precision(0.1)
-        const path = geoPath().projection(projection)
-        return path
-    }
+    ),
 
     // From http://bl.ocks.org/espinielli/10587361
-    @computed get Europe(): GeoPath<any, any> {
-        const projection = geoAzimuthalEqualArea()
+    Europe: geoPath().projection(
+        geoAzimuthalEqualArea()
             .scale(200)
             .translate([262, 1187])
             .clipAngle(180 - 1e-3)
             .precision(1)
-        const path = geoPath().projection(projection)
-        return path
-        //empiric
-        /*const projection = geoConicConformal()
-            .rotate([-15, 0])
-            .center([0, 55])
-            .parallels([60, 40])
-        const path = geoPath().projection(projection)
-        return path*/
-    }
+    ),
 
-    @computed get Oceania(): GeoPath<any, any> {
-        const projection = geoConicConformal()
+    Oceania: geoPath().projection(
+        geoConicConformal()
             .rotate([-135, 0])
             .center([0, -20])
             .parallels([-10, -30])
-        const path = geoPath().projection(projection)
-        return path
-    }
+    )
 }
-
-const MapProjections = new MapProjectionsKlass()
-export { MapProjections }


### PR DESCRIPTION
Looking at the Heap snapshot, the MapProjectionsKlass had a huge retained size. It seems we use mobx computed on that class purely for cacheing. But then when a chart uses those computeds, that creates a reference inside the singleton instance to that chart, and so that chart will never be GC'd. At least that's my working theory, without knowing the exact details of how computeds are implemented. Does this make sense?

Just computing the values in MapProjections statically seems to fix the issue, and the GC continually gets mem usage back down to 50MB or so in my ad hoc test harness. I haven't looked at whether computing these values on every load is efficient. If not we could just do our own simple on demand cacheing.

Before:
![Screen Shot 2020-08-04 at 10 17 25 AM](https://user-images.githubusercontent.com/74692/89340681-d0a35100-d63b-11ea-959a-bd0757bb5a12.png)

After:
![Screen Shot 2020-08-04 at 10 12 52 AM](https://user-images.githubusercontent.com/74692/89340690-d4cf6e80-d63b-11ea-8214-9efcd8487982.png)
