### PR TITLE
Timeline Tooltips + Upgrades

### DIFF
--- a/charts/controls/Timeline.tsx
+++ b/charts/controls/Timeline.tsx
@@ -370,6 +370,14 @@ export class Timeline extends React.Component<TimelineProps> {
         this.dragTarget = undefined
         if (this.startTooltipVisible) this.hideStartTooltip()
         if (this.endTooltipVisible) this.hideEndTooltip()
+
+        // if handles within 1 year of each other, snap to closest year.
+        if (this.endYear - this.startYear < 1) {
+            ;[this.startYearRaw, this.endYearRaw] = [
+                this.startYearClosest,
+                this.endYearClosest
+            ]
+        }
     }
 
     hideStartTooltip = debounce(() => {

--- a/charts/controls/Timeline.tsx
+++ b/charts/controls/Timeline.tsx
@@ -223,7 +223,7 @@ export class Timeline extends React.Component<TimelineProps> {
             : new Bounds(0, 0, 100, 100)
     }
 
-    private slider?: Element | null
+    private slider?: Element | HTMLElement | null
 
     getInputYearFromMouse(evt: MouseEvent) {
         const { minYear, maxYear } = this
@@ -460,6 +460,9 @@ export class Timeline extends React.Component<TimelineProps> {
             "touchmove",
             this.onMouseMove
         )
+        this.slider?.removeEventListener("touchstart", this.onMouseDown, {
+            passive: false
+        } as EventListenerOptions)
         this.disposers.forEach(dispose => dispose())
     }
 

--- a/charts/controls/Timeline.tsx
+++ b/charts/controls/Timeline.tsx
@@ -42,7 +42,7 @@ import classNames from "classnames"
 const DEFAULT_MIN_YEAR = 1900
 const DEFAULT_MAX_YEAR = 2000
 
-const TOOLTIP_FADE_TIME_MS = 2000
+const HANDLE_TOOLTIP_FADE_TIME_MS = 2000
 
 interface TimelineProps {
     years: number[]
@@ -370,10 +370,10 @@ export class Timeline extends React.Component<TimelineProps> {
 
     hideStartTooltip = debounce(() => {
         this.startTooltipVisible = false
-    }, TOOLTIP_FADE_TIME_MS)
+    }, HANDLE_TOOLTIP_FADE_TIME_MS)
     hideEndTooltip = debounce(() => {
         this.endTooltipVisible = false
-    }, TOOLTIP_FADE_TIME_MS)
+    }, HANDLE_TOOLTIP_FADE_TIME_MS)
 
     @action updateChartTimeDomain() {
         if (this.props.onTargetChange) {

--- a/charts/controls/Timeline.tsx
+++ b/charts/controls/Timeline.tsx
@@ -371,6 +371,18 @@ export class Timeline extends React.Component<TimelineProps> {
         if (this.startTooltipVisible) this.hideStartTooltip()
         if (this.endTooltipVisible) this.hideEndTooltip()
 
+        // In case start handle has been dragged past end handle, make sure
+        //  startYearRaw is still smallest value
+        if (!this.isPlaying) {
+            // NOTE: This needs to be an atomic assignment.
+            if (this.startYearRaw > this.endYearRaw) {
+                ;[this.startYearRaw, this.endYearRaw] = [
+                    this.startYear,
+                    this.endYear
+                ]
+            }
+        }
+
         // if handles within 1 year of each other, snap to closest year.
         if (this.endYear - this.startYear < 1) {
             ;[this.startYearRaw, this.endYearRaw] = [
@@ -430,24 +442,6 @@ export class Timeline extends React.Component<TimelineProps> {
                 } else {
                     this.context.chart.url.debounceMode = false
                     if (onStopDrag) onStopDrag()
-                }
-            }),
-            autorun(() => {
-                // If we're not playing or dragging, lock the input to the closest year (no interpolation)
-                const { isPlaying, isDragging } = this
-                if (!isPlaying && !isDragging) {
-                    runInAction(() => {
-                        // NOTE: This needs to be an atomic assignment.
-                        // As start/end values can flip while dragging one handle past another, we
-                        // have logic to flip start/end on the fly. But when they get reassigned, to
-                        // avoid the unintentional flip, it needs to be done atomically.
-                        if (this.startYearRaw > this.endYearRaw) {
-                            ;[this.startYearRaw, this.endYearRaw] = [
-                                this.startYear,
-                                this.endYear
-                            ]
-                        }
-                    })
                 }
             })
         ]

--- a/charts/controls/Timeline.tsx
+++ b/charts/controls/Timeline.tsx
@@ -293,7 +293,7 @@ export class Timeline extends React.Component<TimelineProps> {
         this.updateTooltipVisibility()
     }
 
-    updateTooltipVisibility() {
+    @action updateTooltipVisibility() {
         if (this.startYearRaw > this.endYearRaw) {
             this.startTooltipVisible = true
             this.endTooltipVisible = true

--- a/charts/controls/Timeline.tsx
+++ b/charts/controls/Timeline.tsx
@@ -297,15 +297,19 @@ export class Timeline extends React.Component<TimelineProps> {
         if (this.startYearRaw > this.endYearRaw) {
             this.startTooltipVisible = true
             this.endTooltipVisible = true
+            this.lastUpdatedTooltip =
+                this.dragTarget === "start" ? "endMarker" : "startMarker"
         } else {
             if (this.dragTarget === "start" || this.dragTarget === "both") {
                 this.hideStartTooltip.cancel()
                 this.startTooltipVisible = true
+                this.lastUpdatedTooltip = "startMarker"
             }
 
             if (this.dragTarget === "end" || this.dragTarget === "both") {
                 this.hideEndTooltip.cancel()
                 this.endTooltipVisible = true
+                this.lastUpdatedTooltip = "endMarker"
             }
         }
     }
@@ -487,6 +491,7 @@ export class Timeline extends React.Component<TimelineProps> {
 
     @observable startTooltipVisible: boolean = false
     @observable endTooltipVisible: boolean = false
+    @observable lastUpdatedTooltip?: "startMarker" | "endMarker"
 
     render() {
         const { minYear, maxYear, isPlaying, startYearUI, endYearUI } = this
@@ -521,6 +526,9 @@ export class Timeline extends React.Component<TimelineProps> {
                         offsetPercent={startYearProgress}
                         tooltipContent={this.formatYear(chart.minYear)}
                         tooltipVisible={this.startTooltipVisible}
+                        zIndex={
+                            this.lastUpdatedTooltip === "startMarker" ? 2 : 1
+                        }
                     />
                     <div
                         className="interval"
@@ -534,6 +542,7 @@ export class Timeline extends React.Component<TimelineProps> {
                         offsetPercent={endYearProgress}
                         tooltipContent={this.formatYear(chart.maxYear)}
                         tooltipVisible={this.endTooltipVisible}
+                        zIndex={this.lastUpdatedTooltip === "endMarker" ? 2 : 1}
                     />
                 </div>
                 {this.timelineDate("end", maxYear)}
@@ -546,12 +555,14 @@ export const TimelineHandle = ({
     type,
     offsetPercent,
     tooltipContent,
-    tooltipVisible
+    tooltipVisible,
+    zIndex
 }: {
     type: "startMarker" | "endMarker"
     offsetPercent: number
     tooltipContent: string
     tooltipVisible: boolean
+    zIndex: number
 }) => {
     return (
         <div
@@ -560,7 +571,11 @@ export const TimelineHandle = ({
                 left: `${offsetPercent * 100}%`
             }}
         >
-            <Tippy content={tooltipContent} visible={tooltipVisible}>
+            <Tippy
+                content={tooltipContent}
+                visible={tooltipVisible}
+                zIndex={zIndex}
+            >
                 <div className="icon" />
             </Tippy>
         </div>

--- a/charts/controls/Timeline.tsx
+++ b/charts/controls/Timeline.tsx
@@ -526,7 +526,7 @@ export class Timeline extends React.Component<TimelineProps> {
                         offsetPercent={startYearProgress}
                         tooltipContent={this.formatYear(chart.minYear)}
                         tooltipVisible={this.startTooltipVisible}
-                        zIndex={
+                        tooltipZIndex={
                             this.lastUpdatedTooltip === "startMarker" ? 2 : 1
                         }
                     />
@@ -542,7 +542,9 @@ export class Timeline extends React.Component<TimelineProps> {
                         offsetPercent={endYearProgress}
                         tooltipContent={this.formatYear(chart.maxYear)}
                         tooltipVisible={this.endTooltipVisible}
-                        zIndex={this.lastUpdatedTooltip === "endMarker" ? 2 : 1}
+                        tooltipZIndex={
+                            this.lastUpdatedTooltip === "endMarker" ? 2 : 1
+                        }
                     />
                 </div>
                 {this.timelineDate("end", maxYear)}
@@ -556,13 +558,13 @@ export const TimelineHandle = ({
     offsetPercent,
     tooltipContent,
     tooltipVisible,
-    zIndex
+    tooltipZIndex
 }: {
     type: "startMarker" | "endMarker"
     offsetPercent: number
     tooltipContent: string
     tooltipVisible: boolean
-    zIndex: number
+    tooltipZIndex: number
 }) => {
     return (
         <div
@@ -574,7 +576,7 @@ export const TimelineHandle = ({
             <Tippy
                 content={tooltipContent}
                 visible={tooltipVisible}
-                zIndex={zIndex}
+                zIndex={tooltipZIndex}
             >
                 <div className="icon" />
             </Tippy>

--- a/charts/controls/Timeline.tsx
+++ b/charts/controls/Timeline.tsx
@@ -42,6 +42,8 @@ import classNames from "classnames"
 const DEFAULT_MIN_YEAR = 1900
 const DEFAULT_MAX_YEAR = 2000
 
+const TOOLTIP_FADE_TIME_MS = 2000
+
 interface TimelineProps {
     years: number[]
     startYear: TimeBound
@@ -359,10 +361,10 @@ export class Timeline extends React.Component<TimelineProps> {
 
     hideStartTooltip = debounce(() => {
         this.startTooltipVisible = false
-    }, 2000)
+    }, TOOLTIP_FADE_TIME_MS)
     hideEndTooltip = debounce(() => {
         this.endTooltipVisible = false
-    }, 2000)
+    }, TOOLTIP_FADE_TIME_MS)
 
     @action updateChartTimeDomain() {
         if (this.props.onTargetChange) {

--- a/charts/controls/Timeline.tsx
+++ b/charts/controls/Timeline.tsx
@@ -403,6 +403,9 @@ export class Timeline extends React.Component<TimelineProps> {
         document.documentElement.addEventListener("mousemove", this.onMouseMove)
         document.documentElement.addEventListener("touchend", this.onMouseUp)
         document.documentElement.addEventListener("touchmove", this.onMouseMove)
+        this.slider?.addEventListener("touchstart", this.onMouseDown, {
+            passive: false
+        })
 
         this.disposers = [
             autorun(() => {
@@ -518,7 +521,6 @@ export class Timeline extends React.Component<TimelineProps> {
                 {this.timelineDate("start", minYear)}
                 <div
                     className="slider clickable"
-                    onTouchStart={this.onMouseDown}
                     onMouseDown={this.onMouseDown}
                 >
                     <TimelineHandle

--- a/charts/controls/Timeline.tsx
+++ b/charts/controls/Timeline.tsx
@@ -7,8 +7,8 @@ import {
     getRelativeMouse,
     isMobile,
     debounce
-} from "./Util"
-import { Bounds } from "./Bounds"
+} from "charts/utils/Util"
+import { Bounds } from "charts/utils/Bounds"
 import { Analytics } from "site/client/Analytics"
 import {
     observable,
@@ -35,7 +35,7 @@ import {
     isUnboundedLeft,
     isUnboundedRight,
     getBoundFromTimeRange
-} from "./TimeBounds"
+} from "charts/utils/TimeBounds"
 import Tippy from "@tippyjs/react"
 import classNames from "classnames"
 

--- a/charts/controls/Timeline.tsx
+++ b/charts/controls/Timeline.tsx
@@ -290,27 +290,23 @@ export class Timeline extends React.Component<TimelineProps> {
             this.onRangeYearChange([startYear, endYear])
         }
 
-        if (isMobile()) this.updateTooltipVisibility()
+        this.updateTooltipVisibility()
     }
 
     @action updateTooltipVisibility() {
         if (this.startYearRaw > this.endYearRaw) {
             this.startTooltipVisible = true
             this.endTooltipVisible = true
-            this.lastUpdatedTooltip =
-                this.dragTarget === "start" ? "endMarker" : "startMarker"
-        } else {
-            if (this.dragTarget === "start" || this.dragTarget === "both") {
-                this.hideStartTooltip.cancel()
-                this.startTooltipVisible = true
-                this.lastUpdatedTooltip = "startMarker"
-            }
-
-            if (this.dragTarget === "end" || this.dragTarget === "both") {
-                this.hideEndTooltip.cancel()
-                this.endTooltipVisible = true
-                this.lastUpdatedTooltip = "endMarker"
-            }
+        }
+        if (this.dragTarget === "start" || this.dragTarget === "both") {
+            this.hideStartTooltip.cancel()
+            this.startTooltipVisible = true
+            this.lastUpdatedTooltip = "startMarker"
+        }
+        if (this.dragTarget === "end" || this.dragTarget === "both") {
+            this.hideEndTooltip.cancel()
+            this.endTooltipVisible = true
+            this.lastUpdatedTooltip = "endMarker"
         }
     }
 

--- a/charts/controls/Timeline.tsx
+++ b/charts/controls/Timeline.tsx
@@ -384,7 +384,10 @@ export class Timeline extends React.Component<TimelineProps> {
         }
 
         // if handles within 1 year of each other, snap to closest year.
-        if (this.endYear - this.startYear < 1) {
+        if (
+            this.endYear - this.startYear < 1 &&
+            this.startYear !== this.endYear
+        ) {
             ;[this.startYearRaw, this.endYearRaw] = [
                 this.startYearClosest,
                 this.endYearClosest

--- a/charts/controls/Timeline.tsx
+++ b/charts/controls/Timeline.tsx
@@ -528,7 +528,7 @@ export class Timeline extends React.Component<TimelineProps> {
                 >
                     <TimelineHandle
                         type="startMarker"
-                        offsetPercent={startYearProgress}
+                        offsetPercent={startYearProgress * 100}
                         tooltipContent={this.formatYear(chart.minYear)}
                         tooltipVisible={this.startTooltipVisible}
                         tooltipZIndex={
@@ -544,7 +544,7 @@ export class Timeline extends React.Component<TimelineProps> {
                     />
                     <TimelineHandle
                         type="endMarker"
-                        offsetPercent={endYearProgress}
+                        offsetPercent={endYearProgress * 100}
                         tooltipContent={this.formatYear(chart.maxYear)}
                         tooltipVisible={this.endTooltipVisible}
                         tooltipZIndex={
@@ -575,7 +575,7 @@ export const TimelineHandle = ({
         <div
             className={classNames("handle", type)}
             style={{
-                left: `${offsetPercent * 100}%`
+                left: `${offsetPercent}%`
             }}
         >
             <Tippy

--- a/charts/controls/Timeline.tsx
+++ b/charts/controls/Timeline.tsx
@@ -289,6 +289,25 @@ export class Timeline extends React.Component<TimelineProps> {
 
             this.onRangeYearChange([startYear, endYear])
         }
+
+        this.updateTooltipVisibility()
+    }
+
+    updateTooltipVisibility() {
+        if (this.startYearRaw > this.endYearRaw) {
+            this.startTooltipVisible = true
+            this.endTooltipVisible = true
+        } else {
+            if (this.dragTarget === "start" || this.dragTarget === "both") {
+                this.hideStartTooltip.cancel()
+                this.startTooltipVisible = true
+            }
+
+            if (this.dragTarget === "end" || this.dragTarget === "both") {
+                this.hideEndTooltip.cancel()
+                this.endTooltipVisible = true
+            }
+        }
     }
 
     @action.bound onMouseDown(e: any) {
@@ -322,16 +341,6 @@ export class Timeline extends React.Component<TimelineProps> {
                 this.startYearUI - inputYear,
                 this.endYearUI - inputYear
             ]
-        }
-
-        if (this.dragTarget === "start" || this.dragTarget === "both") {
-            this.hideStartTooltip.cancel()
-            this.startTooltipVisible = true
-        }
-
-        if (this.dragTarget === "end" || this.dragTarget === "both") {
-            this.hideEndTooltip.cancel()
-            this.endTooltipVisible = true
         }
 
         this.onDrag(inputYear)

--- a/charts/controls/Timeline.tsx
+++ b/charts/controls/Timeline.tsx
@@ -512,7 +512,7 @@ export class Timeline extends React.Component<TimelineProps> {
                 )}
                 {this.timelineDate("start", minYear)}
                 <div
-                    className="slider"
+                    className="slider clickable"
                     onTouchStart={this.onMouseDown}
                     onMouseDown={this.onMouseDown}
                 >
@@ -554,13 +554,15 @@ export const TimelineHandle = ({
     tooltipVisible: boolean
 }) => {
     return (
-        <Tippy content={tooltipContent} visible={tooltipVisible}>
-            <div
-                className={classNames("handle", type)}
-                style={{
-                    left: `${offsetPercent * 100}%`
-                }}
-            ></div>
-        </Tippy>
+        <div
+            className={classNames("handle", type)}
+            style={{
+                left: `${offsetPercent * 100}%`
+            }}
+        >
+            <Tippy content={tooltipContent} visible={tooltipVisible}>
+                <div className="icon" />
+            </Tippy>
+        </div>
     )
 }

--- a/charts/controls/Timeline.tsx
+++ b/charts/controls/Timeline.tsx
@@ -428,8 +428,8 @@ export class Timeline extends React.Component<TimelineProps> {
                         // avoid the unintentional flip, it needs to be done atomically.
                         if (this.startYearRaw > this.endYearRaw) {
                             ;[this.startYearRaw, this.endYearRaw] = [
-                                this.startYearClosest,
-                                this.endYearClosest
+                                this.startYear,
+                                this.endYear
                             ]
                         }
                     })

--- a/charts/controls/Timeline.tsx
+++ b/charts/controls/Timeline.tsx
@@ -290,24 +290,22 @@ export class Timeline extends React.Component<TimelineProps> {
             this.onRangeYearChange([startYear, endYear])
         }
 
-        this.updateTooltipVisibility()
+        this.showTooltips()
     }
 
-    @action updateTooltipVisibility() {
-        if (this.startYearRaw > this.endYearRaw) {
-            this.startTooltipVisible = true
-            this.endTooltipVisible = true
-        }
-        if (this.dragTarget === "start" || this.dragTarget === "both") {
-            this.hideStartTooltip.cancel()
-            this.startTooltipVisible = true
-            this.lastUpdatedTooltip = "startMarker"
-        }
-        if (this.dragTarget === "end" || this.dragTarget === "both") {
-            this.hideEndTooltip.cancel()
-            this.endTooltipVisible = true
-            this.lastUpdatedTooltip = "endMarker"
-        }
+    @action showTooltips() {
+        this.hideStartTooltip.cancel()
+        this.hideEndTooltip.cancel()
+        this.startTooltipVisible = true
+        this.endTooltipVisible = true
+
+        if (this.dragTarget === "start") this.lastUpdatedTooltip = "startMarker"
+        if (this.dragTarget === "end") this.lastUpdatedTooltip = "endMarker"
+        if (this.startYearRaw > this.endYearRaw)
+            this.lastUpdatedTooltip =
+                this.lastUpdatedTooltip === "startMarker"
+                    ? "endMarker"
+                    : "startMarker"
     }
 
     @action.bound onMouseDown(e: any) {

--- a/charts/core/chart.scss
+++ b/charts/core/chart.scss
@@ -872,23 +872,30 @@ $zindex-EntitySelector: 30;
             align-items: center;
             margin-left: $handle-diameter;
             margin-right: $handle-diameter;
+
+            padding: 12px 0;
         }
 
         .handle {
-            height: $handle-diameter;
-            width: $handle-diameter;
-            border-radius: 100%;
+            $handleSidePadding: 6px;
+
             position: absolute;
-
-            background: #ffffff;
-            border: 1.5px solid $controls-color;
-            box-sizing: border-box;
-            box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.15);
             z-index: 1;
-
+            margin-left: (-$handle-diameter / 2) - $handleSidePadding;
             cursor: col-resize;
+            padding: 10px $handleSidePadding;
 
-            margin-left: -$handle-diameter / 2;
+            > .icon {
+                height: $handle-diameter;
+                width: $handle-diameter;
+                border-radius: 100%;
+
+                background: #ffffff;
+                border: 1.5px solid $controls-color;
+                box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.15);
+                z-index: 1;
+                pointer-events: none;
+            }
         }
 
         .interval {
@@ -900,6 +907,15 @@ $zindex-EntitySelector: 30;
             &:active {
                 cursor: grabbing;
             }
+
+            padding: 10px 0;
+        }
+
+        .handle,
+        .interval,
+        .slider {
+            box-sizing: content-box;
+            background-clip: content-box;
         }
     }
 }


### PR DESCRIPTION
**Live on [Nightingale.](https://nightingale-owid.netlify.app/grapher/number-without-clean-cooking-fuel?tab=chart)**

![ezgif-6-952d16debb7e](https://user-images.githubusercontent.com/11683872/90937121-a2ac6380-e3d4-11ea-8d27-7f27c3c2fd8a.gif)


This PR:
- creates tooltips on the Timeline that show the currently selected date, and fade after 2 seconds.
- adds padding around the Timeline to make it easier to click.
- fixes a small Timeline bug where the Handle jumps on click.