### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ENV DB_NAME=owid
 
 # Installing Node.js 12.x and Yarn
 RUN set -x \
-      && apt-get update && apt-get install -y curl jq \
+      && apt-get update && apt-get install -y curl jq git make g++ \
       && NODE_VERSION=$(jq -r .engines.node /app/package.json) \
       && DEB_FILE="nodejs_${NODE_VERSION}-1nodesource1_amd64.deb" \
       && curl -sLO "https://deb.nodesource.com/node_12.x/pool/main/n/nodejs/${DEB_FILE}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM mysql:5.7
+
+ENV MYSQL_ALLOW_EMPTY_PASSWORD=yes
+ENV MYSQL_DATABASE=owid
+ENV DB_NAME=owid
+
+ADD https://files.ourworldindata.org/owid_metadata.sql.gz /docker-entrypoint-initdb.d/00-metadata.sql.gz
+ADD https://files.ourworldindata.org/owid_chartdata.sql.gz /docker-entrypoint-initdb.d/01-data.sql.gz
+# https://github.com/docker-library/mysql/issues/624
+RUN chmod 0777 /docker-entrypoint-initdb.d/*
+
+
+#http://web.archive.org/web/20200324170901/https://city.opendata.by/
+#MYSQL_ALL

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,14 @@ ADD https://files.ourworldindata.org/owid_metadata.sql.gz /docker-entrypoint-ini
 ADD https://files.ourworldindata.org/owid_chartdata.sql.gz /docker-entrypoint-initdb.d/01-data.sql.gz
 # https://github.com/docker-library/mysql/issues/624
 RUN chmod 0777 /docker-entrypoint-initdb.d/*
+
 # Explicitly trigger database import to speed up mysqld startup in final image.
-# --datadir is changed because default is volume that does not persist.
 # https://serverfault.com/questions/796762/creating-a-docker-mysql-container-with-a-prepared-database-scheme/915845#915845
+
+# prevent mysqld from starting after DB import
+RUN ["sed", "-i", "s/exec \"$@\"/echo \"skipping $@\"/", "/entrypoint.sh"]
+
+# --datadir is changed because default is volume that does not persist.
 RUN ["/entrypoint.sh", "--datadir", "/init-db"]
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5.7
+FROM mysql:5.7 as builder
 
 ENV MYSQL_ALLOW_EMPTY_PASSWORD=yes
 ENV MYSQL_DATABASE=owid
@@ -8,7 +8,13 @@ ADD https://files.ourworldindata.org/owid_metadata.sql.gz /docker-entrypoint-ini
 ADD https://files.ourworldindata.org/owid_chartdata.sql.gz /docker-entrypoint-initdb.d/01-data.sql.gz
 # https://github.com/docker-library/mysql/issues/624
 RUN chmod 0777 /docker-entrypoint-initdb.d/*
+# Explicitly trigger database import to speed up mysqld startup in final image.
+# --datadir is changed because default is volume that does not persist.
+# https://serverfault.com/questions/796762/creating-a-docker-mysql-container-with-a-prepared-database-scheme/915845#915845
+RUN ["/entrypoint.sh", "--datadir", "/init-db"]
 
 
-#http://web.archive.org/web/20200324170901/https://city.opendata.by/
-#MYSQL_ALL
+FROM mysql:5.7
+
+COPY --from=builder /init-db /var/lib/mysql
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ENV DB_NAME=owid
 
 # Installing Node.js 12.x and Yarn
 RUN set -x \
-      && apt-get update && apt-get install -y curl jq git make g++ \
+      && apt-get update && apt-get install -y curl jq git build-essential \
       && NODE_VERSION=$(jq -r .engines.node /app/package.json) \
       && DEB_FILE="nodejs_${NODE_VERSION}-1nodesource1_amd64.deb" \
       && curl -sLO "https://deb.nodesource.com/node_12.x/pool/main/n/nodejs/${DEB_FILE}" \


### PR DESCRIPTION
I found these lying on my disk as I was experimenting with self-sufficient containers where the database and application are shipped together. I didn't find a way to run MySQL process in a background (yet), and maybe it will be easier to just use SQLite for now.

As the last resort. the `docker-compose` can help to run this for development locally. I didn't want to switch to `docker-compose`, because it requires a repository checkout to try and see `owid-grapher`.