### PR TITLE
Dev: upgrade prettier to 2.0 and switch to prettyquick and reduce prettify time 96%.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: bionic
 before_script:
     - cp .env.travis .env
     - mysql -e 'CREATE DATABASE test_grapher;'
+    - git fetch origin master:master --depth 50 # Fetch master so pretty-quick can detect changed files and style check only those
 script:
     - yarn testcheck
 cache: yarn

--- a/adminSite/client/ChartIndexPage.tsx
+++ b/adminSite/client/ChartIndexPage.tsx
@@ -34,10 +34,9 @@ export class ChartIndexPage extends React.Component {
             searchIndex.push({
                 chart: chart,
                 term: fuzzysort.prepare(
-                    `${chart.title} ${chart.variantName ||
-                        ""} ${chart.internalNotes || ""} ${chart.publishedBy} ${
-                        chart.lastEditedBy
-                    }`
+                    `${chart.title} ${chart.variantName || ""} ${
+                        chart.internalNotes || ""
+                    } ${chart.publishedBy} ${chart.lastEditedBy}`
                 )
             })
         }

--- a/adminSite/client/ChartList.tsx
+++ b/adminSite/client/ChartList.tsx
@@ -103,9 +103,7 @@ class ChartRow extends React.Component<{
                         <span style={{ color: "#aaa" }}>
                             ({highlight(chart.variantName)})
                         </span>
-                    ) : (
-                        undefined
-                    )}
+                    ) : undefined}
                     {chart.internalNotes && (
                         <div className="internalNotes">
                             {highlight(chart.internalNotes)}

--- a/adminSite/server/apiRouter.ts
+++ b/adminSite/server/apiRouter.ts
@@ -1325,12 +1325,7 @@ apiRouter.get("/posts.json", async req => {
         "type",
         "status",
         "updated_at"
-    ).from(
-        db
-            .knex()
-            .from(Post.table)
-            .orderBy("updated_at", "desc")
-    )
+    ).from(db.knex().from(Post.table).orderBy("updated_at", "desc"))
 
     const tagsByPostId = await Post.tagsByPostId()
 

--- a/adminSite/server/utils/authentication.tsx
+++ b/adminSite/server/utils/authentication.tsx
@@ -44,10 +44,7 @@ export async function authMiddleware(
                 "base64"
             ).toString("utf8")
             const sessionJson = JSON.parse(
-                sessionData
-                    .split(":")
-                    .slice(1)
-                    .join(":")
+                sessionData.split(":").slice(1).join(":")
             )
 
             user = await User.findOne({ id: sessionJson._auth_user_id })

--- a/adminSite/server/utils/gitDataExport.ts
+++ b/adminSite/server/utils/gitDataExport.ts
@@ -14,10 +14,10 @@ import * as db from "db/db"
 
 async function datasetToReadme(dataset: Dataset): Promise<string> {
     const source = await Source.findOne({ datasetId: dataset.id })
-    return `# ${dataset.name}\n\n${(source &&
-        source.description &&
-        source.description.additionalInfo) ||
-        ""}`
+    return `# ${dataset.name}\n\n${
+        (source && source.description && source.description.additionalInfo) ||
+        ""
+    }`
 }
 
 export async function removeDatasetFromGitRepo(
@@ -38,9 +38,9 @@ export async function removeDatasetFromGitRepo(
     }
 
     await execFormatted(
-        `cd %s && rm -rf %s && git add -A %s && (git diff-index --quiet HEAD || (git commit -m %s --quiet --author="${commitName ||
-            GIT_DEFAULT_USERNAME} <${commitEmail ||
-            GIT_DEFAULT_EMAIL}>" && git push))`,
+        `cd %s && rm -rf %s && git add -A %s && (git diff-index --quiet HEAD || (git commit -m %s --quiet --author="${
+            commitName || GIT_DEFAULT_USERNAME
+        } <${commitEmail || GIT_DEFAULT_EMAIL}>" && git push))`,
         [
             repoDir,
             `${repoDir}/datasets/${datasetName}`,
@@ -143,8 +143,9 @@ export async function syncDatasetToGitRepo(
         ? `Adding ${dataset.filename}`
         : `Updating ${dataset.filename}`
     await execFormatted(
-        `cd %s && (git diff-index --quiet HEAD || (git commit -m %s --quiet --author="${commitName ||
-            GIT_DEFAULT_USERNAME} <${commitEmail || GIT_DEFAULT_EMAIL}>"${
+        `cd %s && (git diff-index --quiet HEAD || (git commit -m %s --quiet --author="${
+            commitName || GIT_DEFAULT_USERNAME
+        } <${commitEmail || GIT_DEFAULT_EMAIL}>"${
             commitOnly ? "" : " && git push))"
         }`,
         [repoDir, commitMsg]

--- a/charts/axis/AxisScale.ts
+++ b/charts/axis/AxisScale.ts
@@ -66,9 +66,7 @@ export class AxisScale {
     @computed private get d3_scale():
         | ScaleLinear<number, number>
         | ScaleLogarithmic<number, number> {
-        return this.d3_scaleConstructor()
-            .domain(this.domain)
-            .range(this.range)
+        return this.d3_scaleConstructor().domain(this.domain).range(this.range)
     }
 
     @computed get rangeSize() {

--- a/charts/axis/HorizontalAxis.tsx
+++ b/charts/axis/HorizontalAxis.tsx
@@ -169,9 +169,7 @@ export class HorizontalAxisView extends React.Component<{
                 tickMarkXPositions={ticks.map(tick => scale.place(tick))}
                 color="#ccc"
             />
-        ) : (
-            undefined
-        )
+        ) : undefined
 
         return (
             <g className="HorizontalAxis">

--- a/charts/barCharts/DiscreteBarChart.tsx
+++ b/charts/barCharts/DiscreteBarChart.tsx
@@ -383,8 +383,9 @@ export class DiscreteBarChart extends React.Component<{
                             <rect
                                 x={0}
                                 y={0}
-                                transform={`translate(${barX}, ${-barHeight /
-                                    2})`}
+                                transform={`translate(${barX}, ${
+                                    -barHeight / 2
+                                })`}
                                 width={barWidth}
                                 height={barHeight}
                                 fill={d.color}
@@ -394,10 +395,12 @@ export class DiscreteBarChart extends React.Component<{
                             <text
                                 x={0}
                                 y={0}
-                                transform={`translate(${xScale.place(d.value) +
+                                transform={`translate(${
+                                    xScale.place(d.value) +
                                     (isNegative
                                         ? -labelToBarPadding
-                                        : labelToBarPadding)}, 0)`}
+                                        : labelToBarPadding)
+                                }, 0)`}
                                 fill="#666"
                                 dominantBaseline="middle"
                                 textAnchor={isNegative ? "end" : "start"}

--- a/charts/controls/EntitySelectorModal.tsx
+++ b/charts/controls/EntitySelectorModal.tsx
@@ -169,9 +169,7 @@ class EntitySelectorMulti extends React.Component<{
                                     </span>{" "}
                                     Unselect all
                                 </button>
-                            ) : (
-                                undefined
-                            )}
+                            ) : undefined}
                         </div>
                     </div>
                 </div>

--- a/charts/core/Logos.tsx
+++ b/charts/core/Logos.tsx
@@ -78,8 +78,9 @@ export class Logo {
     }
 
     renderHTML() {
-        const props: React.HTMLAttributes<HTMLDivElement &
-            HTMLAnchorElement> = {
+        const props: React.HTMLAttributes<
+            HTMLDivElement & HTMLAnchorElement
+        > = {
             className: "logo",
             dangerouslySetInnerHTML: { __html: this.spec.svg },
             style: { height: `${this.spec.targetHeight}px` }

--- a/charts/dataTable/DataTable.test.tsx
+++ b/charts/dataTable/DataTable.test.tsx
@@ -109,10 +109,7 @@ describe(DataTable, () => {
         })
 
         it("renders no value when data is not available for years within the tolerance", () => {
-            const cell = view
-                .find("tbody .dimension")
-                .at(1)
-                .first()
+            const cell = view.find("tbody .dimension").at(1).first()
             expect(cell.text()).toBe("")
         })
 

--- a/charts/downloadTab/DownloadTab.tsx
+++ b/charts/downloadTab/DownloadTab.tsx
@@ -37,7 +37,7 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
         if (!HTMLCanvasElement.prototype.toBlob) {
             // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob#Polyfill
             Object.defineProperty(HTMLCanvasElement.prototype, "toBlob", {
-                value: function(
+                value: function (
                     callback: (blob: Blob) => void,
                     type: string,
                     quality: any

--- a/charts/mapCharts/MapProjections.ts
+++ b/charts/mapCharts/MapProjections.ts
@@ -10,10 +10,7 @@ export const MapProjections = {
     World: geoPath().projection(geoRobinson() as GeoProjection),
 
     Africa: geoPath().projection(
-        geoConicConformal()
-            .rotate([-25, 0])
-            .center([0, 0])
-            .parallels([30, -20])
+        geoConicConformal().rotate([-25, 0]).center([0, 0]).parallels([30, -20])
     ),
 
     NorthAmerica: geoPath().projection(

--- a/charts/mapCharts/MapTab.tsx
+++ b/charts/mapCharts/MapTab.tsx
@@ -169,17 +169,17 @@ class MapWithLegend extends React.Component<MapWithLegendProps> {
     componentDidMount() {
         select(this.base.current)
             .selectAll("path")
-            .attr("data-fill", function() {
+            .attr("data-fill", function () {
                 return (this as SVGPathElement).getAttribute("fill")
             })
             .attr("fill", this.props.colorScale.noDataColor)
             .transition()
             .duration(500)
             .ease(easeCubic)
-            .attr("fill", function() {
+            .attr("fill", function () {
                 return (this as SVGPathElement).getAttribute("data-fill")
             })
-            .attr("data-fill", function() {
+            .attr("data-fill", function () {
                 return (this as SVGPathElement).getAttribute("fill")
             })
     }

--- a/charts/scatterCharts/ComparisonLineGenerator.ts
+++ b/charts/scatterCharts/ComparisonLineGenerator.ts
@@ -18,9 +18,7 @@ export function generateComparisonLinePoints(
     // Construct control data by running the equation across sample points
     const numPoints = 500
     const scaleFunction = xScaleType === "log" ? scaleLog : scaleLinear
-    const scale = scaleFunction()
-        .domain(xScaleDomain)
-        .range([0, numPoints])
+    const scale = scaleFunction().domain(xScaleDomain).range([0, numPoints])
     const controlData: Array<[number, number]> = []
     for (let i = 0; i < numPoints; i++) {
         const x = scale.invert(i)

--- a/charts/scatterCharts/PointsWithLabels.tsx
+++ b/charts/scatterCharts/PointsWithLabels.tsx
@@ -287,9 +287,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
     }
 
     @computed private get fontScale(): (d: number) => number {
-        return scaleLinear()
-            .range([10, 13])
-            .domain(this.sizeScale.domain())
+        return scaleLinear().range([10, 13]).domain(this.sizeScale.domain())
     }
 
     @computed private get labelFontFamily(): string {
@@ -874,7 +872,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
         this.animSelection = select(this.base.current).selectAll("circle")
 
         this.animSelection
-            .each(function() {
+            .each(function () {
                 const circle = this as SVGCircleElement
                 radiuses.push(circle.getAttribute("r") as string)
                 circle.setAttribute("r", "0")

--- a/charts/scatterCharts/TimeScatter.tsx
+++ b/charts/scatterCharts/TimeScatter.tsx
@@ -459,7 +459,7 @@ class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
         this.animSelection = select(this.base.current).selectAll("circle")
 
         this.animSelection
-            .each(function() {
+            .each(function () {
                 const circle = this as SVGCircleElement
                 radiuses.push(circle.getAttribute("r") as string)
                 circle.setAttribute("r", "0")
@@ -475,9 +475,7 @@ class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
     }
 
     @computed get linesRender() {
-        return this.hideLines ? (
-            undefined
-        ) : (
+        return this.hideLines ? undefined : (
             <polyline
                 strokeLinecap="round"
                 stroke={this.series.color}

--- a/charts/utils/Util.ts
+++ b/charts/utils/Util.ts
@@ -235,10 +235,7 @@ export function formatDay(
     // Use moments' UTC mode https://momentjs.com/docs/#/parsing/utc/
     // This will force moment to format in UTC time instead of local time,
     // making dates consistent no matter what timezone the user is in.
-    return moment
-        .utc(EPOCH_DATE)
-        .add(dayAsYear, "days")
-        .format(format)
+    return moment.utc(EPOCH_DATE).add(dayAsYear, "days").format(format)
 }
 
 export function formatYear(year: number): string {
@@ -516,7 +513,7 @@ export function sign(n: number) {
 export async function fetchText(url: string): Promise<string> {
     return new Promise((resolve, reject) => {
         const req = new XMLHttpRequest()
-        req.addEventListener("load", function() {
+        req.addEventListener("load", function () {
             resolve(this.responseText)
         })
         req.addEventListener("readystatechange", () => {
@@ -550,7 +547,7 @@ export async function getCountryCodeFromNetlifyRedirect(): Promise<
 export async function fetchJSON(url: string): Promise<any> {
     return new Promise((resolve, reject) => {
         const req = new XMLHttpRequest()
-        req.addEventListener("load", function() {
+        req.addEventListener("load", function () {
             resolve(JSON.parse(this.responseText))
         })
         req.addEventListener("readystatechange", () => {

--- a/cypress/integration/menu.js
+++ b/cypress/integration/menu.js
@@ -1,9 +1,9 @@
-describe("Navigation", function() {
+describe("Navigation", function () {
     beforeEach(() => {
         cy.visit("http://localhost:3099/forests")
     })
 
-    it("Tests mobile navigation", function() {
+    it("Tests mobile navigation", function () {
         cy.viewport("iphone-6")
         cy.get('[data-track-note="mobile-hamburger-button"]').click()
         cy.get(".mobile-topics-dropdown")
@@ -22,7 +22,7 @@ describe("Navigation", function() {
             .click()
         cy.url().should("include", "/cancer")
     })
-    it("Tests desktop navigation", function() {
+    it("Tests desktop navigation", function () {
         cy.contains("Articles by topic").trigger("mouseover")
         cy.get(".topics-dropdown")
             .as("topicsDropdown")

--- a/db/knexMigrations/20190305234711_DenormalizeLatestCountryData.ts
+++ b/db/knexMigrations/20190305234711_DenormalizeLatestCountryData.ts
@@ -1,6 +1,6 @@
 import * as Knex from "knex"
 
-exports.up = async function(knex: Knex): Promise<any> {
+exports.up = async function (knex: Knex): Promise<any> {
     await knex.schema.createTable("country_latest_data", t => {
         t.string("country_code")
         t.integer("variable_id").references("variables.id")
@@ -10,6 +10,6 @@ exports.up = async function(knex: Knex): Promise<any> {
     })
 }
 
-exports.down = async function(knex: Knex): Promise<any> {
+exports.down = async function (knex: Knex): Promise<any> {
     await knex.schema.dropTable("country_latest_data")
 }

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -27,20 +27,11 @@ export class Chart extends BaseEntity {
     @Column() starred!: boolean
     @Column() isExplorable!: boolean
 
-    @ManyToOne(
-        () => User,
-        user => user.lastEditedCharts
-    )
+    @ManyToOne(() => User, user => user.lastEditedCharts)
     lastEditedByUser!: User
-    @ManyToOne(
-        () => User,
-        user => user.publishedCharts
-    )
+    @ManyToOne(() => User, user => user.publishedCharts)
     publishedByUser!: User
-    @OneToMany(
-        () => ChartRevision,
-        rev => rev.chart
-    )
+    @OneToMany(() => ChartRevision, rev => rev.chart)
     logs!: ChartRevision[]
 
     static table: string = "charts"

--- a/db/model/ChartRevision.ts
+++ b/db/model/ChartRevision.ts
@@ -18,15 +18,9 @@ export class ChartRevision extends BaseEntity {
     @Column() createdAt!: Date
     @Column() updatedAt!: Date
 
-    @ManyToOne(
-        () => User,
-        user => user.editedCharts
-    )
+    @ManyToOne(() => User, user => user.editedCharts)
     user!: User
 
-    @ManyToOne(
-        () => Chart,
-        chart => chart.logs
-    )
+    @ManyToOne(() => Chart, chart => chart.logs)
     chart!: Chart
 }

--- a/db/model/Dataset.ts
+++ b/db/model/Dataset.ts
@@ -29,10 +29,7 @@ export class Dataset extends BaseEntity {
     @Column() dataEditedByUserId!: number
     @Column({ default: false }) isPrivate!: boolean
 
-    @ManyToOne(
-        () => User,
-        user => user.createdDatasets
-    )
+    @ManyToOne(() => User, user => user.createdDatasets)
     createdByUser!: User
 
     // Export dataset variables to CSV (not including metadata)

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -106,18 +106,12 @@ export async function syncPostsToGrapher() {
 
     await db.knex().transaction(async t => {
         if (toDelete.length) {
-            await t
-                .whereIn("id", toDelete)
-                .delete()
-                .from(Post.table)
+            await t.whereIn("id", toDelete).delete().from(Post.table)
         }
 
         for (const row of toInsert) {
             if (doesExistInGrapher[row.id])
-                await t
-                    .update(row)
-                    .where("id", "=", row.id)
-                    .into(Post.table)
+                await t.update(row).where("id", "=", row.id).into(Post.table)
             else await t.insert(row).into(Post.table)
         }
     })
@@ -186,10 +180,7 @@ export async function syncPostToGrapher(
     await db.knex().transaction(async t => {
         if (!postRow && existsInGrapher) {
             // Delete from grapher
-            await t
-                .table(Post.table)
-                .where({ id: postId })
-                .delete()
+            await t.table(Post.table).where({ id: postId }).delete()
         } else if (postRow && !existsInGrapher) {
             await t.table(Post.table).insert(postRow)
         } else if (postRow && existsInGrapher) {

--- a/db/model/User.ts
+++ b/db/model/User.ts
@@ -23,28 +23,16 @@ export class User extends BaseEntity {
     @Column() lastLogin!: Date
     @Column() lastSeen!: Date
 
-    @OneToMany(
-        () => Chart,
-        chart => chart.lastEditedByUser
-    )
+    @OneToMany(() => Chart, chart => chart.lastEditedByUser)
     lastEditedCharts!: Chart[]
 
-    @OneToMany(
-        () => Chart,
-        chart => chart.publishedByUser
-    )
+    @OneToMany(() => Chart, chart => chart.publishedByUser)
     publishedCharts!: Chart[]
 
-    @OneToMany(
-        () => ChartRevision,
-        rev => rev.user
-    )
+    @OneToMany(() => ChartRevision, rev => rev.user)
     editedCharts!: ChartRevision[]
 
-    @OneToMany(
-        () => Dataset,
-        dataset => dataset.createdByUser
-    )
+    @OneToMany(() => Dataset, dataset => dataset.createdByUser)
     createdDatasets!: Dataset[]
 
     async setPassword(password: string) {

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -113,12 +113,14 @@ export async function writeVariableCSV(
         [variableIds]
     )
 
-    const dataQuery: Promise<{
-        variableId: number
-        entity: string
-        year: number
-        value: string
-    }[]> = db.query(
+    const dataQuery: Promise<
+        {
+            variableId: number
+            entity: string
+            year: number
+            value: string
+        }[]
+    > = db.query(
         `
         SELECT
             data_values.variableId AS variableId,

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -148,12 +148,7 @@ export async function getAuthorship(): Promise<Map<number, string[]>> {
             authors = []
             authorship.set(row.object_id, authors)
         }
-        authors.push(
-            row.description
-                .split(" ")
-                .slice(0, 2)
-                .join(" ")
-        )
+        authors.push(row.description.split(" ").slice(0, 2).join(" "))
     }
 
     cachedAuthorship = authorship

--- a/explorer/admin/ExplorerBaker.tsx
+++ b/explorer/admin/ExplorerBaker.tsx
@@ -183,9 +183,7 @@ const ExplorerPage = (props: ExplorerPageSettings) => {
             subnavId={subnavId}
             subnavCurrentId={subnavCurrentId}
         />
-    ) : (
-        undefined
-    )
+    ) : undefined
 
     return (
         <html>

--- a/explorer/admin/ExplorerCreatePage.tsx
+++ b/explorer/admin/ExplorerCreatePage.tsx
@@ -114,7 +114,7 @@ export class ExplorerCreatePage extends React.Component<{ slug: string }> {
             outline: 3px dashed rgba(0,0,255,.5);
           }`
 
-        const cells = function(row: number, column: number) {
+        const cells = function (row: number, column: number) {
             const cellProperties: Partial<Handsontable.CellProperties> = {}
 
             if (column === 0) {

--- a/explorer/client/ExplorerControls.tsx
+++ b/explorer/client/ExplorerControls.tsx
@@ -29,9 +29,7 @@ export class ExplorerControlBar extends React.Component<{
             >
                 Done
             </a>
-        ) : (
-            undefined
-        )
+        ) : undefined
 
         const showMobileControls = isMobile && showControls
         return (

--- a/explorer/client/ExplorerShell.tsx
+++ b/explorer/client/ExplorerShell.tsx
@@ -79,9 +79,7 @@ export class ExplorerShell extends React.Component<{
             >
                 <FontAwesomeIcon icon={faChartLine} /> Customize chart
             </a>
-        ) : (
-            undefined
-        )
+        ) : undefined
     }
 
     get countryPicker() {

--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -136,9 +136,7 @@ export class CovidExplorer extends React.Component<{
         )
     }
 
-    private uniqId = Math.random()
-        .toString(36)
-        .substr(2, 8)
+    private uniqId = Math.random().toString(36).substr(2, 8)
 
     // Since there can be multiple explorers embedded on a page, we need to use distinct names when
     // creating radio button groups, etc.
@@ -501,9 +499,7 @@ export class CovidExplorer extends React.Component<{
             >
                 <FontAwesomeIcon icon={faChartLine} /> Customize chart
             </a>
-        ) : (
-            undefined
-        )
+        ) : undefined
     }
 
     render() {

--- a/explorer/indicatorExplorer/ExploreView.test.tsx
+++ b/explorer/indicatorExplorer/ExploreView.test.tsx
@@ -189,12 +189,9 @@ describe(ExploreView, () => {
                 <ExploreView bounds={bounds} model={getDefaultModel()} />
             )
             await updateViewWhenReady(view)
-            expect(
-                view
-                    .find(".indicator-dropdown")
-                    .first()
-                    .text()
-            ).toContain(indicator.title)
+            expect(view.find(".indicator-dropdown").first().text()).toContain(
+                indicator.title
+            )
         })
     })
 })

--- a/gitCms/server.ts
+++ b/gitCms/server.ts
@@ -30,9 +30,9 @@ async function saveFileToGitContentDirectory(
     const pushCommand = shouldPush ? `&& git push` : ""
 
     await execFormatted(
-        `cd %s && git add ${filename} && git commit -m %s --quiet --author="${commitName ||
-            GIT_DEFAULT_USERNAME} <${commitEmail ||
-            GIT_DEFAULT_EMAIL}>" ${pushCommand}`,
+        `cd %s && git add ${filename} && git commit -m %s --quiet --author="${
+            commitName || GIT_DEFAULT_USERNAME
+        } <${commitEmail || GIT_DEFAULT_EMAIL}>" ${pushCommand}`,
         [GIT_CMS_DIR, commitMsg]
     )
     return ""
@@ -48,9 +48,9 @@ async function deleteFileFromGitContentDirectory(
     const pushCommand = shouldPush ? `&& git push` : ""
     await fs.unlink(path)
     await execFormatted(
-        `cd %s && git add ${filename} && git commit -m %s --quiet --author="${commitName ||
-            GIT_DEFAULT_USERNAME} <${commitEmail ||
-            GIT_DEFAULT_EMAIL}>" ${pushCommand}`,
+        `cd %s && git add ${filename} && git commit -m %s --quiet --author="${
+            commitName || GIT_DEFAULT_USERNAME
+        } <${commitEmail || GIT_DEFAULT_EMAIL}>" ${pushCommand}`,
         [GIT_CMS_DIR, `Deleted ${filename}`]
     )
     return ""

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "lint": "eslint .",
         "prettify": "yarn pretty-quick --pattern \"**/*.{tsx,ts,jsx,js,json,md,html,css,scss}\"",
         "prettify:check": "yarn pretty-quick --check --pattern \"**/*.{tsx,ts,jsx,js,json,md,html,css,scss}\"",
+        "prettify-all": "yarn prettier --write \"**/*.{tsx,ts,jsx,js,json,md,html,css,scss}\"",
         "typecheck": "tsc --noEmit",
         "build": "rm -rf dist && ENV=production webpack -p --progress",
         "test": "jest",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
         "knex": "yarn tsn node_modules/.bin/knex --knexfile knexfile.ts",
         "migrate": "yarn knex migrate:latest && yarn typeorm migration:run",
         "lint": "eslint .",
-        "prettify": "yarn prettier --write \"**/*.{tsx,ts,jsx,js,json,md,html,css,scss}\"",
-        "prettify:check": "yarn prettier --check \"**/*.{tsx,ts,jsx,js,json,md,html,css,scss}\"",
+        "prettify": "yarn pretty-quick --pattern \"**/*.{tsx,ts,jsx,js,json,md,html,css,scss}\"",
+        "prettify:check": "yarn pretty-quick --check --pattern \"**/*.{tsx,ts,jsx,js,json,md,html,css,scss}\"",
         "typecheck": "tsc --noEmit",
         "build": "rm -rf dist && ENV=production webpack -p --progress",
         "test": "jest",
@@ -154,7 +154,7 @@
         "optimize-css-assets-webpack-plugin": "^5.0.3",
         "postcss": "^7.0.27",
         "postcss-loader": "^3.0.0",
-        "prettier": "^1.19.1",
+        "prettier": "^2.0.5",
         "prop-types": "^15.7.2",
         "randomstring": "^1.1.5",
         "react": "^16.8.6",
@@ -215,6 +215,7 @@
         "jest": "^24.8.0",
         "npm-run-all": "^4.1.5",
         "opener": "^1.5.1",
+        "pretty-quick": "^3.0.0",
         "source-map-support": "^0.5.12",
         "storybook": "^6.0.13",
         "ts-jest": "^24.0.2",
@@ -222,7 +223,9 @@
         "xhr-mock": "^2.5.1"
     },
     "prettier": {
-        "semi": false
+        "semi": false,
+        "trailingComma": "none",
+        "arrowParens": "avoid"
     },
     "browserslist": [
         ">0.5%",

--- a/site/client/Analytics.ts
+++ b/site/client/Analytics.ts
@@ -137,7 +137,7 @@ export class Analytics {
         }
         if (window.ga) {
             // https://developers.google.com/analytics/devguides/collection/analyticsjs/ga-object-methods-reference
-            window.ga(function() {
+            window.ga(function () {
                 const tracker = window.ga.getAll()[0]
                 // @types/google.analytics seems to suggest this usage is invalid but we know Google
                 // Analytics logs these events correctly.

--- a/site/client/Feedback.tsx
+++ b/site/client/Feedback.tsx
@@ -158,16 +158,12 @@ export class FeedbackForm extends React.Component<{ onClose?: () => void }> {
                     </div>
                     {this.error ? (
                         <div style={{ color: "red" }}>{this.error}</div>
-                    ) : (
-                        undefined
-                    )}
+                    ) : undefined}
                     {this.done ? (
                         <div style={{ color: "green" }}>
                             Thanks for your feedback!
                         </div>
-                    ) : (
-                        undefined
-                    )}
+                    ) : undefined}
                 </div>
                 <div className="footer">
                     <button type="submit" disabled={loading}>

--- a/site/client/Grapher.ts
+++ b/site/client/Grapher.ts
@@ -155,9 +155,7 @@ export class Grapher {
      * any changes.
      */
     public static embedAll() {
-        this.getInstance()
-            .embedder.addFiguresFromDOM()
-            .watchScroll()
+        this.getInstance().embedder.addFiguresFromDOM().watchScroll()
     }
 }
 

--- a/site/client/SearchResults.tsx
+++ b/site/client/SearchResults.tsx
@@ -51,18 +51,14 @@ class ChartResult extends React.Component<{
                 <a href={`${BAKED_GRAPHER_URL}/${slug}`}>{title}</a>
                 {hit.variantName ? (
                     <span className="variantName"> {hit.variantName}</span>
-                ) : (
-                    undefined
-                )}
+                ) : undefined}
                 {hit._snippetResult ? (
                     <p
                         dangerouslySetInnerHTML={{
                             __html: hit._snippetResult.subtitle.value
                         }}
                     />
-                ) : (
-                    undefined
-                )}
+                ) : undefined}
             </li>
         )
     }
@@ -98,9 +94,7 @@ class ArticleResult extends React.Component<{ hit: ArticleHit }> {
                 <a href={`/${hit.slug}`}>{hit.title}</a>{" "}
                 {showType ? (
                     <span className="variantName">{capitalize(hit.type)}</span>
-                ) : (
-                    undefined
-                )}
+                ) : undefined}
                 <p
                     dangerouslySetInnerHTML={{
                         __html: hit._snippetResult.content.value
@@ -178,9 +172,7 @@ export class SearchResults extends React.Component<{
                         <h2>Pages</h2>
                         {!results.pages.length ? (
                             <p>No matching pages.</p>
-                        ) : (
-                            undefined
-                        )}
+                        ) : undefined}
                         <ul>
                             {results.pages.map(hit =>
                                 hit.type === "country" ? (
@@ -201,9 +193,7 @@ export class SearchResults extends React.Component<{
                         <h2>Charts</h2>
                         {!results.charts.length ? (
                             <p>No matching charts.</p>
-                        ) : (
-                            undefined
-                        )}
+                        ) : undefined}
                         {this.bestChartSlug && (
                             <EmbedChart
                                 src={`${BAKED_GRAPHER_URL}/${this.bestChartSlug}`}

--- a/site/client/blocks/AdditionalInformation/AdditionalInformation.tsx
+++ b/site/client/blocks/AdditionalInformation/AdditionalInformation.tsx
@@ -120,7 +120,7 @@ const AdditionalInformation = ({
 export default AdditionalInformation
 
 export const render = ($: CheerioStatic) => {
-    $("block[type='additional-information']").each(function(
+    $("block[type='additional-information']").each(function (
         this: CheerioElement
     ) {
         const $block = $(this)
@@ -128,10 +128,7 @@ export const render = ($: CheerioStatic) => {
             ? VARIATION_MERGE_LEFT
             : VARIATION_FULL_WIDTH
         const title =
-            $block
-                .find("h3")
-                .remove()
-                .text() || "Additional information"
+            $block.find("h3").remove().text() || "Additional information"
         const image =
             variation === VARIATION_MERGE_LEFT
                 ? $block

--- a/site/client/blocks/Help/Help.tsx
+++ b/site/client/blocks/Help/Help.tsx
@@ -29,13 +29,9 @@ const Help = ({
 export default Help
 
 export const render = ($: CheerioStatic) => {
-    $("block[type='help']").each(function(this: CheerioElement) {
+    $("block[type='help']").each(function (this: CheerioElement) {
         const $block = $(this)
-        const title =
-            $block
-                .find("h4")
-                .remove()
-                .text() || null
+        const title = $block.find("h4").remove().text() || null
         const content = $block.find("content").html() // the title has been removed so the rest of the block is content.
         // Side note: "content" refers here to the <content> tag output by the block on the PHP side, not
         // the ".content" class.

--- a/site/client/blocks/RelatedCharts/RelatedCharts.test.tsx
+++ b/site/client/blocks/RelatedCharts/RelatedCharts.test.tsx
@@ -20,19 +20,9 @@ it("renders active chart links and loads respective chart on click", () => {
 
     expect(wrapper.find("li")).toHaveLength(2)
 
-    expect(
-        wrapper
-            .find("li")
-            .first()
-            .hasClass("active")
-    ).toEqual(true)
+    expect(wrapper.find("li").first().hasClass("active")).toEqual(true)
 
-    expect(
-        wrapper
-            .find("li")
-            .first()
-            .text()
-    ).toBe("Chart 1")
+    expect(wrapper.find("li").first().text()).toBe("Chart 1")
 
     wrapper.find("a").forEach((link, idx) => {
         link.simulate("click")
@@ -46,10 +36,5 @@ it("renders active chart links and loads respective chart on click", () => {
         expect(wrapper.find("figure").key()).toEqual(charts[idx].slug)
     })
 
-    expect(
-        wrapper
-            .find("li")
-            .last()
-            .hasClass("active")
-    ).toEqual(true)
+    expect(wrapper.find("li").last().hasClass("active")).toEqual(true)
 })

--- a/site/client/covid/CovidTableColumns.tsx
+++ b/site/client/covid/CovidTableColumns.tsx
@@ -190,9 +190,7 @@ const totalGenerator = (accessor: IntAccessor, noun: NounGenerator) => (
                                     value={formatInt(accessor(d))}
                                     date={d.date}
                                 />
-                            ) : (
-                                undefined
-                            )
+                            ) : undefined
                         }
                     />
                 </div>
@@ -235,9 +233,7 @@ const newGenerator = (accessor: IntAccessor, noun: NounGenerator) => (
                                     })}
                                     date={d && d.date}
                                 />
-                            ) : (
-                                undefined
-                            )
+                            ) : undefined
                         }
                     />
                 </div>
@@ -366,9 +362,7 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                             Up to date for 10&nbsp;AM (CET) on{" "}
                             {formatDate(props.lastUpdated)}.
                         </>
-                    ) : (
-                        undefined
-                    )}
+                    ) : undefined}
                 </span>
             </HeaderCell>
         ),
@@ -393,9 +387,7 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                             Up to date for 10&nbsp;AM (CET) on{" "}
                             {formatDate(props.lastUpdated)}.
                         </>
-                    ) : (
-                        undefined
-                    )}
+                    ) : undefined}
                 </span>
             </HeaderCell>
         ),
@@ -420,9 +412,7 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                             Up to date for 10&nbsp;AM (CET) on{" "}
                             {formatDate(props.lastUpdated)}.
                         </>
-                    ) : (
-                        undefined
-                    )}
+                    ) : undefined}
                 </span>
             </HeaderCell>
         ),
@@ -447,9 +437,7 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                             Up to date for 10&nbsp;AM (CET) on{" "}
                             {formatDate(props.lastUpdated)}.
                         </>
-                    ) : (
-                        undefined
-                    )}
+                    ) : undefined}
                 </span>
             </HeaderCell>
         ),
@@ -491,9 +479,12 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                             style={{
                                 backgroundColor:
                                     props.countryColors[props.datum.location],
-                                width: `${props.totalTestsBarScale(
-                                    props.datum.latestWithTests.tests.totalTests
-                                ) * 100}%`
+                                width: `${
+                                    props.totalTestsBarScale(
+                                        props.datum.latestWithTests.tests
+                                            .totalTests
+                                    ) * 100
+                                }%`
                             }}
                         />
                     )}

--- a/site/client/covid/CovidTableRow.tsx
+++ b/site/client/covid/CovidTableRow.tsx
@@ -121,9 +121,7 @@ export class CovidTableRow extends React.Component<CovidTableRowProps> {
                     <tr className={this.props.className}>
                         {this.props.extraRow(this.cellProps)}
                     </tr>
-                ) : (
-                    undefined
-                )}
+                ) : undefined}
             </React.Fragment>
         )
     }

--- a/site/client/covid/CovidTimeSeriesValue.tsx
+++ b/site/client/covid/CovidTimeSeriesValue.tsx
@@ -42,8 +42,6 @@ export const CovidTimeSeriesValue = ({
                     {formattedDate ?? formatDate(date)}
                 </span>
             </>
-        ) : (
-            undefined
-        )}
+        ) : undefined}
     </div>
 )

--- a/site/server/formatting.tsx
+++ b/site/server/formatting.tsx
@@ -72,10 +72,7 @@ function extractLatex(html: string): [string, string[]] {
     const latexBlocks: string[] = []
     html = html.replace(/\[latex\]([\s\S]*?)\[\/latex\]/gm, (_, latex) => {
         latexBlocks.push(
-            latex
-                .replace("\\[", "")
-                .replace("\\]", "")
-                .replace(/\$\$/g, "")
+            latex.replace("\\[", "").replace("\\]", "").replace(/\$\$/g, "")
         )
         return "[latex]"
     })
@@ -496,11 +493,9 @@ export async function formatWordpressPost(
 
     // Wrap content demarcated by headings into section blocks
     // and automatically divide content into columns
-    const sectionStarts = [
-        $("body")
-            .children()
-            .get(0)
-    ].concat($("body > h2").toArray())
+    const sectionStarts = [$("body").children().get(0)].concat(
+        $("body > h2").toArray()
+    )
     for (const start of sectionStarts) {
         const $start = $(start)
         const $section = $("<section>")
@@ -623,11 +618,7 @@ export async function formatWordpressPost(
         html: getHtmlContentWithStyles($),
         footnotes: footnotes,
         references: references,
-        excerpt:
-            post.excerpt ||
-            $("p")
-                .first()
-                .text(),
+        excerpt: post.excerpt || $("p").first().text(),
         imageUrl: post.imageUrl,
         tocHeadings: tocHeadings,
         relatedCharts: post.relatedCharts

--- a/site/server/views/EntriesByYearPage.tsx
+++ b/site/server/views/EntriesByYearPage.tsx
@@ -16,9 +16,7 @@ export const EntriesByYearPage = (props: { entries: Entry[] }) => {
         moment(e.published_at as Date).year()
     )
 
-    const years = Object.keys(entriesByYear)
-        .sort()
-        .reverse()
+    const years = Object.keys(entriesByYear).sort().reverse()
 
     const pageTitle = "Entries by Year"
     const tocEntries = years.map(year => {

--- a/site/server/views/LongFormPage.tsx
+++ b/site/server/views/LongFormPage.tsx
@@ -231,8 +231,10 @@ export const LongFormPage = (props: {
                                                                 ) => (
                                                                     <li
                                                                         key={i}
-                                                                        id={`note-${i +
-                                                                            1}`}
+                                                                        id={`note-${
+                                                                            i +
+                                                                            1
+                                                                        }`}
                                                                     >
                                                                         <p
                                                                             dangerouslySetInnerHTML={{
@@ -244,9 +246,7 @@ export const LongFormPage = (props: {
                                                             )}
                                                         </ol>
                                                     </React.Fragment>
-                                                ) : (
-                                                    undefined
-                                                )}
+                                                ) : undefined}
                                                 {(isPost ||
                                                     isEntry ||
                                                     isSubEntry) && (
@@ -358,8 +358,9 @@ export const LongFormPage = (props: {
                             <li id="wp-admin-bar-edit">
                                 <a
                                     className="ab-item"
-                                    href={`${WORDPRESS_URL}/wp/wp-admin/post.php?post=${post.postId ||
-                                        post.id}&action=edit`}
+                                    href={`${WORDPRESS_URL}/wp/wp-admin/post.php?post=${
+                                        post.postId || post.id
+                                    }&action=edit`}
                                 >
                                     Edit Page
                                 </a>

--- a/svgTester/SVGTester.tsx
+++ b/svgTester/SVGTester.tsx
@@ -133,10 +133,9 @@ export const getComparePage = async (liveRows: string, devRows: string) => {
 
     const summaryMessage = `${changed.length} (${Math.round(
         (100 * changed.length) / notMissing.length
-    )}%) out of ${notMissing.length} are different. ${notMissing.length -
-        changed.length} unchanged. ${
-        missing.length
-    } files on live missing locally.`
+    )}%) out of ${notMissing.length} are different. ${
+        notMissing.length - changed.length
+    } unchanged. ${missing.length} files on live missing locally.`
 
     const missingDivs = missing.map(el => <div>${el.missing}</div>)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3444,7 +3444,7 @@
   dependencies:
     "@types/webpack" "*"
 
-"@types/minimatch@*":
+"@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
@@ -4685,6 +4685,11 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
+
+array-differ@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-3.0.0.tgz#3cbb3d0f316810eafcc47624734237d6aee4ae6b"
+  integrity sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==
 
 array-each@^1.0.1:
   version "1.0.1"
@@ -9095,6 +9100,21 @@ execa@^3.3.0, execa@^3.4.0:
     npm-run-path "^4.0.0"
     onetime "^5.1.0"
     p-finally "^2.0.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
+execa@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-4.0.3.tgz#0a34dabbad6d66100bd6f2c576c8669403f317f2"
+  integrity sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    human-signals "^1.1.1"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.0"
+    onetime "^5.1.0"
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
@@ -14101,6 +14121,11 @@ move-file@^1.2.0:
     make-dir "^3.0.0"
     path-exists "^3.0.0"
 
+mri@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.6.tgz#49952e1044db21dbf90f6cd92bc9c9a777d415a6"
+  integrity sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -14128,6 +14153,17 @@ multicast-dns@^6.0.1:
   dependencies:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
+
+multimatch@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-4.0.0.tgz#8c3c0f6e3e8449ada0af3dd29efb491a375191b3"
+  integrity sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==
+  dependencies:
+    "@types/minimatch" "^3.0.3"
+    array-differ "^3.0.0"
+    array-union "^2.1.0"
+    arrify "^2.0.1"
+    minimatch "^3.0.4"
 
 multiparty@^4.2.1:
   version "4.2.1"
@@ -16164,11 +16200,6 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
-
 prettier@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
@@ -16218,6 +16249,18 @@ pretty-ms@^6.0.1:
   integrity sha512-ke4njoVmlotekHlHyCZ3wI/c5AMT8peuHs8rKJqekj/oR5G8lND2dVpicFlUz5cbZgE290vvkMuDwfj/OcW1kw==
   dependencies:
     parse-ms "^2.1.0"
+
+pretty-quick@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pretty-quick/-/pretty-quick-3.0.0.tgz#cba8597eca7f3821232abe6a93302d362cc30d71"
+  integrity sha512-oIXlGQUcUxt3XpoNfQECEWvH1Q9PtKfelF2pdp6UvC1CSQ5QcB7gUYKu0kuJGlm3LMBZzJaO/vbRkxA61pWlcg==
+  dependencies:
+    chalk "^3.0.0"
+    execa "^4.0.0"
+    find-up "^4.1.0"
+    ignore "^5.1.4"
+    mri "^1.1.5"
+    multimatch "^4.0.0"
 
 prettyjson@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
Instead of having prettify:check reexamine the whole repo on every push/deploy/testcheck, this nifty little utility checks only files changed with master.

Speedup is huge:

before:
yarn prettify:check  24.34s user 1.17s system 155% cpu 16.421 total

after:
yarn prettify:check  0.99s user 0.26s system 91% cpu 1.376 total

If we change a prettier rule then just use prettier as normal to reformat every file.

I'm not 100% certain how the logic works in every sort of git scenario, but testing with changes on master and on various branches it behaved as I would expect.

This change also upgrades Prettier to 2.0. I didn't want to change our style rules alongside this change, so updated our prettier config to keep existing styles for now.
