### PR TITLE
Add CMS content to the bottom of explorer pages

### DIFF
--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -508,7 +508,7 @@ export async function getRelatedCharts(
     `)
 }
 
-export async function getBlock(id: number): Promise<string | undefined> {
+export async function getBlockContent(id: number): Promise<string | undefined> {
     const WP_GRAPHQL_ENDPOINT = `${WORDPRESS_URL}/wp/graphql`
     const query = `
     query getBlock($id: ID!) {

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -508,6 +508,32 @@ export async function getRelatedCharts(
     `)
 }
 
+export async function getBlock(id: number): Promise<string | undefined> {
+    const WP_GRAPHQL_ENDPOINT = `${WORDPRESS_URL}/wp/graphql`
+    const query = `
+    query getBlock($id: ID!) {
+        post(id: $id, idType: DATABASE_ID) {
+          content
+        }
+      }
+    `
+
+    const response = await fetch(WP_GRAPHQL_ENDPOINT, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json"
+        },
+        body: JSON.stringify({
+            query,
+            variables: { id }
+        })
+    })
+    const json = await response.json()
+
+    return json.data.post.content ?? undefined
+}
+
 export interface FullPost {
     id: number
     type: "post" | "page"

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -531,7 +531,7 @@ export async function getBlockContent(id: number): Promise<string | undefined> {
     })
     const json = await response.json()
 
-    return json.data.post.content ?? undefined
+    return json.data.post?.content ?? undefined
 }
 
 export interface FullPost {

--- a/explorer/admin/ExplorerBaker.tsx
+++ b/explorer/admin/ExplorerBaker.tsx
@@ -29,6 +29,7 @@ import { getChartById } from "db/model/Chart"
 import { Router } from "express"
 import { GIT_CMS_DIR } from "gitCms/constants"
 import { getBlock } from "db/wpdb"
+import { formatReusableBlock } from "site/server/formatting"
 
 const storageFolder = `${GIT_CMS_DIR}/explorers/`
 
@@ -217,7 +218,11 @@ const ExplorerPage = (props: ExplorerPageSettings) => {
                     <LoadingIndicator color="#333" />
                 </main>
                 {wpContent && (
-                    <div dangerouslySetInnerHTML={{ __html: wpContent }}></div>
+                    <div
+                        dangerouslySetInnerHTML={{
+                            __html: formatReusableBlock(wpContent)
+                        }}
+                    ></div>
                 )}
                 <SiteFooter />
                 <script dangerouslySetInnerHTML={{ __html: props.inlineJs }} />

--- a/explorer/admin/ExplorerBaker.tsx
+++ b/explorer/admin/ExplorerBaker.tsx
@@ -28,6 +28,7 @@ import { FunctionalRouter } from "adminSite/server/utils/FunctionalRouter"
 import { getChartById } from "db/model/Chart"
 import { Router } from "express"
 import { GIT_CMS_DIR } from "gitCms/constants"
+import { getBlock } from "db/wpdb"
 
 const storageFolder = `${GIT_CMS_DIR}/explorers/`
 
@@ -148,6 +149,10 @@ async function renderSwitcherExplorerPage(slug: string, code: string) {
 
     const script = `window.SwitcherExplorer.bootstrap(${JSON.stringify(props)})`
 
+    const wpContent = program.wpBlockId
+        ? await getBlock(program.wpBlockId)
+        : undefined
+
     return renderToHtmlPage(
         <ExplorerPage
             title={program.title || ""}
@@ -157,6 +162,7 @@ async function renderSwitcherExplorerPage(slug: string, code: string) {
             subnavCurrentId={program.subNavCurrentId}
             preloads={[]}
             inlineJs={script}
+            wpContent={wpContent}
         />
     )
 }
@@ -174,10 +180,11 @@ interface ExplorerPageSettings {
     hideAlertBanner?: boolean
     subnavId?: SubNavId
     subnavCurrentId?: string
+    wpContent?: string
 }
 
 const ExplorerPage = (props: ExplorerPageSettings) => {
-    const { subnavId, subnavCurrentId } = props
+    const { subnavId, subnavCurrentId, wpContent } = props
     const subNav = subnavId ? (
         <SiteSubnavigation
             subnavId={subnavId}
@@ -209,6 +216,9 @@ const ExplorerPage = (props: ExplorerPageSettings) => {
                 <main id="explorerContainer">
                     <LoadingIndicator color="#333" />
                 </main>
+                {wpContent && (
+                    <div dangerouslySetInnerHTML={{ __html: wpContent }}></div>
+                )}
                 <SiteFooter />
                 <script dangerouslySetInnerHTML={{ __html: props.inlineJs }} />
             </body>

--- a/explorer/admin/ExplorerBaker.tsx
+++ b/explorer/admin/ExplorerBaker.tsx
@@ -5,12 +5,6 @@ import React from "react"
 import { renderToHtmlPage } from "utils/server/serverUtil"
 import { BAKED_SITE_DIR } from "serverSettings"
 import { explorerFileSuffix, ExplorerProgram } from "../client/ExplorerProgram"
-import * as settings from "settings"
-import { Head } from "site/server/views/Head"
-import { SiteHeader } from "site/server/views/SiteHeader"
-import { SiteFooter } from "site/server/views/SiteFooter"
-import { LoadingIndicator } from "site/client/LoadingIndicator"
-import { EmbedDetector } from "site/server/views/EmbedDetector"
 import { Request, Response } from "adminSite/server/utils/authentication"
 
 import {
@@ -19,17 +13,14 @@ import {
     covidPageTitle,
     covidPreloads
 } from "explorer/covidExplorer/CovidConstants"
-import {
-    SiteSubnavigation,
-    SubNavId
-} from "site/server/views/SiteSubnavigation"
+
 import { SwitcherBootstrapProps } from "explorer/client/SwitcherExplorer"
 import { FunctionalRouter } from "adminSite/server/utils/FunctionalRouter"
 import { getChartById } from "db/model/Chart"
 import { Router } from "express"
 import { GIT_CMS_DIR } from "gitCms/constants"
-import { getBlock } from "db/wpdb"
-import { formatReusableBlock } from "site/server/formatting"
+import { getBlockContent } from "db/wpdb"
+import { ExplorerPage } from "./ExplorerPage"
 
 const storageFolder = `${GIT_CMS_DIR}/explorers/`
 
@@ -151,7 +142,7 @@ async function renderSwitcherExplorerPage(slug: string, code: string) {
     const script = `window.SwitcherExplorer.bootstrap(${JSON.stringify(props)})`
 
     const wpContent = program.wpBlockId
-        ? await getBlock(program.wpBlockId)
+        ? await getBlockContent(program.wpBlockId)
         : undefined
 
     return renderToHtmlPage(
@@ -170,65 +161,6 @@ async function renderSwitcherExplorerPage(slug: string, code: string) {
 
 export async function renderCovidExplorerPage(props?: CovidExplorerPageProps) {
     return renderToHtmlPage(<CovidExplorerPage {...props} />)
-}
-
-interface ExplorerPageSettings {
-    title: string
-    slug: string
-    imagePath: string
-    preloads: string[]
-    inlineJs: string
-    hideAlertBanner?: boolean
-    subnavId?: SubNavId
-    subnavCurrentId?: string
-    wpContent?: string
-}
-
-const ExplorerPage = (props: ExplorerPageSettings) => {
-    const { subnavId, subnavCurrentId, wpContent } = props
-    const subNav = subnavId ? (
-        <SiteSubnavigation
-            subnavId={subnavId}
-            subnavCurrentId={subnavCurrentId}
-        />
-    ) : undefined
-
-    return (
-        <html>
-            <Head
-                canonicalUrl={`${settings.BAKED_BASE_URL}/${props.slug}`}
-                pageTitle={props.title}
-                imageUrl={`${settings.BAKED_BASE_URL}/${props.imagePath}`}
-            >
-                <EmbedDetector />
-                {props.preloads.map((url: string, index: number) => (
-                    <link
-                        key={`preload${index}`}
-                        rel="preload"
-                        href={url}
-                        as="fetch"
-                        crossOrigin="anonymous"
-                    />
-                ))}
-            </Head>
-            <body className="ChartPage">
-                <SiteHeader hideAlertBanner={props.hideAlertBanner || false} />
-                {subNav}
-                <main id="explorerContainer">
-                    <LoadingIndicator color="#333" />
-                </main>
-                {wpContent && (
-                    <div
-                        dangerouslySetInnerHTML={{
-                            __html: formatReusableBlock(wpContent)
-                        }}
-                    ></div>
-                )}
-                <SiteFooter />
-                <script dangerouslySetInnerHTML={{ __html: props.inlineJs }} />
-            </body>
-        </html>
-    )
 }
 
 interface CovidExplorerPageProps {

--- a/explorer/admin/ExplorerContent.tsx
+++ b/explorer/admin/ExplorerContent.tsx
@@ -4,6 +4,7 @@ import { formatReusableBlock } from "site/server/formatting"
 const ExplorerContent = ({ content }: { content: string }) => {
     return (
         <div className="explorerContentContainer">
+            <div className="sidebar"></div>
             <div className="article-content">
                 <section>
                     <div className="wp-block-columns is-style-sticky-right">

--- a/explorer/admin/ExplorerContent.tsx
+++ b/explorer/admin/ExplorerContent.tsx
@@ -1,0 +1,24 @@
+import React from "react"
+import { formatReusableBlock } from "site/server/formatting"
+
+const ExplorerContent = ({ content }: { content: string }) => {
+    return (
+        <div className="explorerContentContainer">
+            <div className="article-content">
+                <section>
+                    <div className="wp-block-columns is-style-sticky-right">
+                        <div
+                            className="wp-block-column"
+                            dangerouslySetInnerHTML={{
+                                __html: formatReusableBlock(content)
+                            }}
+                        ></div>
+                        <div className="wp-block-column"></div>
+                    </div>
+                </section>
+            </div>
+        </div>
+    )
+}
+
+export default ExplorerContent

--- a/explorer/admin/ExplorerPage.tsx
+++ b/explorer/admin/ExplorerPage.tsx
@@ -1,0 +1,67 @@
+import React from "react"
+import * as settings from "settings"
+import { Head } from "site/server/views/Head"
+import { SiteHeader } from "site/server/views/SiteHeader"
+import { SiteFooter } from "site/server/views/SiteFooter"
+import { LoadingIndicator } from "site/client/LoadingIndicator"
+import { EmbedDetector } from "site/server/views/EmbedDetector"
+import {
+    SiteSubnavigation,
+    SubNavId
+} from "site/server/views/SiteSubnavigation"
+import ExplorerContent from "./ExplorerContent"
+
+interface ExplorerPageSettings {
+    title: string
+    slug: string
+    imagePath: string
+    preloads: string[]
+    inlineJs: string
+    hideAlertBanner?: boolean
+    subnavId?: SubNavId
+    subnavCurrentId?: string
+    wpContent?: string
+}
+
+export const ExplorerPage = (props: ExplorerPageSettings) => {
+    const { subnavId, subnavCurrentId, wpContent } = props
+    const subNav = subnavId ? (
+        <SiteSubnavigation
+            subnavId={subnavId}
+            subnavCurrentId={subnavCurrentId}
+        />
+    ) : (
+        undefined
+    )
+
+    return (
+        <html>
+            <Head
+                canonicalUrl={`${settings.BAKED_BASE_URL}/${props.slug}`}
+                pageTitle={props.title}
+                imageUrl={`${settings.BAKED_BASE_URL}/${props.imagePath}`}
+            >
+                <EmbedDetector />
+                {props.preloads.map((url: string, index: number) => (
+                    <link
+                        key={`preload${index}`}
+                        rel="preload"
+                        href={url}
+                        as="fetch"
+                        crossOrigin="anonymous"
+                    />
+                ))}
+            </Head>
+            <body className="ChartPage">
+                <SiteHeader hideAlertBanner={props.hideAlertBanner || false} />
+                {subNav}
+                <main id="explorerContainer">
+                    <LoadingIndicator color="#333" />
+                </main>
+                {wpContent && <ExplorerContent content={wpContent} />}
+                <SiteFooter />
+                <script dangerouslySetInnerHTML={{ __html: props.inlineJs }} />
+            </body>
+        </html>
+    )
+}

--- a/explorer/admin/ExplorerPage.tsx
+++ b/explorer/admin/ExplorerPage.tsx
@@ -30,9 +30,7 @@ export const ExplorerPage = (props: ExplorerPageSettings) => {
             subnavId={subnavId}
             subnavCurrentId={subnavCurrentId}
         />
-    ) : (
-        undefined
-    )
+    ) : undefined
 
     return (
         <html>

--- a/explorer/client/ExplorerProgram.ts
+++ b/explorer/client/ExplorerProgram.ts
@@ -40,7 +40,8 @@ export enum ProgramKeyword {
     subNavCurrentId = "subNavCurrentId",
     thumbnail = "thumbnail",
     subtitle = "subtitle",
-    defaultView = "defaultView"
+    defaultView = "defaultView",
+    wpBlockId = "wpBlockId"
 }
 
 export class ExplorerProgram {
@@ -207,6 +208,11 @@ ${ProgramKeyword.switcher}
 
     get isPublished() {
         return this.getLineValue(ProgramKeyword.isPublished) === "true"
+    }
+
+    get wpBlockId(): number | undefined {
+        const blockIdString = this.getLineValue(ProgramKeyword.wpBlockId)
+        return blockIdString ? parseInt(blockIdString, 10) : undefined
     }
 
     set isPublished(value: boolean) {

--- a/explorer/client/explorer.scss
+++ b/explorer/client/explorer.scss
@@ -41,3 +41,13 @@ html.iframe #explorerContainer {
         font-size: 13px;
     }
 }
+
+.explorerContentContainer {
+    max-width: $max-width-covid-data-explorer;
+    margin: 0 auto;
+    & > div {
+        @include wrapper-x-spacing;
+        margin-left: 0;
+        max-width: $content-max-width;
+    }
+}

--- a/explorer/client/explorer.scss
+++ b/explorer/client/explorer.scss
@@ -1,5 +1,8 @@
 $placeholder-height: 800px;
 $chart-border-radius: 2px;
+$explorer-grid-gap: 10px;
+$explorer-min-width-first-col: 200px;
+$explorer-padding: 0.5rem;
 
 $light-shadow: rgba(0, 0, 0, 0.1) 0px 0px 0px 1px,
     rgba(0, 0, 0, 0.08) 0px 2px 2px;
@@ -8,7 +11,7 @@ $light-shadow: rgba(0, 0, 0, 0.1) 0px 0px 0px 1px,
     min-height: $placeholder-height;
     width: 100%;
     position: relative;
-    padding: 8px;
+    padding: $explorer-padding;
 }
 
 html.iframe #explorerContainer {
@@ -21,7 +24,7 @@ html.iframe #explorerContainer {
 
 .ExplorerHeaderBox {
     padding: 8px;
-    min-width: 200px;
+    min-width: $explorer-min-width-first-col;
     background: white;
     border-radius: $chart-border-radius;
     box-shadow: $light-shadow;
@@ -43,11 +46,21 @@ html.iframe #explorerContainer {
 }
 
 .explorerContentContainer {
-    max-width: $max-width-covid-data-explorer;
-    margin: 0 auto;
-    & > div {
+    // liberale approximation of ExplorerShell._isMobile()
+    @media (max-width: 849px) {
         @include wrapper-x-spacing;
-        margin-left: 0;
-        max-width: $content-max-width;
+    }
+
+    @media (min-width: 850px) {
+        max-width: $max-width-covid-data-explorer;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 4fr;
+        column-gap: $explorer-grid-gap;
+        padding: $explorer-padding;
+
+        .sidebar {
+            min-width: $explorer-min-width-first-col;
+        }
     }
 }

--- a/explorer/covidExplorer/covidExplorer.scss
+++ b/explorer/covidExplorer/covidExplorer.scss
@@ -1,7 +1,5 @@
 $controls-color: #3f9eff;
 
-$grid-gap: 10px;
-
 // Match chart styles
 $chart-box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 2px 0px,
     rgba(0, 0, 0, 0.25) 0px 2px 2px 0px;
@@ -24,7 +22,7 @@ html.iframe .CovidExplorerFigure,
 
 .CovidExplorer {
     margin: 0 auto;
-    padding-top: $grid-gap;
+    padding-top: $explorer-grid-gap;
     width: 100%;
     max-width: $max-width-covid-data-explorer;
     height: 90vh;
@@ -33,8 +31,8 @@ html.iframe .CovidExplorerFigure,
     display: grid;
     grid-template-columns: 1fr 4fr;
     grid-template-rows: 1fr 9fr;
-    grid-row-gap: $grid-gap;
-    grid-column-gap: $grid-gap;
+    grid-row-gap: $explorer-grid-gap;
+    grid-column-gap: $explorer-grid-gap;
 
     &.HideControls {
         display: block;

--- a/site/server/formatting.tsx
+++ b/site/server/formatting.tsx
@@ -682,6 +682,18 @@ function parseFormattingOptions(text: string): FormattingOptions {
     return options
 }
 
+export function formatLinks(html: string): string {
+    // Standardize urls
+    return html
+        .replace(new RegExp(WORDPRESS_URL, "g"), BAKED_BASE_URL)
+        .replace(new RegExp("https?://owid.cloud", "g"), BAKED_BASE_URL)
+        .replace(new RegExp("https?://ourworldindata.org", "g"), BAKED_BASE_URL)
+}
+
+export function formatReusableBlock(html: string): string {
+    return formatLinks(html)
+}
+
 export async function formatPost(
     post: FullPost,
     formattingOptions: FormattingOptions,
@@ -689,11 +701,7 @@ export async function formatPost(
 ): Promise<FormattedPost> {
     let html = post.content
 
-    // Standardize urls
-    html = html
-        .replace(new RegExp(WORDPRESS_URL, "g"), BAKED_BASE_URL)
-        .replace(new RegExp("https?://owid.cloud", "g"), BAKED_BASE_URL)
-        .replace(new RegExp("https?://ourworldindata.org", "g"), BAKED_BASE_URL)
+    html = formatLinks(html)
 
     // No formatting applied, plain source HTML returned
     if (formattingOptions.raw) {


### PR DESCRIPTION
Grabs the reusable block identified by `wpBlockId` in the switcher admin and displays it below the explorer (public view only).
Only for switcher explorers.

### Admin view
<img width="454" alt="Screenshot 2020-08-25 at 11 34 04" src="https://user-images.githubusercontent.com/13406362/91158497-0087c680-e6c7-11ea-9c23-6e11ebb73433.png">

### Public view
<img width="1381" alt="Screenshot 2020-08-25 at 11 34 31" src="https://user-images.githubusercontent.com/13406362/91158533-0e3d4c00-e6c7-11ea-8663-57b11ee9884d.png">

 