### PR TITLE
Performance improvements

### DIFF
--- a/charts/areaCharts/StackedArea.tsx
+++ b/charts/areaCharts/StackedArea.tsx
@@ -1,13 +1,13 @@
 import * as React from "react"
 import {
-    sortBy,
     reverse,
     clone,
     last,
     guid,
     pointsToPath,
     getRelativeMouse,
-    makeSafeForCSS
+    makeSafeForCSS,
+    minBy
 } from "../utils/Util"
 import { computed, action, observable } from "mobx"
 import { observer } from "mobx-react"
@@ -70,11 +70,15 @@ export class Areas extends React.Component<AreasProps> {
         const mouse = getRelativeMouse(this.base.current, ev.nativeEvent)
 
         if (axisBox.innerBounds.contains(mouse)) {
-            const closestPoint = sortBy(data[0].values, d =>
+            const closestPoint = minBy(data[0].values, d =>
                 Math.abs(axisBox.xScale.place(d.x) - mouse.x)
-            )[0]
-            const index = data[0].values.indexOf(closestPoint)
-            this.hoverIndex = index
+            )
+            if (closestPoint) {
+                const index = data[0].values.indexOf(closestPoint)
+                this.hoverIndex = index
+            } else {
+                this.hoverIndex = undefined
+            }
         } else {
             this.hoverIndex = undefined
         }

--- a/charts/areaCharts/StackedAreaTransform.ts
+++ b/charts/areaCharts/StackedAreaTransform.ts
@@ -9,10 +9,11 @@ import {
     extend,
     find,
     identity,
-    sortedUniq,
     formatValue,
     defaultTo,
-    flatten
+    flatten,
+    sortNumeric,
+    uniq
 } from "charts/utils/Util"
 import { EntityDimensionKey } from "charts/core/ChartConstants"
 import { StackedAreaSeries, StackedAreaValue } from "./StackedArea"
@@ -93,7 +94,7 @@ export class StackedAreaTransform extends ChartTransform {
         groupedData.forEach(series =>
             allYears.push(...series.values.map(d => d.x))
         )
-        allYears = sortedUniq(sortBy(allYears))
+        allYears = sortNumeric(uniq(allYears))
 
         groupedData.forEach(series => {
             let i = 0

--- a/charts/axis/HorizontalAxis.tsx
+++ b/charts/axis/HorizontalAxis.tsx
@@ -134,10 +134,7 @@ export class HorizontalAxis {
             }
         }
 
-        return sortBy(
-            tickPlacements.filter(t => !t.isHidden).map(t => t.tick),
-            t => t
-        )
+        return sortBy(tickPlacements.filter(t => !t.isHidden).map(t => t.tick))
     }
 
     @computed get tickFormattingOptions() {

--- a/charts/axis/VerticalAxis.tsx
+++ b/charts/axis/VerticalAxis.tsx
@@ -105,10 +105,7 @@ export class VerticalAxis {
             }
         }
 
-        return sortBy(
-            tickPlacements.filter(t => !t.isHidden).map(t => t.tick),
-            t => t
-        )
+        return sortBy(tickPlacements.filter(t => !t.isHidden).map(t => t.tick))
     }
 
     @computed get tickFormattingOptions() {

--- a/charts/axis/VerticalAxis.tsx
+++ b/charts/axis/VerticalAxis.tsx
@@ -1,4 +1,4 @@
-import { sortBy } from "../utils/Util"
+import { sortBy, maxBy } from "../utils/Util"
 import * as React from "react"
 import { computed } from "mobx"
 import { observer } from "mobx-react"
@@ -43,10 +43,10 @@ export class VerticalAxis {
 
     @computed get width() {
         const { props, labelOffset } = this
-        const longestTick = sortBy(
+        const longestTick = maxBy(
             props.scale.getFormattedTicks(),
-            tick => -tick.length
-        )[0]
+            tick => tick.length
+        )
         return (
             Bounds.forText(longestTick, { fontSize: this.tickFontSize }).width +
             labelOffset +

--- a/charts/barCharts/DiscreteBarChart.tsx
+++ b/charts/barCharts/DiscreteBarChart.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
-import { select, Selection, BaseType } from "d3-selection"
-import { sortBy, min, max, first } from "../utils/Util"
+import { select } from "d3-selection"
+import { min, max, maxBy } from "../utils/Util"
 import { computed, action } from "mobx"
 import { observer } from "mobx-react"
 import { ChartConfig } from "charts/core/ChartConfig"
@@ -85,7 +85,7 @@ export class DiscreteBarChart extends React.Component<{
         if (this.hasFloatingAddButton)
             labels.push(` + ${this.context.chartView.controls.addButtonLabel}`)
 
-        const longestLabel = first(sortBy(labels, d => -d.length))
+        const longestLabel = maxBy(labels, d => d.length)
         return Bounds.forText(longestLabel, this.legendLabelStyle).width
     }
 
@@ -103,10 +103,7 @@ export class DiscreteBarChart extends React.Component<{
             const positiveLabels = this.displayData
                 .filter(d => d.value >= 0)
                 .map(d => this.barValueFormat(d))
-            const longestPositiveLabel = sortBy(
-                positiveLabels,
-                l => -l.length
-            )[0]
+            const longestPositiveLabel = maxBy(positiveLabels, l => l.length)
             return Bounds.forText(longestPositiveLabel, this.valueLabelStyle)
                 .width
         } else {
@@ -122,10 +119,7 @@ export class DiscreteBarChart extends React.Component<{
             const negativeLabels = this.displayData
                 .filter(d => d.value < 0)
                 .map(d => this.barValueFormat(d))
-            const longestNegativeLabel = sortBy(
-                negativeLabels,
-                l => -l.length
-            )[0]
+            const longestNegativeLabel = maxBy(negativeLabels, l => l.length)
             return (
                 Bounds.forText(longestNegativeLabel, this.valueLabelStyle)
                     .width + labelToTextPadding

--- a/charts/barCharts/DiscreteBarTransform.ts
+++ b/charts/barCharts/DiscreteBarTransform.ts
@@ -6,13 +6,15 @@ import {
     orderBy,
     values,
     flatten,
-    uniq
+    uniq,
+    sortNumeric,
+    sortedUniq
 } from "charts/utils/Util"
 import { DiscreteBarDatum } from "./DiscreteBarChart"
 import { ChartTransform } from "charts/core/ChartTransform"
 import { ChartDimension } from "charts/core/ChartDimension"
 import { ColorSchemes } from "charts/color/ColorSchemes"
-import { TickFormattingOptions } from "charts/core/ChartConstants"
+import { SortOrder, TickFormattingOptions } from "charts/core/ChartConstants"
 import { Time } from "charts/utils/TimeBounds"
 
 // Responsible for translating chart configuration into the form
@@ -216,11 +218,11 @@ export class DiscreteBarTransform extends ChartTransform {
             ? this._filterArrayForLogScale(allData)
             : allData
 
-        const data = sortBy(filteredData, d => d.value)
+        const data = sortNumeric(filteredData, d => d.value)
         const colorScheme = chart.baseColorScheme
             ? ColorSchemes[chart.baseColorScheme]
             : undefined
-        const uniqValues = uniq(data.map(d => d.value))
+        const uniqValues = sortedUniq(data.map(d => d.value))
         const colors = colorScheme?.getColors(uniqValues.length) || []
         if (chart.props.invertColorScheme) colors.reverse()
 
@@ -234,6 +236,6 @@ export class DiscreteBarTransform extends ChartTransform {
                 d.color
         })
 
-        return sortBy(data, d => -d.value)
+        return sortNumeric(data, d => d.value, SortOrder.desc)
     }
 }

--- a/charts/core/ChartData.ts
+++ b/charts/core/ChartData.ts
@@ -313,7 +313,7 @@ export class ChartData {
 
     // todo: remove
     @computed.struct get availableKeys(): EntityDimensionKey[] {
-        return sortBy([...Array.from(this.entityDimensionMap.keys())])
+        return sortBy(Array.from(this.entityDimensionMap.keys()))
     }
 
     // todo: remove

--- a/charts/core/ChartDimension.ts
+++ b/charts/core/ChartDimension.ts
@@ -7,10 +7,10 @@ import {
     formatDay,
     formatYear,
     last,
-    sortBy,
     isNumber,
     extend,
-    sortedUniq
+    sortedUniq,
+    sortNumeric
 } from "charts/utils/Util"
 import { TickFormattingOptions } from "charts/core/ChartConstants"
 import { AbstractColumn, owidVariableId, entityName } from "owidTable/OwidTable"
@@ -220,7 +220,7 @@ export class ChartDimension {
     }
 
     @computed get sortedNumericValues(): number[] {
-        return sortBy(this.values.filter(isNumber).filter(v => !isNaN(v)))
+        return sortNumeric(this.values.filter(isNumber).filter(v => !isNaN(v)))
     }
 
     get yearsUniq() {

--- a/charts/core/ChartTransform.ts
+++ b/charts/core/ChartTransform.ts
@@ -7,14 +7,7 @@ import {
     isUnboundedRight,
     getClosestTime
 } from "charts/utils/TimeBounds"
-import {
-    defaultTo,
-    first,
-    last,
-    sortedUniq,
-    sortBy,
-    some
-} from "charts/utils/Util"
+import { defaultTo, first, last, some, sortBy, uniq } from "charts/utils/Util"
 import { ChartConfig } from "./ChartConfig"
 import { EntityDimensionKey } from "charts/core/ChartConstants"
 import { ColorScale } from "charts/color/ColorScale"
@@ -70,7 +63,7 @@ export abstract class ChartTransform implements IChartTransform {
             if (max !== undefined && year > max) return false
             return true
         })
-        return sortedUniq(sortBy(filteredYears))
+        return sortBy(uniq(filteredYears))
     }
 
     @computed get minTimelineYear(): Time {

--- a/charts/core/ChartTransform.ts
+++ b/charts/core/ChartTransform.ts
@@ -7,7 +7,14 @@ import {
     isUnboundedRight,
     getClosestTime
 } from "charts/utils/TimeBounds"
-import { defaultTo, first, last, some, sortBy, uniq } from "charts/utils/Util"
+import {
+    defaultTo,
+    first,
+    last,
+    some,
+    sortNumeric,
+    uniq
+} from "charts/utils/Util"
 import { ChartConfig } from "./ChartConfig"
 import { EntityDimensionKey } from "charts/core/ChartConstants"
 import { ColorScale } from "charts/color/ColorScale"
@@ -63,7 +70,7 @@ export abstract class ChartTransform implements IChartTransform {
             if (max !== undefined && year > max) return false
             return true
         })
-        return sortBy(uniq(filteredYears))
+        return sortNumeric(uniq(filteredYears))
     }
 
     @computed get minTimelineYear(): Time {

--- a/charts/lineCharts/LineChart.tsx
+++ b/charts/lineCharts/LineChart.tsx
@@ -18,7 +18,8 @@ import {
     guid,
     getRelativeMouse,
     makeSafeForCSS,
-    pointsToPath
+    pointsToPath,
+    minBy
 } from "../utils/Util"
 import { computed, action, observable } from "mobx"
 import { observer } from "mobx-react"
@@ -153,10 +154,10 @@ class Lines extends React.Component<LinesProps> {
 
         let hoverX
         if (axisBox.innerBounds.contains(mouse)) {
-            const closestValue = sortBy(this.allValues, d =>
+            const closestValue = minBy(this.allValues, d =>
                 Math.abs(xScale.place(d.x) - mouse.x)
-            )[0]
-            hoverX = closestValue.x
+            )
+            hoverX = closestValue?.x
         }
 
         this.props.onHover(hoverX)

--- a/charts/mapCharts/ChoroplethMap.tsx
+++ b/charts/mapCharts/ChoroplethMap.tsx
@@ -3,7 +3,7 @@ import { computed, action, observable } from "mobx"
 import { observer } from "mobx-react"
 import * as topojson from "topojson-client"
 
-import { identity, sortBy, guid, getRelativeMouse } from "../utils/Util"
+import { identity, sortBy, guid, getRelativeMouse, minBy } from "../utils/Util"
 import { Bounds } from "charts/utils/Bounds"
 import { MapProjections } from "./MapProjections"
 import { MapProjection } from "./MapProjection"
@@ -277,9 +277,9 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
             return { feature: d, distance: Vector2.distance(d.center, mouse) }
         })
 
-        const feature = sortBy(featuresWithDistance, d => d.distance)[0]
+        const feature = minBy(featuresWithDistance, d => d.distance)
 
-        if (feature.distance < 20) {
+        if (feature && feature.distance < 20) {
             if (feature.feature !== this.hoverNearbyFeature) {
                 this.hoverNearbyFeature = feature.feature
                 this.props.onHover(feature.feature.geo, ev)

--- a/charts/mapCharts/MapData.ts
+++ b/charts/mapCharts/MapData.ts
@@ -12,10 +12,10 @@ import {
     each,
     keyBy,
     isNumber,
-    sortBy,
     entityNameForMap,
     formatYear,
-    uniq
+    uniq,
+    sortNumeric
 } from "charts/utils/Util"
 import { Time, getClosestTime } from "charts/utils/TimeBounds"
 import { ChartTransform } from "charts/core/ChartTransform"
@@ -143,7 +143,7 @@ export class MapData extends ChartTransform {
     }
 
     @computed get sortedNumericValues(): number[] {
-        return sortBy(
+        return sortNumeric(
             this.mappableData.values.filter(isNumber).filter(v => !isNaN(v))
         )
     }

--- a/charts/scatterCharts/PointsWithLabels.tsx
+++ b/charts/scatterCharts/PointsWithLabels.tsx
@@ -13,7 +13,6 @@ import { scaleLinear } from "d3-scale"
 import {
     some,
     last,
-    sortBy,
     flatten,
     min,
     find,
@@ -24,7 +23,8 @@ import {
     makeSafeForCSS,
     intersection,
     minBy,
-    maxBy
+    maxBy,
+    sortNumeric
 } from "../utils/Util"
 import { computed, action } from "mobx"
 import { observer } from "mobx-react"
@@ -35,7 +35,7 @@ import { Vector2 } from "charts/utils/Vector2"
 import { Triangle } from "./Triangle"
 import { select } from "d3-selection"
 import { getElementWithHalo } from "./Halos"
-import { EntityDimensionKey } from "charts/core/ChartConstants"
+import { EntityDimensionKey, SortOrder } from "charts/core/ChartConstants"
 import { ColorScale } from "charts/color/ColorScale"
 import { MultiColorPolyline } from "./MultiColorPolyline"
 import { entityName } from "owidTable/OwidTable"
@@ -305,7 +305,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
     // Pre-transform data for rendering
     @computed get initialRenderData(): ScatterRenderSeries[] {
         const { data, xScale, yScale, sizeScale, fontScale, colorScale } = this
-        return sortBy(
+        return sortNumeric(
             data.map(d => {
                 const values = d.values.map(v => {
                     const area = sizeScale(v.size || 4)
@@ -338,7 +338,8 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                     offsetVector: Vector2.zero
                 }
             }),
-            d => -d.size
+            d => d.size,
+            SortOrder.desc
         )
     }
 
@@ -570,7 +571,11 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
         // Must do before collision detection since it'll change the positions
         this.moveLabelsInsideChartBounds(labels, this.bounds)
 
-        const labelsByPriority = sortBy(labels, l => -this.labelPriority(l))
+        const labelsByPriority = sortNumeric(
+            labels,
+            l => this.labelPriority(l),
+            SortOrder.desc
+        )
         if (this.focusKeys.length > 0)
             this.hideUnselectedLabels(labelsByPriority)
 

--- a/charts/scatterCharts/PointsWithLabels.tsx
+++ b/charts/scatterCharts/PointsWithLabels.tsx
@@ -22,7 +22,9 @@ import {
     guid,
     getRelativeMouse,
     makeSafeForCSS,
-    intersection
+    intersection,
+    minBy,
+    maxBy
 } from "../utils/Util"
 import { computed, action } from "mobx"
 import { observer } from "mobx-react"
@@ -434,12 +436,12 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                     .normals()
                     .map(x => x.times(5))
                 const potentialSpots = normals.map(n => v.position.add(n))
-                pos = sortBy(potentialSpots, p => {
-                    return -(
+                pos = maxBy(potentialSpots, p => {
+                    return (
                         Vector2.distance(p, prevPos) +
                         Vector2.distance(p, nextPos)
                     )
-                })[0]
+                }) as Vector2
             } else {
                 pos = v.position.subtract(nextSegment.normalize().times(5))
             }
@@ -663,7 +665,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
         this.mouseFrame = requestAnimationFrame(() => {
             const mouse = getRelativeMouse(this.base.current, nativeEvent)
 
-            const closestSeries = sortBy(this.renderData, series => {
+            const closestSeries = minBy(this.renderData, series => {
                 /*if (some(series.allLabels, l => !l.isHidden && l.bounds.contains(mouse)))
                     return -Infinity*/
 
@@ -684,7 +686,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                         )
                     )
                 }
-            })[0]
+            })
 
             /*if (closestSeries)
                 this.hoverKey = closestSeries.key

--- a/charts/scatterCharts/ScatterTransform.ts
+++ b/charts/scatterCharts/ScatterTransform.ts
@@ -22,7 +22,8 @@ import {
     last,
     formatValue,
     domainExtent,
-    identity
+    identity,
+    minBy
 } from "charts/utils/Util"
 import { computed } from "mobx"
 import { ChartDimension } from "charts/core/ChartDimension"
@@ -589,11 +590,11 @@ export class ScatterTransform extends ChartTransform {
         values = map(
             groupBy(values, v => v.time.y),
             (vals: ScatterValue[]) =>
-                sortBy(vals, v =>
+                minBy(vals, v =>
                     v.year === startYear || v.year === endYear
                         ? -Infinity
                         : Math.abs(v.year - v.time.y)
-                )[0]
+                ) as ScatterValue
         )
 
         if (xOverrideYear === undefined) {
@@ -601,11 +602,11 @@ export class ScatterTransform extends ChartTransform {
             values = map(
                 groupBy(values, v => v.time.x),
                 (vals: ScatterValue[]) =>
-                    sortBy(vals, v =>
+                    minBy(vals, v =>
                         v.year === startYear || v.year === endYear
                             ? -Infinity
                             : Math.abs(v.year - v.time.x)
-                    )[0]
+                    ) as ScatterValue
             )
         }
 

--- a/charts/scatterCharts/ScatterTransform.ts
+++ b/charts/scatterCharts/ScatterTransform.ts
@@ -7,7 +7,6 @@ import {
     isNumber,
     has,
     groupBy,
-    sortBy,
     map,
     includes,
     sortedFindClosestIndex,
@@ -23,7 +22,8 @@ import {
     formatValue,
     domainExtent,
     identity,
-    minBy
+    minBy,
+    sortNumeric
 } from "charts/utils/Util"
 import { computed } from "mobx"
 import { ChartDimension } from "charts/core/ChartDimension"
@@ -611,7 +611,7 @@ export class ScatterTransform extends ChartTransform {
         }
 
         // Sort values by year again in case groupBy() above reordered the values
-        values = sortBy(values, v => v.year)
+        values = sortNumeric(values, v => v.year)
 
         // Don't allow values <= 0 for log scales
         if (yScaleType === "log") values = values.filter(v => v.y > 0)

--- a/charts/scatterCharts/TimeScatter.tsx
+++ b/charts/scatterCharts/TimeScatter.tsx
@@ -17,7 +17,8 @@ import {
     isEmpty,
     guid,
     getRelativeMouse,
-    makeSafeForCSS
+    makeSafeForCSS,
+    minBy
 } from "../utils/Util"
 import { Vector2 } from "charts/utils/Vector2"
 import { select } from "d3-selection"
@@ -383,9 +384,9 @@ class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
         const { mousePos } = this
         if (!mousePos) return undefined
 
-        const closestPoint = sortBy(this.values, v => {
-            return Vector2.distanceSq(v.position, mousePos)
-        })[0]
+        const closestPoint = minBy(this.values, v =>
+            Vector2.distanceSq(v.position, mousePos)
+        )
 
         if (
             closestPoint &&

--- a/charts/slopeCharts/LabelledSlopes.tsx
+++ b/charts/slopeCharts/LabelledSlopes.tsx
@@ -14,7 +14,6 @@ import { extent } from "d3-array"
 import { select } from "d3-selection"
 import {
     every,
-    first,
     sortBy,
     extend,
     max,
@@ -25,7 +24,9 @@ import {
     flatten,
     SVGElement,
     getRelativeMouse,
-    domainExtent
+    domainExtent,
+    minBy,
+    maxBy
 } from "../utils/Util"
 import { computed, action } from "mobx"
 import { observer } from "mobx-react"
@@ -71,9 +72,10 @@ class SlopeChartAxis extends React.Component<AxisProps> {
         }
     ) {
         const { scale } = props
-        const longestTick = first(
-            sortBy(scale.ticks(6).map(props.tickFormat), tick => -tick.length)
-        ) as string
+        const longestTick = maxBy(
+            scale.ticks(6).map(props.tickFormat),
+            tick => tick.length
+        )
         const axisWidth = Bounds.forText(longestTick).width
         return new Bounds(
             containerBounds.x,
@@ -627,9 +629,9 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
                     distToSlope.set(s, dist)
                 }
 
-                const closestSlope = sortBy(this.slopeData, s =>
+                const closestSlope = minBy(this.slopeData, s =>
                     distToSlope.get(s)
-                )[0]
+                )
 
                 if (
                     closestSlope &&

--- a/charts/utils/Util.test.ts
+++ b/charts/utils/Util.test.ts
@@ -24,9 +24,11 @@ import {
     trimGrid,
     trimEmptyRows,
     JsTable,
-    anyToString
+    anyToString,
+    sortNumeric
 } from "charts/utils/Util"
 import { strToQueryParams } from "utils/client/url"
+import { SortOrder } from "charts/core/ChartConstants"
 
 describe(findClosestYear, () => {
     describe("without tolerance", () => {
@@ -475,5 +477,32 @@ describe(getAvailableSlugSync, () => {
             "untitled-2"
         )
         expect(getAvailableSlugSync("new", ["untitled"])).toEqual("new")
+    })
+})
+
+describe(sortNumeric, () => {
+    it("sorts numeric values", () => {
+        expect(sortNumeric([3, 4, 2, 1, 3, 8])).toEqual([1, 2, 3, 3, 4, 8])
+    })
+
+    it("sorts numeric values in ascending value", () => {
+        expect(
+            sortNumeric([3, 4, 2, 1, 3, 8], undefined, SortOrder.asc)
+        ).toEqual([1, 2, 3, 3, 4, 8])
+    })
+
+    it("sorts numeric values in descending order", () => {
+        expect(
+            sortNumeric([3, 4, 2, 1, 3, 8], undefined, SortOrder.desc)
+        ).toEqual([8, 4, 3, 3, 2, 1])
+    })
+
+    it("sorts objects using a sortBy function", () => {
+        expect(
+            sortNumeric(
+                [{ a: 3 }, { a: 4 }, { a: 2 }, { a: 1 }, { a: 3 }, { a: 8 }],
+                o => o.a
+            )
+        ).toEqual([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 3 }, { a: 4 }, { a: 8 }])
     })
 })

--- a/charts/utils/Util.ts
+++ b/charts/utils/Util.ts
@@ -1007,3 +1007,22 @@ export const getAvailableSlugSync = (
 
     return slug
 }
+
+/**
+ * Use with caution - please note that this sort function only sorts on numeric data, and that sorts
+ * **in-place** and **not stable**.
+ * If you need a more general sort function that is stable and leaves the original array untouched,
+ * please use lodash's `sortBy` instead. This function is faster, though.
+ */
+export function sortNumeric<T>(
+    arr: T[],
+    sortByFn: (el: T) => number = identity,
+    sortOrder: SortOrder = SortOrder.asc
+): T[] {
+    const compareFn =
+        sortOrder === SortOrder.asc
+            ? (a: T, b: T) => sortByFn(a) - sortByFn(b)
+            : (a: T, b: T) => sortByFn(b) - sortByFn(a)
+
+    return arr.sort(compareFn)
+}


### PR DESCRIPTION
I've had a look at the sorts we're doing, and noticed that in the Covid explorer, `_.sortBy` uses up a surprising amount of time in the profiler.

Fixes included here (I tried to split them nicely into separate commits):
* Use `_.minBy` and `_.maxBy` where possible - many times we were sorting an array just to get the smallest or biggest value, which can obviously be done more efficiently (`O(n)` vs `O(n log n)`).
  As an added bonus, it is also more expressive and its return type includes `undefined` for the case when the array is empty.
* In one case, use `sort(uniq(years))` instead of `sortedUniq(sort(years))` - turns out we have on the order of 25000 years there, and uniq-first is just way faster
* Introduce a custom, fast `sortNumeric` function that uses `arr.sort()`
  In comparison to `_.sortBy` it is not stable, sorts in place and cannot compare string values, _but_ is way faster.