### PR TITLE
Condense Controls

### DIFF
--- a/grapher/axis/AxisViews.tsx
+++ b/grapher/axis/AxisViews.tsx
@@ -132,22 +132,6 @@ export class VerticalAxisComponent extends React.Component<{
     verticalAxis: VerticalAxis
     isInteractive: boolean
 }> {
-    @computed get controls() {
-        const { bounds, verticalAxis } = this.props
-        const showControls =
-            this.props.isInteractive && verticalAxis.scaleTypeOptions.length > 1
-        if (!showControls) return undefined
-        return (
-            <ControlsOverlay id="vertical-scale-selector" paddingTop={18}>
-                <ScaleSelector
-                    x={bounds.left}
-                    y={bounds.top - 34}
-                    scaleTypeConfig={verticalAxis}
-                />
-            </ControlsOverlay>
-        )
-    }
-
     render() {
         const { bounds, verticalAxis } = this.props
         const { ticks, labelTextWrap } = verticalAxis
@@ -174,7 +158,6 @@ export class VerticalAxisComponent extends React.Component<{
                         {verticalAxis.formatTick(tick)}
                     </text>
                 ))}
-                {this.controls}
             </g>
         )
     }

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -16,9 +16,6 @@ import {
     HorizontalAxisGridLines,
 } from "grapher/axis/AxisViews"
 import { NoDataOverlay } from "grapher/chart/NoDataOverlay"
-import { ControlsOverlay } from "grapher/controls/ControlsOverlay"
-import { AddEntityButton } from "grapher/controls/AddEntityButton"
-
 export interface DiscreteBarDatum {
     entityDimensionKey: EntityDimensionKey
     value: number
@@ -79,8 +76,6 @@ export class DiscreteBarChart extends React.Component<{
     // Account for the width of the legend
     @computed private get legendWidth() {
         const labels = this.currentData.map((d) => d.label)
-        if (this.hasFloatingAddButton)
-            labels.push(` + ${this.grapher.addButtonLabel}`)
 
         const longestLabel = maxBy(labels, (d) => d.length)
         return Bounds.forText(longestLabel, this.legendLabelStyle).width
@@ -174,18 +169,9 @@ export class DiscreteBarChart extends React.Component<{
             .padRight(this.rightEndLabelWidth)
     }
 
-    @computed private get hasFloatingAddButton() {
-        return (
-            this.grapher.hasFloatingAddButton &&
-            this.grapher.showAddEntityControls
-        )
-    }
-
     // Leave space for extra bar at bottom to show "Add country" button
     @computed private get totalBars() {
-        return this.hasFloatingAddButton
-            ? this.currentData.length + 1
-            : this.currentData.length
+        return this.currentData.length
     }
 
     @computed private get barHeight() {
@@ -241,32 +227,6 @@ export class DiscreteBarChart extends React.Component<{
 
     @action.bound onAddClick() {
         this.grapher.isSelectingData = true
-    }
-
-    get addEntityButton() {
-        if (!this.hasFloatingAddButton) return undefined
-        const y =
-            this.bounds.top +
-            (this.barHeight + this.barSpacing) * (this.totalBars - 1) +
-            this.barHeight / 2
-        const paddingTop = AddEntityButton.calcPaddingTop(
-            y,
-            "middle",
-            this.barHeight
-        )
-        return (
-            <ControlsOverlay id="add-country" paddingTop={paddingTop}>
-                <AddEntityButton
-                    x={this.bounds.left + this.legendWidth}
-                    y={y}
-                    align="right"
-                    verticalAlign="middle"
-                    height={this.barHeight}
-                    label={`Add ${this.grapher.entityType}`}
-                    onClick={this.onAddClick}
-                />
-            </ControlsOverlay>
-        )
     }
 
     render() {
@@ -386,7 +346,6 @@ export class DiscreteBarChart extends React.Component<{
 
                     return result
                 })}
-                {this.addEntityButton}
             </g>
         )
     }

--- a/grapher/chart/ChartLayout.tsx
+++ b/grapher/chart/ChartLayout.tsx
@@ -109,6 +109,21 @@ export class ChartLayout {
         )
     }
 
+    // TEMP: will be removed when ControlsRow is rendered by individual charts
+    @computed private get hasControlsRow() {
+        const { grapher } = this.props
+        return (
+            (grapher.currentTab === "chart" ||
+                grapher.currentTab === "table") &&
+            ((grapher.canAddData && !grapher.hasFloatingAddButton) ||
+                grapher.isScatter ||
+                grapher.canChangeEntity ||
+                (grapher.isStackedArea && grapher.canToggleRelativeMode) ||
+                (grapher.isLineChart &&
+                    grapher.lineChartTransform.canToggleRelativeMode))
+        )
+    }
+
     @computed get svgHeight() {
         if (this.isExporting) return this.props.bounds.height
 
@@ -116,7 +131,7 @@ export class ChartLayout {
         return (
             this.props.bounds.height -
             this.header.height -
-            ControlsRow.height -
+            (this.hasControlsRow ? ControlsRow.height : 0) -
             this.footer.height -
             overlayPadding.top -
             overlayPadding.bottom -

--- a/grapher/chart/ChartLayout.tsx
+++ b/grapher/chart/ChartLayout.tsx
@@ -116,6 +116,7 @@ export class ChartLayout {
         return (
             this.props.bounds.height -
             this.header.height -
+            ControlsRow.height -
             this.footer.height -
             overlayPadding.top -
             overlayPadding.bottom -

--- a/grapher/chart/ChartLayout.tsx
+++ b/grapher/chart/ChartLayout.tsx
@@ -6,7 +6,7 @@ import { SourcesFooter, SourcesFooterHTML } from "grapher/chart/Footer"
 import { Bounds } from "grapher/utils/Bounds"
 import { GrapherView } from "grapher/core/GrapherView"
 import { observer } from "mobx-react"
-import { ControlsRow } from "grapher/controls/ControlsRow"
+import { ControlsRow, ControlsRowHeight } from "grapher/controls/ControlsRow"
 
 @observer
 class ControlsOverlayView extends React.Component<{
@@ -60,6 +60,7 @@ interface ChartLayoutProps {
     grapher: Grapher
     grapherView: GrapherView
     bounds: Bounds
+    renderControlsRow?: boolean
 }
 
 export class ChartLayout {
@@ -109,20 +110,6 @@ export class ChartLayout {
         )
     }
 
-    // TEMP: will be removed when ControlsRow is rendered by individual charts
-    @computed private get hasControlsRow() {
-        const { grapher } = this.props
-        return (
-            grapher.primaryTab === "chart" &&
-            ((grapher.canAddData && !grapher.hasFloatingAddButton) ||
-                grapher.isScatter ||
-                grapher.canChangeEntity ||
-                (grapher.isStackedArea && grapher.canToggleRelativeMode) ||
-                (grapher.isLineChart &&
-                    grapher.lineChartTransform.canToggleRelativeMode))
-        )
-    }
-
     @computed get svgHeight() {
         if (this.isExporting) return this.props.bounds.height
 
@@ -130,7 +117,7 @@ export class ChartLayout {
         return (
             this.props.bounds.height -
             this.header.height -
-            (this.hasControlsRow ? ControlsRow.height : 0) -
+            (this.props.renderControlsRow ? ControlsRowHeight : 0) -
             this.footer.height -
             overlayPadding.top -
             overlayPadding.bottom -
@@ -150,6 +137,7 @@ export class ChartLayout {
 
 export class ChartLayoutView extends React.Component<{
     layout: ChartLayout
+    controlsRowControls?: React.ReactElement[]
     children: any
 }> {
     @computed get svgStyle() {
@@ -186,13 +174,15 @@ export class ChartLayoutView extends React.Component<{
     }
 
     renderWithHTMLText() {
-        const { layout } = this.props
+        const { layout, controlsRowControls } = this.props
         const { grapher, grapherView } = layout.props
 
         return (
             <React.Fragment>
                 <HeaderHTML grapher={grapher} header={layout.header} />
-                <ControlsRow grapher={grapher} />
+                {controlsRowControls && (
+                    <ControlsRow controls={controlsRowControls} />
+                )}
                 <ControlsOverlayView grapherView={grapherView}>
                     <svg
                         xmlns="http://www.w3.org/2000/svg"

--- a/grapher/chart/ChartLayout.tsx
+++ b/grapher/chart/ChartLayout.tsx
@@ -6,6 +6,7 @@ import { SourcesFooter, SourcesFooterHTML } from "grapher/chart/Footer"
 import { Bounds } from "grapher/utils/Bounds"
 import { GrapherView } from "grapher/core/GrapherView"
 import { observer } from "mobx-react"
+import { ControlsRow } from "grapher/controls/ControlsRow"
 
 @observer
 class ControlsOverlayView extends React.Component<{
@@ -176,6 +177,7 @@ export class ChartLayoutView extends React.Component<{
         return (
             <React.Fragment>
                 <HeaderHTML grapher={grapher} header={layout.header} />
+                <ControlsRow grapher={grapher} />
                 <ControlsOverlayView grapherView={grapherView}>
                     <svg
                         xmlns="http://www.w3.org/2000/svg"

--- a/grapher/chart/ChartLayout.tsx
+++ b/grapher/chart/ChartLayout.tsx
@@ -113,8 +113,7 @@ export class ChartLayout {
     @computed private get hasControlsRow() {
         const { grapher } = this.props
         return (
-            (grapher.currentTab === "chart" ||
-                grapher.currentTab === "table") &&
+            grapher.primaryTab === "chart" &&
             ((grapher.canAddData && !grapher.hasFloatingAddButton) ||
                 grapher.isScatter ||
                 grapher.canChangeEntity ||

--- a/grapher/chart/ChartTab.tsx
+++ b/grapher/chart/ChartTab.tsx
@@ -100,7 +100,9 @@ export class ChartTab extends React.Component<{
 
             grapher.hasFloatingAddButton &&
                 grapher.showAddEntityControls &&
-                controls.push(<AddEntityButton grapher={grapher} />)
+                controls.push(
+                    <AddEntityButton key="AddEntityButton" grapher={grapher} />
+                )
 
             grapher.isScatter &&
                 grapher.hasSelection &&

--- a/grapher/chart/ChartTab.tsx
+++ b/grapher/chart/ChartTab.tsx
@@ -42,7 +42,9 @@ export class ChartTab extends React.Component<{
         if (grapher.tab === "chart") {
             const yAxis =
                 (grapher.isStackedArea && grapher.stackedAreaTransform.yAxis) ||
-                (grapher.isStackedBar && grapher.stackedBarTransform.yAxis) ||
+                (grapher.isStackedBar &&
+                    !grapher.stackedBarTransform.failMessage &&
+                    grapher.stackedBarTransform.yAxis) ||
                 (grapher.isLineChart && grapher.lineChartTransform.yAxis) ||
                 ((grapher.isScatter || grapher.isTimeScatter) &&
                     grapher.scatterTransform.yAxis)

--- a/grapher/chart/ChartTab.tsx
+++ b/grapher/chart/ChartTab.tsx
@@ -75,7 +75,7 @@ export class ChartTab extends React.Component<{
                                 {`Select ${grapher.entityTypePlural}`}
                             </span>
                         ) : (
-                            <span>
+                            <span className="SelectEntitiesButton">
                                 <FontAwesomeIcon icon={faPlus} />{" "}
                                 {grapher.addButtonLabel}
                             </span>

--- a/grapher/chart/ChartTab.tsx
+++ b/grapher/chart/ChartTab.tsx
@@ -167,18 +167,18 @@ export class ChartTab extends React.Component<{
         if (!grapher.isReady) {
             return <LoadingOverlay bounds={bounds} />
         } else if (grapher.isSlopeChart) {
-            return <SlopeChart bounds={bounds.padTop(15)} grapher={grapher} />
+            return <SlopeChart bounds={bounds.padTop(18)} grapher={grapher} />
         } else if (grapher.isScatter) {
             return (
                 <ScatterPlot
-                    bounds={bounds.padTop(15).padBottom(15)}
+                    bounds={bounds.padTop(18).padBottom(15)}
                     grapher={grapher}
                 />
             )
         } else if (grapher.isTimeScatter) {
             return (
                 <TimeScatter
-                    bounds={bounds.padTop(15).padBottom(15)}
+                    bounds={bounds.padTop(18).padBottom(15)}
                     grapher={grapher}
                 />
             )
@@ -186,33 +186,33 @@ export class ChartTab extends React.Component<{
             // Switch to bar chart if a single year is selected
             return grapher.lineChartTransform.isSingleTime ? (
                 <DiscreteBarChart
-                    bounds={bounds.padTop(15).padBottom(15)}
+                    bounds={bounds.padTop(18).padBottom(15)}
                     grapher={grapher}
                 />
             ) : (
                 <LineChart
-                    bounds={bounds.padTop(15).padBottom(15)}
+                    bounds={bounds.padTop(18).padBottom(15)}
                     grapher={grapher}
                 />
             )
         } else if (grapher.isStackedArea) {
             return (
                 <StackedAreaChart
-                    bounds={bounds.padTop(15).padBottom(15)}
+                    bounds={bounds.padTop(18).padBottom(15)}
                     grapher={grapher}
                 />
             )
         } else if (grapher.isDiscreteBar) {
             return (
                 <DiscreteBarChart
-                    bounds={bounds.padTop(15).padBottom(15)}
+                    bounds={bounds.padTop(18).padBottom(15)}
                     grapher={grapher}
                 />
             )
         } else if (grapher.isStackedBar) {
             return (
                 <StackedBarChart
-                    bounds={bounds.padTop(15).padBottom(15)}
+                    bounds={bounds.padTop(18).padBottom(15)}
                     grapher={grapher}
                 />
             )

--- a/grapher/chart/ChartTab.tsx
+++ b/grapher/chart/ChartTab.tsx
@@ -32,22 +32,20 @@ export class ChartTab extends React.Component<{
     grapherView: GrapherView
     bounds: Bounds
 }> {
-    @computed get controlsRowControls() {
+    @computed get controlsRowControls(): React.ReactElement[] {
         const controls: JSX.Element[] = []
-
         const { grapher } = this.props
+
+        if (!grapher.isReady) return []
         const onDataSelect = action(() => (grapher.isSelectingData = true))
 
         if (grapher.tab === "chart") {
             const yAxis =
-                grapher.isReady &&
-                ((grapher.isStackedArea &&
-                    grapher.stackedAreaTransform.yAxis) ||
-                    (grapher.isStackedBar &&
-                        grapher.stackedBarTransform.yAxis) ||
-                    (grapher.isLineChart && grapher.lineChartTransform.yAxis) ||
-                    ((grapher.isScatter || grapher.isTimeScatter) &&
-                        grapher.scatterTransform.yAxis))
+                (grapher.isStackedArea && grapher.stackedAreaTransform.yAxis) ||
+                (grapher.isStackedBar && grapher.stackedBarTransform.yAxis) ||
+                (grapher.isLineChart && grapher.lineChartTransform.yAxis) ||
+                ((grapher.isScatter || grapher.isTimeScatter) &&
+                    grapher.scatterTransform.yAxis)
 
             yAxis &&
                 yAxis.scaleTypeOptions.length > 1 &&

--- a/grapher/chart/ChartTab.tsx
+++ b/grapher/chart/ChartTab.tsx
@@ -167,18 +167,18 @@ export class ChartTab extends React.Component<{
         if (!grapher.isReady) {
             return <LoadingOverlay bounds={bounds} />
         } else if (grapher.isSlopeChart) {
-            return <SlopeChart bounds={bounds.padTop(20)} grapher={grapher} />
+            return <SlopeChart bounds={bounds.padTop(15)} grapher={grapher} />
         } else if (grapher.isScatter) {
             return (
                 <ScatterPlot
-                    bounds={bounds.padTop(20).padBottom(15)}
+                    bounds={bounds.padTop(15).padBottom(15)}
                     grapher={grapher}
                 />
             )
         } else if (grapher.isTimeScatter) {
             return (
                 <TimeScatter
-                    bounds={bounds.padTop(20).padBottom(15)}
+                    bounds={bounds.padTop(15).padBottom(15)}
                     grapher={grapher}
                 />
             )
@@ -186,33 +186,33 @@ export class ChartTab extends React.Component<{
             // Switch to bar chart if a single year is selected
             return grapher.lineChartTransform.isSingleTime ? (
                 <DiscreteBarChart
-                    bounds={bounds.padTop(20).padBottom(15)}
+                    bounds={bounds.padTop(15).padBottom(15)}
                     grapher={grapher}
                 />
             ) : (
                 <LineChart
-                    bounds={bounds.padTop(20).padBottom(15)}
+                    bounds={bounds.padTop(15).padBottom(15)}
                     grapher={grapher}
                 />
             )
         } else if (grapher.isStackedArea) {
             return (
                 <StackedAreaChart
-                    bounds={bounds.padTop(20).padBottom(15)}
+                    bounds={bounds.padTop(15).padBottom(15)}
                     grapher={grapher}
                 />
             )
         } else if (grapher.isDiscreteBar) {
             return (
                 <DiscreteBarChart
-                    bounds={bounds.padTop(20).padBottom(15)}
+                    bounds={bounds.padTop(15).padBottom(15)}
                     grapher={grapher}
                 />
             )
         } else if (grapher.isStackedBar) {
             return (
                 <StackedBarChart
-                    bounds={bounds.padTop(20).padBottom(15)}
+                    bounds={bounds.padTop(15).padBottom(15)}
                     grapher={grapher}
                 />
             )

--- a/grapher/chart/ChartTab.tsx
+++ b/grapher/chart/ChartTab.tsx
@@ -24,6 +24,7 @@ import {
     FilterSmallCountriesToggle,
 } from "grapher/controls/Controls"
 import { ScaleSelector } from "grapher/controls/ScaleSelector"
+import { AddEntityButton } from "grapher/controls/AddEntityButton"
 
 @observer
 export class ChartTab extends React.Component<{
@@ -39,11 +40,14 @@ export class ChartTab extends React.Component<{
 
         if (grapher.tab === "chart") {
             const yAxis =
-                (grapher.isStackedArea && grapher.stackedAreaTransform.yAxis) ||
-                (grapher.isStackedBar && grapher.stackedBarTransform.yAxis) ||
-                (grapher.isLineChart && grapher.lineChartTransform.yAxis) ||
-                ((grapher.isScatter || grapher.isTimeScatter) &&
-                    grapher.scatterTransform.yAxis)
+                grapher.isReady &&
+                ((grapher.isStackedArea &&
+                    grapher.stackedAreaTransform.yAxis) ||
+                    (grapher.isStackedBar &&
+                        grapher.stackedBarTransform.yAxis) ||
+                    (grapher.isLineChart && grapher.lineChartTransform.yAxis) ||
+                    ((grapher.isScatter || grapher.isTimeScatter) &&
+                        grapher.scatterTransform.yAxis))
 
             yAxis &&
                 yAxis.scaleTypeOptions.length > 1 &&
@@ -93,6 +97,10 @@ export class ChartTab extends React.Component<{
                         {grapher.entityType}
                     </button>
                 )
+
+            grapher.hasFloatingAddButton &&
+                grapher.showAddEntityControls &&
+                controls.push(<AddEntityButton grapher={grapher} />)
 
             grapher.isScatter &&
                 grapher.hasSelection &&

--- a/grapher/chart/ChartTab.tsx
+++ b/grapher/chart/ChartTab.tsx
@@ -47,7 +47,8 @@ export class ChartTab extends React.Component<{
                     grapher.stackedBarTransform.yAxis) ||
                 (grapher.isLineChart && grapher.lineChartTransform.yAxis) ||
                 ((grapher.isScatter || grapher.isTimeScatter) &&
-                    grapher.scatterTransform.yAxis)
+                    grapher.scatterTransform.yAxis) ||
+                (grapher.isSlopeChart && grapher.yAxis.toVerticalAxis())
 
             yAxis &&
                 yAxis.scaleTypeOptions.length > 1 &&

--- a/grapher/chart/ChartTransform.ts
+++ b/grapher/chart/ChartTransform.ts
@@ -8,12 +8,14 @@ import { first, last, sortNumeric, uniq } from "grapher/utils/Util"
 import { Grapher } from "grapher/core/Grapher"
 import { Time } from "grapher/core/GrapherConstants"
 import { ColorScale } from "grapher/color/ColorScale"
+import { VerticalAxis } from "grapher/axis/Axis"
 
 export interface IChartTransform {
     timelineTimes: Time[]
     startTimelineTime?: Time
     endTimelineTime?: Time
     colorScale?: ColorScale
+    yAxis?: VerticalAxis
 }
 
 export abstract class ChartTransform implements IChartTransform {

--- a/grapher/controls/AddEntityButton.scss
+++ b/grapher/controls/AddEntityButton.scss
@@ -1,0 +1,49 @@
+.addEntityButton {
+    font-weight: 700;
+    color: $controls-color;
+
+    animation: appear 500ms cubic-bezier(0, 0, 0.4, 1) 1s;
+    animation-iteration-count: initial;
+    animation-fill-mode: backwards;
+
+    .icon {
+        display: inline-block;
+        margin-right: 3px;
+        vertical-align: text-bottom;
+        position: relative;
+        width: 16px;
+        height: 16px;
+
+        svg {
+            position: absolute;
+            top: 0;
+            left: 0;
+            z-index: 1;
+        }
+
+        path {
+            stroke: #fff;
+            stroke-width: 2px;
+        }
+
+        &::before {
+            display: block;
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 16px;
+            height: 16px;
+            background-color: $controls-color;
+            border-radius: 100%;
+            transition: transform 200ms cubic-bezier(0, 0, 0.4, 1);
+
+            animation: bounceIn 750ms cubic-bezier(0, 0, 0.4, 1) 1s;
+            animation-iteration-count: initial;
+        }
+    }
+
+    &:hover .icon::before {
+        transform: scale(1.25) !important;
+    }
+}

--- a/grapher/controls/AddEntityButton.tsx
+++ b/grapher/controls/AddEntityButton.tsx
@@ -1,83 +1,29 @@
 import * as React from "react"
 import { observer } from "mobx-react"
-
-type HorizontalAlign = "left" | "right"
-type VerticalAlign = "top" | "middle" | "bottom"
+import { Grapher } from "grapher/core/Grapher"
+import { runInAction } from "mobx"
 
 @observer
 export class AddEntityButton extends React.Component<{
-    x: number
-    y: number
-    align: HorizontalAlign
-    verticalAlign: VerticalAlign
-    height: number
-    label: string
-    onClick: () => void
+    grapher: Grapher
 }> {
-    static defaultProps = {
-        align: "left",
-        verticalAlign: "bottom",
-        height: 21,
-        label: "Add country",
-    }
-
-    static calcPaddingTop(
-        y: number,
-        verticalAlign: VerticalAlign,
-        height: number
-    ): number {
-        const realY =
-            verticalAlign === "bottom"
-                ? y - height
-                : verticalAlign === "middle"
-                ? y - height / 2
-                : y
-        return Math.max(0, -realY)
-    }
-
     render() {
-        const {
-            x,
-            y,
-            align,
-            verticalAlign,
-            height,
-            label,
-            onClick,
-        } = this.props
-
-        const buttonStyle: React.CSSProperties = {
-            position: "absolute",
-            lineHeight: `${height}px`,
-        }
-
-        if (verticalAlign === "top") {
-            buttonStyle.top = `${y}px`
-        } else if (verticalAlign === "bottom") {
-            buttonStyle.top = `${y - height}px`
-        } else {
-            buttonStyle.top = `${y - height / 2}px`
-        }
-
-        if (align === "left") {
-            buttonStyle.left = `${x}px`
-        } else if (align === "right") {
-            buttonStyle.right = `${-x}px`
-        }
-
         return (
             <button
-                className="addDataButton clickable"
-                onClick={onClick}
+                className="addEntityButton clickable"
+                onClick={() =>
+                    runInAction(
+                        () => (this.props.grapher.isSelectingData = true)
+                    )
+                }
                 data-track-note="chart-add-entity"
-                style={buttonStyle}
             >
                 <span className="icon">
                     <svg width={16} height={16}>
                         <path d="M3,8 h10 m-5,-5 v10" />
                     </svg>
                 </span>
-                <span className="label">{label}</span>
+                <span className="label">{`Add ${this.props.grapher.entityType}`}</span>
             </button>
         )
     }

--- a/grapher/controls/CollapsibleList/CollapsibleList.jsdom.test.tsx
+++ b/grapher/controls/CollapsibleList/CollapsibleList.jsdom.test.tsx
@@ -11,7 +11,7 @@ describe(CollapsibleList, () => {
             const view = shallow(
                 <CollapsibleList>{collapsibleListSampleItems}</CollapsibleList>
             )
-            expect(view.find(".list-item.visible")).not.toHaveLength(0)
+            expect(view.find(".list-item")).not.toHaveLength(0)
         })
     })
 

--- a/grapher/controls/CollapsibleList/CollapsibleList.scss
+++ b/grapher/controls/CollapsibleList/CollapsibleList.scss
@@ -4,7 +4,8 @@
     ul {
         list-style: none;
         > .list-item {
-            &.visible {
+            &.visible,
+            &.moreButton {
                 display: inline-block;
 
                 padding-left: 15px;

--- a/grapher/controls/CollapsibleList/CollapsibleList.scss
+++ b/grapher/controls/CollapsibleList/CollapsibleList.scss
@@ -1,5 +1,4 @@
 .collapsibleList {
-    padding-left: 15px;
     white-space: nowrap;
 
     ul {

--- a/grapher/controls/CollapsibleList/CollapsibleList.scss
+++ b/grapher/controls/CollapsibleList/CollapsibleList.scss
@@ -12,4 +12,8 @@
             }
         }
     }
+
+    .moreButton {
+        cursor: pointer;
+    }
 }

--- a/grapher/controls/CollapsibleList/CollapsibleList.tsx
+++ b/grapher/controls/CollapsibleList/CollapsibleList.tsx
@@ -11,7 +11,9 @@ interface ListChild {
 
 /** A UI component inspired by the "Priority+ Navbar" or "Progressively Collapsing Navbar"*/
 @observer
-export class CollapsibleList extends React.Component {
+export class CollapsibleList extends React.Component<{
+    rendo: React.ReactElement[]
+}> {
     private outerContainerRef: React.RefObject<
         HTMLDivElement
     > = React.createRef()
@@ -28,7 +30,7 @@ export class CollapsibleList extends React.Component {
         this.visibleItems = this.children
     }
 
-    @computed private get children(): ListChild[] {
+    private get children(): ListChild[] {
         return (
             React.Children.map(this.props.children, (child, i) => {
                 return {
@@ -82,6 +84,7 @@ export class CollapsibleList extends React.Component {
     }
 
     render() {
+        console.log("collapsible list rerendering")
         return (
             <div className="collapsibleList" ref={this.outerContainerRef}>
                 <ul>

--- a/grapher/controls/CollapsibleList/CollapsibleList.tsx
+++ b/grapher/controls/CollapsibleList/CollapsibleList.tsx
@@ -14,7 +14,7 @@ interface ListChild {
 /** A UI component inspired by the "Priority+ Navbar" or "Progressively Collapsing Navbar"*/
 @observer
 export class CollapsibleList extends React.Component<{
-    rendo: React.ReactElement[]
+    rendo?: React.ReactElement[]
 }> {
     private outerContainerRef: React.RefObject<
         HTMLDivElement

--- a/grapher/controls/CollapsibleList/CollapsibleList.tsx
+++ b/grapher/controls/CollapsibleList/CollapsibleList.tsx
@@ -3,6 +3,8 @@ import { observable, action, computed } from "mobx"
 import { observer } from "mobx-react"
 import { throttle } from "grapher/utils/Util"
 import { Tippy } from "grapher/chart/Tippy"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faCog } from "@fortawesome/free-solid-svg-icons/faCog"
 
 interface ListChild {
     index: number
@@ -126,8 +128,16 @@ export class MoreButton extends React.Component<{
     render() {
         const { options } = this.props
         return (
-            <Tippy content={options} interactive={true} trigger={"click"}>
-                <span>More</span>
+            <Tippy
+                content={options}
+                interactive={true}
+                trigger={"click"}
+                placement={"bottom"}
+            >
+                <span>
+                    <FontAwesomeIcon icon={faCog} />
+                    &nbsp;More
+                </span>
             </Tippy>
         )
     }

--- a/grapher/controls/CollapsibleList/CollapsibleList.tsx
+++ b/grapher/controls/CollapsibleList/CollapsibleList.tsx
@@ -13,9 +13,7 @@ interface ListChild {
 
 /** A UI component inspired by the "Priority+ Navbar" or "Progressively Collapsing Navbar"*/
 @observer
-export class CollapsibleList extends React.Component<{
-    rendo?: React.ReactElement[]
-}> {
+export class CollapsibleList extends React.Component {
     private outerContainerRef: React.RefObject<
         HTMLDivElement
     > = React.createRef()

--- a/grapher/controls/CollapsibleList/CollapsibleList.tsx
+++ b/grapher/controls/CollapsibleList/CollapsibleList.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react"
-import { observable, action, computed } from "mobx"
+import { observable, action } from "mobx"
 import { observer } from "mobx-react"
 import { throttle } from "grapher/utils/Util"
 import { Tippy } from "grapher/chart/Tippy"
@@ -44,16 +44,24 @@ export class CollapsibleList extends React.Component<{
 
     private calculateItemWidths() {
         this.outerContainerRef.current
-            ?.querySelectorAll(".list-item")
+            ?.querySelectorAll(".list-item.visible")
             .forEach((item) => this.itemsWidths.push(item.clientWidth))
     }
 
     @action private updateNumItemsVisible() {
-        this.numItemsVisible = numItemsVisible(
+        const numItemsVisibleWithoutMoreButton = numItemsVisible(
             this.itemsWidths,
-            this.outerContainerWidth,
-            this.moreButtonWidth
+            this.outerContainerWidth
         )
+
+        this.numItemsVisible =
+            numItemsVisibleWithoutMoreButton >= this.children.length
+                ? numItemsVisibleWithoutMoreButton
+                : numItemsVisible(
+                      this.itemsWidths,
+                      this.outerContainerWidth,
+                      this.moreButtonWidth
+                  )
     }
 
     private get visibleItems() {
@@ -97,7 +105,7 @@ export class CollapsibleList extends React.Component<{
                         </li>
                     ))}
                     <li
-                        className="list-item visible moreButton"
+                        className="list-item moreButton"
                         ref={this.moreButtonRef}
                         style={{
                             visibility: this.dropdownItems.length
@@ -150,7 +158,7 @@ export class MoreButton extends React.Component<{
 export function numItemsVisible(
     itemWidths: number[],
     containerWidth: number,
-    startingWidth: number
+    startingWidth: number = 0
 ) {
     let total = startingWidth
     for (let i = 0; i < itemWidths.length; i++) {

--- a/grapher/controls/Controls.scss
+++ b/grapher/controls/Controls.scss
@@ -9,6 +9,10 @@ $zindex-ControlsFooter: 2;
     }
 }
 
+.ChangeEntityButton {
+    color: $controls-color;
+}
+
 .addDataButton {
     font-size: 0.8em;
     font-weight: 700;

--- a/grapher/controls/Controls.scss
+++ b/grapher/controls/Controls.scss
@@ -13,67 +13,6 @@ $zindex-ControlsFooter: 2;
     color: $controls-color;
 }
 
-.addDataButton {
-    font-size: 0.8em;
-    font-weight: 700;
-    border-radius: 2px;
-    padding: 0;
-    border: none;
-    color: $controls-color;
-    line-height: 21px;
-    text-align: left;
-    white-space: nowrap;
-    padding-left: 6px;
-    padding-right: 6px;
-    margin-left: -25px;
-    outline: none;
-
-    animation: appear 500ms cubic-bezier(0, 0, 0.4, 1) 1s;
-    animation-iteration-count: initial;
-    animation-fill-mode: backwards;
-
-    .icon {
-        display: inline-block;
-        margin-right: 3px;
-        vertical-align: text-bottom;
-        position: relative;
-        width: 16px;
-        height: 16px;
-
-        svg {
-            position: absolute;
-            top: 0;
-            left: 0;
-            z-index: 1;
-        }
-
-        path {
-            stroke: #fff;
-            stroke-width: 2px;
-        }
-
-        &::before {
-            display: block;
-            content: "";
-            position: absolute;
-            left: 0;
-            top: 0;
-            width: 16px;
-            height: 16px;
-            background-color: $controls-color;
-            border-radius: 100%;
-            transition: transform 200ms cubic-bezier(0, 0, 0.4, 1);
-
-            animation: bounceIn 750ms cubic-bezier(0, 0, 0.4, 1) 1s;
-            animation-iteration-count: initial;
-        }
-    }
-
-    &:hover .icon::before {
-        transform: scale(1.25) !important;
-    }
-}
-
 @keyframes bounceIn {
     from,
     20%,

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -14,9 +14,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faDownload } from "@fortawesome/free-solid-svg-icons/faDownload"
 import { faShareAlt } from "@fortawesome/free-solid-svg-icons/faShareAlt"
 import { faExpand } from "@fortawesome/free-solid-svg-icons/faExpand"
-import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus"
-import { faPencilAlt } from "@fortawesome/free-solid-svg-icons/faPencilAlt"
-import { faExchangeAlt } from "@fortawesome/free-solid-svg-icons/faExchangeAlt"
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons/faExternalLinkAlt"
 import { HighlightToggleConfig } from "grapher/core/GrapherConstants"
 import { ShareMenu } from "./ShareMenu"
@@ -242,82 +239,6 @@ export class ControlsFooterView extends React.Component<{
         )
     }
 
-    private _getInlineControlsElement() {
-        const { grapher } = this
-        return (
-            <div className="extraControls">
-                {grapher.currentTab === "chart" &&
-                    grapher.canAddData &&
-                    !grapher.hasFloatingAddButton &&
-                    !grapher.hideEntityControls && (
-                        <button
-                            type="button"
-                            onClick={this.onDataSelect}
-                            data-track-note="chart-select-entities"
-                        >
-                            {grapher.isScatter || grapher.isSlopeChart ? (
-                                <span className="SelectEntitiesButton">
-                                    <FontAwesomeIcon icon={faPencilAlt} />
-                                    {`Select ${grapher.entityTypePlural}`}
-                                </span>
-                            ) : (
-                                <span>
-                                    <FontAwesomeIcon icon={faPlus} />{" "}
-                                    {grapher.addButtonLabel}
-                                </span>
-                            )}
-                        </button>
-                    )}
-
-                {grapher.currentTab === "chart" &&
-                    grapher.canChangeEntity &&
-                    !grapher.hideEntityControls && (
-                        <button
-                            type="button"
-                            onClick={this.onDataSelect}
-                            data-track-note="chart-change-entity"
-                        >
-                            <FontAwesomeIcon icon={faExchangeAlt} /> Change{" "}
-                            {grapher.entityType}
-                        </button>
-                    )}
-
-                {grapher.currentTab === "chart" &&
-                    grapher.isScatter &&
-                    grapher.highlightToggle && (
-                        <HighlightToggle
-                            grapher={grapher}
-                            highlightToggle={grapher.highlightToggle}
-                        />
-                    )}
-                {grapher.currentTab === "chart" &&
-                    grapher.isStackedArea &&
-                    grapher.canToggleRelativeMode && (
-                        <AbsRelToggle grapher={grapher} />
-                    )}
-                {grapher.currentTab === "chart" &&
-                    grapher.isScatter &&
-                    grapher.scatterTransform.canToggleRelativeMode && (
-                        <AbsRelToggle grapher={grapher} />
-                    )}
-                {grapher.currentTab === "chart" &&
-                    grapher.isScatter &&
-                    grapher.hasSelection && <ZoomToggle grapher={grapher} />}
-
-                {(grapher.currentTab === "table" || grapher.isScatter) &&
-                    grapher.hasCountriesSmallerThanFilterOption && (
-                        <FilterSmallCountriesToggle grapher={grapher} />
-                    )}
-
-                {grapher.currentTab === "chart" &&
-                    grapher.isLineChart &&
-                    grapher.lineChartTransform.canToggleRelativeMode && (
-                        <AbsRelToggle grapher={grapher} />
-                    )}
-            </div>
-        )
-    }
-
     @computed private get timeline() {
         if (!this.grapherView.hasTimeline) return null
 
@@ -358,28 +279,10 @@ export class ControlsFooterView extends React.Component<{
 
     render() {
         const { grapher, grapherView } = this
-        const {
-            isShareMenuActive,
-            hasInlineControls,
-            hasSpace,
-            hasRelatedQuestion,
-        } = grapherView
+        const { isShareMenuActive, hasRelatedQuestion } = grapherView
         const { relatedQuestions } = grapher
 
-        const inlineControlsElement = hasInlineControls && !hasSpace && (
-            <div className="footerRowSingle">
-                {this._getInlineControlsElement()}
-            </div>
-        )
-
-        const tabsElement = hasSpace ? (
-            <div className="footerRowMulti">
-                <div className="inline-controls">
-                    {hasInlineControls && this._getInlineControlsElement()}
-                </div>
-                {this._getTabsElement()}
-            </div>
-        ) : (
+        const tabsElement = (
             <div className="footerRowSingle">{this._getTabsElement()}</div>
         )
 
@@ -412,7 +315,6 @@ export class ControlsFooterView extends React.Component<{
                 style={{ height: grapherView.footerHeight }}
             >
                 {this.timeline}
-                {inlineControlsElement}
                 {tabsElement}
                 {shareMenuElement}
                 {relatedQuestionElement}

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -64,7 +64,7 @@ export class HighlightToggle extends React.Component<{
                     checked={isHighlightActive}
                     onChange={this.onHighlightToggle}
                 />{" "}
-                {highlight.description}
+                &nbsp;{highlight.description}
             </label>
         )
     }
@@ -118,6 +118,7 @@ export class ZoomToggle extends React.Component<{
                     onChange={this.onToggle}
                     data-track-note="chart-zoom-to-selection"
                 />{" "}
+                &nbsp;
                 {label}
             </label>
         )

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -92,7 +92,7 @@ export class AbsRelToggle extends React.Component<{ grapher: Grapher }> {
                     onChange={this.onToggle}
                     data-track-note="chart-abs-rel-toggle"
                 />{" "}
-                {label}
+                &nbsp;{label}
             </label>
         )
     }
@@ -143,7 +143,7 @@ export class FilterSmallCountriesToggle extends React.Component<{
                     }
                     data-track-note="chart-filter-small-countries"
                 />{" "}
-                {label}
+                &nbsp;{label}
             </label>
         )
     }

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -22,7 +22,7 @@ import { HighlightToggleConfig } from "grapher/core/GrapherConstants"
 import { ShareMenu } from "./ShareMenu"
 
 @observer
-class HighlightToggle extends React.Component<{
+export class HighlightToggle extends React.Component<{
     grapher: Grapher
     highlightToggle: HighlightToggleConfig
 }> {
@@ -74,7 +74,7 @@ class HighlightToggle extends React.Component<{
 }
 
 @observer
-class AbsRelToggle extends React.Component<{ grapher: Grapher }> {
+export class AbsRelToggle extends React.Component<{ grapher: Grapher }> {
     @action.bound onToggle() {
         this.props.grapher.toggleRelativeMode()
     }
@@ -102,7 +102,7 @@ class AbsRelToggle extends React.Component<{ grapher: Grapher }> {
 }
 
 @observer
-class ZoomToggle extends React.Component<{
+export class ZoomToggle extends React.Component<{
     grapher: GrapherInterface
 }> {
     @action.bound onToggle() {
@@ -128,7 +128,7 @@ class ZoomToggle extends React.Component<{
 }
 
 @observer
-class FilterSmallCountriesToggle extends React.Component<{
+export class FilterSmallCountriesToggle extends React.Component<{
     grapher: Grapher
 }> {
     render() {

--- a/grapher/controls/ControlsRow.scss
+++ b/grapher/controls/ControlsRow.scss
@@ -6,8 +6,13 @@
         font-size: 13px;
         line-height: 20px;
 
-        /* blue dark */
-        color: #1d3d63;
+        /* blue gray */
+        color: #60758c;
+    }
+
+    .moreButton {
+        /* blue medium */
+        color: #0073e6;
     }
 
     margin: 12px 0px;

--- a/grapher/controls/ControlsRow.scss
+++ b/grapher/controls/ControlsRow.scss
@@ -1,4 +1,9 @@
 .controlsRow {
+    ul {
+        margin: 0px;
+        padding: 0px;
+    }
+
     .list-item {
         font-family: Lato;
         font-style: normal;

--- a/grapher/controls/ControlsRow.scss
+++ b/grapher/controls/ControlsRow.scss
@@ -20,5 +20,10 @@
         color: #0073e6;
     }
 
+    input[type="checkbox"] {
+        height: 10px;
+        width: 10px;
+    }
+
     margin: 12px 0px 0px 0px;
 }

--- a/grapher/controls/ControlsRow.scss
+++ b/grapher/controls/ControlsRow.scss
@@ -4,7 +4,7 @@
         font-style: normal;
         font-weight: normal;
         font-size: 13px;
-        line-height: 20px;
+        line-height: 24px;
 
         /* blue gray */
         color: #60758c;
@@ -15,5 +15,5 @@
         color: #0073e6;
     }
 
-    margin: 12px 0px;
+    margin: 12px 0px 0px 0px;
 }

--- a/grapher/controls/ControlsRow.scss
+++ b/grapher/controls/ControlsRow.scss
@@ -1,0 +1,14 @@
+.controlsRow {
+    .list-item {
+        font-family: Lato;
+        font-style: normal;
+        font-weight: normal;
+        font-size: 13px;
+        line-height: 20px;
+
+        /* blue dark */
+        color: #1d3d63;
+    }
+
+    margin: 12px 0px;
+}

--- a/grapher/controls/ControlsRow.tsx
+++ b/grapher/controls/ControlsRow.tsx
@@ -1,0 +1,119 @@
+import React from "react"
+import { computed, action } from "mobx"
+import { observer } from "mobx-react"
+import {
+    FilterSmallCountriesToggle,
+    HighlightToggle,
+    AbsRelToggle,
+    ZoomToggle,
+} from "./Controls"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faPencilAlt } from "@fortawesome/free-solid-svg-icons/faPencilAlt"
+import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus"
+import { faExchangeAlt } from "@fortawesome/free-solid-svg-icons/faExchangeAlt"
+import { Grapher } from "grapher/core/Grapher"
+import { CollapsibleList } from "./CollapsibleList/CollapsibleList"
+
+@observer
+export class ControlsRow extends React.Component<{
+    grapher: Grapher
+}> {
+    static readonly height = 45
+
+    @action.bound onDataSelect() {
+        this.grapher.isSelectingData = true
+    }
+
+    @computed get grapher() {
+        return this.props.grapher
+    }
+
+    @computed get controlsToRender() {
+        const grapher = this.grapher
+        const controls: JSX.Element[] = []
+
+        if (grapher.tab === "chart") {
+            grapher.canAddData &&
+                !grapher.hasFloatingAddButton &&
+                !grapher.hideEntityControls &&
+                controls.push(
+                    <button
+                        type="button"
+                        onClick={this.onDataSelect}
+                        key="grapher-select-entities"
+                        data-track-note="grapher-select-entities"
+                    >
+                        {grapher.isScatter || grapher.isSlopeChart ? (
+                            <span className="SelectEntitiesButton">
+                                <FontAwesomeIcon icon={faPencilAlt} />
+                                {`Select ${grapher.entityTypePlural}`}
+                            </span>
+                        ) : (
+                            <span>
+                                <FontAwesomeIcon icon={faPlus} />{" "}
+                                {grapher.addButtonLabel}
+                            </span>
+                        )}
+                    </button>
+                )
+
+            grapher.canChangeEntity &&
+                !grapher.hideEntityControls &&
+                controls.push(
+                    <button
+                        type="button"
+                        onClick={this.onDataSelect}
+                        key="grapher-change-entities"
+                        data-track-note="grapher-change-entity"
+                    >
+                        <FontAwesomeIcon icon={faExchangeAlt} /> Change{" "}
+                        {grapher.entityType}
+                    </button>
+                )
+
+            grapher.isScatter &&
+                grapher.highlightToggle &&
+                controls.push(
+                    <HighlightToggle
+                        key="highlight-toggle"
+                        grapher={grapher}
+                        highlightToggle={grapher.highlightToggle}
+                    />
+                )
+
+            const absRelToggle =
+                (grapher.isStackedArea && grapher.canToggleRelativeMode) ||
+                (grapher.isScatter &&
+                    grapher.scatterTransform.canToggleRelativeMode) ||
+                (grapher.isLineChart &&
+                    grapher.lineChartTransform.canToggleRelativeMode)
+            absRelToggle &&
+                controls.push(
+                    <AbsRelToggle key="AbsRelToggle" grapher={grapher} />
+                )
+
+            grapher.isScatter &&
+                grapher.hasSelection &&
+                controls.push(<ZoomToggle key="ZoomToggle" grapher={grapher} />)
+        }
+
+        grapher.isScatter &&
+            grapher.hasCountriesSmallerThanFilterOption &&
+            controls.push(
+                <FilterSmallCountriesToggle
+                    key="FilterSmallCountriesToggle"
+                    grapher={grapher}
+                />
+            )
+
+        return controls
+    }
+
+    render() {
+        return this.controlsToRender.length ? (
+            <div className="controlsRow">
+                <CollapsibleList>{this.controlsToRender}</CollapsibleList>
+            </div>
+        ) : null
+    }
+}

--- a/grapher/controls/ControlsRow.tsx
+++ b/grapher/controls/ControlsRow.tsx
@@ -21,16 +21,16 @@ export class ControlsRow extends React.Component<{
 }> {
     static readonly height = 45
 
-    @action.bound onDataSelect() {
+    @action.bound private onDataSelect() {
         this.grapher.isSelectingData = true
     }
 
-    @computed get grapher() {
+    @computed private get grapher() {
         return this.props.grapher
     }
 
-    @computed get controlsToRender() {
-        const grapher = this.grapher
+    @computed private get controlsToRender() {
+        const { grapher } = this
         const controls: JSX.Element[] = []
 
         if (grapher.tab === "chart") {

--- a/grapher/controls/ControlsRow.tsx
+++ b/grapher/controls/ControlsRow.tsx
@@ -93,16 +93,6 @@ export class ControlsRow extends React.Component<{
                 grapher.hasSelection &&
                 controls.push(<ZoomToggle key="ZoomToggle" grapher={grapher} />)
 
-            grapher.isScatter &&
-                grapher.highlightToggle &&
-                controls.push(
-                    <HighlightToggle
-                        key="highlight-toggle"
-                        grapher={grapher}
-                        highlightToggle={grapher.highlightToggle}
-                    />
-                )
-
             const absRelToggle =
                 (grapher.isStackedArea && grapher.canToggleRelativeMode) ||
                 (grapher.isScatter &&
@@ -112,6 +102,16 @@ export class ControlsRow extends React.Component<{
             absRelToggle &&
                 controls.push(
                     <AbsRelToggle key="AbsRelToggle" grapher={grapher} />
+                )
+
+            grapher.isScatter &&
+                grapher.highlightToggle &&
+                controls.push(
+                    <HighlightToggle
+                        key="highlight-toggle"
+                        grapher={grapher}
+                        highlightToggle={grapher.highlightToggle}
+                    />
                 )
         }
 

--- a/grapher/controls/ControlsRow.tsx
+++ b/grapher/controls/ControlsRow.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { CollapsibleList } from "./CollapsibleList/CollapsibleList"
 
-export const ControlsRowHeight = 45
+export const ControlsRowHeight = 36
 
 export class ControlsRow extends React.Component<{
     controls: React.ReactElement[]

--- a/grapher/controls/ControlsRow.tsx
+++ b/grapher/controls/ControlsRow.tsx
@@ -130,9 +130,7 @@ export class ControlsRow extends React.Component<{
     render() {
         return this.grapher.isReady && this.controlsToRender.length ? (
             <div className="controlsRow">
-                <CollapsibleList rendo={this.controlsToRender}>
-                    {this.controlsToRender}
-                </CollapsibleList>
+                <CollapsibleList>{this.controlsToRender}</CollapsibleList>
             </div>
         ) : null
     }

--- a/grapher/controls/ControlsRow.tsx
+++ b/grapher/controls/ControlsRow.tsx
@@ -13,6 +13,7 @@ import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus"
 import { faExchangeAlt } from "@fortawesome/free-solid-svg-icons/faExchangeAlt"
 import { Grapher } from "grapher/core/Grapher"
 import { CollapsibleList } from "./CollapsibleList/CollapsibleList"
+import { ScaleSelector } from "./ScaleSelector"
 
 @observer
 export class ControlsRow extends React.Component<{
@@ -33,29 +34,47 @@ export class ControlsRow extends React.Component<{
         const controls: JSX.Element[] = []
 
         if (grapher.tab === "chart") {
-            grapher.canAddData &&
-                !grapher.hasFloatingAddButton &&
-                !grapher.hideEntityControls &&
+            const yAxis = grapher.activeTransform.yAxis
+            // const yAxis =
+            //     (grapher.isStackedArea && grapher.stackedAreaTransform.yAxis) ||
+            //     (grapher.isStackedBar && grapher.stackedBarTransform.yAxis) ||
+            //     (grapher.isLineChart && grapher.lineChartTransform.yAxis) ||
+            //     ((grapher.isScatter || grapher.isTimeScatter) &&
+            //         grapher.scatterTransform.yAxis)
+
+            yAxis &&
+                yAxis.scaleTypeOptions.length > 1 &&
                 controls.push(
-                    <button
-                        type="button"
-                        onClick={this.onDataSelect}
-                        key="grapher-select-entities"
-                        data-track-note="grapher-select-entities"
-                    >
-                        {grapher.isScatter || grapher.isSlopeChart ? (
-                            <span className="SelectEntitiesButton">
-                                <FontAwesomeIcon icon={faPencilAlt} />
-                                {`Select ${grapher.entityTypePlural}`}
-                            </span>
-                        ) : (
-                            <span>
-                                <FontAwesomeIcon icon={faPlus} />{" "}
-                                {grapher.addButtonLabel}
-                            </span>
-                        )}
-                    </button>
+                    <ScaleSelector
+                        key="scaleSelector"
+                        scaleTypeConfig={yAxis}
+                        inline={true}
+                    />
                 )
+
+            // grapher.canAddData &&
+            //     !grapher.hasFloatingAddButton &&
+            //     !grapher.hideEntityControls &&
+            //     controls.push(
+            //         <button
+            //             type="button"
+            //             onClick={this.onDataSelect}
+            //             key="grapher-select-entities"
+            //             data-track-note="grapher-select-entities"
+            //         >
+            //             {grapher.isScatter || grapher.isSlopeChart ? (
+            //                 <span className="SelectEntitiesButton">
+            //                     <FontAwesomeIcon icon={faPencilAlt} />
+            //                     {`Select ${grapher.entityTypePlural}`}
+            //                 </span>
+            //             ) : (
+            //                 <span>
+            //                     <FontAwesomeIcon icon={faPlus} />{" "}
+            //                     {grapher.addButtonLabel}
+            //                 </span>
+            //             )}
+            //         </button>
+            //     )
 
             grapher.canChangeEntity &&
                 !grapher.hideEntityControls &&
@@ -110,9 +129,12 @@ export class ControlsRow extends React.Component<{
     }
 
     render() {
-        return this.controlsToRender.length ? (
+        console.log("controlsrow rendering")
+        return this.grapher.isReady && this.controlsToRender.length ? (
             <div className="controlsRow">
-                <CollapsibleList>{this.controlsToRender}</CollapsibleList>
+                <CollapsibleList rendo={...this.controlsToRender}>
+                    {...this.controlsToRender}
+                </CollapsibleList>
             </div>
         ) : null
     }

--- a/grapher/controls/ControlsRow.tsx
+++ b/grapher/controls/ControlsRow.tsx
@@ -51,29 +51,29 @@ export class ControlsRow extends React.Component<{
                     />
                 )
 
-            // grapher.canAddData &&
-            //     !grapher.hasFloatingAddButton &&
-            //     !grapher.hideEntityControls &&
-            //     controls.push(
-            //         <button
-            //             type="button"
-            //             onClick={this.onDataSelect}
-            //             key="grapher-select-entities"
-            //             data-track-note="grapher-select-entities"
-            //         >
-            //             {grapher.isScatter || grapher.isSlopeChart ? (
-            //                 <span className="SelectEntitiesButton">
-            //                     <FontAwesomeIcon icon={faPencilAlt} />
-            //                     {`Select ${grapher.entityTypePlural}`}
-            //                 </span>
-            //             ) : (
-            //                 <span>
-            //                     <FontAwesomeIcon icon={faPlus} />{" "}
-            //                     {grapher.addButtonLabel}
-            //                 </span>
-            //             )}
-            //         </button>
-            //     )
+            grapher.canAddData &&
+                !grapher.hasFloatingAddButton &&
+                !grapher.hideEntityControls &&
+                controls.push(
+                    <button
+                        type="button"
+                        onClick={this.onDataSelect}
+                        key="grapher-select-entities"
+                        data-track-note="grapher-select-entities"
+                    >
+                        {grapher.isScatter || grapher.isSlopeChart ? (
+                            <span className="SelectEntitiesButton">
+                                <FontAwesomeIcon icon={faPencilAlt} />
+                                {`Select ${grapher.entityTypePlural}`}
+                            </span>
+                        ) : (
+                            <span>
+                                <FontAwesomeIcon icon={faPlus} />{" "}
+                                {grapher.addButtonLabel}
+                            </span>
+                        )}
+                    </button>
+                )
 
             grapher.canChangeEntity &&
                 !grapher.hideEntityControls &&

--- a/grapher/controls/ControlsRow.tsx
+++ b/grapher/controls/ControlsRow.tsx
@@ -1,137 +1,17 @@
 import React from "react"
-import { computed, action } from "mobx"
-import { observer } from "mobx-react"
-import {
-    FilterSmallCountriesToggle,
-    HighlightToggle,
-    AbsRelToggle,
-    ZoomToggle,
-} from "./Controls"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { faPencilAlt } from "@fortawesome/free-solid-svg-icons/faPencilAlt"
-import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus"
-import { faExchangeAlt } from "@fortawesome/free-solid-svg-icons/faExchangeAlt"
-import { Grapher } from "grapher/core/Grapher"
 import { CollapsibleList } from "./CollapsibleList/CollapsibleList"
-import { ScaleSelector } from "./ScaleSelector"
 
-@observer
+export const ControlsRowHeight = 45
+
 export class ControlsRow extends React.Component<{
-    grapher: Grapher
+    controls: React.ReactElement[]
 }> {
-    static readonly height = 36
-
-    @action.bound private onDataSelect() {
-        this.grapher.isSelectingData = true
-    }
-
-    @computed private get grapher() {
-        return this.props.grapher
-    }
-
-    @computed private get controlsToRender() {
-        const { grapher } = this
-        const controls: JSX.Element[] = []
-
-        if (grapher.tab === "chart") {
-            const yAxis =
-                (grapher.isStackedArea && grapher.stackedAreaTransform.yAxis) ||
-                (grapher.isStackedBar && grapher.stackedBarTransform.yAxis) ||
-                (grapher.isLineChart && grapher.lineChartTransform.yAxis) ||
-                ((grapher.isScatter || grapher.isTimeScatter) &&
-                    grapher.scatterTransform.yAxis)
-
-            yAxis &&
-                yAxis.scaleTypeOptions.length > 1 &&
-                controls.push(
-                    <ScaleSelector
-                        key="scaleSelector"
-                        scaleTypeConfig={yAxis}
-                        inline={true}
-                    />
-                )
-
-            grapher.canAddData &&
-                !grapher.hasFloatingAddButton &&
-                !grapher.hideEntityControls &&
-                controls.push(
-                    <button
-                        type="button"
-                        onClick={this.onDataSelect}
-                        key="grapher-select-entities"
-                        data-track-note="grapher-select-entities"
-                    >
-                        {grapher.isScatter || grapher.isSlopeChart ? (
-                            <span className="SelectEntitiesButton">
-                                <FontAwesomeIcon icon={faPencilAlt} />
-                                {`Select ${grapher.entityTypePlural}`}
-                            </span>
-                        ) : (
-                            <span>
-                                <FontAwesomeIcon icon={faPlus} />{" "}
-                                {grapher.addButtonLabel}
-                            </span>
-                        )}
-                    </button>
-                )
-
-            grapher.canChangeEntity &&
-                !grapher.hideEntityControls &&
-                controls.push(
-                    <button
-                        type="button"
-                        onClick={this.onDataSelect}
-                        key="grapher-change-entities"
-                        data-track-note="grapher-change-entity"
-                        className="ChangeEntityButton"
-                    >
-                        <FontAwesomeIcon icon={faExchangeAlt} /> Change{" "}
-                        {grapher.entityType}
-                    </button>
-                )
-
-            grapher.isScatter &&
-                grapher.hasSelection &&
-                controls.push(<ZoomToggle key="ZoomToggle" grapher={grapher} />)
-
-            const absRelToggle =
-                (grapher.isStackedArea && grapher.canToggleRelativeMode) ||
-                (grapher.isScatter &&
-                    grapher.scatterTransform.canToggleRelativeMode) ||
-                (grapher.isLineChart &&
-                    grapher.lineChartTransform.canToggleRelativeMode)
-            absRelToggle &&
-                controls.push(
-                    <AbsRelToggle key="AbsRelToggle" grapher={grapher} />
-                )
-
-            grapher.isScatter &&
-                grapher.highlightToggle &&
-                controls.push(
-                    <HighlightToggle
-                        key="highlight-toggle"
-                        grapher={grapher}
-                        highlightToggle={grapher.highlightToggle}
-                    />
-                )
-        }
-
-        grapher.isScatter &&
-            grapher.hasCountriesSmallerThanFilterOption &&
-            controls.push(
-                <FilterSmallCountriesToggle
-                    key="FilterSmallCountriesToggle"
-                    grapher={grapher}
-                />
-            )
-
-        return controls
-    }
-
     render() {
-        return this.grapher.isReady && this.controlsToRender.length ? (
+        return this.props.controls.length ? (
             <div className="controlsRow">
-                <CollapsibleList>{this.controlsToRender}</CollapsibleList>
+                <CollapsibleList key={this.props.controls.length}>
+                    {this.props.controls}
+                </CollapsibleList>
             </div>
         ) : null
     }

--- a/grapher/controls/ControlsRow.tsx
+++ b/grapher/controls/ControlsRow.tsx
@@ -34,13 +34,12 @@ export class ControlsRow extends React.Component<{
         const controls: JSX.Element[] = []
 
         if (grapher.tab === "chart") {
-            const yAxis = grapher.activeTransform.yAxis
-            // const yAxis =
-            //     (grapher.isStackedArea && grapher.stackedAreaTransform.yAxis) ||
-            //     (grapher.isStackedBar && grapher.stackedBarTransform.yAxis) ||
-            //     (grapher.isLineChart && grapher.lineChartTransform.yAxis) ||
-            //     ((grapher.isScatter || grapher.isTimeScatter) &&
-            //         grapher.scatterTransform.yAxis)
+            const yAxis =
+                (grapher.isStackedArea && grapher.stackedAreaTransform.yAxis) ||
+                (grapher.isStackedBar && grapher.stackedBarTransform.yAxis) ||
+                (grapher.isLineChart && grapher.lineChartTransform.yAxis) ||
+                ((grapher.isScatter || grapher.isTimeScatter) &&
+                    grapher.scatterTransform.yAxis)
 
             yAxis &&
                 yAxis.scaleTypeOptions.length > 1 &&

--- a/grapher/controls/ControlsRow.tsx
+++ b/grapher/controls/ControlsRow.tsx
@@ -90,6 +90,10 @@ export class ControlsRow extends React.Component<{
                 )
 
             grapher.isScatter &&
+                grapher.hasSelection &&
+                controls.push(<ZoomToggle key="ZoomToggle" grapher={grapher} />)
+
+            grapher.isScatter &&
                 grapher.highlightToggle &&
                 controls.push(
                     <HighlightToggle
@@ -109,10 +113,6 @@ export class ControlsRow extends React.Component<{
                 controls.push(
                     <AbsRelToggle key="AbsRelToggle" grapher={grapher} />
                 )
-
-            grapher.isScatter &&
-                grapher.hasSelection &&
-                controls.push(<ZoomToggle key="ZoomToggle" grapher={grapher} />)
         }
 
         grapher.isScatter &&

--- a/grapher/controls/ControlsRow.tsx
+++ b/grapher/controls/ControlsRow.tsx
@@ -128,7 +128,6 @@ export class ControlsRow extends React.Component<{
     }
 
     render() {
-        console.log("controlsrow rendering")
         return this.grapher.isReady && this.controlsToRender.length ? (
             <div className="controlsRow">
                 <CollapsibleList rendo={...this.controlsToRender}>

--- a/grapher/controls/ControlsRow.tsx
+++ b/grapher/controls/ControlsRow.tsx
@@ -19,7 +19,7 @@ import { ScaleSelector } from "./ScaleSelector"
 export class ControlsRow extends React.Component<{
     grapher: Grapher
 }> {
-    static readonly height = 45
+    static readonly height = 36
 
     @action.bound private onDataSelect() {
         this.grapher.isSelectingData = true

--- a/grapher/controls/ControlsRow.tsx
+++ b/grapher/controls/ControlsRow.tsx
@@ -83,6 +83,7 @@ export class ControlsRow extends React.Component<{
                         onClick={this.onDataSelect}
                         key="grapher-change-entities"
                         data-track-note="grapher-change-entity"
+                        className="ChangeEntityButton"
                     >
                         <FontAwesomeIcon icon={faExchangeAlt} /> Change{" "}
                         {grapher.entityType}

--- a/grapher/controls/ControlsRow.tsx
+++ b/grapher/controls/ControlsRow.tsx
@@ -130,8 +130,8 @@ export class ControlsRow extends React.Component<{
     render() {
         return this.grapher.isReady && this.controlsToRender.length ? (
             <div className="controlsRow">
-                <CollapsibleList rendo={...this.controlsToRender}>
-                    {...this.controlsToRender}
+                <CollapsibleList rendo={this.controlsToRender}>
+                    {this.controlsToRender}
                 </CollapsibleList>
             </div>
         ) : null

--- a/grapher/controls/ScaleSelector.scss
+++ b/grapher/controls/ScaleSelector.scss
@@ -1,7 +1,10 @@
 .toggleSwitch {
+    &:not(.inline) {
+        position: absolute;
+    }
+
     text-transform: uppercase;
     cursor: pointer;
-    position: absolute;
     font-weight: bold;
     white-space: nowrap;
 

--- a/grapher/controls/ScaleSelector.tsx
+++ b/grapher/controls/ScaleSelector.tsx
@@ -44,7 +44,6 @@ export class ScaleSelector extends React.Component<ScaleSelectorOptions> {
     }
 
     @action.bound onClick() {
-        console.log("clicked!")
         const { scaleType, scaleTypeOptions } = this
 
         let nextScaleTypeIndex = scaleTypeOptions.indexOf(scaleType) + 1

--- a/grapher/controls/ScaleSelector.tsx
+++ b/grapher/controls/ScaleSelector.tsx
@@ -12,21 +12,23 @@ import * as React from "react"
 import { computed, action } from "mobx"
 import { observer } from "mobx-react"
 import { ScaleType, ScaleTypeConfig } from "grapher/core/GrapherConstants"
+import classNames from "classnames"
 
 interface ScaleSelectorOptions {
-    x: number
-    y: number
+    x?: number
+    y?: number
     maxX?: number // If set, the scale toggle will shift left if it exceeds this number
     scaleTypeConfig: ScaleTypeConfig
+    inline?: boolean
 }
 
 @observer
 export class ScaleSelector extends React.Component<ScaleSelectorOptions> {
     @computed get x(): number {
-        return this.props.x
+        return this.props.x ?? 0
     }
     @computed get y(): number {
-        return this.props.y
+        return this.props.y ?? 0
     }
 
     @computed get maxX(): number {
@@ -42,6 +44,7 @@ export class ScaleSelector extends React.Component<ScaleSelectorOptions> {
     }
 
     @action.bound onClick() {
+        console.log("clicked!")
         const { scaleType, scaleTypeOptions } = this
 
         let nextScaleTypeIndex = scaleTypeOptions.indexOf(scaleType) + 1
@@ -72,10 +75,14 @@ export class ScaleSelector extends React.Component<ScaleSelectorOptions> {
             top: y,
         }
         return (
-            <div
+            <span
                 onClick={onClick}
-                style={style as any}
-                className="clickable toggleSwitch"
+                style={this.props.inline ? {} : (style as any)}
+                className={classNames([
+                    "clickable",
+                    "toggleSwitch",
+                    { inline: this.props.inline },
+                ])}
             >
                 <span
                     data-track-note="chart-toggle-scale"
@@ -95,7 +102,7 @@ export class ScaleSelector extends React.Component<ScaleSelectorOptions> {
                 >
                     Log
                 </span>
-            </div>
+            </span>
         )
     }
 }

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1045,7 +1045,7 @@ export class Grapher extends GrapherDefaults implements TimeViz {
     }
 
     // WARNING: THIS WILL BE REMOVED!!!! DO NOT USE
-    @computed get activeTransform(): IChartTransform {
+    @computed private get activeTransform(): IChartTransform {
         if (this.currentTab === "table") return this.dataTableTransform
         else if (this.isLineChart) return this.lineChartTransform
         else if (this.isScatter || this.isTimeScatter)

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1045,7 +1045,7 @@ export class Grapher extends GrapherDefaults implements TimeViz {
     }
 
     // WARNING: THIS WILL BE REMOVED!!!! DO NOT USE
-    @computed private get activeTransform(): IChartTransform {
+    @computed get activeTransform(): IChartTransform {
         if (this.currentTab === "table") return this.dataTableTransform
         else if (this.isLineChart) return this.lineChartTransform
         else if (this.isScatter || this.isTimeScatter)

--- a/grapher/core/GrapherView.tsx
+++ b/grapher/core/GrapherView.tsx
@@ -485,20 +485,6 @@ export class GrapherView extends React.Component<GrapherViewProps> {
         return false
     }
 
-    @computed get hasInlineControls(): boolean {
-        const grapher = this.grapher
-        return (
-            (grapher.currentTab === "chart" ||
-                grapher.currentTab === "table") &&
-            ((grapher.canAddData && !grapher.hasFloatingAddButton) ||
-                grapher.isScatter ||
-                grapher.canChangeEntity ||
-                (grapher.isStackedArea && grapher.canToggleRelativeMode) ||
-                (grapher.isLineChart &&
-                    grapher.lineChartTransform.canToggleRelativeMode))
-        )
-    }
-
     @computed get hasSpace(): boolean {
         return this.renderWidth > 700
     }
@@ -516,9 +502,6 @@ export class GrapherView extends React.Component<GrapherViewProps> {
     @computed private get footerLines(): number {
         let numLines = 1
         if (this.hasTimeline) numLines += 1
-        if (this.hasInlineControls) numLines += 1
-        if (this.hasSpace && this.hasInlineControls && numLines > 1)
-            numLines -= 1
         return numLines
     }
 

--- a/grapher/core/grapher.scss
+++ b/grapher/core/grapher.scss
@@ -138,6 +138,7 @@ $zindex-Tooltip: 20;
 @import "grapher/controls/ShareMenu.scss";
 @import "grapher/chart/NoDataOverlay.scss";
 @import "grapher/controls/CollapsibleList/CollapsibleList.scss";
+@import "grapher/controls/ControlsRow.scss";
 @import "grapher/chart/ChartLayout.scss";
 @import "grapher/controls/EntitySelectorModal.scss";
 @import "grapher/downloadTab/DownloadTab.scss";

--- a/grapher/core/grapher.scss
+++ b/grapher/core/grapher.scss
@@ -141,6 +141,7 @@ $zindex-Tooltip: 20;
 @import "grapher/controls/ControlsRow.scss";
 @import "grapher/chart/ChartLayout.scss";
 @import "grapher/controls/EntitySelectorModal.scss";
+@import "grapher/controls/AddEntityButton.scss";
 @import "grapher/downloadTab/DownloadTab.scss";
 @import "grapher/dataTable/DataTable.scss";
 @import "grapher/sourcesTab/SourcesTab.scss";

--- a/grapher/lineCharts/LineLabels.tsx
+++ b/grapher/lineCharts/LineLabels.tsx
@@ -11,13 +11,11 @@ import {
     sign,
     defaultTo,
 } from "grapher/utils/Util"
-import { computed, action } from "mobx"
+import { computed } from "mobx"
 import { observer } from "mobx-react"
 import { TextWrap } from "grapher/text/TextWrap"
 import { VerticalAxis } from "grapher/axis/Axis"
 import { Bounds } from "grapher/utils/Bounds"
-import { AddEntityButton } from "grapher/controls/AddEntityButton"
-import { ControlsOverlay } from "grapher/controls/ControlsOverlay"
 import { EntityDimensionKey } from "grapher/core/GrapherConstants"
 
 // Minimum vertical space between two legend items
@@ -463,50 +461,8 @@ export class LineLabelsComponent extends React.Component<
         ))
     }
 
-    @action.bound onAddClick() {
-        // Do this for mobx
-        this.options.isSelectingData = true
-    }
-
     @computed get options() {
         return this.props.options
-    }
-
-    get addEntityButton() {
-        if (!this.options.showAddEntityControls) return undefined
-
-        const verticalAlign = "bottom"
-
-        const leftOffset = this.needsLines
-            ? this.props.legend.leftPadding
-            : this.props.legend.width > 70
-            ? 21
-            : 5
-
-        const topMarkY = defaultTo(
-            min(this.placedMarks.map((mark) => mark.bounds.top)),
-            0
-        )
-
-        const paddingTop = AddEntityButton.calcPaddingTop(
-            topMarkY,
-            verticalAlign,
-            ADD_BUTTON_HEIGHT
-        )
-
-        return (
-            <ControlsOverlay id="add-country" paddingTop={paddingTop}>
-                <AddEntityButton
-                    x={this.props.x + leftOffset}
-                    y={topMarkY}
-                    align="left"
-                    verticalAlign={verticalAlign}
-                    height={ADD_BUTTON_HEIGHT}
-                    label={`Add ${this.options.entityType}`}
-                    onClick={this.onAddClick}
-                />
-            </ControlsOverlay>
-        )
     }
 
     render() {
@@ -521,7 +477,6 @@ export class LineLabelsComponent extends React.Component<
             >
                 {this.renderBackground()}
                 {this.renderFocus()}
-                {this.addEntityButton}
             </g>
         )
     }

--- a/grapher/slopeCharts/LabelledSlopes.tsx
+++ b/grapher/slopeCharts/LabelledSlopes.tsx
@@ -32,8 +32,6 @@ import { Bounds } from "grapher/utils/Bounds"
 import { Text } from "grapher/text/Text"
 import { TextWrap } from "grapher/text/TextWrap"
 import { NoDataOverlay } from "grapher/chart/NoDataOverlay"
-import { ScaleSelector } from "grapher/controls/ScaleSelector"
-import { ControlsOverlay } from "grapher/controls/ControlsOverlay"
 import { AxisConfig } from "grapher/axis/AxisConfig"
 import { Grapher } from "grapher/core/Grapher"
 
@@ -678,22 +676,6 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
         ))
     }
 
-    @computed get controls() {
-        const { yAxisOptions } = this.props
-        const showScaleSelector =
-            this.props.isInteractive && yAxisOptions.canChangeScaleType
-        if (!showScaleSelector) return undefined
-        return (
-            <ControlsOverlay id="slope-scale-selector" paddingTop={20}>
-                <ScaleSelector
-                    x={this.bounds.x}
-                    y={this.bounds.y - 35}
-                    scaleTypeConfig={yAxisOptions.toVerticalAxis()}
-                />
-            </ControlsOverlay>
-        )
-    }
-
     render() {
         const { yTickFormat, fontSize } = this.props
         const yScaleType = this.yScaleType
@@ -769,7 +751,6 @@ export class LabelledSlopes extends React.Component<LabelledSlopesProps> {
                 )}
                 <line x1={x1} y1={y1} x2={x1} y2={y2} stroke="#333" />
                 <line x1={x2} y1={y1} x2={x2} y2={y2} stroke="#333" />
-                {this.controls}
                 <Text
                     x={x1}
                     y={y1 + 10}

--- a/site/client/css/sidebar.scss
+++ b/site/client/css/sidebar.scss
@@ -65,7 +65,6 @@
         position: absolute;
         top: 0;
         bottom: 0;
-        z-index: $zindex-sidebar;
         margin-left: -($sidebar-content-width + 2 * $padding-x-md) + $sidebar-closed-drawer-width;
         @include sm-only {
             margin-left: -($sidebar-content-width + 2 * $padding-x-md);
@@ -82,6 +81,7 @@
                 right: -$sidebar-toggle-width - $padding-x-sm/2;
             }
             button {
+                z-index: $zindex-sidebar;
                 position: sticky;
                 top: $vertical-spacing;
                 @include sm-only {
@@ -109,6 +109,7 @@
         }
 
         &.toggled {
+            z-index: $zindex-sidebar;
             margin-left: 0;
             @include block-shadow;
 

--- a/site/client/css/variables.scss
+++ b/site/client/css/variables.scss
@@ -173,7 +173,7 @@ $media-color: #0089be;
 $culture-color: #af488f;
 
 /* Controls color */
-$controls-color: #3f9eff;
+$controls-color: #0073e6;
 $light-shadow: rgba(0, 0, 0, 0.1) 0px 0px 0px 1px,
     rgba(0, 0, 0, 0.08) 0px 2px 2px;
 


### PR DESCRIPTION
This PR moves inline controls and the vertical axis log/lin selector into a responsive `ControlsRow`.
In my next PR, I will move `ControlsRow` out of `ChartLayout` and into `LineChart`, etc.

**Live on [Nightingale](https://nightingale-owid.netlify.app/grapher/stunting-vs-level-of-prosperity-over-time).**
![image](https://user-images.githubusercontent.com/11683872/93158493-34f50e00-f6da-11ea-87cc-053474adc1b0.png)


