### PR TITLE
More space for charts on mobile

### DIFF
--- a/deploy/testcheck.sh
+++ b/deploy/testcheck.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
-# Run pretty-quick in git working directories (e.g. dev) and prettier in others (e.g. yarn deploy live -r)
-if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+# Run pretty-quick in full working directories (e.g. dev) and prettier in others (e.g. CI, "yarn deploy live -r")
+if ! $(git rev-parse --is-shallow-repository) > /dev/null 2>&1; then
   PRETTIFY_CMD="yarn prettify:check"
 else
   PRETTIFY_CMD="yarn prettify-all:check"

--- a/deploy/testcheck.sh
+++ b/deploy/testcheck.sh
@@ -1,7 +1,10 @@
 #!/bin/bash -e
 
 # Run pretty-quick in full working directories (e.g. dev) and prettier in others (e.g. CI, "yarn deploy live -r")
-if ! $(git rev-parse --is-shallow-repository) > /dev/null 2>&1; then
+# Not using "git rev-parse --is-inside-work-tree" to avoid printing a potentially confusing fatal error when ran outside
+# a working copy in "yarn deploy live -r" scenarios.
+# if $(git rev-parse --is-inside-work-tree) > /dev/null 2>&1 && ! $(git rev-parse --is-shallow-repository) > /dev/null 2>&1; then
+if [ -d .git ] && ! $(git rev-parse --is-shallow-repository) > /dev/null 2>&1; then
   PRETTIFY_CMD="yarn prettify:check"
 else
   PRETTIFY_CMD="yarn prettify-all:check"

--- a/site/client/blocks/AdditionalInformation/additional-information.scss
+++ b/site/client/blocks/AdditionalInformation/additional-information.scss
@@ -46,8 +46,11 @@
     }
 
     &[data-variation="full-width"] {
-        background-color: $primary-color-100;
+        @include sm-only {
+            @include full-width;
+        }
         padding: 0 $padding-x-sm;
+        background-color: $primary-color-100;
         @include md-up {
             margin-left: -#{$padding-x-md};
             margin-right: -#{$padding-x-md};

--- a/site/client/css/content.scss
+++ b/site/client/css/content.scss
@@ -105,6 +105,13 @@
     height: 575px;
 }
 
+@include sm-only {
+    .article-content figure[data-grapher-src] {
+        width: 100vw;
+        margin-left: -$padding-x-sm;
+    }
+}
+
 figure[data-explorer-src] {
     position: relative;
 }

--- a/site/client/css/content.scss
+++ b/site/client/css/content.scss
@@ -107,8 +107,7 @@
 
 @include sm-only {
     .article-content figure[data-grapher-src] {
-        width: 100vw;
-        margin-left: -$padding-x-sm;
+        @include full-width;
     }
 }
 

--- a/site/client/css/mixins.scss
+++ b/site/client/css/mixins.scss
@@ -178,6 +178,11 @@
     }
 }
 
+@mixin full-width {
+    width: 100vw;
+    margin-left: calc(50% - 50vw);
+}
+
 @mixin posts-list($posts-num) {
     margin-bottom: $vertical-spacing * 2;
     list-style-type: none;

--- a/site/client/css/page.scss
+++ b/site/client/css/page.scss
@@ -21,10 +21,12 @@
 
     &.with-sidebar {
         @include xlg-down {
-            .offset-header,
-            .offset-content,
-            .offset-subnavigation {
-                padding-left: $sidebar-closed-drawer-width;
+            @include md-up {
+                .offset-header,
+                .offset-content,
+                .offset-subnavigation {
+                    padding-left: $sidebar-closed-drawer-width;
+                }
             }
         }
         @include xxlg-up {

--- a/site/client/css/pages/countryPicker.scss
+++ b/site/client/css/pages/countryPicker.scss
@@ -252,5 +252,6 @@ $chart-border-radius: 2px;
 
     .CovidExplorerFigure {
         min-height: 480px;
+        @include full-width;
     }
 }

--- a/site/client/css/sidebar.scss
+++ b/site/client/css/sidebar.scss
@@ -67,6 +67,9 @@
         bottom: 0;
         z-index: $zindex-sidebar;
         margin-left: -($sidebar-content-width + 2 * $padding-x-md) + $sidebar-closed-drawer-width;
+        @include sm-only {
+            margin-left: -($sidebar-content-width + 2 * $padding-x-md);
+        }
         transition: margin 300ms ease;
 
         .toggle-toc {
@@ -75,9 +78,15 @@
             bottom: 0;
             padding: $vertical-spacing 0;
             right: -$sidebar-toggle-width / 2;
+            @include sm-only {
+                right: -$sidebar-toggle-width - $padding-x-sm/2;
+            }
             button {
                 position: sticky;
                 top: $vertical-spacing;
+                @include sm-only {
+                    top: $padding-x-sm/2;
+                }
                 width: $sidebar-toggle-width;
                 height: $sidebar-toggle-width;
                 background-color: $primary-color;
@@ -115,6 +124,7 @@
             }
         }
     }
+
     @include xxlg-up {
         position: relative;
         height: 100%;

--- a/site/client/owid.scss
+++ b/site/client/owid.scss
@@ -720,15 +720,15 @@ div.owid-presentations li:nth-of-type(1) a:hover {
                 $padding-x-md;
         }
     }
-    width: 100vw;
+    @include full-width;
     padding-top: 2.5rem;
     padding-bottom: 2.5rem;
+    margin-bottom: 2rem;
     @include md-up {
         padding-top: 4 * $vertical-spacing;
         padding-bottom: 4 * $vertical-spacing;
+        margin-bottom: 5rem;
     }
-    margin-left: calc(50% - 50vw);
-    margin-bottom: 5rem;
     background-color: $primary-color-200;
 
     @include xxlg-up {

--- a/site/client/owid.scss
+++ b/site/client/owid.scss
@@ -790,10 +790,12 @@ div.owid-presentations li:nth-of-type(1) a:hover {
 }
 
 .with-sidebar .section-heading {
-    position: relative;
-    width: calc(100vw - #{$sidebar-closed-drawer-width});
-    left: $sidebar-closed-drawer-width;
-    margin-left: calc(50% - 50vw - #{$sidebar-closed-drawer-width / 2});
+    @include md-up {
+        position: relative;
+        width: calc(100vw - #{$sidebar-closed-drawer-width});
+        left: $sidebar-closed-drawer-width;
+        margin-left: calc(50% - 50vw - #{$sidebar-closed-drawer-width / 2});
+    }
 
     @include xxlg-up {
         width: calc(100vw - #{$sidebar-content-width + 2 * $padding-x-md});


### PR DESCRIPTION
<img width="828" alt="Screenshot 2020-09-02 at 18 13 16" src="https://user-images.githubusercontent.com/13406362/92010306-f199b780-ed49-11ea-89ec-6fd50a4928a8.png">

See http://localhost:3030/forests

Also applies to "All charts" blocks and explorer views.