### PR TITLE
Dev: stop exporting items not being used

### DIFF
--- a/adminSite/client/ChartEditor.ts
+++ b/adminSite/client/ChartEditor.ts
@@ -11,9 +11,9 @@ import { EditorFeatures } from "./EditorFeatures"
 import { Admin } from "./Admin"
 import { BAKED_GRAPHER_URL } from "settings"
 
-export type EditorTab = string
+type EditorTab = string
 
-export interface Variable {
+interface Variable {
     id: number
     name: string
 }
@@ -66,7 +66,7 @@ export class EditorDatabase {
     }
 }
 
-export interface ChartEditorProps {
+interface ChartEditorProps {
     admin: Admin
     chart: ChartConfig
     database: EditorDatabase

--- a/adminSite/client/ColorSchemeDropdown.tsx
+++ b/adminSite/client/ColorSchemeDropdown.tsx
@@ -15,7 +15,7 @@ export interface ColorSchemeOption {
     value: string
 }
 
-export interface ColorSchemeDropdownProps {
+interface ColorSchemeDropdownProps {
     additionalOptions: ColorSchemeOption[]
     value?: string
     gradientColorCount: number

--- a/adminSite/client/Colorpicker.tsx
+++ b/adminSite/client/Colorpicker.tsx
@@ -5,7 +5,7 @@ import { SketchPicker } from "react-color"
 import { lastOfNonEmptyArray } from "charts/utils/Util"
 import { ColorSchemes, ColorScheme } from "charts/color/ColorSchemes"
 
-export interface ColorpickerProps {
+interface ColorpickerProps {
     color?: string
     onColor: (color: string | undefined) => void
 }

--- a/adminSite/client/CountryStandardizerPage.tsx
+++ b/adminSite/client/CountryStandardizerPage.tsx
@@ -184,8 +184,7 @@ class CSV {
     }
 }
 
-export interface CountryEntry
-    extends React.HTMLAttributes<HTMLTableRowElement> {
+interface CountryEntry extends React.HTMLAttributes<HTMLTableRowElement> {
     originalName: string
     standardizedName?: string
     approximatedMatches: string[]
@@ -194,7 +193,7 @@ export interface CountryEntry
 }
 
 @observer
-export class CountryEntryRowRenderer extends React.Component<{
+class CountryEntryRowRenderer extends React.Component<{
     entry: CountryEntry
     allCountries: string[]
     onUpdate: (value: string, inputCountry: string, isCustom: boolean) => void

--- a/adminSite/client/EditorColorScaleSection.tsx
+++ b/adminSite/client/EditorColorScaleSection.tsx
@@ -2,11 +2,9 @@ import * as React from "react"
 import { action, computed, runInAction } from "mobx"
 import { observer } from "mobx-react"
 import Select, { ValueType } from "react-select"
-
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus"
 import { faMinus } from "@fortawesome/free-solid-svg-icons/faMinus"
-
 import { ColorScale } from "charts/color/ColorScale"
 import {
     ColorScaleBin,
@@ -16,7 +14,6 @@ import {
 import { clone, noop, last } from "charts/utils/Util"
 import { Color } from "charts/core/ChartConstants"
 import { asArray } from "utils/client/react-select"
-
 import {
     Section,
     Toggle,
@@ -238,7 +235,7 @@ class ColorsSection extends React.Component<{
 }
 
 @observer
-export class ColorSchemeEditor extends React.Component<{
+class ColorSchemeEditor extends React.Component<{
     scale: ColorScale
 }> {
     render() {

--- a/adminSite/client/EditorHistoryTab.tsx
+++ b/adminSite/client/EditorHistoryTab.tsx
@@ -6,7 +6,7 @@ import { computed, action } from "mobx"
 import { format } from "timeago.js"
 
 @observer
-export class LogRenderer extends React.Component<{
+class LogRenderer extends React.Component<{
     log: Log
     applyConfig: (config: any) => void
 }> {

--- a/adminSite/client/Forms.tsx
+++ b/adminSite/client/Forms.tsx
@@ -25,7 +25,7 @@ export class FieldsRow extends React.Component {
     }
 }
 
-export interface TextFieldProps extends React.HTMLAttributes<HTMLInputElement> {
+interface TextFieldProps extends React.HTMLAttributes<HTMLInputElement> {
     label?: string
     value: string | undefined
     onValue: (value: string) => void
@@ -106,7 +106,7 @@ export class TextField extends React.Component<TextFieldProps> {
     }
 }
 
-export class TextAreaField extends React.Component<TextFieldProps> {
+class TextAreaField extends React.Component<TextFieldProps> {
     @bind onChange(ev: React.FormEvent<HTMLTextAreaElement>) {
         const value = ev.currentTarget.value
         this.props.onValue(value)
@@ -150,7 +150,7 @@ export class TextAreaField extends React.Component<TextFieldProps> {
 
 export class SearchField extends TextField {}
 
-export interface NumberFieldProps {
+interface NumberFieldProps {
     label?: string
     value: number | undefined
     allowDecimal?: boolean
@@ -208,7 +208,7 @@ export class NumberField extends React.Component<
     }
 }
 
-export interface SelectFieldProps {
+interface SelectFieldProps {
     label?: string
     value: string | undefined
     onValue: (value: string) => void
@@ -272,7 +272,7 @@ export interface SelectGroup {
     options: Option[]
 }
 
-export interface SelectGroupsFieldProps {
+interface SelectGroupsFieldProps {
     label?: string
     value: string | undefined
     onValue: (value: string) => void
@@ -320,12 +320,12 @@ export class SelectGroupsField extends React.Component<SelectGroupsFieldProps> {
     }
 }
 
-export interface RadioGroupOption {
+interface RadioGroupOption {
     label?: string
     value: string
 }
 
-export interface RadioGroupProps {
+interface RadioGroupProps {
     options: RadioGroupOption[]
     value?: string
     onChange: (value: string) => void
@@ -357,7 +357,7 @@ export class RadioGroup extends React.Component<RadioGroupProps> {
     }
 }
 
-export interface NumericSelectFieldProps {
+interface NumericSelectFieldProps {
     label?: string
     value: number | undefined
     onValue: (value: number) => void
@@ -385,7 +385,7 @@ export class NumericSelectField extends React.Component<
     }
 }
 
-export interface ToggleProps {
+interface ToggleProps {
     label: string | JSX.Element
     value: boolean
     onValue: (value: boolean) => void
@@ -418,7 +418,7 @@ export class Toggle extends React.Component<ToggleProps> {
     }
 }
 
-export interface ButtonProps {
+interface ButtonProps {
     onClick: () => void
     label?: string
 }
@@ -517,7 +517,7 @@ export class Section extends React.Component<{ name: string }> {
     }
 }
 
-export interface AutoTextFieldProps {
+interface AutoTextFieldProps {
     label?: string
     value: string | undefined
     placeholder?: string
@@ -692,7 +692,7 @@ export class BindAutoString<
     }
 }
 
-export interface AutoFloatFieldProps {
+interface AutoFloatFieldProps {
     label?: string
     value: number
     isAuto: boolean
@@ -701,7 +701,7 @@ export interface AutoFloatFieldProps {
     onToggleAuto: (value: boolean) => void
 }
 
-export class AutoFloatField extends React.Component<AutoFloatFieldProps> {
+class AutoFloatField extends React.Component<AutoFloatFieldProps> {
     render() {
         const { props } = this
 
@@ -718,14 +718,14 @@ export class AutoFloatField extends React.Component<AutoFloatFieldProps> {
     }
 }
 
-export interface FloatFieldProps {
+interface FloatFieldProps {
     label?: string
     value: number | undefined
     helpText?: string
     onValue: (value: number | undefined) => void
 }
 
-export class FloatField extends React.Component<FloatFieldProps> {
+class FloatField extends React.Component<FloatFieldProps> {
     render() {
         const { props } = this
 

--- a/adminSite/client/Link.tsx
+++ b/adminSite/client/Link.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 import { Link as ReactLink } from "react-router-dom"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext"
 
-export interface LinkProps
-    extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
     to: string
     replace?: boolean
     native?: boolean

--- a/adminSite/client/UserEditPage.tsx
+++ b/adminSite/client/UserEditPage.tsx
@@ -5,15 +5,7 @@ import { BindString, Toggle } from "./Forms"
 import { Redirect } from "react-router-dom"
 import { AdminLayout } from "./AdminLayout"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext"
-
-interface UserIndexMeta {
-    id: number
-    name: string
-    fullName: string
-    createdAt: Date
-    updatedAt: Date
-    isActive: boolean
-}
+import { UserIndexMeta } from "./UserMeta"
 
 @observer
 export class UserEditPage extends React.Component<{ userId: number }> {

--- a/adminSite/client/UserMeta.ts
+++ b/adminSite/client/UserMeta.ts
@@ -1,0 +1,8 @@
+export interface UserIndexMeta {
+    id: number
+    name: string
+    fullName: string
+    createdAt: Date
+    updatedAt: Date
+    isActive: boolean
+}

--- a/adminSite/client/UsersIndexPage.tsx
+++ b/adminSite/client/UsersIndexPage.tsx
@@ -6,14 +6,9 @@ import { Modal, Timeago } from "./Forms"
 import { Link } from "./Link"
 import { AdminLayout } from "./AdminLayout"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext"
+import { UserIndexMeta } from "./UserMeta"
 
-interface UserIndexMeta {
-    id: number
-    name: string
-    fullName: string
-    createdAt: Date
-    updatedAt: Date
-    isActive: boolean
+interface UserIndexMetaWithLastSeen extends UserIndexMeta {
     lastSeen: Date
 }
 
@@ -95,10 +90,10 @@ export class UsersIndexPage extends React.Component {
     static contextType = AdminAppContext
     context!: AdminAppContextType
 
-    @observable users: UserIndexMeta[] = []
+    @observable users: UserIndexMetaWithLastSeen[] = []
     @observable isInviteModal: boolean = false
 
-    @action.bound async onDelete(user: UserIndexMeta) {
+    @action.bound async onDelete(user: UserIndexMetaWithLastSeen) {
         if (
             !window.confirm(
                 `Delete the user ${user.fullName}? This action cannot be undone!`
@@ -202,7 +197,7 @@ export class UsersIndexPage extends React.Component {
         const { admin } = this.context
 
         const json = (await admin.getJSON("/api/users.json")) as {
-            users: UserIndexMeta[]
+            users: UserIndexMetaWithLastSeen[]
         }
 
         runInAction(() => {

--- a/adminSite/client/VisionDeficiencies.tsx
+++ b/adminSite/client/VisionDeficiencies.tsx
@@ -23,7 +23,7 @@ export interface VisionDeficiency {
     transformationMatrix: string
 }
 
-export const visionDeficiencies: VisionDeficiency[] = [
+const visionDeficiencies: VisionDeficiency[] = [
     // Color blindnesses first
     {
         id: "protanopia",

--- a/adminSite/server/apiRouter.ts
+++ b/adminSite/server/apiRouter.ts
@@ -607,15 +607,6 @@ apiRouter.delete("/charts/:chartId", async (req: Request, res: Response) => {
     return { success: true }
 })
 
-export interface UserIndexMeta {
-    id: number
-    name: string
-    fullName: string
-    createdAt: Date
-    updatedAt: Date
-    isActive: boolean
-}
-
 apiRouter.get("/users.json", async (req: Request, res: Response) => {
     return {
         users: await User.find({
@@ -743,7 +734,7 @@ apiRouter.get("/variables.json", async req => {
     return { variables: rows, numTotalRows: numTotalRows }
 })
 
-export interface VariableSingleMeta {
+interface VariableSingleMeta {
     id: number
     name: string
     unit: string

--- a/adminSite/server/utils/authentication.tsx
+++ b/adminSite/server/utils/authentication.tsx
@@ -16,7 +16,7 @@ export interface Response extends express.Response {
     locals: { user: CurrentUser; session: Session }
 }
 
-export interface Session {
+interface Session {
     id: string
     expiryDate: Date
 }

--- a/algolia/searchClient.ts
+++ b/algolia/searchClient.ts
@@ -9,7 +9,7 @@ function getClient() {
     return algolia
 }
 
-export type PageHit = ArticleHit | CountryHit
+type PageHit = ArticleHit | CountryHit
 
 export interface CountryHit {
     objectID: string

--- a/charts/areaCharts/StackedAreaChart.tsx
+++ b/charts/areaCharts/StackedAreaChart.tsx
@@ -52,7 +52,7 @@ interface AreasProps extends React.SVGAttributes<SVGGElement> {
 const BLUR_COLOR = "#ddd"
 
 @observer
-export class Areas extends React.Component<AreasProps> {
+class Areas extends React.Component<AreasProps> {
     base: React.RefObject<SVGGElement> = React.createRef()
 
     @observable hoverIndex?: number

--- a/charts/color/ColorScale.ts
+++ b/charts/color/ColorScale.ts
@@ -22,7 +22,7 @@ import { BinningStrategy, getBinMaximums } from "./BinningStrategies"
 
 const NO_DATA_LABEL = "No data"
 
-export interface ColorScaleProps {
+interface ColorScaleProps {
     config: ColorScaleConfigProps
     sortedNumericValues: number[]
     categoricalValues: string[]

--- a/charts/color/ColorScaleBin.ts
+++ b/charts/color/ColorScaleBin.ts
@@ -1,6 +1,6 @@
 import { Color } from "charts/core/ChartConstants"
 
-export interface NumericBinProps {
+interface NumericBinProps {
     isFirst: boolean
     isOpenLeft: boolean
     isOpenRight: boolean
@@ -69,7 +69,7 @@ export class NumericBin {
     }
 }
 
-export interface CategoricalBinProps {
+interface CategoricalBinProps {
     index: number
     value: string
     color: Color

--- a/charts/controls/Timeline.tsx
+++ b/charts/controls/Timeline.tsx
@@ -623,7 +623,7 @@ export class Timeline extends React.Component<TimelineProps> {
     }
 }
 
-export const TimelineHandle = ({
+const TimelineHandle = ({
     type,
     offsetPercent,
     tooltipContent,

--- a/charts/controls/VerticalScrollContainer.tsx
+++ b/charts/controls/VerticalScrollContainer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react"
 import classnames from "classnames"
 
-export type VerticalScrollContainerProps = React.DetailedHTMLProps<
+type VerticalScrollContainerProps = React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
 > & {

--- a/charts/core/ChartLayout.tsx
+++ b/charts/core/ChartLayout.tsx
@@ -11,7 +11,7 @@ import {
 import { ControlsOverlayView } from "charts/controls/Controls"
 import { ChartView } from "charts/core/ChartView"
 
-export interface ChartLayoutProps {
+interface ChartLayoutProps {
     chart: ChartConfig
     chartView: ChartView
     bounds: Bounds

--- a/charts/dataTable/DataTable.tsx
+++ b/charts/dataTable/DataTable.tsx
@@ -25,19 +25,19 @@ import {
     Value
 } from "./DataTableTransform"
 
-export interface DataTableProps {
+interface DataTableProps {
     chart: ChartConfig
 }
 
-export interface DataTableState {
+interface DataTableState {
     sort: DataTableSortState
 }
 
 const ENTITY_DIM_INDEX = -1
 
-export type DimensionIndex = number
+type DimensionIndex = number
 
-export interface DataTableSortState {
+interface DataTableSortState {
     dimIndex: DimensionIndex
     columnKey: ColumnKey | undefined
     order: SortOrder

--- a/charts/dataTable/DataTableTransform.ts
+++ b/charts/dataTable/DataTableTransform.ts
@@ -32,13 +32,13 @@ type TargetYears = [number] | [number, number]
 
 // Dimensions
 
-export interface Dimension {
+interface Dimension {
     dimension: ChartDimension
     columns: DimensionColumn[]
     valueByEntity: Map<string, DimensionValue>
 }
 
-export interface DimensionColumn {
+interface DimensionColumn {
     key: SingleValueKey | RangeValueKey
     targetYear?: number
     targetYearMode?: TargetYearMode
@@ -61,7 +61,7 @@ export enum RangeValueKey {
     deltaRatio = "deltaRatio"
 }
 
-export type RangeValue = Record<RangeValueKey, Value | undefined>
+type RangeValue = Record<RangeValueKey, Value | undefined>
 
 export function isRangeValue(value: DimensionValue): value is RangeValue {
     return "start" in value
@@ -73,7 +73,7 @@ export enum SingleValueKey {
     single = "single"
 }
 
-export type SingleValue = Record<SingleValueKey, Value | undefined>
+type SingleValue = Record<SingleValueKey, Value | undefined>
 
 export function isSingleValue(value: DimensionValue): value is SingleValue {
     return "single" in value
@@ -87,7 +87,7 @@ export type ColumnKey = SingleValueKey | RangeValueKey
 
 // Data table types
 
-export interface Sortable {
+interface Sortable {
     sortable: boolean
 }
 

--- a/charts/mapCharts/MapColorLegendView.tsx
+++ b/charts/mapCharts/MapColorLegendView.tsx
@@ -13,7 +13,7 @@ import {
 
 const FOCUS_BORDER_COLOR = "#111"
 
-export interface MapColorLegendViewProps {
+interface MapColorLegendViewProps {
     legend: MapColorLegend
     onMouseOver: (d: ColorScaleBin) => void
     onMouseLeave: () => void

--- a/charts/mapCharts/WorldRegions.ts
+++ b/charts/mapCharts/WorldRegions.ts
@@ -3,7 +3,7 @@ import { MapProjection } from "./MapProjections"
 
 // The projections we currently offer are all world regions.
 // In the future this may change.
-export type WorldRegion = MapProjection
+type WorldRegion = MapProjection
 
 const worldRegionByEntity: Record<string, WorldRegion> = {
     Abkhazia: "Asia",

--- a/charts/slopeCharts/LabelledSlopes.tsx
+++ b/charts/slopeCharts/LabelledSlopes.tsx
@@ -282,7 +282,7 @@ class Slope extends React.Component<SlopeProps> {
     }
 }
 
-export interface LabelledSlopesProps {
+interface LabelledSlopesProps {
     bounds: Bounds
     data: SlopeChartSeries[]
     yDomain: [number | undefined, number | undefined]

--- a/charts/text/TextWrap.tsx
+++ b/charts/text/TextWrap.tsx
@@ -12,7 +12,7 @@ import * as React from "react"
 
 declare type FontSize = number
 
-export interface TextWrapProps {
+interface TextWrapProps {
     text: string
     maxWidth: number
     lineHeight?: number

--- a/charts/utils/Util.ts
+++ b/charts/utils/Util.ts
@@ -102,7 +102,6 @@ export {
     clone,
     reduce,
     noop,
-    round,
     toArray,
     throttle,
     has,
@@ -163,23 +162,6 @@ interface TouchListLike {
         clientX: number
         clientY: number
     }
-}
-
-export function getAbsoluteMouse(
-    event:
-        | { clientX: number; clientY: number }
-        | { targetTouches: TouchListLike }
-): Vector2 {
-    let clientX, clientY
-    if ((event as any).clientX != null) {
-        clientX = (event as any).clientX
-        clientY = (event as any).clientY
-    } else {
-        clientX = (event as any).targetTouches[0].clientX
-        clientY = (event as any).targetTouches[0].clientY
-    }
-
-    return new Vector2(clientX, clientY)
 }
 
 export function getRelativeMouse(
@@ -248,21 +230,6 @@ export function formatYear(year: number): string {
     }
 
     return year < 0 ? `${format(",.0f")(Math.abs(year))} BCE` : year.toString()
-}
-
-// Bind a "mobx component"
-// Still working out exactly how this pattern goes
-// export function component<T extends { [key: string]: any }>(current: T | undefined, klass: { new(): T }, props: Partial<T>): T {
-//     const instance = current || new klass()
-//     each(keys(props), (key: string) => {
-//         instance[key] = props[key]
-//     })
-//     return instance
-// }
-
-export function precisionRound(num: number, precision: number) {
-    const factor = Math.pow(10, precision)
-    return Math.round(num * factor) / factor
 }
 
 export function roundSigFig(num: number, sigfigs: number = 1) {
@@ -446,10 +413,6 @@ export function pointsToPath(points: Array<[number, number]>) {
         else path += `L${points[i][0]} ${points[i][1]}`
     }
     return path
-}
-
-export function keysOf<T, K extends keyof T>(obj: T): K[] {
-    return Object.keys(obj) as K[]
 }
 
 // Based on https://stackoverflow.com/a/30245398/1983739
@@ -762,7 +725,7 @@ const trimArray = (arr: any[]) => {
 export const anyToString = (value: any) =>
     value?.toString ? value.toString() : ""
 
-export const trimEmptyColumns = (grid: Grid): Grid => grid.map(trimArray)
+const trimEmptyColumns = (grid: Grid): Grid => grid.map(trimArray)
 export const trimGrid = (grid: Grid): Grid =>
     trimEmptyColumns(trimEmptyRows(grid))
 
@@ -858,11 +821,11 @@ export function insertMissingValuePlaceholders(
 // Scroll Helpers
 // Borrowed from: https://github.com/JedWatson/react-select/blob/32ad5c040b/packages/react-select/src/utils.js
 
-export function isDocumentElement(el: HTMLElement) {
+function isDocumentElement(el: HTMLElement) {
     return [document.documentElement, document.body].indexOf(el) > -1
 }
 
-export function scrollTo(el: HTMLElement, top: number): void {
+function scrollTo(el: HTMLElement, top: number): void {
     // with a scroll distance, we perform scroll on the element
     if (isDocumentElement(el)) {
         window.scrollTo(0, top)

--- a/deploy/queue.ts
+++ b/deploy/queue.ts
@@ -13,13 +13,13 @@ function identity(x: any) {
     return x
 }
 
-export interface IDeployQueueItem {
+interface IDeployQueueItem {
     authorName?: string
     authorEmail?: string
     message?: string
 }
 
-export async function readQueueContent(): Promise<string> {
+async function readQueueContent(): Promise<string> {
     const queueContent = await fs.readFile(DEPLOY_QUEUE_FILE_PATH, "utf8")
     // If any deploys didn't exit cleanly, DEPLOY_PENDING_FILE_PATH would exist.
     // Prepend that message to the current deploy.
@@ -38,7 +38,7 @@ export async function enqueueDeploy(item: IDeployQueueItem) {
     await fs.appendFile(DEPLOY_QUEUE_FILE_PATH, JSON.stringify(item) + "\n")
 }
 
-export async function eraseQueueContent() {
+async function eraseQueueContent() {
     await fs.truncate(DEPLOY_QUEUE_FILE_PATH, 0)
 }
 
@@ -46,7 +46,7 @@ export async function queueIsEmpty(): Promise<boolean> {
     return !(await readQueueContent())
 }
 
-export async function pullQueueContent(): Promise<string> {
+async function pullQueueContent(): Promise<string> {
     // Read line-delimited JSON
     const queueContent = await readQueueContent()
 
@@ -57,7 +57,7 @@ export async function pullQueueContent(): Promise<string> {
     return queueContent
 }
 
-export function parseQueueContent(content: string): IDeployQueueItem[] {
+function parseQueueContent(content: string): IDeployQueueItem[] {
     // Parse all lines in file as JSON
     return content
         .split("\n")
@@ -71,7 +71,7 @@ export function parseQueueContent(content: string): IDeployQueueItem[] {
         .filter(identity)
 }
 
-export function generateCommitMsg(queueItems: IDeployQueueItem[]): string {
+function generateCommitMsg(queueItems: IDeployQueueItem[]): string {
     const date: string = new Date().toISOString()
 
     const message: string = queueItems

--- a/explorer/admin/ExplorersListPage.tsx
+++ b/explorer/admin/ExplorersListPage.tsx
@@ -109,7 +109,7 @@ class ExplorerRow extends React.Component<{
 }
 
 @observer
-export class ExplorerList extends React.Component<{
+class ExplorerList extends React.Component<{
     explorers: ExplorerProgram[]
     searchHighlight?: (text: string) => any
     indexPage: ExplorersIndexPage

--- a/explorer/covidExplorer/CovidConstants.ts
+++ b/explorer/covidExplorer/CovidConstants.ts
@@ -3,7 +3,7 @@ import { ColumnSpec } from "owidTable/OwidTable"
 export const covidPageTitle = "Coronavirus Pandemic Data Explorer"
 export const covidDashboardSlug = "coronavirus-data-explorer"
 export const coronaOpenGraphImagePath = "coronavirus-data-explorer.png"
-export const coronaWordpressElementAttribute = "data-coronavirus-data-explorer"
+const coronaWordpressElementAttribute = "data-coronavirus-data-explorer"
 export const coronaDefaultView =
     "?zoomToSelection=true&time=2020-03-01..latest&country=MEX~IND~USA~ITA~BRA~GBR~FRA~ESP~PER&casesMetric=true&interval=smoothed&perCapita=true&smoothing=7&pickerMetric=total_deaths&pickerSort=desc"
 export const covidDataPath =

--- a/explorer/indicatorExplorer/ExploreView.tsx
+++ b/explorer/indicatorExplorer/ExploreView.tsx
@@ -20,7 +20,7 @@ import { DataTable } from "charts/dataTable/DataTable"
 import { Analytics } from "site/client/Analytics"
 import { UrlBinder } from "charts/utils/UrlBinder"
 
-export interface ChartTypeButton {
+interface ChartTypeButton {
     type: ExplorerChartType
     label: string
     icon: IconDefinition

--- a/explorer/indicatorExplorer/IndicatorDropdown.tsx
+++ b/explorer/indicatorExplorer/IndicatorDropdown.tsx
@@ -13,7 +13,7 @@ import { StoreEntry } from "./Store"
 import { asArray } from "utils/client/react-select"
 import { first } from "charts/utils/Util"
 
-export interface IndicatorDropdownProps {
+interface IndicatorDropdownProps {
     placeholder: string
     indicatorEntry: StoreEntry<Indicator> | null
     onChangeId: (id: number) => void

--- a/explorer/indicatorExplorer/Store.ts
+++ b/explorer/indicatorExplorer/Store.ts
@@ -14,7 +14,7 @@ export class StoreEntry<EntityType> {
     }
 }
 
-export interface StoreEntries<EntityType> {
+interface StoreEntries<EntityType> {
     [id: number]: StoreEntry<EntityType>
 }
 

--- a/owidTable/OwidTable.ts
+++ b/owidTable/OwidTable.ts
@@ -25,7 +25,7 @@ import { computed, action, observable } from "mobx"
 import { OwidSource } from "./OwidSource"
 import { EPOCH_DATE } from "settings"
 
-export declare type int = number
+declare type int = number
 export declare type year = int
 export declare type entityName = string
 export declare type entityCode = string


### PR DESCRIPTION
This commit removes ~78 "Exports" that were only being used internally.

During the cleanup refactor for MCMM it's helpful when it's fast to see what methods are only used internally in a file. In addition, I think this will help eslint find dead code with no-unused-variable.

I used this tool to find them: https://www.npmjs.com/package/ts-unused-exports

I did not do the `db`, `site`, or `utils` folders. I did this by hand, but perhaps there's an autofix tool to implement.

