### PR TITLE
Deploy status page in Admin

### DIFF
--- a/adminSite/client/AdminApp.tsx
+++ b/adminSite/client/AdminApp.tsx
@@ -21,6 +21,7 @@ import { ImportPage } from "./ImportPage"
 import { NotFoundPage } from "./NotFoundPage"
 import { PostEditorPage } from "./PostEditorPage"
 import { NewsletterPage } from "./NewsletterPage"
+import { DeployStatusPage } from "./DeployStatusPage"
 import {
     BrowserRouter as Router,
     Route,
@@ -249,6 +250,11 @@ export class AdminApp extends React.Component<{ admin: Admin }> {
                                 exact
                                 path="/test"
                                 component={TestIndexPage}
+                            />
+                            <Route
+                                exact
+                                path="/deploys"
+                                component={DeployStatusPage}
                             />
                             <Route
                                 exact

--- a/adminSite/client/AdminSidebar.tsx
+++ b/adminSite/client/AdminSidebar.tsx
@@ -14,6 +14,7 @@ import { faEye } from "@fortawesome/free-solid-svg-icons/faEye"
 import { faCoffee } from "@fortawesome/free-solid-svg-icons/faCoffee"
 import { faNewspaper } from "@fortawesome/free-solid-svg-icons/faNewspaper"
 import { faBook } from "@fortawesome/free-solid-svg-icons/faBook"
+import { faSatelliteDish } from "@fortawesome/free-solid-svg-icons/faSatelliteDish"
 
 export const AdminSidebar = () => (
     <aside className="AdminSidebar">
@@ -87,6 +88,9 @@ export const AdminSidebar = () => (
             </li>
             <li className="header">UTILITIES</li>
             <li>
+                <Link to="/deploys">
+                    <FontAwesomeIcon icon={faSatelliteDish} /> Deploy status
+                </Link>
                 <Link to="/newsletter">
                     <FontAwesomeIcon icon={faNewspaper} /> Newsletter
                 </Link>

--- a/adminSite/client/DeployStatusPage.tsx
+++ b/adminSite/client/DeployStatusPage.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { observer } from "mobx-react"
 import { observable, runInAction } from "mobx"
+import { format } from "timeago.js"
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faCheckCircle } from "@fortawesome/free-solid-svg-icons/faCheckCircle"
@@ -28,6 +29,7 @@ export class DeployStatusPage extends React.Component {
                                     <th>Status</th>
                                     <th>Note</th>
                                     <th>Author</th>
+                                    <th>Time</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -44,6 +46,15 @@ export class DeployStatusPage extends React.Component {
                                             </td>
                                             <td className="cell-author">
                                                 {change.authorName}
+                                            </td>
+                                            <td className="cell-time">
+                                                {change.timeISOString
+                                                    ? format(
+                                                          Date.parse(
+                                                              change.timeISOString
+                                                          )
+                                                      )
+                                                    : ""}
                                             </td>
                                         </tr>
                                     ))

--- a/adminSite/client/DeployStatusPage.tsx
+++ b/adminSite/client/DeployStatusPage.tsx
@@ -2,6 +2,9 @@ import * as React from "react"
 import { observer } from "mobx-react"
 import { observable, runInAction } from "mobx"
 
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faCheckCircle } from "@fortawesome/free-solid-svg-icons/faCheckCircle"
+
 import { AdminLayout } from "./AdminLayout"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext"
 import { Deploy } from "deploy/types"
@@ -18,34 +21,45 @@ export class DeployStatusPage extends React.Component {
             <AdminLayout title="Deploys">
                 <main className="DeploysPage">
                     <h1>Deploy status</h1>
-                    <table className="DeploysTable">
-                        <thead>
-                            <tr>
-                                <th>Status</th>
-                                <th>Note</th>
-                                <th>Author</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {this.deploys.map(deploy =>
-                                deploy.changes.map((change, i) => (
-                                    <tr key={`${deploy.status}-${i}`}>
-                                        <td
-                                            className={`cell-status cell-status--${deploy.status}`}
-                                        >
-                                            {deploy.status}
-                                        </td>
-                                        <td className="cell-message">
-                                            {change.message}
-                                        </td>
-                                        <td className="cell-author">
-                                            {change.authorName}
-                                        </td>
-                                    </tr>
-                                ))
-                            )}
-                        </tbody>
-                    </table>
+                    {this.deploys.length > 0 ? (
+                        <table className="DeploysTable">
+                            <thead>
+                                <tr>
+                                    <th>Status</th>
+                                    <th>Note</th>
+                                    <th>Author</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {this.deploys.map(deploy =>
+                                    deploy.changes.map((change, i) => (
+                                        <tr key={`${deploy.status}-${i}`}>
+                                            <td
+                                                className={`cell-status cell-status--${deploy.status}`}
+                                            >
+                                                {deploy.status}
+                                            </td>
+                                            <td className="cell-message">
+                                                {change.message}
+                                            </td>
+                                            <td className="cell-author">
+                                                {change.authorName}
+                                            </td>
+                                        </tr>
+                                    ))
+                                )}
+                            </tbody>
+                        </table>
+                    ) : (
+                        <div className="all-published-notice">
+                            <p>
+                                <span className="icon">
+                                    <FontAwesomeIcon icon={faCheckCircle} />
+                                </span>{" "}
+                                All changes are successfully published.
+                            </p>
+                        </div>
+                    )}
                     <p>
                         Past deploys can be found in the{" "}
                         <a

--- a/adminSite/client/DeployStatusPage.tsx
+++ b/adminSite/client/DeployStatusPage.tsx
@@ -33,7 +33,7 @@ export class DeployStatusPage extends React.Component {
                                 </tr>
                             </thead>
                             <tbody>
-                                {this.deploys.map(deploy =>
+                                {this.deploys.map((deploy) =>
                                     deploy.changes.map((change, i) => (
                                         <tr key={`${deploy.status}-${i}`}>
                                             <td

--- a/adminSite/client/DeployStatusPage.tsx
+++ b/adminSite/client/DeployStatusPage.tsx
@@ -1,0 +1,80 @@
+import * as React from "react"
+import { observer } from "mobx-react"
+import { observable, runInAction } from "mobx"
+
+import { AdminLayout } from "./AdminLayout"
+import { AdminAppContext, AdminAppContextType } from "./AdminAppContext"
+import { Deploy } from "deploy/types"
+
+@observer
+export class DeployStatusPage extends React.Component {
+    static contextType = AdminAppContext
+    context!: AdminAppContextType
+
+    @observable deploys: Deploy[] = []
+
+    render() {
+        return (
+            <AdminLayout title="Deploys">
+                <main className="DeploysPage">
+                    <h1>Deploy status</h1>
+                    <table className="DeploysTable">
+                        <thead>
+                            <tr>
+                                <th>Status</th>
+                                <th>Note</th>
+                                <th>Author</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {this.deploys.map(deploy =>
+                                deploy.changes.map((change, i) => (
+                                    <tr key={`${deploy.status}-${i}`}>
+                                        <td
+                                            className={`cell-status cell-status--${deploy.status}`}
+                                        >
+                                            {deploy.status}
+                                        </td>
+                                        <td className="cell-message">
+                                            {change.message}
+                                        </td>
+                                        <td className="cell-author">
+                                            {change.authorName}
+                                        </td>
+                                    </tr>
+                                ))
+                            )}
+                        </tbody>
+                    </table>
+                    <p>
+                        Past deploys can be found in the{" "}
+                        <a
+                            href="https://github.com/owid/owid-static/commits/master"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            <strong>owid-static</strong> GitHub repository
+                        </a>
+                        .
+                    </p>
+                </main>
+            </AdminLayout>
+        )
+    }
+
+    async getData() {
+        const { admin } = this.context
+        if (admin.currentRequests.length > 0) return
+
+        const json = (await admin.getJSON("/api/deploys.json")) as {
+            deploys: Deploy[]
+        }
+        runInAction(() => {
+            this.deploys = json.deploys
+        })
+    }
+
+    componentDidMount() {
+        this.getData()
+    }
+}

--- a/adminSite/client/admin.scss
+++ b/adminSite/client/admin.scss
@@ -838,7 +838,8 @@ main:not(.ChartEditorPage) {
         font-weight: 700;
         color: #333;
     }
-    .cell-author {
+    .cell-author,
+    .cell-time {
         font-weight: 400;
         color: #777;
     }

--- a/adminSite/client/admin.scss
+++ b/adminSite/client/admin.scss
@@ -788,3 +788,43 @@ main:not(.ChartEditorPage) {
         color: #007bff;
     }
 }
+
+.DeploysTable {
+    width: 100%;
+    max-width: 60rem;
+    margin: 1.5rem 0;
+
+    tr {
+        border-bottom: 1px solid #eee;
+    }
+
+    th,
+    td {
+        padding: 0.625rem;
+    }
+
+    th {
+        font-size: 12px;
+        font-weight: 400;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: #999;
+    }
+
+    .cell-status {
+        font-weight: 700;
+        color: #999;
+        text-transform: capitalize;
+    }
+    .cell-status--pending {
+        color: #c36d00;
+    }
+    .cell-message {
+        font-weight: 700;
+        color: #333;
+    }
+    .cell-author {
+        font-weight: 400;
+        color: #777;
+    }
+}

--- a/adminSite/client/admin.scss
+++ b/adminSite/client/admin.scss
@@ -789,10 +789,25 @@ main:not(.ChartEditorPage) {
     }
 }
 
+.DeploysPage {
+    .all-published-notice {
+        font-size: 18px;
+        font-weight: 700;
+        color: green;
+        margin: 10px 0;
+
+        .icon {
+            font-size: 150%;
+            vertical-align: middle;
+            margin-right: 6px;
+        }
+    }
+}
+
 .DeploysTable {
     width: 100%;
-    max-width: 60rem;
-    margin: 1.5rem 0;
+    max-width: 1000px;
+    margin: 30px 0;
 
     tr {
         border-bottom: 1px solid #eee;
@@ -800,7 +815,7 @@ main:not(.ChartEditorPage) {
 
     th,
     td {
-        padding: 0.625rem;
+        padding: 10px;
     }
 
     th {

--- a/adminSite/server/apiRouter.ts
+++ b/adminSite/server/apiRouter.ts
@@ -54,6 +54,7 @@ async function triggerStaticBuild(user: CurrentUser, commitMessage: string) {
     }
 
     enqueueDeploy({
+        timeISOString: new Date().toISOString(),
         authorName: user.fullName,
         authorEmail: user.email,
         message: commitMessage,

--- a/adminSite/server/apiRouter.ts
+++ b/adminSite/server/apiRouter.ts
@@ -36,7 +36,7 @@ import { log } from "utils/server/log"
 import { denormalizeLatestCountryData } from "site/server/countryProfiles"
 import { BAKED_BASE_URL } from "settings"
 import { PostReference, ChartRedirect } from "adminSite/client/ChartEditor"
-import { enqueueDeploy } from "deploy/queue"
+import { enqueueDeploy, getDeploys } from "deploy/queue"
 import { FunctionalRouter } from "./utils/FunctionalRouter"
 import { addExplorerApiRoutes } from "explorer/admin/ExplorerBaker"
 import { addGitCmsApiRoutes } from "gitCms/server"
@@ -1662,6 +1662,12 @@ apiRouter.get("/sources/:sourceId.json", async (req: Request) => {
     )
 
     return { source: source }
+})
+
+apiRouter.get("/deploys.json", async () => {
+    return {
+        deploys: await getDeploys()
+    }
 })
 
 addExplorerApiRoutes(apiRouter)

--- a/adminSite/server/apiRouter.ts
+++ b/adminSite/server/apiRouter.ts
@@ -36,7 +36,7 @@ import { log } from "utils/server/log"
 import { denormalizeLatestCountryData } from "site/server/countryProfiles"
 import { BAKED_BASE_URL } from "settings"
 import { PostReference, ChartRedirect } from "adminSite/client/ChartEditor"
-import { enqueueDeploy, getDeploys } from "deploy/queue"
+import { enqueueChange, getDeploys } from "deploy/queue"
 import { FunctionalRouter } from "./utils/FunctionalRouter"
 import { addExplorerApiRoutes } from "explorer/admin/ExplorerBaker"
 import { addGitCmsApiRoutes } from "gitCms/server"
@@ -53,7 +53,7 @@ async function triggerStaticBuild(user: CurrentUser, commitMessage: string) {
         return
     }
 
-    enqueueDeploy({
+    enqueueChange({
         timeISOString: new Date().toISOString(),
         authorName: user.fullName,
         authorEmail: user.email,
@@ -1667,7 +1667,7 @@ apiRouter.get("/sources/:sourceId.json", async (req: Request) => {
 
 apiRouter.get("/deploys.json", async () => {
     return {
-        deploys: await getDeploys()
+        deploys: await getDeploys(),
     }
 })
 

--- a/db/postUpdatedHook.ts
+++ b/db/postUpdatedHook.ts
@@ -18,6 +18,7 @@ async function main(
 
     if (BAKE_ON_CHANGE) {
         await enqueueDeploy({
+            timeISOString: new Date().toISOString(),
             authorName: name,
             authorEmail: email,
             message: slug ? `Updating ${slug}` : `Deleting ${postSlug}`,

--- a/db/postUpdatedHook.ts
+++ b/db/postUpdatedHook.ts
@@ -3,7 +3,7 @@
 import { syncPostToGrapher } from "db/model/Post"
 import parseArgs from "minimist"
 import { BAKE_ON_CHANGE } from "serverSettings"
-import { enqueueDeploy } from "deploy/queue"
+import { enqueueChange } from "deploy/queue"
 import { exit } from "db/cleanup"
 const argv = parseArgs(process.argv.slice(2))
 
@@ -17,7 +17,7 @@ async function main(
     const slug = await syncPostToGrapher(postId)
 
     if (BAKE_ON_CHANGE) {
-        await enqueueDeploy({
+        await enqueueChange({
             timeISOString: new Date().toISOString(),
             authorName: name,
             authorEmail: email,

--- a/deploy/deploy.ts
+++ b/deploy/deploy.ts
@@ -2,7 +2,53 @@ import fs from "fs-extra"
 
 import { SiteBaker } from "site/server/SiteBaker"
 import { log } from "utils/server/log"
+import {
+    queueIsEmpty,
+    readQueuedAndPendingFiles,
+    clearQueueFile,
+    deletePendingFile,
+    writePendingFile,
+    parseQueueContent,
+} from "./queue"
+import { DeployChange } from "./types"
 
+async function defaultCommitMessage(): Promise<string> {
+    let message = "Automated update"
+
+    // In the deploy.sh script, we write the current git rev to 'public/head.txt'
+    // and want to include it in the deploy commit message
+    try {
+        const sha = await fs.readFile("public/head.txt", "utf8")
+        message += `\nowid/owid-grapher@${sha}`
+    } catch (err) {
+        log.warn(err)
+    }
+
+    return message
+}
+
+/**
+ * Initiate a deploy, without any checks. Throws error on failure.
+ */
+async function deploy(message?: string, email?: string, name?: string) {
+    message = message ?? (await defaultCommitMessage())
+
+    const baker = new SiteBaker({})
+
+    try {
+        await baker.bakeAll()
+        await baker.deploy(message, email, name)
+    } catch (err) {
+        log.error(err)
+        baker.end()
+        throw err
+    }
+}
+
+/**
+ * Try to initiate a deploy and then terminate the baker, allowing a clean exit.
+ * Used in CLI.
+ */
 export async function tryDeployAndTerminate(
     message?: string,
     email?: string,
@@ -22,31 +68,59 @@ export async function tryDeployAndTerminate(
     }
 }
 
-export async function deploy(message?: string, email?: string, name?: string) {
-    message = message ?? (await defaultCommitMessage())
+function generateCommitMsg(queueItems: DeployChange[]): string {
+    const date: string = new Date().toISOString()
 
-    const baker = new SiteBaker({})
+    const message: string = queueItems
+        .filter((item) => item.message)
+        .map((item) => item.message)
+        .join("\n")
 
-    try {
-        await baker.bakeAll()
-        await baker.deploy(message, email, name)
-    } catch (err) {
-        log.error(err)
-        throw err
-    }
+    const coauthors: string = queueItems
+        .filter((item) => item.authorName)
+        .map((item) => {
+            return `Co-authored-by: ${item.authorName} <${item.authorEmail}>`
+        })
+        .join("\n")
+
+    return `Deploy ${date}\n${message}\n\n\n${coauthors}`
 }
 
-async function defaultCommitMessage(): Promise<string> {
-    let message = "Automated update"
+const MAX_SUCCESSIVE_FAILURES = 2
 
-    // In the deploy.sh script, we write the current git rev to 'public/head.txt'
-    // and want to include it in the deploy commit message
-    try {
-        const sha = await fs.readFile("public/head.txt", "utf8")
-        message += `\nowid/owid-grapher@${sha}`
-    } catch (err) {
-        log.warn(err)
+/** Whether a deploy is currently running */
+let deploying: boolean = false
+
+/**
+ * Initiate deploy if no other deploy is currently pending, and there are changes
+ * in the queue.
+ * If there is a deploy pending, another one will be automatically triggered at
+ * the end of the current one, as long as there are changes in the queue.
+ * If there are no changes in the queue, a deploy won't be initiated.
+ */
+export async function deployIfQueueIsNotEmpty() {
+    if (!deploying) {
+        deploying = true
+        let failures = 0
+        while (!(await queueIsEmpty()) && failures < MAX_SUCCESSIVE_FAILURES) {
+            const deployContent = await readQueuedAndPendingFiles()
+            // Truncate file immediately. Ideally this would be an atomic action, otherwise it's
+            // possible that another process writes to this file in the meantime...
+            await clearQueueFile()
+            // Write to `.deploying` file to be able to recover the deploy message
+            // in case of failure.
+            await writePendingFile(deployContent)
+            const message = generateCommitMsg(parseQueueContent(deployContent))
+            console.log(`Deploying site...\n---\n${message}\n---`)
+            try {
+                await deploy(message)
+                await deletePendingFile
+            } catch (err) {
+                failures++
+                // The error is already sent to Slack inside the deploy() function.
+                // The deploy will be retried unless we've reached MAX_SUCCESSIVE_FAILURES.
+            }
+        }
+        deploying = false
     }
-
-    return message
 }

--- a/deploy/queue.test.ts
+++ b/deploy/queue.test.ts
@@ -1,0 +1,92 @@
+#! /usr/bin/env yarn jest
+
+import fs from "fs-extra"
+
+import { parseQueueContent, getDeploys } from "./queue"
+import {
+    DEPLOY_QUEUE_FILE_PATH,
+    DEPLOY_PENDING_FILE_PATH,
+} from "serverSettings"
+
+describe("deploy queue", () => {
+    describe(parseQueueContent, () => {
+        it("parses newline delimited JSON objects", async () => {
+            const output = parseQueueContent(
+                [
+                    `{"authorName": "Tester", "message": "Updated chart test-chart-please-ignore"}`,
+                    `{"authorName": "Tester", "message": "something one"}`,
+                    ``, // empty line will be ignored
+                    `invalid json`, // invalid json will be ignored
+                    `{"authorName": "Tester", "message": "something two"}`,
+                ].join("\n")
+            )
+            expect(output[0].authorName).toEqual("Tester")
+            expect(output[0].message).toEqual(
+                "Updated chart test-chart-please-ignore"
+            )
+            expect(output[1].message).toEqual("something one")
+            expect(output[2].message).toEqual("something two")
+        })
+    })
+
+    describe(getDeploys, () => {
+        it("is empty when nothing is in the queues", async () => {
+            jest.spyOn(fs, "readFile").mockImplementation(
+                (async (): Promise<string> => {
+                    return ``
+                }) as any
+            )
+            expect(await getDeploys()).toEqual([])
+        })
+
+        it("parses queued deploy file", async () => {
+            jest.spyOn(fs, "readFile").mockImplementation(
+                (async (path: string): Promise<string> => {
+                    if (path === DEPLOY_QUEUE_FILE_PATH)
+                        return [
+                            `{"message": "test1"}`,
+                            `{"message": "test2"}`,
+                        ].join("\n")
+                    if (path === DEPLOY_PENDING_FILE_PATH) return ``
+                    return ``
+                }) as any
+            )
+            expect(await getDeploys()).toEqual([
+                {
+                    status: "queued",
+                    changes: [{ message: "test2" }, { message: "test1" }],
+                },
+            ])
+        })
+
+        it("parses pending deploy file", async () => {
+            jest.spyOn(fs, "pathExists").mockImplementation(async () => true)
+            jest.spyOn(fs, "readFile").mockImplementation(
+                (async (path: string): Promise<string> => {
+                    if (path === DEPLOY_QUEUE_FILE_PATH)
+                        return [
+                            `{"message": "test1"}`,
+                            `{"message": "test2"}`,
+                        ].join("\n")
+                    if (path === DEPLOY_PENDING_FILE_PATH)
+                        return [
+                            `{"message": "test3"}`,
+                            `{"message": "test4"}`,
+                        ].join("\n")
+                    return ``
+                }) as any
+            )
+
+            expect(await getDeploys()).toEqual([
+                {
+                    status: "queued",
+                    changes: [{ message: "test2" }, { message: "test1" }],
+                },
+                {
+                    status: "pending",
+                    changes: [{ message: "test4" }, { message: "test3" }],
+                },
+            ])
+        })
+    })
+})

--- a/deploy/queue.ts
+++ b/deploy/queue.ts
@@ -8,26 +8,25 @@ import { DeployChange, Deploy, DeployStatus } from "./types"
 
 const MAX_SUCCESSIVE_FAILURES = 2
 
-let deploying = false
+/** Whether a deploy is currently running (global variable) */
+let deploying: boolean = false
 
-function identity(x: any) {
-    return x
-}
+// File manipulation
 
-async function readQueueContent(): Promise<string> {
+async function readQueuedFile(): Promise<string> {
     return await fs.readFile(DEPLOY_QUEUE_FILE_PATH, "utf8")
 }
 
-async function readPendingContent(): Promise<string | undefined> {
-    if (fs.existsSync(DEPLOY_PENDING_FILE_PATH)) {
+async function readPendingFile(): Promise<string | undefined> {
+    if (await fs.pathExists(DEPLOY_PENDING_FILE_PATH)) {
         return await fs.readFile(DEPLOY_PENDING_FILE_PATH, "utf8")
     }
     return undefined
 }
 
-async function readQueueAndPendingContent(): Promise<string> {
-    const queueContent = await readQueueContent()
-    const pendingContent = await readPendingContent()
+async function readQueuedAndPendingFiles(): Promise<string> {
+    const queueContent = await readQueuedFile()
+    const pendingContent = await readPendingFile()
     // If any deploys didn't exit cleanly, DEPLOY_PENDING_FILE_PATH would exist.
     // Prepend that message to the current deploy.
     if (pendingContent) {
@@ -37,51 +36,21 @@ async function readQueueAndPendingContent(): Promise<string> {
     }
 }
 
-export async function getDeploys(): Promise<Deploy[]> {
-    const [queueContent, pendingContent] = await Promise.all([
-        readQueueContent(),
-        readPendingContent()
-    ])
-    const deploys: Deploy[] = []
-    if (queueContent) {
-        deploys.push({
-            status: DeployStatus.queued,
-            changes: parseQueueContent(queueContent)
-        })
-    }
-    if (pendingContent) {
-        deploys.push({
-            status: DeployStatus.pending,
-            changes: parseQueueContent(pendingContent)
-        })
-    }
-    return deploys
-}
-
 export async function enqueueDeploy(item: DeployChange) {
     await fs.appendFile(DEPLOY_QUEUE_FILE_PATH, JSON.stringify(item) + "\n")
 }
 
-async function eraseQueueContent() {
+async function clearQueueFile() {
     await fs.truncate(DEPLOY_QUEUE_FILE_PATH, 0)
 }
 
+// Parsing queue content
+
 export async function queueIsEmpty(): Promise<boolean> {
-    return !(await readQueueAndPendingContent())
+    return !(await readQueuedAndPendingFiles())
 }
 
-async function pullQueueContent(): Promise<string> {
-    // Read line-delimited JSON
-    const queueContent = await readQueueAndPendingContent()
-
-    // Truncate file immediately. It's still somewhat possible that another process
-    // writes to this file in the meantime...
-    await eraseQueueContent()
-
-    return queueContent
-}
-
-function parseQueueContent(content: string): DeployChange[] {
+function parseContent(content: string): DeployChange[] {
     // Parse all lines in file as JSON
     return content
         .split("\n")
@@ -92,7 +61,7 @@ function parseQueueContent(content: string): DeployChange[] {
                 return null
             }
         })
-        .filter(identity)
+        .filter(x => x)
 }
 
 function generateCommitMsg(queueItems: DeployChange[]): string {
@@ -113,23 +82,47 @@ function generateCommitMsg(queueItems: DeployChange[]): string {
     return `Deploy ${date}\n${message}\n\n\n${coauthors}`
 }
 
+export async function getDeploys(): Promise<Deploy[]> {
+    const [queueContent, pendingContent] = await Promise.all([
+        readQueuedFile(),
+        readPendingFile()
+    ])
+    const deploys: Deploy[] = []
+    if (queueContent) {
+        deploys.push({
+            status: DeployStatus.queued,
+            changes: parseContent(queueContent)
+        })
+    }
+    if (pendingContent) {
+        deploys.push({
+            status: DeployStatus.pending,
+            changes: parseContent(pendingContent)
+        })
+    }
+    return deploys
+}
+
 export async function triggerDeploy() {
     if (!deploying) {
         deploying = true
         let failures = 0
         while (!(await queueIsEmpty()) && failures < MAX_SUCCESSIVE_FAILURES) {
-            const deployContent = await pullQueueContent()
+            const deployContent = await readQueuedAndPendingFiles()
+            // Truncate file immediately. Ideally this would be an atomic action, otherwise it's
+            // possible that another process writes to this file in the meantime...
+            await clearQueueFile()
             // Write to `.deploying` file to be able to recover the deploy message
             // in case of failure.
             await fs.writeFile(DEPLOY_PENDING_FILE_PATH, deployContent)
-            const message = generateCommitMsg(parseQueueContent(deployContent))
+            const message = generateCommitMsg(parseContent(deployContent))
             console.log(`Deploying site...\n---\n${message}\n---`)
             try {
                 await deploy(message)
                 await fs.unlink(DEPLOY_PENDING_FILE_PATH)
             } catch (err) {
                 failures++
-                // The error will be logged and sent to Slack.
+                // The error is already sent to Slack inside the deploy() function.
                 // The deploy will be retried unless we've reached MAX_SUCCESSIVE_FAILURES.
             }
         }

--- a/deploy/queue.ts
+++ b/deploy/queue.ts
@@ -91,13 +91,16 @@ export async function getDeploys(): Promise<Deploy[]> {
     if (queueContent) {
         deploys.push({
             status: DeployStatus.queued,
-            changes: parseContent(queueContent)
+            // Changes are always appended. Reversing them means the latest changes are first
+            // (which is what we want in the UI).
+            // We can't sort by time because the presence of "time" is not guaranteed.
+            changes: parseContent(queueContent).reverse()
         })
     }
     if (pendingContent) {
         deploys.push({
             status: DeployStatus.pending,
-            changes: parseContent(pendingContent)
+            changes: parseContent(pendingContent).reverse()
         })
     }
     return deploys

--- a/deploy/queue.ts
+++ b/deploy/queue.ts
@@ -3,13 +3,7 @@ import {
     DEPLOY_QUEUE_FILE_PATH,
     DEPLOY_PENDING_FILE_PATH,
 } from "serverSettings"
-import { deploy } from "./deploy"
 import { DeployChange, Deploy, DeployStatus } from "./types"
-
-const MAX_SUCCESSIVE_FAILURES = 2
-
-/** Whether a deploy is currently running (global variable) */
-let deploying: boolean = false
 
 // File manipulation
 
@@ -24,7 +18,7 @@ async function readPendingFile(): Promise<string | undefined> {
     return undefined
 }
 
-async function readQueuedAndPendingFiles(): Promise<string> {
+export async function readQueuedAndPendingFiles(): Promise<string> {
     const queueContent = await readQueuedFile()
     const pendingContent = await readPendingFile()
     // If any deploys didn't exit cleanly, DEPLOY_PENDING_FILE_PATH would exist.
@@ -36,12 +30,20 @@ async function readQueuedAndPendingFiles(): Promise<string> {
     }
 }
 
-export async function enqueueDeploy(item: DeployChange) {
+export async function enqueueChange(item: DeployChange) {
     await fs.appendFile(DEPLOY_QUEUE_FILE_PATH, JSON.stringify(item) + "\n")
 }
 
-async function clearQueueFile() {
+export async function clearQueueFile() {
     await fs.truncate(DEPLOY_QUEUE_FILE_PATH, 0)
+}
+
+export async function writePendingFile(content: string) {
+    await fs.writeFile(DEPLOY_PENDING_FILE_PATH, content)
+}
+
+export async function deletePendingFile() {
+    await fs.unlink(DEPLOY_PENDING_FILE_PATH)
 }
 
 // Parsing queue content
@@ -50,7 +52,7 @@ export async function queueIsEmpty(): Promise<boolean> {
     return !(await readQueuedAndPendingFiles())
 }
 
-function parseContent(content: string): DeployChange[] {
+export function parseQueueContent(content: string): DeployChange[] {
     // Parse all lines in file as JSON
     return content
         .split("\n")
@@ -61,31 +63,13 @@ function parseContent(content: string): DeployChange[] {
                 return null
             }
         })
-        .filter(x => x)
-}
-
-function generateCommitMsg(queueItems: DeployChange[]): string {
-    const date: string = new Date().toISOString()
-
-    const message: string = queueItems
-        .filter((item) => item.message)
-        .map((item) => item.message)
-        .join("\n")
-
-    const coauthors: string = queueItems
-        .filter((item) => item.authorName)
-        .map((item) => {
-            return `Co-authored-by: ${item.authorName} <${item.authorEmail}>`
-        })
-        .join("\n")
-
-    return `Deploy ${date}\n${message}\n\n\n${coauthors}`
+        .filter((x) => x)
 }
 
 export async function getDeploys(): Promise<Deploy[]> {
     const [queueContent, pendingContent] = await Promise.all([
         readQueuedFile(),
-        readPendingFile()
+        readPendingFile(),
     ])
     const deploys: Deploy[] = []
     if (queueContent) {
@@ -94,41 +78,14 @@ export async function getDeploys(): Promise<Deploy[]> {
             // Changes are always appended. Reversing them means the latest changes are first
             // (which is what we want in the UI).
             // We can't sort by time because the presence of "time" is not guaranteed.
-            changes: parseContent(queueContent).reverse()
+            changes: parseQueueContent(queueContent).reverse(),
         })
     }
     if (pendingContent) {
         deploys.push({
             status: DeployStatus.pending,
-            changes: parseContent(pendingContent).reverse()
+            changes: parseQueueContent(pendingContent).reverse(),
         })
     }
     return deploys
-}
-
-export async function triggerDeploy() {
-    if (!deploying) {
-        deploying = true
-        let failures = 0
-        while (!(await queueIsEmpty()) && failures < MAX_SUCCESSIVE_FAILURES) {
-            const deployContent = await readQueuedAndPendingFiles()
-            // Truncate file immediately. Ideally this would be an atomic action, otherwise it's
-            // possible that another process writes to this file in the meantime...
-            await clearQueueFile()
-            // Write to `.deploying` file to be able to recover the deploy message
-            // in case of failure.
-            await fs.writeFile(DEPLOY_PENDING_FILE_PATH, deployContent)
-            const message = generateCommitMsg(parseContent(deployContent))
-            console.log(`Deploying site...\n---\n${message}\n---`)
-            try {
-                await deploy(message)
-                await fs.unlink(DEPLOY_PENDING_FILE_PATH)
-            } catch (err) {
-                failures++
-                // The error is already sent to Slack inside the deploy() function.
-                // The deploy will be retried unless we've reached MAX_SUCCESSIVE_FAILURES.
-            }
-        }
-        deploying = false
-    }
 }

--- a/deploy/types.ts
+++ b/deploy/types.ts
@@ -1,6 +1,6 @@
 export enum DeployStatus {
     queued = "queued",
-    pending = "pending"
+    pending = "pending",
     // done = "done"
 }
 

--- a/deploy/types.ts
+++ b/deploy/types.ts
@@ -1,0 +1,16 @@
+export enum DeployStatus {
+    queued = "queued",
+    pending = "pending"
+    // done = "done"
+}
+
+export interface DeployChange {
+    authorName?: string
+    authorEmail?: string
+    message?: string
+}
+
+export interface Deploy {
+    status: DeployStatus
+    changes: DeployChange[]
+}

--- a/deploy/types.ts
+++ b/deploy/types.ts
@@ -5,6 +5,7 @@ export enum DeployStatus {
 }
 
 export interface DeployChange {
+    timeISOString?: string
     authorName?: string
     authorEmail?: string
     message?: string

--- a/deploy/watch.ts
+++ b/deploy/watch.ts
@@ -1,18 +1,16 @@
 import * as fs from "fs-extra"
 import { DEPLOY_QUEUE_FILE_PATH } from "serverSettings"
-import { triggerDeploy, queueIsEmpty } from "./queue"
+import { deployIfQueueIsNotEmpty } from "./deploy"
 
 async function main() {
     // Listen for file changes
     fs.watchFile(DEPLOY_QUEUE_FILE_PATH, () => {
         // Start deploy after 10 seconds in order to avoid the quick successive
         // deploys triggered by Wordpress.
-        setTimeout(triggerDeploy, 10 * 1000)
+        setTimeout(deployIfQueueIsNotEmpty, 10 * 1000)
     })
 
-    if (!(await queueIsEmpty())) {
-        triggerDeploy()
-    }
+    deployIfQueueIsNotEmpty()
 }
 
 main()

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,7 @@ process.env.EXPLORER = true
 const common = {
     preset: "ts-jest",
     moduleNameMapper: {
-        "^(adminSite|site|grapher|explorer|owidTable|utils|db|settings|test)/(.*)$":
+        "^(adminSite|site|grapher|explorer|owidTable|utils|db|deploy|settings|test)/(.*)$":
             "<rootDir>/$1/$2",
         "^settings$": "<rootDir>/settings",
         "^serverSettings$": "<rootDir>/serverSettings",


### PR DESCRIPTION
As described on Notion issue: https://www.notion.so/owid/Create-deploy-status-page-in-Grapher-Admin-2e38fc965531418db65234297056c3d4

http://localhost:3030/admin/deploys

<img width="1440" alt="Screenshot 2020-09-07 at 17 51 25" src="https://user-images.githubusercontent.com/1308115/92407858-c3461e80-f133-11ea-98c2-c0669b30ea0a.png">

It helps have an easily accessible page for authors (and developers) to check whether their changes have been deployed. It's awkward to bug a colleague about this – authors would usually wait quite some time before reaching out to us.

This is just a first step – exposing the information that's already in the `.queue` and `.pending` files. Ideally, it would be **visible on the chart page itself** what the deploy status of the chart is – whether it's already published, pending or waiting.

We could also add more deploy info on this page, e.g. what commit is the admin server running currently, pull and parse commits from GitHub, etc.