### PR TITLE
Add support for Vectorization

### DIFF
--- a/coreTable/CoreTable.test.ts
+++ b/coreTable/CoreTable.test.ts
@@ -16,6 +16,15 @@ it("a table can be made from csv", () => {
     expect(table.columnNames).toEqual(["country", "population"])
 })
 
+it("can create a table from columns", () => {
+    const table = new CoreTable({
+        scores: [0, 1, 2],
+        team: ["usa", "france", "canada"],
+    })
+    expect(table.numRows).toEqual(3)
+    expect(table.columnNames).toEqual(["scores", "team"])
+})
+
 it("rows can be added without mutating the parent table", () => {
     const table = CoreTable.fromDelimited(sampleCsv)
     expect(table.numRows).toEqual(4)
@@ -61,7 +70,7 @@ it("it always parses all values in all rows to Javascript primitives when the ta
         { country: "Germany", gdp: undefined },
     ]
     const table = new CoreTable(rows)
-    expect(table.get("gdp")?.validRows.length).toEqual(1)
+    expect(table.get("gdp")?.numValues).toEqual(1)
 })
 
 describe("it can add new computed columns", () => {

--- a/coreTable/CoreTable.test.ts
+++ b/coreTable/CoreTable.test.ts
@@ -63,12 +63,12 @@ describe("explain", () => {
     })
 
     it("explain short has a row for each transform", () => {
-        expect(table.explainShort().split("\n").length).toEqual(3)
+        expect(table.explain().split("\n").length).toEqual(3)
     })
 
     it("explain long contains useful info like Javscript types and perf info", () => {
-        expect(table.explain()).toContain("jsType")
-        expect(table.explain()).toContain("ms")
+        expect(table.explainLong()).toContain("jsType")
+        expect(table.explainLong()).toContain("ms")
     })
 })
 

--- a/coreTable/CoreTable.test.ts
+++ b/coreTable/CoreTable.test.ts
@@ -25,6 +25,14 @@ it("can create a table from columns", () => {
     expect(table.columnNames).toEqual(["scores", "team"])
 })
 
+it("can create a table from csv", () => {
+    const table = new CoreTable(sampleCsv)
+    expect(table.numRows).toEqual(4)
+    expect(table.columnNames).toEqual(["country", "population"])
+    expect(table.columnTypes).toEqual(["String", "Numeric"])
+    expect(table.columnJsTypes).toEqual(["string", "number"])
+})
+
 it("rows can be added without mutating the parent table", () => {
     const table = CoreTable.fromDelimited(sampleCsv)
     expect(table.numRows).toEqual(4)

--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -69,6 +69,12 @@ class RowStorageEngine<
         super()
         this._inputRows = rows
         this.table = table
+        this.builtRows = rows
+
+        if (this.needsBuilding) this.buildRows()
+    }
+
+    private buildRows() {
         this.builtRows = this._inputRows.map((row, index) => {
             const newRow: any = Object.assign({}, row)
             this.columnsToParse.forEach((col) => {
@@ -79,6 +85,10 @@ class RowStorageEngine<
             })
             return newRow as ROW_TYPE
         })
+    }
+
+    private get needsBuilding() {
+        return this.colsToCompute.length || this.columnsToParse.length
     }
 
     private get colsToCompute() {

--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -23,6 +23,7 @@ import {
     ColumnTypeNames,
     CoreColumnDef,
     CoreRow,
+    CsvString,
     PrimitiveType,
     SortOrder,
     TransformType,
@@ -182,8 +183,6 @@ interface AdvancedOptions {
     rowConversionFunction?: (row: any) => CoreRow
 }
 
-type csv = string
-
 const autoType = (object: any) => {
     for (const key in object) {
         let value = object[key].trim()
@@ -219,7 +218,7 @@ export class CoreTable<
 
     inputColumnDefs: COL_DEF_TYPE[]
     constructor(
-        rowsOrColumnsOrCsv: ROW_TYPE[] | ColumnStore | csv = [],
+        rowsOrColumnsOrCsv: ROW_TYPE[] | ColumnStore | CsvString = [],
         inputColumnDefs: COL_DEF_TYPE[] = [],
         advancedOptions: AdvancedOptions = {}
     ) {

--- a/coreTable/CoreTableColumns.ts
+++ b/coreTable/CoreTableColumns.ts
@@ -244,7 +244,7 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
     }
 
     @computed get isEmpty() {
-        return this.validRows.length === 0
+        return this.allValues.length === 0
     }
 
     @computed get name() {
@@ -306,8 +306,15 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
     }
 
     @computed get allValues() {
-        const slug = this.slug
-        return this.table.rows.map((row) => row[slug])
+        return this.table.getValuesFor(this.slug)
+    }
+
+    @computed get parsedValues() {
+        return this.table
+            .getValuesFor(this.slug)
+            .filter(
+                (value) => !((value as any) instanceof InvalidCell)
+            ) as JS_TYPE[]
     }
 
     @computed private get allValuesAsSet() {
@@ -327,17 +334,12 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
         return last(this.valuesAscending)!
     }
 
-    @computed private get rowsWithParseErrors() {
-        const slug = this.def.slug
-        return this.table.rows.filter((row) => row[slug] instanceof InvalidCell)
-    }
-
     @computed get numParseErrors() {
-        return this.rowsWithParseErrors.length
+        return this.allValues.length - this.numValues
     }
 
     // Rows containing a value for this column
-    @computed get validRows() {
+    @computed private get validRows() {
         const slug = this.def.slug
         return this.table.rows.filter(
             (row) => !(row[slug] instanceof InvalidCell)
@@ -346,16 +348,11 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
 
     // Number of correctly parsed values
     @computed get numValues() {
-        return this.validRows.length
+        return this.parsedValues.length
     }
 
     @computed get numUniqs() {
         return this.uniqValues.length
-    }
-
-    @computed get parsedValues(): JS_TYPE[] {
-        const slug = this.def.slug
-        return this.validRows.map((row) => row[slug])
     }
 
     @computed get valuesAscending() {

--- a/coreTable/CoreTableConstants.ts
+++ b/coreTable/CoreTableConstants.ts
@@ -94,6 +94,8 @@ export enum JsTypes {
     number = "number",
 }
 
+export type CsvString = string
+
 // todo: remove index param?
 // todo: improve typings on this
 export type ColumnFn = (row: CoreRow, index?: Integer) => any

--- a/coreTable/InvalidCells.ts
+++ b/coreTable/InvalidCells.ts
@@ -4,33 +4,32 @@
 // it may be helpful to parse those invalid values into specific types, to provide better error messages
 // and perhaps in the future suggested autocorrections or workarounds. Or this could be a dumb idea and can be discarded.
 export abstract class InvalidCell {
-    protected invalidCellValue?: any
-    constructor(invalidCellValue?: any) {
-        this.invalidCellValue = invalidCellValue
-    }
     toString() {
-        return this.invalidCellValue instanceof InvalidCell
-            ? ""
-            : this.invalidCellValue ?? ""
+        return ""
     }
     toErrorString() {
         return this.constructor.name
     }
 }
-export class NaNButShouldBeNumber extends InvalidCell {
-    toErrorString() {
-        return this.constructor.name + `: '${this.invalidCellValue}'`
-    }
-}
-export class DroppedForTesting extends InvalidCell {}
-export class InvalidOnALogScale extends InvalidCell {}
-export class UndefinedButShouldBeNumber extends InvalidCell {}
-export class NullButShouldBeNumber extends InvalidCell {}
-export class BlankButShouldBeNumber extends InvalidCell {}
-export class UndefinedButShouldBeString extends InvalidCell {}
-export class NullButShouldBeString extends InvalidCell {}
-export class NotAParseableNumberButShouldBeNumber extends InvalidCell {
-    toErrorString() {
-        return this.constructor.name + `: '${this.invalidCellValue}'`
-    }
+
+class NaNButShouldBeNumber extends InvalidCell {}
+class DroppedForTesting extends InvalidCell {}
+class InvalidOnALogScale extends InvalidCell {}
+class UndefinedButShouldBeNumber extends InvalidCell {}
+class NullButShouldBeNumber extends InvalidCell {}
+class BlankButShouldBeNumber extends InvalidCell {}
+class UndefinedButShouldBeString extends InvalidCell {}
+class NullButShouldBeString extends InvalidCell {}
+class NotAParseableNumberButShouldBeNumber extends InvalidCell {}
+
+export const InvalidCellTypes = {
+    NaNButShouldBeNumber: new NaNButShouldBeNumber(),
+    DroppedForTesting: new DroppedForTesting(),
+    InvalidOnALogScale: new InvalidOnALogScale(),
+    UndefinedButShouldBeNumber: new UndefinedButShouldBeNumber(),
+    NullButShouldBeNumber: new NullButShouldBeNumber(),
+    BlankButShouldBeNumber: new BlankButShouldBeNumber(),
+    UndefinedButShouldBeString: new UndefinedButShouldBeString(),
+    NullButShouldBeString: new NullButShouldBeString(),
+    NotAParseableNumberButShouldBeNumber: new NotAParseableNumberButShouldBeNumber(),
 }

--- a/coreTable/OwidTable.test.ts
+++ b/coreTable/OwidTable.test.ts
@@ -274,7 +274,7 @@ describe("time filtering", () => {
     })
 
     it("time options are sorted in ascending order", () => {
-        const csv = `entityName,entityId,entityCode,date,value
+        const csv = `entityName,entityId,entityCode,day,value
 usa,1,usa,-4,1
 usa,1,usa,1,1
 usa,1,usa,-5,1`

--- a/coreTable/OwidTable.test.ts
+++ b/coreTable/OwidTable.test.ts
@@ -165,11 +165,11 @@ it("can drop random cells", () => {
         timeRange: [2000, 2010],
         entityCount: 1,
     })
-    expect(table.get(SampleColumnSlugs.GDP)!.validRows.length).toBe(10)
+    expect(table.get(SampleColumnSlugs.GDP)!.numValues).toBe(10)
     expect(
         table
             .replaceRandomCells(7, [SampleColumnSlugs.GDP])
-            .get(SampleColumnSlugs.GDP)!.validRows.length
+            .get(SampleColumnSlugs.GDP)!.numValues
     ).toBe(3)
 })
 

--- a/coreTable/OwidTable.ts
+++ b/coreTable/OwidTable.ts
@@ -207,11 +207,10 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
 
     // Does a stable sort by time. Mobx will cache this, and then you can refer to this table for
     // fast time filtering.
-    @computed private get sortedByTime(): this {
-        return new (this.constructor as any)(
+    @computed private get sortedByTime() {
+        return this.transform(
             sortBy(this.rows, (row) => rowTime(row)),
             this.defs,
-            this,
             `Sort rows by time before filtering for speed`,
             TransformType.SortRows
         )
@@ -238,10 +237,10 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
             (row) => row[timeColumnSlug]
         )
 
-        return new (this.constructor as any)(
+        // NB: this one does something tricky in that it is a 2 step transform. Probably want to do indexes instead.
+        return sortedTable.transform(
             rowsSortedByTime.slice(firstRowIndex, lastRowIndex),
             this.defs,
-            sortedTable,
             `Keep only rows with Time between ${adjustedStart} - ${adjustedEnd}`,
             TransformType.FilterRows
         )

--- a/coreTable/OwidTable.ts
+++ b/coreTable/OwidTable.ts
@@ -196,13 +196,12 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     }
 
     filterByEntityName(name: EntityName) {
-        return new OwidTable(
-            this.rowsByEntityName.get(name) || [],
-            this.defs,
-            this,
-            `Filter out all entities except '${name}'`,
-            TransformType.FilterRows
-        )
+        // todo; why not a filter by?
+        return new OwidTable(this.rowsByEntityName.get(name) || [], this.defs, {
+            parent: this,
+            tableDescription: `Filter out all entities except '${name}'`,
+            transformCategory: TransformType.FilterRows,
+        })
     }
 
     // Does a stable sort by time. Mobx will cache this, and then you can refer to this table for
@@ -299,9 +298,11 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
                 return newRow
             }),
             newDefs,
-            this,
-            `Transformed ${columnSlug} column to be % contribution of each entity for that time`,
-            TransformType.UpdateColumnDefs
+            {
+                parent: this,
+                tableDescription: `Transformed ${columnSlug} column to be % contribution of each entity for that time`,
+                transformCategory: TransformType.UpdateColumnDefs,
+            }
         )
     }
 
@@ -324,11 +325,13 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
                 return newRow
             }),
             newDefs,
-            this,
-            `Transformed columns from absolute values to % of sum of ${columnSlugs.join(
-                ","
-            )} `,
-            TransformType.UpdateColumnDefs
+            {
+                parent: this,
+                tableDescription: `Transformed columns from absolute values to % of sum of ${columnSlugs.join(
+                    ","
+                )} `,
+                transformCategory: TransformType.UpdateColumnDefs,
+            }
         )
     }
 
@@ -360,11 +363,13 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
                 return newRow
             }),
             newDefs,
-            this,
-            `Transformed columns from absolute values to % of time ${startTime} for columns ${columnSlugs.join(
-                ","
-            )} `,
-            TransformType.UpdateColumnDefs
+            {
+                parent: this,
+                tableDescription: `Transformed columns from absolute values to % of time ${startTime} for columns ${columnSlugs.join(
+                    ","
+                )} `,
+                transformCategory: TransformType.UpdateColumnDefs,
+            }
         )
     }
 

--- a/coreTable/OwidTable.ts
+++ b/coreTable/OwidTable.ts
@@ -198,7 +198,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     filterByEntityName(name: EntityName) {
         return new OwidTable(
             this.rowsByEntityName.get(name) || [],
-            undefined,
+            this.defs,
             this,
             `Filter out all entities except '${name}'`,
             TransformType.FilterRows
@@ -210,7 +210,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     @computed private get sortedByTime(): this {
         return new (this.constructor as any)(
             sortBy(this.rows, (row) => rowTime(row)),
-            undefined,
+            this.defs,
             this,
             `Sort rows by time before filtering for speed`,
             TransformType.SortRows
@@ -240,7 +240,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
 
         return new (this.constructor as any)(
             rowsSortedByTime.slice(firstRowIndex, lastRowIndex),
-            undefined,
+            this.defs,
             sortedTable,
             `Keep only rows with Time between ${adjustedStart} - ${adjustedEnd}`,
             TransformType.FilterRows

--- a/explorer/covidExplorer/CovidAnnotations.ts
+++ b/explorer/covidExplorer/CovidAnnotations.ts
@@ -5,7 +5,7 @@ import {
     CoreRow,
 } from "coreTable/CoreTableConstants"
 import { EntityName } from "coreTable/OwidTableConstants"
-import { csvParse } from "d3"
+import { csvParse } from "d3-dsv"
 import moment from "moment"
 
 // todo: auto import from covid repo.

--- a/explorer/covidExplorer/CovidConstants.ts
+++ b/explorer/covidExplorer/CovidConstants.ts
@@ -227,8 +227,17 @@ export interface MegaRow extends CoreRow {
     hospital_beds_per_thousand?: number
 }
 
+export enum MegaSlugs {
+    location = "location",
+    iso_code = "iso_code",
+    date = "date",
+    test_units = "test_units",
+    continent = "continent",
+}
+
 // We parse MegaRows and turn them into CovidRows immediately.
-export interface CovidRow extends Omit<MegaRow, "location" | "iso_code"> {
+export interface CovidRow
+    extends Omit<MegaRow, MegaSlugs.location | MegaSlugs.iso_code> {
     group_members?: string
     entityName: string
     entityCode: string
@@ -242,7 +251,7 @@ export const MegaColumnMap: Partial<Record<
     CovidColumnSlug,
     Partial<OwidColumnDef>
 >> = {
-    location: {
+    entityName: {
         name: "Country name",
         type: ColumnTypeNames.Region,
     },

--- a/explorer/covidExplorer/CovidConstants.ts
+++ b/explorer/covidExplorer/CovidConstants.ts
@@ -237,7 +237,8 @@ export interface CovidRow extends Omit<MegaRow, "location" | "iso_code"> {
 }
 
 export declare type CovidColumnSlug = keyof CovidRow
-const MegaColumnMap: Partial<Record<
+
+export const MegaColumnMap: Partial<Record<
     CovidColumnSlug,
     Partial<OwidColumnDef>
 >> = {
@@ -324,9 +325,3 @@ export const CovidCountryPickerSlugs = [
     OwidTableSlugs.entityName,
     ...Object.keys(MegaColumnMap),
 ]
-export const MegaColumnDefs = Object.keys(MegaColumnMap).map((slug) => {
-    return {
-        ...MegaColumnMap[slug],
-        slug,
-    } as OwidColumnDef
-})

--- a/explorer/covidExplorer/CovidExplorer.jsdom.test.tsx
+++ b/explorer/covidExplorer/CovidExplorer.jsdom.test.tsx
@@ -5,7 +5,7 @@ import { CovidQueryParams } from "explorer/covidExplorer/CovidParams"
 import React from "react"
 import { mount, ReactWrapper } from "enzyme"
 import { IntervalOptions, metricLabels, MetricOptions } from "./CovidConstants"
-import { sampleMegaRows } from "./CovidExplorerUtils"
+import { sampleMegaCsv } from "./CovidExplorerUtils"
 
 const dummyMeta = {
     charts: {},
@@ -17,7 +17,7 @@ describe(CovidExplorer, () => {
         const startingParams = new CovidQueryParams("")
         const element = mount(
             <CovidExplorer
-                megaRows={sampleMegaRows}
+                megaCsv={sampleMegaCsv}
                 params={startingParams}
                 covidChartAndVariableMeta={dummyMeta}
                 updated="2020-05-09T18:59:31"
@@ -45,7 +45,7 @@ class ExplorerDataTableTest {
         this.params = params
         this.view = mount(
             <CovidExplorer
-                megaRows={sampleMegaRows}
+                megaCsv={sampleMegaCsv}
                 params={this.params}
                 queryStr="?tab=table&time=2020-05-06"
                 covidChartAndVariableMeta={dummyMeta}

--- a/explorer/covidExplorer/CovidExplorer.stories.tsx
+++ b/explorer/covidExplorer/CovidExplorer.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { CovidExplorer } from "explorer/covidExplorer/CovidExplorer"
 import { CovidQueryParams } from "explorer/covidExplorer/CovidParams"
-import { sampleMegaRows } from "./CovidExplorerUtils"
+import { sampleMegaCsv } from "./CovidExplorerUtils"
 
 export default {
     title: "CovidExplorer",
@@ -16,7 +16,7 @@ const EMPTY_DUMMY_META = {
 export const SingleExplorerWithKeyboardShortcuts = () => {
     return (
         <CovidExplorer
-            megaRows={sampleMegaRows}
+            megaCsv={sampleMegaCsv}
             params={new CovidQueryParams("")}
             covidChartAndVariableMeta={EMPTY_DUMMY_META}
             updated="2020-05-09T18:59:31"
@@ -29,13 +29,13 @@ export const MultipleExplorers = () => {
     return (
         <div>
             <CovidExplorer
-                megaRows={sampleMegaRows}
+                megaCsv={sampleMegaCsv}
                 params={new CovidQueryParams("")}
                 covidChartAndVariableMeta={EMPTY_DUMMY_META}
                 updated="2020-05-09T18:59:31"
             />
             <CovidExplorer
-                megaRows={sampleMegaRows}
+                megaCsv={sampleMegaCsv}
                 params={new CovidQueryParams("")}
                 covidChartAndVariableMeta={EMPTY_DUMMY_META}
                 updated="2020-05-09T18:59:31"
@@ -50,7 +50,7 @@ export const MultiMetricExplorer = () => {
     )
     return (
         <CovidExplorer
-            megaRows={sampleMegaRows}
+            megaCsv={sampleMegaCsv}
             params={startingParams}
             queryStr="?tab=table&time=2020-05-06"
             covidChartAndVariableMeta={EMPTY_DUMMY_META}

--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -38,7 +38,6 @@ import {
     MetricOptions,
     IntervalOptions,
     ColorScaleOptions,
-    MegaRow,
     CovidCountryPickerSlugs,
 } from "./CovidConstants"
 import { ColorSchemes } from "grapher/color/ColorSchemes"
@@ -74,9 +73,10 @@ import {
     ExplorerControlType,
     ExplorerControlOption,
 } from "explorer/client/ExplorerConstants"
-import { Color, ColumnSlug } from "coreTable/CoreTableConstants"
+import { Color, ColumnSlug, CsvString } from "coreTable/CoreTableConstants"
 import { ContinentColors } from "grapher/color/ColorConstants"
 import { MapProjectionName } from "grapher/mapCharts/MapProjections"
+import { MegaCsvToCovidExplorerTable } from "./MegaCsv"
 
 interface BootstrapProps {
     containerNode: HTMLElement
@@ -87,7 +87,7 @@ interface BootstrapProps {
 }
 
 interface CovidExplorerProps {
-    megaRows: MegaRow[]
+    megaCsv: CsvString
     params: CovidQueryParams
     covidChartAndVariableMeta: {
         charts: any
@@ -106,7 +106,7 @@ export class CovidExplorer
     extends React.Component<CovidExplorerProps>
     implements ObservableUrl, SlideShowManager {
     static async bootstrap(props: BootstrapProps) {
-        const { megaRows, updated, covidMeta } = await fetchRequiredData()
+        const { megaCsv, updated, covidMeta } = await fetchRequiredData()
         const queryStr =
             props.queryStr && CovidQueryParams.hasAnyCovidParam(props.queryStr)
                 ? props.queryStr
@@ -114,7 +114,7 @@ export class CovidExplorer
         const startingParams = new CovidQueryParams(queryStr)
         return ReactDOM.render(
             <CovidExplorer
-                megaRows={megaRows}
+                megaCsv={megaCsv}
                 updated={updated}
                 params={startingParams}
                 covidChartAndVariableMeta={covidMeta}
@@ -544,7 +544,7 @@ export class CovidExplorer
         }, 1)
     }
 
-    private inputTable = CovidExplorerTable.fromMegaRows(this.props.megaRows)
+    private inputTable = MegaCsvToCovidExplorerTable(this.props.megaCsv)
         .updateColumnsToHideInDataTable()
         .loadColumnDefTemplatesFromGrapherBackend(
             this.props.covidChartAndVariableMeta.variables

--- a/explorer/covidExplorer/CovidExplorerTable.test.ts
+++ b/explorer/covidExplorer/CovidExplorerTable.test.ts
@@ -3,34 +3,32 @@
 import { CovidExplorerTable } from "./CovidExplorerTable"
 import { CovidQueryParams } from "explorer/covidExplorer/CovidParams"
 import { queryParamsToStr } from "utils/client/url"
-import { sampleMegaRows } from "./CovidExplorerUtils"
+import { sampleMegaCsv } from "./CovidExplorerUtils"
+import { MegaCsvToCovidExplorerTable } from "./MegaCsv"
+
+const table = MegaCsvToCovidExplorerTable(sampleMegaCsv)
 
 it("correctly parses data from mega file", () => {
-    expect(
-        CovidExplorerTable.fromMegaRows(sampleMegaRows).rows[0].total_cases
-    ).toEqual(2)
+    expect(table.rows[0].total_cases).toEqual(2)
 })
 
 it("correctly computes makeCountryOptions", () => {
-    const table = CovidExplorerTable.fromMegaRows(sampleMegaRows)
     expect(table.availableEntityNames[3]).toEqual("World")
 })
 
 it("correctly groups continents and adds rows for each", () => {
-    const table = CovidExplorerTable.fromMegaRows(sampleMegaRows)
     const regionRows = table.where({ entityName: "North America" })
     expect(regionRows.numRows).toEqual(6)
     expect(regionRows.lastRow?.total_cases).toEqual(46451)
 })
 
 it("correctly adds EU aggregates and drops last day", () => {
-    const table = CovidExplorerTable.fromMegaRows(sampleMegaRows)
     const regionRows = table.where({ entityName: "European Union" })
     expect(regionRows.numRows).toEqual(1)
 })
 
 describe("build covid column", () => {
-    let table = CovidExplorerTable.fromMegaRows(sampleMegaRows)
+    let table = MegaCsvToCovidExplorerTable(sampleMegaCsv)
     const def = table.makeRollingAverageColumnDef(
         { slug: "totalCasesSmoothed" },
         (row) => row.total_cases,
@@ -95,7 +93,7 @@ describe("build covid column", () => {
 })
 
 describe("builds aligned tests column", () => {
-    let table = CovidExplorerTable.fromMegaRows(sampleMegaRows)
+    let table = MegaCsvToCovidExplorerTable(sampleMegaCsv)
 
     expect(table.columnSlugs.includes("tests-daily")).toEqual(false)
 
@@ -113,7 +111,7 @@ describe("builds aligned tests column", () => {
     expect(table.columnSlugs.includes("tests-perThousand-daily")).toEqual(true)
 
     it("rows are immutable", () => {
-        const table3 = CovidExplorerTable.fromMegaRows(sampleMegaRows)
+        const table3 = MegaCsvToCovidExplorerTable(sampleMegaCsv)
         expect(table3.columnSlugs.includes("tests-perThousand-daily")).toEqual(
             false
         )
@@ -134,7 +132,7 @@ describe("builds aligned tests column", () => {
 })
 
 it("can filter rows without continent", () => {
-    let table = CovidExplorerTable.fromMegaRows(sampleMegaRows)
+    let table = MegaCsvToCovidExplorerTable(sampleMegaCsv)
     expect(table.availableEntityNameSet.has("World")).toBeTruthy()
 
     table = table.filterGroups()

--- a/explorer/covidExplorer/CovidExplorerTable.ts
+++ b/explorer/covidExplorer/CovidExplorerTable.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, flatten, isPresent } from "grapher/utils/Util"
+import { cloneDeep, isPresent } from "grapher/utils/Util"
 import { OwidTable } from "coreTable/OwidTable"
 import { OwidColumnDef, OwidTableSlugs } from "coreTable/OwidTableConstants"
 import {
@@ -17,89 +17,18 @@ import {
     makeColumnDefTemplates,
 } from "./CovidParams"
 import {
-    CovidRow,
     IntervalOptions,
     intervalsAvailableByMetric,
     intervalSpecs,
-    MegaColumnDefs,
-    MegaRow,
     MetricOptions,
     SmoothingOption,
     testRateExcludeList,
 } from "./CovidConstants"
-import {
-    calculateCovidRowsForGroup,
-    computeRollingAveragesForEachGroup,
-    euCountries,
-    megaDateToTime,
-} from "./CovidExplorerUtils"
+import { computeRollingAveragesForEachGroup } from "./CovidExplorerUtils"
 import { CovidAnnotationColumnDefs } from "./CovidAnnotations"
-import { CoreTable } from "coreTable/CoreTable"
 import { WorldEntityName } from "grapher/core/GrapherConstants"
 
 export class CovidExplorerTable extends OwidTable {
-    static fromMegaRows(megaRows: MegaRow[]) {
-        const coreTable = new CoreTable<MegaRow>(megaRows, MegaColumnDefs, {
-            tableDescription: "Load from MegaCSV",
-        })
-            .withRenamedColumns({
-                location: OwidTableSlugs.entityName,
-                iso_code: OwidTableSlugs.entityCode,
-            }) // todo: after a rename, the row interface has changed. how can we update the child tables with correct typings?
-            .filter(
-                (row: MegaRow) => row.location !== "International",
-                "Drop International rows"
-            )
-            .appendColumns([
-                {
-                    slug: OwidTableSlugs.time,
-                    type: ColumnTypeNames.Date,
-                    fn: ((row: MegaRow) => megaDateToTime(row.date)) as any,
-                }, // todo: improve typings on ColumnFn.
-            ])
-
-        // todo: this can be better expressed as a group + reduce.
-        const continentGroups = coreTable.get("continent")!.valuesToRows
-        const continentNames = Array.from(continentGroups.keys()).filter(
-            (cont) => cont
-        )
-
-        const continentRows = flatten(
-            continentNames.map((continentName) => {
-                const rows = Array.from(
-                    continentGroups.get(continentName)!.values()
-                ) as CovidRow[]
-                return calculateCovidRowsForGroup(rows, continentName)
-            })
-        )
-
-        const euRows = calculateCovidRowsForGroup(
-            coreTable.rows.filter((row) =>
-                euCountries.has(row.entityName)
-            ) as any,
-            "European Union"
-        )
-
-        // Drop the last day in aggregates containing Spain & Sweden
-        euRows.pop()
-
-        const tableWithRows = coreTable
-            .withRows(
-                continentRows as any,
-                `Added ${continentRows.length} continent rows`
-            )
-            .withRows(euRows as any, `Added ${euRows.length} EU rows`)
-
-        return new CovidExplorerTable(
-            (tableWithRows.rows as any) as CovidRow[], // todo: clean up typings
-            tableWithRows.defs,
-            {
-                parent: tableWithRows as any,
-                tableDescription: "Loaded into CovidExplorerTable",
-            }
-        )
-    }
-
     get mainTable(): CovidExplorerTable {
         return this.parent && this.parent instanceof CovidExplorerTable
             ? this.parent.mainTable

--- a/explorer/covidExplorer/CovidExplorerTable.ts
+++ b/explorer/covidExplorer/CovidExplorerTable.ts
@@ -39,12 +39,9 @@ import { WorldEntityName } from "grapher/core/GrapherConstants"
 
 export class CovidExplorerTable extends OwidTable {
     static fromMegaRows(megaRows: MegaRow[]) {
-        const coreTable = new CoreTable<MegaRow>(
-            megaRows,
-            MegaColumnDefs,
-            undefined,
-            "Load from MegaCSV"
-        )
+        const coreTable = new CoreTable<MegaRow>(megaRows, MegaColumnDefs, {
+            tableDescription: "Load from MegaCSV",
+        })
             .withRenamedColumns({
                 location: OwidTableSlugs.entityName,
                 iso_code: OwidTableSlugs.entityCode,
@@ -96,8 +93,10 @@ export class CovidExplorerTable extends OwidTable {
         return new CovidExplorerTable(
             (tableWithRows.rows as any) as CovidRow[], // todo: clean up typings
             tableWithRows.defs,
-            tableWithRows as any,
-            "Loaded into CovidExplorerTable"
+            {
+                parent: tableWithRows as any,
+                tableDescription: "Loaded into CovidExplorerTable",
+            }
         )
     }
 

--- a/explorer/covidExplorer/CovidExplorerTable.ts
+++ b/explorer/covidExplorer/CovidExplorerTable.ts
@@ -95,7 +95,7 @@ export class CovidExplorerTable extends OwidTable {
 
         return new CovidExplorerTable(
             (tableWithRows.rows as any) as CovidRow[], // todo: clean up typings
-            undefined,
+            tableWithRows.defs,
             tableWithRows as any,
             "Loaded into CovidExplorerTable"
         )

--- a/explorer/covidExplorer/MegaCsv.ts
+++ b/explorer/covidExplorer/MegaCsv.ts
@@ -1,0 +1,78 @@
+import { CoreTable } from "coreTable/CoreTable"
+import { CsvString, ColumnTypeNames } from "coreTable/CoreTableConstants"
+import { OwidColumnDef, OwidTableSlugs } from "coreTable/OwidTableConstants"
+import { flatten } from "grapher/utils/Util"
+import { MegaRow, CovidRow, MegaColumnMap } from "./CovidConstants"
+import { CovidExplorerTable } from "./CovidExplorerTable"
+import {
+    megaDateToTime,
+    calculateCovidRowsForGroup,
+    euCountries,
+} from "./CovidExplorerUtils"
+
+export const MegaColumnDefs = Object.keys(MegaColumnMap).map((slug) => {
+    return {
+        ...MegaColumnMap[slug],
+        slug,
+    } as OwidColumnDef
+})
+
+export const MegaCsvToCovidExplorerTable = (megaCsv: CsvString) => {
+    const coreTable = new CoreTable<MegaRow>(megaCsv, MegaColumnDefs, {
+        tableDescription: "Load from MegaCSV",
+    })
+        .withRenamedColumns({
+            location: OwidTableSlugs.entityName,
+            iso_code: OwidTableSlugs.entityCode,
+        }) // todo: after a rename, the row interface has changed. how can we update the child tables with correct typings?
+        .filter(
+            (row: MegaRow) => row.location !== "International",
+            "Drop International rows"
+        )
+        .appendColumns([
+            {
+                slug: OwidTableSlugs.time,
+                type: ColumnTypeNames.Date,
+                fn: ((row: MegaRow) => megaDateToTime(row.date)) as any,
+            }, // todo: improve typings on ColumnFn.
+        ])
+
+    // todo: this can be better expressed as a group + reduce.
+    const continentGroups = coreTable.get("continent")!.valuesToRows
+    const continentNames = Array.from(continentGroups.keys()).filter(
+        (cont) => cont
+    )
+
+    const continentRows = flatten(
+        continentNames.map((continentName) => {
+            const rows = Array.from(
+                continentGroups.get(continentName)!.values()
+            ) as CovidRow[]
+            return calculateCovidRowsForGroup(rows, continentName)
+        })
+    )
+
+    const euRows = calculateCovidRowsForGroup(
+        coreTable.rows.filter((row) => euCountries.has(row.entityName)) as any,
+        "European Union"
+    )
+
+    // Drop the last day in aggregates containing Spain & Sweden
+    euRows.pop()
+
+    const tableWithRows = coreTable
+        .withRows(
+            continentRows as any,
+            `Added ${continentRows.length} continent rows`
+        )
+        .withRows(euRows as any, `Added ${euRows.length} EU rows`)
+
+    return new CovidExplorerTable(
+        (tableWithRows.rows as any) as CovidRow[], // todo: clean up typings
+        tableWithRows.defs,
+        {
+            parent: tableWithRows as any,
+            tableDescription: "Loaded into CovidExplorerTable",
+        }
+    )
+}

--- a/grapher/facetChart/FacetChart.stories.tsx
+++ b/grapher/facetChart/FacetChart.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { FacetChart } from "./FacetChart"
 import {
+    SampleColumnSlugs,
     SynthesizeFruitTable,
     SynthesizeGDPTable,
 } from "coreTable/OwidTableSynthesizers"
@@ -12,75 +13,57 @@ import { Meta } from "@storybook/react"
 const CSF: Meta = {
     title: "FacetChart",
     component: FacetChart,
-    argTypes: {
-        countryCount: {
-            defaultValue: 10,
-            control: { type: "range", min: 1, max: 200 },
-        },
-        chartTypeName: {
-            defaultValue: ChartTypeName.LineChart,
-            control: { type: "radio", options: Object.keys(ChartTypeName) },
-        },
-        dropRandomRows: {
-            defaultValue: 0,
-            control: { type: "range", min: 0, max: 100 },
-        },
-    },
 }
 
 export default CSF
 
 const bounds = new Bounds(0, 0, 1000, 500)
 
-export const OneMetricOneCountryPerChart = (args: any) => {
+export const OneMetricOneCountryPerChart = () => {
+    const manager = {
+        table: SynthesizeGDPTable({
+            entityCount: 4,
+        }).selectAll(),
+        yColumnSlug: SampleColumnSlugs.GDP,
+        xColumnSlug: SampleColumnSlugs.Population,
+    }
+
     return (
         <svg width={bounds.width} height={bounds.height}>
             <FacetChart
                 bounds={bounds}
-                chartTypeName={args.chartTypeName}
-                manager={{
-                    table: SynthesizeGDPTable({
-                        entityCount: (args.countryCount ?? 4) || 1,
-                    })
-                        .selectAll()
-                        .dropRandomPercent(args.dropRandomRows),
-                    yColumnSlug: "GDP",
-                    xColumnSlug: "Population",
-                }}
+                chartTypeName={ChartTypeName.LineChart}
+                manager={manager}
             />
         </svg>
     )
 }
 
-export const MultipleMetricsOneCountryPerChart = (args: any) => {
+export const MultipleMetricsOneCountryPerChart = () => {
     return (
         <svg width={bounds.width} height={bounds.height}>
             <FacetChart
                 bounds={bounds}
-                chartTypeName={args.chartTypeName}
+                chartTypeName={ChartTypeName.LineChart}
                 manager={{
                     table: SynthesizeFruitTable({
-                        entityCount: (args.countryCount ?? 4) || 1,
-                    })
-                        .selectAll()
-                        .dropRandomPercent(args.dropRandomRows),
+                        entityCount: 4,
+                    }).selectAll(),
                 }}
             />
         </svg>
     )
 }
 
-export const OneChartPerMetric = (args: any) => {
+export const OneChartPerMetric = () => {
     const table = SynthesizeGDPTable({
-        entityCount: (args.countryCount ?? 2) || 1,
-    })
-        .selectAll()
-        .dropRandomPercent(args.dropRandomRows)
+        entityCount: 2,
+    }).selectAll()
     return (
         <svg width={bounds.width} height={bounds.height}>
             <FacetChart
                 bounds={bounds}
-                chartTypeName={args.chartTypeName}
+                chartTypeName={ChartTypeName.LineChart}
                 manager={{
                     facetStrategy: FacetStrategy.column,
                     yColumnSlugs: table.numericColumnSlugs,

--- a/grapher/facetChart/FacetChart.test.ts
+++ b/grapher/facetChart/FacetChart.test.ts
@@ -1,0 +1,22 @@
+#! /usr/bin/env yarn jest
+
+import { FacetChart } from "./FacetChart"
+import { SynthesizeGDPTable } from "coreTable/OwidTableSynthesizers"
+import { ChartManager } from "grapher/chart/ChartManager"
+import { FacetStrategy } from "grapher/core/GrapherConstants"
+
+it("can create a new FacetChart", () => {
+    const manager: ChartManager = {
+        table: SynthesizeGDPTable({ timeRange: [2000, 2010] }).selectAll(),
+    }
+    const chart = new FacetChart({ manager })
+    expect(chart.series.length).toEqual(2)
+    manager.facetStrategy = FacetStrategy.column
+    expect(chart.series.length).toEqual(3)
+
+    // note: not sure if we want these strategies.
+    manager.facetStrategy = FacetStrategy.countryWithMap
+    expect(chart.series.length).toEqual(5)
+    manager.facetStrategy = FacetStrategy.columnWithMap
+    expect(chart.series.length).toEqual(6)
+})

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -18,6 +18,7 @@ import {
     PlacedFacetSeries,
 } from "./FacetChartConstants"
 import { OwidTable } from "coreTable/OwidTable"
+import { autoDetectYColumnSlugs } from "grapher/chart/ChartUtils"
 
 @observer
 export class FacetChart
@@ -166,7 +167,7 @@ export class FacetChart
     }
 
     @computed private get yColumnSlugs() {
-        return this.manager.yColumnSlugs || []
+        return autoDetectYColumnSlugs(this.manager)
     }
 
     @computed get series() {


### PR DESCRIPTION
This adds a "StorageEngine" concept so you can make a CoreTable from rows or columns. The latter is faster for a number of ops. It's a little clunky but decently tested and we can sharpen the design over time.

This restores *some* perf to CovidExplorer. Tomorrow I will do vector transforms for generating new columns and then next CovidExplorer should be faster than prod.

This should be good to merge into Next if anyone wants to. It's a decent number of lines so probably good to merge it before doing other related work on next.

Otherwise I will merge in the morning.

Other minor thing:

- Adds `table.dump()` method, which just calls console.table. Very pretty table printing in dev tools and/or nodejs.
