### PR TITLE
Dev: Energy Explorer params fix.

### DIFF
--- a/charts/core/ChartUrl.jsdom.test.ts
+++ b/charts/core/ChartUrl.jsdom.test.ts
@@ -36,6 +36,18 @@ describe(ChartUrl, () => {
         ).toEqual(undefined)
     })
 
+    describe("if a user sets a query param but dropUnchangedParams is false, do not delete the param even if it is a default", () => {
+        const chart = new ChartConfig(
+            {
+                xAxis: { scaleType: ScaleType.linear, canChangeScaleType: true }
+            } as ChartScript,
+            { queryStr: "scaleType=linear" }
+        )
+        expect(chart.url.params.xScale).toEqual(undefined)
+        chart.url.dropUnchangedParams = false
+        expect(chart.url.params.xScale).toEqual(ScaleType.linear)
+    })
+
     describe("time parameter", () => {
         describe("with years", () => {
             const tests: {

--- a/explorer/client/SwitcherExplorer.tsx
+++ b/explorer/client/SwitcherExplorer.tsx
@@ -49,21 +49,21 @@ export class SwitcherExplorer extends React.Component<{
         )
     }
 
-    urlBinding?: UrlBinder
+    private urlBinding?: UrlBinder
     private lastId = 0
 
     @observable private _chart?: ChartConfig = undefined
     @observable availableEntities: string[] = []
 
-    get explorerRuntime() {
+    private get explorerRuntime() {
         return this.props.program.explorerRuntime
     }
 
-    get switcherRuntime() {
+    private get switcherRuntime() {
         return this.props.program.switcherRuntime
     }
 
-    bindToWindow() {
+    private bindToWindow() {
         const url = new ExtendedChartUrl(this._chart!.url, [
             this.switcherRuntime,
             this.explorerRuntime
@@ -91,21 +91,23 @@ export class SwitcherExplorer extends React.Component<{
         })
     }
 
-    @action.bound switchChart() {
+    @action.bound private switchChart() {
         const newId: number = this.switcherRuntime.chartId
         if (newId === this.lastId) return
 
-        const params = this._chart
+        const currentParams = this._chart
             ? this._chart.url.params
             : strToQueryParams(this.props.program.queryString)
+
         const props = this.props.chartConfigs.get(newId) || new ChartScript()
 
         this._chart = new ChartConfig(props)
-        this._chart.url.populateFromQueryParams(params)
+        this._chart.url.dropUnchangedParams = false
         this._chart.hideEntityControls =
             !this.explorerRuntime.hideControls && !this.isEmbed
-
         if (this.props.bindToWindow) this.bindToWindow()
+
+        this._chart.url.populateFromQueryParams(currentParams)
 
         // disposer?
         when(
@@ -122,10 +124,6 @@ export class SwitcherExplorer extends React.Component<{
         )
 
         this.lastId = newId
-    }
-
-    private isSelected(entityName: string) {
-        return this.explorerRuntime.selectedEntityNames.has(entityName)
     }
 
     @action.bound private updateChartSelection() {
@@ -147,7 +145,7 @@ export class SwitcherExplorer extends React.Component<{
         this._chart!.props.selectedData = selectedData
     }
 
-    get panels() {
+    private get panels() {
         return this.switcherRuntime.groups.map(group => (
             <ExplorerControlPanel
                 key={group.title}
@@ -165,7 +163,7 @@ export class SwitcherExplorer extends React.Component<{
         ))
     }
 
-    get header() {
+    private get header() {
         return (
             <>
                 <div></div>
@@ -181,7 +179,7 @@ export class SwitcherExplorer extends React.Component<{
     }
 
     //todo
-    get isEmbed() {
+    private get isEmbed() {
         return false
     }
 


### PR DESCRIPTION
In the Switcher Explorer when you change charts, if the new chart has default params that match the user's current params, those will be dropped from the query string.

With this new flag that behavior can be turned off and user settings are preserved during chart switching.

Before:
![2020-09-01 18 15 21](https://user-images.githubusercontent.com/74692/91931467-386eab00-ec7f-11ea-9268-c27946da6eae.gif)

After:
![2020-09-01 18 15 43](https://user-images.githubusercontent.com/74692/91931462-3573ba80-ec7f-11ea-8927-a7f73478ed98.gif)
