### PR TITLE
VariableSelector namespaces dropdown improvements

### DIFF
--- a/adminSite/client/ChartEditor.ts
+++ b/adminSite/client/ChartEditor.ts
@@ -48,6 +48,7 @@ export interface ChartRedirect {
 export interface Namespace {
     name: string
     description?: string
+    isArchived: boolean
 }
 
 // This contains the dataset/variable metadata for the entire database

--- a/adminSite/client/VariableSelector.tsx
+++ b/adminSite/client/VariableSelector.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as lodash from "lodash"
-import { groupBy, isString, sortBy, defaultTo } from "grapher/utils/Util"
+import { groupBy, isString, sortBy, defaultTo, first } from "grapher/utils/Util"
 import {
     computed,
     action,
@@ -10,8 +10,11 @@ import {
     IReactionDisposer,
 } from "mobx"
 import { observer } from "mobx-react"
+import Select, { ValueType } from "react-select"
+
+import { asArray } from "utils/client/react-select"
 import { ChartEditor, Dataset, Namespace } from "./ChartEditor"
-import { SelectField, TextField, FieldsRow, Toggle, Modal } from "./Forms"
+import { TextField, FieldsRow, Toggle, Modal } from "./Forms"
 import fuzzysort from "fuzzysort"
 import { highlight as fuzzyHighlight } from "grapher/controls/FuzzySearch"
 import { LegacyVariableId } from "owidTable/OwidTableConstants"
@@ -52,7 +55,7 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
     @computed get currentNamespace() {
         return defaultTo(
             this.chosenNamespace,
-            this.database.namespaces.find((n) => n.name === "owid") as Namespace
+            this.database.namespaces.find((n) => n.name === "owid")!
         )
     }
 
@@ -129,6 +132,26 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
         return this.searchResultRows.length
     }
 
+    formatNamespaceLabel(namespace: Namespace) {
+        if (namespace.description)
+            return `${namespace.description} — ${namespace.name}`
+        else return namespace.name
+    }
+
+    filterNamespace(option: any, input: string) {
+        return input
+            .split(" ")
+            .map((word) => word.toLowerCase())
+            .map((word) => {
+                const namespace = option.data as Namespace
+                return (
+                    namespace.name.toLowerCase().includes(word) ||
+                    namespace.description?.toLowerCase().includes(word)
+                )
+            })
+            .every((v) => v)
+    }
+
     render() {
         const { slot } = this.props
         const { database } = this.props.editor
@@ -137,8 +160,6 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
             searchInput,
             chosenVariables,
             datasetsByName,
-        } = this
-        const {
             rowHeight,
             rowOffset,
             numVisibleRows,
@@ -155,12 +176,6 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
             } else return text
         }
 
-        const getOptionLabel = (namespace: Namespace) => {
-            if (namespace.description)
-                return `${namespace.description} — ${namespace.name}`
-            else return namespace.name
-        }
-
         return (
             <Modal onClose={this.onDismiss} className="VariableSelector">
                 <div className="modal-header">
@@ -172,17 +187,23 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
                     <div>
                         <div className="searchResults">
                             <FieldsRow>
-                                <SelectField
-                                    label="Database"
-                                    options={database.namespaces.map(
-                                        (n) => n.name
-                                    )}
-                                    optionLabels={database.namespaces.map(
-                                        getOptionLabel
-                                    )}
-                                    value={currentNamespace.name}
-                                    onValue={this.onNamespace}
-                                />
+                                <div className="form-group">
+                                    <label>Database</label>
+                                    <Select
+                                        options={database.namespaces}
+                                        formatOptionLabel={
+                                            this.formatNamespaceLabel
+                                        }
+                                        getOptionValue={(v) => v.name}
+                                        onChange={this.onNamespace}
+                                        value={currentNamespace}
+                                        filterOption={this.filterNamespace}
+                                        components={{
+                                            IndicatorSeparator: null,
+                                        }}
+                                        menuPlacement="bottom"
+                                    />
+                                </div>
                                 <TextField
                                     placeholder="Search..."
                                     value={searchInput}
@@ -321,10 +342,9 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
         this.rowOffset = rowOffset
     }
 
-    @action.bound onNamespace(namespace: string | undefined) {
-        this.chosenNamespace = this.database.namespaces.find(
-            (n) => n.name === namespace
-        )
+    @action.bound onNamespace(selected: ValueType<Namespace>) {
+        const value = first(asArray(selected))
+        if (value) this.chosenNamespace = value
     }
 
     @action.bound onSearchInput(input: string) {

--- a/adminSite/client/VariableSelector.tsx
+++ b/adminSite/client/VariableSelector.tsx
@@ -133,9 +133,14 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
     }
 
     formatNamespaceLabel(namespace: Namespace) {
-        if (namespace.description)
-            return `${namespace.description} — ${namespace.name}`
-        else return namespace.name
+        const { name, description, isArchived } = namespace
+        return (
+            <span className={isArchived ? "muted-option" : ""}>
+                {description ? `${description} — ` : null}
+                {name}
+                {isArchived && <span className="badge">Archived</span>}
+            </span>
+        )
     }
 
     filterNamespace(option: any, input: string) {

--- a/adminSite/client/admin.scss
+++ b/adminSite/client/admin.scss
@@ -344,6 +344,21 @@ body {
         margin-bottom: 0.4em;
         border: 1px solid #ccc;
     }
+
+    .muted-option {
+        opacity: 0.55;
+    }
+
+    .badge {
+        background-color: #999;
+        border-radius: 2px;
+        text-transform: uppercase;
+        font-size: 10px;
+        font-weight: 700;
+        padding: 3px 4px;
+        color: white;
+        margin-left: 4px;
+    }
 }
 
 .EditorDataTab {

--- a/adminSite/server/apiRouter.ts
+++ b/adminSite/server/apiRouter.ts
@@ -357,11 +357,21 @@ apiRouter.get(
     "/editorData/namespaces.json",
     async (req: Request, res: Response) => {
         const rows = (await db.query(
-            `SELECT DISTINCT namespace AS name, namespaces.description FROM datasets JOIN namespaces ON namespaces.name = datasets.namespace`
-        )) as { name: string; description: string }[]
+            `SELECT DISTINCT
+                namespace AS name,
+                namespaces.description AS description,
+                namespaces.isArchived AS isArchived
+            FROM datasets
+            JOIN namespaces ON namespaces.name = datasets.namespace`
+        )) as { name: string; description?: string; isArchived: boolean }[]
 
         return {
-            namespaces: lodash.sortBy(rows, (row) => row.description),
+            namespaces: lodash
+                .sortBy(rows, (row) => row.description)
+                .map((namespace) => ({
+                    ...namespace,
+                    isArchived: !!namespace.isArchived,
+                })),
         }
     }
 )

--- a/db/migration/1601548270564-AddArchivedNamespaceColumn.ts
+++ b/db/migration/1601548270564-AddArchivedNamespaceColumn.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddArchivedNamespaceColumn1601548270564
+    implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(
+            "ALTER TABLE namespaces ADD isArchived BOOLEAN NOT NULL DEFAULT FALSE"
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query("ALTER TABLE namespaces DROP COLUMN isArchived")
+    }
+}


### PR DESCRIPTION
Just some easy improvements:
- Can filter the namespaces dropdown (using `react-select`)
- Visually distinguish archived namespaces

<img width="493" alt="Screenshot 2020-10-01 at 11 51 05" src="https://user-images.githubusercontent.com/1308115/94800746-f1d6b280-03dc-11eb-8864-033f9909f90c.png">
