### PR TITLE
Migrate row operations to column operations

### DIFF
--- a/coreTable/CoreTable.test.ts
+++ b/coreTable/CoreTable.test.ts
@@ -492,10 +492,10 @@ fra 2002 red
 turk 2002  77`
 
     it("can create indices", () => {
-        const { index } = leftTable.rowIndex(["color"])
+        const index = leftTable.rowIndex(["color"])
         expect(index.size).toEqual(2)
         const index2 = leftTable.rowIndex(["color", "country"])
-        expect(index2.index.get("red usa")?.length).toEqual(1)
+        expect(index2.get("red usa")?.length).toEqual(1)
     })
 
     describe("outer joins", () => {

--- a/coreTable/CoreTable.test.ts
+++ b/coreTable/CoreTable.test.ts
@@ -89,6 +89,11 @@ describe("creating tables", () => {
         const firstRow = table.firstRow as any
         expect(firstRow.canada).toEqual(456)
     })
+
+    it("can create a table with columns but no rows", () => {
+        const table = new CoreTable({}, [{ slug: "entityId" }])
+        expect(table.getValuesFor("entityId")).toEqual([])
+    })
 })
 
 describe("adding rows", () => {

--- a/coreTable/CoreTable.test.ts
+++ b/coreTable/CoreTable.test.ts
@@ -117,6 +117,11 @@ describe("adding rows", () => {
         expect(expandedTable.numRows).toEqual(6)
         expect(expandedTable.rows[5].pop).toEqual(321)
     })
+
+    it("can drop rows", () => {
+        const table = new CoreTable(sampleCsv)
+        expect(table.dropRowsAt([0, 1, 3]).numRows).toEqual(1)
+    })
 })
 
 describe("column operations", () => {
@@ -296,7 +301,7 @@ hi,1,,2001`
 
 describe("filtering", () => {
     const rootTable = new CoreTable(sampleCsv)
-    const filteredTable = rootTable.filter(
+    const filteredTable = rootTable.rowFilter(
         (row) => parseInt(row.population) > 40,
         "Pop filter"
     )
@@ -308,7 +313,7 @@ describe("filtering", () => {
     })
 
     it("multiple filters work", () => {
-        const filteredTwiceTable = filteredTable.filter(
+        const filteredTwiceTable = filteredTable.rowFilter(
             (row: any) => (row.country as string).startsWith("u"),
             "Letter filter"
         )
@@ -321,7 +326,7 @@ describe("filtering", () => {
         const table = new CoreTable(`country,pop
 usa,123
 can,333`)
-        const allFiltered = table.filter((row) => false, "filter all")
+        const allFiltered = table.rowFilter((row) => false, "filter all")
         expect(allFiltered.getValuesFor("pop")).toEqual([])
     })
 })

--- a/coreTable/CoreTable.test.ts
+++ b/coreTable/CoreTable.test.ts
@@ -329,6 +329,19 @@ can,333`)
         const allFiltered = table.rowFilter((row) => false, "filter all")
         expect(allFiltered.getValuesFor("pop")).toEqual([])
     })
+
+    it("can filter negatives", () => {
+        const table = new CoreTable(`country,pop
+fra,0
+usa,-2
+can,333
+ger,0.1`)
+        expect(table.filterNegatives("pop").getValuesFor("pop")).toEqual([
+            0,
+            333,
+            0.1,
+        ])
+    })
 })
 
 describe("debugging", () => {

--- a/coreTable/CoreTable.test.ts
+++ b/coreTable/CoreTable.test.ts
@@ -267,7 +267,7 @@ describe("searching", () => {
         ).toEqual(0)
     })
 
-    it("can just do simple grep like searching to find rows", () => {
+    it("can do grep like searching to find rows", () => {
         expect(table.grep("Germany").numRows).toEqual(2)
         expect(table.grep("USA").numRows).toEqual(1)
         expect(table.grep("USA").numRows).toEqual(1)

--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -141,7 +141,7 @@ export class CoreTable<
                   this.inputRowsToParsedColumns,
                   this.inputRowsToComputedColumns
               )
-            : this.inputAsColumnStore
+            : Object.assign(this.blankColumnStore, this.inputAsColumnStore)
     }
 
     @imemo private get delimitedAsRows() {

--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -1046,6 +1046,14 @@ export class CoreTable<
         )
     }
 
+    filterNegatives(slug: ColumnSlug) {
+        return this.columnFilter(
+            slug,
+            (value) => value >= 0,
+            `Filter negative values for ${slug}`
+        )
+    }
+
     appendColumns(defs: COL_DEF_TYPE[]) {
         return this.transform(
             this.columnStore,

--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -112,11 +112,11 @@ export class CoreTable<
     }
 
     getValuesFor(columnSlug: ColumnSlug) {
-        return this.vectorizedComputedAndParsedColumns[columnSlug]
+        return this.columnStore[columnSlug]
     }
 
     @imemo private get rowsFromColumns() {
-        const columnStore = this.vectorizedComputedAndParsedColumns
+        const { columnStore } = this
         return range(
             0,
             Object.values(columnStore)[0]?.length ?? 0
@@ -133,7 +133,7 @@ export class CoreTable<
         return columnsObject
     }
 
-    @imemo private get vectorizedComputedAndParsedColumns() {
+    @imemo private get columnStore() {
         return this.slugsToBuild.length || this.isInputFromRowsOrDelimited
             ? Object.assign(
                   this.blankColumnStore,
@@ -626,10 +626,22 @@ export class CoreTable<
     }
 
     dump(rowLimit = 30) {
+        this.dumpPipeline()
+        this.dumpColumns()
+        this.dumpRows(rowLimit)
+    }
+
+    dumpPipeline() {
         // eslint-disable-next-line no-console
         console.table(this.ancestors.map((tb) => tb.explanation))
+    }
+
+    dumpColumns() {
         // eslint-disable-next-line no-console
         console.table(this.explainColumns)
+    }
+
+    dumpRows(rowLimit = 30) {
         // eslint-disable-next-line no-console
         console.table(this.rows.slice(0, rowLimit), this.columnSlugs)
     }
@@ -705,7 +717,7 @@ export class CoreTable<
             numColumnsWithInvalidCells,
         } = this
         return {
-            tableDescription,
+            tableDescription: tableDescription.substr(0, 30),
             transformCategory,
             guid,
             numColumns,

--- a/coreTable/CoreTableColumns.ts
+++ b/coreTable/CoreTableColumns.ts
@@ -217,7 +217,7 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
         const indexValues = this.table.getValuesAtIndices(
             indexColumnSlug,
             this.validRowIndices
-        )
+        ) as PrimitiveType[]
         indexValues.forEach((indexVal, index) => {
             if (!map.has(indexVal)) map.set(indexVal, new Set())
             map.get(indexVal)!.add(values[index])

--- a/coreTable/CoreTableConstants.ts
+++ b/coreTable/CoreTableConstants.ts
@@ -1,3 +1,4 @@
+import { InvalidCell } from "./InvalidCells"
 import { LegacyVariableDisplayConfigInterface } from "./LegacyVariableCode"
 
 export type Integer = number
@@ -43,7 +44,7 @@ export interface CoreColumnDef {
     unit?: string
     shortUnit?: string
     fn?: ColumnFn
-    values?: PrimitiveType[] // Similar to Fn, but the already computed values.
+    values?: CoreValueType[] // Similar to Fn, but the already computed values.
     type?: ColumnTypeNames
     generator?: () => number // A function for generating synthetic data for testing
     growthRateGenerator?: () => number // A function for generating synthetic data for testing. Can probably combine with the above.
@@ -99,6 +100,8 @@ export enum JsTypes {
 
 export type CsvString = string
 
+export type CoreValueType = PrimitiveType | InvalidCell
+
 /**
  * An Object Literal of Column Slugs and Primitives of the same type:
  * {
@@ -106,7 +109,9 @@ export type CsvString = string
  *  year: [2000, 2001]
  * }
  */
-export type CoreColumnStore = { [columnSlug: string]: PrimitiveType[] }
+export type CoreColumnStore = {
+    [columnSlug: string]: CoreValueType[]
+}
 
 export type CoreTableInputOption = CoreRow[] | CoreColumnStore | CsvString
 

--- a/coreTable/CoreTableUtils.test.ts
+++ b/coreTable/CoreTableUtils.test.ts
@@ -1,6 +1,10 @@
 #! /usr/bin/env yarn jest
 
-import { imemo, interpolateRowValuesWithTolerance } from "./CoreTableUtils"
+import {
+    getDropIndexes,
+    imemo,
+    interpolateRowValuesWithTolerance,
+} from "./CoreTableUtils"
 import { InvalidCellTypes } from "./InvalidCells"
 
 describe(interpolateRowValuesWithTolerance, () => {
@@ -89,4 +93,11 @@ describe("immutable memoization", () => {
         forecast2.conditions = "sunny"
         expect(forecast2.forecast).toEqual("sunny")
     })
+})
+
+it("can get indexes of cell values to drop in an array", () => {
+    const drops = getDropIndexes(3, 2, 1)
+    expect(
+        [1, 2, 3].map((value, index) => (drops.has(index) ? undefined : value))
+    ).toEqual([undefined, undefined, 3])
 })

--- a/coreTable/CoreTableUtils.ts
+++ b/coreTable/CoreTableUtils.ts
@@ -218,8 +218,11 @@ export function interpolateRowValuesWithTolerance<
 }
 
 // A dumb function for making a function that makes a key for a row given certain columns.
-export const makeKeyFn = (columnSlugs: ColumnSlug[]) => (row: CoreRow) =>
-    columnSlugs.map((slug) => row[slug]).join(" ")
+export const makeKeyFn = (
+    columnStore: CoreColumnStore,
+    columnSlugs: ColumnSlug[]
+) => (rowIndex: number) =>
+    columnSlugs.map((slug) => columnStore[slug][rowIndex].toString()).join(" ")
 
 // Memoization for immutable getters. Run the function once for this instance and cache the result.
 export const imemo = (
@@ -333,3 +336,10 @@ export const applyFilterMask = (
     })
     return columnsObject
 }
+
+// Convenience method when you are replacing columns
+export const replaceDef = (defs: CoreColumnDef[], newDefs: CoreColumnDef[]) =>
+    defs.map((def) => {
+        const newDef = newDefs.find((newDef) => newDef.slug === def.slug)
+        return newDef ?? def
+    })

--- a/coreTable/CoreTableUtils.ts
+++ b/coreTable/CoreTableUtils.ts
@@ -239,3 +239,86 @@ export const imemo = (
         return this[propName]
     }
 }
+
+export const appendRowsToColumnStore = (
+    columnStore: CoreColumnStore,
+    rows: CoreRow[]
+) => {
+    const slugs = Object.keys(columnStore)
+    const newColumnStore = columnStore
+    slugs.forEach((slug) => {
+        newColumnStore[slug] = columnStore[slug].concat(
+            rows.map((row) => row[slug])
+        )
+    })
+    return newColumnStore
+}
+
+export const concatColumnStores = (
+    target: CoreColumnStore,
+    source: CoreColumnStore
+) => {
+    const slugs = Object.keys(target)
+    const newColumnStore: CoreColumnStore = {}
+    slugs.forEach((slug) => {
+        newColumnStore[slug] = target[slug].concat(source[slug])
+    })
+    return newColumnStore
+}
+
+export const rowsToColumnStore = (rows: CoreRow[]) => {
+    const columnsObject: CoreColumnStore = {}
+    if (!rows.length) return columnsObject
+
+    Object.keys(rows[0]).forEach((slug) => {
+        columnsObject[slug] = rows.map((row) => row[slug])
+    })
+    return columnsObject
+}
+
+export const autodetectColumnDefs = (
+    rowsOrColumnStore: CoreColumnStore | CoreRow[],
+    definedSlugs: Map<ColumnSlug, any>
+) => {
+    if (!Array.isArray(rowsOrColumnStore)) {
+        const columnStore = rowsOrColumnStore as CoreColumnStore
+        return Object.keys(columnStore)
+            .filter((slug) => !definedSlugs.has(slug))
+            .map((slug) => {
+                return guessColumnDefFromSlugAndRow(
+                    slug,
+                    columnStore[slug].find(
+                        (val) => val !== undefined && val !== null
+                    )
+                )
+            })
+    }
+    const rows = rowsOrColumnStore as CoreRow[]
+    if (!rows[0]) return []
+
+    return Object.keys(rows[0])
+        .filter((slug) => !definedSlugs.has(slug))
+        .map((slug) => {
+            const firstRowWithValue = rows.find(
+                (row) => row[slug] !== undefined && row[slug] !== null
+            )
+            const firstValue = firstRowWithValue
+                ? firstRowWithValue[slug]
+                : undefined
+
+            return guessColumnDefFromSlugAndRow(slug, firstValue)
+        })
+}
+
+export const applyFilterMask = (
+    columnStore: CoreColumnStore,
+    filterMask: boolean[]
+) => {
+    const columnsObject: CoreColumnStore = {}
+    Object.keys(columnStore).forEach((slug) => {
+        columnsObject[slug] = columnStore[slug].filter(
+            (slug, index) => filterMask[index]
+        )
+    })
+    return columnsObject
+}

--- a/coreTable/LegacyToOwidTable.ts
+++ b/coreTable/LegacyToOwidTable.ts
@@ -140,10 +140,8 @@ export const legacyVariablesToColDefsAndOwidRowsSortedByTimeAsc = (
             if (annotationsColumnSlug)
                 row[annotationsColumnSlug] = annotationMap.get(entityName)
 
-            if (colorColumnSlug) {
-                const color = entityColorMap.get(entityId)
-                if (color) row[colorColumnSlug] = color
-            }
+            if (colorColumnSlug)
+                row[colorColumnSlug] = entityColorMap.get(entityId)
             return row
         })
         rows = rows.concat(newRows)

--- a/coreTable/OwidTable.test.ts
+++ b/coreTable/OwidTable.test.ts
@@ -4,7 +4,7 @@ import {
     SynthesizeFruitTable,
     SynthesizeGDPTable,
 } from "coreTable/OwidTableSynthesizers"
-import { OwidTable } from "coreTable/OwidTable"
+import { BlankOwidTable, OwidTable } from "coreTable/OwidTable"
 import { flatten } from "grapher/utils/Util"
 import { ColumnTypeNames } from "./CoreTableConstants"
 import { LegacyVariablesAndEntityKey } from "./LegacyVariableCode"
@@ -255,6 +255,20 @@ it("can handle columns with commas", () => {
 france,fr,23,4
 iceland,ice,123,3
 usa,us,23,`)
+})
+
+describe("filtering", () => {
+    it("can filter by population", () => {
+        const table = SynthesizeFruitTable({ timeRange: [2000, 2001] })
+        expect(table.filterByPopulation(100).numRows).toEqual(2)
+    })
+
+    it("can filter by population on empty table", () => {
+        const table = BlankOwidTable()
+        expect(
+            table.filterByPopulation(1).filterByPopulation(1e12).numRows
+        ).toEqual(0)
+    })
 })
 
 describe("time filtering", () => {

--- a/coreTable/OwidTable.test.ts
+++ b/coreTable/OwidTable.test.ts
@@ -135,7 +135,7 @@ it("can perform queries needed by discrete bar", () => {
         },
         10
     )
-    expect(table.rowsByEntityName.size).toEqual(3)
+    expect(table.rowIndicesByEntityName.size).toEqual(3)
     expect(table.numSelectedEntities).toEqual(0)
 
     table.selectAll()
@@ -143,13 +143,13 @@ it("can perform queries needed by discrete bar", () => {
     expect(table.numSelectedEntities).toEqual(3)
     const entityNames = table.selectedEntityNames
     expect(
-        table.getClosestRowForEachEntity(entityNames, 2003, 0).length
+        table.getClosestIndexForEachEntity(entityNames, 2003, 0).length
     ).toEqual(3)
     expect(
-        table.getClosestRowForEachEntity(entityNames, 2004, 1).length
+        table.getClosestIndexForEachEntity(entityNames, 2004, 1).length
     ).toEqual(3)
     expect(
-        table.getClosestRowForEachEntity(entityNames, 2005, 1).length
+        table.getClosestIndexForEachEntity(entityNames, 2005, 1).length
     ).toEqual(0)
 })
 

--- a/coreTable/OwidTable.ts
+++ b/coreTable/OwidTable.ts
@@ -450,11 +450,15 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         )
     }
 
-    getColorForEntityName(entityName: EntityName) {
-        return this.getLatestValueForEntity(
-            entityName,
+    @imemo private get entityNameColorIndex() {
+        return this.valueIndex(
+            OwidTableSlugs.entityName,
             OwidTableSlugs.entityColor
         )
+    }
+
+    getColorForEntityName(entityName: EntityName) {
+        return this.entityNameColorIndex.get(entityName)
     }
 
     @imemo get columnDisplayNameToColorMap() {

--- a/coreTable/OwidTable.ts
+++ b/coreTable/OwidTable.ts
@@ -109,15 +109,6 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         ) as Map<string, string>
     }
 
-    @imemo get entityIndex() {
-        const map = new Map<EntityName, OwidRow[]>()
-        this.rows.forEach((row) => {
-            if (!map.has(row.entityName)) map.set(row.entityName, [])
-            map.get(row.entityName)!.push(row)
-        })
-        return map
-    }
-
     @imemo get maxTime() {
         return last(this.allTimes)
     }
@@ -180,17 +171,10 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         )
     }
 
-    // Does a stable sort by time. Mobx will cache this, and then you can refer to this table for
-    // fast time filtering.
+    // Does a stable sort by time. You can refer to this table for fast time filtering.
     @imemo private get sortedByTime() {
         if (!this.timeColumn) return this
-        const timeColumnSlug = this.timeColumn.slug
-        return this.transform(
-            sortBy(this.rows, (row) => row[timeColumnSlug]),
-            this.defs,
-            `Sort rows by time before filtering for speed`,
-            TransformType.SortRows
-        )
+        return this.sortBy([this.timeColumn.slug])
     }
 
     filterByTimeRange(start: TimeBound, end: TimeBound): this {

--- a/explorer/client/SwitcherExplorer.tsx
+++ b/explorer/client/SwitcherExplorer.tsx
@@ -13,7 +13,7 @@ import { ExplorerShell } from "./ExplorerShell"
 import { ExplorerProgram } from "./ExplorerProgram"
 import { QueryParams, strToQueryParams } from "utils/client/url"
 import { EntityUrlBuilder } from "grapher/core/EntityUrlBuilder"
-import { OwidTable } from "coreTable/OwidTable"
+import { BlankOwidTable, OwidTable } from "coreTable/OwidTable"
 import { GrapherProgrammaticInterface } from "grapher/core/Grapher"
 import { exposeInstanceOnWindow } from "grapher/utils/Util"
 import {
@@ -150,7 +150,7 @@ export class SwitcherExplorer
             )
 
         grapher.updateFromObject(config)
-        grapher.inputTable = new OwidTable()
+        grapher.inputTable = BlankOwidTable()
         grapher.populateFromQueryParams(strToQueryParams(queryStr ?? ""))
         grapher.downloadData()
         this.addEntityOptionsToPickerWhenReady()
@@ -177,7 +177,7 @@ export class SwitcherExplorer
         )
     }
 
-    @observable.ref countryPickerTable = new OwidTable()
+    @observable.ref countryPickerTable = BlankOwidTable()
 
     private get panels() {
         return this.explorerProgram.switcherRuntime.choicesWithAvailability.map(

--- a/explorer/covidExplorer/CovidConstants.ts
+++ b/explorer/covidExplorer/CovidConstants.ts
@@ -240,7 +240,6 @@ export enum MegaSlugs {
 // We parse MegaRows and turn them into CovidRows immediately.
 export interface CovidRow
     extends Omit<MegaRow, MegaSlugs.location | MegaSlugs.iso_code> {
-    group_members?: string
     entityName: string
     entityCode: string
     entityId: number

--- a/explorer/covidExplorer/CovidExplorerTable.test.ts
+++ b/explorer/covidExplorer/CovidExplorerTable.test.ts
@@ -10,6 +10,7 @@ import { sampleMegaCsv } from "./CovidExplorerUtils"
 import { MegaCsvToCovidExplorerTable } from "./MegaCsv"
 import { flatten } from "grapher/utils/Util"
 import { InvalidCell } from "coreTable/InvalidCells"
+import { WorldEntityName } from "grapher/core/GrapherConstants"
 
 const table = MegaCsvToCovidExplorerTable(sampleMegaCsv)
 
@@ -160,20 +161,21 @@ describe("builds aligned tests column", () => {
 
 it("can filter rows without continent", () => {
     let table = MegaCsvToCovidExplorerTable(sampleMegaCsv)
-    expect(table.availableEntityNameSet.has("World")).toBeTruthy()
+    expect(table.availableEntityNameSet.has(WorldEntityName)).toBeTruthy()
 
     table = table.filterRegionsUnlessSelected()
-    expect(table.availableEntityNameSet.has("World")).toBeFalsy()
+    expect(table.availableEntityNameSet.has(WorldEntityName)).toBeFalsy()
+    expect(table.availableEntityNameSet.has("Aruba")).toBeTruthy()
 
-    table.mainTable.selectEntity("World")
+    table.mainTable.selectEntity(WorldEntityName)
     table = table.mainTable.filterRegionsUnlessSelected()
-    expect(table.availableEntityNameSet.has("World")).toBeTruthy()
+    expect(table.availableEntityNameSet.has(WorldEntityName)).toBeTruthy()
 
-    table.mainTable.deselectEntity("World")
+    table.mainTable.deselectEntity(WorldEntityName)
     table = table.mainTable.filterRegionsUnlessSelected()
-    expect(table.availableEntityNameSet.has("World")).toBeFalsy()
+    expect(table.availableEntityNameSet.has(WorldEntityName)).toBeFalsy()
 
-    table.mainTable.setSelectedEntities(["World"])
+    table.mainTable.setSelectedEntities([WorldEntityName])
     table = table.mainTable.filterRegionsUnlessSelected()
-    expect(table.availableEntityNameSet.has("World")).toBeTruthy()
+    expect(table.availableEntityNameSet.has(WorldEntityName)).toBeTruthy()
 })

--- a/explorer/covidExplorer/CovidExplorerTable.ts
+++ b/explorer/covidExplorer/CovidExplorerTable.ts
@@ -243,14 +243,6 @@ export class CovidExplorerTable extends OwidTable {
         })
     }
 
-    filterNegatives(slug: ColumnSlug) {
-        return this.columnFilter(
-            slug,
-            (value) => value >= 0,
-            `Filter negative values for ${slug}`
-        )
-    }
-
     filterRegionsUnlessSelected() {
         const groupNames = new Set(
             Object.keys(ContinentColors).concat(
@@ -264,9 +256,7 @@ export class CovidExplorerTable extends OwidTable {
             OwidTableSlugs.entityName,
             (value) => {
                 const name = value as string
-                return groupNames.has(name)
-                    ? this.isEntitySelected(name)
-                    : false
+                return groupNames.has(name) ? this.isEntitySelected(name) : true
             },
             `Filter out regions unless selected`
         )

--- a/explorer/covidExplorer/CovidExplorerTable.ts
+++ b/explorer/covidExplorer/CovidExplorerTable.ts
@@ -28,6 +28,7 @@ import {
 import { computeRollingAveragesForEachGroup } from "./CovidExplorerUtils"
 import { WorldEntityName } from "grapher/core/GrapherConstants"
 import { InvalidCell } from "coreTable/InvalidCells"
+import { ContinentColors } from "grapher/color/ColorConstants"
 
 class NotApplicableCell extends InvalidCell {}
 class TestRateExclusionList extends InvalidCell {}
@@ -243,20 +244,30 @@ export class CovidExplorerTable extends OwidTable {
     }
 
     filterNegatives(slug: ColumnSlug) {
-        return this.filter(
-            (row) => !(row[slug] < 0),
+        return this.columnFilter(
+            slug,
+            (value) => value >= 0,
             `Filter negative values for ${slug}`
         )
     }
 
     filterRegionsUnlessSelected() {
+        const groupNames = new Set(
+            Object.keys(ContinentColors).concat(
+                "European Union",
+                WorldEntityName
+            )
+        )
+
         // "World" and our previously aggregated groups we sometimes want to filter out.
-        return this.filter(
-            (row) =>
-                row.entityName === WorldEntityName
-                    ? this.isEntitySelected(WorldEntityName)
-                    : !row.group_members ||
-                      this.isEntitySelected(row.entityName),
+        return this.columnFilter(
+            OwidTableSlugs.entityName,
+            (value) => {
+                const name = value as string
+                return groupNames.has(name)
+                    ? this.isEntitySelected(name)
+                    : false
+            },
             `Filter out regions unless selected`
         )
     }

--- a/explorer/covidExplorer/CovidExplorerUtils.ts
+++ b/explorer/covidExplorer/CovidExplorerUtils.ts
@@ -98,14 +98,12 @@ export const calculateCovidRowsForGroup = (
     let total_cases = 0
     let total_deaths = 0
     let maxPopulation = 0
-    const group_members = Array.from(groupMembers).join("")
     // We need to compute cumulatives again because sometimes data will stop for a country.
     newRowsForGroup.forEach((row) => {
         total_cases += row.new_cases
         total_deaths += row.new_deaths
         row.total_cases = total_cases
         row.total_deaths = total_deaths
-        row.group_members = group_members
         if (row.population > maxPopulation) maxPopulation = row.population
 
         // Once we add a country to a group, we assume we will always have data for that country, so even if the

--- a/explorer/covidExplorer/MegaCsv.ts
+++ b/explorer/covidExplorer/MegaCsv.ts
@@ -50,8 +50,9 @@ export const MegaCsvToCovidExplorerTable = (
             }
             return object
         },
-    }).filter(
-        (row: MegaRow) => row[OwidTableSlugs.entityName] !== "International",
+    }).columnFilter(
+        OwidTableSlugs.entityName,
+        (name) => name !== "International",
         "Drop International rows"
     )
 
@@ -89,7 +90,7 @@ export const MegaCsvToCovidExplorerTable = (
         .appendRows(euRows as any, `Added ${euRows.length} EU rows`)
 
     return new CovidExplorerTable(
-        (tableWithRows.rows as any) as CovidRow[], // todo: clean up typings
+        tableWithRows.columnStore,
         tableWithRows.defs,
         {
             parent: tableWithRows as any,

--- a/explorer/covidExplorer/MegaCsv.ts
+++ b/explorer/covidExplorer/MegaCsv.ts
@@ -75,7 +75,11 @@ export const MegaCsvToCovidExplorerTable = (
     )
 
     const euRows = calculateCovidRowsForGroup(
-        coreTable.rows.filter((row) => euCountries.has(row.entityName)) as any,
+        coreTable.columnFilter(
+            OwidTableSlugs.entityName,
+            (name) => euCountries.has(name as string),
+            "Get EU countries"
+        ).rows,
         "European Union"
     )
 

--- a/explorer/covidExplorer/perfTest.ts
+++ b/explorer/covidExplorer/perfTest.ts
@@ -66,11 +66,16 @@ const main = () => {
     new CoreTable(str)
     timer.tick("csv to core table")
 
+    let table = MegaCsvToCovidExplorerTable(str)
     MegaCsvToCovidExplorerTable(str)
     timer.tick("csv to covid explorer table")
+    table.dumpPipeline()
+    timer.tick("dumped pipelin")
 
-    MegaCsvToCovidExplorerTable(str).appendEveryColumn()
+    table = MegaCsvToCovidExplorerTable(str).appendEveryColumn()
     timer.tick("csv to covid explorer table with every possible column")
+    table.dumpPipeline()
+    timer.tick("dumped pipelin")
 }
 
 main()

--- a/grapher/chart/ChartDimension.test.ts
+++ b/grapher/chart/ChartDimension.test.ts
@@ -3,14 +3,14 @@
 // todo: remove this when we remove chartDimension
 
 import { ChartDimension } from "./ChartDimension"
-import { OwidTable } from "coreTable/OwidTable"
+import { BlankOwidTable } from "coreTable/OwidTable"
 import { DimensionProperty } from "grapher/core/GrapherConstants"
 
 it("can serialize for saving", () => {
     expect(
         new ChartDimension(
             { property: DimensionProperty.x, variableId: 1 },
-            { table: new OwidTable() }
+            { table: BlankOwidTable() }
         ).toObject()
     ).toEqual({ property: "x", variableId: 1 })
 })

--- a/grapher/controls/countryPicker/CountryPicker.stories.tsx
+++ b/grapher/controls/countryPicker/CountryPicker.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { CountryPicker } from "grapher/controls/countryPicker/CountryPicker"
-import { OwidTable } from "coreTable/OwidTable"
+import { BlankOwidTable } from "coreTable/OwidTable"
 import { observer } from "mobx-react"
 import {
     SampleColumnSlugs,
@@ -70,7 +70,7 @@ export default {
 
 export const Empty = () => (
     <CountryPickerHolder>
-        <CountryPicker table={new OwidTable()} />
+        <CountryPicker table={BlankOwidTable()} />
     </CountryPickerHolder>
 )
 

--- a/grapher/controls/countryPicker/CountryPicker.tsx
+++ b/grapher/controls/countryPicker/CountryPicker.tsx
@@ -153,8 +153,11 @@ export class CountryPicker extends React.Component<{
         const entityNames = table.availableEntityNames.slice().sort()
         return entityNames.map((entityName) => {
             const plotValue = col
-                ? table.getLatestValueForEntity(entityName, col.slug)
+                ? (table.getLatestValueForEntity(entityName, col.slug) as
+                      | string
+                      | number)
                 : undefined
+
             const formattedValue =
                 plotValue !== undefined
                     ? col?.formatValue(plotValue)

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -68,7 +68,6 @@ import {
     minTimeToJSON,
     maxTimeToJSON,
     timeBoundToTimeBoundString,
-    timeFromTimebounds,
 } from "grapher/utils/TimeBounds"
 import {
     GlobalEntitySelection,
@@ -143,7 +142,7 @@ import {
     EntityName,
     OwidColumnDef,
 } from "coreTable/OwidTableConstants"
-import { OwidTable } from "coreTable/OwidTable"
+import { BlankOwidTable, OwidTable } from "coreTable/OwidTable"
 import * as Mousetrap from "mousetrap"
 import { SlideShowController } from "grapher/slideshowController/SlideShowController"
 import { ChartComponentClassMap } from "grapher/chart/ChartTypeMap"
@@ -284,7 +283,7 @@ export class Grapher
 
         const { getGrapherInstance, ...props } = propsWithGrapherInstanceGetter
 
-        this.inputTable = props.table ?? new OwidTable()
+        this.inputTable = props.table ?? BlankOwidTable()
         const modernConfig = props ? legacyConfigToConfig(props) : props
 
         this.legacyConfigAsAuthored = props || {}

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -22,7 +22,7 @@ import {
 } from "grapher/utils/Util"
 import { SortIcon } from "grapher/controls/SortIcon"
 import { Tippy } from "grapher/chart/Tippy"
-import { OwidTable } from "coreTable/OwidTable"
+import { BlankOwidTable, OwidTable } from "coreTable/OwidTable"
 import { CoreColumn } from "coreTable/CoreTableColumns"
 import { Bounds, DEFAULT_BOUNDS } from "grapher/utils/Bounds"
 
@@ -115,7 +115,7 @@ export class DataTable extends React.Component<{
     }
 
     @computed get manager() {
-        return this.props.manager || { table: new OwidTable() }
+        return this.props.manager || { table: BlankOwidTable() }
     }
 
     @computed private get entityType() {

--- a/grapher/downloadTab/DownloadTab.tsx
+++ b/grapher/downloadTab/DownloadTab.tsx
@@ -7,7 +7,7 @@ import { LoadingIndicator } from "grapher/loadingIndicator/LoadingIndicator"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faDownload } from "@fortawesome/free-solid-svg-icons/faDownload"
 import classNames from "classnames"
-import { OwidTable } from "coreTable/OwidTable"
+import { BlankOwidTable, OwidTable } from "coreTable/OwidTable"
 
 export interface DownloadTabManager {
     idealBounds?: Bounds
@@ -170,7 +170,7 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
     }
 
     @computed private get inputTable() {
-        return this.manager.table ?? new OwidTable()
+        return this.manager.table ?? BlankOwidTable()
     }
 
     private onCsvDownload(ev: React.MouseEvent<HTMLAnchorElement>) {

--- a/grapher/utils/Util.test.ts
+++ b/grapher/utils/Util.test.ts
@@ -28,7 +28,6 @@ import {
     getRandomNumberGenerator,
     findClosestTimeIndex,
     trimArray,
-    getDropIndexes,
 } from "grapher/utils/Util"
 import { strToQueryParams } from "utils/client/url"
 import { SortOrder } from "coreTable/CoreTableConstants"
@@ -147,15 +146,6 @@ describe("random functions", () => {
     it("can generate a repeatable sequence of random numbers between 1 and 100 given a seed", () => {
         const rand = getRandomNumberGenerator(1, 100, 123)
         expect([rand(), rand()]).toEqual([96, 13])
-    })
-
-    it("can get indexes of cell values to drop in an array", () => {
-        const drops = getDropIndexes(3, 2, 1)
-        expect(
-            [1, 2, 3].map((value, index) =>
-                drops.has(index) ? undefined : value
-            )
-        ).toEqual([undefined, undefined, 3])
     })
 })
 

--- a/grapher/utils/Util.ts
+++ b/grapher/utils/Util.ts
@@ -627,13 +627,6 @@ export const getRandomNumberGenerator = (
     return Math.floor(min + (max - min) * (semiRand - Math.floor(semiRand)))
 }
 
-// Returns a Set of random indexes to drop in an array, preserving the order of the array
-export const getDropIndexes = (
-    arrayLength: number,
-    howMany: number,
-    seed = Date.now()
-) => new Set(sampleFrom(range(0, arrayLength), howMany, seed))
-
 export const sampleFrom = <T>(
     collection: T[],
     howMany: number,


### PR DESCRIPTION
Just simplifying CoreTable a bit:

- A `ColumnStore` is just basically:  { [columnSlug: string] : number|string[] } 
- Input data can be from CSV, Rows, or Columns `delimited: string | {}[] | ColumnStore`
- Any data passed into a table is immediately converted into a ColumnStore if not already one
- All operations are then performed on Columns

You can still use row methods and they behave as expected, but it is better to use column methods because they are noticeably faster when your data is in the 100K+ value range (like the MegaCSV set).



