### PR TITLE
Dev: beautify JSON output on Grapher page

### DIFF
--- a/site/server/views/GrapherPage.tsx
+++ b/site/server/views/GrapherPage.tsx
@@ -34,7 +34,7 @@ export const GrapherPage = (props: {
     )
 
     const script = `
-        var jsonConfig = ${JSON.stringify(grapher)};
+        var jsonConfig = ${JSON.stringify(grapher, null, 2)};
         var figure = document.getElementsByTagName("figure")[0];
 
         try {


### PR DESCRIPTION
Often I need to glance at the JSON config on a Grapher page. I think we should beautify it:

- Faster debuggability for us
- The size difference should be inconsequential over the wire after Gzipping
- Like the new trailing commas rule in Prettier, this might help when looking at diffs in owid-static
- In case other devs want to use our stuff later on, making it more visible in our source could be useful to them
