### PR TITLE
Improve comparison line generation for log axes

### DIFF
--- a/admin/client/TestIndexPage.tsx
+++ b/admin/client/TestIndexPage.tsx
@@ -99,6 +99,16 @@ export class TestIndexPage extends React.Component {
                             <Link
                                 native
                                 target="_blank"
+                                to="/test/embeds?comparisonLines=true"
+                            >
+                                All charts with comparison lines
+                            </Link>
+                        </li>
+
+                        <li>
+                            <Link
+                                native
+                                target="_blank"
                                 to="/test/embedVariants"
                             >
                                 Embed Variants

--- a/admin/server/testPages.tsx
+++ b/admin/server/testPages.tsx
@@ -160,6 +160,11 @@ testPages.get("/embeds", async (req, res) => {
         tab = "chart"
     }
 
+    if (req.query.comparisonLines) {
+        query = query.andWhere(`config->'$.comparisonLines[0].yEquals' != ''`)
+        tab = "chart"
+    }
+
     if (tab) {
         if (tab === "map") {
             query = query.andWhere(`config->"$.hasMapTab" IS TRUE`)

--- a/charts/ComparisonLineGenerator.ts
+++ b/charts/ComparisonLineGenerator.ts
@@ -1,12 +1,13 @@
 import { Parser, Expression } from "expr-eval"
 import { scaleLinear, scaleLog } from "d3-scale"
+import { ScaleType } from "./ScaleType"
 
 export function generateComparisonLinePoints(
     lineFunction: string = "x",
     xScaleDomain: [number, number],
     yScaleDomain: [number, number],
-    xScaleType: string,
-    yScaleType: string
+    xScaleType: ScaleType,
+    yScaleType: ScaleType
 ) {
     const expr = parseEquation(lineFunction)?.simplify({
         e: Math.E,

--- a/charts/ComparisonLineGenerator.ts
+++ b/charts/ComparisonLineGenerator.ts
@@ -8,9 +8,11 @@ export function generateComparisonLinePoints(
     xScaleType: string,
     yScaleType: string
 ) {
-    const expr = parseEquation(lineFunction)
-    const yFunc = (x: number) =>
-        evalExpression(expr, { x: x, e: Math.E, pi: Math.PI }, x)
+    const expr = parseEquation(lineFunction)?.simplify({
+        e: Math.E,
+        pi: Math.PI
+    })
+    const yFunc = (x: number) => evalExpression(expr, { x }, undefined)
 
     // Construct control data by running the equation across sample points
     const numPoints = 500
@@ -23,6 +25,7 @@ export function generateComparisonLinePoints(
         const x = scale.invert(i)
         const y = yFunc(x)
 
+        if (y === undefined) continue
         if (xScaleType === "log" && x <= 0) continue
         if (yScaleType === "log" && y <= 0) continue
         if (y > yScaleDomain[1]) continue
@@ -32,14 +35,14 @@ export function generateComparisonLinePoints(
     return controlData
 }
 
-function evalExpression(
+function evalExpression<D>(
     expr: Expression | undefined,
-    context: Record<string, any>,
-    defaultOnError: any
+    context: Record<string, number>,
+    defaultOnError: D
 ) {
     if (expr === undefined) return defaultOnError
     try {
-        return expr.evaluate(context)
+        return expr.evaluate(context) as number
     } catch (e) {
         return defaultOnError
     }

--- a/charts/ComparisonLineGenerator.ts
+++ b/charts/ComparisonLineGenerator.ts
@@ -1,5 +1,5 @@
 import { Parser, Expression } from "expr-eval"
-import { scaleLinear } from "d3-scale"
+import { scaleLinear, scaleLog } from "d3-scale"
 
 export function generateComparisonLinePoints(
     lineFunction: string = "x",
@@ -13,13 +13,14 @@ export function generateComparisonLinePoints(
         evalExpression(expr, { x: x, e: Math.E, pi: Math.PI }, x)
 
     // Construct control data by running the equation across sample points
-    const numPoints = 100
-    const scale = scaleLinear()
-        .domain([0, 100])
-        .range(xScaleDomain)
+    const numPoints = 500
+    const scaleFunction = xScaleType === "log" ? scaleLog : scaleLinear
+    const scale = scaleFunction()
+        .domain(xScaleDomain)
+        .range([0, numPoints])
     const controlData: Array<[number, number]> = []
     for (let i = 0; i < numPoints; i++) {
-        const x = scale(i)
+        const x = scale.invert(i)
         const y = yFunc(x)
 
         if (xScaleType === "log" && x <= 0) continue

--- a/charts/ComparisonLineGenerator.ts
+++ b/charts/ComparisonLineGenerator.ts
@@ -1,4 +1,4 @@
-import { Parser } from "expr-eval"
+import { Parser, Expression } from "expr-eval"
 import { scaleLinear } from "d3-scale"
 
 export function generateComparisonLinePoints(
@@ -8,8 +8,9 @@ export function generateComparisonLinePoints(
     xScaleType: string,
     yScaleType: string
 ) {
+    const expr = parseEquation(lineFunction)
     const yFunc = (x: number) =>
-        evalEquation(lineFunction, { x: x, e: Math.E, pi: Math.PI }, x)
+        evalExpression(expr, { x: x, e: Math.E, pi: Math.PI }, x)
 
     // Construct control data by running the equation across sample points
     const numPoints = 100
@@ -30,17 +31,24 @@ export function generateComparisonLinePoints(
     return controlData
 }
 
-function evalEquation(
-    equation: string,
-    context: { [key: string]: any },
+function evalExpression(
+    expr: Expression | undefined,
+    context: Record<string, any>,
     defaultOnError: any
 ) {
+    if (expr === undefined) return defaultOnError
     try {
-        const parser = new Parser()
-        const expr = parser.parse(equation)
         return expr.evaluate(context)
     } catch (e) {
-        //console.error(e)
         return defaultOnError
+    }
+}
+
+function parseEquation(equation: string) {
+    try {
+        return Parser.parse(equation)
+    } catch (e) {
+        console.error(e)
+        return undefined
     }
 }

--- a/charts/__tests__/ComparisonLineGenerator.test.ts
+++ b/charts/__tests__/ComparisonLineGenerator.test.ts
@@ -12,7 +12,7 @@ describe(generateComparisonLinePoints, () => {
                 "linear",
                 "linear"
             )
-            expect(points.length).toEqual(100)
+            expect(points.length).toEqual(500)
         })
 
         it("it clamps points if they exceed the y max", () => {
@@ -23,7 +23,31 @@ describe(generateComparisonLinePoints, () => {
                 "linear",
                 "linear"
             )
-            expect(points.length).toEqual(51)
+            expect(points.length).toEqual(251)
+        })
+    })
+
+    describe("For y = 50*x", () => {
+        it("returns the correct number of points", () => {
+            const points = generateComparisonLinePoints(
+                "50*x",
+                [0, 10],
+                [0, 10],
+                "linear",
+                "linear"
+            )
+            expect(points.length).toEqual(11)
+        })
+
+        it("returns the correct number of points for a log chart", () => {
+            const points = generateComparisonLinePoints(
+                "50*x",
+                [1e-6, 1e6],
+                [0, 10],
+                "log",
+                "linear"
+            )
+            expect(points.length).toEqual(221)
         })
     })
 })

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
         "enzyme": "^3.10.0",
         "enzyme-adapter-react-16": "^1.15.1",
         "eslint": "^6.8.0",
-        "expr-eval": "^1.2.2",
+        "expr-eval": "^2.0.2",
         "express": "^4.17.1",
         "express-async-errors": "^3.1.1",
         "express-error-slack": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9065,10 +9065,10 @@ expect@^24.8.0:
     jest-message-util "^24.8.0"
     jest-regex-util "^24.3.0"
 
-expr-eval@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/expr-eval/-/expr-eval-1.2.2.tgz#8b1a160b814e67da7652007e2693714895221ea0"
-  integrity sha1-ixoWC4FOZ9p2UgB+JpNxSJUiHqA=
+expr-eval@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/expr-eval/-/expr-eval-2.0.2.tgz#fa6f044a7b0c93fde830954eb9c5b0f7fbc7e201"
+  integrity sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg==
 
 express-async-errors@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
(https://www.notion.so/owid/Comparison-line-log-linear-issues-10b4a258ee994b3eb3a4bd705b9692d7)

Comparison line generation was quite bad for charts with log x axes, because some lines just wouldn't display because not enough data points could be created.
I also incorporated some other changes here, like:
* Parsing the expression only once instead of every time it is evaluated
* Increasing the number of sample points from 100 to 500, which sometimes helps with the "line resolution"
* Not falling back to `y = x` in case of an evaluation error
* Adding a test page (http://localhost:3030/admin/test/embeds?comparisonLines=true) for all comparison line charts

## Before & After
![image](https://user-images.githubusercontent.com/2641501/90121315-1eb30580-dd5c-11ea-9d87-0317ffb1d64b.png)
(notice how the `0.02%` lines was absent before)

![image](https://user-images.githubusercontent.com/2641501/90121391-38ece380-dd5c-11ea-9597-a6bf9099e2bf.png)
