### PR TITLE
Lodash cleanup

### DIFF
--- a/adminSite/client/ChartEditorPage.tsx
+++ b/adminSite/client/ChartEditorPage.tsx
@@ -13,7 +13,7 @@ import { Prompt, Redirect } from "react-router-dom"
 
 import { GrapherView } from "grapher/core/GrapherView"
 import { Bounds } from "grapher/utils/Bounds"
-import { includes, capitalize } from "grapher/utils/Util"
+import { capitalize } from "grapher/utils/Util"
 import { Grapher } from "grapher/core/Grapher"
 
 import {
@@ -72,7 +72,7 @@ class TabBinder extends React.Component<{ editor: ChartEditor }> {
             const tab = match[1]
             if (
                 this.props.editor.grapher &&
-                includes(this.props.editor.availableTabs, tab)
+                this.props.editor.availableTabs.includes(tab)
             )
                 this.props.editor.tab = tab
         }

--- a/adminSite/client/CountryStandardizerPage.tsx
+++ b/adminSite/client/CountryStandardizerPage.tsx
@@ -20,7 +20,7 @@ import {
     CountryNameFormatDefs,
     CountryDefByKey,
 } from "adminSite/client/CountryNameFormat"
-import { uniq, toString, csvEscape, values, sortBy } from "grapher/utils/Util"
+import { uniq, toString, csvEscape, sortBy } from "grapher/utils/Util"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext"
 import { faDownload } from "@fortawesome/free-solid-svg-icons/faDownload"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
@@ -41,9 +41,9 @@ class CSV {
     }
 
     @computed get allCountries(): string[] {
-        const standardNames = values(this.mapCountriesInputToOutput).filter(
-            (value: string | undefined) => value !== undefined
-        ) as string[]
+        const standardNames = Object.values(
+            this.mapCountriesInputToOutput
+        ).filter((value: string | undefined) => value !== undefined) as string[]
         return uniq(sortBy(standardNames)) as string[]
     }
 

--- a/adminSite/client/EditorBasicTab.tsx
+++ b/adminSite/client/EditorBasicTab.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { observable, action, reaction, IReactionDisposer } from "mobx"
 import { observer } from "mobx-react"
 
-import { includes, sample, sampleSize } from "grapher/utils/Util"
+import { sample, sampleSize } from "grapher/utils/Util"
 import { ChartTypeDefs, ChartTypeName } from "grapher/core/GrapherConstants"
 import {
     ChartDimension,
@@ -56,8 +56,7 @@ class DimensionSlotView extends React.Component<{
                 if (grapher.isScatter || grapher.isSlopeChart) {
                     grapher.selectedKeys = []
                 } else if (grapher.primaryDimensions.length > 1) {
-                    const entityName = includes(
-                        grapher.availableEntityNames,
+                    const entityName = grapher.availableEntityNames.includes(
                         "World"
                     )
                         ? "World"

--- a/adminSite/client/EditorDataTab.tsx
+++ b/adminSite/client/EditorDataTab.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { clone, map } from "grapher/utils/Util"
+import { clone } from "grapher/utils/Util"
 import { computed, action, observable } from "mobx"
 import { observer } from "mobx-react"
 import { Grapher } from "grapher/core/Grapher"
@@ -113,7 +113,7 @@ class KeysSection extends React.Component<{ grapher: Grapher }> {
                     optionLabels={["Select data"].concat(keyLabels)}
                 />
                 <EditableList>
-                    {map(selectedKeys, (key) => (
+                    {selectedKeys.map((key) => (
                         <EntityDimensionKeyItem
                             key={key}
                             grapher={grapher}

--- a/adminSite/client/EditorScatterTab.tsx
+++ b/adminSite/client/EditorScatterTab.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { extend, debounce } from "grapher/utils/Util"
+import { debounce } from "grapher/utils/Util"
 import { observable, computed, action, toJS } from "mobx"
 import { observer } from "mobx-react"
 import { Grapher } from "grapher/core/Grapher"
@@ -26,7 +26,10 @@ export class EditorScatterTab extends React.Component<{ grapher: Grapher }> {
 
     constructor(props: { grapher: Grapher }) {
         super(props)
-        extend(this.highlightToggle, props.grapher.highlightToggle)
+        this.highlightToggle = {
+            ...this.highlightToggle,
+            ...props.grapher.highlightToggle,
+        }
     }
 
     @action.bound onToggleHideTimeline(value: boolean) {

--- a/adminSite/client/Forms.tsx
+++ b/adminSite/client/Forms.tsx
@@ -10,7 +10,7 @@ import { bind } from "decko"
 import { observable, action } from "mobx"
 import { observer } from "mobx-react"
 
-import { extend, pick, capitalize } from "grapher/utils/Util"
+import { pick, capitalize } from "grapher/utils/Util"
 import { Colorpicker } from "./Colorpicker"
 import { faCog } from "@fortawesome/free-solid-svg-icons/faCog"
 import { faLink } from "@fortawesome/free-solid-svg-icons/faLink"
@@ -184,7 +184,8 @@ export class NumberField extends React.Component<
     render() {
         const { props, state } = this
 
-        const textFieldProps = extend({}, props, {
+        const textFieldProps = {
+            ...props,
             value: state.inputValue ?? props.value?.toString(),
             onValue: (value: string) => {
                 const allowInputRegex = new RegExp(
@@ -202,7 +203,7 @@ export class NumberField extends React.Component<
                 this.setState({
                     inputValue: undefined,
                 }),
-        })
+        }
 
         return <TextField {...textFieldProps} />
     }
@@ -370,7 +371,8 @@ export class NumericSelectField extends React.Component<
     NumericSelectFieldProps
 > {
     render() {
-        const props = extend({}, this.props, {
+        const props = {
+            ...this.props,
             value:
                 this.props.value !== undefined
                     ? this.props.value.toString()
@@ -380,7 +382,7 @@ export class NumericSelectField extends React.Component<
                 const asNumber = parseFloat(value as string)
                 this.props.onValue(asNumber)
             },
-        })
+        }
         return <SelectField {...props} />
     }
 }
@@ -705,14 +707,15 @@ class AutoFloatField extends React.Component<AutoFloatFieldProps> {
     render() {
         const { props } = this
 
-        const textFieldProps = extend({}, props, {
+        const textFieldProps = {
+            ...props,
             value: props.isAuto ? undefined : props.value.toString(),
             onValue: (value: string) => {
                 const asNumber = parseFloat(value)
                 props.onValue(isNaN(asNumber) ? undefined : asNumber)
             },
             placeholder: props.isAuto ? props.value.toString() : undefined,
-        })
+        }
 
         return <AutoTextField {...textFieldProps} />
     }
@@ -729,14 +732,15 @@ class FloatField extends React.Component<FloatFieldProps> {
     render() {
         const { props } = this
 
-        const textFieldProps = extend({}, props, {
+        const textFieldProps = {
+            ...props,
             value:
                 props.value === undefined ? undefined : props.value.toString(),
             onValue: (value: string) => {
                 const asNumber = parseFloat(value)
                 props.onValue(isNaN(asNumber) ? undefined : asNumber)
             },
-        })
+        }
 
         return <TextField {...textFieldProps} />
     }

--- a/adminSite/client/ImportPage.tsx
+++ b/adminSite/client/ImportPage.tsx
@@ -1,7 +1,7 @@
 // WIP
 
 import * as React from "react"
-import { keys, isEmpty, difference, clone, uniq } from "grapher/utils/Util"
+import { isEmpty, difference, clone, uniq } from "grapher/utils/Util"
 import {
     observable,
     computed,
@@ -330,7 +330,7 @@ class CSV {
             uniqCheck[key] += 1
         }
 
-        keys(uniqCheck).forEach((key) => {
+        Object.keys(uniqCheck).forEach((key) => {
             const count = uniqCheck[key]
             if (count > 1) {
                 validation.results.push({
@@ -538,7 +538,7 @@ class Importer extends React.Component<ImportPageData> {
                     (v) => v.name === variable.name
                 )[0]
                 if (match) {
-                    keys(match).forEach((key) => {
+                    Object.keys(match).forEach((key) => {
                         if (key === "id")
                             variable.overwriteId = (match as any)[key]
                         else (variable as any)[key] = (match as any)[key]

--- a/adminSite/client/VariableSelector.tsx
+++ b/adminSite/client/VariableSelector.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as lodash from "lodash"
-import { groupBy, each, isString, sortBy, defaultTo } from "grapher/utils/Util"
+import { groupBy, isString, sortBy, defaultTo } from "grapher/utils/Util"
 import {
     computed,
     action,
@@ -115,7 +115,7 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
         const { resultsByDataset } = this
 
         const rows: Array<string | Variable[]> = []
-        each(resultsByDataset, (variables, datasetName) => {
+        Object.entries(resultsByDataset).forEach(([datasetName, variables]) => {
             rows.push(datasetName)
 
             for (let i = 0; i < variables.length; i += 2) {

--- a/explorer/covidExplorer/CovidExplorerTable.ts
+++ b/explorer/covidExplorer/CovidExplorerTable.ts
@@ -4,7 +4,6 @@ import {
     groupBy,
     parseFloatOrUndefined,
     difference,
-    entries,
     minBy,
     sortBy,
     cloneDeep,
@@ -759,10 +758,9 @@ export function getLeastUsedColor(
     }
     // If all colors are used, we want to count the times each color is used, and use the most
     // unused one.
-    const colorCounts = entries(groupBy(usedColors)).map(([color, arr]) => [
-        color,
-        arr.length,
-    ])
+    const colorCounts = Object.entries(
+        groupBy(usedColors)
+    ).map(([color, arr]) => [color, arr.length])
     const mostUnusedColor = minBy(colorCounts, ([, count]) => count) as [
         string,
         number

--- a/explorer/indicatorExplorer/ExploreUrl.ts
+++ b/explorer/indicatorExplorer/ExploreUrl.ts
@@ -4,7 +4,7 @@ import { ObservableUrl } from "grapher/utils/UrlBinder"
 import { ExploreModel, ExplorerChartType } from "./ExploreModel"
 import { GrapherUrl, GrapherQueryParams } from "grapher/core/GrapherUrl"
 import { QueryParams, strToQueryParams } from "utils/client/url"
-import { omit, extend } from "grapher/utils/Util"
+import { omit } from "grapher/utils/Util"
 
 type ExploreQueryParams = Omit<GrapherQueryParams, "tab"> & {
     type?: string
@@ -21,10 +21,9 @@ export class ExploreUrl implements ObservableUrl {
     }
 
     @computed get params(): QueryParams {
-        const params: ExploreQueryParams = {}
         const { model } = this
 
-        extend(params, omit(this.chartUrl.params, "tab"))
+        const params: ExploreQueryParams = omit(this.chartUrl.params, "tab")
 
         params.type =
             model.chartType === ExploreModel.defaultChartType

--- a/explorer/indicatorExplorer/Store.ts
+++ b/explorer/indicatorExplorer/Store.ts
@@ -1,6 +1,6 @@
 import { Indicator } from "./Indicator"
 import { observable, runInAction } from "mobx"
-import { fetchJSON, difference, values } from "grapher/utils/Util"
+import { fetchJSON, difference } from "grapher/utils/Util"
 import { BAKED_BASE_URL } from "settings"
 
 export class StoreEntry<EntityType> {
@@ -92,7 +92,7 @@ export class IndicatorStore {
     async search(props: { query: string }): Promise<StoreEntry<Indicator>[]> {
         await this.fetchAllIdempotent()
         const { query } = props
-        const indicatorEntries = values(this.indicatorsById)
+        const indicatorEntries = Object.values(this.indicatorsById)
         if (!query) {
             // If there is no search query, return full list
             return indicatorEntries

--- a/grapher/areaCharts/StackedAreaTransform.ts
+++ b/grapher/areaCharts/StackedAreaTransform.ts
@@ -4,7 +4,6 @@ import {
     sortBy,
     cloneDeep,
     sum,
-    find,
     identity,
     flatten,
     sortNumeric,
@@ -264,7 +263,7 @@ export class StackedAreaTransform extends ChartTransform {
     }
 
     @computed get yDimensionFirst() {
-        return find(this.grapher.filledDimensions, (d) => d.property === "y")
+        return this.grapher.filledDimensions.find((d) => d.property === "y")
     }
 
     formatYTick(v: number) {

--- a/grapher/areaCharts/StackedAreaTransform.ts
+++ b/grapher/areaCharts/StackedAreaTransform.ts
@@ -1,7 +1,6 @@
 import { computed } from "mobx"
 import { scaleOrdinal } from "d3-scale"
 import {
-    some,
     sortBy,
     cloneDeep,
     sum,
@@ -24,7 +23,7 @@ import { Time } from "grapher/utils/TimeBounds"
 export class StackedAreaTransform extends ChartTransform {
     @computed get failMessage(): string | undefined {
         const { filledDimensions } = this.grapher
-        if (!some(filledDimensions, (d) => d.property === "y"))
+        if (!filledDimensions.some((d) => d.property === "y"))
             return "Missing Y axis variable"
         else if (
             this.groupedData.length === 0 ||
@@ -229,8 +228,7 @@ export class StackedAreaTransform extends ChartTransform {
         const { groupedData, startYear, endYear } = this
 
         if (
-            some(
-                groupedData,
+            groupedData.some(
                 (series) =>
                     series.values.length !== groupedData[0].values.length
             )

--- a/grapher/barCharts/DiscreteBarTransform.ts
+++ b/grapher/barCharts/DiscreteBarTransform.ts
@@ -4,7 +4,6 @@ import {
     isEmpty,
     sortBy,
     orderBy,
-    values,
     flatten,
     uniq,
     sortNumeric,
@@ -132,7 +131,7 @@ export class DiscreteBarTransform extends ChartTransform {
             }
         } else {
             const data = sortBy(
-                values(dataByEntityDimensionKey),
+                Object.values(dataByEntityDimensionKey),
                 (d) => d.value
             )
             const colorScheme = grapher.baseColorScheme
@@ -159,7 +158,7 @@ export class DiscreteBarTransform extends ChartTransform {
             this._filterDataForLogScaleInPlace(dataByEntityDimensionKey)
 
         return orderBy(
-            values(dataByEntityDimensionKey),
+            Object.values(dataByEntityDimensionKey),
             ["value", "key"],
             ["desc", "asc"]
         )

--- a/grapher/barCharts/DiscreteBarTransform.ts
+++ b/grapher/barCharts/DiscreteBarTransform.ts
@@ -1,6 +1,5 @@
 import { computed } from "mobx"
 import {
-    some,
     isEmpty,
     sortBy,
     orderBy,
@@ -25,7 +24,7 @@ import { Time } from "grapher/utils/TimeBounds"
 export class DiscreteBarTransform extends ChartTransform {
     @computed get failMessage(): string | undefined {
         const { filledDimensions } = this.grapher
-        if (!some(filledDimensions, (d) => d.property === "y"))
+        if (!filledDimensions.some((d) => d.property === "y"))
             return "Missing variable"
         else if (isEmpty(this.currentData)) return "No matching data"
         else return undefined

--- a/grapher/barCharts/StackedBarChart.tsx
+++ b/grapher/barCharts/StackedBarChart.tsx
@@ -4,7 +4,7 @@ import { observer } from "mobx-react"
 import { select } from "d3-selection"
 import { easeLinear } from "d3-ease"
 
-import { includes, guid, uniq, makeSafeForCSS } from "grapher/utils/Util"
+import { guid, uniq, makeSafeForCSS } from "grapher/utils/Util"
 import { Grapher } from "grapher/core/Grapher"
 import { Bounds } from "grapher/utils/Bounds"
 import {
@@ -471,8 +471,7 @@ export class StackedBarChart extends React.Component<{
 
                 <g clipPath={`url(#boundsClip-${renderUid})`}>
                     {stackedData.map((series) => {
-                        const isLegendHovered: boolean = includes(
-                            this.hoverKeys,
+                        const isLegendHovered: boolean = this.hoverKeys.includes(
                             series.entityDimensionKey
                         )
                         const opacity =

--- a/grapher/barCharts/StackedBarTransform.ts
+++ b/grapher/barCharts/StackedBarTransform.ts
@@ -2,7 +2,6 @@ import { computed } from "mobx"
 import {
     includes,
     identity,
-    some,
     cloneDeep,
     find,
     sortBy,
@@ -23,7 +22,7 @@ import { ColorScale } from "grapher/color/ColorScale"
 export class StackedBarTransform extends ChartTransform {
     @computed get failMessage(): string | undefined {
         const { filledDimensions } = this.grapher
-        if (!some(filledDimensions, (d) => d.property === "y"))
+        if (!filledDimensions.some((d) => d.property === "y"))
             return "Missing variable"
         else if (
             this.groupedData.length === 0 ||

--- a/grapher/barCharts/StackedBarTransform.ts
+++ b/grapher/barCharts/StackedBarTransform.ts
@@ -2,7 +2,6 @@ import { computed } from "mobx"
 import {
     identity,
     cloneDeep,
-    find,
     sortBy,
     max,
     defaultTo,
@@ -32,13 +31,10 @@ export class StackedBarTransform extends ChartTransform {
     }
 
     @computed get primaryDimension(): ChartDimension | undefined {
-        return find(this.grapher.filledDimensions, (d) => d.property === "y")
+        return this.grapher.filledDimensions.find((d) => d.property === "y")
     }
     @computed get colorDimension(): ChartDimension | undefined {
-        return find(
-            this.grapher.filledDimensions,
-            (d) => d.property === "color"
-        )
+        return this.grapher.filledDimensions.find((d) => d.property === "color")
     }
 
     @computed get availableYears(): Time[] {
@@ -93,7 +89,7 @@ export class StackedBarTransform extends ChartTransform {
     }
 
     @computed get yDimensionFirst() {
-        return find(this.grapher.filledDimensions, (d) => d.property === "y")
+        return this.grapher.filledDimensions.find((d) => d.property === "y")
     }
 
     @computed get yTickFormat() {

--- a/grapher/barCharts/StackedBarTransform.ts
+++ b/grapher/barCharts/StackedBarTransform.ts
@@ -1,6 +1,5 @@
 import { computed } from "mobx"
 import {
-    includes,
     identity,
     cloneDeep,
     find,
@@ -147,7 +146,7 @@ export class StackedBarTransform extends ChartTransform {
                 // Stacked bar chart can't go negative!
                 if (value < 0) continue
                 // only consider years that are part of timeline to line up the bars
-                if (!includes(timelineYears, year)) continue
+                if (!timelineYears.includes(year)) continue
 
                 if (!series) {
                     series = {

--- a/grapher/chart/ChartDimension.ts
+++ b/grapher/chart/ChartDimension.ts
@@ -7,7 +7,6 @@ import {
     formatYear,
     last,
     isNumber,
-    extend,
     sortedUniq,
     sortNumeric,
 } from "grapher/utils/Util"
@@ -82,7 +81,7 @@ export class ChartDimensionSpec implements ChartDimensionInterface {
     @observable saveToVariable?: true = undefined
 
     constructor(spec: ChartDimensionInterface) {
-        if (spec.display) extend(this.display, spec.display)
+        if (spec.display) this.display = { ...this.display, ...spec.display }
 
         this.targetYear = spec.targetYear
         this.variableId = spec.variableId

--- a/grapher/chart/ChartDimension.ts
+++ b/grapher/chart/ChartDimension.ts
@@ -2,7 +2,6 @@ import { observable, computed } from "mobx"
 import {
     defaultTo,
     formatValue,
-    some,
     isString,
     formatDay,
     formatYear,
@@ -187,7 +186,7 @@ export class ChartDimension {
         if (unit.length < 3) return unit
         else {
             const commonShortUnits = ["$", "£", "€", "%"]
-            if (some(commonShortUnits, (u) => unit[0] === u)) return unit[0]
+            if (commonShortUnits.some((u) => unit[0] === u)) return unit[0]
             else return ""
         }
     }

--- a/grapher/chart/ChartTransform.ts
+++ b/grapher/chart/ChartTransform.ts
@@ -5,14 +5,7 @@ import {
     isUnboundedRight,
     getClosestTime,
 } from "grapher/utils/TimeBounds"
-import {
-    defaultTo,
-    first,
-    last,
-    some,
-    sortNumeric,
-    uniq,
-} from "grapher/utils/Util"
+import { defaultTo, first, last, sortNumeric, uniq } from "grapher/utils/Util"
 import { Grapher } from "grapher/core/Grapher"
 import { EntityDimensionKey } from "grapher/core/GrapherConstants"
 import { ColorScale } from "grapher/color/ColorScale"
@@ -41,7 +34,7 @@ export abstract class ChartTransform implements IChartTransform {
     }
 
     @computed protected get hasYDimension() {
-        return some(this.grapher.dimensions, (d) => d.property === "y")
+        return this.grapher.dimensions.some((d) => d.property === "y")
     }
 
     /**

--- a/grapher/chart/Tooltip.tsx
+++ b/grapher/chart/Tooltip.tsx
@@ -1,4 +1,3 @@
-import { extend } from "grapher/utils/Util"
 import * as React from "react"
 import { observable, computed, action } from "mobx"
 import { observer } from "mobx-react"
@@ -54,7 +53,7 @@ export class TooltipView extends React.Component<{
             <div
                 ref={this.base}
                 className="Tooltip"
-                style={extend(tooltipStyle, tooltip.style || {})}
+                style={{ ...tooltipStyle, ...tooltip.style }}
             >
                 {tooltip.children}
             </div>

--- a/grapher/color/ColorScale.ts
+++ b/grapher/color/ColorScale.ts
@@ -10,7 +10,6 @@ import {
     toArray,
     first,
     last,
-    find,
     identity,
     roundSigFig,
     mapNullToUndefined,
@@ -338,6 +337,6 @@ export class ColorScale {
 
     @bind getColor(value: number | string | undefined): string | undefined {
         if (value === undefined) return this.customCategoryColors[NO_DATA_LABEL]
-        return find(this.legendData, (b) => b.contains(value))?.color
+        return this.legendData.find((b) => b.contains(value))?.color
     }
 }

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -6,7 +6,7 @@ import { Grapher } from "grapher/core/Grapher"
 import { getQueryParams, getWindowQueryParams } from "utils/client/url"
 import { GrapherView } from "grapher/core/GrapherView"
 import { Timeline, TimelineProps } from "./Timeline"
-import { extend, keys, entries, max, formatValue } from "grapher/utils/Util"
+import { extend, entries, max, formatValue } from "grapher/utils/Util"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faDownload } from "@fortawesome/free-solid-svg-icons/faDownload"
 import { faShareAlt } from "@fortawesome/free-solid-svg-icons/faShareAlt"
@@ -82,7 +82,7 @@ class HighlightToggle extends React.Component<{
     get isHighlightActive() {
         const params = getWindowQueryParams()
         let isActive = true
-        keys(this.highlightParams).forEach((key) => {
+        Object.keys(this.highlightParams).forEach((key) => {
             if (params[key] !== this.highlightParams[key]) isActive = false
         })
         return isActive

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -6,7 +6,7 @@ import { Grapher } from "grapher/core/Grapher"
 import { getQueryParams, getWindowQueryParams } from "utils/client/url"
 import { GrapherView } from "grapher/core/GrapherView"
 import { Timeline, TimelineProps } from "./Timeline"
-import { extend, max, formatValue } from "grapher/utils/Util"
+import { max, formatValue } from "grapher/utils/Util"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faDownload } from "@fortawesome/free-solid-svg-icons/faDownload"
 import { faShareAlt } from "@fortawesome/free-solid-svg-icons/faShareAlt"
@@ -72,7 +72,10 @@ class HighlightToggle extends React.Component<{
 
     @action.bound onHighlightToggle(e: React.FormEvent<HTMLInputElement>) {
         if (e.currentTarget.checked) {
-            const params = extend(getWindowQueryParams(), this.highlightParams)
+            const params = {
+                ...getWindowQueryParams(),
+                ...this.highlightParams,
+            }
             this.grapher.url.populateFromQueryParams(params)
         } else {
             this.grapher.selectedKeys = []

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -6,7 +6,7 @@ import { Grapher } from "grapher/core/Grapher"
 import { getQueryParams, getWindowQueryParams } from "utils/client/url"
 import { GrapherView } from "grapher/core/GrapherView"
 import { Timeline, TimelineProps } from "./Timeline"
-import { extend, entries, max, formatValue } from "grapher/utils/Util"
+import { extend, max, formatValue } from "grapher/utils/Util"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faDownload } from "@fortawesome/free-solid-svg-icons/faDownload"
 import { faShareAlt } from "@fortawesome/free-solid-svg-icons/faShareAlt"
@@ -512,7 +512,7 @@ export class ControlsOverlayView extends React.Component<{
             <div style={containerStyle}>
                 {this.props.children}
                 <div className="ControlsOverlay" style={overlayStyle}>
-                    {entries(this.props.grapherView.overlays).map(
+                    {Object.entries(this.props.grapherView.overlays).map(
                         ([key, overlay]) => (
                             <React.Fragment key={key}>
                                 {overlay.props.children}

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -13,7 +13,6 @@ import {
 import { bind } from "decko"
 
 import {
-    map,
     uniqWith,
     isEqual,
     formatDay,
@@ -517,7 +516,7 @@ export class Grapher extends PersistableGrapher {
 
     @computed get validDimensions(): ChartDimensionSpec[] {
         const { dimensions } = this
-        const validProperties = map(this.dimensionSlots, "property")
+        const validProperties = this.dimensionSlots.map((d) => d.property)
         let validDimensions = dimensions.filter((dim) =>
             validProperties.includes(dim.property)
         )
@@ -544,7 +543,7 @@ export class Grapher extends PersistableGrapher {
     @computed.struct get filledDimensions(): ChartDimension[] {
         if (!this.isReady) return []
 
-        return map(this.dimensions, (dim, i) => {
+        return this.dimensions.map((dim, i) => {
             return new ChartDimension(
                 i,
                 dim,
@@ -745,7 +744,7 @@ export class Grapher extends PersistableGrapher {
             return this.axisDimensions.map((d) => d.displayName).join(" vs. ")
         else if (
             primaryDimensions.length > 1 &&
-            uniq(map(primaryDimensions, (d) => d.column.datasetName)).length ===
+            uniq(primaryDimensions.map((d) => d.column.datasetName)).length ===
                 1
         )
             return primaryDimensions[0].column.datasetName!
@@ -931,7 +930,7 @@ export class Grapher extends PersistableGrapher {
             (a: any, b: any) => a.entityId === b.entityId && a.index === b.index
         )
 
-        return map(validSelections, (sel) => {
+        return validSelections.map((sel) => {
             return {
                 entityDimensionKey: this.makeEntityDimensionKey(
                     entityIdToNameMap.get(sel.entityId)!,
@@ -1062,7 +1061,7 @@ export class Grapher extends PersistableGrapher {
     set selectedKeys(keys: EntityDimensionKey[]) {
         if (!this.isReady) return
 
-        const selection = map(keys, (key) => {
+        const selection = keys.map((key) => {
             const { entityName: entity, index } = this.lookupKey(key)
             return {
                 entityId: this.table.entityNameToIdMap.get(entity)!,

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -30,7 +30,6 @@ import {
     without,
     xor,
     lastOfNonEmptyArray,
-    find,
     identity,
 } from "grapher/utils/Util"
 import {
@@ -267,7 +266,7 @@ export class Grapher extends PersistableGrapher {
     }
 
     @computed get primaryVariableId() {
-        const yDimension = find(this.dimensions, { property: "y" })
+        const yDimension = this.dimensions.find((d) => d.property === "y")
         return yDimension ? yDimension.variableId : undefined
     }
 

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -14,7 +14,6 @@ import { bind } from "decko"
 
 import {
     map,
-    filter,
     uniqWith,
     isEqual,
     formatDay,
@@ -33,6 +32,7 @@ import {
     xor,
     lastOfNonEmptyArray,
     find,
+    identity,
 } from "grapher/utils/Util"
 import {
     ChartType,
@@ -518,7 +518,7 @@ export class Grapher extends PersistableGrapher {
     @computed get validDimensions(): ChartDimensionSpec[] {
         const { dimensions } = this
         const validProperties = map(this.dimensionSlots, "property")
-        let validDimensions = filter(dimensions, (dim) =>
+        let validDimensions = dimensions.filter((dim) =>
             validProperties.includes(dim.property)
         )
 
@@ -562,13 +562,13 @@ export class Grapher extends PersistableGrapher {
     }
 
     @computed get availableTabs(): GrapherTabOption[] {
-        return filter([
+        return [
             this.hasChartTab && "chart",
             this.hasMapTab && "map",
             "table",
             "sources",
             "download",
-        ]) as GrapherTabOption[]
+        ].filter(identity) as GrapherTabOption[]
     }
 
     @computed get currentTitle(): string {

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -15,7 +15,6 @@ import { bind } from "decko"
 import {
     map,
     filter,
-    includes,
     uniqWith,
     isEqual,
     formatDay,
@@ -520,7 +519,7 @@ export class Grapher extends PersistableGrapher {
         const { dimensions } = this
         const validProperties = map(this.dimensionSlots, "property")
         let validDimensions = filter(dimensions, (dim) =>
-            includes(validProperties, dim.property)
+            validProperties.includes(dim.property)
         )
 
         this.dimensionSlots.forEach((slot) => {
@@ -914,7 +913,7 @@ export class Grapher extends PersistableGrapher {
 
             // Entity must be within that dimension
             const entityName = entityIdToNameMap.get(sel.entityId)
-            if (!entityName || !includes(dimension.entityNamesUniq, entityName))
+            if (!entityName || !dimension.entityNamesUniq.includes(entityName))
                 return false
 
             // "change entity" charts can only have one entity selected
@@ -1197,7 +1196,7 @@ export class Grapher extends PersistableGrapher {
 
     // todo: remove
     toggleKey(key: EntityDimensionKey) {
-        if (includes(this.selectedKeys, key)) {
+        if (this.selectedKeys.includes(key)) {
             this.selectedKeys = this.selectedKeys.filter((k) => k !== key)
         } else {
             this.selectedKeys = this.selectedKeys.concat([key])

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -23,7 +23,6 @@ import {
     sortBy,
     getErrorMessageRelatedQuestionUrl,
     slugify,
-    each,
     keyBy,
     cloneDeep,
     union,
@@ -699,7 +698,7 @@ export class Grapher extends PersistableGrapher {
         const { filledDimensions } = this
 
         const sources: SourceWithDimension[] = []
-        each(filledDimensions, (dim) => {
+        filledDimensions.forEach((dim) => {
             const { column } = dim
             // HACK (Mispy): Ignore the default color source on scatterplots.
             if (

--- a/grapher/core/GrapherUrl.ts
+++ b/grapher/core/GrapherUrl.ts
@@ -13,7 +13,7 @@ import {
     StackMode,
 } from "grapher/core/GrapherConstants"
 
-import { includes, defaultTo } from "grapher/utils/Util"
+import { defaultTo } from "grapher/utils/Util"
 
 // todo: we should probably factor out this circular dependency
 import { Grapher } from "grapher/core/Grapher"
@@ -228,14 +228,14 @@ export class GrapherUrl implements ObservableUrl {
         // Set tab if specified
         const tab = params.tab
         if (tab) {
-            if (!includes(grapher.availableTabs, tab))
+            if (!grapher.availableTabs.includes(tab as GrapherTabOption))
                 console.error("Unexpected tab: " + tab)
             else grapher.tab = tab as GrapherTabOption
         }
 
         const overlay = params.overlay
         if (overlay) {
-            if (!includes(grapher.availableTabs, overlay))
+            if (!grapher.availableTabs.includes(overlay as GrapherTabOption))
                 console.error("Unexpected overlay: " + overlay)
             else grapher.overlay = overlay as GrapherTabOption
         }

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -8,7 +8,7 @@ import { faInfoCircle } from "@fortawesome/free-solid-svg-icons/faInfoCircle"
 
 import { Grapher } from "grapher/core/Grapher"
 import { SortOrder } from "grapher/core/GrapherConstants"
-import { capitalize, some, orderBy, upperFirst } from "grapher/utils/Util"
+import { capitalize, orderBy, upperFirst } from "grapher/utils/Util"
 import { SortIcon } from "grapher/controls/SortIcon"
 import { Tippy } from "grapher/chart/Tippy"
 import {
@@ -162,8 +162,7 @@ export class DataTable extends React.Component<DataTableProps> {
     }
 
     @computed get hasSubheaders() {
-        return some(
-            this.displayDimensions,
+        return this.displayDimensions.some(
             (header) => header.columns.length > 1
         )
     }

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -2,7 +2,6 @@ import * as React from "react"
 import {
     map,
     flatten,
-    some,
     includes,
     sortBy,
     filter,
@@ -106,7 +105,7 @@ class Lines extends React.Component<LinesProps> {
     }
 
     @computed get isFocusMode(): boolean {
-        return some(this.renderData, (d) => d.isFocus)
+        return this.renderData.some((d) => d.isFocus)
     }
 
     @computed get allValues(): LineChartValue[] {

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -3,7 +3,6 @@ import {
     map,
     flatten,
     sortBy,
-    filter,
     sum,
     guid,
     getRelativeMouse,
@@ -159,11 +158,11 @@ class Lines extends React.Component<LinesProps> {
     }
 
     @computed get focusGroups() {
-        return filter(this.renderData, (g) => g.isFocus)
+        return this.renderData.filter((g) => g.isFocus)
     }
 
     @computed get backgroundGroups() {
-        return filter(this.renderData, (g) => !g.isFocus)
+        return this.renderData.filter((g) => !g.isFocus)
     }
 
     // Don't display point markers if there are very many of them for performance reasons

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -1,6 +1,5 @@
 import * as React from "react"
 import {
-    map,
     flatten,
     sortBy,
     sum,
@@ -83,23 +82,21 @@ class Lines extends React.Component<LinesProps> {
 
     @computed get renderData(): LineRenderSeries[] {
         const { data, xAxis, yAxis, focusKeys } = this.props
-        return map(data, (series) => {
-            return {
-                entityDimensionKey: series.entityDimensionKey,
-                displayKey: `key-${makeSafeForCSS(series.entityDimensionKey)}`,
-                color: series.color,
-                values: series.values.map((v) => {
-                    return new Vector2(
-                        Math.round(xAxis.place(v.x)),
-                        Math.round(yAxis.place(v.y))
-                    )
-                }),
-                isFocus:
-                    !focusKeys.length ||
-                    focusKeys.includes(series.entityDimensionKey),
-                isProjection: series.isProjection,
-            }
-        })
+        return data.map((series) => ({
+            entityDimensionKey: series.entityDimensionKey,
+            displayKey: `key-${makeSafeForCSS(series.entityDimensionKey)}`,
+            color: series.color,
+            values: series.values.map((v) => {
+                return new Vector2(
+                    Math.round(xAxis.place(v.x)),
+                    Math.round(yAxis.place(v.y))
+                )
+            }),
+            isFocus:
+                !focusKeys.length ||
+                focusKeys.includes(series.entityDimensionKey),
+            isProjection: series.isProjection,
+        }))
     }
 
     @computed get isFocusMode(): boolean {

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -2,7 +2,6 @@ import * as React from "react"
 import {
     map,
     flatten,
-    includes,
     sortBy,
     filter,
     sum,
@@ -98,7 +97,7 @@ class Lines extends React.Component<LinesProps> {
                 }),
                 isFocus:
                     !focusKeys.length ||
-                    includes(focusKeys, series.entityDimensionKey),
+                    focusKeys.includes(series.entityDimensionKey),
                 isProjection: series.isProjection,
             }
         })

--- a/grapher/lineCharts/LineChartTransform.ts
+++ b/grapher/lineCharts/LineChartTransform.ts
@@ -9,7 +9,6 @@ import {
     clone,
     formatValue,
     flatten,
-    findIndex,
     last,
 } from "grapher/utils/Util"
 import { EntityDimensionKey, ScaleType } from "grapher/core/GrapherConstants"
@@ -112,8 +111,7 @@ export class LineChartTransform extends ChartTransform {
         if (!this.isRelativeMode) return this.initialData
 
         return cloneDeep(this.initialData).map((series) => {
-            const startIndex = findIndex(
-                series.values,
+            const startIndex = series.values.findIndex(
                 (v) => v.time >= this.startYear && v.y !== 0
             )
             if (startIndex < 0) {

--- a/grapher/lineCharts/LineChartTransform.ts
+++ b/grapher/lineCharts/LineChartTransform.ts
@@ -1,6 +1,5 @@
 import { computed } from "mobx"
 import {
-    some,
     min,
     max,
     isEmpty,
@@ -27,7 +26,7 @@ import { EntityName } from "owidTable/OwidTable"
 export class LineChartTransform extends ChartTransform {
     @computed get failMessage(): string | undefined {
         const { filledDimensions } = this.grapher
-        if (!some(filledDimensions, (d) => d.property === "y"))
+        if (!filledDimensions.some((d) => d.property === "y"))
             return "Missing Y axis variable"
         else if (isEmpty(this.groupedData)) return "No matching data"
         else return undefined

--- a/grapher/lineCharts/LineLabels.tsx
+++ b/grapher/lineCharts/LineLabels.tsx
@@ -1,7 +1,6 @@
 // This implements the line labels that appear to the right of the lines/polygons in LineCharts/StackedAreas.
 import * as React from "react"
 import {
-    some,
     noop,
     includes,
     cloneDeep,
@@ -246,7 +245,7 @@ export class LineLabelsComponent extends React.Component<
     }
 
     @computed get isFocusMode() {
-        return some(this.props.legend.marks, (m) =>
+        return this.props.legend.marks.some((m) =>
             includes(this.props.focusKeys, m.item.entityDimensionKey)
         )
     }

--- a/grapher/lineCharts/LineLabels.tsx
+++ b/grapher/lineCharts/LineLabels.tsx
@@ -2,7 +2,6 @@
 import * as React from "react"
 import {
     noop,
-    includes,
     cloneDeep,
     max,
     min,
@@ -246,7 +245,7 @@ export class LineLabelsComponent extends React.Component<
 
     @computed get isFocusMode() {
         return this.props.legend.marks.some((m) =>
-            includes(this.props.focusKeys, m.item.entityDimensionKey)
+            this.props.focusKeys.includes(m.item.entityDimensionKey)
         )
     }
 
@@ -402,7 +401,7 @@ export class LineLabelsComponent extends React.Component<
         const { isFocusMode } = this
         return this.placedMarks.filter((m) =>
             isFocusMode
-                ? !includes(focusKeys, m.mark.item.entityDimensionKey)
+                ? !focusKeys.includes(m.mark.item.entityDimensionKey)
                 : m.isOverlap
         )
     }
@@ -412,7 +411,7 @@ export class LineLabelsComponent extends React.Component<
         const { isFocusMode } = this
         return this.placedMarks.filter((m) =>
             isFocusMode
-                ? includes(focusKeys, m.mark.item.entityDimensionKey)
+                ? focusKeys.includes(m.mark.item.entityDimensionKey)
                 : !m.isOverlap
         )
     }

--- a/grapher/mapCharts/MapColorLegend.ts
+++ b/grapher/mapCharts/MapColorLegend.ts
@@ -1,6 +1,6 @@
 import { computed } from "mobx"
 
-import { min, max, each, last, flatten, find, sum } from "grapher/utils/Util"
+import { min, max, each, last, flatten, sum } from "grapher/utils/Util"
 import { Bounds } from "grapher/utils/Bounds"
 import { TextWrap } from "grapher/text/TextWrap"
 import {
@@ -387,7 +387,7 @@ export class MapColorLegend {
 
         if (focusBracket) return focusBracket
         else if (focusValue)
-            return find(numericLegendData, (bin) => bin.contains(focusValue))
+            return numericLegendData.find((bin) => bin.contains(focusValue))
         else return undefined
     }
 
@@ -397,9 +397,7 @@ export class MapColorLegend {
         if (focusBracket && focusBracket instanceof CategoricalBin)
             return focusBracket
         else if (focusValue)
-            return find(categoricalLegendData, (bin) =>
-                bin.contains(focusValue)
-            )
+            return categoricalLegendData.find((bin) => bin.contains(focusValue))
         else return undefined
     }
 

--- a/grapher/mapCharts/MapColorLegend.ts
+++ b/grapher/mapCharts/MapColorLegend.ts
@@ -1,15 +1,6 @@
 import { computed } from "mobx"
 
-import {
-    min,
-    max,
-    map,
-    each,
-    last,
-    flatten,
-    find,
-    sum,
-} from "grapher/utils/Util"
+import { min, max, each, last, flatten, find, sum } from "grapher/utils/Util"
 import { Bounds } from "grapher/utils/Bounds"
 import { TextWrap } from "grapher/text/TextWrap"
 import {
@@ -327,7 +318,7 @@ export class MapCategoricalColorLegend {
             })
         })
 
-        return flatten(map(lines, (l) => l.marks))
+        return flatten(lines.map((l) => l.marks))
     }
 
     @computed get height(): number {

--- a/grapher/mapCharts/MapColorLegend.ts
+++ b/grapher/mapCharts/MapColorLegend.ts
@@ -7,7 +7,6 @@ import {
     each,
     last,
     flatten,
-    some,
     find,
     sum,
 } from "grapher/utils/Util"
@@ -355,8 +354,7 @@ export class MapColorLegend {
     @computed get numericLegendData(): ColorScaleBin[] {
         if (
             this.hasCategorical ||
-            !some(
-                this.props.legendData,
+            !this.props.legendData.some(
                 (d) => (d as CategoricalBin).value === "No data" && !d.isHidden
             )
         ) {

--- a/grapher/mapCharts/MapColorLegend.ts
+++ b/grapher/mapCharts/MapColorLegend.ts
@@ -1,6 +1,6 @@
 import { computed } from "mobx"
 
-import { min, max, each, last, flatten, sum } from "grapher/utils/Util"
+import { min, max, last, flatten, sum } from "grapher/utils/Util"
 import { Bounds } from "grapher/utils/Bounds"
 import { TextWrap } from "grapher/text/TextWrap"
 import {
@@ -258,7 +258,7 @@ export class MapCategoricalColorLegend {
         let marks: CategoricalMark[] = [],
             xOffset = 0,
             yOffset = 0
-        each(props.legendData, (d) => {
+        props.legendData.forEach((d) => {
             const labelBounds = Bounds.forText(d.text, { fontSize: fontSize })
             const markWidth =
                 rectSize + rectPadding + labelBounds.width + markPadding
@@ -308,9 +308,9 @@ export class MapCategoricalColorLegend {
         const lines = this.markLines
 
         // Center each line
-        each(lines, (line) => {
+        lines.forEach((line) => {
             const xShift = this.width / 2 - line.totalWidth / 2
-            each(line.marks, (m) => {
+            line.marks.forEach((m) => {
                 m.x += xShift
                 m.label.bounds = m.label.bounds.extend({
                     x: m.label.bounds.x + xShift,

--- a/grapher/mapCharts/MapTransform.ts
+++ b/grapher/mapCharts/MapTransform.ts
@@ -4,7 +4,6 @@ import {
     defaultTo,
     isString,
     findClosestYear,
-    extend,
     keyBy,
     isNumber,
     entityNameForMap,
@@ -250,10 +249,11 @@ export class MapTransform extends ChartTransform {
         Object.entries(valuesByEntity).forEach(([entity, datum]) => {
             const color = this.colorScale.getColor(datum.value)
             if (color) {
-                choroplethData[entity] = extend({}, datum, {
+                choroplethData[entity] = {
+                    ...datum,
                     color: color,
                     highlightFillColor: color,
-                })
+                }
             }
         })
 

--- a/grapher/mapCharts/MapTransform.ts
+++ b/grapher/mapCharts/MapTransform.ts
@@ -5,7 +5,6 @@ import {
     isString,
     findClosestYear,
     extend,
-    each,
     keyBy,
     isNumber,
     entityNameForMap,
@@ -248,7 +247,7 @@ export class MapTransform extends ChartTransform {
         const { valuesByEntity } = this
         const choroplethData: ChoroplethData = {}
 
-        each(valuesByEntity, (datum, entity) => {
+        Object.entries(valuesByEntity).forEach(([entity, datum]) => {
             const color = this.colorScale.getColor(datum.value)
             if (color) {
                 choroplethData[entity] = extend({}, datum, {

--- a/grapher/mapCharts/WorldRegions.ts
+++ b/grapher/mapCharts/WorldRegions.ts
@@ -1,4 +1,4 @@
-import { uniq, values, entityNameForMap } from "grapher/utils/Util"
+import { uniq, entityNameForMap } from "grapher/utils/Util"
 import { MapProjection } from "./MapProjections"
 
 // The projections we currently offer are all world regions.
@@ -297,7 +297,7 @@ for (const entity in worldRegionByEntity) {
 
 export const worldRegions: WorldRegion[] = [
     "World",
-    ...uniq(values(worldRegionByMapEntity)),
+    ...uniq(Object.values(worldRegionByMapEntity)),
 ]
 
 export const labelsByRegion: Record<WorldRegion, string> = {

--- a/grapher/scatterCharts/PointsWithLabels.tsx
+++ b/grapher/scatterCharts/PointsWithLabels.tsx
@@ -14,7 +14,6 @@ import {
     last,
     flatten,
     min,
-    find,
     first,
     isEmpty,
     guid,
@@ -693,8 +692,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
                 this.hoverKey = null*/
 
             if (closestSeries && this.props.onMouseOver) {
-                const datum = find(
-                    this.data,
+                const datum = this.data.find(
                     (d) =>
                         d.entityDimensionKey ===
                         closestSeries.entityDimensionKey

--- a/grapher/scatterCharts/PointsWithLabels.tsx
+++ b/grapher/scatterCharts/PointsWithLabels.tsx
@@ -11,7 +11,6 @@
 import * as React from "react"
 import { scaleLinear } from "d3-scale"
 import {
-    some,
     last,
     flatten,
     min,
@@ -237,7 +236,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
     }
 
     @computed private get isConnected(): boolean {
-        return some(this.data, (g) => g.values.length > 1)
+        return this.data.some((g) => g.values.length > 1)
     }
 
     @computed private get focusKeys(): string[] {
@@ -265,7 +264,7 @@ export class PointsWithLabels extends React.Component<PointsWithLabelsProps> {
     @computed private get isSubtleForeground(): boolean {
         return (
             this.focusKeys.length > 1 &&
-            some(this.props.data, (series) => series.values.length > 2)
+            this.props.data.some((series) => series.values.length > 2)
         )
     }
 

--- a/grapher/scatterCharts/ScatterColorLegend.tsx
+++ b/grapher/scatterCharts/ScatterColorLegend.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { sum, includes, max, defaultTo } from "grapher/utils/Util"
+import { sum, max, defaultTo } from "grapher/utils/Util"
 import { computed } from "mobx"
 import { observer } from "mobx-react"
 import { TextWrap } from "grapher/text/TextWrap"
@@ -138,8 +138,9 @@ export class ScatterColorLegendView extends React.Component<
                     style={{ cursor: "pointer" }}
                 >
                     {labelMarks.map((mark, index) => {
-                        const isActive = includes(activeColors, mark.color)
-                        const isFocus = includes(focusColors, mark.color)
+                        const isActive = activeColors.includes(mark.color)
+                        const isFocus =
+                            focusColors?.includes(mark.color) ?? false
                         const mouseOver = onMouseOver
                             ? () => onMouseOver(mark.color)
                             : undefined

--- a/grapher/scatterCharts/ScatterTransform.ts
+++ b/grapher/scatterCharts/ScatterTransform.ts
@@ -1,5 +1,4 @@
 import {
-    some,
     isEmpty,
     intersection,
     keyBy,
@@ -81,9 +80,9 @@ export class ScatterTransform extends ChartTransform {
 
     @computed get failMessage(): string | undefined {
         const { filledDimensions } = this.grapher
-        if (!some(filledDimensions, (d) => d.property === "y"))
+        if (!filledDimensions.some((d) => d.property === "y"))
             return "Missing Y axis variable"
-        else if (!some(filledDimensions, (d) => d.property === "x"))
+        else if (!filledDimensions.some((d) => d.property === "x"))
             return "Missing X axis variable"
         else if (isEmpty(this.possibleEntityNames))
             return "No entities with data for both X and Y"

--- a/grapher/scatterCharts/ScatterTransform.ts
+++ b/grapher/scatterCharts/ScatterTransform.ts
@@ -6,7 +6,6 @@ import {
     has,
     groupBy,
     map,
-    includes,
     sortedFindClosestIndex,
     firstOfNonEmptyArray,
     lastOfNonEmptyArray,
@@ -167,7 +166,7 @@ export class ScatterTransform extends ChartTransform {
 
         if (this.excludedEntityNames)
             entityNames = entityNames.filter(
-                (entity) => !includes(this.excludedEntityNames, entity)
+                (entity) => !this.excludedEntityNames.includes(entity)
             )
 
         return entityNames

--- a/grapher/slopeCharts/LabelledSlopes.tsx
+++ b/grapher/slopeCharts/LabelledSlopes.tsx
@@ -14,7 +14,6 @@ import { extent } from "d3-array"
 import { select } from "d3-selection"
 import {
     sortBy,
-    extend,
     max,
     isEmpty,
     intersection,
@@ -504,12 +503,13 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
                 slope.rightLabel.height
             )
 
-            return extend({}, slope, {
+            return {
+                ...slope,
                 x1: x1,
                 x2: x2,
                 leftLabelBounds: leftLabelBounds,
                 rightLabelBounds: rightLabelBounds,
-            })
+            }
         })
     }
 
@@ -531,10 +531,11 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
         let slopeData = this.labelAccountedSlopeData
 
         slopeData = slopeData.map((slope) => {
-            return extend({}, slope, {
+            return {
+                ...slope,
                 isFocused: focusKeys.includes(slope.entityDimensionKey),
                 isHovered: hoverKeys.includes(slope.entityDimensionKey),
-            })
+            }
         })
 
         // How to work out which of two slopes to prioritize for labelling conflicts

--- a/grapher/slopeCharts/LabelledSlopes.tsx
+++ b/grapher/slopeCharts/LabelledSlopes.tsx
@@ -18,7 +18,6 @@ import {
     max,
     isEmpty,
     intersection,
-    filter,
     flatten,
     SVGElement,
     getRelativeMouse,
@@ -515,15 +514,13 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
     }
 
     @computed get backgroundGroups(): SlopeProps[] {
-        return filter(
-            this.slopeData,
+        return this.slopeData.filter(
             (group) => !(group.isHovered || group.isFocused)
         )
     }
 
     @computed get foregroundGroups(): SlopeProps[] {
-        return filter(
-            this.slopeData,
+        return this.slopeData.filter(
             (group) => !!(group.isHovered || group.isFocused)
         )
     }

--- a/grapher/slopeCharts/LabelledSlopes.tsx
+++ b/grapher/slopeCharts/LabelledSlopes.tsx
@@ -18,7 +18,6 @@ import {
     max,
     isEmpty,
     intersection,
-    includes,
     filter,
     flatten,
     SVGElement,
@@ -536,8 +535,8 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
 
         slopeData = slopeData.map((slope) => {
             return extend({}, slope, {
-                isFocused: includes(focusKeys, slope.entityDimensionKey),
-                isHovered: includes(hoverKeys, slope.entityDimensionKey),
+                isFocused: focusKeys.includes(slope.entityDimensionKey),
+                isHovered: hoverKeys.includes(slope.entityDimensionKey),
             })
         })
 

--- a/grapher/slopeCharts/LabelledSlopes.tsx
+++ b/grapher/slopeCharts/LabelledSlopes.tsx
@@ -13,7 +13,6 @@ import { scaleLinear, scaleLog, ScaleLinear, ScaleLogarithmic } from "d3-scale"
 import { extent } from "d3-array"
 import { select } from "d3-selection"
 import {
-    every,
     sortBy,
     extend,
     max,
@@ -427,8 +426,7 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
         data.forEach((series) => {
             // Ensure values fit inside the chart
             if (
-                !every(
-                    series.values,
+                !series.values.every(
                     (d) => d.y >= yDomain[0] && d.y <= yDomain[1]
                 )
             )

--- a/grapher/slopeCharts/SlopeChartTransform.ts
+++ b/grapher/slopeCharts/SlopeChartTransform.ts
@@ -1,5 +1,5 @@
 import { computed } from "mobx"
-import { find, isEmpty, flatten, identity, last } from "grapher/utils/Util"
+import { isEmpty, flatten, identity, last } from "grapher/utils/Util"
 import { ChartDimension } from "grapher/chart/ChartDimension"
 import { SlopeChartSeries, SlopeChartValue } from "./LabelledSlopes"
 import { ChartTransform } from "grapher/chart/ChartTransform"
@@ -54,7 +54,7 @@ export class SlopeChartTransform extends ChartTransform {
     }
 
     @computed.struct get sizeDim(): ChartDimension | undefined {
-        return find(this.grapher.filledDimensions, (d) => d.property === "size")
+        return this.grapher.filledDimensions.find((d) => d.property === "size")
     }
 
     @computed.struct get colorDimension(): ChartDimension | undefined {
@@ -62,7 +62,7 @@ export class SlopeChartTransform extends ChartTransform {
     }
 
     @computed.struct get yDimension(): ChartDimension | undefined {
-        return find(this.grapher.filledDimensions, (d) => d.property === "y")
+        return this.grapher.filledDimensions.find((d) => d.property === "y")
     }
 
     // helper method to directly get the associated color value given an Entity

--- a/grapher/slopeCharts/SlopeChartTransform.ts
+++ b/grapher/slopeCharts/SlopeChartTransform.ts
@@ -1,12 +1,5 @@
 import { computed } from "mobx"
-import {
-    some,
-    find,
-    isEmpty,
-    flatten,
-    identity,
-    last,
-} from "grapher/utils/Util"
+import { find, isEmpty, flatten, identity, last } from "grapher/utils/Util"
 import { ChartDimension } from "grapher/chart/ChartDimension"
 import { SlopeChartSeries, SlopeChartValue } from "./LabelledSlopes"
 import { ChartTransform } from "grapher/chart/ChartTransform"
@@ -19,7 +12,7 @@ import { ColorScale } from "grapher/color/ColorScale"
 export class SlopeChartTransform extends ChartTransform {
     @computed get failMessage(): string | undefined {
         const { filledDimensions } = this.grapher
-        if (!some(filledDimensions, (d) => d.property === "y"))
+        if (!filledDimensions.some((d) => d.property === "y"))
             return "Missing Y axis variable"
         else if (isEmpty(this.data)) return "No matching data"
         else return undefined

--- a/grapher/text/TextWrap.tsx
+++ b/grapher/text/TextWrap.tsx
@@ -1,11 +1,4 @@
-import {
-    isEmpty,
-    reduce,
-    max,
-    stripHTML,
-    defaultTo,
-    linkify,
-} from "grapher/utils/Util"
+import { isEmpty, max, stripHTML, defaultTo, linkify } from "grapher/utils/Util"
 import { computed } from "mobx"
 import { Bounds } from "grapher/utils/Bounds"
 import * as React from "react"
@@ -110,7 +103,7 @@ export class TextWrap {
 
     @computed get height(): number {
         return (
-            reduce(this.lines, (total, line) => total + line.height, 0) +
+            this.lines.reduce((total, line) => total + line.height, 0) +
             this.lineHeight * (this.lines.length - 1)
         )
     }

--- a/grapher/utils/Bounds.ts
+++ b/grapher/utils/Bounds.ts
@@ -1,4 +1,4 @@
-import { extend, range } from "grapher/utils/Util"
+import { range } from "grapher/utils/Util"
 import { Vector2 } from "grapher/utils/Vector2"
 import pixelWidth from "string-pixel-width"
 
@@ -233,7 +233,7 @@ export class Bounds {
         width?: number
         height?: number
     }): Bounds {
-        return Bounds.fromProps(extend({}, this, props))
+        return Bounds.fromProps({ ...this, ...props })
     }
 
     scale(scale: number): Bounds {

--- a/grapher/utils/Util.ts
+++ b/grapher/utils/Util.ts
@@ -4,7 +4,6 @@ import map from "lodash/map"
 import sortBy from "lodash/sortBy"
 import orderBy from "lodash/orderBy"
 import each from "lodash/each"
-import keys from "lodash/keys"
 import entries from "lodash/entries"
 import isNumber from "lodash/isNumber"
 import filter from "lodash/filter"
@@ -71,7 +70,6 @@ export {
     orderBy,
     xor,
     each,
-    keys,
     entries,
     isNumber,
     range,

--- a/grapher/utils/Util.ts
+++ b/grapher/utils/Util.ts
@@ -1,130 +1,130 @@
 // We're importing every item on its own to enable webpack tree shaking
-import isEqual from "lodash/isEqual"
-import map from "lodash/map"
-import sortBy from "lodash/sortBy"
-import orderBy from "lodash/orderBy"
+import assign from "lodash/assign"
+import capitalize from "lodash/capitalize"
+import clone from "lodash/clone"
+import cloneDeep from "lodash/cloneDeep"
+import compact from "lodash/compact"
+import countBy from "lodash/countBy"
+import debounce from "lodash/debounce"
+import difference from "lodash/difference"
 import each from "lodash/each"
 import entries from "lodash/entries"
-import isNumber from "lodash/isNumber"
-import filter from "lodash/filter"
-import extend from "lodash/extend"
-import isEmpty from "lodash/isEmpty"
-import some from "lodash/some"
 import every from "lodash/every"
-import min from "lodash/min"
-import max from "lodash/max"
-import minBy from "lodash/minBy"
-import maxBy from "lodash/maxBy"
-import compact from "lodash/compact"
-import uniq from "lodash/uniq"
-import cloneDeep from "lodash/cloneDeep"
-import sum from "lodash/sum"
-import sumBy from "lodash/sumBy"
+import extend from "lodash/extend"
+import filter from "lodash/filter"
 import find from "lodash/find"
+import findIndex from "lodash/findIndex"
+import flatten from "lodash/flatten"
+import fromPairs from "lodash/fromPairs"
+import groupBy from "lodash/groupBy"
+import has from "lodash/has"
 import identity from "lodash/identity"
-import union from "lodash/union"
-import debounce from "lodash/debounce"
 import includes from "lodash/includes"
-import toString from "lodash/toString"
+import intersection from "lodash/intersection"
+import isEmpty from "lodash/isEmpty"
+import isEqual from "lodash/isEqual"
+import isNumber from "lodash/isNumber"
 import isString from "lodash/isString"
 import keyBy from "lodash/keyBy"
-import values from "lodash/values"
-import flatten from "lodash/flatten"
-import groupBy from "lodash/groupBy"
-import reverse from "lodash/reverse"
-import clone from "lodash/clone"
-import reduce from "lodash/reduce"
+import map from "lodash/map"
+import mapKeys from "lodash/mapKeys"
+import max from "lodash/max"
+import maxBy from "lodash/maxBy"
+import memoize from "lodash/memoize"
+import min from "lodash/min"
+import minBy from "lodash/minBy"
 import noop from "lodash/noop"
+import omit from "lodash/omit"
+import orderBy from "lodash/orderBy"
+import partition from "lodash/partition"
+import pick from "lodash/pick"
+import range from "lodash/range"
+import reduce from "lodash/reduce"
+import reverse from "lodash/reverse"
 import round from "lodash/round"
-import toArray from "lodash/toArray"
-import throttle from "lodash/throttle"
-import has from "lodash/has"
-import intersection from "lodash/intersection"
-import uniqWith from "lodash/uniqWith"
-import without from "lodash/without"
-import uniqBy from "lodash/uniqBy"
-import capitalize from "lodash/capitalize"
 import sample from "lodash/sample"
 import sampleSize from "lodash/sampleSize"
-import pick from "lodash/pick"
-import omit from "lodash/omit"
-import difference from "lodash/difference"
+import some from "lodash/some"
+import sortBy from "lodash/sortBy"
 import sortedUniq from "lodash/sortedUniq"
-import partition from "lodash/partition"
-import findIndex from "lodash/findIndex"
-import fromPairs from "lodash/fromPairs"
-import mapKeys from "lodash/mapKeys"
-import memoize from "lodash/memoize"
-import takeWhile from "lodash/takeWhile"
-import upperFirst from "lodash/upperFirst"
-import assign from "lodash/assign"
-import countBy from "lodash/countBy"
 import startCase from "lodash/startCase"
+import sum from "lodash/sum"
+import sumBy from "lodash/sumBy"
+import takeWhile from "lodash/takeWhile"
+import throttle from "lodash/throttle"
+import toArray from "lodash/toArray"
+import toString from "lodash/toString"
+import union from "lodash/union"
+import uniq from "lodash/uniq"
+import uniqBy from "lodash/uniqBy"
+import uniqWith from "lodash/uniqWith"
+import upperFirst from "lodash/upperFirst"
+import values from "lodash/values"
+import without from "lodash/without"
 import xor from "lodash/xor"
-import range from "lodash/range"
 
 export {
-    isEqual,
-    map,
-    sortBy,
-    orderBy,
-    xor,
+    capitalize,
+    clone,
+    cloneDeep,
+    compact,
+    countBy,
+    debounce,
+    difference,
     each,
     entries,
-    isNumber,
-    range,
-    filter,
-    extend,
-    isEmpty,
-    some,
     every,
-    min,
-    max,
-    minBy,
-    maxBy,
-    compact,
-    uniq,
-    cloneDeep,
-    sum,
-    sumBy,
+    extend,
+    filter,
     find,
+    findIndex,
+    flatten,
+    fromPairs,
+    groupBy,
+    has,
     identity,
-    union,
-    debounce,
     includes,
-    toString,
+    intersection,
+    isEmpty,
+    isEqual,
+    isNumber,
     isString,
     keyBy,
-    values,
-    flatten,
-    groupBy,
-    reverse,
-    clone,
-    reduce,
+    map,
+    mapKeys,
+    max,
+    maxBy,
+    memoize,
+    min,
+    minBy,
     noop,
-    toArray,
-    throttle,
-    has,
-    intersection,
-    uniqWith,
-    without,
-    uniqBy,
-    capitalize,
+    omit,
+    orderBy,
+    partition,
+    pick,
+    range,
+    reduce,
+    reverse,
     sample,
     sampleSize,
-    pick,
-    omit,
-    difference,
+    some,
+    sortBy,
     sortedUniq,
-    partition,
-    findIndex,
-    fromPairs,
-    mapKeys,
-    memoize,
-    takeWhile,
-    upperFirst,
-    countBy,
     startCase,
+    sum,
+    sumBy,
+    takeWhile,
+    throttle,
+    toArray,
+    toString,
+    union,
+    uniq,
+    uniqBy,
+    uniqWith,
+    upperFirst,
+    values,
+    without,
+    xor,
 }
 
 import moment from "moment"

--- a/grapher/utils/Util.ts
+++ b/grapher/utils/Util.ts
@@ -9,7 +9,6 @@ import debounce from "lodash/debounce"
 import difference from "lodash/difference"
 import each from "lodash/each"
 import extend from "lodash/extend"
-import find from "lodash/find"
 import flatten from "lodash/flatten"
 import fromPairs from "lodash/fromPairs"
 import groupBy from "lodash/groupBy"
@@ -65,7 +64,6 @@ export {
     difference,
     each,
     extend,
-    find,
     flatten,
     fromPairs,
     groupBy,

--- a/grapher/utils/Util.ts
+++ b/grapher/utils/Util.ts
@@ -8,7 +8,6 @@ import countBy from "lodash/countBy"
 import debounce from "lodash/debounce"
 import difference from "lodash/difference"
 import each from "lodash/each"
-import entries from "lodash/entries"
 import every from "lodash/every"
 import extend from "lodash/extend"
 import filter from "lodash/filter"
@@ -71,7 +70,6 @@ export {
     debounce,
     difference,
     each,
-    entries,
     every,
     extend,
     filter,

--- a/grapher/utils/Util.ts
+++ b/grapher/utils/Util.ts
@@ -7,7 +7,6 @@ import compact from "lodash/compact"
 import countBy from "lodash/countBy"
 import debounce from "lodash/debounce"
 import difference from "lodash/difference"
-import each from "lodash/each"
 import extend from "lodash/extend"
 import flatten from "lodash/flatten"
 import fromPairs from "lodash/fromPairs"
@@ -62,7 +61,6 @@ export {
     countBy,
     debounce,
     difference,
-    each,
     extend,
     flatten,
     fromPairs,
@@ -983,7 +981,10 @@ export const getErrorMessageRelatedQuestionUrl = (
 
 export function getAttributesOfHTMLElement(el: HTMLElement) {
     const attributes: { [key: string]: string } = {}
-    each(el.attributes, (attr) => (attributes[attr.name] = attr.value))
+    for (let i = 0; i < el.attributes.length; i++) {
+        const attr = el.attributes.item(i)
+        if (attr) attributes[attr.name] = attr.value
+    }
     return attributes
 }
 

--- a/grapher/utils/Util.ts
+++ b/grapher/utils/Util.ts
@@ -42,7 +42,6 @@ import reverse from "lodash/reverse"
 import round from "lodash/round"
 import sample from "lodash/sample"
 import sampleSize from "lodash/sampleSize"
-import some from "lodash/some"
 import sortBy from "lodash/sortBy"
 import sortedUniq from "lodash/sortedUniq"
 import startCase from "lodash/startCase"
@@ -102,7 +101,6 @@ export {
     reverse,
     sample,
     sampleSize,
-    some,
     sortBy,
     sortedUniq,
     startCase,

--- a/grapher/utils/Util.ts
+++ b/grapher/utils/Util.ts
@@ -35,7 +35,6 @@ import orderBy from "lodash/orderBy"
 import partition from "lodash/partition"
 import pick from "lodash/pick"
 import range from "lodash/range"
-import reduce from "lodash/reduce"
 import reverse from "lodash/reverse"
 import round from "lodash/round"
 import sample from "lodash/sample"
@@ -93,7 +92,6 @@ export {
     partition,
     pick,
     range,
-    reduce,
     reverse,
     sample,
     sampleSize,

--- a/grapher/utils/Util.ts
+++ b/grapher/utils/Util.ts
@@ -17,7 +17,6 @@ import fromPairs from "lodash/fromPairs"
 import groupBy from "lodash/groupBy"
 import has from "lodash/has"
 import identity from "lodash/identity"
-import includes from "lodash/includes"
 import intersection from "lodash/intersection"
 import isEmpty from "lodash/isEmpty"
 import isEqual from "lodash/isEqual"
@@ -77,7 +76,6 @@ export {
     groupBy,
     has,
     identity,
-    includes,
     intersection,
     isEmpty,
     isEqual,
@@ -510,7 +508,7 @@ export interface Json {
 // Escape a function for storage in a csv cell
 export function csvEscape(value: any): string {
     const valueStr = toString(value)
-    if (includes(valueStr, ",")) return `"${value.replace(/\"/g, '""')}"`
+    if (valueStr.includes(",")) return `"${value.replace(/\"/g, '""')}"`
     else return value
 }
 

--- a/grapher/utils/Util.ts
+++ b/grapher/utils/Util.ts
@@ -8,7 +8,6 @@ import countBy from "lodash/countBy"
 import debounce from "lodash/debounce"
 import difference from "lodash/difference"
 import each from "lodash/each"
-import every from "lodash/every"
 import extend from "lodash/extend"
 import filter from "lodash/filter"
 import find from "lodash/find"
@@ -70,7 +69,6 @@ export {
     debounce,
     difference,
     each,
-    every,
     extend,
     filter,
     find,

--- a/grapher/utils/Util.ts
+++ b/grapher/utils/Util.ts
@@ -256,32 +256,26 @@ export function formatValue(
     if (!isNoSpaceUnit && numberPrefixes && absValue >= 1e6) {
         if (!isFinite(absValue)) output = "Infinity"
         else if (absValue >= 1e12)
-            output = formatValue(
-                value / 1e12,
-                extend({}, options, {
-                    unit: shortNumberPrefixes ? "T" : "trillion",
-                    noSpaceUnit: shortNumberPrefixes,
-                    numDecimalPlaces: 2,
-                })
-            )
+            output = formatValue(value / 1e12, {
+                ...options,
+                unit: shortNumberPrefixes ? "T" : "trillion",
+                noSpaceUnit: shortNumberPrefixes,
+                numDecimalPlaces: 2,
+            })
         else if (absValue >= 1e9)
-            output = formatValue(
-                value / 1e9,
-                extend({}, options, {
-                    unit: shortNumberPrefixes ? "B" : "billion",
-                    noSpaceUnit: shortNumberPrefixes,
-                    numDecimalPlaces: 2,
-                })
-            )
+            output = formatValue(value / 1e9, {
+                ...options,
+                unit: shortNumberPrefixes ? "B" : "billion",
+                noSpaceUnit: shortNumberPrefixes,
+                numDecimalPlaces: 2,
+            })
         else if (absValue >= 1e6)
-            output = formatValue(
-                value / 1e6,
-                extend({}, options, {
-                    unit: shortNumberPrefixes ? "M" : "million",
-                    noSpaceUnit: shortNumberPrefixes,
-                    numDecimalPlaces: 2,
-                })
-            )
+            output = formatValue(value / 1e6, {
+                ...options,
+                unit: shortNumberPrefixes ? "M" : "million",
+                noSpaceUnit: shortNumberPrefixes,
+                numDecimalPlaces: 2,
+            })
     } else {
         const targetDigits = Math.pow(10, -numDecimalPlaces)
 

--- a/grapher/utils/Util.ts
+++ b/grapher/utils/Util.ts
@@ -9,7 +9,6 @@ import debounce from "lodash/debounce"
 import difference from "lodash/difference"
 import each from "lodash/each"
 import extend from "lodash/extend"
-import filter from "lodash/filter"
 import find from "lodash/find"
 import findIndex from "lodash/findIndex"
 import flatten from "lodash/flatten"
@@ -68,7 +67,6 @@ export {
     difference,
     each,
     extend,
-    filter,
     find,
     findIndex,
     flatten,

--- a/grapher/utils/Util.ts
+++ b/grapher/utils/Util.ts
@@ -59,7 +59,6 @@ import uniq from "lodash/uniq"
 import uniqBy from "lodash/uniqBy"
 import uniqWith from "lodash/uniqWith"
 import upperFirst from "lodash/upperFirst"
-import values from "lodash/values"
 import without from "lodash/without"
 import xor from "lodash/xor"
 
@@ -122,7 +121,6 @@ export {
     uniqBy,
     uniqWith,
     upperFirst,
-    values,
     without,
     xor,
 }

--- a/grapher/utils/Util.ts
+++ b/grapher/utils/Util.ts
@@ -10,7 +10,6 @@ import difference from "lodash/difference"
 import each from "lodash/each"
 import extend from "lodash/extend"
 import find from "lodash/find"
-import findIndex from "lodash/findIndex"
 import flatten from "lodash/flatten"
 import fromPairs from "lodash/fromPairs"
 import groupBy from "lodash/groupBy"
@@ -67,7 +66,6 @@ export {
     each,
     extend,
     find,
-    findIndex,
     flatten,
     fromPairs,
     groupBy,

--- a/site/client/SiteHeaderMenus.tsx
+++ b/site/client/SiteHeaderMenus.tsx
@@ -11,7 +11,7 @@ import { observer } from "mobx-react"
 import { HeaderSearch } from "./HeaderSearch"
 import { CategoryWithEntries, EntryMeta } from "db/wpdb"
 import classnames from "classnames"
-import { find, flatten } from "grapher/utils/Util"
+import { flatten } from "grapher/utils/Util"
 import { bind } from "decko"
 
 import { BAKED_BASE_URL } from "settings"
@@ -339,8 +339,7 @@ export class DesktopTopicsMenu extends React.Component<{
 
     @bind onActivate(categorySlug: string) {
         if (categorySlug) {
-            const category = find(
-                this.props.categories,
+            const category = this.props.categories.find(
                 (c) => c.slug === categorySlug
             )
             if (category) this.setCategory(category)
@@ -349,8 +348,7 @@ export class DesktopTopicsMenu extends React.Component<{
 
     @bind onDeactivate(categorySlug: string) {
         if (categorySlug) {
-            const category = find(
-                this.props.categories,
+            const category = this.props.categories.find(
                 (c) => c.slug === categorySlug
             )
             if (category === this.activeCategory) this.setCategory(undefined)

--- a/site/client/covid/CovidTable.tsx
+++ b/site/client/covid/CovidTable.tsx
@@ -10,7 +10,6 @@ import { faAngleDoubleDown } from "@fortawesome/free-solid-svg-icons/faAngleDoub
 
 import {
     throttle,
-    entries,
     groupBy,
     sortBy,
     maxBy,
@@ -122,7 +121,7 @@ export class CovidTable extends React.Component<CovidTableProps> {
 
     @computed get countrySeries(): CovidCountrySeries {
         if (this.data) {
-            return entries(groupBy(this.data, (d) => d.location)).map(
+            return Object.entries(groupBy(this.data, (d) => d.location)).map(
                 ([location, series]) => {
                     const sortedSeries: CovidSeries = sortBy(
                         series,

--- a/utils/client/url.ts
+++ b/utils/client/url.ts
@@ -1,4 +1,4 @@
-import { filter, each, isEmpty } from "grapher/utils/Util"
+import { each, isEmpty } from "grapher/utils/Util"
 
 export interface QueryParams {
     [key: string]: string | undefined
@@ -17,7 +17,7 @@ export function getWindowQueryParams(): QueryParams {
 export function strToQueryParams(queryStr: string): QueryParams {
     if (queryStr[0] === "?") queryStr = queryStr.substring(1)
 
-    const querySplit = filter(queryStr.split("&"), (s) => !isEmpty(s))
+    const querySplit = queryStr.split("&").filter((s) => !isEmpty(s))
     const params: QueryParams = {}
 
     for (const param of querySplit) {

--- a/utils/client/url.ts
+++ b/utils/client/url.ts
@@ -1,4 +1,4 @@
-import { each, isEmpty } from "grapher/utils/Util"
+import { isEmpty } from "grapher/utils/Util"
 
 export interface QueryParams {
     [key: string]: string | undefined
@@ -31,7 +31,7 @@ export function strToQueryParams(queryStr: string): QueryParams {
 export function queryParamsToStr(params: QueryParams) {
     let newQueryStr = ""
 
-    each(params, (v, k) => {
+    Object.entries(params).forEach(([k, v]) => {
         if (v === undefined) return
 
         if (isEmpty(newQueryStr)) newQueryStr += "?"


### PR DESCRIPTION
Many of the lodash methods we use have ES6 counterparts by now, so this PR moves some of our code over to the ES6 style.

The changes are nicely separated into commits, and there are two exceptions where I kept lodash:
* In `ScatterTransform` we are still using `_.map` for mapping over an object, because that's still cumbersome in JS
* In some places we do `_.extend(this, props)`. I kept that because I wouldn't know exactly what the alternative would be?

In some cases the Lodash and ES6 behavior differs (especially in regards to `null` and `undefined`), so I just hope I didn't break anything 🤞