### PR TITLE
Break lines in line chart tooltip, so the annotation is not cut off on mobile

### DIFF
--- a/charts/LineChart.tsx
+++ b/charts/LineChart.tsx
@@ -149,15 +149,20 @@ export class LineChart extends React.Component<{
                 style={{ padding: "0.3em" }}
                 offsetX={5}
             >
-                <table style={{ fontSize: "0.9em", lineHeight: "1.4em" }}>
+                <table
+                    style={{
+                        fontSize: "0.9em",
+                        lineHeight: "1.4em",
+                        whiteSpace: "normal"
+                    }}
+                >
                     <tbody>
                         <tr>
-                            <td>
+                            <td colSpan={3}>
                                 <strong>
                                     {this.chart.formatYearFunction(hoverX)}
                                 </strong>
                             </td>
-                            <td></td>
                         </tr>
                         {sortedData.map(series => {
                             const value = series.values.find(
@@ -200,12 +205,7 @@ export class LineChart extends React.Component<{
                                     key={series.entityDimensionKey}
                                     style={{ color: textColor }}
                                 >
-                                    <td
-                                        style={{
-                                            paddingRight: "0.8em",
-                                            fontSize: "0.9em"
-                                        }}
-                                    >
+                                    <td>
                                         <div
                                             style={{
                                                 width: "10px",
@@ -215,7 +215,14 @@ export class LineChart extends React.Component<{
                                                 display: "inline-block",
                                                 marginRight: "2px"
                                             }}
-                                        />{" "}
+                                        />
+                                    </td>
+                                    <td
+                                        style={{
+                                            paddingRight: "0.8em",
+                                            fontSize: "0.9em"
+                                        }}
+                                    >
                                         {chart.data.getLabelForKey(
                                             series.entityDimensionKey
                                         )}
@@ -223,7 +230,8 @@ export class LineChart extends React.Component<{
                                             <span
                                                 className="tooltipAnnotation"
                                                 style={{
-                                                    color: annotationColor
+                                                    color: annotationColor,
+                                                    fontSize: "90%"
                                                 }}
                                             >
                                                 {" "}
@@ -231,7 +239,12 @@ export class LineChart extends React.Component<{
                                             </span>
                                         )}
                                     </td>
-                                    <td style={{ textAlign: "right" }}>
+                                    <td
+                                        style={{
+                                            textAlign: "right",
+                                            whiteSpace: "nowrap"
+                                        }}
+                                    >
                                         {!value
                                             ? "No data"
                                             : transform.yAxis.tickFormat(


### PR DESCRIPTION
Notion: https://www.notion.so/owid/Annotation-is-cut-off-on-mobile-0114f4d6568c4ce48e25513edf7a163e

It's still not perfect, mind you, but at least now the actual numbers are visible in the tooltip, which is arguably the most important information in the tooltip.

## Before
![image](https://user-images.githubusercontent.com/2641501/90658648-1cf9ae00-e244-11ea-9093-b25df1cf5b26.png)

## After
![image](https://user-images.githubusercontent.com/2641501/90658686-284cd980-e244-11ea-9dc0-702ca6cbf481.png)

Dev note: In the future, we probably should rework that use of a HTML table and use CSS grid instead. But I didn't want to go there for this simple fix.