### PR TITLE
Switch from computes in CoreTable to simple memoization decorator

### DIFF
--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -45,6 +45,7 @@ import {
     autoType,
     columnStoreToRows,
     guessColumnDefFromSlugAndRow,
+    imemo,
     makeKeyFn,
     makeRowFromColumnStore,
     standardizeSlugs,
@@ -159,7 +160,7 @@ export class CoreTable<
         return this._processedRows
     }
 
-    @computed private get csvAsRows() {
+    @imemo private get csvAsRows() {
         const { inputData, advancedOptions } = this
         const parsed = csvParse(
             inputData as string,
@@ -171,7 +172,7 @@ export class CoreTable<
         return parsed
     }
 
-    @computed private get inputAsRows() {
+    @imemo private get inputAsRows() {
         const { inputData, isFromCsv } = this
         return (isFromCsv ? this.csvAsRows : inputData) as ROW_TYPE[]
     }
@@ -205,7 +206,7 @@ export class CoreTable<
             : []
     }
 
-    @computed private get newProvidedColumnDefsToCompute() {
+    @imemo private get newProvidedColumnDefsToCompute() {
         const cols = this.parent
             ? difference(this.inputColumnDefs, this.parent.defs)
             : this.inputColumnDefs
@@ -238,7 +239,7 @@ export class CoreTable<
         return cols.filter((col) => col.needsParsing(firstInputRow[col.slug]))
     }
 
-    @computed private get numColsToCompute() {
+    @imemo private get numColsToCompute() {
         return this.colsToCompute.length
     }
 
@@ -246,7 +247,7 @@ export class CoreTable<
         return this.inputData as CoreColumnStore
     }
 
-    @computed private get isFromCsv() {
+    @imemo private get isFromCsv() {
         return typeof this.inputData === "string"
     }
 
@@ -328,7 +329,7 @@ export class CoreTable<
             : 0
     }
 
-    @computed get rows() {
+    @imemo get rows() {
         return this.isInputFromRowsOrCsv
             ? this.rowsFromRowsProcessed
             : this.rowsFromColumns
@@ -343,19 +344,19 @@ export class CoreTable<
         return indices.map((index) => values[index])
     }
 
-    @computed get firstRow() {
+    @imemo get firstRow() {
         return this.rows[0]
     }
 
-    @computed get lastRow() {
+    @imemo get lastRow() {
         return last(this.rows)
     }
 
-    @computed get numRows() {
+    @imemo get numRows() {
         return this.rows.length
     }
 
-    @computed get numColumns() {
+    @imemo get numColumns() {
         return this.columnSlugs.length
     }
 
@@ -372,7 +373,7 @@ export class CoreTable<
     // TODO: remove this. Currently we use this to get the right day/year time formatting. For now a chart is either a "day chart" or a "year chart".
     // But we can have charts with multiple time columns. Ideally each place that needs access to the timeColumn, would get the specific column
     // and not the first time column from the table.
-    @computed get timeColumn() {
+    @imemo get timeColumn() {
         // For now, return a day column first if present. But see note above about removing this method.
         const col =
             this.columnsAsArray.find(
@@ -388,7 +389,7 @@ export class CoreTable<
 
     // Todo: remove this. Generally this should not be called until the data is loaded. Even then, all calls should probably be made
     // on the column itself, and not tied tightly to the idea of a time column.
-    @computed get timeColumnFormatFunction() {
+    @imemo get timeColumnFormatFunction() {
         return this.timeColumn ? this.timeColumn.formatValue : formatYear
     }
 
@@ -396,19 +397,19 @@ export class CoreTable<
         return this.timeColumnFormatFunction(value)
     }
 
-    @computed private get columnsWithParseErrors() {
+    @imemo private get columnsWithParseErrors() {
         return this.columnsAsArray.filter((col) => col.numInvalidCells)
     }
 
-    @computed get numColumnsWithInvalidCells() {
+    @imemo get numColumnsWithInvalidCells() {
         return this.columnsWithParseErrors.length
     }
 
-    @computed get numInvalidCells() {
+    @imemo get numInvalidCells() {
         return sum(this.columnsAsArray.map((col) => col.numInvalidCells))
     }
 
-    @computed get numValidCells() {
+    @imemo get numValidCells() {
         return sum(this.columnsAsArray.map((col) => col.numValues))
     }
 
@@ -489,11 +490,11 @@ export class CoreTable<
         }, `Kept rows that matched '${searchStringOrRegex.toString()}'`)
     }
 
-    @computed get rowsAsSet() {
+    @imemo get rowsAsSet() {
         return new Set(this.rows)
     }
 
-    @computed get opposite() {
+    @imemo get opposite() {
         if (this.isRoot) return this
         const { rowsAsSet } = this
         return this.transform(
@@ -504,7 +505,7 @@ export class CoreTable<
         )
     }
 
-    @computed get oppositeColumns() {
+    @imemo get oppositeColumns() {
         if (this.isRoot) return this
         const columnsToDrop = new Set(this.columnSlugs)
         const defs = this.parent!.columnsAsArray.filter(
@@ -575,27 +576,27 @@ export class CoreTable<
         )
     }
 
-    @computed get defs() {
+    @imemo get defs() {
         return this.columnsAsArray.map((col) => col.def) as COL_DEF_TYPE[]
     }
 
-    @computed get columnNames() {
+    @imemo get columnNames() {
         return this.columnsAsArray.map((col) => col.name)
     }
 
-    @computed get columnTypes() {
+    @imemo get columnTypes() {
         return this.columnsAsArray.map((col) => col.def.type)
     }
 
-    @computed get columnJsTypes() {
+    @imemo get columnJsTypes() {
         return this.columnsAsArray.map((col) => col.jsType)
     }
 
-    @computed get columnSlugs() {
+    @imemo get columnSlugs() {
         return Array.from(this._columns.keys())
     }
 
-    @computed get numericColumnSlugs() {
+    @imemo get numericColumnSlugs() {
         return this.columnsAsArray
             .filter((col) => col instanceof ColumnTypeMap.Numeric)
             .map((col) => col.slug)
@@ -636,7 +637,7 @@ export class CoreTable<
         return this
     }
 
-    @computed get columnsAsArray() {
+    @imemo get columnsAsArray() {
         return Array.from(this._columns.values())
     }
 
@@ -674,15 +675,15 @@ export class CoreTable<
         console.table(this.inputAsTable)
     }
 
-    @computed private get isInputFromRowsOrCsv() {
+    @imemo private get isInputFromRowsOrCsv() {
         return Array.isArray(this.inputData) || this.isFromCsv
     }
 
-    @computed private get isInputFromColumns() {
+    @imemo private get isInputFromColumns() {
         return !this.isInputFromRowsOrCsv
     }
 
-    @computed private get inputAsTable() {
+    @imemo private get inputAsTable() {
         return this.isInputFromRowsOrCsv
             ? this.inputAsRows
             : columnStoreToRows(this.inputAsColumnStore)
@@ -716,7 +717,7 @@ export class CoreTable<
         return this.parent ? [...this.parent.ancestors, this] : [this]
     }
 
-    @computed private get numColsToParse() {
+    @imemo private get numColsToParse() {
         return this.columnsToParse.length
     }
 
@@ -891,7 +892,7 @@ export class CoreTable<
         )
     }
 
-    @computed get duplicateRowIndices() {
+    @imemo get duplicateRowIndices() {
         const keyFn = makeKeyFn(this.columnSlugs)
         const dupeSet = new Set()
         const dupeIndices: number[] = []

--- a/coreTable/CoreTableUtils.test.ts
+++ b/coreTable/CoreTableUtils.test.ts
@@ -1,6 +1,6 @@
 #! /usr/bin/env yarn jest
 
-import { interpolateRowValuesWithTolerance } from "./CoreTableUtils"
+import { imemo, interpolateRowValuesWithTolerance } from "./CoreTableUtils"
 import { InvalidCellTypes } from "./InvalidCells"
 
 describe(interpolateRowValuesWithTolerance, () => {
@@ -66,5 +66,27 @@ describe(interpolateRowValuesWithTolerance, () => {
             3,
         ])
         expect(result.map((r) => r.time)).toEqual([0, 2, 2, 2, 4, 6, 6, 6])
+    })
+})
+
+describe("immutable memoization", () => {
+    class WeatherForecast {
+        conditions = "rainy"
+
+        @imemo get forecast() {
+            return this.conditions
+        }
+    }
+
+    it("runs getters once", () => {
+        const forecast = new WeatherForecast()
+        expect(forecast.forecast).toEqual("rainy")
+
+        forecast.conditions = "sunny"
+        expect(forecast.forecast).toEqual("rainy")
+
+        const forecast2 = new WeatherForecast()
+        forecast2.conditions = "sunny"
+        expect(forecast2.forecast).toEqual("sunny")
     })
 })

--- a/coreTable/CoreTableUtils.ts
+++ b/coreTable/CoreTableUtils.ts
@@ -191,3 +191,25 @@ export function interpolateRowValuesWithTolerance<
 // A dumb function for making a function that makes a key for a row given certain columns.
 export const makeKeyFn = (columnSlugs: ColumnSlug[]) => (row: CoreRow) =>
     columnSlugs.map((slug) => row[slug]).join(" ")
+
+// Memoization for immutable getters. Run the function once for this instance and cache the result.
+export const imemo = (
+    target: any,
+    propertyName: string,
+    descriptor: TypedPropertyDescriptor<any>
+) => {
+    const originalFn = descriptor.get!
+    descriptor.get = function (this: any) {
+        const propName = `${propertyName}_memoized`
+        if (this[propName] === undefined) {
+            // Define the prop the long way so we don't enumerate over it
+            Object.defineProperty(this, propName, {
+                configurable: false,
+                enumerable: false,
+                writable: false,
+                value: originalFn.apply(this),
+            })
+        }
+        return this[propName]
+    }
+}

--- a/coreTable/OwidTable.ts
+++ b/coreTable/OwidTable.ts
@@ -52,7 +52,7 @@ import {
     makeOriginalTimeSlugFromColumnSlug,
     timeColumnSlugFromColumnDef,
 } from "./OwidTableUtil"
-import { interpolateRowValuesWithTolerance } from "./CoreTableUtils"
+import { imemo, interpolateRowValuesWithTolerance } from "./CoreTableUtils"
 
 // An OwidTable is a subset of Table. An OwidTable always has EntityName, EntityCode, EntityId, and Time columns,
 // and value column(s). Whether or not we need in the long run is uncertain and it may just be a stepping stone
@@ -71,24 +71,22 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         return new OwidTable(rows, [OwidEntityNameColumnDef, ...defs])
     }
 
-    @computed get entityType() {
-        return "Country"
-    }
+    entityType = "Country"
 
-    @computed get availableEntityNames() {
+    @imemo get availableEntityNames() {
         return Array.from(this.availableEntityNameSet)
     }
 
-    @computed get numAvailableEntityNames() {
+    @imemo get numAvailableEntityNames() {
         return this.availableEntityNames.length
     }
 
-    @computed get availableEntityNameSet() {
+    @imemo get availableEntityNameSet() {
         return new Set(this.rows.map((row) => row.entityName))
     }
 
     // todo: can we remove at some point?
-    @computed get entityIdToNameMap() {
+    @imemo get entityIdToNameMap() {
         return this.valueIndex(
             OwidTableSlugs.entityId,
             OwidTableSlugs.entityName
@@ -96,7 +94,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     }
 
     // todo: can we remove at some point?
-    @computed private get entityCodeToNameMap() {
+    @imemo private get entityCodeToNameMap() {
         return this.valueIndex(
             OwidTableSlugs.entityCode,
             OwidTableSlugs.entityName
@@ -104,7 +102,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     }
 
     // todo: can we remove at some point?
-    @computed get entityNameToIdMap() {
+    @imemo get entityNameToIdMap() {
         return this.valueIndex(
             OwidTableSlugs.entityName,
             OwidTableSlugs.entityId
@@ -112,14 +110,14 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     }
 
     // todo: can we remove at some point?
-    @computed get entityNameToCodeMap() {
+    @imemo get entityNameToCodeMap() {
         return this.valueIndex(
             OwidTableSlugs.entityName,
             OwidTableSlugs.entityCode
         ) as Map<string, string>
     }
 
-    @computed get entityIndex() {
+    @imemo get entityIndex() {
         const map = new Map<EntityName, OwidRow[]>()
         this.rows.forEach((row) => {
             if (!map.has(row.entityName)) map.set(row.entityName, [])
@@ -128,31 +126,31 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         return map
     }
 
-    @computed get maxTime() {
+    @imemo get maxTime() {
         return last(this.allTimes)
     }
 
-    @computed get minTime() {
+    @imemo get minTime() {
         return this.allTimes[0]
     }
 
-    @computed private get allTimes(): Time[] {
+    @imemo private get allTimes(): Time[] {
         return this.sortedByTime.get(this.timeColumn?.slug)?.parsedValues ?? []
     }
 
-    @computed get hasDayColumn() {
+    @imemo get hasDayColumn() {
         return this.has(OwidTableSlugs.day)
     }
 
-    @computed get dayColumn() {
+    @imemo get dayColumn() {
         return this.get(OwidTableSlugs.day)
     }
 
-    @computed get rowsByEntityName() {
+    @imemo get rowsByEntityName() {
         return this.rowIndex([OwidTableSlugs.entityName]).index
     }
 
-    @computed get rowsByTime() {
+    @imemo get rowsByTime() {
         return this.rowTypedIndex<Time>(this.timeColumn!.slug)
     }
 
@@ -199,7 +197,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
 
     // Does a stable sort by time. Mobx will cache this, and then you can refer to this table for
     // fast time filtering.
-    @computed private get sortedByTime() {
+    @imemo private get sortedByTime() {
         if (!this.timeColumn) return this
         const timeColumnSlug = this.timeColumn.slug
         return this.transform(
@@ -598,7 +596,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         )
     }
 
-    @computed get columnDisplayNameToColorMap() {
+    @imemo get columnDisplayNameToColorMap() {
         return keyBy(this.columnsAsArray, (col) => col.displayName)
     }
 

--- a/explorer/covidExplorer/.gitignore
+++ b/explorer/covidExplorer/.gitignore
@@ -1,0 +1,1 @@
+owid-covid-data.csv

--- a/explorer/covidExplorer/CovidExplorerTable.ts
+++ b/explorer/covidExplorer/CovidExplorerTable.ts
@@ -10,6 +10,7 @@ import {
     CoreColumnDef,
 } from "coreTable/CoreTableConstants"
 import {
+    allAvailableQueryStringCombos,
     CovidColumnDefObjectMap,
     CovidConstrainedQueryParams,
     CovidQueryParams,
@@ -177,6 +178,17 @@ export class CovidExplorerTable extends OwidTable {
             (params) =>
                 makeColumnDefFromParams(params, this.columnDefTemplates).slug
         )
+    }
+
+    appendEveryColumn() {
+        const defs = flatten(
+            allAvailableQueryStringCombos().map((str) =>
+                this.makeColumnDefsFromParams(
+                    new CovidQueryParams(str).toConstrainedParams()
+                )
+            )
+        )
+        return this.appendColumnsIfNew(defs)
     }
 
     private paramsForDataTableColumns(params: CovidConstrainedQueryParams) {

--- a/explorer/covidExplorer/perfTest.ts
+++ b/explorer/covidExplorer/perfTest.ts
@@ -1,0 +1,76 @@
+#! /usr/bin/env yarn tsn
+
+// owid-covid-data.csv can be downloaded with:
+// wget https://raw.githubusercontent.com/owid/covid-19-data/master/public/data/owid-covid-data.csv
+
+import { csvParse } from "d3-dsv"
+import { CoreTable } from "coreTable/CoreTable"
+import { MegaCsvToCovidExplorerTable } from "./MegaCsv"
+
+import * as fs from "fs"
+const megaCsvPath = __dirname + "/owid-covid-data.csv"
+const getCsv = () => fs.readFileSync(megaCsvPath, "utf8")
+
+export class Timer {
+    constructor() {
+        this._tickTime = Date.now()
+        this._firstTickTime = this._tickTime
+    }
+
+    private _tickTime: number
+    private _firstTickTime: number
+
+    tick(msg?: string) {
+        const elapsed = Date.now() - this._tickTime
+        // eslint-disable-next-line no-console
+        if (msg) console.log(`${elapsed}ms ${msg}`)
+        this._tickTime = Date.now()
+        return elapsed
+    }
+
+    getTotalElapsedTime() {
+        return Date.now() - this._firstTickTime
+    }
+}
+
+// Use this to get baseline perf with typing
+// https://github.com/d3/d3-dsv/blob/master/src/autoType.js
+const d3AutoType = (object: any) => {
+    for (var key in object) {
+        var value = object[key].trim(),
+            number,
+            m
+        if (!value) value = null
+        else if (value === "true") value = true
+        else if (value === "false") value = false
+        else if (value === "NaN") value = NaN
+        else if (!isNaN((number = +value))) value = number
+        else continue
+        object[key] = value
+    }
+    return object
+}
+
+const main = () => {
+    const timer = new Timer()
+    timer.tick("start")
+    const str = getCsv()
+    timer.tick("file read")
+
+    csvParse(str)
+    timer.tick("csv parsed no types")
+
+    csvParse(str, d3AutoType)
+    timer.tick("csv parsed with types")
+
+    new CoreTable(str)
+    timer.tick("csv to core table")
+
+    MegaCsvToCovidExplorerTable(str)
+    timer.tick("csv to covid explorer table")
+
+    MegaCsvToCovidExplorerTable(str).appendEveryColumn()
+    timer.tick("csv to covid explorer table with every possible column")
+}
+
+main()


### PR DESCRIPTION
This adds a dead simple decorator `@imemo` for memoizing compute-heavy getters that will never change. (I'm actually probably still using this too much, as some of these getters are not compute heavy). I'm not attached to the name just picked something unique.

I then replace mobx `@computeds`  with `@imemo`. CoreTables are immutable so once you call a getter the result will never change. No need then for any tracking overhead.

We still have some Mobx computed and actions in Tables for selection, but the selection concept should probably move to Grapher anyway.

3 perf runs:

Before:
1593ms csv to covid explorer table
6945ms csv to covid explorer table with every possible column

1637ms csv to covid explorer table
7136ms csv to covid explorer table with every possible column

1581ms csv to covid explorer table
7266ms csv to covid explorer table with every possible column

After:
886ms csv to covid explorer table
6390ms csv to covid explorer table with every possible column

931ms csv to covid explorer table
6912ms csv to covid explorer table with every possible column

1004ms csv to covid explorer table
6692ms csv to covid explorer table with every possible column