### PR TITLE
"undefined" decimal separator with d3 formatting

### DIFF
--- a/charts/utils/Util.ts
+++ b/charts/utils/Util.ts
@@ -169,6 +169,7 @@ interface TouchListLike {
 // For that reason we change that back to a plain old hyphen.
 // See https://observablehq.com/@d3/d3v6-migration-guide#minus
 const d3Format = formatLocale({
+    decimal: ".",
     thousands: ",",
     grouping: [3],
     minus: "-",


### PR DESCRIPTION
Returned "24undefined50" instead of "24.50"