### PR TITLE
show correct number of charts on the front page

### DIFF
--- a/site/server/siteBaking.tsx
+++ b/site/server/siteBaking.tsx
@@ -194,7 +194,14 @@ export async function renderFrontPage() {
     const entries = await wpdb.getEntriesByCategory()
     const posts = await wpdb.getBlogIndex()
     const totalCharts = (
-        await db.query(`SELECT COUNT(*) as count FROM charts`)
+        await db.query(
+            `SELECT COUNT(*) AS count
+            FROM charts
+            WHERE
+                is_indexable IS TRUE
+                AND publishedAt IS NOT NULL
+                AND config -> "$.isPublished" IS TRUE`
+        )
     )[0].count as number
     return renderToHtmlPage(
         <FrontPage entries={entries} posts={posts} totalCharts={totalCharts} />


### PR DESCRIPTION
Turns out we've been lying the whole time, and have included charts that are not published or not indexable in the number shown on the front page.

This now includes exactly those charts that are listed on the "All charts" page.

_Before_: 3708 charts across 297 topics
_After_: 2968 charts across 297 topics