### PR TITLE
Fix race condition in bar chart when quickly dragging timeline

### DIFF
--- a/charts/DiscreteBarChart.tsx
+++ b/charts/DiscreteBarChart.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { select } from "d3-selection"
+import { select, Selection, BaseType } from "d3-selection"
 import { sortBy, min, max, first } from "./Util"
 import { computed, action } from "mobx"
 import { observer } from "mobx-react"
@@ -237,17 +237,22 @@ export class DiscreteBarChart extends React.Component<{
         return select(this.base.current).selectAll("g.bar > rect")
     }
 
-    componentDidMount() {
+    private animateBarWidth() {
         this.d3Bars()
-            .attr("width", 0)
             .transition()
             .attr("width", (_, i) => this.barWidths[i])
     }
 
+    componentDidMount() {
+        this.d3Bars().attr("width", 0)
+        this.animateBarWidth()
+    }
+
     componentDidUpdate() {
-        this.d3Bars()
-            .transition()
-            .attr("width", (_, i) => this.barWidths[i])
+        // Animating the bar width after a render ensures there's no race condition, where the
+        // initial animation (in componentDidMount) did override the now-changed bar width in
+        // some cases. Updating the animation with the updated bar widths fixes that.
+        this.animateBarWidth()
     }
 
     @computed get barValueFormat() {

--- a/charts/DiscreteBarChart.tsx
+++ b/charts/DiscreteBarChart.tsx
@@ -229,12 +229,25 @@ export class DiscreteBarChart extends React.Component<{
         })
     }
 
+    @computed get barWidths() {
+        return this.barPlacements.map(b => b.width)
+    }
+
+    private d3Bars() {
+        return select(this.base.current).selectAll("g.bar > rect")
+    }
+
     componentDidMount() {
-        const widths = this.barPlacements.map(b => b.width)
-        const bars = select(this.base.current).selectAll("g.bar > rect")
-        bars.attr("width", 0)
+        this.d3Bars()
+            .attr("width", 0)
             .transition()
-            .attr("width", (_, i) => widths[i])
+            .attr("width", (_, i) => this.barWidths[i])
+    }
+
+    componentDidUpdate() {
+        this.d3Bars()
+            .transition()
+            .attr("width", (_, i) => this.barWidths[i])
     }
 
     @computed get barValueFormat() {


### PR DESCRIPTION
... as mentioned earlier in [Slack](https://owid.slack.com/archives/C46U9LXRR/p1597956936008200).

Turns out this was a race condition between the d3 width animation and React re-rendering the bar with an updated width.

I tried several methods, and this one seems to be the nicest that also keeps the animation. But since I'm still new to d3 there might be a better solution, so please do comment if you know of a nicer solution.


Live at [Tufte](https://tufte-owid.netlify.app/grapher/political-regime-updated2016?tab=chart&time=latest)