### PR TITLE
Use post template when previewing unpublished posts

### DIFF
--- a/adminSite/server/adminRouter.tsx
+++ b/adminSite/server/adminRouter.tsx
@@ -19,7 +19,7 @@ import { Dataset } from "db/model/Dataset"
 
 import { User } from "db/model/User"
 import { UserInvitation } from "db/model/UserInvitation"
-import { renderPageById } from "site/server/siteBaking"
+import { renderPreview } from "site/server/siteBaking"
 import { ENV } from "settings"
 import { addExplorerAdminRoutes } from "explorer/admin/ExplorerBaker"
 
@@ -216,7 +216,7 @@ adminRouter.get("/datasets/:datasetId/downloadZip", async (req, res) => {
 adminRouter.get("/posts/preview/:postId", async (req, res) => {
     const postId = expectInt(req.params.postId)
 
-    res.send(await renderPageById(postId, true))
+    res.send(await renderPreview(postId, true))
 })
 
 addExplorerAdminRoutes(adminRouter)

--- a/adminSite/server/adminRouter.tsx
+++ b/adminSite/server/adminRouter.tsx
@@ -216,7 +216,7 @@ adminRouter.get("/datasets/:datasetId/downloadZip", async (req, res) => {
 adminRouter.get("/posts/preview/:postId", async (req, res) => {
     const postId = expectInt(req.params.postId)
 
-    res.send(await renderPreview(postId, true))
+    res.send(await renderPreview(postId))
 })
 
 addExplorerAdminRoutes(adminRouter)

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -495,6 +495,13 @@ export async function getLatestPostRevision(id: number): Promise<any> {
         authors_name: postApi.authors_name,
         type: postApi.type,
         path: postApi.path,
+        // revision.date holds the modified date and not the published date
+        // (visible in the admin sidebar), so it is not being used. The
+        // published date will only be correctly displayed when previewing
+        // unpublished posts. When previewing published posts, the current
+        // published date will be displayed, regardless of what is shown in the
+        // admin.
+        date: postApi.date,
         postId: id
     }
 }

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -456,16 +456,6 @@ export async function getPostType(search: number | string): Promise<string> {
     return type
 }
 
-export async function getPost(id: number): Promise<any> {
-    const type = await getPostType(id)
-    const response = await apiQuery(
-        `${WP_API_ENDPOINT}/${getEndpointSlugFromType(type)}/${id}`
-    )
-    const post = await response.json()
-
-    return post
-}
-
 export async function getPostBySlug(slug: string): Promise<any[]> {
     const type = await getPostType(slug)
     const response = await apiQuery(
@@ -481,19 +471,32 @@ export async function getPostBySlug(slug: string): Promise<any[]> {
     return postApiArray[0]
 }
 
+// the /revisions endpoint does not send back all the metadata required for
+// the proper rendering of the post (e.g. authors), hence the double request.
 export async function getLatestPostRevision(id: number): Promise<any> {
     const type = await getPostType(id)
-    const response = await apiQuery(
-        `${WP_API_ENDPOINT}/${getEndpointSlugFromType(
-            type
-        )}/${id}/revisions?per_page=1`,
+    const endpointSlug = getEndpointSlugFromType(type)
+
+    let response = await apiQuery(`${WP_API_ENDPOINT}/${endpointSlug}/${id}`, {
+        isAuthenticated: true
+    })
+    const postApi = await response.json()
+
+    response = await apiQuery(
+        `${WP_API_ENDPOINT}/${endpointSlug}/${id}/revisions?per_page=1`,
         {
             isAuthenticated: true
         }
     )
-    const revisions = await response.json()
+    const revision = (await response.json())[0]
 
-    return revisions[0]
+    return {
+        ...revision,
+        authors_name: postApi.authors_name,
+        type: postApi.type,
+        path: postApi.path,
+        postId: id
+    }
 }
 
 export async function getRelatedCharts(

--- a/site/server/siteBaking.tsx
+++ b/site/server/siteBaking.tsx
@@ -128,21 +128,8 @@ export async function renderPageBySlug(slug: string) {
     return renderPage(postApi)
 }
 
-export async function renderPageById(
-    id: number,
-    isPreview?: boolean
-): Promise<string> {
-    let postApi = await wpdb.getPost(id)
-    if (isPreview) {
-        const revision = await wpdb.getLatestPostRevision(id)
-        postApi = {
-            ...revision,
-            authors_name: postApi.authors_name,
-            type: postApi.type,
-            path: postApi.path,
-            postId: id
-        }
-    }
+export async function renderPreview(postId: number): Promise<string> {
+    const postApi = await wpdb.getLatestPostRevision(postId)
     return renderPage(postApi)
 }
 


### PR DESCRIPTION
Unpublished posts were wrongly using the article template when being previewed.