### PR TITLE
fix(webpack): "can't resolve module" error

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,6 @@
         "live-commit": "yarn tsn scripts/liveCommit.ts"
     },
     "dependencies": {
-        "@emotion/core": "^10.0.10",
-        "@emotion/styled": "^10.0.12",
         "@fortawesome/fontawesome-svg-core": "^1.2.19",
         "@fortawesome/free-brands-svg-icons": "^5.9.0",
         "@fortawesome/free-regular-svg-icons": "^5.9.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,7 @@ module.exports = (env, argv) => {
         },
         resolve: {
             extensions: [".ts", ".tsx", ".js", ".css"],
-            modules: [path.join(__dirname, "node_modules"), __dirname]
+            modules: ["node_modules", __dirname]
         },
         module: {
             rules: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1868,7 +1868,7 @@
     "@emotion/utils" "0.11.1"
     "@emotion/weak-memoize" "0.2.2"
 
-"@emotion/core@^10.0.10", "@emotion/core@^10.0.20":
+"@emotion/core@^10.0.20":
   version "10.0.28"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.28.tgz#bb65af7262a234593a9e952c041d0f1c9b9bef3d"
   integrity sha512-pH8UueKYO5jgg0Iq+AmCLxBsvuGtvlmiDCOuv8fGNYn3cowFpLN98L8zO56U0H1PjDIyAlXymgL3Wu7u7v6hbA==
@@ -1978,7 +1978,7 @@
     "@emotion/serialize" "^0.11.15"
     "@emotion/utils" "0.11.3"
 
-"@emotion/styled@^10.0.12", "@emotion/styled@^10.0.17":
+"@emotion/styled@^10.0.17":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-10.0.27.tgz#12cb67e91f7ad7431e1875b1d83a94b814133eaf"
   integrity sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==
@@ -6437,8 +6437,6 @@ clean-css@4.2.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.1.tgz#2d411ef76b8569b6d0c84068dabe85b0aa5e5c17"
   integrity sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==
-  dependencies:
-    source-map "~0.6.0"
 
 clean-deep@^3.0.2:
   version "3.0.2"
@@ -18712,7 +18710,7 @@ source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==


### PR DESCRIPTION
This is a better fix for the issue where an error message like this would show up during a build:
<details>

```
ERROR in ./node_modules/@emotion/core/dist/core.browser.esm.js
Module not found: Error: Can't resolve '@emotion/serialize' in '/home/owid/tmp/live-breck-tmp/node_modules/@emotion/core/dist'
 @ ./node_modules/@emotion/core/dist/core.browser.esm.js 4:0-53 53:19-34 167:23-38 175:19-34 335:23-38
 @ ./node_modules/react-select/async/dist/react-select.browser.esm.js
 @ ./charts/IndicatorDropdown.tsx
 @ ./charts/ExploreView.tsx
 @ ./site/client/owid.entry.ts
```
</details>

Turns out this is documented behavior in webpack, and happens due to the reasons described in https://github.com/owid/owid-grapher/commit/aba10dbca8ac0bac7544fd1abf64e7495ec05b8a#r41260036.

From the webpack docs (https://v4.webpack.js.org/configuration/resolve/#resolvemodules):
> resolve.modules
> [string] = ['node_modules']
>
> Tell webpack what directories should be searched when resolving modules.
>
> Absolute and relative paths can both be used, but be aware that they will behave a bit differently.
>
> __A relative path will be scanned similarly to how Node scans for node_modules__, by looking through the current directory as well as its ancestors (i.e. ./node_modules, ../node_modules, and on).
>
> __With an absolute path, it will only search in the given directory.__

Turns out we were using an absolute path, effectively turning off the Node-like module resolution that we actually want.