### PR TITLE
Fix exportMetadata script following MySQL 5.7.31 update

### DIFF
--- a/scripts/exportMetadata.ts
+++ b/scripts/exportMetadata.ts
@@ -34,12 +34,12 @@ async function dataExport() {
 
     // Dump all tables including schema but exclude the rows of data_values
     await exec(
-        `mysqldump --default-character-set=utf8mb4 -u '${DB_USER}' -h '${DB_HOST}' -P ${DB_PORT} ${DB_NAME} ${excludeTables
+        `mysqldump --default-character-set=utf8mb4 --no-tablespaces -u '${DB_USER}' -h '${DB_HOST}' -P ${DB_PORT} ${DB_NAME} ${excludeTables
             .map(tableName => `--ignore-table=${DB_NAME}.${tableName}`)
             .join(" ")} -r ${filePath}`
     )
     await exec(
-        `mysqldump --default-character-set=utf8mb4 -u '${DB_USER}' -h '${DB_HOST}' -P ${DB_PORT} --no-data ${DB_NAME} ${excludeTables.join(
+        `mysqldump --default-character-set=utf8mb4 --no-tablespaces -u '${DB_USER}' -h '${DB_HOST}' -P ${DB_PORT} --no-data ${DB_NAME} ${excludeTables.join(
             " "
         )} >> ${filePath}`
     )


### PR DESCRIPTION
When running `./refresh.sh` from a staging server:
```
$ ts-node --transpile-only -r tsconfig-paths/register -r dotenv/config scripts/exportMetadata.ts --with-passwords /tmp/owid_metadata_with_passwords.sql
Exporting database structure and metadata to /tmp/owid_metadata_with_passwords.sql...
mysqldump: Error: 'Access denied; you need (at least one of) the PROCESS privilege(s) for this operation' when trying to dump tablespaces
mysqldump: Error: 'Access denied; you need (at least one of) the PROCESS privilege(s) for this operation' when trying to dump tablespaces
```

Adding the `--no-tablespaces` flag to the `mysqldump` commands silences the error (as described in the release doc: 
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-31.html), although I'm unclear about the implications for us.