### PR TITLE
CDE Fix: Transform per capita after computing rolling averages

### DIFF
--- a/charts/covidDataExplorer/CovidExplorerTable.ts
+++ b/charts/covidDataExplorer/CovidExplorerTable.ts
@@ -338,22 +338,20 @@ export class CovidExplorerTable {
                 columnName === "positive_test_rate") &&
             smoothing === 7
 
-        // todo: have perCapita column derived from regular column.
-        if (perCapita > 1) {
-            const originalRowFn = rowFn
-            rowFn = row => {
-                const value = originalRowFn(row)
-                if (value === undefined) return undefined
-                const pop = row.population
-                if (!pop) {
-                    console.log(
-                        `Warning: Missing population for ${row.location}. Excluding from perCapita`
-                    )
-                    return undefined
-                }
-                return perCapita * (value / pop)
-            }
-        }
+        const perCapitaTransform =
+            perCapita > 1
+                ? (value: any, row: any) => {
+                      if (value === undefined) return undefined
+                      const pop = row.population
+                      if (!pop) {
+                          console.log(
+                              `Warning: Missing population for ${row.location}. Excluding from perCapita`
+                          )
+                          return undefined
+                      }
+                      return perCapita * (value / pop)
+                  }
+                : undefined
 
         if (smoothing && !alreadySmoothed)
             table.addRollingAverageColumn(
@@ -363,7 +361,8 @@ export class CovidExplorerTable {
                 "day",
                 "entityName",
                 params.rollingMultiplier,
-                params.intervalChange
+                params.intervalChange,
+                perCapitaTransform
             )
         else table.addNumericComputedColumn({ ...spec, fn: rowFn })
         return spec

--- a/charts/covidDataExplorer/CovidExplorerTable.ts
+++ b/charts/covidDataExplorer/CovidExplorerTable.ts
@@ -33,7 +33,8 @@ import {
     ColumnSpec,
     entityName,
     columnSlug,
-    columnTypes
+    columnTypes,
+    Row
 } from "charts/owidData/OwidTable"
 import { CovidConstrainedQueryParams, CovidQueryParams } from "./CovidChartUrl"
 import { covidAnnotations } from "./CovidAnnotations"
@@ -340,7 +341,8 @@ export class CovidExplorerTable {
 
         const perCapitaTransform =
             perCapita > 1
-                ? (value: any, row: any) => {
+                ? (fn: RowToValueMapper) => (row: Row, index?: number) => {
+                      const value = fn(row, index)
                       if (value === undefined) return undefined
                       const pop = row.population
                       if (!pop) {
@@ -364,7 +366,12 @@ export class CovidExplorerTable {
                 params.intervalChange,
                 perCapitaTransform
             )
-        else table.addNumericComputedColumn({ ...spec, fn: rowFn })
+        else {
+            if (perCapitaTransform) {
+                rowFn = perCapitaTransform(rowFn)
+            }
+            table.addNumericComputedColumn({ ...spec, fn: rowFn })
+        }
         return spec
     }
 

--- a/charts/covidDataExplorer/CovidExplorerTable.ts
+++ b/charts/covidDataExplorer/CovidExplorerTable.ts
@@ -367,10 +367,10 @@ export class CovidExplorerTable {
                 perCapitaTransform
             )
         else {
-            if (perCapitaTransform) {
-                rowFn = perCapitaTransform(rowFn)
-            }
-            table.addNumericComputedColumn({ ...spec, fn: rowFn })
+            table.addNumericComputedColumn({
+                ...spec,
+                fn: perCapitaTransform ? perCapitaTransform(rowFn) : rowFn
+            })
         }
         return spec
     }

--- a/charts/covidDataExplorer/CovidExplorerTable.ts
+++ b/charts/covidDataExplorer/CovidExplorerTable.ts
@@ -339,6 +339,7 @@ export class CovidExplorerTable {
                 columnName === "positive_test_rate") &&
             smoothing === 7
 
+        // Per-capita transform done after rolling average to preserve precision.
         const perCapitaTransform =
             perCapita > 1
                 ? (fn: RowToValueMapper) => (row: Row, index?: number) => {

--- a/charts/owidData/OwidTable.ts
+++ b/charts/owidData/OwidTable.ts
@@ -31,7 +31,7 @@ export declare type entityId = number
 export declare type owidVariableId = int
 export declare type columnSlug = string // let's be very restrictive on valid column names to start.
 
-interface Row {
+export interface Row {
     [columnName: string]: any
 }
 
@@ -397,7 +397,10 @@ abstract class AbstractTable<ROW_TYPE extends Row> {
         groupBy: columnSlug,
         multiplier = 1,
         intervalChange?: number,
-        transformation: (value: any, row: Row) => any = value => value
+        transformation: (fn: RowToValueMapper) => RowToValueMapper = fn => (
+            row,
+            index
+        ) => fn(row, index)
     ) {
         const averages = computeRollingAveragesForEachGroup(
             this.rows,
@@ -419,8 +422,7 @@ abstract class AbstractTable<ROW_TYPE extends Row> {
         this._addComputedColumn(
             new NumericColumn(this, {
                 ...spec,
-                fn: (row, index) =>
-                    transformation(computeIntervalTotals(row, index), row)
+                fn: transformation(computeIntervalTotals)
             })
         )
     }

--- a/charts/owidData/OwidTable.ts
+++ b/charts/owidData/OwidTable.ts
@@ -407,7 +407,7 @@ abstract class AbstractTable<ROW_TYPE extends Row> {
             windowSize
         )
 
-        const some_fn: RowToValueMapper = (row, index) => {
+        const computeIntervalTotals: RowToValueMapper = (row, index) => {
             const val = averages[index!]
             if (!intervalChange) return val ? val * multiplier : val
             const previousValue = averages[index! - intervalChange]
@@ -419,7 +419,8 @@ abstract class AbstractTable<ROW_TYPE extends Row> {
         this._addComputedColumn(
             new NumericColumn(this, {
                 ...spec,
-                fn: (row, index) => transformation(some_fn(row, index), row)
+                fn: (row, index) =>
+                    transformation(computeIntervalTotals(row, index), row)
             })
         )
     }


### PR DESCRIPTION
[Link to bug.](https://www.notion.so/owid/CDE-with-Per-Million-and-Unaligned-Outbreaks-doesn-t-show-any-data-or-axes-ee0dc032294441aab024cd44d2d6a469)

Live at [Nightingale](https://nightingale-owid.netlify.app/coronavirus-data-explorer?yScale=log&zoomToSelection=true&casesMetric=true&interval=smoothed&perCapita=true&smoothing=7&country=USA~GBR~CAN~BRA~AUS~IND~DEU~MEX~ZAF~COL~KOR~NOR~UGA~NGA&pickerMetric=location&pickerSort=asc).

**Before:**
![image](https://user-images.githubusercontent.com/11683872/89952564-79811b80-dbfb-11ea-824b-efc1d78cca72.png)


**After:**
![image](https://user-images.githubusercontent.com/11683872/89952583-8271ed00-dbfb-11ea-8b03-c1aac6faf8d8.png)
