### PR TITLE
Use map config to generate timeline when tab = map

### DIFF
--- a/grapher/chart/ChartTransform.ts
+++ b/grapher/chart/ChartTransform.ts
@@ -48,11 +48,11 @@ export abstract class ChartTransform implements IChartTransform {
         return sortNumeric(uniq(filteredTimes))
     }
 
-    @computed private get minTimelineTime(): Time {
+    @computed get minTimelineTime(): Time {
         return first(this.timelineTimes) ?? 1900
     }
 
-    @computed private get maxTimelineTime(): Time {
+    @computed get maxTimelineTime(): Time {
         return last(this.timelineTimes) ?? 2000
     }
 

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -550,26 +550,26 @@ export class Grapher extends GrapherDefaults implements TimeViz {
 
     // todo: remove ifs
     set startTime(value: any) {
-        if (this.tab === "map") this.timeDomain = [value, value]
+        if (this.tab === "map") this.map.time = value
         else this.timeDomain = [value, this.timeDomain[1]]
     }
 
     // todo: remove ifs
     set endTime(value: any) {
         const activeTab = this.tab
-        if (activeTab === "map" || activeTab === "table")
-            this.timeDomain = [value, value]
+        if (activeTab === "map") this.map.time = value
+        if (activeTab === "table") this.timeDomain = [value, value]
         else this.timeDomain = [this.timeDomain[0], value]
     }
 
     // todo: remove ifs
     @computed get endTime() {
         const activeTab = this.tab
-        if (activeTab === "table")
+        if (activeTab === "map") return this.mapTransform.endTimelineTime
+        else if (activeTab === "table")
             return this.multiMetricTableMode
                 ? this.dataTableTransform.startTimelineTime
                 : this.timeDomain[1]
-        else if (activeTab === "map") return this.mapTransform.endTimelineTime
         return this.activeTransform.endTimelineTime!
     }
 

--- a/grapher/dataTable/DataTable.jsdom.test.tsx
+++ b/grapher/dataTable/DataTable.jsdom.test.tsx
@@ -36,6 +36,9 @@ const childMortalityGrapher = (props: any = {}) =>
                 "207": { name: "Iceland", id: 207 },
             },
         },
+        map: {
+            time: 2019,
+        },
     })
 
 describe(DataTable, () => {

--- a/grapher/mapCharts/MapConfig.ts
+++ b/grapher/mapCharts/MapConfig.ts
@@ -29,7 +29,7 @@ export type MapConfigInterface = MapConfigDefaults
 
 interface MapConfigWithLegacyInterface extends MapConfigInterface {
     variableId?: LegacyVariableId
-    year?: number
+    targetYear?: number
 }
 
 export class MapConfig extends MapConfigDefaults implements Persistable {
@@ -39,7 +39,7 @@ export class MapConfig extends MapConfigDefaults implements Persistable {
             obj.columnSlug = obj.variableId.toString()
 
         // Migrate "targetYear" to "time"
-        if (obj.year) this.time = maxTimeFromJSON(obj.year)
+        if (obj.targetYear) this.time = maxTimeFromJSON(obj.targetYear)
 
         updatePersistables(this, obj)
     }

--- a/grapher/mapCharts/MapTransform.ts
+++ b/grapher/mapCharts/MapTransform.ts
@@ -15,6 +15,11 @@ import { MapTopology } from "./MapTopology"
 import { ChartTransform } from "grapher/chart/ChartTransform"
 import { ColorScale } from "grapher/color/ColorScale"
 import { Time } from "grapher/core/GrapherConstants"
+import {
+    isUnboundedLeft,
+    isUnboundedRight,
+    getClosestTime,
+} from "grapher/utils/TimeBounds"
 
 interface MapDataValue {
     entity: string
@@ -226,5 +231,22 @@ export class MapTransform extends ChartTransform {
                   else return customLabels[d] ?? formatValueLong(d)
               }
             : () => ""
+    }
+
+    @computed private get targetTimelineTime(): Time {
+        const time = this.props.time ?? 2000
+
+        if (isUnboundedLeft(time)) return this.minTimelineTime
+        else if (isUnboundedRight(time)) return this.maxTimelineTime
+
+        return getClosestTime(this.timelineTimes, time, this.minTimelineTime)
+    }
+
+    @computed get startTimelineTime(): Time {
+        return this.targetTimelineTime
+    }
+
+    @computed get endTimelineTime(): Time {
+        return this.targetTimelineTime
     }
 }


### PR DESCRIPTION
**This is a temporary fix.**

Notion issue: https://www.notion.so/owid/Map-shows-ranges-instead-of-single-date-d4b9ee92baf541faa9027966e609d359

- Corrected conversion from legacy interface: used to translate `map.year` → `map.time`, but the correct is `map.targetYear` → `map.time`
- There are existing code paths that pass different timeline brackets based on the tab, I just updated those to use the map config. It's better to implement the `TimeViz` interface, but I thought I'd keep this minimal to avoid conflicts.

cc @breck7