### PR TITLE
Change post thumbnail aspect ratio to be more in line with Twitter/Facebook

### DIFF
--- a/site/client/css/mixins.scss
+++ b/site/client/css/mixins.scss
@@ -178,7 +178,7 @@
     }
 }
 
-@mixin posts-list {
+@mixin posts-list($posts-num) {
     margin-bottom: $vertical-spacing * 2;
     list-style-type: none;
 
@@ -191,7 +191,7 @@
         display: grid;
         grid-gap: 1.5rem 1.25rem;
         grid-template-columns: repeat(2, 1fr);
-        grid-template-rows: repeat(10, auto);
+        grid-template-rows: repeat(ceil($posts-num / 2), auto);
 
         li {
             margin-bottom: 0;
@@ -201,7 +201,7 @@
     @include md-up {
         /* autoprefixer grid: autoplace */
         grid-template-columns: repeat(4, 1fr);
-        grid-template-rows: repeat(5, auto);
+        grid-template-rows: repeat(ceil($posts-num / 4), auto);
     }
 }
 

--- a/site/client/css/pages/homepage.scss
+++ b/site/client/css/pages/homepage.scss
@@ -316,7 +316,7 @@
     .cover-image {
         width: 100%;
         height: 0;
-        padding-bottom: 70%;
+        padding-bottom: 52.5%;
         background-repeat: no-repeat;
         background-position: center center;
         background-size: cover;

--- a/site/client/css/pages/homepage.scss
+++ b/site/client/css/pages/homepage.scss
@@ -402,7 +402,7 @@
 
 .homepage-posts--explainers {
     ul {
-        @include posts-list;
+        @include posts-list(8);
     }
 
     .thumbnail {

--- a/site/client/owid.scss
+++ b/site/client/owid.scss
@@ -146,15 +146,20 @@ body.blog li.post a:hover h3 {
     color: #d10a11;
 }
 
-body.blog li.post a:hover img {
-    border: 1px solid #999;
+body.blog li.post a .cover-image {
+    width: 100%;
+    height: 0;
+    padding-bottom: 52.5%;
+    background-repeat: no-repeat;
+    background-position: center center;
+    background-size: cover;
+    background-color: rgba(white, 0.05);
+
+    border: 1px solid #e0e0e0;
 }
 
-body.blog li.post img {
-    border: 1px solid #e0e0e0;
-    width: 100%;
-    height: 215px;
-    object-fit: cover;
+body.blog li.post a:hover .cover-image {
+    border: 1px solid #999;
 }
 
 @include md-up {

--- a/site/client/owid.scss
+++ b/site/client/owid.scss
@@ -122,7 +122,7 @@ body.blog h2 {
 }
 
 body.blog ul.posts {
-    @include posts-list;
+    @include posts-list(20);
 }
 
 body.blog li.post h3 {

--- a/site/server/views/BlogIndexPage.tsx
+++ b/site/server/views/BlogIndexPage.tsx
@@ -37,7 +37,12 @@ export const BlogIndexPage = (props: {
                                 <li key={post.slug} className="post">
                                     <a href={`/${post.path}`}>
                                         {post.imageUrl && (
-                                            <img src={post.imageUrl} />
+                                            <div
+                                                className="cover-image"
+                                                style={{
+                                                    backgroundImage: `url(${post.imageUrl})`
+                                                }}
+                                            />
                                         )}
                                         <h3>{post.title}</h3>
                                         <div className="entry-meta">


### PR DESCRIPTION
(https://www.notion.so/owid/Change-wordpress-post-thumbnail-size-to-match-twitter-preview-card-aspect-ratio-5dd98184fd074caa93009f4be444bd95)

This changes the aspect ratio of the "Latest publications" and "All posts" preview images, from roughly 1.42 : 1 to 1.91 : 1.
Why 1.91 : 1, you may ask? Because that's the same aspect ratio Twitter and Facebook use, and this will as such make preview cards there look nicer.

Live on https://tufte-owid.netlify.app/