### PR TITLE
DataTable Regression Fixes

### DIFF
--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -547,9 +547,9 @@ export class Grapher extends GrapherDefaults implements TimeViz {
         if (activeTab === "table")
             return (
                 this.dataTableTransform.autoSelectedStartTime ??
-                this.timeDomain[0]
+                this.activeTransform.startTimelineTime!
             )
-        else if (activeTab === "map") return this.mapTransform.startTimelineTime // todo: always use endTimelineTime for maps?
+        if (activeTab === "map") return this.mapTransform.startTimelineTime // todo: always use endTimelineTime for maps?
         return this.activeTransform.startTimelineTime!
     }
 
@@ -563,7 +563,7 @@ export class Grapher extends GrapherDefaults implements TimeViz {
     set endTime(value: any) {
         const activeTab = this.tab
         if (activeTab === "map") this.map.time = value
-        if (activeTab === "table") this.timeDomain = [value, value]
+        if (activeTab === "table") this.timeDomain = [this.timeDomain[0], value]
         else this.timeDomain = [this.timeDomain[0], value]
     }
 
@@ -574,7 +574,7 @@ export class Grapher extends GrapherDefaults implements TimeViz {
         else if (activeTab === "table")
             return this.multiMetricTableMode
                 ? this.dataTableTransform.startTimelineTime
-                : this.timeDomain[1]
+                : this.activeTransform.endTimelineTime
         return this.activeTransform.endTimelineTime!
     }
 

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -563,7 +563,6 @@ export class Grapher extends GrapherDefaults implements TimeViz {
     set endTime(value: any) {
         const activeTab = this.tab
         if (activeTab === "map") this.map.time = value
-        if (activeTab === "table") this.timeDomain = [this.timeDomain[0], value]
         else this.timeDomain = [this.timeDomain[0], value]
     }
 

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -306,7 +306,13 @@ export class DataTable extends React.Component<DataTableProps> {
                 {value.formattedValue}
                 {value.time !== undefined &&
                     column.targetTimeMode === TargetTimeMode.range && (
-                        <span className="range-time"> in {value.time}</span>
+                        <span className="range-time">
+                            {" "}
+                            in{" "}
+                            {formatTime(value.time!, {
+                                format: "MMM D",
+                            })}
+                        </span>
                     )}
             </td>
         )

--- a/grapher/timeline/TimelineComponent.tsx
+++ b/grapher/timeline/TimelineComponent.tsx
@@ -251,10 +251,19 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
         this.controller.togglePlay()
     }
 
+    convertToTime(time: number) {
+        if (time === -Infinity) return this.controller.minTime
+        if (time === +Infinity) return this.controller.maxTime
+        return time
+    }
+
     render() {
         const { subject, controller } = this
         const { startTimeProgress, endTimeProgress } = controller
-        const { startTime, endTime } = subject
+        let { startTime, endTime } = subject
+
+        startTime = this.convertToTime(startTime)
+        endTime = this.convertToTime(endTime)
 
         return (
             <div


### PR DESCRIPTION
This fixes a couple of the recent regressions in DataTables:
- Timeline not working on DataTables
- "Closest year" notices not formatting properly

Noticing now that embeds have separate issues -- will fix in a separate hotfix.