### PR TITLE
change prettier config: set `trailingComma` and `allowParens` to default

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,21 +6,21 @@ module.exports = {
         "prettier/react",
         "prettier/@typescript-eslint",
         "plugin:import/recommended",
-        "plugin:import/typescript"
+        "plugin:import/typescript",
     ],
     parser: "@typescript-eslint/parser",
     parserOptions: {
         ecmaFeatures: {
-            jsx: true
+            jsx: true,
         },
         project: "./tsconfig.json",
         ecmaVersion: 2018,
-        sourceType: "module"
+        sourceType: "module",
     },
     overrides: [
         {
-            files: ["*.ts", "*.tsx"]
-        }
+            files: ["*.ts", "*.tsx"],
+        },
     ],
     rules: {
         // These rules are only preliminary to ease the migration from tslint, many of them might make sense to have enabled!
@@ -42,8 +42,8 @@ module.exports = {
         "no-restricted-imports": [
             "warn",
             {
-                patterns: ["../*"]
-            }
+                patterns: ["../*"],
+            },
         ],
         "no-console": ["warn", { allow: ["warn", "error"] }],
         "no-var": "off",
@@ -53,12 +53,12 @@ module.exports = {
         "react/jsx-no-target-blank": "off",
         "react/no-render-return-value": "off",
         "react/no-unescaped-entities": "off",
-        "react/prop-types": "off"
+        "react/prop-types": "off",
     },
     settings: {
         react: {
-            version: "detect"
+            version: "detect",
         },
-        "import/resolver": "webpack"
-    }
+        "import/resolver": "webpack",
+    },
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ package.json
 *.mock.json
 covidChartAndVariableMeta.json
 .storybook/build
+coverage

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -4,8 +4,8 @@ module.exports = {
         {
             name: "@storybook/addon-essentials",
             options: {
-                backgrounds: false
-            }
-        }
-    ]
+                backgrounds: false,
+            },
+        },
+    ],
 }

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,6 +3,6 @@ import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport"
 
 addParameters({
     viewport: {
-        viewports: INITIAL_VIEWPORTS
-    }
+        viewports: INITIAL_VIEWPORTS,
+    },
 })

--- a/.storybook/webpack.config.ts
+++ b/.storybook/webpack.config.ts
@@ -14,20 +14,20 @@ module.exports = ({ config }: { config: any }) => {
                     loader: "sass-loader",
                     options: {
                         sassOptions: {
-                            outputStyle: "expanded" // Needed so autoprefixer comments are included
-                        }
-                    }
-                }
-            ]
-        }
+                            outputStyle: "expanded", // Needed so autoprefixer comments are included
+                        },
+                    },
+                },
+            ],
+        },
     ])
     config.resolve.plugins = [
         new TsconfigPathsPlugin({
-            configFile: path.join(__dirname, "../tsconfig.client.json")
-        })
+            configFile: path.join(__dirname, "../tsconfig.client.json"),
+        }),
     ]
     config.plugins = config.plugins.concat([
-        new MiniCssExtractPlugin({ filename: "css/[name].css" })
+        new MiniCssExtractPlugin({ filename: "css/[name].css" }),
     ])
 
     return config

--- a/adminSite/client/Admin.tsx
+++ b/adminSite/client/Admin.tsx
@@ -76,7 +76,7 @@ export class Admin {
             method: method,
             credentials: "same-origin",
             headers: headers,
-            body: method !== "GET" ? data : undefined
+            body: method !== "GET" ? data : undefined,
         })
     }
 
@@ -121,7 +121,7 @@ export class Admin {
                         `Failed to ${method} ${targetPath}` +
                         (response ? ` (${response.status})` : ""),
                     content: err?.message || text || err,
-                    isFatal: response?.status !== 404
+                    isFatal: response?.status !== 404,
                 })
             throw err
         } finally {
@@ -141,7 +141,7 @@ export class Admin {
 
     @action.bound private removeRequest(request: Promise<Response>) {
         this.currentRequests = this.currentRequests.filter(
-            req => req !== request
+            (req) => req !== request
         )
     }
 

--- a/adminSite/client/AdminApp.tsx
+++ b/adminSite/client/AdminApp.tsx
@@ -25,7 +25,7 @@ import {
     BrowserRouter as Router,
     Route,
     Switch,
-    Redirect
+    Redirect,
 } from "react-router-dom"
 import { LoadingBlocker, Modal } from "./Forms"
 import { AdminAppContext } from "./AdminAppContext"

--- a/adminSite/client/ChartEditor.ts
+++ b/adminSite/client/ChartEditor.ts
@@ -228,7 +228,7 @@ export class ChartEditor {
         if (window.confirm(`Publish chart at ${url}?`)) {
             this.grapher.isPublished = true
             this.saveGrapher({
-                onError: () => (this.grapher.isPublished = undefined)
+                onError: () => (this.grapher.isPublished = undefined),
             })
         }
     }
@@ -241,7 +241,7 @@ export class ChartEditor {
         if (window.confirm(message)) {
             this.grapher.isPublished = undefined
             this.saveGrapher({
-                onError: () => (this.grapher.isPublished = true)
+                onError: () => (this.grapher.isPublished = true),
             })
         }
     }

--- a/adminSite/client/ChartEditorPage.tsx
+++ b/adminSite/client/ChartEditorPage.tsx
@@ -7,7 +7,7 @@ import {
     autorun,
     action,
     reaction,
-    IReactionDisposer
+    IReactionDisposer,
 } from "mobx"
 import { Prompt, Redirect } from "react-router-dom"
 
@@ -21,7 +21,7 @@ import {
     EditorDatabase,
     Log,
     PostReference,
-    ChartRedirect
+    ChartRedirect,
 } from "./ChartEditor"
 import { EditorBasicTab } from "./EditorBasicTab"
 import { EditorDataTab } from "./EditorDataTab"
@@ -42,7 +42,7 @@ import {
     VisionDeficiency,
     VisionDeficiencySvgFilters,
     VisionDeficiencyDropdown,
-    VisionDeficiencyEntity
+    VisionDeficiencyEntity,
 } from "./VisionDeficiencies"
 
 @observer
@@ -166,7 +166,7 @@ export class ChartEditorPage extends React.Component<{
                 },
                 // Hack: Allow overriding redirects so that we can update it
                 // from the inner "add redirect" form
-                redirects: that.redirects || []
+                redirects: that.redirects || [],
             })
         }
     }
@@ -236,7 +236,7 @@ export class ChartEditorPage extends React.Component<{
                 <div className="chart-editor-settings">
                     <div className="p-2">
                         <ul className="nav nav-tabs">
-                            {availableTabs.map(tab => (
+                            {availableTabs.map((tab) => (
                                 <li key={tab} className="nav-item">
                                     <a
                                         className={
@@ -290,7 +290,7 @@ export class ChartEditorPage extends React.Component<{
                         style={{
                             filter:
                                 this.simulateVisionDeficiency &&
-                                `url(#${this.simulateVisionDeficiency.id})`
+                                `url(#${this.simulateVisionDeficiency.id})`,
                         }}
                     >
                         {

--- a/adminSite/client/ChartIndexPage.tsx
+++ b/adminSite/client/ChartIndexPage.tsx
@@ -37,7 +37,7 @@ export class ChartIndexPage extends React.Component {
                     `${chart.title} ${chart.variantName || ""} ${
                         chart.internalNotes || ""
                     } ${chart.publishedBy} ${chart.lastEditedBy}`
-                )
+                ),
             })
         }
 
@@ -49,7 +49,7 @@ export class ChartIndexPage extends React.Component {
         if (searchInput) {
             const results = fuzzysort.go(searchInput, searchIndex, {
                 limit: 50,
-                key: "term"
+                key: "term",
             })
             return uniq(results.map((result: any) => result.obj.chart))
         } else {

--- a/adminSite/client/ChartList.tsx
+++ b/adminSite/client/ChartList.tsx
@@ -59,7 +59,7 @@ class ChartRow extends React.Component<{
         const { chart } = this.props
         const json = await this.context.admin.requestJSON(
             `/api/charts/${chart.id}/setTags`,
-            { tagIds: tags.map(t => t.id) },
+            { tagIds: tags.map((t) => t.id) },
             "POST"
         )
         if (json.success) {
@@ -236,7 +236,7 @@ export class ChartList extends React.Component<{
                     </tr>
                 </thead>
                 <tbody>
-                    {charts.map(chart => (
+                    {charts.map((chart) => (
                         <ChartRow
                             chart={chart}
                             key={chart.id}

--- a/adminSite/client/ColorSchemeDropdown.tsx
+++ b/adminSite/client/ColorSchemeDropdown.tsx
@@ -30,7 +30,7 @@ export class ColorSchemeDropdown extends React.Component<
     static defaultProps = {
         additionalOptions: [],
         gradientColorCount: 6,
-        invertedColorScheme: false
+        invertedColorScheme: false,
     }
 
     @computed get additionalOptions() {
@@ -52,7 +52,7 @@ export class ColorSchemeDropdown extends React.Component<
                         this.gradientColorCount
                     ),
                     label: (scheme as ColorScheme).name,
-                    value: key
+                    value: key,
                 }
             })
     }
@@ -87,7 +87,7 @@ export class ColorSchemeDropdown extends React.Component<
                 style={{
                     display: "flex",
                     justifyContent: "space-between",
-                    alignItems: "center"
+                    alignItems: "center",
                 }}
             >
                 <div>{option.label}</div>
@@ -103,7 +103,7 @@ export class ColorSchemeDropdown extends React.Component<
                             // Mirror the element if color schemes are inverted
                             transform: invertedColorScheme
                                 ? "scaleX(-1)"
-                                : undefined
+                                : undefined,
                         }}
                     />
                 )}
@@ -118,18 +118,18 @@ export class ColorSchemeDropdown extends React.Component<
                 formatOptionLabel={this.formatOptionLabel}
                 onChange={this.onChange}
                 value={this.allOptions.find(
-                    scheme => scheme.value === this.props.value
+                    (scheme) => scheme.value === this.props.value
                 )}
                 components={{
-                    IndicatorSeparator: null
+                    IndicatorSeparator: null,
                 }}
                 styles={{
-                    singleValue: provided => {
+                    singleValue: (provided) => {
                         return {
                             ...provided,
-                            width: "calc(100% - 10px)"
+                            width: "calc(100% - 10px)",
                         }
-                    }
+                    },
                 }}
                 menuPlacement="auto"
             />

--- a/adminSite/client/Colorpicker.tsx
+++ b/adminSite/client/Colorpicker.tsx
@@ -28,7 +28,7 @@ export class Colorpicker extends React.Component<ColorpickerProps> {
                 disableAlpha
                 presetColors={availableColors}
                 color={this.props.color}
-                onChange={color => this.onColor(color.hex)}
+                onChange={(color) => this.onColor(color.hex)}
             />
         )
     }

--- a/adminSite/client/CountryNameFormat.ts
+++ b/adminSite/client/CountryNameFormat.ts
@@ -24,42 +24,42 @@ export const CountryNameFormatDefs = [
         key: CountryNameFormat.NonStandardCountryName,
         label: "Non-Standard Country Name",
         use_as_input: true,
-        use_as_output: false
+        use_as_output: false,
     },
     {
         key: CountryNameFormat.OurWorldInDataName,
         label: "Our World In Data Name",
         use_as_input: true,
         column_name: "owid_name",
-        use_as_output: true
+        use_as_output: true,
     },
     {
         key: CountryNameFormat.IsoAlpha2,
         label: "ISO 3166-1 ALPHA-2 CODE",
         use_as_input: true,
         column_name: "iso_alpha2",
-        use_as_output: true
+        use_as_output: true,
     },
     {
         key: CountryNameFormat.IsoAlpha3,
         label: "ISO 3166-1 ALPHA-3 CODE",
         use_as_input: true,
         column_name: "iso_alpha3",
-        use_as_output: true
+        use_as_output: true,
     },
     {
         key: CountryNameFormat.ImfCode,
         label: "IMF code",
         use_as_input: true,
         column_name: "imf_code",
-        use_as_output: true
+        use_as_output: true,
     },
     {
         key: CountryNameFormat.CowLetter,
         label: "COW Letters",
         use_as_input: true,
         column_name: "cow_letter",
-        use_as_output: true
+        use_as_output: true,
     },
 
     {
@@ -67,57 +67,57 @@ export const CountryNameFormatDefs = [
         label: "COW Codes",
         use_as_input: true,
         column_name: "cow_code",
-        use_as_output: true
+        use_as_output: true,
     },
     {
         key: CountryNameFormat.UnctadCode,
         label: "Unctad 3-Letter Codes",
         use_as_input: true,
         column_name: "unctad_code",
-        use_as_output: true
+        use_as_output: true,
     },
     {
         key: CountryNameFormat.MarcCode,
         label: "MARC Codes",
         use_as_input: true,
         column_name: "marc_code",
-        use_as_output: true
+        use_as_output: true,
     },
     {
         key: CountryNameFormat.NCDCode,
         label: "National Capabilities Codes",
         use_as_input: true,
         column_name: "ncd_code",
-        use_as_output: true
+        use_as_output: true,
     },
     {
         key: CountryNameFormat.KansasCode,
         label: "Kansas Event Data System, Cameo Country Codes",
         use_as_input: true,
         column_name: "kansas_code",
-        use_as_output: true
+        use_as_output: true,
     },
     {
         key: CountryNameFormat.PennCode,
         label: "Penn World Table",
         use_as_input: true,
         column_name: "penn_code",
-        use_as_output: true
+        use_as_output: true,
     },
     {
         key: CountryNameFormat.ContinentName,
         label: "Continent Name",
         use_as_input: false,
         column_name: "continent_name",
-        use_as_output: true
+        use_as_output: true,
     },
     {
         key: CountryNameFormat.ContinentCode,
         label: "Continent Code",
         use_as_input: false,
         column_name: "continent_code",
-        use_as_output: true
-    }
+        use_as_output: true,
+    },
 ]
 
 export const CountryDefByKey = keyBy(CountryNameFormatDefs, "key")

--- a/adminSite/client/CountryStandardizerPage.tsx
+++ b/adminSite/client/CountryStandardizerPage.tsx
@@ -6,7 +6,7 @@ import {
     action,
     runInAction,
     reaction,
-    IReactionDisposer
+    IReactionDisposer,
 } from "mobx"
 import parse from "csv-parse"
 
@@ -18,7 +18,7 @@ import { SelectField, SelectGroupsField, SelectGroup } from "./Forms"
 import {
     CountryNameFormat,
     CountryNameFormatDefs,
-    CountryDefByKey
+    CountryDefByKey,
 } from "adminSite/client/CountryNameFormat"
 import { uniq, toString, csvEscape, values, sortBy } from "grapher/utils/Util"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext"
@@ -53,7 +53,7 @@ class CSV {
             return -1
         }
         return rows[0].findIndex(
-            columnName => columnName.toLowerCase() === "country"
+            (columnName) => columnName.toLowerCase() === "country"
         )
     }
 
@@ -117,7 +117,7 @@ class CSV {
             rows,
             countryColumnIndex,
             mapCountriesInputToOutput,
-            findSimilarCountries
+            findSimilarCountries,
         } = this
 
         if (countryColumnIndex < 0) {
@@ -138,10 +138,10 @@ class CSV {
 
         // for fuzzy-match, use the input and output values as target to improve matching potential
         const inputCountries = Object.keys(mapCountriesInputToOutput).filter(
-            key => mapCountriesInputToOutput[key] !== undefined
+            (key) => mapCountriesInputToOutput[key] !== undefined
         )
         const outputCountries = inputCountries.map(
-            key => mapCountriesInputToOutput[key]
+            (key) => mapCountriesInputToOutput[key]
         ) as string[]
         const fuzz = FuzzySet(inputCountries.concat(outputCountries))
 
@@ -162,7 +162,7 @@ class CSV {
                                 fuzzyMatch[1]
                         )
                     approximatedMatches = approximatedMatches.filter(
-                        key => key !== undefined
+                        (key) => key !== undefined
                     )
                 }
             } else {
@@ -174,7 +174,7 @@ class CSV {
                 standardizedName: outputCountry || undefined,
                 approximatedMatches: approximatedMatches,
                 selectedMatch: "",
-                customName: ""
+                customName: "",
             }
             entriesByCountry.set(country, entry)
         })
@@ -237,19 +237,19 @@ class CountryEntryRowRenderer extends React.Component<{
         const optgroups: SelectGroup[] = []
 
         if (entry.approximatedMatches.length > 0) {
-            const options = entry.approximatedMatches.map(countryName => ({
+            const options = entry.approximatedMatches.map((countryName) => ({
                 value: countryName,
-                label: countryName
+                label: countryName,
             }))
             optgroups.push({ title: "Likely matches", options: options })
         }
 
         optgroups.push({
             title: "All standard names",
-            options: allCountries.map(countryName => ({
+            options: allCountries.map((countryName) => ({
                 value: countryName,
-                label: countryName
-            }))
+                label: countryName,
+            })),
         })
 
         return (
@@ -265,7 +265,7 @@ class CountryEntryRowRenderer extends React.Component<{
                         value={defaultValue}
                         onValue={this.onEntrySelected}
                         options={[
-                            { value: defaultOption, label: defaultOption }
+                            { value: defaultOption, label: defaultOption },
                         ]}
                         groups={optgroups}
                     />
@@ -275,7 +275,7 @@ class CountryEntryRowRenderer extends React.Component<{
                         type="text"
                         className="form-control"
                         value={entry.customName}
-                        onChange={e =>
+                        onChange={(e) =>
                             onUpdate(
                                 e.currentTarget.value,
                                 entry.originalName,
@@ -354,14 +354,14 @@ export class CountryStandardizerPage extends React.Component {
         if (!file) return
 
         const reader = new FileReader()
-        reader.onload = e => {
+        reader.onload = (e) => {
             const csv = (e as any).target.result
             parse(
                 csv,
                 {
                     relax_column_count: true,
                     skip_empty_lines: true,
-                    rtrim: true
+                    rtrim: true,
                 },
                 (err, rows) => {
                     this.csv.onFileUpload(
@@ -485,8 +485,8 @@ export class CountryStandardizerPage extends React.Component {
             outputRows.push(newRow)
         })
 
-        const strRows = outputRows.map(row =>
-            row.map(val => csvEscape(val)).join(",")
+        const strRows = outputRows.map((row) =>
+            row.map((val) => csvEscape(val)).join(",")
         )
         return new Blob([strRows.join("\n")], { type: "text/csv" })
     }
@@ -532,7 +532,7 @@ export class CountryStandardizerPage extends React.Component {
         const countries: any = {}
         let needToSave: boolean = false
 
-        csv.countryEntriesMap.forEach(entry => {
+        csv.countryEntriesMap.forEach((entry) => {
             // ignore if there was a user entered a new name
             if (entry.customName !== undefined && entry.customName.length > 0) {
                 console.log(
@@ -560,7 +560,7 @@ export class CountryStandardizerPage extends React.Component {
         if (this.csv === undefined) return []
 
         const countries: CountryEntry[] = []
-        this.csv.countryEntriesMap.forEach(entry => {
+        this.csv.countryEntriesMap.forEach((entry) => {
             if (this.showAllRows) {
                 countries.push(entry)
             } else if (entry.standardizedName === undefined) {
@@ -575,10 +575,10 @@ export class CountryStandardizerPage extends React.Component {
         const { showDownloadOption, validationError } = csv
 
         const allowedInputFormats = CountryNameFormatDefs.filter(
-            c => c.use_as_input
+            (c) => c.use_as_input
         )
         const allowedOutputFormats = CountryNameFormatDefs.filter(
-            c => c.use_as_output
+            (c) => c.use_as_output
         )
 
         return (
@@ -622,9 +622,9 @@ export class CountryStandardizerPage extends React.Component {
                             label="Input Format"
                             value={this.inputFormat}
                             onValue={this.onInputFormat}
-                            options={allowedInputFormats.map(def => def.key)}
+                            options={allowedInputFormats.map((def) => def.key)}
                             optionLabels={allowedInputFormats.map(
-                                def => def.label
+                                (def) => def.label
                             )}
                             helpText="Choose the current format of the country names. If input format is other than the default, the tool won't attempt to find similar countries when there is no exact match."
                             data-step="1"
@@ -633,9 +633,9 @@ export class CountryStandardizerPage extends React.Component {
                             label="Output Format"
                             value={this.outputFormat}
                             onValue={this.onOutputFormat}
-                            options={allowedOutputFormats.map(def => def.key)}
+                            options={allowedOutputFormats.map((def) => def.key)}
                             optionLabels={allowedOutputFormats.map(
-                                def => def.label
+                                (def) => def.label
                             )}
                             helpText="Choose the desired format of the country names. If the chosen format is other than OWID name, the tool won't attempt to find similar countries when there is no exact match."
                         />

--- a/adminSite/client/DatasetEditPage.tsx
+++ b/adminSite/client/DatasetEditPage.tsx
@@ -7,7 +7,7 @@ import {
     autorun,
     action,
     IReactionDisposer,
-    when
+    when,
 } from "mobx"
 import * as lodash from "lodash"
 import { Prompt, Redirect } from "react-router-dom"
@@ -99,9 +99,9 @@ class VariableEditRow extends React.Component<{
                 {
                     property: "y",
                     variableId: this.props.variable.id,
-                    display: lodash.clone(this.newVariable.display)
-                }
-            ]
+                    display: lodash.clone(this.newVariable.display),
+                },
+            ],
         }
     }
 
@@ -120,7 +120,7 @@ class VariableEditRow extends React.Component<{
                     ? "World"
                     : lodash.sample(grapher.availableEntityNames)
                 grapher.selectedKeys = grapher.availableKeys.filter(
-                    key => grapher.lookupKey(key).entityName === entity
+                    (key) => grapher.lookupKey(key).entityName === entity
                 )
                 grapher.addCountryMode = "change-country"
             } else {
@@ -145,7 +145,7 @@ class VariableEditRow extends React.Component<{
     dispose2!: IReactionDisposer
     componentDidMount() {
         this.chart = new Grapher(this.grapherConfig as any, {
-            isEmbed: true
+            isEmbed: true,
         })
 
         this.dispose2 = when(
@@ -181,7 +181,7 @@ class VariableEditRow extends React.Component<{
                 />
                 <div className="col">
                     <form
-                        onSubmit={e => {
+                        onSubmit={(e) => {
                             e.preventDefault()
                             this.save()
                         }}
@@ -233,7 +233,7 @@ class VariableEditRow extends React.Component<{
                                     value={
                                         newVariable.display.yearIsDay === true
                                     }
-                                    onValue={value =>
+                                    onValue={(value) =>
                                         (newVariable.display.yearIsDay = value)
                                     }
                                     label="Treat year column as day series"
@@ -337,7 +337,7 @@ class DatasetEditable {
         dataPublisherSource: "",
         link: "",
         retrievedDate: "",
-        additionalInfo: ""
+        additionalInfo: "",
     }
 
     @observable tags: Tag[] = []
@@ -553,7 +553,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                 <section>
                     <h3>Dataset metadata</h3>
                     <form
-                        onSubmit={e => {
+                        onSubmit={(e) => {
                             e.preventDefault()
                             this.save()
                         }}
@@ -610,7 +610,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                                 <Toggle
                                     label="Is publishable (include in exported OWID collection)"
                                     value={!newDataset.isPrivate}
-                                    onValue={v => (newDataset.isPrivate = !v)}
+                                    onValue={(v) => (newDataset.isPrivate = !v)}
                                     disabled={isBulkImport}
                                 />
                             </div>
@@ -663,7 +663,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                             variables={dataset.variables as VariableListItem[]}
                         />
                     ) : (
-                        dataset.variables.map(variable => (
+                        dataset.variables.map((variable) => (
                             <VariableEditRow
                                 key={`${variable.id}-${timesUpdated}`}
                                 variable={variable}

--- a/adminSite/client/DatasetList.tsx
+++ b/adminSite/client/DatasetList.tsx
@@ -36,7 +36,7 @@ class DatasetRow extends React.Component<{
         const { dataset } = this.props
         const json = await this.context.admin.requestJSON(
             `/api/datasets/${dataset.id}/setTags`,
-            { tagIds: tags.map(t => t.id) },
+            { tagIds: tags.map((t) => t.id) },
             "POST"
         )
         if (json.success) {
@@ -117,7 +117,7 @@ export class DatasetList extends React.Component<{
                     </tr>
                 </thead>
                 <tbody>
-                    {props.datasets.map(dataset => (
+                    {props.datasets.map((dataset) => (
                         <DatasetRow
                             dataset={dataset}
                             availableTags={this.availableTags}

--- a/adminSite/client/DatasetsIndexPage.tsx
+++ b/adminSite/client/DatasetsIndexPage.tsx
@@ -32,14 +32,14 @@ export class DatasetsIndexPage extends React.Component {
                 term: fuzzysort.prepare(
                     dataset.name +
                         " " +
-                        dataset.tags.map(t => t.name).join(" ") +
+                        dataset.tags.map((t) => t.name).join(" ") +
                         " " +
                         dataset.namespace +
                         " " +
                         dataset.dataEditedByUserName +
                         " " +
                         dataset.description
-                )
+                ),
             })
         }
 
@@ -51,7 +51,7 @@ export class DatasetsIndexPage extends React.Component {
         if (searchInput) {
             const results = fuzzysort.go(searchInput, searchIndex, {
                 limit: 50,
-                key: "term"
+                key: "term",
             })
             return lodash.uniq(results.map((result: any) => result.obj.dataset))
         } else {
@@ -60,7 +60,7 @@ export class DatasetsIndexPage extends React.Component {
     }
 
     @computed get namespaces() {
-        return lodash.uniq(this.datasets.map(d => d.namespace))
+        return lodash.uniq(this.datasets.map((d) => d.namespace))
     }
 
     @computed get numTotalRows(): number {

--- a/adminSite/client/DimensionCard.tsx
+++ b/adminSite/client/DimensionCard.tsx
@@ -7,7 +7,7 @@ import {
     Toggle,
     EditableListItem,
     BindAutoString,
-    BindAutoFloat
+    BindAutoFloat,
 } from "./Forms"
 import { Link } from "./Link"
 import { faChevronDown } from "@fortawesome/free-solid-svg-icons/faChevronDown"
@@ -55,12 +55,16 @@ export class DimensionCard extends React.Component<{
                 <Toggle
                     label="Hide absolute change column"
                     value={tableDisplay.hideAbsoluteChange}
-                    onValue={value => (tableDisplay.hideAbsoluteChange = value)}
+                    onValue={(value) =>
+                        (tableDisplay.hideAbsoluteChange = value)
+                    }
                 />
                 <Toggle
                     label="Hide relative change column"
                     value={tableDisplay.hideRelativeChange}
-                    onValue={value => (tableDisplay.hideRelativeChange = value)}
+                    onValue={(value) =>
+                        (tableDisplay.hideRelativeChange = value)
+                    }
                 />
                 <hr className="ui divider" />
             </React.Fragment>

--- a/adminSite/client/EditorBasicTab.tsx
+++ b/adminSite/client/EditorBasicTab.tsx
@@ -6,7 +6,7 @@ import { includes, sample, sampleSize } from "grapher/utils/Util"
 import { ChartTypeDefs, ChartTypeName } from "grapher/core/GrapherConstants"
 import {
     ChartDimension,
-    ChartDimensionSpec
+    ChartDimensionSpec,
 } from "grapher/chart/ChartDimension"
 
 import { Toggle, SelectField, EditableList, FieldsRow, Section } from "./Forms"
@@ -28,9 +28,9 @@ class DimensionSlotView extends React.Component<{
     @action.bound onVariables(variableIds: number[]) {
         const { slot } = this.props
 
-        slot.dimensions = variableIds.map(id => {
+        slot.dimensions = variableIds.map((id) => {
             const existingDimension = slot.dimensions.find(
-                d => d.variableId === id
+                (d) => d.variableId === id
             )
             return existingDimension || slot.createDimension(id)
         })
@@ -41,7 +41,7 @@ class DimensionSlotView extends React.Component<{
 
     @action.bound onRemoveDimension(dim: ChartDimension) {
         this.props.slot.dimensions = this.props.slot.dimensions.filter(
-            d => d.variableId !== dim.variableId
+            (d) => d.variableId !== dim.variableId
         )
         this.updateDefaults()
     }
@@ -63,7 +63,8 @@ class DimensionSlotView extends React.Component<{
                         ? "World"
                         : sample(grapher.availableEntityNames)
                     grapher.selectedKeys = grapher.availableKeys.filter(
-                        key => grapher.lookupKey(key).entityName === entityName
+                        (key) =>
+                            grapher.lookupKey(key).entityName === entityName
                     )
                     grapher.addCountryMode = "change-country"
                 } else {
@@ -90,7 +91,7 @@ class DimensionSlotView extends React.Component<{
             <div>
                 <h5>{slot.name}</h5>
                 <EditableList>
-                    {slot.dimensionsWithData.map(dim => {
+                    {slot.dimensionsWithData.map((dim) => {
                         return (
                             dim.property === slot.property && (
                                 <DimensionCard
@@ -151,7 +152,7 @@ class VariablesSection extends React.Component<{ editor: ChartEditor }> {
 
         return (
             <Section name="Add variables">
-                {dimensionSlots.map(slot => (
+                {dimensionSlots.map((slot) => (
                     <DimensionSlotView
                         key={slot.name}
                         slot={slot}
@@ -172,7 +173,7 @@ export class EditorBasicTab extends React.Component<{ editor: ChartEditor }> {
         // Give scatterplots and slope charts a default color and size dimension if they don't have one
         if (
             (grapher.isScatter || grapher.isSlopeChart) &&
-            !grapher.dimensions.find(d => d.property === "color")
+            !grapher.dimensions.find((d) => d.property === "color")
         ) {
             grapher.dimensions = grapher.dimensions.concat(
                 new ChartDimensionSpec({ variableId: 123, property: "color" })
@@ -181,7 +182,7 @@ export class EditorBasicTab extends React.Component<{ editor: ChartEditor }> {
 
         if (
             (grapher.isScatter || grapher.isSlopeChart) &&
-            !grapher.dimensions.find(d => d.property === "color")
+            !grapher.dimensions.find((d) => d.property === "color")
         ) {
             grapher.dimensions = grapher.dimensions.concat(
                 new ChartDimensionSpec({ variableId: 72, property: "size" })
@@ -199,15 +200,15 @@ export class EditorBasicTab extends React.Component<{ editor: ChartEditor }> {
                     <SelectField
                         value={grapher.type}
                         onValue={this.onChartType}
-                        options={ChartTypeDefs.map(def => def.key)}
-                        optionLabels={ChartTypeDefs.map(def => def.label)}
+                        options={ChartTypeDefs.map((def) => def.key)}
+                        optionLabels={ChartTypeDefs.map((def) => def.label)}
                     />
                     {editor.features.explorer && (
                         <FieldsRow>
                             <Toggle
                                 label="Explorable chart"
                                 value={grapher.isExplorable}
-                                onValue={value =>
+                                onValue={(value) =>
                                     (grapher.isExplorable = value)
                                 }
                                 disabled={!canBeExplorable(grapher)}
@@ -218,13 +219,13 @@ export class EditorBasicTab extends React.Component<{ editor: ChartEditor }> {
                         <Toggle
                             label="Chart tab"
                             value={grapher.hasChartTab}
-                            onValue={value => (grapher.hasChartTab = value)}
+                            onValue={(value) => (grapher.hasChartTab = value)}
                             disabled={grapher.isExplorable}
                         />
                         <Toggle
                             label="Map tab"
                             value={grapher.hasMapTab}
-                            onValue={value => (grapher.hasMapTab = value)}
+                            onValue={(value) => (grapher.hasMapTab = value)}
                             disabled={grapher.isExplorable}
                         />
                     </FieldsRow>

--- a/adminSite/client/EditorColorScaleSection.tsx
+++ b/adminSite/client/EditorColorScaleSection.tsx
@@ -9,7 +9,7 @@ import { ColorScale } from "grapher/color/ColorScale"
 import {
     ColorScaleBin,
     NumericBin,
-    CategoricalBin
+    CategoricalBin,
 } from "grapher/color/ColorScaleBin"
 import { clone, noop, last } from "grapher/utils/Util"
 import { Color } from "grapher/core/GrapherConstants"
@@ -24,12 +24,12 @@ import {
     TextField,
     ColorBox,
     BindAutoFloat,
-    BindString
+    BindString,
 } from "./Forms"
 import { ColorSchemeOption, ColorSchemeDropdown } from "./ColorSchemeDropdown"
 import {
     BinningStrategy,
-    binningStrategyLabels
+    binningStrategyLabels,
 } from "grapher/color/BinningStrategies"
 
 interface EditorColorScaleSectionFeatures {
@@ -144,7 +144,7 @@ class ColorsSection extends React.Component<{
         const options = Object.entries(binningStrategyLabels).map(
             ([value, label]) => ({
                 label: label,
-                value: value as BinningStrategy
+                value: value as BinningStrategy,
             })
         )
         // Remove the manual binning strategy from the options if
@@ -161,7 +161,7 @@ class ColorsSection extends React.Component<{
 
     @computed get currentBinningStrategyOption() {
         return this.binningStrategyOptions.find(
-            option => option.value === this.props.scale.config.binningStrategy
+            (option) => option.value === this.props.scale.config.binningStrategy
         )
     }
 
@@ -184,8 +184,8 @@ class ColorsSection extends React.Component<{
                                     colorScheme: undefined,
                                     gradient: undefined,
                                     label: "Custom",
-                                    value: "custom"
-                                }
+                                    value: "custom",
+                                },
                             ]}
                         />
                     </div>
@@ -205,7 +205,7 @@ class ColorsSection extends React.Component<{
                             onChange={this.onBinningStrategy}
                             value={this.currentBinningStrategyOption}
                             components={{
-                                IndicatorSeparator: null
+                                IndicatorSeparator: null,
                             }}
                             menuPlacement="auto"
                             isSearchable={false}

--- a/adminSite/client/EditorCustomizeTab.tsx
+++ b/adminSite/client/EditorCustomizeTab.tsx
@@ -12,7 +12,7 @@ import {
     BindAutoString,
     BindString,
     TextField,
-    Button
+    Button,
 } from "./Forms"
 import { debounce } from "grapher/utils/Util"
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus"
@@ -54,8 +54,8 @@ class ColorSchemeSelector extends React.Component<{ grapher: Grapher }> {
                                     colorScheme: undefined,
                                     gradient: undefined,
                                     label: "Default",
-                                    value: "default"
-                                }
+                                    value: "default",
+                                },
                             ]}
                         />
                     </div>
@@ -258,7 +258,7 @@ export class EditorCustomizeTab extends React.Component<{
                                     <NumberField
                                         label={`Min`}
                                         value={yAxisOptions.min}
-                                        onValue={value =>
+                                        onValue={(value) =>
                                             (yAxisOptions.min = value)
                                         }
                                         allowDecimal
@@ -267,7 +267,7 @@ export class EditorCustomizeTab extends React.Component<{
                                     <NumberField
                                         label={`Max`}
                                         value={yAxisOptions.max}
-                                        onValue={value =>
+                                        onValue={(value) =>
                                             (yAxisOptions.max = value)
                                         }
                                         allowDecimal
@@ -282,7 +282,7 @@ export class EditorCustomizeTab extends React.Component<{
                                                 yAxisOptions.removePointsOutsideDomain ||
                                                 false
                                             }
-                                            onValue={value =>
+                                            onValue={(value) =>
                                                 (yAxisOptions.removePointsOutsideDomain =
                                                     value || undefined)
                                             }
@@ -296,7 +296,7 @@ export class EditorCustomizeTab extends React.Component<{
                                             yAxisOptions.canChangeScaleType ||
                                             false
                                         }
-                                        onValue={value =>
+                                        onValue={(value) =>
                                             (yAxisOptions.canChangeScaleType =
                                                 value || undefined)
                                         }
@@ -321,7 +321,7 @@ export class EditorCustomizeTab extends React.Component<{
                                     <NumberField
                                         label={`Min`}
                                         value={xAxisOptions.min}
-                                        onValue={value =>
+                                        onValue={(value) =>
                                             (xAxisOptions.min = value)
                                         }
                                         allowDecimal
@@ -330,7 +330,7 @@ export class EditorCustomizeTab extends React.Component<{
                                     <NumberField
                                         label={`Max`}
                                         value={xAxisOptions.max}
-                                        onValue={value =>
+                                        onValue={(value) =>
                                             (xAxisOptions.max = value)
                                         }
                                         allowDecimal
@@ -345,7 +345,7 @@ export class EditorCustomizeTab extends React.Component<{
                                                 xAxisOptions.removePointsOutsideDomain ||
                                                 false
                                             }
-                                            onValue={value =>
+                                            onValue={(value) =>
                                                 (xAxisOptions.removePointsOutsideDomain =
                                                     value || undefined)
                                             }
@@ -359,7 +359,7 @@ export class EditorCustomizeTab extends React.Component<{
                                             xAxisOptions.canChangeScaleType ||
                                             false
                                         }
-                                        onValue={value =>
+                                        onValue={(value) =>
                                             (xAxisOptions.canChangeScaleType =
                                                 value || undefined)
                                         }
@@ -388,7 +388,7 @@ export class EditorCustomizeTab extends React.Component<{
                             legendDescription:
                                 grapher.isScatter ||
                                 grapher.isSlopeChart ||
-                                grapher.isStackedBar
+                                grapher.isStackedBar,
                         }}
                     />
                 )}
@@ -399,7 +399,7 @@ export class EditorCustomizeTab extends React.Component<{
                                 <Toggle
                                     label={`Hide legend`}
                                     value={!!grapher.hideLegend}
-                                    onValue={value =>
+                                    onValue={(value) =>
                                         (grapher.hideLegend =
                                             value || undefined)
                                     }
@@ -422,7 +422,7 @@ export class EditorCustomizeTab extends React.Component<{
                             <Toggle
                                 label={`Hide relative toggle`}
                                 value={!!grapher.hideRelativeToggle}
-                                onValue={value =>
+                                onValue={(value) =>
                                     (grapher.hideRelativeToggle =
                                         value || false)
                                 }

--- a/adminSite/client/EditorDataTab.tsx
+++ b/adminSite/client/EditorDataTab.tsx
@@ -10,7 +10,7 @@ import {
     EditableListItemProps,
     ColorBox,
     SelectField,
-    Section
+    Section,
 } from "./Forms"
 import { ChartEditor } from "./ChartEditor"
 import { faArrowsAltV } from "@fortawesome/free-solid-svg-icons/faArrowsAltV"
@@ -101,7 +101,7 @@ class KeysSection extends React.Component<{ grapher: Grapher }> {
         const { selectedKeys, remainingKeys } = grapher
 
         const keyLabels = remainingKeys.map(
-            key => grapher.lookupKey(key).fullLabel
+            (key) => grapher.lookupKey(key).fullLabel
         )
 
         return (
@@ -113,7 +113,7 @@ class KeysSection extends React.Component<{ grapher: Grapher }> {
                     optionLabels={["Select data"].concat(keyLabels)}
                 />
                 <EditableList>
-                    {map(selectedKeys, key => (
+                    {map(selectedKeys, (key) => (
                         <EntityDimensionKeyItem
                             key={key}
                             grapher={grapher}

--- a/adminSite/client/EditorHistoryTab.tsx
+++ b/adminSite/client/EditorHistoryTab.tsx
@@ -59,7 +59,7 @@ export class EditorHistoryTab extends React.Component<{ editor: ChartEditor }> {
         // Due to mobx memoizing computed values, the JSON can be mutated.
         const chartConfigObject = {
             ...this.props.editor.currentGrapherObject,
-            externalDataUrl: this.props.editor.grapher.dataUrl
+            externalDataUrl: this.props.editor.grapher.dataUrl,
         }
         return (
             <div>

--- a/adminSite/client/EditorMapTab.tsx
+++ b/adminSite/client/EditorMapTab.tsx
@@ -12,7 +12,7 @@ import {
     NumberField,
     SelectField,
     Toggle,
-    Section
+    Section,
 } from "./Forms"
 import { EditorColorScaleSection } from "./EditorColorScaleSection"
 import { owidVariableId } from "owidTable/OwidTable"
@@ -45,7 +45,7 @@ class VariableSection extends React.Component<{ mapTransform: MapTransform }> {
             "SouthAmerica",
             "Asia",
             "Europe",
-            "Oceania"
+            "Oceania",
         ]
         const labels = [
             "World",
@@ -54,7 +54,7 @@ class VariableSection extends React.Component<{ mapTransform: MapTransform }> {
             "South America",
             "Asia",
             "Europe",
-            "Oceania"
+            "Oceania",
         ]
 
         return (
@@ -62,8 +62,8 @@ class VariableSection extends React.Component<{ mapTransform: MapTransform }> {
                 <NumericSelectField
                     label="Variable"
                     value={mapTransform.variableId as number}
-                    options={filledDimensions.map(d => d.variableId)}
-                    optionLabels={filledDimensions.map(d => d.displayName)}
+                    options={filledDimensions.map((d) => d.variableId)}
+                    optionLabels={filledDimensions.map((d) => d.displayName)}
                     onValue={this.onVariableId}
                 />
                 <SelectField
@@ -164,7 +164,7 @@ export class EditorMapTab extends React.Component<{ editor: ChartEditor }> {
                             scale={mapTransform.colorScale}
                             features={{
                                 visualScaling: true,
-                                legendDescription: false
+                                legendDescription: false,
                             }}
                         />
                         <TooltipSection mapTransform={mapTransform} />

--- a/adminSite/client/EditorReferencesTab.tsx
+++ b/adminSite/client/EditorReferencesTab.tsx
@@ -37,7 +37,7 @@ export class EditorReferencesTab extends React.Component<{
                                 Public pages that embed or reference this chart:
                             </p>
                             <ul className="list-group">
-                                {this.references.map(post => (
+                                {this.references.map((post) => (
                                     <li
                                         key={post.id}
                                         className="list-group-item"
@@ -67,7 +67,7 @@ export class EditorReferencesTab extends React.Component<{
                         <React.Fragment>
                             <p>The following URLs redirect to this chart:</p>
                             <ul className="list-group">
-                                {this.redirects.map(redirect => (
+                                {this.redirects.map((redirect) => (
                                     <li
                                         key={redirect.id}
                                         className="list-group-item"
@@ -157,7 +157,7 @@ class AddRedirectForm extends React.Component<{
                         className="form-control"
                         placeholder="URL"
                         value={this.slug}
-                        onChange={event => this.onChange(event.target.value)}
+                        onChange={(event) => this.onChange(event.target.value)}
                     />
                     <div className="input-group-append">
                         <button

--- a/adminSite/client/EditorScatterTab.tsx
+++ b/adminSite/client/EditorScatterTab.tsx
@@ -9,7 +9,7 @@ import { faMinus } from "@fortawesome/free-solid-svg-icons/faMinus"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
     ScatterPointLabelStrategy,
-    HighlightToggleConfig
+    HighlightToggleConfig,
 } from "grapher/core/GrapherConstants"
 
 @observer
@@ -17,7 +17,7 @@ export class EditorScatterTab extends React.Component<{ grapher: Grapher }> {
     @observable comparisonLine: ComparisonLineConfig = { yEquals: undefined }
     @observable highlightToggle: HighlightToggleConfig = {
         description: "",
-        paramStr: ""
+        paramStr: "",
     }
 
     @computed get hasHighlightToggle() {
@@ -72,7 +72,7 @@ export class EditorScatterTab extends React.Component<{ grapher: Grapher }> {
 
         const entityId = grapher.table.entityNameToIdMap.get(entity)
         grapher.excludedEntities = grapher.excludedEntities.filter(
-            e => e !== entityId
+            (e) => e !== entityId
         )
     }
 
@@ -89,7 +89,7 @@ export class EditorScatterTab extends React.Component<{ grapher: Grapher }> {
         const {
             hasHighlightToggle,
             highlightToggle,
-            excludedEntityChoices
+            excludedEntityChoices,
         } = this
         const { grapher } = this.props
 
@@ -139,13 +139,13 @@ export class EditorScatterTab extends React.Component<{ grapher: Grapher }> {
                         label="Exclude individual entities"
                         placeholder="Select an entity to exclude"
                         value={undefined}
-                        onValue={v => v && this.onExcludeEntity(v)}
+                        onValue={(v) => v && this.onExcludeEntity(v)}
                         options={excludedEntityChoices}
                     />
                     {grapher.scatterTransform.excludedEntityNames && (
                         <ul className="excludedEntities">
                             {grapher.scatterTransform.excludedEntityNames.map(
-                                entity => (
+                                (entity) => (
                                     <li key={entity}>
                                         <div
                                             className="clickable"

--- a/adminSite/client/EditorTextTab.tsx
+++ b/adminSite/client/EditorTextTab.tsx
@@ -10,7 +10,7 @@ import {
     AutoTextField,
     RadioGroup,
     TextField,
-    Button
+    Button,
 } from "./Forms"
 import { LogoOption } from "grapher/chart/Logos"
 import slugify from "slugify"
@@ -42,7 +42,7 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
         }
         grapher.relatedQuestions.push({
             text: "",
-            url: ""
+            url: "",
         })
     }
 
@@ -105,7 +105,7 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                             { label: "OWID", value: "owid" },
                             { label: "CORE+OWID", value: "core+owid" },
                             { label: "GV+OWID", value: "gv+owid" },
-                            { label: "No logo", value: "none" }
+                            { label: "No logo", value: "none" },
                         ]}
                         value={
                             grapher.hideLogo ? "none" : grapher.logo || "owid"
@@ -133,7 +133,7 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                         <div className="originSuggestions">
                             <p>Origin url suggestions</p>
                             <ul>
-                                {references.map(post => (
+                                {references.map((post) => (
                                     <li key={post.id}>{post.url}</li>
                                 ))}
                             </ul>

--- a/adminSite/client/Forms.tsx
+++ b/adminSite/client/Forms.tsx
@@ -73,7 +73,7 @@ export class TextField extends React.Component<TextFieldProps> {
             "title",
             "disabled",
             "required",
-            "onBlur"
+            "onBlur",
         ])
 
         return (
@@ -83,7 +83,7 @@ export class TextField extends React.Component<TextFieldProps> {
                     className="form-control"
                     type="text"
                     value={props.value || ""}
-                    onChange={e => this.props.onValue(e.currentTarget.value)}
+                    onChange={(e) => this.props.onValue(e.currentTarget.value)}
                     onKeyDown={this.onKeyDown}
                     {...passthroughProps}
                 />
@@ -119,7 +119,7 @@ class TextAreaField extends React.Component<TextFieldProps> {
             "title",
             "disabled",
             "label",
-            "rows"
+            "rows",
         ])
 
         return (
@@ -177,7 +177,7 @@ export class NumberField extends React.Component<
         super(props)
 
         this.state = {
-            inputValue: undefined
+            inputValue: undefined,
         }
     }
 
@@ -200,8 +200,8 @@ export class NumberField extends React.Component<
             },
             onBlur: () =>
                 this.setState({
-                    inputValue: undefined
-                })
+                    inputValue: undefined,
+                }),
         })
 
         return <TextField {...textFieldProps} />
@@ -226,7 +226,7 @@ export class SelectField extends React.Component<SelectFieldProps> {
             return {
                 key: opt,
                 value: opt,
-                text: (props.optionLabels && props.optionLabels[i]) || opt
+                text: (props.optionLabels && props.optionLabels[i]) || opt,
             }
         })
 
@@ -235,7 +235,7 @@ export class SelectField extends React.Component<SelectFieldProps> {
                 {props.label && <label>{props.label}</label>}
                 <select
                     className="form-control"
-                    onChange={e =>
+                    onChange={(e) =>
                         props.onValue(e.currentTarget.value as string)
                     }
                     value={props.value}
@@ -246,7 +246,7 @@ export class SelectField extends React.Component<SelectFieldProps> {
                             {props.placeholder}
                         </option>
                     ) : null}
-                    {options.map(opt => (
+                    {options.map((opt) => (
                         <option key={opt.value} value={opt.value}>
                             {opt.text}
                         </option>
@@ -290,19 +290,19 @@ export class SelectGroupsField extends React.Component<SelectGroupsFieldProps> {
                 {props.label && <label>{props.label}</label>}
                 <select
                     className="form-control"
-                    onChange={e =>
+                    onChange={(e) =>
                         props.onValue(e.currentTarget.value as string)
                     }
                     value={props.value}
                 >
-                    {props.options.map(opt => (
+                    {props.options.map((opt) => (
                         <option key={opt.value} value={opt.value}>
                             {opt.label}
                         </option>
                     ))}
-                    {props.groups.map(group => (
+                    {props.groups.map((group) => (
                         <optgroup key={group.title} label={group.title}>
-                            {group.options.map(opt => (
+                            {group.options.map((opt) => (
                                 <option key={opt.value} value={opt.value}>
                                     {opt.label || opt.value}
                                 </option>
@@ -335,7 +335,7 @@ export class RadioGroup extends React.Component<RadioGroupProps> {
     render() {
         return (
             <div className="RadioGroup">
-                {this.props.options.map(option => {
+                {this.props.options.map((option) => {
                     return (
                         <div key={option.value} className="radioOption">
                             <input
@@ -375,11 +375,11 @@ export class NumericSelectField extends React.Component<
                 this.props.value !== undefined
                     ? this.props.value.toString()
                     : "",
-            options: this.props.options.map(opt => opt.toString()),
+            options: this.props.options.map((opt) => opt.toString()),
             onValue: (value: string | undefined) => {
                 const asNumber = parseFloat(value as string)
                 this.props.onValue(asNumber)
-            }
+            },
         })
         return <SelectField {...props} />
     }
@@ -479,7 +479,7 @@ export class ColorBox extends React.Component<{
                             style={{
                                 display: "flex",
                                 alignItems: "center",
-                                flexDirection: "column"
+                                flexDirection: "column",
                             }}
                         >
                             <Button
@@ -574,7 +574,7 @@ export class AutoTextField extends React.Component<AutoTextFieldProps> {
                         className="form-control"
                         value={props.value}
                         placeholder={props.placeholder}
-                        onChange={e => props.onValue(e.currentTarget.value)}
+                        onChange={(e) => props.onValue(e.currentTarget.value)}
                     />
                     <div
                         className="input-group-addon"
@@ -711,7 +711,7 @@ class AutoFloatField extends React.Component<AutoFloatFieldProps> {
                 const asNumber = parseFloat(value)
                 props.onValue(isNaN(asNumber) ? undefined : asNumber)
             },
-            placeholder: props.isAuto ? props.value.toString() : undefined
+            placeholder: props.isAuto ? props.value.toString() : undefined,
         })
 
         return <AutoTextField {...textFieldProps} />
@@ -735,7 +735,7 @@ class FloatField extends React.Component<FloatFieldProps> {
             onValue: (value: string) => {
                 const asNumber = parseFloat(value)
                 props.onValue(isNaN(asNumber) ? undefined : asNumber)
-            }
+            },
         })
 
         return <TextField {...textFieldProps} />
@@ -942,8 +942,8 @@ export class EditableTags extends React.Component<{
     @action.bound onAddTag(tag: Tag) {
         this.tags.push(tag)
         this.tags = lodash
-            .uniqBy(this.tags, t => t.id)
-            .filter(t => t.name !== "Uncategorized")
+            .uniqBy(this.tags, (t) => t.id)
+            .filter((t) => t.name !== "Uncategorized")
 
         this.ensureUncategorized()
     }
@@ -956,7 +956,7 @@ export class EditableTags extends React.Component<{
     @action.bound ensureUncategorized() {
         if (this.tags.length === 0) {
             const uncategorized = this.props.suggestions.find(
-                t => t.name === "Uncategorized"
+                (t) => t.name === "Uncategorized"
             )
             if (uncategorized) this.tags.push(uncategorized)
         }
@@ -964,7 +964,9 @@ export class EditableTags extends React.Component<{
 
     @action.bound onToggleEdit() {
         if (this.isEditing) {
-            this.props.onSave(this.tags.filter(t => t.name !== "Uncategorized"))
+            this.props.onSave(
+                this.tags.filter((t) => t.name !== "Uncategorized")
+            )
         }
         this.isEditing = !this.isEditing
     }
@@ -993,7 +995,7 @@ export class EditableTags extends React.Component<{
                     />
                 ) : (
                     <div>
-                        {tags.map(t => (
+                        {tags.map((t) => (
                             <TagBadge key={t.id} tag={t} />
                         ))}
                         {!disabled && (

--- a/adminSite/client/ImportPage.tsx
+++ b/adminSite/client/ImportPage.tsx
@@ -8,7 +8,7 @@ import {
     action,
     reaction,
     runInAction,
-    IReactionDisposer
+    IReactionDisposer,
 } from "mobx"
 import { observer } from "mobx-react"
 import { Redirect } from "react-router-dom"
@@ -71,7 +71,7 @@ class EditableDataset {
         dataPublisherSource: "",
         link: "",
         retrievedDate: "",
-        additionalInfo: ""
+        additionalInfo: "",
     }
 
     update(json: any) {
@@ -118,7 +118,7 @@ class DataPreview extends React.Component<{ csv: CSV }> {
                 <div
                     style={{
                         height: height * numRows,
-                        paddingTop: height * rowOffset
+                        paddingTop: height * rowOffset,
                     }}
                 >
                     <table className="table" style={{ background: "white" }}>
@@ -159,7 +159,7 @@ class EditVariable extends React.Component<{
                 <FieldsRow>
                     <BindString store={variable} field="name" label="" />
                     <select
-                        onChange={e => {
+                        onChange={(e) => {
                             variable.overwriteId = e.target.value
                                 ? parseInt(e.target.value)
                                 : undefined
@@ -167,7 +167,7 @@ class EditVariable extends React.Component<{
                         value={variable.overwriteId || ""}
                     >
                         <option value="">Create new variable</option>
-                        {dataset.existingVariables.map(v => (
+                        {dataset.existingVariables.map((v) => (
                             <option key={v.id} value={v.id}>
                                 Overwrite {v.name}
                             </option>
@@ -186,7 +186,7 @@ class EditVariables extends React.Component<{ dataset: EditableDataset }> {
         const deletingVariables: ExistingVariable[] = []
         for (const variable of dataset.existingVariables) {
             if (
-                !dataset.newVariables.some(v => v.overwriteId === variable.id)
+                !dataset.newVariables.some((v) => v.overwriteId === variable.id)
             ) {
                 deletingVariables.push(variable)
             }
@@ -217,7 +217,7 @@ class EditVariables extends React.Component<{ dataset: EditableDataset }> {
                     <div className="alert alert-danger">
                         Some existing variables are not selected to overwrite
                         and will be deleted:{" "}
-                        {this.deletingVariables.map(v => v.name).join(",")}
+                        {this.deletingVariables.map((v) => v.name).join(",")}
                     </div>
                 )}
             </section>
@@ -285,7 +285,7 @@ class CSV {
         return {
             variables: variables,
             entities: entities,
-            years: years
+            years: years,
         }
     }
 
@@ -297,7 +297,7 @@ class CSV {
         if (rows[0].length < 3) {
             validation.results.push({
                 class: "danger",
-                message: `No variables detected. CSV should have at least 3 columns.`
+                message: `No variables detected. CSV should have at least 3 columns.`,
             })
         }
 
@@ -315,7 +315,7 @@ class CSV {
                 class: "danger",
                 message: `Invalid or missing entity/year on lines: ${invalidLines.join(
                     ", "
-                )}`
+                )}`,
             })
         }
 
@@ -330,12 +330,12 @@ class CSV {
             uniqCheck[key] += 1
         }
 
-        keys(uniqCheck).forEach(key => {
+        keys(uniqCheck).forEach((key) => {
             const count = uniqCheck[key]
             if (count > 1) {
                 validation.results.push({
                     class: "danger",
-                    message: `Duplicates detected: ${count} instances of ${key}.`
+                    message: `Duplicates detected: ${count} instances of ${key}.`,
                 })
             }
         })
@@ -357,7 +357,8 @@ class CSV {
             validation.results.push({
                 class: "warning",
                 message:
-                    "Non-numeric data detected on line " + nonNumeric.join(", ")
+                    "Non-numeric data detected on line " +
+                    nonNumeric.join(", "),
             })
 
         // Warn if we're creating novel entities
@@ -370,12 +371,12 @@ class CSV {
                 class: "warning",
                 message: `These entities were not found in the database and will be created: ${newEntities.join(
                     ", "
-                )}`
+                )}`,
             })
         }
 
         validation.passed = validation.results.every(
-            result => result.class !== "danger"
+            (result) => result.class !== "danger"
         )
 
         return validation
@@ -425,14 +426,14 @@ class CSVSelector extends React.Component<{
         if (!file) return
 
         const reader = new FileReader()
-        reader.onload = e => {
+        reader.onload = (e) => {
             const csv = (e as any).target.result
             parse(
                 csv,
                 {
                     relax_column_count: true,
                     skip_empty_lines: true,
-                    rtrim: true
+                    rtrim: true,
                 },
                 (_, rows) => {
                     // TODO error handling
@@ -442,7 +443,7 @@ class CSVSelector extends React.Component<{
                     this.csv = new CSV({
                         filename: file.name,
                         rows,
-                        existingEntities
+                        existingEntities,
                     } as any)
                     this.props.onCSV(this.csv as any)
                 }
@@ -459,7 +460,7 @@ class CSVSelector extends React.Component<{
                 <input
                     type="file"
                     onChange={this.onChooseCSV}
-                    ref={e => (this.fileInput = e as HTMLInputElement)}
+                    ref={(e) => (this.fileInput = e as HTMLInputElement)}
                 />
                 {csv && <DataPreview csv={csv} />}
                 {csv && <ValidationView validation={csv.validation} />}
@@ -489,7 +490,7 @@ class Importer extends React.Component<ImportPageData> {
 
         // Look for an existing dataset that matches this csv filename
         const existingDataset = this.props.datasets.find(
-            d => d.name === csv.basename
+            (d) => d.name === csv.basename
         )
 
         if (existingDataset) {
@@ -532,12 +533,12 @@ class Importer extends React.Component<ImportPageData> {
 
         if (existingDataset) {
             // Match new variables to existing variables
-            dataset.newVariables.forEach(variable => {
+            dataset.newVariables.forEach((variable) => {
                 const match = dataset.existingVariables.filter(
-                    v => v.name === variable.name
+                    (v) => v.name === variable.name
                 )[0]
                 if (match) {
-                    keys(match).forEach(key => {
+                    keys(match).forEach((key) => {
                         if (key === "id")
                             variable.overwriteId = (match as any)[key]
                         else (variable as any)[key] = (match as any)[key]
@@ -562,11 +563,11 @@ class Importer extends React.Component<ImportPageData> {
             dataset: {
                 id: this.existingDataset ? this.existingDataset.id : undefined,
                 name: this.dataset.name,
-                description: this.dataset.description
+                description: this.dataset.description,
             },
             years,
             entities,
-            variables: newVariables
+            variables: newVariables,
         }
         this.context.admin
             .requestJSON("/api/importDataset", requestData, "POST")
@@ -625,7 +626,7 @@ class Importer extends React.Component<ImportPageData> {
                     <section>
                         <p
                             style={{
-                                opacity: dataset.id !== undefined ? 1 : 0
+                                opacity: dataset.id !== undefined ? 1 : 0,
                             }}
                             className="updateWarning"
                         >
@@ -634,9 +635,9 @@ class Importer extends React.Component<ImportPageData> {
                         <NumericSelectField
                             value={existingDataset ? existingDataset.id : -1}
                             onValue={this.onChooseDataset}
-                            options={[-1].concat(datasets.map(d => d.id))}
+                            options={[-1].concat(datasets.map((d) => d.id))}
                             optionLabels={["Create new dataset"].concat(
-                                datasets.map(d => d.name)
+                                datasets.map((d) => d.name)
                             )}
                         />
                         <hr />
@@ -678,7 +679,7 @@ class Importer extends React.Component<ImportPageData> {
                                         ? "Update dataset"
                                         : "Create dataset"
                                 }
-                            />
+                            />,
                         ]}
                         {this.postImportDatasetId && (
                             <Redirect

--- a/adminSite/client/NewsletterPage.tsx
+++ b/adminSite/client/NewsletterPage.tsx
@@ -87,7 +87,7 @@ export class NewsletterPage extends React.Component {
         for (const post of this.posts) {
             searchIndex.push({
                 post: post,
-                term: fuzzysort.prepare(post.title)
+                term: fuzzysort.prepare(post.title),
             })
         }
 
@@ -99,7 +99,7 @@ export class NewsletterPage extends React.Component {
         if (searchInput) {
             const results = fuzzysort.go(searchInput, searchIndex, {
                 limit: 50,
-                key: "term"
+                key: "term",
             })
             return lodash.uniq(results.map((result: any) => result.obj.post))
         } else {
@@ -157,7 +157,7 @@ export class NewsletterPage extends React.Component {
                             </tr>
                         </thead>
                         <tbody>
-                            {postsToShow.map(post => (
+                            {postsToShow.map((post) => (
                                 <PostRow
                                     key={post.id}
                                     post={post}

--- a/adminSite/client/PostsIndexPage.tsx
+++ b/adminSite/client/PostsIndexPage.tsx
@@ -40,7 +40,7 @@ class PostRow extends React.Component<{
         const { post } = this.props
         const json = await this.context.admin.requestJSON(
             `/api/posts/${post.id}/setTags`,
-            { tagIds: tags.map(t => t.id) },
+            { tagIds: tags.map((t) => t.id) },
             "POST"
         )
         if (json.success) {
@@ -102,7 +102,7 @@ export class PostsIndexPage extends React.Component {
                 post: post,
                 term: fuzzysort.prepare(
                     post.title + " " + post.authors.join(", ")
-                )
+                ),
             })
         }
 
@@ -114,7 +114,7 @@ export class PostsIndexPage extends React.Component {
         if (searchInput) {
             const results = fuzzysort.go(searchInput, searchIndex, {
                 limit: 50,
-                key: "term"
+                key: "term",
             })
             return lodash.uniq(results.map((result: any) => result.obj.post))
         } else {
@@ -173,7 +173,7 @@ export class PostsIndexPage extends React.Component {
                             </tr>
                         </thead>
                         <tbody>
-                            {postsToShow.map(post => (
+                            {postsToShow.map((post) => (
                                 <PostRow
                                     key={post.id}
                                     post={post}

--- a/adminSite/client/RedirectsIndexPage.tsx
+++ b/adminSite/client/RedirectsIndexPage.tsx
@@ -93,7 +93,7 @@ export class RedirectsIndexPage extends React.Component {
                                 <th>Redirects To</th>
                                 <th></th>
                             </tr>
-                            {redirects.map(redirect => (
+                            {redirects.map((redirect) => (
                                 <RedirectRow
                                     key={redirect.id}
                                     redirect={redirect}

--- a/adminSite/client/SourceEditPage.tsx
+++ b/adminSite/client/SourceEditPage.tsx
@@ -31,7 +31,7 @@ class SourceEditable {
         dataPublisherSource: undefined,
         link: undefined,
         retrievedDate: undefined,
-        additionalInfo: undefined
+        additionalInfo: undefined,
     }
 
     constructor(json: SourcePageData) {
@@ -95,7 +95,7 @@ class SourceEditor extends React.Component<{ source: SourcePageData }> {
                 </section>
                 <section>
                     <form
-                        onSubmit={e => {
+                        onSubmit={(e) => {
                             e.preventDefault()
                             this.save()
                         }}

--- a/adminSite/client/TagEditPage.tsx
+++ b/adminSite/client/TagEditPage.tsx
@@ -107,7 +107,7 @@ class TagEditor extends React.Component<{ tag: TagPageData }> {
     @computed get parentTag() {
         const { parentId } = this.props.tag
         return parentId
-            ? this.props.tag.possibleParents.find(c => c.id === parentId)
+            ? this.props.tag.possibleParents.find((c) => c.id === parentId)
             : undefined
     }
 
@@ -127,7 +127,7 @@ class TagEditor extends React.Component<{ tag: TagPageData }> {
                 </section>
                 <section>
                     <form
-                        onSubmit={e => {
+                        onSubmit={(e) => {
                             e.preventDefault()
                             this.save()
                         }}
@@ -146,11 +146,11 @@ class TagEditor extends React.Component<{ tag: TagPageData }> {
                                     value={newtag.parentId || -1}
                                     options={[-1].concat(
                                         tag.possibleParents.map(
-                                            p => p.id as number
+                                            (p) => p.id as number
                                         )
                                     )}
                                     optionLabels={["None"].concat(
-                                        tag.possibleParents.map(p => p.name)
+                                        tag.possibleParents.map((p) => p.name)
                                     )}
                                     onValue={this.onChooseParent}
                                 />
@@ -186,7 +186,7 @@ class TagEditor extends React.Component<{ tag: TagPageData }> {
                 {tag.children.length > 0 && (
                     <section>
                         <h3>Subcategories</h3>
-                        {tag.children.map(c => (
+                        {tag.children.map((c) => (
                             <TagBadge tag={c as Tag} key={c.id} />
                         ))}
                     </section>

--- a/adminSite/client/TagsIndexPage.tsx
+++ b/adminSite/client/TagsIndexPage.tsx
@@ -31,7 +31,7 @@ class AddTagModal extends React.Component<{
 
         return {
             parentId: this.props.parentId,
-            name: this.tagName
+            name: this.tagName,
         }
     }
 
@@ -56,7 +56,7 @@ class AddTagModal extends React.Component<{
         return (
             <Modal onClose={this.props.onClose}>
                 <form
-                    onSubmit={e => {
+                    onSubmit={(e) => {
                         e.preventDefault()
                         this.submit()
                     }}
@@ -99,7 +99,7 @@ export class TagsIndexPage extends React.Component {
     @observable addTagParentId?: number
 
     @computed get categoriesById(): lodash.Dictionary<TagListItem> {
-        return lodash.keyBy(this.tags, t => t.id)
+        return lodash.keyBy(this.tags, (t) => t.id)
     }
 
     @computed get parentCategories(): {
@@ -109,12 +109,12 @@ export class TagsIndexPage extends React.Component {
         children: TagListItem[]
     }[] {
         const parentCategories = this.tags
-            .filter(c => !c.parentId)
-            .map(c => ({
+            .filter((c) => !c.parentId)
+            .map((c) => ({
                 id: c.id,
                 name: c.name,
                 specialType: c.specialType,
-                children: this.tags.filter(c2 => c2.parentId === c.id)
+                children: this.tags.filter((c2) => c2.parentId === c.id),
             }))
 
         return parentCategories
@@ -142,7 +142,7 @@ export class TagsIndexPage extends React.Component {
                     <div className="cardHolder">
                         <section>
                             <h4>Top-Level Categories</h4>
-                            {parentCategories.map(parent => (
+                            {parentCategories.map((parent) => (
                                 <TagBadge key={parent.id} tag={parent as Tag} />
                             ))}
                             <button
@@ -152,7 +152,7 @@ export class TagsIndexPage extends React.Component {
                                 + New Tag
                             </button>
                         </section>
-                        {parentCategories.map(parent => (
+                        {parentCategories.map((parent) => (
                             <section key={`${parent.id}-section`}>
                                 <h4>{parent.name}</h4>
                                 {parent.specialType === "systemParent" && (
@@ -161,7 +161,7 @@ export class TagsIndexPage extends React.Component {
                                         assigned automatically.
                                     </p>
                                 )}
-                                {parent.children.map(tag => (
+                                {parent.children.map((tag) => (
                                     <TagBadge key={tag.id} tag={tag as Tag} />
                                 ))}
                                 <button

--- a/adminSite/client/UserEditPage.tsx
+++ b/adminSite/client/UserEditPage.tsx
@@ -31,7 +31,7 @@ export class UserEditPage extends React.Component<{ userId: number }> {
                     <Toggle
                         label="User has access"
                         value={user.isActive}
-                        onValue={v => (user.isActive = v)}
+                        onValue={(v) => (user.isActive = v)}
                     />
                     <button
                         className="btn btn-success"

--- a/adminSite/client/UsersIndexPage.tsx
+++ b/adminSite/client/UsersIndexPage.tsx
@@ -59,7 +59,7 @@ class InviteModal extends React.Component<{ onClose: () => void }> {
                             <input
                                 type="email"
                                 className="form-control"
-                                onChange={e =>
+                                onChange={(e) =>
                                     (this.email = e.currentTarget.value)
                                 }
                                 required
@@ -146,7 +146,7 @@ export class UsersIndexPage extends React.Component {
                                 {isSuperuser && <th></th>}
                                 {isSuperuser && <th></th>}
                             </tr>
-                            {users.map(user => (
+                            {users.map((user) => (
                                 <tr key={user.id}>
                                     <td>{user.fullName}</td>
                                     <td>

--- a/adminSite/client/VariableEditPage.tsx
+++ b/adminSite/client/VariableEditPage.tsx
@@ -5,7 +5,7 @@ import {
     computed,
     runInAction,
     autorun,
-    IReactionDisposer
+    IReactionDisposer,
 } from "mobx"
 import * as lodash from "lodash"
 import { Prompt, Redirect } from "react-router-dom"
@@ -129,7 +129,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                 <div className="row">
                     <div className="col">
                         <form
-                            onSubmit={e => {
+                            onSubmit={(e) => {
                                 e.preventDefault()
                                 this.save()
                             }}
@@ -193,7 +193,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                             newVariable.display.yearIsDay ===
                                             true
                                         }
-                                        onValue={value =>
+                                        onValue={(value) =>
                                             (newVariable.display.yearIsDay = value)
                                         }
                                         label="Treat year column as day series"
@@ -219,7 +219,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                             newVariable.display
                                                 .includeInTable === true
                                         }
-                                        onValue={value =>
+                                        onValue={(value) =>
                                             (newVariable.display.includeInTable = value)
                                         }
                                         label="Include in table"
@@ -297,9 +297,9 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                 {
                     property: "y",
                     variableId: this.props.variable.id,
-                    display: lodash.clone(this.newVariable.display)
-                }
-            ]
+                    display: lodash.clone(this.newVariable.display),
+                },
+            ],
         }
     }
 

--- a/adminSite/client/VariableList.tsx
+++ b/adminSite/client/VariableList.tsx
@@ -67,12 +67,12 @@ export class VariableList extends React.Component<{
                     <tr>
                         <th>Variable</th>
                         {props.variables.some(
-                            v => v.uploadedAt !== undefined
+                            (v) => v.uploadedAt !== undefined
                         ) && <th>Uploaded</th>}
                     </tr>
                 </thead>
                 <tbody>
-                    {props.variables.map(variable => (
+                    {props.variables.map((variable) => (
                         <VariableRow
                             key={variable.id}
                             variable={variable}

--- a/adminSite/client/VariableSelector.tsx
+++ b/adminSite/client/VariableSelector.tsx
@@ -7,7 +7,7 @@ import {
     observable,
     autorun,
     runInAction,
-    IReactionDisposer
+    IReactionDisposer,
 } from "mobx"
 import { observer } from "mobx-react"
 import { ChartEditor, Dataset, Namespace } from "./ChartEditor"
@@ -52,7 +52,7 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
     @computed get currentNamespace() {
         return defaultTo(
             this.chosenNamespace,
-            this.database.namespaces.find(n => n.name === "owid") as Namespace
+            this.database.namespaces.find((n) => n.name === "owid") as Namespace
         )
     }
 
@@ -67,28 +67,28 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
 
         if (this.currentNamespace.name !== "owid") {
             // The default temporal ordering has no real use for bulk imports
-            return sortBy(datasets, d => d.name)
+            return sortBy(datasets, (d) => d.name)
         } else {
             return datasets
         }
     }
 
     @computed get datasetsByName(): lodash.Dictionary<Dataset> {
-        return lodash.keyBy(this.datasets, d => d.name)
+        return lodash.keyBy(this.datasets, (d) => d.name)
     }
 
     @computed get availableVariables(): Variable[] {
         const variables: Variable[] = []
-        this.datasets.forEach(dataset => {
-            const sorted = sortBy(dataset.variables, v => v.name)
-            sorted.forEach(variable => {
+        this.datasets.forEach((dataset) => {
+            const sorted = sortBy(dataset.variables, (v) => v.name)
+            sorted.forEach((variable) => {
                 variables.push({
                     id: variable.id,
                     name: variable.name,
                     datasetName: dataset.name,
                     searchKey: fuzzysort.prepare(
                         dataset.name + " - " + variable.name
-                    )
+                    ),
                     //name: variable.name.includes(dataset.name) ? variable.name : dataset.name + " - " + variable.name
                 })
             })
@@ -100,7 +100,7 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
         const results =
             this.searchInput &&
             fuzzysort.go(this.searchInput, this.availableVariables, {
-                key: "searchKey"
+                key: "searchKey",
             })
         return results && results.length
             ? results.map((result: any) => result.obj)
@@ -108,7 +108,7 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
     }
 
     @computed get resultsByDataset(): { [datasetName: string]: Variable[] } {
-        return groupBy(this.searchResults, d => d.datasetName)
+        return groupBy(this.searchResults, (d) => d.datasetName)
     }
 
     @computed get searchResultRows() {
@@ -136,14 +136,14 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
             currentNamespace,
             searchInput,
             chosenVariables,
-            datasetsByName
+            datasetsByName,
         } = this
         const {
             rowHeight,
             rowOffset,
             numVisibleRows,
             numTotalRows,
-            searchResultRows
+            searchResultRows,
         } = this
 
         const highlight = (text: string) => {
@@ -175,7 +175,7 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
                                 <SelectField
                                     label="Database"
                                     options={database.namespaces.map(
-                                        n => n.name
+                                        (n) => n.name
                                     )}
                                     optionLabels={database.namespaces.map(
                                         getOptionLabel
@@ -195,17 +195,17 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
                             <div
                                 style={{
                                     height: numVisibleRows * rowHeight,
-                                    overflowY: "scroll"
+                                    overflowY: "scroll",
                                 }}
                                 onScroll={this.onScroll}
-                                ref={e =>
+                                ref={(e) =>
                                     (this.scrollElement = e as HTMLDivElement)
                                 }
                             >
                                 <div
                                     style={{
                                         height: numTotalRows * rowHeight,
-                                        paddingTop: rowHeight * rowOffset
+                                        paddingTop: rowHeight * rowOffset,
                                     }}
                                 >
                                     <ul>
@@ -214,7 +214,7 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
                                                 rowOffset,
                                                 rowOffset + numVisibleRows
                                             )
-                                            .map(d => {
+                                            .map((d) => {
                                                 if (isString(d)) {
                                                     const dataset =
                                                         datasetsByName[d]
@@ -222,7 +222,8 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
                                                         <li
                                                             key={dataset.name}
                                                             style={{
-                                                                minWidth: "100%"
+                                                                minWidth:
+                                                                    "100%",
                                                             }}
                                                         >
                                                             <h5>
@@ -241,17 +242,17 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
                                                         </li>
                                                     )
                                                 } else {
-                                                    return d.map(v => (
+                                                    return d.map((v) => (
                                                         <li
                                                             key={`${v.id}-${v.name}`}
                                                             style={{
-                                                                minWidth: "50%"
+                                                                minWidth: "50%",
                                                             }}
                                                         >
                                                             <Toggle
                                                                 value={this.chosenVariables
                                                                     .map(
-                                                                        cv =>
+                                                                        (cv) =>
                                                                             cv.id
                                                                     )
                                                                     .includes(
@@ -276,7 +277,7 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
                         </div>
                         <div className="selectedData">
                             <ul>
-                                {chosenVariables.map(d => {
+                                {chosenVariables.map((d) => {
                                     return (
                                         <li key={d.id}>
                                             <Toggle
@@ -322,7 +323,7 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
 
     @action.bound onNamespace(namespace: string | undefined) {
         this.chosenNamespace = this.database.namespaces.find(
-            n => n.name === namespace
+            (n) => n.name === namespace
         )
     }
 
@@ -340,7 +341,7 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
 
     @action.bound unselectVariable(variable: Variable) {
         this.chosenVariables = this.chosenVariables.filter(
-            v => v.id !== variable.id
+            (v) => v.id !== variable.id
         )
     }
 
@@ -376,10 +377,10 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
     }
 
     @action.bound private initChosenVariables() {
-        this.chosenVariables = this.props.slot.dimensionsWithData.map(d => ({
+        this.chosenVariables = this.props.slot.dimensionsWithData.map((d) => ({
             name: d.displayName,
             id: d.variableId,
-            datasetName: ""
+            datasetName: "",
         }))
     }
 
@@ -388,6 +389,6 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
     }
 
     @action.bound onComplete() {
-        this.props.onComplete(this.chosenVariables.map(v => v.id))
+        this.props.onComplete(this.chosenVariables.map((v) => v.id))
     }
 }

--- a/adminSite/client/VariablesIndexPage.tsx
+++ b/adminSite/client/VariablesIndexPage.tsx
@@ -6,7 +6,7 @@ import {
     action,
     runInAction,
     reaction,
-    IReactionDisposer
+    IReactionDisposer,
 } from "mobx"
 import * as lodash from "lodash"
 
@@ -47,7 +47,7 @@ export class VariablesIndexPage extends React.Component {
                         ),
                         "i"
                     ),
-                    s => `<b>${s}</b>`
+                    (s) => `<b>${s}</b>`
                 )
                 return <span dangerouslySetInnerHTML={{ __html: html }} />
             } else return text
@@ -91,7 +91,7 @@ export class VariablesIndexPage extends React.Component {
         const { searchInput, maxVisibleRows } = this
         const json = await this.context.admin.getJSON("/api/variables.json", {
             search: searchInput,
-            limit: maxVisibleRows
+            limit: maxVisibleRows,
         })
         runInAction(() => {
             if (searchInput === this.searchInput) {

--- a/adminSite/client/VisionDeficiencies.tsx
+++ b/adminSite/client/VisionDeficiencies.tsx
@@ -3,7 +3,7 @@ import Select, {
     components,
     OptionProps,
     GroupedOptionsType,
-    ValueType
+    ValueType,
 } from "react-select"
 import classNames from "classnames"
 import { observer } from "mobx-react"
@@ -36,7 +36,7 @@ const visionDeficiencies: VisionDeficiency[] = [
                 0.558, 0.442, 0,     0, 0
                 0,     0.242, 0.758, 0, 0
                 0,     0,     0,     1, 0
-                `
+                `,
     },
 
     {
@@ -50,7 +50,7 @@ const visionDeficiencies: VisionDeficiency[] = [
                 0.7,   0.3,   0,   0, 0
                 0,     0.3,   0.7, 0, 0
                 0,     0,     0,   1, 0
-                `
+                `,
     },
     {
         id: "tritanopia",
@@ -63,7 +63,7 @@ const visionDeficiencies: VisionDeficiency[] = [
                 0,    0.433, 0.567, 0, 0
                 0,    0.475, 0.525, 0, 0
                 0,    0,     0,     1, 0
-                `
+                `,
     },
     {
         id: "achromatopsia",
@@ -76,7 +76,7 @@ const visionDeficiencies: VisionDeficiency[] = [
                 0.299, 0.587, 0.114, 0, 0
                 0.299, 0.587, 0.114, 0, 0
                 0,     0,     0,     1, 0
-                `
+                `,
     },
     // Then weaknesses
     {
@@ -90,7 +90,7 @@ const visionDeficiencies: VisionDeficiency[] = [
                 0.333, 0.667, 0,     0, 0
                 0,     0.125, 0.875, 0, 0
                 0,     0,     0,     1, 0
-                `
+                `,
     },
     {
         id: "deuteranomaly",
@@ -103,7 +103,7 @@ const visionDeficiencies: VisionDeficiency[] = [
                 0.258, 0.742, 0,     0, 0
                 0,     0.142, 0.858, 0, 0
                 0,     0,     0,     1, 0
-                `
+                `,
     },
     {
         id: "tritanomaly",
@@ -116,7 +116,7 @@ const visionDeficiencies: VisionDeficiency[] = [
                 0,     0.733, 0.267, 0, 0
                 0,     0.183, 0.817, 0, 0
                 0,     0,     0,     1, 0
-                `
+                `,
     },
     {
         id: "achromatomaly",
@@ -129,14 +129,14 @@ const visionDeficiencies: VisionDeficiency[] = [
                 0.163, 0.775, 0.062, 0, 0
                 0.163, 0.320, 0.516, 0, 0
                 0,     0,     0,     1, 0
-                `
-    }
+                `,
+    },
 ]
 
 export const VisionDeficiencySvgFilters = () => (
     <svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="0">
         <defs>
-            {visionDeficiencies.map(deficiency => (
+            {visionDeficiencies.map((deficiency) => (
                 <filter id={deficiency.id} key={deficiency.id}>
                     <feColorMatrix
                         in="SourceGraphic"
@@ -181,16 +181,16 @@ export class VisionDeficiencyDropdown extends React.Component<
 > {
     noDeficiencyOption = {
         label: "No deficiencies",
-        value: "none"
+        value: "none",
     }
 
     @computed get options(): GroupedOptionsType<VisionDeficiencyEntity> {
-        const options = visionDeficiencies.map(deficiency => ({
+        const options = visionDeficiencies.map((deficiency) => ({
             label: `${deficiency.name} (${deficiency.alternativeName})`,
             value: deficiency.id,
-            deficiency
+            deficiency,
         }))
-        const grouped = groupBy(options, option => option.deficiency.group)
+        const grouped = groupBy(options, (option) => option.deficiency.group)
         const selectGroups = Object.entries(
             grouped
         ).map(([label, options]) => ({ label, options }))
@@ -198,9 +198,9 @@ export class VisionDeficiencyDropdown extends React.Component<
         return [
             {
                 label: "No deficiencies",
-                options: [this.noDeficiencyOption]
+                options: [this.noDeficiencyOption],
             },
-            ...selectGroups
+            ...selectGroups,
         ]
     }
 
@@ -217,7 +217,7 @@ export class VisionDeficiencyDropdown extends React.Component<
                 defaultValue={this.noDeficiencyOption}
                 menuPlacement="top"
                 components={{
-                    Option: VisionDeficiencyOption
+                    Option: VisionDeficiencyOption,
                 }}
                 styles={getStylesForTargetHeight(30)}
             />

--- a/adminSite/server/adminRouter.tsx
+++ b/adminSite/server/adminRouter.tsx
@@ -10,7 +10,7 @@ import {
     expectInt,
     tryInt,
     renderToHtmlPage,
-    JsonError
+    JsonError,
 } from "utils/server/serverUtil"
 import { tryLogin } from "./utils/authentication"
 import { LoginPage } from "./pages/LoginPage"
@@ -31,7 +31,7 @@ const limiterMiddleware = (
         windowMs: 60_000, // 1 minute
         max: 10, // max. 10 requests per minute
         handler: (req, res) =>
-            res.status(429).send(renderToHtmlPage(onFailRender(req, res)))
+            res.status(429).send(renderToHtmlPage(onFailRender(req, res))),
     })
 
 const adminRouter = Router()
@@ -71,7 +71,7 @@ adminRouter.get("/login", async (req, res) => {
 })
 adminRouter.post(
     "/login",
-    limiterMiddleware(req => (
+    limiterMiddleware((req) => (
         <LoginPage
             errorMessage="Too many attempts, please try again in a minute."
             next={req.query.next}
@@ -83,7 +83,7 @@ adminRouter.post(
             res.cookie("sessionid", session.id, {
                 httpOnly: true,
                 sameSite: "lax",
-                secure: ENV === "production"
+                secure: ENV === "production",
             })
             res.redirect(req.query.next || "/admin")
         } catch (err) {
@@ -102,7 +102,7 @@ adminRouter.post(
 adminRouter.get("/logout", async (req, res) => {
     if (res.locals.user)
         await db.query(`DELETE FROM sessions WHERE session_key = ?`, [
-            res.locals.session.id
+            res.locals.session.id,
         ])
 
     res.redirect("/admin")
@@ -110,7 +110,7 @@ adminRouter.get("/logout", async (req, res) => {
 
 adminRouter.get(
     "/register",
-    limiterMiddleware(req => (
+    limiterMiddleware((req) => (
         <RegisterPage
             errorMessage="Too many attempts, please try again in a minute."
             body={req.query}
@@ -154,7 +154,7 @@ adminRouter.get(
 
 adminRouter.post(
     "/register",
-    limiterMiddleware(req => (
+    limiterMiddleware((req) => (
         <RegisterPage
             errorMessage="Too many attempts, please try again in a minute."
             body={req.query}
@@ -177,7 +177,7 @@ adminRouter.post(
                 throw new JsonError("Passwords don't match!", 400)
             }
 
-            await getConnection().transaction(async manager => {
+            await getConnection().transaction(async (manager) => {
                 const user = new User()
                 user.email = req.body.email
                 user.fullName = req.body.fullName

--- a/adminSite/server/apiRouter.ts
+++ b/adminSite/server/apiRouter.ts
@@ -11,7 +11,7 @@ import {
     JsonError,
     expectInt,
     isValidSlug,
-    absoluteUrl
+    absoluteUrl,
 } from "utils/server/serverUtil"
 import { sendMail } from "adminSite/server/utils/mail"
 import { OldChart, Chart, getChartById } from "db/model/Chart"
@@ -21,13 +21,13 @@ import { getVariableData } from "db/model/Variable"
 import { GrapherInterface } from "grapher/core/GrapherInterface"
 import {
     CountryNameFormat,
-    CountryDefByKey
+    CountryDefByKey,
 } from "adminSite/client/CountryNameFormat"
 import { Dataset } from "db/model/Dataset"
 import { User } from "db/model/User"
 import {
     syncDatasetToGitRepo,
-    removeDatasetFromGitRepo
+    removeDatasetFromGitRepo,
 } from "adminSite/server/utils/gitDataExport"
 import { ChartRevision } from "db/model/ChartRevision"
 import { Post } from "db/model/Post"
@@ -56,7 +56,7 @@ async function triggerStaticBuild(user: CurrentUser, commitMessage: string) {
     enqueueDeploy({
         authorName: user.fullName,
         authorEmail: user.email,
-        message: commitMessage
+        message: commitMessage,
     })
 }
 
@@ -127,13 +127,13 @@ async function getReferencesByChartId(
             // We can ignore errors due to not being able to connect.
         }
         const permalinks = await wpdb.getPermalinks()
-        return posts.map(post => {
+        return posts.map((post) => {
             const slug = permalinks.get(post.ID, post.post_name)
             return {
                 id: post.ID,
                 title: post.post_title,
                 slug: slug,
-                url: `${BAKED_BASE_URL}/${slug}`
+                url: `${BAKED_BASE_URL}/${slug}`,
             }
         })
     } else {
@@ -167,7 +167,7 @@ async function expectChartById(chartId: any): Promise<GrapherInterface> {
 
 function omitSaveToVariable(config: GrapherInterface): GrapherInterface {
     const newConfig = lodash.clone(config)
-    newConfig.dimensions = newConfig.dimensions!.map(dim => {
+    newConfig.dimensions = newConfig.dimensions!.map((dim) => {
         return lodash.omit(dim, ["saveToVariable"])
     })
     return newConfig
@@ -178,7 +178,7 @@ async function saveGrapher(
     newConfig: GrapherInterface,
     existingConfig?: GrapherInterface
 ) {
-    return db.transaction(async t => {
+    return db.transaction(async (t) => {
         // Slugs need some special logic to ensure public urls remain consistent whenever possible
         async function isSlugUsedInRedirect() {
             const rows = await t.query(
@@ -254,7 +254,7 @@ async function saveGrapher(
                     now,
                     user.id,
                     isExplorable(newConfig),
-                    chartId
+                    chartId,
                 ]
             )
         } else {
@@ -268,8 +268,8 @@ async function saveGrapher(
                         now,
                         user.id,
                         false,
-                        isExplorable(newConfig)
-                    ]
+                        isExplorable(newConfig),
+                    ],
                 ]
             )
             chartId = result.insertId
@@ -288,7 +288,7 @@ async function saveGrapher(
         // Remove any old dimensions and store the new ones
         // We only note that a relationship exists between the chart and variable in the database; the actual dimension configuration is left to the json
         await t.execute(`DELETE FROM chart_dimensions WHERE chartId=?`, [
-            chartId
+            chartId,
         ])
         for (let i = 0; i < newConfig.dimensions!.length; i++) {
             const dim = newConfig.dimensions![i]
@@ -313,7 +313,7 @@ async function saveGrapher(
 
                 await t.execute(`UPDATE variables SET display=? WHERE id=?`, [
                     JSON.stringify(display),
-                    dim.variableId
+                    dim.variableId,
                 ])
             }
         }
@@ -321,7 +321,7 @@ async function saveGrapher(
         // So we can generate country profiles including this chart data
         if (newConfig.isPublished) {
             await denormalizeLatestCountryData(
-                newConfig.dimensions!.map(d => d.variableId)
+                newConfig.dimensions!.map((d) => d.variableId)
             )
         }
 
@@ -373,7 +373,7 @@ apiRouter.get("/charts.json", async (req: Request, res: Response) => {
     await Chart.assignTagsForCharts(charts)
 
     return {
-        charts: charts
+        charts: charts,
     }
 })
 
@@ -392,7 +392,7 @@ apiRouter.get(
         )) as { name: string; description: string }[]
 
         return {
-            namespaces: lodash.sortBy(rows, row => row.description)
+            namespaces: lodash.sortBy(rows, (row) => row.description),
         }
     }
 )
@@ -402,7 +402,7 @@ apiRouter.get(
     async (req: Request, res: Response) => {
         const logs = await getLogsByChartId(req.params.chartId)
         return {
-            logs: logs
+            logs: logs,
         }
     }
 )
@@ -412,7 +412,7 @@ apiRouter.get(
     async (req: Request, res: Response) => {
         const references = await getReferencesByChartId(req.params.chartId)
         return {
-            references: references
+            references: references,
         }
     }
 )
@@ -422,7 +422,7 @@ apiRouter.get(
     async (req: Request, res: Response) => {
         const redirects = await getRedirectsByChartId(req.params.chartId)
         return {
-            redirects: redirects
+            redirects: redirects,
         }
     }
 )
@@ -453,7 +453,7 @@ apiRouter.get("/countries.json", async (req: Request, res: Response) => {
     }
 
     return {
-        countries: rows
+        countries: rows,
     }
 })
 
@@ -464,7 +464,7 @@ apiRouter.post("/countries", async (req: Request, res: Response) => {
     let owidRows = []
 
     // find owid ID
-    const owidNames = Object.keys(countries).map(key => countries[key])
+    const owidNames = Object.keys(countries).map((key) => countries[key])
     owidRows = await db.query(
         `SELECT id, owid_name
         FROM country_name_tool_countrydata
@@ -521,13 +521,13 @@ apiRouter.get(
                     name: row.datasetName,
                     namespace: row.namespace,
                     isPrivate: row.isPrivate,
-                    variables: []
+                    variables: [],
                 }
             }
 
             dataset.variables.push({
                 id: row.id,
-                name: row.name
+                name: row.name,
             })
         }
 
@@ -588,12 +588,12 @@ apiRouter.put("/charts/:chartId", async (req: Request, res: Response) => {
 apiRouter.delete("/charts/:chartId", async (req: Request, res: Response) => {
     const chart = await expectChartById(req.params.chartId)
 
-    await db.transaction(async t => {
+    await db.transaction(async (t) => {
         await t.execute(`DELETE FROM chart_dimensions WHERE chartId=?`, [
-            chart.id
+            chart.id,
         ])
         await t.execute(`DELETE FROM chart_slug_redirects WHERE chart_id=?`, [
-            chart.id
+            chart.id,
         ])
         await t.execute(`DELETE FROM charts WHERE id=?`, [chart.id])
     })
@@ -619,10 +619,10 @@ apiRouter.get("/users.json", async (req: Request, res: Response) => {
                 "createdAt",
                 "updatedAt",
                 "lastLogin",
-                "lastSeen"
+                "lastSeen",
             ],
-            order: { lastSeen: "DESC" }
-        })
+            order: { lastSeen: "DESC" },
+        }),
     }
 })
 
@@ -637,8 +637,8 @@ apiRouter.get("/users/:userId.json", async (req: Request, res: Response) => {
             "createdAt",
             "updatedAt",
             "lastLogin",
-            "lastSeen"
-        ]
+            "lastSeen",
+        ],
     })
     return { user: user }
 })
@@ -649,7 +649,7 @@ apiRouter.delete("/users/:userId", async (req: Request, res: Response) => {
     }
 
     const userId = expectInt(req.params.userId)
-    await db.transaction(async t => {
+    await db.transaction(async (t) => {
         await t.execute(`DELETE FROM users WHERE id=?`, [userId])
     })
 
@@ -678,7 +678,7 @@ apiRouter.post("/users/invite", async (req: Request, res: Response) => {
 
     const { email } = req.body
 
-    await getConnection().transaction(async manager => {
+    await getConnection().transaction(async (manager) => {
         // Remove any previous invites for this email address to avoid duplicate accounts
         const repo = manager.getRepository(UserInvitation)
         await repo
@@ -701,14 +701,14 @@ apiRouter.post("/users/invite", async (req: Request, res: Response) => {
             from: "no-reply@ourworldindata.org",
             to: email,
             subject: "Invitation to join owid-admin",
-            text: `Hi, please follow this link to register on owid-admin: ${inviteLink}`
+            text: `Hi, please follow this link to register on owid-admin: ${inviteLink}`,
         })
     })
 
     return { success: true }
 })
 
-apiRouter.get("/variables.json", async req => {
+apiRouter.get("/variables.json", async (req) => {
     const limit = req.query.limit !== undefined ? parseInt(req.query.limit) : 50
     const searchStr = req.query.search
 
@@ -795,7 +795,7 @@ apiRouter.get(
         variable.charts = charts
 
         return {
-            variable: variable as VariableSingleMeta
+            variable: variable as VariableSingleMeta,
         } /*, vardata: await getVariableData([variableId]) }*/
     }
 )
@@ -811,7 +811,7 @@ apiRouter.put("/variables/:variableId", async (req: Request) => {
             variable.description,
             new Date(),
             JSON.stringify(variable.display),
-            variableId
+            variableId,
         ]
     )
 
@@ -832,9 +832,9 @@ apiRouter.delete("/variables/:variableId", async (req: Request) => {
         throw new JsonError(`Cannot delete bulk import variable`, 400)
     }
 
-    await db.transaction(async t => {
+    await db.transaction(async (t) => {
         await t.execute(`DELETE FROM data_values WHERE variableId=?`, [
-            variableId
+            variableId,
         ])
         await t.execute(`DELETE FROM variables WHERE id=?`, [variableId])
     })
@@ -842,7 +842,7 @@ apiRouter.delete("/variables/:variableId", async (req: Request) => {
     return { success: true }
 })
 
-apiRouter.get("/datasets.json", async req => {
+apiRouter.get("/datasets.json", async (req) => {
     const datasets = await db.query(`
         SELECT d.id, d.namespace, d.name, d.description, d.dataEditedAt, du.fullName AS dataEditedByUserName, d.metadataEditedAt, mu.fullName AS metadataEditedByUserName, d.isPrivate
         FROM datasets d
@@ -855,9 +855,9 @@ apiRouter.get("/datasets.json", async req => {
         SELECT dt.datasetId, t.id, t.name FROM dataset_tags dt
         JOIN tags t ON dt.tagId = t.id
     `)
-    const tagsByDatasetId = lodash.groupBy(tags, t => t.datasetId)
+    const tagsByDatasetId = lodash.groupBy(tags, (t) => t.datasetId)
     for (const dataset of datasets) {
-        dataset.tags = (tagsByDatasetId[dataset.id] || []).map(t =>
+        dataset.tags = (tagsByDatasetId[dataset.id] || []).map((t) =>
             lodash.omit(t, "datasetId")
         )
     }
@@ -967,7 +967,7 @@ apiRouter.put("/datasets/:datasetId", async (req: Request, res: Response) => {
     const dataset = await Dataset.findOne({ id: datasetId })
     if (!dataset) throw new JsonError(`No dataset by id ${datasetId}`, 404)
 
-    await db.transaction(async t => {
+    await db.transaction(async (t) => {
         const newDataset = (req.body as { dataset: any }).dataset
         await t.execute(
             `UPDATE datasets SET name=?, description=?, isPrivate=?, metadataEditedAt=?, metadataEditedByUserId=? WHERE id=?`,
@@ -977,13 +977,13 @@ apiRouter.put("/datasets/:datasetId", async (req: Request, res: Response) => {
                 newDataset.isPrivate,
                 new Date(),
                 res.locals.user.id,
-                datasetId
+                datasetId,
             ]
         )
 
         const tagRows = newDataset.tags.map((tag: any) => [tag.id, datasetId])
         await t.execute(`DELETE FROM dataset_tags WHERE datasetId=?`, [
-            datasetId
+            datasetId,
         ])
         if (tagRows.length)
             await t.execute(
@@ -996,7 +996,7 @@ apiRouter.put("/datasets/:datasetId", async (req: Request, res: Response) => {
         await t.execute(`UPDATE sources SET name=?, description=? WHERE id=?`, [
             source.name,
             JSON.stringify(description),
-            source.id
+            source.id,
         ])
     })
 
@@ -1005,7 +1005,7 @@ apiRouter.put("/datasets/:datasetId", async (req: Request, res: Response) => {
         await syncDatasetToGitRepo(datasetId, {
             oldDatasetName: dataset.name,
             commitName: res.locals.user.fullName,
-            commitEmail: res.locals.user.email
+            commitEmail: res.locals.user.email,
         })
     } catch (err) {
         log.error(err)
@@ -1032,9 +1032,9 @@ apiRouter.router.put(
     async (req: Request, res: Response) => {
         const datasetId = expectInt(req.params.datasetId)
 
-        await db.transaction(async t => {
+        await db.transaction(async (t) => {
             await t.execute(`DELETE FROM dataset_files WHERE datasetId=?`, [
-                datasetId
+                datasetId,
             ])
             await t.execute(
                 `INSERT INTO dataset_files (datasetId, filename, file) VALUES (?, ?, ?)`,
@@ -1054,7 +1054,7 @@ apiRouter.delete(
         const dataset = await Dataset.findOne({ id: datasetId })
         if (!dataset) throw new JsonError(`No dataset by id ${datasetId}`, 404)
 
-        await db.transaction(async t => {
+        await db.transaction(async (t) => {
             await t.execute(
                 `DELETE d FROM data_values AS d JOIN variables AS v ON d.variableId=v.id WHERE v.datasetId=?`,
                 [datasetId]
@@ -1064,13 +1064,13 @@ apiRouter.delete(
                 [datasetId]
             )
             await t.execute(`DELETE FROM dataset_files WHERE datasetId=?`, [
-                datasetId
+                datasetId,
             ])
             await t.execute(`DELETE FROM variables WHERE datasetId=?`, [
-                datasetId
+                datasetId,
             ])
             await t.execute(`DELETE FROM sources WHERE datasetId=?`, [
-                datasetId
+                datasetId,
             ])
             await t.execute(`DELETE FROM datasets WHERE id=?`, [datasetId])
         })
@@ -1078,7 +1078,7 @@ apiRouter.delete(
         try {
             await removeDatasetFromGitRepo(dataset.name, dataset.namespace, {
                 commitName: res.locals.user.fullName,
-                commitEmail: res.locals.user.email
+                commitEmail: res.locals.user.email,
             })
         } catch (err) {
             log.error(err)
@@ -1098,7 +1098,7 @@ apiRouter.post(
         if (!dataset) throw new JsonError(`No dataset by id ${datasetId}`, 404)
 
         if (req.body.republish) {
-            await db.transaction(async t => {
+            await db.transaction(async (t) => {
                 await t.execute(
                     `
             UPDATE charts
@@ -1132,7 +1132,7 @@ apiRouter.get("/redirects.json", async (req: Request, res: Response) => {
         ORDER BY r.id DESC`)
 
     return {
-        redirects: redirects
+        redirects: redirects,
     }
 })
 
@@ -1182,10 +1182,10 @@ apiRouter.get("/tags/:tagId.json", async (req: Request, res: Response) => {
             )
             const tagsByDatasetId = lodash.groupBy(
                 datasetTags,
-                t => t.datasetId
+                (t) => t.datasetId
             )
             for (const dataset of tag.datasets) {
-                dataset.tags = tagsByDatasetId[dataset.id].map(t =>
+                dataset.tags = tagsByDatasetId[dataset.id].map((t) =>
                     lodash.omit(t, "datasetId")
                 )
             }
@@ -1227,7 +1227,7 @@ apiRouter.get("/tags/:tagId.json", async (req: Request, res: Response) => {
     tag.possibleParents = possibleParents
 
     return {
-        tag: tag
+        tag: tag,
     }
 })
 
@@ -1260,14 +1260,14 @@ apiRouter.get("/tags.json", async (req: Request, res: Response) => {
     `)
 
     return {
-        tags: tags
+        tags: tags,
     }
 })
 
 apiRouter.delete("/tags/:tagId/delete", async (req: Request, res: Response) => {
     const tagId = expectInt(req.params.tagId)
 
-    await db.transaction(async t => {
+    await db.transaction(async (t) => {
         await t.execute(`DELETE FROM tags WHERE id=?`, [tagId])
     })
 
@@ -1310,7 +1310,7 @@ apiRouter.delete("/redirects/:id", async (req: Request, res: Response) => {
     return { success: true }
 })
 
-apiRouter.get("/posts.json", async req => {
+apiRouter.get("/posts.json", async (req) => {
     const rows = await Post.select(
         "id",
         "title",
@@ -1335,10 +1335,10 @@ apiRouter.get("/posts.json", async req => {
         ;(post as any).tags = tagsByPostId.get(post.id) || []
     }
 
-    return { posts: rows.map(r => camelCaseProperties(r)) }
+    return { posts: rows.map((r) => camelCaseProperties(r)) }
 })
 
-apiRouter.get("/newsletterPosts.json", async req => {
+apiRouter.get("/newsletterPosts.json", async (req) => {
     const rows = await wpdb.query(`
         SELECT
             ID AS id,
@@ -1356,7 +1356,7 @@ apiRouter.get("/newsletterPosts.json", async req => {
     const permalinks = await wpdb.getPermalinks()
     const featuresImages = await wpdb.getFeaturedImages()
 
-    const posts = rows.map(row => {
+    const posts = rows.map((row) => {
         const slug = permalinks.get(row.id, row.name)
         return {
             id: row.id,
@@ -1368,7 +1368,7 @@ apiRouter.get("/newsletterPosts.json", async req => {
             excerpt: row.excerpt,
             slug: slug,
             imageUrl: featuresImages.get(row.id),
-            url: `${BAKED_BASE_URL}/${slug}`
+            url: `${BAKED_BASE_URL}/${slug}`,
         }
     })
 
@@ -1396,7 +1396,7 @@ apiRouter.get("/posts/:postId.json", async (req: Request, res: Response) => {
     return camelCaseProperties(post)
 })
 
-apiRouter.get("/importData.json", async req => {
+apiRouter.get("/importData.json", async (req) => {
     // Get all datasets from the importable namespace to match against
     const datasets = await db.query(
         `SELECT id, name FROM datasets WHERE namespace='owid' ORDER BY name ASC`
@@ -1410,7 +1410,7 @@ apiRouter.get("/importData.json", async req => {
     return { datasets: datasets, existingEntities: existingEntities }
 })
 
-apiRouter.get("/importData/datasets/:datasetId.json", async req => {
+apiRouter.get("/importData/datasets/:datasetId.json", async (req) => {
     const datasetId = expectInt(req.params.datasetId)
 
     const dataset = await db.get(
@@ -1477,7 +1477,7 @@ apiRouter.post("/importDataset", async (req: Request, res: Response) => {
     const userId = res.locals.user.id
     const { dataset, entities, years, variables } = req.body as ImportPostData
 
-    const newDatasetId = await db.transaction(async t => {
+    const newDatasetId = await db.transaction(async (t) => {
         const now = new Date()
 
         let datasetId: number
@@ -1502,7 +1502,7 @@ apiRouter.post("/importDataset", async (req: Request, res: Response) => {
                 now,
                 userId,
                 userId,
-                true
+                true,
             ]
             const datasetResult = await t.execute(
                 `INSERT INTO datasets (name, namespace, description, createdAt, updatedAt, dataEditedAt, dataEditedByUserId, metadataEditedAt, metadataEditedByUserId, createdByUserId, isPrivate) VALUES (?)`,
@@ -1535,7 +1535,13 @@ apiRouter.post("/importDataset", async (req: Request, res: Response) => {
 
         // Insert any new entities into the db
         const entitiesUniq = lodash.uniq(entities)
-        const importEntityRows = entitiesUniq.map(e => [e, false, now, now, ""])
+        const importEntityRows = entitiesUniq.map((e) => [
+            e,
+            false,
+            now,
+            now,
+            "",
+        ])
         await t.execute(
             `INSERT IGNORE entities (name, validated, createdAt, updatedAt, displayName) VALUES ?`,
             [importEntityRows]
@@ -1560,17 +1566,17 @@ apiRouter.post("/importDataset", async (req: Request, res: Response) => {
             [datasetId]
         )
         const removingVariables = existingVariables.filter(
-            (v: any) => !variables.some(v2 => v2.overwriteId === v.id)
+            (v: any) => !variables.some((v2) => v2.overwriteId === v.id)
         )
         const removingVariableIds = removingVariables.map(
             (v: any) => v.id
         ) as number[]
         if (removingVariableIds.length) {
             await t.execute(`DELETE FROM data_values WHERE variableId IN (?)`, [
-                removingVariableIds
+                removingVariableIds,
             ])
             await t.execute(`DELETE FROM variables WHERE id IN (?)`, [
-                removingVariableIds
+                removingVariableIds,
             ])
         }
 
@@ -1580,7 +1586,7 @@ apiRouter.post("/importDataset", async (req: Request, res: Response) => {
             if (variable.overwriteId) {
                 // Remove any existing data values
                 await t.execute(`DELETE FROM data_values WHERE variableId=?`, [
-                    variable.overwriteId
+                    variable.overwriteId,
                 ])
 
                 variableId = variable.overwriteId
@@ -1594,7 +1600,7 @@ apiRouter.post("/importDataset", async (req: Request, res: Response) => {
                     "",
                     "",
                     "",
-                    "{}"
+                    "{}",
                 ]
 
                 // Create a new variable
@@ -1614,7 +1620,7 @@ apiRouter.post("/importDataset", async (req: Request, res: Response) => {
                         value,
                         years[i],
                         entityIdLookup[entities[i]],
-                        variableId
+                        variableId,
                     ])
                 }
             }

--- a/adminSite/server/app.tsx
+++ b/adminSite/server/app.tsx
@@ -74,12 +74,12 @@ app.use(async (err: any, req: any, res: express.Response, next: any) => {
     if (!res.headersSent) {
         res.status(err.status || 500)
         res.send({
-            error: { message: err.stack || err, status: err.status || 500 }
+            error: { message: err.stack || err, status: err.status || 500 },
         })
     } else {
         res.write(
             JSON.stringify({
-                error: { message: err.stack || err, status: err.status || 500 }
+                error: { message: err.stack || err, status: err.status || 500 },
             })
         )
         res.end()

--- a/adminSite/server/mockSiteRouter.tsx
+++ b/adminSite/server/mockSiteRouter.tsx
@@ -17,7 +17,7 @@ import {
     renderNotFoundPage,
     renderBlogByPageNum,
     renderCovidPage,
-    countryProfileCountryPage
+    countryProfileCountryPage,
 } from "site/server/siteBaking"
 import { chartDataJson, grapherPageFromSlug } from "site/server/grapherBaking"
 import { BAKED_GRAPHER_URL } from "settings"
@@ -27,14 +27,14 @@ import { expectInt, JsonError } from "utils/server/serverUtil"
 import { embedSnippet } from "site/server/embedCharts"
 import {
     countryProfilePage,
-    countriesIndexPage
+    countriesIndexPage,
 } from "site/server/countryProfiles"
 import { makeSitemap } from "site/server/sitemap"
 import { OldChart } from "db/model/Chart"
 import { chartToSVG } from "site/server/svgPngExport"
 import {
     covidDashboardSlug,
-    covidChartAndVariableMetaPath
+    covidChartAndVariableMetaPath,
 } from "explorer/covidExplorer/CovidConstants"
 import { bakeCovidChartAndVariableMeta } from "explorer/covidExplorer/bakeCovidChartAndVariableMeta"
 import { chartExplorerRedirectsBySlug } from "explorer/covidExplorer/bakeCovidExplorerRedirects"
@@ -71,7 +71,7 @@ mockSiteRouter.get(
             await chartDataJson(
                 (req.params.variableIds as string)
                     .split("+")
-                    .map(v => expectInt(v))
+                    .map((v) => expectInt(v))
             )
         )
     }
@@ -125,7 +125,7 @@ mockSiteRouter.get(`/${covidDashboardSlug}`, async (req, res) => {
     res.send(await renderCovidExplorerPage())
 })
 
-countryProfileSpecs.forEach(spec => {
+countryProfileSpecs.forEach((spec) => {
     mockSiteRouter.get(`/${spec.rootPath}/:countrySlug`, async (req, res) => {
         res.send(await countryProfileCountryPage(spec, req.params.countrySlug))
     })
@@ -171,7 +171,7 @@ mockSiteRouter.use(
     // on front page.
     ["/uploads", "/app/uploads"],
     express.static(path.join(WORDPRESS_DIR, "web/app/uploads"), {
-        fallthrough: false
+        fallthrough: false,
     })
 )
 

--- a/adminSite/server/testPageRouter.tsx
+++ b/adminSite/server/testPageRouter.tsx
@@ -95,7 +95,7 @@ function EmbedTestPage(props: EmbedTestPageProps) {
                         {!IS_LIVE && <h3>{BAKED_BASE_URL}</h3>}
                     </div>
                 </div>
-                {props.charts.map(chart => (
+                {props.charts.map((chart) => (
                     <div key={chart.slug} className="row">
                         <div className="chart-id">{chart.id}</div>
                         <div className="side-by-side">
@@ -206,13 +206,13 @@ testPageRouter.get("/embeds", async (req, res) => {
         )
     }
 
-    const charts: ChartItem[] = (await query.getMany()).map(c => ({
+    const charts: ChartItem[] = (await query.getMany()).map((c) => ({
         id: c.id,
-        slug: c.config.slug
+        slug: c.config.slug,
     }))
 
     if (tab) {
-        charts.forEach(c => (c.slug += `?tab=${tab}`))
+        charts.forEach((c) => (c.slug += `?tab=${tab}`))
     }
 
     const count = await query.getCount()
@@ -259,8 +259,8 @@ testPageRouter.get("/embeds/:id", async (req, res) => {
                 id: chart.id,
                 slug: `${chart.config.slug}${
                     req.query.tab ? `?tab=${req.query.tab}` : ""
-                }`
-            }
+                }`,
+            },
         ]
         res.send(renderToHtmlPage(<EmbedTestPage charts={charts} />))
     } else {
@@ -295,7 +295,7 @@ function PreviewTestPage(props: { charts: any[] }) {
                 <style dangerouslySetInnerHTML={{ __html: style }} />
             </head>
             <body>
-                {props.charts.map(chart => (
+                {props.charts.map((chart) => (
                     <div key={chart.slug} className="row">
                         <a
                             href={`https://ourworldindata.org/grapher/${chart.slug}`}
@@ -373,7 +373,7 @@ function EmbedVariantsTestPage(props: EmbedTestPageProps) {
                 <style dangerouslySetInnerHTML={{ __html: style }} />
             </head>
             <body>
-                {props.charts.map(chart => (
+                {props.charts.map((chart) => (
                     <div key={chart.slug} className="row">
                         <div className="chart-id">{chart.id}</div>
                         <div className="side-by-side">

--- a/adminSite/server/utils/authentication.tsx
+++ b/adminSite/server/utils/authentication.tsx
@@ -103,7 +103,7 @@ export async function tryLogin(
             _auth_user_hash: saltedHmac(
                 "django.contrib.auth.models.AbstractBaseUser.get_session_auth_hash",
                 password
-            )
+            ),
         })
         const sessionHash = saltedHmac(
             "django.contrib.sessions.SessionStore",

--- a/adminSite/server/utils/gitDataExport.ts
+++ b/adminSite/server/utils/gitDataExport.ts
@@ -4,7 +4,7 @@ import {
     JsonError,
     filenamify,
     exec,
-    execFormatted
+    execFormatted,
 } from "utils/server/serverUtil"
 import { Dataset } from "db/model/Dataset"
 import { Source } from "db/model/Source"
@@ -45,7 +45,7 @@ export async function removeDatasetFromGitRepo(
             repoDir,
             `${repoDir}/datasets/${datasetName}`,
             `${repoDir}/datasets/${datasetName}`,
-            `Removing ${datasetName}`
+            `Removing ${datasetName}`,
         ]
     )
 }
@@ -114,7 +114,7 @@ export async function syncDatasetToGitRepo(
         fs.writeFile(
             path.join(tmpDatasetDir, `README.md`),
             await datasetToReadme(dataset)
-        )
+        ),
     ])
 
     const datasetsDir = path.join(repoDir, "datasets")
@@ -127,7 +127,7 @@ export async function syncDatasetToGitRepo(
         finalDatasetDir,
         tmpDatasetDir,
         finalDatasetDir,
-        finalDatasetDir
+        finalDatasetDir,
     ])
 
     if (oldDatasetFilename && oldDatasetFilename !== dataset.filename) {
@@ -135,7 +135,7 @@ export async function syncDatasetToGitRepo(
         await execFormatted(`cd %s && rm -rf %s && git add -A %s`, [
             repoDir,
             oldDatasetDir,
-            oldDatasetDir
+            oldDatasetDir,
         ])
     }
 

--- a/adminSite/server/utils/mail.ts
+++ b/adminSite/server/utils/mail.ts
@@ -4,7 +4,7 @@ import {
     EMAIL_HOST,
     EMAIL_PORT,
     EMAIL_HOST_USER,
-    EMAIL_HOST_PASSWORD
+    EMAIL_HOST_PASSWORD,
 } from "serverSettings"
 
 const transporter = nodemailer.createTransport({
@@ -13,8 +13,8 @@ const transporter = nodemailer.createTransport({
     secure: EMAIL_PORT === 465,
     auth: {
         user: EMAIL_HOST_USER,
-        pass: EMAIL_HOST_PASSWORD
-    }
+        pass: EMAIL_HOST_PASSWORD,
+    },
 })
 
 export async function sendMail(

--- a/algolia/configureAlgolia.ts
+++ b/algolia/configureAlgolia.ts
@@ -18,7 +18,7 @@ export async function configureAlgolia() {
             "unordered(variantName)",
             "unordered(subtitle)",
             "unordered(_tags)",
-            "unordered(availableEntities)"
+            "unordered(availableEntities)",
         ],
         ranking: ["exact", "typo", "attribute", "words", "proximity", "custom"],
         customRanking: ["asc(numDimensions)", "asc(titleLength)"],
@@ -27,12 +27,12 @@ export async function configureAlgolia() {
         alternativesAsExact: [
             "ignorePlurals",
             "singleWordSynonym",
-            "multiWordsSynonym"
+            "multiWordsSynonym",
         ],
         exactOnSingleWordQuery: "none",
         disableExactOnAttributes: ["_tags"],
         optionalWords: ["vs"],
-        removeStopWords: ["en"]
+        removeStopWords: ["en"],
     })
 
     const pagesIndex = client.initIndex("pages")
@@ -42,7 +42,7 @@ export async function configureAlgolia() {
             "unordered(title)",
             "unordered(content)",
             "unordered(_tags)",
-            "unordered(authors)"
+            "unordered(authors)",
         ],
         ranking: ["exact", "typo", "attribute", "words", "proximity", "custom"],
         customRanking: ["desc(importance)"],
@@ -51,12 +51,12 @@ export async function configureAlgolia() {
         alternativesAsExact: [
             "ignorePlurals",
             "singleWordSynonym",
-            "multiWordsSynonym"
+            "multiWordsSynonym",
         ],
         attributesForFaceting: ["searchable(_tags)", "searchable(authors)"],
         exactOnSingleWordQuery: "none",
         disableExactOnAttributes: ["_tags"],
-        removeStopWords: ["en"]
+        removeStopWords: ["en"],
     })
 
     const synonyms = [
@@ -72,7 +72,7 @@ export async function configureAlgolia() {
         ["co2", "CO₂", "carbon dioxide"],
         ["ch4", "CH₄", "methane"],
         ["n2o", "N₂O", "nitrous oxide"],
-        ["NOx", "NOₓ", "nitrogen dioxide"]
+        ["NOx", "NOₓ", "nitrogen dioxide"],
     ]
 
     // Send all our country variant names to algolia as synonyms
@@ -82,19 +82,19 @@ export async function configureAlgolia() {
         }
     }
 
-    const algoliaSynonyms = synonyms.map(s => {
+    const algoliaSynonyms = synonyms.map((s) => {
         return {
             objectID: s.join("-"),
             type: "synonym",
-            synonyms: s
+            synonyms: s,
         } as Synonym
     })
 
     await pagesIndex.saveSynonyms(algoliaSynonyms, {
-        replaceExistingSynonyms: true
+        replaceExistingSynonyms: true,
     })
     await chartsIndex.saveSynonyms(algoliaSynonyms, {
-        replaceExistingSynonyms: true
+        replaceExistingSynonyms: true,
     })
 }
 

--- a/algolia/indexChartsToAlgolia.ts
+++ b/algolia/indexChartsToAlgolia.ts
@@ -26,7 +26,7 @@ async function indexChartsToAlgolia() {
         c.tags = []
     }
 
-    const chartsById = lodash.keyBy(allCharts, c => c.id)
+    const chartsById = lodash.keyBy(allCharts, (c) => c.id)
 
     const chartsToIndex = []
     for (const ct of chartTags) {
@@ -56,7 +56,7 @@ async function indexChartsToAlgolia() {
             publishedAt: c.publishedAt,
             updatedAt: c.updatedAt,
             numDimensions: parseInt(c.numDimensions),
-            titleLength: c.title.length
+            titleLength: c.title.length,
         })
     }
     await index.replaceAllObjects(records)

--- a/algolia/indexToAlgolia.ts
+++ b/algolia/indexToAlgolia.ts
@@ -25,12 +25,12 @@ function getPostType(post: FormattedPost, tags: Tag[]) {
     if (post.slug.startsWith("about/")) {
         return "about"
     } else if (post.type === "post") {
-        if (tags.some(t => t.name === "Explainers")) return "explainer"
-        else if (tags.some(t => t.name === "Short updates and facts"))
+        if (tags.some((t) => t.name === "Explainers")) return "explainer"
+        else if (tags.some((t) => t.name === "Short updates and facts"))
             return "fact"
         else return "post"
     } else {
-        if (tags.some(t => t.name === "Entries")) {
+        if (tags.some((t) => t.name === "Entries")) {
             return "entry"
         } else {
             return "page"
@@ -51,7 +51,7 @@ async function indexToAlgolia() {
             type: "country",
             slug: country.slug,
             title: country.name,
-            content: `All available indicators for ${country.name}.`
+            content: `All available indicators for ${country.name}.`,
         })
     }
 
@@ -83,8 +83,8 @@ async function indexToAlgolia() {
                 date: post.date,
                 modifiedDate: post.modifiedDate,
                 content: c,
-                _tags: tags.map(t => t.name),
-                importance: importance
+                _tags: tags.map((t) => t.name),
+                importance: importance,
             })
             i += 1
         }

--- a/algolia/searchClient.ts
+++ b/algolia/searchClient.ts
@@ -102,12 +102,12 @@ export async function siteSearch(query: string): Promise<SiteSearchResults> {
                     "title",
                     "type",
                     "code",
-                    "content"
+                    "content",
                 ],
                 attributesToSnippet: ["content:24"],
                 distinct: true,
-                hitsPerPage: 10
-            }
+                hitsPerPage: 10,
+            },
         },
         {
             indexName: "charts",
@@ -117,20 +117,20 @@ export async function siteSearch(query: string): Promise<SiteSearchResults> {
                     "chartId",
                     "slug",
                     "title",
-                    "variantName"
+                    "variantName",
                 ],
                 attributesToSnippet: ["subtitle:24"],
                 attributesToHighlight: ["availableEntities"],
                 hitsPerPage: 10,
                 removeStopWords: true,
-                replaceSynonymsInHighlight: false
-            }
-        }
+                replaceSynonymsInHighlight: false,
+            },
+        },
     ])
 
     return {
         pages: json.results[0].hits as PageHit[],
         charts: (json.results[1].hits as unknown) as ChartHit[],
-        countries: matchCountries
+        countries: matchCountries,
     }
 }

--- a/db/database.ts
+++ b/db/database.ts
@@ -25,7 +25,7 @@ export function createConnection(props: { database: string }) {
         mysql.createConnection({
             host: "localhost",
             user: "root",
-            database: props.database
+            database: props.database,
         })
     )
 }

--- a/db/db.ts
+++ b/db/db.ts
@@ -51,7 +51,7 @@ export class TransactionContext {
 export async function transaction<T>(
     callback: (t: TransactionContext) => Promise<T>
 ): Promise<T> {
-    return (await getConnection()).transaction(async manager => {
+    return (await getConnection()).transaction(async (manager) => {
         const t = new TransactionContext(manager)
         return callback(t)
     })
@@ -94,8 +94,8 @@ export function knex() {
                         return field.string() === "1" // 1 = true, 0 = false
                     }
                     return next()
-                }
-            }
+                },
+            },
         })
 
         registerExitHandler(async () => {

--- a/db/exportMetadata.ts
+++ b/db/exportMetadata.ts
@@ -20,7 +20,7 @@ const excludeTables = [
     "sessions",
     "user_invitations",
     "dataset_files",
-    "data_values"
+    "data_values",
 ]
 
 async function dataExport() {
@@ -35,7 +35,7 @@ async function dataExport() {
     // Dump all tables including schema but exclude the rows of data_values
     await exec(
         `mysqldump --default-character-set=utf8mb4 --no-tablespaces -u '${DB_USER}' -h '${DB_HOST}' -P ${DB_PORT} ${DB_NAME} ${excludeTables
-            .map(tableName => `--ignore-table=${DB_NAME}.${tableName}`)
+            .map((tableName) => `--ignore-table=${DB_NAME}.${tableName}`)
             .join(" ")} -r ${filePath}`
     )
     await exec(

--- a/db/importVDemDataset.ts
+++ b/db/importVDemDataset.ts
@@ -25,7 +25,7 @@ async function importCodebook() {
 
     const now = new Date()
     const codebookRows = await parseCSV(codebookCSV)
-    const vdemVariables = codebookRows.slice(1).map(row => ({
+    const vdemVariables = codebookRows.slice(1).map((row) => ({
         indicatorCode: row[0],
         indicatorName: row[1],
         shortDefinition: row[2],
@@ -33,13 +33,13 @@ async function importCodebook() {
         responses: row[4],
         dataRelease: row[5],
         aggregationMethod: row[6],
-        variableSource: row[7].trim()
+        variableSource: row[7].trim(),
     }))
 
     // Need to handle these fussy subset codes separately
     const variablesByCode = lodash.keyBy(
-        vdemVariables.filter(v => v.shortDefinition),
-        v => v.indicatorCode
+        vdemVariables.filter((v) => v.shortDefinition),
+        (v) => v.indicatorCode
     )
     for (const v of vdemVariables) {
         const orig = variablesByCode[v.indicatorCode]
@@ -69,7 +69,7 @@ async function importCodebook() {
         await db.get(`SELECT * FROM users WHERE fullName=?`, ["Jaiden Mispy"])
     ).id
 
-    await db.transaction(async t => {
+    await db.transaction(async (t) => {
         const existingDataset = (
             await t.query("SELECT id FROM datasets WHERE namespace='vdem'")
         )[0]
@@ -79,13 +79,13 @@ async function importCodebook() {
                 [existingDataset.id]
             )
             await t.execute(`DELETE FROM variables WHERE datasetId=?`, [
-                existingDataset.id
+                existingDataset.id,
             ])
             await t.execute(`DELETE FROM sources WHERE datasetId=?`, [
-                existingDataset.id
+                existingDataset.id,
             ])
             await t.execute(`DELETE FROM datasets WHERE id=?`, [
-                existingDataset.id
+                existingDataset.id,
             ])
         }
 
@@ -100,7 +100,7 @@ async function importCodebook() {
             userId,
             now,
             userId,
-            userId
+            userId,
         ]
         const result = await t.query(
             "INSERT INTO datasets (namespace, name, description, isPrivate, createdAt, updatedAt, metadataEditedAt, metadataEditedByUserId, dataEditedAt, dataEditedByUserId, createdByUserId) VALUES (?)",
@@ -138,14 +138,14 @@ async function importCodebook() {
                 dataPublishedBy: "V-Dem Institute",
                 dataPublisherSource: v.variableSource,
                 link: findUrlsInText(v.variableSource).join(","),
-                additionalInfo: additionalInfo
+                additionalInfo: additionalInfo,
             }
             const sourceRow = [
                 datasetId,
                 sourceName,
                 now,
                 now,
-                JSON.stringify(sourceDescription)
+                JSON.stringify(sourceDescription),
             ]
 
             const sourceResult = await t.query(
@@ -167,7 +167,7 @@ async function importCodebook() {
                 "",
                 "",
                 "",
-                "{}"
+                "{}",
             ]
             await t.query(
                 "INSERT INTO variables (datasetId, sourceId, columnOrder, name, code, description, createdAt, updatedAt, originalMetadata, unit, coverage, timespan, display) VALUES (?)",
@@ -193,7 +193,7 @@ async function importData() {
         "Timor-Leste": "Timor",
         "United States of America": "United States",
         "Democratic Republic of Vietnam": "Vietnam",
-        Würtemberg: "Wurtemberg"
+        Würtemberg: "Wurtemberg",
     } as { [key: string]: string | undefined }
 
     const entitiesUniq = [
@@ -397,17 +397,23 @@ async function importData() {
         "South Africa",
         "Zambia",
         "Zimbabwe",
-        "Zanzibar"
+        "Zanzibar",
     ]
 
-    await db.transaction(async t => {
+    await db.transaction(async (t) => {
         await t.execute(
             `DELETE dv FROM data_values dv JOIN variables v ON dv.variableId=v.id JOIN datasets d ON v.datasetId=d.id WHERE d.namespace='vdem'`
         )
 
         const now = new Date()
         // Insert any new entities into the db
-        const importEntityRows = entitiesUniq.map(e => [e, false, now, now, ""])
+        const importEntityRows = entitiesUniq.map((e) => [
+            e,
+            false,
+            now,
+            now,
+            "",
+        ])
         await t.execute(
             `INSERT IGNORE entities (name, validated, createdAt, updatedAt, displayName) VALUES ?`,
             [importEntityRows]
@@ -474,7 +480,7 @@ async function importData() {
                         row[i],
                         parseInt(year),
                         entityId,
-                        variableId
+                        variableId,
                     ])
                 }
             }

--- a/db/knexMigrations/20190305234711_DenormalizeLatestCountryData.ts
+++ b/db/knexMigrations/20190305234711_DenormalizeLatestCountryData.ts
@@ -1,7 +1,7 @@
 import * as Knex from "knex"
 
 exports.up = async function (knex: Knex): Promise<any> {
-    await knex.schema.createTable("country_latest_data", t => {
+    await knex.schema.createTable("country_latest_data", (t) => {
         t.string("country_code")
         t.integer("variable_id").references("variables.id")
         t.integer("year")

--- a/db/migration/1537515786863-DatasetSourceSplit.ts
+++ b/db/migration/1537515786863-DatasetSourceSplit.ts
@@ -32,7 +32,7 @@ export class DatasetSourceSplit1537515786863 implements MigrationInterface {
                         dataset.metadataEditedAt,
                         dataset.metadataEditedByUserId,
                         dataset.createdByUserId,
-                        true
+                        true,
                     ]
                     const result = await queryRunner.query(
                         `INSERT INTO datasets (name, namespace, description, createdAt, updatedAt, dataEditedAt, dataEditedByUserId, metadataEditedAt, metadataEditedByUserId, createdByUserId, isPrivate) VALUES (?)`,
@@ -51,7 +51,7 @@ export class DatasetSourceSplit1537515786863 implements MigrationInterface {
                     )
                 } else {
                     await queryRunner.query("delete from sources where id=?", [
-                        source.id
+                        source.id,
                     ])
                 }
             }

--- a/db/migration/1542908319140-CreateChartLogs.ts
+++ b/db/migration/1542908319140-CreateChartLogs.ts
@@ -19,7 +19,7 @@ export class CreateChartLogs1542908319140 implements MigrationInterface {
                 chart.lastEditedByUserId,
                 chart.updatedAt,
                 chart.updatedAt,
-                chart.config
+                chart.config,
             ])
 
             if (i % 100 === 0 || i === charts.length - 1) {

--- a/db/migration/1559906810277-AddNamespaceLabels.ts
+++ b/db/migration/1559906810277-AddNamespaceLabels.ts
@@ -14,35 +14,36 @@ export class AddNamespaceLabels1559906810277 implements MigrationInterface {
             {
                 name: "owid",
                 description:
-                    "Our World in Data [data uploaded by the OWID-team]"
+                    "Our World in Data [data uploaded by the OWID-team]",
             },
             {
                 name: "wdi",
-                description: "World Development Indicators [via World Bank]"
+                description: "World Development Indicators [via World Bank]",
             },
             { name: "penn_world", description: "Penn World Tables" },
             { name: "clioinfra", description: "ClioInfra" },
             { name: "qog", description: "Quality of Government (QOG)" },
             {
                 name: "un_sdg",
-                description: "UN - Sustainable Development Goals"
+                description: "UN - Sustainable Development Goals",
             },
             { name: "oecd_stat", description: "OECD Statistics" },
             {
                 name: "gbd_cause",
-                description: "Global Burden of Disease - Deaths & DALYs"
+                description: "Global Burden of Disease - Deaths & DALYs",
             },
             {
                 name: "gbd_prevalence",
-                description: "Global Burden of Disease - Prevalence & Incidence"
+                description:
+                    "Global Burden of Disease - Prevalence & Incidence",
             },
             {
                 name: "gbd_risk",
-                description: "Global Burden of Disease - Risk Factors"
+                description: "Global Burden of Disease - Risk Factors",
             },
             {
                 name: "gbd_mental_health",
-                description: "Global Burden of Disease - Mental Health"
+                description: "Global Burden of Disease - Mental Health",
             },
             { name: "who_gho", description: "WHO - Global Health Observatory" },
             { name: "unaids", description: "UN HIV/AIDS" },
@@ -50,77 +51,77 @@ export class AddNamespaceLabels1559906810277 implements MigrationInterface {
             { name: "who_wash", description: "WHO - Water & Sanitation" },
             {
                 name: "edstats",
-                description: "EdStats [Education Stats via World Bank]"
+                description: "EdStats [Education Stats via World Bank]",
             },
             {
                 name: "genderstats",
-                description: "Gender Stats [via World Bank]"
+                description: "Gender Stats [via World Bank]",
             },
             { name: "findex", description: "Financial Index [via World Bank]" },
             { name: "povstats", description: "Poverty Stats [via World Bank]" },
             {
                 name: "ilostat",
-                description: "International Labour Organization (ILO)"
+                description: "International Labour Organization (ILO)",
             },
             {
                 name: "aspire",
-                description: "Social Protection [via World Bank]"
+                description: "Social Protection [via World Bank]",
             },
             {
                 name: "bbsc",
-                description: "Statistical Capacity [via World Bank]"
+                description: "Statistical Capacity [via World Bank]",
             },
             {
                 name: "faostat",
-                description: "UN - Food and Agriculture Organziation (FAO)"
+                description: "UN - Food and Agriculture Organziation (FAO)",
             },
             {
                 name: "hnqstats",
-                description: "Nutrition & Population Stats [via World Bank]"
+                description: "Nutrition & Population Stats [via World Bank]",
             },
             {
                 name: "hnpqstats",
                 description:
-                    "Nutrition & Population Stats by Quintile [via World Bank]"
+                    "Nutrition & Population Stats by Quintile [via World Bank]",
             },
             { name: "bpstatreview", description: "BP Energy Review" },
             { name: "un_ep", description: "UN Environment Programme" },
             {
                 name: "se4all",
-                description: "Sustainable Energy [via World Bank]"
+                description: "Sustainable Energy [via World Bank]",
             },
             {
                 name: "climatech",
-                description: "Climate Change [via World Bank]"
+                description: "Climate Change [via World Bank]",
             },
             {
                 name: "unwpp_female_population",
-                description: "UN Population - Female Population"
+                description: "UN Population - Female Population",
             },
             {
                 name: "unwpp_percentage_of_total_population",
-                description: "UN Population - % total population"
+                description: "UN Population - % total population",
             },
             {
                 name: "unwpp_total_population",
-                description: "UN Population - Total Population"
+                description: "UN Population - Total Population",
             },
             {
                 name: "unwpp_interpolated_demographic_indicators",
-                description: "UN Population - Interpolated Demographics"
+                description: "UN Population - Interpolated Demographics",
             },
             {
                 name: "unwpp_dependency_ratios",
-                description: "UN Population - Dependency Ratios"
+                description: "UN Population - Dependency Ratios",
             },
             {
                 name: "unwpp_interpolated_total_population",
-                description: "UN Population - Interpolated Population"
+                description: "UN Population - Interpolated Population",
             },
             {
                 name: "unwpp_male_population",
-                description: "UN Population - Male Population"
-            }
+                description: "UN Population - Male Population",
+            },
         ]
         for (const row of namespaceLabels) {
             await queryRunner.query(

--- a/db/migration/1562601461734-OmitSaveToVariable.ts
+++ b/db/migration/1562601461734-OmitSaveToVariable.ts
@@ -4,7 +4,7 @@ import * as lodash from "lodash"
 
 function omitSaveToVariable(config: GrapherInterface): GrapherInterface {
     const newConfig = lodash.clone(config)
-    newConfig.dimensions = newConfig.dimensions?.map(dim => {
+    newConfig.dimensions = newConfig.dimensions?.map((dim) => {
         return lodash.omit(dim, ["saveToVariable"])
     })
     return newConfig

--- a/db/migration/1590583070171-ExtractMapColorScale.ts
+++ b/db/migration/1590583070171-ExtractMapColorScale.ts
@@ -78,8 +78,8 @@ function extractColorScaleConfig(
             customCategoryLabels,
             customHiddenCategories,
             legendDescription,
-            binStepSize
-        }
+            binStepSize,
+        },
     }
 }
 
@@ -90,7 +90,7 @@ function mergeColorScaleConfig(
     const { colorScale } = newConfig
     return {
         ...omit(newConfig, "colorScale"),
-        ...colorScale
+        ...colorScale,
     }
 }
 
@@ -101,7 +101,7 @@ async function transformAllCharts(
     await Promise.all(
         [
             { idField: "id", tableName: "charts" },
-            { idField: "chartId", tableName: "chart_revisions" }
+            { idField: "chartId", tableName: "chart_revisions" },
         ].map(async ({ idField, tableName }) => {
             const charts = (await queryRunner.query(`
                 SELECT ${idField} AS id, config
@@ -125,7 +125,7 @@ async function transformAllCharts(
 
 export class ExtractMapColorScale1590583070171 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<any> {
-        await transformAllCharts(queryRunner, oldConfig => {
+        await transformAllCharts(queryRunner, (oldConfig) => {
             // Clone and modify in place to avoid changing order of keys
             const newConfig = clone(oldConfig)
             newConfig.map = extractColorScaleConfig(
@@ -136,7 +136,7 @@ export class ExtractMapColorScale1590583070171 implements MigrationInterface {
     }
 
     public async down(queryRunner: QueryRunner): Promise<any> {
-        await transformAllCharts(queryRunner, newConfig => {
+        await transformAllCharts(queryRunner, (newConfig) => {
             // Clone and modify in place to avoid changing order of keys
             const oldConfig = clone(newConfig)
             oldConfig.map = mergeColorScaleConfig(newConfig.map as NewMapConfig)

--- a/db/migration/1591128415343-NewChartColorScale.ts
+++ b/db/migration/1591128415343-NewChartColorScale.ts
@@ -53,8 +53,8 @@ function injectColorScheme(oldConfig: OldChartConfig): NewChartConfig {
             customHiddenCategories: {},
             colorSchemeInvert: invertColorScheme,
             isManualBuckets: customColors ? true : undefined,
-            customColorsActive: customColors ? true : undefined
-        }
+            customColorsActive: customColors ? true : undefined,
+        },
     }
 }
 
@@ -64,7 +64,7 @@ function dropColorScheme(newConfig: NewChartConfig): OldChartConfig {
         ...rest,
         baseColorScheme: colorScale.baseColorScheme,
         customColors: colorScale.customCategoryColors,
-        invertColorScheme: colorScale.colorSchemeInvert
+        invertColorScheme: colorScale.colorSchemeInvert,
     }
 }
 
@@ -75,7 +75,7 @@ async function transformScatterPlotCharts(
     await Promise.all(
         [
             { idField: "id", tableName: "charts" },
-            { idField: "chartId", tableName: "chart_revisions" }
+            { idField: "chartId", tableName: "chart_revisions" },
         ].map(async ({ idField, tableName }) => {
             const charts = (await queryRunner.query(`
             SELECT ${idField} AS id, config

--- a/db/migration/1597151871804-ColorScaleStrategies.ts
+++ b/db/migration/1597151871804-ColorScaleStrategies.ts
@@ -24,7 +24,7 @@ interface OldColorScaleConfig {
 
 enum ColorScaleBinningStrategy {
     equalInterval = "equalInterval",
-    manual = "manual"
+    manual = "manual",
 }
 
 interface NewColorScaleConfig {
@@ -85,7 +85,7 @@ function oldToNewColorScaleConfig(
         customCategoryLabels: oldConfig.customCategoryLabels,
         customHiddenCategories: oldConfig.customHiddenCategories,
 
-        legendDescription: oldConfig.legendDescription
+        legendDescription: oldConfig.legendDescription,
     }
 }
 
@@ -113,7 +113,7 @@ function newToOldColorScaleConfig(
         customCategoryLabels: newConfig.customCategoryLabels,
         customHiddenCategories: newConfig.customHiddenCategories,
 
-        legendDescription: newConfig.legendDescription
+        legendDescription: newConfig.legendDescription,
     }
 }
 
@@ -132,8 +132,8 @@ function transformColorScaleConfig<I, O>(
                 ? undefined
                 : {
                       ...config.map,
-                      colorScale: transform(config.map.colorScale)
-                  }
+                      colorScale: transform(config.map.colorScale),
+                  },
     }
 }
 
@@ -144,7 +144,7 @@ async function transformAllCharts(
     await Promise.all(
         [
             { idField: "id", tableName: "charts" },
-            { idField: "chartId", tableName: "chart_revisions" }
+            { idField: "chartId", tableName: "chart_revisions" },
         ].map(async ({ idField, tableName }) => {
             const charts = (await queryRunner.query(`
             SELECT ${idField} AS id, config

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -4,7 +4,7 @@ import {
     Column,
     BaseEntity,
     ManyToOne,
-    OneToMany
+    OneToMany,
 } from "typeorm"
 import * as lodash from "lodash"
 import * as db from "db/db"
@@ -27,11 +27,11 @@ export class Chart extends BaseEntity {
     @Column() starred!: boolean
     @Column() isExplorable!: boolean
 
-    @ManyToOne(() => User, user => user.lastEditedCharts)
+    @ManyToOne(() => User, (user) => user.lastEditedCharts)
     lastEditedByUser!: User
-    @ManyToOne(() => User, user => user.publishedCharts)
+    @ManyToOne(() => User, (user) => user.publishedCharts)
     publishedByUser!: User
-    @OneToMany(() => ChartRevision, rev => rev.chart)
+    @OneToMany(() => ChartRevision, (rev) => rev.chart)
     logs!: ChartRevision[]
 
     static table: string = "charts"
@@ -64,8 +64,8 @@ export class Chart extends BaseEntity {
     }
 
     static async setTags(chartId: number, tagIds: number[]) {
-        await db.transaction(async t => {
-            const tagRows = tagIds.map(tagId => [tagId, chartId])
+        await db.transaction(async (t) => {
+            const tagRows = tagIds.map((tagId) => [tagId, chartId])
             await t.execute(`DELETE FROM chart_tags WHERE chartId=?`, [chartId])
             if (tagRows.length)
                 await t.execute(
@@ -75,16 +75,16 @@ export class Chart extends BaseEntity {
 
             const tags = tagIds.length
                 ? ((await t.query("select parentId from tags where id in (?)", [
-                      tagIds
+                      tagIds,
                   ])) as { parentId: number }[])
                 : []
-            const isIndexable = tags.some(t =>
+            const isIndexable = tags.some((t) =>
                 PUBLIC_TAG_PARENT_IDS.includes(t.parentId)
             )
 
             await t.execute("update charts set is_indexable = ? where id = ?", [
                 isIndexable,
-                chartId
+                chartId,
             ])
         })
     }
@@ -100,7 +100,7 @@ export class Chart extends BaseEntity {
             chart.tags = []
         }
 
-        const chartsById = lodash.keyBy(charts, c => c.id)
+        const chartsById = lodash.keyBy(charts, (c) => c.id)
 
         for (const ct of chartTags) {
             const chart = chartsById[ct.chartId]
@@ -168,7 +168,7 @@ export class OldChart {
 
     async getVariableData(): Promise<any> {
         const variableIds = lodash.uniq(
-            this.config.dimensions!.map(d => d.variableId)
+            this.config.dimensions!.map((d) => d.variableId)
         )
         return getVariableData(variableIds)
     }

--- a/db/model/ChartRevision.ts
+++ b/db/model/ChartRevision.ts
@@ -3,7 +3,7 @@ import {
     PrimaryGeneratedColumn,
     Column,
     BaseEntity,
-    ManyToOne
+    ManyToOne,
 } from "typeorm"
 import { Chart } from "./Chart"
 import { User } from "./User"
@@ -18,9 +18,9 @@ export class ChartRevision extends BaseEntity {
     @Column() createdAt!: Date
     @Column() updatedAt!: Date
 
-    @ManyToOne(() => User, user => user.editedCharts)
+    @ManyToOne(() => User, (user) => user.editedCharts)
     user!: User
 
-    @ManyToOne(() => Chart, chart => chart.logs)
+    @ManyToOne(() => Chart, (chart) => chart.logs)
     chart!: Chart
 }

--- a/db/model/Dataset.ts
+++ b/db/model/Dataset.ts
@@ -4,7 +4,7 @@ import {
     Column,
     BaseEntity,
     ManyToOne,
-    Unique
+    Unique,
 } from "typeorm"
 import { Writable } from "stream"
 
@@ -29,7 +29,7 @@ export class Dataset extends BaseEntity {
     @Column() dataEditedByUserId!: number
     @Column({ default: false }) isPrivate!: boolean
 
-    @ManyToOne(() => User, user => user.createdDatasets)
+    @ManyToOne(() => User, (user) => user.createdDatasets)
     createdByUser!: User
 
     // Export dataset variables to CSV (not including metadata)
@@ -86,10 +86,10 @@ export class Dataset extends BaseEntity {
     }
 
     static async setTags(datasetId: number, tagIds: number[]) {
-        await db.transaction(async t => {
-            const tagRows = tagIds.map(tagId => [tagId, datasetId])
+        await db.transaction(async (t) => {
+            const tagRows = tagIds.map((tagId) => [tagId, datasetId])
             await t.execute(`DELETE FROM dataset_tags WHERE datasetId=?`, [
-                datasetId
+                datasetId,
             ])
             if (tagRows.length)
                 await t.execute(
@@ -103,7 +103,7 @@ export class Dataset extends BaseEntity {
         let csv = ""
         await Dataset.writeCSV(this.id, {
             write: (s: string) => (csv += s),
-            end: () => null
+            end: () => null,
         } as any)
         return csv
     }
@@ -130,7 +130,7 @@ export class Dataset extends BaseEntity {
 
         const initialFields = [
             { name: "Entity", type: "string" },
-            { name: "Year", type: "year" }
+            { name: "Year", type: "year" },
         ]
 
         const dataPackage = {
@@ -142,23 +142,23 @@ export class Dataset extends BaseEntity {
                     sources[0].description &&
                     sources[0].description.additionalInfo) ||
                 "",
-            sources: sources.map(s => s.toDatapackage()),
+            sources: sources.map((s) => s.toDatapackage()),
             owidTags: tags.map((t: any) => t.name),
             resources: [
                 {
                     path: `${this.name}.csv`,
                     schema: {
                         fields: initialFields.concat(
-                            variables.map(v => ({
+                            variables.map((v) => ({
                                 name: v.name,
                                 type: "any",
                                 description: v.description,
-                                owidDisplaySettings: v.display
+                                owidDisplaySettings: v.display,
                             }))
-                        )
-                    }
-                }
-            ]
+                        ),
+                    },
+                },
+            ],
         }
 
         return dataPackage

--- a/db/model/Tag.ts
+++ b/db/model/Tag.ts
@@ -17,7 +17,7 @@ export namespace Tag {
         ...args: K[]
     ): { from: (query: QueryBuilder) => Promise<Pick<Row, K>[]> } {
         return {
-            from: query => query.select(...args) as any
+            from: (query) => query.select(...args) as any,
         }
     }
 }

--- a/db/model/User.ts
+++ b/db/model/User.ts
@@ -3,7 +3,7 @@ import {
     PrimaryGeneratedColumn,
     Column,
     BaseEntity,
-    OneToMany
+    OneToMany,
 } from "typeorm"
 import { Chart } from "./Chart"
 import { Dataset } from "./Dataset"
@@ -23,16 +23,16 @@ export class User extends BaseEntity {
     @Column() lastLogin!: Date
     @Column() lastSeen!: Date
 
-    @OneToMany(() => Chart, chart => chart.lastEditedByUser)
+    @OneToMany(() => Chart, (chart) => chart.lastEditedByUser)
     lastEditedCharts!: Chart[]
 
-    @OneToMany(() => Chart, chart => chart.publishedByUser)
+    @OneToMany(() => Chart, (chart) => chart.publishedByUser)
     publishedCharts!: Chart[]
 
-    @OneToMany(() => ChartRevision, rev => rev.user)
+    @OneToMany(() => ChartRevision, (rev) => rev.user)
     editedCharts!: ChartRevision[]
 
-    @OneToMany(() => Dataset, dataset => dataset.createdByUser)
+    @OneToMany(() => Dataset, (dataset) => dataset.createdByUser)
     createdDatasets!: Dataset[]
 
     async setPassword(password: string) {

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -65,13 +65,13 @@ export async function getVariableData(variableIds: number[]): Promise<any> {
             dataPublisherSource: sourceDescription.dataPublisherSource || "",
             link: sourceDescription.link || "",
             retrievedData: sourceDescription.retrievedData || "",
-            additionalInfo: sourceDescription.additionalInfo || ""
+            additionalInfo: sourceDescription.additionalInfo || "",
         }
         data.variables[row.id] = lodash.extend(
             {
                 years: [],
                 entities: [],
-                values: []
+                values: [],
             },
             row
         )
@@ -91,7 +91,7 @@ export async function getVariableData(variableIds: number[]): Promise<any> {
         if (data.entityKey[row.entityId] === undefined) {
             data.entityKey[row.entityId] = {
                 name: row.entityName,
-                code: row.entityCode
+                code: row.entityCode,
             }
         }
     }
@@ -145,7 +145,7 @@ export async function writeVariableCSV(
 
     // Throw an error if not all variables exist
     if (variables.length !== variableIds.length) {
-        const fetchedVariableIds = variables.map(v => v.id)
+        const fetchedVariableIds = variables.map((v) => v.id)
         const missingVariables = lodash.difference(
             variableIds,
             fetchedVariableIds
@@ -153,9 +153,9 @@ export async function writeVariableCSV(
         throw Error(`Variable IDs do not exist: ${missingVariables.join(", ")}`)
     }
 
-    variables = variableIds.map(variableId => variablesById[variableId])
+    variables = variableIds.map((variableId) => variablesById[variableId])
 
-    const columns = ["Entity", "Year"].concat(variables.map(v => v.name))
+    const columns = ["Entity", "Year"].concat(variables.map((v) => v.name))
     stream.write(csvRow(columns))
 
     const variableColumnIndex: { [id: number]: number } = {}

--- a/db/postCategoriesToGrapher.ts
+++ b/db/postCategoriesToGrapher.ts
@@ -23,7 +23,7 @@ async function main() {
         for (const post of postRows) {
             const categories = categoriesByPostId.get(post.ID) || []
 
-            const tagNames = categories.map(t => decodeHTML(t))
+            const tagNames = categories.map((t) => decodeHTML(t))
 
             const matchingTags = await Tag.select(
                 "id",
@@ -44,8 +44,8 @@ async function main() {
             )
 
             const tagIds = matchingTags
-                .map(t => t.id)
-                .concat(existingTags.map(t => t.id))
+                .map((t) => t.id)
+                .concat(existingTags.map((t) => t.id))
             // if (matchingTags.map(t => t.name).includes(post.post_title)) {
             //     tagIds.push(1640)
             // }

--- a/db/postUpdatedHook.ts
+++ b/db/postUpdatedHook.ts
@@ -20,7 +20,7 @@ async function main(
         await enqueueDeploy({
             authorName: name,
             authorEmail: email,
-            message: slug ? `Updating ${slug}` : `Deleting ${postSlug}`
+            message: slug ? `Updating ${slug}` : `Deleting ${postSlug}`,
         })
     }
 

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -7,7 +7,7 @@ import {
     WORDPRESS_DB_USER,
     WORDPRESS_DB_PASS,
     WORDPRESS_API_PASS,
-    WORDPRESS_API_USER
+    WORDPRESS_API_USER,
 } from "serverSettings"
 import { WORDPRESS_URL, BAKED_BASE_URL, BLOG_SLUG } from "settings"
 import * as db from "db/db"
@@ -21,7 +21,7 @@ import { RelatedChart } from "site/client/blocks/RelatedCharts/RelatedCharts"
 import { JsonError } from "utils/server/serverUtil"
 import {
     CountryProfileSpec,
-    countryProfileSpecs
+    countryProfileSpecs,
 } from "site/server/countryProfileProjects"
 
 class WPDB {
@@ -36,8 +36,8 @@ class WPDB {
                     port: WORDPRESS_DB_PORT,
                     user: WORDPRESS_DB_USER,
                     password: WORDPRESS_DB_PASS,
-                    database: WORDPRESS_DB_NAME
-                }
+                    database: WORDPRESS_DB_NAME,
+                },
             })
 
             registerExitHandler(async () => {
@@ -54,7 +54,7 @@ class WPDB {
             port: WORDPRESS_DB_PORT,
             user: WORDPRESS_DB_USER,
             password: WORDPRESS_DB_PASS,
-            database: WORDPRESS_DB_NAME
+            database: WORDPRESS_DB_NAME,
         })
         await this.conn.connect()
 
@@ -92,7 +92,7 @@ async function apiQuery(
     const url = new URL(endpoint)
 
     if (params && params.searchParams) {
-        params.searchParams.forEach(param => {
+        params.searchParams.forEach((param) => {
             url.searchParams.append(param[0], String(param[1]))
         })
     }
@@ -105,9 +105,9 @@ async function apiQuery(
                     "Basic " +
                         Base64.encode(
                             `${WORDPRESS_API_USER}:${WORDPRESS_API_PASS}`
-                        )
-                ]
-            ]
+                        ),
+                ],
+            ],
         })
     } else {
         return fetch(url.toString())
@@ -273,12 +273,12 @@ export async function getEntriesByCategory(): Promise<CategoryWithEntries[]> {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
-            Accept: "application/json"
+            Accept: "application/json",
         },
         body: JSON.stringify({
             query,
-            variables: { first, orderby }
-        })
+            variables: { first, orderby },
+        }),
     })
     const json = await response.json()
 
@@ -293,7 +293,7 @@ export async function getEntriesByCategory(): Promise<CategoryWithEntries[]> {
         slug,
         title: decodeHTML(title),
         excerpt: excerpt === null ? "" : decodeHTML(excerpt),
-        kpi
+        kpi,
     })
 
     const isEntryInSubcategories = (entry: EntryNode, subcategories: any) => {
@@ -338,8 +338,8 @@ export async function getEntriesByCategory(): Promise<CategoryWithEntries[]> {
                     slug,
                     entries: pages.nodes.map((node: EntryNode) =>
                         getEntryNode(node)
-                    )
-                }))
+                    ),
+                })),
         })
     )
 
@@ -349,17 +349,17 @@ export async function getEntriesByCategory(): Promise<CategoryWithEntries[]> {
 export enum PageType {
     Entry = "ENTRY",
     SubEntry = "SUBENTRY",
-    Standard = "STANDARD"
+    Standard = "STANDARD",
 }
 
 export async function getPageType(post: FullPost): Promise<PageType> {
     const entries = await getEntriesByCategory()
-    const isEntry = entries.some(category => {
+    const isEntry = entries.some((category) => {
         return (
-            category.entries.some(entry => entry.slug === post.slug) ||
+            category.entries.some((entry) => entry.slug === post.slug) ||
             category.subcategories.some((subcategory: CategoryWithEntries) => {
                 return subcategory.entries.some(
-                    subCategoryEntry => subCategoryEntry.slug === post.slug
+                    (subCategoryEntry) => subCategoryEntry.slug === post.slug
                 )
             })
         )
@@ -376,7 +376,7 @@ export async function getPermalinks() {
             postName
                 .replace(/\/+$/g, "")
                 .replace(/--/g, "/")
-                .replace(/__/g, "/")
+                .replace(/__/g, "/"),
     }
 }
 
@@ -428,8 +428,8 @@ export async function getPosts(
             response = await apiQuery(endpoint, {
                 searchParams: [
                     ["per_page", perPage],
-                    ["page", page]
-                ]
+                    ["page", page],
+                ],
             })
             const postsCurrentPage = await response.json()
             posts.push(...postsCurrentPage)
@@ -439,9 +439,9 @@ export async function getPosts(
     // Published pages excluded from public views
     const excludedSlugs = [
         BLOG_SLUG,
-        ...countryProfileSpecs.map(spec => spec.genericProfileSlug)
+        ...countryProfileSpecs.map((spec) => spec.genericProfileSlug),
     ]
-    posts = posts.filter(post => !excludedSlugs.includes(post.slug))
+    posts = posts.filter((post) => !excludedSlugs.includes(post.slug))
 
     return limit ? posts.slice(0, limit) : posts
 }
@@ -449,7 +449,7 @@ export async function getPosts(
 export async function getPostType(search: number | string): Promise<string> {
     const paramName = typeof search === "number" ? "id" : "slug"
     const response = await apiQuery(`${OWID_API_ENDPOINT}/type`, {
-        searchParams: [[paramName, search]]
+        searchParams: [[paramName, search]],
     })
     const type = await response.json()
 
@@ -461,7 +461,7 @@ export async function getPostBySlug(slug: string): Promise<any[]> {
     const response = await apiQuery(
         `${WP_API_ENDPOINT}/${getEndpointSlugFromType(type)}`,
         {
-            searchParams: [["slug", slug]]
+            searchParams: [["slug", slug]],
         }
     )
     const postApiArray = await response.json()
@@ -478,14 +478,14 @@ export async function getLatestPostRevision(id: number): Promise<any> {
     const endpointSlug = getEndpointSlugFromType(type)
 
     let response = await apiQuery(`${WP_API_ENDPOINT}/${endpointSlug}/${id}`, {
-        isAuthenticated: true
+        isAuthenticated: true,
     })
     const postApi = await response.json()
 
     response = await apiQuery(
         `${WP_API_ENDPOINT}/${endpointSlug}/${id}/revisions?per_page=1`,
         {
-            isAuthenticated: true
+            isAuthenticated: true,
         }
     )
     const revision = (await response.json())[0]
@@ -502,7 +502,7 @@ export async function getLatestPostRevision(id: number): Promise<any> {
         // published date will be displayed, regardless of what is shown in the
         // admin.
         date: postApi.date,
-        postId: id
+        postId: id,
     }
 }
 
@@ -537,12 +537,12 @@ export async function getBlockContent(id: number): Promise<string | undefined> {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
-            Accept: "application/json"
+            Accept: "application/json",
         },
         body: JSON.stringify({
             query,
-            variables: { id }
-        })
+            variables: { id },
+        }),
     })
     const json = await response.json()
 
@@ -587,7 +587,7 @@ export async function getFullPost(
         relatedCharts:
             postApi.type === "page"
                 ? await getRelatedCharts(postApi.id)
-                : undefined
+                : undefined,
     }
 }
 
@@ -610,7 +610,7 @@ export async function getBlogIndex(): Promise<FullPost[]> {
     const posts = await getPosts(["post"])
 
     cachedPosts = Promise.all(
-        posts.map(post => {
+        posts.map((post) => {
             return getFullPost(post, true)
         })
     )
@@ -649,7 +649,7 @@ export async function getTables(): Promise<Map<string, TablepressTable>> {
         )
         cachedTables.set(tableId, {
             tableId: tableId,
-            data: data
+            data: data,
         })
     }
 

--- a/deploy/liveCommit.ts
+++ b/deploy/liveCommit.ts
@@ -29,7 +29,7 @@ const servers = [
     "jefferson",
     "nightingale",
     "tufte",
-    "roser"
+    "roser",
 ]
 
 const args = parseArgs(process.argv.slice(2))
@@ -45,11 +45,11 @@ function getServerUrl(server: string): string {
 
 async function fetchCommitSha(server: string): Promise<string> {
     return fetch(`${getServerUrl(server)}/head.txt`)
-        .then(res => {
+        .then((res) => {
             if (res.ok) return res
             else throw Error(`Request rejected with status ${res.status}`)
         })
-        .then(resp => resp.text())
+        .then((resp) => resp.text())
 }
 
 interface ServerCommitInformation {
@@ -62,7 +62,7 @@ interface ServerCommitInformation {
 
 async function fetchAll(): Promise<Array<ServerCommitInformation>> {
     const commits = await Promise.all(
-        servers.map(async serverName => {
+        servers.map(async (serverName) => {
             let commitSha = undefined
             try {
                 commitSha = await fetchCommitSha(serverName)
@@ -75,21 +75,21 @@ async function fetchAll(): Promise<Array<ServerCommitInformation>> {
                 commitSha,
                 commitDate: undefined,
                 commitAuthor: undefined,
-                commitMessage: undefined
+                commitMessage: undefined,
             }
         })
     )
 
     const commitsWithInformation = await Promise.all(
-        commits.map(async commit => {
+        commits.map(async (commit) => {
             if (!commit.commitSha) return commit
 
             const apiResponse = (await fetch(
                 `https://api.github.com/repos/owid/owid-grapher/git/commits/${commit.commitSha}`,
                 {
                     headers: {
-                        Accept: "application/vnd.github.v3"
-                    }
+                        Accept: "application/vnd.github.v3",
+                    },
                 }
             )) as any
 
@@ -101,18 +101,18 @@ async function fetchAll(): Promise<Array<ServerCommitInformation>> {
                 commitDate:
                     response?.author?.date && new Date(response?.author?.date),
                 commitAuthor: response?.author?.name,
-                commitMessage: response?.message?.split("\n")?.[0]
+                commitMessage: response?.message?.split("\n")?.[0],
             }
         })
     )
 
-    return sortBy(commitsWithInformation, c => c.commitDate ?? 0)
+    return sortBy(commitsWithInformation, (c) => c.commitDate ?? 0)
         .reverse()
-        .map(commitInformation => ({
+        .map((commitInformation) => ({
             ...commitInformation,
             commitDate:
                 commitInformation.commitDate &&
-                timeago.format(commitInformation.commitDate)
+                timeago.format(commitInformation.commitDate),
         }))
 }
 
@@ -120,7 +120,7 @@ if (args._[0]) {
     // fetch information for one specific server
     const server = args._[0]
     fetchCommitSha(server)
-        .then(async headSha => {
+        .then(async (headSha) => {
             if (showTree)
                 await exec(
                     `git log -10 --graph --oneline --decorate --color=always ${headSha}`
@@ -134,7 +134,7 @@ if (args._[0]) {
             if (openInBrowser)
                 opener(`https://github.com/owid/owid-grapher/commit/${headSha}`)
         })
-        .catch(err =>
+        .catch((err) =>
             console.error(
                 `Could not retrieve commit information from ${getServerUrl(
                     server
@@ -143,18 +143,18 @@ if (args._[0]) {
         )
 } else {
     // fetch information for _all_ servers
-    fetchAll().then(commitInformation => {
+    fetchAll().then((commitInformation) => {
         const data = mapValues(
             keyBy(
                 commitInformation,
-                commitInformation => commitInformation.serverName
+                (commitInformation) => commitInformation.serverName
             ),
-            commitInformation => {
+            (commitInformation) => {
                 const {
                     commitSha,
                     commitDate,
                     commitAuthor,
-                    commitMessage
+                    commitMessage,
                 } = commitInformation
 
                 return {
@@ -165,7 +165,7 @@ if (args._[0]) {
                         // truncate to 50 characters
                         commitMessage && commitMessage.length > 50
                             ? commitMessage?.substr(0, 50) + "…"
-                            : commitMessage
+                            : commitMessage,
                 }
             }
         )

--- a/deploy/queue.ts
+++ b/deploy/queue.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs-extra"
 import {
     DEPLOY_QUEUE_FILE_PATH,
-    DEPLOY_PENDING_FILE_PATH
+    DEPLOY_PENDING_FILE_PATH,
 } from "serverSettings"
 import { deploy } from "./deploy"
 
@@ -61,7 +61,7 @@ function parseQueueContent(content: string): IDeployQueueItem[] {
     // Parse all lines in file as JSON
     return content
         .split("\n")
-        .map(line => {
+        .map((line) => {
             try {
                 return JSON.parse(line)
             } catch (err) {
@@ -75,13 +75,13 @@ function generateCommitMsg(queueItems: IDeployQueueItem[]): string {
     const date: string = new Date().toISOString()
 
     const message: string = queueItems
-        .filter(item => item.message)
-        .map(item => item.message)
+        .filter((item) => item.message)
+        .map((item) => item.message)
         .join("\n")
 
     const coauthors: string = queueItems
-        .filter(item => item.authorName)
-        .map(item => {
+        .filter((item) => item.authorName)
+        .map((item) => {
             return `Co-authored-by: ${item.authorName} <${item.authorEmail}>`
         })
         .join("\n")

--- a/explorer/admin/ExplorerBaker.tsx
+++ b/explorer/admin/ExplorerBaker.tsx
@@ -6,7 +6,7 @@ import { renderToHtmlPage } from "utils/server/serverUtil"
 import { BAKED_SITE_DIR } from "serverSettings"
 import {
     explorerFileSuffix,
-    ExplorerProgram
+    ExplorerProgram,
 } from "explorer/client/ExplorerProgram"
 import { Request, Response } from "adminSite/server/utils/authentication"
 
@@ -15,7 +15,7 @@ import {
     coronaOpenGraphImagePath,
     covidPageTitle,
     covidPreloads,
-    covidWpBlockId
+    covidWpBlockId,
 } from "explorer/covidExplorer/CovidConstants"
 
 import { SwitcherBootstrapProps } from "explorer/client/SwitcherExplorer"
@@ -34,12 +34,12 @@ export const addExplorerApiRoutes = (app: FunctionalRouter) => {
     app.get("/explorers.json", async () => {
         const explorers = await getAllExplorers()
         return {
-            explorers: explorers.map(explorer => {
+            explorers: explorers.map((explorer) => {
                 return {
                     program: explorer.toString(),
-                    slug: explorer.slug
+                    slug: explorer.slug,
                 }
-            })
+            }),
         }
     })
 
@@ -84,14 +84,14 @@ export const bakeAllPublishedExplorers = async (
     outputFolder = `${BAKED_SITE_DIR}/explorers/`
 ) => {
     const explorers = await getAllExplorers(inputFolder)
-    const published = explorers.filter(exp => exp.isPublished)
+    const published = explorers.filter((exp) => exp.isPublished)
     await bakeExplorersToDir(outputFolder, published)
 }
 
 const getAllExplorers = async (directory = storageFolder) => {
     if (!fs.existsSync(directory)) return []
     const files = await fs.readdir(directory)
-    const explorerFiles = files.filter(filename =>
+    const explorerFiles = files.filter((filename) =>
         filename.endsWith(explorerFileSuffix)
     )
     const explorers: ExplorerProgram[] = []
@@ -136,11 +136,11 @@ async function renderSwitcherExplorerPage(slug: string, code: string) {
         bindToWindow: true,
         slug,
         explorerProgramCode: program.toString(),
-        chartConfigs: chartConfigs.map(row => {
+        chartConfigs: chartConfigs.map((row) => {
             const config = JSON.parse(row.config)
             config.id = row.id
             return config
-        })
+        }),
     }
 
     const script = `window.SwitcherExplorer.bootstrap(${JSON.stringify(props)})`

--- a/explorer/admin/ExplorerContent.tsx
+++ b/explorer/admin/ExplorerContent.tsx
@@ -11,7 +11,7 @@ const ExplorerContent = ({ content }: { content: string }) => {
                         <div
                             className="wp-block-column"
                             dangerouslySetInnerHTML={{
-                                __html: formatReusableBlock(content)
+                                __html: formatReusableBlock(content),
                             }}
                         ></div>
                         <div className="wp-block-column"></div>

--- a/explorer/admin/ExplorerCreatePage.tsx
+++ b/explorer/admin/ExplorerCreatePage.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { AdminLayout } from "adminSite/client/AdminLayout"
 import {
     AdminAppContextType,
-    AdminAppContext
+    AdminAppContext,
 } from "adminSite/client/AdminAppContext"
 import { SwitcherExplorer } from "explorer/client/SwitcherExplorer"
 import { HotTable } from "@handsontable/react"
@@ -12,7 +12,7 @@ import { GrapherInterface } from "grapher/core/GrapherInterface"
 import { Grid } from "grapher/utils/Util"
 import {
     ExplorerProgram,
-    ProgramKeyword
+    ProgramKeyword,
 } from "explorer/client/ExplorerProgram"
 import { readRemoteFile, writeRemoteFile } from "gitCms/client"
 import { Prompt } from "react-router-dom"
@@ -39,7 +39,7 @@ export class ExplorerCreatePage extends React.Component<{ slug: string }> {
 
     @action.bound async fetchExplorerProgramOnLoad() {
         const response = await readRemoteFile({
-            filepath: ExplorerProgram.fullPath(this.props.slug)
+            filepath: ExplorerProgram.fullPath(this.props.slug),
         })
         this.sourceOnDisk =
             response.content || ExplorerProgram.defaultExplorerProgram
@@ -52,7 +52,7 @@ export class ExplorerCreatePage extends React.Component<{ slug: string }> {
     }
 
     @action.bound async fetchChartConfigs(chartIds: number[]) {
-        const missing = chartIds.filter(id => !this.chartConfigs.has(id))
+        const missing = chartIds.filter((id) => !this.chartConfigs.has(id))
         if (!missing.length) return
         const response = await fetch(
             `/admin/api/charts/explorer-charts.json?chartIds=${chartIds.join(
@@ -93,7 +93,7 @@ export class ExplorerCreatePage extends React.Component<{ slug: string }> {
         this.program.slug = slug
         await writeRemoteFile({
             filepath: this.program.fullPath,
-            content: this.program.toString()
+            content: this.program.toString(),
         })
         this.context.admin.loadingIndicatorSetting = "off"
         this.sourceOnDisk = this.program.toString()
@@ -141,7 +141,7 @@ export class ExplorerCreatePage extends React.Component<{ slug: string }> {
             minRows: 20,
             rowHeaders: true,
             cells,
-            afterChange: () => this.updateConfig()
+            afterChange: () => this.updateConfig(),
         }
 
         return (
@@ -157,7 +157,7 @@ export class ExplorerCreatePage extends React.Component<{ slug: string }> {
                             right: "15px",
                             top: "5px",
                             position: "absolute",
-                            zIndex: 2
+                            zIndex: 2,
                         }}
                     >
                         {this.isModified ? (

--- a/explorer/admin/ExplorerPage.tsx
+++ b/explorer/admin/ExplorerPage.tsx
@@ -7,7 +7,7 @@ import { LoadingIndicator } from "grapher/loadingIndicator/LoadingIndicator"
 import { EmbedDetector } from "site/server/views/EmbedDetector"
 import {
     SiteSubnavigation,
-    SubNavId
+    SubNavId,
 } from "site/server/views/SiteSubnavigation"
 import ExplorerContent from "./ExplorerContent"
 

--- a/explorer/admin/ExplorersListPage.tsx
+++ b/explorer/admin/ExplorersListPage.tsx
@@ -3,7 +3,7 @@ import { observer } from "mobx-react"
 import { Link } from "adminSite/client/Link"
 import {
     AdminAppContext,
-    AdminAppContextType
+    AdminAppContextType,
 } from "adminSite/client/AdminAppContext"
 import {
     observable,
@@ -11,7 +11,7 @@ import {
     action,
     runInAction,
     reaction,
-    IReactionDisposer
+    IReactionDisposer,
 } from "mobx"
 import * as lodash from "lodash"
 import { AdminLayout } from "adminSite/client/AdminLayout"
@@ -133,7 +133,7 @@ class ExplorerList extends React.Component<{
                     </tr>
                 </thead>
                 <tbody>
-                    {props.explorers.map(explorer => (
+                    {props.explorers.map((explorer) => (
                         <ExplorerRow
                             indexPage={this.props.indexPage}
                             key={explorer.slug}
@@ -179,7 +179,7 @@ export class ExplorersIndexPage extends React.Component {
                         ),
                         "i"
                     ),
-                    s => `<b>${s}</b>`
+                    (s) => `<b>${s}</b>`
                 )
                 return <span dangerouslySetInnerHTML={{ __html: html }} />
             } else return text
@@ -187,7 +187,7 @@ export class ExplorersIndexPage extends React.Component {
 
         const nextAvailableSlug = getAvailableSlugSync(
             "untitled",
-            this.explorersToShow.map(exp => exp.slug)
+            this.explorersToShow.map((exp) => exp.slug)
         )
         return (
             <AdminLayout title="Explorers">
@@ -228,13 +228,15 @@ export class ExplorersIndexPage extends React.Component {
     }
 
     @action.bound async togglePublishedStatus(filename: string) {
-        const explorer = this.explorers.find(exp => exp.filename === filename)!
+        const explorer = this.explorers.find(
+            (exp) => exp.filename === filename
+        )!
         explorer.isPublished = !explorer.isPublished
 
         this.context.admin.loadingIndicatorSetting = "loading"
         await writeRemoteFile({
             filepath: explorer.fullPath,
-            content: explorer.toString()
+            content: explorer.toString(),
         })
         this.context.admin.loadingIndicatorSetting = "default"
         this.getData()

--- a/explorer/client/ExplorerControls.tsx
+++ b/explorer/client/ExplorerControls.tsx
@@ -69,7 +69,7 @@ export class ExplorerControlPanel extends React.Component<{
             comment,
             isCheckbox,
             explorerSlug,
-            value
+            value,
         } = this.props
         const onChangeValue = isCheckbox
             ? option.checked
@@ -83,7 +83,7 @@ export class ExplorerControlPanel extends React.Component<{
                         option.checked ? "SelectedOption" : "Option",
                         option.available
                             ? "AvailableOption"
-                            : "UnavailableOption"
+                            : "UnavailableOption",
                     ].join(" ")}
                     data-track-note={`${explorerSlug}-click-${title.toLowerCase()}`}
                 >
@@ -102,7 +102,7 @@ export class ExplorerControlPanel extends React.Component<{
                                 "comment",
                                 option.available
                                     ? "AvailableOption"
-                                    : "UnavailableOption"
+                                    : "UnavailableOption",
                             ].join(" ")}
                         >
                             {comment}
@@ -115,11 +115,11 @@ export class ExplorerControlPanel extends React.Component<{
 
     get renderDropdown() {
         const options = this.props
-            .dropdownOptions!.filter(option => option.available)
-            .map(option => {
+            .dropdownOptions!.filter((option) => option.available)
+            .map((option) => {
                 return {
                     label: option.label,
-                    value: option.value
+                    value: option.value,
                 }
             })
 
@@ -134,12 +134,12 @@ export class ExplorerControlPanel extends React.Component<{
                 options={options}
                 value={
                     options.find(
-                        option => option.value === this.props.value
+                        (option) => option.value === this.props.value
                     ) || { label: "-", value: "-" }
                 }
                 onChange={(option: any) => this.customOnChange(option.value)}
                 components={{
-                    IndicatorSeparator: null
+                    IndicatorSeparator: null,
                 }}
                 styles={styles}
                 isSearchable={false}

--- a/explorer/client/ExplorerProgram.test.ts
+++ b/explorer/client/ExplorerProgram.test.ts
@@ -44,7 +44,7 @@ describe("switcherCode", () => {
             29,
             33,
             55,
-            56
+            56,
         ])
     })
 

--- a/explorer/client/ExplorerProgram.ts
+++ b/explorer/client/ExplorerProgram.ts
@@ -3,12 +3,12 @@ import {
     detectDelimiter,
     uniq,
     parseDelimited,
-    isCellEmpty
+    isCellEmpty,
 } from "grapher/utils/Util"
 import {
     queryParamsToStr,
     strToQueryParams,
-    QueryParams
+    QueryParams,
 } from "utils/client/url"
 import { ControlOption, DropdownOption } from "explorer/client/ExplorerControls"
 import { action, observable, computed } from "mobx"
@@ -41,7 +41,7 @@ export enum ProgramKeyword {
     thumbnail = "thumbnail",
     subtitle = "subtitle",
     defaultView = "defaultView",
-    wpBlockId = "wpBlockId"
+    wpBlockId = "wpBlockId",
 }
 
 export class ExplorerProgram {
@@ -87,7 +87,7 @@ ${ProgramKeyword.switcher}
 \t46\tMobile`
 
     private getLineValue(keyword: string) {
-        const line = this.lines.find(line =>
+        const line = this.lines.find((line) =>
             line.startsWith(keyword + this.cellDelimiter)
         )
         return line ? line.split(this.cellDelimiter)[1] : undefined
@@ -95,7 +95,7 @@ ${ProgramKeyword.switcher}
 
     getLineIndex(key: ProgramKeyword) {
         return this.lines.findIndex(
-            line => line.startsWith(key + this.cellDelimiter) || line === key
+            (line) => line.startsWith(key + this.cellDelimiter) || line === key
         )
     }
 
@@ -112,7 +112,7 @@ ${ProgramKeyword.switcher}
         if (!ends) return undefined
         return this.lines
             .slice(ends.start, ends.end)
-            .map(line => line.substr(1))
+            .map((line) => line.substr(1))
             .join(this.nodeDelimiter)
     }
 
@@ -122,13 +122,13 @@ ${ProgramKeyword.switcher}
 
     static fromArrays(slug: string, table: any[][]) {
         const str = table
-            .map(row => row.join(cellDelimiter))
+            .map((row) => row.join(cellDelimiter))
             .join(nodeDelimiter)
         return new ExplorerProgram(slug, str)
     }
 
     toArrays() {
-        return this.lines.map(line => line.split(this.cellDelimiter))
+        return this.lines.map((line) => line.split(this.cellDelimiter))
     }
 
     toString() {
@@ -137,7 +137,7 @@ ${ProgramKeyword.switcher}
 
     private prettify() {
         return trimGrid(this.toArrays())
-            .map(line => line.join(this.cellDelimiter))
+            .map((line) => line.join(this.cellDelimiter))
             .join(this.nodeDelimiter)
     }
 
@@ -147,7 +147,7 @@ ${ProgramKeyword.switcher}
         const blockStart = keyLine + 1
         let length = this.lines
             .slice(blockStart)
-            .findIndex(line => !line.startsWith(this.edgeDelimiter))
+            .findIndex((line) => !line.startsWith(this.edgeDelimiter))
         if (length === -1) length = this.lines.slice(blockStart).length
         return { start: blockStart, end: blockStart + length, length }
     }
@@ -164,7 +164,7 @@ ${ProgramKeyword.switcher}
             key,
             ...value
                 .split(this.nodeDelimiter)
-                .map(line => this.edgeDelimiter + line)
+                .map((line) => this.edgeDelimiter + line)
         )
     }
 
@@ -172,7 +172,7 @@ ${ProgramKeyword.switcher}
         this.lines.push(key)
         value
             .split(this.nodeDelimiter)
-            .forEach(line => this.lines.push(this.edgeDelimiter + line))
+            .forEach((line) => this.lines.push(this.edgeDelimiter + line))
     }
 
     private deleteBlock(key: ProgramKeyword) {
@@ -227,7 +227,7 @@ ${ProgramKeyword.switcher}
 enum ControlType {
     Radio = "Radio",
     Checkbox = "Checkbox",
-    Dropdown = "Dropdown"
+    Dropdown = "Dropdown",
 }
 
 // todo: remove
@@ -237,7 +237,8 @@ const extractColumnTypes = (str: string) => {
         .split(detectDelimiter(header))
         .slice(1)
         .map(
-            name => ControlType[name.split(" ").pop() as ControlType] || "Radio"
+            (name) =>
+                ControlType[name.split(" ").pop() as ControlType] || "Radio"
         )
 }
 
@@ -250,7 +251,7 @@ const removeColumnTypeInfo = (str: string) => {
     const reg = new RegExp("(" + types + ")$")
     lines[0] = header
         .split(delimiter)
-        .map(cell => cell.replace(reg, ""))
+        .map((cell) => cell.replace(reg, ""))
         .join(delimiter)
     return lines.join("\n")
 }
@@ -264,11 +265,11 @@ export class SwitcherRuntime {
         this.columnTypes = extractColumnTypes(delimited)
         delimited = removeColumnTypeInfo(delimited)
         this.parsed = parseDelimited(delimited)
-        this.parsed.forEach(row => {
+        this.parsed.forEach((row) => {
             row.chartId = parseInt(row.chartId)
         })
         const queryParams = strToQueryParams(decodeURIComponent(queryString))
-        this.columnNames.forEach(name => {
+        this.columnNames.forEach((name) => {
             if (queryParams[name] === undefined)
                 this.setValue(name, this.firstAvailableOptionForGroup(name))
             else this.setValue(name, queryParams[name])
@@ -287,13 +288,13 @@ export class SwitcherRuntime {
 
     static getRequiredChartIds(code: string) {
         return parseDelimited(code)
-            .map(row => parseInt(row.chartId!))
-            .filter(id => !isNaN(id))
+            .map((row) => parseInt(row.chartId!))
+            .filter((id) => !isNaN(id))
     }
 
     toConstrainedOptions() {
         const settings = this.toObject()
-        this.columnNames.forEach(group => {
+        this.columnNames.forEach((group) => {
             if (!this.isOptionAvailable(group, settings[group]))
                 settings[group] = this.firstAvailableOptionForGroup(group)
         })
@@ -307,22 +308,22 @@ export class SwitcherRuntime {
     @computed get columnNames() {
         if (!this.parsed[0]) return []
         return Object.keys(this.parsed[0]).filter(
-            name => name !== CHART_ID_SYMBOL
+            (name) => name !== CHART_ID_SYMBOL
         )
     }
 
     @computed get groupOptions(): { [title: string]: string[] } {
         const optionMap: any = {}
         this.columnNames.forEach((title, index) => {
-            optionMap[title] = uniq(this.parsed.map(row => row[title])).filter(
-                cell => !isCellEmpty(cell)
-            ) as string[]
+            optionMap[title] = uniq(
+                this.parsed.map((row) => row[title])
+            ).filter((cell) => !isCellEmpty(cell)) as string[]
         })
         return optionMap
     }
 
     firstAvailableOptionForGroup(group: string) {
-        return this.groupOptions[group].find(option =>
+        return this.groupOptions[group].find((option) =>
             this.isOptionAvailable(group, option)
         )
     }
@@ -330,7 +331,7 @@ export class SwitcherRuntime {
     isOptionAvailable(groupName: string, optionName: string) {
         const query: any = {}
         const columnNames = this.columnNames
-        columnNames.slice(0, columnNames.indexOf(groupName)).forEach(col => {
+        columnNames.slice(0, columnNames.indexOf(groupName)).forEach((col) => {
             query[col] = this._settings[col]
         })
         query[groupName] = optionName
@@ -341,9 +342,9 @@ export class SwitcherRuntime {
         return this.parsed
             .map((row, rowIndex) =>
                 Object.keys(query)
-                    .filter(key => query[key] !== undefined)
+                    .filter((key) => query[key] !== undefined)
                     .every(
-                        key =>
+                        (key) =>
                             row[key] === query[key] ||
                             (groupName && groupName !== key
                                 ? isCellEmpty(row[key])
@@ -352,12 +353,12 @@ export class SwitcherRuntime {
                     ? rowIndex
                     : null
             )
-            .filter(index => index !== null) as number[]
+            .filter((index) => index !== null) as number[]
     }
 
     rowsWith(query: any, groupName?: string) {
         return this.rowIndexesWith(query, groupName).map(
-            index => this.parsed[index]
+            (index) => this.parsed[index]
         )
     }
 
@@ -379,7 +380,7 @@ export class SwitcherRuntime {
             label: optionName,
             checked: value === optionName,
             value: optionName,
-            available: this.isOptionAvailable(groupName, optionName)
+            available: this.isOptionAvailable(groupName, optionName),
         }
     }
 
@@ -387,7 +388,7 @@ export class SwitcherRuntime {
         const constrainedOptions = this.toConstrainedOptions()
         return this.columnNames.map((title, index) => {
             const optionNames = this.groupOptions[title]
-            let options = optionNames.map(optionName =>
+            let options = optionNames.map((optionName) =>
                 this.toControlOption(
                     title,
                     optionName,
@@ -399,7 +400,7 @@ export class SwitcherRuntime {
 
             const isCheckbox = type === ControlType.Checkbox
             if (isCheckbox)
-                options = options.filter(opt => opt.label !== FALSE_SYMBOL)
+                options = options.filter((opt) => opt.label !== FALSE_SYMBOL)
 
             if (type === "Dropdown") {
                 dropdownOptions = options
@@ -410,7 +411,7 @@ export class SwitcherRuntime {
                 value: constrainedOptions[title],
                 options,
                 dropdownOptions,
-                isCheckbox
+                isCheckbox,
             }
         })
     }
@@ -429,7 +430,7 @@ export class ExplorerQueryParams {
         this.hideControls = obj.hideControls === "true"
 
         if (obj.country) {
-            EntityUrlBuilder.queryParamToEntities(obj.country).forEach(code =>
+            EntityUrlBuilder.queryParamToEntities(obj.country).forEach((code) =>
                 this.selectedEntityNames.add(code)
             )
         }

--- a/explorer/client/ExplorerShell.tsx
+++ b/explorer/client/ExplorerShell.tsx
@@ -162,7 +162,7 @@ export class ExplorerShell extends React.Component<{
                         CovidExplorer: true,
                         "mobile-explorer": this.isMobile,
                         HideControls: !this.showExplorerControls,
-                        "is-embed": this.props.isEmbed
+                        "is-embed": this.props.isEmbed,
                     })}
                 >
                     {this.showExplorerControls && (

--- a/explorer/client/SwitcherExplorer.stories.tsx
+++ b/explorer/client/SwitcherExplorer.stories.tsx
@@ -6,7 +6,7 @@ import { ExplorerProgram } from "explorer/client/ExplorerProgram"
 
 export default {
     title: "SwitcherExplorer",
-    component: SwitcherExplorer
+    component: SwitcherExplorer,
 }
 
 export const SwitcherTest = () => {

--- a/explorer/client/SwitcherExplorer.tsx
+++ b/explorer/client/SwitcherExplorer.tsx
@@ -37,7 +37,9 @@ export class SwitcherExplorer extends React.Component<{
             window.location.search
         )
         const chartConfigsMap: Map<number, GrapherInterface> = new Map()
-        chartConfigs.forEach(config => chartConfigsMap.set(config.id!, config))
+        chartConfigs.forEach((config) =>
+            chartConfigsMap.set(config.id!, config)
+        )
 
         return ReactDOM.render(
             <SwitcherExplorer
@@ -66,7 +68,7 @@ export class SwitcherExplorer extends React.Component<{
     private bindToWindow() {
         const url = new ExtendedGrapherUrl(this._grapher!.url, [
             this.switcherRuntime,
-            this.explorerRuntime
+            this.explorerRuntime,
         ])
 
         if (this.urlBinding) this.urlBinding.unbindFromWindow()
@@ -80,7 +82,7 @@ export class SwitcherExplorer extends React.Component<{
     componentWillMount() {
         // todo: add disposer
         reaction(() => this.switcherRuntime.chartId, this.switchGrapher, {
-            fireImmediately: true
+            fireImmediately: true,
         })
     }
 
@@ -114,7 +116,7 @@ export class SwitcherExplorer extends React.Component<{
                 // Add any missing entities
                 this.availableEntities = uniq([
                     ...this.availableEntities,
-                    ...this._grapher!.table.availableEntities
+                    ...this._grapher!.table.availableEntities,
                 ]).sort()
 
                 this.updateGrapherSelection()
@@ -130,13 +132,13 @@ export class SwitcherExplorer extends React.Component<{
         const selectedData = Array.from(
             this.explorerRuntime.selectedEntityNames
         )
-            .filter(i => i)
-            .map(countryOption => {
+            .filter((i) => i)
+            .map((countryOption) => {
                 return {
                     index: 0,
                     entityId: countryOption
                         ? entityIdMap.get(countryOption)!
-                        : 0
+                        : 0,
                 }
             })
 
@@ -144,7 +146,7 @@ export class SwitcherExplorer extends React.Component<{
     }
 
     private get panels() {
-        return this.switcherRuntime.groups.map(group => (
+        return this.switcherRuntime.groups.map((group) => (
             <ExplorerControlPanel
                 key={group.title}
                 value={group.value}
@@ -154,7 +156,7 @@ export class SwitcherExplorer extends React.Component<{
                 dropdownOptions={group.dropdownOptions}
                 options={group.options}
                 isCheckbox={group.isCheckbox}
-                onChange={value => {
+                onChange={(value) => {
                     this.switcherRuntime.setValue(group.title, value)
                 }}
             />
@@ -169,7 +171,7 @@ export class SwitcherExplorer extends React.Component<{
                 <div
                     className="ExplorerSubtitle"
                     dangerouslySetInnerHTML={{
-                        __html: this.props.program.subtitle || ""
+                        __html: this.props.program.subtitle || "",
                     }}
                 ></div>
             </>

--- a/explorer/covidExplorer/CovidConstants.ts
+++ b/explorer/covidExplorer/CovidConstants.ts
@@ -18,13 +18,13 @@ export const testRateExcludeList = new Set([
     "Peru",
     "Ecuador",
     "Brazil",
-    "Costa Rica"
+    "Costa Rica",
 ])
 
 export const covidPreloads = [
     covidDataPath,
     covidChartAndVariableMetaPath,
-    covidLastUpdatedPath
+    covidLastUpdatedPath,
 ]
 
 export declare type SmoothingOption = 0 | 3 | 7 | 14
@@ -45,7 +45,7 @@ export const intervalOptions: IntervalOption[] = [
     "smoothed",
     "biweekly",
     "weeklyChange",
-    "biweeklyChange"
+    "biweeklyChange",
 ]
 
 export interface IntervalSpec {
@@ -60,7 +60,7 @@ export const intervalSpecs: { [key in IntervalOption]: IntervalSpec } = {
     smoothed: { label: "7-day rolling average", smoothing: 7 },
     biweekly: { label: "Biweekly", smoothing: 14 },
     weeklyChange: { label: "Weekly change", smoothing: 7 },
-    biweeklyChange: { label: "Biweekly Change", smoothing: 14 }
+    biweeklyChange: { label: "Biweekly Change", smoothing: 14 },
 }
 
 export declare type colorScaleOption = "continents" | "ptr" | "none"
@@ -79,7 +79,7 @@ export const MetricOptions: MetricKind[] = [
     "tests",
     "case_fatality_rate",
     "tests_per_case",
-    "positive_test_rate"
+    "positive_test_rate",
 ]
 
 export const sourceCharts = {
@@ -110,7 +110,7 @@ export const sourceCharts = {
     positive_test_rate_total: 4198,
     positive_test_rate_daily: 4198,
 
-    case_fatality_rate_total: 4056
+    case_fatality_rate_total: 4056,
 }
 
 export const sourceVariables = {
@@ -121,7 +121,7 @@ export const sourceVariables = {
     deaths: 142583,
     tests: 142601,
     days_since: 142712,
-    continents: 123
+    continents: 123,
 }
 
 export const trajectoryColumnSpecs = {
@@ -129,37 +129,37 @@ export const trajectoryColumnSpecs = {
         total: {
             name: "Days since the 5th total confirmed death",
             threshold: 5,
-            owidVariableId: 4561
+            owidVariableId: 4561,
         },
         daily: {
             name: "Days since 5 daily new deaths first reported",
             threshold: 5,
-            owidVariableId: 4562
+            owidVariableId: 4562,
         },
         perCapita: {
             name: "Days since total confirmed deaths reached 0.1 per million",
             threshold: 0.1,
-            owidVariableId: 4563
-        }
+            owidVariableId: 4563,
+        },
     },
     cases: {
         total: {
             name: "Days since the 100th confirmed case",
             threshold: 100,
-            owidVariableId: 4564
+            owidVariableId: 4564,
         },
         daily: {
             name: "Days since confirmed cases first reached 30 per day",
             threshold: 30,
-            owidVariableId: 4565
+            owidVariableId: 4565,
         },
         perCapita: {
             name:
                 "Days since the total confirmed cases per million people reached 1",
             threshold: 1,
-            owidVariableId: 4566
-        }
-    }
+            owidVariableId: 4566,
+        },
+    },
 }
 
 export const metricLabels: { [key in MetricKind]: string } = {
@@ -168,7 +168,7 @@ export const metricLabels: { [key in MetricKind]: string } = {
     tests: "Tests",
     case_fatality_rate: "Case fatality rate",
     tests_per_case: "Tests per confirmed case",
-    positive_test_rate: "Share of positive tests"
+    positive_test_rate: "Share of positive tests",
 }
 
 export const intervalsAvailableByMetric: Map<
@@ -180,7 +180,7 @@ export const intervalsAvailableByMetric: Map<
     ["tests", new Set(["total", "smoothed", "daily"])],
     ["case_fatality_rate", new Set(["total"])],
     ["tests_per_case", new Set(["total", "smoothed"])],
-    ["positive_test_rate", new Set(["total", "smoothed"])]
+    ["positive_test_rate", new Set(["total", "smoothed"])],
 ])
 
 // todo: auto import from covid repo.
@@ -266,38 +266,38 @@ export const metricPickerColumnSpecs: Partial<Record<
     population_density: {
         slug: "population_density",
         name: "Population density (people per km²)",
-        type: "PopulationDensity"
+        type: "PopulationDensity",
     },
     median_age: { slug: "median_age", name: "Median age", type: "Age" },
     aged_65_older: {
         slug: "aged_65_older",
         name: "Share aged 65+",
-        type: "Percentage"
+        type: "Percentage",
     },
     aged_70_older: {
         slug: "aged_70_older",
         name: "Share aged 70+",
-        type: "Percentage"
+        type: "Percentage",
     },
     gdp_per_capita: {
         slug: "gdp_per_capita",
         name: "GDP per capita (int.-$)",
-        type: "Currency"
+        type: "Currency",
     },
     extreme_poverty: {
         slug: "extreme_poverty",
         name: "Population in extreme poverty",
-        type: "Percentage"
+        type: "Percentage",
     },
     hospital_beds_per_thousand: {
         slug: "hospital_beds_per_thousand",
         name: "Hospital beds (per 1000)",
-        type: "Ratio"
+        type: "Ratio",
     },
     stringency_index: {
         slug: "stringency_index",
         name: "Stringency Index",
-        type: "Numeric"
+        type: "Numeric",
     },
     life_expectancy: { name: "Life expectancy", type: "Age" },
     total_deaths: { name: "Total deaths", type: "Integer" },
@@ -311,7 +311,7 @@ export const metricPickerColumnSpecs: Partial<Record<
     total_deaths_per_million: { name: "Total deaths (per 1M)", type: "Ratio" },
     total_cases_per_million: { name: "Total cases (per 1M)", type: "Ratio" },
     new_deaths_per_million: { name: "New deaths (per 1M)", type: "Ratio" },
-    new_cases_per_million: { name: "New cases (per 1M)", type: "Ratio" }
+    new_cases_per_million: { name: "New cases (per 1M)", type: "Ratio" },
 }
 // The ID of the Wordpress reusable block to show below the COVID explorer
 export const covidWpBlockId = 36313

--- a/explorer/covidExplorer/CovidExplorer.jsdom.test.tsx
+++ b/explorer/covidExplorer/CovidExplorer.jsdom.test.tsx
@@ -10,7 +10,7 @@ import { defaultTo } from "grapher/utils/Util"
 
 const dummyMeta = {
     charts: {},
-    variables: {}
+    variables: {},
 }
 
 describe(CovidExplorer, () => {
@@ -63,7 +63,7 @@ class ExplorerDataTableTest {
             .find("thead tr")
             .first()
             .find("th span.name")
-            .map(tableHeader => tableHeader.text())
+            .map((tableHeader) => tableHeader.text())
     }
 
     bodyRow(index: number) {
@@ -71,7 +71,7 @@ class ExplorerDataTableTest {
             .find("tbody tr")
             .at(index)
             .find("td")
-            .map(td => td.text())
+            .map((td) => td.text())
     }
 }
 
@@ -92,7 +92,7 @@ describe("When you try to create a multimetric Data Explorer", () => {
             "Tests",
             "Tests per confirmed case",
             "Case fatality rate",
-            "Share of positive tests"
+            "Share of positive tests",
         ])
     })
 
@@ -103,7 +103,7 @@ describe("When you try to create a multimetric Data Explorer", () => {
         "May 5 7.54 million",
         "May 5 6",
         "5.9",
-        "May 5 0.2"
+        "May 5 0.2",
     ]
 
     it("renders correct table rows", () => {
@@ -123,14 +123,14 @@ describe("When you try to create a multimetric Data Explorer", () => {
             expect(dataTableTester.headers).toEqual([
                 "Confirmed cases",
                 "Confirmed deaths",
-                "Tests per confirmed case"
+                "Tests per confirmed case",
             ])
         })
     })
 
     describe("It doesn't change when", () => {
         it("explorer metrics change", () => {
-            MetricOptions.forEach(metric => {
+            MetricOptions.forEach((metric) => {
                 const params = ExplorerDataTableTest.defaultParams
                 params.setMetric(metric)
                 const dataTableTester = new ExplorerDataTableTest(params)
@@ -159,7 +159,7 @@ describe("When you try to create a multimetric Data Explorer", () => {
                 "May 5 3.77 million",
                 "May 5 6",
                 "5.9",
-                "May 5 0.2"
+                "May 5 0.2",
             ])
         })
 
@@ -179,7 +179,7 @@ describe("When you try to create a multimetric Data Explorer", () => {
                     "May 5 258,954",
                     "May 5 6",
                     "5.9",
-                    "May 5 0.2"
+                    "May 5 0.2",
                 ])
             })
 
@@ -197,7 +197,7 @@ describe("When you try to create a multimetric Data Explorer", () => {
                     "May 5 7.54 million",
                     "May 5 6",
                     "5.9",
-                    "May 5 0.2"
+                    "May 5 0.2",
                 ])
             })
         })

--- a/explorer/covidExplorer/CovidExplorer.stories.tsx
+++ b/explorer/covidExplorer/CovidExplorer.stories.tsx
@@ -5,12 +5,12 @@ import { CovidQueryParams } from "explorer/covidExplorer/CovidParams"
 
 export default {
     title: "CovidExplorer",
-    component: CovidExplorer
+    component: CovidExplorer,
 }
 
 const EMPTY_DUMMY_META = {
     charts: {},
-    variables: {}
+    variables: {},
 }
 
 export const SingleExplorerWithKeyboardShortcuts = () => {

--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -13,7 +13,7 @@ import {
     IReactionDisposer,
     observe,
     Lambda,
-    reaction
+    reaction,
 } from "mobx"
 import { observer } from "mobx-react"
 import { bind } from "decko"
@@ -27,13 +27,13 @@ import {
     next,
     previous,
     startCase,
-    flatten
+    flatten,
 } from "grapher/utils/Util"
 import {
     ControlOption,
     ExplorerControlPanel,
     DropdownOption,
-    ExplorerControlBar
+    ExplorerControlBar,
 } from "explorer/client/ExplorerControls"
 import { CovidQueryParams, CovidConstrainedQueryParams } from "./CovidParams"
 import { CountryPicker } from "grapher/controls/CountryPicker"
@@ -44,7 +44,7 @@ import {
     CovidExplorerTable,
     fetchCovidChartAndVariableMeta,
     buildColumnSlug,
-    perCapitaDivisorByMetric
+    perCapitaDivisorByMetric,
 } from "./CovidExplorerTable"
 import { BAKED_BASE_URL } from "settings"
 import moment from "moment"
@@ -60,17 +60,17 @@ import {
     metricPickerColumnSpecs,
     covidCsvColumnSlug,
     intervalSpecs,
-    intervalsAvailableByMetric
+    intervalsAvailableByMetric,
 } from "./CovidConstants"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
     ColorScheme,
     ColorSchemes,
-    continentColors
+    continentColors,
 } from "grapher/color/ColorSchemes"
 import {
     GlobalEntitySelection,
-    GlobalEntitySelectionModes
+    GlobalEntitySelectionModes,
 } from "site/globalEntityControl/GlobalEntitySelection"
 import { ColorScaleConfig } from "grapher/color/ColorScaleConfig"
 import * as Mousetrap from "mousetrap"
@@ -79,7 +79,7 @@ import { TimeBoundValue } from "grapher/utils/TimeBounds"
 import {
     ChartDimensionSpec,
     ChartDimension,
-    ChartDimensionInterface
+    ChartDimensionInterface,
 } from "grapher/chart/ChartDimension"
 import { BinningStrategy } from "grapher/color/BinningStrategies"
 import { UrlBinder } from "grapher/utils/UrlBinder"
@@ -115,7 +115,7 @@ export class CovidExplorer extends React.Component<{
         const [typedData, updated, covidMeta] = await Promise.all([
             fetchAndParseData(),
             fetchLastUpdatedTime(),
-            fetchCovidChartAndVariableMeta()
+            fetchCovidChartAndVariableMeta(),
         ])
         const queryStr =
             props.queryStr && CovidQueryParams.hasAnyCovidParam(props.queryStr)
@@ -159,7 +159,7 @@ export class CovidExplorer extends React.Component<{
         )
         return CovidExplorer.bootstrap({
             ...props,
-            queryStr
+            queryStr,
         })
     }
 
@@ -175,7 +175,7 @@ export class CovidExplorer extends React.Component<{
 
     @action.bound selectAllCommand() {
         const codeMap = this.grapher.table.entityNameToCodeMap
-        this.grapher.table.availableEntities.forEach(option =>
+        this.grapher.table.availableEntities.forEach((option) =>
             this.props.params.selectedCountryCodes.add(codeMap.get(option)!)
         )
         this.selectionChangeFromBuilder = true
@@ -188,21 +188,21 @@ export class CovidExplorer extends React.Component<{
                 available: true,
                 label: metricLabels.cases,
                 checked: this.constrainedParams.casesMetric,
-                value: "cases"
+                value: "cases",
             },
             {
                 available: true,
                 label: metricLabels.deaths,
                 checked: this.constrainedParams.deathsMetric,
-                value: "deaths"
+                value: "deaths",
             },
 
             {
                 available: true,
                 label: metricLabels.case_fatality_rate,
                 checked: this.constrainedParams.cfrMetric,
-                value: "case_fatality_rate"
-            }
+                value: "case_fatality_rate",
+            },
         ]
 
         const optionsColumn2: ControlOption[] = [
@@ -210,20 +210,20 @@ export class CovidExplorer extends React.Component<{
                 available: true,
                 label: metricLabels.tests,
                 checked: this.constrainedParams.testsMetric,
-                value: "tests"
+                value: "tests",
             },
             {
                 available: true,
                 label: metricLabels.tests_per_case,
                 checked: this.constrainedParams.testsPerCaseMetric,
-                value: "tests_per_case"
+                value: "tests_per_case",
             },
             {
                 available: true,
                 label: metricLabels.positive_test_rate,
                 checked: this.constrainedParams.positiveTestRate,
-                value: "positive_test_rate"
-            }
+                value: "positive_test_rate",
+            },
         ]
         return (
             <>
@@ -260,38 +260,38 @@ export class CovidExplorer extends React.Component<{
             {
                 available: true,
                 label: intervalSpecs.total.label,
-                value: "total"
+                value: "total",
             },
             {
                 available: available.smoothed,
                 label: intervalSpecs.smoothed.label,
-                value: "smoothed"
+                value: "smoothed",
             },
             {
                 available: available.daily,
                 label: intervalSpecs.daily.label,
-                value: "daily"
+                value: "daily",
             },
             {
                 available: available.weekly,
                 label: intervalSpecs.weekly.label,
-                value: "weekly"
+                value: "weekly",
             },
             {
                 available: available.weekly,
                 label: intervalSpecs.weeklyChange.label,
-                value: "weeklyChange"
+                value: "weeklyChange",
             },
             {
                 available: available.weekly,
                 label: intervalSpecs.biweekly.label,
-                value: "biweekly"
+                value: "biweekly",
             },
             {
                 available: available.weekly,
                 label: intervalSpecs.biweeklyChange.label,
-                value: "biweeklyChange"
-            }
+                value: "biweeklyChange",
+            },
         ]
         return (
             <ExplorerControlPanel
@@ -320,8 +320,8 @@ export class CovidExplorer extends React.Component<{
                 available: available.perCapita,
                 label: capitalize(this.perCapitaOptions[this.perCapitaDivisor]),
                 checked: this.constrainedParams.perCapita,
-                value: "true"
-            }
+                value: "true",
+            },
         ]
         return (
             <ExplorerControlPanel
@@ -330,7 +330,7 @@ export class CovidExplorer extends React.Component<{
                 isCheckbox={true}
                 options={options}
                 explorerSlug="covid"
-                onChange={value => {
+                onChange={(value) => {
                     this.props.params.perCapita = value === "true"
                     this.renderControlsThenUpdateChart()
                 }}
@@ -345,8 +345,8 @@ export class CovidExplorer extends React.Component<{
                 available: available.aligned,
                 label: "Align outbreaks",
                 checked: this.constrainedParams.aligned,
-                value: "true"
-            }
+                value: "true",
+            },
         ]
         return (
             <ExplorerControlPanel
@@ -354,7 +354,7 @@ export class CovidExplorer extends React.Component<{
                 name={this.getScopedName("timeline")}
                 isCheckbox={true}
                 options={options}
-                onChange={value => {
+                onChange={(value) => {
                     this.props.params.aligned = value === "true"
                     this.renderControlsThenUpdateChart()
                 }}
@@ -460,7 +460,7 @@ export class CovidExplorer extends React.Component<{
 
     @computed get activeColumnSlugs(): string[] {
         return [this.xColumn?.slug, this.yColumn?.slug].filter(
-            i => i
+            (i) => i
         ) as string[]
     }
 
@@ -517,7 +517,7 @@ export class CovidExplorer extends React.Component<{
                         CovidExplorer: true,
                         "mobile-explorer": this.isMobile,
                         HideControls: !this.showExplorerControls,
-                        "is-embed": this.props.isEmbed
+                        "is-embed": this.props.isEmbed,
                     })}
                 >
                     {this.showExplorerControls && this.header}
@@ -568,7 +568,7 @@ export class CovidExplorer extends React.Component<{
 
     @computed get selectedCountryOptions(): string[] {
         const codeMap = this.grapher.table.entityNameToCodeMap
-        return this.grapher.table.availableEntities.filter(option =>
+        return this.grapher.table.availableEntities.filter((option) =>
             this.props.params.selectedCountryCodes.has(codeMap.get(option)!)
         )
     }
@@ -581,7 +581,7 @@ export class CovidExplorer extends React.Component<{
         return {
             1: "",
             1e3: "per 1,000 people",
-            1e6: "per million people"
+            1e6: "per million people",
         }
     }
 
@@ -662,15 +662,15 @@ export class CovidExplorer extends React.Component<{
         const countryCodeMap = this.grapher.table.entityCodeToNameMap
         const entityIdMap = this.grapher.table.entityNameToIdMap
         return Array.from(this.props.params.selectedCountryCodes)
-            .map(code => countryCodeMap.get(code))
-            .filter(i => i)
-            .map(countryOption => {
+            .map((code) => countryCodeMap.get(code))
+            .filter((i) => i)
+            .map((countryOption) => {
                 return {
                     index: 0,
                     entityId: countryOption
                         ? entityIdMap.get(countryOption)!
                         : 0,
-                    color: this.countryNameToColorMap[countryOption!]
+                    color: this.countryNameToColorMap[countryOption!],
                 }
             })
     }
@@ -682,22 +682,22 @@ export class CovidExplorer extends React.Component<{
     @computed get countryNameToColorMap(): {
         [key: string]: string | undefined
     } {
-        const names = this.selectedCountryOptions.map(country => country)
+        const names = this.selectedCountryOptions.map((country) => country)
         // If there isn't a color for every country name, we need to update the color map
-        if (!names.every(name => name in this._countryNameToColorMapCache)) {
+        if (!names.every((name) => name in this._countryNameToColorMapCache)) {
             // Omit any unselected country names from color map
             const newColorMap = pick(this._countryNameToColorMapCache, names)
             // Check for name *key* existence, not value.
             // `undefined` value means we want the color to be automatic, determined by the chart.
             const namesWithoutColor = names.filter(
-                name => !(name in newColorMap)
+                (name) => !(name in newColorMap)
             )
             // For names that don't have a color, assign one.
-            namesWithoutColor.forEach(name => {
+            namesWithoutColor.forEach((name) => {
                 const scheme = ColorSchemes["owid-distinct"] as ColorScheme
                 const availableColors = lastOfNonEmptyArray(scheme.colorSets)
                 const usedColors = Object.values(newColorMap).filter(
-                    color => color !== undefined
+                    (color) => color !== undefined
                 ) as string[]
                 newColorMap[name] = getLeastUsedColor(
                     availableColors,
@@ -740,8 +740,8 @@ export class CovidExplorer extends React.Component<{
     @computed get selectedEntityNames(): string[] {
         const entityCodeMap = this.grapher.table.entityCodeToNameMap
         return Array.from(this.props.params.selectedCountryCodes.values())
-            .map(code => entityCodeMap.get(code))
-            .filter(i => i) as string[]
+            .map((code) => entityCodeMap.get(code))
+            .filter((i) => i) as string[]
     }
 
     @computed get canDoLogScale() {
@@ -800,7 +800,7 @@ export class CovidExplorer extends React.Component<{
 
         // When dimensions changes, chart.variableIds change, which calls downloadData(), which reparses variableSet
         chartProps.dimensions = this.dimensionSpecs.map(
-            spec => new ChartDimensionSpec(spec)
+            (spec) => new ChartDimensionSpec(spec)
         )
 
         // multimetric table
@@ -882,7 +882,7 @@ export class CovidExplorer extends React.Component<{
         ;(window as any).covidDataExplorer = this
 
         if (this.props.enableKeyboardShortcuts)
-            this.keyboardShortcuts.forEach(shortcut => {
+            this.keyboardShortcuts.forEach((shortcut) => {
                 Mousetrap.bind(shortcut.combo, () => {
                     shortcut.fn()
                     this.grapher.analytics.logKeyboardShortcut(
@@ -901,7 +901,7 @@ export class CovidExplorer extends React.Component<{
         this.grapher.yAxis.scaleType = ScaleType.log
         this.grapher.timeDomain = [
             TimeBoundValue.unboundedLeft,
-            TimeBoundValue.unboundedRight
+            TimeBoundValue.unboundedRight,
         ]
         this.props.params.setParamsFromQueryString(coronaDefaultView)
         this.renderControlsThenUpdateChart()
@@ -925,31 +925,31 @@ export class CovidExplorer extends React.Component<{
                 combo: "h",
                 fn: () => this.playDefaultViewCommand(),
                 title: "Default view",
-                category: "Browse"
+                category: "Browse",
             },
             {
                 combo: "right",
                 fn: () => this.playIndexCommand(++this.currentIndex),
                 title: "Next view",
-                category: "Browse"
+                category: "Browse",
             },
             {
                 combo: "left",
                 fn: () => this.playIndexCommand(--this.currentIndex),
                 title: "Previous view",
-                category: "Browse"
+                category: "Browse",
             },
             {
                 combo: "t",
                 fn: () => this.toggleTabCommand(),
                 title: "Toggle tab",
-                category: "Navigation"
+                category: "Navigation",
             },
             {
                 combo: "?",
                 fn: () => this.toggleKeyboardHelpCommand(),
                 title: "Toggle Help",
-                category: "Navigation"
+                category: "Navigation",
             },
             {
                 combo: "a",
@@ -958,38 +958,38 @@ export class CovidExplorer extends React.Component<{
                         ? this.clearSelectionCommand()
                         : this.selectAllCommand(),
                 title: "Select/Deselect all",
-                category: "Selection"
+                category: "Selection",
             },
             {
                 combo: "f",
                 fn: () => this.toggleFilterAllCommand(),
                 title: "Hide unselected",
-                category: "Selection"
+                category: "Selection",
             },
             {
                 combo: "c",
                 fn: () => this.toggleColorStrategyCommand(),
                 title: "Change line colors",
-                category: "Chart"
+                category: "Chart",
             },
             {
                 combo: "l",
                 fn: () => this.toggleYScaleTypeCommand(),
                 title: "Toggle Y log/linear",
-                category: "Chart"
+                category: "Chart",
             },
             {
                 combo: "z",
                 fn: () => this.toggleTimelineCommand(),
                 title: "Latest/Earliest/All period",
-                category: "Timeline"
+                category: "Timeline",
             },
             {
                 combo: "p",
                 fn: () => this.togglePlayingCommand(),
                 title: "Play/Pause",
-                category: "Timeline"
-            }
+                category: "Timeline",
+            },
         ]
     }
 
@@ -1061,7 +1061,7 @@ export class CovidExplorer extends React.Component<{
     // todo: remove
     private observeChartEntitySelection() {
         this.disposers.push(
-            observe(this.grapher, "selectedEntityCodes", change => {
+            observe(this.grapher, "selectedEntityCodes", (change) => {
                 // Ignore the change if it was triggered by the chart builder,
                 // but do not ignore subsequent changes.
                 if (this.selectionChangeFromBuilder) {
@@ -1079,8 +1079,10 @@ export class CovidExplorer extends React.Component<{
                 // but which may be selected in the explorer.
                 const added = difference(newCodes, oldCodes)
                 const removed = difference(oldCodes, newCodes)
-                added.forEach(code => this.toggleSelectedCountry(code, true))
-                removed.forEach(code => this.toggleSelectedCountry(code, false))
+                added.forEach((code) => this.toggleSelectedCountry(code, true))
+                removed.forEach((code) =>
+                    this.toggleSelectedCountry(code, false)
+                )
                 // Trigger an update in order to apply color changes
                 this._updateChart()
             })
@@ -1094,13 +1096,13 @@ export class CovidExplorer extends React.Component<{
                 reaction(
                     () => [
                         globalEntitySelection.mode,
-                        globalEntitySelection.selectedEntities
+                        globalEntitySelection.selectedEntities,
                     ],
                     () => {
                         const { mode, selectedEntities } = globalEntitySelection
                         if (mode === GlobalEntitySelectionModes.override) {
                             this.props.params.selectedCountryCodes = new Set(
-                                selectedEntities.map(entity => entity.code)
+                                selectedEntities.map((entity) => entity.code)
                             )
                             this.renderControlsThenUpdateChart()
                         }
@@ -1120,7 +1122,7 @@ export class CovidExplorer extends React.Component<{
     disposers: (IReactionDisposer | Lambda)[] = []
 
     @bind dispose() {
-        this.disposers.forEach(dispose => dispose())
+        this.disposers.forEach((dispose) => dispose())
     }
 
     @computed private get yColumn() {
@@ -1174,17 +1176,17 @@ export class CovidExplorer extends React.Component<{
                     (interval === "weeklyChange" ||
                         interval === "biweeklyChange") &&
                     "%",
-                tableDisplay: column?.display.tableDisplay
-            }
+                tableDisplay: column?.display.tableDisplay,
+            },
         } as ChartDimensionInterface
     }
 
     @computed private get dataTableOnlyDimensions(): ChartDimensionInterface[] {
         const params = this.constrainedParams
         return flatten(
-            params.tableMetrics?.map(metric => {
+            params.tableMetrics?.map((metric) => {
                 const specs = [
-                    this._buildDataTableOnlyDimensionSpec(metric, "total")
+                    this._buildDataTableOnlyDimensionSpec(metric, "total"),
                 ]
 
                 if (
@@ -1212,7 +1214,7 @@ export class CovidExplorer extends React.Component<{
 
         const dataTableParams = new CovidConstrainedQueryParams("")
 
-        params.tableMetrics?.forEach(metric => {
+        params.tableMetrics?.forEach((metric) => {
             dataTableParams.setMetric(metric)
             dataTableParams.interval = "total"
             dataTableParams.smoothing = 0
@@ -1262,8 +1264,8 @@ export class CovidExplorer extends React.Component<{
                 tolerance: 1,
                 unit,
                 name: this.chartTitle,
-                tableDisplay: yColumn.display.tableDisplay
-            }
+                tableDisplay: yColumn.display.tableDisplay,
+            },
         }
     }
 
@@ -1274,8 +1276,8 @@ export class CovidExplorer extends React.Component<{
             variableId: xColumn.spec.owidVariableId!,
             display: {
                 name: xColumn.spec.name,
-                tableDisplay: xColumn.display.tableDisplay
-            }
+                tableDisplay: xColumn.display.tableDisplay,
+            },
         }
     }
 
@@ -1294,7 +1296,7 @@ export class CovidExplorer extends React.Component<{
     @computed private get sizeDimension(): ChartDimensionInterface {
         return {
             property: "size",
-            variableId: this.sizeColumn!.spec.owidVariableId!
+            variableId: this.sizeColumn!.spec.owidVariableId!,
         }
     }
 
@@ -1309,8 +1311,8 @@ export class CovidExplorer extends React.Component<{
             property: "color",
             variableId,
             display: {
-                tolerance: 10
-            }
+                tolerance: 10,
+            },
         }
     }
 
@@ -1329,9 +1331,9 @@ export class CovidExplorer extends React.Component<{
                 customNumericColors: [],
                 customCategoryColors: continentColors,
                 customCategoryLabels: {
-                    "No data": "Other"
+                    "No data": "Other",
                 },
-                customHiddenCategories: {}
+                customHiddenCategories: {},
             },
             none: {
                 binningStrategy: BinningStrategy.manual,
@@ -1342,10 +1344,10 @@ export class CovidExplorer extends React.Component<{
                 customNumericColors: [],
                 customCategoryColors: continentColors,
                 customCategoryLabels: {
-                    "No data": ""
+                    "No data": "",
                 },
-                customHiddenCategories: {}
-            }
+                customHiddenCategories: {},
+            },
         }
     }
 
@@ -1360,8 +1362,8 @@ export class CovidExplorer extends React.Component<{
                 customNumericColors: [],
                 customCategoryColors: {},
                 customCategoryLabels: {},
-                customHiddenCategories: {}
-            }
+                customHiddenCategories: {},
+            },
         }
     }
 
@@ -1383,14 +1385,14 @@ export class CovidExplorer extends React.Component<{
             note: this.note,
             hideTitleAnnotation: true,
             xAxis: {
-                scaleType: ScaleType.linear
+                scaleType: ScaleType.linear,
             },
             yAxis: {
                 min: 0,
                 removePointsOutsideDomain: true,
                 scaleType: ScaleType.linear,
                 canChangeScaleType: true,
-                label: this.yAxisLabel
+                label: this.yAxisLabel,
             },
             selectedData: [],
             dimensions: [],
@@ -1406,11 +1408,11 @@ export class CovidExplorer extends React.Component<{
             isPublished: true,
             map: this.defaultMapConfig as any,
             data: {
-                availableEntities: []
-            }
+                availableEntities: [],
+            },
         },
         {
-            queryStr: this.props.queryStr
+            queryStr: this.props.queryStr,
         }
     )
 }

--- a/explorer/covidExplorer/CovidExplorerFigure.ts
+++ b/explorer/covidExplorer/CovidExplorerFigure.ts
@@ -41,7 +41,7 @@ export class CovidExplorerFigure implements Figure {
                 containerNode: this.container,
                 isEmbed: true,
                 queryStr: this.props.queryStr,
-                globalEntitySelection: loadProps.globalEntitySelection
+                globalEntitySelection: loadProps.globalEntitySelection,
             })
         }
     }
@@ -53,17 +53,17 @@ export class CovidExplorerFigure implements Figure {
             container.querySelectorAll<HTMLElement>("*[data-explorer-src]")
         )
         return excludeUndefined(
-            elements.map(element => {
+            elements.map((element) => {
                 const dataSrc = element.getAttribute("data-explorer-src")
                 if (!dataSrc) return undefined
                 const {
                     path: explorerUrl,
-                    queryString: queryStr
+                    queryString: queryStr,
                 } = splitURLintoPathAndQueryString(dataSrc)
                 if (!explorerUrl.includes(covidDashboardSlug)) return undefined
                 return new CovidExplorerFigure({
                     queryStr,
-                    container: element
+                    container: element,
                 })
             })
         )

--- a/explorer/covidExplorer/CovidExplorerTable.test.ts
+++ b/explorer/covidExplorer/CovidExplorerTable.test.ts
@@ -38,7 +38,7 @@ describe("build covid column", () => {
     dataTable.table.addRollingAverageColumn(
         { slug: "totalCasesSmoothed" },
         3,
-        row => row.total_cases,
+        (row) => row.total_cases,
         "day",
         "entityName"
     )
@@ -64,14 +64,14 @@ describe("build covid column", () => {
         rows.push({
             entityName: "USA",
             cases: index < 15 ? 10 : 20,
-            day: index
+            day: index,
         })
     }
     const table = new BasicTable(rows)
     table.addRollingAverageColumn(
         { slug: "weeklyCases" },
         7,
-        row => row.cases,
+        (row) => row.cases,
         "day",
         "entityName",
         7
@@ -84,7 +84,7 @@ describe("build covid column", () => {
     table.addRollingAverageColumn(
         { slug: "weeklyChange" },
         7,
-        row => row.cases,
+        (row) => row.cases,
         "day",
         "entityName",
         7,
@@ -126,7 +126,7 @@ describe("builds aligned tests column", () => {
                 aligned: "true",
                 perCapita: "true",
                 testsMetric: "true",
-                totalFreq: "true"
+                totalFreq: "true",
             })
         )
 
@@ -187,9 +187,9 @@ describe("column specs", () => {
                     "casesMetric=true&dailyFreq=true&smoothing=3&perCapita=true",
                     "testsMetric=true&dailyFreq=true&smoothing=3&perCapita=false",
                     "testsMetric=true&dailyFreq=true&smoothing=0&perCapita=true",
-                    "testsMetric=true&totalFreq=true&smoothing=3&perCapita=true"
+                    "testsMetric=true&totalFreq=true&smoothing=3&perCapita=true",
                 ].map(
-                    queryStr =>
+                    (queryStr) =>
                         dataTable.buildColumnSpec(
                             new CovidQueryParams(queryStr)
                         ).owidVariableId

--- a/explorer/covidExplorer/CovidExplorerTable.ts
+++ b/explorer/covidExplorer/CovidExplorerTable.ts
@@ -11,7 +11,7 @@ import {
     retryPromise,
     memoize,
     fetchText,
-    fetchJSON
+    fetchJSON,
 } from "grapher/utils/Util"
 import moment from "moment"
 import { csv } from "d3-fetch"
@@ -25,7 +25,7 @@ import {
     columnSlug,
     columnTypes,
     Row,
-    generateEntityId
+    generateEntityId,
 } from "owidTable/OwidTable"
 import { CovidConstrainedQueryParams, CovidQueryParams } from "./CovidParams"
 import {
@@ -41,7 +41,7 @@ import {
     intervalOptions,
     sourceVariables,
     testRateExcludeList,
-    metricPickerColumnSpecs
+    metricPickerColumnSpecs,
 } from "./CovidConstants"
 
 type MetricKey = {
@@ -73,9 +73,9 @@ export const buildColumnSlug = (
             ? "perMil"
             : undefined,
         interval,
-        rollingAverage ? rollingAverage + "DayAvg" : undefined
+        rollingAverage ? rollingAverage + "DayAvg" : undefined,
     ]
-        .filter(i => i)
+        .filter((i) => i)
         .join("-")
 
 export class CovidExplorerTable {
@@ -96,7 +96,7 @@ export class CovidExplorerTable {
         // This simply looks at the first row of the Covid CSV, and generates a spec for each column found.
         // I assume that the first row contains a key/value pair for every column
         const firstRow = data[0] || {}
-        const specs = Object.keys(firstRow).map(slug =>
+        const specs = Object.keys(firstRow).map((slug) =>
             CovidExplorerTable.makeSpec(slug)
         )
         this.table.addSpecs(specs)
@@ -110,7 +110,7 @@ export class CovidExplorerTable {
             slug,
             type: stringColumnSlugs.has(slug)
                 ? "String"
-                : ("Numeric" as columnTypes)
+                : ("Numeric" as columnTypes),
         }
         const metricSpec = (metricPickerColumnSpecs as any)[spec.slug]
         if (metricSpec) spec = Object.assign({}, spec, metricSpec)
@@ -129,9 +129,9 @@ export class CovidExplorerTable {
                 dataPublisherSource: "",
                 link: "",
                 retrievedDate: "",
-                additionalInfo: ""
+                additionalInfo: "",
             },
-            ...spec
+            ...spec,
         }
 
         return basicSpec
@@ -145,55 +145,55 @@ export class CovidExplorerTable {
                 ...owidVariableSpecs[sourceVariables.positive_test_rate],
                 isDailyMeasurement: true,
                 description:
-                    "The number of confirmed cases divided by the number of tests, expressed as a percentage. Tests may refer to the number of tests performed or the number of people tested – depending on which is reported by the particular country."
+                    "The number of confirmed cases divided by the number of tests, expressed as a percentage. Tests may refer to the number of tests performed or the number of people tested – depending on which is reported by the particular country.",
             },
             tests_per_case: {
                 ...owidVariableSpecs[sourceVariables.tests_per_case],
                 isDailyMeasurement: true,
                 description:
-                    "The number of tests divided by the number of confirmed cases. Not all countries report testing data on a daily basis."
+                    "The number of tests divided by the number of confirmed cases. Not all countries report testing data on a daily basis.",
             },
             case_fatality_rate: {
                 ...owidVariableSpecs[sourceVariables.case_fatality_rate],
                 annotationsColumnSlug: "case_fatality_rate_annotations",
                 isDailyMeasurement: true,
-                description: `The Case Fatality Rate (CFR) is the ratio between confirmed deaths and confirmed cases. During an outbreak of a pandemic the CFR is a poor measure of the mortality risk of the disease. We explain this in detail at OurWorldInData.org/Coronavirus`
+                description: `The Case Fatality Rate (CFR) is the ratio between confirmed deaths and confirmed cases. During an outbreak of a pandemic the CFR is a poor measure of the mortality risk of the disease. We explain this in detail at OurWorldInData.org/Coronavirus`,
             },
             cases: {
                 ...owidVariableSpecs[sourceVariables.cases],
                 isDailyMeasurement: true,
                 annotationsColumnSlug: "cases_annotations",
                 name: "Confirmed cases of COVID-19",
-                description: `The number of confirmed cases is lower than the number of actual cases; the main reason for that is limited testing.`
+                description: `The number of confirmed cases is lower than the number of actual cases; the main reason for that is limited testing.`,
             },
             deaths: {
                 ...owidVariableSpecs[sourceVariables.deaths],
                 isDailyMeasurement: true,
                 annotationsColumnSlug: "deaths_annotations",
                 name: "Confirmed deaths due to COVID-19",
-                description: `Limited testing and challenges in the attribution of the cause of death means that the number of confirmed deaths may not be an accurate count of the true number of deaths from COVID-19.`
+                description: `Limited testing and challenges in the attribution of the cause of death means that the number of confirmed deaths may not be an accurate count of the true number of deaths from COVID-19.`,
             },
             tests: {
                 ...owidVariableSpecs[sourceVariables.tests],
                 isDailyMeasurement: true,
                 description: "",
                 name: "tests",
-                annotationsColumnSlug: "tests_units"
+                annotationsColumnSlug: "tests_units",
             },
             days_since: {
                 ...owidVariableSpecs[sourceVariables.days_since],
                 isDailyMeasurement: true,
                 description: "",
-                name: "days_since"
+                name: "days_since",
             },
             continents: {
                 ...owidVariableSpecs[sourceVariables.continents],
                 description: "",
                 name: "continent",
-                slug: "continent"
-            }
+                slug: "continent",
+            },
         }
-        Object.keys(this.columnSpecs).forEach(key => {
+        Object.keys(this.columnSpecs).forEach((key) => {
             this.columnSpecs[key].owidVariableId = (sourceVariables as any)[key]
         })
 
@@ -201,13 +201,13 @@ export class CovidExplorerTable {
         const ptrDisplay = this.columnSpecs.positive_test_rate.display
         if (ptrDisplay)
             ptrDisplay.tableDisplay = {
-                hideRelativeChange: true
+                hideRelativeChange: true,
             } as any
 
         const cfrDisplay = this.columnSpecs.case_fatality_rate.display
         if (cfrDisplay)
             cfrDisplay.tableDisplay = {
-                hideRelativeChange: true
+                hideRelativeChange: true,
             } as any
     }
 
@@ -217,25 +217,25 @@ export class CovidExplorerTable {
         const cfrSlug = "case_fatality_rate_annotations"
         this.table.addStringColumnSpec({ slug: caseSlug })
         this.table.addStringColumnSpec({
-            slug: deathSlug
+            slug: deathSlug,
         })
         this.table.addStringColumnSpec({
-            slug: cfrSlug
+            slug: cfrSlug,
         })
 
         const index = this.table.entityIndex
         const annotationRows = csvParse(covidAnnotations) as AnnotationsRow[]
-        annotationRows.forEach(annoRow => {
+        annotationRows.forEach((annoRow) => {
             const rows = index.get(annoRow.location)
             if (!rows) return
             // If no date on annotation apply to all rows
             const applyTo = annoRow.date
-                ? rows.filter(row => row.date === annoRow.date)
+                ? rows.filter((row) => row.date === annoRow.date)
                 : rows
             const datePrefix = annoRow.date
                 ? moment(annoRow.date).format("MMM D") + ": "
                 : ""
-            applyTo.forEach(row => {
+            applyTo.forEach((row) => {
                 if (annoRow[caseSlug])
                     row[caseSlug] = datePrefix + annoRow[caseSlug]
                 if (annoRow[deathSlug])
@@ -272,14 +272,14 @@ export class CovidExplorerTable {
             deaths: 2,
             positive_test_rate: 3,
             case_fatality_rate: 4,
-            tests_per_case: 5
+            tests_per_case: 5,
         }
         const parts = [
             arbitraryStartingPrefix,
             names[params.metricName],
             intervalOptions.indexOf(params.interval),
             params.perCapitaAdjustment,
-            params.smoothing
+            params.smoothing,
         ]
         return parseInt(parts.join(""))
     }
@@ -297,7 +297,7 @@ export class CovidExplorerTable {
         const messages: { [index: number]: string } = {
             1: "",
             1e3: " per thousand people",
-            1e6: " per million people"
+            1e6: " per million people",
         }
 
         if (!spec.display) spec.display = {}
@@ -372,7 +372,7 @@ export class CovidExplorerTable {
         else {
             table.addNumericComputedColumn({
                 ...spec,
-                fn: perCapitaTransform ? perCapitaTransform(rowFn) : rowFn
+                fn: perCapitaTransform ? perCapitaTransform(rowFn) : rowFn,
             })
         }
         return spec
@@ -380,17 +380,17 @@ export class CovidExplorerTable {
 
     initTestingColumn(params: CovidConstrainedQueryParams) {
         if (params.interval === "daily")
-            this.initColumn(params, row => row.new_tests)
+            this.initColumn(params, (row) => row.new_tests)
         else if (params.interval === "smoothed")
-            this.initColumn(params, row => row.new_tests_smoothed)
+            this.initColumn(params, (row) => row.new_tests_smoothed)
         else if (params.interval === "total")
-            this.initColumn(params, row => row.total_tests)
+            this.initColumn(params, (row) => row.total_tests)
     }
 
     initTestsPerCaseColumn(params: CovidConstrainedQueryParams) {
         if (params.interval === "smoothed") {
             const casesSlug = this.addNewCasesSmoothedColumn(params.smoothing)
-            this.initColumn(params, row => {
+            this.initColumn(params, (row) => {
                 if (
                     row.new_tests_smoothed === undefined ||
                     !(row as any)[casesSlug]
@@ -403,7 +403,7 @@ export class CovidExplorerTable {
                 return tpc >= 1 ? tpc : undefined
             })
         } else if (params.interval === "total")
-            this.initColumn(params, row => {
+            this.initColumn(params, (row) => {
                 if (row.total_tests === undefined || !row.total_cases)
                     return undefined
 
@@ -417,7 +417,7 @@ export class CovidExplorerTable {
     initCfrColumn(params: CovidConstrainedQueryParams) {
         // We do not support daily freq for CFR
         if (params.interval === "total")
-            this.initColumn(params, row =>
+            this.initColumn(params, (row) =>
                 row.total_cases < 100
                     ? undefined
                     : row.total_deaths && row.total_cases
@@ -430,8 +430,8 @@ export class CovidExplorerTable {
         this.initColumn(
             params,
             params.interval === "total"
-                ? row => row.total_cases
-                : row => row.new_cases
+                ? (row) => row.total_cases
+                : (row) => row.new_cases
         )
     }
 
@@ -449,7 +449,7 @@ export class CovidExplorerTable {
     initTestRateColumn(params: CovidConstrainedQueryParams) {
         if (params.isDailyOrSmoothed) {
             const casesSlug = this.addNewCasesSmoothedColumn(params.smoothing)
-            return this.initColumn(params, row => {
+            return this.initColumn(params, (row) => {
                 const testCount =
                     params.smoothing === 7
                         ? row.new_tests_smoothed
@@ -468,7 +468,7 @@ export class CovidExplorerTable {
                 return rate >= 0 && rate <= 1 ? rate : undefined
             })
         }
-        return this.initColumn(params, row => {
+        return this.initColumn(params, (row) => {
             if (row.total_cases === undefined || !row.total_tests)
                 return undefined
 
@@ -483,8 +483,8 @@ export class CovidExplorerTable {
         this.initColumn(
             params,
             params.interval === "total"
-                ? row => row.total_deaths
-                : row => row.new_deaths
+                ? (row) => row.total_deaths
+                : (row) => row.new_deaths
         )
     }
 
@@ -509,7 +509,10 @@ export class CovidExplorerTable {
         if (filterSlug !== this.negativeFilterSlug)
             this.removeNegativeFilterColumn()
         if (!this.table.columnsBySlug.has(filterSlug))
-            this.table.addFilterColumn(filterSlug, row => !(row[slugName] < 0))
+            this.table.addFilterColumn(
+                filterSlug,
+                (row) => !(row[slugName] < 0)
+            )
         this.negativeFilterSlug = filterSlug
     }
 
@@ -568,7 +571,7 @@ export class CovidExplorerTable {
             name: title,
             owidVariableId: id,
             slug,
-            fn: row => {
+            fn: (row) => {
                 if (row.entityName !== currentCountry) {
                     const sourceValue = row[sourceColumnSlug]
                     if (sourceValue === undefined || sourceValue < threshold)
@@ -577,7 +580,7 @@ export class CovidExplorerTable {
                     countryExceededThresholdOnDay = row.day
                 }
                 return row.day - countryExceededThresholdOnDay
-            }
+            },
         }
 
         let currentCountry: number
@@ -591,10 +594,10 @@ export class CovidExplorerTable {
         if (this.table.columnsBySlug.has(slug)) return slug
         this.table.addRollingAverageColumn(
             {
-                slug
+                slug,
             },
             smoothing,
-            row => row.new_cases,
+            (row) => row.new_cases,
             "day",
             "entityName"
         )
@@ -607,8 +610,8 @@ export class CovidExplorerTable {
         const grouped = groupBy(rows, "continent")
         return flatten(
             Object.keys(grouped)
-                .filter(cont => cont)
-                .map(continentName =>
+                .filter((cont) => cont)
+                .map((continentName) =>
                     this.calculateRowsForGroup(
                         grouped[continentName],
                         continentName
@@ -622,14 +625,14 @@ export class CovidExplorerTable {
         groupName: string
     ) => {
         const rowsByDay = new Map<string, CovidGrapherRow>()
-        const rows = sortBy(group, row => dateToYear(row.date))
+        const rows = sortBy(group, (row) => dateToYear(row.date))
         const groupMembers = new Set()
-        rows.forEach(row => {
+        rows.forEach((row) => {
             const day = row.date
             groupMembers.add(row.iso_code)
             if (!rowsByDay.has(day)) {
                 const newRow: any = {}
-                Object.keys(row).forEach(key => (newRow[key] = undefined))
+                Object.keys(row).forEach((key) => (newRow[key] = undefined))
                 rowsByDay.set(day, {
                     location: groupName,
                     continent: row.continent,
@@ -641,7 +644,7 @@ export class CovidExplorerTable {
                     entityCode: groupName.replace(" ", ""),
                     entityId: generateEntityId(groupName),
                     new_deaths: 0,
-                    population: 0
+                    population: 0,
                 } as CovidGrapherRow)
             }
             const newRow = rowsByDay.get(day)!
@@ -655,7 +658,7 @@ export class CovidExplorerTable {
         let maxPopulation = 0
         const group_members = Array.from(groupMembers).join("")
         // We need to compute cumulatives again because sometimes data will stop for a country.
-        newRows.forEach(row => {
+        newRows.forEach((row) => {
             total_cases += row.new_cases
             total_deaths += row.new_deaths
             row.total_cases = total_cases
@@ -697,12 +700,12 @@ export class CovidExplorerTable {
         "Slovakia",
         "Slovenia",
         "Spain",
-        "Sweden"
+        "Sweden",
     ])
 
     static parseCovidRow(row: ParsedCovidCsvRow): CovidGrapherRow {
         const newRow: Partial<CovidGrapherRow> = row
-        Object.keys(row).forEach(key => {
+        Object.keys(row).forEach((key) => {
             const isNumeric = !stringColumnSlugs.has(key)
             if (isNumeric)
                 (row as any)[key] = parseFloatOrUndefined((row as any)[key])
@@ -758,7 +761,7 @@ export function getLeastUsedColor(
     // unused one.
     const colorCounts = entries(groupBy(usedColors)).map(([color, arr]) => [
         color,
-        arr.length
+        arr.length,
     ])
     const mostUnusedColor = minBy(colorCounts, ([, count]) => count) as [
         string,

--- a/explorer/covidExplorer/CovidParams.test.ts
+++ b/explorer/covidExplorer/CovidParams.test.ts
@@ -52,21 +52,21 @@ describe(CovidQueryParams, () => {
             {
                 str: `deathsMetric=true&dailyFreq=true&smoothing=0`,
                 interval: "daily",
-                smoothing: 0
+                smoothing: 0,
             },
             {
                 str: `deathsMetric=true&totalFreq=true&smoothing=0`,
                 interval: "total",
-                smoothing: 0
+                smoothing: 0,
             },
             {
                 str: `deathsMetric=true&dailyFreq=true&smoothing=7`,
                 interval: "smoothed",
-                smoothing: 7
-            }
+                smoothing: 7,
+            },
         ]
 
-        cases.forEach(testCase => {
+        cases.forEach((testCase) => {
             const params = new CovidQueryParams(testCase.str)
             expect(params.interval).toEqual(testCase.interval)
             expect(params.smoothing).toEqual(testCase.smoothing)

--- a/explorer/covidExplorer/CovidParams.ts
+++ b/explorer/covidExplorer/CovidParams.ts
@@ -2,12 +2,12 @@ import { computed, observable, action } from "mobx"
 import {
     QueryParams,
     strToQueryParams,
-    queryParamsToStr
+    queryParamsToStr,
 } from "utils/client/url"
 import {
     SortOrder,
     ChartTypeName,
-    ScaleType
+    ScaleType,
 } from "grapher/core/GrapherConstants"
 import { oneOf, uniq, intersection } from "grapher/utils/Util"
 import {
@@ -17,7 +17,7 @@ import {
     colorScaleOption,
     MetricKind,
     IntervalOption,
-    intervalOptions
+    intervalOptions,
 } from "./CovidConstants"
 import { buildColumnSlug, perCapitaDivisorByMetric } from "./CovidExplorerTable"
 import { EntityUrlBuilder } from "grapher/core/EntityUrlBuilder"
@@ -80,17 +80,17 @@ export class CovidQueryParams {
             "cfrMetric",
             "testsMetric",
             "testsPerCaseMetric",
-            "positiveTestRate"
+            "positiveTestRate",
         ]
         const perCapita = [true, false]
         const aligned = [true, false]
         const yScale = [ScaleType.log, ScaleType.linear] // todo
         const tab = ["map", "chart"] // todo
         const combos: any = []
-        metrics.forEach(metric => {
-            intervalOptions.forEach(interval => {
-                perCapita.forEach(perCapita => {
-                    aligned.forEach(aligned => {
+        metrics.forEach((metric) => {
+            intervalOptions.forEach((interval) => {
+                perCapita.forEach((perCapita) => {
+                    aligned.forEach((aligned) => {
                         const combo: any = {}
                         combo[metric] = true
                         combo.interval = interval
@@ -143,7 +143,7 @@ export class CovidQueryParams {
             this.selectedCountryCodes.clear()
             EntityUrlBuilder.queryParamToEntities(
                 params.country
-            ).forEach(code => this.selectedCountryCodes.add(code))
+            ).forEach((code) => this.selectedCountryCodes.add(code))
         }
 
         if (params.pickerMetric)
@@ -196,7 +196,7 @@ export class CovidQueryParams {
             weekly: "Weekly",
             biweekly: "Biweekly",
             weeklyChange: "Week by week change of",
-            biweeklyChange: "Biweekly change of"
+            biweeklyChange: "Biweekly change of",
         }
         return titles[this.interval]
     }
@@ -293,7 +293,7 @@ export class CovidQueryParams {
         return {
             ...config,
             slug: `daysSince${sourceSlug}Hit${config.threshold}`,
-            sourceSlug
+            sourceSlug,
         }
     }
 
@@ -341,9 +341,9 @@ export class CovidQueryParams {
             this.metricName,
             interval,
             this.perCapita ? "per_capita" : "",
-            this.intervalChange ? "change" : ""
+            this.intervalChange ? "change" : "",
         ]
-            .filter(i => i)
+            .filter((i) => i)
             .join("_")
     }
 
@@ -365,8 +365,8 @@ export class CovidConstrainedQueryParams extends CovidQueryParams {
             this.deathsMetric,
             this.testsMetric,
             this.testsPerCaseMetric,
-            this.positiveTestRate
-        ].some(i => i)
+            this.positiveTestRate,
+        ].some((i) => i)
         if (!hasMetric) this.casesMetric = true
 
         const available = this.available
@@ -420,11 +420,11 @@ export class CovidConstrainedQueryParams extends CovidQueryParams {
             aligned: !this.isRate && !isWeekly,
             daily: !this.isRate,
             smoothed: !this.cfrMetric,
-            weekly
+            weekly,
         }
 
         if (this.everythingAvailable) {
-            Object.keys(constraints).forEach(key => {
+            Object.keys(constraints).forEach((key) => {
                 constraints[key as keyof typeof constraints] = true
             })
         }
@@ -442,5 +442,5 @@ export class CovidConstrainedQueryParams extends CovidQueryParams {
 function getTableMetrics(queryParam?: string): MetricKind[] | undefined {
     if (!queryParam) return undefined
     const metricStrings = queryParam.split("~")
-    return metricStrings.map(metric => metric as MetricKind)
+    return metricStrings.map((metric) => metric as MetricKind)
 }

--- a/explorer/covidExplorer/bakeCovidChartAndVariableMeta.ts
+++ b/explorer/covidExplorer/bakeCovidChartAndVariableMeta.ts
@@ -6,7 +6,7 @@ import { getVariableData } from "db/model/Variable"
 import {
     covidChartAndVariableMetaFilename,
     sourceCharts,
-    sourceVariables
+    sourceVariables,
 } from "explorer/covidExplorer/CovidConstants"
 import { uniq } from "lodash"
 
@@ -17,7 +17,7 @@ export const bakeCovidChartAndVariableMeta = async () => {
     const output: any = {
         NOTICE: "This file is generated. Hand edits will be overwritten.",
         charts: {},
-        variables: {}
+        variables: {},
     }
 
     const charts = await db.query(

--- a/explorer/covidExplorer/bakeCovidExplorerRedirects.ts
+++ b/explorer/covidExplorer/bakeCovidExplorerRedirects.ts
@@ -3,7 +3,7 @@ import {
     fromPairs,
     flatten,
     urlToSlug,
-    mergeQueryStr
+    mergeQueryStr,
 } from "grapher/utils/Util"
 import { covidDashboardSlug } from "explorer/covidExplorer/CovidConstants"
 
@@ -25,125 +25,125 @@ export const chartExplorerRedirects: ChartExplorerRedirect[] = [
         slugs: [
             "total-cases-covid-19",
             "total-confirmed-cases-of-covid-19",
-            "total-cases-covid-19-who"
+            "total-cases-covid-19-who",
         ],
         explorerQueryStr:
-            "zoomToSelection=true&casesMetric=true&totalFreq=true&smoothing=0&country=~OWID_WRL"
+            "zoomToSelection=true&casesMetric=true&totalFreq=true&smoothing=0&country=~OWID_WRL",
     },
     {
         id: 4019,
         slugs: [
             "daily-cases-covid-19",
             "daily-new-confirmed-cases-of-covid-19",
-            "daily-cases-covid-19-who"
+            "daily-cases-covid-19-who",
         ],
         explorerQueryStr:
-            "zoomToSelection=true&casesMetric=true&dailyFreq=true&smoothing=0&country=~OWID_WRL"
+            "zoomToSelection=true&casesMetric=true&dailyFreq=true&smoothing=0&country=~OWID_WRL",
     },
     {
         id: 4020,
         slugs: ["total-deaths-covid-19", "total-deaths-covid-19-who"],
         explorerQueryStr:
-            "zoomToSelection=true&deathsMetric=true&totalFreq=true&smoothing=0&country=~OWID_WRL"
+            "zoomToSelection=true&deathsMetric=true&totalFreq=true&smoothing=0&country=~OWID_WRL",
     },
     {
         id: 4021,
         slugs: [
             "daily-deaths-covid-19",
             "daily-new-confirmed-deaths-due-to-covid-19",
-            "daily-deaths-covid-19-who"
+            "daily-deaths-covid-19-who",
         ],
         explorerQueryStr:
-            "zoomToSelection=true&deathsMetric=true&dailyFreq=true&smoothing=0&country=~OWID_WRL"
+            "zoomToSelection=true&deathsMetric=true&dailyFreq=true&smoothing=0&country=~OWID_WRL",
     },
     {
         id: 4025,
         slugs: ["covid-confirmed-cases-per-million-since-1-per-million"],
         explorerQueryStr:
-            "yScale=log&zoomToSelection=true&casesMetric=true&totalFreq=true&aligned=true&perCapita=true&smoothing=0&country="
+            "yScale=log&zoomToSelection=true&casesMetric=true&totalFreq=true&aligned=true&perCapita=true&smoothing=0&country=",
     },
     {
         id: 4037,
         slugs: [
             "covid-confirmed-deaths-since-5th-death",
-            "covid-confirmed-deaths-since-10th-death"
+            "covid-confirmed-deaths-since-10th-death",
         ],
         explorerQueryStr:
-            "yScale=log&zoomToSelection=true&deathsMetric=true&totalFreq=true&aligned=true&smoothing=0&country="
+            "yScale=log&zoomToSelection=true&deathsMetric=true&totalFreq=true&aligned=true&smoothing=0&country=",
     },
     {
         id: 4039,
         slugs: [
             "covid-confirmed-cases-since-100th-case",
-            "covid-tests-since-100th-case"
+            "covid-tests-since-100th-case",
         ],
         explorerQueryStr:
-            "yScale=log&zoomToSelection=true&casesMetric=true&totalFreq=true&aligned=true&smoothing=0&country="
+            "yScale=log&zoomToSelection=true&casesMetric=true&totalFreq=true&aligned=true&smoothing=0&country=",
     },
     {
         id: 4049,
         slugs: ["case-fatality-rate-covid-19"],
         explorerQueryStr:
-            "zoomToSelection=true&time=2020-03-14..&cfrMetric=true&totalFreq=true&aligned=true&smoothing=0&country=OWID_WRL~USA~ITA~BRA~ESP~SWE~DEU~IND~IRN"
+            "zoomToSelection=true&time=2020-03-14..&cfrMetric=true&totalFreq=true&aligned=true&smoothing=0&country=OWID_WRL~USA~ITA~BRA~ESP~SWE~DEU~IND~IRN",
     },
     {
         id: 4056,
         slugs: ["coronavirus-cfr"],
         explorerQueryStr:
-            "zoomToSelection=true&time=2020-03-14..&cfrMetric=true&totalFreq=true&aligned=true&smoothing=0&country=OWID_WRL~USA~ITA~BRA~ESP~SWE~DEU~IND~IRN"
+            "zoomToSelection=true&time=2020-03-14..&cfrMetric=true&totalFreq=true&aligned=true&smoothing=0&country=OWID_WRL~USA~ITA~BRA~ESP~SWE~DEU~IND~IRN",
     },
     {
         id: 4057,
         slugs: ["covid-deaths-days-since-per-million"],
         explorerQueryStr:
-            "yScale=log&zoomToSelection=true&minPopulationFilter=1000000&deathsMetric=true&totalFreq=true&aligned=true&perCapita=true&smoothing=0&country="
+            "yScale=log&zoomToSelection=true&minPopulationFilter=1000000&deathsMetric=true&totalFreq=true&aligned=true&perCapita=true&smoothing=0&country=",
     },
     {
         id: 4063,
         slugs: [
             "covid-confirmed-daily-cases-epidemiological-trajectory",
-            "covid-confirmed-daily-cases-since-100th-case"
+            "covid-confirmed-daily-cases-since-100th-case",
         ],
         explorerQueryStr:
-            "yScale=log&zoomToSelection=true&minPopulationFilter=1000000&casesMetric=true&dailyFreq=true&aligned=true&smoothing=7&country="
+            "yScale=log&zoomToSelection=true&minPopulationFilter=1000000&casesMetric=true&dailyFreq=true&aligned=true&smoothing=7&country=",
     },
     {
         id: 4078,
         slugs: ["covid-confirmed-daily-deaths-epidemiological-trajectory"],
         explorerQueryStr:
-            "yScale=log&zoomToSelection=true&minPopulationFilter=1000000&deathsMetric=true&dailyFreq=true&aligned=true&smoothing=7&country="
+            "yScale=log&zoomToSelection=true&minPopulationFilter=1000000&deathsMetric=true&dailyFreq=true&aligned=true&smoothing=7&country=",
     },
     {
         id: 4101,
         slugs: ["covid-confirmed-cases-since-100th-case"],
         explorerQueryStr:
-            "yScale=log&zoomToSelection=true&casesMetric=true&totalFreq=true&aligned=true&smoothing=0&country="
+            "yScale=log&zoomToSelection=true&casesMetric=true&totalFreq=true&aligned=true&smoothing=0&country=",
     },
     {
         id: 4106,
         slugs: ["covid-daily-deaths-trajectory-per-million"],
         explorerQueryStr:
-            "yScale=log&zoomToSelection=true&minPopulationFilter=1000000&deathsMetric=true&dailyFreq=true&aligned=true&perCapita=true&smoothing=7&country="
+            "yScale=log&zoomToSelection=true&minPopulationFilter=1000000&deathsMetric=true&dailyFreq=true&aligned=true&perCapita=true&smoothing=7&country=",
     },
     {
         id: 4107,
         slugs: ["covid-daily-cases-trajectory-per-million"],
         explorerQueryStr:
-            "yScale=log&zoomToSelection=true&minPopulationFilter=1000000&casesMetric=true&dailyFreq=true&aligned=true&perCapita=true&smoothing=7&country="
+            "yScale=log&zoomToSelection=true&minPopulationFilter=1000000&casesMetric=true&dailyFreq=true&aligned=true&perCapita=true&smoothing=7&country=",
     },
     {
         id: 4129,
         slugs: ["total-tests-per-thousand-since-per-cap-death-threshold"],
         explorerQueryStr:
-            "yScale=log&zoomToSelection=true&testsMetric=true&totalFreq=true&aligned=true&perCapita=true&smoothing=0&country="
-    }
-].map(redirect => ({
+            "yScale=log&zoomToSelection=true&testsMetric=true&totalFreq=true&aligned=true&perCapita=true&smoothing=0&country=",
+    },
+].map((redirect) => ({
     ...redirect,
     // Ensure all have hideControls=true, unless specified otherwise.
     explorerQueryStr: mergeQueryStr(
         "hideControls=true",
         redirect.explorerQueryStr
-    )
+    ),
 }))
 
 export const chartExplorerRedirectsBySlug: Record<
@@ -151,8 +151,8 @@ export const chartExplorerRedirectsBySlug: Record<
     ChartExplorerRedirect
 > = fromPairs(
     flatten(
-        chartExplorerRedirects.map(redirect =>
-            redirect.slugs.map(slug => [slug, redirect])
+        chartExplorerRedirects.map((redirect) =>
+            redirect.slugs.map((slug) => [slug, redirect])
         )
     )
 )
@@ -160,7 +160,7 @@ export const chartExplorerRedirectsBySlug: Record<
 export function replaceChartIframesWithExplorerIframes($: CheerioStatic) {
     const grapherIframes = $("iframe")
         .toArray()
-        .filter(el => (el.attribs["src"] || "").match(/\/grapher\//))
+        .filter((el) => (el.attribs["src"] || "").match(/\/grapher\//))
     for (const el of grapherIframes) {
         const url = el.attribs["src"].trim()
         const slug = urlToSlug(url)

--- a/explorer/indicatorExplorer/ExplorableChartConfig.jsdom.test.ts
+++ b/explorer/indicatorExplorer/ExplorableChartConfig.jsdom.test.ts
@@ -9,7 +9,7 @@ describe("ChartConfig", () => {
             hasChartTab: false,
             hasMapTab: false,
             isExplorable: true,
-            dimensions: [{ property: "y", variableId: 1, display: {} }]
+            dimensions: [{ property: "y", variableId: 1, display: {} }],
         })
         expect(grapher.isExplorable).toBe(true)
     })
@@ -19,7 +19,7 @@ describe("ChartConfig", () => {
             type: "ScatterPlot",
             hasChartTab: true,
             isExplorable: true,
-            dimensions: [{ property: "y", variableId: 1, display: {} }]
+            dimensions: [{ property: "y", variableId: 1, display: {} }],
         })
         expect(grapher.isExplorable).toBe(false)
     })
@@ -31,8 +31,8 @@ describe("ChartConfig", () => {
             isExplorable: true,
             dimensions: [
                 { property: "y", variableId: 1, display: {} },
-                { property: "y", variableId: 2, display: {} }
-            ]
+                { property: "y", variableId: 2, display: {} },
+            ],
         })
         expect(grapher.isExplorable).toBe(false)
     })

--- a/explorer/indicatorExplorer/ExploreModel.ts
+++ b/explorer/indicatorExplorer/ExploreModel.ts
@@ -19,9 +19,9 @@ function chartConfigFromIndicator(
         selectedData: [
             {
                 index: 0,
-                entityId: 355
-            }
-        ]
+                entityId: 355,
+            },
+        ],
     }
 }
 
@@ -84,7 +84,7 @@ export class ExploreModel {
     }
 
     dispose() {
-        this.disposers.forEach(dispose => dispose())
+        this.disposers.forEach((dispose) => dispose())
     }
 
     populateFromQueryStr(queryStr?: string) {

--- a/explorer/indicatorExplorer/ExploreView.jsdom.test.tsx
+++ b/explorer/indicatorExplorer/ExploreView.jsdom.test.tsx
@@ -42,7 +42,7 @@ function mockDataResponse() {
 }
 
 async function whenReady(grapherView: GrapherView): Promise<void> {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
         const grapher = grapherView.grapher
         observe(grapher, "isReady", () => {
             if (grapher.isReady) resolve()
@@ -123,10 +123,10 @@ describe(ExploreView, () => {
             { key: ChartType.StackedBar, expectedView: StackedBarChart },
             { key: ChartType.DiscreteBar, expectedView: DiscreteBarChart },
             { key: ChartType.SlopeChart, expectedView: SlopeChart },
-            { key: "WorldMap", expectedView: ChoroplethMap }
+            { key: "WorldMap", expectedView: ChoroplethMap },
         ]
 
-        chartTypes.forEach(type => {
+        chartTypes.forEach((type) => {
             describe(`when you click ${type.key}`, () => {
                 let view: ReactWrapper
                 const button = `.chart-type-button[data-type="${type.key}"]`

--- a/explorer/indicatorExplorer/ExploreView.tsx
+++ b/explorer/indicatorExplorer/ExploreView.tsx
@@ -31,7 +31,7 @@ const CHART_TYPE_BUTTONS: ChartTypeButton[] = [
     { type: ChartType.StackedBar, label: "Stacked", icon: faChartBar },
     { type: ChartType.DiscreteBar, label: "Bar", icon: faChartBar },
     { type: ChartType.SlopeChart, label: "Slope", icon: faChartLine },
-    { type: ExploreModel.WorldMap, label: "Map", icon: faMap }
+    { type: ExploreModel.WorldMap, label: "Map", icon: faMap },
 ]
 
 // This component was modeled after GrapherView.
@@ -52,7 +52,7 @@ interface ExploreProps {
 export class ExploreView extends React.Component<ExploreProps> {
     static bootstrap({
         containerNode,
-        queryStr
+        queryStr,
     }: {
         containerNode: HTMLElement
         queryStr?: string
@@ -86,7 +86,7 @@ export class ExploreView extends React.Component<ExploreProps> {
 
     get childContext() {
         return {
-            store: this.model.store
+            store: this.model.store,
         }
     }
 
@@ -110,7 +110,7 @@ export class ExploreView extends React.Component<ExploreProps> {
     renderChartTypes() {
         return (
             <div className="chart-type-buttons">
-                {CHART_TYPE_BUTTONS.map(button =>
+                {CHART_TYPE_BUTTONS.map((button) =>
                     this.renderChartTypeButton(button)
                 )}
             </div>
@@ -122,7 +122,7 @@ export class ExploreView extends React.Component<ExploreProps> {
             <div className="indicator-bar">
                 <IndicatorDropdown
                     placeholder="Select variable"
-                    onChangeId={id => (this.model.indicatorId = id)}
+                    onChangeId={(id) => (this.model.indicatorId = id)}
                     indicatorEntry={this.model.indicatorEntry}
                 />
             </div>

--- a/explorer/indicatorExplorer/IndicatorBaking.ts
+++ b/explorer/indicatorExplorer/IndicatorBaking.ts
@@ -15,21 +15,21 @@ export async function renderExplorableIndicatorsJson() {
     )
 
     const explorableCharts = query
-        .map(chart => ({
+        .map((chart) => ({
             id: chart.id,
-            config: JSON.parse(chart.config) as GrapherInterface
+            config: JSON.parse(chart.config) as GrapherInterface,
         }))
         // Ensure config is consistent with the current "explorable" requirements
-        .filter(chart => isExplorable(chart.config))
+        .filter((chart) => isExplorable(chart.config))
 
-    const result: Indicator[] = explorableCharts.map(chart => ({
+    const result: Indicator[] = explorableCharts.map((chart) => ({
         id: chart.id,
         title: chart.config.title,
         subtitle: chart.config.subtitle,
         sourceDesc: chart.config.sourceDesc,
         note: chart.config.note,
         dimensions: chart.config.dimensions,
-        map: chart.config.map
+        map: chart.config.map,
     }))
 
     return JSON.stringify({ indicators: result })

--- a/explorer/indicatorExplorer/IndicatorDropdown.tsx
+++ b/explorer/indicatorExplorer/IndicatorDropdown.tsx
@@ -5,7 +5,7 @@ import { bind } from "decko"
 
 import {
     ExplorerViewContext,
-    ExplorerViewContextType
+    ExplorerViewContextType,
 } from "./ExplorerViewContext"
 import { Indicator } from "./Indicator"
 import { observer } from "mobx-react"
@@ -25,7 +25,7 @@ export class IndicatorDropdown extends React.Component<IndicatorDropdownProps> {
     context!: ExplorerViewContextType
 
     static defaultProps = {
-        placeholder: "Type to search..."
+        placeholder: "Type to search...",
     }
 
     @bind onChange(indicator: ValueType<Indicator>) {
@@ -35,9 +35,9 @@ export class IndicatorDropdown extends React.Component<IndicatorDropdownProps> {
 
     @bind async loadOptions(query: string): Promise<Indicator[]> {
         const entries = await this.context.store.indicators.search({
-            query
+            query,
         })
-        return entries.map(entry => entry.entity) as Indicator[]
+        return entries.map((entry) => entry.entity) as Indicator[]
     }
 
     @bind getValue(indicator: Indicator): string {

--- a/explorer/indicatorExplorer/IndicatorUtils.ts
+++ b/explorer/indicatorExplorer/IndicatorUtils.ts
@@ -4,7 +4,7 @@ import { EXPLORER } from "settings"
 
 export const EXPLORABLE_CHART_TYPES: ChartTypeName[] = [
     "LineChart",
-    "DiscreteBar"
+    "DiscreteBar",
 ]
 
 // *****************************************************************************
@@ -80,7 +80,7 @@ export const FORCE_EXPLORABLE_CHART_IDS: number[] = [
     3873,
     3874,
     3875,
-    3876
+    3876,
 ]
 
 // A centralized predicate to test whether a chart can be explorable.

--- a/explorer/indicatorExplorer/Store.test.ts
+++ b/explorer/indicatorExplorer/Store.test.ts
@@ -28,7 +28,7 @@ describe(IndicatorStore, () => {
             expect(store.get(indicator.id))
         })
 
-        it("updates placeholder value with indicator", done => {
+        it("updates placeholder value with indicator", (done) => {
             const entry = store.get(indicator.id)
             const dispose = observe(entry, "entity", () => {
                 expect(entry.isLoading).toBe(false)
@@ -40,7 +40,7 @@ describe(IndicatorStore, () => {
             })
         })
 
-        it("updates placeholder with error", done => {
+        it("updates placeholder with error", (done) => {
             const entry = store.get(123123123)
             const dispose = observe(entry, "error", () => {
                 expect(entry.isLoading).toBe(false)
@@ -70,7 +70,7 @@ describe(IndicatorStore, () => {
 
         it("returns no indicators for non-matching query", async () => {
             const results = await store.search({
-                query: "a thing that probably shouldn't exist"
+                query: "a thing that probably shouldn't exist",
             })
             expect(results).toHaveLength(0)
         })

--- a/explorer/indicatorExplorer/Store.ts
+++ b/explorer/indicatorExplorer/Store.ts
@@ -40,7 +40,7 @@ export class IndicatorStore {
 
     private async fetchAllIdempotent(): Promise<Indicator[]> {
         if (!this.fetchAllPromise) {
-            this.fetchAllPromise = new Promise(async resolve => {
+            this.fetchAllPromise = new Promise(async (resolve) => {
                 const indicators = await this.fetchAll()
 
                 // Find all IDs which are marked as loading but were not
@@ -50,12 +50,12 @@ export class IndicatorStore {
                 const loadingIds = Object.entries(this.indicatorsById)
                     .filter(([, entry]) => entry.isLoading)
                     .map(([id]) => parseInt(id))
-                const loadedIds = indicators.map(i => i.id)
+                const loadedIds = indicators.map((i) => i.id)
                 const missingIds = difference(loadingIds, loadedIds)
 
                 runInAction(() => {
                     // Update each loaded indicator in place
-                    indicators.forEach(indicator => {
+                    indicators.forEach((indicator) => {
                         const storeEntry = this.get(indicator.id)
                         storeEntry.isLoading = false
                         storeEntry.lastRetrieved = new Date()
@@ -63,7 +63,7 @@ export class IndicatorStore {
                         storeEntry.entity = indicator
                     })
                     // Mark all other indicators as failed
-                    missingIds.forEach(id => {
+                    missingIds.forEach((id) => {
                         const storeEntry = this.get(id)
                         storeEntry.isLoading = false
                         storeEntry.lastRetrieved = undefined
@@ -98,7 +98,7 @@ export class IndicatorStore {
             return indicatorEntries
         }
         const queryLower = query.toLowerCase()
-        return indicatorEntries.filter(entry => {
+        return indicatorEntries.filter((entry) => {
             // Filter out entities that haven't loaded
             if (!entry.entity) return false
             const indicator = entry.entity

--- a/explorer/indicatorExplorer/apiMock.ts
+++ b/explorer/indicatorExplorer/apiMock.ts
@@ -7,7 +7,7 @@ import { Indicator } from "explorer/indicatorExplorer/Indicator"
 export function mockIndicators() {
     const pattern = /\/explore\/indicators\.json/
     xhrMock.get(pattern, {
-        body: fs.readFileSync(__dirname + `/indicators.mock.json`)
+        body: fs.readFileSync(__dirname + `/indicators.mock.json`),
     })
 }
 
@@ -16,7 +16,7 @@ export function mockVariable(id: number | string) {
     xhrMock.get(pattern, {
         body: fs.readFileSync(
             __dirname + "/../../grapher/test/" + `variable-${id}.mock.json`
-        )
+        ),
     })
 }
 

--- a/gitCms/client.ts
+++ b/gitCms/client.ts
@@ -4,7 +4,7 @@ import {
     ReadRequest,
     GitCmsResponse,
     GitCmsReadResponse,
-    DeleteRequest
+    DeleteRequest,
 } from "./constants"
 const gitCmsApiPath = `/admin/api${gitCmsRoute}`
 
@@ -18,7 +18,7 @@ export const deleteRemoteFile = async (request: DeleteRequest) => {
     const response = await fetch(
         `${gitCmsApiPath}?filepath=${request.filepath}`,
         {
-            method: "DELETE"
+            method: "DELETE",
         }
     )
     const parsed: GitCmsResponse = await response.json()
@@ -41,9 +41,9 @@ export const writeRemoteFile = async (request: WriteRequest) => {
     const response = await fetch(gitCmsApiPath, {
         method: "POST",
         headers: {
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         },
-        body: JSON.stringify(request)
+        body: JSON.stringify(request),
     })
 
     const parsed: GitCmsResponse = await response.json()

--- a/gitCms/server.ts
+++ b/gitCms/server.ts
@@ -10,7 +10,7 @@ import {
     GitCmsReadResponse,
     WriteRequest,
     ReadRequest,
-    DeleteRequest
+    DeleteRequest,
 } from "./constants"
 const IS_PROD = ENV === "production"
 
@@ -65,7 +65,7 @@ export const addGitCmsApiRoutes = (app: FunctionalRouter) => {
             if (filename.includes(".."))
                 return {
                     success: false,
-                    errorMessage: `Invalid filepath: ${filename}`
+                    errorMessage: `Invalid filepath: ${filename}`,
                 }
             const errorMessage = await saveFileToGitContentDirectory(
                 filename,
@@ -86,7 +86,7 @@ export const addGitCmsApiRoutes = (app: FunctionalRouter) => {
                 return {
                     success: false,
                     errorMessage: `Invalid filepath: ${filepath}`,
-                    content: ""
+                    content: "",
                 }
             const path = GIT_CMS_DIR + filepath
             const exists = fs.existsSync(path)
@@ -94,7 +94,7 @@ export const addGitCmsApiRoutes = (app: FunctionalRouter) => {
                 return {
                     success: false,
                     errorMessage: `File '${filepath}' not found`,
-                    content: ""
+                    content: "",
                 }
             const content = await fs.readFile(path, "utf8")
             return { success: true, content }
@@ -109,7 +109,7 @@ export const addGitCmsApiRoutes = (app: FunctionalRouter) => {
             if (filepath.includes(".."))
                 return {
                     success: false,
-                    errorMessage: `Invalid filepath: ${filepath}`
+                    errorMessage: `Invalid filepath: ${filepath}`,
                 }
             const errorMessage = await deleteFileFromGitContentDirectory(
                 filepath,

--- a/grapher/areaCharts/StackedAreaChart.stories.tsx
+++ b/grapher/areaCharts/StackedAreaChart.stories.tsx
@@ -7,7 +7,7 @@ import { Bounds } from "grapher/utils/Bounds"
 
 export default {
     title: "StackedAreaChart",
-    component: StackedAreaChart
+    component: StackedAreaChart,
 }
 
 export const Default = () => {

--- a/grapher/areaCharts/StackedAreaChart.tsx
+++ b/grapher/areaCharts/StackedAreaChart.tsx
@@ -7,7 +7,7 @@ import {
     pointsToPath,
     getRelativeMouse,
     makeSafeForCSS,
-    minBy
+    minBy,
 } from "grapher/utils/Util"
 import { computed, action, observable } from "mobx"
 import { observer } from "mobx-react"
@@ -18,7 +18,7 @@ import { DualAxis } from "grapher/axis/Axis"
 import {
     LineLabelsHelper,
     LineLabel,
-    LineLabelsComponent
+    LineLabelsComponent,
 } from "grapher/lineCharts/LineLabels"
 import { NoDataOverlay } from "grapher/chart/NoDataOverlay"
 import { Tooltip } from "grapher/chart/Tooltip"
@@ -66,7 +66,7 @@ class Areas extends React.Component<AreasProps> {
         const mouse = getRelativeMouse(this.base.current, ev.nativeEvent)
 
         if (dualAxis.innerBounds.contains(mouse)) {
-            const closestPoint = minBy(data[0].values, d =>
+            const closestPoint = minBy(data[0].values, (d) =>
                 Math.abs(dualAxis.xAxis.place(d.x) - mouse.x)
             )
             if (closestPoint) {
@@ -104,9 +104,9 @@ class Areas extends React.Component<AreasProps> {
 
         // Stacked area chart stacks each series upon the previous series, so we must keep track of the last point set we used
         let prevPoints = [xBottomLeft, xBottomRight]
-        return data.map(series => {
+        return data.map((series) => {
             const mainPoints = series.values.map(
-                v => [xAxis.place(v.x), yAxis.place(v.y)] as [number, number]
+                (v) => [xAxis.place(v.x), yAxis.place(v.y)] as [number, number]
             )
             const points = mainPoints.concat(reverse(clone(prevPoints)) as any)
             prevPoints = mainPoints
@@ -132,9 +132,9 @@ class Areas extends React.Component<AreasProps> {
         const { xAxis, yAxis } = dualAxis
 
         // Stacked area chart stacks each series upon the previous series, so we must keep track of the last point set we used
-        return data.map(series => {
+        return data.map((series) => {
             const points = series.values.map(
-                v => [xAxis.place(v.x), yAxis.place(v.y)] as [number, number]
+                (v) => [xAxis.place(v.x), yAxis.place(v.y)] as [number, number]
             )
 
             return (
@@ -187,7 +187,7 @@ class Areas extends React.Component<AreasProps> {
                 {this.borders}
                 {hoverIndex !== undefined && (
                     <g className="hoverIndicator">
-                        {data.map(series => {
+                        {data.map((series) => {
                             return this.seriesIsBlur(series) ? null : (
                                 <circle
                                     key={series.entityDimensionKey}
@@ -235,7 +235,7 @@ export class StackedAreaChart extends React.Component<{
 
     @computed get midpoints(): number[] {
         let prevY = 0
-        return this.transform.stackedData.map(series => {
+        return this.transform.stackedData.map((series) => {
             const lastValue = last(series.values)
             if (lastValue) {
                 const middleY = prevY + (lastValue.y - prevY) / 2
@@ -254,7 +254,7 @@ export class StackedAreaChart extends React.Component<{
                 color: d.color,
                 entityDimensionKey: d.entityDimensionKey,
                 label: this.grapher.getLabelForKey(d.entityDimensionKey),
-                yValue: midpoints[i]
+                yValue: midpoints[i],
             }))
             .reverse()
         return items
@@ -273,7 +273,7 @@ export class StackedAreaChart extends React.Component<{
             },
             get items() {
                 return that.legendItems
-            }
+            },
         })
     }
 
@@ -295,7 +295,7 @@ export class StackedAreaChart extends React.Component<{
         return new DualAxis({
             bounds: bounds.padRight(legend ? legend.width : 20),
             xAxis,
-            yAxis
+            yAxis,
         })
     }
 
@@ -332,14 +332,14 @@ export class StackedAreaChart extends React.Component<{
 
         // If some data is missing, don't calculate a total
         const someMissing = transform.stackedData.some(
-            g => !!g.values[hoverIndex].isFake
+            (g) => !!g.values[hoverIndex].isFake
         )
 
         const legendBlockStyle = {
             width: "10px",
             height: "10px",
             display: "inline-block",
-            marginRight: "2px"
+            marginRight: "2px",
         }
 
         return (
@@ -362,7 +362,7 @@ export class StackedAreaChart extends React.Component<{
                             </td>
                             <td></td>
                         </tr>
-                        {reverse(clone(transform.stackedData)).map(series => {
+                        {reverse(clone(transform.stackedData)).map((series) => {
                             const value = series.values[hoverIndex]
                             const isBlur = this.seriesIsBlur(series)
                             const textColor = isBlur ? "#ddd" : "#333"
@@ -377,13 +377,13 @@ export class StackedAreaChart extends React.Component<{
                                     <td
                                         style={{
                                             paddingRight: "0.8em",
-                                            fontSize: "0.9em"
+                                            fontSize: "0.9em",
                                         }}
                                     >
                                         <div
                                             style={{
                                                 ...legendBlockStyle,
-                                                backgroundColor: blockColor
+                                                backgroundColor: blockColor,
                                             }}
                                         />{" "}
                                         {grapher.getLabelForKey(
@@ -407,7 +407,7 @@ export class StackedAreaChart extends React.Component<{
                                     <div
                                         style={{
                                             ...legendBlockStyle,
-                                            backgroundColor: "transparent"
+                                            backgroundColor: "transparent",
                                         }}
                                     />{" "}
                                     <strong>Total</strong>

--- a/grapher/areaCharts/StackedAreaTransform.ts
+++ b/grapher/areaCharts/StackedAreaTransform.ts
@@ -11,7 +11,7 @@ import {
     sortNumeric,
     uniq,
     max,
-    formatValue
+    formatValue,
 } from "grapher/utils/Util"
 import { EntityDimensionKey } from "grapher/core/GrapherConstants"
 import { StackedAreaSeries, StackedAreaValue } from "./StackedAreaChart"
@@ -24,7 +24,7 @@ import { Time } from "grapher/utils/TimeBounds"
 export class StackedAreaTransform extends ChartTransform {
     @computed get failMessage(): string | undefined {
         const { filledDimensions } = this.grapher
-        if (!some(filledDimensions, d => d.property === "y"))
+        if (!some(filledDimensions, (d) => d.property === "y"))
             return "Missing Y axis variable"
         else if (
             this.groupedData.length === 0 ||
@@ -69,7 +69,7 @@ export class StackedAreaTransform extends ChartTransform {
                         values: [],
                         entityDimensionKey: entityDimensionKey,
                         isProjection: dimension.isProjection,
-                        color: "#fff" // tmp
+                        color: "#fff", // tmp
                     }
                     seriesByKey.set(entityDimensionKey, series)
                 }
@@ -78,18 +78,18 @@ export class StackedAreaTransform extends ChartTransform {
             }
 
             groupedData = groupedData.concat([
-                ...Array.from(seriesByKey.values())
+                ...Array.from(seriesByKey.values()),
             ])
         })
 
         // Now ensure that every series has a value entry for every year in the data
         let allYears: number[] = []
-        groupedData.forEach(series =>
-            allYears.push(...series.values.map(d => d.x))
+        groupedData.forEach((series) =>
+            allYears.push(...series.values.map((d) => d.x))
         )
         allYears = sortNumeric(uniq(allYears))
 
-        groupedData.forEach(series => {
+        groupedData.forEach((series) => {
             let i = 0
             let isBeforeStart = true
 
@@ -111,7 +111,7 @@ export class StackedAreaTransform extends ChartTransform {
                         x: expectedYear,
                         y: fakeY,
                         time: expectedYear,
-                        isFake: true
+                        isFake: true,
                     })
                 } else {
                     isBeforeStart = false
@@ -123,7 +123,7 @@ export class StackedAreaTransform extends ChartTransform {
         // Strip years at start and end where we couldn't successfully interpolate
         for (const firstSeries of groupedData.slice(0, 1)) {
             for (let i = firstSeries.values.length - 1; i >= 0; i--) {
-                if (groupedData.some(series => isNaN(series.values[i].y))) {
+                if (groupedData.some((series) => isNaN(series.values[i].y))) {
                     for (const series of groupedData) {
                         series.values.splice(i, 1)
                     }
@@ -134,14 +134,14 @@ export class StackedAreaTransform extends ChartTransform {
         // Preserve order
         groupedData = sortBy(
             groupedData,
-            series => -selectedKeys.indexOf(series.entityDimensionKey)
+            (series) => -selectedKeys.indexOf(series.entityDimensionKey)
         )
 
         // Assign colors
         const baseColors = this.colorScheme.getColors(groupedData.length)
         if (grapher.invertColorScheme) baseColors.reverse()
         const colorScale = scaleOrdinal(baseColors)
-        groupedData.forEach(series => {
+        groupedData.forEach((series) => {
             series.color =
                 grapher.keyColors[series.entityDimensionKey] ||
                 colorScale(series.entityDimensionKey)
@@ -152,7 +152,9 @@ export class StackedAreaTransform extends ChartTransform {
             if (groupedData.length === 0) return []
 
             for (let i = 0; i < groupedData[0].values.length; i++) {
-                const total = sum(groupedData.map(series => series.values[i].y))
+                const total = sum(
+                    groupedData.map((series) => series.values[i].y)
+                )
                 for (let j = 0; j < groupedData.length; j++) {
                     groupedData[j].values[i].y =
                         total === 0
@@ -177,7 +179,7 @@ export class StackedAreaTransform extends ChartTransform {
     }
 
     @computed private get yDomainDefault(): [number, number] {
-        const yValues = this.allStackedValues.map(d => d.y)
+        const yValues = this.allStackedValues.map((d) => d.y)
         return [0, max(yValues) ?? 100]
     }
 
@@ -190,7 +192,7 @@ export class StackedAreaTransform extends ChartTransform {
         else
             axis.updateDomainPreservingUserSettings([
                 yDomainDefault[0],
-                yDomainDefault[1]
+                yDomainDefault[1],
             ]) // Stacked area chart must have its own y domain)
 
         axis.tickFormat = isRelativeMode
@@ -203,7 +205,7 @@ export class StackedAreaTransform extends ChartTransform {
 
     @computed get availableYears(): Time[] {
         // Since we've already aligned the data, the years of any series corresponds to the years of all of them
-        return this.groupedData[0].values.map(v => v.x)
+        return this.groupedData[0].values.map((v) => v.x)
     }
 
     @computed get canToggleRelativeMode(): boolean {
@@ -229,12 +231,13 @@ export class StackedAreaTransform extends ChartTransform {
         if (
             some(
                 groupedData,
-                series => series.values.length !== groupedData[0].values.length
+                (series) =>
+                    series.values.length !== groupedData[0].values.length
             )
         )
             throw new Error(
                 `Unexpected variation in stacked area chart series: ${groupedData.map(
-                    series => series.values.length
+                    (series) => series.values.length
                 )}`
             )
 
@@ -242,7 +245,7 @@ export class StackedAreaTransform extends ChartTransform {
 
         for (const series of stackedData) {
             series.values = series.values.filter(
-                v => v.x >= startYear && v.x <= endYear
+                (v) => v.x >= startYear && v.x <= endYear
             )
             for (const value of series.values) {
                 value.origY = value.y
@@ -259,11 +262,11 @@ export class StackedAreaTransform extends ChartTransform {
     }
 
     @computed get allStackedValues(): StackedAreaValue[] {
-        return flatten(this.stackedData.map(series => series.values))
+        return flatten(this.stackedData.map((series) => series.values))
     }
 
     @computed get yDimensionFirst() {
-        return find(this.grapher.filledDimensions, d => d.property === "y")
+        return find(this.grapher.filledDimensions, (d) => d.property === "y")
     }
 
     formatYTick(v: number) {

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -8,12 +8,12 @@ import {
     isMobile,
     uniq,
     sortBy,
-    maxBy
+    maxBy,
 } from "grapher/utils/Util"
 import {
     TickFormattingOptions,
     ScaleType,
-    ScaleTypeConfig
+    ScaleTypeConfig,
 } from "grapher/core/GrapherConstants"
 import { Bounds } from "grapher/utils/Bounds"
 import { TextWrap } from "grapher/text/TextWrap"
@@ -35,7 +35,7 @@ declare type TickFormatFunction = (
 abstract class AbstractAxis implements ScaleTypeConfig {
     protected options: PersistableAxisOptions
     @observable.ref domain: [number, number]
-    @observable tickFormat: TickFormatFunction = d => `${d}`
+    @observable tickFormat: TickFormatFunction = (d) => `${d}`
     @observable hideFractionalTicks = false
     @observable hideGridlines = false
     @observable.struct range: [number, number] = [0, 0]
@@ -48,7 +48,7 @@ abstract class AbstractAxis implements ScaleTypeConfig {
     updateDomainPreservingUserSettings(domain: [number, number]) {
         this.domain = [
             Math.min(this.domain[0], domain[0]),
-            Math.max(this.domain[1], domain[1])
+            Math.max(this.domain[1], domain[1]),
         ]
         return this
     }
@@ -154,7 +154,7 @@ abstract class AbstractAxis implements ScaleTypeConfig {
             //
             // -@MarcelGerber, 2020-08-07
             const tickCandidates = d3_scale.ticks(maxLogLines)
-            ticks = tickCandidates.map(tickValue => {
+            ticks = tickCandidates.map((tickValue) => {
                 // 10^x
                 if (Math.fround(Math.log10(tickValue)) % 1 === 0)
                     return { value: tickValue, priority: 1 }
@@ -170,7 +170,7 @@ abstract class AbstractAxis implements ScaleTypeConfig {
             if (ticks.length > maxLogLines) {
                 if (ticks.length <= 2 * maxLogLines) {
                     // Convert all "in-between" lines to faint grid lines without labels
-                    ticks = ticks.map(tick => {
+                    ticks = ticks.map((tick) => {
                         if (tick.priority === 3)
                             tick = { ...tick, faint: true, gridLineOnly: true }
                         return tick
@@ -180,7 +180,7 @@ abstract class AbstractAxis implements ScaleTypeConfig {
                     // otherwise
                     for (let prio = 3; prio > 1; prio--) {
                         if (ticks.length > maxLogLines) {
-                            ticks = ticks.filter(tick => tick.priority < prio)
+                            ticks = ticks.filter((tick) => tick.priority < prio)
                         }
                     }
                 }
@@ -190,11 +190,11 @@ abstract class AbstractAxis implements ScaleTypeConfig {
             // to be priority 1
             ticks = d3_scale
                 .ticks(6)
-                .map(tickValue => ({ value: tickValue, priority: 2 }))
+                .map((tickValue) => ({ value: tickValue, priority: 2 }))
         }
 
         if (this.hideFractionalTicks)
-            ticks = ticks.filter(t => t.value % 1 === 0)
+            ticks = ticks.filter((t) => t.value % 1 === 0)
 
         return uniq(ticks)
     }
@@ -235,7 +235,7 @@ abstract class AbstractAxis implements ScaleTypeConfig {
 
     getFormattedTicks(): string[] {
         const options = this.getTickFormattingOptions()
-        return this.getTickValues().map(tickmark =>
+        return this.getTickValues().map((tickmark) =>
             this.tickFormat(tickmark.value, options)
         )
     }
@@ -274,30 +274,32 @@ abstract class AbstractAxis implements ScaleTypeConfig {
             }
         }
 
-        return sortBy(tickPlacements.filter(t => !t.isHidden).map(t => t.tick))
+        return sortBy(
+            tickPlacements.filter((t) => !t.isHidden).map((t) => t.tick)
+        )
     }
 
     formatTick(tick: number, isFirstOrLastTick?: boolean) {
         const tickFormattingOptions = this.getTickFormattingOptions()
         return this.tickFormat(tick, {
             ...tickFormattingOptions,
-            isFirstOrLastTick
+            isFirstOrLastTick,
         })
     }
 
     // calculates coordinates for ticks, sorted by priority
     @computed private get tickPlacements() {
-        return sortBy(this.baseTicks, tick => tick.priority).map(tick => {
+        return sortBy(this.baseTicks, (tick) => tick.priority).map((tick) => {
             const bounds = Bounds.forText(
                 this.formatTick(tick.value, !!tick.isFirstOrLastTick),
                 {
-                    fontSize: this.tickFontSize
+                    fontSize: this.tickFontSize,
                 }
             )
             return {
                 tick: tick.value,
                 bounds: bounds.extend(this.placeTick(tick.value, bounds)),
-                isHidden: false
+                isHidden: false,
             }
         })
     }
@@ -307,7 +309,7 @@ abstract class AbstractAxis implements ScaleTypeConfig {
     }
 
     @computed protected get baseTicks() {
-        return this.getTickValues().filter(tick => !tick.gridLineOnly)
+        return this.getTickValues().filter((tick) => !tick.gridLineOnly)
     }
 
     abstract get labelWidth(): number
@@ -323,7 +325,7 @@ abstract class AbstractAxis implements ScaleTypeConfig {
             ? new TextWrap({
                   maxWidth: this.labelWidth,
                   fontSize: this.labelFontSize,
-                  text
+                  text,
               })
             : undefined
     }
@@ -362,7 +364,7 @@ export class HorizontalAxis extends AbstractAxis {
 
         return (
             Bounds.forText(firstFormattedTick, {
-                fontSize
+                fontSize,
             }).height +
             labelOffset +
             5
@@ -370,7 +372,7 @@ export class HorizontalAxis extends AbstractAxis {
     }
 
     @computed protected get baseTicks() {
-        let ticks = this.getTickValues().filter(tick => !tick.gridLineOnly)
+        let ticks = this.getTickValues().filter((tick) => !tick.gridLineOnly)
         const { domain } = this
 
         // Make sure the start and end values are present, if they're whole numbers
@@ -380,9 +382,9 @@ export class HorizontalAxis extends AbstractAxis {
                 {
                     value: domain[0],
                     priority: startEndPrio,
-                    isFirstOrLastTick: true
+                    isFirstOrLastTick: true,
                 },
-                ...ticks
+                ...ticks,
             ]
         if (domain[1] % 1 === 0 && this.hideFractionalTicks)
             ticks = [
@@ -390,8 +392,8 @@ export class HorizontalAxis extends AbstractAxis {
                 {
                     value: domain[1],
                     priority: startEndPrio,
-                    isFirstOrLastTick: true
-                }
+                    isFirstOrLastTick: true,
+                },
             ]
         return uniq(ticks)
     }
@@ -400,7 +402,7 @@ export class HorizontalAxis extends AbstractAxis {
         const { labelOffset } = this
         return {
             x: this.place(tickValue) - bounds.width / 2,
-            y: bounds.bottom - labelOffset
+            y: bounds.bottom - labelOffset,
         }
     }
 
@@ -426,7 +428,10 @@ export class VerticalAxis extends AbstractAxis {
 
     @computed get width() {
         const { labelOffset } = this
-        const longestTick = maxBy(this.getFormattedTicks(), tick => tick.length)
+        const longestTick = maxBy(
+            this.getFormattedTicks(),
+            (tick) => tick.length
+        )
         return (
             Bounds.forText(longestTick, { fontSize: this.tickFontSize }).width +
             labelOffset +
@@ -443,7 +448,7 @@ export class VerticalAxis extends AbstractAxis {
             y: this.place(tickValue),
             // x placement doesn't really matter here, so we're using
             // 1 for simplicity
-            x: 1
+            x: 1,
         }
     }
 }

--- a/grapher/axis/AxisOptions.test.ts
+++ b/grapher/axis/AxisOptions.test.ts
@@ -18,7 +18,7 @@ describe("basics", () => {
         const axis = new PersistableAxisOptions({
             min: 0,
             max: 100,
-            scaleType: ScaleType.linear
+            scaleType: ScaleType.linear,
         })
         const clone = axis.toVerticalAxis()
         clone.updateDomainPreservingUserSettings([5, 50])

--- a/grapher/axis/AxisOptions.ts
+++ b/grapher/axis/AxisOptions.ts
@@ -38,7 +38,7 @@ export class PersistableAxisOptions
             min: this.min,
             max: this.max,
             canChangeScaleType: this.canChangeScaleType,
-            removePointsOutsideDomain: this.removePointsOutsideDomain
+            removePointsOutsideDomain: this.removePointsOutsideDomain,
         })
     }
 
@@ -53,7 +53,7 @@ export class PersistableAxisOptions
     @observable label: string = ""
     @observable.ref removePointsOutsideDomain?: true = undefined
     @observable.ref private containerOptions: AxisContainerOptions = {
-        fontSize: 16
+        fontSize: 16,
     }
 
     @computed get fontSize() {

--- a/grapher/axis/AxisViews.tsx
+++ b/grapher/axis/AxisViews.tsx
@@ -214,7 +214,7 @@ export class HorizontalAxisComponent extends React.Component<{
         const tickMarks = showTickMarks ? (
             <AxisTickMarks
                 tickMarkTopPosition={axisPosition}
-                tickMarkXPositions={ticks.map(tick => axis.place(tick))}
+                tickMarkXPositions={ticks.map((tick) => axis.place(tick))}
                 color="#ccc"
             />
         ) : undefined

--- a/grapher/barCharts/DiscreteBarChart.stories.tsx
+++ b/grapher/barCharts/DiscreteBarChart.stories.tsx
@@ -7,7 +7,7 @@ import { Bounds } from "grapher/utils/Bounds"
 
 export default {
     title: "DiscreteBarChart",
-    component: DiscreteBarChart
+    component: DiscreteBarChart,
 }
 
 export const Default = () => {

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -9,11 +9,11 @@ import {
     Color,
     TickFormattingOptions,
     EntityDimensionKey,
-    ScaleType
+    ScaleType,
 } from "grapher/core/GrapherConstants"
 import {
     HorizontalAxisComponent,
-    HorizontalAxisGridLines
+    HorizontalAxisGridLines,
 } from "grapher/axis/AxisViews"
 import { NoDataOverlay } from "grapher/chart/NoDataOverlay"
 import { ControlsOverlay } from "grapher/controls/ControlsOverlay"
@@ -65,42 +65,42 @@ export class DiscreteBarChart extends React.Component<{
     @computed private get legendLabelStyle() {
         return {
             fontSize: 0.75 * this.props.grapher.baseFontSize,
-            fontWeight: 700
+            fontWeight: 700,
         }
     }
 
     @computed private get valueLabelStyle() {
         return {
             fontSize: 0.75 * this.props.grapher.baseFontSize,
-            fontWeight: 400
+            fontWeight: 400,
         }
     }
 
     // Account for the width of the legend
     @computed private get legendWidth() {
-        const labels = this.currentData.map(d => d.label)
+        const labels = this.currentData.map((d) => d.label)
         if (this.hasFloatingAddButton)
             labels.push(` + ${this.grapher.addButtonLabel}`)
 
-        const longestLabel = maxBy(labels, d => d.length)
+        const longestLabel = maxBy(labels, (d) => d.length)
         return Bounds.forText(longestLabel, this.legendLabelStyle).width
     }
 
     @computed private get hasPositive() {
-        return this.displayData.some(d => d.value >= 0)
+        return this.displayData.some((d) => d.value >= 0)
     }
 
     @computed private get hasNegative() {
-        return this.displayData.some(d => d.value < 0)
+        return this.displayData.some((d) => d.value < 0)
     }
 
     // The amount of space we need to allocate for bar end labels on the right
     @computed private get rightEndLabelWidth(): number {
         if (this.hasPositive) {
             const positiveLabels = this.displayData
-                .filter(d => d.value >= 0)
-                .map(d => this.barValueFormat(d))
-            const longestPositiveLabel = maxBy(positiveLabels, l => l.length)
+                .filter((d) => d.value >= 0)
+                .map((d) => this.barValueFormat(d))
+            const longestPositiveLabel = maxBy(positiveLabels, (l) => l.length)
             return Bounds.forText(longestPositiveLabel, this.valueLabelStyle)
                 .width
         } else {
@@ -114,9 +114,9 @@ export class DiscreteBarChart extends React.Component<{
     @computed private get leftEndLabelWidth(): number {
         if (this.hasNegative) {
             const negativeLabels = this.displayData
-                .filter(d => d.value < 0)
-                .map(d => this.barValueFormat(d))
-            const longestNegativeLabel = maxBy(negativeLabels, l => l.length)
+                .filter((d) => d.value < 0)
+                .map((d) => this.barValueFormat(d))
+            const longestNegativeLabel = maxBy(negativeLabels, (l) => l.length)
             return (
                 Bounds.forText(longestNegativeLabel, this.valueLabelStyle)
                     .width + labelToTextPadding
@@ -128,7 +128,7 @@ export class DiscreteBarChart extends React.Component<{
 
     @computed private get x0(): number {
         if (this.isLogScale) {
-            const minValue = min(this.allData.map(d => d.value))
+            const minValue = min(this.allData.map((d) => d.value))
             return minValue !== undefined ? Math.min(1, minValue) : 1
         }
         return 0
@@ -136,12 +136,12 @@ export class DiscreteBarChart extends React.Component<{
 
     // Now we can work out the main x axis scale
     @computed private get xDomainDefault(): [number, number] {
-        const allValues = this.displayData.map(d => d.value)
+        const allValues = this.displayData.map((d) => d.value)
 
         const minStart = this.x0
         return [
             Math.min(minStart, min(allValues) as number),
-            Math.max(minStart, max(allValues) as number)
+            Math.max(minStart, max(allValues) as number),
         ]
     }
 
@@ -152,7 +152,7 @@ export class DiscreteBarChart extends React.Component<{
     @computed private get xRange(): [number, number] {
         return [
             this.bounds.left + this.legendWidth + this.leftEndLabelWidth,
-            this.bounds.right - this.rightEndLabelWidth
+            this.bounds.right - this.rightEndLabelWidth,
         ]
     }
 
@@ -198,7 +198,7 @@ export class DiscreteBarChart extends React.Component<{
 
     @computed private get barPlacements() {
         const { currentData, axis } = this
-        return currentData.map(d => {
+        return currentData.map((d) => {
             const isNegative = d.value < 0
             const barX = isNegative ? axis.place(d.value) : axis.place(this.x0)
             const barWidth = isNegative
@@ -210,7 +210,7 @@ export class DiscreteBarChart extends React.Component<{
     }
 
     @computed private get barWidths() {
-        return this.barPlacements.map(b => b.width)
+        return this.barPlacements.map((b) => b.width)
     }
 
     private d3Bars() {
@@ -286,7 +286,7 @@ export class DiscreteBarChart extends React.Component<{
             innerBounds,
             barHeight,
             barSpacing,
-            barValueFormat
+            barValueFormat,
         } = this
 
         let yOffset = innerBounds.top + barHeight / 2
@@ -314,7 +314,7 @@ export class DiscreteBarChart extends React.Component<{
                     horizontalAxis={axis}
                     bounds={innerBounds}
                 />
-                {currentData.map(d => {
+                {currentData.map((d) => {
                     const isNegative = d.value < 0
                     const barX = isNegative
                         ? axis.place(d.value)

--- a/grapher/barCharts/DiscreteBarTransform.ts
+++ b/grapher/barCharts/DiscreteBarTransform.ts
@@ -8,7 +8,7 @@ import {
     flatten,
     uniq,
     sortNumeric,
-    sortedUniq
+    sortedUniq,
 } from "grapher/utils/Util"
 import { DiscreteBarDatum } from "./DiscreteBarChart"
 import { ChartTransform } from "grapher/chart/ChartTransform"
@@ -17,7 +17,7 @@ import { ColorSchemes } from "grapher/color/ColorSchemes"
 import {
     SortOrder,
     TickFormattingOptions,
-    ScaleType
+    ScaleType,
 } from "grapher/core/GrapherConstants"
 import { Time } from "grapher/utils/TimeBounds"
 
@@ -26,18 +26,18 @@ import { Time } from "grapher/utils/TimeBounds"
 export class DiscreteBarTransform extends ChartTransform {
     @computed get failMessage(): string | undefined {
         const { filledDimensions } = this.grapher
-        if (!some(filledDimensions, d => d.property === "y"))
+        if (!some(filledDimensions, (d) => d.property === "y"))
             return "Missing variable"
         else if (isEmpty(this.currentData)) return "No matching data"
         else return undefined
     }
 
     @computed get primaryDimensions(): ChartDimension[] {
-        return this.grapher.filledDimensions.filter(d => d.property === "y")
+        return this.grapher.filledDimensions.filter((d) => d.property === "y")
     }
 
     @computed get availableYears(): Time[] {
-        return flatten(this.primaryDimensions.map(dim => dim.yearsUniq))
+        return flatten(this.primaryDimensions.map((dim) => dim.yearsUniq))
     }
 
     @computed get hasTimeline(): boolean {
@@ -114,7 +114,7 @@ export class DiscreteBarTransform extends ChartTransform {
                     year: year,
                     label: grapher.getLabelForKey(entityDimensionKey),
                     color: "#2E5778",
-                    formatValue: dimension.formatValueShort
+                    formatValue: dimension.formatValueShort,
                 }
 
                 dataByEntityDimensionKey[entityDimensionKey] = datum
@@ -125,17 +125,20 @@ export class DiscreteBarTransform extends ChartTransform {
             // If derived from line chart, use line chart colors
             for (const key in dataByEntityDimensionKey) {
                 const lineSeries = this.grapher.lineChartTransform.predomainData.find(
-                    series => series.entityDimensionKey === key
+                    (series) => series.entityDimensionKey === key
                 )
                 if (lineSeries)
                     dataByEntityDimensionKey[key].color = lineSeries.color
             }
         } else {
-            const data = sortBy(values(dataByEntityDimensionKey), d => d.value)
+            const data = sortBy(
+                values(dataByEntityDimensionKey),
+                (d) => d.value
+            )
             const colorScheme = grapher.baseColorScheme
                 ? ColorSchemes[grapher.baseColorScheme]
                 : undefined
-            const uniqValues = uniq(data.map(d => d.value))
+            const uniqValues = uniq(data.map((d) => d.value))
             const colors = colorScheme?.getColors(uniqValues.length) || []
             if (grapher.invertColorScheme) colors.reverse()
 
@@ -144,7 +147,7 @@ export class DiscreteBarTransform extends ChartTransform {
             const colorByValue = new Map<number, string>()
             uniqValues.forEach((value, i) => colorByValue.set(value, colors[i]))
 
-            data.forEach(d => {
+            data.forEach((d) => {
                 d.color =
                     grapher.keyColors[d.entityDimensionKey] ||
                     colorByValue.get(d.value) ||
@@ -165,7 +168,7 @@ export class DiscreteBarTransform extends ChartTransform {
     private _filterDataForLogScaleInPlace(dataByEntityDimensionKey: {
         [entityDimensionKey: string]: DiscreteBarDatum
     }) {
-        Object.keys(dataByEntityDimensionKey).forEach(key => {
+        Object.keys(dataByEntityDimensionKey).forEach((key) => {
             const datum = dataByEntityDimensionKey[key]
             if (datum.value <= 0) delete dataByEntityDimensionKey[key]
         })
@@ -176,7 +179,7 @@ export class DiscreteBarTransform extends ChartTransform {
         // This is because, as d3 puts it: "a log scale domain must be strictly-positive or strictly-negative;
         // the domain must not include or cross zero". We may want to update to d3 5.8 and explore switching to
         // scaleSymlog which handles a wider domain.
-        return allData.filter(datum => datum.value > 0)
+        return allData.filter((datum) => datum.value > 0)
     }
 
     @computed get isLogScale() {
@@ -210,7 +213,7 @@ export class DiscreteBarTransform extends ChartTransform {
                     year: year,
                     label: grapher.getLabelForKey(entityDimensionKey),
                     color: "#2E5778",
-                    formatValue: dimension.formatValueShort
+                    formatValue: dimension.formatValueShort,
                 }
 
                 allData.push(datum)
@@ -221,24 +224,24 @@ export class DiscreteBarTransform extends ChartTransform {
             ? this._filterArrayForLogScale(allData)
             : allData
 
-        const data = sortNumeric(filteredData, d => d.value)
+        const data = sortNumeric(filteredData, (d) => d.value)
         const colorScheme = grapher.baseColorScheme
             ? ColorSchemes[grapher.baseColorScheme]
             : undefined
-        const uniqValues = sortedUniq(data.map(d => d.value))
+        const uniqValues = sortedUniq(data.map((d) => d.value))
         const colors = colorScheme?.getColors(uniqValues.length) || []
         if (grapher.invertColorScheme) colors.reverse()
 
         const colorByValue = new Map<number, string>()
         uniqValues.forEach((value, i) => colorByValue.set(value, colors[i]))
 
-        data.forEach(d => {
+        data.forEach((d) => {
             d.color =
                 grapher.keyColors[d.entityDimensionKey] ||
                 colorByValue.get(d.value) ||
                 d.color
         })
 
-        return sortNumeric(data, d => d.value, SortOrder.desc)
+        return sortNumeric(data, (d) => d.value, SortOrder.desc)
     }
 }

--- a/grapher/barCharts/StackedBarChart.tsx
+++ b/grapher/barCharts/StackedBarChart.tsx
@@ -10,14 +10,14 @@ import { Bounds } from "grapher/utils/Bounds"
 import {
     VerticalAxisComponent,
     AxisTickMarks,
-    VerticalAxisGridLines
+    VerticalAxisGridLines,
 } from "grapher/axis/AxisViews"
 import { VerticalAxis, DualAxis } from "grapher/axis/Axis"
 import { NoDataOverlay } from "grapher/chart/NoDataOverlay"
 import { Text } from "grapher/text/Text"
 import {
     VerticalColorLegend,
-    ScatterColorLegendView
+    ScatterColorLegendView,
 } from "grapher/scatterCharts/ScatterColorLegend"
 import { Tooltip } from "grapher/chart/Tooltip"
 import { EntityDimensionKey } from "grapher/core/GrapherConstants"
@@ -162,7 +162,7 @@ export class StackedBarChart extends React.Component<{
         return new DualAxis({
             bounds: bounds.padRight(sidebarWidth + 20),
             xAxis,
-            yAxis
+            yAxis,
         })
     }
 
@@ -183,8 +183,8 @@ export class StackedBarChart extends React.Component<{
                 ? []
                 : uniq(
                       transform.stackedData
-                          .filter(g => g.color === hoverColor)
-                          .map(g => g.entityDimensionKey)
+                          .filter((g) => g.color === hoverColor)
+                          .map((g) => g.entityDimensionKey)
                   )
 
         return hoverKeys
@@ -197,21 +197,21 @@ export class StackedBarChart extends React.Component<{
         let colors = []
         if (activeKeys.length === 0)
             // No hover means they're all active by default
-            colors = uniq(transform.stackedData.map(g => g.color))
+            colors = uniq(transform.stackedData.map((g) => g.color))
         else
             colors = uniq(
                 transform.stackedData
                     .filter(
-                        g => activeKeys.indexOf(g.entityDimensionKey) !== -1
+                        (g) => activeKeys.indexOf(g.entityDimensionKey) !== -1
                     )
-                    .map(g => g.color)
+                    .map((g) => g.color)
             )
         return colors
     }
 
     // Only show colors on legend that are actually in use
     @computed get colorsInUse() {
-        return uniq(this.transform.stackedData.map(g => g.color))
+        return uniq(this.transform.stackedData.map((g) => g.color))
     }
 
     @computed get legend(): VerticalColorLegend {
@@ -225,15 +225,15 @@ export class StackedBarChart extends React.Component<{
             },
             get colorables() {
                 return that.transform.colorScale.legendData
-                    .filter(bin => that.colorsInUse.includes(bin.color))
-                    .map(bin => {
+                    .filter((bin) => that.colorsInUse.includes(bin.color))
+                    .map((bin) => {
                         return {
                             key: bin.label ?? "",
                             label: bin.label ?? "",
-                            color: bin.color
+                            color: bin.color,
                         }
                     })
-            }
+            },
         })
     }
 
@@ -275,7 +275,7 @@ export class StackedBarChart extends React.Component<{
                         backgroundColor: "#fcfcfc",
                         borderBottom: "1px solid #ebebeb",
                         fontWeight: "normal",
-                        fontSize: "1em"
+                        fontSize: "1em",
                     }}
                 >
                     {hoverBar.label}
@@ -284,7 +284,7 @@ export class StackedBarChart extends React.Component<{
                     style={{
                         margin: 0,
                         padding: "0.3em 0.9em",
-                        fontSize: "0.8em"
+                        fontSize: "0.8em",
                     }}
                 >
                     <span>{yFormatTooltip(hoverBar.y)}</span>
@@ -316,7 +316,7 @@ export class StackedBarChart extends React.Component<{
         const { xValues } = this.transform
         const { xAxis } = dualAxis
 
-        return xValues.map(x => {
+        return xValues.map((x) => {
             const text = xAxis.tickFormat(x)
             const xPos = mapXValueToOffset.get(x) as number
 
@@ -325,9 +325,9 @@ export class StackedBarChart extends React.Component<{
                 text: text,
                 bounds: bounds.extend({
                     x: xPos + barWidth / 2 - bounds.width / 2,
-                    y: dualAxis.innerBounds.bottom + 5
+                    y: dualAxis.innerBounds.bottom + 5,
                 }),
-                isHidden: false
+                isHidden: false,
             }
         })
     }
@@ -350,7 +350,7 @@ export class StackedBarChart extends React.Component<{
             }
         }
 
-        return tickPlacements.filter(t => !t.isHidden)
+        return tickPlacements.filter((t) => !t.isHidden)
     }
 
     @action.bound onLegendMouseOver(color: string) {
@@ -407,7 +407,7 @@ export class StackedBarChart extends React.Component<{
             tooltip,
             barWidth,
             mapXValueToOffset,
-            ticks
+            ticks,
         } = this
         const { stackedData } = this.transform
         const { innerBounds } = dualAxis
@@ -447,7 +447,9 @@ export class StackedBarChart extends React.Component<{
 
                 <AxisTickMarks
                     tickMarkTopPosition={innerBounds.bottom}
-                    tickMarkXPositions={ticks.map(tick => tick.bounds.centerX)}
+                    tickMarkXPositions={ticks.map(
+                        (tick) => tick.bounds.centerX
+                    )}
                     color={textColor}
                 />
 
@@ -468,7 +470,7 @@ export class StackedBarChart extends React.Component<{
                 </g>
 
                 <g clipPath={`url(#boundsClip-${renderUid})`}>
-                    {stackedData.map(series => {
+                    {stackedData.map((series) => {
                         const isLegendHovered: boolean = includes(
                             this.hoverKeys,
                             series.entityDimensionKey
@@ -486,7 +488,7 @@ export class StackedBarChart extends React.Component<{
                                     "-segments"
                                 }
                             >
-                                {series.values.map(bar => {
+                                {series.values.map((bar) => {
                                     const xPos = mapXValueToOffset.get(
                                         bar.x
                                     ) as number

--- a/grapher/barCharts/StackedBarTransform.ts
+++ b/grapher/barCharts/StackedBarTransform.ts
@@ -9,7 +9,7 @@ import {
     max,
     defaultTo,
     uniq,
-    flatten
+    flatten,
 } from "grapher/utils/Util"
 import { StackedBarValue, StackedBarSeries } from "./StackedBarChart"
 import { ChartTransform } from "grapher/chart/ChartTransform"
@@ -23,7 +23,7 @@ import { ColorScale } from "grapher/color/ColorScale"
 export class StackedBarTransform extends ChartTransform {
     @computed get failMessage(): string | undefined {
         const { filledDimensions } = this.grapher
-        if (!some(filledDimensions, d => d.property === "y"))
+        if (!some(filledDimensions, (d) => d.property === "y"))
             return "Missing variable"
         else if (
             this.groupedData.length === 0 ||
@@ -34,10 +34,13 @@ export class StackedBarTransform extends ChartTransform {
     }
 
     @computed get primaryDimension(): ChartDimension | undefined {
-        return find(this.grapher.filledDimensions, d => d.property === "y")
+        return find(this.grapher.filledDimensions, (d) => d.property === "y")
     }
     @computed get colorDimension(): ChartDimension | undefined {
-        return find(this.grapher.filledDimensions, d => d.property === "color")
+        return find(
+            this.grapher.filledDimensions,
+            (d) => d.property === "color"
+        )
     }
 
     @computed get availableYears(): Time[] {
@@ -87,12 +90,12 @@ export class StackedBarTransform extends ChartTransform {
     @computed get yDomainDefault(): [number, number] {
         const lastSeries = this.stackedData[this.stackedData.length - 1]
 
-        const yValues = lastSeries.values.map(d => d.yOffset + d.y)
+        const yValues = lastSeries.values.map((d) => d.yOffset + d.y)
         return [0, defaultTo(max(yValues), 100)]
     }
 
     @computed get yDimensionFirst() {
-        return find(this.grapher.filledDimensions, d => d.property === "y")
+        return find(this.grapher.filledDimensions, (d) => d.property === "y")
     }
 
     @computed get yTickFormat() {
@@ -111,11 +114,11 @@ export class StackedBarTransform extends ChartTransform {
     }
 
     @computed get allStackedValues(): StackedBarValue[] {
-        return flatten(this.stackedData.map(series => series.values))
+        return flatten(this.stackedData.map((series) => series.values))
     }
 
     @computed get xValues(): number[] {
-        return uniq(this.allStackedValues.map(bar => bar.x))
+        return uniq(this.allStackedValues.map((bar) => bar.x))
     }
 
     @computed get groupedData(): StackedBarSeries[] {
@@ -152,7 +155,7 @@ export class StackedBarTransform extends ChartTransform {
                         entityDimensionKey: entityDimensionKey,
                         label: grapher.getLabelForKey(entityDimensionKey),
                         values: [],
-                        color: "#fff" // Temp
+                        color: "#fff", // Temp
                     }
                     seriesByKey.set(entityDimensionKey, series)
                 }
@@ -161,17 +164,17 @@ export class StackedBarTransform extends ChartTransform {
                     y: value,
                     yOffset: 0,
                     isFake: false,
-                    label: series.label
+                    label: series.label,
                 })
             }
 
             groupedData = groupedData.concat([
-                ...Array.from(seriesByKey.values())
+                ...Array.from(seriesByKey.values()),
             ])
         })
 
         // Now ensure that every series has a value entry for every year in the data
-        groupedData.forEach(series => {
+        groupedData.forEach((series) => {
             let i = 0
 
             while (i < timelineYears.length) {
@@ -187,7 +190,7 @@ export class StackedBarTransform extends ChartTransform {
                         y: fakeY,
                         yOffset: 0,
                         isFake: true,
-                        label: series.label
+                        label: series.label,
                     })
                 }
                 i += 1
@@ -197,7 +200,7 @@ export class StackedBarTransform extends ChartTransform {
         // Preserve order
         groupedData = sortBy(
             groupedData,
-            series => -selectedKeys.indexOf(series.entityDimensionKey)
+            (series) => -selectedKeys.indexOf(series.entityDimensionKey)
         )
 
         return groupedData
@@ -217,7 +220,7 @@ export class StackedBarTransform extends ChartTransform {
             },
             get categoricalValues() {
                 return uniq(
-                    that.groupedData.map(d => d.entityDimensionKey)
+                    that.groupedData.map((d) => d.entityDimensionKey)
                 ).reverse()
             },
             get hasNoDataBin() {
@@ -229,7 +232,7 @@ export class StackedBarTransform extends ChartTransform {
             get formatCategoricalValue() {
                 return (key: EntityDimensionKey) =>
                     that.grapher.getLabelForKey(key)
-            }
+            },
         })
     }
 
@@ -243,7 +246,7 @@ export class StackedBarTransform extends ChartTransform {
             series.color =
                 this.colorScale.getColor(series.entityDimensionKey) ?? "#ddd"
             series.values = series.values.filter(
-                v => v.x >= startYear && v.x <= endYear
+                (v) => v.x >= startYear && v.x <= endYear
             )
         }
 
@@ -265,7 +268,7 @@ export class StackedBarTransform extends ChartTransform {
             }
         })
         for (let i = keyIndicesToRemove.length - 1; i >= 0; i--) {
-            stackedData.forEach(series => {
+            stackedData.forEach((series) => {
                 series.values.splice(keyIndicesToRemove[i], 1)
             })
         }

--- a/grapher/chart/ChartDimension.ts
+++ b/grapher/chart/ChartDimension.ts
@@ -10,23 +10,23 @@ import {
     isNumber,
     extend,
     sortedUniq,
-    sortNumeric
+    sortNumeric,
 } from "grapher/utils/Util"
 import {
     TickFormattingOptions,
-    EntityDimensionKey
+    EntityDimensionKey,
 } from "grapher/core/GrapherConstants"
 import {
     AbstractColumn,
     owidVariableId,
     EntityName,
-    EntityId
+    EntityId,
 } from "owidTable/OwidTable"
 import { Time } from "grapher/utils/TimeBounds"
 
 import {
     OwidVariableDisplaySettings,
-    OwidVariableTableDisplaySettings
+    OwidVariableTableDisplaySettings,
 } from "owidTable/OwidVariable"
 import { OwidSource } from "owidTable/OwidSource"
 
@@ -71,7 +71,7 @@ export class ChartDimensionSpec implements ChartDimensionInterface {
         conversionFactor: undefined,
         numDecimalPlaces: undefined,
         tolerance: undefined,
-        tableDisplay: new OwidVariableTableDisplaySettings()
+        tableDisplay: new OwidVariableTableDisplaySettings(),
     }
 
     // XXX move this somewhere else, it's only used for scatter x override
@@ -187,7 +187,7 @@ export class ChartDimension {
         if (unit.length < 3) return unit
         else {
             const commonShortUnits = ["$", "£", "€", "%"]
-            if (some(commonShortUnits, u => unit[0] === u)) return unit[0]
+            if (some(commonShortUnits, (u) => unit[0] === u)) return unit[0]
             else return ""
         }
     }
@@ -203,7 +203,7 @@ export class ChartDimension {
                 return formatValue(value, {
                     unit: shortUnit,
                     numDecimalPlaces,
-                    ...options
+                    ...options,
                 })
         }
     }
@@ -219,7 +219,7 @@ export class ChartDimension {
                 return formatValue(value, {
                     unit: unit,
                     numDecimalPlaces: numDecimalPlaces,
-                    ...options
+                    ...options,
                 })
         }
     }
@@ -239,13 +239,15 @@ export class ChartDimension {
         const { unitConversionFactor } = this
         if (unitConversionFactor !== 1)
             return this.column.values.map(
-                v => (v as number) * unitConversionFactor
+                (v) => (v as number) * unitConversionFactor
             )
         else return this.column.values
     }
 
     @computed get sortedNumericValues(): number[] {
-        return sortNumeric(this.values.filter(isNumber).filter(v => !isNaN(v)))
+        return sortNumeric(
+            this.values.filter(isNumber).filter((v) => !isNaN(v))
+        )
     }
 
     get yearsUniq() {

--- a/grapher/chart/ChartLayout.tsx
+++ b/grapher/chart/ChartLayout.tsx
@@ -31,7 +31,7 @@ export class ChartLayout {
             },
             get maxWidth() {
                 return that.paddedBounds.width
-            }
+            },
         })
     }
 
@@ -43,7 +43,7 @@ export class ChartLayout {
             },
             get maxWidth() {
                 return that.paddedBounds.width
-            }
+            },
         })
     }
 
@@ -94,7 +94,7 @@ export class ChartLayoutView extends React.Component<{
             fontSize: this.props.layout.props.grapher.baseFontSize,
             backgroundColor: "white",
             textRendering: "optimizeLegibility",
-            WebkitFontSmoothing: "antialiased"
+            WebkitFontSmoothing: "antialiased",
         }
     }
 

--- a/grapher/chart/ChartTab.tsx
+++ b/grapher/chart/ChartTab.tsx
@@ -31,7 +31,7 @@ export class ChartTab extends React.Component<{
             },
             get bounds() {
                 return that.props.bounds
-            }
+            },
         })
     }
 

--- a/grapher/chart/ChartTransform.ts
+++ b/grapher/chart/ChartTransform.ts
@@ -3,7 +3,7 @@ import {
     Time,
     isUnboundedLeft,
     isUnboundedRight,
-    getClosestTime
+    getClosestTime,
 } from "grapher/utils/TimeBounds"
 import {
     defaultTo,
@@ -11,7 +11,7 @@ import {
     last,
     some,
     sortNumeric,
-    uniq
+    uniq,
 } from "grapher/utils/Util"
 import { Grapher } from "grapher/core/Grapher"
 import { EntityDimensionKey } from "grapher/core/GrapherConstants"
@@ -41,7 +41,7 @@ export abstract class ChartTransform implements IChartTransform {
     }
 
     @computed protected get hasYDimension() {
-        return some(this.grapher.dimensions, d => d.property === "y")
+        return some(this.grapher.dimensions, (d) => d.property === "y")
     }
 
     /**
@@ -64,7 +64,7 @@ export abstract class ChartTransform implements IChartTransform {
     @computed get timelineYears(): Time[] {
         const min = this.grapher.timelineMinTime
         const max = this.grapher.timelineMaxTime
-        const filteredYears = this.availableYears.filter(year => {
+        const filteredYears = this.availableYears.filter((year) => {
             if (min !== undefined && year < min) return false
             if (max !== undefined && year > max) return false
             return true

--- a/grapher/chart/ChartTypes.tsx
+++ b/grapher/chart/ChartTypes.tsx
@@ -13,7 +13,7 @@ export const ChartTypeMap = {
     StackedBarChart,
     DiscreteBarChart,
     ScatterPlot,
-    TimeScatter
+    TimeScatter,
 }
 
 export type ChartTypeName = keyof typeof ChartTypeMap

--- a/grapher/chart/DimensionSlot.ts
+++ b/grapher/chart/DimensionSlot.ts
@@ -2,7 +2,7 @@ import { Grapher } from "grapher/core/Grapher"
 import {
     dimensionProperty,
     ChartDimensionSpec,
-    ChartDimension
+    ChartDimension,
 } from "./ChartDimension"
 import { computed } from "mobx"
 
@@ -20,7 +20,7 @@ export class DimensionSlot {
             x: "X axis",
             size: "Size",
             color: "Color",
-            filter: "Filter"
+            filter: "Filter",
         }
 
         return (names as any)[this.property] || ""
@@ -42,12 +42,14 @@ export class DimensionSlot {
     }
 
     @computed get dimensions(): ChartDimensionSpec[] {
-        return this.grapher.dimensions.filter(d => d.property === this.property)
+        return this.grapher.dimensions.filter(
+            (d) => d.property === this.property
+        )
     }
 
     set dimensions(dims: ChartDimensionSpec[]) {
         let newDimensions: ChartDimensionSpec[] = []
-        this.grapher.dimensionSlots.forEach(slot => {
+        this.grapher.dimensionSlots.forEach((slot) => {
             if (slot.property === this.property)
                 newDimensions = newDimensions.concat(dims)
             else newDimensions = newDimensions.concat(slot.dimensions)
@@ -57,7 +59,7 @@ export class DimensionSlot {
 
     @computed get dimensionsWithData(): ChartDimension[] {
         return this.grapher.filledDimensions.filter(
-            d => d.property === this.property
+            (d) => d.property === this.property
         )
     }
 

--- a/grapher/chart/Footer.tsx
+++ b/grapher/chart/Footer.tsx
@@ -99,7 +99,7 @@ export class SourcesFooter {
             maxWidth: maxWidth,
             fontSize: fontSize,
             text: sourcesText,
-            linkifyText: true
+            linkifyText: true,
         })
     }
 
@@ -109,7 +109,7 @@ export class SourcesFooter {
             maxWidth: maxWidth,
             fontSize: fontSize,
             text: noteText,
-            linkifyText: true
+            linkifyText: true,
         })
     }
 
@@ -119,7 +119,7 @@ export class SourcesFooter {
             maxWidth: maxWidth * 3,
             fontSize: fontSize,
             text: licenseSvg,
-            rawHtml: true
+            rawHtml: true,
         })
     }
 
@@ -175,7 +175,7 @@ class SourcesFooterView extends React.Component<{
             maxWidth,
             isCompact,
             paraMargin,
-            onSourcesClick
+            onSourcesClick,
         } = this.props.footer
 
         return (
@@ -239,7 +239,7 @@ export class SourcesFooterHTML extends React.Component<{
                 className="license"
                 style={{
                     fontSize: footer.license.fontSize,
-                    lineHeight: footer.sources.lineHeight
+                    lineHeight: footer.sources.lineHeight,
                 }}
             >
                 {footer.finalUrlText && (
@@ -295,7 +295,7 @@ export class SourcesFooterHTML extends React.Component<{
                             maxWidth: "300px",
                             whiteSpace: "inherit",
                             padding: "10px",
-                            fontSize: "0.8em"
+                            fontSize: "0.8em",
                         }}
                     >
                         <p>

--- a/grapher/chart/Header.tsx
+++ b/grapher/chart/Header.tsx
@@ -32,7 +32,7 @@ export class Header {
             return new Logo({
                 logo: this.props.grapher.logo,
                 isLink: !this.props.grapher.isNativeEmbed,
-                fontSize: this.props.grapher.baseFontSize
+                fontSize: this.props.grapher.baseFontSize,
             })
         }
     }
@@ -56,7 +56,7 @@ export class Header {
                 maxWidth: maxWidth,
                 fontSize: fontScale * props.grapher.baseFontSize,
                 text: this.titleText,
-                lineHeight: 1
+                lineHeight: 1,
             })
             if (fontScale <= 1.2 || title.lines.length <= 1) break
             fontScale -= 0.05
@@ -66,7 +66,7 @@ export class Header {
             maxWidth: maxWidth,
             fontSize: fontScale * props.grapher.baseFontSize,
             text: this.titleText,
-            lineHeight: 1
+            lineHeight: 1,
         })
     }
 
@@ -98,7 +98,7 @@ export class Header {
             },
             get linkifyText() {
                 return true
-            }
+            },
         })
     }
 
@@ -140,7 +140,7 @@ class HeaderView extends React.Component<{
                     href={grapher.url.canonicalUrl}
                     style={{
                         fontFamily:
-                            '"Playfair Display", Georgia, "Times New Roman", serif'
+                            '"Playfair Display", Georgia, "Times New Roman", serif',
                     }}
                     target="_blank"
                 >
@@ -166,13 +166,13 @@ export class HeaderHTML extends React.Component<{
 
         const titleStyle = {
             ...header.title.htmlStyle,
-            marginBottom: header.titleMarginBottom
+            marginBottom: header.titleMarginBottom,
         }
 
         const subtitleStyle = {
             ...header.subtitle.htmlStyle,
             // make sure there are no scrollbars on subtitle
-            overflowY: "hidden"
+            overflowY: "hidden",
         }
 
         return (

--- a/grapher/chart/Logos.tsx
+++ b/grapher/chart/Logos.tsx
@@ -18,20 +18,20 @@ const logos: Record<LogoOption, LogoAttributes> = {
         width: 210,
         height: 120,
         targetHeight: 35,
-        url: "https://ourworldindata.org"
+        url: "https://ourworldindata.org",
     },
     "core+owid": {
         svg: CORE_LOGO_SVG,
         width: 102,
         height: 37,
-        targetHeight: 35
+        targetHeight: 35,
     },
     "gv+owid": {
         svg: GV_LOGO_SVG,
         width: 420,
         height: 350,
-        targetHeight: 52
-    }
+        targetHeight: 52,
+    },
 }
 
 interface LogoProps {
@@ -83,7 +83,7 @@ export class Logo {
         > = {
             className: "logo",
             dangerouslySetInnerHTML: { __html: this.spec.svg },
-            style: { height: `${this.spec.targetHeight}px` }
+            style: { height: `${this.spec.targetHeight}px` },
         }
         if (this.props.isLink || !this.spec.url) {
             return <div {...props} />

--- a/grapher/chart/NoDataOverlay.stories.tsx
+++ b/grapher/chart/NoDataOverlay.stories.tsx
@@ -6,7 +6,7 @@ import { Bounds } from "grapher/utils/Bounds"
 
 export default {
     title: "NoDataOverlay",
-    component: NoDataOverlay
+    component: NoDataOverlay,
 }
 
 export const Default = () => {
@@ -20,7 +20,7 @@ export const Default = () => {
                     canAddData: true,
                     isSelectingData: false,
                     entityType: "Country",
-                    standalone: true
+                    standalone: true,
                 }}
             />
         </div>

--- a/grapher/chart/NoDataOverlay.tsx
+++ b/grapher/chart/NoDataOverlay.tsx
@@ -35,7 +35,7 @@ export class NoDataOverlay extends React.Component<{
                     top: bounds.top,
                     left: bounds.left,
                     width: bounds.width,
-                    height: bounds.height
+                    height: bounds.height,
                 }}
             >
                 <p className="message">{message || "No available data"}</p>

--- a/grapher/chart/Tooltip.tsx
+++ b/grapher/chart/Tooltip.tsx
@@ -47,7 +47,7 @@ export class TooltipView extends React.Component<{
             boxShadow: "0 2px 2px rgba(0,0,0,.12), 0 0 1px rgba(0,0,0,.35)",
             borderRadius: "2px",
             textAlign: "left",
-            fontSize: "0.9em"
+            fontSize: "0.9em",
         }
 
         return (

--- a/grapher/color/BinningStrategies.test.ts
+++ b/grapher/color/BinningStrategies.test.ts
@@ -9,7 +9,7 @@ describe("BinningStrategies", () => {
                 getBinMaximums({
                     binningStrategy: BinningStrategy.quantiles,
                     sortedValues: [],
-                    binCount: 5
+                    binCount: 5,
                 })
             ).toEqual([])
         })
@@ -19,7 +19,7 @@ describe("BinningStrategies", () => {
                 getBinMaximums({
                     binningStrategy: BinningStrategy.quantiles,
                     sortedValues: [1, 2, 3, 4, 5],
-                    binCount: 0
+                    binCount: 0,
                 })
             ).toEqual([])
         })
@@ -30,7 +30,7 @@ describe("BinningStrategies", () => {
                     getBinMaximums({
                         binningStrategy: BinningStrategy.ckmeans,
                         sortedValues: [1, 1, 1, 1, 1, 5],
-                        binCount: 5
+                        binCount: 5,
                     })
                 ).toEqual([1, 5])
             })
@@ -41,7 +41,7 @@ describe("BinningStrategies", () => {
                         binningStrategy: BinningStrategy.ckmeans,
                         sortedValues: [1, 1, 1, 1, 1, 5],
                         binCount: 5,
-                        minBinValue: 1
+                        minBinValue: 1,
                     })
                 ).toEqual([5])
             })
@@ -51,7 +51,7 @@ describe("BinningStrategies", () => {
                     getBinMaximums({
                         binningStrategy: BinningStrategy.ckmeans,
                         sortedValues: [1, 2, 4, 5, 12, 43, 52, 123, 234, 1244],
-                        binCount: 5
+                        binCount: 5,
                     })
                 ).toEqual([12, 52, 123, 234, 1244])
             })
@@ -63,7 +63,7 @@ describe("BinningStrategies", () => {
                     getBinMaximums({
                         binningStrategy: BinningStrategy.quantiles,
                         sortedValues: [1, 1, 1, 1, 1, 5],
-                        binCount: 5
+                        binCount: 5,
                     })
                 ).toEqual([1, 5])
             })
@@ -74,7 +74,7 @@ describe("BinningStrategies", () => {
                         binningStrategy: BinningStrategy.quantiles,
                         sortedValues: [1, 1, 1, 1, 1, 5],
                         binCount: 5,
-                        minBinValue: 1
+                        minBinValue: 1,
                     })
                 ).toEqual([5])
             })
@@ -84,7 +84,7 @@ describe("BinningStrategies", () => {
                     getBinMaximums({
                         binningStrategy: BinningStrategy.quantiles,
                         sortedValues: [1, 10, 20, 50, 100],
-                        binCount: 4
+                        binCount: 4,
                     })
                 ).toEqual([10, 20, 50, 100])
             })
@@ -97,7 +97,7 @@ describe("BinningStrategies", () => {
                         binningStrategy: BinningStrategy.equalInterval,
                         sortedValues: [300],
                         binCount: 3,
-                        minBinValue: 0
+                        minBinValue: 0,
                     })
                 ).toEqual([100, 200, 300])
             })
@@ -107,7 +107,7 @@ describe("BinningStrategies", () => {
                     getBinMaximums({
                         binningStrategy: BinningStrategy.equalInterval,
                         sortedValues: [100, 300],
-                        binCount: 2
+                        binCount: 2,
                     })
                 ).toEqual([200, 300])
             })
@@ -118,7 +118,7 @@ describe("BinningStrategies", () => {
                         binningStrategy: BinningStrategy.equalInterval,
                         sortedValues: [1, 1.5, 2, 3, 7.5],
                         binCount: 5,
-                        minBinValue: 0
+                        minBinValue: 0,
                     })
                 ).toEqual([2, 4, 6, 8, 10])
             })

--- a/grapher/color/BinningStrategies.ts
+++ b/grapher/color/BinningStrategies.ts
@@ -6,7 +6,7 @@ import {
     uniq,
     last,
     roundSigFig,
-    first
+    first,
 } from "grapher/utils/Util"
 
 export enum BinningStrategy {
@@ -15,7 +15,7 @@ export enum BinningStrategy {
     ckmeans = "ckmeans",
     // The `manual` option is ignored in the algorithms below,
     // but it is stored and handled by the chart.
-    manual = "manual"
+    manual = "manual",
 }
 
 /** Human-readable labels for the binning strategies */
@@ -23,7 +23,7 @@ export const binningStrategyLabels: Record<BinningStrategy, string> = {
     equalInterval: "Equal-interval",
     quantiles: "Quantiles",
     ckmeans: "Ckmeans",
-    manual: "Manual"
+    manual: "Manual",
 }
 
 function calcEqualIntervalStepSize(
@@ -53,7 +53,7 @@ function normalizeBinValues(
 ) {
     const values = uniq(excludeUndefined(binValues))
     return minBinValue !== undefined
-        ? values.filter(v => v > minBinValue)
+        ? values.filter((v) => v > minBinValue)
         : values
 }
 
@@ -67,7 +67,7 @@ export function getBinMaximums(args: GetBinMaximumsWithStrategyArgs): number[] {
         return normalizeBinValues(clusters.map(last), minBinValue)
     } else if (binningStrategy === BinningStrategy.quantiles) {
         return normalizeBinValues(
-            range(1, binCount + 1).map(v =>
+            range(1, binCount + 1).map((v) =>
                 quantile(sortedValues, v / binCount)
             ),
             minBinValue
@@ -81,7 +81,7 @@ export function getBinMaximums(args: GetBinMaximumsWithStrategyArgs): number[] {
             minValue
         )
         return normalizeBinValues(
-            range(1, binCount + 1).map(n => minValue + n * binStepSize),
+            range(1, binCount + 1).map((n) => minValue + n * binStepSize),
             minBinValue
         )
     }

--- a/grapher/color/ColorScale.ts
+++ b/grapher/color/ColorScale.ts
@@ -13,7 +13,7 @@ import {
     find,
     identity,
     roundSigFig,
-    mapNullToUndefined
+    mapNullToUndefined,
 } from "grapher/utils/Util"
 import { Color } from "grapher/core/GrapherConstants"
 import { ColorScheme, ColorSchemes } from "grapher/color/ColorSchemes"
@@ -172,7 +172,7 @@ export class ColorScale {
             binningStrategy: this.config.binningStrategy,
             sortedValues: this.sortedNumericBinningValues,
             binCount: this.numAutoBins,
-            minBinValue: this.minBinValue
+            minBinValue: this.minBinValue,
         })
     }
 
@@ -185,7 +185,7 @@ export class ColorScale {
     @computed get customCategoryColors(): { [key: string]: Color } {
         return {
             [NO_DATA_LABEL]: this.defaultNoDataColor, // default 'no data' color
-            ...this.config.customCategoryColors
+            ...this.config.customCategoryColors,
         }
     }
 
@@ -198,7 +198,7 @@ export class ColorScale {
             categoricalValues,
             colorScheme,
             bucketMaximums,
-            isColorSchemeInverted
+            isColorSchemeInverted,
         } = this
         const numColors = bucketMaximums.length + categoricalValues.length
         const colors = colorScheme.getColors(numColors)
@@ -231,14 +231,14 @@ export class ColorScale {
         const sampleMean = mean(sortedNumericValues) as number
         const sampleDeviation = deviation(sortedNumericValues) as number
         return sortedNumericValues.filter(
-            d => Math.abs(d - sampleMean) <= sampleDeviation * 2
+            (d) => Math.abs(d - sampleMean) <= sampleDeviation * 2
         )
     }
 
     /** Sorted numeric values passed onto the binning algorithms */
     @computed private get sortedNumericBinningValues(): number[] {
         return this.sortedNumericValuesWithoutOutliers.filter(
-            v => v > this.minBinValue
+            (v) => v > this.minBinValue
         )
     }
 
@@ -261,7 +261,7 @@ export class ColorScale {
             customNumericColors,
             customCategoryLabels,
             customHiddenCategories,
-            formatNumericValue
+            formatNumericValue,
         } = this
 
         /*var unitsString = chart.model.get("units"),
@@ -292,7 +292,7 @@ export class ColorScale {
                         max: maxValue,
                         color: color,
                         label: label,
-                        format: formatNumericValue
+                        format: formatNumericValue,
                     })
                 )
                 minValue = maxValue
@@ -328,7 +328,7 @@ export class ColorScale {
                     value: value,
                     color: color,
                     label: label,
-                    isHidden: !!customHiddenCategories[value]
+                    isHidden: !!customHiddenCategories[value],
                 })
             )
         }
@@ -338,6 +338,6 @@ export class ColorScale {
 
     @bind getColor(value: number | string | undefined): string | undefined {
         if (value === undefined) return this.customCategoryColors[NO_DATA_LABEL]
-        return find(this.legendData, b => b.contains(value))?.color
+        return find(this.legendData, (b) => b.contains(value))?.color
     }
 }

--- a/grapher/color/ColorSchemes.ts
+++ b/grapher/color/ColorSchemes.ts
@@ -13,7 +13,7 @@ export const continentColors = {
     Europe: "#4C5C78",
     "North America": "#E04E4B",
     Oceania: "#A8633C",
-    "South America": "#932834"
+    "South America": "#932834",
 }
 
 const schemeProps: {
@@ -22,13 +22,13 @@ const schemeProps: {
     YlGn: { displayName: "Yellow-Green shades", singleColorScale: true },
     YlGnBu: {
         displayName: "Yellow-Green-Blue shades",
-        singleColorScale: false
+        singleColorScale: false,
     },
     GnBu: { displayName: "Green-Blue shades", singleColorScale: true },
     BuGn: { displayName: "Blue-Green shades", singleColorScale: true },
     PuBuGn: {
         displayName: "Purple-Blue-Green shades",
-        singleColorScale: false
+        singleColorScale: false,
     },
     BuPu: { displayName: "Blue-Purple shades", singleColorScale: true },
     RdPu: { displayName: "Red-Purple shades", singleColorScale: true },
@@ -36,11 +36,11 @@ const schemeProps: {
     OrRd: { displayName: "Orange-Red shades", singleColorScale: true },
     YlOrRd: {
         displayName: "Yellow-Orange-Red shades",
-        singleColorScale: true
+        singleColorScale: true,
     },
     YlOrBr: {
         displayName: "Yellow-Orange-Brown shades",
-        singleColorScale: true
+        singleColorScale: true,
     },
     Purples: { displayName: "Purple shades", singleColorScale: true },
     Blues: { displayName: "Blue shades", singleColorScale: true },
@@ -67,7 +67,7 @@ const schemeProps: {
     Set3: { displayName: "Set 3 colors", singleColorScale: false },
     PuBu: { displayName: "Purple-Blue shades", singleColorScale: true },
     "hsv-RdBu": { displayName: "HSV Red-Blue", singleColorScale: false },
-    "hsv-CyMg": { displayName: "HSV Cyan-Magenta", singleColorScale: false }
+    "hsv-CyMg": { displayName: "HSV Cyan-Magenta", singleColorScale: false },
 }
 
 function interpolateArray(scaleArr: string[]) {
@@ -98,7 +98,7 @@ export class ColorScheme {
     ) {
         const colorSetsArray: Color[][] = []
         Object.keys(colorSets).forEach(
-            numColors => (colorSetsArray[+numColors] = colorSets[numColors])
+            (numColors) => (colorSetsArray[+numColors] = colorSets[numColors])
         )
         return new ColorScheme(name, colorSetsArray, singleColorScale)
     }
@@ -118,7 +118,7 @@ export class ColorScheme {
         this.colorSets = []
         this.singleColorScale = !!singleColorScale
         this.isDistinct = !!isDistinct
-        colorSets.forEach(set => (this.colorSets[set.length] = set))
+        colorSets.forEach((set) => (this.colorSets[set.length] = set))
     }
 
     improviseGradientFromShorter(
@@ -160,12 +160,12 @@ export class ColorScheme {
         else {
             const prevColors = clone(colorSets)
                 .reverse()
-                .find(set => set && set.length < numColors)
+                .find((set) => set && set.length < numColors)
             if (prevColors)
                 return this.improviseGradientFromShorter(prevColors, numColors)
             else
                 return this.improviseGradientFromLonger(
-                    colorSets.find(set => !!set) as Color[],
+                    colorSets.find((set) => !!set) as Color[],
                     numColors
                 )
         }
@@ -479,8 +479,8 @@ export const ColorSchemes = (() => {
                 "#f6e620",
                 "#f8e621",
                 "#fbe723",
-                "#fde725"
-            ]
+                "#fde725",
+            ],
         ],
         false
     )
@@ -742,8 +742,8 @@ export const ColorSchemes = (() => {
             "#f8fb9a",
             "#f9fc9d",
             "#fafda1",
-            "#fcffa4"
-        ]
+            "#fcffa4",
+        ],
     ])
 
     colorSchemes["Magma"] = new ColorScheme("Magma", [
@@ -1003,8 +1003,8 @@ export const ColorSchemes = (() => {
             "#fcf7b9",
             "#fcf9bb",
             "#fcfbbd",
-            "#fcfdbf"
-        ]
+            "#fcfdbf",
+        ],
     ])
 
     colorSchemes["Plasma"] = new ColorScheme("Plasma", [
@@ -1264,8 +1264,8 @@ export const ColorSchemes = (() => {
             "#f1f426",
             "#f1f525",
             "#f0f724",
-            "#f0f921"
-        ]
+            "#f0f921",
+        ],
     ])
 
     // Create some of our own!
@@ -1297,8 +1297,8 @@ export const ColorSchemes = (() => {
                 "#D7263F",
                 "#18470F",
                 "#BC8E5A",
-                "#585C64"
-            ]
+                "#585C64",
+            ],
         ],
         false,
         true
@@ -1320,8 +1320,8 @@ export const ColorSchemes = (() => {
             "#ca2628",
             "#ffd53e",
             "#9ecc8a",
-            "#34983f"
-        ]
+            "#34983f",
+        ],
     ])
 
     colorSchemes["continents"] = new ColorScheme(
@@ -1354,8 +1354,8 @@ export const ColorSchemes = (() => {
                 "dbdb8d",
                 "17becf",
                 "9edae5",
-                "1f77b4"
-            ]
+                "1f77b4",
+            ],
         ],
         false,
         true

--- a/grapher/controls/CommandPalette.stories.tsx
+++ b/grapher/controls/CommandPalette.stories.tsx
@@ -5,7 +5,7 @@ import { CommandPalette, Command } from "grapher/controls/CommandPalette"
 
 export default {
     title: "CommandPalette",
-    component: CommandPalette
+    component: CommandPalette,
 }
 
 export const Default = () => {
@@ -14,20 +14,20 @@ export const Default = () => {
             combo: "ctrl+o",
             fn: () => {},
             title: "Open",
-            category: "File"
+            category: "File",
         },
         {
             combo: "ctrl+s",
             fn: () => {},
             title: "Save",
-            category: "File"
+            category: "File",
         },
         {
             combo: "ctrl+c",
             fn: () => {},
             title: "Copy",
-            category: "Edit"
-        }
+            category: "Edit",
+        },
     ]
     return <CommandPalette commands={demoCommands} display="block" />
 }

--- a/grapher/controls/CommandPalette.tsx
+++ b/grapher/controls/CommandPalette.tsx
@@ -17,7 +17,7 @@ export class CommandPalette extends React.Component<{
 }> {
     render() {
         const style: any = {
-            display: this.props.display
+            display: this.props.display,
         }
         let lastCat = ""
         const commands = this.props.commands.map((command, index) => {

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -19,7 +19,7 @@ import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons/faExternalL
 import { TimeBound } from "grapher/utils/TimeBounds"
 import {
     HighlightToggleConfig,
-    GrapherTabOption
+    GrapherTabOption,
 } from "grapher/core/GrapherConstants"
 import { ShareMenu } from "./ShareMenu"
 
@@ -46,7 +46,7 @@ class SettingsMenu extends React.Component<{
         return (
             <div
                 className="SettingsMenu"
-                onClick={evt => evt.stopPropagation()}
+                onClick={(evt) => evt.stopPropagation()}
             >
                 <h2>Settings</h2>
             </div>
@@ -82,7 +82,7 @@ class HighlightToggle extends React.Component<{
     get isHighlightActive() {
         const params = getWindowQueryParams()
         let isActive = true
-        keys(this.highlightParams).forEach(key => {
+        keys(this.highlightParams).forEach((key) => {
             if (params[key] !== this.highlightParams[key]) isActive = false
         })
         return isActive
@@ -190,7 +190,7 @@ interface TimelineControlProps {
 @observer
 class TimelineControl extends React.Component<TimelineControlProps> {
     @action.bound onMapTargetChange({
-        targetStartYear
+        targetStartYear,
     }: {
         targetStartYear: TimeBound
     }) {
@@ -199,7 +199,7 @@ class TimelineControl extends React.Component<TimelineControlProps> {
 
     @action.bound onChartTargetChange({
         targetStartYear,
-        targetEndYear
+        targetEndYear,
     }: {
         targetStartYear: TimeBound
         targetEndYear: TimeBound
@@ -243,7 +243,7 @@ class TimelineControl extends React.Component<TimelineControlProps> {
         )
             this.onChartTargetChange({
                 targetStartYear: this.startYear,
-                targetEndYear: this.endYear
+                targetEndYear: this.endYear,
             })
     }
 
@@ -259,7 +259,7 @@ class TimelineControl extends React.Component<TimelineControlProps> {
             endYear: this.endYear,
             onTargetChange: this.onChartTargetChange,
             onStartDrag: this.onTimelineStart,
-            onStopDrag: this.onTimelineStop
+            onStopDrag: this.onTimelineStop,
         }
     }
 
@@ -316,12 +316,14 @@ export class Controls {
     } {
         const overlays = Object.values(this.props.grapherView.overlays)
         return {
-            top: max(overlays.map(overlay => overlay.props.paddingTop)) ?? 0,
+            top: max(overlays.map((overlay) => overlay.props.paddingTop)) ?? 0,
             right:
-                max(overlays.map(overlay => overlay.props.paddingRight)) ?? 0,
+                max(overlays.map((overlay) => overlay.props.paddingRight)) ?? 0,
             bottom:
-                max(overlays.map(overlay => overlay.props.paddingBottom)) ?? 0,
-            left: max(overlays.map(overlay => overlay.props.paddingLeft)) ?? 0
+                max(overlays.map((overlay) => overlay.props.paddingBottom)) ??
+                0,
+            left:
+                max(overlays.map((overlay) => overlay.props.paddingLeft)) ?? 0,
         }
     }
 
@@ -408,7 +410,7 @@ export class AddEntityButton extends React.Component<{
         align: "left",
         verticalAlign: "bottom",
         height: 21,
-        label: "Add country"
+        label: "Add country",
     }
 
     static calcPaddingTop(
@@ -433,12 +435,12 @@ export class AddEntityButton extends React.Component<{
             verticalAlign,
             height,
             label,
-            onClick
+            onClick,
         } = this.props
 
         const buttonStyle: React.CSSProperties = {
             position: "absolute",
-            lineHeight: `${height}px`
+            lineHeight: `${height}px`,
         }
 
         if (verticalAlign === "top") {
@@ -492,7 +494,7 @@ export class ControlsOverlayView extends React.Component<{
             paddingTop: `${overlayPadding.top}px`,
             paddingRight: `${overlayPadding.right}px`,
             paddingBottom: `${overlayPadding.bottom}px`,
-            paddingLeft: `${overlayPadding.left}px`
+            paddingLeft: `${overlayPadding.left}px`,
         }
         const overlayStyle: React.CSSProperties = {
             position: "absolute",
@@ -504,7 +506,7 @@ export class ControlsOverlayView extends React.Component<{
             // Can achieve the same with `pointer-events: none`, but then control
             // has to override `pointer-events` to capture events.
             width: "0px",
-            height: "0px"
+            height: "0px",
         }
         return (
             <div style={containerStyle}>
@@ -549,7 +551,7 @@ export class ControlsFooterView extends React.Component<{
         return (
             <nav className="tabs">
                 <ul>
-                    {grapher.availableTabs.map(tabName => {
+                    {grapher.availableTabs.map((tabName) => {
                         return (
                             tabName !== "download" && (
                                 <li
@@ -710,7 +712,7 @@ export class ControlsFooterView extends React.Component<{
             hasTimeline,
             hasInlineControls,
             hasSpace,
-            hasRelatedQuestion
+            hasRelatedQuestion,
         } = props.controls
         const { grapher, grapherView } = props.controls.props
         const { relatedQuestions } = grapher

--- a/grapher/controls/ControlsOverlay.tsx
+++ b/grapher/controls/ControlsOverlay.tsx
@@ -2,7 +2,7 @@ import { observer } from "mobx-react"
 import React from "react"
 import {
     GrapherViewContext,
-    GrapherViewContextInterface
+    GrapherViewContextInterface,
 } from "grapher/core/GrapherViewContext"
 import { action } from "mobx"
 

--- a/grapher/controls/CountryPicker.stories.tsx
+++ b/grapher/controls/CountryPicker.stories.tsx
@@ -14,7 +14,7 @@ class CountryPickerHolder extends React.Component {
                     padding: "20px",
                     height: "500px",
                     width: "300px",
-                    display: "grid"
+                    display: "grid",
                 }}
             >
                 {this.props.children}
@@ -39,7 +39,7 @@ france,3,fra,,400`)
 
     @action.bound toggleSelection(name: string) {
         this.selected.includes(name)
-            ? (this.selected = this.selected.filter(i => i !== name))
+            ? (this.selected = this.selected.filter((i) => i !== name))
             : this.selected.push(name)
     }
 
@@ -61,7 +61,7 @@ france,3,fra,,400`)
 
 export default {
     title: "CountryPicker",
-    component: CountryPicker
+    component: CountryPicker,
 }
 
 export const Empty = () => (

--- a/grapher/controls/CountryPicker.tsx
+++ b/grapher/controls/CountryPicker.tsx
@@ -20,7 +20,7 @@ import {
     isNumber,
     sortBy,
     sortByUndefinedLast,
-    first
+    first,
 } from "grapher/utils/Util"
 import { VerticalScrollContainer } from "grapher/controls/VerticalScrollContainer"
 import { Analytics } from "grapher/core/Analytics"
@@ -37,7 +37,7 @@ enum FocusDirection {
     first = "first",
     last = "last",
     up = "up",
-    down = "down"
+    down = "down",
 }
 
 interface CountryOptionWithMetricValue {
@@ -86,7 +86,7 @@ export class CountryPicker extends React.Component<{
         availableEntities: [],
         selectedEntities: [],
         countriesMustHaveColumns: [],
-        pickerColumnSlugs: new Set()
+        pickerColumnSlugs: new Set(),
     }
 
     @observable private searchInput?: string
@@ -135,17 +135,17 @@ export class CountryPicker extends React.Component<{
     }
 
     @computed get availablePickerColumns() {
-        return this.props.table.columnsAsArray.filter(col =>
+        return this.props.table.columnsAsArray.filter((col) =>
             this.props.pickerColumnSlugs.has(col.slug)
         )
     }
 
     @computed get metricOptions() {
         return sortBy(
-            this.availablePickerColumns.map(col => {
+            this.availablePickerColumns.map((col) => {
                 return {
                     label: col.spec.name, // todo: name
-                    value: col.slug
+                    value: col.slug,
                 }
             }),
             "label"
@@ -154,7 +154,7 @@ export class CountryPicker extends React.Component<{
 
     @computed get activePickerMetricColumn(): AbstractColumn {
         return this.availablePickerColumns.find(
-            col => col.slug === this.metric
+            (col) => col.slug === this.metric
         )!
     }
 
@@ -169,13 +169,13 @@ export class CountryPicker extends React.Component<{
     @computed
     private get optionsWithMetricValue(): CountryOptionWithMetricValue[] {
         const col = this.activePickerMetricColumn
-        return this.props.availableEntities.map(name => {
+        return this.props.availableEntities.map((name) => {
             const plotValue = col?.getLatestValueForEntity(name)
             const formattedValue = col?.formatValue(plotValue)
             return {
                 name,
                 plotValue,
-                formattedValue
+                formattedValue,
             }
         })
     }
@@ -196,7 +196,7 @@ export class CountryPicker extends React.Component<{
         const [selected, unselected] = partition(
             sortByUndefinedLast(
                 this.optionsWithMetricValue,
-                option => option.plotValue,
+                (option) => option.plotValue,
                 this.sortOrder
             ),
             this.isSelected
@@ -338,7 +338,7 @@ export class CountryPicker extends React.Component<{
                     if (!currentToken || currentToken.match !== match) {
                         tokens.push({
                             match,
-                            text: char
+                            text: char,
                         })
                     } else {
                         currentToken.text += char
@@ -365,7 +365,7 @@ export class CountryPicker extends React.Component<{
     @computed get barScale() {
         const maxValue = max(
             this.optionsWithMetricValue
-                .map(option => option.plotValue)
+                .map((option) => option.plotValue)
                 .filter(isNumber)
         )
         return scaleLinear()
@@ -423,15 +423,15 @@ export class CountryPicker extends React.Component<{
                         className="metricDropdown"
                         options={this.metricOptions}
                         value={this.metricOptions.find(
-                            option => option.value === this.metric
+                            (option) => option.value === this.metric
                         )}
-                        onChange={option => {
+                        onChange={(option) => {
                             const value = first(asArray(option))?.value
                             if (value) this.updateMetric(value)
                         }}
                         menuPlacement="bottom"
                         components={{
-                            IndicatorSeparator: null
+                            IndicatorSeparator: null,
                         }}
                         styles={getStylesForTargetHeight(26)}
                         isSearchable={false}
@@ -472,12 +472,12 @@ export class CountryPicker extends React.Component<{
                 <div className="CountryPickerSearchInput">
                     <input
                         className={classnames("input-field", {
-                            "with-done-button": this.showDoneButton
+                            "with-done-button": this.showDoneButton,
                         })}
                         type="text"
                         placeholder="Type to add a country..."
                         value={this.searchInput ?? ""}
-                        onChange={e =>
+                        onChange={(e) =>
                             (this.searchInput = e.currentTarget.value)
                         }
                         onFocus={this.onSearchFocus}
@@ -499,7 +499,7 @@ export class CountryPicker extends React.Component<{
                     {(!this.isDropdownMenu || this.isOpen) && (
                         <div
                             className={classnames("CountryList", {
-                                isDropdown: this.isDropdownMenu
+                                isDropdown: this.isDropdownMenu,
                             })}
                             onMouseDown={this.onMenuMouseDown}
                         >
@@ -508,7 +508,7 @@ export class CountryPicker extends React.Component<{
                                 scrollLock={true}
                                 className="CountrySearchResults"
                                 contentsId={countries
-                                    .map(c => c.name)
+                                    .map((c) => c.name)
                                     .join(",")}
                                 onMouseMove={this.unblockHover}
                                 ref={this.scrollContainerRef}
@@ -516,7 +516,7 @@ export class CountryPicker extends React.Component<{
                                 <Flipper
                                     spring={{
                                         stiffness: 300,
-                                        damping: 33
+                                        damping: 33,
                                     }}
                                     // We only want to animate when the selection changes, but not on changes due to
                                     // searching
@@ -601,7 +601,7 @@ class PickerOption extends React.Component<CountryOptionProps> {
             isSelected,
             isFocused,
             hasDataForActiveMetric,
-            highlight
+            highlight,
         } = this.props
         const { name, plotValue, formattedValue } = optionWithMetricValue
         const metricValue = formattedValue === name ? "" : formattedValue // If the user has "country name" selected, don't show the name twice.
@@ -613,7 +613,7 @@ class PickerOption extends React.Component<CountryOptionProps> {
                         "CountryOption",
                         {
                             selected: isSelected,
-                            focused: isFocused
+                            focused: isFocused,
                         },
                         hasDataForActiveMetric ? undefined : "MissingData"
                     )}
@@ -643,7 +643,7 @@ class PickerOption extends React.Component<CountryOptionProps> {
                                 <div
                                     className="bar"
                                     style={{
-                                        width: `${barScale(plotValue) * 100}%`
+                                        width: `${barScale(plotValue) * 100}%`,
                                     }}
                                 />
                             </div>

--- a/grapher/controls/EntitySelectorModal.tsx
+++ b/grapher/controls/EntitySelectorModal.tsx
@@ -25,7 +25,7 @@ class EntitySelectorMulti extends React.Component<{
     }
 
     @computed get selectedEntities() {
-        return this.availableEntities.filter(d =>
+        return this.availableEntities.filter((d) =>
             this.isSelectedKey(d.entityDimensionKey)
         )
     }
@@ -37,7 +37,7 @@ class EntitySelectorMulti extends React.Component<{
     @computed get searchResults(): EntityDimensionInfo[] {
         return this.searchInput
             ? this.fuzzy.search(this.searchInput)
-            : sortBy(this.availableEntities, result => result.label)
+            : sortBy(this.availableEntities, (result) => result.label)
     }
 
     isSelectedKey(entityDimensionKey: EntityDimensionKey): boolean {
@@ -83,7 +83,7 @@ class EntitySelectorMulti extends React.Component<{
         const {
             selectedEntities: selectedData,
             searchResults,
-            searchInput
+            searchInput,
         } = this
 
         return (
@@ -103,16 +103,16 @@ class EntitySelectorMulti extends React.Component<{
                                 type="search"
                                 placeholder="Search..."
                                 value={searchInput}
-                                onInput={e =>
+                                onInput={(e) =>
                                     (this.searchInput = e.currentTarget.value)
                                 }
                                 onKeyDown={this.onSearchKeyDown}
-                                ref={e =>
+                                ref={(e) =>
                                     (this.searchField = e as HTMLInputElement)
                                 }
                             />
                             <ul>
-                                {searchResults.map(d => {
+                                {searchResults.map((d) => {
                                     return (
                                         <li key={d.entityDimensionKey}>
                                             <label className="clickable">
@@ -136,7 +136,7 @@ class EntitySelectorMulti extends React.Component<{
                         </div>
                         <div className="selectedData">
                             <ul>
-                                {selectedData.map(d => {
+                                {selectedData.map((d) => {
                                     return (
                                         <li key={d.entityDimensionKey}>
                                             <label className="clickable">
@@ -189,13 +189,13 @@ class EntitySelectorSingle extends React.Component<{
 
     @computed private get availableEntities() {
         const availableItems: { id: number; label: string }[] = []
-        this.props.grapher.entityDimensionMap.forEach(meta => {
+        this.props.grapher.entityDimensionMap.forEach((meta) => {
             availableItems.push({
                 id: meta.entityId,
-                label: meta.entityName
+                label: meta.entityName,
             })
         })
-        return uniqBy(availableItems, d => d.label)
+        return uniqBy(availableItems, (d) => d.label)
     }
 
     @computed get fuzzy(): FuzzySearch<{ id: number; label: string }> {
@@ -205,7 +205,7 @@ class EntitySelectorSingle extends React.Component<{
     @computed get searchResults(): { id: number; label: string }[] {
         return this.searchInput
             ? this.fuzzy.search(this.searchInput)
-            : sortBy(this.availableEntities, result => result.label)
+            : sortBy(this.availableEntities, (result) => result.label)
     }
 
     @action.bound onClickOutside(e: MouseEvent) {
@@ -261,16 +261,16 @@ class EntitySelectorSingle extends React.Component<{
                             type="search"
                             placeholder="Search..."
                             value={searchInput}
-                            onInput={e =>
+                            onInput={(e) =>
                                 (this.searchInput = e.currentTarget.value)
                             }
                             onKeyDown={this.onSearchKeyDown}
-                            ref={e =>
+                            ref={(e) =>
                                 (this.searchField = e as HTMLInputElement)
                             }
                         />
                         <ul>
-                            {searchResults.map(d => {
+                            {searchResults.map((d) => {
                                 return (
                                     <li
                                         key={d.id}

--- a/grapher/controls/ScaleSelector.stories.tsx
+++ b/grapher/controls/ScaleSelector.stories.tsx
@@ -7,7 +7,7 @@ import { observable, action } from "mobx"
 
 export default {
     title: "ScaleSelector",
-    component: ScaleSelector
+    component: ScaleSelector,
 }
 
 class ScaleConfig {
@@ -29,7 +29,7 @@ export const StayInBounds = () => {
                 width: 200,
                 height: 200,
                 background: "gray",
-                position: "relative"
+                position: "relative",
             }}
         >
             <ScaleSelector

--- a/grapher/controls/ScaleSelector.tsx
+++ b/grapher/controls/ScaleSelector.tsx
@@ -69,7 +69,7 @@ export class ScaleSelector extends React.Component<ScaleSelectorOptions> {
 
         const style = {
             left: x - this.getLeftShiftIfNeeded(x),
-            top: y
+            top: y,
         }
         return (
             <div

--- a/grapher/controls/ShareMenu.tsx
+++ b/grapher/controls/ShareMenu.tsx
@@ -47,7 +47,7 @@ class EmbedMenu extends React.Component<{
                 <p>Paste this into any HTML page:</p>
                 <textarea
                     readOnly={true}
-                    onFocus={evt => evt.currentTarget.select()}
+                    onFocus={(evt) => evt.currentTarget.select()}
                     value={`<iframe src="${url}" loading="lazy" style="width: 100%; height: 600px; border: 0px none;"></iframe>`}
                 />
                 {this.props.grapherView.grapher.embedExplorerCheckbox}
@@ -74,7 +74,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
         super(props)
 
         this.state = {
-            copied: false
+            copied: false,
         }
     }
 
@@ -133,7 +133,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
         if (this.canonicalUrl && navigator.share) {
             const shareData = {
                 title: this.title,
-                url: this.canonicalUrl
+                url: this.canonicalUrl,
             }
 
             try {

--- a/grapher/controls/Timeline.tsx
+++ b/grapher/controls/Timeline.tsx
@@ -6,7 +6,7 @@ import {
     findClosestYear,
     getRelativeMouse,
     isMobile,
-    debounce
+    debounce,
 } from "grapher/utils/Util"
 import { Bounds } from "grapher/utils/Bounds"
 import {
@@ -15,7 +15,7 @@ import {
     autorun,
     action,
     runInAction,
-    IReactionDisposer
+    IReactionDisposer,
 } from "mobx"
 import { observer } from "mobx-react"
 import { faPlay } from "@fortawesome/free-solid-svg-icons/faPlay"
@@ -29,7 +29,7 @@ import {
     Time,
     isUnboundedLeft,
     isUnboundedRight,
-    getBoundFromTimeRange
+    getBoundFromTimeRange,
 } from "grapher/utils/TimeBounds"
 import Tippy from "@tippyjs/react"
 import classNames from "classnames"
@@ -47,7 +47,7 @@ export interface TimelineProps {
     endYear: TimeBound
     onTargetChange: ({
         targetStartYear,
-        targetEndYear
+        targetEndYear,
     }: {
         targetStartYear: TimeBound
         targetEndYear: TimeBound
@@ -341,7 +341,7 @@ export class Timeline extends React.Component<TimelineProps> {
         if (this.dragTarget === "both") {
             this.dragOffsets = [
                 this.startYearUI - inputYear,
-                this.endYearUI - inputYear
+                this.endYearUI - inputYear,
             ]
         }
 
@@ -382,7 +382,7 @@ export class Timeline extends React.Component<TimelineProps> {
         if (this.startYearRaw > this.endYearRaw) {
             ;[this.startYearRaw, this.endYearRaw] = [
                 this.startYear,
-                this.endYear
+                this.endYear,
             ]
         }
 
@@ -393,7 +393,7 @@ export class Timeline extends React.Component<TimelineProps> {
         ) {
             ;[this.startYearRaw, this.endYearRaw] = [
                 this.startYearClosest,
-                this.endYearClosest
+                this.endYearClosest,
             ]
         }
     }
@@ -428,7 +428,7 @@ export class Timeline extends React.Component<TimelineProps> {
         if (this.props.onTargetChange) {
             this.props.onTargetChange({
                 targetStartYear: this.startYearClosest,
-                targetEndYear: this.endYearClosest
+                targetEndYear: this.endYearClosest,
             })
         }
     }
@@ -456,10 +456,10 @@ export class Timeline extends React.Component<TimelineProps> {
         document.documentElement.addEventListener("touchend", this.onMouseUp)
         document.documentElement.addEventListener("touchmove", this.onMouseMove)
         this.slider?.addEventListener("touchstart", this.onMouseDown, {
-            passive: false
+            passive: false,
         })
         this.playButton?.addEventListener("touchend", this.onPlayTouchEnd, {
-            passive: false
+            passive: false,
         })
 
         this.disposers = [
@@ -478,7 +478,7 @@ export class Timeline extends React.Component<TimelineProps> {
                     this.grapher.url.debounceMode = false
                     if (onStopDrag) onStopDrag()
                 }
-            })
+            }),
         ]
     }
 
@@ -498,12 +498,12 @@ export class Timeline extends React.Component<TimelineProps> {
             this.onMouseMove
         )
         this.slider?.removeEventListener("touchstart", this.onMouseDown, {
-            passive: false
+            passive: false,
         } as EventListenerOptions)
         this.playButton?.removeEventListener("touchend", this.onPlayTouchEnd, {
-            passive: false
+            passive: false,
         } as EventListenerOptions)
-        this.disposers.forEach(dispose => dispose())
+        this.disposers.forEach((dispose) => dispose())
     }
 
     @action.bound onTogglePlay() {
@@ -558,7 +558,7 @@ export class Timeline extends React.Component<TimelineProps> {
             startYearUI,
             endYearUI,
             startYearClosestUI,
-            endYearClosestUI
+            endYearClosestUI,
         } = this
 
         const startYearProgress = (startYearUI - minYear) / (maxYear - minYear)
@@ -573,7 +573,7 @@ export class Timeline extends React.Component<TimelineProps> {
             >
                 {!this.props.disablePlay && (
                     <div
-                        onMouseDown={e => e.stopPropagation()}
+                        onMouseDown={(e) => e.stopPropagation()}
                         onClick={this.onTogglePlay}
                         className="play"
                     >
@@ -602,7 +602,7 @@ export class Timeline extends React.Component<TimelineProps> {
                         className="interval"
                         style={{
                             left: `${startYearProgress * 100}%`,
-                            right: `${100 - endYearProgress * 100}%`
+                            right: `${100 - endYearProgress * 100}%`,
                         }}
                     />
                     <TimelineHandle
@@ -626,7 +626,7 @@ const TimelineHandle = ({
     offsetPercent,
     tooltipContent,
     tooltipVisible,
-    tooltipZIndex
+    tooltipZIndex,
 }: {
     type: "startMarker" | "endMarker"
     offsetPercent: number
@@ -638,7 +638,7 @@ const TimelineHandle = ({
         <div
             className={classNames("handle", type)}
             style={{
-                left: `${offsetPercent}%`
+                left: `${offsetPercent}%`,
             }}
         >
             <Tippy

--- a/grapher/controls/VerticalScrollContainer.tsx
+++ b/grapher/controls/VerticalScrollContainer.tsx
@@ -19,7 +19,7 @@ function useCombinedRefs<T>(...refs: ReactRef<T>[]): React.RefObject<T> {
     const targetRef = React.useRef<T>(null)
 
     React.useEffect(() => {
-        refs.forEach(ref => {
+        refs.forEach((ref) => {
             if (!ref) return
             if (typeof ref === "function") {
                 ref(targetRef.current || null)
@@ -62,7 +62,7 @@ export const VerticalScrollContainer = React.forwardRef(
                 className="VerticalScrollContainerShadows"
                 style={{
                     position: "relative",
-                    height: "100%"
+                    height: "100%",
                 }}
             >
                 {scrollingShadows && (
@@ -81,7 +81,7 @@ export const VerticalScrollContainer = React.forwardRef(
                         right: 0,
                         bottom: 0,
                         left: 0,
-                        ...style
+                        ...style,
                     }}
                     ref={scrollContainerRef}
                     {...rest}
@@ -136,7 +136,7 @@ const ScrollingShadow = (props: {
                 background: background,
                 opacity: props.opacity,
                 pointerEvents: "none",
-                zIndex: 10
+                zIndex: 10,
             }}
         />
     )
@@ -204,7 +204,7 @@ function useScrollLock<ElementType extends HTMLElement>(
         const el = ref.current
         const options: ScrollLockOptions = {
             doNotLockIfNoScroll: false,
-            ...opts
+            ...opts,
         }
         if (el) {
             function onWheel(ev: MouseWheelEvent) {
@@ -242,7 +242,7 @@ function useScrollLock<ElementType extends HTMLElement>(
             }
             el.addEventListener("mousewheel", onWheel as any, {
                 // We need to be in non-passive mode to be able to cancel the event
-                passive: false
+                passive: false,
             })
             return () => {
                 if (el) {

--- a/grapher/core/Analytics.ts
+++ b/grapher/core/Analytics.ts
@@ -60,7 +60,7 @@ export class Analytics {
             `${countryPickerName.toUpperCase()}_DATA_EXPLORER_COUNTRY_SELECTOR`,
             {
                 action,
-                note
+                note,
             }
         )
         this.logToGA(
@@ -80,7 +80,7 @@ export class Analytics {
         this.logToAmplitude("OWID_SITE_CLICK", {
             text,
             href,
-            note
+            note,
         })
         this.logToGA("SiteClick", note || "unknown-category", text)
     }
@@ -106,8 +106,8 @@ export class Analytics {
                 context: {
                     pageHref: window.location.href,
                     pagePath: window.location.pathname,
-                    pageTitle: document.title.replace(/ - [^-]+/, "")
-                }
+                    pageTitle: document.title.replace(/ - [^-]+/, ""),
+                },
             },
             props
         )
@@ -135,7 +135,7 @@ export class Analytics {
             eventCategory,
             eventAction,
             eventLabel,
-            eventValue
+            eventValue,
         }
         if (window.ga) {
             // https://developers.google.com/analytics/devguides/collection/analyticsjs/ga-object-methods-reference

--- a/grapher/core/EntityUrlBuilder.test.ts
+++ b/grapher/core/EntityUrlBuilder.test.ts
@@ -7,41 +7,41 @@ describe(EntityUrlBuilder, () => {
         { entities: ["USA", "GB"], queryString: "USA~GB" },
         {
             entities: ["YouTube", "Google+"],
-            queryString: "YouTube~Google%2B"
+            queryString: "YouTube~Google%2B",
         },
         {
             entities: [
                 "Bogebakken (Denmark); 4300 - 3800 BCE",
                 "British Columbia (30 sites); 3500 BCE - 1674 CE",
-                "Brittany; 6000 BCE"
+                "Brittany; 6000 BCE",
             ],
             queryString:
-                "Bogebakken%20(Denmark)%3B%204300%20-%203800%20BCE~British%20Columbia%20(30%20sites)%3B%203500%20BCE%20-%201674%20CE~Brittany%3B%206000%20BCE"
+                "Bogebakken%20(Denmark)%3B%204300%20-%203800%20BCE~British%20Columbia%20(30%20sites)%3B%203500%20BCE%20-%201674%20CE~Brittany%3B%206000%20BCE",
         },
         {
             entities: ["British Columbia (30 sites); 3500 BCE - 1674 CE"],
             queryString:
-                "~British%20Columbia%20(30%20sites)%3B%203500%20BCE%20-%201674%20CE"
+                "~British%20Columbia%20(30%20sites)%3B%203500%20BCE%20-%201674%20CE",
         },
         {
             entities: ["Caribbean small states"],
-            queryString: "~Caribbean%20small%20states"
+            queryString: "~Caribbean%20small%20states",
         },
         {
             entities: ["North America"],
-            queryString: "~North%20America"
+            queryString: "~North%20America",
         },
         {
             entities: [
                 "Men and Women Ages 65+",
-                "Australia & New Zealand + (Total)"
+                "Australia & New Zealand + (Total)",
             ],
             queryString:
-                "Men%20and%20Women%20Ages%2065%2B~Australia%20%26%20New%20Zealand%20%2B%20(Total)"
-        }
+                "Men%20and%20Women%20Ages%2065%2B~Australia%20%26%20New%20Zealand%20%2B%20(Total)",
+        },
     ]
 
-    encodeTests.forEach(testCase => {
+    encodeTests.forEach((testCase) => {
         it(`correctly encodes url strings`, () => {
             expect(
                 EntityUrlBuilder.entitiesToQueryParam(testCase.entities)
@@ -58,13 +58,13 @@ describe(EntityUrlBuilder, () => {
     const legacyLinks = [
         {
             entities: ["North America", "DOM"],
-            queryString: "North%20America+DOM"
+            queryString: "North%20America+DOM",
         },
         { entities: ["USA", "GB"], queryString: "USA+GB" },
-        { entities: ["YouTube", "Google+"], queryString: "YouTube+Google%2B" }
+        { entities: ["YouTube", "Google+"], queryString: "YouTube+Google%2B" },
     ]
 
-    legacyLinks.forEach(testCase => {
+    legacyLinks.forEach((testCase) => {
         it(`correctly decodes legacy url strings`, () => {
             expect(
                 EntityUrlBuilder.queryParamToEntities(testCase.queryString)
@@ -75,11 +75,11 @@ describe(EntityUrlBuilder, () => {
     const facebookLinks = [
         {
             entities: ["Caribbean small states"],
-            queryString: "Caribbean+small+states~"
-        }
+            queryString: "Caribbean+small+states~",
+        },
     ]
 
-    facebookLinks.forEach(testCase => {
+    facebookLinks.forEach((testCase) => {
         it(`correctly decodes Facebook altered links`, () => {
             expect(
                 EntityUrlBuilder.queryParamToEntities(testCase.queryString)

--- a/grapher/core/EntityUrlBuilder.ts
+++ b/grapher/core/EntityUrlBuilder.ts
@@ -35,6 +35,6 @@ export class EntityUrlBuilder {
         // Facebook turns %20 into +. v2 links will never contain a +, so we can safely replace all of them with %20.
         return decodeURIComponent(queryParam.replace(/\+/g, "%20"))
             .split(this.v2Delimiter)
-            .filter(item => item)
+            .filter((item) => item)
     }
 }

--- a/grapher/core/FullStory.ts
+++ b/grapher/core/FullStory.ts
@@ -29,7 +29,7 @@ function getTypedKey(value: any, key: string): string {
         return key
     } else if (Array.isArray(value)) {
         const allTypes = value.map(getType)
-        if (allTypes.some(type => type !== allTypes[0])) {
+        if (allTypes.some((type) => type !== allTypes[0])) {
             throw new Error("All array items must be of same type")
         } else {
             if (allTypes[0]) return `${key}_${allTypes[0]}s`

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -8,7 +8,7 @@ import {
     toJS,
     runInAction,
     reaction,
-    IReactionDisposer
+    IReactionDisposer,
 } from "mobx"
 import { bind } from "decko"
 
@@ -33,27 +33,27 @@ import {
     without,
     xor,
     lastOfNonEmptyArray,
-    find
+    find,
 } from "grapher/utils/Util"
 import {
     ChartType,
     GrapherTabOption,
     Color,
     TickFormattingOptions,
-    EntityDimensionKey
+    EntityDimensionKey,
 } from "grapher/core/GrapherConstants"
 import { OwidVariablesAndEntityKey } from "owidTable/OwidVariable"
 import {
     OwidTable,
     EntityName,
     EntityId,
-    EntityCode
+    EntityCode,
 } from "owidTable/OwidTable"
 import {
     EntityDimensionInfo,
     ChartDimension,
     ChartDimensionSpec,
-    SourceWithDimension
+    SourceWithDimension,
 } from "grapher/chart/ChartDimension"
 import { MapTransform } from "grapher/mapCharts/MapTransform"
 import { GrapherUrl } from "./GrapherUrl"
@@ -72,11 +72,11 @@ import {
     minTimeFromJSON,
     maxTimeFromJSON,
     TimeBounds,
-    TimeBoundValue
+    TimeBoundValue,
 } from "grapher/utils/TimeBounds"
 import {
     GlobalEntitySelection,
-    subscribeGrapherToGlobalEntitySelection
+    subscribeGrapherToGlobalEntitySelection,
 } from "site/globalEntityControl/GlobalEntitySelection"
 import { countries } from "utils/countries"
 import { DataTableTransform } from "grapher/dataTable/DataTableTransform"
@@ -84,7 +84,7 @@ import { getWindowQueryParams } from "utils/client/url"
 import { populationMap } from "owidTable/PopulationMap"
 import {
     GrapherInterface,
-    PersistableGrapher
+    PersistableGrapher,
 } from "grapher/core/GrapherInterface"
 import { DimensionSlot } from "grapher/chart/DimensionSlot"
 import { canBeExplorable } from "explorer/indicatorExplorer/IndicatorUtils"
@@ -158,7 +158,7 @@ export class Grapher extends PersistableGrapher {
     // Checks if the data 1) is about countries and 2) has countries with less than the filter option. Used to partly determine whether to show the filter control.
     @computed get hasCountriesSmallerThanFilterOption() {
         return this.table.availableEntities.some(
-            entityName =>
+            (entityName) =>
                 populationMap[entityName] &&
                 populationMap[entityName] < this.populationFilterOption
         )
@@ -226,9 +226,11 @@ export class Grapher extends PersistableGrapher {
         )
         return new Set<string>(
             countryCodes
-                .map(code => countries.find(country => country.code === code))
-                .filter(i => i)
-                .map(c => c!.name)
+                .map((code) =>
+                    countries.find((country) => country.code === code)
+                )
+                .filter((i) => i)
+                .map((c) => c!.name)
         )
     }
 
@@ -262,7 +264,7 @@ export class Grapher extends PersistableGrapher {
 
     @computed get sortedUniqueEntitiesAcrossDimensions() {
         return sortBy(
-            uniq(flatten(this.filledDimensions.map(d => d.entityNamesUniq)))
+            uniq(flatten(this.filledDimensions.map((d) => d.entityNamesUniq)))
         )
     }
 
@@ -278,8 +280,8 @@ export class Grapher extends PersistableGrapher {
 
     @computed private get loadingVarIds(): number[] {
         return this.dimensions
-            .map(dim => dim.variableId)
-            .filter(id => !this.table.columnsByOwidVarId.has(id))
+            .map((dim) => dim.variableId)
+            .filter((id) => !this.table.columnsByOwidVarId.has(id))
     }
 
     url: GrapherUrl
@@ -293,7 +295,7 @@ export class Grapher extends PersistableGrapher {
     }
 
     @computed.struct private get variableIds() {
-        return uniq(this.dimensions.map(d => d.variableId))
+        return uniq(this.dimensions.map((d) => d.variableId))
     }
 
     @computed get dataFileName(): string {
@@ -330,7 +332,7 @@ export class Grapher extends PersistableGrapher {
         const { relatedQuestions } = this
         return (
             relatedQuestions?.some(
-                question => !!getErrorMessageRelatedQuestionUrl(question)
+                (question) => !!getErrorMessageRelatedQuestionUrl(question)
             ) || false
         )
     }
@@ -338,7 +340,7 @@ export class Grapher extends PersistableGrapher {
     disposers: IReactionDisposer[] = []
 
     @bind dispose() {
-        this.disposers.forEach(dispose => dispose())
+        this.disposers.forEach((dispose) => dispose())
     }
 
     private initFontSizeInAxisContainers() {
@@ -347,7 +349,7 @@ export class Grapher extends PersistableGrapher {
         const axisContainer = {
             get fontSize() {
                 return that.baseFontSize
-            }
+            },
         }
         this.xAxis.container = axisContainer
         this.yAxis.container = axisContainer
@@ -383,7 +385,7 @@ export class Grapher extends PersistableGrapher {
 
         this.disposers.push(
             reaction(() => this.variableIds, this.downloadData, {
-                fireImmediately: true
+                fireImmediately: true,
             })
         )
 
@@ -442,7 +444,7 @@ export class Grapher extends PersistableGrapher {
                 if (this.isExplorable && !canBeExplorable(this)) {
                     this.isExplorable = false
                 }
-            })
+            }),
         ]
         this.disposers.push(...disposers)
     }
@@ -469,7 +471,7 @@ export class Grapher extends PersistableGrapher {
         if (!this.userHasSetTimeline)
             this.timeDomain = [
                 this.initialScript.minTime ?? TimeBoundValue.unboundedLeft,
-                this.timeDomain[1]
+                this.timeDomain[1],
             ]
 
         /** Revert the state of minPopulationFilter */
@@ -503,7 +505,7 @@ export class Grapher extends PersistableGrapher {
         return [
             // Handle `undefined` values in minTime/maxTime
             minTimeFromJSON(this.minTime),
-            maxTimeFromJSON(this.maxTime)
+            maxTimeFromJSON(this.maxTime),
         ]
     }
 
@@ -528,11 +530,11 @@ export class Grapher extends PersistableGrapher {
     @computed get validDimensions(): ChartDimensionSpec[] {
         const { dimensions } = this
         const validProperties = map(this.dimensionSlots, "property")
-        let validDimensions = filter(dimensions, dim =>
+        let validDimensions = filter(dimensions, (dim) =>
             includes(validProperties, dim.property)
         )
 
-        this.dimensionSlots.forEach(slot => {
+        this.dimensionSlots.forEach((slot) => {
             if (!slot.allowMultiple)
                 validDimensions = uniqWith(
                     validDimensions,
@@ -564,7 +566,7 @@ export class Grapher extends PersistableGrapher {
     }
 
     @computed get primaryDimensions() {
-        return this.filledDimensions.filter(dim => dim.property === "y")
+        return this.filledDimensions.filter((dim) => dim.property === "y")
     }
 
     @computed get displaySlug(): string {
@@ -577,7 +579,7 @@ export class Grapher extends PersistableGrapher {
             this.hasMapTab && "map",
             "table",
             "sources",
-            "download"
+            "download",
         ]) as GrapherTabOption[]
     }
 
@@ -711,7 +713,7 @@ export class Grapher extends PersistableGrapher {
         const { filledDimensions } = this
 
         const sources: SourceWithDimension[] = []
-        each(filledDimensions, dim => {
+        each(filledDimensions, (dim) => {
             const { column } = dim
             // HACK (Mispy): Ignore the default color source on scatterplots.
             if (
@@ -725,15 +727,15 @@ export class Grapher extends PersistableGrapher {
 
     @computed private get defaultSourcesLine(): string {
         let sourceNames = this.sourcesWithDimension.map(
-            source => source.source?.name || ""
+            (source) => source.source?.name || ""
         )
 
         // Shorten automatic source names for certain major sources
-        sourceNames = sourceNames.map(sourceName => {
+        sourceNames = sourceNames.map((sourceName) => {
             for (const majorSource of [
                 "World Bank – WDI",
                 "World Bank",
-                "ILOSTAT"
+                "ILOSTAT",
             ]) {
                 if (sourceName.startsWith(majorSource)) return majorSource
             }
@@ -745,22 +747,23 @@ export class Grapher extends PersistableGrapher {
 
     @computed get axisDimensions() {
         return this.filledDimensions.filter(
-            dim => dim.property === "y" || dim.property === "x"
+            (dim) => dim.property === "y" || dim.property === "x"
         )
     }
 
     @computed private get defaultTitle(): string {
         const { primaryDimensions } = this
         if (this.isScatter)
-            return this.axisDimensions.map(d => d.displayName).join(" vs. ")
+            return this.axisDimensions.map((d) => d.displayName).join(" vs. ")
         else if (
             primaryDimensions.length > 1 &&
-            uniq(map(primaryDimensions, d => d.column.datasetName)).length === 1
+            uniq(map(primaryDimensions, (d) => d.column.datasetName)).length ===
+                1
         )
             return primaryDimensions[0].column.datasetName!
         else if (primaryDimensions.length === 2)
-            return primaryDimensions.map(d => d.displayName).join(" and ")
-        else return primaryDimensions.map(d => d.displayName).join(", ")
+            return primaryDimensions.map((d) => d.displayName).join(" and ")
+        else return primaryDimensions.map((d) => d.displayName).join(", ")
     }
 
     @computed get displayTitle(): string {
@@ -851,7 +854,7 @@ export class Grapher extends PersistableGrapher {
     }
 
     @computed get selectableEntityDimensionKeys() {
-        return this.activeTransform.selectableEntityDimensionKeys.map(key =>
+        return this.activeTransform.selectableEntityDimensionKeys.map((key) =>
             this.lookupKey(key)
         )
     }
@@ -915,7 +918,7 @@ export class Grapher extends PersistableGrapher {
     }> {
         const primaryDimensions = this.primaryDimensions
         const entityIdToNameMap = this.table.entityIdToNameMap
-        let validSelections = this.selectedData.filter(sel => {
+        let validSelections = this.selectedData.filter((sel) => {
             // Must be a dimension that's on the chart
             const dimension = primaryDimensions[sel.index]
             if (!dimension) return false
@@ -940,13 +943,13 @@ export class Grapher extends PersistableGrapher {
             (a: any, b: any) => a.entityId === b.entityId && a.index === b.index
         )
 
-        return map(validSelections, sel => {
+        return map(validSelections, (sel) => {
             return {
                 entityDimensionKey: this.makeEntityDimensionKey(
                     entityIdToNameMap.get(sel.entityId)!,
                     sel.index
                 ),
-                color: sel.color
+                color: sel.color,
             }
         })
     }
@@ -963,7 +966,7 @@ export class Grapher extends PersistableGrapher {
         const keyColors: {
             [entityDimensionKey: string]: Color | undefined
         } = {}
-        this.selectionData.forEach(d => {
+        this.selectionData.forEach((d) => {
             if (d.color) keyColors[d.entityDimensionKey] = d.color
         })
         return keyColors
@@ -973,7 +976,7 @@ export class Grapher extends PersistableGrapher {
     setKeyColor(key: EntityDimensionKey, color: Color | undefined) {
         const meta = this.lookupKey(key)
         const selectedData = cloneDeep(this.selectedData)
-        selectedData.forEach(d => {
+        selectedData.forEach((d) => {
             if (d.entityId === meta.entityId && d.index === meta.index) {
                 d.color = color
             }
@@ -984,17 +987,17 @@ export class Grapher extends PersistableGrapher {
     // todo: remove
     @computed get selectedEntityNames(): EntityName[] {
         return uniq(
-            this.selectedKeys.map(key => this.lookupKey(key).entityName)
+            this.selectedKeys.map((key) => this.lookupKey(key).entityName)
         )
     }
 
     // todo: remove
     @computed get availableEntityNames(): EntityName[] {
-        const entitiesForDimensions = this.axisDimensions.map(dim => {
+        const entitiesForDimensions = this.axisDimensions.map((dim) => {
             return this.availableKeys
-                .map(key => this.lookupKey(key))
-                .filter(d => d.dimension.variableId === dim.variableId)
-                .map(d => d.entityName)
+                .map((key) => this.lookupKey(key))
+                .filter((d) => d.dimension.variableId === dim.variableId)
+                .map((d) => d.entityName)
         })
 
         return union(...entitiesForDimensions)
@@ -1003,16 +1006,16 @@ export class Grapher extends PersistableGrapher {
     // todo: remove
     @action.bound setSingleSelectedEntity(entityId: EntityId) {
         const selectedData = cloneDeep(this.selectedData)
-        selectedData.forEach(d => (d.entityId = entityId))
+        selectedData.forEach((d) => (d.entityId = entityId))
         this.selectedData = selectedData
     }
 
     // todo: remove
     @action.bound setSelectedEntitiesByCode(entityCodes: EntityCode[]) {
         const matchedEntities = new Map<string, boolean>()
-        entityCodes.forEach(code => matchedEntities.set(code, false))
+        entityCodes.forEach((code) => matchedEntities.set(code, false))
         if (this.canChangeEntity) {
-            this.availableEntityNames.forEach(entityName => {
+            this.availableEntityNames.forEach((entityName) => {
                 const entityId = this.table.entityNameToIdMap.get(entityName)!
                 const entityCode = this.table.entityNameToCodeMap.get(
                     entityName
@@ -1026,19 +1029,19 @@ export class Grapher extends PersistableGrapher {
                 }
             })
         } else {
-            this.selectedKeys = this.availableKeys.filter(key => {
+            this.selectedKeys = this.availableKeys.filter((key) => {
                 const meta = this.lookupKey(key)
                 const entityName = meta.entityName
                 const entityCode = this.table.entityNameToCodeMap.get(
                     entityName
                 )
                 return [meta.shortCode, entityCode, entityName]
-                    .map(key => {
+                    .map((key) => {
                         if (!matchedEntities.has(key!)) return false
                         matchedEntities.set(key!, true)
                         return true
                     })
-                    .some(item => item)
+                    .some((item) => item)
             })
         }
         return matchedEntities
@@ -1051,19 +1054,19 @@ export class Grapher extends PersistableGrapher {
 
     // todo: remove
     @computed get selectedEntityCodes(): EntityCode[] {
-        return uniq(this.selectedKeys.map(k => this.lookupKey(k).shortCode))
+        return uniq(this.selectedKeys.map((k) => this.lookupKey(k).shortCode))
     }
 
     // todo: remove
     deselect(entityDimensionKey: EntityDimensionKey) {
         this.selectedKeys = this.selectedKeys.filter(
-            e => e !== entityDimensionKey
+            (e) => e !== entityDimensionKey
         )
     }
 
     // todo: remove
     @computed get selectedKeys(): EntityDimensionKey[] {
-        return this.selectionData.map(d => d.entityDimensionKey)
+        return this.selectionData.map((d) => d.entityDimensionKey)
     }
 
     // remove
@@ -1071,12 +1074,12 @@ export class Grapher extends PersistableGrapher {
     set selectedKeys(keys: EntityDimensionKey[]) {
         if (!this.isReady) return
 
-        const selection = map(keys, key => {
+        const selection = map(keys, (key) => {
             const { entityName: entity, index } = this.lookupKey(key)
             return {
                 entityId: this.table.entityNameToIdMap.get(entity)!,
                 index: index,
-                color: this.keyColors[key]
+                color: this.keyColors[key],
             }
         })
         this.selectedData = selection
@@ -1111,7 +1114,7 @@ export class Grapher extends PersistableGrapher {
 
         const keyData = new Map<EntityDimensionKey, EntityDimensionInfo>()
         primaryDimensions.forEach((dimension, dimensionIndex) => {
-            dimension.entityNamesUniq.forEach(entityName => {
+            dimension.entityNamesUniq.forEach((entityName) => {
                 const entityCode = this.table.entityNameToCodeMap.get(
                     entityName
                 )
@@ -1144,7 +1147,7 @@ export class Grapher extends PersistableGrapher {
                         primaryDimensions.length > 1 &&
                         this.addCountryMode !== "change-country"
                             ? `${entityCode || entityName}-${dimension.index}`
-                            : entityCode || entityName
+                            : entityCode || entityName,
                 })
             })
         })
@@ -1206,7 +1209,7 @@ export class Grapher extends PersistableGrapher {
     // todo: remove
     toggleKey(key: EntityDimensionKey) {
         if (includes(this.selectedKeys, key)) {
-            this.selectedKeys = this.selectedKeys.filter(k => k !== key)
+            this.selectedKeys = this.selectedKeys.filter((k) => k !== key)
         } else {
             this.selectedKeys = this.selectedKeys.concat([key])
         }

--- a/grapher/core/GrapherConstants.ts
+++ b/grapher/core/GrapherConstants.ts
@@ -40,7 +40,7 @@ export type Color = string
 
 export enum ScaleType {
     linear = "linear",
-    log = "log"
+    log = "log",
 }
 
 export interface ScaleTypeConfig {
@@ -66,7 +66,7 @@ export declare type ScatterPointLabelStrategy = "year" | "x" | "y"
 
 export enum SortOrder {
     asc = "asc",
-    desc = "desc"
+    desc = "desc",
 }
 
 export interface TickFormattingOptions {
@@ -83,33 +83,33 @@ export interface TickFormattingOptions {
 export const ChartTypeDefs = [
     {
         key: ChartType.LineChart,
-        label: "Line Chart"
+        label: "Line Chart",
     },
     {
         key: ChartType.ScatterPlot,
-        label: "Scatter Plot"
+        label: "Scatter Plot",
     },
     {
         key: ChartType.TimeScatter,
-        label: "Time Scatter"
+        label: "Time Scatter",
     },
     {
         key: ChartType.StackedArea,
-        label: "Stacked Area"
+        label: "Stacked Area",
     },
     {
         key: ChartType.DiscreteBar,
-        label: "Discrete Bar"
+        label: "Discrete Bar",
     },
     {
         key: ChartType.SlopeChart,
-        label: "Slope Chart"
+        label: "Slope Chart",
     },
     {
         key: ChartType.StackedBar,
-        label: "Stacked Bar"
-    }
+        label: "Stacked Bar",
+    },
 ]
 
 // TODO make this a string enum in TypeScript 2.4
-export const ChartTypeDefsByKey = keyBy(ChartTypeDefs, e => e.key)
+export const ChartTypeDefsByKey = keyBy(ChartTypeDefs, (e) => e.key)

--- a/grapher/core/GrapherInterface.ts
+++ b/grapher/core/GrapherInterface.ts
@@ -6,11 +6,11 @@ import {
     HighlightToggleConfig,
     Color,
     RelatedQuestionsConfig,
-    AddCountryMode
+    AddCountryMode,
 } from "./GrapherConstants"
 import {
     AxisOptionsInterface,
-    PersistableAxisOptions
+    PersistableAxisOptions,
 } from "grapher/axis/AxisOptions"
 import { OwidVariablesAndEntityKey } from "owidTable/OwidVariable"
 import {
@@ -19,24 +19,24 @@ import {
     minTimeToJSON,
     maxTimeToJSON,
     minTimeFromJSON,
-    maxTimeFromJSON
+    maxTimeFromJSON,
 } from "grapher/utils/TimeBounds"
 import {
     ChartDimensionSpec,
-    ChartDimensionInterface
+    ChartDimensionInterface,
 } from "grapher/chart/ChartDimension"
 import { ComparisonLineConfig } from "grapher/scatterCharts/ComparisonLine"
 import { LogoOption } from "grapher/chart/Logos"
 import {
     ColorScaleConfig,
-    PersistableColorScaleConfig
+    PersistableColorScaleConfig,
 } from "grapher/color/ColorScaleConfig"
 import { MapConfig, PersistableMapConfig } from "grapher/mapCharts/MapConfig"
 import { observable, action } from "mobx"
 import {
     Persistable,
     objectWithPersistablesToObject,
-    updatePersistables
+    updatePersistables,
 } from "./Persistable"
 
 interface EntitySelection {
@@ -199,7 +199,7 @@ export class PersistableGrapher implements GrapherInterface, Persistable {
             new PersistableGrapher()
         )
         const defaultKeys = new Set(Object.keys(defaultObj))
-        Object.keys(obj).forEach(prop => {
+        Object.keys(obj).forEach((prop) => {
             const key = prop as GrapherProperty
             if (!defaultKeys.has(key)) {
                 // Don't persist any runtime props not in the persistable instance

--- a/grapher/core/GrapherUrl.jsdom.test.ts
+++ b/grapher/core/GrapherUrl.jsdom.test.ts
@@ -20,7 +20,7 @@ function toQueryParams(props?: Partial<GrapherInterface>) {
     const grapher = createGrapher({
         minTime: -5000,
         maxTime: 5000,
-        map: { targetYear: 5000 }
+        map: { targetYear: 5000 },
     })
     if (props) grapher.updateFromObject(props)
     return grapher.url.params
@@ -31,7 +31,7 @@ describe(GrapherUrl, () => {
         expect(new Grapher().url.params.xScale).toEqual(undefined)
         expect(
             new Grapher({
-                xAxis: { scaleType: ScaleType.linear }
+                xAxis: { scaleType: ScaleType.linear },
             } as GrapherInterface).url.params.xScale
         ).toEqual(undefined)
     })
@@ -46,7 +46,10 @@ describe(GrapherUrl, () => {
     describe("if a user sets a query param but dropUnchangedParams is false, do not delete the param even if it is a default", () => {
         const grapher = new Grapher(
             {
-                xAxis: { scaleType: ScaleType.linear, canChangeScaleType: true }
+                xAxis: {
+                    scaleType: ScaleType.linear,
+                    canChangeScaleType: true,
+                },
             },
             { queryStr: "scaleType=linear" }
         )
@@ -67,7 +70,7 @@ describe(GrapherUrl, () => {
                 {
                     name: "single year negative",
                     query: "-1500",
-                    param: [-1500, -1500]
+                    param: [-1500, -1500],
                 },
                 { name: "single year zero", query: "0", param: [0, 0] },
                 {
@@ -75,40 +78,40 @@ describe(GrapherUrl, () => {
                     query: "latest",
                     param: [
                         TimeBoundValue.unboundedRight,
-                        TimeBoundValue.unboundedRight
-                    ]
+                        TimeBoundValue.unboundedRight,
+                    ],
                 },
                 {
                     name: "single year earliest",
                     query: "earliest",
                     param: [
                         TimeBoundValue.unboundedLeft,
-                        TimeBoundValue.unboundedLeft
-                    ]
+                        TimeBoundValue.unboundedLeft,
+                    ],
                 },
                 { name: "two years", query: "2000..2005", param: [2000, 2005] },
                 {
                     name: "negative years",
                     query: "-500..-1",
-                    param: [-500, -1]
+                    param: [-500, -1],
                 },
                 {
                     name: "right unbounded",
                     query: "2000..latest",
-                    param: [2000, TimeBoundValue.unboundedRight]
+                    param: [2000, TimeBoundValue.unboundedRight],
                 },
                 {
                     name: "left unbounded",
                     query: "earliest..2005",
-                    param: [TimeBoundValue.unboundedLeft, 2005]
+                    param: [TimeBoundValue.unboundedLeft, 2005],
                 },
                 {
                     name: "left unbounded",
                     query: "earliest..latest",
                     param: [
                         TimeBoundValue.unboundedLeft,
-                        TimeBoundValue.unboundedRight
-                    ]
+                        TimeBoundValue.unboundedRight,
+                    ],
                 },
 
                 // The queries below can be considered legacy and are no longer generated this way,
@@ -117,23 +120,23 @@ describe(GrapherUrl, () => {
                     name: "right unbounded [legacy]",
                     query: "2000..",
                     param: [2000, TimeBoundValue.unboundedRight],
-                    irreversible: true
+                    irreversible: true,
                 },
                 {
                     name: "left unbounded [legacy]",
                     query: "..2005",
                     param: [TimeBoundValue.unboundedLeft, 2005],
-                    irreversible: true
+                    irreversible: true,
                 },
                 {
                     name: "both unbounded [legacy]",
                     query: "..",
                     param: [
                         TimeBoundValue.unboundedLeft,
-                        TimeBoundValue.unboundedRight
+                        TimeBoundValue.unboundedRight,
                     ],
-                    irreversible: true
-                }
+                    irreversible: true,
+                },
             ]
 
             for (const test of tests) {
@@ -147,7 +150,7 @@ describe(GrapherUrl, () => {
                     it(`encode ${test.name}`, () => {
                         const params = toQueryParams({
                             minTime: test.param[0],
-                            maxTime: test.param[1]
+                            maxTime: test.param[1],
                         })
                         expect(params.time).toEqual(test.query)
                     })
@@ -167,7 +170,7 @@ describe(GrapherUrl, () => {
             it("doesn't include URL param if it's identical to original config", () => {
                 const chart = createGrapher({
                     minTime: 0,
-                    maxTime: 75
+                    maxTime: 75,
                 })
                 expect(chart.url.params.time).toEqual(undefined)
             })
@@ -175,7 +178,7 @@ describe(GrapherUrl, () => {
             it("doesn't include URL param if unbounded is encoded as `undefined`", () => {
                 const chart = createGrapher({
                     minTime: undefined,
-                    maxTime: 75
+                    maxTime: 75,
                 })
                 expect(chart.url.params.time).toEqual(undefined)
             })
@@ -191,56 +194,56 @@ describe(GrapherUrl, () => {
                 {
                     name: "single day (date)",
                     query: "2020-01-22",
-                    param: [1, 1]
+                    param: [1, 1],
                 },
                 {
                     name: "single day negative (date)",
                     query: "2020-01-01",
-                    param: [-20, -20]
+                    param: [-20, -20],
                 },
                 {
                     name: "single day zero (date)",
                     query: "2020-01-21",
-                    param: [0, 0]
+                    param: [0, 0],
                 },
                 {
                     name: "single day latest",
                     query: "latest",
                     param: [
                         TimeBoundValue.unboundedRight,
-                        TimeBoundValue.unboundedRight
-                    ]
+                        TimeBoundValue.unboundedRight,
+                    ],
                 },
                 {
                     name: "single day earliest",
                     query: "earliest",
                     param: [
                         TimeBoundValue.unboundedLeft,
-                        TimeBoundValue.unboundedLeft
-                    ]
+                        TimeBoundValue.unboundedLeft,
+                    ],
                 },
                 {
                     name: "two days",
                     query: "2020-01-01..2020-02-01",
-                    param: [-20, 11]
+                    param: [-20, 11],
                 },
                 {
                     name: "left unbounded (date)",
                     query: "earliest..2020-02-01",
-                    param: [TimeBoundValue.unboundedLeft, 11]
+                    param: [TimeBoundValue.unboundedLeft, 11],
                 },
                 {
                     name: "right unbounded (date)",
                     query: "2020-01-01..latest",
-                    param: [-20, TimeBoundValue.unboundedRight]
+                    param: [-20, TimeBoundValue.unboundedRight],
                 },
                 {
                     name: "both unbounded (date)",
                     query: "earliest..latest",
                     param: [
                         TimeBoundValue.unboundedLeft,
-                        TimeBoundValue.unboundedRight
-                    ]
+                        TimeBoundValue.unboundedRight,
+                    ],
                 },
 
                 // The queries below can be considered legacy and are no longer generated this way,
@@ -249,42 +252,42 @@ describe(GrapherUrl, () => {
                     name: "right unbounded (date) [legacy]",
                     query: "2020-01-01..",
                     param: [-20, TimeBoundValue.unboundedRight],
-                    irreversible: true
+                    irreversible: true,
                 },
                 {
                     name: "left unbounded (date) [legacy]",
                     query: "..2020-01-01",
                     param: [TimeBoundValue.unboundedLeft, -20],
-                    irreversible: true
+                    irreversible: true,
                 },
                 {
                     name: "both unbounded [legacy]",
                     query: "..",
                     param: [
                         TimeBoundValue.unboundedLeft,
-                        TimeBoundValue.unboundedRight
+                        TimeBoundValue.unboundedRight,
                     ],
-                    irreversible: true
+                    irreversible: true,
                 },
 
                 {
                     name: "single day (number)",
                     query: "5",
                     param: [5, 5],
-                    irreversible: true
+                    irreversible: true,
                 },
                 {
                     name: "range (number)",
                     query: "-5..5",
                     param: [-5, 5],
-                    irreversible: true
+                    irreversible: true,
                 },
                 {
                     name: "unbounded range (number)",
                     query: "-500..",
                     param: [-500, TimeBoundValue.unboundedRight],
-                    irreversible: true
-                }
+                    irreversible: true,
+                },
             ]
 
             for (const test of tests) {
@@ -300,7 +303,7 @@ describe(GrapherUrl, () => {
                         const grapher = setupGrapher(4066, [142708])
                         grapher.updateFromObject({
                             minTime: test.param[0],
-                            maxTime: test.param[1]
+                            maxTime: test.param[1],
                         })
                         const params = grapher.url.params
                         expect(params.time).toEqual(test.query)
@@ -321,19 +324,19 @@ describe(GrapherUrl, () => {
                 {
                     name: "single year negative",
                     query: "-1500",
-                    param: -1500
+                    param: -1500,
                 },
                 { name: "single year zero", query: "0", param: 0 },
                 {
                     name: "single year latest",
                     query: "latest",
-                    param: TimeBoundValue.unboundedRight
+                    param: TimeBoundValue.unboundedRight,
                 },
                 {
                     name: "single year earliest",
                     query: "earliest",
-                    param: TimeBoundValue.unboundedLeft
-                }
+                    param: TimeBoundValue.unboundedLeft,
+                },
             ]
 
             for (const test of tests) {
@@ -345,7 +348,7 @@ describe(GrapherUrl, () => {
                 })
                 it(`encode ${test.name}`, () => {
                     const params = toQueryParams({
-                        map: { targetYear: test.param }
+                        map: { targetYear: test.param },
                     })
                     expect(params.year).toEqual(test.query)
                 })
@@ -371,25 +374,25 @@ describe(GrapherUrl, () => {
                 {
                     name: "single day negative",
                     query: "2020-01-01",
-                    param: -20
+                    param: -20,
                 },
                 { name: "single day zero", query: "2020-01-21", param: 0 },
                 {
                     name: "single day latest",
                     query: "latest",
-                    param: TimeBoundValue.unboundedRight
+                    param: TimeBoundValue.unboundedRight,
                 },
                 {
                     name: "single day earliest",
                     query: "earliest",
-                    param: TimeBoundValue.unboundedLeft
+                    param: TimeBoundValue.unboundedLeft,
                 },
                 {
                     name: "single day (number)",
                     query: "0",
                     param: 0,
-                    irreversible: true
-                }
+                    irreversible: true,
+                },
             ]
 
             for (const test of tests) {
@@ -404,7 +407,7 @@ describe(GrapherUrl, () => {
                     it(`encode ${test.name}`, () => {
                         const grapher = setupGrapher(4066, [142708])
                         grapher.updateFromObject({
-                            map: { targetYear: test.param }
+                            map: { targetYear: test.param },
                         })
                         const params = grapher.url.params
                         expect(params.year).toEqual(test.query)

--- a/grapher/core/GrapherUrl.ts
+++ b/grapher/core/GrapherUrl.ts
@@ -10,7 +10,7 @@ import { computed, when, runInAction, observable, action } from "mobx"
 import {
     GrapherTabOption,
     ScaleType,
-    StackMode
+    StackMode,
 } from "grapher/core/GrapherConstants"
 
 import { includes, defaultTo } from "grapher/utils/Util"
@@ -21,7 +21,7 @@ import { Grapher } from "grapher/core/Grapher"
 import {
     queryParamsToStr,
     strToQueryParams,
-    QueryParams
+    QueryParams,
 } from "utils/client/url"
 import { MapProjection } from "grapher/mapCharts/MapProjections"
 import { ObservableUrl } from "grapher/utils/UrlBinder"
@@ -29,7 +29,7 @@ import {
     TimeBoundValue,
     formatTimeURIComponent,
     getTimeDomainFromQueryString,
-    parseTimeURIComponent
+    parseTimeURIComponent,
 } from "grapher/utils/TimeBounds"
 import { EntityUrlBuilder } from "./EntityUrlBuilder"
 
@@ -140,7 +140,7 @@ export class GrapherUrl implements ObservableUrl {
         const externalParams = this.externallyProvidedParams || {}
         const queryParams = {
             ...this.params,
-            ...externalParams
+            ...externalParams,
         }
         return queryParamsToStr(queryParams)
     }
@@ -315,7 +315,7 @@ export class GrapherUrl implements ObservableUrl {
                     )
                     const notFoundEntities = Array.from(
                         matchedEntities.keys()
-                    ).filter(key => !matchedEntities.get(key))
+                    ).filter((key) => !matchedEntities.get(key))
 
                     if (notFoundEntities.length)
                         grapher.analytics.logEntitiesNotFoundError(
@@ -345,7 +345,7 @@ export class ExtendedGrapherUrl implements ObservableUrl {
 
     @computed get params(): QueryParams {
         let obj = Object.assign({}, this.grapherUrl.params)
-        this.objectsWithParams.forEach(p => {
+        this.objectsWithParams.forEach((p) => {
             obj = Object.assign(obj, p.toQueryParams)
         })
         return obj

--- a/grapher/core/GrapherView.stories.tsx
+++ b/grapher/core/GrapherView.stories.tsx
@@ -46,13 +46,13 @@ const variableSet = {
                     "https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/LKYT53  and https://esa.un.org/unpd/wpp/Download/Standard/Population/",
                 retrievedData: "",
                 additionalInfo:
-                    "For historical data up until 1949, Clio-Infra's dataset compiled by Zijdeman and Ribeira da Silva (2015) was used. Further information can be found using this link: https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/LKYT53. \nData from 1950 onward uses the UN Population Division data, further information can be found at https://esa.un.org/unpd/wpp/Download/Standard/Population/"
-            }
-        }
+                    "For historical data up until 1949, Clio-Infra's dataset compiled by Zijdeman and Ribeira da Silva (2015) was used. Further information can be found using this link: https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/LKYT53. \nData from 1950 onward uses the UN Population Division data, further information can be found at https://esa.un.org/unpd/wpp/Download/Standard/Population/",
+            },
+        },
     },
     entityKey: {
-        "1": { name: "United Kingdom", code: "GBR" }
-    }
+        "1": { name: "United Kingdom", code: "GBR" },
+    },
 }
 
 // Wrapper for GrapherView that uses css on figure element to determine the bounds
@@ -80,7 +80,7 @@ class GrapherViewStory extends React.Component {
         const chart = new Grapher(
             {
                 hasMapTab: true,
-                dimensions: [{ property: "y", variableId: 66287, display: {} }]
+                dimensions: [{ property: "y", variableId: 66287, display: {} }],
             } as GrapherInterface,
             {}
         )
@@ -102,7 +102,7 @@ class GrapherViewStory extends React.Component {
 
 export default {
     title: "GrapherView",
-    component: GrapherView
+    component: GrapherView,
 }
 
 export const Default = () => <GrapherViewStory />

--- a/grapher/core/GrapherView.tsx
+++ b/grapher/core/GrapherView.tsx
@@ -19,7 +19,7 @@ import { Bounds } from "grapher/utils/Bounds"
 import { EntitySelectorModal } from "grapher/controls/EntitySelectorModal"
 import {
     GrapherViewContext,
-    GrapherViewContextInterface
+    GrapherViewContextInterface,
 } from "grapher/core/GrapherViewContext"
 import { TooltipView } from "grapher/chart/Tooltip"
 import { FullStory } from "grapher/core/FullStory"
@@ -55,7 +55,7 @@ export class GrapherView extends React.Component<GrapherViewProps> {
         isEditor,
         isEmbed,
         queryStr,
-        globalEntitySelection
+        globalEntitySelection,
     }: {
         jsonConfig: GrapherInterface
         containerNode: HTMLElement
@@ -68,7 +68,7 @@ export class GrapherView extends React.Component<GrapherViewProps> {
         const grapher = new Grapher(jsonConfig, {
             isEmbed: isEmbed,
             queryStr: queryStr,
-            globalEntitySelection: globalEntitySelection
+            globalEntitySelection: globalEntitySelection,
         })
 
         function render() {
@@ -105,7 +105,7 @@ export class GrapherView extends React.Component<GrapherViewProps> {
             hasChartTab_bool: grapher.hasChartTab,
             hasMapTab_bool: grapher.hasMapTab,
             tab_str: grapher.currentTab,
-            totalSelectedEntities_int: grapher.selectedData.length
+            totalSelectedEntities_int: grapher.selectedData.length,
         })
 
         return view
@@ -160,7 +160,7 @@ export class GrapherView extends React.Component<GrapherViewProps> {
             isExport,
             containerBounds,
             authorWidth,
-            authorHeight
+            authorHeight,
         } = this
 
         if (isEditor) return false
@@ -220,7 +220,7 @@ export class GrapherView extends React.Component<GrapherViewProps> {
             },
             get width() {
                 return that.renderWidth
-            }
+            },
         })
     }
 
@@ -247,10 +247,10 @@ export class GrapherView extends React.Component<GrapherViewProps> {
             this.isEmbed && "embed",
             this.isPortrait && "portrait",
             this.isLandscape && "landscape",
-            isTouchDevice() && "is-touch"
+            isTouchDevice() && "is-touch",
         ]
 
-        return classNames.filter(n => !!n).join(" ")
+        return classNames.filter((n) => !!n).join(" ")
     }
 
     addPopup(vnode: VNode) {
@@ -258,7 +258,7 @@ export class GrapherView extends React.Component<GrapherViewProps> {
     }
 
     removePopup(vnodeType: any) {
-        this.popups = this.popups.filter(d => !(d.type === vnodeType))
+        this.popups = this.popups.filter((d) => !(d.type === vnodeType))
     }
 
     get childContext(): GrapherViewContextInterface {
@@ -268,7 +268,7 @@ export class GrapherView extends React.Component<GrapherViewProps> {
             baseFontSize: this.grapher.baseFontSize,
             isStatic: this.isExport,
             addPopup: this.addPopup.bind(this),
-            removePopup: this.removePopup.bind(this)
+            removePopup: this.removePopup.bind(this),
         }
     }
 
@@ -363,7 +363,7 @@ export class GrapherView extends React.Component<GrapherViewProps> {
                     justifyContent: "center",
                     textAlign: "center",
                     lineHeight: 1.5,
-                    padding: "3rem"
+                    padding: "3rem",
                 }}
             >
                 <p style={{ color: "#cc0000", fontWeight: 700 }}>
@@ -396,7 +396,7 @@ export class GrapherView extends React.Component<GrapherViewProps> {
             const style = {
                 width: renderWidth,
                 height: renderHeight,
-                fontSize: this.grapher.baseFontSize
+                fontSize: this.grapher.baseFontSize,
             }
 
             return (

--- a/grapher/core/Persistable.test.ts
+++ b/grapher/core/Persistable.test.ts
@@ -3,7 +3,7 @@
 import {
     objectWithPersistablesToObject,
     Persistable,
-    updatePersistables
+    updatePersistables,
 } from "./Persistable"
 
 class SomePersistable implements Persistable {
@@ -27,11 +27,11 @@ describe("basics", () => {
     it("can serialize and rehydrate nested persistables", () => {
         const item = {
             a: new SomePersistable(),
-            b: [new SomeOtherPersistable(), new SomeOtherPersistable(), 3]
+            b: [new SomeOtherPersistable(), new SomeOtherPersistable(), 3],
         }
         expect(objectWithPersistablesToObject(item)).toEqual({
             a: 4,
-            b: [1, 1, 3]
+            b: [1, 1, 3],
         })
 
         updatePersistables(item, { a: 7, b: [0] })
@@ -42,7 +42,7 @@ describe("basics", () => {
     it("handles missing values", () => {
         expect(objectWithPersistablesToObject({})).toEqual({})
         expect(objectWithPersistablesToObject({ foo: undefined })).toEqual({
-            foo: undefined
+            foo: undefined,
         })
     })
 })

--- a/grapher/core/Persistable.ts
+++ b/grapher/core/Persistable.ts
@@ -10,7 +10,7 @@ export interface Persistable {
 // Note: this does not recurse! If we need that should be easy to add, but we didn't need it yet.
 export function objectWithPersistablesToObject(objWithPersistables: any) {
     const obj = toJS(objWithPersistables) as any
-    Object.keys(obj).forEach(key => {
+    Object.keys(obj).forEach((key) => {
         const val = objWithPersistables[key]
         const valIsPersistable = val && val.toObject
 
@@ -18,7 +18,7 @@ export function objectWithPersistablesToObject(objWithPersistables: any) {
         if (valIsPersistable) obj[key] = val.toObject()
         else if (Array.isArray(val))
             // Scan array for persistables and seriazile.
-            obj[key] = val.map(item =>
+            obj[key] = val.map((item) =>
                 item?.toObject ? item.toObject() : item
             )
         else obj[key] = val

--- a/grapher/dataTable/DataTable.jsdom.test.tsx
+++ b/grapher/dataTable/DataTable.jsdom.test.tsx
@@ -66,7 +66,7 @@ describe(DataTable, () => {
                 type: "LineChart",
                 tab: "chart",
                 minTime: 1990,
-                maxTime: 2017
+                maxTime: 2017,
             })
             view = mount(<DataTable grapher={chart} />)
         })

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -22,7 +22,7 @@ import {
     isRangeValue,
     RangeValueKey,
     SingleValueKey,
-    Value
+    Value,
 } from "./DataTableTransform"
 
 interface DataTableProps {
@@ -46,7 +46,7 @@ interface DataTableSortState {
 const DEFAULT_SORT_STATE: DataTableSortState = {
     dimIndex: ENTITY_DIM_INDEX,
     columnKey: undefined,
-    order: SortOrder.asc
+    order: SortOrder.asc,
 }
 
 const columnNameByType: Record<ColumnKey, string> = {
@@ -54,7 +54,7 @@ const columnNameByType: Record<ColumnKey, string> = {
     start: "Start",
     end: "End",
     delta: "Absolute Change",
-    deltaRatio: "Relative Change"
+    deltaRatio: "Relative Change",
 }
 
 function inverseSortOrder(order: SortOrder): SortOrder {
@@ -64,19 +64,19 @@ function inverseSortOrder(order: SortOrder): SortOrder {
 @observer
 export class DataTable extends React.Component<DataTableProps> {
     @observable private storedState: DataTableState = {
-        sort: DEFAULT_SORT_STATE
+        sort: DEFAULT_SORT_STATE,
     }
 
     @computed get tableState(): DataTableState {
         return {
-            sort: this.sortState
+            sort: this.sortState,
         }
     }
 
     @computed get sortState(): DataTableSortState {
         let { dimIndex, columnKey, order } = {
             ...DEFAULT_SORT_STATE,
-            ...this.storedState.sort
+            ...this.storedState.sort,
         }
 
         // If not sorted by entity, then make sure the index of the chosen column exists
@@ -84,7 +84,7 @@ export class DataTable extends React.Component<DataTableProps> {
         if (dimIndex !== ENTITY_DIM_INDEX) {
             const availableColumns = this.transform.dimensionsWithValues[
                 dimIndex
-            ].columns.map(sub => sub.key)
+            ].columns.map((sub) => sub.key)
             if (
                 columnKey === undefined ||
                 !availableColumns.includes(columnKey)
@@ -96,7 +96,7 @@ export class DataTable extends React.Component<DataTableProps> {
         return {
             dimIndex,
             columnKey,
-            order
+            order,
         }
     }
 
@@ -118,10 +118,10 @@ export class DataTable extends React.Component<DataTableProps> {
         const { dimIndex, columnKey, order } = this.tableState.sort
 
         if (dimIndex === ENTITY_DIM_INDEX) {
-            return row => row.entity
+            return (row) => row.entity
         }
 
-        return row => {
+        return (row) => {
             const dv = row.dimensionValues[dimIndex] as DimensionValue
 
             let value: number | string | undefined
@@ -157,12 +157,15 @@ export class DataTable extends React.Component<DataTableProps> {
     @computed get displayRows() {
         const { order } = this.tableState.sort
         return orderBy(this.transform.displayRows, this.sortValueMapper, [
-            order
+            order,
         ])
     }
 
     @computed get hasSubheaders() {
-        return some(this.displayDimensions, header => header.columns.length > 1)
+        return some(
+            this.displayDimensions,
+            (header) => header.columns.length > 1
+        )
     }
 
     @action.bound updateSort(dimIndex: DimensionIndex, columnKey?: ColumnKey) {
@@ -217,7 +220,7 @@ export class DataTable extends React.Component<DataTableProps> {
                 colSpan: dim.columns.length,
                 headerText: dimensionHeaderText,
                 colType: "dimension" as const,
-                dataType: "numeric" as const
+                dataType: "numeric" as const,
             }
 
             return <ColumnHeader key={dim.key} {...props} />
@@ -227,7 +230,7 @@ export class DataTable extends React.Component<DataTableProps> {
     private get dimensionSubheaders() {
         const { sort } = this.tableState
         return this.displayDimensions.map((dim, dimIndex) =>
-            dim.columns.map(column => {
+            dim.columns.map((column) => {
                 const headerText =
                     column.targetYearMode === TargetYearMode.point
                         ? dim.formatYear(column.targetYear!)
@@ -289,8 +292,8 @@ export class DataTable extends React.Component<DataTableProps> {
                     "dimension",
                     `dimension-${column.key}`,
                     {
-                        sorted: sorted
-                    }
+                        sorted: sorted,
+                    },
                 ])}
             >
                 {value.year !== undefined &&
@@ -299,7 +302,7 @@ export class DataTable extends React.Component<DataTableProps> {
                     column.targetYear !== value.year && (
                         <ClosestYearNotice
                             closestYear={formatYear(value.year, {
-                                format: "MMM D"
+                                format: "MMM D",
                             })}
                             targetYear={formatYear(column.targetYear)}
                         />
@@ -324,7 +327,7 @@ export class DataTable extends React.Component<DataTableProps> {
                     key="entity"
                     className={classnames({
                         entity: true,
-                        sorted: sort.dimIndex === ENTITY_DIM_INDEX
+                        sorted: sort.dimIndex === ENTITY_DIM_INDEX,
                     })}
                 >
                     {row.entity}
@@ -348,7 +351,7 @@ export class DataTable extends React.Component<DataTableProps> {
     }
 
     private get valueRows() {
-        return this.displayRows.map(row =>
+        return this.displayRows.map((row) =>
             this.renderEntityRow(row, this.displayDimensions)
         )
     }
@@ -379,7 +382,7 @@ function ColumnHeader(props: {
         <th
             className={classnames(colType, {
                 sortable: sortable,
-                sorted: sortedCol
+                sorted: sortedCol,
             })}
             rowSpan={props.rowSpan ?? 1}
             colSpan={props.colSpan ?? 1}
@@ -405,7 +408,7 @@ function ColumnHeader(props: {
 
 export const ClosestYearNotice = ({
     targetYear,
-    closestYear: year
+    closestYear: year,
 }: {
     targetYear: string
     closestYear: string

--- a/grapher/dataTable/DataTableTransform.ts
+++ b/grapher/dataTable/DataTableTransform.ts
@@ -9,14 +9,14 @@ import {
     flatten,
     sortBy,
     countBy,
-    union
+    union,
 } from "grapher/utils/Util"
 import { Grapher } from "grapher/core/Grapher"
 import { ChartDimension } from "grapher/chart/ChartDimension"
 import { TickFormattingOptions } from "grapher/core/GrapherConstants"
 import {
     getTimeWithinTimeRange,
-    isUnboundedLeft
+    isUnboundedLeft,
 } from "grapher/utils/TimeBounds"
 import { ChartTransform } from "grapher/chart/ChartTransform"
 
@@ -24,7 +24,7 @@ import { ChartTransform } from "grapher/chart/ChartTransform"
 
 export enum TargetYearMode {
     point = "point",
-    range = "range"
+    range = "range",
 }
 
 type TargetYears = [number] | [number, number]
@@ -57,7 +57,7 @@ export enum RangeValueKey {
     start = "start",
     end = "end",
     delta = "delta",
-    deltaRatio = "deltaRatio"
+    deltaRatio = "deltaRatio",
 }
 
 type RangeValue = Record<RangeValueKey, Value | undefined>
@@ -69,7 +69,7 @@ export function isRangeValue(value: DimensionValue): value is RangeValue {
 // single point values
 
 export enum SingleValueKey {
-    single = "single"
+    single = "single",
 }
 
 type SingleValue = Record<SingleValueKey, Value | undefined>
@@ -141,14 +141,14 @@ export class DataTableTransform extends ChartTransform {
 
         const numEntitiesInTable = this.entities.length
 
-        this.dimensions.forEach(dim => {
+        this.dimensions.forEach((dim) => {
             const numberOfEntitiesWithDataSortedByYear = sortBy(
                 Object.entries(countBy(dim.years)),
-                value => parseInt(value[0])
+                (value) => parseInt(value[0])
             )
 
             const firstYearWithSufficientData = numberOfEntitiesWithDataSortedByYear.find(
-                year => {
+                (year) => {
                     const numEntitiesWithData = year[1]
                     const percentEntitiesWithData =
                         numEntitiesWithData / numEntitiesInTable
@@ -174,17 +174,19 @@ export class DataTableTransform extends ChartTransform {
     }
 
     @computed get availableYears() {
-        return intersection(flatten(this.dimensions.map(dim => dim.yearsUniq)))
+        return intersection(
+            flatten(this.dimensions.map((dim) => dim.yearsUniq))
+        )
     }
 
     @computed get dimensions() {
         return this.grapher.multiMetricTableMode
             ? this.grapher.dataTableOnlyDimensions
-            : this.grapher.filledDimensions.filter(dim => dim.includeInTable)
+            : this.grapher.filledDimensions.filter((dim) => dim.includeInTable)
     }
 
     @computed get entities() {
-        return union(...this.dimensions.map(dim => dim.entityNamesUniq))
+        return union(...this.dimensions.map((dim) => dim.entityNamesUniq))
     }
 
     // TODO move this logic to chart
@@ -223,7 +225,7 @@ export class DataTableTransform extends ChartTransform {
                 getTimeWithinTimeRange(
                     [this.grapher.minYear, this.grapher.maxYear],
                     this.grapher.mapTransform.targetYearProp
-                )
+                ),
             ]
 
         return this.startYear === this.endYear
@@ -241,12 +243,12 @@ export class DataTableTransform extends ChartTransform {
             numberPrefixes: false,
             noTrailingZeroes: false,
             unit: dimension.shortUnit,
-            ...formattingOverrides
+            ...formattingOverrides,
         })
     }
 
     @computed get dimensionsWithValues(): Dimension[] {
-        return this.dimensions.map(dim => {
+        return this.dimensions.map((dim) => {
             const targetYears =
                 // If a targetYear override is specified on the dimension (scatter plots
                 // can do this) then use that target year and ignore the timeline.
@@ -298,12 +300,12 @@ export class DataTableTransform extends ChartTransform {
                             : RangeValueKey.end
                         : SingleValueKey.single,
                     targetYear,
-                    targetYearMode
+                    targetYearMode,
                 })),
-                ...deltaColumns
+                ...deltaColumns,
             ]
 
-            const finalValueByEntity = es6mapValues(valuesByEntity, dvs => {
+            const finalValueByEntity = es6mapValues(valuesByEntity, (dvs) => {
                 // There is always a column, but not always a data value (in the delta column the
                 // value needs to be calculated)
                 if (isRange) {
@@ -311,14 +313,14 @@ export class DataTableTransform extends ChartTransform {
                     const result: RangeValue = {
                         start: {
                             ...start,
-                            formattedValue: this.formatValue(dim, start?.value)
+                            formattedValue: this.formatValue(dim, start?.value),
                         },
                         end: {
                             ...end,
-                            formattedValue: this.formatValue(dim, end?.value)
+                            formattedValue: this.formatValue(dim, end?.value),
                         },
                         delta: undefined,
-                        deltaRatio: undefined
+                        deltaRatio: undefined,
                     }
 
                     if (
@@ -336,8 +338,10 @@ export class DataTableTransform extends ChartTransform {
                             formattedValue: this.formatValue(dim, deltaValue, {
                                 showPlus: true,
                                 unit:
-                                    dim.shortUnit === "%" ? "pp" : dim.shortUnit
-                            })
+                                    dim.shortUnit === "%"
+                                        ? "pp"
+                                        : dim.shortUnit,
+                            }),
                         }
 
                         result.deltaRatio = {
@@ -351,10 +355,10 @@ export class DataTableTransform extends ChartTransform {
                                           {
                                               unit: "%",
                                               numDecimalPlaces: 0,
-                                              showPlus: true
+                                              showPlus: true,
                                           }
                                       )
-                                    : undefined
+                                    : undefined,
                         }
                     }
                     return result
@@ -362,7 +366,7 @@ export class DataTableTransform extends ChartTransform {
                     // if single year
                     const dv = dvs[0]
                     const result: SingleValue = {
-                        single: { ...dv }
+                        single: { ...dv },
                     }
                     if (dv !== undefined) {
                         result.single!.formattedValue = this.formatValue(
@@ -377,37 +381,37 @@ export class DataTableTransform extends ChartTransform {
             return {
                 dimension: dim,
                 columns: columns,
-                valueByEntity: finalValueByEntity
+                valueByEntity: finalValueByEntity,
             }
         })
     }
 
     @computed get displayDimensions(): DataTableDimension[] {
-        return this.dimensionsWithValues.map(d => ({
+        return this.dimensionsWithValues.map((d) => ({
             key: d.dimension.variableId,
             name: d.dimension.displayName || d.dimension.column.name || "",
             unit: getHeaderUnit(d.dimension.unit),
             // A top-level header is only sortable if it has a single nested column, because
             // in that case the nested column is not rendered.
             sortable: d.columns.length === 1,
-            columns: d.columns.map(column => ({
+            columns: d.columns.map((column) => ({
                 ...column,
                 // All columns are sortable for now, but in the future we will have a sparkline that
                 // is not sortable.
-                sortable: true
+                sortable: true,
             })),
-            formatYear: d.dimension.formatYear
+            formatYear: d.dimension.formatYear,
         }))
     }
 
     @computed get displayRows(): DataTableRow[] {
-        const rows = this.entities.map(entity => {
-            const dimensionValues = this.dimensionsWithValues.map(d =>
+        const rows = this.entities.map((entity) => {
+            const dimensionValues = this.dimensionsWithValues.map((d) =>
                 d.valueByEntity.get(entity)
             )
             return {
                 entity,
-                dimensionValues
+                dimensionValues,
             }
         })
         return rows

--- a/grapher/dataTable/TableTab.tsx
+++ b/grapher/dataTable/TableTab.tsx
@@ -27,7 +27,7 @@ export class TableTab extends React.Component<{
                     style={{
                         width: "100%",
                         height: "100%",
-                        overflow: "auto"
+                        overflow: "auto",
                     }}
                 >
                     <DataTable grapher={this.props.grapher} />

--- a/grapher/downloadTab/CSVGenerator.jsdom.test.ts
+++ b/grapher/downloadTab/CSVGenerator.jsdom.test.ts
@@ -27,24 +27,24 @@ function testIfCSVMatchesSnapshot(
 }
 
 describe("CSV data downloads", () => {
-    test("one year-based variable", done => {
+    test("one year-based variable", (done) => {
         const csvGenerator = setupCSVGenerator(792, [3512])
         testIfCSVMatchesSnapshot(csvGenerator, done, 500)
     })
 
-    test("one day-based variable, one year-based variable", done => {
+    test("one day-based variable, one year-based variable", (done) => {
         const grapher = setupGrapher(4041, [142586, 2209, 123])
         grapher.scatterTransform.xOverrideYear = 2016
         testIfCSVMatchesSnapshot(new CSVGenerator({ grapher }), done)
     })
 
-    test("two day-based variables, one year-based variable", done => {
+    test("two day-based variables, one year-based variable", (done) => {
         const grapher = setupGrapher(4058, [142600, 97587, 142583, 123])
         grapher.scatterTransform.xOverrideYear = 2100
         testIfCSVMatchesSnapshot(new CSVGenerator({ grapher }), done)
     })
 
-    test("two day-based variables", done => {
+    test("two day-based variables", (done) => {
         const csvGenerator = setupCSVGenerator(4054, [142586, 142587, 123])
         testIfCSVMatchesSnapshot(csvGenerator, done)
     })

--- a/grapher/downloadTab/CSVGenerator.ts
+++ b/grapher/downloadTab/CSVGenerator.ts
@@ -5,7 +5,7 @@ import {
     flatten,
     csvEscape,
     first,
-    valuesAtYears
+    valuesAtYears,
 } from "grapher/utils/Util"
 import { ChartDimension } from "grapher/chart/ChartDimension"
 
@@ -29,18 +29,20 @@ export class CSVGenerator {
     }
 
     @computed get csvDimensions() {
-        return this.grapher.filledDimensions.filter(d => d.property !== "color")
+        return this.grapher.filledDimensions.filter(
+            (d) => d.property !== "color"
+        )
     }
 
     /** Returns dimensions for which we want to show all values */
     @computed get allValueDimensions() {
         return this.csvDimensions.filter(
-            dim => !this.isSingleValueDimension(dim)
+            (dim) => !this.isSingleValueDimension(dim)
         )
     }
 
     @computed get singleValueDimensions() {
-        return this.csvDimensions.filter(dim =>
+        return this.csvDimensions.filter((dim) =>
             this.isSingleValueDimension(dim)
         )
     }
@@ -59,17 +61,17 @@ export class CSVGenerator {
         const titleRow = this.baseTitleRow
         titleRow.push("Date")
 
-        this.allValueDimensions.map(dim =>
+        this.allValueDimensions.map((dim) =>
             titleRow.push(csvEscape(dim.fullNameWithUnit))
         )
-        this.singleValueDimensions.map(dim => {
+        this.singleValueDimensions.map((dim) => {
             titleRow.push("Year")
             titleRow.push(csvEscape(dim.fullNameWithUnit))
         })
 
         return {
             indexingYears: this.dayColumn!.valuesUniq,
-            titleRow: titleRow
+            titleRow: titleRow,
         }
     }
 
@@ -77,15 +79,15 @@ export class CSVGenerator {
         const titleRow = this.baseTitleRow
         titleRow.push("Year")
 
-        this.csvDimensions.map(dim =>
+        this.csvDimensions.map((dim) =>
             titleRow.push(csvEscape(dim.fullNameWithUnit))
         )
 
         return {
             indexingYears: uniq(
-                flatten(this.csvDimensions.map(d => d.yearsUniq))
+                flatten(this.csvDimensions.map((d) => d.yearsUniq))
             ),
-            titleRow: titleRow
+            titleRow: titleRow,
         }
     }
 
@@ -141,7 +143,7 @@ export class CSVGenerator {
     private dimensionsValues(entity: string, year: number) {
         const values: (string | number)[] = []
 
-        this.allValueDimensions.map(dim => {
+        this.allValueDimensions.map((dim) => {
             const value = this.valueForDimensionEntityYear(dim, entity, year)
 
             if (value !== undefined) {
@@ -149,7 +151,7 @@ export class CSVGenerator {
             } else values.push("")
         })
 
-        this.singleValueDimensions.map(dim => {
+        this.singleValueDimensions.map((dim) => {
             const yearAndValue = this.yearAndValueForSingleYearDimension(
                 dim,
                 entity
@@ -163,14 +165,14 @@ export class CSVGenerator {
 
     private row(entity: string, year: number) {
         const dimensionsValues = this.dimensionsValues(entity, year)
-        const rowHasSomeValue = dimensionsValues.some(v => v !== "")
+        const rowHasSomeValue = dimensionsValues.some((v) => v !== "")
 
         if (rowHasSomeValue) {
             return [
                 entity,
                 this.entityCode(entity),
                 this.formattedYear(year),
-                ...dimensionsValues
+                ...dimensionsValues,
             ]
         } else return null
     }
@@ -180,8 +182,8 @@ export class CSVGenerator {
         const chartEntities = this.grapher.sortedUniqueEntitiesAcrossDimensions
 
         const rows: (string | number)[][] = []
-        chartEntities.forEach(entity => {
-            indexingYears.forEach(year => {
+        chartEntities.forEach((entity) => {
+            indexingYears.forEach((year) => {
                 const row = this.row(entity, year)
                 if (row) rows.push(row)
             })
@@ -194,9 +196,9 @@ export class CSVGenerator {
         const { timeUnitDependentParams, dataRows: dataRows } = this
         return [
             timeUnitDependentParams.titleRow,
-            ...dataRows.map(row => row.map(csvEscape))
+            ...dataRows.map((row) => row.map(csvEscape)),
         ]
-            .map(row => row.join(","))
+            .map((row) => row.join(","))
             .join("\n")
     }
 

--- a/grapher/downloadTab/DownloadTab.tsx
+++ b/grapher/downloadTab/DownloadTab.tsx
@@ -55,7 +55,7 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
                     }
 
                     callback(new Blob([arr], { type: type || "image/png" }))
-                }
+                },
             })
         }
 
@@ -67,7 +67,7 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
         grapher.isExporting = false
 
         this.svgBlob = new Blob([staticSVG], {
-            type: "image/svg+xml;charset=utf-8"
+            type: "image/svg+xml;charset=utf-8",
         })
         this.svgBlobUrl = URL.createObjectURL(this.svgBlob)
         const reader = new FileReader()
@@ -82,13 +82,13 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
                     canvas.width = targetWidth * 4
                     canvas.height = targetHeight * 4
                     const ctx = canvas.getContext("2d", {
-                        alpha: false
+                        alpha: false,
                     }) as CanvasRenderingContext2D
                     ctx.imageSmoothingEnabled = false
                     ctx.setTransform(4, 0, 0, 4, 0, 0)
                     ctx.drawImage(img, 0, 0)
                     this.pngDataUri = canvas.toDataURL("image/png")
-                    canvas.toBlob(blob => {
+                    canvas.toBlob((blob) => {
                         this.pngBlob = blob as Blob
                         this.pngBlobUrl = URL.createObjectURL(blob)
                         this.markAsReady()
@@ -98,7 +98,7 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
                     this.markAsReady()
                 }
             }
-            img.onerror = err => {
+            img.onerror = (err) => {
                 console.error(JSON.stringify(err))
                 this.markAsReady()
             }
@@ -167,7 +167,7 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
             pngDownloadUrl,
             svgPreviewUrl,
             svgDownloadUrl,
-            baseFilename
+            baseFilename,
         } = this
 
         let previewWidth: number
@@ -189,11 +189,11 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
             minHeight: previewHeight,
             maxWidth: previewWidth,
             maxHeight: previewHeight,
-            border: "1px solid #ccc"
+            border: "1px solid #ccc",
         }
 
         const asideStyle = {
-            maxWidth: previewWidth
+            maxWidth: previewWidth,
         }
 
         const externalCsvLink = this.props.grapher.externalCsvLink
@@ -287,7 +287,7 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
         return (
             <div
                 className={classNames("DownloadTab", {
-                    mobile: isMobile()
+                    mobile: isMobile(),
                 })}
                 style={{ ...this.props.bounds.toCSS(), position: "absolute" }}
             >

--- a/grapher/facetChart/FacetChart.stories.tsx
+++ b/grapher/facetChart/FacetChart.stories.tsx
@@ -14,14 +14,14 @@ export default {
         padding: { control: "range", defaultValue: 1 },
         width: {
             control: { type: "range", min: 50, max: 2000 },
-            defaultValue: 640
+            defaultValue: 640,
         },
         height: {
             control: { type: "range", min: 50, max: 2000 },
-            defaultValue: 480
+            defaultValue: 480,
         },
-        chart: { control: null }
-    }
+        chart: { control: null },
+    },
 }
 
 export const Default = (args: any) => {

--- a/grapher/lineCharts/LineChart.stories.tsx
+++ b/grapher/lineCharts/LineChart.stories.tsx
@@ -6,7 +6,7 @@ import { basicGdpGrapher } from "grapher/test/samples"
 
 export default {
     title: "LineChart",
-    component: LineChart
+    component: LineChart,
 }
 
 export const Default = () => {

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -11,7 +11,7 @@ import {
     getRelativeMouse,
     makeSafeForCSS,
     pointsToPath,
-    minBy
+    minBy,
 } from "grapher/utils/Util"
 import { computed, action, observable } from "mobx"
 import { observer } from "mobx-react"
@@ -25,7 +25,7 @@ import { Vector2 } from "grapher/utils/Vector2"
 import { LineLabelsHelper, LineLabelsComponent } from "./LineLabels"
 import {
     ComparisonLine,
-    ComparisonLineConfig
+    ComparisonLineConfig,
 } from "grapher/scatterCharts/ComparisonLine"
 import { Tooltip, TooltipProps } from "grapher/chart/Tooltip"
 import { NoDataOverlay } from "grapher/chart/NoDataOverlay"
@@ -86,12 +86,12 @@ class Lines extends React.Component<LinesProps> {
 
     @computed get renderData(): LineRenderSeries[] {
         const { data, xAxis, yAxis, focusKeys } = this.props
-        return map(data, series => {
+        return map(data, (series) => {
             return {
                 entityDimensionKey: series.entityDimensionKey,
                 displayKey: `key-${makeSafeForCSS(series.entityDimensionKey)}`,
                 color: series.color,
-                values: series.values.map(v => {
+                values: series.values.map((v) => {
                     return new Vector2(
                         Math.round(xAxis.place(v.x)),
                         Math.round(yAxis.place(v.y))
@@ -100,13 +100,13 @@ class Lines extends React.Component<LinesProps> {
                 isFocus:
                     !focusKeys.length ||
                     includes(focusKeys, series.entityDimensionKey),
-                isProjection: series.isProjection
+                isProjection: series.isProjection,
             }
         })
     }
 
     @computed get isFocusMode(): boolean {
-        return some(this.renderData, d => d.isFocus)
+        return some(this.renderData, (d) => d.isFocus)
     }
 
     @computed get allValues(): LineChartValue[] {
@@ -125,7 +125,7 @@ class Lines extends React.Component<LinesProps> {
                     return {
                         pos: v,
                         series: data[i],
-                        value: data[i].values[j]
+                        value: data[i].values[j],
                     }
                 })
             })
@@ -139,7 +139,7 @@ class Lines extends React.Component<LinesProps> {
 
         let hoverX
         if (dualAxis.innerBounds.contains(mouse)) {
-            const closestValue = minBy(this.allValues, d =>
+            const closestValue = minBy(this.allValues, (d) =>
                 Math.abs(xAxis.place(d.x) - mouse.x)
             )
             hoverX = closestValue?.x
@@ -161,27 +161,30 @@ class Lines extends React.Component<LinesProps> {
     }
 
     @computed get focusGroups() {
-        return filter(this.renderData, g => g.isFocus)
+        return filter(this.renderData, (g) => g.isFocus)
     }
 
     @computed get backgroundGroups() {
-        return filter(this.renderData, g => !g.isFocus)
+        return filter(this.renderData, (g) => !g.isFocus)
     }
 
     // Don't display point markers if there are very many of them for performance reasons
     // Note that we're using circle elements instead of marker-mid because marker performance in Safari 10 is very poor for some reason
     @computed get hasMarkers(): boolean {
-        return sum(this.renderData.map(g => g.values.length)) < 500
+        return sum(this.renderData.map((g) => g.values.length)) < 500
     }
 
     renderFocusGroups() {
-        return this.focusGroups.map(series => (
+        return this.focusGroups.map((series) => (
             <g key={series.displayKey} className={series.displayKey}>
                 <path
                     stroke={series.color}
                     strokeLinecap="round"
                     d={pointsToPath(
-                        series.values.map(v => [v.x, v.y]) as [number, number][]
+                        series.values.map((v) => [v.x, v.y]) as [
+                            number,
+                            number
+                        ][]
                     )}
                     fill="none"
                     strokeWidth={1.5}
@@ -199,14 +202,17 @@ class Lines extends React.Component<LinesProps> {
     }
 
     renderBackgroundGroups() {
-        return this.backgroundGroups.map(series => (
+        return this.backgroundGroups.map((series) => (
             <g key={series.displayKey} className={series.displayKey}>
                 <path
                     key={series.entityDimensionKey + "-line"}
                     strokeLinecap="round"
                     stroke="#ddd"
                     d={pointsToPath(
-                        series.values.map(v => [v.x, v.y]) as [number, number][]
+                        series.values.map((v) => [v.x, v.y]) as [
+                            number,
+                            number
+                        ][]
                     )}
                     fill="none"
                     strokeWidth={1}
@@ -292,7 +298,7 @@ export class LineChart extends React.Component<{
 
     // Set default props
     static defaultProps = {
-        bounds: new Bounds(0, 0, 640, 480)
+        bounds: new Bounds(0, 0, 640, 480),
     }
 
     @observable hoverX?: number
@@ -323,7 +329,7 @@ export class LineChart extends React.Component<{
             },
             get items() {
                 return that.transform.legendItems
-            }
+            },
         })
     }
 
@@ -339,8 +345,8 @@ export class LineChart extends React.Component<{
 
         if (hoverX === undefined) return undefined
 
-        const sortedData = sortBy(transform.groupedData, series => {
-            const value = series.values.find(v => v.x === hoverX)
+        const sortedData = sortBy(transform.groupedData, (series) => {
+            const value = series.values.find((v) => v.x === hoverX)
             return value !== undefined ? -value.y : Infinity
         })
 
@@ -360,7 +366,7 @@ export class LineChart extends React.Component<{
                     style={{
                         fontSize: "0.9em",
                         lineHeight: "1.4em",
-                        whiteSpace: "normal"
+                        whiteSpace: "normal",
                     }}
                 >
                     <tbody>
@@ -369,9 +375,9 @@ export class LineChart extends React.Component<{
                                 <strong>{formatYearFunction(hoverX)}</strong>
                             </td>
                         </tr>
-                        {sortedData.map(series => {
+                        {sortedData.map((series) => {
                             const value = series.values.find(
-                                v => v.x === hoverX
+                                (v) => v.x === hoverX
                             )
 
                             const annotation = this.transform.getAnnotationsForSeries(
@@ -386,7 +392,7 @@ export class LineChart extends React.Component<{
                             if (!value) {
                                 const [startX, endX] = extent(
                                     series.values,
-                                    v => v.x
+                                    (v) => v.x
                                 )
                                 if (
                                     startX === undefined ||
@@ -418,14 +424,14 @@ export class LineChart extends React.Component<{
                                                 borderRadius: "5px",
                                                 backgroundColor: circleColor,
                                                 display: "inline-block",
-                                                marginRight: "2px"
+                                                marginRight: "2px",
                                             }}
                                         />
                                     </td>
                                     <td
                                         style={{
                                             paddingRight: "0.8em",
-                                            fontSize: "0.9em"
+                                            fontSize: "0.9em",
                                         }}
                                     >
                                         {this.transform.getLabelForKey(
@@ -436,7 +442,7 @@ export class LineChart extends React.Component<{
                                                 className="tooltipAnnotation"
                                                 style={{
                                                     color: annotationColor,
-                                                    fontSize: "90%"
+                                                    fontSize: "90%",
                                                 }}
                                             >
                                                 {" "}
@@ -447,7 +453,7 @@ export class LineChart extends React.Component<{
                                     <td
                                         style={{
                                             textAlign: "right",
-                                            whiteSpace: "nowrap"
+                                            whiteSpace: "nowrap",
                                         }}
                                     >
                                         {!value
@@ -472,7 +478,7 @@ export class LineChart extends React.Component<{
         return new DualAxis({
             bounds: this.bounds.padRight(this.legend ? this.legend.width : 20),
             yAxis,
-            xAxis
+            xAxis,
         })
     }
 
@@ -545,7 +551,7 @@ export class LineChart extends React.Component<{
             tooltip,
             dualAxis,
             renderUid,
-            hoverX
+            hoverX,
         } = this
         const { xAxis, yAxis } = dualAxis
         const { groupedData } = transform
@@ -601,9 +607,9 @@ export class LineChart extends React.Component<{
                 </g>
                 {hoverX !== undefined && (
                     <g className="hoverIndicator">
-                        {transform.groupedData.map(series => {
+                        {transform.groupedData.map((series) => {
                             const value = series.values.find(
-                                v => v.x === hoverX
+                                (v) => v.x === hoverX
                             )
                             if (!value || this.seriesIsBlur(series)) return null
                             else

--- a/grapher/lineCharts/LineChartTransform.ts
+++ b/grapher/lineCharts/LineChartTransform.ts
@@ -11,7 +11,7 @@ import {
     formatValue,
     flatten,
     findIndex,
-    last
+    last,
 } from "grapher/utils/Util"
 import { EntityDimensionKey, ScaleType } from "grapher/core/GrapherConstants"
 import { LineChartSeries, LineChartValue } from "./LineChart"
@@ -27,7 +27,7 @@ import { EntityName } from "owidTable/OwidTable"
 export class LineChartTransform extends ChartTransform {
     @computed get failMessage(): string | undefined {
         const { filledDimensions } = this.grapher
-        if (!some(filledDimensions, d => d.property === "y"))
+        if (!some(filledDimensions, (d) => d.property === "y"))
             return "Missing Y axis variable"
         else if (isEmpty(this.groupedData)) return "No matching data"
         else return undefined
@@ -73,7 +73,7 @@ export class LineChartTransform extends ChartTransform {
                         entityDimensionKey: entityDimensionKey,
                         isProjection: dimension.isProjection,
                         formatValue: dimension.formatValueLong,
-                        color: "#000" // tmp
+                        color: "#000", // tmp
                     }
                     seriesByKey.set(entityDimensionKey, series)
                 }
@@ -87,7 +87,7 @@ export class LineChartTransform extends ChartTransform {
         // Color from lowest to highest
         chartData = sortBy(
             chartData,
-            series => series.values[series.values.length - 1].y
+            (series) => series.values[series.values.length - 1].y
         )
 
         const colors = this.colorScheme.getColors(chartData.length)
@@ -98,7 +98,7 @@ export class LineChartTransform extends ChartTransform {
         })
 
         // Preserve the original ordering for render. Note for line charts, the series order only affects the visual stacking order on overlaps.
-        chartData = sortBy(chartData, series =>
+        chartData = sortBy(chartData, (series) =>
             selectedKeys.indexOf(series.entityDimensionKey)
         )
 
@@ -106,16 +106,16 @@ export class LineChartTransform extends ChartTransform {
     }
 
     @computed get availableYears(): Time[] {
-        return flatten(this.initialData.map(g => g.values.map(d => d.x)))
+        return flatten(this.initialData.map((g) => g.values.map((d) => d.x)))
     }
 
     @computed get predomainData() {
         if (!this.isRelativeMode) return this.initialData
 
-        return cloneDeep(this.initialData).map(series => {
+        return cloneDeep(this.initialData).map((series) => {
             const startIndex = findIndex(
                 series.values,
-                v => v.time >= this.startYear && v.y !== 0
+                (v) => v.time >= this.startYear && v.y !== 0
             )
             if (startIndex < 0) {
                 series.values = []
@@ -124,7 +124,7 @@ export class LineChartTransform extends ChartTransform {
                 const relativeValues = series.values.slice(startIndex)
                 // Clone to avoid overwriting in next loop
                 const indexValue = clone(relativeValues[0])
-                series.values = relativeValues.map(v => {
+                series.values = relativeValues.map((v) => {
                     v.y = (v.y - indexValue.y) / Math.abs(indexValue.y)
                     return v
                 })
@@ -134,11 +134,11 @@ export class LineChartTransform extends ChartTransform {
     }
 
     @computed get allValues(): LineChartValue[] {
-        return flatten(this.predomainData.map(series => series.values))
+        return flatten(this.predomainData.map((series) => series.values))
     }
 
     @computed get filteredValues(): LineChartValue[] {
-        return flatten(this.groupedData.map(series => series.values))
+        return flatten(this.groupedData.map((series) => series.values))
     }
 
     @computed get annotationsMap() {
@@ -162,10 +162,10 @@ export class LineChartTransform extends ChartTransform {
         // If there are any projections, ignore non-projection legends
         // Bit of a hack
         let toShow = this.groupedData
-        if (toShow.some(g => !!g.isProjection))
-            toShow = this.groupedData.filter(g => g.isProjection)
+        if (toShow.some((g) => !!g.isProjection))
+            toShow = this.groupedData.filter((g) => g.isProjection)
 
-        return toShow.map(series => {
+        return toShow.map((series) => {
             const lastValue = (last(series.values) as LineChartValue).y
             return {
                 color: series.color,
@@ -175,7 +175,7 @@ export class LineChartTransform extends ChartTransform {
                     ? ""
                     : `${this.getLabelForKey(series.entityDimensionKey)}`,
                 annotation: this.getAnnotationsForSeries(series.entityName),
-                yValue: lastValue
+                yValue: lastValue,
             }
         })
     }
@@ -192,14 +192,14 @@ export class LineChartTransform extends ChartTransform {
     }
 
     @computed private get yDimensionFirst(): ChartDimension | undefined {
-        return this.grapher.filledDimensions.find(d => d.property === "y")
+        return this.grapher.filledDimensions.find((d) => d.property === "y")
     }
 
     @computed private get yDomainDefault(): [number, number] {
         const yValues = (this.grapher.useTimelineDomains
             ? this.allValues
             : this.filteredValues
-        ).map(v => v.y)
+        ).map((v) => v.y)
         return [min(yValues) ?? 0, max(yValues) ?? 100]
     }
 
@@ -208,7 +208,7 @@ export class LineChartTransform extends ChartTransform {
         const domain = grapher.yAxis.domain
         return [
             Math.min(domain[0], yDomainDefault[0]),
-            Math.max(domain[1], yDomainDefault[1])
+            Math.max(domain[1], yDomainDefault[1]),
         ]
     }
 
@@ -234,7 +234,9 @@ export class LineChartTransform extends ChartTransform {
         const axis = grapher.yAxis.toVerticalAxis()
         axis.updateDomainPreservingUserSettings(yDomain)
         if (isRelativeMode) axis.scaleTypeOptions = [ScaleType.linear]
-        axis.hideFractionalTicks = this.allValues.every(val => val.y % 1 === 0) // all y axis points are integral, don't show fractional ticks in that case
+        axis.hideFractionalTicks = this.allValues.every(
+            (val) => val.y % 1 === 0
+        ) // all y axis points are integral, don't show fractional ticks in that case
         axis.label = ""
         axis.tickFormat = yTickFormat
         return axis
@@ -252,13 +254,13 @@ export class LineChartTransform extends ChartTransform {
         for (const g of groupedData) {
             // The values can include non-numerical values, so we need to filter with isNaN()
             g.values = g.values.filter(
-                d =>
+                (d) =>
                     d.x >= xAxis.domain[0] &&
                     d.x <= xAxis.domain[1] &&
                     !isNaN(d.y)
             )
         }
 
-        return groupedData.filter(g => g.values.length > 0)
+        return groupedData.filter((g) => g.values.length > 0)
     }
 }

--- a/grapher/lineCharts/LineLabels.tsx
+++ b/grapher/lineCharts/LineLabels.tsx
@@ -11,7 +11,7 @@ import {
     sumBy,
     flatten,
     sign,
-    defaultTo
+    defaultTo,
 } from "grapher/utils/Util"
 import { computed, action } from "mobx"
 import { observer } from "mobx-react"
@@ -66,7 +66,7 @@ function groupBounds(group: PlacedLabel[]): Bounds {
 
 function stackGroupVertically(group: PlacedLabel[], y: number) {
     let currentY = y
-    group.forEach(mark => {
+    group.forEach((mark) => {
         mark.bounds = mark.bounds.extend({ y: currentY })
         mark.repositions += 1
         currentY += mark.bounds.height + LEGEND_ITEM_MIN_SPACING
@@ -99,18 +99,18 @@ export class LineLabelsHelper {
         const maxTextWidth = maxWidth - leftPadding
         const maxAnnotationWidth = Math.min(maxTextWidth, 150)
 
-        return this.props.items.map(item => {
+        return this.props.items.map((item) => {
             const annotationTextWrap = item.annotation
                 ? new TextWrap({
                       text: item.annotation,
                       maxWidth: maxAnnotationWidth,
-                      fontSize: fontSize * 0.9
+                      fontSize: fontSize * 0.9,
                   })
                 : undefined
             const textWrap = new TextWrap({
                 text: item.label,
                 maxWidth: maxTextWidth,
-                fontSize
+                fontSize,
             })
             return {
                 item,
@@ -124,14 +124,14 @@ export class LineLabelsHelper {
                     ),
                 height:
                     textWrap.height +
-                    (annotationTextWrap ? annotationTextWrap.height : 0)
+                    (annotationTextWrap ? annotationTextWrap.height : 0),
             }
         })
     }
 
     @computed get width(): number {
         if (this.marks.length === 0) return 0
-        else return defaultTo(max(this.marks.map(d => d.width)), 0)
+        else return defaultTo(max(this.marks.map((d) => d.width)), 0)
     }
 
     constructor(props: LineLabelsHelperProps) {
@@ -157,7 +157,7 @@ class PlacedMarkComponent extends React.Component<{
             needsLines,
             onMouseOver,
             onMouseLeave,
-            onClick
+            onClick,
         } = this.props
         const x = mark.origBounds.x
         const markerX1 = x + MARKER_MARGIN
@@ -204,7 +204,7 @@ class PlacedMarkComponent extends React.Component<{
                         {
                             fill: annotationColor,
                             className: "textAnnotation",
-                            style: { fontWeight: "lighter" }
+                            style: { fontWeight: "lighter" },
                         }
                     )}
             </g>
@@ -246,7 +246,7 @@ export class LineLabelsComponent extends React.Component<
     }
 
     @computed get isFocusMode() {
-        return some(this.props.legend.marks, m =>
+        return some(this.props.legend.marks, (m) =>
             includes(this.props.focusKeys, m.item.entityDimensionKey)
         )
     }
@@ -256,7 +256,7 @@ export class LineLabelsComponent extends React.Component<
         const { legend, x, yAxis } = this.props
 
         return sortBy(
-            legend.marks.map(mark => {
+            legend.marks.map((mark) => {
                 // place vertically centered at Y value
                 const initialY = yAxis.place(mark.item.yValue) - mark.height / 2
                 const origBounds = new Bounds(
@@ -281,12 +281,12 @@ export class LineLabelsComponent extends React.Component<
                     isOverlap: false,
                     repositions: 0,
                     level: 0,
-                    totalLevels: 0
+                    totalLevels: 0,
                 }
 
                 // Ensure list is sorted by the visual position in ascending order
             }),
-            mark => yAxis.place(mark.mark.item.yValue)
+            (mark) => yAxis.place(mark.mark.item.yValue)
         )
     }
 
@@ -295,7 +295,7 @@ export class LineLabelsComponent extends React.Component<
 
         const groups: PlacedLabel[][] = cloneDeep(
             this.initialMarks
-        ).map(mark => [mark])
+        ).map((mark) => [mark])
 
         let hasOverlap
 
@@ -346,8 +346,8 @@ export class LineLabelsComponent extends React.Component<
                 mark.level = currentLevel
                 prevSign = currentSign
             }
-            const minLevel = min(group.map(mark => mark.level)) as number
-            const maxLevel = max(group.map(mark => mark.level)) as number
+            const minLevel = min(group.map((mark) => mark.level)) as number
+            const maxLevel = max(group.map((mark) => mark.level)) as number
             for (const mark of group) {
                 mark.level -= minLevel
                 mark.totalLevels = maxLevel - minLevel + 1
@@ -377,7 +377,7 @@ export class LineLabelsComponent extends React.Component<
 
     @computed get placedMarks() {
         const nonOverlappingMinHeight =
-            sumBy(this.initialMarks, mark => mark.bounds.height) +
+            sumBy(this.initialMarks, (mark) => mark.bounds.height) +
             this.initialMarks.length * LEGEND_ITEM_MIN_SPACING
         const availableHeight = this.options.canAddData
             ? this.props.yAxis.rangeSize - ADD_BUTTON_HEIGHT
@@ -401,7 +401,7 @@ export class LineLabelsComponent extends React.Component<
     @computed private get backgroundMarks() {
         const { focusKeys } = this.props
         const { isFocusMode } = this
-        return this.placedMarks.filter(m =>
+        return this.placedMarks.filter((m) =>
             isFocusMode
                 ? !includes(focusKeys, m.mark.item.entityDimensionKey)
                 : m.isOverlap
@@ -411,7 +411,7 @@ export class LineLabelsComponent extends React.Component<
     @computed private get focusMarks() {
         const { focusKeys } = this.props
         const { isFocusMode } = this
-        return this.placedMarks.filter(m =>
+        return this.placedMarks.filter((m) =>
             isFocusMode
                 ? includes(focusKeys, m.mark.item.entityDimensionKey)
                 : !m.isOverlap
@@ -421,17 +421,17 @@ export class LineLabelsComponent extends React.Component<
     // TODO: looks unused. Can we remove?
     @computed get numMovesNeeded() {
         return this.placedMarks.filter(
-            m => m.isOverlap || !m.bounds.equals(m.origBounds)
+            (m) => m.isOverlap || !m.bounds.equals(m.origBounds)
         ).length
     }
 
     // Does this placement need line markers or is the position of the labels already clear?
     @computed private get needsLines(): boolean {
-        return this.placedMarks.some(mark => mark.totalLevels > 1)
+        return this.placedMarks.some((mark) => mark.totalLevels > 1)
     }
 
     private renderBackground() {
-        return this.backgroundMarks.map(mark => (
+        return this.backgroundMarks.map((mark) => (
             <PlacedMarkComponent
                 key={mark.mark.item.entityDimensionKey}
                 mark={mark}
@@ -447,7 +447,7 @@ export class LineLabelsComponent extends React.Component<
 
     // All labels are focused by default, moved to background when mouseover of other label
     private renderFocus() {
-        return this.focusMarks.map(mark => (
+        return this.focusMarks.map((mark) => (
             <PlacedMarkComponent
                 key={mark.mark.item.entityDimensionKey}
                 mark={mark}
@@ -486,7 +486,7 @@ export class LineLabelsComponent extends React.Component<
             : 5
 
         const topMarkY = defaultTo(
-            min(this.placedMarks.map(mark => mark.bounds.top)),
+            min(this.placedMarks.map((mark) => mark.bounds.top)),
             0
         )
 
@@ -518,7 +518,7 @@ export class LineLabelsComponent extends React.Component<
                 style={{
                     cursor: this.options.areMarksClickable
                         ? "pointer"
-                        : "default"
+                        : "default",
                 }}
             >
                 {this.renderBackground()}

--- a/grapher/loadingIndicator/LoadingIndicator.tsx
+++ b/grapher/loadingIndicator/LoadingIndicator.tsx
@@ -11,12 +11,12 @@ export const LoadingIndicator = (props: {
             className="loading-indicator"
             style={{
                 backgroundColor: props.backgroundColor,
-                ...props.bounds?.toCSS()
+                ...props.bounds?.toCSS(),
             }}
         >
             <span
                 style={{
-                    borderColor: props.color
+                    borderColor: props.color,
                 }}
             />
         </div>

--- a/grapher/mapCharts/ChoroplethMap.tsx
+++ b/grapher/mapCharts/ChoroplethMap.tsx
@@ -8,7 +8,7 @@ import {
     sortBy,
     guid,
     getRelativeMouse,
-    minBy
+    minBy,
 } from "grapher/utils/Util"
 import { Bounds } from "grapher/utils/Bounds"
 import { MapProjections, MapProjection } from "./MapProjections"
@@ -101,7 +101,7 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
 
     // Get the bounding box for every geographical feature
     @computed get geoBounds(): Bounds[] {
-        return this.geoFeatures.map(d => {
+        return this.geoFeatures.map((d) => {
             const b = this.pathGen.bounds(d)
 
             const bounds = Bounds.fromCorners(
@@ -113,7 +113,7 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
             if (d.id === "Fiji")
                 return bounds.extend({
                     x: bounds.right - bounds.height,
-                    width: bounds.height
+                    width: bounds.height,
                 })
             else return bounds
         })
@@ -128,16 +128,16 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
     @computed get geoPaths(): string[] {
         const { geoFeatures, pathGen } = this
 
-        return geoFeatures.map(d => {
+        return geoFeatures.map((d) => {
             const s = pathGen(d) as string
             const paths = s.split(/Z/).filter(identity)
 
-            const newPaths = paths.map(path => {
+            const newPaths = paths.map((path) => {
                 const points = path.split(/[MLZ]/).filter((f: any) => f)
-                const rounded = points.map(p =>
+                const rounded = points.map((p) =>
                     p
                         .split(/,/)
-                        .map(v => parseFloat(v).toFixed(1))
+                        .map((v) => parseFloat(v).toFixed(1))
                         .join(",")
                 )
                 return "M" + rounded.join("L")
@@ -154,7 +154,7 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
             geo: geo,
             path: this.geoPaths[i],
             bounds: this.geoBounds[i],
-            center: this.geoBounds[i].centerPos
+            center: this.geoBounds[i].centerPos,
         }))
     }
 
@@ -190,7 +190,7 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
             NorthAmerica: { x: 0.49, y: 0.4, width: 0.19, height: 0.32 },
             SouthAmerica: { x: 0.52, y: 0.815, width: 0.1, height: 0.26 },
             Asia: { x: 0.75, y: 0.45, width: 0.3, height: 0.5 },
-            Oceania: { x: 0.51, y: 0.75, width: 0.1, height: 0.2 }
+            Oceania: { x: 0.51, y: 0.75, width: 0.1, height: 0.2 },
         }
 
         return viewports[this.props.projection]
@@ -235,7 +235,7 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
     @computed get nonProjectionFeatures(): RenderFeature[] {
         const { projection } = this.props
         return this.renderFeatures.filter(
-            feature =>
+            (feature) =>
                 projection !== "World" &&
                 worldRegionByMapEntity[feature.id] !== projection
         )
@@ -244,7 +244,7 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
     @computed get projectionFeatures(): RenderFeature[] {
         const { projection } = this.props
         return this.renderFeatures.filter(
-            feature =>
+            (feature) =>
                 projection === "World" ||
                 worldRegionByMapEntity[feature.id] === projection
         )
@@ -252,13 +252,13 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
 
     @computed get noDataFeatures(): RenderFeature[] {
         return this.projectionFeatures.filter(
-            feature => !this.choroplethData[feature.id]
+            (feature) => !this.choroplethData[feature.id]
         )
     }
 
     @computed get dataFeatures(): RenderFeature[] {
         return this.projectionFeatures.filter(
-            feature => this.choroplethData[feature.id]
+            (feature) => this.choroplethData[feature.id]
         )
     }
 
@@ -279,11 +279,11 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
             ev
         )
 
-        const featuresWithDistance = projectionFeatures.map(d => {
+        const featuresWithDistance = projectionFeatures.map((d) => {
             return { feature: d, distance: Vector2.distance(d.center, mouse) }
         })
 
-        const feature = minBy(featuresWithDistance, d => d.distance)
+        const feature = minBy(featuresWithDistance, (d) => d.distance)
 
         if (feature && feature.distance < 20) {
             if (feature.feature !== this.hoverNearbyFeature) {
@@ -330,7 +330,7 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
             viewportScale,
             nonProjectionFeatures,
             noDataFeatures,
-            dataFeatures
+            dataFeatures,
         } = this
         const focusStrokeColor = "#111"
         const focusStrokeWidth = 1.5
@@ -372,7 +372,7 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
                 <g className="subunits" transform={matrixTransform}>
                     {nonProjectionFeatures.length && (
                         <g className="nonProjectionFeatures">
-                            {nonProjectionFeatures.map(d => {
+                            {nonProjectionFeatures.map((d) => {
                                 return (
                                     <path
                                         key={d.id}
@@ -388,7 +388,7 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
 
                     {noDataFeatures.length && (
                         <g className="noDataFeatures">
-                            {noDataFeatures.map(d => {
+                            {noDataFeatures.map((d) => {
                                 const isFocus = this.hasFocus(d.id)
                                 const outOfFocusBracket =
                                     !!this.focusBracket && !isFocus
@@ -417,7 +417,7 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
                                         onClick={(ev: SVGMouseEvent) =>
                                             this.props.onClick(d.geo, ev)
                                         }
-                                        onMouseEnter={ev =>
+                                        onMouseEnter={(ev) =>
                                             this.onMouseEnter(d, ev)
                                         }
                                         onMouseLeave={this.onMouseLeave}
@@ -428,7 +428,7 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
                     )}
 
                     {sortBy(
-                        dataFeatures.map(d => {
+                        dataFeatures.map((d) => {
                             const isFocus = this.hasFocus(d.id)
                             const showSelectedStyle =
                                 this.showSelectedStyle && this.isSelected(d.id)
@@ -466,14 +466,14 @@ export class ChoroplethMap extends React.Component<ChoroplethMapProps> {
                                     onClick={(ev: SVGMouseEvent) =>
                                         this.props.onClick(d.geo, ev)
                                     }
-                                    onMouseEnter={ev =>
+                                    onMouseEnter={(ev) =>
                                         this.onMouseEnter(d, ev)
                                     }
                                     onMouseLeave={this.onMouseLeave}
                                 />
                             )
                         }),
-                        p => p.props["strokeWidth"]
+                        (p) => p.props["strokeWidth"]
                     )}
 
                     {/*dataFeatures.map(d => <rect x={d.bounds.x} y={d.bounds.y} width={d.bounds.width} height={d.bounds.height} fill="none" stroke="#000"/>)*/}

--- a/grapher/mapCharts/MapColorLegend.ts
+++ b/grapher/mapCharts/MapColorLegend.ts
@@ -9,14 +9,14 @@ import {
     flatten,
     some,
     find,
-    sum
+    sum,
 } from "grapher/utils/Util"
 import { Bounds } from "grapher/utils/Bounds"
 import { TextWrap } from "grapher/text/TextWrap"
 import {
     ColorScaleBin,
     NumericBin,
-    CategoricalBin
+    CategoricalBin,
 } from "grapher/color/ColorScaleBin"
 
 interface PositionedBin {
@@ -53,7 +53,7 @@ export class MapNumericColorLegend {
     }
     @computed get numericBins(): NumericBin[] {
         return this.props.legendData.filter(
-            l => l instanceof NumericBin
+            (l) => l instanceof NumericBin
         ) as NumericBin[]
     }
     @computed get rectHeight(): number {
@@ -66,10 +66,10 @@ export class MapNumericColorLegend {
     // NumericColorLegend wants to map a range to a width. However, sometimes we are given
     // data without a clear min/max. So we must fit these scurrilous bins into the width somehow.
     @computed get minValue(): number {
-        return min(this.numericBins.map(d => d.min)) as number
+        return min(this.numericBins.map((d) => d.min)) as number
     }
     @computed get maxValue(): number {
-        return max(this.numericBins.map(d => d.max)) as number
+        return max(this.numericBins.map((d) => d.max)) as number
     }
     @computed get rangeSize(): number {
         return this.maxValue - this.minValue
@@ -83,7 +83,7 @@ export class MapNumericColorLegend {
     @computed get totalCategoricalWidth(): number {
         const { legendData } = this.props
         const { categoryBinWidth, categoryBinMargin } = this
-        const widths = legendData.map(d =>
+        const widths = legendData.map((d) =>
             d instanceof CategoricalBin
                 ? categoryBinWidth + categoryBinMargin
                 : 0
@@ -101,11 +101,11 @@ export class MapNumericColorLegend {
             categoryBinWidth,
             categoryBinMargin,
             availableNumericWidth,
-            numericBins
+            numericBins,
         } = this
         let xOffset = 0
 
-        return props.legendData.map(d => {
+        return props.legendData.map((d) => {
             let width = categoryBinWidth,
                 margin = categoryBinMargin
             if (d instanceof NumericBin) {
@@ -124,7 +124,7 @@ export class MapNumericColorLegend {
                 x: x,
                 width: width,
                 margin: margin,
-                bin: d
+                bin: d,
             }
         })
     }
@@ -146,13 +146,13 @@ export class MapNumericColorLegend {
                 text: text,
                 fontSize: tickFontSize,
                 bounds: labelBounds.extend({ x: x, y: y }),
-                hidden: false
+                hidden: false,
             }
         }
 
         const makeRangeLabel = (d: PositionedBin) => {
             const labelBounds = Bounds.forText(d.bin.text, {
-                fontSize: tickFontSize
+                fontSize: tickFontSize,
             })
             const x = d.x + d.width / 2 - labelBounds.width / 2
             const y = -rectHeight - labelBounds.height - 3
@@ -162,7 +162,7 @@ export class MapNumericColorLegend {
                 fontSize: tickFontSize,
                 bounds: labelBounds.extend({ x: x, y: y }),
                 priority: true,
-                hidden: false
+                hidden: false,
             }
         }
 
@@ -190,7 +190,7 @@ export class MapNumericColorLegend {
             }
         }
 
-        labels = labels.filter(l => !l.hidden)
+        labels = labels.filter((l) => !l.hidden)
 
         // If labels overlap, first we try alternating raised labels
         let raisedMode = false
@@ -208,7 +208,7 @@ export class MapNumericColorLegend {
                 const l = labels[i]
                 if (i % 2 !== 0) {
                     l.bounds = l.bounds.extend({
-                        y: l.bounds.y - l.bounds.height - 1
+                        y: l.bounds.y - l.bounds.height - 1,
                     })
                 }
             }
@@ -218,7 +218,7 @@ export class MapNumericColorLegend {
     }
 
     @computed get height(): number {
-        return Math.abs(min(this.numericLabels.map(l => l.bounds.y)) ?? 0)
+        return Math.abs(min(this.numericLabels.map((l) => l.bounds.y)) ?? 0)
     }
 
     @computed get width(): number {
@@ -268,7 +268,7 @@ export class MapCategoricalColorLegend {
         let marks: CategoricalMark[] = [],
             xOffset = 0,
             yOffset = 0
-        each(props.legendData, d => {
+        each(props.legendData, (d) => {
             const labelBounds = Bounds.forText(d.text, { fontSize: fontSize })
             const markWidth =
                 rectSize + rectPadding + labelBounds.width + markPadding
@@ -287,9 +287,9 @@ export class MapCategoricalColorLegend {
                 text: d.text,
                 bounds: labelBounds.extend({
                     x: markX + rectSize + rectPadding,
-                    y: markY + 1
+                    y: markY + 1,
                 }),
-                fontSize: fontSize
+                fontSize: fontSize,
             }
 
             marks.push({
@@ -297,7 +297,7 @@ export class MapCategoricalColorLegend {
                 y: markY,
                 rectSize: rectSize,
                 label: label,
-                bin: d
+                bin: d,
             })
 
             xOffset += markWidth
@@ -311,28 +311,28 @@ export class MapCategoricalColorLegend {
     }
 
     @computed get width(): number {
-        return max(this.markLines.map(l => l.totalWidth)) as number
+        return max(this.markLines.map((l) => l.totalWidth)) as number
     }
 
     @computed get marks(): CategoricalMark[] {
         const lines = this.markLines
 
         // Center each line
-        each(lines, line => {
+        each(lines, (line) => {
             const xShift = this.width / 2 - line.totalWidth / 2
-            each(line.marks, m => {
+            each(line.marks, (m) => {
                 m.x += xShift
                 m.label.bounds = m.label.bounds.extend({
-                    x: m.label.bounds.x + xShift
+                    x: m.label.bounds.x + xShift,
                 })
             })
         })
 
-        return flatten(map(lines, l => l.marks))
+        return flatten(map(lines, (l) => l.marks))
     }
 
     @computed get height(): number {
-        return max(this.marks.map(m => m.y + m.rectSize)) as number
+        return max(this.marks.map((m) => m.y + m.rectSize)) as number
     }
 }
 
@@ -357,15 +357,15 @@ export class MapColorLegend {
             this.hasCategorical ||
             !some(
                 this.props.legendData,
-                d => (d as CategoricalBin).value === "No data" && !d.isHidden
+                (d) => (d as CategoricalBin).value === "No data" && !d.isHidden
             )
         ) {
             return this.props.legendData.filter(
-                l => l instanceof NumericBin && !l.isHidden
+                (l) => l instanceof NumericBin && !l.isHidden
             )
         } else {
             const bin = this.props.legendData.filter(
-                l =>
+                (l) =>
                     (l instanceof NumericBin || l.value === "No data") &&
                     !l.isHidden
             )
@@ -377,7 +377,7 @@ export class MapColorLegend {
     }
     @computed get categoricalLegendData(): CategoricalBin[] {
         return this.props.legendData.filter(
-            l => l instanceof CategoricalBin && !l.isHidden
+            (l) => l instanceof CategoricalBin && !l.isHidden
         ) as CategoricalBin[]
     }
     @computed get hasCategorical(): boolean {
@@ -388,7 +388,7 @@ export class MapColorLegend {
         return new TextWrap({
             maxWidth: this.props.bounds.width,
             fontSize: 0.7 * this.props.fontSize,
-            text: this.props.title
+            text: this.props.title,
         })
     }
 
@@ -398,7 +398,7 @@ export class MapColorLegend {
 
         if (focusBracket) return focusBracket
         else if (focusValue)
-            return find(numericLegendData, bin => bin.contains(focusValue))
+            return find(numericLegendData, (bin) => bin.contains(focusValue))
         else return undefined
     }
 
@@ -408,7 +408,9 @@ export class MapColorLegend {
         if (focusBracket && focusBracket instanceof CategoricalBin)
             return focusBracket
         else if (focusValue)
-            return find(categoricalLegendData, bin => bin.contains(focusValue))
+            return find(categoricalLegendData, (bin) =>
+                bin.contains(focusValue)
+            )
         else return undefined
     }
 
@@ -427,7 +429,7 @@ export class MapColorLegend {
                   },
                   get fontSize() {
                       return that.props.fontSize
-                  }
+                  },
               })
             : undefined
     }
@@ -454,7 +456,7 @@ export class MapColorLegend {
                   },
                   get fontSize() {
                       return that.props.fontSize
-                  }
+                  },
               })
             : undefined
     }

--- a/grapher/mapCharts/MapColorLegendView.tsx
+++ b/grapher/mapCharts/MapColorLegendView.tsx
@@ -8,7 +8,7 @@ import { ColorScaleBin, CategoricalBin } from "grapher/color/ColorScaleBin"
 import {
     MapColorLegend,
     MapNumericColorLegend,
-    MapCategoricalColorLegend
+    MapCategoricalColorLegend,
 } from "./MapColorLegend"
 
 const FOCUS_BORDER_COLOR = "#111"
@@ -30,7 +30,7 @@ export class MapColorLegendView extends React.Component<
             mainLabel,
             numericLegend,
             categoryLegend,
-            categoryLegendHeight
+            categoryLegendHeight,
         } = legend
 
         return (
@@ -118,7 +118,7 @@ class NumericColorLegendView extends React.Component<{
 
         // If inside legend bounds, trigger onMouseOver with the bin closest to the cursor.
         let newFocusBracket = null
-        legend.positionedBins.forEach(d => {
+        legend.positionedBins.forEach((d) => {
             if (mouse.x >= props.x + d.x && mouse.x <= props.x + d.x + d.width)
                 newFocusBracket = d.bin
         })
@@ -149,7 +149,7 @@ class NumericColorLegendView extends React.Component<{
             numericLabels,
             height,
             positionedBins,
-            focusBracket
+            focusBracket,
         } = legend
         //Bounds.debug([this.bounds])
 
@@ -188,7 +188,7 @@ class NumericColorLegendView extends React.Component<{
                             />
                         )
                     }),
-                    r => r.props["strokeWidth"]
+                    (r) => r.props["strokeWidth"]
                 )}
                 {numericLabels.map((label, i) => (
                     <text

--- a/grapher/mapCharts/MapConfig.ts
+++ b/grapher/mapCharts/MapConfig.ts
@@ -2,7 +2,7 @@ import { observable, toJS } from "mobx"
 import { MapProjection } from "./MapProjections"
 import {
     ColorScaleConfig,
-    PersistableColorScaleConfig
+    PersistableColorScaleConfig,
 } from "grapher/color/ColorScaleConfig"
 import { owidVariableId } from "owidTable/OwidTable"
 import { Persistable, updatePersistables } from "grapher/core/Persistable"

--- a/grapher/mapCharts/MapProjections.ts
+++ b/grapher/mapCharts/MapProjections.ts
@@ -2,7 +2,7 @@ import {
     geoPath,
     geoConicConformal,
     geoAzimuthalEqualArea,
-    GeoProjection
+    GeoProjection,
 } from "d3-geo"
 import { geoRobinson, geoPatterson } from "d3-geo-projection"
 
@@ -59,5 +59,5 @@ export const MapProjections = {
             .rotate([-135, 0])
             .center([0, -20])
             .parallels([-10, -30])
-    )
+    ),
 }

--- a/grapher/mapCharts/MapTab.tsx
+++ b/grapher/mapCharts/MapTab.tsx
@@ -8,7 +8,7 @@ import {
     ChoroplethDatum,
     GeoFeature,
     MapBracket,
-    MapEntity
+    MapEntity,
 } from "grapher/mapCharts/ChoroplethMap"
 import { MapColorLegend } from "grapher/mapCharts/MapColorLegend"
 import { MapColorLegendView } from "./MapColorLegendView"
@@ -64,7 +64,7 @@ class MapWithLegend extends React.Component<MapWithLegendProps> {
             this.tooltipTarget = {
                 x: mouse.x,
                 y: mouse.y,
-                featureId: d.id as string
+                featureId: d.id as string,
             }
     }
 
@@ -117,7 +117,7 @@ class MapWithLegend extends React.Component<MapWithLegendProps> {
     }
 
     @action.bound onTargetChange({
-        targetStartYear
+        targetStartYear,
     }: {
         targetStartYear: number
     }) {
@@ -155,7 +155,7 @@ class MapWithLegend extends React.Component<MapWithLegendProps> {
             },
             get fontSize() {
                 return that.grapher.baseFontSize
-            }
+            },
         })
     }
 
@@ -200,7 +200,7 @@ class MapWithLegend extends React.Component<MapWithLegendProps> {
             focusEntity,
             mapLegend,
             tooltipTarget,
-            projectionChooserBounds
+            projectionChooserBounds,
         } = this
 
         const tooltipProps = {
@@ -208,7 +208,7 @@ class MapWithLegend extends React.Component<MapWithLegendProps> {
             formatYear: this.props.formatYear,
             mapToDataEntities: this.props.mapToDataEntities,
             tooltipDatum: this.tooltipDatum,
-            isEntityClickable: this.isEntityClickable(tooltipTarget?.featureId)
+            isEntityClickable: this.isEntityClickable(tooltipTarget?.featureId),
         }
 
         return (
@@ -271,7 +271,7 @@ export class MapTab extends React.Component<MapTabProps> {
             },
             get bounds() {
                 return that.props.bounds
-            }
+            },
         })
     }
 

--- a/grapher/mapCharts/MapTooltip.jsdom.test.tsx
+++ b/grapher/mapCharts/MapTooltip.jsdom.test.tsx
@@ -11,7 +11,7 @@ const bounds = new Bounds(0, 0, 800, 600)
 
 const mockEvent = {
     clientX: 50,
-    clientY: 50
+    clientY: 50,
 }
 
 const chart = setupGrapher(792, [3512], { hasMapTab: true })
@@ -23,7 +23,7 @@ describe(MapTooltip, () => {
 
         const chartWrapperWithHover = chartWrapper
             .find("path")
-            .findWhere(node => node.key() === "United States")
+            .findWhere((node) => node.key() === "United States")
             .simulate("mouseenter", mockEvent)
             .update()
 

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -7,7 +7,7 @@ import { takeWhile, last, first, isMobile } from "grapher/utils/Util"
 import {
     SparkBars,
     SparkBarsDatum,
-    SparkBarsProps
+    SparkBarsProps,
 } from "grapher/sparkBars/SparkBars"
 import { CovidTimeSeriesValue } from "site/client/covid/CovidTimeSeriesValue"
 import { Grapher } from "grapher/core/Grapher"
@@ -39,7 +39,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
             data: this.sparkBarsData,
             x: this.sparkBarsDatumXAccessor,
             y: (d: SparkBarsDatum) => d.value,
-            xDomain: this.sparkBarsDomain
+            xDomain: this.sparkBarsDomain,
         }
     }
 
@@ -53,13 +53,13 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
             ?.forEach((value, key) => {
                 sparkBarValues.push({
                     year: key,
-                    value: value as number
+                    value: value as number,
                 })
             })
 
         return takeWhile(
             sparkBarValues,
-            d => d.year <= tooltipDatum.year
+            (d) => d.year <= tooltipDatum.year
         ).slice(-this.sparkBarsToDisplay)
     }
 
@@ -107,7 +107,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
             inputYear,
             mapToDataEntities,
             tooltipDatum,
-            isEntityClickable
+            isEntityClickable,
         } = this.props
 
         const tooltipMessage = this.grapher.isScatter
@@ -131,7 +131,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                         padding: "0.3em 0.3em",
                         margin: 0,
                         fontWeight: "normal",
-                        fontSize: "1em"
+                        fontSize: "1em",
                     }}
                 >
                     {mapToDataEntities[tooltipTarget.featureId] ||
@@ -140,7 +140,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                 <div
                     style={{
                         margin: 0,
-                        padding: "0.3em 0.3em"
+                        padding: "0.3em 0.3em",
                     }}
                 >
                     {tooltipDatum ? (
@@ -189,7 +189,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                                 margin: 0,
                                 padding: "0.3em 0.9em",
                                 fontSize: "13px",
-                                opacity: 0.6
+                                opacity: 0.6,
                             }}
                         >
                             {tooltipMessage}

--- a/grapher/mapCharts/MapTransform.ts
+++ b/grapher/mapCharts/MapTransform.ts
@@ -11,13 +11,13 @@ import {
     entityNameForMap,
     formatYear,
     uniq,
-    sortNumeric
+    sortNumeric,
 } from "grapher/utils/Util"
 import {
     TimeBound,
     TimeBoundValue,
     Time,
-    getClosestTime
+    getClosestTime,
 } from "grapher/utils/TimeBounds"
 
 import { ChoroplethData } from "grapher/mapCharts/ChoroplethMap"
@@ -116,7 +116,7 @@ export class MapTransform extends ChartTransform {
 
     @computed get dimension(): ChartDimension | undefined {
         return this.grapher.filledDimensions.find(
-            d => d.variableId === this.variableId
+            (d) => d.variableId === this.variableId
         )
     }
 
@@ -129,7 +129,7 @@ export class MapTransform extends ChartTransform {
             MapTopology.objects.world.geometries.map((g: any) => g.id)
         )
         const entities = this.dimension.entityNamesUniq.filter(
-            e => !!idLookup[entityNameForMap(e)]
+            (e) => !!idLookup[entityNameForMap(e)]
         )
         return keyBy(entities)
     }
@@ -156,7 +156,7 @@ export class MapTransform extends ChartTransform {
         } = {
             years: [],
             entities: [],
-            values: []
+            values: [],
         }
 
         if (dimension) {
@@ -179,7 +179,7 @@ export class MapTransform extends ChartTransform {
 
     @computed get sortedNumericValues(): number[] {
         return sortNumeric(
-            this.mappableData.values.filter(isNumber).filter(v => !isNaN(v))
+            this.mappableData.values.filter(isNumber).filter((v) => !isNaN(v))
         )
     }
 
@@ -219,7 +219,7 @@ export class MapTransform extends ChartTransform {
             },
             get formatNumericValue() {
                 return that.formatValueShort
-            }
+            },
         })
     }
 
@@ -241,7 +241,7 @@ export class MapTransform extends ChartTransform {
 
         const selectedEntityNames = new Set(grapher.selectedEntityNames)
 
-        entities.forEach(entity => {
+        entities.forEach((entity) => {
             const valueByYear = valueByEntityAndYear.get(entity)
             if (!valueByYear) return
             const years = Array.from(valueByYear.keys())
@@ -253,7 +253,7 @@ export class MapTransform extends ChartTransform {
                 entity,
                 year,
                 value,
-                isSelected: selectedEntityNames.has(entity)
+                isSelected: selectedEntityNames.has(entity),
             }
         })
 
@@ -270,7 +270,7 @@ export class MapTransform extends ChartTransform {
             if (color) {
                 choroplethData[entity] = extend({}, datum, {
                     color: color,
-                    highlightFillColor: color
+                    highlightFillColor: color,
                 })
             }
         })

--- a/grapher/mapCharts/ProjectionChooser.tsx
+++ b/grapher/mapCharts/ProjectionChooser.tsx
@@ -25,10 +25,10 @@ export class ProjectionChooser extends React.Component<{
     }
 
     @computed get options() {
-        return worldRegions.map(region => {
+        return worldRegions.map((region) => {
             return {
                 value: region,
-                label: labelsByRegion[region]
+                label: labelsByRegion[region],
             }
         })
     }
@@ -39,7 +39,7 @@ export class ProjectionChooser extends React.Component<{
         const style: React.CSSProperties = {
             position: "absolute",
             fontSize: "0.75rem",
-            ...bounds.toCSS()
+            ...bounds.toCSS(),
         }
 
         return (
@@ -47,10 +47,10 @@ export class ProjectionChooser extends React.Component<{
                 <Select
                     options={this.options}
                     onChange={this.onChange}
-                    value={this.options.find(opt => opt.value === value)}
+                    value={this.options.find((opt) => opt.value === value)}
                     menuPlacement="bottom"
                     components={{
-                        IndicatorSeparator: null
+                        IndicatorSeparator: null,
                     }}
                     styles={getStylesForTargetHeight(22)}
                     isSearchable={false}

--- a/grapher/mapCharts/WorldRegions.ts
+++ b/grapher/mapCharts/WorldRegions.ts
@@ -286,7 +286,7 @@ const worldRegionByEntity: Record<string, WorldRegion> = {
     Zambia: "Africa",
     Zanzibar: "Africa",
     Zimbabwe: "Africa",
-    "Åland Islands": "Europe"
+    "Åland Islands": "Europe",
 }
 
 export const worldRegionByMapEntity: { [key: string]: WorldRegion } = {}
@@ -297,7 +297,7 @@ for (const entity in worldRegionByEntity) {
 
 export const worldRegions: WorldRegion[] = [
     "World",
-    ...uniq(values(worldRegionByMapEntity))
+    ...uniq(values(worldRegionByMapEntity)),
 ]
 
 export const labelsByRegion: Record<WorldRegion, string> = {
@@ -307,5 +307,5 @@ export const labelsByRegion: Record<WorldRegion, string> = {
     SouthAmerica: "South America",
     Asia: "Asia",
     Europe: "Europe",
-    Oceania: "Oceania"
+    Oceania: "Oceania",
 }

--- a/grapher/sandbox/chart.sample.js
+++ b/grapher/sandbox/chart.sample.js
@@ -7,7 +7,7 @@ const sandboxGrapher = {
         customNumericColors: [],
         customCategoryColors: {},
         customCategoryLabels: {},
-        customHiddenCategories: {}
+        customHiddenCategories: {},
     },
     tab: "chart",
     data: { availableEntities: ["Germany", "Spain"] },
@@ -23,34 +23,34 @@ const sandboxGrapher = {
             {
                 year: 2000,
                 entity: "Germany",
-                value: 452
+                value: 452,
             },
             {
                 year: 2001,
                 entity: "Germany",
-                value: 459
+                value: 459,
             },
             {
                 year: 2002,
                 entity: "Germany",
-                value: 259
+                value: 259,
             },
             {
                 year: 2000,
                 entity: "Spain",
-                value: 564
+                value: 564,
             },
             {
                 year: 2001,
                 entity: "Spain",
-                value: 122
+                value: 122,
             },
             {
                 year: 2002,
                 entity: "Spain",
-                value: 999
-            }
-        ]
+                value: 999,
+            },
+        ],
     },
     minTime: 2000,
     version: 1,
@@ -65,5 +65,5 @@ const sandboxGrapher = {
     isExplorable: false,
     selectedData: [{ index: 0, entityId: 0 }],
     addCountryMode: "add-country",
-    hideRelativeToggle: true
+    hideRelativeToggle: true,
 }

--- a/grapher/sandbox/index.html
+++ b/grapher/sandbox/index.html
@@ -29,7 +29,7 @@
                 var view = window.GrapherView.bootstrap({
                     jsonConfig: sandboxGrapher,
                     containerNode: figure,
-                    queryStr: window.location.search
+                    queryStr: window.location.search,
                 })
                 view.bindToWindow()
             } catch (err) {

--- a/grapher/scatterCharts/ComparisonLine.tsx
+++ b/grapher/scatterCharts/ComparisonLine.tsx
@@ -38,8 +38,8 @@ export class ComparisonLine extends React.Component<{
         const { xAxis, yAxis } = this.props.dualAxis
         const line = d3_line()
             .curve(curveLinear)
-            .x(d => xAxis.place(d[0]))
-            .y(d => yAxis.place(d[1]))
+            .x((d) => xAxis.place(d[0]))
+            .y((d) => yAxis.place(d[1]))
         return line(controlData)
     }
 
@@ -54,8 +54,8 @@ export class ComparisonLine extends React.Component<{
 
         // Find the points of the line that are actually placeable on the chart
         const linePoints = controlData
-            .map(d => new Vector2(xAxis.place(d[0]), yAxis.place(d[1])))
-            .filter(p => innerBounds.contains(p))
+            .map((d) => new Vector2(xAxis.place(d[0]), yAxis.place(d[1])))
+            .filter((p) => innerBounds.contains(p))
         if (!linePoints.length) return
 
         const midPoint = linePoints[Math.floor(linePoints.length / 2)]
@@ -68,7 +68,7 @@ export class ComparisonLine extends React.Component<{
             y: midPoint.y,
             bounds: bounds,
             angle: angle,
-            text: label
+            text: label,
         }
     }
 
@@ -93,7 +93,7 @@ export class ComparisonLine extends React.Component<{
                         opacity: 0.9,
                         fill: "none",
                         stroke: "#ccc",
-                        strokeDasharray: "2 2"
+                        strokeDasharray: "2 2",
                     }}
                     id={`path-${renderUid}`}
                     d={linePath || undefined}
@@ -105,7 +105,7 @@ export class ComparisonLine extends React.Component<{
                             fontSize: "80%",
                             opacity: 0.9,
                             textAnchor: "end",
-                            fill: "#999"
+                            fill: "#999",
                         }}
                         clipPath={`url(#axisBounds-${renderUid})`}
                     >

--- a/grapher/scatterCharts/ComparisonLineGenerator.ts
+++ b/grapher/scatterCharts/ComparisonLineGenerator.ts
@@ -11,7 +11,7 @@ export function generateComparisonLinePoints(
 ) {
     const expr = parseEquation(lineFunction)?.simplify({
         e: Math.E,
-        pi: Math.PI
+        pi: Math.PI,
     })
     const yFunc = (x: number) => evalExpression(expr, { x }, undefined)
 

--- a/grapher/scatterCharts/ConnectedScatterLegend.tsx
+++ b/grapher/scatterCharts/ConnectedScatterLegend.tsx
@@ -33,7 +33,7 @@ export class ConnectedScatterLegend {
         return new TextWrap({
             text: this.props.formatYearFunction(props.startYear),
             fontSize: fontSize,
-            maxWidth: maxLabelWidth
+            maxWidth: maxLabelWidth,
         })
     }
 
@@ -42,7 +42,7 @@ export class ConnectedScatterLegend {
         return new TextWrap({
             text: this.props.formatYearFunction(props.endYear),
             fontSize: fontSize,
-            maxWidth: maxLabelWidth
+            maxWidth: maxLabelWidth,
         })
     }
 

--- a/grapher/scatterCharts/Halos.tsx
+++ b/grapher/scatterCharts/Halos.tsx
@@ -5,7 +5,7 @@ const HaloStyle: React.CSSProperties = {
     stroke: "#fff",
     strokeLinecap: "round",
     strokeLinejoin: "round",
-    strokeWidth: ".25em"
+    strokeWidth: ".25em",
 }
 
 export const getElementWithHalo = (
@@ -13,7 +13,7 @@ export const getElementWithHalo = (
     element: React.ReactElement
 ) => {
     const halo = React.cloneElement(element, {
-        style: HaloStyle
+        style: HaloStyle,
     })
     return (
         <React.Fragment key={key}>

--- a/grapher/scatterCharts/MultiColorPolyline.test.ts
+++ b/grapher/scatterCharts/MultiColorPolyline.test.ts
@@ -6,7 +6,7 @@ describe(getSegmentsFromPoints, () => {
     it("splits different-colored segments", () => {
         const points = [
             { x: 0, y: 0, color: "#000" },
-            { x: 1, y: 0, color: "#111" }
+            { x: 1, y: 0, color: "#111" },
         ]
         const segments = getSegmentsFromPoints(points)
 
@@ -24,7 +24,7 @@ describe(getSegmentsFromPoints, () => {
     it("preserves same-colored segments", () => {
         const points = [
             { x: 0, y: 0, color: "#000" },
-            { x: 1, y: 0, color: "#000" }
+            { x: 1, y: 0, color: "#000" },
         ]
         const segments = getSegmentsFromPoints(points)
 
@@ -40,7 +40,7 @@ describe(getSegmentsFromPoints, () => {
             { x: 1, y: 0, color: "#000" },
             { x: 5, y: 3, color: "#000" },
             { x: 5, y: 4, color: "#111" },
-            { x: 6, y: 4, color: "#000" }
+            { x: 6, y: 4, color: "#000" },
         ]
         const segments = getSegmentsFromPoints(points)
 

--- a/grapher/scatterCharts/MultiColorPolyline.tsx
+++ b/grapher/scatterCharts/MultiColorPolyline.tsx
@@ -23,14 +23,14 @@ interface Segment {
 function getMidpoint(a: Point, b: Point) {
     return {
         x: (a.x + b.x) / 2,
-        y: (a.y + b.y) / 2
+        y: (a.y + b.y) / 2,
     }
 }
 
 function toPoint(point: MultiColorPolylinePoint): Point {
     return {
         x: point.x,
-        y: point.y
+        y: point.y,
     }
 }
 
@@ -38,12 +38,12 @@ export function getSegmentsFromPoints(
     points: MultiColorPolylinePoint[]
 ): Segment[] {
     const segments: Segment[] = []
-    points.forEach(currentPoint => {
+    points.forEach((currentPoint) => {
         const currentSegment = segments[segments.length - 1]
         if (!currentSegment) {
             segments.push({
                 points: [toPoint(currentPoint)],
-                color: currentPoint.color
+                color: currentPoint.color,
             })
         } else if (currentSegment.color === currentPoint.color) {
             currentSegment.points.push(toPoint(currentPoint))
@@ -55,7 +55,7 @@ export function getSegmentsFromPoints(
             currentSegment.points.push(midPoint)
             segments.push({
                 points: [midPoint, toPoint(currentPoint)],
-                color: currentPoint.color
+                color: currentPoint.color,
             })
         }
     })
@@ -63,7 +63,7 @@ export function getSegmentsFromPoints(
 }
 
 function toSvgPoints(points: Point[]): string {
-    return points.map(p => `${p.x.toFixed(2)},${p.y.toFixed(2)}`).join(" ")
+    return points.map((p) => `${p.x.toFixed(2)},${p.y.toFixed(2)}`).join(" ")
 }
 
 type MultiColorPolylineProps = Omit<

--- a/grapher/scatterCharts/PointsWithLabels.tsx
+++ b/grapher/scatterCharts/PointsWithLabels.tsx
@@ -24,7 +24,7 @@ import {
     intersection,
     minBy,
     maxBy,
-    sortNumeric
+    sortNumeric,
 } from "grapher/utils/Util"
 import { computed, action } from "mobx"
 import { observer } from "mobx-react"
@@ -135,7 +135,7 @@ class ScatterGroupSingle extends React.Component<{
 
         const color = group.isFocus || !isLayerMode ? value.color : "#e2e2e2"
 
-        const isLabelled = group.allLabels.some(label => !label.isHidden)
+        const isLabelled = group.allLabels.some((label) => !label.isHidden)
         const size =
             !group.isFocus && isConnected ? 1 + value.size / 16 : value.size
         const cx = value.position.x.toFixed(2)
@@ -205,10 +205,10 @@ class ScatterBackgroundLine extends React.Component<{
                         opacity={opacity}
                     />
                     <MultiColorPolyline
-                        points={group.values.map(v => ({
+                        points={group.values.map((v) => ({
                             x: v.position.x,
                             y: v.position.y,
-                            color: isLayerMode ? "#ccc" : v.color
+                            color: isLayerMode ? "#ccc" : v.color,
                         }))}
                         strokeWidth={(0.3 + group.size / 16).toFixed(2)}
                         opacity={opacity}
@@ -237,13 +237,13 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
     }
 
     @computed private get isConnected(): boolean {
-        return some(this.data, g => g.values.length > 1)
+        return some(this.data, (g) => g.values.length > 1)
     }
 
     @computed private get focusKeys(): string[] {
         return intersection(
             this.props.focusKeys || [],
-            this.data.map(g => g.entityDimensionKey)
+            this.data.map((g) => g.entityDimensionKey)
         )
     }
 
@@ -265,7 +265,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
     @computed private get isSubtleForeground(): boolean {
         return (
             this.focusKeys.length > 1 &&
-            some(this.props.data, series => series.values.length > 2)
+            some(this.props.data, (series) => series.values.length > 2)
         )
     }
 
@@ -301,8 +301,8 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
         yAxis.range = this.bounds.yRange()
 
         return sortNumeric(
-            data.map(d => {
-                const values = d.values.map(v => {
+            data.map((d) => {
+                const values = d.values.map((v) => {
                     const area = sizeScale(v.size || 4)
                     const scaleColor =
                         colorScale !== undefined
@@ -317,7 +317,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                         size: Math.sqrt(area / Math.PI),
                         fontSize: fontScale(d.size || 1),
                         time: v.time,
-                        label: this.props.formatLabel(v)
+                        label: this.props.formatLabel(v),
                     }
                 })
 
@@ -330,10 +330,10 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                     text: d.label,
                     midLabels: [],
                     allLabels: [],
-                    offsetVector: Vector2.zero
+                    offsetVector: Vector2.zero,
                 }
             }),
-            d => d.size,
+            (d) => d.size,
             SortOrder.desc
         )
     }
@@ -372,7 +372,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
             x: pos.x,
             y: pos.y,
             fontSize: fontSize,
-            fontFamily: labelFontFamily
+            fontFamily: labelFontFamily,
         })
         if (pos.x < firstValue.position.x)
             bounds = new Bounds(
@@ -396,7 +396,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
             color: firstValue.color,
             bounds: bounds,
             series: series,
-            isStart: true
+            isStart: true,
         }
     }
 
@@ -430,9 +430,9 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                     .add(nextSegment)
                     .normalize()
                     .normals()
-                    .map(x => x.times(5))
-                const potentialSpots = normals.map(n => v.position.add(n))
-                pos = maxBy(potentialSpots, p => {
+                    .map((x) => x.times(5))
+                const potentialSpots = normals.map((n) => v.position.add(n))
+                pos = maxBy(potentialSpots, (p) => {
                     return (
                         Vector2.distance(p, prevPos) +
                         Vector2.distance(p, nextPos)
@@ -447,7 +447,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                 y: pos.y,
                 fontSize: fontSize,
                 fontWeight: fontWeight,
-                fontFamily: labelFontFamily
+                fontFamily: labelFontFamily,
             })
             if (pos.x < v.position.x)
                 bounds = new Bounds(
@@ -471,7 +471,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                 color: v.color,
                 bounds: bounds,
                 series: series,
-                isMid: true
+                isMid: true,
             }
         })
     }
@@ -513,16 +513,16 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
             x: labelPos.x,
             y: labelPos.y,
             fontSize: fontSize,
-            fontFamily: labelFontFamily
+            fontFamily: labelFontFamily,
         })
 
         if (labelPos.x < lastPos.x)
             labelBounds = labelBounds.extend({
-                x: labelBounds.x - labelBounds.width
+                x: labelBounds.x - labelBounds.width,
             })
         if (labelPos.y > lastPos.y)
             labelBounds = labelBounds.extend({
-                y: labelBounds.y + labelBounds.height / 2
+                y: labelBounds.y + labelBounds.height / 2,
             })
 
         return {
@@ -535,7 +535,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
             color: lastValue.color,
             bounds: labelBounds,
             series: series,
-            isEnd: true
+            isEnd: true,
         }
     }
 
@@ -557,10 +557,10 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
             series.allLabels = [series.startLabel]
                 .concat(series.midLabels)
                 .concat([series.endLabel])
-                .filter(x => x) as ScatterLabel[]
+                .filter((x) => x) as ScatterLabel[]
         }
 
-        const labels = flatten(renderData.map(series => series.allLabels))
+        const labels = flatten(renderData.map((series) => series.allLabels))
 
         // Ensure labels fit inside bounds
         // Must do before collision detection since it'll change the positions
@@ -568,7 +568,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
 
         const labelsByPriority = sortNumeric(
             labels,
-            l => this.labelPriority(l),
+            (l) => this.labelPriority(l),
             SortOrder.desc
         )
         if (this.focusKeys.length > 0)
@@ -581,8 +581,8 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
 
     private hideUnselectedLabels(labelsByPriority: ScatterLabel[]) {
         labelsByPriority
-            .filter(label => !label.series.isFocus && !label.series.isHover)
-            .forEach(label => (label.isHidden = true))
+            .filter((label) => !label.series.isFocus && !label.series.isHover)
+            .forEach((label) => (label.isHidden = true))
     }
 
     private hideCollidingLabelsByPriority(labelsByPriority: ScatterLabel[]) {
@@ -632,11 +632,11 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
         for (const label of labels) {
             if (label.bounds.left < bounds.left - 1) {
                 label.bounds = label.bounds.extend({
-                    x: label.bounds.x + label.bounds.width
+                    x: label.bounds.x + label.bounds.width,
                 })
             } else if (label.bounds.right > bounds.right + 1) {
                 label.bounds = label.bounds.extend({
-                    x: label.bounds.x - label.bounds.width
+                    x: label.bounds.x - label.bounds.width,
                 })
             }
 
@@ -644,7 +644,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                 label.bounds = label.bounds.extend({ y: bounds.top })
             } else if (label.bounds.bottom > bounds.bottom + 1) {
                 label.bounds = label.bounds.extend({
-                    y: bounds.bottom - label.bounds.height
+                    y: bounds.bottom - label.bounds.height,
                 })
             }
         }
@@ -665,7 +665,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
         this.mouseFrame = requestAnimationFrame(() => {
             const mouse = getRelativeMouse(this.base.current, nativeEvent)
 
-            const closestSeries = minBy(this.renderData, series => {
+            const closestSeries = minBy(this.renderData, (series) => {
                 /*if (some(series.allLabels, l => !l.isHidden && l.bounds.contains(mouse)))
                     return -Infinity*/
 
@@ -681,7 +681,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                     )
                 } else {
                     return min(
-                        series.values.map(v =>
+                        series.values.map((v) =>
                             Vector2.distanceSq(v.position, mouse)
                         )
                     )
@@ -696,7 +696,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
             if (closestSeries && this.props.onMouseOver) {
                 const datum = find(
                     this.data,
-                    d =>
+                    (d) =>
                         d.entityDimensionKey ===
                         closestSeries.entityDimensionKey
                 )
@@ -710,11 +710,11 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
     }
 
     @computed get backgroundGroups(): ScatterRenderSeries[] {
-        return this.renderData.filter(group => !group.isForeground)
+        return this.renderData.filter((group) => !group.isForeground)
     }
 
     @computed get foregroundGroups(): ScatterRenderSeries[] {
-        return this.renderData.filter(group => !!group.isForeground)
+        return this.renderData.filter((group) => !!group.isForeground)
     }
 
     private renderBackgroundGroups() {
@@ -722,7 +722,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
 
         return hideLines
             ? []
-            : backgroundGroups.map(group => (
+            : backgroundGroups.map((group) => (
                   <ScatterBackgroundLine
                       key={group.entityDimensionKey}
                       group={group}
@@ -740,10 +740,10 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                 className="backgroundLabels"
                 fill={!isLayerMode ? "#333" : "#aaa"}
             >
-                {backgroundGroups.map(series => {
+                {backgroundGroups.map((series) => {
                     return series.allLabels
-                        .filter(l => !l.isHidden)
-                        .map(l =>
+                        .filter((l) => !l.isHidden)
+                        .map((l) =>
                             getElementWithHalo(
                                 series.displayKey + "-endLabel",
                                 <text
@@ -771,7 +771,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
     private renderForegroundGroups() {
         const { foregroundGroups, isSubtleForeground, hideLines } = this
 
-        return foregroundGroups.map(series => {
+        return foregroundGroups.map((series) => {
             const lastValue = last(series.values) as ScatterRenderValue
             const strokeWidth =
                 (series.isHover ? 3 : isSubtleForeground ? 1.5 : 2) +
@@ -793,10 +793,10 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                 return (
                     <g key={series.displayKey} className={series.displayKey}>
                         <MultiColorPolyline
-                            points={series.values.map(v => ({
+                            points={series.values.map((v) => ({
                                 x: v.position.x,
                                 y: v.position.y,
-                                color: hideLines ? "rgba(0,0,0,0)" : v.color
+                                color: hideLines ? "rgba(0,0,0,0)" : v.color,
                             }))}
                             strokeWidth={strokeWidth}
                             opacity={opacity}
@@ -844,9 +844,9 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
 
     private renderForegroundLabels() {
         const { foregroundGroups, labelFontFamily } = this
-        return foregroundGroups.map(series => {
+        return foregroundGroups.map((series) => {
             return series.allLabels
-                .filter(l => !l.isHidden)
+                .filter((l) => !l.isHidden)
                 .map((l, i) =>
                     getElementWithHalo(
                         `${series.displayKey}-label-${i}`,

--- a/grapher/scatterCharts/ScatterColorLegend.tsx
+++ b/grapher/scatterCharts/ScatterColorLegend.tsx
@@ -47,7 +47,7 @@ export class VerticalColorLegend {
                 maxWidth: this.props.maxWidth,
                 fontSize: 0.75 * this.props.fontSize,
                 fontWeight: 700,
-                text: this.props.title
+                text: this.props.title,
             })
         }
         return
@@ -64,24 +64,24 @@ export class VerticalColorLegend {
         const { props, fontSize, rectSize, rectPadding } = this
 
         return props.colorables
-            .map(c => {
+            .map((c) => {
                 const label = new TextWrap({
                     maxWidth: props.maxWidth,
                     fontSize: fontSize,
-                    text: c.label
+                    text: c.label,
                 })
                 return {
                     label: label,
                     color: c.color,
                     width: rectSize + rectPadding + label.width,
-                    height: Math.max(label.height, rectSize)
+                    height: Math.max(label.height, rectSize),
                 }
             })
-            .filter(v => !!v) as LabelMark[]
+            .filter((v) => !!v) as LabelMark[]
     }
 
     @computed get width(): number {
-        const widths = this.labelMarks.map(d => d.width)
+        const widths = this.labelMarks.map((d) => d.width)
         if (this.title) widths.push(this.title.width)
         return defaultTo(max(widths), 0)
     }
@@ -89,7 +89,7 @@ export class VerticalColorLegend {
     @computed get height() {
         return (
             this.titleHeight +
-            sum(this.labelMarks.map(d => d.height)) +
+            sum(this.labelMarks.map((d) => d.height)) +
             this.lineHeight * this.labelMarks.length
         )
     }
@@ -117,7 +117,7 @@ export class ScatterColorLegendView extends React.Component<
             activeColors,
             onMouseOver,
             onMouseLeave,
-            onClick
+            onClick,
         } = props
         const {
             title,
@@ -125,7 +125,7 @@ export class ScatterColorLegendView extends React.Component<
             labelMarks,
             rectSize,
             rectPadding,
-            lineHeight
+            lineHeight,
         } = props.legend
 
         let markOffset = titleHeight

--- a/grapher/scatterCharts/ScatterPlot.stories.tsx
+++ b/grapher/scatterCharts/ScatterPlot.stories.tsx
@@ -6,7 +6,7 @@ import { basicScatterGrapher } from "grapher/test/samples"
 
 export default {
     title: "ScatterPlot",
-    component: ScatterPlot
+    component: ScatterPlot,
 }
 
 export const Default = () => {

--- a/grapher/scatterCharts/ScatterPlot.tsx
+++ b/grapher/scatterCharts/ScatterPlot.tsx
@@ -18,7 +18,7 @@ import {
     first,
     last,
     excludeUndefined,
-    flatten
+    flatten,
 } from "grapher/utils/Util"
 import { observer } from "mobx-react"
 import { Bounds } from "grapher/utils/Bounds"
@@ -27,13 +27,13 @@ import { NoDataOverlay } from "grapher/chart/NoDataOverlay"
 import {
     PointsWithLabels,
     ScatterSeries,
-    ScatterValue
+    ScatterValue,
 } from "./PointsWithLabels"
 import { TextWrap } from "grapher/text/TextWrap"
 import { ConnectedScatterLegend } from "./ConnectedScatterLegend"
 import {
     VerticalColorLegend,
-    ScatterColorLegendView
+    ScatterColorLegendView,
 } from "./ScatterColorLegend"
 import { DualAxisComponent } from "grapher/axis/AxisViews"
 import { DualAxis } from "grapher/axis/Axis"
@@ -48,7 +48,7 @@ export class ScatterPlot extends React.Component<{
 }> {
     // Set default props
     static defaultProps = {
-        bounds: new Bounds(0, 0, 640, 480)
+        bounds: new Bounds(0, 0, 640, 480),
     }
 
     // currently hovered individual series key
@@ -70,7 +70,7 @@ export class ScatterPlot extends React.Component<{
 
     @action.bound onTargetChange({
         targetStartYear,
-        targetEndYear
+        targetEndYear,
     }: {
         targetStartYear: TimeBound
         targetEndYear: TimeBound
@@ -87,7 +87,7 @@ export class ScatterPlot extends React.Component<{
     @computed get colorsInUse(): string[] {
         return excludeUndefined(
             uniq(
-                this.transform.allPoints.map(point =>
+                this.transform.allPoints.map((point) =>
                     this.transform.colorScale.getColor(point.color)
                 )
             )
@@ -105,18 +105,18 @@ export class ScatterPlot extends React.Component<{
             },
             get colorables() {
                 return that.transform.colorScale.legendData
-                    .filter(bin => that.colorsInUse.includes(bin.color))
-                    .map(bin => {
+                    .filter((bin) => that.colorsInUse.includes(bin.color))
+                    .map((bin) => {
                         return {
                             key: bin.label ?? "",
                             label: bin.label ?? "",
-                            color: bin.color
+                            color: bin.color,
                         }
                     })
             },
             get title() {
                 return that.transform.colorScale.legendDescription
-            }
+            },
         })
     }
 
@@ -136,8 +136,8 @@ export class ScatterPlot extends React.Component<{
 
         const { transform } = this
         const keysToToggle = transform.currentData
-            .filter(g => g.color === hoverColor)
-            .map(g => g.entityDimensionKey)
+            .filter((g) => g.color === hoverColor)
+            .map((g) => g.entityDimensionKey)
         const allKeysActive =
             intersection(keysToToggle, grapher.selectedKeys).length ===
             keysToToggle.length
@@ -155,10 +155,10 @@ export class ScatterPlot extends React.Component<{
     // Colors on the legend for which every matching group is focused
     @computed private get focusColors(): string[] {
         const { colorsInUse, transform, grapher } = this
-        return colorsInUse.filter(color => {
+        return colorsInUse.filter((color) => {
             const matchingKeys = transform.currentData
-                .filter(g => g.color === color)
-                .map(g => g.entityDimensionKey)
+                .filter((g) => g.color === color)
+                .map((g) => g.entityDimensionKey)
             return (
                 intersection(matchingKeys, grapher.selectedKeys).length ===
                 matchingKeys.length
@@ -175,8 +175,8 @@ export class ScatterPlot extends React.Component<{
                 ? []
                 : uniq(
                       transform.currentData
-                          .filter(g => g.color === hoverColor)
-                          .map(g => g.entityDimensionKey)
+                          .filter((g) => g.color === hoverColor)
+                          .map((g) => g.entityDimensionKey)
                   )
 
         if (hoverKey !== undefined) hoverKeys.push(hoverKey)
@@ -211,7 +211,7 @@ export class ScatterPlot extends React.Component<{
             get endpointsOnly() {
                 return that.transform.compareEndPointsOnly
             },
-            formatYearFunction: that.grapher.formatYearFunction
+            formatYearFunction: that.grapher.formatYearFunction,
         })
     }
 
@@ -231,11 +231,11 @@ export class ScatterPlot extends React.Component<{
         const { hoverKey, focusKeys, transform } = this
         if (hoverKey !== undefined)
             return transform.currentData.find(
-                g => g.entityDimensionKey === hoverKey
+                (g) => g.entityDimensionKey === hoverKey
             )
         else if (focusKeys && focusKeys.length === 1)
             return transform.currentData.find(
-                g => g.entityDimensionKey === focusKeys[0]
+                (g) => g.entityDimensionKey === focusKeys[0]
             )
         else return undefined
     }
@@ -260,7 +260,7 @@ export class ScatterPlot extends React.Component<{
         const axis = new DualAxis({
             bounds: this.bounds.padRight(this.sidebarWidth + 20),
             xAxis,
-            yAxis
+            yAxis,
         })
 
         return axis
@@ -283,13 +283,13 @@ export class ScatterPlot extends React.Component<{
         let series = transform.currentData
 
         if (activeKeys.length) {
-            series = series.filter(g =>
+            series = series.filter((g) =>
                 activeKeys.includes(g.entityDimensionKey)
             )
         }
 
         const colorValues = uniq(
-            flatten(series.map(s => s.values.map(p => p.color)))
+            flatten(series.map((s) => s.values.map((p) => p.color)))
         )
         return excludeUndefined(colorValues.map(transform.colorScale.getColor))
     }
@@ -305,7 +305,7 @@ export class ScatterPlot extends React.Component<{
             y: (scatterValue: ScatterValue) =>
                 this.transform.yFormatTooltip(scatterValue.y),
             x: (scatterValue: ScatterValue) =>
-                this.transform.xFormatTooltip(scatterValue.x)
+                this.transform.xFormatTooltip(scatterValue.x),
         }
 
         return scatterPointLabelFormatFunctions[
@@ -336,7 +336,7 @@ export class ScatterPlot extends React.Component<{
             tooltipSeries,
             comparisonLines,
             hideLines,
-            grapher
+            grapher,
         } = this
         const { currentData, sizeDomain, colorScale } = transform
 
@@ -467,15 +467,15 @@ class ScatterTooltip extends React.Component<ScatterTooltipProps> {
             wrap: new TextWrap({
                 maxWidth: maxWidth,
                 fontSize: 0.75 * fontSize,
-                text: series.label
-            })
+                text: series.label,
+            }),
         }
         elements.push(heading)
         offset += heading.wrap.height + lineHeight
 
         const { formatYYear } = this.props
 
-        values.forEach(v => {
+        values.forEach((v) => {
             const year = {
                 x: x,
                 y: y + offset,
@@ -486,8 +486,8 @@ class ScatterTooltip extends React.Component<ScatterTooltipProps> {
                         ? `${formatYYear(v.time.span[0])} to ${formatYYear(
                               v.time.span[1]
                           )}`
-                        : formatYYear(v.time.y)
-                })
+                        : formatYYear(v.time.y),
+                }),
             }
             offset += year.wrap.height
             const line1 = {
@@ -496,8 +496,8 @@ class ScatterTooltip extends React.Component<ScatterTooltipProps> {
                 wrap: new TextWrap({
                     maxWidth: maxWidth,
                     fontSize: 0.55 * fontSize,
-                    text: this.formatValueY(v)
-                })
+                    text: this.formatValueY(v),
+                }),
             }
             offset += line1.wrap.height
             const line2 = {
@@ -506,8 +506,8 @@ class ScatterTooltip extends React.Component<ScatterTooltipProps> {
                 wrap: new TextWrap({
                     maxWidth: maxWidth,
                     fontSize: 0.55 * fontSize,
-                    text: this.formatValueX(v)
-                })
+                    text: this.formatValueX(v),
+                }),
             }
             offset += line2.wrap.height + lineHeight
             elements.push(...[year, line1, line2])

--- a/grapher/scatterCharts/ScatterTransform.ts
+++ b/grapher/scatterCharts/ScatterTransform.ts
@@ -25,7 +25,7 @@ import {
     sortNumeric,
     lowerCaseFirstLetterUnlessAbbreviation,
     cagr,
-    relativeMinAndMax
+    relativeMinAndMax,
 } from "grapher/utils/Util"
 import { computed } from "mobx"
 import { ChartDimension } from "grapher/chart/ChartDimension"
@@ -60,7 +60,7 @@ export class ScatterTransform extends ChartTransform {
             get hasNoDataBin() {
                 return !!(
                     that.colorDimension &&
-                    that.allPoints.some(point => point.color === undefined)
+                    that.allPoints.some((point) => point.color === undefined)
                 )
             },
             get defaultNoDataColor() {
@@ -68,22 +68,22 @@ export class ScatterTransform extends ChartTransform {
             },
             get formatNumericValue() {
                 return that.colorDimension?.formatValueShort ?? identity
-            }
+            },
         })
     }
 
     @computed get isValidConfig(): boolean {
         return (
             this.hasYDimension &&
-            this.grapher.dimensions.some(d => d.property === "x")
+            this.grapher.dimensions.some((d) => d.property === "x")
         )
     }
 
     @computed get failMessage(): string | undefined {
         const { filledDimensions } = this.grapher
-        if (!some(filledDimensions, d => d.property === "y"))
+        if (!some(filledDimensions, (d) => d.property === "y"))
             return "Missing Y axis variable"
-        else if (!some(filledDimensions, d => d.property === "x"))
+        else if (!some(filledDimensions, (d) => d.property === "x"))
             return "Missing X axis variable"
         else if (isEmpty(this.possibleEntityNames))
             return "No entities with data for both X and Y"
@@ -100,13 +100,13 @@ export class ScatterTransform extends ChartTransform {
     // Scatterplot should have exactly one dimension for each of x and y
     // The y dimension is treated as the "primary" variable
     @computed private get yDimension() {
-        return this.grapher.filledDimensions.find(d => d.property === "y")
+        return this.grapher.filledDimensions.find((d) => d.property === "y")
     }
     @computed private get xDimension() {
-        return this.grapher.filledDimensions.find(d => d.property === "x")
+        return this.grapher.filledDimensions.find((d) => d.property === "x")
     }
     @computed get colorDimension() {
-        return this.grapher.filledDimensions.find(d => d.property === "color")
+        return this.grapher.filledDimensions.find((d) => d.property === "color")
     }
 
     // Possible to override the x axis dimension to target a special year
@@ -140,7 +140,7 @@ export class ScatterTransform extends ChartTransform {
 
     // todo: remove
     @computed get selectableEntityDimensionKeys(): EntityDimensionKey[] {
-        return this.currentData.map(series => series.entityDimensionKey)
+        return this.currentData.map((series) => series.entityDimensionKey)
     }
 
     // todo: move to table
@@ -148,8 +148,8 @@ export class ScatterTransform extends ChartTransform {
         const entityIds = this.grapher.excludedEntities || []
         const entityNameMap = this.grapher.table.entityIdToNameMap
         return entityIds
-            .map(entityId => entityNameMap.get(entityId)!)
-            .filter(d => d)
+            .map((entityId) => entityNameMap.get(entityId)!)
+            .filter((d) => d)
     }
 
     // todo: remove. do this at table filter level
@@ -168,7 +168,7 @@ export class ScatterTransform extends ChartTransform {
 
         if (this.excludedEntityNames)
             entityNames = entityNames.filter(
-                entity => !includes(this.excludedEntityNames, entity)
+                (entity) => !includes(this.excludedEntityNames, entity)
             )
 
         return entityNames
@@ -312,7 +312,7 @@ export class ScatterTransform extends ChartTransform {
                     point = {
                         entityName,
                         year: outputYear,
-                        time: {}
+                        time: {},
                     } as ScatterValue
                     dataByYear.set(outputYear, point)
                 }
@@ -332,7 +332,7 @@ export class ScatterTransform extends ChartTransform {
         // values being joined.
         // -@danielgavrilov, 2020-04-29
         const { yAxis, xAxis } = this.grapher
-        dataByEntityAndYear.forEach(dataByYear => {
+        dataByEntityAndYear.forEach((dataByYear) => {
             dataByYear.forEach((point, year) => {
                 // Exclude any points with data for only one axis
                 if (!has(point, "x") || !has(point, "y"))
@@ -349,8 +349,8 @@ export class ScatterTransform extends ChartTransform {
 
     @computed get allPoints() {
         const allPoints: ScatterValue[] = []
-        this.getDataByEntityAndYear().forEach(dataByYear => {
-            dataByYear.forEach(point => {
+        this.getDataByEntityAndYear().forEach((dataByYear) => {
+            dataByYear.forEach((point) => {
                 allPoints.push(point)
             })
         })
@@ -359,11 +359,11 @@ export class ScatterTransform extends ChartTransform {
 
     // The selectable years that will end up on the timeline UI (if enabled)
     @computed get availableYears(): Time[] {
-        return this.allPoints.map(point => point.year)
+        return this.allPoints.map((point) => point.year)
     }
 
     @computed private get currentValues() {
-        return flatten(this.currentData.map(g => g.values))
+        return flatten(this.currentData.map((g) => g.values))
     }
 
     // domains across the entire timeline
@@ -371,7 +371,7 @@ export class ScatterTransform extends ChartTransform {
         const scaleType = property === "x" ? this.xScaleType : this.yScaleType
         if (!this.grapher.useTimelineDomains) {
             return domainExtent(
-                this.pointsForAxisDomains.map(d => d[property]),
+                this.pointsForAxisDomains.map((d) => d[property]),
                 scaleType,
                 this.grapher.zoomToSelection && this.selectedPoints.length
                     ? 1.1
@@ -383,7 +383,7 @@ export class ScatterTransform extends ChartTransform {
             return relativeMinAndMax(this.allPoints, property)
 
         return domainExtent(
-            this.allPoints.map(v => v[property]),
+            this.allPoints.map((v) => v[property]),
             scaleType
         )
     }
@@ -395,7 +395,7 @@ export class ScatterTransform extends ChartTransform {
     @computed private get selectedPoints() {
         const entitiesFor = new Set(this.getEntityNamesToShow(true))
         return this.allPoints.filter(
-            point => point.entityName && entitiesFor.has(point.entityName)
+            (point) => point.entityName && entitiesFor.has(point.entityName)
         )
     }
 
@@ -410,7 +410,7 @@ export class ScatterTransform extends ChartTransform {
 
     @computed get sizeDomain(): [number, number] {
         const sizeValues: number[] = []
-        this.allPoints.forEach(g => g.size && sizeValues.push(g.size))
+        this.allPoints.forEach((g) => g.size && sizeValues.push(g.size))
         if (sizeValues.length === 0) return [1, 100]
         else return domainExtent(sizeValues, ScaleType.linear)
     }
@@ -479,7 +479,7 @@ export class ScatterTransform extends ChartTransform {
             xDomainDefault,
             xDimension,
             isRelativeMode,
-            xAxisLabelBase
+            xAxisLabelBase,
         } = this
 
         const { xAxis } = this.grapher
@@ -543,9 +543,9 @@ export class ScatterTransform extends ChartTransform {
 
         // NOTE: since groupBy() creates an object, the values may be reordered. we reorder a few lines below.
         values = map(
-            groupBy(values, v => v.time.y),
+            groupBy(values, (v) => v.time.y),
             (vals: ScatterValue[]) =>
-                minBy(vals, v =>
+                minBy(vals, (v) =>
                     v.year === startYear || v.year === endYear
                         ? -Infinity
                         : Math.abs(v.year - v.time.y)
@@ -555,9 +555,9 @@ export class ScatterTransform extends ChartTransform {
         if (xOverrideYear === undefined) {
             // NOTE: since groupBy() creates an object, the values may be reordered
             values = map(
-                groupBy(values, v => v.time.x),
+                groupBy(values, (v) => v.time.x),
                 (vals: ScatterValue[]) =>
-                    minBy(vals, v =>
+                    minBy(vals, (v) =>
                         v.year === startYear || v.year === endYear
                             ? -Infinity
                             : Math.abs(v.year - v.time.x)
@@ -566,14 +566,15 @@ export class ScatterTransform extends ChartTransform {
         }
 
         // Sort values by year again in case groupBy() above reordered the values
-        values = sortNumeric(values, v => v.year)
+        values = sortNumeric(values, (v) => v.year)
 
         // Don't allow values <= 0 for log scales
-        if (yScaleType === ScaleType.log) values = values.filter(v => v.y > 0)
-        if (xScaleType === ScaleType.log) values = values.filter(v => v.x > 0)
+        if (yScaleType === ScaleType.log) values = values.filter((v) => v.y > 0)
+        if (xScaleType === ScaleType.log) values = values.filter((v) => v.x > 0)
 
         // Don't allow values *equal* to zero for CAGR mode
-        if (isRelativeMode) values = values.filter(v => v.y !== 0 && v.x !== 0)
+        if (isRelativeMode)
+            values = values.filter((v) => v.y !== 0 && v.x !== 0)
 
         return values
     }
@@ -590,7 +591,7 @@ export class ScatterTransform extends ChartTransform {
             yScaleType,
             isRelativeMode,
             compareEndPointsOnly,
-            xOverrideYear
+            xOverrideYear,
         } = this
         const { keyColors } = grapher
         let currentData: ScatterSeries[] = []
@@ -608,7 +609,7 @@ export class ScatterTransform extends ChartTransform {
                 label: grapher.getLabelForKey(entityDimensionKey),
                 color: "#932834", // Default color, used when no color dimension is present
                 size: 0,
-                values: []
+                values: [],
             } as ScatterSeries
 
             dataByYear.forEach((point, year) => {
@@ -624,20 +625,23 @@ export class ScatterTransform extends ChartTransform {
                 if (keyColor !== undefined) {
                     group.color = keyColor
                 } else if (this.colorDimension) {
-                    const colorValue = last(group.values.map(v => v.color))
+                    const colorValue = last(group.values.map((v) => v.color))
                     const color = this.colorScale.getColor(colorValue)
                     if (color !== undefined) {
                         group.color = color
                         group.isScaleColor = true
                     }
                 }
-                const sizes = group.values.map(v => v.size)
-                group.size = defaultTo(last(sizes.filter(s => isNumber(s))), 0)
+                const sizes = group.values.map((v) => v.size)
+                group.size = defaultTo(
+                    last(sizes.filter((s) => isNumber(s))),
+                    0
+                )
                 currentData.push(group)
             }
         })
 
-        currentData.forEach(series => {
+        currentData.forEach((series) => {
             series.values = this._filterValues(
                 series.values,
                 startYear,
@@ -649,7 +653,7 @@ export class ScatterTransform extends ChartTransform {
             )
         })
 
-        currentData = currentData.filter(series => {
+        currentData = currentData.filter((series) => {
             // No point trying to render series with no valid points!
             if (series.values.length === 0) return false
 
@@ -664,14 +668,14 @@ export class ScatterTransform extends ChartTransform {
         })
 
         if (compareEndPointsOnly) {
-            currentData.forEach(series => {
+            currentData.forEach((series) => {
                 const endPoints = [first(series.values), last(series.values)]
                 series.values = compact(uniq(endPoints))
             })
         }
 
         if (isRelativeMode) {
-            currentData.forEach(series => {
+            currentData.forEach((series) => {
                 if (series.values.length === 0) return
                 const startValue = firstOfNonEmptyArray(series.values)
                 const endValue = lastOfNonEmptyArray(series.values)
@@ -685,9 +689,9 @@ export class ScatterTransform extends ChartTransform {
                         time: {
                             y: endValue.time.y,
                             x: endValue.time.x,
-                            span: [startValue.time.y, endValue.time.y]
-                        }
-                    }
+                            span: [startValue.time.y, endValue.time.y],
+                        },
+                    },
                 ]
             })
         }

--- a/grapher/scatterCharts/TimeScatter.tsx
+++ b/grapher/scatterCharts/TimeScatter.tsx
@@ -19,7 +19,7 @@ import {
     guid,
     getRelativeMouse,
     makeSafeForCSS,
-    minBy
+    minBy,
 } from "grapher/utils/Util"
 import { Vector2 } from "grapher/utils/Vector2"
 import { select } from "d3-selection"
@@ -143,7 +143,7 @@ class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                         backgroundColor: "#fcfcfc",
                         borderBottom: "1px solid #ebebeb",
                         fontWeight: "normal",
-                        fontSize: "1em"
+                        fontSize: "1em",
                     }}
                 >
                     {year}
@@ -152,7 +152,7 @@ class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                     style={{
                         margin: 0,
                         padding: "0.3em 0.9em",
-                        fontSize: "0.8em"
+                        fontSize: "0.8em",
                     }}
                 >
                     <span>
@@ -190,7 +190,7 @@ class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
         const { xAxis, yAxis } = this
         const data = cloneDeep(this.props.data[0])
 
-        const points = data.values.map(v => {
+        const points = data.values.map((v) => {
             const area = 1
             return {
                 position: new Vector2(
@@ -200,7 +200,7 @@ class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                 size: Math.sqrt(area / Math.PI),
                 time: v.time,
                 value: v,
-                fontSize: 8
+                fontSize: 8,
             }
         })
 
@@ -210,7 +210,7 @@ class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
             color: data.color,
             points: points,
             text: data.label,
-            offsetVector: Vector2.zero
+            offsetVector: Vector2.zero,
         }
     }
 
@@ -236,7 +236,7 @@ class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
     }
 
     @computed get labelCandidates() {
-        return this.values.map(v => {
+        return this.values.map((v) => {
             return {
                 text: v.time.y.toString(),
                 fontSize: this.labelFontSize,
@@ -245,9 +245,9 @@ class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                     x: v.position.x + 3,
                     y: v.position.y - 3,
                     fontSize: this.labelFontSize,
-                    fontFamily: this.labelFontFamily
+                    fontFamily: this.labelFontFamily,
                 }),
-                isHidden: false
+                isHidden: false,
             }
         })
     }
@@ -355,13 +355,13 @@ class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                 l.bounds = l.bounds.extend({ y: bounds.top })
             } else if (l.bounds.bottom > bounds.bottom + 1) {
                 l.bounds = l.bounds.extend({
-                    y: bounds.bottom - l.bounds.height
+                    y: bounds.bottom - l.bounds.height,
                 })
             }
         }
 
         // Main collision detection
-        const labelsByPriority = sortBy(labels, l => -this.labelPriority(l))
+        const labelsByPriority = sortBy(labels, (l) => -this.labelPriority(l))
         for (let i = 0; i < labelsByPriority.length; i++) {
             const l1 = labelsByPriority[i]
             if (l1.isHidden) continue
@@ -389,7 +389,7 @@ class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
         const { mousePos } = this
         if (!mousePos) return undefined
 
-        const closestPoint = minBy(this.values, v =>
+        const closestPoint = minBy(this.values, (v) =>
             Vector2.distanceSq(v.position, mousePos)
         )
 
@@ -487,7 +487,7 @@ class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                 stroke={this.series.color}
                 points={this.values
                     .map(
-                        v =>
+                        (v) =>
                             `${v.position.x.toFixed(2)},${v.position.y.toFixed(
                                 2
                             )}`
@@ -597,7 +597,7 @@ export class TimeScatter extends React.Component<{
 
     @action.bound onTargetChange({
         targetStartYear,
-        targetEndYear
+        targetEndYear,
     }: {
         targetStartYear: TimeBound
         targetEndYear: TimeBound
@@ -611,7 +611,7 @@ export class TimeScatter extends React.Component<{
         return new DualAxis({
             bounds: this.bounds,
             xAxis,
-            yAxis
+            yAxis,
         })
     }
 

--- a/grapher/scatterCharts/Triangle.tsx
+++ b/grapher/scatterCharts/Triangle.tsx
@@ -21,13 +21,13 @@ export class Triangle extends React.Component<TriangleProps> {
         const points = [
             [x, y + r * 2],
             [x + (r * 2) / 2, y],
-            [x + r * 2, y + r * 2]
+            [x + r * 2, y + r * 2],
         ]
 
         return (
             <polygon
                 points={points
-                    .map(p => `${p[0].toFixed(2)},${p[1].toFixed(2)}`)
+                    .map((p) => `${p[0].toFixed(2)},${p[1].toFixed(2)}`)
                     .join(" ")}
                 {...this.props}
             />

--- a/grapher/slopeCharts/LabelledSlopes.tsx
+++ b/grapher/slopeCharts/LabelledSlopes.tsx
@@ -26,7 +26,7 @@ import {
     getRelativeMouse,
     domainExtent,
     minBy,
-    maxBy
+    maxBy,
 } from "grapher/utils/Util"
 import { computed, action } from "mobx"
 import { observer } from "mobx-react"
@@ -75,7 +75,7 @@ class SlopeChartAxis extends React.Component<AxisProps> {
         const { scale } = props
         const longestTick = maxBy(
             scale.ticks(6).map(props.tickFormat),
-            tick => tick.length
+            (tick) => tick.length
         )
         const axisWidth = Bounds.forText(longestTick).width
         return new Bounds(
@@ -194,7 +194,7 @@ class Slope extends React.Component<SlopeProps> {
             leftLabelBounds,
             rightLabelBounds,
             isFocused,
-            isHovered
+            isHovered,
         } = this.props
         const { isInBackground } = this
 
@@ -208,10 +208,10 @@ class Slope extends React.Component<SlopeProps> {
             : size
 
         const leftValueLabelBounds = Bounds.forText(leftValueStr, {
-            fontSize: labelFontSize
+            fontSize: labelFontSize,
         })
         const rightValueLabelBounds = Bounds.forText(rightValueStr, {
-            fontSize: labelFontSize
+            fontSize: labelFontSize,
         })
 
         return (
@@ -224,7 +224,7 @@ class Slope extends React.Component<SlopeProps> {
                             textAnchor: "end",
                             fill: labelColor,
                             fontWeight:
-                                isFocused || isHovered ? "bold" : undefined
+                                isFocused || isHovered ? "bold" : undefined,
                         }
                     )}
                 {hasLeftLabel && (
@@ -247,7 +247,7 @@ class Slope extends React.Component<SlopeProps> {
                     opacity={opacity}
                 />
                 <line
-                    ref={el => (this.line = el)}
+                    ref={(el) => (this.line = el)}
                     x1={x1}
                     y1={y1}
                     x2={x2}
@@ -277,7 +277,7 @@ class Slope extends React.Component<SlopeProps> {
                 {hasRightLabel &&
                     rightLabel.render(rightLabelBounds.x, rightLabelBounds.y, {
                         fill: labelColor,
-                        fontWeight: isFocused || isHovered ? "bold" : undefined
+                        fontWeight: isFocused || isHovered ? "bold" : undefined,
                     })}
             </g>
         )
@@ -315,14 +315,14 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
     @computed get focusKeys(): string[] {
         return intersection(
             this.props.focusKeys || [],
-            this.data.map(g => g.entityDimensionKey)
+            this.data.map((g) => g.entityDimensionKey)
         )
     }
 
     @computed get hoverKeys(): string[] {
         return intersection(
             this.props.hoverKeys || [],
-            this.data.map(g => g.entityDimensionKey)
+            this.data.map((g) => g.entityDimensionKey)
         )
     }
 
@@ -337,12 +337,12 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
     }
 
     @computed get allValues(): SlopeChartValue[] {
-        return flatten(this.props.data.map(g => g.values))
+        return flatten(this.props.data.map((g) => g.values))
     }
 
     @computed get xDomainDefault(): [number, number] {
         return domainExtent(
-            this.allValues.map(v => v.x),
+            this.allValues.map((v) => v.x),
             ScaleType.linear
         )
     }
@@ -353,7 +353,7 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
 
     @computed private get yDomainDefault(): [number, number] {
         return domainExtent(
-            this.allValues.map(v => v.y),
+            this.allValues.map((v) => v.y),
             this.yScaleType || ScaleType.linear
         )
     }
@@ -367,14 +367,14 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
         const domainDefault = this.yDomainDefault
         return [
             Math.min(domain[0], domainDefault[0]),
-            Math.max(domain[1], domainDefault[1])
+            Math.max(domain[1], domainDefault[1]),
         ]
     }
 
     @computed get sizeScale(): ScaleLinear<number, number> {
         return scaleLinear()
             .domain(
-                extent(this.props.data.map(d => d.size)) as [number, number]
+                extent(this.props.data.map((d) => d.size)) as [number, number]
             )
             .range([1, 4])
     }
@@ -398,7 +398,7 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
             : SlopeChartAxis.calculateBounds(bounds, {
                   orient: "left",
                   scale: yScale,
-                  tickFormat: this.props.yTickFormat
+                  tickFormat: this.props.yTickFormat,
               }).width
         return scaleLinear()
             .domain(xDomain)
@@ -416,7 +416,7 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
             xScale,
             yScale,
             sizeScale,
-            maxLabelWidth
+            maxLabelWidth,
         } = this
 
         const yTickFormat = this.props.yTickFormat
@@ -424,12 +424,12 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
         const slopeData: SlopeProps[] = []
         const yDomain = yScale.domain()
 
-        data.forEach(series => {
+        data.forEach((series) => {
             // Ensure values fit inside the chart
             if (
                 !every(
                     series.values,
-                    d => d.y >= yDomain[0] && d.y <= yDomain[1]
+                    (d) => d.y >= yDomain[0] && d.y <= yDomain[1]
                 )
             )
                 return
@@ -441,20 +441,20 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
             const leftValueStr = yTickFormat(v1.y)
             const rightValueStr = yTickFormat(v2.y)
             const leftValueWidth = Bounds.forText(leftValueStr, {
-                fontSize: fontSize
+                fontSize: fontSize,
             }).width
             const rightValueWidth = Bounds.forText(rightValueStr, {
-                fontSize: fontSize
+                fontSize: fontSize,
             }).width
             const leftLabel = new TextWrap({
                 maxWidth: maxLabelWidth,
                 fontSize: fontSize,
-                text: series.label
+                text: series.label,
             })
             const rightLabel = new TextWrap({
                 maxWidth: maxLabelWidth,
                 fontSize: fontSize,
-                text: series.label
+                text: series.label,
             })
 
             slopeData.push({
@@ -475,7 +475,7 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
                 isFocused: false,
                 isHovered: false,
                 hasLeftLabel: true,
-                hasRightLabel: true
+                hasRightLabel: true,
             } as SlopeProps)
         })
 
@@ -483,13 +483,13 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
     }
 
     @computed get maxValueWidth(): number {
-        return max(this.initialSlopeData.map(s => s.leftValueWidth)) as number
+        return max(this.initialSlopeData.map((s) => s.leftValueWidth)) as number
     }
 
     @computed get labelAccountedSlopeData() {
         const { maxLabelWidth, maxValueWidth } = this
 
-        return this.initialSlopeData.map(slope => {
+        return this.initialSlopeData.map((slope) => {
             // Squish slopes to make room for labels
             const x1 = slope.x1 + maxLabelWidth + maxValueWidth + 8
             const x2 = slope.x2 - maxLabelWidth - maxValueWidth - 8
@@ -512,7 +512,7 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
                 x1: x1,
                 x2: x2,
                 leftLabelBounds: leftLabelBounds,
-                rightLabelBounds: rightLabelBounds
+                rightLabelBounds: rightLabelBounds,
             })
         })
     }
@@ -520,14 +520,14 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
     @computed get backgroundGroups(): SlopeProps[] {
         return filter(
             this.slopeData,
-            group => !(group.isHovered || group.isFocused)
+            (group) => !(group.isHovered || group.isFocused)
         )
     }
 
     @computed get foregroundGroups(): SlopeProps[] {
         return filter(
             this.slopeData,
-            group => !!(group.isHovered || group.isFocused)
+            (group) => !!(group.isHovered || group.isFocused)
         )
     }
 
@@ -536,10 +536,10 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
         const { focusKeys, hoverKeys } = this
         let slopeData = this.labelAccountedSlopeData
 
-        slopeData = slopeData.map(slope => {
+        slopeData = slopeData.map((slope) => {
             return extend({}, slope, {
                 isFocused: includes(focusKeys, slope.entityDimensionKey),
-                isHovered: includes(hoverKeys, slope.entityDimensionKey)
+                isHovered: includes(hoverKeys, slope.entityDimensionKey),
             })
         })
 
@@ -565,8 +565,8 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
         }
 
         // Eliminate overlapping labels, one pass for each side
-        slopeData.forEach(s1 => {
-            slopeData.forEach(s2 => {
+        slopeData.forEach((s1) => {
+            slopeData.forEach((s2) => {
                 if (
                     s1 !== s2 &&
                     s1.hasLeftLabel &&
@@ -579,8 +579,8 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
             })
         })
 
-        slopeData.forEach(s1 => {
-            slopeData.forEach(s2 => {
+        slopeData.forEach((s1) => {
+            slopeData.forEach((s2) => {
                 if (
                     s1 !== s2 &&
                     s1.hasRightLabel &&
@@ -594,8 +594,8 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
         })
 
         // Order by focus/hover and size for draw order
-        slopeData = sortBy(slopeData, slope => slope.size)
-        slopeData = sortBy(slopeData, slope =>
+        slopeData = sortBy(slopeData, (slope) => slope.size)
+        slopeData = sortBy(slopeData, (slope) =>
             slope.isFocused || slope.isHovered ? 1 : 0
         )
 
@@ -628,7 +628,7 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
                     distToSlope.set(s, dist)
                 }
 
-                const closestSlope = minBy(this.slopeData, s =>
+                const closestSlope = minBy(this.slopeData, (s) =>
                     distToSlope.get(s)
                 )
 
@@ -662,7 +662,7 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
     renderBackgroundGroups() {
         const { backgroundGroups, isLayerMode } = this
 
-        return backgroundGroups.map(slope => (
+        return backgroundGroups.map((slope) => (
             <Slope
                 key={slope.entityDimensionKey}
                 {...slope}
@@ -674,7 +674,7 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
     renderForegroundGroups() {
         const { foregroundGroups, isLayerMode } = this
 
-        return foregroundGroups.map(slope => (
+        return foregroundGroups.map((slope) => (
             <Slope
                 key={slope.entityDimensionKey}
                 {...slope}
@@ -708,7 +708,7 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
             isPortrait,
             xDomain,
             yScale,
-            onMouseMove
+            onMouseMove,
         } = this
 
         if (isEmpty(slopeData))

--- a/grapher/slopeCharts/SlopeChart.tsx
+++ b/grapher/slopeCharts/SlopeChart.tsx
@@ -8,7 +8,7 @@ import { LabelledSlopes, SlopeProps } from "./LabelledSlopes"
 import { NoDataOverlay } from "grapher/chart/NoDataOverlay"
 import {
     VerticalColorLegend,
-    ScatterColorLegendView
+    ScatterColorLegendView,
 } from "grapher/scatterCharts/ScatterColorLegend"
 
 @observer
@@ -44,15 +44,15 @@ export class SlopeChart extends React.Component<{
             },
             get colorables() {
                 return that.transform.colorScale.legendData
-                    .filter(bin => that.colorsInUse.includes(bin.color))
-                    .map(bin => {
+                    .filter((bin) => that.colorsInUse.includes(bin.color))
+                    .map((bin) => {
                         return {
                             key: bin.label ?? "",
                             label: bin.label ?? "",
-                            color: bin.color
+                            color: bin.color,
                         }
                     })
-            }
+            },
         })
     }
 
@@ -89,8 +89,8 @@ export class SlopeChart extends React.Component<{
 
         const { transform } = this
         const keysToToggle = transform.data
-            .filter(g => g.color === hoverColor)
-            .map(g => g.entityDimensionKey)
+            .filter((g) => g.color === hoverColor)
+            .map((g) => g.entityDimensionKey)
         const allKeysActive =
             intersection(keysToToggle, grapher.selectedKeys).length ===
             keysToToggle.length
@@ -108,10 +108,10 @@ export class SlopeChart extends React.Component<{
     // Colors on the legend for which every matching group is focused
     @computed get focusColors(): string[] {
         const { colorsInUse, transform, grapher } = this
-        return colorsInUse.filter(color => {
+        return colorsInUse.filter((color) => {
             const matchingKeys = transform.data
-                .filter(g => g.color === color)
-                .map(g => g.entityDimensionKey)
+                .filter((g) => g.color === color)
+                .map((g) => g.entityDimensionKey)
             return (
                 intersection(matchingKeys, grapher.selectedKeys).length ===
                 matchingKeys.length
@@ -132,8 +132,8 @@ export class SlopeChart extends React.Component<{
                 ? []
                 : uniq(
                       transform.data
-                          .filter(g => g.color === hoverColor)
-                          .map(g => g.entityDimensionKey)
+                          .filter((g) => g.color === hoverColor)
+                          .map((g) => g.entityDimensionKey)
                   )
 
         if (hoverKey !== undefined) hoverKeys.push(hoverKey)
@@ -148,20 +148,20 @@ export class SlopeChart extends React.Component<{
 
         if (activeKeys.length === 0)
             // No hover or focus means they're all active by default
-            return uniq(transform.data.map(g => g.color))
+            return uniq(transform.data.map((g) => g.color))
         else
             return uniq(
                 transform.data
                     .filter(
-                        g => activeKeys.indexOf(g.entityDimensionKey) !== -1
+                        (g) => activeKeys.indexOf(g.entityDimensionKey) !== -1
                     )
-                    .map(g => g.color)
+                    .map((g) => g.color)
             )
     }
 
     // Only show colors on legend that are actually in use
     @computed get colorsInUse() {
-        return uniq(this.transform.data.map(g => g.color))
+        return uniq(this.transform.data.map((g) => g.color))
     }
 
     @computed get sidebarMaxWidth() {
@@ -193,7 +193,7 @@ export class SlopeChart extends React.Component<{
     @computed get showLegend(): boolean {
         const { colorsInUse } = this
         const { legendData } = this.transform.colorScale
-        return legendData.some(bin => colorsInUse.includes(bin.color))
+        return legendData.some((bin) => colorsInUse.includes(bin.color))
     }
 
     render() {
@@ -217,7 +217,7 @@ export class SlopeChart extends React.Component<{
             activeColors,
             sidebarWidth,
             innerBounds,
-            showLegend
+            showLegend,
         } = this
 
         return (

--- a/grapher/slopeCharts/SlopeChartTransform.ts
+++ b/grapher/slopeCharts/SlopeChartTransform.ts
@@ -5,7 +5,7 @@ import {
     isEmpty,
     flatten,
     identity,
-    last
+    last,
 } from "grapher/utils/Util"
 import { ChartDimension } from "grapher/chart/ChartDimension"
 import { SlopeChartSeries, SlopeChartValue } from "./LabelledSlopes"
@@ -19,7 +19,7 @@ import { ColorScale } from "grapher/color/ColorScale"
 export class SlopeChartTransform extends ChartTransform {
     @computed get failMessage(): string | undefined {
         const { filledDimensions } = this.grapher
-        if (!some(filledDimensions, d => d.property === "y"))
+        if (!some(filledDimensions, (d) => d.property === "y"))
             return "Missing Y axis variable"
         else if (isEmpty(this.data)) return "No matching data"
         else return undefined
@@ -48,12 +48,12 @@ export class SlopeChartTransform extends ChartTransform {
             },
             get formatNumericValue() {
                 return that.colorDimension?.formatValueShort ?? identity
-            }
+            },
         })
     }
 
     @computed get availableYears(): Time[] {
-        return flatten(this.grapher.axisDimensions.map(d => d.yearsUniq))
+        return flatten(this.grapher.axisDimensions.map((d) => d.yearsUniq))
     }
 
     @computed.struct get xDomain(): [number, number] {
@@ -61,15 +61,15 @@ export class SlopeChartTransform extends ChartTransform {
     }
 
     @computed.struct get sizeDim(): ChartDimension | undefined {
-        return find(this.grapher.filledDimensions, d => d.property === "size")
+        return find(this.grapher.filledDimensions, (d) => d.property === "size")
     }
 
     @computed.struct get colorDimension(): ChartDimension | undefined {
-        return this.grapher.filledDimensions.find(d => d.property === "color")
+        return this.grapher.filledDimensions.find((d) => d.property === "color")
     }
 
     @computed.struct get yDimension(): ChartDimension | undefined {
-        return find(this.grapher.filledDimensions, d => d.property === "y")
+        return find(this.grapher.filledDimensions, (d) => d.property === "y")
     }
 
     // helper method to directly get the associated color value given an Entity
@@ -109,11 +109,13 @@ export class SlopeChartTransform extends ChartTransform {
     }
 
     @computed get yTickFormat(): (d: number) => string {
-        return this.yDimension ? this.yDimension.formatValueShort : d => `${d}`
+        return this.yDimension
+            ? this.yDimension.formatValueShort
+            : (d) => `${d}`
     }
 
     @computed get selectableEntityDimensionKeys(): EntityDimensionKey[] {
-        return this.data.map(series => series.entityDimensionKey)
+        return this.data.map((series) => series.entityDimensionKey)
     }
 
     @computed get data(): SlopeChartSeries[] {
@@ -124,7 +126,7 @@ export class SlopeChartTransform extends ChartTransform {
             xDomain,
             colorByEntity,
             sizeByEntity,
-            grapher
+            grapher,
         } = this
         const { keyColors } = grapher
 
@@ -132,7 +134,7 @@ export class SlopeChartTransform extends ChartTransform {
         const maxYear = Math.min(xDomain[1])
 
         const entityNames = yDimension.entityNamesUniq
-        let data: SlopeChartSeries[] = entityNames.map(entityName => {
+        let data: SlopeChartSeries[] = entityNames.map((entityName) => {
             const slopeValues: SlopeChartValue[] = []
             const yValues = yDimension.valueByEntityAndYear.get(entityName)
             if (yValues !== undefined) {
@@ -143,7 +145,7 @@ export class SlopeChartTransform extends ChartTransform {
                             y:
                                 typeof value === "string"
                                     ? parseInt(value)
-                                    : value
+                                    : value,
                         })
                     }
                 })
@@ -161,10 +163,10 @@ export class SlopeChartTransform extends ChartTransform {
                     colorByEntity.get(entityName) ||
                     "#ff7f0e",
                 size: sizeByEntity.get(entityName) || 1,
-                values: slopeValues
+                values: slopeValues,
             }
         })
-        data = data.filter(d => d.values.length >= 2)
+        data = data.filter((d) => d.values.length >= 2)
         return data
     }
 }

--- a/grapher/sourcesTab/SourcesTab.tsx
+++ b/grapher/sourcesTab/SourcesTab.tsx
@@ -60,7 +60,7 @@ export class SourcesTab extends React.Component<{
                                 <td>Variable description</td>
                                 <td
                                     dangerouslySetInnerHTML={{
-                                        __html: formatText(column.description)
+                                        __html: formatText(column.description),
                                     }}
                                 />
                             </tr>
@@ -90,7 +90,7 @@ export class SourcesTab extends React.Component<{
                                     dangerouslySetInnerHTML={{
                                         __html: formatText(
                                             source.dataPublishedBy
-                                        )
+                                        ),
                                     }}
                                 />
                             </tr>
@@ -102,7 +102,7 @@ export class SourcesTab extends React.Component<{
                                     dangerouslySetInnerHTML={{
                                         __html: formatText(
                                             source.dataPublisherSource
-                                        )
+                                        ),
                                     }}
                                 />
                             </tr>
@@ -112,7 +112,7 @@ export class SourcesTab extends React.Component<{
                                 <td>Link</td>
                                 <td
                                     dangerouslySetInnerHTML={{
-                                        __html: formatText(source.link)
+                                        __html: formatText(source.link),
                                     }}
                                 />
                             </tr>
@@ -128,7 +128,7 @@ export class SourcesTab extends React.Component<{
                 {source.additionalInfo && (
                     <p
                         dangerouslySetInnerHTML={{
-                            __html: formatText(source.additionalInfo)
+                            __html: formatText(source.additionalInfo),
                         }}
                     />
                 )}
@@ -147,7 +147,7 @@ export class SourcesTab extends React.Component<{
                 <div>
                     <h2>Sources</h2>
                     <div>
-                        {this.sourcesWithDimensions.map(source =>
+                        {this.sourcesWithDimensions.map((source) =>
                             this.renderSource(source)
                         )}
                     </div>

--- a/grapher/sparkBars/SparkBars.tsx
+++ b/grapher/sparkBars/SparkBars.tsx
@@ -10,7 +10,7 @@ enum BarState {
     highlighted = "highlighted",
     current = "current",
     normal = "normal",
-    faint = "faint"
+    faint = "faint",
 }
 
 export interface SparkBarsProps<T> {
@@ -35,11 +35,11 @@ export interface SparkBarsDatum {
 export class SparkBars<T> extends React.Component<SparkBarsProps<T>> {
     static defaultProps = {
         onHover: () => undefined,
-        className: "spark-bars"
+        className: "spark-bars",
     }
 
     @computed get maxY(): number | undefined {
-        return max(this.bars.map(d => (d ? this.props.y(d) ?? 0 : 0)))
+        return max(this.bars.map((d) => (d ? this.props.y(d) ?? 0 : 0)))
     }
 
     @computed get barHeightScale() {
@@ -104,7 +104,7 @@ export class SparkBars<T> extends React.Component<SparkBarsProps<T>> {
                             }`}
                             style={{
                                 height: this.barHeight(d),
-                                backgroundColor: this.props.color
+                                backgroundColor: this.props.color,
                             }}
                         ></div>
                     </div>

--- a/grapher/test/samples.ts
+++ b/grapher/test/samples.ts
@@ -7,12 +7,12 @@ export function basicGdpGrapher() {
     const props = {
         selectedData: [
             { index: 0, entityId: 0 },
-            { index: 0, entityId: 1 }
+            { index: 0, entityId: 1 },
         ],
         data: { availableEntities: ["Germany", "France"] },
         useV2: true,
         yAxis: {},
-        dimensions: [{ variableId: 99, property: "y" }]
+        dimensions: [{ variableId: 99, property: "y" }],
     } as Partial<GrapherInterface>
 
     const grapher = new Grapher(props as any)

--- a/grapher/test/utils.ts
+++ b/grapher/test/utils.ts
@@ -27,6 +27,6 @@ export function setupGrapher(
     return new Grapher({
         ...readGrapher(id),
         ...configOverrides,
-        owidDataset: variableSet
+        owidDataset: variableSet,
     })
 }

--- a/grapher/text/Text.tsx
+++ b/grapher/text/Text.tsx
@@ -17,7 +17,7 @@ export class Text extends React.Component<TextProps> {
     render() {
         const bounds = Bounds.forText(this.props.children, {
             fontSize: this.props.fontSize,
-            fontFamily: this.props["fontFamily"]
+            fontFamily: this.props["fontFamily"],
         })
         const y = this.props.y + bounds.height - bounds.height * 0.2
 

--- a/grapher/text/TextWrap.test.ts
+++ b/grapher/text/TextWrap.test.ts
@@ -16,7 +16,7 @@ describe(TextWrap, () => {
                 maxWidth: Infinity,
                 fontSize: FONT_SIZE,
                 text,
-                rawHtml: raw
+                rawHtml: raw,
             })
             return textwrap.width
         }

--- a/grapher/text/TextWrap.tsx
+++ b/grapher/text/TextWrap.tsx
@@ -4,7 +4,7 @@ import {
     max,
     stripHTML,
     defaultTo,
-    linkify
+    linkify,
 } from "grapher/utils/Util"
 import { computed } from "mobx"
 import { Bounds } from "grapher/utils/Bounds"
@@ -69,7 +69,7 @@ export class TextWrap {
         let line: string[] = []
         let lineBounds = Bounds.empty()
 
-        words.forEach(word => {
+        words.forEach((word) => {
             const nextLine = line.concat([word])
 
             // Strip HTML if a raw string is passed
@@ -79,7 +79,7 @@ export class TextWrap {
 
             const nextBounds = Bounds.forText(text, {
                 fontSize,
-                fontWeight
+                fontWeight,
             })
 
             if (
@@ -89,7 +89,7 @@ export class TextWrap {
                 lines.push({
                     text: line.join(" "),
                     width: lineBounds.width,
-                    height: lineBounds.height
+                    height: lineBounds.height,
                 })
                 line = [word]
                 lineBounds = Bounds.forText(word, { fontSize, fontWeight })
@@ -102,7 +102,7 @@ export class TextWrap {
             lines.push({
                 text: line.join(" "),
                 width: lineBounds.width,
-                height: lineBounds.height
+                height: lineBounds.height,
             })
 
         return lines
@@ -116,7 +116,7 @@ export class TextWrap {
     }
 
     @computed get width(): number {
-        return defaultTo(max(this.lines.map(l => l.width)), 0)
+        return defaultTo(max(this.lines.map((l) => l.width)), 0)
     }
 
     @computed get htmlStyle(): any {
@@ -125,7 +125,7 @@ export class TextWrap {
             fontSize: fontSize.toFixed(2) + "px",
             fontWeight: fontWeight,
             lineHeight: lineHeight,
-            overflowY: "visible"
+            overflowY: "visible",
         }
     }
 
@@ -145,13 +145,13 @@ export class TextWrap {
                     const content = props.rawHtml ? (
                         <span
                             dangerouslySetInnerHTML={{
-                                __html: line.text
+                                __html: line.text,
                             }}
                         />
                     ) : props.linkifyText ? (
                         <span
                             dangerouslySetInnerHTML={{
-                                __html: linkify(line.text)
+                                __html: linkify(line.text),
                             }}
                         />
                     ) : (

--- a/grapher/utils/Bounds.ts
+++ b/grapher/utils/Bounds.ts
@@ -67,7 +67,7 @@ export class Bounds {
         xPosition: number
     ) {
         const bounds = Bounds.forText(label, {
-            fontSize
+            fontSize,
         })
         const overflow = xPosition - Math.ceil(bounds.width / 2)
         return overflow < 0 ? Math.abs(overflow) : 0
@@ -83,7 +83,7 @@ export class Bounds {
             x = 0,
             y = 0,
             fontSize = 16,
-            fontWeight = 400
+            fontWeight = 400,
         }: {
             x?: number
             y?: number
@@ -106,7 +106,7 @@ export class Bounds {
             const width = pixelWidth(str, {
                 font: "arial",
                 size: fontSize,
-                bold: fontWeight >= 600
+                bold: fontWeight >= 600,
             })
             const height = fontSize
             bounds = new Bounds(x, y - height, width, height)
@@ -262,7 +262,7 @@ export class Bounds {
             [this.topLeft, this.topRight],
             [this.topRight, this.bottomRight],
             [this.bottomRight, this.bottomLeft],
-            [this.bottomLeft, this.topLeft]
+            [this.bottomLeft, this.topLeft],
         ]
     }
 
@@ -300,7 +300,7 @@ export class Bounds {
             left: `${this.left}px`,
             top: `${this.top}px`,
             width: `${this.width}px`,
-            height: `${this.height}px`
+            height: `${this.height}px`,
         }
     }
 
@@ -311,7 +311,7 @@ export class Bounds {
     toArray(): [[number, number], [number, number]] {
         return [
             [this.left, this.top],
-            [this.right, this.bottom]
+            [this.right, this.bottom],
         ]
     }
 

--- a/grapher/utils/TimeBounds.test.ts
+++ b/grapher/utils/TimeBounds.test.ts
@@ -5,7 +5,7 @@ import {
     minTimeFromJSON,
     maxTimeFromJSON,
     minTimeToJSON,
-    maxTimeToJSON
+    maxTimeToJSON,
 } from "grapher/utils/TimeBounds"
 
 describe(minTimeFromJSON, () => {

--- a/grapher/utils/TimeBounds.ts
+++ b/grapher/utils/TimeBounds.ts
@@ -3,7 +3,7 @@ import {
     findClosestYear,
     isString,
     diffDateISOStringInDays,
-    formatDay
+    formatDay,
 } from "grapher/utils/Util"
 import { EPOCH_DATE } from "grapher/core/GrapherConstants"
 
@@ -25,12 +25,12 @@ export type TimeBounds = [TimeBound, TimeBound]
  */
 export enum TimeBoundValue {
     unboundedLeft = -Infinity,
-    unboundedRight = Infinity
+    unboundedRight = Infinity,
 }
 
 enum TimeBoundValueStr {
     unboundedLeft = "earliest",
-    unboundedRight = "latest"
+    unboundedRight = "latest",
 }
 
 export function isUnbounded(time: TimeBound): time is TimeBoundValue {
@@ -171,7 +171,7 @@ export function getTimeDomainFromQueryString(time: string): [number, number] {
         const [start, end] = time.split("..")
         return [
             parseTimeURIComponent(start, TimeBoundValue.unboundedLeft),
-            parseTimeURIComponent(end, TimeBoundValue.unboundedRight)
+            parseTimeURIComponent(end, TimeBoundValue.unboundedRight),
         ]
     } else {
         const t = parseTimeURIComponent(time, TimeBoundValue.unboundedRight)

--- a/grapher/utils/UrlBinder.ts
+++ b/grapher/utils/UrlBinder.ts
@@ -4,7 +4,7 @@ import { reaction, IReactionDisposer } from "mobx"
 import {
     setWindowQueryStr,
     queryParamsToStr,
-    QueryParams
+    QueryParams,
 } from "utils/client/url"
 
 import { debounce } from "grapher/utils/Util"

--- a/grapher/utils/Util.test.ts
+++ b/grapher/utils/Util.test.ts
@@ -26,7 +26,7 @@ import {
     JsTable,
     anyToString,
     sortNumeric,
-    lowerCaseFirstLetterUnlessAbbreviation
+    lowerCaseFirstLetterUnlessAbbreviation,
 } from "grapher/utils/Util"
 import { strToQueryParams } from "utils/client/url"
 import { SortOrder, ScaleType } from "grapher/core/GrapherConstants"
@@ -78,7 +78,7 @@ describe(getStartEndValues, () => {
     })
     it("handles a single element array", () => {
         const extent = getStartEndValues([
-            { year: 2016, value: 1 }
+            { year: 2016, value: 1 },
         ]) as DataValue[]
         expect(extent[0].year).toEqual(2016)
         expect(extent[1].year).toEqual(2016)
@@ -87,7 +87,7 @@ describe(getStartEndValues, () => {
         const extent = getStartEndValues([
             { year: 2016, value: -20 },
             { year: 2014, value: 5 },
-            { year: 2017, value: 7 }
+            { year: 2017, value: 7 },
         ]) as DataValue[]
         expect(extent[0].year).toEqual(2014)
         expect(extent[1].year).toEqual(2017)
@@ -100,35 +100,35 @@ describe(next, () => {
             list: [55, 33, 22],
             current: 33,
             next: 22,
-            previous: 55
+            previous: 55,
         },
         {
             list: [55, 33, 22],
             current: 44,
             next: 55,
-            previous: 22
+            previous: 22,
         },
         {
             list: [55, 33, 22],
             current: 22,
             next: 55,
-            previous: 33
+            previous: 33,
         },
         {
             list: [55, 33, 22],
             current: 55,
             next: 33,
-            previous: 22
+            previous: 22,
         },
         {
             list: [55],
             current: 55,
             next: 55,
-            previous: 55
-        }
+            previous: 55,
+        },
     ]
     it("iterates correctly", () => {
-        scenarios.forEach(scenario => {
+        scenarios.forEach((scenario) => {
             expect(next(scenario.list, scenario.current)).toBe(scenario.next)
             expect(previous(scenario.list, scenario.current)).toBe(
                 scenario.previous
@@ -149,35 +149,35 @@ describe(computeRollingAverage, () => {
             numbers: [2, 4, 6, 8],
             window: 1,
             align: "right",
-            result: [2, 4, 6, 8]
+            result: [2, 4, 6, 8],
         },
         {
             numbers: [1, -1, 1, -1],
             window: 2,
             align: "right",
-            result: [1, 0, 0, 0]
+            result: [1, 0, 0, 0],
         },
         {
             numbers: [1, undefined, null, -1, 1],
             window: 2,
             align: "right",
-            result: [1, undefined, null, -1, 0]
+            result: [1, undefined, null, -1, 0],
         },
         {
             numbers: [1, 3, 5, 1],
             window: 3,
             align: "right",
-            result: [1, 2, 3, 3]
+            result: [1, 2, 3, 3],
         },
         {
             numbers: [0, 2, 4, 0],
             window: 3,
             align: "center",
-            result: [1, 2, 2, 2]
-        }
+            result: [1, 2, 2, 2],
+        },
     ]
     it("computes the rolling average", () => {
-        testCases.forEach(testCase => {
+        testCases.forEach((testCase) => {
             expect(
                 computeRollingAverage(
                     testCase.numbers,
@@ -194,11 +194,11 @@ describe(insertMissingValuePlaceholders, () => {
         {
             values: [2, -3, 10],
             years: [0, 2, 3],
-            expected: [2, null, -3, 10]
-        }
+            expected: [2, null, -3, 10],
+        },
     ]
     it("computes the rolling average", () => {
-        testCases.forEach(testCase => {
+        testCases.forEach((testCase) => {
             expect(
                 insertMissingValuePlaceholders(testCase.values, testCase.years)
             ).toEqual(testCase.expected)
@@ -209,12 +209,12 @@ describe(insertMissingValuePlaceholders, () => {
         {
             values: [0, 2, 3],
             years: [0, 2, 3],
-            expected: [0, null, 2, 2.5]
-        }
+            expected: [0, null, 2, 2.5],
+        },
     ]
 
     it("computes the rolling average for data with missing values", () => {
-        testCasesWithMissing.forEach(testCase => {
+        testCasesWithMissing.forEach((testCase) => {
             expect(
                 computeRollingAverage(
                     insertMissingValuePlaceholders(
@@ -337,7 +337,7 @@ describe("jsTables", () => {
 1,2`
         expect(toJsTable(parseDelimited(str))).toEqual([
             ["gdp", "pop"],
-            ["1", "2"]
+            ["1", "2"],
         ])
 
         expect(toJsTable(parseDelimited(""))).toEqual(undefined)
@@ -373,7 +373,7 @@ describe("anyToString", () => {
         NaN,
         Infinity,
         {},
-        0.1
+        0.1,
     ]
     const expected = [
         "false",
@@ -388,7 +388,7 @@ describe("anyToString", () => {
         "NaN",
         "Infinity",
         "[object Object]",
-        "0.1"
+        "0.1",
     ]
     it("handles edge cases in format value", () => {
         expect(values.map(anyToString)).toEqual(expected)
@@ -400,23 +400,23 @@ describe(trimEmptyRows, () => {
         const testCases: { input: JsTable; length: number }[] = [
             {
                 input: [["pop"], [123], [null], [""], [undefined]],
-                length: 2
+                length: 2,
             },
             {
                 input: [[]],
-                length: 0
+                length: 0,
             },
             {
                 input: [
                     ["pop", "gdp"],
                     [123, 345],
-                    [undefined, 456]
+                    [undefined, 456],
                 ],
-                length: 3
-            }
+                length: 3,
+            },
         ]
 
-        testCases.forEach(testCase => {
+        testCases.forEach((testCase) => {
             expect(trimEmptyRows(testCase.input).length).toEqual(
                 testCase.length
             )
@@ -426,7 +426,7 @@ describe(trimEmptyRows, () => {
 
 describe(groupMap, () => {
     it("groups by key", () => {
-        const group = groupMap([0, 1, "a", 1, 1], v => v)
+        const group = groupMap([0, 1, "a", 1, 1], (v) => v)
         expect(group.get(0)).toEqual([0])
         expect(group.get(1)).toEqual([1, 1, 1])
         expect(group.get("a")).toEqual(["a"])
@@ -511,7 +511,7 @@ describe(sortNumeric, () => {
         expect(
             sortNumeric(
                 [{ a: 3 }, { a: 4 }, { a: 2 }, { a: 1 }, { a: 3 }, { a: 8 }],
-                o => o.a
+                (o) => o.a
             )
         ).toEqual([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 3 }, { a: 4 }, { a: 8 }])
     })

--- a/grapher/utils/Util.ts
+++ b/grapher/utils/Util.ts
@@ -126,7 +126,7 @@ export {
     takeWhile,
     upperFirst,
     countBy,
-    startCase
+    startCase,
 }
 
 import moment from "moment"
@@ -142,7 +142,7 @@ import {
     SortOrder,
     RelatedQuestionsConfig,
     ScaleType,
-    EPOCH_DATE
+    EPOCH_DATE,
 } from "grapher/core/GrapherConstants"
 import { isUnboundedLeft, isUnboundedRight } from "./TimeBounds"
 import { queryParamsToStr, strToQueryParams } from "utils/client/url"
@@ -176,7 +176,7 @@ const d3Format = formatLocale({
     thousands: ",",
     grouping: [3],
     minus: "-",
-    currency: ["$", ""]
+    currency: ["$", ""],
 } as any).format
 
 export function getRelativeMouse(
@@ -212,7 +212,7 @@ export function getRelativeMouse(
 
 // Make an arbitrary string workable as a css class name
 export function makeSafeForCSS(name: string) {
-    return name.replace(/[^a-z0-9]/g, s => {
+    return name.replace(/[^a-z0-9]/g, (s) => {
         const c = s.charCodeAt(0)
         if (c === 32) return "-"
         if (c === 95) return "_"
@@ -283,7 +283,7 @@ export function formatValue(
                 extend({}, options, {
                     unit: shortNumberPrefixes ? "T" : "trillion",
                     noSpaceUnit: shortNumberPrefixes,
-                    numDecimalPlaces: 2
+                    numDecimalPlaces: 2,
                 })
             )
         else if (absValue >= 1e9)
@@ -292,7 +292,7 @@ export function formatValue(
                 extend({}, options, {
                     unit: shortNumberPrefixes ? "B" : "billion",
                     noSpaceUnit: shortNumberPrefixes,
-                    numDecimalPlaces: 2
+                    numDecimalPlaces: 2,
                 })
             )
         else if (absValue >= 1e6)
@@ -301,7 +301,7 @@ export function formatValue(
                 extend({}, options, {
                     unit: shortNumberPrefixes ? "M" : "million",
                     noSpaceUnit: shortNumberPrefixes,
-                    numDecimalPlaces: 2
+                    numDecimalPlaces: 2,
                 })
             )
     } else {
@@ -352,7 +352,7 @@ export function last<T>(arr: T[]): T | undefined {
 }
 
 export function excludeUndefined<T>(arr: (T | undefined)[]): T[] {
-    return arr.filter(x => x !== undefined) as T[]
+    return arr.filter((x) => x !== undefined) as T[]
 }
 
 export function firstOfNonEmptyArray<T>(arr: T[]): T {
@@ -383,7 +383,7 @@ export function domainExtent(
     maxValueMultiplierForPadding = 1
 ): [number, number] {
     const filterValues =
-        scaleType === ScaleType.log ? numValues.filter(v => v > 0) : numValues
+        scaleType === ScaleType.log ? numValues.filter((v) => v > 0) : numValues
     const [minValue, maxValue] = extent(filterValues)
 
     if (
@@ -431,7 +431,7 @@ export const relativeMinAndMax = (
     let minChange = 0
     let maxChange = 0
 
-    const values = points.filter(point => point.x !== 0 && point.y !== 0)
+    const values = points.filter((point) => point.x !== 0 && point.y !== 0)
 
     for (let i = 0; i < values.length; i++) {
         const indexValue = values[i]
@@ -526,7 +526,7 @@ export function csvEscape(value: any): string {
 
 export function urlToSlug(url: string): string {
     const urlobj = parseUrl(url)
-    const slug = last(urlobj.pathname.split("/").filter(x => x)) as string
+    const slug = last(urlobj.pathname.split("/").filter((x) => x)) as string
     return slug
 }
 
@@ -537,7 +537,7 @@ export function sign(n: number) {
 // Removes all undefineds from an object. If there are no keys left, returns undefined.
 export function trimObject(obj: any) {
     const clone: any = {}
-    Object.keys(obj).forEach(key => {
+    Object.keys(obj).forEach((key) => {
         if (obj[key] !== undefined) clone[key] = obj[key]
     })
     return Object.keys(clone).length ? clone : undefined
@@ -663,7 +663,7 @@ export function valuesAtYears(
     tolerance: number = 0
 ) {
     const years = Array.from(valueByYear.keys())
-    const values = targetYears.map(targetYear => {
+    const values = targetYears.map((targetYear) => {
         let value
         const year = findClosestYear(years, targetYear, tolerance)
         if (year !== undefined) {
@@ -671,7 +671,7 @@ export function valuesAtYears(
         }
         return {
             year,
-            value
+            value,
         }
     })
     return values
@@ -682,7 +682,7 @@ export function valuesByEntityAtYears(
     targetYears: number[],
     tolerance: number = 0
 ): Map<string, DataValue[]> {
-    return es6mapValues(valueByEntityAndYear, valueByYear =>
+    return es6mapValues(valueByEntityAndYear, (valueByYear) =>
         valuesAtYears(valueByYear, targetYears, tolerance)
     )
 }
@@ -693,13 +693,13 @@ export function valuesByEntityWithinYears(
 ): Map<string, DataValue[]> {
     const start = range[0] !== undefined ? range[0] : -Infinity
     const end = range[1] !== undefined ? range[1] : Infinity
-    return es6mapValues(valueByEntityAndYear, valueByYear => {
+    return es6mapValues(valueByEntityAndYear, (valueByYear) => {
         const years = Array.from(valueByYear.keys()).filter(
-            year => year >= start && year <= end
+            (year) => year >= start && year <= end
         )
-        const values = years.map(year => ({
+        const values = years.map((year) => ({
             year,
-            value: valueByYear.get(year)
+            value: valueByYear.get(year),
         }))
         return values
     })
@@ -708,8 +708,8 @@ export function valuesByEntityWithinYears(
 export function getStartEndValues(
     values: DataValue[]
 ): (DataValue | undefined)[] {
-    const start = minBy(values, dv => dv.year)
-    const end = maxBy(values, dv => dv.year)
+    const start = minBy(values, (dv) => dv.year)
+    const end = maxBy(values, (dv) => dv.year)
     return [start, end]
 }
 
@@ -765,7 +765,7 @@ export const toJsTable = (rows: any[]): JsTable | undefined =>
     rows.length
         ? [
               Object.keys(rows[0]) as HeaderRow,
-              ...rows.map(row => Object.values(row) as ValueRow)
+              ...rows.map((row) => Object.values(row) as ValueRow),
           ]
         : undefined
 
@@ -939,7 +939,7 @@ export function rollingMap<T, U>(array: T[], mapper: (a: T, b: T) => U) {
 
 export function groupMap<T, K>(array: T[], accessor: (v: T) => K): Map<K, T[]> {
     const result = new Map<K, T[]>()
-    array.forEach(item => {
+    array.forEach((item) => {
         const key = accessor(item)
         if (result.has(key)) {
             result.get(key)?.push(item)
@@ -965,7 +965,7 @@ export function intersectionOfSets<T>(sets: Set<T>[]) {
     if (!sets.length) return new Set<T>()
     const intersection = new Set<T>(sets[0])
 
-    sets.slice(1).forEach(set => {
+    sets.slice(1).forEach((set) => {
         for (const elem of intersection) {
             if (!set.has(elem)) {
                 intersection.delete(elem)
@@ -980,7 +980,7 @@ export function sortByUndefinedLast<T>(
     accessor: (t: T) => string | number | undefined,
     order: SortOrder = SortOrder.asc
 ) {
-    const sorted = sortBy(array, value => {
+    const sorted = sortBy(array, (value) => {
         const mapped = accessor(value)
         if (mapped === undefined) {
             return order === SortOrder.asc ? Infinity : -Infinity
@@ -1003,7 +1003,7 @@ export const getErrorMessageRelatedQuestionUrl = (
 
 export function getAttributesOfHTMLElement(el: HTMLElement) {
     const attributes: { [key: string]: string } = {}
-    each(el.attributes, attr => (attributes[attr.name] = attr.value))
+    each(el.attributes, (attr) => (attributes[attr.name] = attr.value))
     return attributes
 }
 
@@ -1016,7 +1016,7 @@ export function mergeQueryStr(...queryStrs: (string | undefined)[]) {
 export function mapNullToUndefined<T>(
     array: (T | undefined | null)[]
 ): (T | undefined)[] {
-    return array.map(v => (v === null ? undefined : v))
+    return array.map((v) => (v === null ? undefined : v))
 }
 
 export const lowerCaseFirstLetterUnlessAbbreviation = (str: string) =>

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,8 +18,8 @@ const common = {
         "^serverSettings$": "<rootDir>/serverSettings",
         // Jest cannot handle importing CSS
         // https://stackoverflow.com/questions/39418555/syntaxerror-with-jest-and-react-and-importing-css-files
-        "\\.(css|less|sass|scss)$": "<rootDir>/utils/styleMock.ts"
-    }
+        "\\.(css|less|sass|scss)$": "<rootDir>/utils/styleMock.ts",
+    },
 }
 
 module.exports = {
@@ -29,14 +29,14 @@ module.exports = {
             displayName: "node",
             testEnvironment: "node",
             testPathIgnorePatterns: [".jsdom.test."],
-            testMatch: ["**/*.test.(tsx|ts)"]
+            testMatch: ["**/*.test.(tsx|ts)"],
         },
         {
             ...common,
             displayName: "jsdom",
             testEnvironment: "jsdom",
             setupFilesAfterEnv: ["<rootDir>/.enzymeSetup.ts"],
-            testMatch: ["**/*.jsdom.test.(tsx|ts)"]
-        }
-    ]
+            testMatch: ["**/*.jsdom.test.(tsx|ts)"],
+        },
+    ],
 }

--- a/knexfile.ts
+++ b/knexfile.ts
@@ -9,20 +9,20 @@ const dbConfig = {
         user: DB_USER,
         password: DB_PASS,
         host: DB_HOST,
-        port: DB_PORT
+        port: DB_PORT,
     },
     pool: {
         min: 2,
-        max: 10
+        max: 10,
     },
     migrations: {
         tableName: "knex_migrations",
-        directory: "./db/knexMigrations"
-    }
+        directory: "./db/knexMigrations",
+    },
 }
 
 export = {
     development: dbConfig,
     staging: dbConfig,
-    production: dbConfig
+    production: dbConfig,
 }

--- a/ormconfig.js
+++ b/ormconfig.js
@@ -12,6 +12,6 @@ module.exports = {
     migrations: ["db/migration/**/*.ts"],
     cli: {
         entitiesDir: "db/model",
-        migrationsDir: "db/migration"
-    }
+        migrationsDir: "db/migration",
+    },
 }

--- a/owidTable/OwidTable.test.ts
+++ b/owidTable/OwidTable.test.ts
@@ -19,8 +19,8 @@ describe(OwidTable, () => {
             entityName: "United States",
             population: 3e8,
             entityId: 1,
-            entityCode: "USA"
-        }
+            entityCode: "USA",
+        },
     ]
     const table = new OwidTable(rows)
     it("can create a table and detect columns", () => {
@@ -31,7 +31,7 @@ describe(OwidTable, () => {
     it("a column can be added", () => {
         table.addNumericComputedColumn({
             slug: "populationInMillions",
-            fn: row => row.population / 1000000
+            fn: (row) => row.population / 1000000,
         })
         expect(table.rows[0].populationInMillions).toEqual(300)
     })
@@ -50,7 +50,7 @@ describe("from legacy", () => {
             "entityId",
             "entityCode",
             "year",
-            name
+            name,
         ])
     })
 })
@@ -89,7 +89,7 @@ canada,20`
         expect(table.rows.length).toEqual(4)
         expect(Array.from(table.columnsByName.keys())).toEqual([
             "country",
-            "population"
+            "population",
         ])
     })
 
@@ -99,14 +99,14 @@ canada,20`
             expect(col.values[3]).toEqual("canada")
             table.addFilterColumn(
                 "pop_filter",
-                row => parseInt(row.population) > 40
+                (row) => parseInt(row.population) > 40
             )
             expect(col?.values[0]).toEqual("france")
             expect(col?.values[1]).toEqual("usa")
         })
 
         it("multiple filters work", () => {
-            table.addFilterColumn("name_filter", row =>
+            table.addFilterColumn("name_filter", (row) =>
                 (row.country as string).startsWith("u")
             )
             expect(col?.values[0]).toEqual("usa")
@@ -116,7 +116,7 @@ canada,20`
         it("adding rows works with filters", () => {
             table.cloneAndAddRowsAndDetectColumns([
                 { country: "ireland", population: "7" },
-                { country: "united kingdom", population: "60" }
+                { country: "united kingdom", population: "60" },
             ])
             expect(col?.values[0]).toEqual("usa")
             expect(col?.values[1]).toEqual("united kingdom")
@@ -141,7 +141,7 @@ describe("immutability", () => {
     it("does not modify rows", () => {
         table.addNumericComputedColumn({
             slug: "firstLetter",
-            fn: row => row.country.length
+            fn: (row) => row.country.length,
         })
         expect(table.columnsBySlug.get("firstLetter")?.values.join("")).toEqual(
             `37`
@@ -179,7 +179,7 @@ describe("rolling averages", () => {
             population: 3e8,
             entityId: 1,
             entityCode: "USA",
-            continent: "North America"
+            continent: "North America",
         },
         {
             year: 2020,
@@ -187,7 +187,7 @@ describe("rolling averages", () => {
             population: 10e8,
             entityId: 12,
             entityCode: "World",
-            continent: ""
+            continent: "",
         },
         {
             year: 2020,
@@ -195,8 +195,8 @@ describe("rolling averages", () => {
             population: 3e8,
             entityId: 1,
             entityCode: "USA",
-            continent: "North America"
-        }
+            continent: "North America",
+        },
     ]
     const colLength = Object.keys(rows[0]).length
     const table = new OwidTable(rows)
@@ -205,7 +205,7 @@ describe("rolling averages", () => {
         expect(Array.from(table.columnsByName.keys()).length).toEqual(colLength)
         table.addNumericComputedColumn({
             slug: "populationInMillions",
-            fn: row => row.population / 1000000
+            fn: (row) => row.population / 1000000,
         })
         expect(table.rows[0].populationInMillions).toEqual(300)
         expect(Array.from(table.columnsByName.keys()).length).toEqual(

--- a/owidTable/OwidTable.ts
+++ b/owidTable/OwidTable.ts
@@ -2,7 +2,7 @@ import {
     OwidVariable,
     OwidVariableDisplaySettings,
     EntityMeta,
-    OwidVariablesAndEntityKey
+    OwidVariablesAndEntityKey,
 } from "./OwidVariable"
 import {
     slugifySameCase,
@@ -19,7 +19,7 @@ import {
     parseDelimited,
     intersectionOfSets,
     formatValue,
-    anyToString
+    anyToString,
 } from "grapher/utils/Util"
 import { computed, action, observable } from "mobx"
 import { OwidSource } from "./OwidSource"
@@ -64,10 +64,10 @@ const computeRollingAveragesForEachGroup = (
             const averages = computeRollingAverage(
                 insertMissingValuePlaceholders(
                     currentRows.map(valueAccessor),
-                    currentRows.map(row => row[dateColName])
+                    currentRows.map((row) => row[dateColName])
                 ),
                 rollingAverage
-            ).filter(value => value !== null) as number[]
+            ).filter((value) => value !== null) as number[]
             groups.push(averages)
             if (!row) break
             currentRows = []
@@ -81,7 +81,7 @@ const computeRollingAveragesForEachGroup = (
 enum OwidRequiredColumns {
     entityName = "entityName",
     entityCode = "entityCode",
-    entityId = "entityId"
+    entityId = "entityId",
 }
 
 // This is a row with the additional columns specific to our OWID data model
@@ -188,7 +188,7 @@ export abstract class AbstractColumn {
     private mapBy(columnSlug: columnSlug) {
         const map = new Map<any, Set<any>>()
         const slug = this.slug
-        this.rows.forEach(row => {
+        this.rows.forEach((row) => {
             const value = row[slug]
             // For now the behavior is to not overwrite an existing value with a falsey one
             if (value === undefined || value === "") return
@@ -225,7 +225,7 @@ export abstract class AbstractColumn {
     // todo: is the isString necessary?
     @computed get sortedUniqNonEmptyStringVals(): string[] {
         return Array.from(
-            new Set(this.values.filter(isString).filter(i => i))
+            new Set(this.values.filter(isString).filter((i) => i))
         ).sort()
     }
 
@@ -235,7 +235,7 @@ export abstract class AbstractColumn {
 
     // todo: remove
     @computed get entityNames() {
-        return this.rows.map(row => row.entityName)
+        return this.rows.map((row) => row.entityName)
     }
 
     // todo: remove
@@ -250,25 +250,25 @@ export abstract class AbstractColumn {
 
     // todo: remove
     @computed get years() {
-        return this.rows.map(row => (row.year ?? row.day)!)
+        return this.rows.map((row) => (row.year ?? row.day)!)
     }
 
     // Rows containing a value for this column
     @computed get rows() {
         const slug = this.spec.slug
         return this.table.unfilteredRows.filter(
-            row => row[slug] !== undefined && row[slug] !== ""
+            (row) => row[slug] !== undefined && row[slug] !== ""
         )
     }
 
     @computed get values() {
         const slug = this.spec.slug
-        return this.rows.map(row => row[slug])
+        return this.rows.map((row) => row[slug])
     }
 
     @computed get latestValuesMap() {
         const map = new Map<EntityName, any>()
-        this.rows.forEach(row => map.set(row.entityName, row[this.slug]))
+        this.rows.forEach((row) => map.set(row.entityName, row[this.slug]))
         return map
     }
 
@@ -292,7 +292,7 @@ class IntegerColumn extends NumericColumn {
             numDecimalPlaces: 0,
             noTrailingZeroes: false,
             numberPrefixes: true,
-            shortNumberPrefixes: true
+            shortNumberPrefixes: true,
         })
     }
 }
@@ -303,7 +303,7 @@ class CurrencyColumn extends NumericColumn {
             numDecimalPlaces: 0,
             noTrailingZeroes: false,
             numberPrefixes: false,
-            unit: "$"
+            unit: "$",
         })
     }
 }
@@ -315,7 +315,7 @@ class PercentageColumn extends NumericColumn {
             numDecimalPlaces: 0,
             noTrailingZeroes: false,
             numberPrefixes: false,
-            unit: "%"
+            unit: "%",
         })
     }
 }
@@ -327,7 +327,7 @@ class DecimalPercentageColumn extends NumericColumn {
             numDecimalPlaces: 0,
             noTrailingZeroes: false,
             numberPrefixes: false,
-            unit: "%"
+            unit: "%",
         })
     }
 }
@@ -338,7 +338,7 @@ class PopulationDensityColumn extends NumericColumn {
         return formatValue(value, {
             numDecimalPlaces: 0,
             noTrailingZeroes: false,
-            numberPrefixes: false
+            numberPrefixes: false,
         })
     }
 }
@@ -348,7 +348,7 @@ class AgeColumn extends NumericColumn {
         return formatValue(value, {
             numDecimalPlaces: 1,
             noTrailingZeroes: false,
-            numberPrefixes: false
+            numberPrefixes: false,
         })
     }
 }
@@ -358,7 +358,7 @@ class RatioColumn extends NumericColumn {
         return formatValue(value, {
             numDecimalPlaces: 1,
             noTrailingZeroes: false,
-            numberPrefixes: true
+            numberPrefixes: true,
         })
     }
 }
@@ -376,7 +376,7 @@ const columnTypeMap: { [key in columnTypes]: any } = {
     Population: PopulationColumn,
     PopulationDensity: PopulationDensityColumn,
     Age: AgeColumn,
-    Ratio: RatioColumn
+    Ratio: RatioColumn,
 }
 // Todo: Add DayColumn, YearColumn, EntityColumn, etc?
 
@@ -416,14 +416,14 @@ abstract class AbstractTable<ROW_TYPE extends Row> {
 
     addSpecs(columnSpecs: ColumnSpecs | ColumnSpecObject | ColumnSpec[]) {
         if (Array.isArray(columnSpecs))
-            columnSpecs = new Map(columnSpecs.map(spec => [spec.slug, spec]))
+            columnSpecs = new Map(columnSpecs.map((spec) => [spec.slug, spec]))
         else if (!(columnSpecs instanceof Map))
             columnSpecs = new Map(
                 Object.entries(columnSpecs as ColumnSpecObject)
             )
         const specs = columnSpecs as ColumnSpecs
         const cols = this.columns
-        Array.from(specs.keys()).forEach(slug => {
+        Array.from(specs.keys()).forEach((slug) => {
             const spec = specs.get(slug)!
             const columnType =
                 (spec.type && columnTypeMap[spec.type]) || AnyColumn
@@ -435,8 +435,8 @@ abstract class AbstractTable<ROW_TYPE extends Row> {
     static makeSpecsFromRows(rows: any[]): ColumnSpecs {
         const map = new Map()
         // Todo: type detection
-        rows.forEach(row => {
-            Object.keys(row).forEach(key => {
+        rows.forEach((row) => {
+            Object.keys(row).forEach((key) => {
                 map.set(key, { slug: key })
             })
         })
@@ -444,7 +444,7 @@ abstract class AbstractTable<ROW_TYPE extends Row> {
     }
 
     @action.bound deleteColumnBySlug(slug: columnSlug) {
-        this.rows.forEach(row => delete row[slug])
+        this.rows.forEach((row) => delete row[slug])
         this.columns.delete(slug)
     }
 
@@ -497,7 +497,7 @@ abstract class AbstractTable<ROW_TYPE extends Row> {
         groupBy: columnSlug,
         multiplier = 1,
         intervalChange?: number,
-        transformation: (fn: RowToValueMapper) => RowToValueMapper = fn => (
+        transformation: (fn: RowToValueMapper) => RowToValueMapper = (fn) => (
             row,
             index
         ) => fn(row, index)
@@ -522,7 +522,7 @@ abstract class AbstractTable<ROW_TYPE extends Row> {
         this._addComputedColumn(
             new NumericColumn(this, {
                 ...spec,
-                fn: transformation(computeIntervalTotals)
+                fn: transformation(computeIntervalTotals),
             })
         )
     }
@@ -533,7 +533,7 @@ abstract class AbstractTable<ROW_TYPE extends Row> {
 
     @computed get columnsByName() {
         const map = new Map<string, AbstractColumn>()
-        this.columns.forEach(col => {
+        this.columns.forEach((col) => {
             map.set(col.name, col)
         })
         return map
@@ -545,14 +545,14 @@ abstract class AbstractTable<ROW_TYPE extends Row> {
 
     @computed get numericColumnSlugs() {
         return this.columnsAsArray
-            .filter(col => col instanceof NumericColumn)
-            .map(col => col.slug)
+            .filter((col) => col instanceof NumericColumn)
+            .map((col) => col.slug)
     }
 
     @computed get isSelectedFn() {
         const selectionColumnSlugs = this.selectionColumnSlugs
         return selectionColumnSlugs.length
-            ? (row: Row) => selectionColumnSlugs.some(slug => row[slug])
+            ? (row: Row) => selectionColumnSlugs.some((slug) => row[slug])
             : undefined
     }
 
@@ -562,19 +562,19 @@ abstract class AbstractTable<ROW_TYPE extends Row> {
 
     @computed get selectedRows() {
         const isSelectedFn = this.isSelectedFn
-        return isSelectedFn ? this.rows.filter(row => isSelectedFn(row)) : []
+        return isSelectedFn ? this.rows.filter((row) => isSelectedFn(row)) : []
     }
 
     // Currently only used for debugging
     get filteredRows() {
         const unfiltered = new Set(this.unfilteredRows)
-        return this.rows.filter(row => !unfiltered.has(row))
+        return this.rows.filter((row) => !unfiltered.has(row))
     }
 
     @computed get unfilteredRows() {
         const filterFn = this.combinedFilterFn
         const res = this.filterColumnSlugs.length
-            ? this.rows.filter(row => filterFn(row))
+            ? this.rows.filter((row) => filterFn(row))
             : this.rows
 
         return res
@@ -583,7 +583,7 @@ abstract class AbstractTable<ROW_TYPE extends Row> {
     @computed private get combinedFilterFn() {
         const filterSlugs = this.filterColumnSlugs
         const filterFns = filterSlugs.map(
-            slug =>
+            (slug) =>
                 (this.columnsBySlug.get(slug)!.spec as ComputedColumnSpec).fn
         )
         return (row: Row) => {
@@ -596,14 +596,14 @@ abstract class AbstractTable<ROW_TYPE extends Row> {
 
     @computed private get filterColumnSlugs() {
         return this.columnsAsArray
-            .filter(col => col instanceof FilterColumn)
-            .map(col => col.slug)
+            .filter((col) => col instanceof FilterColumn)
+            .map((col) => col.slug)
     }
 
     @computed private get selectionColumnSlugs() {
         return this.columnsAsArray
-            .filter(col => col instanceof SelectionColumn)
-            .map(col => col.slug)
+            .filter((col) => col instanceof SelectionColumn)
+            .map((col) => col.slug)
     }
 
     @computed get columnsAsArray() {
@@ -613,23 +613,23 @@ abstract class AbstractTable<ROW_TYPE extends Row> {
     // for debugging
     rowsWith(query: string) {
         const slugs = this.columnSlugs
-        return this.rows.filter(row =>
+        return this.rows.filter((row) =>
             slugs
-                .map(slug => slug + " " + (row[slug] ?? ""))
+                .map((slug) => slug + " " + (row[slug] ?? ""))
                 .join(" ")
                 .includes(query)
         )
     }
 
     extract(slugs = this.columnSlugs) {
-        return this.rows.map(row => slugs.map(slug => row[slug] ?? ""))
+        return this.rows.map((row) => slugs.map((slug) => row[slug] ?? ""))
     }
 
     toDelimited(slugs = this.columnSlugs, rowLimit?: number, delimiter = ",") {
         const header = slugs.join(delimiter) + "\n"
         const body = this.extract(slugs)
             .slice(0, rowLimit)
-            .map(row => row.join(delimiter))
+            .map((row) => row.join(delimiter))
             .join("\n")
         return header + body
     }
@@ -647,16 +647,16 @@ export class BasicTable extends AbstractTable<Row> {
     }
 
     private static standardizeSlugs(rows: Row[]) {
-        const colSpecs = Object.keys(rows[0]).map(name => {
+        const colSpecs = Object.keys(rows[0]).map((name) => {
             return {
                 name,
-                slug: slugifySameCase(name)
+                slug: slugifySameCase(name),
             }
         })
-        const colsToRename = colSpecs.filter(col => col.name !== col.slug)
+        const colsToRename = colSpecs.filter((col) => col.name !== col.slug)
         if (colsToRename.length) {
             rows.forEach((row: Row) => {
-                colsToRename.forEach(col => {
+                colsToRename.forEach((col) => {
                     row[col.slug] = row[col.name]
                     delete row[col.name]
                 })
@@ -671,7 +671,7 @@ export class OwidTable extends AbstractTable<OwidRow> {
         const parsed = parseDelimited(csvOrTsv)
         const colSlugs = parsed[0] ? Object.keys(parsed[0]) : []
         const missingColumns: string[] = []
-        Object.keys(OwidRequiredColumns).forEach(slug => {
+        Object.keys(OwidRequiredColumns).forEach((slug) => {
             if (!colSlugs.includes(slug)) missingColumns.push(slug)
         })
         if (missingColumns.length)
@@ -697,17 +697,17 @@ export class OwidTable extends AbstractTable<OwidRow> {
     }
 
     @computed get availableEntitiesSet() {
-        return new Set(this.rows.map(row => row.entityName))
+        return new Set(this.rows.map((row) => row.entityName))
     }
 
     @computed get unfilteredEntities() {
-        return new Set(this.unfilteredRows.map(row => row.entityName))
+        return new Set(this.unfilteredRows.map((row) => row.entityName))
     }
 
     // todo: can we remove at some point?
     @computed get entityIdToNameMap() {
         const map = new Map<EntityId, EntityName>()
-        this.rows.forEach(row => {
+        this.rows.forEach((row) => {
             map.set(row.entityId, row.entityName)
         })
         return map
@@ -716,7 +716,7 @@ export class OwidTable extends AbstractTable<OwidRow> {
     // todo: can we remove at some point?
     @computed get entityCodeToNameMap() {
         const map = new Map<EntityCode, EntityName>()
-        this.rows.forEach(row => {
+        this.rows.forEach((row) => {
             if (row.entityCode) map.set(row.entityCode, row.entityName)
             else map.set(row.entityName, row.entityName)
         })
@@ -726,7 +726,7 @@ export class OwidTable extends AbstractTable<OwidRow> {
     // todo: can we remove at some point?
     @computed get entityNameToIdMap() {
         const map = new Map<EntityName, number>()
-        this.rows.forEach(row => {
+        this.rows.forEach((row) => {
             map.set(row.entityName, row.entityId)
         })
         return map
@@ -735,7 +735,7 @@ export class OwidTable extends AbstractTable<OwidRow> {
     // todo: can we remove at some point?
     @computed get entityNameToCodeMap() {
         const map = new Map<EntityName, EntityCode>()
-        this.rows.forEach(row => {
+        this.rows.forEach((row) => {
             map.set(row.entityName, row.entityCode)
         })
         return map
@@ -743,7 +743,7 @@ export class OwidTable extends AbstractTable<OwidRow> {
 
     @computed get entityIndex() {
         const map = new Map<EntityName, OwidRow[]>()
-        this.rows.forEach(row => {
+        this.rows.forEach((row) => {
             if (!map.has(row.entityName)) map.set(row.entityName, [])
             map.get(row.entityName)!.push(row)
         })
@@ -759,7 +759,7 @@ export class OwidTable extends AbstractTable<OwidRow> {
     }
 
     @computed get allYears() {
-        return this.rows.filter(row => row.year).map(row => row.year!)
+        return this.rows.filter((row) => row.year).map((row) => row.year!)
     }
 
     @computed get hasDayColumn() {
@@ -772,7 +772,7 @@ export class OwidTable extends AbstractTable<OwidRow> {
 
     @computed get rowsByEntityName() {
         const map = new Map<EntityName, OwidRow[]>()
-        this.rows.forEach(row => {
+        this.rows.forEach((row) => {
             const name = row.entityName
             if (!map.has(name)) map.set(name, [])
             map.get(name)!.push(row)
@@ -784,7 +784,7 @@ export class OwidTable extends AbstractTable<OwidRow> {
     @action.bound setSelectedEntities(entityNames: EntityName[]) {
         this.initDefaultEntitySelectionColumn()
         const set = new Set(entityNames)
-        this.rows.forEach(row => {
+        this.rows.forEach((row) => {
             row[this.defaultEntitySelectionSlug] = set.has(row.entityName)
         })
         return this
@@ -796,7 +796,7 @@ export class OwidTable extends AbstractTable<OwidRow> {
             this.columns.set(
                 this.defaultEntitySelectionSlug,
                 new SelectionColumn(this, {
-                    slug: this.defaultEntitySelectionSlug
+                    slug: this.defaultEntitySelectionSlug,
                 })
             )
     }
@@ -806,20 +806,20 @@ export class OwidTable extends AbstractTable<OwidRow> {
 
         this.rowsByEntityName
             .get(entityName)
-            ?.forEach(row => (row[this.defaultEntitySelectionSlug] = true))
+            ?.forEach((row) => (row[this.defaultEntitySelectionSlug] = true))
         return this
     }
 
     @action.bound deselectEntity(entityName: EntityName) {
         this.rowsByEntityName
             .get(entityName)
-            ?.forEach(row => delete row[this.defaultEntitySelectionSlug])
+            ?.forEach((row) => delete row[this.defaultEntitySelectionSlug])
         return this
     }
 
     specToObject() {
         const output: any = {}
-        Array.from(this.columns.values()).forEach(col => {
+        Array.from(this.columns.values()).forEach((col) => {
             output[col.slug] = col.spec
         })
         return output
@@ -828,7 +828,7 @@ export class OwidTable extends AbstractTable<OwidRow> {
     toJs() {
         return {
             columns: this.specToObject(),
-            rows: this.rows
+            rows: this.rows,
         }
     }
 
@@ -839,7 +839,7 @@ export class OwidTable extends AbstractTable<OwidRow> {
 
         return intersectionOfSets<string>(
             columnSlugs.map(
-                slug => this.columnsBySlug.get(slug)!.entityNamesUniq
+                (slug) => this.columnsBySlug.get(slug)!.entityNamesUniq
             )
         )
     }
@@ -848,7 +848,7 @@ export class OwidTable extends AbstractTable<OwidRow> {
         // Todo: let's delete this and switch to traditional columns
         const entityAnnotationsMap = new Map<string, string>()
         const delimiter = ":"
-        annotations.split("\n").forEach(line => {
+        annotations.split("\n").forEach((line) => {
             const [key, ...words] = line.split(delimiter)
             entityAnnotationsMap.set(key.trim(), words.join(delimiter).trim())
         })
@@ -871,7 +871,7 @@ export class OwidTable extends AbstractTable<OwidRow> {
             datasetId,
             datasetName,
             source,
-            display
+            display,
         } = variable
 
         return {
@@ -887,7 +887,7 @@ export class OwidTable extends AbstractTable<OwidRow> {
             display,
             source,
             owidVariableId: variable.id,
-            type: "Numeric"
+            type: "Numeric",
         }
     }
 
@@ -897,22 +897,22 @@ export class OwidTable extends AbstractTable<OwidRow> {
         const columnSpecs: Map<columnSlug, ColumnSpec> = new Map()
         columnSpecs.set("entityName", {
             slug: "entityName",
-            type: "Categorical"
+            type: "Categorical",
         })
         columnSpecs.set("entityId", { slug: "entityId", type: "Categorical" })
         columnSpecs.set("entityCode", {
             slug: "entityCode",
-            type: "Categorical"
+            type: "Categorical",
         })
 
         for (const key in json.variables) {
             const variable = new OwidVariable(json.variables[key])
 
             const entityNames = variable.entities.map(
-                id => entityMetaById[id].name
+                (id) => entityMetaById[id].name
             )
             const entityCodes = variable.entities.map(
-                id => entityMetaById[id].code
+                (id) => entityMetaById[id].code
             )
 
             const columnSpec = this.columnSpecFromLegacyVariable(variable)
@@ -934,7 +934,7 @@ export class OwidTable extends AbstractTable<OwidRow> {
                 )
                 columnSpecs.set(annotationsColumnSlug, {
                     slug: annotationsColumnSlug,
-                    type: "String"
+                    type: "String",
                 })
                 columnSpec.annotationsColumnSlug = annotationsColumnSlug
             }
@@ -960,7 +960,7 @@ export class OwidTable extends AbstractTable<OwidRow> {
                     [columnSlug]: value,
                     entityName,
                     entityId: variable.entities[index],
-                    entityCode: entityCodes[index]
+                    entityCode: entityCodes[index],
                 }
                 if (annotationsColumnSlug)
                     row[annotationsColumnSlug] = annotationMap.get(entityName)
@@ -968,13 +968,13 @@ export class OwidTable extends AbstractTable<OwidRow> {
             })
             rows = rows.concat(newRows)
         }
-        const groupMap = groupBy(rows, row => {
+        const groupMap = groupBy(rows, (row) => {
             const timePart =
                 row.year !== undefined ? `year:` + row.year : `day:` + row.day
             return timePart + " " + row.entityName
         })
 
-        const joinedRows: OwidRow[] = Object.keys(groupMap).map(groupKey =>
+        const joinedRows: OwidRow[] = Object.keys(groupMap).map((groupKey) =>
             Object.assign({}, ...groupMap[groupKey])
         )
 
@@ -990,6 +990,6 @@ export class OwidTable extends AbstractTable<OwidRow> {
         // In order to correctly join variables with different `zeroDay`s in a single chart, we
         // normalize all days to be in reference to a single epoch date.
         const diff = diffDateISOStringInDays(zeroDay, EPOCH_DATE)
-        return years.map(y => y + diff)
+        return years.map((y) => y + diff)
     }
 }

--- a/owidTable/PopulationMap.ts
+++ b/owidTable/PopulationMap.ts
@@ -279,5 +279,5 @@ export const populationMap: { [country: string]: number } = {
     World: 7794798729,
     Yemen: 29825968,
     Zambia: 18383956,
-    Zimbabwe: 14862927
+    Zimbabwe: 14862927,
 }

--- a/package.json
+++ b/package.json
@@ -233,9 +233,7 @@
         "xhr-mock": "^2.5.1"
     },
     "prettier": {
-        "semi": false,
-        "trailingComma": "none",
-        "arrowParens": "avoid"
+        "semi": false
     },
     "browserslist": [
         ">0.5%",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,5 @@
 module.exports = {
     plugins: {
-        autoprefixer: {}
-    }
+        autoprefixer: {},
+    },
 }

--- a/settings.ts
+++ b/settings.ts
@@ -64,7 +64,7 @@ export const PUBLIC_TAG_PARENT_IDS: number[] = [
     1505,
     1508,
     1512,
-    1510
+    1510,
 ]
 
 // Feature flag for explorable charts

--- a/site/client/AmazonMenu.tsx
+++ b/site/client/AmazonMenu.tsx
@@ -45,7 +45,7 @@ export class AmazonMenu extends React.Component<{
     @bind onMouseMove(event: React.MouseEvent<HTMLDivElement>) {
         this.mouseLocs.push({
             x: event.pageX,
-            y: event.pageY
+            y: event.pageY,
         })
         if (this.mouseLocs.length > MOUSE_LOCS_TRACKED) this.mouseLocs.shift()
     }
@@ -105,19 +105,19 @@ export class AmazonMenu extends React.Component<{
 
         const upperLeft = {
             x: submenuRect.left,
-            y: submenuRect.top - TOLERANCE_PX
+            y: submenuRect.top - TOLERANCE_PX,
         }
         const upperRight = {
             x: submenuRect.right,
-            y: upperLeft.y
+            y: upperLeft.y,
         }
         const lowerLeft = {
             x: submenuRect.left,
-            y: submenuRect.bottom + TOLERANCE_PX
+            y: submenuRect.bottom + TOLERANCE_PX,
         }
         const lowerRight = {
             x: submenuRect.right,
-            y: lowerLeft.y
+            y: lowerLeft.y,
         }
         const loc = this.mouseLocs[this.mouseLocs.length - 1]
         let prevLoc = this.mouseLocs[0]

--- a/site/client/EmbedChart.tsx
+++ b/site/client/EmbedChart.tsx
@@ -6,7 +6,7 @@ import {
     observable,
     runInAction,
     autorun,
-    IReactionDisposer
+    IReactionDisposer,
 } from "mobx"
 import { Grapher } from "grapher/core/Grapher"
 import { GrapherFigureView } from "./GrapherFigureView"
@@ -35,7 +35,7 @@ export class EmbedChart extends React.Component<{ src: string }> {
         runInAction(() => {
             this.chart = new Grapher(config, {
                 isEmbed: true,
-                queryStr: this.queryStr
+                queryStr: this.queryStr,
             })
         })
     }

--- a/site/client/Feedback.stories.tsx
+++ b/site/client/Feedback.stories.tsx
@@ -5,7 +5,7 @@ import { FeedbackForm } from "site/client/Feedback"
 
 export default {
     title: "FeedbackForm",
-    component: FeedbackForm
+    component: FeedbackForm,
 }
 
 export const Default = () => <FeedbackForm />

--- a/site/client/Feedback.tsx
+++ b/site/client/Feedback.tsx
@@ -178,7 +178,7 @@ export class FeedbackForm extends React.Component<{ onClose?: () => void }> {
         return (
             <form
                 className={classnames("FeedbackForm", {
-                    loading: this.loading
+                    loading: this.loading,
                 })}
                 onSubmit={this.onSubmit}
             >

--- a/site/client/Footnote.tsx
+++ b/site/client/Footnote.tsx
@@ -6,7 +6,7 @@ import ReactDOM from "react-dom"
 export const Footnote = ({
     index,
     htmlContent,
-    triggerTarget
+    triggerTarget,
 }: {
     index: number
     htmlContent?: string
@@ -24,7 +24,7 @@ export const Footnote = ({
                     <div>
                         <div
                             dangerouslySetInnerHTML={{
-                                __html: htmlContent
+                                __html: htmlContent,
                             }}
                         />
                     </div>
@@ -64,7 +64,7 @@ function getFootnoteContent(element: Element): FootnoteContent | null {
 export function runFootnotes() {
     const footnotes = document.querySelectorAll("a.ref")
 
-    footnotes.forEach(f => {
+    footnotes.forEach((f) => {
         const footnoteContent = getFootnoteContent(f)
         if (footnoteContent == null) return
 

--- a/site/client/GrapherPageUtils.ts
+++ b/site/client/GrapherPageUtils.ts
@@ -3,7 +3,7 @@ import { bind } from "decko"
 import { throttle, isMobile } from "grapher/utils/Util"
 import {
     GlobalEntitySelection,
-    pageContainsGlobalEntityControl
+    pageContainsGlobalEntityControl,
 } from "site/globalEntityControl/GlobalEntitySelection"
 import { Figure } from "./figures/Figure"
 import { ChartFigure } from "./figures/ChartFigure"
@@ -35,7 +35,7 @@ class MultiEmbedder {
 
     @bind private addFigure(figure: Figure) {
         // Prevent adding duplicates
-        if (!this.figures.map(f => f.container).includes(figure.container)) {
+        if (!this.figures.map((f) => f.container).includes(figure.container)) {
             this.figures.push(figure)
         }
     }
@@ -71,9 +71,9 @@ class MultiEmbedder {
      * otherwise automatically loads interactive charts when they approach the viewport.
      */
     @bind public loadVisibleFigures() {
-        this.figures.filter(this.shouldLoadFigure).forEach(figure =>
+        this.figures.filter(this.shouldLoadFigure).forEach((figure) =>
             figure.load({
-                globalEntitySelection: this.globalEntitySelection
+                globalEntitySelection: this.globalEntitySelection,
             })
         )
     }
@@ -172,7 +172,7 @@ class GrapherPageUtilsSingleton {
     public constructor() {
         this.globalEntitySelection = new GlobalEntitySelection()
         this.embedder = new MultiEmbedder({
-            globalEntitySelection: this.globalEntitySelection
+            globalEntitySelection: this.globalEntitySelection,
         })
     }
 }

--- a/site/client/HeaderSearch.tsx
+++ b/site/client/HeaderSearch.tsx
@@ -55,7 +55,7 @@ export class HeaderSearch extends React.Component<{ autoFocus?: boolean }> {
                 <input
                     type="search"
                     name="q"
-                    onChange={e => this.onSearch(e)}
+                    onChange={(e) => this.onSearch(e)}
                     placeholder="Search..."
                     autoFocus={this.props.autoFocus}
                 />

--- a/site/client/Lightbox.tsx
+++ b/site/client/Lightbox.tsx
@@ -14,7 +14,7 @@ import { PROMINENT_LINK_CLASSNAME } from "./blocks/ProminentLink/ProminentLink"
 const Lightbox = ({
     children,
     containerNode,
-    imgSrc
+    imgSrc,
 }: {
     children: any
     containerNode: Element | null
@@ -51,7 +51,7 @@ const Lightbox = ({
                         <div
                             className="content"
                             ref={contentRef}
-                            onClick={e => {
+                            onClick={(e) => {
                                 if (e.target === contentRef.current) {
                                     close()
                                 }
@@ -109,7 +109,7 @@ const Lightbox = ({
 const Image = ({
     src,
     isLoaded,
-    setIsLoaded
+    setIsLoaded,
 }: {
     src: string
     isLoaded: boolean
@@ -137,7 +137,7 @@ export const runLightbox = () => {
     }
     Array.from(
         document.querySelectorAll<HTMLImageElement>(".article-content img")
-    ).forEach(img => {
+    ).forEach((img) => {
         if (
             img.closest(`.${PROMINENT_LINK_CLASSNAME}`) ||
             img.closest("[data-no-lightbox]")

--- a/site/client/NewsletterSubscription.tsx
+++ b/site/client/NewsletterSubscription.tsx
@@ -11,11 +11,11 @@ const analytics = new Analytics(ENV)
 export enum NewsletterSubscriptionContext {
     Homepage = "homepage",
     MobileMenu = "mobile-menu",
-    Floating = "floating"
+    Floating = "floating",
 }
 
 export const NewsletterSubscription = ({
-    context
+    context,
 }: {
     context?: NewsletterSubscriptionContext
 }) => {
@@ -59,7 +59,7 @@ export const NewsletterSubscription = ({
 }
 
 export const NewsletterSubscriptionForm = ({
-    context
+    context,
 }: {
     context?: NewsletterSubscriptionContext
 }) => {
@@ -78,7 +78,7 @@ export const NewsletterSubscriptionForm = ({
             setFrequencies([e.target.value, ...frequencies])
         } else {
             setFrequencies(
-                frequencies.filter(frequency => frequency !== e.target.value)
+                frequencies.filter((frequency) => frequency !== e.target.value)
             )
         }
     }

--- a/site/client/SearchCountry.tsx
+++ b/site/client/SearchCountry.tsx
@@ -20,7 +20,7 @@ const SearchCountry = (props: { countryProfileRootPath: string }) => {
     const sorted = sortBy(countries, "name")
     return (
         <Select
-            options={sorted.map(c => {
+            options={sorted.map((c) => {
                 return { label: c.name, value: c.slug }
             })}
             onChange={(selected: ValueType<CountrySelectOption>) => {
@@ -39,11 +39,11 @@ export function runSearchCountry() {
     const searchElements = document.querySelectorAll(
         ".wp-block-search-country-profile"
     )
-    searchElements.forEach(element => {
+    searchElements.forEach((element) => {
         const project = element.getAttribute("data-project")
         if (project) {
             const profileSpec = countryProfileSpecs.find(
-                spec => spec.project === project
+                (spec) => spec.project === project
             )
             if (profileSpec) {
                 ReactDOM.render(

--- a/site/client/SearchResults.tsx
+++ b/site/client/SearchResults.tsx
@@ -2,7 +2,7 @@ import {
     SiteSearchResults,
     ChartHit,
     CountryHit,
-    ArticleHit
+    ArticleHit,
 } from "algolia/searchClient"
 import { observer } from "mobx-react"
 import { computed } from "mobx"
@@ -55,7 +55,7 @@ class ChartResult extends React.Component<{
                 {hit._snippetResult ? (
                     <p
                         dangerouslySetInnerHTML={{
-                            __html: hit._snippetResult.subtitle.value
+                            __html: hit._snippetResult.subtitle.value,
                         }}
                     />
                 ) : undefined}
@@ -74,7 +74,7 @@ class CountryResult extends React.Component<{ hit: CountryHit }> {
                 <span className="variantName">Country</span>
                 <p
                     dangerouslySetInnerHTML={{
-                        __html: hit._snippetResult.content.value
+                        __html: hit._snippetResult.content.value,
                     }}
                 />
             </li>
@@ -97,7 +97,7 @@ class ArticleResult extends React.Component<{ hit: ArticleHit }> {
                 ) : undefined}
                 <p
                     dangerouslySetInnerHTML={{
-                        __html: hit._snippetResult.content.value
+                        __html: hit._snippetResult.content.value,
                     }}
                 />
             </li>
@@ -114,7 +114,7 @@ function pickEntitiesForChart(hit: ChartHit, queryCountries: Country[]) {
         const entity = res.value.replace(/<\/?em>/g, "")
         if (
             res.matchLevel !== "none" ||
-            queryCountries.some(c => c.name === entity)
+            queryCountries.some((c) => c.name === entity)
         ) {
             entities.push(entity)
         }
@@ -134,11 +134,11 @@ export class SearchResults extends React.Component<{
     }
 
     @computed get entries() {
-        return this.props.results.pages.filter(p => p.type === "page")
+        return this.props.results.pages.filter((p) => p.type === "page")
     }
 
     @computed get blogposts() {
-        return this.props.results.pages.filter(p => p.type === "post")
+        return this.props.results.pages.filter((p) => p.type === "post")
     }
 
     @computed get bestChartEntities() {
@@ -174,7 +174,7 @@ export class SearchResults extends React.Component<{
                             <p>No matching pages.</p>
                         ) : undefined}
                         <ul>
-                            {results.pages.map(hit =>
+                            {results.pages.map((hit) =>
                                 hit.type === "country" ? (
                                     <CountryResult
                                         key={hit.objectID}
@@ -200,7 +200,7 @@ export class SearchResults extends React.Component<{
                             />
                         )}
                         <ul>
-                            {results.charts.map(hit => (
+                            {results.charts.map((hit) => (
                                 <ChartResult
                                     key={hit.chartId}
                                     hit={hit}

--- a/site/client/SectionHeading/SectionHeading.tsx
+++ b/site/client/SectionHeading/SectionHeading.tsx
@@ -6,14 +6,14 @@ import { faArrowDown } from "@fortawesome/free-solid-svg-icons/faArrowDown"
 export const SectionHeading = ({
     title,
     tocHeadings,
-    children
+    children,
 }: {
     title: string
     tocHeadings: TocHeading[]
     children: any
 }) => {
     const sectionHeadingIdx = tocHeadings.findIndex(
-        heading => !heading.isSubheading && heading.text === title
+        (heading) => !heading.isSubheading && heading.text === title
     )
     const subHeadings = []
 
@@ -36,14 +36,14 @@ export const SectionHeading = ({
                             <div className="border"></div>
                         </div>
                         <ul className="subheadings">
-                            {subHeadings.map(subHeading => (
+                            {subHeadings.map((subHeading) => (
                                 <li key={subHeading.slug}>
                                     <a href={`#${subHeading.slug}`}>
                                         <FontAwesomeIcon icon={faArrowDown} />
                                         {subHeading.html ? (
                                             <span
                                                 dangerouslySetInnerHTML={{
-                                                    __html: subHeading.html
+                                                    __html: subHeading.html,
                                                 }}
                                             ></span>
                                         ) : (

--- a/site/client/SiteHeaderMenus.tsx
+++ b/site/client/SiteHeaderMenus.tsx
@@ -5,7 +5,7 @@ import {
     action,
     reaction,
     runInAction,
-    IReactionDisposer
+    IReactionDisposer,
 } from "mobx"
 import { observer } from "mobx-react"
 import { HeaderSearch } from "./HeaderSearch"
@@ -27,7 +27,7 @@ import { faEnvelopeOpenText } from "@fortawesome/free-solid-svg-icons/faEnvelope
 import { AmazonMenu } from "./AmazonMenu"
 import {
     NewsletterSubscriptionForm,
-    NewsletterSubscriptionContext
+    NewsletterSubscriptionContext,
 } from "./NewsletterSubscription"
 
 @observer
@@ -141,7 +141,7 @@ export class Header extends React.Component<{
                             <a
                                 href="/#entries"
                                 className={classnames("topics-button", {
-                                    active: this.dropdownIsOpen
+                                    active: this.dropdownIsOpen,
                                 })}
                                 onMouseEnter={() =>
                                     this.scheduleOpenTimeout(200)
@@ -318,8 +318,8 @@ const allEntries = (category: CategoryWithEntries): EntryMeta[] => {
     return [
         ...category.entries,
         ...flatten(
-            category.subcategories.map(subcategory => subcategory.entries)
-        )
+            category.subcategories.map((subcategory) => subcategory.entries)
+        ),
     ]
 }
 
@@ -341,7 +341,7 @@ export class DesktopTopicsMenu extends React.Component<{
         if (categorySlug) {
             const category = find(
                 this.props.categories,
-                c => c.slug === categorySlug
+                (c) => c.slug === categorySlug
             )
             if (category) this.setCategory(category)
         }
@@ -351,7 +351,7 @@ export class DesktopTopicsMenu extends React.Component<{
         if (categorySlug) {
             const category = find(
                 this.props.categories,
-                c => c.slug === categorySlug
+                (c) => c.slug === categorySlug
             )
             if (category === this.activeCategory) this.setCategory(undefined)
         }
@@ -378,7 +378,7 @@ export class DesktopTopicsMenu extends React.Component<{
         return (
             <div
                 className={classnames("topics-dropdown", sizeClass, {
-                    open: isOpen
+                    open: isOpen,
                 })}
                 onMouseEnter={onMouseEnter}
                 onMouseLeave={onMouseLeave}
@@ -394,7 +394,7 @@ export class DesktopTopicsMenu extends React.Component<{
                         }
                     >
                         <ul>
-                            {categories.map(category => (
+                            {categories.map((category) => (
                                 <li
                                     key={category.slug}
                                     className={
@@ -443,7 +443,7 @@ export class DesktopTopicsMenu extends React.Component<{
                 </div>
                 <ul className="submenu" ref={this.submenuRef}>
                     {activeCategory &&
-                        allEntries(activeCategory).map(entry =>
+                        allEntries(activeCategory).map((entry) =>
                             renderEntry(entry)
                         )}
                 </ul>
@@ -472,7 +472,7 @@ export class MobileTopicsMenu extends React.Component<{
                     <li className="header">
                         <h2>Topics</h2>
                     </li>
-                    {categories.map(category => (
+                    {categories.map((category) => (
                         <li
                             key={category.slug}
                             className={`category ${
@@ -486,7 +486,7 @@ export class MobileTopicsMenu extends React.Component<{
                                     </span>
                                     <span className="entries-muted">
                                         {allEntries(category)
-                                            .map(entry => entry.title)
+                                            .map((entry) => entry.title)
                                             .join(", ")}
                                     </span>
                                 </span>
@@ -503,7 +503,7 @@ export class MobileTopicsMenu extends React.Component<{
                             {activeCategory === category && (
                                 <div className="subcategory-menu">
                                     <ul>
-                                        {allEntries(category).map(entry =>
+                                        {allEntries(category).map((entry) =>
                                             renderEntry(entry)
                                         )}
                                     </ul>
@@ -565,8 +565,8 @@ export class SiteHeaderMenus extends React.Component {
                 method: "GET",
                 credentials: "same-origin",
                 headers: {
-                    Accept: "application/json"
-                }
+                    Accept: "application/json",
+                },
             })
         ).json()
 

--- a/site/client/SiteTools.tsx
+++ b/site/client/SiteTools.tsx
@@ -4,7 +4,7 @@ import { FeedbackPrompt } from "./Feedback"
 import {
     NewsletterSubscription,
     NewsletterSubscriptionForm,
-    NewsletterSubscriptionContext
+    NewsletterSubscriptionContext,
 } from "./NewsletterSubscription"
 
 const SiteTools = () => {

--- a/site/client/TableOfContents.tsx
+++ b/site/client/TableOfContents.tsx
@@ -26,14 +26,14 @@ const getPreviousHeading = (
     previousHeadings: Array<{ slug: string; previous: string | null }>
 ) => {
     return previousHeadings.find(
-        heading => heading.slug === nextHeadingRecord?.target.id
+        (heading) => heading.slug === nextHeadingRecord?.target.id
     )?.previous
 }
 
 export const TableOfContents = ({
     headings,
     pageTitle,
-    hideSubheadings
+    hideSubheadings,
 }: TableOfContentsData) => {
     const [isToggled, setIsToggled] = useState(false)
     const [isSticky, setIsSticky] = useState(false)
@@ -52,7 +52,7 @@ export const TableOfContents = ({
             // Sets up an intersection observer to notify when the element with the class
             // `.sticky-sentinel` becomes visible/invisible at the top of the viewport.
             // Inspired by https://developers.google.com/web/updates/2017/09/sticky-headers
-            const observer = new IntersectionObserver(records => {
+            const observer = new IntersectionObserver((records) => {
                 for (const record of records) {
                     const targetInfo = record.boundingClientRect
                     // Started sticking
@@ -75,19 +75,19 @@ export const TableOfContents = ({
         if ("IntersectionObserver" in window) {
             const previousHeadings = headings.map((heading, i) => ({
                 slug: heading.slug,
-                previous: i > 0 ? headings[i - 1].slug : null
+                previous: i > 0 ? headings[i - 1].slug : null,
             }))
 
             let currentHeadingRecord: IntersectionObserverEntry | undefined
             let init = true
 
             const observer = new IntersectionObserver(
-                records => {
+                (records) => {
                     let nextHeadingRecord: IntersectionObserverEntry | undefined
 
                     // Target headings going down
                     currentHeadingRecord = records.find(
-                        record =>
+                        (record) =>
                             // filter out records no longer intersecting (triggering on exit)
                             record.isIntersecting &&
                             // filter out records fully in the page (upcoming section)
@@ -101,7 +101,7 @@ export const TableOfContents = ({
                     } else {
                         // Target headings going up
                         nextHeadingRecord = records.find(
-                            record =>
+                            (record) =>
                                 isRecordTopViewport(record) &&
                                 record.intersectionRatio === 1
                         )
@@ -116,7 +116,8 @@ export const TableOfContents = ({
                             currentHeadingRecord = records
                                 .reverse()
                                 .find(
-                                    record => record.boundingClientRect.top < 0
+                                    (record) =>
+                                        record.boundingClientRect.top < 0
                                 )
                             setActiveHeading(
                                 currentHeadingRecord?.target.id || ""
@@ -127,7 +128,7 @@ export const TableOfContents = ({
                 },
                 {
                     rootMargin: "-10px", // 10px offset to trigger intersection when landing exactly at the border when clicking an anchor
-                    threshold: new Array(11).fill(0).map((v, i) => i / 10)
+                    threshold: new Array(11).fill(0).map((v, i) => i / 10),
                 }
             )
 
@@ -137,7 +138,7 @@ export const TableOfContents = ({
             } else {
                 contentHeadings = document.querySelectorAll("h2, h3")
             }
-            contentHeadings.forEach(contentHeading => {
+            contentHeadings.forEach((contentHeading) => {
                 observer.observe(contentHeading)
             })
         }
@@ -165,7 +166,7 @@ export const TableOfContents = ({
                         </a>
                     </li>
                     {headings
-                        .filter(heading =>
+                        .filter((heading) =>
                             hideSubheadings && heading.isSubheading
                                 ? false
                                 : true

--- a/site/client/blocks/AdditionalInformation/AdditionalInformation.tsx
+++ b/site/client/blocks/AdditionalInformation/AdditionalInformation.tsx
@@ -25,7 +25,7 @@ const AdditionalInformation = ({
     title,
     image,
     variation,
-    defaultOpen
+    defaultOpen,
 }: {
     content: string | null
     title: string | null
@@ -161,25 +161,28 @@ export const render = ($: CheerioStatic) => {
 }
 
 export const hydrate = () => {
-    document.querySelectorAll<HTMLElement>(`.${CLASS_NAME}`).forEach(block => {
-        const blockWrapper = block.parentElement
-        const titleEl = block.querySelector("h3")
-        const title = titleEl ? titleEl.textContent : null
-        const variation = block.getAttribute("data-variation") || ""
-        const defaultOpen = block.getAttribute("data-default-open") === "true"
-        const figureEl = block.querySelector(".content-wrapper > figure")
-        const image = figureEl ? figureEl.innerHTML : null
-        const contentEl = block.querySelector(".content")
-        const content = contentEl ? contentEl.innerHTML : null
-        ReactDOM.hydrate(
-            <AdditionalInformation
-                content={content}
-                title={title}
-                image={image}
-                variation={variation}
-                defaultOpen={defaultOpen}
-            />,
-            blockWrapper
-        )
-    })
+    document
+        .querySelectorAll<HTMLElement>(`.${CLASS_NAME}`)
+        .forEach((block) => {
+            const blockWrapper = block.parentElement
+            const titleEl = block.querySelector("h3")
+            const title = titleEl ? titleEl.textContent : null
+            const variation = block.getAttribute("data-variation") || ""
+            const defaultOpen =
+                block.getAttribute("data-default-open") === "true"
+            const figureEl = block.querySelector(".content-wrapper > figure")
+            const image = figureEl ? figureEl.innerHTML : null
+            const contentEl = block.querySelector(".content")
+            const content = contentEl ? contentEl.innerHTML : null
+            ReactDOM.hydrate(
+                <AdditionalInformation
+                    content={content}
+                    title={title}
+                    image={image}
+                    variation={variation}
+                    defaultOpen={defaultOpen}
+                />,
+                blockWrapper
+            )
+        })
 }

--- a/site/client/blocks/Help/Help.tsx
+++ b/site/client/blocks/Help/Help.tsx
@@ -5,7 +5,7 @@ import { faLightbulb } from "@fortawesome/free-solid-svg-icons/faLightbulb"
 
 const Help = ({
     title,
-    content
+    content,
 }: {
     title: string | null
     content: string | null

--- a/site/client/blocks/ProminentLink/ProminentLink.tsx
+++ b/site/client/blocks/ProminentLink/ProminentLink.tsx
@@ -7,7 +7,7 @@ import {
     strToQueryParams,
     queryParamsToStr,
     splitURLintoPathAndQueryString,
-    QueryParams
+    QueryParams,
 } from "utils/client/url"
 import { union, isEmpty, getAttributesOfHTMLElement } from "grapher/utils/Util"
 import { EntityUrlBuilder } from "grapher/core/EntityUrlBuilder"
@@ -55,7 +55,7 @@ class ProminentLink extends React.Component<{
 
     @computed private get entitiesInGlobalEntitySelection(): string[] {
         return GrapherPageUtils.globalEntitySelection.selectedEntities.map(
-            entity => entity.code
+            (entity) => entity.code
         )
     }
 
@@ -74,8 +74,8 @@ class ProminentLink extends React.Component<{
         return {
             ...originalURLQueryParams,
             ...(!isEmpty(updatedEntityQueryParam) && {
-                country: updatedEntityQueryParam
-            })
+                country: updatedEntityQueryParam,
+            }),
         }
     }
 
@@ -97,7 +97,7 @@ class ProminentLink extends React.Component<{
 export const renderProminentLink = () => {
     document
         .querySelectorAll<HTMLElement>(`.${PROMINENT_LINK_CLASSNAME}`)
-        .forEach(el => {
+        .forEach((el) => {
             const anchorTag = el.querySelector("a")
             if (!anchorTag) return
 

--- a/site/client/blocks/RelatedCharts/RelatedCharts.jsdom.test.tsx
+++ b/site/client/blocks/RelatedCharts/RelatedCharts.jsdom.test.tsx
@@ -7,12 +7,12 @@ import { RelatedCharts } from "./RelatedCharts"
 const charts = [
     {
         title: "Chart 1",
-        slug: "chart-1"
+        slug: "chart-1",
     },
     {
         title: "Chart 2",
-        slug: "chart-2"
-    }
+        slug: "chart-2",
+    },
 ]
 
 it("renders active chart links and loads respective chart on click", () => {

--- a/site/client/blocks/RelatedCharts/RelatedCharts.tsx
+++ b/site/client/blocks/RelatedCharts/RelatedCharts.tsx
@@ -29,7 +29,7 @@ export const RelatedCharts = ({ charts }: { charts: RelatedChart[] }) => {
             <div className="wp-block-columns is-style-sticky-right">
                 <div className="wp-block-column">
                     <ul>
-                        {charts.map(chart => (
+                        {charts.map((chart) => (
                             <li
                                 className={
                                     currentChart &&
@@ -41,7 +41,7 @@ export const RelatedCharts = ({ charts }: { charts: RelatedChart[] }) => {
                             >
                                 <a
                                     href={`/grapher/${chart.slug}`}
-                                    onClick={event => {
+                                    onClick={(event) => {
                                         // Allow opening charts in new tab/window with ⌘+CLICK
                                         if (
                                             !event.metaKey &&
@@ -50,7 +50,7 @@ export const RelatedCharts = ({ charts }: { charts: RelatedChart[] }) => {
                                         ) {
                                             setCurrentChart({
                                                 title: chart.title,
-                                                slug: chart.slug
+                                                slug: chart.slug,
                                             })
                                             event.preventDefault()
                                         }

--- a/site/client/blocks/index.ts
+++ b/site/client/blocks/index.ts
@@ -1,6 +1,6 @@
 import {
     hydrate as hydrateAdditionalInformation,
-    render as renderAdditionalInformation
+    render as renderAdditionalInformation,
 } from "./AdditionalInformation/AdditionalInformation"
 import { render as renderHelp } from "./Help/Help"
 import { renderProminentLink } from "./ProminentLink/ProminentLink"

--- a/site/client/covid/CovidConstants.ts
+++ b/site/client/covid/CovidConstants.ts
@@ -13,5 +13,5 @@ export const nouns: Record<NounKey, NounGenerator> = {
     cases: createNoun("case", "cases"),
     deaths: createNoun("death", "deaths"),
     tests: createNoun("test", "tests"),
-    days: createNoun("day", "days")
+    days: createNoun("day", "days"),
 }

--- a/site/client/covid/CovidFetch.ts
+++ b/site/client/covid/CovidFetch.ts
@@ -5,7 +5,7 @@ import {
     fetchText,
     retryPromise,
     memoize,
-    parseIntOrUndefined
+    parseIntOrUndefined,
 } from "grapher/utils/Util"
 
 import { CovidSeries } from "./CovidTypes"
@@ -13,14 +13,14 @@ import { ECDC_DATA_URL, TESTS_DATA_URL } from "./CovidConstants"
 
 async function _fetchECDCData(): Promise<CovidSeries> {
     const responseText = await retryPromise(() => fetchText(ECDC_DATA_URL))
-    const rows: CovidSeries = csvParse(responseText).map(row => {
+    const rows: CovidSeries = csvParse(responseText).map((row) => {
         return {
             date: new Date(row.date as string),
             location: row.location as string,
             totalCases: parseIntOrUndefined(row.total_cases),
             totalDeaths: parseIntOrUndefined(row.total_deaths),
             newCases: parseIntOrUndefined(row.new_cases),
-            newDeaths: parseIntOrUndefined(row.new_deaths)
+            newDeaths: parseIntOrUndefined(row.new_deaths),
         }
     })
     return rows
@@ -58,7 +58,7 @@ export interface CovidTestsDatum {
 
 export async function fetchTestsData(): Promise<CovidSeries> {
     const responseText = await retryPromise(() => fetchText(TESTS_DATA_URL))
-    const rows: CovidSeries = csvParse(responseText).map(row => {
+    const rows: CovidSeries = csvParse(responseText).map((row) => {
         return {
             date: moment(
                 row["Date to which estimate refers (dd mmm yyyy)"] as string,
@@ -83,8 +83,8 @@ export async function fetchTestsData(): Promise<CovidSeries> {
                 nonOfficial:
                     parseIntOrUndefined(
                         row["Non-official / Non-verifiable (=1)"]
-                    ) === 1
-            }
+                    ) === 1,
+            },
         }
     })
     return rows

--- a/site/client/covid/CovidTable.tsx
+++ b/site/client/covid/CovidTable.tsx
@@ -20,7 +20,7 @@ import {
     addDays,
     extend,
     fromPairs,
-    uniq
+    uniq,
 } from "grapher/utils/Util"
 import { SortOrder } from "grapher/core/GrapherConstants"
 
@@ -31,7 +31,7 @@ import {
     CovidSeries,
     CovidCountrySeries,
     DateRange,
-    CovidCountryDatum
+    CovidCountryDatum,
 } from "./CovidTypes"
 
 import { getDoublingRange, sortAccessors, inverseSortOrder } from "./CovidUtils"
@@ -41,7 +41,7 @@ import {
     CovidTableColumnKey,
     CovidTableHeaderSpec,
     columns,
-    CovidTableCellSpec
+    CovidTableCellSpec,
 } from "./CovidTableColumns"
 import { fetchECDCData } from "./CovidFetch"
 
@@ -73,9 +73,9 @@ export class CovidTable extends React.Component<CovidTableProps> {
     static defaultProps: CovidTableProps = {
         columns: [],
         mobileColumns: [],
-        filter: d => d,
+        filter: (d) => d,
         loadData: fetchECDCData,
-        defaultState: {}
+        defaultState: {},
     }
 
     @observable.ref data: CovidSeries | undefined =
@@ -122,29 +122,29 @@ export class CovidTable extends React.Component<CovidTableProps> {
 
     @computed get countrySeries(): CovidCountrySeries {
         if (this.data) {
-            return entries(groupBy(this.data, d => d.location)).map(
+            return entries(groupBy(this.data, (d) => d.location)).map(
                 ([location, series]) => {
                     const sortedSeries: CovidSeries = sortBy(
                         series,
-                        d => d.date
+                        (d) => d.date
                     )
                     return {
                         id: location,
                         location: location,
                         series: sortedSeries,
-                        latest: maxBy(series, d => d.date),
+                        latest: maxBy(series, (d) => d.date),
                         latestWithTests: maxBy(
-                            series.filter(d => d.tests),
-                            d => d.date
+                            series.filter((d) => d.tests),
+                            (d) => d.date
                         ),
                         caseDoublingRange: getDoublingRange(
                             sortedSeries,
-                            d => d.totalCases
+                            (d) => d.totalCases
                         ),
                         deathDoublingRange: getDoublingRange(
                             sortedSeries,
-                            d => d.totalDeaths
-                        )
+                            (d) => d.totalDeaths
+                        ),
                     }
                 }
             )
@@ -157,7 +157,7 @@ export class CovidTable extends React.Component<CovidTableProps> {
         const accessor = sortAccessors[sortKey]
         const sortedSeries = orderBy(
             this.countrySeries,
-            d => {
+            (d) => {
                 const value = accessor(d)
                 // In order for undefined values to always be last, we map them to +- Infinity
                 return value !== undefined
@@ -177,14 +177,14 @@ export class CovidTable extends React.Component<CovidTableProps> {
         if (truncate) {
             ;[shown, truncated] = [
                 rest.slice(0, truncateLength),
-                rest.slice(truncateLength)
+                rest.slice(truncateLength),
             ]
         }
 
         return {
             shown,
             truncated,
-            hidden
+            hidden,
         }
     }
 
@@ -195,7 +195,7 @@ export class CovidTable extends React.Component<CovidTableProps> {
     @computed get dateRange(): DateRange {
         const difference = this.tableState.isMobile ? 13 : 20 // inclusive, so 21 days technically
         if (this.data !== undefined && this.data.length > 0) {
-            const maxDate = max(this.data.map(d => d.date)) as Date
+            const maxDate = max(this.data.map((d) => d.date)) as Date
             const minDate = addDays(maxDate, -difference)
             return [minDate, maxDate]
         }
@@ -207,7 +207,7 @@ export class CovidTable extends React.Component<CovidTableProps> {
     }
 
     @computed get totalTestsBarScale() {
-        const maxTests = max(this.data?.map(d => d.tests?.totalTests))
+        const maxTests = max(this.data?.map((d) => d.tests?.totalTests))
         return scaleLinear()
             .domain([0, maxTests ?? 1])
             .range([0, 1])
@@ -235,12 +235,12 @@ export class CovidTable extends React.Component<CovidTableProps> {
             currentSortOrder: sortOrder,
             isMobile: isMobile,
             lastUpdated: this.lastUpdated,
-            onSort: this.onSort
+            onSort: this.onSort,
         }
     }
 
     @computed get countryColors(): Record<string, string> {
-        const locations = uniq((this.data || []).map(d => d.location))
+        const locations = uniq((this.data || []).map((d) => d.location))
         const colors = schemeCategory10
         return fromPairs(
             locations.map((l, i) => [l, colors[i % colors.length]])
@@ -267,18 +267,18 @@ export class CovidTable extends React.Component<CovidTableProps> {
         return (
             <div
                 className={classnames("covid-table-container", {
-                    "covid-table-mobile": this.tableState.isMobile
+                    "covid-table-mobile": this.tableState.isMobile,
                 })}
             >
                 <div
                     className={classnames("covid-table-wrapper", {
-                        truncated: this.isTruncated
+                        truncated: this.isTruncated,
                     })}
                 >
                     <table className="covid-table">
                         <thead>
                             <tr>
-                                {this.columns.map(key => (
+                                {this.columns.map((key) => (
                                     <React.Fragment key={key}>
                                         {columns[key].header(
                                             this.headerCellProps
@@ -288,7 +288,7 @@ export class CovidTable extends React.Component<CovidTableProps> {
                             </tr>
                         </thead>
                         <tbody>
-                            {this.rowData.shown.map(datum => (
+                            {this.rowData.shown.map((datum) => (
                                 <CovidTableRow
                                     key={datum.id}
                                     datum={datum}
@@ -297,7 +297,7 @@ export class CovidTable extends React.Component<CovidTableProps> {
                                         dateRange: this.dateRange,
                                         totalTestsBarScale: this
                                             .totalTestsBarScale,
-                                        countryColors: this.countryColors
+                                        countryColors: this.countryColors,
                                     }}
                                     extraRow={this.props.extraRow}
                                     state={this.tableState}

--- a/site/client/covid/CovidTableColumns.tsx
+++ b/site/client/covid/CovidTableColumns.tsx
@@ -12,14 +12,14 @@ import { Tippy } from "grapher/chart/Tippy"
 
 import {
     CovidTableHeaderCell as HeaderCell,
-    CovidTableHeaderCellProps
+    CovidTableHeaderCellProps,
 } from "./CovidTableHeaderCell"
 import {
     CovidSortKey,
     CovidCountryDatum,
     CovidDatum,
     NounGenerator,
-    CovidDoublingRange
+    CovidDoublingRange,
 } from "./CovidTypes"
 import { formatDate, formatInt } from "./CovidUtils"
 import { nouns } from "./CovidConstants"
@@ -38,7 +38,7 @@ export enum CovidTableColumnKey {
     daysToDoubleDeaths = "daysToDoubleDeaths",
     totalTests = "totalTests",
     testDate = "testDate",
-    testSource = "testSource"
+    testSource = "testSource",
 }
 
 export type CovidTableHeaderSpec = Omit<
@@ -116,7 +116,7 @@ const daysToDoubleGenerator = (
                                     backgroundColor: doubingBackgColorScale(
                                         range.length
                                     ),
-                                    color: doubingTextColorScale(range.length)
+                                    color: doubingTextColorScale(range.length),
                                 }}
                             >
                                 {range.length}
@@ -183,7 +183,7 @@ const totalGenerator = (accessor: IntAccessor, noun: NounGenerator) => (
                         className="spark-bars covid-bars"
                         {...bars}
                         y={accessor}
-                        renderValue={d =>
+                        renderValue={(d) =>
                             d && accessor(d) !== undefined ? (
                                 <CovidTimeSeriesValue
                                     className="highlighted"
@@ -224,12 +224,12 @@ const newGenerator = (accessor: IntAccessor, noun: NounGenerator) => (
                         className="spark-bars covid-bars"
                         {...bars}
                         y={accessor}
-                        renderValue={d =>
+                        renderValue={(d) =>
                             d && accessor(d) !== undefined ? (
                                 <CovidTimeSeriesValue
                                     className="highlighted"
                                     value={formatInt(accessor(d), "", {
-                                        showPlus: true
+                                        showPlus: true,
                                     })}
                                     date={d && d.date}
                                 />
@@ -242,7 +242,7 @@ const newGenerator = (accessor: IntAccessor, noun: NounGenerator) => (
                         <CovidTimeSeriesValue
                             className="current"
                             value={`${formatInt(accessor(datum.latest), "", {
-                                showPlus: true
+                                showPlus: true,
                             })} new`}
                             date={datum.latest.date}
                             latest={true}
@@ -261,7 +261,7 @@ const newGenerator = (accessor: IntAccessor, noun: NounGenerator) => (
 export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
     location: {
         sortKey: CovidSortKey.location,
-        header: props => (
+        header: (props) => (
             <HeaderCell
                 {...props}
                 className="location"
@@ -270,15 +270,15 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                 <strong>Location</strong>
             </HeaderCell>
         ),
-        cell: props => (
+        cell: (props) => (
             <td className="location" rowSpan={props.baseRowSpan}>
                 {props.datum.location}
             </td>
-        )
+        ),
     },
     locationTests: {
         sortKey: CovidSortKey.location,
-        header: props => (
+        header: (props) => (
             <HeaderCell
                 {...props}
                 className="location-tests"
@@ -287,15 +287,15 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                 <strong>Location</strong>
             </HeaderCell>
         ),
-        cell: props => (
+        cell: (props) => (
             <td className="location-tests" rowSpan={props.baseRowSpan}>
                 {props.datum.location}
             </td>
-        )
+        ),
     },
     daysToDoubleCases: {
         sortKey: CovidSortKey.daysToDoubleCases,
-        header: props => (
+        header: (props) => (
             <HeaderCell
                 {...props}
                 className={`measure--${nouns.cases()}`}
@@ -311,16 +311,16 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
             </HeaderCell>
         ),
         cell: daysToDoubleGenerator(
-            d => d.totalCases,
-            d => d.caseDoublingRange,
+            (d) => d.totalCases,
+            (d) => d.caseDoublingRange,
             nouns.cases,
             casesDoubingBackgColorScale,
             casesDoubingTextColorScale
-        )
+        ),
     },
     daysToDoubleDeaths: {
         sortKey: CovidSortKey.daysToDoubleDeaths,
-        header: props => (
+        header: (props) => (
             <HeaderCell
                 {...props}
                 className={`measure--${nouns.deaths()}`}
@@ -336,16 +336,16 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
             </HeaderCell>
         ),
         cell: daysToDoubleGenerator(
-            d => d.totalDeaths,
-            d => d.deathDoublingRange,
+            (d) => d.totalDeaths,
+            (d) => d.deathDoublingRange,
             nouns.deaths,
             deathsDoubingBackgColorScale,
             deathsDoubingTextColorScale
-        )
+        ),
     },
     totalCases: {
         sortKey: CovidSortKey.totalCases,
-        header: props => (
+        header: (props) => (
             <HeaderCell
                 {...props}
                 className={`measure--${nouns.cases()}`}
@@ -366,11 +366,11 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                 </span>
             </HeaderCell>
         ),
-        cell: totalGenerator(d => d.totalCases, nouns.cases)
+        cell: totalGenerator((d) => d.totalCases, nouns.cases),
     },
     totalDeaths: {
         sortKey: CovidSortKey.totalDeaths,
-        header: props => (
+        header: (props) => (
             <HeaderCell
                 {...props}
                 className={`measure--${nouns.deaths()}`}
@@ -391,11 +391,11 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                 </span>
             </HeaderCell>
         ),
-        cell: totalGenerator(d => d.totalDeaths, nouns.deaths)
+        cell: totalGenerator((d) => d.totalDeaths, nouns.deaths),
     },
     newCases: {
         sortKey: CovidSortKey.newCases,
-        header: props => (
+        header: (props) => (
             <HeaderCell
                 {...props}
                 className={`measure--${nouns.cases()}`}
@@ -416,11 +416,11 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                 </span>
             </HeaderCell>
         ),
-        cell: newGenerator(d => d.newCases, nouns.cases)
+        cell: newGenerator((d) => d.newCases, nouns.cases),
     },
     newDeaths: {
         sortKey: CovidSortKey.newDeaths,
-        header: props => (
+        header: (props) => (
             <HeaderCell
                 {...props}
                 className={`measure--${nouns.deaths()}`}
@@ -441,11 +441,11 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                 </span>
             </HeaderCell>
         ),
-        cell: newGenerator(d => d.newDeaths, nouns.deaths)
+        cell: newGenerator((d) => d.newDeaths, nouns.deaths),
     },
     totalTests: {
         sortKey: CovidSortKey.totalTests,
-        header: props => (
+        header: (props) => (
             <HeaderCell
                 {...props}
                 className={`measure--${nouns.tests()}`}
@@ -457,7 +457,7 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                 </strong>
             </HeaderCell>
         ),
-        cell: props => (
+        cell: (props) => (
             <React.Fragment>
                 <td
                     className={`measure--${nouns.tests()} total-tests`}
@@ -484,17 +484,17 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                                         props.datum.latestWithTests.tests
                                             .totalTests
                                     ) * 100
-                                }%`
+                                }%`,
                             }}
                         />
                     )}
                 </td>
             </React.Fragment>
-        )
+        ),
     },
     testDate: {
         sortKey: CovidSortKey.testDate,
-        header: props => (
+        header: (props) => (
             <HeaderCell
                 {...props}
                 className={`measure--${nouns.tests()}`}
@@ -503,19 +503,19 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                 <strong>Date</strong>
             </HeaderCell>
         ),
-        cell: props => (
+        cell: (props) => (
             <td className="date" rowSpan={1}>
                 {formatDate(props.datum.latestWithTests?.date, "")}
             </td>
-        )
+        ),
     },
     testSource: {
-        header: props => (
+        header: (props) => (
             <HeaderCell {...props} className={`measure--${nouns.tests()}`}>
                 <strong>Source</strong>
             </HeaderCell>
         ),
-        cell: props => {
+        cell: (props) => {
             if (props.datum.latestWithTests?.tests === undefined)
                 return <td></td>
 
@@ -525,13 +525,13 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                 sourceLabel,
                 publicationDate,
                 remarks,
-                nonOfficial
+                nonOfficial,
             } = tests
             return (
                 <td className="testing-notes">
                     <span
                         className={classnames("official", {
-                            "is-official": !nonOfficial
+                            "is-official": !nonOfficial,
                         })}
                     >
                         <Tippy
@@ -560,6 +560,6 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                     </span>
                 </td>
             )
-        }
-    }
+        },
+    },
 }

--- a/site/client/covid/CovidTableHeaderCell.tsx
+++ b/site/client/covid/CovidTableHeaderCell.tsx
@@ -33,7 +33,7 @@ export class CovidTableHeaderCell extends React.Component<
             children,
             colSpan,
             currentSortKey,
-            currentSortOrder
+            currentSortOrder,
         } = this.props
 
         const isSorted = sortKey !== undefined && sortKey === currentSortKey
@@ -44,7 +44,7 @@ export class CovidTableHeaderCell extends React.Component<
             <th
                 className={classnames(className, {
                     sortable: sortKey !== undefined,
-                    sorted: isSorted
+                    sorted: isSorted,
                 })}
                 onClick={this.onClick}
                 colSpan={colSpan}

--- a/site/client/covid/CovidTableRow.tsx
+++ b/site/client/covid/CovidTableRow.tsx
@@ -11,7 +11,7 @@ import { CovidTableState } from "./CovidTable"
 import {
     CovidTableColumnKey,
     columns,
-    CovidTableCellSpec
+    CovidTableCellSpec,
 } from "./CovidTableColumns"
 
 export interface CovidTableTransform {
@@ -33,7 +33,7 @@ export interface CovidTableRowProps {
 @observer
 export class CovidTableRow extends React.Component<CovidTableRowProps> {
     static defaultProps = {
-        onHighlightDate: () => undefined
+        onHighlightDate: () => undefined,
     }
 
     @observable.ref highlightDate: Date | undefined = undefined
@@ -41,7 +41,7 @@ export class CovidTableRow extends React.Component<CovidTableRowProps> {
     @computed get data() {
         const d = this.props.datum
         const [start, end] = this.props.transform.dateRange
-        return d.series.filter(d => d.date >= start && d.date <= end)
+        return d.series.filter((d) => d.date >= start && d.date <= end)
     }
 
     @bind dateToIndex(date: Date): number {
@@ -99,11 +99,11 @@ export class CovidTableRow extends React.Component<CovidTableRowProps> {
                 x: this.x,
                 currentX: this.currentX,
                 highlightedX: this.hightlightedX,
-                onHover: this.onBarHover
+                onHover: this.onBarHover,
             },
             totalTestsBarScale: this.props.transform.totalTestsBarScale,
             countryColors: this.props.transform.countryColors,
-            baseRowSpan: this.props.extraRow ? 2 : 1
+            baseRowSpan: this.props.extraRow ? 2 : 1,
         }
     }
 
@@ -111,7 +111,7 @@ export class CovidTableRow extends React.Component<CovidTableRowProps> {
         return (
             <React.Fragment>
                 <tr className={this.props.className}>
-                    {this.props.columns.map(key => (
+                    {this.props.columns.map((key) => (
                         <React.Fragment key={key}>
                             {columns[key].cell(this.cellProps)}
                         </React.Fragment>

--- a/site/client/covid/CovidTableSortIcon.tsx
+++ b/site/client/covid/CovidTableSortIcon.tsx
@@ -15,7 +15,7 @@ export const CovidTableSortIcon = (props: CovidTableSortIconProps) => {
     return (
         <span
             className={classnames("sort-icon", props.sortOrder, {
-                active: isActive
+                active: isActive,
             })}
         />
     )

--- a/site/client/covid/CovidTimeSeriesValue.tsx
+++ b/site/client/covid/CovidTimeSeriesValue.tsx
@@ -15,7 +15,7 @@ export const CovidTimeSeriesValue = ({
     tooltip,
     className,
     formattedDate,
-    valueColor
+    valueColor,
 }: {
     value: string | undefined
     date?: Date

--- a/site/client/covid/CovidTypes.ts
+++ b/site/client/covid/CovidTypes.ts
@@ -42,7 +42,7 @@ export enum CovidSortKey {
     daysToDoubleCases = "daysToDoubleCases",
     daysToDoubleDeaths = "daysToDoubleDeaths",
     totalTests = "totalTests",
-    testDate = "testDate"
+    testDate = "testDate",
 }
 
 export type CovidSortAccessor = (

--- a/site/client/covid/CovidUtils.ts
+++ b/site/client/covid/CovidUtils.ts
@@ -9,7 +9,7 @@ import {
     CovidDoublingRange,
     CovidSortKey,
     CovidCountryDatum,
-    CovidSortAccessor
+    CovidSortAccessor,
 } from "./CovidTypes"
 
 export function inverseSortOrder(order: SortOrder): SortOrder {
@@ -48,14 +48,14 @@ export function getDoublingRange(
     accessor: (d: CovidDatum) => number | undefined
 ): CovidDoublingRange | undefined {
     if (series.length > 1) {
-        const latestDay = maxBy(series, d => d.date) as CovidDatum
+        const latestDay = maxBy(series, (d) => d.date) as CovidDatum
         const latestValue = accessor(latestDay)
         if (latestValue === undefined) return undefined
-        const filteredSeries = series.filter(d => {
+        const filteredSeries = series.filter((d) => {
             const value = accessor(d)
             return value && value <= latestValue / 2
         })
-        const halfDay = maxBy(filteredSeries, d => d.date)
+        const halfDay = maxBy(filteredSeries, (d) => d.date)
         if (halfDay === undefined) return undefined
         const halfValue = accessor(halfDay)
         if (halfValue === undefined) return undefined
@@ -63,7 +63,7 @@ export function getDoublingRange(
             latestDay,
             halfDay,
             length: dateDiffInDays(latestDay.date, halfDay.date),
-            ratio: latestValue / halfValue
+            ratio: latestValue / halfValue,
         }
     }
     return undefined
@@ -84,5 +84,5 @@ export const sortAccessors: Record<CovidSortKey, CovidSortAccessor> = {
             ? d.deathDoublingRange.length - d.deathDoublingRange.ratio * 1e-4
             : undefined,
     totalTests: (d: CovidCountryDatum) => d.latestWithTests?.tests?.totalTests,
-    testDate: (d: CovidCountryDatum) => d.latestWithTests?.date
+    testDate: (d: CovidCountryDatum) => d.latestWithTests?.date,
 }

--- a/site/client/covid/index.tsx
+++ b/site/client/covid/index.tsx
@@ -27,18 +27,18 @@ const propsByMeasure: Record<Measure, Partial<CovidTableProps>> = {
             CovidTableColumnKey.location,
             CovidTableColumnKey.daysToDoubleCases,
             CovidTableColumnKey.totalCases,
-            CovidTableColumnKey.newCases
+            CovidTableColumnKey.newCases,
         ],
         mobileColumns: [
             CovidTableColumnKey.location,
-            CovidTableColumnKey.daysToDoubleCases
+            CovidTableColumnKey.daysToDoubleCases,
         ],
         defaultState: {
             sortKey: CovidSortKey.daysToDoubleCases,
             sortOrder: SortOrder.asc,
-            truncate: true
+            truncate: true,
         },
-        filter: d =>
+        filter: (d) =>
             d.location.indexOf("International") === -1 &&
             (d.latest && d.latest.totalCases !== undefined
                 ? d.latest.totalCases >= CASE_THRESHOLD
@@ -63,7 +63,7 @@ const propsByMeasure: Record<Measure, Partial<CovidTableProps>> = {
                     .
                 </p>
             </React.Fragment>
-        )
+        ),
     },
     deaths: {
         loadData: fetchECDCData,
@@ -71,18 +71,18 @@ const propsByMeasure: Record<Measure, Partial<CovidTableProps>> = {
             CovidTableColumnKey.location,
             CovidTableColumnKey.daysToDoubleDeaths,
             CovidTableColumnKey.totalDeaths,
-            CovidTableColumnKey.newDeaths
+            CovidTableColumnKey.newDeaths,
         ],
         mobileColumns: [
             CovidTableColumnKey.location,
-            CovidTableColumnKey.daysToDoubleDeaths
+            CovidTableColumnKey.daysToDoubleDeaths,
         ],
         defaultState: {
             sortKey: CovidSortKey.daysToDoubleDeaths,
             sortOrder: SortOrder.asc,
-            truncate: true
+            truncate: true,
         },
-        filter: d =>
+        filter: (d) =>
             d.location.indexOf("International") === -1 &&
             (d.latest && d.latest.totalDeaths !== undefined
                 ? d.latest.totalDeaths >= DEATH_THRESHOLD
@@ -107,25 +107,25 @@ const propsByMeasure: Record<Measure, Partial<CovidTableProps>> = {
                     .
                 </p>
             </React.Fragment>
-        )
+        ),
     },
     tests: {
         loadData: fetchTestsData,
         columns: [
             CovidTableColumnKey.locationTests,
             CovidTableColumnKey.totalTests,
-            CovidTableColumnKey.testDate
+            CovidTableColumnKey.testDate,
             // CovidTableColumnKey.testSource
         ],
         mobileColumns: [
             CovidTableColumnKey.locationTests,
-            CovidTableColumnKey.totalTests
+            CovidTableColumnKey.totalTests,
         ],
         defaultState: {
             sortKey: CovidSortKey.totalTests,
-            sortOrder: SortOrder.desc
+            sortOrder: SortOrder.desc,
         },
-        extraRow: props => {
+        extraRow: (props) => {
             if (props.datum.latestWithTests?.tests === undefined)
                 return undefined
             const { date, tests } = props.datum.latestWithTests
@@ -134,13 +134,13 @@ const propsByMeasure: Record<Measure, Partial<CovidTableProps>> = {
                 sourceLabel,
                 publicationDate,
                 remarks,
-                nonOfficial
+                nonOfficial,
             } = tests
             return (
                 <td colSpan={3} className="testing-notes">
                     <span
                         className={classnames("official", {
-                            "is-official": !nonOfficial
+                            "is-official": !nonOfficial,
                         })}
                     >
                         <Tippy
@@ -171,7 +171,7 @@ const propsByMeasure: Record<Measure, Partial<CovidTableProps>> = {
                     <br />
                 </td>
             )
-        }
+        },
     },
     deathsAndCases: {
         loadData: fetchECDCData,
@@ -182,19 +182,19 @@ const propsByMeasure: Record<Measure, Partial<CovidTableProps>> = {
             CovidTableColumnKey.newDeaths,
             CovidTableColumnKey.daysToDoubleCases,
             CovidTableColumnKey.totalCases,
-            CovidTableColumnKey.newCases
+            CovidTableColumnKey.newCases,
         ],
         mobileColumns: [
             CovidTableColumnKey.location,
             CovidTableColumnKey.daysToDoubleDeaths,
-            CovidTableColumnKey.daysToDoubleCases
+            CovidTableColumnKey.daysToDoubleCases,
         ],
         defaultState: {
             sortKey: CovidSortKey.totalDeaths,
             sortOrder: SortOrder.desc,
-            truncate: true
+            truncate: true,
         },
-        filter: d =>
+        filter: (d) =>
             d.location.indexOf("International") === -1 &&
             (d.latest && d.latest.totalCases !== undefined
                 ? d.latest.totalCases >= CASE_THRESHOLD
@@ -219,15 +219,15 @@ const propsByMeasure: Record<Measure, Partial<CovidTableProps>> = {
                     .
                 </p>
             </React.Fragment>
-        )
-    }
+        ),
+    },
 }
 
 export function runCovid() {
     const elements = Array.from(
         document.querySelectorAll("*[data-covid-table], #covid-table-embed")
     )
-    elements.forEach(element => {
+    elements.forEach((element) => {
         const attr = element.getAttribute("data-measure")
         const measure = oneOf<Measure>(
             attr,

--- a/site/client/figures/ChartFigure.ts
+++ b/site/client/figures/ChartFigure.ts
@@ -54,7 +54,7 @@ export class ChartFigure implements Figure {
                 containerNode: this.container,
                 isEmbed: true,
                 queryStr: this.props.queryStr,
-                globalEntitySelection: loadProps.globalEntitySelection
+                globalEntitySelection: loadProps.globalEntitySelection,
             })
         }
     }
@@ -66,7 +66,7 @@ export class ChartFigure implements Figure {
             container.querySelectorAll<HTMLElement>("*[data-grapher-src]")
         )
         return excludeUndefined(
-            elements.map(element => {
+            elements.map((element) => {
                 const dataSrc = element.getAttribute("data-grapher-src")
                 if (!dataSrc) return undefined
                 const { path, queryString } = splitURLintoPathAndQueryString(
@@ -75,7 +75,7 @@ export class ChartFigure implements Figure {
                 return new ChartFigure({
                     configUrl: path,
                     queryStr: queryString,
-                    container: element
+                    container: element,
                 })
             })
         )

--- a/site/client/owid.entry.ts
+++ b/site/client/owid.entry.ts
@@ -75,12 +75,12 @@ new SmoothScroll('a[href*="#"][data-smooth-scroll]', {
     speed: 600,
     durationMax: 800,
     durationMin: 100,
-    popstate: false
+    popstate: false,
 })
 
 const dataTrackAttr = "data-track-note"
 
-document.addEventListener("click", async ev => {
+document.addEventListener("click", async (ev) => {
     const targetElement = ev.target as HTMLElement
     const trackedElement = getParent(
         targetElement,

--- a/site/client/runChartsIndexPage.ts
+++ b/site/client/runChartsIndexPage.ts
@@ -33,7 +33,7 @@ class ChartFilter {
     @observable query: string = ""
 
     @computed get searchStrings(): (Fuzzysort.Prepared | undefined)[] {
-        return this.chartItems.map(c => fuzzysort.prepare(c.title))
+        return this.chartItems.map((c) => fuzzysort.prepare(c.title))
     }
 
     @computed get searchResults(): Fuzzysort.Results {
@@ -54,13 +54,13 @@ class ChartFilter {
         const lis = Array.from(
             document.querySelectorAll(".ChartsIndexPage main .content li")
         ) as HTMLLIElement[]
-        this.chartItems = lis.map(li => ({
+        this.chartItems = lis.map((li) => ({
             title: (li.children[0].textContent as string).replace(/₂/g, "2"),
             li: li,
-            ul: li.closest("ul") as HTMLUListElement
+            ul: li.closest("ul") as HTMLUListElement,
         }))
         this.chartItemsByTitle = keyBy(this.chartItems, "title")
-        this.strings = this.chartItems.map(c => fuzzysort.prepare(c.title))
+        this.strings = this.chartItems.map((c) => fuzzysort.prepare(c.title))
     }
 
     analytics = new Analytics(ENV)
@@ -126,7 +126,7 @@ class ChartFilter {
         for (const section of this.sections) {
             if (
                 !Array.from(section.querySelectorAll("li")).some(
-                    li => li.style.display !== "none"
+                    (li) => li.style.display !== "none"
                 )
             ) {
                 section.style.display = "none"

--- a/site/client/runCookieNotice.tsx
+++ b/site/client/runCookieNotice.tsx
@@ -31,7 +31,7 @@ export class CookieNotice extends React.Component {
         return (
             <div
                 className={classnames("cookie-notice", {
-                    open: this.mounted && !this.accepted
+                    open: this.mounted && !this.accepted,
                 })}
             >
                 <div className="wrapper">

--- a/site/client/runCountryProfilePage.ts
+++ b/site/client/runCountryProfilePage.ts
@@ -33,7 +33,7 @@ class ChartFilter {
     @observable query: string = ""
 
     @computed get searchStrings(): (Fuzzysort.Prepared | undefined)[] {
-        return this.chartItems.map(c => fuzzysort.prepare(c.title))
+        return this.chartItems.map((c) => fuzzysort.prepare(c.title))
     }
 
     @computed get searchResults(): Fuzzysort.Results {
@@ -54,16 +54,16 @@ class ChartFilter {
         const lis = Array.from(
             document.querySelectorAll(".CountryProfilePage main li")
         ) as HTMLLIElement[]
-        this.chartItems = lis.map(li => ({
+        this.chartItems = lis.map((li) => ({
             title: ((li.firstChild as any).textContent as string).replace(
                 /₂/g,
                 "2"
             ),
             li: li,
-            ul: li.closest("ul") as HTMLUListElement
+            ul: li.closest("ul") as HTMLUListElement,
         }))
         this.chartItemsByTitle = keyBy(this.chartItems, "title")
-        this.strings = this.chartItems.map(c => fuzzysort.prepare(c.title))
+        this.strings = this.chartItems.map((c) => fuzzysort.prepare(c.title))
     }
 
     analytics = new Analytics(ENV)
@@ -130,7 +130,7 @@ class ChartFilter {
         for (const section of this.sections) {
             if (
                 !Array.from(section.querySelectorAll("li")).some(
-                    li => li.style.display !== "none"
+                    (li) => li.style.display !== "none"
                 )
             ) {
                 section.style.display = "none"

--- a/site/client/runVariableCountryPage.tsx
+++ b/site/client/runVariableCountryPage.tsx
@@ -46,22 +46,22 @@ class ClientVariableCountryPage extends React.Component<{
                 {
                     property: "y",
                     variableId: variable.id,
-                    display: clone(variable.display)
-                }
+                    display: clone(variable.display),
+                },
             ],
             selectedData: [
                 {
                     entityId: country.id,
-                    index: 0
-                }
-            ]
+                    index: 0,
+                },
+            ],
         }
     }
 
     dispose!: IReactionDisposer
     componentDidMount() {
         this.chart = new Grapher(this.chartConfig as any, {
-            isEmbed: true
+            isEmbed: true,
         })
     }
 

--- a/site/globalEntityControl/GlobalEntityControl.tsx
+++ b/site/globalEntityControl/GlobalEntityControl.tsx
@@ -8,7 +8,7 @@ import Select, {
     components,
     OptionProps,
     Props,
-    GroupedOptionsType
+    GroupedOptionsType,
 } from "react-select"
 import classnames from "classnames"
 
@@ -20,25 +20,25 @@ import {
     throttle,
     noop,
     getCountryCodeFromNetlifyRedirect,
-    sortBy
+    sortBy,
 } from "grapher/utils/Util"
 import {
     GlobalEntitySelection,
     GlobalEntitySelectionEntity,
-    GlobalEntitySelectionModes
+    GlobalEntitySelectionModes,
 } from "./GlobalEntitySelection"
 import { asArray } from "utils/client/react-select"
 import { Analytics } from "grapher/core/Analytics"
 import { ENV } from "settings"
 
-const allEntities = sortBy(countries, c => c.name)
+const allEntities = sortBy(countries, (c) => c.name)
     // Add 'World'
     .concat([
         {
             name: "World",
             code: "OWID_WRL",
-            slug: "world"
-        }
+            slug: "world",
+        },
     ])
 
 const Option = (props: OptionProps<GlobalEntitySelectionEntity>) => {
@@ -57,7 +57,7 @@ const EntitySelect = (props: Props<GlobalEntitySelectionEntity>) => {
         <Select
             components={{
                 IndicatorSeparator: null,
-                Option
+                Option,
             }}
             menuPlacement="bottom"
             isClearable={false}
@@ -69,14 +69,14 @@ const EntitySelect = (props: Props<GlobalEntitySelectionEntity>) => {
             hideSelectedOptions={false}
             placeholder="Add a country to all charts..."
             styles={{
-                placeholder: base => ({ ...base, whiteSpace: "nowrap" }),
-                valueContainer: base => ({
+                placeholder: (base) => ({ ...base, whiteSpace: "nowrap" }),
+                valueContainer: (base) => ({
                     ...base,
                     paddingTop: 0,
-                    paddingBottom: 0
+                    paddingBottom: 0,
                 }),
-                control: base => ({ ...base, minHeight: "initial" }),
-                dropdownIndicator: base => ({ ...base, padding: "0 5px" })
+                control: (base) => ({ ...base, minHeight: "initial" }),
+                dropdownIndicator: (base) => ({ ...base, padding: "0 5px" }),
             }}
             {...props}
         />
@@ -99,11 +99,11 @@ function SelectedItems<T>(props: {
                 <div className="empty">{props.emptyLabel}</div>
             ) : (
                 <div className="selected-items">
-                    {props.selectedItems.map(item => (
+                    {props.selectedItems.map((item) => (
                         <div
                             key={props.getLabel(item)}
                             className={classnames("selected-item", {
-                                removable: canRemove
+                                removable: canRemove,
                             })}
                         >
                             <div className="label">{props.getLabel(item)}</div>
@@ -153,7 +153,7 @@ class GlobalEntityControl extends React.Component<GlobalEntityControlProps> {
 
     componentWillUnmount() {
         window.removeEventListener("resize", this.onResizeThrottled)
-        this.disposers.forEach(dispose => dispose())
+        this.disposers.forEach((dispose) => dispose())
     }
 
     private onResizeThrottled = throttle(this.onResize, 200)
@@ -169,7 +169,7 @@ class GlobalEntityControl extends React.Component<GlobalEntityControlProps> {
             const localCountryCode = await getCountryCodeFromNetlifyRedirect()
             if (localCountryCode) {
                 const [country] = allEntities.filter(
-                    c => c.code === localCountryCode
+                    (c) => c.code === localCountryCode
                 )
                 if (country) {
                     this.localEntity = country
@@ -211,23 +211,23 @@ class GlobalEntityControl extends React.Component<GlobalEntityControlProps> {
             optionGroups = optionGroups.concat([
                 {
                     label: "Suggestions",
-                    options: [this.localEntity]
-                }
+                    options: [this.localEntity],
+                },
             ])
         }
         if (this.selectedEntities.length > 0) {
             optionGroups = optionGroups.concat([
                 {
                     label: "Selected",
-                    options: this.selectedEntities
-                }
+                    options: this.selectedEntities,
+                },
             ])
         }
         optionGroups = optionGroups.concat([
             {
                 label: "All countries",
-                options: allEntities
-            }
+                options: allEntities,
+            },
         ])
         this.selectOptions = optionGroups
         return optionGroups
@@ -244,7 +244,7 @@ class GlobalEntityControl extends React.Component<GlobalEntityControlProps> {
 
         this.analytics.logGlobalEntityControl(
             "change",
-            entities.map(c => c.code).join(",")
+            entities.map((c) => c.code).join(",")
         )
     }
 
@@ -252,7 +252,7 @@ class GlobalEntityControl extends React.Component<GlobalEntityControlProps> {
         entityToRemove: GlobalEntitySelectionEntity
     ) {
         this.setSelectedEntities(
-            this.selectedEntities.filter(entity => entity !== entityToRemove)
+            this.selectedEntities.filter((entity) => entity !== entityToRemove)
         )
     }
 
@@ -289,7 +289,7 @@ class GlobalEntityControl extends React.Component<GlobalEntityControlProps> {
             <React.Fragment>
                 <div
                     className={classnames("narrow-summary", {
-                        "narrow-summary-selected-items": !this.isOpen
+                        "narrow-summary-selected-items": !this.isOpen,
                     })}
                 >
                     {this.isOpen ? (
@@ -307,7 +307,7 @@ class GlobalEntityControl extends React.Component<GlobalEntityControlProps> {
                             {this.selectedEntities.length === 0
                                 ? "None selected"
                                 : this.selectedEntities
-                                      .map(entity => (
+                                      .map((entity) => (
                                           <span
                                               className="narrow-summary-selected-item"
                                               key={entity.code}
@@ -371,7 +371,7 @@ class GlobalEntityControl extends React.Component<GlobalEntityControlProps> {
             <div
                 className={classnames("global-entity-control", {
                     "is-narrow": this.isNarrow,
-                    "is-wide": !this.isNarrow
+                    "is-wide": !this.isNarrow,
                 })}
                 ref={this.refContainer}
                 onClick={

--- a/site/globalEntityControl/GlobalEntitySelection.ts
+++ b/site/globalEntityControl/GlobalEntitySelection.ts
@@ -15,7 +15,7 @@ export enum GlobalEntitySelectionModes {
     // be for single-entity charts.
 
     // add = "add",
-    override = "override"
+    override = "override",
 }
 
 export type GlobalEntitySelectionEntity = Country
@@ -33,7 +33,9 @@ export class GlobalEntitySelection {
         // We want to preserve the order, because order matters – the first entity is the "primary"
         // that is used on single-entity charts.
         this.selectedEntities = excludeUndefined(
-            codes.map(code => countries.find(country => country.code === code))
+            codes.map((code) =>
+                countries.find((country) => country.code === code)
+            )
         )
     }
 
@@ -54,7 +56,7 @@ export function subscribeGrapherToGlobalEntitySelection(
         () => [
             grapher.isReady,
             globalSelection.mode,
-            globalSelection.selectedEntities
+            globalSelection.selectedEntities,
         ],
         () => {
             if (!grapher.canAddData && !grapher.canChangeEntity) {
@@ -66,7 +68,7 @@ export function subscribeGrapherToGlobalEntitySelection(
             if (mode === GlobalEntitySelectionModes.override) {
                 if (selectedEntities.length > 0) {
                     grapher.setSelectedEntitiesByCode(
-                        selectedEntities.map(entity => entity.code)
+                        selectedEntities.map((entity) => entity.code)
                     )
                 } else {
                     grapher.resetSelectedEntities()
@@ -98,7 +100,7 @@ class GlobalEntitySelectionUrl implements ObservableUrl {
         // Do not add 'country' param unless at least one country is selected
         if (entities.length > 0) {
             params.country = EntityUrlBuilder.entitiesToQueryParam(
-                entities.map(entity => entity.code)
+                entities.map((entity) => entity.code)
             )
         }
         return params

--- a/site/server/MathJax.ts
+++ b/site/server/MathJax.ts
@@ -13,12 +13,12 @@ export function initMathJax() {
     const svg = new SVG({ fontCache: "none" })
     const doc = mathjax.document("", {
         InputJax: tex,
-        OutputJax: svg
+        OutputJax: svg,
     })
 
     return function format(latex: string): string {
         const node = doc.convert(latex, {
-            display: true
+            display: true,
         })
         return adaptor.outerHTML(node) // as HTML
     }

--- a/site/server/SiteBaker.tsx
+++ b/site/server/SiteBaker.tsx
@@ -26,12 +26,12 @@ import {
     feedbackPage,
     renderNotFoundPage,
     renderCountryProfile,
-    flushCache as siteBakingFlushCache
+    flushCache as siteBakingFlushCache,
 } from "./siteBaking"
 import {
     bakeGrapherUrls,
     getGrapherExportsByUrl,
-    GrapherExports
+    GrapherExports,
 } from "./grapherUtil"
 import { makeSitemap } from "./sitemap"
 
@@ -48,14 +48,14 @@ import { exec } from "utils/server/serverUtil"
 import { log } from "utils/server/log"
 import {
     covidDashboardSlug,
-    covidChartAndVariableMetaFilename
+    covidChartAndVariableMetaFilename,
 } from "explorer/covidExplorer/CovidConstants"
 import { bakeCovidChartAndVariableMeta } from "explorer/covidExplorer/bakeCovidChartAndVariableMeta"
 import { chartExplorerRedirects } from "explorer/covidExplorer/bakeCovidExplorerRedirects"
 import { countryProfileSpecs } from "site/server/countryProfileProjects"
 import {
     bakeAllPublishedExplorers,
-    renderCovidExplorerPage
+    renderCovidExplorerPage,
 } from "explorer/admin/ExplorerBaker"
 import { renderExplorableIndicatorsJson } from "explorer/indicatorExplorer/IndicatorBaking"
 
@@ -109,10 +109,10 @@ export class SiteBaker {
             "/grapher/public/* /grapher/:splat 301",
             "/grapher/view/* /grapher/:splat 301",
 
-            "/slides/* https://slides.ourworldindata.org/:splat 301"
+            "/slides/* https://slides.ourworldindata.org/:splat 301",
         ]
 
-        getCountryDetectionRedirects().forEach(redirect =>
+        getCountryDetectionRedirects().forEach((redirect) =>
             redirects.push(redirect)
         )
 
@@ -122,7 +122,7 @@ export class SiteBaker {
         )
         redirects.push(
             ...rows.map(
-                row =>
+                (row) =>
                     `${row.url.replace(/__/g, "/")} ${row.action_data.replace(
                         /__/g,
                         "/"
@@ -170,10 +170,10 @@ export class SiteBaker {
             grapherUrls.push(
                 ...$("iframe")
                     .toArray()
-                    .filter(el =>
+                    .filter((el) =>
                         (el.attribs["src"] || "").match(/\/grapher\//)
                     )
-                    .map(el => el.attribs["src"].trim())
+                    .map((el) => el.attribs["src"].trim())
             )
         }
         grapherUrls = lodash.uniq(grapherUrls)
@@ -184,7 +184,7 @@ export class SiteBaker {
     }
 
     async bakeCountryProfiles() {
-        countryProfileSpecs.forEach(async spec => {
+        countryProfileSpecs.forEach(async (spec) => {
             // Delete all country profiles before regenerating them
             await fs.remove(`${BAKED_SITE_DIR}/${spec.rootPath}`)
 
@@ -241,11 +241,11 @@ export class SiteBaker {
     private getPostSlugsToRemove(postSlugsFromDb: string[]) {
         const existingSlugs = glob
             .sync(`${BAKED_SITE_DIR}/**/*.html`)
-            .map(path =>
+            .map((path) =>
                 path.replace(`${BAKED_SITE_DIR}/`, "").replace(".html", "")
             )
             .filter(
-                path =>
+                (path) =>
                     !path.startsWith("uploads") &&
                     !path.startsWith("grapher") &&
                     !path.startsWith("countries") &&
@@ -255,7 +255,7 @@ export class SiteBaker {
                     !path.startsWith("entries-by-year") &&
                     !path.startsWith("explore") &&
                     !path.startsWith(covidDashboardSlug) &&
-                    !countryProfileSpecs.some(spec =>
+                    !countryProfileSpecs.some((spec) =>
                         path.startsWith(spec.rootPath)
                     ) &&
                     path !== "donate" &&
@@ -373,7 +373,7 @@ export class SiteBaker {
             .select(db.raw("distinct year(published_at) as year"))
             .orderBy("year", "DESC")) as { year: number }[]
 
-        const years = rows.map(r => r.year)
+        const years = rows.map((r) => r.year)
 
         for (const year of years) {
             await this.stageWrite(
@@ -458,7 +458,7 @@ export class SiteBaker {
         await this.bakeGrapherPage(grapher)
 
         const variableIds = lodash.uniq(
-            grapher.dimensions?.map(d => d.variableId)
+            grapher.dimensions?.map((d) => d.variableId)
         )
         if (!variableIds.length) return
 
@@ -525,7 +525,7 @@ export class SiteBaker {
         // Delete any that are missing from the database
         const oldSlugs = glob
             .sync(`${BAKED_SITE_DIR}/grapher/*.html`)
-            .map(slug =>
+            .map((slug) =>
                 slug
                     .replace(`${BAKED_SITE_DIR}/grapher/`, "")
                     .replace(".html", "")
@@ -536,10 +536,10 @@ export class SiteBaker {
             try {
                 const paths = [
                     `${BAKED_SITE_DIR}/grapher/${slug}.html`,
-                    `${BAKED_SITE_DIR}/grapher/exports/${slug}.png`
+                    `${BAKED_SITE_DIR}/grapher/exports/${slug}.png`,
                 ] //, `${BAKED_SITE_DIR}/grapher/exports/${slug}.svg`]
-                await Promise.all(paths.map(p => fs.unlink(p)))
-                paths.map(p => this.stage(p))
+                await Promise.all(paths.map((p) => fs.unlink(p)))
+                paths.map((p) => this.stage(p))
             } catch (err) {
                 console.error(err)
             }
@@ -553,7 +553,7 @@ export class SiteBaker {
             const { slugs, explorerQueryStr } = chartExplorerRedirect
             const html = await renderCovidExplorerPage({ explorerQueryStr })
             await Promise.all(
-                slugs.map(slug =>
+                slugs.map((slug) =>
                     this.stageWrite(
                         `${BAKED_SITE_DIR}/grapher/${slug}.html`,
                         html

--- a/site/server/bakeChartsToImages.tsx
+++ b/site/server/bakeChartsToImages.tsx
@@ -61,7 +61,7 @@ export async function bakeChartToImage(
 
     if (fs.existsSync(outPath) && !overwriteExisting) return
 
-    const variableIds = lodash.uniq(chart.dimensions.map(d => d.variableId))
+    const variableIds = lodash.uniq(chart.dimensions.map((d) => d.variableId))
     const vardata = await getVariableData(variableIds)
     chart.receiveData(vardata)
 

--- a/site/server/countryProfileProjects.ts
+++ b/site/server/countryProfileProjects.ts
@@ -1,7 +1,7 @@
 enum CountryProfileProject {
     coronavirus = "coronavirus",
     co2 = "co2",
-    energy = "energy"
+    energy = "energy",
 }
 
 export const countryProfileDefaultCountryPlaceholder =
@@ -22,26 +22,26 @@ const countryProfileProjectConfigurations: CountryProfileProjectConfiguration[] 
     {
         project: CountryProfileProject.coronavirus,
         pageTitle: "Coronavirus Pandemic",
-        landingPageSlug: "coronavirus"
+        landingPageSlug: "coronavirus",
     },
     {
         project: CountryProfileProject.co2,
         pageTitle: "CO2",
-        landingPageSlug: "co2-and-other-greenhouse-gas-emissions"
+        landingPageSlug: "co2-and-other-greenhouse-gas-emissions",
     },
     {
         project: CountryProfileProject.energy,
         pageTitle: "Energy",
-        landingPageSlug: "energy"
-    }
+        landingPageSlug: "energy",
+    },
 ]
 
 export const countryProfileSpecs: CountryProfileSpec[] = countryProfileProjectConfigurations.map(
-    config => {
+    (config) => {
         return {
             ...config,
             rootPath: `${config.project}/country`,
-            genericProfileSlug: `${config.project}-country-profile`
+            genericProfileSlug: `${config.project}-country-profile`,
         }
     }
 )

--- a/site/server/countryProfiles.tsx
+++ b/site/server/countryProfiles.tsx
@@ -6,7 +6,7 @@ import { GrapherInterface } from "grapher/core/GrapherInterface"
 import * as lodash from "lodash"
 import {
     CountryProfileIndicator,
-    CountryProfilePage
+    CountryProfilePage,
 } from "./views/CountryProfilePage"
 import { ChartDimension } from "grapher/chart/ChartDimension"
 import { Variable } from "db/model/Variable"
@@ -40,7 +40,7 @@ async function countryIndicatorCharts(): Promise<GrapherInterface[]> {
                 .whereRaw("publishedAt is not null and is_indexable is true")
         ).map((c: any) => JSON.parse(c.config)) as GrapherInterface[]
         return charts.filter(
-            c =>
+            (c) =>
                 c.hasChartTab &&
                 c.type === "LineChart" &&
                 c.dimensions?.length === 1
@@ -51,7 +51,7 @@ async function countryIndicatorCharts(): Promise<GrapherInterface[]> {
 async function countryIndicatorVariables(): Promise<Variable.Row[]> {
     return bakeCache(countryIndicatorVariables, async () => {
         const variableIds = (await countryIndicatorCharts()).map(
-            c => c.dimensions![0]!.variableId
+            (c) => c.dimensions![0]!.variableId
         )
         return Variable.rows(
             await db.table(Variable.table).whereIn("id", variableIds)
@@ -68,12 +68,12 @@ export async function denormalizeLatestCountryData(variableIds?: number[]) {
         code: string
     }[]
 
-    const entitiesByCode = lodash.keyBy(entities, e => e.code)
-    const entitiesById = lodash.keyBy(entities, e => e.id)
-    const entityIds = countries.map(c => entitiesByCode[c.code].id)
+    const entitiesByCode = lodash.keyBy(entities, (e) => e.code)
+    const entitiesById = lodash.keyBy(entities, (e) => e.id)
+    const entityIds = countries.map((c) => entitiesByCode[c.code].id)
 
     if (!variableIds) {
-        variableIds = (await countryIndicatorVariables()).map(v => v.id)
+        variableIds = (await countryIndicatorVariables()).map((v) => v.id)
     }
 
     const dataValuesQuery = db
@@ -93,16 +93,16 @@ export async function denormalizeLatestCountryData(variableIds?: number[]) {
     }[]
     dataValues = lodash.uniqBy(
         dataValues,
-        dv => `${dv.variableId}-${dv.entityId}`
+        (dv) => `${dv.variableId}-${dv.entityId}`
     )
-    const rows = dataValues.map(dv => ({
+    const rows = dataValues.map((dv) => ({
         variable_id: dv.variableId,
         country_code: entitiesById[dv.entityId].code,
         year: dv.year,
-        value: dv.value
+        value: dv.value,
     }))
 
-    db.knex().transaction(async t => {
+    db.knex().transaction(async (t) => {
         // Remove existing values
         await t
             .table("country_latest_data")
@@ -132,7 +132,7 @@ async function countryIndicatorLatestData(countryCode: string) {
                 value: string
             }[]
 
-            return lodash.groupBy(dataValues, dv => dv.code)
+            return lodash.groupBy(dataValues, (dv) => dv.code)
         }
     )
 
@@ -175,10 +175,10 @@ export async function countryProfilePage(countrySlug: string) {
 
     const charts = await countryIndicatorCharts()
     const variables = await countryIndicatorVariables()
-    const variablesById = lodash.keyBy(variables, v => v.id)
+    const variablesById = lodash.keyBy(variables, (v) => v.id)
     const dataValues = await countryIndicatorLatestData(country.code)
 
-    const valuesByVariableId = lodash.groupBy(dataValues, v => v.variableId)
+    const valuesByVariableId = lodash.groupBy(dataValues, (v) => v.variableId)
 
     let indicators: CountryProfileIndicator[] = []
     for (const c of charts) {
@@ -194,7 +194,7 @@ export async function countryProfilePage(countrySlug: string) {
             const spec = new Map()
             spec.set(variable.name, {
                 unit: variable.unit,
-                display: variable.display
+                display: variable.display,
             })
             const column = new OwidTable([], spec)
             const dim = new ChartDimension(
@@ -218,12 +218,12 @@ export async function countryProfilePage(countrySlug: string) {
                 value: formatValueShort(value),
                 name: c.title as string,
                 slug: `/grapher/${c.slug}?tab=chart&country=${country.code}`,
-                variantName: c.variantName
+                variantName: c.variantName,
             })
         }
     }
 
-    indicators = lodash.sortBy(indicators, i => i.name.trim())
+    indicators = lodash.sortBy(indicators, (i) => i.name.trim())
 
     return renderToHtmlPage(
         <CountryProfilePage indicators={indicators} country={country} />

--- a/site/server/database.ts
+++ b/site/server/database.ts
@@ -26,7 +26,7 @@ export function createConnection(props: { database: string }) {
             host: "localhost",
             user: "root",
             database: props.database,
-            charset: "utf8mb4"
+            charset: "utf8mb4",
         })
     )
 }

--- a/site/server/formatting.tsx
+++ b/site/server/formatting.tsx
@@ -13,7 +13,7 @@ import * as path from "path"
 import { renderBlocks } from "site/client/blocks"
 import {
     RelatedCharts,
-    RelatedChart
+    RelatedChart,
 } from "site/client/blocks/RelatedCharts/RelatedCharts"
 import { initMathJax } from "./MathJax"
 import { bakeGlobalEntityControl } from "site/globalEntityControl/GlobalEntityControl"
@@ -26,7 +26,7 @@ import { replaceChartIframesWithExplorerIframes } from "explorer/covidExplorer/b
 import { SubNavId } from "./views/SiteSubnavigation"
 import {
     countryProfileDefaultCountryPlaceholder,
-    countryProfileSpecs
+    countryProfileSpecs,
 } from "site/server/countryProfileProjects"
 
 // A modifed FontAwesome icon
@@ -178,7 +178,9 @@ export async function formatWordpressPost(
     // Related charts
     // Mimicking SSR output of additional information block from PHP
     if (
-        !countryProfileSpecs.some(spec => post.slug === spec.landingPageSlug) &&
+        !countryProfileSpecs.some(
+            (spec) => post.slug === spec.landingPageSlug
+        ) &&
         post.relatedCharts &&
         post.relatedCharts.length !== 0
     ) {
@@ -247,7 +249,7 @@ export async function formatWordpressPost(
     if (grapherExports) {
         const grapherIframes = $("iframe")
             .toArray()
-            .filter(el => (el.attribs["src"] || "").match(/\/grapher\//))
+            .filter((el) => (el.attribs["src"] || "").match(/\/grapher\//))
         for (const el of grapherIframes) {
             const $el = $(el)
             const src = el.attribs["src"].trim()
@@ -296,7 +298,7 @@ export async function formatWordpressPost(
     // Replace explorer iframes with iframeless embed
     const explorerIframes = $("iframe")
         .toArray()
-        .filter(el => (el.attribs["src"] || "").includes(covidDashboardSlug))
+        .filter((el) => (el.attribs["src"] || "").includes(covidDashboardSlug))
     for (const el of explorerIframes) {
         const $el = $(el)
         const src = el.attribs["src"].trim()
@@ -373,7 +375,7 @@ export async function formatWordpressPost(
             const originalSrc = path.format({
                 dir: parsedPath.dir,
                 name: originalFilename,
-                ext: parsedPath.ext
+                ext: parsedPath.ext,
             })
             el.attribs["data-high-res-src"] = originalSrc
         } else {
@@ -424,14 +426,14 @@ export async function formatWordpressPost(
                 tocHeadings.push({
                     text: headingText,
                     slug: "footnotes",
-                    isSubheading: false
+                    isSubheading: false,
                 })
             } else if (!$heading.is("h1") && !$heading.is("h4")) {
                 if ($heading.is("h2")) {
                     const tocHeading = {
                         text: headingText,
                         slug: slug,
-                        isSubheading: false
+                        isSubheading: false,
                     }
                     tocHeadings.push(tocHeading)
                     parentHeading = tocHeading
@@ -445,7 +447,7 @@ export async function formatWordpressPost(
                         text: headingText,
                         html: $heading.html() || undefined,
                         slug: slug,
-                        isSubheading: true
+                        isSubheading: true,
                     })
                 }
             }
@@ -477,7 +479,7 @@ export async function formatWordpressPost(
         return {
             wrapper: $columns,
             first: $columns.children().first(),
-            last: $columns.children().last()
+            last: $columns.children().last(),
         }
     }
 
@@ -520,7 +522,7 @@ export async function formatWordpressPost(
                         >
                             <div
                                 dangerouslySetInnerHTML={{
-                                    __html: $.html($el)
+                                    __html: $.html($el),
                                 }}
                             />
                         </SectionHeading>
@@ -623,7 +625,7 @@ export async function formatWordpressPost(
         excerpt: post.excerpt || $("p").first().text(),
         imageUrl: post.imageUrl,
         tocHeadings: tocHeadings,
-        relatedCharts: post.relatedCharts
+        relatedCharts: post.relatedCharts,
     }
 }
 
@@ -668,7 +670,7 @@ function parseFormattingOptions(text: string): FormattingOptions {
     const options: { [key: string]: string | boolean } = {}
     text.split(/\s+/)
         // filter out empty strings
-        .filter(s => s && s.length > 0)
+        .filter((s) => s && s.length > 0)
         // populate options object
         .forEach((option: string) => {
             const [name, value] = option.split(":") as [
@@ -723,14 +725,14 @@ export async function formatPost(
             excerpt: post.excerpt || "",
             imageUrl: post.imageUrl,
             tocHeadings: [],
-            relatedCharts: post.relatedCharts
+            relatedCharts: post.relatedCharts,
         }
     } else {
         // Override formattingOptions if specified in the post (as an HTML comment)
         const options: FormattingOptions = Object.assign(
             {
                 toc: post.type === "page",
-                footnotes: true
+                footnotes: true,
             },
             formattingOptions
         )
@@ -775,6 +777,6 @@ export function formatDate(date: Date): string {
     return date.toLocaleDateString("en-US", {
         year: "numeric",
         month: "long",
-        day: "2-digit"
+        day: "2-digit",
     })
 }

--- a/site/server/grapherUtil.ts
+++ b/site/server/grapherUtil.ts
@@ -114,7 +114,7 @@ export async function getGrapherExportsByUrl(): Promise<GrapherExports> {
                 svgUrl: `${BAKED_BASE_URL}/exports/${filename}`,
                 version: versionNumber,
                 width: parseInt(width),
-                height: parseInt(height)
+                height: parseInt(height),
             })
         }
     }
@@ -124,7 +124,7 @@ export async function getGrapherExportsByUrl(): Promise<GrapherExports> {
             return exportsByKey.get(
                 grapherUrlToFilekey(grapherUrl).toLowerCase()
             )
-        }
+        },
     }
 }
 interface ChartItemWithTags {
@@ -150,7 +150,7 @@ export async function getIndexableCharts(): Promise<ChartItemWithTags[]> {
         c.tags = []
     }
 
-    const chartsById = lodash.keyBy(chartItems, c => c.id)
+    const chartsById = lodash.keyBy(chartItems, (c) => c.id)
 
     for (const ct of chartTags) {
         // XXX hardcoded filtering to public parent tags
@@ -171,7 +171,7 @@ export async function getIndexableCharts(): Promise<ChartItemWithTags[]> {
                 1505,
                 1508,
                 1512,
-                1510
+                1510,
             ].indexOf(ct.tagParentId) === -1
         )
             continue

--- a/site/server/siteBaking.tsx
+++ b/site/server/siteBaking.tsx
@@ -18,12 +18,12 @@ import {
     extractFormattingOptions,
     FormattedPost,
     FormattingOptions,
-    formatCountryProfile
+    formatCountryProfile,
 } from "./formatting"
 import {
     bakeGrapherUrls,
     getGrapherExportsByUrl,
-    GrapherExports
+    GrapherExports,
 } from "./grapherUtil"
 import * as cheerio from "cheerio"
 import { JsonError } from "utils/server/serverUtil"
@@ -31,7 +31,7 @@ import { Post } from "db/model/Post"
 import { BAKED_BASE_URL, BLOG_POSTS_PER_PAGE } from "settings"
 import {
     EntriesByYearPage,
-    EntriesForYearPage
+    EntriesForYearPage,
 } from "./views/EntriesByYearPage"
 import { VariableCountryPage } from "./views/VariableCountryPage"
 import { FeedbackPage } from "./views/FeedbackPage"
@@ -68,7 +68,7 @@ export async function renderChartsPage() {
         c.tags = []
     }
 
-    const chartsById = lodash.keyBy(chartItems, c => c.id)
+    const chartsById = lodash.keyBy(chartItems, (c) => c.id)
 
     for (const ct of chartTags) {
         const c = chartsById[ct.chartId]
@@ -111,8 +111,8 @@ async function renderPage(postApi: any) {
 
     const grapherUrls = $("iframe")
         .toArray()
-        .filter(el => (el.attribs["src"] || "").match(/\/grapher\//))
-        .map(el => el.attribs["src"].trim())
+        .filter((el) => (el.attribs["src"] || "").match(/\/grapher\//))
+        .map((el) => el.attribs["src"].trim())
 
     // This can be slow if uncached!
     await bakeGrapherUrls(grapherUrls)
@@ -182,7 +182,7 @@ export async function renderNotFoundPage() {
 export async function makeAtomFeed() {
     const postsApi = await wpdb.getPosts(["post"], 10)
     const posts: wpdb.FullPost[] = await Promise.all(
-        postsApi.map(postApi => wpdb.getFullPost(postApi, true))
+        postsApi.map((postApi) => wpdb.getFullPost(postApi, true))
     )
 
     const feed = `<?xml version="1.0" encoding="utf-8"?>
@@ -194,7 +194,7 @@ export async function makeAtomFeed() {
 <link type="application/atom+xml" rel="self" href="${BAKED_BASE_URL}/atom.xml"/>
 <updated>${posts[0].date.toISOString()}</updated>
 ${posts
-    .map(post => {
+    .map((post) => {
         const postUrl = `${BAKED_BASE_URL}/${post.path}`
         const image = post.imageUrl
             ? `<br><br><a href="${postUrl}" target="_blank"><img src="${post.imageUrl}"/></a>`
@@ -329,7 +329,7 @@ export async function renderCountryProfile(
         citationAuthors: landing.authors,
         publicationDate: landing.date,
         canonicalUrl: `${BAKED_BASE_URL}/${profileSpec.rootPath}/${country.slug}`,
-        excerpt: `${country.name}: ${formattedCountryProfile.excerpt}`
+        excerpt: `${country.name}: ${formattedCountryProfile.excerpt}`,
     }
     return renderToHtmlPage(
         <LongFormPage

--- a/site/server/sitemap.ts
+++ b/site/server/sitemap.ts
@@ -38,34 +38,34 @@ export async function makeSitemap() {
         slug: string
     }[]
 
-    let urls = countries.map(c => ({
-        loc: urljoin(BAKED_BASE_URL, "country", c.slug)
+    let urls = countries.map((c) => ({
+        loc: urljoin(BAKED_BASE_URL, "country", c.slug),
     })) as SitemapUrl[]
 
     urls = urls
         .concat(
-            ...countryProfileSpecs.map(spec => {
-                return countries.map(c => ({
-                    loc: urljoin(BAKED_BASE_URL, spec.rootPath, c.slug)
+            ...countryProfileSpecs.map((spec) => {
+                return countries.map((c) => ({
+                    loc: urljoin(BAKED_BASE_URL, spec.rootPath, c.slug),
                 }))
             })
         )
         .concat(
-            posts.map(p => ({
+            posts.map((p) => ({
                 loc: urljoin(BAKED_BASE_URL, p.slug),
-                lastmod: moment(p.updated_at).format("YYYY-MM-DD")
+                lastmod: moment(p.updated_at).format("YYYY-MM-DD"),
             }))
         )
         .concat(
-            charts.map(c => ({
+            charts.map((c) => ({
                 loc: urljoin(BAKED_GRAPHER_URL, c.slug),
-                lastmod: moment(c.updatedAt).format("YYYY-MM-DD")
+                lastmod: moment(c.updatedAt).format("YYYY-MM-DD"),
             }))
         ) as SitemapUrl[]
 
     const sitemap = `<?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-${urls.map(url => xmlify(url)).join("\n")}
+${urls.map((url) => xmlify(url)).join("\n")}
 </urlset>`
 
     return sitemap

--- a/site/server/svgPngExport.tsx
+++ b/site/server/svgPngExport.tsx
@@ -15,8 +15,8 @@ const svgoConfig: svgo.Options = {
         { collapseGroups: false }, // breaks the "Our World in Data" logo in the upper right
         { removeUnknownsAndDefaults: false }, // would remove hrefs from links (<a>)
         { removeViewBox: false },
-        { removeXMLNS: false }
-    ]
+        { removeXMLNS: false },
+    ],
 }
 
 const svgoInstance = new svgo(svgoConfig)
@@ -58,6 +58,6 @@ export async function bakeImageExports(
             .png()
             .resize(chart.idealBounds.width, chart.idealBounds.height)
             .flatten({ background: "#ffffff" })
-            .toFile(`${outPath}.png`)
+            .toFile(`${outPath}.png`),
     ])
 }

--- a/site/server/views/BlogIndexPage.tsx
+++ b/site/server/views/BlogIndexPage.tsx
@@ -33,14 +33,14 @@ export const BlogIndexPage = (props: {
                     <div className="site-content">
                         <h2>{pageTitle}</h2>
                         <ul className="posts">
-                            {posts.map(post => (
+                            {posts.map((post) => (
                                 <li key={post.slug} className="post">
                                     <a href={`/${post.path}`}>
                                         {post.imageUrl && (
                                             <div
                                                 className="cover-image"
                                                 style={{
-                                                    backgroundImage: `url(${post.imageUrl})`
+                                                    backgroundImage: `url(${post.imageUrl})`,
                                                 }}
                                             />
                                         )}
@@ -61,7 +61,7 @@ export const BlogIndexPage = (props: {
                                 Posts navigation
                             </h2>
                             <div className="nav-link">
-                                {pageNums.map(num => (
+                                {pageNums.map((num) => (
                                     <a
                                         key={num}
                                         className={

--- a/site/server/views/ChartsIndexPage.tsx
+++ b/site/server/views/ChartsIndexPage.tsx
@@ -26,29 +26,32 @@ export const ChartsIndexPage = (props: { chartItems: ChartIndexItem[] }) => {
     const { chartItems } = props
 
     const allTags = lodash.sortBy(
-        lodash.uniqBy(lodash.flatten(chartItems.map(c => c.tags)), t => t.id),
-        t => t.name
+        lodash.uniqBy(
+            lodash.flatten(chartItems.map((c) => c.tags)),
+            (t) => t.id
+        ),
+        (t) => t.name
     ) as TagWithCharts[]
 
     for (const c of chartItems) {
         for (const tag of allTags) {
             if (tag.charts === undefined) tag.charts = []
 
-            if (c.tags.some(t => t.id === tag.id)) tag.charts.push(c)
+            if (c.tags.some((t) => t.id === tag.id)) tag.charts.push(c)
         }
     }
 
     // Sort the charts in each tag
     for (const tag of allTags) {
-        tag.charts = lodash.sortBy(tag.charts, c => c.title.trim())
+        tag.charts = lodash.sortBy(tag.charts, (c) => c.title.trim())
     }
 
     const pageTitle = "Charts"
-    const tocEntries = allTags.map(t => {
+    const tocEntries = allTags.map((t) => {
         return {
             isSubheading: true,
             slug: slugify(t.name),
-            text: t.name
+            text: t.name,
         }
     })
 
@@ -80,13 +83,13 @@ export const ChartsIndexPage = (props: { chartItems: ChartIndexItem[] }) => {
                                             autoFocus
                                         />
                                     </header>
-                                    {allTags.map(t => (
+                                    {allTags.map((t) => (
                                         <section key={t.id}>
                                             <h2 id={slugify(t.name)}>
                                                 {t.name}
                                             </h2>
                                             <ul>
-                                                {t.charts.map(c => (
+                                                {t.charts.map((c) => (
                                                     <ChartListItemVariant
                                                         key={c.slug}
                                                         chart={c}
@@ -107,8 +110,8 @@ export const ChartsIndexPage = (props: { chartItems: ChartIndexItem[] }) => {
                         window.runChartsIndexPage()
                         runTableOfContents(${JSON.stringify({
                             headings: tocEntries,
-                            pageTitle
-                        })})`
+                            pageTitle,
+                        })})`,
                     }}
                 />
             </body>

--- a/site/server/views/CitationMeta.tsx
+++ b/site/server/views/CitationMeta.tsx
@@ -29,7 +29,7 @@ export const CitationMeta = (props: {
             />
             <meta name="citation_journal_title" content="Our World in Data" />
             <meta name="citation_journal_abbrev" content="Our World in Data" />
-            {authors.map(author => (
+            {authors.map((author) => (
                 <meta key={author} name="citation_author" content={author} />
             ))}
         </React.Fragment>

--- a/site/server/views/CountriesIndexPage.tsx
+++ b/site/server/views/CountriesIndexPage.tsx
@@ -25,7 +25,7 @@ export const CountriesIndexPage = (props: { countries: Country[] }) => {
                 <main>
                     <h1>Data by country</h1>
                     <ul>
-                        {countries.map(country => (
+                        {countries.map((country) => (
                             <li key={country.code}>
                                 <img
                                     className="flag"

--- a/site/server/views/CountryProfilePage.tsx
+++ b/site/server/views/CountryProfilePage.tsx
@@ -69,7 +69,7 @@ export const CountryProfilePage = (props: CountryProfilePageProps) => {
                     </div>
                     <section>
                         <ul className="indicators">
-                            {indicators.map(indicator => (
+                            {indicators.map((indicator) => (
                                 <li key={indicator.slug}>
                                     <div className="indicatorName">
                                         <a

--- a/site/server/views/DonatePage.tsx
+++ b/site/server/views/DonatePage.tsx
@@ -95,7 +95,7 @@ export const DonatePage = () => {
                     dangerouslySetInnerHTML={{
                         __html: `
                 runDonateForm()
-            `
+            `,
                     }}
                 />
             </body>

--- a/site/server/views/EmbedDetector.tsx
+++ b/site/server/views/EmbedDetector.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 export const EmbedDetector = () => (
     <script
         dangerouslySetInnerHTML={{
-            __html: `if (window != window.top) document.documentElement.classList.add('iframe')`
+            __html: `if (window != window.top) document.documentElement.classList.add('iframe')`,
         }}
     />
 )

--- a/site/server/views/EntriesByYearPage.tsx
+++ b/site/server/views/EntriesByYearPage.tsx
@@ -12,18 +12,18 @@ import { TableOfContents } from "site/client/TableOfContents"
 type Entry = Pick<Post.Row, "title" | "slug" | "published_at">
 
 export const EntriesByYearPage = (props: { entries: Entry[] }) => {
-    const entriesByYear = lodash.groupBy(props.entries, e =>
+    const entriesByYear = lodash.groupBy(props.entries, (e) =>
         moment(e.published_at as Date).year()
     )
 
     const years = Object.keys(entriesByYear).sort().reverse()
 
     const pageTitle = "Entries by Year"
-    const tocEntries = years.map(year => {
+    const tocEntries = years.map((year) => {
         return {
             isSubheading: false,
             slug: year,
-            text: year
+            text: year,
         }
     })
 
@@ -52,7 +52,7 @@ export const EntriesByYearPage = (props: { entries: Entry[] }) => {
                                         Note that older entries are often
                                         updated with new content.
                                     </p>
-                                    {years.map(year => (
+                                    {years.map((year) => (
                                         <section key={year}>
                                             <h2 id={year}>
                                                 <a
@@ -63,7 +63,7 @@ export const EntriesByYearPage = (props: { entries: Entry[] }) => {
                                             </h2>
                                             <ul>
                                                 {entriesByYear[year].map(
-                                                    entry => (
+                                                    (entry) => (
                                                         <li key={entry.slug}>
                                                             <a
                                                                 href={`${BAKED_BASE_URL}/${entry.slug}`}
@@ -88,8 +88,8 @@ export const EntriesByYearPage = (props: { entries: Entry[] }) => {
                         __html: `
                         runTableOfContents(${JSON.stringify({
                             headings: tocEntries,
-                            pageTitle
-                        })})`
+                            pageTitle,
+                        })})`,
                     }}
                 />
             </body>
@@ -101,14 +101,14 @@ export const EntriesForYearPage = (props: {
     entries: Entry[]
     year: number
 }) => {
-    const entriesByYear = lodash.groupBy(props.entries, e =>
+    const entriesByYear = lodash.groupBy(props.entries, (e) =>
         moment(e.published_at as Date).year()
     )
 
     const years = Object.keys(entriesByYear)
         .sort()
         .reverse()
-        .filter(y => parseInt(y) === props.year)
+        .filter((y) => parseInt(y) === props.year)
 
     return (
         <html>
@@ -124,12 +124,12 @@ export const EntriesForYearPage = (props: {
                         <div className="content-wrapper">
                             <div className="offset-content">
                                 <div className="content">
-                                    {years.map(year => (
+                                    {years.map((year) => (
                                         <section key={year}>
                                             <h2>{year}</h2>
                                             <ul>
                                                 {entriesByYear[year].map(
-                                                    entry => (
+                                                    (entry) => (
                                                         <li key={entry.slug}>
                                                             <a
                                                                 href={`${BAKED_BASE_URL}/${entry.slug}`}

--- a/site/server/views/FrontPage.tsx
+++ b/site/server/views/FrontPage.tsx
@@ -15,7 +15,7 @@ import { faArrowRight } from "@fortawesome/free-solid-svg-icons/faArrowRight"
 import { splitOnLastWord } from "utils/server/serverUtil"
 import {
     NewsletterSubscriptionForm,
-    NewsletterSubscriptionContext
+    NewsletterSubscriptionContext,
 } from "site/client/NewsletterSubscription"
 
 export const FrontPage = (props: {
@@ -33,8 +33,8 @@ export const FrontPage = (props: {
         potentialAction: {
             "@type": "SearchAction",
             target: `${settings.BAKED_BASE_URL}/search?q={search_term_string}`,
-            "query-input": "required name=search_term_string"
-        }
+            "query-input": "required name=search_term_string",
+        },
     }
 
     const renderEntry = (entry: EntryNode, categorySlug: string) => {
@@ -54,7 +54,7 @@ export const FrontPage = (props: {
                             <div
                                 className="kpi"
                                 dangerouslySetInnerHTML={{
-                                    __html: entry.kpi
+                                    __html: entry.kpi,
                                 }}
                             />
                         )}
@@ -80,7 +80,7 @@ export const FrontPage = (props: {
                 <script
                     type="application/ld+json"
                     dangerouslySetInnerHTML={{
-                        __html: JSON.stringify(structuredMarkup)
+                        __html: JSON.stringify(structuredMarkup),
                     }}
                 />
             </Head>
@@ -279,7 +279,7 @@ export const FrontPage = (props: {
                                         <h2>Latest publications</h2>
                                     </div>
                                     <ul>
-                                        {posts.slice(0, 8).map(post => (
+                                        {posts.slice(0, 8).map((post) => (
                                             <li key={post.slug}>
                                                 <a
                                                     href={`/${post.path}`}
@@ -291,7 +291,7 @@ export const FrontPage = (props: {
                                                             style={{
                                                                 backgroundImage:
                                                                     post.imageUrl &&
-                                                                    `url(${post.imageUrl})`
+                                                                    `url(${post.imageUrl})`,
                                                             }}
                                                         />
                                                     </div>
@@ -468,7 +468,7 @@ export const FrontPage = (props: {
                             All our articles on global problems and global
                             changes
                         </h2>
-                        {entries.map(category => (
+                        {entries.map((category) => (
                             <div
                                 key={category.slug}
                                 className="category-wrapper"
@@ -481,12 +481,12 @@ export const FrontPage = (props: {
                                 </h3>
                                 {!!category.entries.length && (
                                     <div className="category-entries">
-                                        {category.entries.map(entry =>
+                                        {category.entries.map((entry) =>
                                             renderEntry(entry, category.slug)
                                         )}
                                     </div>
                                 )}
-                                {category.subcategories.map(subcategory => (
+                                {category.subcategories.map((subcategory) => (
                                     <div key={subcategory.slug}>
                                         <h4
                                             className={`${category.slug}-color`}
@@ -494,7 +494,7 @@ export const FrontPage = (props: {
                                             {subcategory.name}
                                         </h4>
                                         <div className="category-entries">
-                                            {subcategory.entries.map(entry =>
+                                            {subcategory.entries.map((entry) =>
                                                 renderEntry(
                                                     entry,
                                                     category.slug

--- a/site/server/views/GrapherPage.jsdom.test.tsx
+++ b/site/server/views/GrapherPage.jsdom.test.tsx
@@ -30,17 +30,17 @@ describe(GrapherPage, () => {
             status: "publish",
             type: "page",
             updated_at: "Wed Mar 25 2020 14:11:30 GMT+0000 (GMT)",
-            content: ""
+            content: "",
         } as any
         relatedCharts = [
             {
                 title: "Chart 1",
-                slug: "chart-1"
+                slug: "chart-1",
             },
             {
                 title: "Chart 2",
-                slug: "chart-2"
-            }
+                slug: "chart-2",
+            },
         ]
     })
 

--- a/site/server/views/GrapherPage.tsx
+++ b/site/server/views/GrapherPage.tsx
@@ -53,7 +53,9 @@ export const GrapherPage = (props: {
         }
     `
 
-    const variableIds = lodash.uniq(grapher.dimensions!.map(d => d.variableId))
+    const variableIds = lodash.uniq(
+        grapher.dimensions!.map((d) => d.variableId)
+    )
 
     return (
         <html>
@@ -108,11 +110,11 @@ export const GrapherPage = (props: {
                                     <ul>
                                         {relatedCharts
                                             .filter(
-                                                chartItem =>
+                                                (chartItem) =>
                                                     chartItem.slug !==
                                                     grapher.slug
                                             )
-                                            .map(c => (
+                                            .map((c) => (
                                                 <ChartListItemVariant
                                                     key={c.slug}
                                                     chart={c}

--- a/site/server/views/LongFormPage.tsx
+++ b/site/server/views/LongFormPage.tsx
@@ -9,7 +9,7 @@ import {
     formatDate,
     FormattedPost,
     FormattingOptions,
-    TocHeading
+    TocHeading,
 } from "site/server/formatting"
 import { SiteSubnavigation } from "./SiteSubnavigation"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
@@ -61,12 +61,12 @@ export const LongFormPage = (props: {
     let hasSidebar = false
     const endNotes = { text: "Endnotes", slug: "endnotes" }
     const tocHeadings: TocHeading[] = [...post.tocHeadings]
-    if (tocHeadings.some(tocHeading => !tocHeading.isSubheading)) {
+    if (tocHeadings.some((tocHeading) => !tocHeading.isSubheading)) {
         hasSidebar = true
         if (post.footnotes.length) {
             tocHeadings.push({
                 ...endNotes,
-                isSubheading: false
+                isSubheading: false,
             })
         }
         if (isEntry || isSubEntry) {
@@ -74,12 +74,12 @@ export const LongFormPage = (props: {
                 {
                     text: "Licence",
                     slug: "licence",
-                    isSubheading: false
+                    isSubheading: false,
                 },
                 {
                     text: "Citation",
                     slug: "citation",
-                    isSubheading: false
+                    isSubheading: false,
                 }
             )
         }
@@ -136,7 +136,7 @@ export const LongFormPage = (props: {
                                         {post.byline ? (
                                             <div
                                                 dangerouslySetInnerHTML={{
-                                                    __html: post.byline
+                                                    __html: post.byline,
                                                 }}
                                             ></div>
                                         ) : (
@@ -154,7 +154,7 @@ export const LongFormPage = (props: {
                                     <div
                                         className="blog-info"
                                         dangerouslySetInnerHTML={{
-                                            __html: post.info
+                                            __html: post.info,
                                         }}
                                     />
                                 )}
@@ -163,7 +163,7 @@ export const LongFormPage = (props: {
                                     <div
                                         className="last-updated"
                                         dangerouslySetInnerHTML={{
-                                            __html: post.lastUpdated
+                                            __html: post.lastUpdated,
                                         }}
                                     />
                                 )}
@@ -212,7 +212,7 @@ export const LongFormPage = (props: {
                                     <div
                                         className="article-content"
                                         dangerouslySetInnerHTML={{
-                                            __html: post.html
+                                            __html: post.html,
                                         }}
                                     />
                                     <footer className="article-footer">
@@ -238,7 +238,7 @@ export const LongFormPage = (props: {
                                                                     >
                                                                         <p
                                                                             dangerouslySetInnerHTML={{
-                                                                                __html: footnote
+                                                                                __html: footnote,
                                                                             }}
                                                                         />
                                                                     </li>
@@ -374,11 +374,11 @@ export const LongFormPage = (props: {
                         __html: `
                         runTableOfContents(${JSON.stringify({
                             headings: tocHeadings,
-                            pageTitle
+                            pageTitle,
                             // hideSubheadings: true
                         })})
                         runRelatedCharts(${JSON.stringify(post.relatedCharts)})
-                        `
+                        `,
                     }}
                 />
             </body>

--- a/site/server/views/NotFoundPage.tsx
+++ b/site/server/views/NotFoundPage.tsx
@@ -42,7 +42,7 @@ export const NotFoundPage = () => {
                     dangerouslySetInnerHTML={{
                         __html: `
                 window.runNotFoundPage()
-            `
+            `,
                     }}
                 />
             </body>

--- a/site/server/views/SiteFooter.tsx
+++ b/site/server/views/SiteFooter.tsx
@@ -5,7 +5,7 @@ import { faAngleRight } from "@fortawesome/free-solid-svg-icons/faAngleRight"
 import { BAKED_BASE_URL } from "settings"
 
 export const SiteFooter = ({
-    hideDonate = false
+    hideDonate = false,
 }: {
     hideDonate?: boolean
 }) => {
@@ -251,7 +251,7 @@ export const SiteFooter = ({
                     GrapherPageUtils.embedAll();
                     runGlobalEntityControl(GrapherPageUtils.globalEntitySelection);
                 }
-            `
+            `,
                     }}
                 />
             </footer>

--- a/site/server/views/SiteHeader.tsx
+++ b/site/server/views/SiteHeader.tsx
@@ -12,13 +12,13 @@ export interface SiteHeaderProps {
 }
 
 const DEFAULT_PROPS: SiteHeaderProps = {
-    hideAlertBanner: false
+    hideAlertBanner: false,
 }
 
 export const SiteHeader = (overrideProps: Partial<SiteHeaderProps>) => {
     const props: SiteHeaderProps = {
         ...DEFAULT_PROPS,
-        ...overrideProps
+        ...overrideProps,
     }
     return (
         <>

--- a/site/server/views/SiteSubnavigation.tsx
+++ b/site/server/views/SiteSubnavigation.tsx
@@ -24,17 +24,17 @@ const subnavs: { [key in SubNavId]: SubnavItem[] } = {
         {
             label: "History",
             href: "/history-of-our-world-in-data",
-            id: "history"
+            id: "history",
         },
         { label: "Supporters", href: "/supporters", id: "supporters" },
         { label: "FAQs", href: "/faqs", id: "faqs" },
         {
             label: "How-Tos",
             href: "/how-to-use-our-world-in-data",
-            id: "how-tos"
+            id: "how-tos",
         },
         { label: "Grapher", href: "/owid-grapher", id: "grapher" },
-        { label: "Contact", href: "/about#contact", id: "contact" }
+        { label: "Contact", href: "/about#contact", id: "contact" },
     ],
     coronavirus: [
         { label: "Coronavirus", href: "/coronavirus", id: "coronavirus" },
@@ -42,13 +42,13 @@ const subnavs: { [key in SubNavId]: SubnavItem[] } = {
             label: "By country",
             href: "/coronavirus#coronavirus-country-profiles",
             id: "by-country",
-            highlight: true
+            highlight: true,
         },
         {
             label: "Data explorer",
             href: "/coronavirus-data-explorer",
             id: "data-explorer",
-            highlight: true
+            highlight: true,
         },
         { label: "Deaths", href: "/covid-deaths", id: "deaths" },
         { label: "Cases", href: "/covid-cases", id: "cases" },
@@ -56,94 +56,94 @@ const subnavs: { [key in SubNavId]: SubnavItem[] } = {
         {
             label: "Mortality risk",
             href: "/mortality-risk-covid",
-            id: "mortality-risk"
+            id: "mortality-risk",
         },
         {
             label: "Policy responses",
             href: "/policy-responses-covid",
-            id: "policy-responses"
+            id: "policy-responses",
         },
         {
             label: "Exemplars",
             href: "/identify-covid-exemplars",
-            id: "exemplars"
+            id: "exemplars",
         },
-        { label: "All charts", href: "/coronavirus-data", id: "data" }
+        { label: "All charts", href: "/coronavirus-data", id: "data" },
     ],
     co2: [
         {
             label: "CO₂ and GHG Emissions",
             href: "/co2-and-other-greenhouse-gas-emissions",
-            id: "co2-and-ghg-emissions"
+            id: "co2-and-ghg-emissions",
         },
         {
             label: "By country",
             href:
                 "/co2-and-other-greenhouse-gas-emissions#co2-and-greenhouse-gas-emissions-country-profiles",
             id: "by-country",
-            highlight: true
+            highlight: true,
         },
         {
             label: "Data explorer",
             href: "/explorers/co2",
-            id: "co2-data-explorer"
+            id: "co2-data-explorer",
         },
         { label: "CO₂ emissions", href: "/co2-emissions", id: "co2-emissions" },
         { label: "CO₂ by fuel", href: "/emissions-by-fuel", id: "by-fuel" },
         {
             label: "GHG emissions",
             href: "/greenhouse-gas-emissions",
-            id: "ghg-emissions"
+            id: "ghg-emissions",
         },
         { label: "By sector", href: "/emissions-by-sector", id: "by-sector" },
         {
             label: "Emissions drivers",
             href: "/emissions-drivers",
-            id: "emissions-drivers"
+            id: "emissions-drivers",
         },
         {
             label: "Atmospheric concentrations",
             href: "/atmospheric-concentrations",
-            id: "atm-concentrations"
-        }
+            id: "atm-concentrations",
+        },
     ],
     energy: [
         {
             label: "Energy",
             href: "/energy",
-            id: "energy"
+            id: "energy",
         },
         {
             label: "By country",
             href: "/energy#energy-country-profiles",
             id: "by-country",
-            highlight: true
+            highlight: true,
         },
         {
             label: "Data explorer",
             href: "/explorers/energy",
-            id: "energy-data-explorer"
+            id: "energy-data-explorer",
         },
         { label: "Energy access", href: "/energy-access", id: "energy-access" },
         {
             label: "Production & Consumption",
             href: "/energy-production-consumption",
-            id: "production-consumption"
+            id: "production-consumption",
         },
         { label: "Energy mix", href: "/energy-mix", id: "energy-mix" },
         {
             label: "Electricity mix",
             href: "/electricity-mix",
-            id: "electricity-mix"
+            id: "electricity-mix",
         },
         { label: "Fossil fuels", href: "/fossil-fuels", id: "fossil-fuels" },
         {
             label: "Renewables",
             href: "/renewable-energy",
-            id: "renewable-energy"
+            id: "renewable-energy",
         },
-        { label: "Nuclear", href: "/nuclear-energy", id: "nuclear-energy" }
-    ]
+        { label: "Nuclear", href: "/nuclear-energy", id: "nuclear-energy" },
+    ],
 }
 
 export class SiteSubnavigation extends React.Component<{
@@ -164,7 +164,7 @@ export class SiteSubnavigation extends React.Component<{
                                     const dataTrackNote = [
                                         subnavId,
                                         "subnav",
-                                        id
+                                        id,
                                     ].join("-")
                                     if (id === subnavCurrentId)
                                         classes.push("current")

--- a/site/server/views/Tablepress.tsx
+++ b/site/server/views/Tablepress.tsx
@@ -10,7 +10,7 @@ function cell(data?: string) {
     return {
         data: data || "",
         colspan: 1,
-        rowspan: 1
+        rowspan: 1,
     }
 }
 

--- a/stripe/DonateForm.tsx
+++ b/stripe/DonateForm.tsx
@@ -102,7 +102,7 @@ export class DonateForm extends React.Component {
             method: "POST",
             credentials: "same-origin",
             headers: {
-                Accept: "application/json"
+                Accept: "application/json",
             },
             body: JSON.stringify({
                 name: this.name,
@@ -111,13 +111,13 @@ export class DonateForm extends React.Component {
                 interval: this.interval,
                 successUrl: `${BAKED_BASE_URL}/donate/thank-you`,
                 cancelUrl: `${BAKED_BASE_URL}/donate`,
-                captchaToken: captchaToken
-            })
+                captchaToken: captchaToken,
+            }),
         })
         const session = await response.json()
         if (!response.ok) throw session
         const result: { error: any } = await stripe.redirectToCheckout({
-            sessionId: session.id
+            sessionId: session.id,
         })
         if (result.error) {
             // If `redirectToCheckout` fails due to a browser or network
@@ -204,7 +204,7 @@ export class DonateForm extends React.Component {
                         <h3>Amount (USD)</h3>
                     </legend>
                     <div className="radios">
-                        {this.intervalAmounts.map(amount => (
+                        {this.intervalAmounts.map((amount) => (
                             <div key={amount} className="owid-radio">
                                 <input
                                     type="radio"
@@ -230,7 +230,7 @@ export class DonateForm extends React.Component {
                                 id="custom"
                                 name="amount"
                                 checked={this.isCustom}
-                                onChange={event =>
+                                onChange={(event) =>
                                     this.setIsCustom(event.target.checked)
                                 }
                             />
@@ -241,7 +241,7 @@ export class DonateForm extends React.Component {
                                     placeholder="Other"
                                     name="custom-amount"
                                     className="custom-amount-input"
-                                    onChange={event =>
+                                    onChange={(event) =>
                                         this.setCustomAmount(event.target.value)
                                     }
                                     value={this.customAmount}
@@ -261,7 +261,9 @@ export class DonateForm extends React.Component {
                             type="text"
                             className="owid-input"
                             value={this.name}
-                            onChange={event => this.setName(event.target.value)}
+                            onChange={(event) =>
+                                this.setName(event.target.value)
+                            }
                         />
                     </div>
                 </fieldset>
@@ -275,7 +277,7 @@ export class DonateForm extends React.Component {
                                 value="showOnList"
                                 name="type"
                                 checked={this.showOnList}
-                                onChange={event =>
+                                onChange={(event) =>
                                     this.setShowOnList(event.target.checked)
                                 }
                             />
@@ -294,7 +296,7 @@ export class DonateForm extends React.Component {
                 )}
 
                 <Recaptcha
-                    ref={inst => (this.captchaInstance = inst)}
+                    ref={(inst) => (this.captchaInstance = inst)}
                     sitekey={RECAPTCHA_SITE_KEY}
                     size="invisible"
                     badge="bottomleft"
@@ -306,7 +308,7 @@ export class DonateForm extends React.Component {
                 <button
                     type="submit"
                     className={classnames("owid-button", {
-                        disabled: this.isSubmitting
+                        disabled: this.isSubmitting,
                     })}
                     disabled={this.isLoading}
                 >

--- a/stripe/exportStripeDonors.ts
+++ b/stripe/exportStripeDonors.ts
@@ -5,7 +5,7 @@ import { STRIPE_SECRET_KEY } from "serverSettings"
 import { csvRow } from "utils/server/serverUtil"
 
 const stripe = new Stripe(STRIPE_SECRET_KEY, {
-    apiVersion: "2020-03-02"
+    apiVersion: "2020-03-02",
 })
 
 interface CustomerWithPaymentIntents extends Stripe.Customer {
@@ -25,7 +25,7 @@ async function getAll<T extends StripeObject>(
     while (firstRun || startingAfter) {
         const response: Stripe.ApiList<T> = await getter({
             limit: 100,
-            starting_after: startingAfter
+            starting_after: startingAfter,
         })
         result.push(...response.data)
         startingAfter =
@@ -49,33 +49,33 @@ async function getCustomersWithPaymentIntents(): Promise<
 > {
     const [paymentIntents, customers] = await Promise.all([
         getAllPaymentIntents(),
-        getAllCustomers()
+        getAllCustomers(),
     ])
     const successfulPaymentIntents = paymentIntents.filter(
-        paymentIntent => paymentIntent.status === "succeeded"
+        (paymentIntent) => paymentIntent.status === "succeeded"
     )
     const paymentIntentsByCustomerId = groupBy(
         successfulPaymentIntents,
         "customer"
     )
     return customers
-        .map(customer => {
+        .map((customer) => {
             const customerWithPaymentIntent: CustomerWithPaymentIntents = {
                 ...customer,
-                paymentIntents: paymentIntentsByCustomerId[customer.id] || []
+                paymentIntents: paymentIntentsByCustomerId[customer.id] || [],
             }
             return customerWithPaymentIntent
         })
-        .filter(customer => customer.paymentIntents.length > 0)
+        .filter((customer) => customer.paymentIntents.length > 0)
 }
 
 async function getDonors() {
     const customers = await getCustomersWithPaymentIntents()
-    return customers.map(customer => {
+    return customers.map((customer) => {
         const metadata: Stripe.Metadata = {
             ...customer.metadata,
             ...customer.paymentIntents[0]?.metadata,
-            ...customer.subscriptions?.data[0]?.metadata
+            ...customer.subscriptions?.data[0]?.metadata,
         }
         return {
             email: customer.email,
@@ -83,7 +83,7 @@ async function getDonors() {
             showOnList: metadata?.showOnList,
             isMonthly: !!customer.subscriptions?.data.length,
             created: new Date(customer.created * 1000).toISOString(),
-            total: sum(customer.paymentIntents.map(pi => pi.amount)) / 100
+            total: sum(customer.paymentIntents.map((pi) => pi.amount)) / 100,
         }
     })
 }
@@ -91,7 +91,7 @@ async function getDonors() {
 function toCSV(headers: string[], data: any[]) {
     return [
         csvRow(headers),
-        ...data.map(json => csvRow(headers.map(header => json[header])))
+        ...data.map((json) => csvRow(headers.map((header) => json[header]))),
     ].join("") // csvRow() already adds newlines
 }
 

--- a/svgTester/SVGTester.tsx
+++ b/svgTester/SVGTester.tsx
@@ -5,7 +5,7 @@ import { BAKED_GRAPHER_URL } from "settings"
 import React from "react"
 import {
     bakeChartToImage,
-    getChartsBySlug
+    getChartsBySlug,
 } from "site/server/bakeChartsToImages"
 
 const header = `bakeOrder,timeToBake,slug,chartType,md5`
@@ -20,7 +20,7 @@ interface BakedSvgInfo {
 const svgResultsPlaceholder = `${header}\n${sampleRow}\n`
 const style = {
     width: 600,
-    height: 300
+    height: 300,
 }
 
 export const svgCompareFormPage = (
@@ -72,7 +72,7 @@ export async function bakeAndSaveResultsFile(
             timeToBake: Date.now() - startTime,
             slug,
             chartType: config.type,
-            md5: md5(svg!)
+            md5: md5(svg!),
         }
         const line = `${bakeOrder},${row.timeToBake},${row.slug},${row.chartType},${row.md5}`
         // eslint-disable-next-line no-console
@@ -85,15 +85,15 @@ export async function bakeAndSaveResultsFile(
 
 const compareSets = (liveSvgs: BakedSvgInfo[], localSvgs: BakedSvgInfo[]) => {
     const localSvgMap = new Map<string, BakedSvgInfo>()
-    localSvgs.forEach(svg => {
+    localSvgs.forEach((svg) => {
         localSvgMap.set(svg.slug, svg)
     })
-    return liveSvgs.map(liveSvg => {
+    return liveSvgs.map((liveSvg) => {
         const { slug } = liveSvg
         const localSvg = localSvgMap.get(slug)
         if (!localSvg)
             return {
-                missing: slug
+                missing: slug,
             }
 
         const changed = liveSvg.md5 !== localSvg.md5
@@ -106,7 +106,7 @@ const compareSets = (liveSvgs: BakedSvgInfo[], localSvgs: BakedSvgInfo[]) => {
             liveSvgUrl,
             liveInteractiveUrl,
             devSvgPath,
-            devInteractiveUrl
+            devInteractiveUrl,
         }
     })
 }
@@ -115,11 +115,11 @@ export const getComparePage = async (liveRows: string, devRows: string) => {
     const live = csvParse(liveRows)
     const dev = csvParse(devRows)
     const files = compareSets(live as any, dev as any)
-    const missing = files.filter(file => file.missing)
-    const notMissing = files.filter(file => !file.missing)
-    const changed = notMissing.filter(file => file.changed)
+    const missing = files.filter((file) => file.missing)
+    const notMissing = files.filter((file) => !file.missing)
+    const changed = notMissing.filter((file) => file.changed)
 
-    const rows = changed.map(file => (
+    const rows = changed.map((file) => (
         <tr>
             <td>
                 <a href={file.liveSvgUrl}>
@@ -142,7 +142,7 @@ export const getComparePage = async (liveRows: string, devRows: string) => {
         notMissing.length - changed.length
     } unchanged. ${missing.length} files on live missing locally.`
 
-    const missingDivs = missing.map(el => <div>${el.missing}</div>)
+    const missingDivs = missing.map((el) => <div>${el.missing}</div>)
 
     return (
         <div>

--- a/utils/client/react-select.tsx
+++ b/utils/client/react-select.tsx
@@ -23,48 +23,48 @@ export function getStylesForTargetHeight(
         container,
         dropdownIndicator,
         option,
-        menu
+        menu,
     } = props
     return {
         container: (base: React.CSSProperties) => ({
             ...base,
-            ...container
+            ...container,
         }),
         control: (base: React.CSSProperties) => ({
             ...base,
             minHeight: "initial",
-            ...control
+            ...control,
         }),
         valueContainer: (base: React.CSSProperties) => ({
             ...base,
             height: `${targetHeight - 1 - 1}px`,
             padding: "0 4px",
-            ...valueContainer
+            ...valueContainer,
         }),
         singleValue: (base: React.CSSProperties) => ({
             ...base,
-            ...singleValue
+            ...singleValue,
         }),
         clearIndicator: (base: React.CSSProperties) => ({
             ...base,
             padding: `${(targetHeight - 20 - 1 - 1) / 2}px`,
-            ...clearIndicator
+            ...clearIndicator,
         }),
         dropdownIndicator: (base: React.CSSProperties) => ({
             ...base,
             padding: `${(targetHeight - 20 - 1 - 1) / 2}px`,
-            ...dropdownIndicator
+            ...dropdownIndicator,
         }),
         option: (base: React.CSSProperties) => ({
             ...base,
             paddingTop: "5px",
             paddingBottom: "5px",
-            ...option
+            ...option,
         }),
         menu: (base: React.CSSProperties) => ({
             ...base,
             zIndex: 10000,
-            ...menu
-        })
+            ...menu,
+        }),
     }
 }

--- a/utils/client/url.ts
+++ b/utils/client/url.ts
@@ -17,7 +17,7 @@ export function getWindowQueryParams(): QueryParams {
 export function strToQueryParams(queryStr: string): QueryParams {
     if (queryStr[0] === "?") queryStr = queryStr.substring(1)
 
-    const querySplit = filter(queryStr.split("&"), s => !isEmpty(s))
+    const querySplit = filter(queryStr.split("&"), (s) => !isEmpty(s))
     const params: QueryParams = {}
 
     for (const param of querySplit) {

--- a/utils/countries.ts
+++ b/utils/countries.ts
@@ -15,1509 +15,1509 @@ const allCountriesSortedByCode: FilterableCountry[] = [
         name: "Aruba",
         code: "ABW",
         slug: "aruba",
-        iso3166: "AW"
+        iso3166: "AW",
     },
     {
         name: "Afghanistan",
         code: "AFG",
         slug: "afghanistan",
-        iso3166: "AF"
+        iso3166: "AF",
     },
     {
         name: "Angola",
         code: "AGO",
         slug: "angola",
-        iso3166: "AO"
+        iso3166: "AO",
     },
     {
         name: "Anguilla",
         code: "AIA",
         slug: "anguilla",
-        iso3166: "AI"
+        iso3166: "AI",
     },
     {
         name: "Åland Islands",
         code: "ALA",
         slug: "aland-islands",
-        filter: true
+        filter: true,
     },
     {
         name: "Albania",
         code: "ALB",
         slug: "albania",
-        iso3166: "AL"
+        iso3166: "AL",
     },
     {
         name: "Andorra",
         code: "AND",
         slug: "andorra",
-        iso3166: "AD"
+        iso3166: "AD",
     },
     {
         name: "Netherlands Antilles",
         code: "ANT",
         slug: "netherlands-antilles",
-        filter: true
+        filter: true,
     },
     {
         name: "United Arab Emirates",
         code: "ARE",
         slug: "united-arab-emirates",
-        iso3166: "AE"
+        iso3166: "AE",
     },
     {
         name: "Argentina",
         code: "ARG",
         slug: "argentina",
-        iso3166: "AR"
+        iso3166: "AR",
     },
     {
         name: "Armenia",
         code: "ARM",
         slug: "armenia",
-        iso3166: "AM"
+        iso3166: "AM",
     },
     {
         name: "American Samoa",
         code: "ASM",
         slug: "american-samoa",
-        iso3166: "AS"
+        iso3166: "AS",
     },
     {
         name: "Antarctica",
         code: "ATA",
         slug: "antarctica",
         filter: true,
-        iso3166: "AQ"
+        iso3166: "AQ",
     },
     {
         name: "French Southern Territories",
         code: "ATF",
         slug: "french-southern-territories",
         filter: true,
-        iso3166: "TF"
+        iso3166: "TF",
     },
     {
         name: "Antigua and Barbuda",
         code: "ATG",
         slug: "antigua-and-barbuda",
-        iso3166: "AG"
+        iso3166: "AG",
     },
     {
         name: "Australia",
         code: "AUS",
         slug: "australia",
-        iso3166: "AU"
+        iso3166: "AU",
     },
     {
         name: "Austria",
         code: "AUT",
         slug: "austria",
-        iso3166: "AT"
+        iso3166: "AT",
     },
     {
         name: "Azerbaijan",
         code: "AZE",
         slug: "azerbaijan",
-        iso3166: "AZ"
+        iso3166: "AZ",
     },
     {
         name: "Burundi",
         code: "BDI",
         slug: "burundi",
-        iso3166: "BI"
+        iso3166: "BI",
     },
     {
         name: "Belgium",
         code: "BEL",
         slug: "belgium",
-        iso3166: "BE"
+        iso3166: "BE",
     },
     {
         name: "Benin",
         code: "BEN",
         slug: "benin",
-        iso3166: "BJ"
+        iso3166: "BJ",
     },
     {
         name: "Bonaire Sint Eustatius and Saba",
         code: "BES",
         slug: "bonaire-sint-eustatius-and-saba",
-        filter: true
+        filter: true,
     },
     {
         name: "Burkina Faso",
         code: "BFA",
         slug: "burkina-faso",
-        iso3166: "BF"
+        iso3166: "BF",
     },
     {
         name: "Bangladesh",
         code: "BGD",
         slug: "bangladesh",
-        iso3166: "BD"
+        iso3166: "BD",
     },
     {
         name: "Bulgaria",
         code: "BGR",
         slug: "bulgaria",
-        iso3166: "BG"
+        iso3166: "BG",
     },
     {
         name: "Bahrain",
         code: "BHR",
         slug: "bahrain",
-        iso3166: "BH"
+        iso3166: "BH",
     },
     {
         name: "Bahamas",
         code: "BHS",
         slug: "bahamas",
-        iso3166: "BS"
+        iso3166: "BS",
     },
     {
         name: "Bosnia and Herzegovina",
         code: "BIH",
         slug: "bosnia-and-herzegovina",
-        iso3166: "BA"
+        iso3166: "BA",
     },
     {
         name: "Saint Barthélemy",
         code: "BLM",
-        slug: "saint-barthelemy"
+        slug: "saint-barthelemy",
     },
     {
         name: "Belarus",
         code: "BLR",
         slug: "belarus",
-        iso3166: "BY"
+        iso3166: "BY",
     },
     {
         name: "Belize",
         code: "BLZ",
         slug: "belize",
-        iso3166: "BZ"
+        iso3166: "BZ",
     },
     {
         name: "Bermuda",
         code: "BMU",
         slug: "bermuda",
-        iso3166: "BM"
+        iso3166: "BM",
     },
     {
         name: "Bolivia",
         code: "BOL",
         slug: "bolivia",
-        iso3166: "BO"
+        iso3166: "BO",
     },
     {
         name: "Brazil",
         code: "BRA",
         slug: "brazil",
-        iso3166: "BR"
+        iso3166: "BR",
     },
     {
         name: "Barbados",
         code: "BRB",
         slug: "barbados",
-        iso3166: "BB"
+        iso3166: "BB",
     },
     {
         name: "Brunei",
         code: "BRN",
-        slug: "brunei"
+        slug: "brunei",
     },
     {
         name: "Bhutan",
         code: "BTN",
         slug: "bhutan",
-        iso3166: "BT"
+        iso3166: "BT",
     },
     {
         name: "Bouvet Island",
         code: "BVT",
         slug: "bouvet-island",
         filter: true,
-        iso3166: "BV"
+        iso3166: "BV",
     },
     {
         name: "Botswana",
         code: "BWA",
         slug: "botswana",
-        iso3166: "BW"
+        iso3166: "BW",
     },
     {
         name: "Central African Republic",
         code: "CAF",
         slug: "central-african-republic",
-        iso3166: "CF"
+        iso3166: "CF",
     },
     {
         name: "Canada",
         code: "CAN",
         slug: "canada",
-        iso3166: "CA"
+        iso3166: "CA",
     },
     {
         name: "Cocos Islands",
         code: "CCK",
         slug: "cocos-islands",
-        filter: true
+        filter: true,
     },
     {
         name: "Switzerland",
         code: "CHE",
         slug: "switzerland",
-        iso3166: "CH"
+        iso3166: "CH",
     },
     {
         name: "Chile",
         code: "CHL",
         slug: "chile",
-        iso3166: "CL"
+        iso3166: "CL",
     },
     {
         name: "China",
         code: "CHN",
         slug: "china",
-        iso3166: "CN"
+        iso3166: "CN",
     },
     {
         name: "Cote d'Ivoire",
         code: "CIV",
         slug: "cote-divoire",
-        iso3166: "CI"
+        iso3166: "CI",
     },
     {
         name: "Cameroon",
         code: "CMR",
         slug: "cameroon",
-        iso3166: "CM"
+        iso3166: "CM",
     },
     {
         name: "Democratic Republic of Congo",
         code: "COD",
-        slug: "democratic-republic-of-congo"
+        slug: "democratic-republic-of-congo",
     },
     {
         name: "Congo",
         code: "COG",
         slug: "congo",
-        iso3166: "CG"
+        iso3166: "CG",
     },
     {
         name: "Cook Islands",
         code: "COK",
         slug: "cook-islands",
         filter: true,
-        iso3166: "CK"
+        iso3166: "CK",
     },
     {
         name: "Colombia",
         code: "COL",
         slug: "colombia",
-        iso3166: "CO"
+        iso3166: "CO",
     },
     {
         name: "Comoros",
         code: "COM",
         slug: "comoros",
-        iso3166: "KM"
+        iso3166: "KM",
     },
     {
         name: "Cape Verde",
         code: "CPV",
         slug: "cape-verde",
-        iso3166: "CV"
+        iso3166: "CV",
     },
     {
         name: "Costa Rica",
         code: "CRI",
         slug: "costa-rica",
-        iso3166: "CR"
+        iso3166: "CR",
     },
     {
         name: "Cuba",
         code: "CUB",
         slug: "cuba",
-        iso3166: "CU"
+        iso3166: "CU",
     },
     {
         name: "Curacao",
         code: "CUW",
         slug: "curacao",
         filter: true,
-        iso3166: "CW"
+        iso3166: "CW",
     },
     {
         name: "Christmas Island",
         code: "CXR",
         slug: "christmas-island",
-        iso3166: "CX"
+        iso3166: "CX",
     },
     {
         name: "Cayman Islands",
         code: "CYM",
         slug: "cayman-islands",
-        iso3166: "KY"
+        iso3166: "KY",
     },
     {
         name: "Cyprus",
         code: "CYP",
         slug: "cyprus",
-        iso3166: "CY"
+        iso3166: "CY",
     },
     {
         name: "Czech Republic",
         code: "CZE",
         slug: "czech-republic",
-        iso3166: "CZ"
+        iso3166: "CZ",
     },
     {
         name: "Germany",
         code: "DEU",
         slug: "germany",
-        iso3166: "DE"
+        iso3166: "DE",
     },
     {
         name: "Djibouti",
         code: "DJI",
         slug: "djibouti",
-        iso3166: "DJ"
+        iso3166: "DJ",
     },
     {
         name: "Dominica",
         code: "DMA",
         slug: "dominica",
-        iso3166: "DM"
+        iso3166: "DM",
     },
     {
         name: "Denmark",
         code: "DNK",
         slug: "denmark",
-        iso3166: "DK"
+        iso3166: "DK",
     },
     {
         name: "Dominican Republic",
         code: "DOM",
         slug: "dominican-republic",
-        iso3166: "DO"
+        iso3166: "DO",
     },
     {
         name: "Algeria",
         code: "DZA",
         slug: "algeria",
-        iso3166: "DZ"
+        iso3166: "DZ",
     },
     {
         name: "Ecuador",
         code: "ECU",
         slug: "ecuador",
-        iso3166: "EC"
+        iso3166: "EC",
     },
     {
         name: "Egypt",
         code: "EGY",
         slug: "egypt",
-        iso3166: "EG"
+        iso3166: "EG",
     },
     {
         name: "Eritrea",
         code: "ERI",
         slug: "eritrea",
-        iso3166: "ER"
+        iso3166: "ER",
     },
     {
         name: "Western Sahara",
         code: "ESH",
         slug: "western-sahara",
         filter: true,
-        iso3166: "EH"
+        iso3166: "EH",
     },
     {
         name: "Spain",
         code: "ESP",
         slug: "spain",
-        iso3166: "ES"
+        iso3166: "ES",
     },
     {
         name: "Estonia",
         code: "EST",
         slug: "estonia",
-        iso3166: "EE"
+        iso3166: "EE",
     },
     {
         name: "Ethiopia",
         code: "ETH",
         slug: "ethiopia",
-        iso3166: "ET"
+        iso3166: "ET",
     },
     {
         name: "Finland",
         code: "FIN",
         slug: "finland",
-        iso3166: "FI"
+        iso3166: "FI",
     },
     {
         name: "Fiji",
         code: "FJI",
         slug: "fiji",
-        iso3166: "FJ"
+        iso3166: "FJ",
     },
     {
         name: "Falkland Islands",
         code: "FLK",
-        slug: "falkland-islands"
+        slug: "falkland-islands",
     },
     {
         name: "France",
         code: "FRA",
         slug: "france",
-        iso3166: "FR"
+        iso3166: "FR",
     },
     {
         name: "Faeroe Islands",
         code: "FRO",
-        slug: "faeroe-islands"
+        slug: "faeroe-islands",
     },
     {
         name: "Micronesia (country)",
         code: "FSM",
-        slug: "micronesia-country"
+        slug: "micronesia-country",
     },
     {
         name: "Gabon",
         code: "GAB",
         slug: "gabon",
-        iso3166: "GA"
+        iso3166: "GA",
     },
     {
         name: "United Kingdom",
         code: "GBR",
         slug: "united-kingdom",
         variantNames: ["UK"],
-        iso3166: "GB"
+        iso3166: "GB",
     },
     {
         name: "Georgia",
         code: "GEO",
         slug: "georgia",
-        iso3166: "GE"
+        iso3166: "GE",
     },
     {
         name: "Guernsey",
         code: "GGY",
         slug: "guernsey",
         filter: true,
-        iso3166: "GG"
+        iso3166: "GG",
     },
     {
         name: "Ghana",
         code: "GHA",
         slug: "ghana",
-        iso3166: "GH"
+        iso3166: "GH",
     },
     {
         name: "Gibraltar",
         code: "GIB",
         slug: "gibraltar",
-        iso3166: "GI"
+        iso3166: "GI",
     },
     {
         name: "Guinea",
         code: "GIN",
         slug: "guinea",
-        iso3166: "GN"
+        iso3166: "GN",
     },
     {
         name: "Guadeloupe",
         code: "GLP",
         slug: "guadeloupe",
         filter: true,
-        iso3166: "GP"
+        iso3166: "GP",
     },
     {
         name: "Gambia",
         code: "GMB",
         slug: "gambia",
-        iso3166: "GM"
+        iso3166: "GM",
     },
     {
         name: "Guinea-Bissau",
         code: "GNB",
         slug: "guinea-bissau",
-        iso3166: "GW"
+        iso3166: "GW",
     },
     {
         name: "Equatorial Guinea",
         code: "GNQ",
         slug: "equatorial-guinea",
-        iso3166: "GQ"
+        iso3166: "GQ",
     },
     {
         name: "Greece",
         code: "GRC",
         slug: "greece",
-        iso3166: "GR"
+        iso3166: "GR",
     },
     {
         name: "Grenada",
         code: "GRD",
         slug: "grenada",
-        iso3166: "GD"
+        iso3166: "GD",
     },
     {
         name: "Greenland",
         code: "GRL",
         slug: "greenland",
-        iso3166: "GL"
+        iso3166: "GL",
     },
     {
         name: "Guatemala",
         code: "GTM",
         slug: "guatemala",
-        iso3166: "GT"
+        iso3166: "GT",
     },
     {
         name: "French Guiana",
         code: "GUF",
         slug: "french-guiana",
-        iso3166: "GF"
+        iso3166: "GF",
     },
     {
         name: "Guam",
         code: "GUM",
         slug: "guam",
-        iso3166: "GU"
+        iso3166: "GU",
     },
     {
         name: "Guyana",
         code: "GUY",
         slug: "guyana",
-        iso3166: "GY"
+        iso3166: "GY",
     },
     {
         name: "Hong Kong",
         code: "HKG",
         slug: "hong-kong",
-        iso3166: "HK"
+        iso3166: "HK",
     },
     {
         name: "Heard Island and McDonald Islands",
         code: "HMD",
         slug: "heard-island-and-mcdonald-islands",
         filter: true,
-        iso3166: "HM"
+        iso3166: "HM",
     },
     {
         name: "Honduras",
         code: "HND",
         slug: "honduras",
-        iso3166: "HN"
+        iso3166: "HN",
     },
     {
         name: "Croatia",
         code: "HRV",
         slug: "croatia",
-        iso3166: "HR"
+        iso3166: "HR",
     },
     {
         name: "Haiti",
         code: "HTI",
         slug: "haiti",
-        iso3166: "HT"
+        iso3166: "HT",
     },
     {
         name: "Hungary",
         code: "HUN",
         slug: "hungary",
-        iso3166: "HU"
+        iso3166: "HU",
     },
     {
         name: "Indonesia",
         code: "IDN",
         slug: "indonesia",
-        iso3166: "ID"
+        iso3166: "ID",
     },
     {
         name: "Isle of Man",
         code: "IMN",
         slug: "isle-of-man",
-        iso3166: "IM"
+        iso3166: "IM",
     },
     {
         name: "India",
         code: "IND",
         slug: "india",
-        iso3166: "IN"
+        iso3166: "IN",
     },
     {
         name: "British Indian Ocean Territory",
         code: "IOT",
         slug: "british-indian-ocean-territory",
         filter: true,
-        iso3166: "IO"
+        iso3166: "IO",
     },
     {
         name: "Ireland",
         code: "IRL",
         slug: "ireland",
-        iso3166: "IE"
+        iso3166: "IE",
     },
     {
         name: "Iran",
         code: "IRN",
-        slug: "iran"
+        slug: "iran",
     },
     {
         name: "Iraq",
         code: "IRQ",
         slug: "iraq",
-        iso3166: "IQ"
+        iso3166: "IQ",
     },
     {
         name: "Iceland",
         code: "ISL",
         slug: "iceland",
-        iso3166: "IS"
+        iso3166: "IS",
     },
     {
         name: "Israel",
         code: "ISR",
         slug: "israel",
-        iso3166: "IL"
+        iso3166: "IL",
     },
     {
         name: "Italy",
         code: "ITA",
         slug: "italy",
-        iso3166: "IT"
+        iso3166: "IT",
     },
     {
         name: "Jamaica",
         code: "JAM",
         slug: "jamaica",
-        iso3166: "JM"
+        iso3166: "JM",
     },
     {
         name: "Jersey",
         code: "JEY",
         slug: "jersey",
-        iso3166: "JE"
+        iso3166: "JE",
     },
     {
         name: "Jordan",
         code: "JOR",
         slug: "jordan",
-        iso3166: "JO"
+        iso3166: "JO",
     },
     {
         name: "Japan",
         code: "JPN",
         slug: "japan",
-        iso3166: "JP"
+        iso3166: "JP",
     },
     {
         name: "Kazakhstan",
         code: "KAZ",
         slug: "kazakhstan",
-        iso3166: "KZ"
+        iso3166: "KZ",
     },
     {
         name: "Kenya",
         code: "KEN",
         slug: "kenya",
-        iso3166: "KE"
+        iso3166: "KE",
     },
     {
         name: "Kyrgyzstan",
         code: "KGZ",
         slug: "kyrgyzstan",
-        iso3166: "KG"
+        iso3166: "KG",
     },
     {
         name: "Cambodia",
         code: "KHM",
         slug: "cambodia",
-        iso3166: "KH"
+        iso3166: "KH",
     },
     {
         name: "Kiribati",
         code: "KIR",
         slug: "kiribati",
-        iso3166: "KI"
+        iso3166: "KI",
     },
     {
         name: "Saint Kitts and Nevis",
         code: "KNA",
         slug: "saint-kitts-and-nevis",
-        iso3166: "KN"
+        iso3166: "KN",
     },
     {
         name: "South Korea",
         code: "KOR",
-        slug: "south-korea"
+        slug: "south-korea",
     },
     {
         name: "Kuwait",
         code: "KWT",
         slug: "kuwait",
-        iso3166: "KW"
+        iso3166: "KW",
     },
     {
         name: "Laos",
         code: "LAO",
-        slug: "laos"
+        slug: "laos",
     },
     {
         name: "Lebanon",
         code: "LBN",
         slug: "lebanon",
-        iso3166: "LB"
+        iso3166: "LB",
     },
     {
         name: "Liberia",
         code: "LBR",
         slug: "liberia",
-        iso3166: "LR"
+        iso3166: "LR",
     },
     {
         name: "Libya",
         code: "LBY",
-        slug: "libya"
+        slug: "libya",
     },
     {
         name: "Saint Lucia",
         code: "LCA",
         slug: "saint-lucia",
-        iso3166: "LC"
+        iso3166: "LC",
     },
     {
         name: "Liechtenstein",
         code: "LIE",
         slug: "liechtenstein",
-        iso3166: "LI"
+        iso3166: "LI",
     },
     {
         name: "Sri Lanka",
         code: "LKA",
         slug: "sri-lanka",
-        iso3166: "LK"
+        iso3166: "LK",
     },
     {
         name: "Lesotho",
         code: "LSO",
         slug: "lesotho",
-        iso3166: "LS"
+        iso3166: "LS",
     },
     {
         name: "Lithuania",
         code: "LTU",
         slug: "lithuania",
-        iso3166: "LT"
+        iso3166: "LT",
     },
     {
         name: "Luxembourg",
         code: "LUX",
         slug: "luxembourg",
-        iso3166: "LU"
+        iso3166: "LU",
     },
     {
         name: "Latvia",
         code: "LVA",
         slug: "latvia",
-        iso3166: "LV"
+        iso3166: "LV",
     },
     {
         name: "Macao",
         code: "MAC",
         slug: "macao",
-        iso3166: "MO"
+        iso3166: "MO",
     },
     {
         name: "Saint Martin (French part)",
         code: "MAF",
         slug: "saint-martin-french-part",
-        filter: true
+        filter: true,
     },
     {
         name: "Morocco",
         code: "MAR",
         slug: "morocco",
-        iso3166: "MA"
+        iso3166: "MA",
     },
     {
         name: "Monaco",
         code: "MCO",
         slug: "monaco",
-        iso3166: "MC"
+        iso3166: "MC",
     },
     {
         name: "Moldova",
         code: "MDA",
-        slug: "moldova"
+        slug: "moldova",
     },
     {
         name: "Madagascar",
         code: "MDG",
         slug: "madagascar",
-        iso3166: "MG"
+        iso3166: "MG",
     },
     {
         name: "Maldives",
         code: "MDV",
         slug: "maldives",
-        iso3166: "MV"
+        iso3166: "MV",
     },
     {
         name: "Mexico",
         code: "MEX",
         slug: "mexico",
-        iso3166: "MX"
+        iso3166: "MX",
     },
     {
         name: "Marshall Islands",
         code: "MHL",
         slug: "marshall-islands",
-        iso3166: "MH"
+        iso3166: "MH",
     },
     {
         name: "Macedonia",
         code: "MKD",
         slug: "macedonia",
-        iso3166: "MK"
+        iso3166: "MK",
     },
     {
         name: "Mali",
         code: "MLI",
         slug: "mali",
-        iso3166: "ML"
+        iso3166: "ML",
     },
     {
         name: "Malta",
         code: "MLT",
         slug: "malta",
-        iso3166: "MT"
+        iso3166: "MT",
     },
     {
         name: "Myanmar",
         code: "MMR",
         slug: "myanmar",
-        iso3166: "MM"
+        iso3166: "MM",
     },
     {
         name: "Montenegro",
         code: "MNE",
         slug: "montenegro",
-        iso3166: "ME"
+        iso3166: "ME",
     },
     {
         name: "Mongolia",
         code: "MNG",
         slug: "mongolia",
-        iso3166: "MN"
+        iso3166: "MN",
     },
     {
         name: "Northern Mariana Islands",
         code: "MNP",
         slug: "northern-mariana-islands",
-        iso3166: "MP"
+        iso3166: "MP",
     },
     {
         name: "Mozambique",
         code: "MOZ",
         slug: "mozambique",
-        iso3166: "MZ"
+        iso3166: "MZ",
     },
     {
         name: "Mauritania",
         code: "MRT",
         slug: "mauritania",
-        iso3166: "MR"
+        iso3166: "MR",
     },
     {
         name: "Montserrat",
         code: "MSR",
         slug: "montserrat",
         filter: true,
-        iso3166: "MS"
+        iso3166: "MS",
     },
     {
         name: "Martinique",
         code: "MTQ",
         slug: "martinique",
-        iso3166: "MQ"
+        iso3166: "MQ",
     },
     {
         name: "Mauritius",
         code: "MUS",
         slug: "mauritius",
-        iso3166: "MU"
+        iso3166: "MU",
     },
     {
         name: "Malawi",
         code: "MWI",
         slug: "malawi",
-        iso3166: "MW"
+        iso3166: "MW",
     },
     {
         name: "Malaysia",
         code: "MYS",
         slug: "malaysia",
-        iso3166: "MY"
+        iso3166: "MY",
     },
     {
         name: "Mayotte",
         code: "MYT",
         slug: "mayotte",
-        iso3166: "YT"
+        iso3166: "YT",
     },
     {
         name: "Namibia",
         code: "NAM",
         slug: "namibia",
-        iso3166: "NA"
+        iso3166: "NA",
     },
     {
         name: "New Caledonia",
         code: "NCL",
         slug: "new-caledonia",
-        iso3166: "NC"
+        iso3166: "NC",
     },
     {
         name: "Niger",
         code: "NER",
         slug: "niger",
-        iso3166: "NE"
+        iso3166: "NE",
     },
     {
         name: "Norfolk Island",
         code: "NFK",
         slug: "norfolk-island",
-        iso3166: "NF"
+        iso3166: "NF",
     },
     {
         name: "Nigeria",
         code: "NGA",
         slug: "nigeria",
-        iso3166: "NG"
+        iso3166: "NG",
     },
     {
         name: "Nicaragua",
         code: "NIC",
         slug: "nicaragua",
-        iso3166: "NI"
+        iso3166: "NI",
     },
     {
         name: "Niue",
         code: "NIU",
         slug: "niue",
-        iso3166: "NU"
+        iso3166: "NU",
     },
     {
         name: "Netherlands",
         code: "NLD",
         slug: "netherlands",
-        iso3166: "NL"
+        iso3166: "NL",
     },
     {
         name: "Norway",
         code: "NOR",
         slug: "norway",
-        iso3166: "NO"
+        iso3166: "NO",
     },
     {
         name: "Nepal",
         code: "NPL",
         slug: "nepal",
-        iso3166: "NP"
+        iso3166: "NP",
     },
     {
         name: "Nauru",
         code: "NRU",
         slug: "nauru",
-        iso3166: "NR"
+        iso3166: "NR",
     },
     {
         name: "New Zealand",
         code: "NZL",
         slug: "new-zealand",
-        iso3166: "NZ"
+        iso3166: "NZ",
     },
     {
         name: "Oman",
         code: "OMN",
         slug: "oman",
-        iso3166: "OM"
+        iso3166: "OM",
     },
     {
         name: "Pakistan",
         code: "PAK",
         slug: "pakistan",
-        iso3166: "PK"
+        iso3166: "PK",
     },
     {
         name: "Panama",
         code: "PAN",
         slug: "panama",
-        iso3166: "PA"
+        iso3166: "PA",
     },
     {
         name: "Pitcairn",
         code: "PCN",
         slug: "pitcairn",
-        iso3166: "PN"
+        iso3166: "PN",
     },
     {
         name: "Peru",
         code: "PER",
         slug: "peru",
-        iso3166: "PE"
+        iso3166: "PE",
     },
     {
         name: "Philippines",
         code: "PHL",
         slug: "philippines",
-        iso3166: "PH"
+        iso3166: "PH",
     },
     {
         name: "Palau",
         code: "PLW",
         slug: "palau",
-        iso3166: "PW"
+        iso3166: "PW",
     },
     {
         name: "Papua New Guinea",
         code: "PNG",
         slug: "papua-new-guinea",
-        iso3166: "PG"
+        iso3166: "PG",
     },
     {
         name: "Poland",
         code: "POL",
         slug: "poland",
-        iso3166: "PL"
+        iso3166: "PL",
     },
     {
         name: "Puerto Rico",
         code: "PRI",
         slug: "puerto-rico",
-        iso3166: "PR"
+        iso3166: "PR",
     },
     {
         name: "North Korea",
         code: "PRK",
-        slug: "north-korea"
+        slug: "north-korea",
     },
     {
         name: "Portugal",
         code: "PRT",
         slug: "portugal",
-        iso3166: "PT"
+        iso3166: "PT",
     },
     {
         name: "Paraguay",
         code: "PRY",
         slug: "paraguay",
-        iso3166: "PY"
+        iso3166: "PY",
     },
     {
         name: "Palestine",
         code: "PSE",
-        slug: "palestine"
+        slug: "palestine",
     },
     {
         name: "French Polynesia",
         code: "PYF",
         slug: "french-polynesia",
-        iso3166: "PF"
+        iso3166: "PF",
     },
     {
         name: "Qatar",
         code: "QAT",
         slug: "qatar",
-        iso3166: "QA"
+        iso3166: "QA",
     },
     {
         name: "Reunion",
         code: "REU",
         slug: "reunion",
-        iso3166: "RE"
+        iso3166: "RE",
     },
     {
         name: "Romania",
         code: "ROU",
         slug: "romania",
-        iso3166: "RO"
+        iso3166: "RO",
     },
     {
         name: "Russia",
         code: "RUS",
-        slug: "russia"
+        slug: "russia",
     },
     {
         name: "Rwanda",
         code: "RWA",
         slug: "rwanda",
-        iso3166: "RW"
+        iso3166: "RW",
     },
     {
         name: "Saudi Arabia",
         code: "SAU",
         slug: "saudi-arabia",
-        iso3166: "SA"
+        iso3166: "SA",
     },
     {
         name: "Sudan",
         code: "SDN",
         slug: "sudan",
-        iso3166: "SD"
+        iso3166: "SD",
     },
     {
         name: "Senegal",
         code: "SEN",
         slug: "senegal",
-        iso3166: "SN"
+        iso3166: "SN",
     },
     {
         name: "Singapore",
         code: "SGP",
         slug: "singapore",
-        iso3166: "SG"
+        iso3166: "SG",
     },
     {
         name: "South Georgia and the South Sandwich Islands",
         code: "SGS",
         slug: "south-georgia-and-the-south-sandwich-islands",
         filter: true,
-        iso3166: "GS"
+        iso3166: "GS",
     },
     {
         name: "Saint Helena",
         code: "SHN",
         slug: "saint-helena",
         filter: true,
-        iso3166: "SH"
+        iso3166: "SH",
     },
     {
         name: "Svalbard and Jan Mayen",
         code: "SJM",
         slug: "svalbard-and-jan-mayen",
         filter: true,
-        iso3166: "SJ"
+        iso3166: "SJ",
     },
     {
         name: "Solomon Islands",
         code: "SLB",
         slug: "solomon-islands",
-        iso3166: "SB"
+        iso3166: "SB",
     },
     {
         name: "Sierra Leone",
         code: "SLE",
         slug: "sierra-leone",
-        iso3166: "SL"
+        iso3166: "SL",
     },
     {
         name: "El Salvador",
         code: "SLV",
         slug: "el-salvador",
-        iso3166: "SV"
+        iso3166: "SV",
     },
     {
         name: "San Marino",
         code: "SMR",
         slug: "san-marino",
-        iso3166: "SM"
+        iso3166: "SM",
     },
     {
         name: "Somalia",
         code: "SOM",
         slug: "somalia",
-        iso3166: "SO"
+        iso3166: "SO",
     },
     {
         name: "Saint Pierre and Miquelon",
         code: "SPM",
         slug: "saint-pierre-and-miquelon",
-        iso3166: "PM"
+        iso3166: "PM",
     },
     {
         name: "Serbia",
         code: "SRB",
         slug: "serbia",
-        iso3166: "RS"
+        iso3166: "RS",
     },
     {
         name: "South Sudan",
         code: "SSD",
         slug: "south-sudan",
-        iso3166: "SS"
+        iso3166: "SS",
     },
     {
         name: "Sao Tome and Principe",
         code: "STP",
         slug: "sao-tome-and-principe",
-        iso3166: "ST"
+        iso3166: "ST",
     },
     {
         name: "Suriname",
         code: "SUR",
         slug: "suriname",
-        iso3166: "SR"
+        iso3166: "SR",
     },
     {
         name: "Slovakia",
         code: "SVK",
         slug: "slovakia",
-        iso3166: "SK"
+        iso3166: "SK",
     },
     {
         name: "Slovenia",
         code: "SVN",
         slug: "slovenia",
-        iso3166: "SI"
+        iso3166: "SI",
     },
     {
         name: "Sweden",
         code: "SWE",
         slug: "sweden",
-        iso3166: "SE"
+        iso3166: "SE",
     },
     {
         name: "Swaziland",
         code: "SWZ",
         slug: "swaziland",
-        iso3166: "SZ"
+        iso3166: "SZ",
     },
     {
         name: "Seychelles",
         code: "SYC",
         slug: "seychelles",
-        iso3166: "SC"
+        iso3166: "SC",
     },
     {
         name: "Syria",
         code: "SYR",
-        slug: "syria"
+        slug: "syria",
     },
     {
         name: "Turks and Caicos Islands",
         code: "TCA",
         slug: "turks-and-caicos-islands",
-        iso3166: "TC"
+        iso3166: "TC",
     },
     {
         name: "Chad",
         code: "TCD",
         slug: "chad",
-        iso3166: "TD"
+        iso3166: "TD",
     },
     {
         name: "Togo",
         code: "TGO",
         slug: "togo",
-        iso3166: "TG"
+        iso3166: "TG",
     },
     {
         name: "Thailand",
         code: "THA",
         slug: "thailand",
-        iso3166: "TH"
+        iso3166: "TH",
     },
     {
         name: "Tajikistan",
         code: "TJK",
         slug: "tajikistan",
-        iso3166: "TJ"
+        iso3166: "TJ",
     },
     {
         name: "Tokelau",
         code: "TKL",
         slug: "tokelau",
-        iso3166: "TK"
+        iso3166: "TK",
     },
     {
         name: "Turkmenistan",
         code: "TKM",
         slug: "turkmenistan",
-        iso3166: "TM"
+        iso3166: "TM",
     },
     {
         name: "Timor",
         code: "TLS",
-        slug: "timor"
+        slug: "timor",
     },
     {
         name: "Tonga",
         code: "TON",
         slug: "tonga",
-        iso3166: "TO"
+        iso3166: "TO",
     },
     {
         name: "Trinidad and Tobago",
         code: "TTO",
         slug: "trinidad-and-tobago",
-        iso3166: "TT"
+        iso3166: "TT",
     },
     {
         name: "Tunisia",
         code: "TUN",
         slug: "tunisia",
-        iso3166: "TN"
+        iso3166: "TN",
     },
     {
         name: "Turkey",
         code: "TUR",
         slug: "turkey",
-        iso3166: "TR"
+        iso3166: "TR",
     },
     {
         name: "Tuvalu",
         code: "TUV",
         slug: "tuvalu",
-        iso3166: "TV"
+        iso3166: "TV",
     },
     {
         name: "Taiwan",
         code: "TWN",
         slug: "taiwan",
-        iso3166: "TW"
+        iso3166: "TW",
     },
     {
         name: "Tanzania",
         code: "TZA",
-        slug: "tanzania"
+        slug: "tanzania",
     },
     {
         name: "Uganda",
         code: "UGA",
         slug: "uganda",
-        iso3166: "UG"
+        iso3166: "UG",
     },
     {
         name: "Ukraine",
         code: "UKR",
         slug: "ukraine",
-        iso3166: "UA"
+        iso3166: "UA",
     },
     {
         name: "United States Minor Outlying Islands",
         code: "UMI",
         slug: "united-states-minor-outlying-islands",
         filter: true,
-        iso3166: "UM"
+        iso3166: "UM",
     },
     {
         name: "Uruguay",
         code: "URY",
         slug: "uruguay",
-        iso3166: "UY"
+        iso3166: "UY",
     },
     {
         name: "United States",
         code: "USA",
         slug: "united-states",
         variantNames: ["US", "USA"],
-        iso3166: "US"
+        iso3166: "US",
     },
     {
         name: "Uzbekistan",
         code: "UZB",
         slug: "uzbekistan",
-        iso3166: "UZ"
+        iso3166: "UZ",
     },
     {
         name: "Vatican",
         code: "VAT",
-        slug: "vatican"
+        slug: "vatican",
     },
     {
         name: "Saint Vincent and the Grenadines",
         code: "VCT",
         slug: "saint-vincent-and-the-grenadines",
-        iso3166: "VC"
+        iso3166: "VC",
     },
     {
         name: "Venezuela",
         code: "VEN",
         slug: "venezuela",
-        iso3166: "VE"
+        iso3166: "VE",
     },
     {
         name: "British Virgin Islands",
         code: "VGB",
-        slug: "british-virgin-islands"
+        slug: "british-virgin-islands",
     },
     {
         name: "United States Virgin Islands",
         code: "VIR",
-        slug: "united-states-virgin-islands"
+        slug: "united-states-virgin-islands",
     },
     {
         name: "Vietnam",
         code: "VNM",
         slug: "vietnam",
-        iso3166: "VN"
+        iso3166: "VN",
     },
     {
         name: "Vanuatu",
         code: "VUT",
         slug: "vanuatu",
-        iso3166: "VU"
+        iso3166: "VU",
     },
     {
         name: "Wallis and Futuna",
         code: "WLF",
         slug: "wallis-and-futuna",
         filter: true,
-        iso3166: "WF"
+        iso3166: "WF",
     },
     {
         name: "Samoa",
         code: "WSM",
         slug: "samoa",
-        iso3166: "WS"
+        iso3166: "WS",
     },
     {
         name: "Yemen",
         code: "YEM",
         slug: "yemen",
-        iso3166: "YE"
+        iso3166: "YE",
     },
     {
         name: "South Africa",
         code: "ZAF",
         slug: "south-africa",
-        iso3166: "ZA"
+        iso3166: "ZA",
     },
     {
         name: "Zambia",
         code: "ZMB",
         slug: "zambia",
-        iso3166: "ZM"
+        iso3166: "ZM",
     },
     {
         name: "Zimbabwe",
         code: "ZWE",
         slug: "zimbabwe",
-        iso3166: "ZW"
-    }
+        iso3166: "ZW",
+    },
 ]
 
 export const countries: Country[] = allCountriesSortedByCode.filter(
-    country => !country.filter
+    (country) => !country.filter
 )
 
 export const getCountry = (slug: string): Country | undefined => {
-    return countries.find(c => c.slug === slug)
+    return countries.find((c) => c.slug === slug)
 }
 
 export const getCountryDetectionRedirects = () =>
     countries
-        .filter(country => country.iso3166 && country.code)
+        .filter((country) => country.iso3166 && country.code)
         .map(
-            country =>
+            (country) =>
                 `/detect-country-redirect /detect-country.js?${
                     country.code
                 } 302! Country=${country.iso3166!.toLowerCase()}`

--- a/utils/csv.ts
+++ b/utils/csv.ts
@@ -27,7 +27,7 @@ export class CSVStreamParser {
         const parser = parse({
             relax_column_count: true,
             skip_empty_lines: true,
-            trim: true
+            trim: true,
         })
 
         parser.on("readable", () => {

--- a/utils/object.ts
+++ b/utils/object.ts
@@ -6,7 +6,7 @@ export function camelToSnake(s: string) {
 }
 
 export function snakeToCamel(s: string) {
-    return s.replace(/(\_\w)/g, m => m[1].toUpperCase())
+    return s.replace(/(\_\w)/g, (m) => m[1].toUpperCase())
 }
 
 export function camelCaseProperties<T>(obj: T): T {

--- a/utils/search.ts
+++ b/utils/search.ts
@@ -8,7 +8,7 @@ export function htmlToPlaintext(html: string): string {
         ignoreHref: true,
         wordwrap: false,
         uppercaseHeadings: false,
-        ignoreImage: true
+        ignoreImage: true,
     })
 }
 
@@ -23,12 +23,12 @@ export function chunkSentences(text: string, maxChunkLength: number): string[] {
     const sentences = flatten(
         text
             .split(sentenceRegex)
-            .map(s =>
+            .map((s) =>
                 s.length > maxChunkLength ? chunkWords(s, maxChunkLength) : s
             )
     )
-        .map(s => s.trim())
-        .filter(s => s)
+        .map((s) => s.trim())
+        .filter((s) => s)
         .reverse() as string[]
 
     const chunks = []
@@ -63,14 +63,14 @@ export function chunkParagraphs(
     const paragraphs = flatten(
         text
             .split("\n\n")
-            .map(p =>
+            .map((p) =>
                 p.length > maxChunkLength
                     ? chunkSentences(p, maxChunkLength)
                     : p
             )
     )
-        .map(p => p.trim())
-        .filter(p => p)
+        .map((p) => p.trim())
+        .filter((p) => p)
         .reverse() as string[]
 
     const chunks = []

--- a/utils/server/log.ts
+++ b/utils/server/log.ts
@@ -23,7 +23,7 @@ export namespace log {
         if (err.stderr) {
             blocks.push({
                 title: "stderr",
-                code: err.stderr
+                code: err.stderr,
             })
         }
 
@@ -39,14 +39,14 @@ export namespace log {
             //     { title: 'Remote Address', value: getRemoteAddress(req), short: true }
             //   ],
             text: blocks
-                .map(data => createCodeBlock(data.title, data.code))
+                .map((data) => createCodeBlock(data.title, data.code))
                 .join(""),
             mrkdwn_in: ["text"],
             footer: "sendErrorToSlack",
-            ts: Math.floor(Date.now() / 1000)
+            ts: Math.floor(Date.now() / 1000),
         }
 
-        slack.webhook({ attachments: [attachment] }, error => {
+        slack.webhook({ attachments: [attachment] }, (error) => {
             if (error) console.error(error)
         })
     }

--- a/utils/server/serverUtil.node.test.ts
+++ b/utils/server/serverUtil.node.test.ts
@@ -8,19 +8,19 @@ describe("serverUtil", () => {
     describe("exec()", () => {
         it("should resolve when there is a zero exit code", async () => {
             const result = await exec(`echo "it works"; exit 0`, {
-                silent: true
+                silent: true,
             })
             expect(result).toEqual({
                 code: 0,
                 stdout: "it works\n",
-                stderr: ""
+                stderr: "",
             })
         })
 
         it("should reject when there is a non-zero exit code", async () => {
             try {
                 await exec(`echo "begin"; echo "fail" 1>&2; exit 1`, {
-                    silent: true
+                    silent: true,
                 })
             } catch (err) {
                 expect(err).toBeInstanceOf(ExecError)

--- a/utils/server/serverUtil.tsx
+++ b/utils/server/serverUtil.tsx
@@ -83,7 +83,7 @@ export function csvEscape(value: any): string {
 }
 
 export function csvRow(arr: string[]): string {
-    return arr.map(x => csvEscape(x)).join(",") + "\n"
+    return arr.map((x) => csvEscape(x)).join(",") + "\n"
 }
 
 export function absoluteUrl(path: string): string {
@@ -103,12 +103,12 @@ export const splitOnLastWord = (s: string) => {
     const endIndex = (s.lastIndexOf(" ") as number) + 1
     return {
         start: endIndex === 0 ? "" : s.substring(0, endIndex),
-        end: s.substring(endIndex)
+        end: s.substring(endIndex),
     }
 }
 
 export async function execFormatted(cmd: string, args: string[]) {
-    const formatCmd = util.format(cmd, ...args.map(s => quote([s])))
+    const formatCmd = util.format(cmd, ...args.map((s) => quote([s])))
     console.log(formatCmd)
     await exec(formatCmd)
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = (env, argv) => {
         context: __dirname,
         entry: {
             admin: "./adminSite/client/admin.entry.ts",
-            owid: "./site/client/owid.entry.ts"
+            owid: "./site/client/owid.entry.ts",
         },
         optimization: {
             splitChunks: {
@@ -21,21 +21,21 @@ module.exports = (env, argv) => {
                     commons: {
                         name: "commons",
                         chunks: "all",
-                        minChunks: 2
-                    }
-                }
+                        minChunks: 2,
+                    },
+                },
             },
             minimize: isProduction,
-            minimizer: [new TerserJSPlugin(), new OptimizeCSSAssetsPlugin()]
+            minimizer: [new TerserJSPlugin(), new OptimizeCSSAssetsPlugin()],
         },
         output: {
             path: path.join(__dirname, "dist/webpack"),
-            filename: "js/[name].js"
+            filename: "js/[name].js",
             //filename: (isProduction ? "js/[name].bundle.[hash].js" : "js/[name].js")
         },
         resolve: {
             extensions: [".ts", ".tsx", ".js", ".css"],
-            modules: ["node_modules", __dirname]
+            modules: ["node_modules", __dirname],
         },
         module: {
             rules: [
@@ -45,8 +45,11 @@ module.exports = (env, argv) => {
                     exclude: /serverSettings/,
                     options: {
                         transpileOnly: true,
-                        configFile: path.join(__dirname, "tsconfig.client.json")
-                    }
+                        configFile: path.join(
+                            __dirname,
+                            "tsconfig.client.json"
+                        ),
+                    },
                 },
                 {
                     test: /\.s?css$/,
@@ -58,11 +61,11 @@ module.exports = (env, argv) => {
                             loader: "sass-loader",
                             options: {
                                 sassOptions: {
-                                    outputStyle: "expanded" // Needed so autoprefixer comments are included
-                                }
-                            }
-                        }
-                    ]
+                                    outputStyle: "expanded", // Needed so autoprefixer comments are included
+                                },
+                            },
+                        },
+                    ],
                 },
                 {
                     test: /\.(jpe?g|gif|png|eot|woff|ttf|svg|woff2)$/,
@@ -70,10 +73,10 @@ module.exports = (env, argv) => {
                     options: {
                         limit: 10000,
                         useRelativePaths: true,
-                        publicPath: "../"
-                    }
-                }
-            ]
+                        publicPath: "../",
+                    },
+                },
+            ],
         },
         plugins: [
             // This plugin extracts css files required in the entry points
@@ -89,7 +92,7 @@ module.exports = (env, argv) => {
 
             // This plugin loads settings from .env so we can import them
             // Note that this means the settings become part of the client-side JS at webpack build time, not at server run time
-            new Dotenv()
+            new Dotenv(),
         ],
         devServer: {
             host: "localhost",
@@ -101,8 +104,8 @@ module.exports = (env, argv) => {
                 "Access-Control-Allow-Methods":
                     "GET, POST, PUT, DELETE, PATCH, OPTIONS",
                 "Access-Control-Allow-Headers":
-                    "X-Requested-With, content-type, Authorization"
-            }
-        }
+                    "X-Requested-With, content-type, Authorization",
+            },
+        },
     }
 }


### PR DESCRIPTION
This PR changes our Prettier config to use the defaults for `trailingComma` and `allowParens`.
This is a huge diff, but I literally just changed `package.json` and ran `yarn prettify-all`.

The [Prettier 2.0 post](https://prettier.io/blog/2020/03/21/2.0.0.html) has some good justifications as to why these options make sense.
tl;dr:
* `trailingComma` makes sense for cleaner diffs and for the ability to move lines around or copy-paste them more easily
* `allowParens` makes sense because you need parens if you want to add a type or a second param to a lambda, and that's easier to do if they're already there