### PR TITLE
Dev: refactor LineChart so it is testable

### DIFF
--- a/charts/areaCharts/StackedArea.tsx
+++ b/charts/areaCharts/StackedArea.tsx
@@ -24,10 +24,6 @@ import { Tooltip } from "charts/core/Tooltip"
 import { select } from "d3-selection"
 import { easeLinear } from "d3-ease"
 import { rgb } from "d3-color"
-import {
-    ChartViewContext,
-    ChartViewContextType
-} from "charts/core/ChartViewContext"
 import { EntityDimensionKey } from "charts/core/ChartConstants" // todo: remove
 
 export interface StackedAreaValue {
@@ -226,9 +222,6 @@ export class StackedArea extends React.Component<{
 }> {
     base: React.RefObject<SVGGElement> = React.createRef()
 
-    static contextType = ChartViewContext
-    context!: ChartViewContextType
-
     @computed get chart(): ChartConfig {
         return this.props.chart
     }
@@ -302,7 +295,7 @@ export class StackedArea extends React.Component<{
     @observable hoverKey?: string
     @action.bound onLegendClick(key: EntityDimensionKey) {
         if (this.chart.showAddEntityControls) {
-            this.context.chartView.isSelectingData = true
+            this.chart.isSelectingData = true
         }
     }
 
@@ -351,6 +344,7 @@ export class StackedArea extends React.Component<{
 
         return (
             <Tooltip
+                tooltipOwner={this.props.chart}
                 x={axisBox.xScale.place(refValue.x)}
                 y={axisBox.yScale.rangeMin + axisBox.yScale.rangeSize / 2}
                 style={{ padding: "0.3em" }}
@@ -501,11 +495,11 @@ export class StackedArea extends React.Component<{
                             legend={legend}
                             x={bounds.right - legend.width}
                             yScale={axisBox.yScale}
+                            options={chart}
                             focusKeys={this.focusKeys}
                             onClick={this.onLegendClick}
                             onMouseOver={this.onLegendMouseOver}
                             onMouseLeave={this.onLegendMouseLeave}
-                            areMarksClickable={this.chart.showAddEntityControls}
                         />
                     )}
                     <Areas

--- a/charts/barCharts/DiscreteBarChart.tsx
+++ b/charts/barCharts/DiscreteBarChart.tsx
@@ -259,7 +259,7 @@ export class DiscreteBarChart extends React.Component<{
     }
 
     @action.bound onAddClick() {
-        this.context.chartView.isSelectingData = true
+        this.chart.isSelectingData = true
     }
 
     get addEntityButton() {
@@ -281,7 +281,7 @@ export class DiscreteBarChart extends React.Component<{
                     align="right"
                     verticalAlign="middle"
                     height={this.barHeight}
-                    label={`Add ${this.context.chart.entityType}`}
+                    label={`Add ${this.chart.entityType}`}
                     onClick={this.onAddClick}
                 />
             </ControlsOverlay>

--- a/charts/barCharts/StackedBarChart.tsx
+++ b/charts/barCharts/StackedBarChart.tsx
@@ -276,6 +276,7 @@ export class StackedBarChart extends React.Component<{
 
         return (
             <Tooltip
+                tooltipOwner={this.props.chart}
                 x={xPos + barWidth}
                 y={yPos}
                 style={{ textAlign: "center" }}

--- a/charts/controls/Controls.tsx
+++ b/charts/controls/Controls.tsx
@@ -750,11 +750,14 @@ export class ControlsOverlay extends React.Component<{
     context!: ChartViewContextType
 
     componentDidMount() {
-        this.context.chartView.overlays[this.props.id] = this
+        // todo: remove context
+        if (this.context?.chartView)
+            this.context.chartView.overlays[this.props.id] = this
     }
 
     @action.bound deleteOverlay() {
-        delete this.context.chartView.overlays[this.props.id]
+        // todo: remove context
+        delete this.context?.chartView?.overlays[this.props.id]
     }
 
     componentWillUnmount() {
@@ -769,11 +772,12 @@ export class ControlsOverlay extends React.Component<{
 @observer
 export class ControlsOverlayView extends React.Component<{
     chartView: ChartView
+    chart: ChartConfig
     controls: Controls
     children: JSX.Element
 }> {
     @action.bound onDataSelect() {
-        this.props.controls.props.chartView.isSelectingData = true
+        this.props.chart.isSelectingData = true
     }
 
     render() {
@@ -818,6 +822,7 @@ export class ControlsOverlayView extends React.Component<{
 @observer
 export class ControlsFooterView extends React.Component<{
     controls: Controls
+    chart: ChartConfig
 }> {
     @action.bound onShareMenu() {
         this.props.controls.isShareMenuActive = !this.props.controls
@@ -830,7 +835,7 @@ export class ControlsFooterView extends React.Component<{
     }
 
     @action.bound onDataSelect() {
-        this.props.controls.props.chartView.isSelectingData = true
+        this.props.chart.isSelectingData = true
     }
 
     private _getTabsElement() {

--- a/charts/core/ChartConfig.tsx
+++ b/charts/core/ChartConfig.tsx
@@ -323,6 +323,7 @@ export class ChartConfig {
     @observable.ref isExporting?: boolean
     @observable.ref tooltip?: TooltipProps
     @observable isPlaying: boolean = false
+    @observable.ref isSelectingData: boolean = false
 
     @action.bound toggleMinPopulationFilter() {
         this.props.minPopulationFilter = this.props.minPopulationFilter
@@ -496,6 +497,10 @@ export class ChartConfig {
 
     @computed get showAddEntityControls() {
         return !this.hideEntityControls && this.canAddData
+    }
+
+    @computed get areMarksClickable() {
+        return this.showAddEntityControls
     }
 
     // For now I am only exposing this programmatically for the dashboard builder. Setting this to true
@@ -739,6 +744,14 @@ export class ChartConfig {
 
     @computed get yAxis() {
         return new AxisConfig(this.props.yAxis)
+    }
+
+    @computed get xAxisProps() {
+        return this.xAxis.props
+    }
+
+    @computed get yAxisProps() {
+        return this.yAxis.props
     }
 
     // Get the dimension slots appropriate for this type of chart

--- a/charts/core/ChartLayout.tsx
+++ b/charts/core/ChartLayout.tsx
@@ -130,11 +130,13 @@ export class ChartLayoutView extends React.Component<{
 
     renderWithHTMLText() {
         const { layout } = this.props
+        const chart = layout.props.chart
 
         return (
             <React.Fragment>
-                <HeaderHTML chart={layout.props.chart} header={layout.header} />
+                <HeaderHTML chart={chart} header={layout.header} />
                 <ControlsOverlayView
+                    chart={chart}
                     chartView={this.context.chartView}
                     controls={this.context.chartView.controls}
                 >

--- a/charts/core/ChartTab.tsx
+++ b/charts/core/ChartTab.tsx
@@ -69,7 +69,7 @@ export class ChartTab extends React.Component<{
             ) : (
                 <LineChart
                     bounds={bounds.padTop(20).padBottom(15)}
-                    chart={chart}
+                    options={chart}
                 />
             )
         } else if (chart.isStackedArea) {

--- a/charts/core/ChartView.tsx
+++ b/charts/core/ChartView.tsx
@@ -245,7 +245,6 @@ export class ChartView extends React.Component<ChartViewProps> {
     @observable.shallow overlays: { [id: string]: ControlsOverlay } = {}
 
     @observable.ref popups: VNode[] = []
-    @observable.ref isSelectingData: boolean = false
 
     base: React.RefObject<HTMLDivElement> = React.createRef()
 
@@ -329,16 +328,22 @@ export class ChartView extends React.Component<ChartViewProps> {
         return (
             <React.Fragment>
                 {this.hasBeenVisible && this.renderSVG()}
-                <ControlsFooterView controls={this.controls} />
+                <ControlsFooterView chart={chart} controls={this.controls} />
                 {this.renderOverlayTab(tabBounds)}
                 {this.popups}
-                <TooltipView />
-                {this.isSelectingData && (
+                <TooltipView
+                    width={this.renderWidth}
+                    height={this.renderHeight}
+                    tooltipOwner={this.chart}
+                />
+                {chart.isSelectingData && (
                     <EntitySelectorModal
                         key="entitySelector"
                         chart={chart}
                         isMobile={this.isMobile}
-                        onDismiss={action(() => (this.isSelectingData = false))}
+                        onDismiss={action(
+                            () => (chart.isSelectingData = false)
+                        )}
                     />
                 )}
             </React.Fragment>

--- a/charts/core/ChartViewContext.ts
+++ b/charts/core/ChartViewContext.ts
@@ -1,3 +1,5 @@
+// todo: remove
+
 import * as React from "react"
 import { ChartConfig } from "charts/core/ChartConfig"
 import { ChartView } from "charts/core/ChartView"

--- a/charts/core/Footer.tsx
+++ b/charts/core/Footer.tsx
@@ -287,6 +287,7 @@ export class SourcesFooterHTML extends React.Component<{
                 {!footer.isCompact && license}
                 {tooltipTarget && (
                     <Tooltip
+                        tooltipOwner={this.props.chart}
                         x={tooltipTarget.x}
                         y={tooltipTarget.y}
                         style={{

--- a/charts/core/NoDataOverlay.tsx
+++ b/charts/core/NoDataOverlay.tsx
@@ -1,7 +1,6 @@
 import * as React from "react"
 import { action } from "mobx"
 import { observer } from "mobx-react"
-
 import { Bounds } from "charts/utils/Bounds"
 import {
     ChartViewContext,
@@ -12,17 +11,15 @@ import { ChartConfig } from "charts/core/ChartConfig"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus"
 import { faExchangeAlt } from "@fortawesome/free-solid-svg-icons/faExchangeAlt"
-import { ChartView } from "charts/core/ChartView"
 
 @observer
 class Message extends React.Component<{
     chart: ChartConfig
-    chartView: ChartView
     bounds: Bounds
     message?: string
 }> {
     @action.bound onDataSelect() {
-        this.props.chartView.isSelectingData = true
+        this.props.chart.isSelectingData = true
     }
 
     render() {
@@ -68,15 +65,10 @@ export class NoDataOverlay extends React.Component<{
 
     render() {
         const { bounds, message } = this.props
-        const { chart, chartView } = this.context
+        const { chart } = this.context
         return (
             <ControlsOverlay id="no-data">
-                <Message
-                    chart={chart}
-                    chartView={chartView}
-                    bounds={bounds}
-                    message={message}
-                />
+                <Message chart={chart} bounds={bounds} message={message} />
             </ControlsOverlay>
         )
     }

--- a/charts/lineCharts/LineChart.stories.tsx
+++ b/charts/lineCharts/LineChart.stories.tsx
@@ -1,0 +1,47 @@
+import * as React from "react"
+import "site/client/owid.scss"
+import "charts/core/chart.scss"
+import { LineChart } from "charts/lineCharts/LineChart"
+import { ChartConfig, ChartConfigProps } from "charts/core/ChartConfig"
+import { parseDelimited } from "charts/utils/Util"
+import { OwidTable } from "owidTable/OwidTable"
+
+export default {
+    title: "LineChart",
+    component: LineChart
+}
+
+export const Default = () => {
+    const props = {
+        selectedData: [
+            { index: 0, entityId: 0 },
+            { index: 0, entityId: 1 }
+        ],
+        data: { availableEntities: ["Germany", "France"] },
+        useV2: true,
+        yAxis: {},
+        dimensions: [{ variableId: 99, property: "y" }]
+    } as Partial<ChartConfigProps>
+
+    const chartConfig = new ChartConfig(props as any)
+    const rows = parseDelimited(`entityName,year,gdp,entityId
+France,2000,100,0
+Germany,2000,200,1
+France,2001,200,0
+Germany,2001,300,1
+France,2002,220,0
+Germany,2002,320,1
+France,2003,120,0
+Germany,2003,120,1`) as any
+    rows.forEach((row: any) => (row.entityId = parseInt(row.entityId)))
+    chartConfig.table.cloneAndAddRowsAndDetectColumns(rows)
+    chartConfig.table.columnsBySlug.get("gdp")!.spec.owidVariableId = 99
+    chartConfig.hideEntityControls = true
+    console.log(chartConfig)
+
+    return (
+        <svg width={640} height={480}>
+            <LineChart options={chartConfig} />
+        </svg>
+    )
+}

--- a/charts/lineCharts/LineChart.stories.tsx
+++ b/charts/lineCharts/LineChart.stories.tsx
@@ -37,7 +37,6 @@ Germany,2003,120,1`) as any
     chartConfig.table.cloneAndAddRowsAndDetectColumns(rows)
     chartConfig.table.columnsBySlug.get("gdp")!.spec.owidVariableId = 99
     chartConfig.hideEntityControls = true
-    console.log(chartConfig)
 
     return (
         <svg width={640} height={480}>

--- a/charts/mapCharts/MapTooltip.tsx
+++ b/charts/mapCharts/MapTooltip.tsx
@@ -122,6 +122,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
         const { renderSparkBars, barColor } = this
         return (
             <Tooltip
+                tooltipOwner={this.chart}
                 key="mapTooltip"
                 x={tooltipTarget.x}
                 y={tooltipTarget.y}

--- a/charts/scatterCharts/TimeScatter.tsx
+++ b/charts/scatterCharts/TimeScatter.tsx
@@ -5,7 +5,7 @@ import { observable, computed, action, runInAction } from "mobx"
 import { observer } from "mobx-react"
 import { Bounds } from "charts/utils/Bounds"
 import { ChartConfig } from "charts/core/ChartConfig"
-import { NoDataOverlay } from "../core/NoDataOverlay"
+import { NoDataOverlay } from "charts/core/NoDataOverlay"
 import { AxisBox, AxisBoxView } from "charts/axis/AxisBox"
 import { ComparisonLine } from "./ComparisonLine"
 import { AxisScale } from "charts/axis/AxisScale"
@@ -19,11 +19,11 @@ import {
     getRelativeMouse,
     makeSafeForCSS,
     minBy
-} from "../utils/Util"
+} from "charts/utils/Util"
 import { Vector2 } from "charts/utils/Vector2"
 import { select } from "d3-selection"
 import { Tooltip } from "charts/core/Tooltip"
-import { TimeBound } from "../utils/TimeBounds"
+import { TimeBound } from "charts/utils/TimeBounds"
 
 interface ScatterSeries {
     color: string
@@ -138,6 +138,7 @@ class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
 
         return (
             <Tooltip
+                tooltipOwner={this.props.chart}
                 x={hoverPoint.position.x + 5}
                 y={hoverPoint.position.y + 5}
                 style={{ textAlign: "center" }}


### PR DESCRIPTION
In order to add faceting, I think it's best to clean up all the chart code so the components of each chart can be tested independently. Then when we show many charts in one screen it will be a lot easier and more reliable.

This is a step in that direction. It ain't pretty yet, but it's slightly prettier than our current code.

The main things to be done are:
- remove globals like Context
- create interfaces with only the needed properties/methods instead of requiring chartConfig
- create stories and/or unit tests for each component so that we can sanity check the APIs

Before:
[No unit tests or stories]

After:
![Screen Shot 2020-08-25 at 8 52 50 PM](https://user-images.githubusercontent.com/74692/91271529-0c4ea980-e716-11ea-9d90-bc59c00d5f35.png)
