### PR TITLE
DataTable Spiffification

### DIFF
--- a/grapher/dataTable/DataTable.scss
+++ b/grapher/dataTable/DataTable.scss
@@ -1,3 +1,9 @@
+$cell-border: 1px solid rgba(0, 0, 0, 0.08);
+
+.tableTab {
+    border-bottom: $cell-border;
+}
+
 .tableTab .data-table {
     th {
         position: sticky;
@@ -35,8 +41,9 @@
     box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 2px 0px,
         rgba(0, 0, 0, 0.25) 0px 2px 2px 0px;
 
-    th {
-        border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+    thead tr:last-child th,
+    th.entity {
+        border-bottom: $cell-border;
     }
 
     tr th:first-child,
@@ -76,7 +83,6 @@
         background-color: white;
     }
 
-    th.sorted,
     th.sortable:hover {
         background-color: rgb(245, 245, 245);
     }
@@ -85,8 +91,17 @@
     td {
         padding-left: 15px;
         padding-right: 15px;
-        border-right: 1px solid rgba(0, 0, 0, 0.08);
         vertical-align: text-top;
+    }
+
+    th.subdimension {
+        border-right: $cell-border;
+    }
+
+    th.subdimension:first-child,
+    th.dimension.sortable,
+    tbody td:nth-child(2) {
+        border-left: $cell-border;
     }
 
     th:last-child,
@@ -109,18 +124,11 @@
     }
 
     tbody tr:nth-child(2n) td {
-        background-color: rgb(250, 250, 250);
-    }
-    tbody tr:nth-child(2n) td.sorted {
-        background-color: rgb(246, 246, 246);
+        background-color: rgba(250, 250, 250);
     }
 
-    td.sorted {
-        background-color: rgb(250, 250, 250);
-    }
-
-    tbody tr:hover {
-        background-color: rgba(0, 0, 0, 0.035);
+    tbody tr:hover td {
+        background-color: rgba(245, 245, 245);
     }
 
     .entity {

--- a/grapher/dataTable/DataTable.scss
+++ b/grapher/dataTable/DataTable.scss
@@ -149,11 +149,11 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
     }
 
     tbody tr:nth-child(2n) td {
-        background-color: rgba(250, 250, 250);
+        background-color: rgba(247, 247, 247);
     }
 
     tbody tr:hover td {
-        background-color: rgba(245, 245, 245);
+        background-color: rgba(241, 241, 241);
     }
 
     .entity {

--- a/grapher/dataTable/DataTable.scss
+++ b/grapher/dataTable/DataTable.scss
@@ -112,7 +112,7 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
 
     tr > .dimension-start ~ .dimension-start,
     tr > th.dimension ~ th.dimension,
-    tr > th.dimStart ~ th.dimStart {
+    tr > th.firstSubdimension ~ th.firstSubdimension {
         border-left: $cell-border;
     }
 

--- a/grapher/dataTable/DataTable.scss
+++ b/grapher/dataTable/DataTable.scss
@@ -95,6 +95,10 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
 
     th.dimension {
         text-align: center;
+
+        > div {
+            min-height: 32px;
+        }
     }
 
     th.subdimension {

--- a/grapher/dataTable/DataTable.scss
+++ b/grapher/dataTable/DataTable.scss
@@ -8,7 +8,6 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
     th {
         position: sticky;
         z-index: 10;
-        height: 51px;
         white-space: nowrap;
 
         &.dimension,
@@ -21,7 +20,7 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
         }
 
         &.subdimension {
-            top: 51px;
+            top: 50px;
         }
     }
 
@@ -34,6 +33,7 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
 
 .data-table {
     font-size: 0.9375rem;
+    line-height: 16px;
     border: none;
     background: white;
     width: 100%;
@@ -59,12 +59,12 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
     thead tr:first-child th {
         padding-top: 10px;
         padding-bottom: 8px;
-        vertical-align: text-top;
     }
 
     th {
         padding-top: 8px;
         padding-bottom: 8px;
+        vertical-align: bottom;
     }
 
     tr:first-child td {
@@ -91,17 +91,33 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
     td {
         padding-left: 15px;
         padding-right: 15px;
-        vertical-align: text-top;
+    }
+
+    th.dimension {
+        text-align: center;
     }
 
     th.subdimension {
         border-right: $cell-border;
     }
 
-    th.subdimension:first-child,
-    th.dimension.sortable,
-    tbody td:nth-child(2) {
+    .deltaColumn {
+        min-width: 145px;
+    }
+
+    th.entity,
+    td.entity {
+        border-right: $cell-border;
+    }
+
+    tr > .dimension-start ~ .dimension-start,
+    tr > th.dimension ~ th.dimension,
+    tr > th.dimStart ~ th.dimStart {
         border-left: $cell-border;
+    }
+
+    th.lastSubdimension {
+        border-right: none;
     }
 
     th:last-child,

--- a/grapher/dataTable/DataTable.scss
+++ b/grapher/dataTable/DataTable.scss
@@ -20,7 +20,7 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
         }
 
         &.subdimension {
-            top: 50px;
+            top: 53px;
         }
     }
 
@@ -97,7 +97,7 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
         text-align: center;
 
         > div {
-            min-height: 32px;
+            min-height: 35px;
         }
     }
 
@@ -120,7 +120,8 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
         border-left: $cell-border;
     }
 
-    th.firstSubdimension div {
+    th.firstSubdimension div,
+    th.endSubdimension div {
         min-width: 56px;
     }
 
@@ -171,6 +172,7 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
         .unit {
             font-weight: 700;
             opacity: 0.5;
+            padding-bottom: 3px;
         }
     }
 

--- a/grapher/dataTable/DataTable.scss
+++ b/grapher/dataTable/DataTable.scss
@@ -116,6 +116,10 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
         border-left: $cell-border;
     }
 
+    th.firstSubdimension div {
+        min-width: 56px;
+    }
+
     th.lastSubdimension {
         border-right: none;
     }

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -388,6 +388,7 @@ function ColumnHeader(props: {
                 sortable,
                 sorted: sortedCol,
                 firstSubdimension: subdimensionType === "start",
+                endSubdimension: subdimensionType === "end",
                 lastSubdimension,
             })}
             rowSpan={props.rowSpan ?? 1}

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -223,7 +223,7 @@ export class DataTable extends React.Component<DataTableProps> {
     private get dimensionSubheaders() {
         const { sort } = this.tableState
         return this.displayDimensions.map((dim, dimIndex) =>
-            dim.columns.map((column) => {
+            dim.columns.map((column, i) => {
                 const headerText =
                     column.targetTimeMode === TargetTimeMode.point
                         ? dim.formatTime(column.targetTime!)
@@ -241,6 +241,8 @@ export class DataTable extends React.Component<DataTableProps> {
                         headerText={headerText}
                         colType="subdimension"
                         dataType="numeric"
+                        subdimensionType={column.key}
+                        lastSubdimension={i === dim.columns.length - 1}
                     />
                 )
             })
@@ -370,32 +372,50 @@ function ColumnHeader(props: {
     headerText: React.ReactFragment
     colType: "entity" | "dimension" | "subdimension"
     dataType: "text" | "numeric"
+    subdimensionType?: ColumnKey
+    lastSubdimension?: boolean
 }) {
-    const { sortable, sortedCol, colType } = props
+    const {
+        sortable,
+        sortedCol,
+        colType,
+        subdimensionType,
+        lastSubdimension,
+    } = props
     return (
         <th
             className={classnames(colType, {
-                sortable: sortable,
+                sortable,
                 sorted: sortedCol,
+                dimStart: subdimensionType === "start",
+                lastSubdimension,
             })}
             rowSpan={props.rowSpan ?? 1}
             colSpan={props.colSpan ?? 1}
             onClick={props.onClick}
         >
-            {props.headerText}
-            {sortable && (
-                <SortIcon
-                    type={props.dataType}
-                    isActiveIcon={sortedCol}
-                    order={
-                        sortedCol
-                            ? props.sortOrder
-                            : colType === "entity"
-                            ? SortOrder.asc
-                            : SortOrder.desc
-                    }
-                />
-            )}
+            <div
+                className={classnames({
+                    deltaColumn:
+                        subdimensionType === "delta" ||
+                        subdimensionType === "deltaRatio",
+                })}
+            >
+                {props.headerText}
+                {sortable && (
+                    <SortIcon
+                        type={props.dataType}
+                        isActiveIcon={sortedCol}
+                        order={
+                            sortedCol
+                                ? props.sortOrder
+                                : colType === "entity"
+                                ? SortOrder.asc
+                                : SortOrder.desc
+                        }
+                    />
+                )}
+            </div>
         </th>
     )
 }

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -387,7 +387,7 @@ function ColumnHeader(props: {
             className={classnames(colType, {
                 sortable,
                 sorted: sortedCol,
-                dimStart: subdimensionType === "start",
+                firstSubdimension: subdimensionType === "start",
                 lastSubdimension,
             })}
             rowSpan={props.rowSpan ?? 1}

--- a/grapher/downloadTab/DownloadTab.scss
+++ b/grapher/downloadTab/DownloadTab.scss
@@ -34,7 +34,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: 5px;
     background: rgba(255, 255, 255, 0.95);
     text-align: center;
 }


### PR DESCRIPTION
This PR cleans up the DataTable a bit, fixes some layout bugs, and adds a line hover effect.

**Live at [Nightingale](https://nightingale-owid.netlify.app/coronavirus-data-explorer?tab=table&zoomToSelection=true&time=2020-03-15..latest&country=MEX~IND~USA~ITA~BRA~GBR~FRA~ESP~PER&region=World&casesMetric=true&interval=smoothed&perCapita=true&smoothing=7&pickerMetric=total_deaths&pickerSort=desc).**

**Before:**
![image](https://user-images.githubusercontent.com/11683872/94750243-9b716180-0353-11eb-9bdd-c484913fd9d7.png)


**After:**
![image](https://user-images.githubusercontent.com/11683872/94750254-a1ffd900-0353-11eb-9f4d-dcd9f12e7084.png)
