### PR TITLE
Dev: add group and reduce methods to CoreTable. Add perf test harness for CE

### DIFF
--- a/coreTable/CoreTable.test.ts
+++ b/coreTable/CoreTable.test.ts
@@ -532,3 +532,20 @@ describe("joins", () => {
         })
     })
 })
+
+describe("groups", () => {
+    const csv = `continent,year,country,gdp
+asia,2000,china,900
+europe,2001,france,200
+asia,2000,japan,300
+europe,2000,france,600`
+
+    describe("create groups", () => {
+        const table = new CoreTable(csv)
+        const groups = table.groupBy("continent")
+        expect(groups.length).toBe(2)
+        it("can reduce", () => {
+            expect(groups[0].reduce({ gdp: "sum" }).firstRow.gdp).toBe(1200)
+        })
+    })
+})

--- a/coreTable/CoreTable.test.ts
+++ b/coreTable/CoreTable.test.ts
@@ -24,7 +24,9 @@ describe("creating tables", () => {
     })
 
     it("tables can be combined", () => {
-        const table = new CoreTable(sampleCsv).concat(new CoreTable(sampleCsv))
+        const table = new CoreTable(sampleCsv).concat([
+            new CoreTable(sampleCsv),
+        ])
         expect(table.numRows).toEqual(8)
     })
 
@@ -136,14 +138,16 @@ describe("adding rows", () => {
         expect(expandedTable.numRows).toBe(5)
         expect(table.numRows).toEqual(4)
 
-        expandedTable = expandedTable
-            .renameColumns({ population: "pop" })
-            .appendRows(
-                [{ country: "USA", pop: 321 }],
-                "Added a row after column renaming"
-            )
-        expect(expandedTable.numRows).toEqual(6)
-        expect(expandedTable.rows[5].pop).toEqual(321)
+        it.only("can append rows", () => {
+            expandedTable = expandedTable
+                .renameColumns({ population: "pop" })
+                .appendRows(
+                    [{ country: "USA", pop: 321 }],
+                    "Added a row after column renaming"
+                )
+            expect(expandedTable.numRows).toEqual(6)
+            expect(expandedTable.rows[5].pop).toEqual(321)
+        })
     })
 
     it("can drop rows", () => {

--- a/coreTable/CoreTableColumns.ts
+++ b/coreTable/CoreTableColumns.ts
@@ -34,9 +34,6 @@ interface ColumnSummary {
     numInvalidCells: number
     numUniqs: number
     numValues: number
-}
-
-interface ExtendedColumnSummary extends ColumnSummary {
     median: PrimitiveType
     sum: number
     mean: number
@@ -81,16 +78,32 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
         return this.sortedValuesString
     }
 
+    get sum() {
+        return this.summary.sum
+    }
+
+    get median() {
+        return this.summary.median
+    }
+
+    get max() {
+        return this.summary.max
+    }
+
+    get min() {
+        return this.summary.min
+    }
+
     // todo: switch to a lib and/or add tests for this. handle non numerics better.
     @imemo get summary() {
         const { numInvalidCells, numValues, numUniqs } = this
-        const basicSummary: ColumnSummary = {
+        const basicSummary: Partial<ColumnSummary> = {
             numInvalidCells,
             numUniqs,
             numValues,
         }
         if (!numValues) return basicSummary
-        const summary: Partial<ExtendedColumnSummary> = { ...basicSummary }
+        const summary: Partial<ColumnSummary> = { ...basicSummary }
         const arr = this.sortedValues
         const isNumeric = typeof arr[0] === "number"
 

--- a/coreTable/CoreTableConstants.ts
+++ b/coreTable/CoreTableConstants.ts
@@ -58,6 +58,7 @@ export enum TransformType {
     Transpose = "Transpose",
     Reload = "Reload",
     Concat = "Concat",
+    Reduce = "Reduce",
 
     // Row ops
     FilterRows = "FilterRows",

--- a/coreTable/CoreTableUtils.ts
+++ b/coreTable/CoreTableUtils.ts
@@ -265,14 +265,15 @@ export const appendRowsToColumnStore = (
     return newColumnStore
 }
 
-export const concatColumnStores = (
-    target: CoreColumnStore,
-    source: CoreColumnStore
-) => {
-    const slugs = Object.keys(target)
+export const concatColumnStores = (stores: CoreColumnStore[]) => {
     const newColumnStore: CoreColumnStore = {}
+    const firstStore = stores[0]
+    const restStores = stores.slice(1)
+    const slugs = Object.keys(firstStore)
     slugs.forEach((slug) => {
-        newColumnStore[slug] = target[slug].concat(source[slug])
+        newColumnStore[slug] = firstStore[slug].concat(
+            ...restStores.map((store) => store[slug])
+        )
     })
     return newColumnStore
 }

--- a/coreTable/CoreTableUtils.ts
+++ b/coreTable/CoreTableUtils.ts
@@ -329,19 +329,6 @@ export const autodetectColumnDefs = (
     return guessColumnDefsFromRows(rowsOrColumnStore, definedSlugs)
 }
 
-export const applyFilterMask = (
-    columnStore: CoreColumnStore,
-    filterMask: boolean[]
-) => {
-    const columnsObject: CoreColumnStore = {}
-    Object.keys(columnStore).forEach((slug) => {
-        columnsObject[slug] = columnStore[slug].filter(
-            (slug, index) => filterMask[index]
-        )
-    })
-    return columnsObject
-}
-
 // Convenience method when you are replacing columns
 export const replaceDef = (defs: CoreColumnDef[], newDefs: CoreColumnDef[]) =>
     defs.map((def) => {
@@ -406,4 +393,26 @@ export const replaceRandomCellsInColumnStore = (
         )
     })
     return newStore
+}
+
+export class Timer {
+    constructor() {
+        this._tickTime = Date.now()
+        this._firstTickTime = this._tickTime
+    }
+
+    private _tickTime: number
+    private _firstTickTime: number
+
+    tick(msg?: string) {
+        const elapsed = Date.now() - this._tickTime
+        // eslint-disable-next-line no-console
+        if (msg) console.log(`${elapsed}ms ${msg}`)
+        this._tickTime = Date.now()
+        return elapsed
+    }
+
+    getTotalElapsedTime() {
+        return Date.now() - this._firstTickTime
+    }
 }

--- a/explorer/covidExplorer/CovidExplorer.stories.tsx
+++ b/explorer/covidExplorer/CovidExplorer.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { CovidExplorer } from "explorer/covidExplorer/CovidExplorer"
+import { CovidExplorer, PerfTest } from "explorer/covidExplorer/CovidExplorer"
 
 export default {
     title: "CovidExplorer",
@@ -8,6 +8,12 @@ export default {
 
 export const SingleExplorerWithKeyboardShortcuts = () => (
     <CovidExplorer enableKeyboardShortcuts={true} />
+)
+
+export const Perf = () => (
+    <div>
+        <button onClick={PerfTest}>Perf</button>
+    </div>
 )
 
 export const MultipleExplorersOnOnePage = () => (

--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -63,6 +63,7 @@ import {
     fetchRequiredData,
     perCapitaDivisorByMetric,
     sampleMegaCsv,
+    memoizedFetchedMegaRows,
 } from "./CovidExplorerUtils"
 import { ExplorerShell } from "explorer/client/ExplorerShell"
 import {
@@ -84,6 +85,8 @@ import { ContinentColors } from "grapher/color/ColorConstants"
 import { MapProjectionName } from "grapher/mapCharts/MapProjections"
 import { MegaCsvToCovidExplorerTable } from "./MegaCsv"
 import { CovidAnnotationColumnDefs } from "./CovidAnnotations"
+import { Timer } from "coreTable/CoreTableUtils"
+import { CoreTable } from "coreTable/CoreTable"
 
 interface BootstrapProps {
     containerNode: HTMLElement
@@ -902,4 +905,24 @@ export class CovidExplorer
         grapher.id = this.sourceChartId
         grapher.baseQueryString = queryParamsToStr(this.params)
     }
+}
+
+export const PerfTest = async () => {
+    const timer = new Timer()
+    timer.tick("start")
+    const megaCsv = await memoizedFetchedMegaRows()
+    timer.tick("file get")
+    // new CoreTable(megaCsv)
+    // timer.tick("csv to core table")
+
+    // let table = MegaCsvToCovidExplorerTable(megaCsv)
+    // MegaCsvToCovidExplorerTable(megaCsv)
+    // timer.tick("csv to covid explorer table")
+    // table.dumpPipeline()
+    // timer.tick("dumped pipelin")
+
+    const table = MegaCsvToCovidExplorerTable(megaCsv).appendEveryColumn()
+    timer.tick("csv to covid explorer table with every possible column")
+    // table.dumpPipeline()
+    // timer.tick("dumped pipelin")
 }

--- a/explorer/covidExplorer/CovidExplorerTable.test.ts
+++ b/explorer/covidExplorer/CovidExplorerTable.test.ts
@@ -8,7 +8,6 @@ import {
 import { queryParamsToStr } from "utils/client/url"
 import { sampleMegaCsv } from "./CovidExplorerUtils"
 import { MegaCsvToCovidExplorerTable } from "./MegaCsv"
-import { flatten } from "grapher/utils/Util"
 import { InvalidCell } from "coreTable/InvalidCells"
 import { WorldEntityName } from "grapher/core/GrapherConstants"
 

--- a/explorer/covidExplorer/CovidExplorerUtils.ts
+++ b/explorer/covidExplorer/CovidExplorerUtils.ts
@@ -239,7 +239,7 @@ const fetchMegaCsv = async () => {
     return csv
 }
 
-const memoizedFetchedMegaRows = memoize(fetchMegaCsv)
+export const memoizedFetchedMegaRows = memoize(fetchMegaCsv)
 
 const fetchLastUpdatedTime = memoize(() =>
     retryPromise(() => fetchText(covidLastUpdatedPath))

--- a/explorer/covidExplorer/MegaCsv.ts
+++ b/explorer/covidExplorer/MegaCsv.ts
@@ -56,6 +56,21 @@ export const MegaCsvToCovidExplorerTable = (
         "Drop International rows"
     )
 
+    const tableWithRows = addGroups(coreTable)
+
+    return new CovidExplorerTable(
+        tableWithRows.columnStore,
+        tableWithRows.defs,
+        {
+            parent: tableWithRows as any,
+            tableDescription: "Loaded into CovidExplorerTable",
+        }
+    )
+        .updateColumnsToHideInDataTable()
+        .loadColumnDefTemplatesFromGrapherBackend(metaDataFromGrapherBackend)
+}
+
+const addGroups = (coreTable: CoreTable) => {
     // todo: this can be better expressed as a group + reduce.
     const continentGroups = coreTable.get(MegaSlugs.continent)!.valuesToIndices
     const continentNames = Array.from(continentGroups.keys()).filter(
@@ -86,21 +101,10 @@ export const MegaCsvToCovidExplorerTable = (
     // Drop the last day in aggregates containing Spain & Sweden
     euRows.pop()
 
-    const tableWithRows = coreTable
+    return coreTable
         .appendRows(
             continentRows as any,
             `Added ${continentRows.length} continent rows`
         )
         .appendRows(euRows as any, `Added ${euRows.length} EU rows`)
-
-    return new CovidExplorerTable(
-        tableWithRows.columnStore,
-        tableWithRows.defs,
-        {
-            parent: tableWithRows as any,
-            tableDescription: "Loaded into CovidExplorerTable",
-        }
-    )
-        .updateColumnsToHideInDataTable()
-        .loadColumnDefTemplatesFromGrapherBackend(metaDataFromGrapherBackend)
 }

--- a/explorer/covidExplorer/perfTest.ts
+++ b/explorer/covidExplorer/perfTest.ts
@@ -8,30 +8,9 @@ import { CoreTable } from "coreTable/CoreTable"
 import { MegaCsvToCovidExplorerTable } from "./MegaCsv"
 
 import * as fs from "fs"
+import { Timer } from "coreTable/CoreTableUtils"
 const megaCsvPath = __dirname + "/owid-covid-data.csv"
 const getCsv = () => fs.readFileSync(megaCsvPath, "utf8")
-
-export class Timer {
-    constructor() {
-        this._tickTime = Date.now()
-        this._firstTickTime = this._tickTime
-    }
-
-    private _tickTime: number
-    private _firstTickTime: number
-
-    tick(msg?: string) {
-        const elapsed = Date.now() - this._tickTime
-        // eslint-disable-next-line no-console
-        if (msg) console.log(`${elapsed}ms ${msg}`)
-        this._tickTime = Date.now()
-        return elapsed
-    }
-
-    getTotalElapsedTime() {
-        return Date.now() - this._firstTickTime
-    }
-}
 
 // Use this to get baseline perf with typing
 // https://github.com/d3/d3-dsv/blob/master/src/autoType.js


### PR DESCRIPTION
I am switching off perf for now to work on other issues but wanted to merge this in.

This adds general "groupBy" and "reduce" methods. The benefits of having these general GroupBy/Reduce methods, in addition to fixing this perf, will be that we may find them useful elsewhere for new functionality.

It also separates the (now) slowest part of loading the CE into an `addGroups` method in MegaCsv.ts. Next step would be to use the new methods for that method. My other branch does that but haven't optimized perf yet.

I also turned the plain `boolean[]` filter mask into a tiny class. There's some perf gains that can be had in filtering and just took a step in that direction.

I also turned the table.concat method from accepting a single table to an array of tables which makes more sense.

Finally, I am committing my "perf harness" for the CE to a Story so when I switch back to perf can get some help on figuring it out.





