### PR TITLE
Fix: Ensure all column slugs are present in all rows in legacy conversion

### DIFF
--- a/coreTable/LegacyToOwidTable.test.ts
+++ b/coreTable/LegacyToOwidTable.test.ts
@@ -69,6 +69,7 @@ describe(legacyVariablesToColDefsAndOwidRowsSortedByTimeAsc, () => {
             legacyVariableConfig
         )
 
-        expect(Object.keys(table.rows[0]).includes("3")).toBeFalsy()
+        expect(Object.keys(table.rows[0]).includes("3")).toBeTruthy()
+        expect(table.rows[0]["3"]).toBeUndefined()
     })
 })

--- a/coreTable/LegacyToOwidTable.ts
+++ b/coreTable/LegacyToOwidTable.ts
@@ -152,10 +152,18 @@ export const legacyVariablesToColDefsAndOwidRowsSortedByTimeAsc = (
         return timePart + " " + row.entityName
     })
 
+    const blankForEverySlug: Record<string, undefined> = {}
+    const slugs = Array.from(columnDefs.keys())
+    slugs.forEach((slug) => (blankForEverySlug[slug] = undefined))
+
     const joinedRows: OwidRow[] = Object.keys(
         rowsGroupedByTimeAndEntityName
     ).map((timeAndEntityName) =>
-        Object.assign({}, ...rowsGroupedByTimeAndEntityName[timeAndEntityName])
+        Object.assign(
+            {},
+            blankForEverySlug,
+            ...rowsGroupedByTimeAndEntityName[timeAndEntityName]
+        )
     )
 
     return {


### PR DESCRIPTION
Quick fix for https://www.notion.so/owid/Chart-timeline-and-or-entities-may-be-truncated-02e0bf42622c431ba42ef77dbdfae826

The alternative, better way is to use the column store and new table joins, but this is quicker.