### PR TITLE
Map legend fixes

### DIFF
--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -405,12 +405,12 @@ export class MapChart
         )
     }
 
-    @computed get numericLegendHeight() {
-        return 5
+    @computed get numericLegendHeight(): number {
+        return this.numericLegend ? this.numericLegend.height : 0
     }
 
-    @computed get categoryLegendHeight() {
-        return 5
+    @computed get categoryLegendHeight(): number {
+        return this.categoryLegend ? this.categoryLegend.height + 5 : 0
     }
 
     @computed get categoryLegend() {

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -18,6 +18,7 @@ import {
     guid,
     minBy,
     difference,
+    uniq,
 } from "grapher/utils/Util"
 import { MapProjectionName, MapProjectionGeos } from "./MapProjections"
 import { select } from "d3-selection"
@@ -271,7 +272,7 @@ export class MapChart
     @computed get categoricalValues() {
         // return uniq(this.mappableData.values.filter(isString))
         // return this.options.mapColumn.values || [] // todo: mappable data
-        return this.mapColumn!.parsedValues.filter(isString)
+        return uniq(this.mapColumn!.parsedValues.filter(isString))
     }
 
     componentDidMount() {

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -48,7 +48,6 @@ import {
     ColorScaleBin,
     NumericBin,
 } from "grapher/color/ColorScaleBin"
-import { TextWrap } from "grapher/text/TextWrap"
 import * as topojson from "topojson-client"
 import { MapTopology } from "./MapTopology"
 import { PointVector } from "grapher/utils/PointVector"
@@ -311,10 +310,6 @@ export class MapChart
         return this.colorScale.config.equalSizeBins
     }
 
-    @computed get legendTitle() {
-        return ""
-    }
-
     @computed get focusValue() {
         return this.focusEntity?.series?.value
     }
@@ -356,14 +351,6 @@ export class MapChart
         return this.categoricalLegendData.length > 1
     }
 
-    @computed get mainLegendLabel() {
-        return new TextWrap({
-            maxWidth: this.legendBounds.width,
-            fontSize: 0.7 * this.fontSize,
-            text: this.legendTitle,
-        })
-    }
-
     @computed get numericFocusBracket(): ColorScaleBin | undefined {
         const { focusBracket, focusValue } = this
         const { numericLegendData } = this
@@ -397,12 +384,7 @@ export class MapChart
     }
 
     @computed get legendHeight() {
-        return (
-            this.mainLegendLabel.height +
-            this.categoryLegendHeight +
-            this.numericLegendHeight +
-            10
-        )
+        return this.categoryLegendHeight + this.numericLegendHeight + 10
     }
 
     @computed get numericLegendHeight(): number {
@@ -438,34 +420,24 @@ export class MapChart
             bounds,
             numericLegend,
             categoryLegend,
-            mainLegendLabel,
             categoryLegendHeight,
         } = this
         if (numericLegend)
             return (
-                bounds.bottom -
-                mainLegendLabel.height -
-                categoryLegendHeight -
-                numericLegend!.height -
-                4
+                bounds.bottom - categoryLegendHeight - numericLegend!.height - 4
             )
 
-        if (categoryLegend)
-            return bounds.bottom - mainLegendLabel.height - categoryLegendHeight
+        if (categoryLegend) return bounds.bottom - categoryLegendHeight
         return 0
     }
 
     renderMapLegend() {
-        const { bounds, mainLegendLabel, numericLegend, categoryLegend } = this
+        const { numericLegend, categoryLegend } = this
 
         return (
             <g className="mapLegend">
                 {numericLegend && <NumericColorLegend manager={this} />}
                 {categoryLegend && <CategoricalColorLegend manager={this} />}
-                {mainLegendLabel.render(
-                    bounds.centerX - mainLegendLabel.width / 2,
-                    bounds.bottom - mainLegendLabel.height
-                )}
             </g>
         )
     }

--- a/grapher/text/TextWrap.test.ts
+++ b/grapher/text/TextWrap.test.ts
@@ -46,3 +46,20 @@ describe("width()", () => {
         expect(stringWidth(text)).toEqual(renderedWidth(text, true))
     })
 })
+
+describe("height()", () => {
+    const renderedHeight = (text: string, raw?: boolean) => {
+        const textwrap = new TextWrap({
+            maxWidth: Infinity,
+            fontSize: FONT_SIZE,
+            text,
+            rawHtml: raw,
+        })
+        return textwrap.height
+    }
+
+    it("calculates a height of zero for an empty string", () => {
+        const text = ""
+        expect(renderedHeight(text)).toEqual(0)
+    })
+})

--- a/grapher/text/TextWrap.tsx
+++ b/grapher/text/TextWrap.tsx
@@ -102,6 +102,8 @@ export class TextWrap {
     }
 
     @computed get height() {
+        if (this.lines.length === 0) return 0
+
         return (
             this.lines.reduce((total, line) => total + line.height, 0) +
             this.lineHeight * (this.lines.length - 1)


### PR DESCRIPTION
Fixes https://www.notion.so/owid/Categorial-map-legend-contains-entries-for-every-country-fa7f01e8ff524cc3ac12943bdc6a5840 and https://www.notion.so/owid/Hovering-over-map-legend-doesn-t-highlight-respective-countries-545a42f7acb148ef81f88da9dbc5e606

I also decided to remove `mainLegendLabel` since we're currently not using it (it's always an empty string). If there's any reason why we would want to use it again in the future, let me know and I'll revert that change.

During that work I also realised that `new TextWrap("")` returns a height of `-1.1`, so I fixed that, too, and added a test.