### PR TITLE
Add ckmeans & quantiles binning strategies for color scales

### DIFF
--- a/admin/client/EditorColorScaleSection.tsx
+++ b/admin/client/EditorColorScaleSection.tsx
@@ -15,7 +15,7 @@ import { faMinus } from "@fortawesome/free-solid-svg-icons/faMinus"
 
 import { ColorScale } from "charts/ColorScale"
 import { ColorScaleBin, NumericBin, CategoricalBin } from "charts/ColorScaleBin"
-import { clone, noop } from "charts/Util"
+import { clone, noop, last } from "charts/Util"
 import { Color } from "charts/Color"
 import { asArray } from "utils/client/react-select"
 
@@ -408,7 +408,9 @@ class NumericBinView extends React.Component<{
         populateManualBinValuesIfAutomatic(scale)
 
         if (index === customNumericValues.length - 1)
-            customNumericValues.push(currentValue + scale.binStepSize)
+            customNumericValues.push(
+                last(scale.sortedNumericValues) ?? currentValue
+            )
         else {
             const newValue = (currentValue + customNumericValues[index + 1]) / 2
             customNumericValues.splice(index + 1, 0, newValue)

--- a/admin/client/EditorColorScaleSection.tsx
+++ b/admin/client/EditorColorScaleSection.tsx
@@ -181,18 +181,21 @@ class ColorsSection extends React.Component<{
             : scale.baseColorScheme
     }
 
-    render() {
-        const { scale } = this.props
-
-        const binningStrategyOptions = Object.entries(
-            binningStrategyLabels
-        ).map(([value, label]) => ({
+    @computed get binningStrategyOptions() {
+        return Object.entries(binningStrategyLabels).map(([value, label]) => ({
             label: label,
             value: value as BinningStrategy
         }))
-        const currentBinningStrategyOption = binningStrategyOptions.find(
-            option => option.value === scale.config.binningStrategy
+    }
+
+    @computed get currentBinningStrategyOption() {
+        return this.binningStrategyOptions.find(
+            option => option.value === this.props.scale.config.binningStrategy
         )
+    }
+
+    render() {
+        const { scale } = this.props
 
         return (
             <Section name="Color scale">
@@ -227,9 +230,9 @@ class ColorsSection extends React.Component<{
                     <div className="form-group">
                         <label>Binning strategy</label>
                         <Select
-                            options={binningStrategyOptions}
+                            options={this.binningStrategyOptions}
                             onChange={this.onBinningStrategy}
-                            value={currentBinningStrategyOption}
+                            value={this.currentBinningStrategyOption}
                             components={{
                                 IndicatorSeparator: null
                             }}

--- a/admin/client/EditorColorScaleSection.tsx
+++ b/admin/client/EditorColorScaleSection.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { action, IReactionDisposer, reaction, computed } from "mobx"
+import { action, IReactionDisposer, reaction, computed, runInAction } from "mobx"
 import { observer } from "mobx-react"
 import Select, { ValueType } from "react-select"
 
@@ -334,10 +334,12 @@ class BinLabelView extends React.Component<{
 }
 
 function populateManualBinValuesIfAutomatic(scale: ColorScale) {
-    if (scale.config.binningStrategy !== ColorScaleBinningStrategy.manual) {
-        scale.config.binningStrategy = ColorScaleBinningStrategy.manual
-        scale.config.customNumericValues = scale.autoBinMaximums
-    }
+    runInAction(() => {
+        if (scale.config.binningStrategy !== ColorScaleBinningStrategy.manual) {
+            scale.config.customNumericValues = scale.autoBinMaximums
+            scale.config.binningStrategy = ColorScaleBinningStrategy.manual
+        }
+    })
 }
 
 @observer

--- a/admin/client/EditorColorScaleSection.tsx
+++ b/admin/client/EditorColorScaleSection.tsx
@@ -199,14 +199,6 @@ class ColorsSection extends React.Component<{
                     label="Minimum value"
                     auto={scale.autoMinBinValue}
                 />
-                {!scale.config.isManualBuckets && (
-                    <BindAutoFloat
-                        label="Step size"
-                        field="binStepSize"
-                        store={scale.config}
-                        auto={scale.binStepSizeDefault}
-                    />
-                )}
                 {scale.config.isManualBuckets && (
                     <ColorSchemeEditor scale={scale} />
                 )}
@@ -350,7 +342,7 @@ class NumericBinView extends React.Component<{
         const currentValue = colorSchemeValues[index]
 
         if (index === colorSchemeValues.length - 1)
-            colorSchemeValues.push(currentValue + scale.binStepSizeDefault)
+            colorSchemeValues.push(currentValue + scale.binStepSize)
         else {
             const newValue = (currentValue + colorSchemeValues[index + 1]) / 2
             colorSchemeValues.splice(index + 1, 0, newValue)

--- a/admin/client/EditorColorScaleSection.tsx
+++ b/admin/client/EditorColorScaleSection.tsx
@@ -1,5 +1,11 @@
 import * as React from "react"
-import { action, IReactionDisposer, reaction, computed, runInAction } from "mobx"
+import {
+    action,
+    IReactionDisposer,
+    reaction,
+    computed,
+    runInAction
+} from "mobx"
 import { observer } from "mobx-react"
 import Select, { ValueType } from "react-select"
 
@@ -232,12 +238,22 @@ class ColorsSection extends React.Component<{
                         />
                     </div>
                 </FieldsRow>
-                <BindAutoFloat
-                    field="customNumericMinValue"
-                    store={scale.config}
-                    label="Minimum value"
-                    auto={scale.autoMinBinValue}
-                />
+                <FieldsRow>
+                    <BindAutoFloat
+                        field="customNumericMinValue"
+                        store={scale.config}
+                        label="Minimum value"
+                        auto={scale.autoMinBinValue}
+                    />
+                    {!scale.isManualBuckets && (
+                        <BindAutoFloat
+                            field="binningStrategyBinCount"
+                            store={scale.config}
+                            label="Number of bins"
+                            auto={scale.numAutoBins}
+                        />
+                    )}
+                </FieldsRow>
                 <ColorSchemeEditor scale={scale} />
             </Section>
         )

--- a/admin/client/EditorColorScaleSection.tsx
+++ b/admin/client/EditorColorScaleSection.tsx
@@ -15,7 +15,7 @@ import { faMinus } from "@fortawesome/free-solid-svg-icons/faMinus"
 
 import { ColorScale } from "charts/ColorScale"
 import { ColorScaleBin, NumericBin, CategoricalBin } from "charts/ColorScaleBin"
-import { clone, noop, entries } from "charts/Util"
+import { clone, noop } from "charts/Util"
 import { Color } from "charts/Color"
 import { asArray } from "utils/client/react-select"
 
@@ -184,7 +184,7 @@ class ColorsSection extends React.Component<{
     render() {
         const { scale } = this.props
 
-        const binningStrategyOptions = entries(
+        const binningStrategyOptions = Object.entries(
             colorScaleBinningStrategyLabels
         ).map(([value, label]) => ({
             label: label,

--- a/admin/client/EditorColorScaleSection.tsx
+++ b/admin/client/EditorColorScaleSection.tsx
@@ -333,6 +333,13 @@ class BinLabelView extends React.Component<{
     }
 }
 
+function populateManualBinValuesIfAutomatic(scale: ColorScale) {
+    if (scale.config.binningStrategy !== ColorScaleBinningStrategy.manual) {
+        scale.config.binningStrategy = ColorScaleBinningStrategy.manual
+        scale.config.customNumericValues = scale.autoBinMaximums
+    }
+}
+
 @observer
 class NumericBinView extends React.Component<{
     scale: ColorScale
@@ -357,6 +364,7 @@ class NumericBinView extends React.Component<{
 
     @action.bound onMaximumValue(value: number | undefined) {
         const { scale, index } = this.props
+        populateManualBinValuesIfAutomatic(scale)
         if (value !== undefined) scale.config.customNumericValues[index] = value
     }
 
@@ -369,6 +377,7 @@ class NumericBinView extends React.Component<{
 
     @action.bound onRemove() {
         const { scale, index } = this.props
+        populateManualBinValuesIfAutomatic(scale)
         scale.config.customNumericValues.splice(index, 1)
         scale.config.customNumericColors.splice(index, 1)
     }
@@ -377,6 +386,8 @@ class NumericBinView extends React.Component<{
         const { scale, index } = this.props
         const { customNumericValues, customNumericColors } = scale.config
         const currentValue = customNumericValues[index]
+
+        populateManualBinValuesIfAutomatic(scale)
 
         if (index === customNumericValues.length - 1)
             customNumericValues.push(currentValue + scale.binStepSize)

--- a/admin/client/EditorColorScaleSection.tsx
+++ b/admin/client/EditorColorScaleSection.tsx
@@ -353,6 +353,7 @@ function populateManualBinValuesIfAutomatic(scale: ColorScale) {
     runInAction(() => {
         if (scale.config.binningStrategy !== BinningStrategy.manual) {
             scale.config.customNumericValues = scale.autoBinMaximums
+            scale.config.customNumericLabels = []
             scale.config.binningStrategy = BinningStrategy.manual
         }
     })

--- a/admin/client/EditorColorScaleSection.tsx
+++ b/admin/client/EditorColorScaleSection.tsx
@@ -249,7 +249,7 @@ class ColorsSection extends React.Component<{
                         <BindAutoFloat
                             field="binningStrategyBinCount"
                             store={scale.config}
-                            label="Number of bins"
+                            label="Target number of bins"
                             auto={scale.numAutoBins}
                         />
                     )}

--- a/admin/client/EditorColorScaleSection.tsx
+++ b/admin/client/EditorColorScaleSection.tsx
@@ -33,9 +33,9 @@ import {
 } from "./Forms"
 import { ColorSchemeOption, ColorSchemeDropdown } from "./ColorSchemeDropdown"
 import {
-    ColorScaleBinningStrategy,
-    colorScaleBinningStrategyLabels
-} from "charts/ColorScaleConfig"
+    BinningStrategy,
+    binningStrategyLabels
+} from "charts/BinningStrategies"
 
 interface EditorColorScaleSectionFeatures {
     visualScaling: boolean
@@ -166,7 +166,7 @@ class ColorsSection extends React.Component<{
     @action.bound onBinningStrategy(
         binningStrategy: ValueType<{
             label: string
-            value: ColorScaleBinningStrategy
+            value: BinningStrategy
         }>
     ) {
         this.props.scale.config.binningStrategy = asArray(
@@ -185,10 +185,10 @@ class ColorsSection extends React.Component<{
         const { scale } = this.props
 
         const binningStrategyOptions = Object.entries(
-            colorScaleBinningStrategyLabels
+            binningStrategyLabels
         ).map(([value, label]) => ({
             label: label,
-            value: value as ColorScaleBinningStrategy
+            value: value as BinningStrategy
         }))
         const currentBinningStrategyOption = binningStrategyOptions.find(
             option => option.value === scale.config.binningStrategy
@@ -351,9 +351,9 @@ class BinLabelView extends React.Component<{
 
 function populateManualBinValuesIfAutomatic(scale: ColorScale) {
     runInAction(() => {
-        if (scale.config.binningStrategy !== ColorScaleBinningStrategy.manual) {
+        if (scale.config.binningStrategy !== BinningStrategy.manual) {
             scale.config.customNumericValues = scale.autoBinMaximums
-            scale.config.binningStrategy = ColorScaleBinningStrategy.manual
+            scale.config.binningStrategy = BinningStrategy.manual
         }
     })
 }

--- a/charts/BinningStrategies.ts
+++ b/charts/BinningStrategies.ts
@@ -1,0 +1,82 @@
+import { ckmeans } from "simple-statistics"
+import { range, quantile } from "d3-array"
+
+import { excludeUndefined, uniq, last, roundSigFig, first } from "./Util"
+
+export enum BinningStrategy {
+    equalInterval = "equalInterval",
+    quantiles = "quantiles",
+    ckmeans = "ckmeans",
+    // The `manual` option is ignored in the algorithms below,
+    // but it is stored and handled by the chart.
+    manual = "manual"
+}
+
+/** Human-readable labels for the binning strategies */
+export const binningStrategyLabels: Record<BinningStrategy, string> = {
+    equalInterval: "Equal-interval",
+    quantiles: "Quantiles",
+    ckmeans: "Ckmeans",
+    manual: "Manual"
+}
+
+function calcEqualIntervalStepSize(
+    sortedValues: number[],
+    binCount: number,
+    minBinValue: number
+) {
+    if (!sortedValues.length) return 10
+    const stepSizeInitial = (last(sortedValues)! - minBinValue) / binCount
+    return roundSigFig(stepSizeInitial, 1)
+}
+
+interface GetBinMaximumsWithStrategyArgs {
+    binningStrategy: BinningStrategy
+    sortedValues: number[]
+    binCount: number
+    /** `minBinValue` is only used in the `equalInterval` binning strategy. */
+    minBinValue?: number
+}
+
+// Some algorithms can create bins that start & end at the same value.
+// This also means the first bin can both start and end at the same value – the minimum
+// value. This is why we uniq() and why we remove any values <= minimum value.
+function normalizeBinValues(
+    binValues: (number | undefined)[],
+    minBinValue?: number
+) {
+    const values = uniq(excludeUndefined(binValues))
+    return minBinValue !== undefined
+        ? values.filter(v => v > minBinValue)
+        : values
+}
+
+export function getBinMaximums(args: GetBinMaximumsWithStrategyArgs): number[] {
+    const { binningStrategy, sortedValues, binCount, minBinValue } = args
+
+    if (sortedValues.length < 1 || binCount < 1) return []
+
+    if (binningStrategy === BinningStrategy.ckmeans) {
+        const clusters = ckmeans(sortedValues, binCount)
+        return normalizeBinValues(clusters.map(last), minBinValue)
+    } else if (binningStrategy === BinningStrategy.quantiles) {
+        return normalizeBinValues(
+            range(1, binCount + 1).map(v =>
+                quantile(sortedValues, v / binCount)
+            ),
+            minBinValue
+        )
+    } else {
+        // Equal-interval strategy by default
+        const minValue = minBinValue ?? first(sortedValues) ?? 0
+        const binStepSize = calcEqualIntervalStepSize(
+            sortedValues,
+            binCount,
+            minValue
+        )
+        return normalizeBinValues(
+            range(1, binCount + 1).map(n => minValue + n * binStepSize),
+            minBinValue
+        )
+    }
+}

--- a/charts/ColorLegendView.tsx
+++ b/charts/ColorLegendView.tsx
@@ -156,9 +156,9 @@ class NumericColorLegendView extends React.Component<{
 
         return (
             <g ref={this.base} className="numericColorLegend">
-                {numericLabels.map(label => (
+                {numericLabels.map((label, i) => (
                     <line
-                        key={label.text}
+                        key={i}
                         x1={props.x + label.bounds.x + label.bounds.width / 2}
                         y1={bottomY - rectHeight}
                         x2={props.x + label.bounds.x + label.bounds.width / 2}
@@ -188,9 +188,9 @@ class NumericColorLegendView extends React.Component<{
                     }),
                     r => r.props["strokeWidth"]
                 )}
-                {numericLabels.map(label => (
+                {numericLabels.map((label, i) => (
                     <text
-                        key={label.text}
+                        key={i}
                         x={props.x + label.bounds.x}
                         y={bottomY + label.bounds.y}
                         fontSize={label.fontSize}

--- a/charts/ColorScale.ts
+++ b/charts/ColorScale.ts
@@ -12,7 +12,8 @@ import {
     last,
     find,
     identity,
-    roundSigFig
+    roundSigFig,
+    mapNullToUndefined
 } from "./Util"
 import { Color } from "./Color"
 import { ColorScheme, ColorSchemes } from "./ColorSchemes"
@@ -52,10 +53,10 @@ export class ColorScale {
         return defaultTo(this.config.customNumericColorsActive, false)
     }
 
-    @computed get customNumericColors() {
+    @computed get customNumericColors(): (Color | undefined)[] {
         return defaultTo(
             this.customNumericColorsActive
-                ? this.config.customNumericColors
+                ? mapNullToUndefined(this.config.customNumericColors)
                 : [],
             []
         )
@@ -69,7 +70,8 @@ export class ColorScale {
 
     @computed get customNumericLabels(): (string | undefined)[] {
         if (this.isManualBuckets) {
-            const labels = toJS(this.config.customNumericLabels) || []
+            const labels =
+                mapNullToUndefined(toJS(this.config.customNumericLabels)) || []
             while (labels.length < this.numBins) labels.push(undefined)
             return labels
         }

--- a/charts/ColorScale.ts
+++ b/charts/ColorScale.ts
@@ -222,7 +222,7 @@ export class ColorScale {
             : this.numAutoBins
     }
 
-    @computed get binStepSizeDefault(): number {
+    @computed get binStepSize(): number {
         const { numAutoBins, minBinValue, valuesWithoutOutliers } = this
         if (!valuesWithoutOutliers.length) return 10
 
@@ -234,12 +234,6 @@ export class ColorScale {
             Math.log(stepSizeInitial) / Math.log(10)
         )
         return round(stepSizeInitial, -stepMagnitude)
-    }
-
-    @computed get binStepSize(): number {
-        return this.config.binStepSize !== undefined
-            ? this.config.binStepSize
-            : this.binStepSizeDefault
     }
 
     // Exclude any major outliers for legend calculation (they will be relegated to open-ended bins)

--- a/charts/ColorScale.ts
+++ b/charts/ColorScale.ts
@@ -236,7 +236,7 @@ export class ColorScale {
     /** Sorted numeric values passed onto the binning algorithms */
     @computed private get sortedNumericBinningValues(): number[] {
         return this.sortedNumericValuesWithoutOutliers.filter(
-            v => v >= this.minBinValue
+            v => v > this.minBinValue
         )
     }
 

--- a/charts/ColorScale.ts
+++ b/charts/ColorScale.ts
@@ -148,7 +148,7 @@ export class ColorScale {
 
     @computed get autoMinBinValue(): number {
         const minValue = Math.min(0, this.sortedNumericValuesWithoutOutliers[0])
-        return Math.min(0, roundSigFig(minValue, 1))
+        return isNaN(minValue) ? 0 : roundSigFig(minValue, 1)
     }
 
     @computed get minBinValue(): number {

--- a/charts/ColorScale.ts
+++ b/charts/ColorScale.ts
@@ -240,8 +240,8 @@ export class ColorScale {
         return colors
     }
 
-    @computed private get numAutoBins(): number {
-        return 5
+    @computed get numAutoBins(): number {
+        return defaultTo(this.config.binningStrategyBinCount, 5)
     }
 
     @computed get isManualBuckets(): boolean {

--- a/charts/ColorScale.ts
+++ b/charts/ColorScale.ts
@@ -144,7 +144,7 @@ export class ColorScale {
     }
 
     @computed get autoMinBinValue(): number {
-        const minValue = Math.min(0, this.valuesWithoutOutliers[0])
+        const minValue = Math.min(0, this.sortedNumericValuesWithoutOutliers[0])
         return Math.min(0, roundSigFig(minValue, 1))
     }
 
@@ -229,18 +229,24 @@ export class ColorScale {
     }
 
     @computed get binStepSize(): number {
-        const { numAutoBins, minBinValue, valuesWithoutOutliers } = this
-        if (!valuesWithoutOutliers.length) return 10
+        const {
+            numAutoBins,
+            minBinValue,
+            sortedNumericValuesWithoutOutliers
+        } = this
+        if (!sortedNumericValuesWithoutOutliers.length) return 10
 
         const stepSizeInitial =
-            (valuesWithoutOutliers[valuesWithoutOutliers.length - 1] -
+            (sortedNumericValuesWithoutOutliers[
+                sortedNumericValuesWithoutOutliers.length - 1
+            ] -
                 minBinValue) /
             numAutoBins
         return roundSigFig(stepSizeInitial, 1)
     }
 
     // Exclude any major outliers for legend calculation (they will be relegated to open-ended bins)
-    @computed private get valuesWithoutOutliers(): number[] {
+    @computed private get sortedNumericValuesWithoutOutliers(): number[] {
         const { sortedNumericValues } = this
         if (!sortedNumericValues.length) return []
         const sampleMean = mean(sortedNumericValues) as number

--- a/charts/ColorScale.ts
+++ b/charts/ColorScale.ts
@@ -15,7 +15,8 @@ import {
     first,
     last,
     find,
-    identity
+    identity,
+    roundSigFig
 } from "./Util"
 import { Color } from "./Color"
 import { ColorScheme, ColorSchemes } from "./ColorSchemes"
@@ -144,8 +145,7 @@ export class ColorScale {
 
     @computed get autoMinBinValue(): number {
         const minValue = Math.min(0, this.valuesWithoutOutliers[0])
-        const magnitude = Math.floor(Math.log(minValue) / Math.log(10))
-        return Math.min(0, round(minValue, -magnitude))
+        return Math.min(0, roundSigFig(minValue, 1))
     }
 
     @computed get minBinValue(): number {
@@ -236,10 +236,7 @@ export class ColorScale {
             (valuesWithoutOutliers[valuesWithoutOutliers.length - 1] -
                 minBinValue) /
             numAutoBins
-        const stepMagnitude = Math.floor(
-            Math.log(stepSizeInitial) / Math.log(10)
-        )
-        return round(stepSizeInitial, -stepMagnitude)
+        return roundSigFig(stepSizeInitial, 1)
     }
 
     // Exclude any major outliers for legend calculation (they will be relegated to open-ended bins)

--- a/charts/ColorScale.ts
+++ b/charts/ColorScale.ts
@@ -41,7 +41,7 @@ export class ColorScale {
 
     // Config accessors
 
-    @computed get config() {
+    @computed get config(): ColorScaleConfigProps {
         return this.props.config
     }
 
@@ -49,7 +49,7 @@ export class ColorScale {
         return defaultTo(this.config.customNumericValues, [])
     }
 
-    @computed get customNumericColorsActive() {
+    @computed get customNumericColorsActive(): boolean {
         return defaultTo(this.config.customNumericColorsActive, false)
     }
 
@@ -78,7 +78,7 @@ export class ColorScale {
         return []
     }
 
-    @computed get isColorSchemeInverted() {
+    @computed get isColorSchemeInverted(): boolean {
         return defaultTo(this.config.colorSchemeInvert, false)
     }
 
@@ -189,11 +189,11 @@ export class ColorScale {
         }
     }
 
-    @computed get noDataColor() {
+    @computed get noDataColor(): Color {
         return this.customCategoryColors[NO_DATA_LABEL]
     }
 
-    @computed get baseColors() {
+    @computed get baseColors(): Color[] {
         const {
             categoricalValues,
             colorScheme,

--- a/charts/ColorScale.ts
+++ b/charts/ColorScale.ts
@@ -1,8 +1,6 @@
 import { computed, toJS } from "mobx"
 import { mean, deviation } from "d3-array"
 import { bind } from "decko"
-import { quantile, range } from "d3-array"
-import { ckmeans } from "simple-statistics"
 
 import { ColorScaleConfigProps } from "./ColorScaleConfig"
 import {
@@ -14,9 +12,7 @@ import {
     last,
     find,
     identity,
-    roundSigFig,
-    excludeUndefined,
-    uniq
+    roundSigFig
 } from "./Util"
 import { Color } from "./Color"
 import { ColorScheme, ColorSchemes } from "./ColorSchemes"

--- a/charts/ColorScale.ts
+++ b/charts/ColorScale.ts
@@ -67,10 +67,13 @@ export class ColorScale {
         return defaultTo(this.config.customHiddenCategories, {})
     }
 
-    @computed get customNumericLabels() {
-        const labels = toJS(this.config.customNumericLabels) || []
-        while (labels.length < this.numBins) labels.push(undefined)
-        return labels
+    @computed get customNumericLabels(): (string | undefined)[] {
+        if (this.isManualBuckets) {
+            const labels = toJS(this.config.customNumericLabels) || []
+            while (labels.length < this.numBins) labels.push(undefined)
+            return labels
+        }
+        return []
     }
 
     @computed get isColorSchemeInverted() {

--- a/charts/ColorScale.ts
+++ b/charts/ColorScale.ts
@@ -10,7 +10,6 @@ import {
     defaultTo,
     isEmpty,
     reverse,
-    round,
     toArray,
     first,
     last,

--- a/charts/ColorScale.ts
+++ b/charts/ColorScale.ts
@@ -155,9 +155,9 @@ export class ColorScale {
     @computed get manualBinMaximums(): number[] {
         if (!this.sortedNumericValues.length || this.numBins <= 0) return []
 
-        const { numBins, customNumericValues: colorSchemeValues } = this
+        const { numBins, customNumericValues } = this
 
-        let values = toArray(colorSchemeValues)
+        let values = toArray(customNumericValues)
         while (values.length < numBins) values.push(0)
         while (values.length > numBins) values = values.slice(0, numBins)
         return values as number[]

--- a/charts/ColorScale.ts
+++ b/charts/ColorScale.ts
@@ -196,13 +196,9 @@ export class ColorScale {
         } else {
             // Equal-interval strategy by default
             const { binStepSize, numAutoBins, minBinValue } = this
-            const bucketMaximums = []
-            let nextMaximum = minBinValue + binStepSize
-            for (let i = 0; i < numAutoBins; i++) {
-                bucketMaximums.push(nextMaximum)
-                nextMaximum += binStepSize
-            }
-            return bucketMaximums
+            return range(1, numAutoBins + 1).map(
+                n => minBinValue + n * binStepSize
+            )
         }
     }
 

--- a/charts/ColorScaleConfig.ts
+++ b/charts/ColorScaleConfig.ts
@@ -34,7 +34,6 @@ export class ColorScaleConfigProps {
     } = {}
 
     @observable.ref legendDescription?: string = undefined
-    @observable.ref binStepSize?: number = undefined
 
     constructor(json?: Partial<ColorScaleConfigProps>) {
         if (json !== undefined) {

--- a/charts/ColorScaleConfig.ts
+++ b/charts/ColorScaleConfig.ts
@@ -36,7 +36,7 @@ export class ColorScaleConfigProps {
     @observable binningStrategy: ColorScaleBinningStrategy =
         ColorScaleBinningStrategy.ckmeans
     /** The *suggested* number of bins for the automatic binning algorithm */
-    @observable binningStrategyBinCount: number | undefined = undefined
+    @observable binningStrategyBinCount?: number
 
     // Iff the binningStrategy is `manual`, then overrides are specified below.
     // Otherwise, the overrides are ignored.

--- a/charts/ColorScaleConfig.ts
+++ b/charts/ColorScaleConfig.ts
@@ -78,6 +78,7 @@ export class ColorScaleConfigProps {
     // Other
     // =====
 
+    /** A custom legend description. Only used in ScatterPlot legend titles for now. */
     @observable legendDescription?: string = undefined
 
     constructor(json?: Partial<ColorScaleConfigProps>) {

--- a/charts/ColorScaleConfig.ts
+++ b/charts/ColorScaleConfig.ts
@@ -4,8 +4,8 @@ import { Color } from "./Color"
 
 export enum ColorScaleBinningStrategy {
     equalInterval = "equalInterval",
-    // quantile = "quantile",
-    // ckmeans = "ckmeans",
+    quantiles = "quantiles",
+    ckmeans = "ckmeans",
     manual = "manual"
 }
 
@@ -14,8 +14,8 @@ export const colorScaleBinningStrategyLabels: Record<
     string
 > = {
     equalInterval: "Equal-interval",
-    // quantile: "Quantiles",
-    // ckmeans: "Ckmeans",
+    quantiles: "Quantiles",
+    ckmeans: "Ckmeans",
     manual: "Manual"
 }
 

--- a/charts/ColorScaleConfig.ts
+++ b/charts/ColorScaleConfig.ts
@@ -25,16 +25,23 @@ export class ColorScaleConfigProps {
     @observable customNumericMinValue?: number
     /** Custom maximum brackets for each numeric bin. Only applied when strategy is `manual`. */
     @observable customNumericValues: number[] = []
-    /** Custom labels for each numeric bin. Only applied when strategy is `manual`. */
-    @observable customNumericLabels: (string | undefined)[] = []
+    /**
+     * Custom labels for each numeric bin. Only applied when strategy is `manual`.
+     * `undefined` or `null` falls back to default label.
+     * We need to handle `null` because JSON serializes `undefined` values
+     * inside arrays into `null`.
+     */
+    @observable customNumericLabels: (string | undefined | null)[] = []
 
     /** Whether `customNumericColors` are used to override the color scheme. */
     @observable customNumericColorsActive?: true = undefined
     /**
      * Override some or all colors for the numerical color legend.
-     * `undefined` uses the color scheme color.
+     * `undefined` or `null` falls back the color scheme color.
+     * We need to handle `null` because JSON serializes `undefined` values
+     * inside arrays into `null`.
      */
-    @observable customNumericColors: (Color | undefined)[] = []
+    @observable customNumericColors: (Color | undefined | null)[] = []
 
     /** Whether the visual scaling for the color legend is disabled. */
     @observable equalSizeBins?: true = undefined

--- a/charts/ColorScaleConfig.ts
+++ b/charts/ColorScaleConfig.ts
@@ -35,6 +35,8 @@ export class ColorScaleConfigProps {
     /** The strategy for generating the bin boundaries */
     @observable binningStrategy: ColorScaleBinningStrategy =
         ColorScaleBinningStrategy.ckmeans
+    /** The *suggested* number of bins for the automatic binning algorithm */
+    @observable binningStrategyBinCount: number | undefined = undefined
 
     // Iff the binningStrategy is `manual`, then overrides are specified below.
     // Otherwise, the overrides are ignored.

--- a/charts/ColorScaleConfig.ts
+++ b/charts/ColorScaleConfig.ts
@@ -21,14 +21,11 @@ export class ColorScaleConfigProps {
     /** The *suggested* number of bins for the automatic binning algorithm */
     @observable binningStrategyBinCount?: number
 
-    // Iff the binningStrategy is `manual`, then overrides are specified below.
-    // Otherwise, the overrides are ignored.
-
     /** The minimum bracket of the first bin */
     @observable customNumericMinValue?: number
-    /** Custom maximum brackets for each numeric bin */
+    /** Custom maximum brackets for each numeric bin. Only applied when strategy is `manual`. */
     @observable customNumericValues: number[] = []
-    /** Custom labels for each numeric bin */
+    /** Custom labels for each numeric bin. Only applied when strategy is `manual`. */
     @observable customNumericLabels: (string | undefined)[] = []
 
     /** Whether `customNumericColors` are used to override the color scheme. */

--- a/charts/ColorScaleConfig.ts
+++ b/charts/ColorScaleConfig.ts
@@ -34,7 +34,7 @@ export class ColorScaleConfigProps {
 
     /** The strategy for generating the bin boundaries */
     @observable binningStrategy: ColorScaleBinningStrategy =
-        ColorScaleBinningStrategy.equalInterval
+        ColorScaleBinningStrategy.ckmeans
 
     // Iff the binningStrategy is `manual`, then overrides are specified below.
     // Otherwise, the overrides are ignored.

--- a/charts/ColorScaleConfig.ts
+++ b/charts/ColorScaleConfig.ts
@@ -2,28 +2,71 @@ import { observable } from "mobx"
 
 import { Color } from "./Color"
 
+export enum ColorScaleBinningStrategy {
+    quantize = "quantize",
+    // quantile = "quantile",
+    // ckmeans = "ckmeans",
+    manual = "manual"
+}
+
+export const colorScaleBinningStrategyLabels: Record<
+    ColorScaleBinningStrategy,
+    string
+> = {
+    quantize: "Equally-spaced (quantize)",
+    // quantile: "Quantile",
+    // ckmeans: "Ckmeans",
+    manual: "Manual"
+}
+
 export class ColorScaleConfigProps {
-    // Key for a colorbrewer scheme, may then be further customized
-    @observable.ref baseColorScheme?: string
+    // Color scheme
+    // ============
 
-    // Minimum value shown on map legend
-    @observable.ref colorSchemeMinValue?: number
-    @observable colorSchemeValues: number[] = []
-    @observable colorSchemeLabels: (string | undefined)[] = []
-    @observable.ref isManualBuckets?: true = undefined
-    @observable.ref equalSizeBins?: true = undefined
+    /** Key for a colorbrewer scheme */
+    @observable baseColorScheme?: string
 
-    // Whether to reverse the color scheme on output
-    @observable.ref colorSchemeInvert?: true = undefined
-    @observable.ref customColorsActive?: true = undefined
+    /** Reverse the order of colors in the color scheme (defined by `baseColorScheme`) */
+    @observable colorSchemeInvert?: true = undefined
 
-    // e.g. ["#000", "#c00", "#0c0", "#00c", "#c0c"]
+    // Numeric bins
+    // ============
+
+    /** The strategy for generating the bin boundaries */
+    @observable binningStrategy: ColorScaleBinningStrategy =
+        ColorScaleBinningStrategy.quantize
+
+    // Iff the binningStrategy is `manual`, then overrides are specified below.
+    // Otherwise, the overrides are ignored.
+
+    /** The minimum bracket of the first bin */
+    @observable customNumericMinValue?: number
+    /** Custom maximum brackets for each numeric bin */
+    @observable customNumericValues: number[] = []
+    /** Custom labels for each numeric bin */
+    @observable customNumericLabels: (string | undefined)[] = []
+
+    /**
+     * Whether `customNumericColors` are used to override the color scheme.
+     * Does not apply to categorical color overrides.
+     */
+    @observable customNumericColorsActive?: true = undefined
+    /**
+     * Override some or all colors for the numerical color legend.
+     * `undefined` uses the color scheme color.
+     */
     @observable customNumericColors: (Color | undefined)[] = []
 
-    // e.g. { 'foo' => '#c00' }
+    /** Whether the visual scaling for the color legend is disabled. */
+    @observable equalSizeBins?: true = undefined
+
+    // Categorical bins
+    // ================
+
     @observable.ref customCategoryColors: {
         [key: string]: string | undefined
     } = {}
+
     @observable.ref customCategoryLabels: {
         [key: string]: string | undefined
     } = {}
@@ -33,7 +76,10 @@ export class ColorScaleConfigProps {
         [key: string]: true | undefined
     } = {}
 
-    @observable.ref legendDescription?: string = undefined
+    // Other
+    // =====
+
+    @observable legendDescription?: string = undefined
 
     constructor(json?: Partial<ColorScaleConfigProps>) {
         if (json !== undefined) {

--- a/charts/ColorScaleConfig.ts
+++ b/charts/ColorScaleConfig.ts
@@ -13,8 +13,8 @@ export const colorScaleBinningStrategyLabels: Record<
     ColorScaleBinningStrategy,
     string
 > = {
-    quantize: "Equally-spaced (quantize)",
-    // quantile: "Quantile",
+    quantize: "Equal-sized bins (quantize)",
+    // quantile: "Quantiles",
     // ckmeans: "Ckmeans",
     manual: "Manual"
 }
@@ -46,10 +46,7 @@ export class ColorScaleConfigProps {
     /** Custom labels for each numeric bin */
     @observable customNumericLabels: (string | undefined)[] = []
 
-    /**
-     * Whether `customNumericColors` are used to override the color scheme.
-     * Does not apply to categorical color overrides.
-     */
+    /** Whether `customNumericColors` are used to override the color scheme. */
     @observable customNumericColorsActive?: true = undefined
     /**
      * Override some or all colors for the numerical color legend.

--- a/charts/ColorScaleConfig.ts
+++ b/charts/ColorScaleConfig.ts
@@ -3,7 +3,7 @@ import { observable } from "mobx"
 import { Color } from "./Color"
 
 export enum ColorScaleBinningStrategy {
-    quantize = "quantize",
+    equalInterval = "equalInterval",
     // quantile = "quantile",
     // ckmeans = "ckmeans",
     manual = "manual"
@@ -13,7 +13,7 @@ export const colorScaleBinningStrategyLabels: Record<
     ColorScaleBinningStrategy,
     string
 > = {
-    quantize: "Equal-sized bins (quantize)",
+    equalInterval: "Equal-interval",
     // quantile: "Quantiles",
     // ckmeans: "Ckmeans",
     manual: "Manual"
@@ -34,7 +34,7 @@ export class ColorScaleConfigProps {
 
     /** The strategy for generating the bin boundaries */
     @observable binningStrategy: ColorScaleBinningStrategy =
-        ColorScaleBinningStrategy.quantize
+        ColorScaleBinningStrategy.equalInterval
 
     // Iff the binningStrategy is `manual`, then overrides are specified below.
     // Otherwise, the overrides are ignored.

--- a/charts/ColorScaleConfig.ts
+++ b/charts/ColorScaleConfig.ts
@@ -1,23 +1,7 @@
 import { observable } from "mobx"
 
 import { Color } from "./Color"
-
-export enum ColorScaleBinningStrategy {
-    equalInterval = "equalInterval",
-    quantiles = "quantiles",
-    ckmeans = "ckmeans",
-    manual = "manual"
-}
-
-export const colorScaleBinningStrategyLabels: Record<
-    ColorScaleBinningStrategy,
-    string
-> = {
-    equalInterval: "Equal-interval",
-    quantiles: "Quantiles",
-    ckmeans: "Ckmeans",
-    manual: "Manual"
-}
+import { BinningStrategy } from "./BinningStrategies"
 
 export class ColorScaleConfigProps {
     // Color scheme
@@ -33,8 +17,7 @@ export class ColorScaleConfigProps {
     // ============
 
     /** The strategy for generating the bin boundaries */
-    @observable binningStrategy: ColorScaleBinningStrategy =
-        ColorScaleBinningStrategy.ckmeans
+    @observable binningStrategy: BinningStrategy = BinningStrategy.ckmeans
     /** The *suggested* number of bins for the automatic binning algorithm */
     @observable binningStrategyBinCount?: number
 

--- a/charts/MapData.ts
+++ b/charts/MapData.ts
@@ -244,7 +244,7 @@ export class MapData extends ChartTransform {
     @computed get formatTooltipValue(): (d: number | string) => string {
         const formatValueLong = this.dimension && this.dimension.formatValueLong
         const customLabels = this.map.tooltipUseCustomLabels
-            ? this.map.data.colorScale.customBucketLabels
+            ? this.map.data.colorScale.customNumericLabels
             : []
         return formatValueLong
             ? (d: number | string) => {

--- a/charts/MapTooltip.tsx
+++ b/charts/MapTooltip.tsx
@@ -89,7 +89,8 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
 
     @computed get barColor() {
         const { colorScale } = this.chart.map.data
-        return colorScale.singleColorScale && !colorScale.isCustomColors
+        return colorScale.singleColorScale &&
+            !colorScale.customNumericColorsActive
             ? this.darkestColorInColorScheme
             : undefined
     }

--- a/charts/Util.ts
+++ b/charts/Util.ts
@@ -256,7 +256,7 @@ export function precisionRound(num: number, precision: number) {
 }
 
 export function roundSigFig(num: number, sigfigs: number = 1) {
-    const magnitude = Math.floor(Math.log10(num))
+    const magnitude = Math.floor(Math.log10(Math.abs(num)))
     return round(num, -magnitude + sigfigs - 1)
 }
 

--- a/charts/Util.ts
+++ b/charts/Util.ts
@@ -255,6 +255,11 @@ export function precisionRound(num: number, precision: number) {
     return Math.round(num * factor) / factor
 }
 
+export function roundSigFig(num: number, sigfigs: number = 1) {
+    const magnitude = Math.floor(Math.log(num) / Math.log(10))
+    return round(num, -magnitude + sigfigs - 1)
+}
+
 export function formatValue(
     value: number,
     options: TickFormattingOptions

--- a/charts/Util.ts
+++ b/charts/Util.ts
@@ -256,6 +256,7 @@ export function precisionRound(num: number, precision: number) {
 }
 
 export function roundSigFig(num: number, sigfigs: number = 1) {
+    if (num === 0) return 0
     const magnitude = Math.floor(Math.log10(Math.abs(num)))
     return round(num, -magnitude + sigfigs - 1)
 }

--- a/charts/Util.ts
+++ b/charts/Util.ts
@@ -256,7 +256,7 @@ export function precisionRound(num: number, precision: number) {
 }
 
 export function roundSigFig(num: number, sigfigs: number = 1) {
-    const magnitude = Math.floor(Math.log(num) / Math.log(10))
+    const magnitude = Math.floor(Math.log10(num))
     return round(num, -magnitude + sigfigs - 1)
 }
 

--- a/charts/Util.ts
+++ b/charts/Util.ts
@@ -922,3 +922,9 @@ export function mergeQueryStr(...queryStrs: (string | undefined)[]) {
         assign({}, ...excludeUndefined(queryStrs).map(strToQueryParams))
     )
 }
+
+export function mapNullToUndefined<T>(
+    array: (T | undefined | null)[]
+): (T | undefined)[] {
+    return array.map(v => (v === null ? undefined : v))
+}

--- a/charts/__tests__/BinningStrategies.test.ts
+++ b/charts/__tests__/BinningStrategies.test.ts
@@ -1,0 +1,127 @@
+#! /usr/bin/env yarn jest
+
+import { getBinMaximums, BinningStrategy } from "charts/BinningStrategies"
+
+describe("BinningStrategies", () => {
+    describe(getBinMaximums, () => {
+        it("returns no bins for empty array", () => {
+            expect(
+                getBinMaximums({
+                    binningStrategy: BinningStrategy.quantiles,
+                    sortedValues: [],
+                    binCount: 5
+                })
+            ).toEqual([])
+        })
+
+        it("returns no bins for zero bins", () => {
+            expect(
+                getBinMaximums({
+                    binningStrategy: BinningStrategy.quantiles,
+                    sortedValues: [1, 2, 3, 4, 5],
+                    binCount: 0
+                })
+            ).toEqual([])
+        })
+
+        describe("ckmeans strategy", () => {
+            it("doesn't duplicate bins for skewed distributions", () => {
+                expect(
+                    getBinMaximums({
+                        binningStrategy: BinningStrategy.ckmeans,
+                        sortedValues: [1, 1, 1, 1, 1, 5],
+                        binCount: 5
+                    })
+                ).toEqual([1, 5])
+            })
+
+            it("excludes bins less than minBinValue", () => {
+                expect(
+                    getBinMaximums({
+                        binningStrategy: BinningStrategy.ckmeans,
+                        sortedValues: [1, 1, 1, 1, 1, 5],
+                        binCount: 5,
+                        minBinValue: 1
+                    })
+                ).toEqual([5])
+            })
+
+            it("handles example", () => {
+                expect(
+                    getBinMaximums({
+                        binningStrategy: BinningStrategy.ckmeans,
+                        sortedValues: [1, 2, 4, 5, 12, 43, 52, 123, 234, 1244],
+                        binCount: 5
+                    })
+                ).toEqual([12, 52, 123, 234, 1244])
+            })
+        })
+
+        describe("quantiles strategy", () => {
+            it("doesn't duplicate bins for skewed distributions", () => {
+                expect(
+                    getBinMaximums({
+                        binningStrategy: BinningStrategy.quantiles,
+                        sortedValues: [1, 1, 1, 1, 1, 5],
+                        binCount: 5
+                    })
+                ).toEqual([1, 5])
+            })
+
+            it("excludes bins less than minBinValue", () => {
+                expect(
+                    getBinMaximums({
+                        binningStrategy: BinningStrategy.quantiles,
+                        sortedValues: [1, 1, 1, 1, 1, 5],
+                        binCount: 5,
+                        minBinValue: 1
+                    })
+                ).toEqual([5])
+            })
+
+            it("handles example", () => {
+                expect(
+                    getBinMaximums({
+                        binningStrategy: BinningStrategy.quantiles,
+                        sortedValues: [1, 10, 20, 50, 100],
+                        binCount: 4
+                    })
+                ).toEqual([10, 20, 50, 100])
+            })
+        })
+
+        describe("equalInterval strategy", () => {
+            it("starts from minBinValue", () => {
+                expect(
+                    getBinMaximums({
+                        binningStrategy: BinningStrategy.equalInterval,
+                        sortedValues: [300],
+                        binCount: 3,
+                        minBinValue: 0
+                    })
+                ).toEqual([100, 200, 300])
+            })
+
+            it("derives minBinValue if not specified", () => {
+                expect(
+                    getBinMaximums({
+                        binningStrategy: BinningStrategy.equalInterval,
+                        sortedValues: [100, 300],
+                        binCount: 2
+                    })
+                ).toEqual([200, 300])
+            })
+
+            it("handles example", () => {
+                expect(
+                    getBinMaximums({
+                        binningStrategy: BinningStrategy.equalInterval,
+                        sortedValues: [1, 1.5, 2, 3, 7.5],
+                        binCount: 5,
+                        minBinValue: 0
+                    })
+                ).toEqual([2, 4, 6, 8, 10])
+            })
+        })
+    })
+})

--- a/charts/__tests__/Util.test.ts
+++ b/charts/__tests__/Util.test.ts
@@ -17,7 +17,8 @@ import {
     previous,
     parseDelimited,
     toJsTable,
-    intersectionOfSets
+    intersectionOfSets,
+    roundSigFig
 } from "../Util"
 import { strToQueryParams } from "utils/client/url"
 
@@ -357,5 +358,15 @@ describe(mergeQueryStr, () => {
 
     it("handles undefined", () => {
         expect(mergeQueryStr(undefined, "")).toEqual("")
+    })
+})
+
+describe(roundSigFig, () => {
+    it("rounds to 1 sig fig by default", () => {
+        expect(roundSigFig(652)).toEqual(700)
+    })
+
+    it("correctly rounds to provided sig figs", () => {
+        expect(roundSigFig(652, 2)).toEqual(650)
     })
 })

--- a/charts/__tests__/Util.test.ts
+++ b/charts/__tests__/Util.test.ts
@@ -377,4 +377,8 @@ describe(roundSigFig, () => {
     it("rounds negative values to provided sig figs", () => {
         expect(roundSigFig(-652, 1)).toEqual(-700)
     })
+
+    it("leaves zero unchanged", () => {
+        expect(roundSigFig(0, 2)).toEqual(0)
+    })
 })

--- a/charts/__tests__/Util.test.ts
+++ b/charts/__tests__/Util.test.ts
@@ -366,7 +366,15 @@ describe(roundSigFig, () => {
         expect(roundSigFig(652)).toEqual(700)
     })
 
-    it("correctly rounds to provided sig figs", () => {
+    it("rounds integer to provided sig figs", () => {
         expect(roundSigFig(652, 2)).toEqual(650)
+    })
+
+    it("rounds floating point to provided sig figs", () => {
+        expect(roundSigFig(0.00652, 1)).toEqual(0.007)
+    })
+
+    it("rounds negative values to provided sig figs", () => {
+        expect(roundSigFig(-652, 1)).toEqual(-700)
     })
 })

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -72,7 +72,10 @@ import {
     GlobalEntitySelectionModes
 } from "site/client/global-entity/GlobalEntitySelection"
 import { entityCode } from "charts/owidData/OwidTable"
-import { ColorScaleConfigProps } from "charts/ColorScaleConfig"
+import {
+    ColorScaleConfigProps,
+    ColorScaleBinningStrategy
+} from "charts/ColorScaleConfig"
 import * as Mousetrap from "mousetrap"
 import { CommandPalette, Command } from "./CommandPalette"
 import { TimeBoundValue } from "charts/TimeBounds"
@@ -1308,10 +1311,11 @@ export class CovidDataExplorer extends React.Component<{
             ptr: this.props.covidChartAndVariableMeta.charts[sourceCharts.epi]
                 ?.colorScale as any,
             continents: {
+                binningStrategy: ColorScaleBinningStrategy.manual,
                 legendDescription: "Continent",
                 baseColorScheme: undefined,
-                colorSchemeValues: [],
-                colorSchemeLabels: [],
+                customNumericValues: [],
+                customNumericLabels: [],
                 customNumericColors: [],
                 customCategoryColors: continentColors,
                 customCategoryLabels: {
@@ -1320,10 +1324,11 @@ export class CovidDataExplorer extends React.Component<{
                 customHiddenCategories: {}
             },
             none: {
+                binningStrategy: ColorScaleBinningStrategy.manual,
                 legendDescription: "",
                 baseColorScheme: undefined,
-                colorSchemeValues: [],
-                colorSchemeLabels: [],
+                customNumericValues: [],
+                customNumericLabels: [],
                 customNumericColors: [],
                 customCategoryColors: continentColors,
                 customCategoryLabels: {

--- a/charts/covidDataExplorer/CovidDataExplorer.tsx
+++ b/charts/covidDataExplorer/CovidDataExplorer.tsx
@@ -72,15 +72,13 @@ import {
     GlobalEntitySelectionModes
 } from "site/client/global-entity/GlobalEntitySelection"
 import { entityCode } from "charts/owidData/OwidTable"
-import {
-    ColorScaleConfigProps,
-    ColorScaleBinningStrategy
-} from "charts/ColorScaleConfig"
+import { ColorScaleConfigProps } from "charts/ColorScaleConfig"
 import * as Mousetrap from "mousetrap"
 import { CommandPalette, Command } from "./CommandPalette"
 import { TimeBoundValue } from "charts/TimeBounds"
 import { Analytics } from "site/client/Analytics"
 import { ChartDimensionWithOwidVariable } from "charts/ChartDimensionWithOwidVariable"
+import { BinningStrategy } from "charts/BinningStrategies"
 
 const abSeed = Math.random()
 
@@ -1311,7 +1309,7 @@ export class CovidDataExplorer extends React.Component<{
             ptr: this.props.covidChartAndVariableMeta.charts[sourceCharts.epi]
                 ?.colorScale as any,
             continents: {
-                binningStrategy: ColorScaleBinningStrategy.manual,
+                binningStrategy: BinningStrategy.manual,
                 legendDescription: "Continent",
                 baseColorScheme: undefined,
                 customNumericValues: [],
@@ -1324,7 +1322,7 @@ export class CovidDataExplorer extends React.Component<{
                 customHiddenCategories: {}
             },
             none: {
-                binningStrategy: ColorScaleBinningStrategy.manual,
+                binningStrategy: BinningStrategy.manual,
                 legendDescription: "",
                 baseColorScheme: undefined,
                 customNumericValues: [],

--- a/db/migration/1597151871804-ColorScaleStrategies.ts
+++ b/db/migration/1597151871804-ColorScaleStrategies.ts
@@ -1,0 +1,181 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+interface OldColorScaleConfig {
+    baseColorScheme?: string
+    colorSchemeMinValue?: number
+    colorSchemeValues: number[]
+    colorSchemeLabels: (string | undefined)[]
+    isManualBuckets?: true
+    equalSizeBins?: true
+    colorSchemeInvert?: true
+    customColorsActive?: true
+    customNumericColors: (string | undefined)[]
+    customCategoryColors: {
+        [key: string]: string | undefined
+    }
+    customCategoryLabels: {
+        [key: string]: string | undefined
+    }
+    customHiddenCategories: {
+        [key: string]: true | undefined
+    }
+    legendDescription?: string
+}
+
+enum ColorScaleBinningStrategy {
+    quantize = "quantize",
+    manual = "manual"
+}
+
+interface NewColorScaleConfig {
+    baseColorScheme?: string
+    colorSchemeInvert?: true
+
+    binningStrategy: ColorScaleBinningStrategy
+    customNumericMinValue?: number
+    customNumericValues: number[]
+    customNumericLabels: (string | undefined)[]
+    customNumericColorsActive?: true
+    customNumericColors: (string | undefined)[]
+
+    equalSizeBins?: true
+
+    customCategoryColors: {
+        [key: string]: string | undefined
+    }
+    customCategoryLabels: {
+        [key: string]: string | undefined
+    }
+    customHiddenCategories: {
+        [key: string]: true | undefined
+    }
+
+    legendDescription?: string
+}
+
+interface ChartConfig<ColorScaleConfig> {
+    colorScale?: ColorScaleConfig
+    map?: {
+        colorScale: ColorScaleConfig
+    }
+}
+
+type OldChartConfig = ChartConfig<OldColorScaleConfig>
+type NewChartConfig = ChartConfig<NewColorScaleConfig>
+
+function oldToNewColorScaleConfig(
+    oldConfig: OldColorScaleConfig
+): NewColorScaleConfig {
+    return {
+        baseColorScheme: oldConfig.baseColorScheme,
+        colorSchemeInvert: oldConfig.colorSchemeInvert,
+
+        binningStrategy: oldConfig.isManualBuckets
+            ? ColorScaleBinningStrategy.manual
+            : ColorScaleBinningStrategy.quantize,
+        customNumericMinValue: oldConfig.colorSchemeMinValue,
+        customNumericValues: oldConfig.colorSchemeValues,
+        customNumericLabels: oldConfig.colorSchemeLabels,
+        customNumericColorsActive: oldConfig.customColorsActive,
+        customNumericColors: oldConfig.customNumericColors,
+
+        equalSizeBins: oldConfig.equalSizeBins,
+
+        customCategoryColors: oldConfig.customCategoryColors,
+        customCategoryLabels: oldConfig.customCategoryLabels,
+        customHiddenCategories: oldConfig.customHiddenCategories,
+
+        legendDescription: oldConfig.legendDescription
+    }
+}
+
+function newToOldColorScaleConfig(
+    newConfig: NewColorScaleConfig
+): OldColorScaleConfig {
+    return {
+        baseColorScheme: newConfig.baseColorScheme,
+        colorSchemeInvert: newConfig.colorSchemeInvert,
+
+        isManualBuckets:
+            newConfig.binningStrategy === ColorScaleBinningStrategy.manual
+                ? true
+                : undefined,
+
+        colorSchemeMinValue: newConfig.customNumericMinValue,
+        colorSchemeValues: newConfig.customNumericValues,
+        colorSchemeLabels: newConfig.customNumericLabels,
+        customColorsActive: newConfig.customNumericColorsActive,
+        customNumericColors: newConfig.customNumericColors,
+
+        equalSizeBins: newConfig.equalSizeBins,
+
+        customCategoryColors: newConfig.customCategoryColors,
+        customCategoryLabels: newConfig.customCategoryLabels,
+        customHiddenCategories: newConfig.customHiddenCategories,
+
+        legendDescription: newConfig.legendDescription
+    }
+}
+
+function transformColorScaleConfig<I, O>(
+    config: ChartConfig<I>,
+    transform: (_: I) => O
+): ChartConfig<O> {
+    return {
+        ...config,
+        colorScale:
+            config.colorScale === undefined
+                ? undefined
+                : transform(config.colorScale),
+        map:
+            config.map === undefined
+                ? undefined
+                : {
+                      ...config.map,
+                      colorScale: transform(config.map.colorScale)
+                  }
+    }
+}
+
+async function transformAllCharts(
+    queryRunner: QueryRunner,
+    getNewConfig: (oldConfig: any) => any
+) {
+    await Promise.all(
+        [
+            { idField: "id", tableName: "charts" },
+            { idField: "chartId", tableName: "chart_revisions" }
+        ].map(async ({ idField, tableName }) => {
+            const charts = (await queryRunner.query(`
+            SELECT ${idField} AS id, config
+            FROM ${tableName}
+        `)) as { id: number; config: string }[]
+            const toUpdate: { id: number; config: string }[] = []
+            for (const chart of charts) {
+                const oldConfig = JSON.parse(chart.config)
+                const newConfig = getNewConfig(oldConfig)
+                if (JSON.stringify(oldConfig) !== JSON.stringify(newConfig)) {
+                    toUpdate.push({ id: chart.id, config: chart.config })
+                    await queryRunner.query(
+                        `UPDATE ${tableName} SET config = ? WHERE ${idField} = ?`,
+                        [JSON.stringify(newConfig), chart.id]
+                    )
+                }
+            }
+        })
+    )
+}
+
+export class ColorScaleStrategies1597151871804 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await transformAllCharts(queryRunner, (config: OldChartConfig) =>
+            transformColorScaleConfig(config, oldToNewColorScaleConfig)
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await transformAllCharts(queryRunner, (config: NewChartConfig) =>
+            transformColorScaleConfig(config, newToOldColorScaleConfig)
+        )
+    }
+}

--- a/db/migration/1597151871804-ColorScaleStrategies.ts
+++ b/db/migration/1597151871804-ColorScaleStrategies.ts
@@ -23,7 +23,7 @@ interface OldColorScaleConfig {
 }
 
 enum ColorScaleBinningStrategy {
-    quantize = "quantize",
+    equalInterval = "equalInterval",
     manual = "manual"
 }
 
@@ -72,7 +72,7 @@ function oldToNewColorScaleConfig(
 
         binningStrategy: oldConfig.isManualBuckets
             ? ColorScaleBinningStrategy.manual
-            : ColorScaleBinningStrategy.quantize,
+            : ColorScaleBinningStrategy.equalInterval,
         customNumericMinValue: oldConfig.colorSchemeMinValue,
         customNumericValues: oldConfig.colorSchemeValues,
         customNumericLabels: oldConfig.colorSchemeLabels,

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
         "sharp": "^0.23.0",
         "shell-quote": "^1.6.1",
         "shelljs": "^0.8.3",
+        "simple-statistics": "^7.1.0",
         "slack-node": "^0.1.8",
         "slugify": "^1.3.4",
         "smooth-scroll": "^16.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17902,6 +17902,11 @@ simple-get@^3.0.3:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
+simple-statistics@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/simple-statistics/-/simple-statistics-7.1.0.tgz#22a3ae8476650ff4cc1643fff6b636334629d352"
+  integrity sha512-aA7JgiiptQJFB1xJDySzUJ64XTtl1zkR5U79Qa0AxSYVTxws2UlsZt/chyJm+2lMt3xIPKzAsNzVhZhMUXlY+g==
+
 simple-swizzle@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"


### PR DESCRIPTION
Notion: https://www.notion.so/owid/Improve-the-automatic-binning-algorithm-for-legend-bins-d6090ee49df5461aa6fd4fddc44d34a6

- Migrates a bunch of the color scale props that weren't named consistently
- Migrates all old charts to the `equalInterval` binning strategy
- Implements `ckmeans` and `quantiles` binning strategies
- Sets `ckmeans` as the new default binning strategy
- Allows configuring how many automatically-generated bins should be created
- Allows using the automatically-generated bins as a starting point (in the past, the bin brackets were hidden if automatic classification was selected)

<img width="1399" alt="Screenshot 2020-08-13 at 14 23 34" src="https://user-images.githubusercontent.com/1308115/90139738-a9056480-dd70-11ea-94e2-5e2beac0257c.png">
