### PR TITLE
Make ScaleType an enum

### DIFF
--- a/charts/axis/AxisBox.tsx
+++ b/charts/axis/AxisBox.tsx
@@ -54,7 +54,7 @@ export class AxisBox {
         // If we have a log axis and are animating from linear to log do not set domain min to 0
         const progress = this.animProgress
             ? this.animProgress
-            : this.props.yAxis.scaleType === "log"
+            : this.props.yAxis.scaleType === ScaleType.log
             ? 0.01
             : 0
 
@@ -73,7 +73,7 @@ export class AxisBox {
         // If we have a log axis and are animating from linear to log do not set domain min to 0
         const progress = this.animProgress
             ? this.animProgress
-            : this.props.xAxis.scaleType === "log"
+            : this.props.xAxis.scaleType === ScaleType.log
             ? 0.01
             : 0
 

--- a/charts/axis/AxisScale.ts
+++ b/charts/axis/AxisScale.ts
@@ -33,8 +33,8 @@ export class AxisScale {
     @observable hideGridlines: boolean
 
     constructor({
-        scaleType = "linear",
-        scaleTypeOptions = ["linear"],
+        scaleType = ScaleType.linear,
+        scaleTypeOptions = [ScaleType.linear],
         tickFormat = d => d.toString(),
         domain = [0, 0],
         range = [0, 0],
@@ -59,7 +59,7 @@ export class AxisScale {
     }
 
     @computed private get d3_scaleConstructor(): any {
-        return this.scaleType === "log" ? scaleLog : scaleLinear
+        return this.scaleType === ScaleType.log ? scaleLog : scaleLinear
     }
 
     @computed private get d3_scale():
@@ -90,7 +90,7 @@ export class AxisScale {
         const { scaleType, d3_scale, maxLogLines } = this
 
         let ticks: Tickmark[]
-        if (scaleType === "log") {
+        if (scaleType === ScaleType.log) {
             // This is a wild heuristic that decides how many tick lines and grid lines we want to
             // show for log charts.
             //
@@ -211,7 +211,7 @@ export class AxisScale {
                 "Can't place value on scale without a defined output range"
             )
             return value
-        } else if (this.scaleType === "log" && value <= 0) {
+        } else if (this.scaleType === ScaleType.log && value <= 0) {
             console.error("Can't have values <= 0 on a log scale")
             return value
         }

--- a/charts/axis/AxisSpec.ts
+++ b/charts/axis/AxisSpec.ts
@@ -23,7 +23,7 @@ export interface AxisSpec {
 export class AxisConfigProps {
     @observable.ref min?: number = undefined
     @observable.ref max?: number = undefined
-    @observable.ref scaleType: ScaleType = "linear"
+    @observable.ref scaleType: ScaleType = ScaleType.linear
     @observable.ref canChangeScaleType?: true = undefined
     @observable label?: string = undefined
     @observable.ref removePointsOutsideDomain?: true = undefined
@@ -40,7 +40,7 @@ export class AxisConfig {
     // A log scale domain cannot have values <= 0, so we
     // double check here
     @computed get min(): number | undefined {
-        if (this.scaleType === "log" && (this.props.min || 0) <= 0) {
+        if (this.scaleType === ScaleType.log && (this.props.min || 0) <= 0) {
             return undefined
         } else {
             return this.props.min
@@ -48,7 +48,7 @@ export class AxisConfig {
     }
 
     @computed get max(): number | undefined {
-        if (this.scaleType === "log" && (this.props.max || 0) <= 0)
+        if (this.scaleType === ScaleType.log && (this.props.max || 0) <= 0)
             return undefined
         else return this.props.max
     }
@@ -73,7 +73,7 @@ export class AxisConfig {
 
     @computed get scaleTypeOptions(): ScaleType[] {
         if (this.canChangeScaleType) {
-            return ["linear", "log"]
+            return [ScaleType.linear, ScaleType.log]
         } else {
             return [this.scaleType]
         }

--- a/charts/axis/HorizontalAxis.tsx
+++ b/charts/axis/HorizontalAxis.tsx
@@ -75,7 +75,7 @@ export class HorizontalAxis {
             .filter(tick => !tick.gridLineOnly)
 
         // Make sure the start and end values are present, if they're whole numbers
-        const startEndPrio = this.scale.scaleType === "log" ? 2 : 1
+        const startEndPrio = this.scale.scaleType === ScaleType.log ? 2 : 1
         if (domain[0] % 1 === 0)
             ticks = [
                 {

--- a/charts/barCharts/DiscreteBarChart.tsx
+++ b/charts/barCharts/DiscreteBarChart.tsx
@@ -151,7 +151,7 @@ export class DiscreteBarChart extends React.Component<{
     }
 
     @computed get isLogScale() {
-        return this.chart.yAxis.scaleType === "log"
+        return this.chart.yAxis.scaleType === ScaleType.log
     }
 
     @computed get xRange() {

--- a/charts/barCharts/DiscreteBarTransform.ts
+++ b/charts/barCharts/DiscreteBarTransform.ts
@@ -14,7 +14,11 @@ import { DiscreteBarDatum } from "./DiscreteBarChart"
 import { ChartTransform } from "charts/core/ChartTransform"
 import { ChartDimension } from "charts/core/ChartDimension"
 import { ColorSchemes } from "charts/color/ColorSchemes"
-import { SortOrder, TickFormattingOptions } from "charts/core/ChartConstants"
+import {
+    SortOrder,
+    TickFormattingOptions,
+    ScaleType
+} from "charts/core/ChartConstants"
 import { Time } from "charts/utils/TimeBounds"
 
 // Responsible for translating chart configuration into the form
@@ -177,7 +181,7 @@ export class DiscreteBarTransform extends ChartTransform {
     }
 
     @computed get isLogScale() {
-        return this.chart.yAxis.scaleType === "log"
+        return this.chart.yAxis.scaleType === ScaleType.log
     }
 
     @computed get allData(): DiscreteBarDatum[] {

--- a/charts/controls/ScaleSelector.tsx
+++ b/charts/controls/ScaleSelector.tsx
@@ -84,7 +84,7 @@ export class ScaleSelector extends React.Component<ScaleSelectorProps> {
                     data-track-note="chart-toggle-scale"
                     className={
                         "leftToggle " +
-                        (scaleType === "linear" ? "activeToggle" : "")
+                        (scaleType === ScaleType.linear ? "activeToggle" : "")
                     }
                 >
                     Linear
@@ -93,7 +93,7 @@ export class ScaleSelector extends React.Component<ScaleSelectorProps> {
                     data-track-note="chart-toggle-scale"
                     className={
                         "rightToggle " +
-                        (scaleType === "log" ? "activeToggle" : "")
+                        (scaleType === ScaleType.log ? "activeToggle" : "")
                     }
                 >
                     Log

--- a/charts/core/ChartConstants.ts
+++ b/charts/core/ChartConstants.ts
@@ -23,11 +23,14 @@ export class ChartType {
 // todo: remove
 export type EntityDimensionKey = string
 
-export type ScaleType = "linear" | "log"
-
 export type ChartTabOption = "chart" | "map" | "sources" | "download" | "table"
 
 export type Color = string
+
+export enum ScaleType {
+    linear = "linear",
+    log = "log"
+}
 
 export enum SortOrder {
     asc = "asc",

--- a/charts/core/ChartUrl.ts
+++ b/charts/core/ChartUrl.ts
@@ -15,7 +15,7 @@ import {
     formatDay,
     diffDateISOStringInDays
 } from "charts/utils/Util"
-import { ChartTabOption } from "charts/core/ChartConstants"
+import { ChartTabOption, ScaleType } from "charts/core/ChartConstants"
 import { ChartConfig } from "./ChartConfig"
 import {
     queryParamsToStr,
@@ -348,14 +348,14 @@ export class ChartUrl implements ObservableUrl {
         // Axis scale mode
         const xScaleType = params.xScale
         if (xScaleType) {
-            if (xScaleType === "linear" || xScaleType === "log")
+            if (xScaleType === ScaleType.linear || xScaleType === ScaleType.log)
                 chart.xAxis.scaleType = xScaleType
             else console.error("Unexpected xScale: " + xScaleType)
         }
 
         const yScaleType = params.yScale
         if (yScaleType) {
-            if (yScaleType === "linear" || yScaleType === "log")
+            if (yScaleType === ScaleType.linear || yScaleType === ScaleType.log)
                 chart.yAxis.scaleType = yScaleType
             else console.error("Unexpected xScale: " + yScaleType)
         }

--- a/charts/lineCharts/LineChartTransform.ts
+++ b/charts/lineCharts/LineChartTransform.ts
@@ -13,7 +13,7 @@ import {
     flatten,
     findIndex
 } from "charts/utils/Util"
-import { EntityDimensionKey } from "charts/core/ChartConstants"
+import { EntityDimensionKey, ScaleType } from "charts/core/ChartConstants"
 import { LineChartSeries, LineChartValue } from "./LineChart"
 import { AxisSpec } from "charts/axis/AxisSpec"
 import { ColorSchemes, ColorScheme } from "charts/color/ColorSchemes"
@@ -68,7 +68,7 @@ export class LineChartTransform extends ChartTransform {
                 // Not a selected key, don't add any data for it
                 if (!selectedKeysByKey[entityDimensionKey]) continue
                 // Can't have values <= 0 on log scale
-                if (value <= 0 && yAxis.scaleType === "log") continue
+                if (value <= 0 && yAxis.scaleType === ScaleType.log) continue
 
                 if (!series) {
                     series = {
@@ -155,8 +155,8 @@ export class LineChartTransform extends ChartTransform {
             label: this.chart.xAxis.label || "",
             tickFormat: this.chart.formatYearTickFunction,
             domain: xDomain,
-            scaleType: "linear",
-            scaleTypeOptions: ["linear"],
+            scaleType: ScaleType.linear,
+            scaleTypeOptions: [ScaleType.linear],
             hideFractionalTicks: true,
             hideGridlines: true
         }
@@ -189,7 +189,9 @@ export class LineChartTransform extends ChartTransform {
     }
 
     @computed get yScaleType() {
-        return this.isRelativeMode ? "linear" : this.chart.yAxis.scaleType
+        return this.isRelativeMode
+            ? ScaleType.linear
+            : this.chart.yAxis.scaleType
     }
 
     @computed get yTickFormat() {
@@ -216,7 +218,7 @@ export class LineChartTransform extends ChartTransform {
             domain: yDomain,
             scaleType: yScaleType,
             scaleTypeOptions: isRelativeMode
-                ? ["linear"]
+                ? [ScaleType.linear]
                 : chart.yAxis.scaleTypeOptions,
             hideFractionalTicks: this.yAxisHideFractionalTicks
         }

--- a/charts/scatterCharts/ComparisonLineGenerator.test.ts
+++ b/charts/scatterCharts/ComparisonLineGenerator.test.ts
@@ -1,6 +1,7 @@
 #! /usr/bin/env yarn jest
 
 import { generateComparisonLinePoints } from "./ComparisonLineGenerator"
+import { ScaleType } from "charts/core/ChartConstants"
 
 describe(generateComparisonLinePoints, () => {
     describe("For y = x", () => {
@@ -9,8 +10,8 @@ describe(generateComparisonLinePoints, () => {
                 "x",
                 [0, 10],
                 [0, 10],
-                "linear",
-                "linear"
+                ScaleType.linear,
+                ScaleType.linear
             )
             expect(points.length).toEqual(500)
         })
@@ -20,8 +21,8 @@ describe(generateComparisonLinePoints, () => {
                 "x",
                 [0, 10],
                 [0, 5],
-                "linear",
-                "linear"
+                ScaleType.linear,
+                ScaleType.linear
             )
             expect(points.length).toEqual(251)
         })
@@ -33,8 +34,8 @@ describe(generateComparisonLinePoints, () => {
                 "50*x",
                 [0, 10],
                 [0, 10],
-                "linear",
-                "linear"
+                ScaleType.linear,
+                ScaleType.linear
             )
             expect(points.length).toEqual(11)
         })
@@ -44,8 +45,8 @@ describe(generateComparisonLinePoints, () => {
                 "50*x",
                 [1e-6, 1e6],
                 [0, 10],
-                "log",
-                "linear"
+                ScaleType.log,
+                ScaleType.linear
             )
             expect(points.length).toEqual(221)
         })

--- a/charts/scatterCharts/ComparisonLineGenerator.ts
+++ b/charts/scatterCharts/ComparisonLineGenerator.ts
@@ -17,16 +17,18 @@ export function generateComparisonLinePoints(
 
     // Construct control data by running the equation across sample points
     const numPoints = 500
-    const scaleFunction = xScaleType === "log" ? scaleLog : scaleLinear
+
+    const scaleFunction = xScaleType === ScaleType.log ? scaleLog : scaleLinear
     const scale = scaleFunction().domain(xScaleDomain).range([0, numPoints])
+
     const controlData: Array<[number, number]> = []
     for (let i = 0; i < numPoints; i++) {
         const x = scale.invert(i)
         const y = yFunc(x)
 
         if (y === undefined) continue
-        if (xScaleType === "log" && x <= 0) continue
-        if (yScaleType === "log" && y <= 0) continue
+        if (xScaleType === ScaleType.log && x <= 0) continue
+        if (yScaleType === ScaleType.log && y <= 0) continue
         if (y > yScaleDomain[1]) continue
         controlData.push([x, y])
     }

--- a/charts/scatterCharts/ScatterTransform.ts
+++ b/charts/scatterCharts/ScatterTransform.ts
@@ -464,11 +464,13 @@ export class ScatterTransform extends ChartTransform {
         const sizeValues: number[] = []
         this.allPoints.forEach(g => g.size && sizeValues.push(g.size))
         if (sizeValues.length === 0) return [1, 100]
-        else return domainExtent(sizeValues, "linear")
+        else return domainExtent(sizeValues, ScaleType.linear)
     }
 
     @computed private get yScaleType() {
-        return this.isRelativeMode ? "linear" : this.chart.yAxis.scaleType
+        return this.isRelativeMode
+            ? ScaleType.linear
+            : this.chart.yAxis.scaleType
     }
 
     @computed private get yAxisLabelBase(): string | undefined {
@@ -490,7 +492,7 @@ export class ScatterTransform extends ChartTransform {
         const label = chart.yAxis.label ?? yAxisLabelBase
         if (isRelativeMode) {
             props.domain = yDomainDefault
-            props.scaleTypeOptions = ["linear"]
+            props.scaleTypeOptions = [ScaleType.linear]
             if (label && label.length > 1) {
                 props.label =
                     "Average annual change in " +
@@ -510,8 +512,10 @@ export class ScatterTransform extends ChartTransform {
         ) as AxisSpec
     }
 
-    @computed private get xScaleType(): "linear" | "log" {
-        return this.isRelativeMode ? "linear" : this.chart.xAxis.scaleType
+    @computed private get xScaleType(): ScaleType {
+        return this.isRelativeMode
+            ? ScaleType.linear
+            : this.chart.xAxis.scaleType
     }
 
     @computed private get xAxisLabelBase(): string | undefined {
@@ -535,7 +539,7 @@ export class ScatterTransform extends ChartTransform {
         props.scaleType = xScaleType
         if (isRelativeMode) {
             props.domain = xDomainDefault
-            props.scaleTypeOptions = ["linear"]
+            props.scaleTypeOptions = [ScaleType.linear]
             const label = chart.xAxis.label || xAxisLabelBase
             if (label && label.length > 1) {
                 props.label =
@@ -617,8 +621,8 @@ export class ScatterTransform extends ChartTransform {
         values = sortNumeric(values, v => v.year)
 
         // Don't allow values <= 0 for log scales
-        if (yScaleType === "log") values = values.filter(v => v.y > 0)
-        if (xScaleType === "log") values = values.filter(v => v.x > 0)
+        if (yScaleType === ScaleType.log) values = values.filter(v => v.y > 0)
+        if (xScaleType === ScaleType.log) values = values.filter(v => v.x > 0)
 
         // Don't allow values *equal* to zero for CAGR mode
         if (isRelativeMode) values = values.filter(v => v.y !== 0 && v.x !== 0)

--- a/charts/slopeCharts/LabelledSlopes.tsx
+++ b/charts/slopeCharts/LabelledSlopes.tsx
@@ -88,7 +88,7 @@ class SlopeChartAxis extends React.Component<AxisProps> {
         scale: ScaleLinear<number, number> | ScaleLogarithmic<number, number>,
         scaleType: ScaleType
     ) {
-        if (scaleType === "log") {
+        if (scaleType === ScaleType.log) {
             let minPower10 = Math.ceil(
                 Math.log(scale.domain()[0]) / Math.log(10)
             )
@@ -346,7 +346,7 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
     @computed get xDomainDefault(): [number, number] {
         return domainExtent(
             this.allValues.map(v => v.x),
-            "linear"
+            ScaleType.linear
         )
     }
 
@@ -381,7 +381,7 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
     }
 
     @computed get yScaleConstructor(): any {
-        return this.props.yScaleType === "log" ? scaleLog : scaleLinear
+        return this.props.yScaleType === ScaleType.log ? scaleLog : scaleLinear
     }
 
     @computed get yScale():

--- a/charts/utils/Util.test.ts
+++ b/charts/utils/Util.test.ts
@@ -28,7 +28,7 @@ import {
     sortNumeric
 } from "charts/utils/Util"
 import { strToQueryParams } from "utils/client/url"
-import { SortOrder } from "charts/core/ChartConstants"
+import { SortOrder, ScaleType } from "charts/core/ChartConstants"
 
 describe(findClosestYear, () => {
     describe("without tolerance", () => {
@@ -440,7 +440,7 @@ describe(mergeQueryStr, () => {
                 "country=GBR~ESP"
             )
         )
-        expect(params.yScale).toEqual("log")
+        expect(params.yScale).toEqual(ScaleType.log)
         expect(params.country).toEqual("GBR~ESP")
     })
 

--- a/charts/utils/Util.ts
+++ b/charts/utils/Util.ts
@@ -136,7 +136,11 @@ import parseUrl from "url-parse"
 import linkifyHtml from "linkifyjs/html"
 
 import { Vector2 } from "./Vector2"
-import { TickFormattingOptions, SortOrder } from "charts/core/ChartConstants"
+import {
+    TickFormattingOptions,
+    SortOrder,
+    ScaleType
+} from "charts/core/ChartConstants"
 import { isUnboundedLeft, isUnboundedRight } from "./TimeBounds"
 import { EPOCH_DATE } from "settings"
 import { RelatedQuestionsConfig } from "charts/core/ChartConfig"
@@ -391,11 +395,11 @@ export function previous<T>(set: T[], current: T) {
 // Calculate the extents of a set of numbers, with safeguards for log scales
 export function domainExtent(
     numValues: number[],
-    scaleType: "linear" | "log",
+    scaleType: ScaleType,
     maxValueMultiplierForPadding = 1
 ): [number, number] {
     const filterValues =
-        scaleType === "log" ? numValues.filter(v => v > 0) : numValues
+        scaleType === ScaleType.log ? numValues.filter(v => v > 0) : numValues
     const [minValue, maxValue] = extent(filterValues)
 
     if (
@@ -408,12 +412,12 @@ export function domainExtent(
             return [minValue, maxValue * maxValueMultiplierForPadding]
         } else {
             // Only one value, make up a reasonable default
-            return scaleType === "log"
+            return scaleType === ScaleType.log
                 ? [minValue / 10, minValue * 10]
                 : [minValue - 1, maxValue + 1]
         }
     } else {
-        return scaleType === "log" ? [1, 100] : [-1, 1]
+        return scaleType === ScaleType.log ? [1, 100] : [-1, 1]
     }
 }
 

--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -82,6 +82,7 @@ import {
 import { BinningStrategy } from "charts/color/BinningStrategies"
 import { UrlBinder } from "charts/utils/UrlBinder"
 import { ExtendedChartUrl } from "charts/core/ChartUrl"
+import { ScaleType } from "charts/core/ChartConstants"
 
 interface BootstrapProps {
     containerNode: HTMLElement
@@ -782,13 +783,13 @@ export class CovidExplorer extends React.Component<{
         chartProps.yAxis.label = this.yAxisLabel
 
         if (!this.canDoLogScale) {
-            this.switchBackToLog = chartProps.yAxis.scaleType === "log"
-            chartProps.yAxis.scaleType = "linear"
+            this.switchBackToLog = chartProps.yAxis.scaleType === ScaleType.log
+            chartProps.yAxis.scaleType = ScaleType.linear
             chartProps.yAxis.canChangeScaleType = undefined
         } else {
             chartProps.yAxis.canChangeScaleType = true
             if (this.switchBackToLog) {
-                chartProps.yAxis.scaleType = "log"
+                chartProps.yAxis.scaleType = ScaleType.log
                 this.switchBackToLog = false
             }
         }
@@ -894,8 +895,8 @@ export class CovidExplorer extends React.Component<{
     @action.bound playDefaultViewCommand() {
         const props = this.chart.props
         props.tab = "chart"
-        props.xAxis.scaleType = "linear"
-        props.yAxis.scaleType = "log"
+        props.xAxis.scaleType = ScaleType.linear
+        props.yAxis.scaleType = ScaleType.log
         this.chart.timeDomain = [
             TimeBoundValue.unboundedLeft,
             TimeBoundValue.unboundedRight
@@ -995,7 +996,7 @@ export class CovidExplorer extends React.Component<{
 
     @action.bound toggleYScaleTypeCommand() {
         this.chart.props.yAxis.scaleType = next(
-            ["linear", "log"],
+            [ScaleType.linear, ScaleType.log],
             this.chart.props.yAxis.scaleType
         )
     }
@@ -1361,12 +1362,12 @@ export class CovidExplorer extends React.Component<{
             note: this.note,
             hideTitleAnnotation: true,
             xAxis: {
-                scaleType: "linear"
+                scaleType: ScaleType.linear
             },
             yAxis: {
                 min: 0,
                 removePointsOutsideDomain: true,
-                scaleType: "linear",
+                scaleType: ScaleType.linear,
                 canChangeScaleType: true,
                 label: this.yAxisLabel
             },

--- a/explorer/covidExplorer/CovidParams.ts
+++ b/explorer/covidExplorer/CovidParams.ts
@@ -5,7 +5,7 @@ import {
     strToQueryParams,
     queryParamsToStr
 } from "utils/client/url"
-import { SortOrder, ChartTypeName } from "charts/core/ChartConstants"
+import { SortOrder, ChartTypeName, ScaleType } from "charts/core/ChartConstants"
 import { oneOf, uniq, intersection } from "charts/utils/Util"
 import {
     trajectoryColumnSpecs,
@@ -74,7 +74,7 @@ export class CovidQueryParams {
         ]
         const perCapita = [true, false]
         const aligned = [true, false]
-        const yScale = ["log", "linear"] // todo
+        const yScale = [ScaleType.log, ScaleType.linear] // todo
         const tab = ["map", "chart"] // todo
         const combos: any = []
         metrics.forEach(metric => {


### PR DESCRIPTION
Introduces a new enum `ScaleType` with values `log` and `linear`, and uses it throughout the code base.

This way it's easier to reason about where log axes are appearing, since we can just search for enum usages.