### PR TITLE
CDE MultiMetric DataTable: Support Intervals

### DIFF
--- a/explorer/covidExplorer/CovidConstants.ts
+++ b/explorer/covidExplorer/CovidConstants.ts
@@ -58,6 +58,19 @@ export const intervalLabels: Map<IntervalOption, string> = new Map([
     ["biweeklyChange", "Biweekly Change"]
 ])
 
+export const smoothingByInterval: Map<
+    IntervalOption,
+    SmoothingOption
+> = new Map([
+    ["daily", 0],
+    ["weekly", 7],
+    ["total", 0],
+    ["smoothed", 7],
+    ["biweekly", 14],
+    ["weeklyChange", 7],
+    ["biweeklyChange", 14]
+])
+
 export declare type colorScaleOption = "continents" | "ptr" | "none"
 
 export declare type MetricKind =

--- a/explorer/covidExplorer/CovidConstants.ts
+++ b/explorer/covidExplorer/CovidConstants.ts
@@ -48,28 +48,20 @@ export const intervalOptions: IntervalOption[] = [
     "biweeklyChange"
 ]
 
-export const intervalLabels: Map<IntervalOption, string> = new Map([
-    ["daily", "New per day"],
-    ["weekly", "Weekly"],
-    ["total", "Cumulative"],
-    ["smoothed", "7-day rolling average"],
-    ["biweekly", "Biweekly"],
-    ["weeklyChange", "Weekly change"],
-    ["biweeklyChange", "Biweekly Change"]
-])
+export interface IntervalSpec {
+    label: string
+    smoothing: SmoothingOption
+}
 
-export const smoothingByInterval: Map<
-    IntervalOption,
-    SmoothingOption
-> = new Map([
-    ["daily", 0],
-    ["weekly", 7],
-    ["total", 0],
-    ["smoothed", 7],
-    ["biweekly", 14],
-    ["weeklyChange", 7],
-    ["biweeklyChange", 14]
-])
+export const intervalSpecs: { [key in IntervalOption]: IntervalSpec } = {
+    daily: { label: "New per day", smoothing: 0 },
+    weekly: { label: "Weekly", smoothing: 7 },
+    total: { label: "Cumulative", smoothing: 0 },
+    smoothed: { label: "7-day rolling average", smoothing: 7 },
+    biweekly: { label: "Biweekly", smoothing: 14 },
+    weeklyChange: { label: "Weekly change", smoothing: 7 },
+    biweeklyChange: { label: "Biweekly Change", smoothing: 14 }
+}
 
 export declare type colorScaleOption = "continents" | "ptr" | "none"
 

--- a/explorer/covidExplorer/CovidConstants.ts
+++ b/explorer/covidExplorer/CovidConstants.ts
@@ -166,16 +166,17 @@ export const metricLabels: { [key in MetricKind]: string } = {
     positive_test_rate: "Share of positive tests"
 }
 
-export const intervalsAvailable: Map<MetricKind, Set<IntervalOption>> = new Map(
-    [
-        ["cases", new Set(intervalOptions)],
-        ["deaths", new Set(intervalOptions)],
-        ["tests", new Set(["total", "smoothed", "daily"])],
-        ["case_fatality_rate", new Set(["total"])],
-        ["tests_per_case", new Set(["total", "smoothed"])],
-        ["positive_test_rate", new Set(["total", "smoothed"])]
-    ]
-)
+export const intervalsAvailableByMetric: Map<
+    MetricKind,
+    Set<IntervalOption>
+> = new Map([
+    ["cases", new Set(intervalOptions)],
+    ["deaths", new Set(intervalOptions)],
+    ["tests", new Set(["total", "smoothed", "daily"])],
+    ["case_fatality_rate", new Set(["total"])],
+    ["tests_per_case", new Set(["total", "smoothed"])],
+    ["positive_test_rate", new Set(["total", "smoothed"])]
+])
 
 // todo: auto import from covid repo.
 export const covidAnnotations = `location,date,cases_annotations,deaths_annotations

--- a/explorer/covidExplorer/CovidConstants.ts
+++ b/explorer/covidExplorer/CovidConstants.ts
@@ -48,6 +48,16 @@ export const intervalOptions: IntervalOption[] = [
     "biweeklyChange"
 ]
 
+export const intervalLabels: Map<IntervalOption, string> = new Map([
+    ["daily", "New per day"],
+    ["weekly", "Weekly"],
+    ["total", "Cumulative"],
+    ["smoothed", "7-day rolling average"],
+    ["biweekly", "Biweekly"],
+    ["weeklyChange", "Weekly change"],
+    ["biweeklyChange", "Biweekly Change"]
+])
+
 export declare type colorScaleOption = "continents" | "ptr" | "none"
 
 export declare type MetricKind =
@@ -155,6 +165,17 @@ export const metricLabels: { [key in MetricKind]: string } = {
     tests_per_case: "Tests per confirmed case",
     positive_test_rate: "Share of positive tests"
 }
+
+export const intervalsAvailable: Map<MetricKind, Set<IntervalOption>> = new Map(
+    [
+        ["cases", new Set(intervalOptions)],
+        ["deaths", new Set(intervalOptions)],
+        ["tests", new Set(["total", "smoothed", "daily"])],
+        ["case_fatality_rate", new Set(["total"])],
+        ["tests_per_case", new Set(["total", "smoothed"])],
+        ["positive_test_rate", new Set(["total", "smoothed"])]
+    ]
+)
 
 // todo: auto import from covid repo.
 export const covidAnnotations = `location,date,cases_annotations,deaths_annotations

--- a/explorer/covidExplorer/CovidExplorer.jsdom.test.tsx
+++ b/explorer/covidExplorer/CovidExplorer.jsdom.test.tsx
@@ -146,7 +146,7 @@ describe("When you try to create a multimetric Data Explorer", () => {
         })
     })
 
-    describe("It does update when", () => {
+    describe("It changes when", () => {
         test("'per capita' is enabled", () => {
             const params = ExplorerDataTableTest.defaultParams
             params.perCapita = true
@@ -161,6 +161,45 @@ describe("When you try to create a multimetric Data Explorer", () => {
                 "5.9",
                 "May 5 0.2"
             ])
+        })
+
+        describe("interval is changed", () => {
+            test("interval is set to daily", () => {
+                const params = ExplorerDataTableTest.defaultParams
+                params.interval = "daily"
+                const dataTableTester = new ExplorerDataTableTest(params)
+
+                expect(dataTableTester.bodyRow(1)).toEqual([
+                    "United States",
+                    "1.20 million",
+                    "23,841",
+                    "71,078",
+                    "2,144",
+                    "May 5 7.54 million",
+                    "May 5 258,954",
+                    "May 5 6",
+                    "5.9",
+                    "May 5 0.2"
+                ])
+            })
+
+            test("interval is set to weekly change", () => {
+                const params = ExplorerDataTableTest.defaultParams
+                params.interval = "weekly"
+                const dataTableTester = new ExplorerDataTableTest(params)
+
+                expect(dataTableTester.bodyRow(1)).toEqual([
+                    "United States",
+                    "1.20 million",
+                    "162,519.0",
+                    "71,078",
+                    "11,886.0",
+                    "May 5 7.54 million",
+                    "May 5 6",
+                    "5.9",
+                    "May 5 0.2"
+                ])
+            })
         })
     })
 })

--- a/explorer/covidExplorer/CovidExplorer.jsdom.test.tsx
+++ b/explorer/covidExplorer/CovidExplorer.jsdom.test.tsx
@@ -88,10 +88,7 @@ describe("When you try to create a multimetric Data Explorer", () => {
     it("renders correct table headers", () => {
         expect(dataTableTester.headers).toEqual([
             "Confirmed cases",
-            "Confirmed cases",
             "Confirmed deaths",
-            "Confirmed deaths",
-            "Tests",
             "Tests",
             "Tests per confirmed case",
             "Case fatality rate",
@@ -102,11 +99,8 @@ describe("When you try to create a multimetric Data Explorer", () => {
     const SECOND_ROW = [
         "United States",
         "1.20 million",
-        "23,841",
         "71,078",
-        "2,144",
         "May 5 7.54 million",
-        "May 5 258,954",
         "May 5 6",
         "5.9",
         "May 5 0.2"
@@ -128,8 +122,6 @@ describe("When you try to create a multimetric Data Explorer", () => {
         test("table headers show only the metrics you select", () => {
             expect(dataTableTester.headers).toEqual([
                 "Confirmed cases",
-                "Confirmed cases",
-                "Confirmed deaths",
                 "Confirmed deaths",
                 "Tests per confirmed case"
             ])
@@ -163,11 +155,8 @@ describe("When you try to create a multimetric Data Explorer", () => {
             expect(dataTableTester.bodyRow(1)).toEqual([
                 "United States",
                 "602.24 million",
-                "11.92 million",
                 "35.54 million",
-                "1.07 million",
                 "May 5 3.77 million",
-                "May 5 129,477.00",
                 "May 5 6",
                 "5.9",
                 "May 5 0.2"

--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -59,7 +59,8 @@ import {
     metricPickerColumnSpecs,
     covidCsvColumnSlug,
     intervalLabels,
-    intervalsAvailableByMetric
+    intervalsAvailableByMetric,
+    smoothingByInterval
 } from "./CovidConstants"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
@@ -1158,7 +1159,7 @@ export class CovidExplorer extends React.Component<{
                 ? perCapitaDivisorByMetric(metric)
                 : 1,
             interval,
-            interval === "smoothed" ? 7 : 0
+            smoothingByInterval.get(interval)
         )
 
         const column = this.chart.table.columnsBySlug.get(colSlug)
@@ -1173,6 +1174,10 @@ export class CovidExplorer extends React.Component<{
                     metricLabels[metric] +
                     (isCountMetric(metric) ? this.perCapitaTitle(metric) : ""),
                 unit: intervalLabels.get(interval),
+                shortUnit:
+                    (interval === "weeklyChange" ||
+                        interval === "biweeklyChange") &&
+                    "%",
                 tableDisplay: column?.display.tableDisplay
             }
         } as ChartDimensionInterface
@@ -1224,8 +1229,9 @@ export class CovidExplorer extends React.Component<{
                     intervalsAvailableByMetric.get(metric)?.has(params.interval)
                 ) {
                     dataTableParams.interval = params.interval
-                    dataTableParams.smoothing =
-                        dataTableParams.interval === "smoothed" ? 7 : 0
+                    dataTableParams.smoothing = smoothingByInterval.get(
+                        params.interval
+                    )!
                 }
             }
 

--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -58,9 +58,8 @@ import {
     metricLabels,
     metricPickerColumnSpecs,
     covidCsvColumnSlug,
-    intervalLabels,
-    intervalsAvailableByMetric,
-    smoothingByInterval
+    intervalSpecs,
+    intervalsAvailableByMetric
 } from "./CovidConstants"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
@@ -260,37 +259,37 @@ export class CovidExplorer extends React.Component<{
         const options: DropdownOption[] = [
             {
                 available: true,
-                label: intervalLabels.get("total")!,
+                label: intervalSpecs.total.label,
                 value: "total"
             },
             {
                 available: available.smoothed,
-                label: intervalLabels.get("smoothed")!,
+                label: intervalSpecs.smoothed.label,
                 value: "smoothed"
             },
             {
                 available: available.daily,
-                label: intervalLabels.get("daily")!,
+                label: intervalSpecs.daily.label,
                 value: "daily"
             },
             {
                 available: available.weekly,
-                label: intervalLabels.get("weekly")!,
+                label: intervalSpecs.weekly.label,
                 value: "weekly"
             },
             {
                 available: available.weekly,
-                label: intervalLabels.get("weeklyChange")!,
+                label: intervalSpecs.weeklyChange.label,
                 value: "weeklyChange"
             },
             {
                 available: available.weekly,
-                label: intervalLabels.get("biweekly")!,
+                label: intervalSpecs.biweekly.label,
                 value: "biweekly"
             },
             {
                 available: available.weekly,
-                label: intervalLabels.get("biweeklyChange")!,
+                label: intervalSpecs.biweeklyChange.label,
                 value: "biweeklyChange"
             }
         ]
@@ -1159,7 +1158,7 @@ export class CovidExplorer extends React.Component<{
                 ? perCapitaDivisorByMetric(metric)
                 : 1,
             interval,
-            smoothingByInterval.get(interval)
+            intervalSpecs[interval].smoothing
         )
 
         const column = this.chart.table.columnsBySlug.get(colSlug)
@@ -1173,7 +1172,7 @@ export class CovidExplorer extends React.Component<{
                 name:
                     metricLabels[metric] +
                     (isCountMetric(metric) ? this.perCapitaTitle(metric) : ""),
-                unit: intervalLabels.get(interval),
+                unit: intervalSpecs[interval].label,
                 shortUnit:
                     (interval === "weeklyChange" ||
                         interval === "biweeklyChange") &&
@@ -1229,9 +1228,8 @@ export class CovidExplorer extends React.Component<{
                     intervalsAvailableByMetric.get(metric)?.has(params.interval)
                 ) {
                     dataTableParams.interval = params.interval
-                    dataTableParams.smoothing = smoothingByInterval.get(
-                        params.interval
-                    )!
+                    dataTableParams.smoothing =
+                        intervalSpecs[params.interval].smoothing
                 }
             }
 

--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -59,7 +59,7 @@ import {
     metricPickerColumnSpecs,
     covidCsvColumnSlug,
     intervalLabels,
-    intervalsAvailable
+    intervalsAvailableByMetric
 } from "./CovidConstants"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
@@ -1189,7 +1189,7 @@ export class CovidExplorer extends React.Component<{
                 if (
                     isCountMetric(metric) &&
                     params.interval !== "total" &&
-                    intervalsAvailable.get(metric)?.has(params.interval)
+                    intervalsAvailableByMetric.get(metric)?.has(params.interval)
                 ) {
                     // add intervals column
                     specs.push(
@@ -1219,7 +1219,7 @@ export class CovidExplorer extends React.Component<{
             if (
                 isCountMetric(metric) &&
                 params.interval != "total" &&
-                intervalsAvailable.get(metric)?.has(params.interval)
+                intervalsAvailableByMetric.get(metric)?.has(params.interval)
             ) {
                 dataTableParams.perCapita = params.perCapita
                 covidExplorerTable.initRequestedColumns(dataTableParams)

--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -1216,17 +1216,17 @@ export class CovidExplorer extends React.Component<{
             dataTableParams.interval = "total"
             dataTableParams.smoothing = 0
             dataTableParams.perCapita = false
-            if (
-                isCountMetric(metric) &&
-                params.interval != "total" &&
-                intervalsAvailableByMetric.get(metric)?.has(params.interval)
-            ) {
+            if (isCountMetric(metric)) {
                 dataTableParams.perCapita = params.perCapita
                 covidExplorerTable.initRequestedColumns(dataTableParams)
-                // generate interval columns too
-                dataTableParams.interval = params.interval
-                dataTableParams.smoothing =
-                    dataTableParams.interval === "smoothed" ? 7 : 0
+                if (
+                    params.interval != "total" &&
+                    intervalsAvailableByMetric.get(metric)?.has(params.interval)
+                ) {
+                    dataTableParams.interval = params.interval
+                    dataTableParams.smoothing =
+                        dataTableParams.interval === "smoothed" ? 7 : 0
+                }
             }
 
             covidExplorerTable.initRequestedColumns(dataTableParams)

--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -1225,7 +1225,7 @@ export class CovidExplorer extends React.Component<{
                 dataTableParams.perCapita = params.perCapita
                 covidExplorerTable.initRequestedColumns(dataTableParams)
                 if (
-                    params.interval != "total" &&
+                    params.interval !== "total" &&
                     intervalsAvailableByMetric.get(metric)?.has(params.interval)
                 ) {
                     dataTableParams.interval = params.interval

--- a/explorer/covidExplorer/CovidParams.ts
+++ b/explorer/covidExplorer/CovidParams.ts
@@ -31,6 +31,12 @@ const legacyTimeToInterval = (
     return undefined
 }
 
+/**
+ * CovidQueryParams is what the user entered and CovidConstrainedParams is a valid
+ * state derived from that. Code that reads params should always read from
+ * constrainedParams and code that writes should always write to the params.
+ */
+
 export class CovidQueryParams {
     // Todo: in hindsight these 6 metrics should have been something like "yColumn". May want to switch to that and translate these
     // for back compat.

--- a/explorer/covidExplorer/CovidParams.ts
+++ b/explorer/covidExplorer/CovidParams.ts
@@ -348,6 +348,17 @@ export class CovidConstrainedQueryParams extends CovidQueryParams {
     constructor(queryString: string) {
         super(queryString)
 
+        // Ensure there is always a metric
+        const hasMetric = [
+            this.cfrMetric,
+            this.casesMetric,
+            this.deathsMetric,
+            this.testsMetric,
+            this.testsPerCaseMetric,
+            this.positiveTestRate
+        ].some(i => i)
+        if (!hasMetric) this.casesMetric = true
+
         const available = this.available
 
         if (this.perCapita && !available.perCapita) this.perCapita = false
@@ -376,17 +387,6 @@ export class CovidConstrainedQueryParams extends CovidQueryParams {
 
         if (this.isWeekly) this.smoothing = 7
         if (this.isBiweekly) this.smoothing = 14
-
-        // Ensure there is always a metric
-        const hasMetric = [
-            this.cfrMetric,
-            this.casesMetric,
-            this.deathsMetric,
-            this.testsMetric,
-            this.testsPerCaseMetric,
-            this.positiveTestRate
-        ].some(i => i)
-        if (!hasMetric) this.casesMetric = true
     }
 
     get rollingMultiplier() {

--- a/explorer/covidExplorer/CovidParams.ts
+++ b/explorer/covidExplorer/CovidParams.ts
@@ -154,17 +154,6 @@ export class CovidQueryParams {
         this.sizeColumn = params.sizeColumn
         this.colorScale = params.colorScale as colorScaleOption
         this.chartType = params.chartType as ChartTypeName
-
-        // Ensure there is always a metric
-        const hasMetric = [
-            this.cfrMetric,
-            this.casesMetric,
-            this.deathsMetric,
-            this.testsMetric,
-            this.testsPerCaseMetric,
-            this.positiveTestRate
-        ].some(i => i)
-        if (!hasMetric) this.casesMetric = true
     }
 
     constructor(queryString: string) {
@@ -387,6 +376,17 @@ export class CovidConstrainedQueryParams extends CovidQueryParams {
 
         if (this.isWeekly) this.smoothing = 7
         if (this.isBiweekly) this.smoothing = 14
+
+        // Ensure there is always a metric
+        const hasMetric = [
+            this.cfrMetric,
+            this.casesMetric,
+            this.deathsMetric,
+            this.testsMetric,
+            this.testsPerCaseMetric,
+            this.positiveTestRate
+        ].some(i => i)
+        if (!hasMetric) this.casesMetric = true
     }
 
     get rollingMultiplier() {

--- a/explorer/covidExplorer/CovidParams.ts
+++ b/explorer/covidExplorer/CovidParams.ts
@@ -154,6 +154,17 @@ export class CovidQueryParams {
         this.sizeColumn = params.sizeColumn
         this.colorScale = params.colorScale as colorScaleOption
         this.chartType = params.chartType as ChartTypeName
+
+        // Ensure there is always a metric
+        const hasMetric = [
+            this.cfrMetric,
+            this.casesMetric,
+            this.deathsMetric,
+            this.testsMetric,
+            this.testsPerCaseMetric,
+            this.positiveTestRate
+        ].some(i => i)
+        if (!hasMetric) this.casesMetric = true
     }
 
     constructor(queryString: string) {
@@ -376,17 +387,6 @@ export class CovidConstrainedQueryParams extends CovidQueryParams {
 
         if (this.isWeekly) this.smoothing = 7
         if (this.isBiweekly) this.smoothing = 14
-
-        // Ensure there is always a metric
-        const hasMetric = [
-            this.cfrMetric,
-            this.casesMetric,
-            this.deathsMetric,
-            this.testsMetric,
-            this.testsPerCaseMetric,
-            this.positiveTestRate
-        ].some(i => i)
-        if (!hasMetric) this.casesMetric = true
     }
 
     get rollingMultiplier() {


### PR DESCRIPTION
This PR allows the CDE "frequency" selector to change columns in the MultriMetric view.

If our explorers migrate into "chart-switchers", I hope to throw out all MultiMetric code and just build a chart with the desired view.

**[Live at Nightingale](https://nightingale-owid.netlify.app/coronavirus-data-explorer?tab=table&time=latest&country=&casesMetric=true&interval=weekly&smoothing=0&pickerMetric=location&pickerSort=asc&tableMetrics=cases~deaths~tests~tests_per_case~case_fatality_rate~positive_test_rate).**