### PR TITLE
Fix map tooltip date

### DIFF
--- a/grapher/mapCharts/MapTab.tsx
+++ b/grapher/mapCharts/MapTab.tsx
@@ -288,7 +288,7 @@ export class MapTab extends React.Component<MapTabProps> {
                         bounds={layout.innerBounds}
                         choroplethData={map.choroplethData}
                         years={map.timelineYears}
-                        inputYear={map.targetYearProp}
+                        inputYear={map.targetYear}
                         colorScale={map.colorScale}
                         projection={map.projection}
                         defaultFill={map.colorScale.noDataColor}


### PR DESCRIPTION
Related Slack discussion: https://owid.slack.com/archives/C46U9LXRR/p1599665841022600?thread_ts=1599557290.007100&cid=C46U9LXRR

@breck7 Do you perchance know why you changed it from `targetYear` to `targetYearProp` in [this commit](https://github.com/owid/owid-grapher/commit/a57bb35880586166f1183884e09e052a5895476b#diff-99f0978524a3e523eae3da0e5cba38eeR289)?
I just want to make sure this doesn't re-surface any other issues.

Basically the problem here was that `targetYearProp` can be `Infinity` (and is in this case), and `formatYear(Infinity)` is a very helpful (and verbose!) `undefined NaN, -0NaN`