### PR TITLE
Dev: start tests for MapConfig and MapTransform. Cleanup Grapher constructor

### DIFF
--- a/adminSite/client/EditorBasicTab.tsx
+++ b/adminSite/client/EditorBasicTab.tsx
@@ -207,7 +207,7 @@ export class EditorBasicTab extends React.Component<{ editor: ChartEditor }> {
                         <FieldsRow>
                             <Toggle
                                 label="Explorable chart"
-                                value={grapher.isExplorable}
+                                value={grapher.isExplorableConstrained}
                                 onValue={(value) =>
                                     (grapher.isExplorable = value)
                                 }
@@ -220,13 +220,13 @@ export class EditorBasicTab extends React.Component<{ editor: ChartEditor }> {
                             label="Chart tab"
                             value={grapher.hasChartTab}
                             onValue={(value) => (grapher.hasChartTab = value)}
-                            disabled={grapher.isExplorable}
+                            disabled={grapher.isExplorableConstrained}
                         />
                         <Toggle
                             label="Map tab"
                             value={grapher.hasMapTab}
                             onValue={(value) => (grapher.hasMapTab = value)}
-                            disabled={grapher.isExplorable}
+                            disabled={grapher.isExplorableConstrained}
                         />
                     </FieldsRow>
                 </Section>

--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -1399,7 +1399,7 @@ export class CovidExplorer extends React.Component<{
             scatterPointLabelStrategy: "y",
             addCountryMode: "add-country",
             stackMode: "absolute",
-            useV2: true,
+            manuallyProvideData: true,
             colorScale: this.colorScales.continents,
             hideRelativeToggle: true,
             hasChartTab: true,

--- a/explorer/indicatorExplorer/ExplorableChartConfig.jsdom.test.ts
+++ b/explorer/indicatorExplorer/ExplorableChartConfig.jsdom.test.ts
@@ -1,31 +1,31 @@
 #! /usr/bin/env yarn jest
 
-import { createGrapher } from "grapher/test/utils"
+import { Grapher } from "grapher/core/Grapher"
 
 describe("ChartConfig", () => {
     it("allows single-dimensional explorer charts", () => {
-        const grapher = createGrapher({
+        const grapher = new Grapher({
             type: "LineChart",
             hasChartTab: false,
             hasMapTab: false,
             isExplorable: true,
             dimensions: [{ property: "y", variableId: 1, display: {} }],
         })
-        expect(grapher.isExplorable).toBe(true)
+        expect(grapher.isExplorableConstrained).toBe(true)
     })
 
     it("does not allow explorable scatter plots", () => {
-        const grapher = createGrapher({
+        const grapher = new Grapher({
             type: "ScatterPlot",
             hasChartTab: true,
             isExplorable: true,
             dimensions: [{ property: "y", variableId: 1, display: {} }],
         })
-        expect(grapher.isExplorable).toBe(false)
+        expect(grapher.isExplorableConstrained).toBe(false)
     })
 
     it("does not allow multi-dimensional charts", () => {
-        const grapher = createGrapher({
+        const grapher = new Grapher({
             type: "LineChart",
             hasChartTab: true,
             isExplorable: true,
@@ -34,6 +34,6 @@ describe("ChartConfig", () => {
                 { property: "y", variableId: 2, display: {} },
             ],
         })
-        expect(grapher.isExplorable).toBe(false)
+        expect(grapher.isExplorableConstrained).toBe(false)
     })
 })

--- a/grapher/core/GrapherConfig.ts
+++ b/grapher/core/GrapherConfig.ts
@@ -65,7 +65,7 @@ export interface GrapherConfigInterface {
     hideTitleAnnotation?: true
     externalDataUrl?: string
     owidDataset?: OwidVariablesAndEntityKey
-    useV2?: boolean
+    manuallyProvideData?: boolean
     selectedData?: EntitySelection[]
     minTime?: TimeBound
     maxTime?: TimeBound
@@ -172,7 +172,7 @@ export class PersistableGrapher implements GrapherConfigInterface, Persistable {
 
     externalDataUrl?: string = undefined // This is temporarily used for testing legacy prod charts locally. Will be removed
     owidDataset?: OwidVariablesAndEntityKey = undefined // This is temporarily used for testing. Will be removed
-    useV2?: boolean = false // This will be removed.
+    manuallyProvideData?: boolean = false // This will be removed.
 
     // Should return the default initialized object. This is what `toObject` will compare against to generate the persistable state.
     defaultObject() {
@@ -185,7 +185,7 @@ export class PersistableGrapher implements GrapherConfigInterface, Persistable {
         // Never save the followingto the DB.
         delete obj.externalDataUrl
         delete obj.owidDataset
-        delete obj.useV2
+        delete obj.manuallyProvideData
 
         // Remove the overlay tab state (e.g. download or sources) in order to avoid saving charts
         // in the Grapher Admin with an overlay tab open

--- a/grapher/core/GrapherUrl.jsdom.test.ts
+++ b/grapher/core/GrapherUrl.jsdom.test.ts
@@ -2,7 +2,7 @@
 
 import { GrapherConfigInterface } from "grapher/core/GrapherConfig"
 import { TimeBoundValue, TimeBound, TimeBounds } from "grapher/utils/TimeBounds"
-import { createGrapher, setupGrapher } from "grapher/test/utils"
+import { setupGrapher } from "grapher/test/utils"
 import { GrapherUrl, GrapherQueryParams } from "./GrapherUrl"
 import { Grapher } from "grapher/core/Grapher"
 import { ScaleType } from "./GrapherConstants"
@@ -11,13 +11,13 @@ function fromQueryParams(
     params: GrapherQueryParams,
     props?: Partial<GrapherConfigInterface>
 ) {
-    const grapher = createGrapher(props)
+    const grapher = new Grapher(props)
     grapher.url.populateFromQueryParams(params)
     return grapher
 }
 
 function toQueryParams(props?: Partial<GrapherConfigInterface>) {
-    const grapher = createGrapher({
+    const grapher = new Grapher({
         minTime: -5000,
         maxTime: 5000,
         map: { targetYear: 5000 },
@@ -168,7 +168,7 @@ describe(GrapherUrl, () => {
             })
 
             it("doesn't include URL param if it's identical to original config", () => {
-                const chart = createGrapher({
+                const chart = new Grapher({
                     minTime: 0,
                     maxTime: 75,
                 })
@@ -176,7 +176,7 @@ describe(GrapherUrl, () => {
             })
 
             it("doesn't include URL param if unbounded is encoded as `undefined`", () => {
-                const chart = createGrapher({
+                const chart = new Grapher({
                     minTime: undefined,
                     maxTime: 75,
                 })

--- a/grapher/core/GrapherUrl.ts
+++ b/grapher/core/GrapherUrl.ts
@@ -301,7 +301,11 @@ export class GrapherUrl implements ObservableUrl {
 
         // Selected countries -- we can't actually look these up until we have the data
         const country = params.country
-        if (grapher.useV2 || !country || grapher.addCountryMode === "disabled")
+        if (
+            grapher.manuallyProvideData ||
+            !country ||
+            grapher.addCountryMode === "disabled"
+        )
             return
         when(
             () => grapher.isReady,

--- a/grapher/core/GrapherView.stories.tsx
+++ b/grapher/core/GrapherView.stories.tsx
@@ -81,6 +81,7 @@ class GrapherViewStory extends React.Component {
             {
                 hasMapTab: true,
                 dimensions: [{ property: "y", variableId: 66287, display: {} }],
+                manuallyProvideData: true,
             } as GrapherConfigInterface,
             {}
         )

--- a/grapher/mapCharts/MapConfig.test.ts
+++ b/grapher/mapCharts/MapConfig.test.ts
@@ -1,0 +1,19 @@
+#! /usr/bin/env yarn jest
+
+import { PersistableMapConfig } from "./MapConfig"
+
+describe(PersistableMapConfig, () => {
+    it("can serialize for saving", () => {
+        expect(Object.keys(new PersistableMapConfig().toObject()).length).toBe(
+            0
+        )
+
+        const map = new PersistableMapConfig()
+        map.hideTimeline = true
+        map.projection = "Africa"
+        expect(map.toObject()).toEqual({
+            hideTimeline: true,
+            projection: "Africa",
+        })
+    })
+})

--- a/grapher/mapCharts/MapConfig.ts
+++ b/grapher/mapCharts/MapConfig.ts
@@ -8,6 +8,8 @@ import { owidVariableId } from "owidTable/OwidTable"
 import {
     Persistable,
     updatePersistables,
+    objectWithPersistablesToObject,
+    deleteRuntimeAndUnchangedProps,
 } from "grapher/persistable/Persistable"
 import { extend } from "grapher/utils/Util"
 import { maxTimeFromJSON, maxTimeToJSON } from "grapher/utils/TimeBounds"
@@ -36,7 +38,9 @@ export class PersistableMapConfig extends MapConfig implements Persistable {
     }
 
     toObject() {
-        const obj = toJS(this)
+        const obj = objectWithPersistablesToObject(this)
+        deleteRuntimeAndUnchangedProps<MapConfigInterface>(obj, new MapConfig())
+
         if (obj.targetYear)
             obj.targetYear = maxTimeToJSON(this.targetYear) as any
 

--- a/grapher/mapCharts/MapTransform.jsdom.test.tsx
+++ b/grapher/mapCharts/MapTransform.jsdom.test.tsx
@@ -1,0 +1,11 @@
+#! /usr/bin/env yarn jest
+
+import { MapTransform } from "./MapTransform"
+import { Grapher } from "grapher/core/Grapher"
+
+describe(MapTransform, () => {
+    test("can create a transform", () => {
+        const transform = new MapTransform(new Grapher())
+        expect(transform.variableId).toBe(undefined)
+    })
+})

--- a/grapher/mapCharts/MapTransform.ts
+++ b/grapher/mapCharts/MapTransform.ts
@@ -36,18 +36,16 @@ interface MapDataValue {
 }
 
 export class MapTransform extends ChartTransform {
-    constructor(grapher: Grapher) {
-        super(grapher)
-
-        if (!grapher.isNode) this.ensureValidConfig()
-    }
-
     get props() {
         return this.grapher.map
     }
 
     @computed get variableId() {
-        return this.props.variableId
+        const { grapher } = this
+        const variableId = this.props.variableId
+        const hasVar =
+            variableId && grapher.table.columnsByOwidVarId.get(variableId)
+        return hasVar ? variableId : grapher.primaryVariableId
     }
 
     @computed get tolerance() {
@@ -78,21 +76,6 @@ export class MapTransform extends ChartTransform {
 
     @computed get isValidConfig() {
         return !!this.grapher.primaryVariableId
-    }
-
-    ensureValidConfig() {
-        const { grapher } = this
-
-        // Validate the map variable id selection to something on the chart
-        autorun(() => {
-            const hasVariable =
-                this.variableId &&
-                grapher.table.columnsByOwidVarId.get(this.variableId)
-            if (!hasVariable && grapher.primaryVariableId)
-                runInAction(
-                    () => (this.props.variableId = grapher.primaryVariableId)
-                )
-        })
     }
 
     @computed get hasTimeline(): boolean {

--- a/grapher/test/samples.ts
+++ b/grapher/test/samples.ts
@@ -10,7 +10,7 @@ export function basicGdpGrapher() {
             { index: 0, entityId: 1 },
         ],
         data: { availableEntities: ["Germany", "France"] },
-        useV2: true,
+        manuallyProvideData: true,
         yAxis: {},
         dimensions: [{ variableId: 99, property: "y" }],
     } as Partial<GrapherConfigInterface>

--- a/grapher/test/utils.ts
+++ b/grapher/test/utils.ts
@@ -6,14 +6,6 @@ import { Grapher } from "grapher/core/Grapher"
 import { readVariableSet, readVariable, readGrapher } from "./fixtures"
 import { first } from "lodash"
 
-export function createGrapher(props?: Partial<GrapherConfigInterface>) {
-    const grapher = new Grapher(props)
-    // ensureValidConfig() is only run on non-node environments, so we have
-    // to manually trigger it.
-    grapher.ensureValidConfig()
-    return grapher
-}
-
 export function setupGrapher(
     id: number,
     varIds: number[],

--- a/site/server/bakeChartsToImages.tsx
+++ b/site/server/bakeChartsToImages.tsx
@@ -51,7 +51,10 @@ export async function bakeChartToImage(
 ) {
     // the type definition for url.query is wrong (bc we have query string parsing disabled),
     // so we have to explicitly cast it
-    const chart = new Grapher(jsonConfig, { queryStr })
+    const chart = new Grapher(
+        { ...jsonConfig, manuallyProvideData: true },
+        { queryStr }
+    )
     chart.isExporting = true
     const { width, height } = chart.idealBounds
     const outPath = `${outDir}/${slug}${queryStr ? "-" + md5(queryStr) : ""}_v${

--- a/site/server/svgPngExport.tsx
+++ b/site/server/svgPngExport.tsx
@@ -30,7 +30,7 @@ export async function chartToSVG(
     jsonConfig: GrapherConfigInterface,
     vardata: any
 ): Promise<string> {
-    const chart = new Grapher(jsonConfig)
+    const chart = new Grapher({ ...jsonConfig, manuallyProvideData: true })
     chart.isExporting = true
     chart.receiveData(vardata)
     return chart.staticSVG
@@ -42,7 +42,7 @@ export async function bakeImageExports(
     vardata: any,
     optimizeSvgs = false
 ) {
-    const chart = new Grapher(jsonConfig)
+    const chart = new Grapher({ ...jsonConfig, manuallyProvideData: true })
     chart.isExporting = true
     chart.receiveData(vardata)
     const outPath = path.join(outDir, chart.slug as string)


### PR DESCRIPTION
Adds a few tests. Removes some code from the Grapher constructor.

Ditches the ugly 'useV2' for 'manuallyProvideData', which is a tiny bit more helpful.