### PR TITLE
Place more grid lines / ticks when using log scale

### DIFF
--- a/charts/AxisBox.tsx
+++ b/charts/AxisBox.tsx
@@ -219,6 +219,11 @@ export class AxisGridLines extends React.Component<AxisGridLinesProps> {
                 )}
             >
                 {scale.getTickValues().map((t, i) => {
+                    const color = t.faint
+                        ? "#eee"
+                        : t.value === 0
+                        ? "#ccc"
+                        : "#d3d3d3"
                     if (orient === "left")
                         return (
                             <line
@@ -227,7 +232,7 @@ export class AxisGridLines extends React.Component<AxisGridLinesProps> {
                                 y1={scale.place(t.value)}
                                 x2={bounds.right.toFixed(2)}
                                 y2={scale.place(t.value)}
-                                stroke={t.value === 0 ? "#ccc" : "#ddd"}
+                                stroke={color}
                                 strokeDasharray={
                                     t.value !== 0 ? "3,2" : undefined
                                 }
@@ -241,7 +246,7 @@ export class AxisGridLines extends React.Component<AxisGridLinesProps> {
                                 y1={bounds.bottom.toFixed(2)}
                                 x2={scale.place(t.value)}
                                 y2={bounds.top.toFixed(2)}
-                                stroke={t.value === 0 ? "#ccc" : "#ddd"}
+                                stroke={color}
                                 strokeDasharray={
                                     t.value !== 0 ? "3,2" : undefined
                                 }

--- a/charts/AxisBox.tsx
+++ b/charts/AxisBox.tsx
@@ -218,29 +218,33 @@ export class AxisGridLines extends React.Component<AxisGridLinesProps> {
                     orient === "left" ? "horizontalLines" : "verticalLines"
                 )}
             >
-                {scale.getTickValues().map((v, i) => {
+                {scale.getTickValues().map((t, i) => {
                     if (orient === "left")
                         return (
                             <line
                                 key={i}
                                 x1={bounds.left.toFixed(2)}
-                                y1={scale.place(v)}
+                                y1={scale.place(t.value)}
                                 x2={bounds.right.toFixed(2)}
-                                y2={scale.place(v)}
-                                stroke={v === 0 ? "#ccc" : "#ddd"}
-                                strokeDasharray={v !== 0 ? "3,2" : undefined}
+                                y2={scale.place(t.value)}
+                                stroke={t.value === 0 ? "#ccc" : "#ddd"}
+                                strokeDasharray={
+                                    t.value !== 0 ? "3,2" : undefined
+                                }
                             />
                         )
                     else
                         return (
                             <line
                                 key={i}
-                                x1={scale.place(v)}
+                                x1={scale.place(t.value)}
                                 y1={bounds.bottom.toFixed(2)}
-                                x2={scale.place(v)}
+                                x2={scale.place(t.value)}
                                 y2={bounds.top.toFixed(2)}
-                                stroke={v === 0 ? "#ccc" : "#ddd"}
-                                strokeDasharray={v !== 0 ? "3,2" : undefined}
+                                stroke={t.value === 0 ? "#ccc" : "#ddd"}
+                                strokeDasharray={
+                                    t.value !== 0 ? "3,2" : undefined
+                                }
                             />
                         )
                 })}

--- a/charts/AxisScale.ts
+++ b/charts/AxisScale.ts
@@ -87,7 +87,7 @@ export class AxisScale {
     // the chart would get too overwhelming. Different for mobile because screens
     // are usually smaller.
     @computed get maxLogLines() {
-        return isMobile() ? 15 : 20
+        return isMobile() ? 9 : 11
     }
 
     getTickValues(): Tickmark[] {
@@ -95,7 +95,8 @@ export class AxisScale {
 
         let ticks: Tickmark[]
         if (scaleType === "log") {
-            ticks = d3_scale.ticks(maxLogLines).map(tickValue => {
+            const tickCandidates = d3_scale.ticks(maxLogLines)
+            ticks = tickCandidates.map(tickValue => {
                 // 10^x
                 if (Math.fround(Math.log10(tickValue)) % 1 === 0)
                     return { value: tickValue, priority: 1 }
@@ -104,9 +105,12 @@ export class AxisScale {
                     return { value: tickValue, priority: 2 }
                 // 2 * 10^x
                 else if (Math.fround(Math.log10(tickValue / 2)) % 1 === 0)
-                    return { value: tickValue, priority: 3 }
+                    return { value: tickValue, priority: 2 }
                 else
-                    return { value: tickValue, priority: 4, gridLineOnly: true }
+                    return {
+                        value: tickValue,
+                        priority: 4
+                    }
             })
 
             // Remove some tickmarks again because the chart would get too


### PR DESCRIPTION
(https://www.notion.so/owid/Fix-how-grid-lines-are-created-c8fab78c8a184dcd87e40dc100786d47)

This improves the placement and number of grid lines and ticks, especially for log axes.

Some comparisons (old/new):
![image](https://user-images.githubusercontent.com/2641501/89517789-8906fb80-d7da-11ea-8286-8634c207cb71.png)
![image](https://user-images.githubusercontent.com/2641501/89518078-b81d6d00-d7da-11ea-87b6-e28ac7a31ced.png)
![image](https://user-images.githubusercontent.com/2641501/89518286-fdda3580-d7da-11ea-8aef-31b7d49a41b8.png)
![image](https://user-images.githubusercontent.com/2641501/89518443-324df180-d7db-11ea-80b2-977f75a261d6.png)

Same on mobile (here there's only `10^x` and `5 * 10^x` grid lines, and most `5...` ticks are missing because of a collision):
![image](https://user-images.githubusercontent.com/2641501/89519220-4c3c0400-d7dc-11ea-8d44-cbc435cc93eb.png)


Sadly, I don't yet have my "own" staging server where I could push this for you to try it out.

The heuristic (when using log scale) roughly works as follows:
* generate many potential tick marks using `d3`, which seems to always generate _all_ the ticks of the form `y * 10^x` for `0 < y < 10`
* assign different priorities to these tick marks: highest priority to ones of the form `10^x`, then `5 * 10^x`, then `2 * 10^x`
* keep the other, in-between ticks as well, but set them to lowest priority and only ever generate lines from them, not labels
* remove labels by _priority_ beginning from the lowest priority, until we have fewer than a set number of labels (15 on mobile, 20 otherwise) (sadly only discerned by user agent, not by chart size because that seems to be way more difficult 😢 )
  * this is so the chart doesn't get too overwhelming
  * this also means the in-between lines without labels are only shown for axes with small range, i.e. only showing 2 orders of magnitude (for example, the solar module prices above)
* labels and grid lines are then drawn out, where the labels use a collision detection so they don't overlap. this also works by priority, so higher-priority labels "win" the collision detection in case they overlap with another label.

This approach seems to work reasonably well in most cases, but let's see what you think of it!