### PR TITLE
fix(baking): don't bake images of draft charts

### DIFF
--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -36,6 +36,7 @@ export class Chart extends BaseEntity {
 
     static table: string = "charts"
 
+    // Only considers published charts, because only in that case the mapping slug -> id is unique
     static async mapSlugsToIds(): Promise<{ [slug: string]: number }> {
         const redirects = await db.query(
             `SELECT chart_id, slug FROM chart_slug_redirects`

--- a/site/server/bakeChartsToImages.tsx
+++ b/site/server/bakeChartsToImages.tsx
@@ -13,7 +13,7 @@ import { GrapherInterface } from "grapher/core/GrapherInterface"
 import { Grapher } from "grapher/core/Grapher"
 
 export async function getChartsAndRedirectsBySlug() {
-    const { chartsBySlug, chartsById } = await getChartsBySlug()
+    const { chartsBySlug, chartsById } = await getPublishedChartsBySlug()
 
     const redirectQuery = db.query(
         `SELECT slug, chart_id FROM chart_slug_redirects`
@@ -26,15 +26,15 @@ export async function getChartsAndRedirectsBySlug() {
     return chartsBySlug
 }
 
-export async function getChartsBySlug(onlyPublished = true) {
+export async function getPublishedChartsBySlug() {
     const chartsBySlug: Map<string, GrapherInterface> = new Map()
     const chartsById = new Map()
 
-    const chartsQuery = db.query(`SELECT * FROM charts`)
+    const chartsQuery = db.query(
+        `SELECT * FROM charts WHERE JSON_EXTRACT(config, "$.isPublished") IS TRUE`
+    )
     for (const row of await chartsQuery) {
         const chart = JSON.parse(row.config)
-
-        if (onlyPublished && !chart.isPublished) continue
 
         chart.id = row.id
         chartsBySlug.set(chart.slug, chart)

--- a/site/server/bakeChartsToImages.tsx
+++ b/site/server/bakeChartsToImages.tsx
@@ -26,13 +26,16 @@ export async function getChartsAndRedirectsBySlug() {
     return chartsBySlug
 }
 
-export async function getChartsBySlug() {
+export async function getChartsBySlug(onlyPublished = true) {
     const chartsBySlug: Map<string, GrapherInterface> = new Map()
     const chartsById = new Map()
 
     const chartsQuery = db.query(`SELECT * FROM charts`)
     for (const row of await chartsQuery) {
         const chart = JSON.parse(row.config)
+
+        if (onlyPublished && !chart.isPublished) continue
+
         chart.id = row.id
         chartsBySlug.set(chart.slug, chart)
         chartsById.set(row.id, chart)

--- a/site/server/bakeChartsToImages.tsx
+++ b/site/server/bakeChartsToImages.tsx
@@ -52,8 +52,6 @@ export async function bakeChartToImage(
     overwriteExisting = false,
     verbose = true
 ) {
-    // the type definition for url.query is wrong (bc we have query string parsing disabled),
-    // so we have to explicitly cast it
     const chart = new Grapher(
         { ...jsonConfig, manuallyProvideData: true },
         { queryStr }

--- a/site/server/grapherUtil.ts
+++ b/site/server/grapherUtil.ts
@@ -30,12 +30,13 @@ export interface GrapherExports {
     get: (grapherUrl: string) => ChartExportMeta | undefined
 }
 
+// Only considers published charts, because only in that case the mapping slug -> id is unique
 export async function mapSlugsToIds(): Promise<{ [slug: string]: number }> {
     const redirects = await db.query(
         `SELECT chart_id, slug FROM chart_slug_redirects`
     )
     const rows = await db.query(
-        `SELECT id, JSON_UNQUOTE(JSON_EXTRACT(config, "$.slug")) AS slug FROM charts`
+        `SELECT id, JSON_UNQUOTE(JSON_EXTRACT(config, "$.slug")) AS slug FROM charts WHERE JSON_EXTRACT(config, "$.isPublished") IS TRUE`
     )
 
     const slugToId: { [slug: string]: number } = {}

--- a/svgTester/SVGTester.tsx
+++ b/svgTester/SVGTester.tsx
@@ -48,7 +48,6 @@ export async function bakeAndSaveResultsFile(
     outDir: string = __dirname + "/bakedSvgs"
 ) {
     if (!fs.existsSync(outDir)) fs.mkdirSync(outDir)
-    // Todo: only bake published charts
     const { chartsBySlug } = await getChartsBySlug()
     const resultsPath = outDir + "/results.csv"
     fs.writeFileSync(resultsPath, header + "\n")

--- a/svgTester/SVGTester.tsx
+++ b/svgTester/SVGTester.tsx
@@ -5,7 +5,7 @@ import { BAKED_GRAPHER_URL } from "settings"
 import React from "react"
 import {
     bakeChartToImage,
-    getChartsBySlug,
+    getPublishedChartsBySlug,
 } from "site/server/bakeChartsToImages"
 
 const header = `bakeOrder,timeToBake,slug,chartType,md5`
@@ -48,7 +48,7 @@ export async function bakeAndSaveResultsFile(
     outDir: string = __dirname + "/bakedSvgs"
 ) {
     if (!fs.existsSync(outDir)) fs.mkdirSync(outDir)
-    const { chartsBySlug } = await getChartsBySlug()
+    const { chartsBySlug } = await getPublishedChartsBySlug()
     const resultsPath = outDir + "/results.csv"
     fs.writeFileSync(resultsPath, header + "\n")
     // eslint-disable-next-line no-console


### PR DESCRIPTION
Fixes the issue reported here: https://owid.slack.com/archives/C46U9LXRR/p1600640963003100

I checked and `getChartsBySlug` is only called in `bakeChartsToImages` and `SVGTester`, so this change should be safe.

For a more permanent solution we should really consider making chart slugs unique, though, so bugs like this don't happen again and again.