### PR TITLE
Set unbounded value when dragging beyond timeline start/end

### DIFF
--- a/grapher/timeline/TimelineController.test.ts
+++ b/grapher/timeline/TimelineController.test.ts
@@ -54,8 +54,6 @@ describe(TimelineController, () => {
         }
 
         const controller = new TimelineController(subject)
-        expect(controller.getTimeFromDrag(1901.5)).toBe(1902)
-        expect(controller.getTimeFromDrag(3000)).toBe(2009)
         controller.dragHandleToTime("end", 1950)
         expect(subject.startTime).toEqual(1950)
         expect(subject.endTime).toEqual(2000)

--- a/grapher/timeline/TimelineController.test.ts
+++ b/grapher/timeline/TimelineController.test.ts
@@ -1,5 +1,6 @@
 #! /usr/bin/env yarn jest
 
+import { TimeBoundValue } from "grapher/utils/TimeBounds"
 import { range } from "grapher/utils/Util"
 import { TimelineController, TimeViz } from "./TimelineController"
 
@@ -58,5 +59,26 @@ describe(TimelineController, () => {
         controller.dragHandleToTime("end", 1950)
         expect(subject.startTime).toEqual(1950)
         expect(subject.endTime).toEqual(2000)
+    })
+
+    it("pins time to unboundedLeft or unboundedRight when marker is dragged beyond end of timeline", () => {
+        const subject: TimeViz = {
+            times: range(1900, 2010),
+            startTime: 2000,
+            endTime: 2005,
+            isPlaying: false,
+        }
+
+        const controller = new TimelineController(subject)
+
+        expect(controller.getTimeFromDrag(2009)).toBe(2009)
+        expect(controller.getTimeFromDrag(2009.1)).toBe(
+            TimeBoundValue.unboundedRight
+        )
+
+        expect(controller.getTimeFromDrag(1900)).toBe(1900)
+        expect(controller.getTimeFromDrag(1899.9)).toBe(
+            TimeBoundValue.unboundedLeft
+        )
     })
 })

--- a/grapher/timeline/TimelineController.ts
+++ b/grapher/timeline/TimelineController.ts
@@ -1,4 +1,5 @@
 import { Time } from "grapher/core/GrapherConstants"
+import { TimeBoundValue } from "grapher/utils/TimeBounds"
 import { findClosestTime, last } from "grapher/utils/Util"
 
 export interface TimeViz {
@@ -134,6 +135,8 @@ export class TimelineController {
     }
 
     getTimeFromDrag(inputTime: Time) {
+        if (inputTime < this.minTime) return TimeBoundValue.unboundedLeft
+        if (inputTime > this.maxTime) return TimeBoundValue.unboundedRight
         return this.getClampedTime(
             findClosestTime(this.timesAsc, inputTime) ?? inputTime
         )


### PR DESCRIPTION
A few months ago we could [set an unbounded value (`"earliest"` or `"latest"`) by dragging past the timeline brackets](https://owid.slack.com/archives/C011F008G6S/p1586599539086300):

<img width="423" alt="Screenshot_2020-04-11_at_11_00_56" src="https://user-images.githubusercontent.com/1308115/93897643-37fb8a00-fcea-11ea-8c8a-366ec83d4885.png">

It seems we lost this feature at some point – not sure if intentionally or not?

This PR adds back that feature, as long as we want it.