### PR TITLE
Selection refactor for explorers and colors

### DIFF
--- a/adminSite/client/DatasetEditPage.tsx
+++ b/adminSite/client/DatasetEditPage.tsx
@@ -120,27 +120,27 @@ class VariableEditRow extends React.Component<{
 
         grapher.tab = GrapherTabOption.chart
         grapher.hasMapTab = false
-        const { table } = grapher
-        const { availableEntityNames } = table
+        const { selection } = grapher
+        const { availableEntityNames } = selection
         if (grapher.isScatter || grapher.isSlopeChart) {
-            table.clearSelection()
+            selection.clearSelection()
         } else if (grapher.yColumns.length > 1) {
-            const entity = table.availableEntityNameSet.has(WorldEntityName)
+            const entity = selection.availableEntityNameSet.has(WorldEntityName)
                 ? WorldEntityName
                 : lodash.sample(availableEntityNames)
-            table.selectEntity(entity!)
+            selection.selectEntity(entity!)
             grapher.addCountryMode = EntitySelectionMode.SingleEntity
         } else {
             grapher.addCountryMode = EntitySelectionMode.MultipleEntities
             if (grapher.filledDimensions[0].column.uniqTimesAsc.length === 1) {
                 grapher.type = ChartTypeName.DiscreteBar
-                table.setSelectedEntities(
+                selection.setSelectedEntities(
                     availableEntityNames.length > 15
                         ? lodash.sampleSize(availableEntityNames, 8)
                         : availableEntityNames
                 )
             } else {
-                table.setSelectedEntities(
+                selection.setSelectedEntities(
                     availableEntityNames.length > 10
                         ? lodash.sampleSize(availableEntityNames, 3)
                         : availableEntityNames

--- a/adminSite/client/EditorBasicTab.tsx
+++ b/adminSite/client/EditorBasicTab.tsx
@@ -63,23 +63,23 @@ class DimensionSlotView extends React.Component<{
 
     private updateDefaults() {
         const { grapher } = this.props.editor
-        const { table } = grapher
-        const { availableEntityNames, availableEntityNameSet } = table
+        const { selection } = grapher
+        const { availableEntityNames, availableEntityNameSet } = selection
 
         if (this.dispose) this.dispose()
         this.dispose = reaction(
             () => grapher.type && grapher.yColumns,
             () => {
                 if (grapher.isScatter || grapher.isSlopeChart) {
-                    table.clearSelection()
+                    selection.clearSelection()
                 } else if (grapher.yColumns.length > 1) {
                     const entity = availableEntityNameSet.has(WorldEntityName)
                         ? WorldEntityName
                         : sample(availableEntityNames)
-                    table.selectEntity(entity!)
+                    selection.selectEntity(entity!)
                     grapher.addCountryMode = EntitySelectionMode.SingleEntity
                 } else {
-                    table.setSelectedEntities(
+                    selection.setSelectedEntities(
                         availableEntityNames.length > 10
                             ? sampleSize(availableEntityNames, 3)
                             : availableEntityNames

--- a/adminSite/client/EditorDataTab.tsx
+++ b/adminSite/client/EditorDataTab.tsx
@@ -75,7 +75,7 @@ class KeysSection extends React.Component<{ grapher: Grapher }> {
     @observable.ref dragKey?: EntityName
 
     @action.bound onAddKey(entityName: EntityName) {
-        this.props.grapher.table.selectEntity(entityName)
+        this.props.grapher.selection.selectEntity(entityName)
     }
 
     @action.bound onStartDrag(key: EntityName) {
@@ -92,18 +92,20 @@ class KeysSection extends React.Component<{ grapher: Grapher }> {
     @action.bound onMouseEnter(targetKey: EntityName) {
         if (!this.dragKey || targetKey === this.dragKey) return
 
-        const selectedKeys = clone(this.props.grapher.table.selectedEntityNames)
+        const selectedKeys = clone(
+            this.props.grapher.selection.selectedEntityNames
+        )
         const dragIndex = selectedKeys.indexOf(this.dragKey)
         const targetIndex = selectedKeys.indexOf(targetKey)
         selectedKeys.splice(dragIndex, 1)
         selectedKeys.splice(targetIndex, 0, this.dragKey)
-        this.props.grapher.table.setSelectedEntities(selectedKeys)
+        this.props.grapher.selection.setSelectedEntities(selectedKeys)
     }
 
     render() {
         const { grapher } = this.props
-        const { table } = grapher
-        const { unselectedEntityNames, selectedEntityNames } = table
+        const { selection } = grapher
+        const { unselectedEntityNames, selectedEntityNames } = selection
 
         return (
             <Section name="Data to show">

--- a/coreTable/CoreTable.test.ts
+++ b/coreTable/CoreTable.test.ts
@@ -127,7 +127,7 @@ describe("creating tables", () => {
 })
 
 describe("adding rows", () => {
-    it("rows can be added without mutating the parent table", () => {
+    describe("rows can be added without mutating the parent table", () => {
         const table = new CoreTable(sampleCsv)
         expect(table.numRows).toEqual(4)
 
@@ -138,7 +138,7 @@ describe("adding rows", () => {
         expect(expandedTable.numRows).toBe(5)
         expect(table.numRows).toEqual(4)
 
-        it.only("can append rows", () => {
+        it("can append rows", () => {
             expandedTable = expandedTable
                 .renameColumns({ population: "pop" })
                 .appendRows(

--- a/coreTable/OwidTable.test.ts
+++ b/coreTable/OwidTable.test.ts
@@ -136,12 +136,7 @@ it("can perform queries needed by discrete bar", () => {
         10
     )
     expect(table.rowIndicesByEntityName.size).toEqual(3)
-    expect(table.numSelectedEntities).toEqual(0)
-
-    table.selectAll()
-
-    expect(table.numSelectedEntities).toEqual(3)
-    const entityNames = table.selectedEntityNames
+    const entityNames = table.availableEntityNames
     expect(
         table.getClosestIndexForEachEntity(entityNames, 2003, 0).length
     ).toEqual(3)
@@ -260,13 +255,14 @@ usa,us,23,`)
 describe("filtering", () => {
     it("can filter by population", () => {
         const table = SynthesizeFruitTable({ timeRange: [2000, 2001] })
-        expect(table.filterByPopulation(100).numRows).toEqual(2)
+        expect(table.filterByPopulationExcept(100).numRows).toEqual(2)
     })
 
     it("can filter by population on empty table", () => {
         const table = BlankOwidTable()
         expect(
-            table.filterByPopulation(1).filterByPopulation(1e12).numRows
+            table.filterByPopulationExcept(1).filterByPopulationExcept(1e12)
+                .numRows
         ).toEqual(0)
     })
 })
@@ -333,8 +329,7 @@ usa,1,usa,-5,1`
 
         expect(
             table
-                .selectEntity(table.availableEntityNames[0])
-                .filterBySelectedOnly()
+                .filterBySelectedOnly(table.sampleEntityName(1))
                 .filterByTargetTimes([2010], 20).numRows
         ).toBe(1)
 
@@ -360,8 +355,7 @@ usa,1,usa,-5,1`
 
         expect(
             table
-                .selectEntity(table.availableEntityNames[0])
-                .filterBySelectedOnly()
+                .filterBySelectedOnly(table.sampleEntityName(1))
                 .filterByTargetTimes([2000, 2003], 1).numRows
         ).toBe(2)
 

--- a/coreTable/readme.md
+++ b/coreTable/readme.md
@@ -35,7 +35,7 @@ Afghanistan       15        AFG 2001 18972552 2001
      Angola       19        AGO 2001 10536418 2001
 ```
 
-Tables are immutable, so all transformations generate a new lightweight table. With Mobx, changes made to a parent table can regenerate the line of child tables.
+Tables are immutable, so all transformations generate a new lightweight table.
 
 ### Columns
 
@@ -72,7 +72,6 @@ The split between CoreTable and OwidTable is also to ensure we minimize the delt
 
 -   Consolidating our transform code and switching from a variable model to a table model is a work-in-progress so currently there is still some legacy code to be removed.
 -   This library should treat Node and the Browser both as first class targets. Even though our primary usage will be in the browser, ensuring a great Node experience will ensure a fast headless testing experience. We may also use this in a headless environment for running the same transform code on bigger datasets.
--   Because our clients are reactive, we are using Mobx in this library. No reason that needs to be a hard dependency here if we remove that.
 -   At some point we may want to look into integrating with Apache Arrow JS (https://github.com/apache/arrow/tree/master/js).
 -   Similarly for speed we may want to look into integrating/learning from CrossFilter (https://github.com/crossfilter/crossfilter).
 -   Table "Sythensizers" are also included for rapid testing. The word Synthesis is used as in "Program Synthesis".

--- a/explorer/client/ExplorerShell.tsx
+++ b/explorer/client/ExplorerShell.tsx
@@ -9,15 +9,14 @@ import { CountryPicker } from "grapher/controls/countryPicker/CountryPicker"
 import { ExplorerControlBar } from "./ExplorerControls"
 import classNames from "classnames"
 import { throttle } from "grapher/utils/Util"
-import { OwidTable } from "coreTable/OwidTable"
+import { CountryPickerManager } from "grapher/controls/countryPicker/CountryPickerConstants"
 
 interface ExplorerShellProps {
     explorerSlug: string
     controlPanels: JSX.Element[]
     headerElement: JSX.Element
     hideControls?: boolean
-    countryPickerTable?: OwidTable
-    countryPickerElement?: JSX.Element
+    countryPickerManager?: CountryPickerManager
     isEmbed: boolean
     enableKeyboardShortcuts?: boolean
 }
@@ -78,21 +77,6 @@ export class ExplorerShell extends React.Component<ExplorerShellProps> {
         ) : undefined
     }
 
-    @computed private get countryPickerTable() {
-        return this.props.countryPickerTable
-    }
-
-    private get countryPicker() {
-        return (
-            <CountryPicker
-                key="countryPicker"
-                analyticsNamespace={this.props.explorerSlug}
-                table={this.countryPickerTable!}
-                isDropdownMenu={this.isMobile}
-            ></CountryPicker>
-        )
-    }
-
     private get controlBar() {
         return (
             <ExplorerControlBar
@@ -124,9 +108,17 @@ export class ExplorerShell extends React.Component<ExplorerShellProps> {
 
     @observable.ref grapherRef: React.RefObject<Grapher> = React.createRef()
 
+    private renderCountryPicker() {
+        return (
+            <CountryPicker
+                key="countryPicker"
+                manager={this.props.countryPickerManager}
+                isDropdownMenu={this.isMobile}
+            />
+        )
+    }
+
     render() {
-        const countryPicker =
-            this.props.countryPickerElement ?? this.countryPicker
         return (
             <>
                 <div
@@ -143,7 +135,7 @@ export class ExplorerShell extends React.Component<ExplorerShellProps> {
                         </div>
                     )}
                     {this.showExplorerControls && this.controlBar}
-                    {this.showExplorerControls && countryPicker}
+                    {this.showExplorerControls && this.renderCountryPicker()}
                     {this.showExplorerControls &&
                         this.customizeChartMobileButton}
                     <div

--- a/explorer/client/SwitcherExplorer.tsx
+++ b/explorer/client/SwitcherExplorer.tsx
@@ -22,6 +22,7 @@ import {
 } from "grapher/slideshowController/SlideShowController"
 import { OwidRow } from "coreTable/OwidTableConstants"
 import { ExplorerContainerId } from "./ExplorerConstants"
+import { CountryPickerManager } from "grapher/controls/countryPicker/CountryPickerConstants"
 
 export interface SwitcherExplorerProps {
     explorerProgramCode: string
@@ -34,7 +35,7 @@ export interface SwitcherExplorerProps {
 @observer
 export class SwitcherExplorer
     extends React.Component<SwitcherExplorerProps>
-    implements ObservableUrl, SlideShowManager {
+    implements ObservableUrl, SlideShowManager, CountryPickerManager {
     static bootstrap(props: SwitcherExplorerProps) {
         return ReactDOM.render(
             <SwitcherExplorer
@@ -233,7 +234,7 @@ export class SwitcherExplorer
                 headerElement={this.header}
                 controlPanels={this.panels}
                 explorerSlug={this.explorerProgram.slug}
-                countryPickerTable={this.countryPickerTable}
+                countryPickerManager={this}
                 hideControls={this.hideControls}
                 isEmbed={this.isEmbed}
                 enableKeyboardShortcuts={!this.isEmbed}

--- a/explorer/covidExplorer/CovidExplorerTable.test.ts
+++ b/explorer/covidExplorer/CovidExplorerTable.test.ts
@@ -162,19 +162,16 @@ it("can filter rows without continent", () => {
     let table = MegaCsvToCovidExplorerTable(sampleMegaCsv)
     expect(table.availableEntityNameSet.has(WorldEntityName)).toBeTruthy()
 
-    table = table.filterRegionsUnlessSelected()
+    table = table.filterRegionsExcept([])
     expect(table.availableEntityNameSet.has(WorldEntityName)).toBeFalsy()
     expect(table.availableEntityNameSet.has("Aruba")).toBeTruthy()
 
-    table.mainTable.selectEntity(WorldEntityName)
-    table = table.mainTable.filterRegionsUnlessSelected()
+    table = table.mainTable.filterRegionsExcept([WorldEntityName])
     expect(table.availableEntityNameSet.has(WorldEntityName)).toBeTruthy()
 
-    table.mainTable.deselectEntity(WorldEntityName)
-    table = table.mainTable.filterRegionsUnlessSelected()
+    table = table.mainTable.filterRegionsExcept([])
     expect(table.availableEntityNameSet.has(WorldEntityName)).toBeFalsy()
 
-    table.mainTable.setSelectedEntities([WorldEntityName])
-    table = table.mainTable.filterRegionsUnlessSelected()
+    table = table.mainTable.filterRegionsExcept([WorldEntityName])
     expect(table.availableEntityNameSet.has(WorldEntityName)).toBeTruthy()
 })

--- a/explorer/covidExplorer/CovidExplorerTable.ts
+++ b/explorer/covidExplorer/CovidExplorerTable.ts
@@ -243,7 +243,8 @@ export class CovidExplorerTable extends OwidTable {
         })
     }
 
-    filterRegionsUnlessSelected() {
+    filterRegionsExcept(selectedEntityNames: string[]) {
+        const set = new Set(selectedEntityNames)
         const groupNames = new Set(
             Object.keys(ContinentColors).concat(
                 "European Union",
@@ -256,7 +257,7 @@ export class CovidExplorerTable extends OwidTable {
             OwidTableSlugs.entityName,
             (value) => {
                 const name = value as string
-                return groupNames.has(name) ? this.isEntitySelected(name) : true
+                return groupNames.has(name) ? set.has(name) : true
             },
             `Filter out regions unless selected`
         )

--- a/explorer/covidExplorer/CovidParams.ts
+++ b/explorer/covidExplorer/CovidParams.ts
@@ -24,7 +24,6 @@ import {
     EntityCode,
     OwidTableSlugs,
 } from "coreTable/OwidTableConstants"
-import { CountryPickerManager } from "grapher/controls/countryPicker/CountryPickerConstants"
 import { CovidAnnotationColumnSlugs } from "./CovidAnnotations"
 
 // Previously the query string was a few booleans like dailyFreq=true. Now it is a single 'interval'.
@@ -46,7 +45,7 @@ const legacyTimeToInterval = (
  * constrainedParams and code that writes should always write to the params.
  */
 
-export class CovidQueryParams implements CountryPickerManager {
+export class CovidQueryParams {
     // Todo: in hindsight these 6 metrics should have been something like "yColumn". May want to switch to that and translate these
     // for back compat.
     @observable casesMetric = false

--- a/grapher/barCharts/DiscreteBarChart.stories.tsx
+++ b/grapher/barCharts/DiscreteBarChart.stories.tsx
@@ -16,10 +16,11 @@ export const EntitiesAsSeries = () => {
     const table = SynthesizeGDPTable({
         timeRange: [2009, 2010],
         entityCount: 10,
-    }).selectAll()
+    })
 
     const manager: DiscreteBarChartManager = {
         table,
+        selection: table.availableEntityNames,
         yColumnSlug: SampleColumnSlugs.Population,
     }
 
@@ -31,9 +32,10 @@ export const EntitiesAsSeries = () => {
 }
 
 export const ColumnsAsSeries = () => {
-    const table = SynthesizeFruitTable({ entityCount: 1 }).selectAll()
+    const table = SynthesizeFruitTable({ entityCount: 1 })
     const manager: DiscreteBarChartManager = {
         table,
+        selection: table.availableEntityNames,
     }
 
     return (

--- a/grapher/barCharts/DiscreteBarChart.test.ts
+++ b/grapher/barCharts/DiscreteBarChart.test.ts
@@ -12,19 +12,24 @@ import {
 } from "./DiscreteBarChartConstants"
 import { ColorSchemeName } from "grapher/color/ColorConstants"
 import { SeriesStrategy } from "grapher/core/GrapherConstants"
+import { SelectionArray } from "grapher/core/SelectionArray"
 
 it("can create a new bar chart", () => {
     const table = SynthesizeGDPTable({ timeRange: [2000, 2001] })
-
+    const selection = new SelectionArray({
+        availableEntities: table.availableEntities,
+        selectedEntityNames: [],
+    })
     const manager: DiscreteBarChartManager = {
         table,
+        selection,
         yColumnSlug: SampleColumnSlugs.Population,
         endTime: 2000,
     }
     const chart = new DiscreteBarChart({ manager })
 
     expect(chart.failMessage).toBeTruthy()
-    table.selectAll()
+    selection.selectAll()
     expect(chart.failMessage).toEqual("")
 
     const series = chart.series
@@ -33,9 +38,11 @@ it("can create a new bar chart", () => {
 })
 
 describe("barcharts with columns as the series", () => {
+    const table = SynthesizeGDPTable({ timeRange: [2000, 2010] })
     const manager: DiscreteBarChartManager = {
-        table: SynthesizeGDPTable({ timeRange: [2000, 2010] }).selectSample(1),
+        table,
         yColumnSlugs: [SampleColumnSlugs.Population, SampleColumnSlugs.GDP],
+        selection: table.sampleEntityName(1),
     }
     const chart = new DiscreteBarChart({ manager })
 
@@ -48,6 +55,10 @@ describe("barcharts with columns as the series", () => {
     })
 
     it("can filter a series when there are no points (column strategy)", () => {
+        const table = SynthesizeFruitTable({
+            entityCount: 1,
+            timeRange: [2000, 2001],
+        }).replaceRandomCells(1, [SampleColumnSlugs.Fruit])
         const chart = new DiscreteBarChart({
             manager: {
                 seriesStrategy: SeriesStrategy.column,
@@ -55,12 +66,8 @@ describe("barcharts with columns as the series", () => {
                     SampleColumnSlugs.Fruit,
                     SampleColumnSlugs.Vegetables,
                 ],
-                table: SynthesizeFruitTable({
-                    entityCount: 1,
-                    timeRange: [2000, 2001],
-                })
-                    .selectSample(1)
-                    .replaceRandomCells(1, [SampleColumnSlugs.Fruit]),
+                selection: table.sampleEntityName(1),
+                table,
             },
         })
 
@@ -68,16 +75,16 @@ describe("barcharts with columns as the series", () => {
     })
 
     it("can filter a series when there are no points (entity strategy)", () => {
+        const table = SynthesizeFruitTable({
+            entityCount: 2,
+            timeRange: [2000, 2001],
+        }).replaceRandomCells(1, [SampleColumnSlugs.Fruit])
         const chart = new DiscreteBarChart({
             manager: {
                 seriesStrategy: SeriesStrategy.entity,
                 yColumnSlugs: [SampleColumnSlugs.Fruit],
-                table: SynthesizeFruitTable({
-                    entityCount: 2,
-                    timeRange: [2000, 2001],
-                })
-                    .selectSample(2)
-                    .replaceRandomCells(1, [SampleColumnSlugs.Fruit]),
+                selection: table.sampleEntityName(2),
+                table,
             },
         })
 

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -32,7 +32,10 @@ import {
     DiscreteBarSeries,
 } from "./DiscreteBarChartConstants"
 import { OwidTable } from "coreTable/OwidTable"
-import { autoDetectYColumnSlugs } from "grapher/chart/ChartUtils"
+import {
+    autoDetectYColumnSlugs,
+    makeSelectionArray,
+} from "grapher/chart/ChartUtils"
 
 const labelToTextPadding = 10
 const labelToBarPadding = 5
@@ -49,7 +52,9 @@ export class DiscreteBarChart
     transformTable(table: OwidTable) {
         if (!this.yColumnSlugs.length) return table
 
-        table = table.filterBySelectedOnly()
+        table = table.filterBySelectedOnly(
+            this.selectionArray.selectedEntityNames
+        )
 
         if (this.isLogScale)
             table = table.replaceNonPositiveCellsForLogScale(this.yColumnSlugs)
@@ -194,6 +199,10 @@ export class DiscreteBarChart
             .padLeft(this.legendWidth + this.leftEndLabelWidth)
             .padBottom(this.axis.height)
             .padRight(this.rightEndLabelWidth)
+    }
+
+    @computed private get selectionArray() {
+        return makeSelectionArray(this.manager)
     }
 
     // Leave space for extra bar at bottom to show "Add country" button
@@ -379,7 +388,7 @@ export class DiscreteBarChart
 
         if (!column) return "No column to chart"
 
-        if (!this.transformedTable.hasSelection) return `No data selected`
+        if (!this.selectionArray.hasSelection) return `No data selected`
 
         // TODO is it better to use .series for this check?
         return this.yColumns.every((col) => col.isEmpty)
@@ -410,7 +419,7 @@ export class DiscreteBarChart
         return (
             this.manager.seriesStrategy ||
             (this.yColumnSlugs.length > 1 &&
-            this.inputTable.numSelectedEntities === 1
+            this.selectionArray.numSelectedEntities === 1
                 ? SeriesStrategy.column
                 : SeriesStrategy.entity)
         )

--- a/grapher/captionedChart/CaptionedChart.stories.tsx
+++ b/grapher/captionedChart/CaptionedChart.stories.tsx
@@ -17,11 +17,12 @@ export default {
     component: CaptionedChart,
 }
 
-const table = SynthesizeGDPTable({ entityCount: 5 }).selectAll()
+const table = SynthesizeGDPTable({ entityCount: 5 })
 
 const manager: CaptionedChartManager = {
     tabBounds: DEFAULT_BOUNDS,
     table,
+    selection: table.availableEntityNames,
     currentTitle: "This is the Title",
     subtitle: "A Subtitle",
     note: "Here are some footer notes",

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -239,6 +239,10 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         return controls
     }
 
+    @computed get selectionArray() {
+        return this.manager.selection
+    }
+
     private renderControlsRow() {
         return this.controls.length ? (
             <div className="controlsRow">

--- a/grapher/chart/ChartManager.ts
+++ b/grapher/chart/ChartManager.ts
@@ -12,6 +12,7 @@ import { ColumnSlug } from "coreTable/CoreTableConstants"
 import { AxisConfigInterface } from "grapher/axis/AxisConfigInterface"
 import { ColorSchemeName } from "grapher/color/ColorConstants"
 import { EntityName } from "coreTable/OwidTableConstants"
+import { SelectionArray } from "grapher/core/SelectionArray"
 
 // The possible options common across our chart types. Not all of these apply to every chart type, so there is room to create a better type hierarchy.
 
@@ -50,8 +51,8 @@ export interface ChartManager {
     sizeColumnSlug?: ColumnSlug
     colorColumnSlug?: ColumnSlug
 
-    selectedColumnNamesInOrder?: string[]
-    selectedEntityNamesInOrder?: EntityName[]
+    selection?: SelectionArray | EntityName[]
+    selectedColumnSlugs?: ColumnSlug[]
 
     hidePoints?: boolean // for line options
     lineStrokeWidth?: number

--- a/grapher/chart/ChartUtils.tsx
+++ b/grapher/chart/ChartUtils.tsx
@@ -1,4 +1,5 @@
 import { Box } from "grapher/core/GrapherConstants"
+import { SelectionArray } from "grapher/core/SelectionArray"
 import React from "react"
 import { ChartManager } from "./ChartManager"
 
@@ -22,3 +23,8 @@ export const makeClipPath = (renderUid: number, box: Box) => {
         ),
     }
 }
+
+export const makeSelectionArray = (manager: ChartManager) =>
+    manager.selection instanceof SelectionArray
+        ? manager.selection
+        : new SelectionArray(manager.selection)

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -20,12 +20,12 @@ import {
     StackMode,
 } from "grapher/core/GrapherConstants"
 import { ShareMenu, ShareMenuManager } from "./ShareMenu"
-import { OwidTable } from "coreTable/OwidTable"
 import { TimelineController } from "grapher/timeline/TimelineController"
+import { SelectionArray } from "grapher/core/SelectionArray"
 
 export interface HighlightToggleManager {
     highlightToggle?: HighlightToggleConfig
-    table: OwidTable
+    selectionArray?: SelectionArray
     populateFromQueryParams: (obj: QueryParams) => void
 }
 
@@ -45,15 +45,15 @@ export class HighlightToggle extends React.Component<{
         return getQueryParams((this.highlight?.paramStr || "").substring(1))
     }
 
-    @computed get inputTable() {
-        return this.manager.table // todo: should this be rootTable?
+    @computed get selection() {
+        return
     }
 
     @action.bound private onHighlightToggle(
         event: React.FormEvent<HTMLInputElement>
     ) {
         if (!event.currentTarget.checked) {
-            this.inputTable.clearSelection()
+            this.manager.selectionArray?.clearSelection()
             return
         }
 

--- a/grapher/controls/EntitySelectorModal.tsx
+++ b/grapher/controls/EntitySelectorModal.tsx
@@ -5,7 +5,7 @@ import { uniqBy, isTouchDevice, sortBy } from "grapher/utils/Util"
 import { FuzzySearch } from "./FuzzySearch"
 import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { OwidTable } from "coreTable/OwidTable"
+import { SelectionArray } from "grapher/core/SelectionArray"
 
 interface SearchableEntity {
     name: string
@@ -13,7 +13,7 @@ interface SearchableEntity {
 
 @observer
 class EntitySelectorMulti extends React.Component<{
-    table: OwidTable
+    selectionArray: SelectionArray
     onDismiss: () => void
 }> {
     @observable searchInput?: string
@@ -22,7 +22,7 @@ class EntitySelectorMulti extends React.Component<{
     dismissable: boolean = true
 
     @computed get availableEntities() {
-        return this.props.table.availableEntityNames
+        return this.props.selectionArray.availableEntityNames
     }
 
     @computed get fuzzy(): FuzzySearch<SearchableEntity> {
@@ -64,20 +64,20 @@ class EntitySelectorMulti extends React.Component<{
 
     @action.bound onSearchKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
         if (e.key === "Enter" && this.searchResults.length > 0) {
-            this.props.table.selectEntity(this.searchResults[0].name)
+            this.props.selectionArray.selectEntity(this.searchResults[0].name)
             this.searchInput = ""
         } else if (e.key === "Escape") this.props.onDismiss()
     }
 
     @action.bound onClear() {
-        this.props.table.clearSelection()
+        this.props.selectionArray.clearSelection()
     }
 
     render() {
-        const { table } = this.props
+        const { selectionArray } = this.props
         const { searchResults, searchInput } = this
 
-        const selectedEntityNames = table.selectedEntityNames
+        const selectedEntityNames = selectionArray.selectedEntityNames
 
         return (
             <div className="entitySelectorOverlay">
@@ -111,11 +111,11 @@ class EntitySelectorMulti extends React.Component<{
                                             <label className="clickable">
                                                 <input
                                                     type="checkbox"
-                                                    checked={table.isEntitySelected(
+                                                    checked={selectionArray.selectedSet.has(
                                                         result.name
                                                     )}
                                                     onChange={() =>
-                                                        table.toggleSelection(
+                                                        selectionArray.toggleSelection(
                                                             result.name
                                                         )
                                                     }
@@ -137,7 +137,7 @@ class EntitySelectorMulti extends React.Component<{
                                                     type="checkbox"
                                                     checked={true}
                                                     onChange={() =>
-                                                        table.deselectEntity(
+                                                        selectionArray.deselectEntity(
                                                             name
                                                         )
                                                     }
@@ -169,7 +169,7 @@ class EntitySelectorMulti extends React.Component<{
 
 @observer
 class EntitySelectorSingle extends React.Component<{
-    table: OwidTable
+    selectionArray: SelectionArray
     isMobile: boolean
     onDismiss: () => void
 }> {
@@ -180,7 +180,7 @@ class EntitySelectorSingle extends React.Component<{
 
     @computed private get availableEntities() {
         const availableItems: { id: string; label: string }[] = []
-        this.props.table.availableEntityNames.forEach((name) => {
+        this.props.selectionArray.availableEntityNames.forEach((name) => {
             availableItems.push({
                 id: name,
                 label: name,
@@ -229,7 +229,7 @@ class EntitySelectorSingle extends React.Component<{
     }
 
     @action.bound onSelect(entityName: string) {
-        this.props.table.setSelectedEntities([entityName])
+        this.props.selectionArray.setSelectedEntities([entityName])
         this.props.onDismiss()
     }
 
@@ -282,7 +282,7 @@ class EntitySelectorSingle extends React.Component<{
 
 @observer
 export class EntitySelectorModal extends React.Component<{
-    table: OwidTable
+    selectionArray: SelectionArray
     canChangeEntity?: boolean
     isMobile: boolean
     onDismiss: () => void

--- a/grapher/controls/countryPicker/CountryPicker.stories.tsx
+++ b/grapher/controls/countryPicker/CountryPicker.stories.tsx
@@ -10,6 +10,7 @@ import { ColumnSlug, SortOrder } from "coreTable/CoreTableConstants"
 import { EntityName, OwidTableSlugs } from "coreTable/OwidTableConstants"
 import { CountryPickerManager } from "grapher/controls/countryPicker/CountryPickerConstants"
 import { computed, observable } from "mobx"
+import { SelectionArray, SelectionManager } from "grapher/core/SelectionArray"
 
 class CountryPickerHolder extends React.Component {
     render() {
@@ -41,17 +42,20 @@ class SomeThingWithACountryPicker
         pickerSlugs?: ColumnSlug[]
         selection?: EntityName[]
     }>
-    implements CountryPickerManager {
-    countryPickerTable = SynthesizeGDPTable(
-        { entityCount: 30 },
-        1
-    ).setSelectedEntities(this.props.selection ?? [])
+    implements CountryPickerManager, SelectionManager {
+    countryPickerTable = SynthesizeGDPTable({ entityCount: 30 }, 1)
 
     @observable countryPickerMetric?: ColumnSlug
     @observable countryPickerSort?: SortOrder
 
     @computed get pickerColumnSlugs() {
         return this.props.pickerSlugs
+    }
+
+    selectionArray = new SelectionArray(this)
+    @observable selectedEntityNames = this.props.selection ?? []
+    @computed get availableEntities() {
+        return this.countryPickerTable.availableEntities
     }
 
     requiredColumnSlugs = defaultSlugs
@@ -72,7 +76,12 @@ export default {
 
 export const Empty = () => (
     <CountryPickerHolder>
-        <CountryPicker manager={{ countryPickerTable: BlankOwidTable() }} />
+        <CountryPicker
+            manager={{
+                countryPickerTable: BlankOwidTable(),
+                selectionArray: new SelectionArray(),
+            }}
+        />
     </CountryPickerHolder>
 )
 

--- a/grapher/controls/countryPicker/CountryPicker.stories.tsx
+++ b/grapher/controls/countryPicker/CountryPicker.stories.tsx
@@ -9,7 +9,7 @@ import {
 import { ColumnSlug, SortOrder } from "coreTable/CoreTableConstants"
 import { EntityName, OwidTableSlugs } from "coreTable/OwidTableConstants"
 import { CountryPickerManager } from "grapher/controls/countryPicker/CountryPickerConstants"
-import { observable } from "mobx"
+import { computed, observable } from "mobx"
 
 class CountryPickerHolder extends React.Component {
     render() {
@@ -42,22 +42,24 @@ class SomeThingWithACountryPicker
         selection?: EntityName[]
     }>
     implements CountryPickerManager {
-    table = SynthesizeGDPTable({ entityCount: 30 }, 1).setSelectedEntities(
-        this.props.selection ?? []
-    )
+    countryPickerTable = SynthesizeGDPTable(
+        { entityCount: 30 },
+        1
+    ).setSelectedEntities(this.props.selection ?? [])
 
     @observable countryPickerMetric?: ColumnSlug
     @observable countryPickerSort?: SortOrder
 
+    @computed get pickerColumnSlugs() {
+        return this.props.pickerSlugs
+    }
+
+    requiredColumnSlugs = defaultSlugs
+
     render() {
         return (
             <CountryPickerHolder>
-                <CountryPicker
-                    table={this.table}
-                    requiredColumnSlugs={defaultSlugs}
-                    pickerColumnSlugs={this.props.pickerSlugs}
-                    manager={this}
-                />
+                <CountryPicker manager={this} />
             </CountryPickerHolder>
         )
     }
@@ -70,7 +72,7 @@ export default {
 
 export const Empty = () => (
     <CountryPickerHolder>
-        <CountryPicker table={BlankOwidTable()} />
+        <CountryPicker manager={{ countryPickerTable: BlankOwidTable() }} />
     </CountryPickerHolder>
 )
 

--- a/grapher/controls/countryPicker/CountryPicker.tsx
+++ b/grapher/controls/countryPicker/CountryPicker.tsx
@@ -80,7 +80,7 @@ export class CountryPicker extends React.Component<{
     }
 
     @action.bound private selectEntity(name: EntityName, checked?: boolean) {
-        this.table.toggleSelection(name)
+        this.manager.selectionArray.toggleSelection(name)
         // Clear search input
         this.searchInput = ""
         this.manager.analytics?.logCountrySelectorEvent(
@@ -132,15 +132,15 @@ export class CountryPicker extends React.Component<{
 
     @computed private get availableEntitiesForCurrentView() {
         if (!this.manager.requiredColumnSlugs?.length)
-            return this.table.availableEntityNameSet
+            return this.selectionArray.availableEntityNameSet
         return this.table.entitiesWith(this.manager.requiredColumnSlugs)
     }
 
     @computed
     private get entitiesWithMetricValue(): EntityOptionWithMetricValue[] {
-        const table = this.table
+        const { table, selectionArray } = this
         const col = this.activePickerMetricColumn
-        const entityNames = table.availableEntityNames.slice().sort()
+        const entityNames = selectionArray.availableEntityNames.slice().sort()
         return entityNames.map((entityName) => {
             const plotValue = col
                 ? (table.getLatestValueForEntity(entityName, col.slug) as
@@ -164,8 +164,14 @@ export class CountryPicker extends React.Component<{
         return this.manager.countryPickerTable
     }
 
+    @computed get selectionArray() {
+        return this.manager.selectionArray
+    }
+
     @bind private isSelected(option: EntityOptionWithMetricValue) {
-        return this.table.selectedEntityNames.includes(option.entityName)
+        return this.selectionArray.selectedEntityNames.includes(
+            option.entityName
+        )
     }
 
     @computed private get fuzzy(): FuzzySearch<EntityOptionWithMetricValue> {
@@ -435,7 +441,7 @@ export class CountryPicker extends React.Component<{
 
     render() {
         const entities = this.searchResults
-        const selectedEntityNames = this.table.selectedEntityNames
+        const selectedEntityNames = this.selectionArray.selectedEntityNames
         const availableEntities = this.availableEntitiesForCurrentView
         const colorMap = this.manager.entityColorMap || {}
 
@@ -526,7 +532,9 @@ export class CountryPicker extends React.Component<{
                                     title={selectedDebugMessage}
                                     className="ClearSelectionButton"
                                     data-track-note={`${this.analyticsNamespace}-clear-selection`}
-                                    onClick={() => this.table.clearSelection()}
+                                    onClick={() =>
+                                        this.selectionArray.clearSelection()
+                                    }
                                 >
                                     <FontAwesomeIcon icon={faTimes} /> Clear
                                     selection

--- a/grapher/controls/countryPicker/CountryPickerConstants.ts
+++ b/grapher/controls/countryPicker/CountryPickerConstants.ts
@@ -1,6 +1,7 @@
 import { Color, ColumnSlug, SortOrder } from "coreTable/CoreTableConstants"
 import { OwidTable } from "coreTable/OwidTable"
 import { Analytics } from "grapher/core/Analytics"
+import { SelectionArray } from "grapher/core/SelectionArray"
 
 export interface CountryPickerManager {
     countryPickerMetric?: ColumnSlug
@@ -9,6 +10,7 @@ export interface CountryPickerManager {
     pickerColumnSlugs?: ColumnSlug[] // These are the columns that can be used for sorting entities.
     analytics?: Analytics
     countryPickerTable: OwidTable
+    selectionArray: SelectionArray
     entityColorMap?: {
         [entityName: string]: Color | undefined
     }

--- a/grapher/controls/countryPicker/CountryPickerConstants.ts
+++ b/grapher/controls/countryPicker/CountryPickerConstants.ts
@@ -1,6 +1,16 @@
-import { ColumnSlug, SortOrder } from "coreTable/CoreTableConstants"
+import { Color, ColumnSlug, SortOrder } from "coreTable/CoreTableConstants"
+import { OwidTable } from "coreTable/OwidTable"
+import { Analytics } from "grapher/core/Analytics"
 
 export interface CountryPickerManager {
     countryPickerMetric?: ColumnSlug
     countryPickerSort?: SortOrder
+    requiredColumnSlugs?: ColumnSlug[] // If this param is provided, and an entity does not have a value for 1+, it will show as unavailable.
+    pickerColumnSlugs?: ColumnSlug[] // These are the columns that can be used for sorting entities.
+    analytics?: Analytics
+    countryPickerTable: OwidTable
+    entityColorMap?: {
+        [entityName: string]: Color | undefined
+    }
+    analyticsNamespace?: string
 }

--- a/grapher/core/Grapher.jsdom.test.ts
+++ b/grapher/core/Grapher.jsdom.test.ts
@@ -19,8 +19,10 @@ import {
 } from "coreTable/OwidTableSynthesizers"
 
 const TestGrapherConfig = () => {
+    const table = SynthesizeGDPTable({ entityCount: 10 })
     return {
-        table: SynthesizeGDPTable({ entityCount: 10 }).selectSample(5),
+        table,
+        selection: table.sampleEntityName(5),
         dimensions: [
             {
                 slug: SampleColumnSlugs.GDP,
@@ -103,7 +105,7 @@ it("can generate a url with country selection even if there is no entity code", 
     }
     const grapher = new Grapher(config)
     expect(grapher.queryStr).toBe("")
-    grapher.inputTable.selectAll()
+    grapher.selection.selectAll()
     expect(grapher.queryStr).toContain("AFG")
 
     const config2 = {
@@ -113,7 +115,7 @@ it("can generate a url with country selection even if there is no entity code", 
     config2.owidDataset.entityKey[15].code = undefined as any
     const grapher2 = new Grapher(config2)
     expect(grapher2.queryStr).toBe("")
-    grapher2.inputTable.selectAll()
+    grapher2.selection.selectAll()
     expect(grapher2.queryStr).toContain("Afghanistan")
 })
 
@@ -182,11 +184,13 @@ it("can serialize scaleType if it changes", () => {
 
 describe("currentTitle", () => {
     it("shows the year of the selected data in the title", () => {
+        const table = SynthesizeGDPTable(
+            { entityCount: 2, timeRange: [2000, 2010] },
+            1
+        )
         const grapher = new Grapher({
-            table: SynthesizeGDPTable(
-                { entityCount: 2, timeRange: [2000, 2010] },
-                1
-            ).selectAll(),
+            table,
+            selectedEntityNames: table.availableEntityNames,
             dimensions: [
                 {
                     slug: SampleColumnSlugs.GDP,
@@ -217,9 +221,11 @@ describe("currentTitle", () => {
 
 describe("authors can use maxTime", () => {
     it("can can create a discretebar chart with correct maxtime", () => {
+        const table = SynthesizeGDPTable({ timeRange: [2000, 2010] })
         const grapher = new Grapher({
-            table: SynthesizeGDPTable({ timeRange: [2000, 2010] }).selectAll(),
+            table,
             type: ChartTypeName.DiscreteBar,
+            selectedEntityNames: table.availableEntityNames,
             maxTime: 2005,
         })
         const chart = grapher.chartInstance
@@ -291,13 +297,13 @@ describe("urls", () => {
 
 describe("time domain tests", () => {
     const seed = 1
+    const table = SynthesizeGDPTable(
+        { entityCount: 2, timeRange: [2000, 2010] },
+        seed
+    ).replaceRandomCells(17, [SampleColumnSlugs.GDP], seed)
     const grapher = new Grapher({
-        table: SynthesizeGDPTable(
-            { entityCount: 2, timeRange: [2000, 2010] },
-            seed
-        )
-            .selectAll()
-            .replaceRandomCells(17, [SampleColumnSlugs.GDP], seed),
+        table,
+        selectedEntityNames: table.availableEntityNames,
         dimensions: [
             {
                 slug: SampleColumnSlugs.GDP,
@@ -583,9 +589,11 @@ describe("time parameter", () => {
 })
 
 it("canChangeEntity reflects all available entities before transforms", () => {
+    const table = SynthesizeGDPTable()
     const grapher = new Grapher({
         addCountryMode: EntitySelectionMode.SingleEntity,
-        table: SynthesizeGDPTable().selectSample(1),
+        table,
+        selectedEntityNames: table.sampleEntityName(1),
     })
     expect(grapher.canChangeEntity).toBe(true)
 })

--- a/grapher/core/Grapher.stories.tsx
+++ b/grapher/core/Grapher.stories.tsx
@@ -17,8 +17,10 @@ export default {
     component: Grapher,
 }
 
+const table = SynthesizeGDPTable({ entityCount: 10 })
 const basics: GrapherProgrammaticInterface = {
-    table: SynthesizeGDPTable({ entityCount: 10 }).selectSample(5),
+    table,
+    selectedEntityNames: table.sampleEntityName(5),
     hasMapTab: true,
     yAxis: {
         canChangeScaleType: true,

--- a/grapher/core/GrapherWithChartTypes.jsdom.test.tsx
+++ b/grapher/core/GrapherWithChartTypes.jsdom.test.tsx
@@ -30,8 +30,10 @@ describe("grapher and map charts", () => {
     })
 })
 
+const table = SynthesizeGDPTable({ entityCount: 10 })
 const basicGrapherConfig: GrapherProgrammaticInterface = {
-    table: SynthesizeGDPTable({ entityCount: 10 }).selectSample(5),
+    table,
+    selectedEntityNames: table.sampleEntityName(5),
     dimensions: [
         {
             slug: SampleColumnSlugs.GDP,

--- a/grapher/core/SelectionArray.test.ts
+++ b/grapher/core/SelectionArray.test.ts
@@ -1,0 +1,17 @@
+#! /usr/bin/env yarn jest
+
+import { SelectionArray, SelectionManager } from "./SelectionArray"
+
+it("can create a selection", () => {
+    const manager: SelectionManager = {
+        availableEntities: [{ entityName: "USA" }, { entityName: "Canada" }],
+        selectedEntityNames: [],
+    }
+
+    const selection = new SelectionArray(manager)
+    expect(selection.hasSelection).toEqual(false)
+
+    selection.selectAll()
+    expect(selection.hasSelection).toEqual(true)
+    expect(manager.selectedEntityNames).toEqual(["USA", "Canada"])
+})

--- a/grapher/core/SelectionArray.ts
+++ b/grapher/core/SelectionArray.ts
@@ -19,8 +19,21 @@ export interface SelectionManager {
 }
 
 export class SelectionArray {
-    constructor(manager: SelectionManager) {
-        this.manager = manager
+    constructor(manager?: SelectionManager | EntityName[]) {
+        if (Array.isArray(manager))
+            this.manager = {
+                selectedEntityNames: manager,
+                availableEntities: manager.map((entityName) => {
+                    return {
+                        entityName,
+                    }
+                }),
+            }
+        else
+            this.manager = manager ?? {
+                selectedEntityNames: [],
+                availableEntities: [],
+            }
     }
 
     private manager: SelectionManager
@@ -35,6 +48,10 @@ export class SelectionArray {
 
     @computed get availableEntityNames() {
         return this.availableEntities.map((entity) => entity.entityName)
+    }
+
+    @computed get availableEntityNameSet() {
+        return new Set(this.availableEntityNames)
     }
 
     private mapBy(col: string, val: string) {
@@ -69,7 +86,7 @@ export class SelectionArray {
         return this.selectedEntityNames.length
     }
 
-    @computed private get selectedEntityNameSet() {
+    @computed get selectedSet() {
         return new Set<EntityName>(this.selectedEntityNames)
     }
 
@@ -127,9 +144,13 @@ export class SelectionArray {
     }
 
     @action.bound toggleSelection(entityName: EntityName) {
-        return this.isEntitySelected(entityName)
+        return this.selectedSet.has(entityName)
             ? this.deselectEntity(entityName)
             : this.selectEntity(entityName)
+    }
+
+    @computed get numAvailableEntityNames() {
+        return this.availableEntityNames.length
     }
 
     @action.bound selectEntity(entityName: EntityName) {
@@ -148,9 +169,5 @@ export class SelectionArray {
             (name) => name !== entityName
         )
         return this
-    }
-
-    isEntitySelected(entityName: EntityName) {
-        return this.selectedEntityNameSet.has(entityName)
     }
 }

--- a/grapher/core/SelectionArray.ts
+++ b/grapher/core/SelectionArray.ts
@@ -1,0 +1,156 @@
+import {
+    EntityCode,
+    EntityId,
+    EntityName,
+    OwidTableSlugs,
+} from "coreTable/OwidTableConstants"
+import { difference, isPresent, mapBy } from "grapher/utils/Util"
+import { action, computed } from "mobx"
+
+interface Entity {
+    entityName: EntityName
+    entityId?: EntityId
+    entityCode?: EntityCode
+}
+
+export interface SelectionManager {
+    selectedEntityNames: EntityName[]
+    availableEntities: Entity[]
+}
+
+export class SelectionArray {
+    constructor(manager: SelectionManager) {
+        this.manager = manager
+    }
+
+    private manager: SelectionManager
+
+    @computed get selectedEntityNames() {
+        return this.manager.selectedEntityNames
+    }
+
+    @computed private get availableEntities() {
+        return this.manager.availableEntities
+    }
+
+    @computed get availableEntityNames() {
+        return this.availableEntities.map((entity) => entity.entityName)
+    }
+
+    private mapBy(col: string, val: string) {
+        return mapBy(this.availableEntities, col, val)
+    }
+
+    @computed get entityNameToCodeMap() {
+        return this.mapBy(OwidTableSlugs.entityName, OwidTableSlugs.entityCode)
+    }
+
+    @computed get entityNameToIdMap() {
+        return this.mapBy(OwidTableSlugs.entityName, OwidTableSlugs.entityId)
+    }
+
+    @computed get entityCodeToNameMap() {
+        return this.mapBy(OwidTableSlugs.entityCode, OwidTableSlugs.entityName)
+    }
+
+    @computed get entityIdToNameMap() {
+        return this.mapBy(OwidTableSlugs.entityId, OwidTableSlugs.entityName)
+    }
+
+    @computed get hasSelection() {
+        return this.selectedEntityNames.length > 0
+    }
+
+    @computed get unselectedEntityNames() {
+        return difference(this.availableEntityNames, this.selectedEntityNames)
+    }
+
+    @computed get numSelectedEntities() {
+        return this.selectedEntityNames.length
+    }
+
+    @computed private get selectedEntityNameSet() {
+        return new Set<EntityName>(this.selectedEntityNames)
+    }
+
+    @computed get selectedEntityCodes(): EntityCode[] {
+        const map = this.entityNameToCodeMap
+        return this.selectedEntityNames
+            .map((name) => map.get(name))
+            .filter(isPresent)
+    }
+
+    @computed get selectedEntityCodesOrNames(): (EntityCode | EntityName)[] {
+        const map = this.entityNameToCodeMap
+        return this.selectedEntityNames.map((name) => map.get(name) ?? name)
+    }
+
+    @computed get allSelectedEntityIds(): EntityId[] {
+        const map = this.entityNameToIdMap
+        return this.selectedEntityNames
+            .map((name) => map.get(name))
+            .filter(isPresent)
+    }
+
+    // Clears and sets selected entities
+    @action.bound setSelectedEntities(entityNames: EntityName[]) {
+        this.clearSelection()
+        return this.addToSelection(entityNames)
+    }
+
+    @action.bound addToSelection(entityNames: EntityName[]) {
+        this.manager.selectedEntityNames = this.selectedEntityNames.concat(
+            entityNames
+        )
+        return this
+    }
+
+    @action.bound setSelectedEntitiesByCode(entityCodes: EntityCode[]) {
+        const map = this.entityCodeToNameMap
+        const codesInData = entityCodes.filter((code) => map.has(code))
+        return this.setSelectedEntities(
+            codesInData.map((code) => map.get(code)!)
+        )
+    }
+
+    @action.bound setSelectedEntitiesByEntityId(entityIds: EntityId[]) {
+        const map = this.entityIdToNameMap
+        return this.setSelectedEntities(entityIds.map((id) => map.get(id)!))
+    }
+
+    @action.bound selectAll() {
+        return this.addToSelection(this.unselectedEntityNames)
+    }
+
+    @action.bound clearSelection() {
+        this.manager.selectedEntityNames = []
+    }
+
+    @action.bound toggleSelection(entityName: EntityName) {
+        return this.isEntitySelected(entityName)
+            ? this.deselectEntity(entityName)
+            : this.selectEntity(entityName)
+    }
+
+    @action.bound selectEntity(entityName: EntityName) {
+        return this.addToSelection([entityName])
+    }
+
+    // Mainly for testing
+    @action.bound selectSample(howMany = 1) {
+        return this.setSelectedEntities(
+            this.availableEntityNames.slice(0, howMany)
+        )
+    }
+
+    @action.bound deselectEntity(entityName: EntityName) {
+        this.manager.selectedEntityNames = this.selectedEntityNames.filter(
+            (name) => name !== entityName
+        )
+        return this
+    }
+
+    isEntitySelected(entityName: EntityName) {
+        return this.selectedEntityNameSet.has(entityName)
+    }
+}

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -25,6 +25,7 @@ import { Tippy } from "grapher/chart/Tippy"
 import { BlankOwidTable, OwidTable } from "coreTable/OwidTable"
 import { CoreColumn } from "coreTable/CoreTableColumns"
 import { Bounds, DEFAULT_BOUNDS } from "grapher/utils/Bounds"
+import { makeSelectionArray } from "grapher/chart/ChartUtils"
 
 interface DataTableState {
     sort: DataTableSortState
@@ -445,11 +446,16 @@ export class DataTable extends React.Component<{
         )
     }
 
+    @computed private get selectionArray() {
+        return makeSelectionArray(this.manager)
+    }
+
     @computed private get entityNames() {
         let tableForEntities = this.table.rootTable
         if (this.manager.minPopulationFilter)
-            tableForEntities = tableForEntities.filterByPopulation(
-                this.manager.minPopulationFilter
+            tableForEntities = tableForEntities.filterByPopulationExcept(
+                this.manager.minPopulationFilter,
+                this.selectionArray.selectedEntityNames
             )
         return union(
             ...this.columnsToShow.map(

--- a/grapher/facetChart/FacetChart.stories.tsx
+++ b/grapher/facetChart/FacetChart.stories.tsx
@@ -20,10 +20,12 @@ export default CSF
 const bounds = new Bounds(0, 0, 1000, 500)
 
 export const OneMetricOneCountryPerChart = () => {
+    const table = SynthesizeGDPTable({
+        entityCount: 4,
+    })
     const manager = {
-        table: SynthesizeGDPTable({
-            entityCount: 4,
-        }).selectAll(),
+        table,
+        selection: table.availableEntityNames,
         yColumnSlug: SampleColumnSlugs.GDP,
         xColumnSlug: SampleColumnSlugs.Population,
     }
@@ -40,15 +42,17 @@ export const OneMetricOneCountryPerChart = () => {
 }
 
 export const MultipleMetricsOneCountryPerChart = () => {
+    const table = SynthesizeFruitTable({
+        entityCount: 4,
+    })
     return (
         <svg width={bounds.width} height={bounds.height}>
             <FacetChart
                 bounds={bounds}
                 chartTypeName={ChartTypeName.LineChart}
                 manager={{
-                    table: SynthesizeFruitTable({
-                        entityCount: 4,
-                    }).selectAll(),
+                    selection: table.availableEntityNames,
+                    table,
                 }}
             />
         </svg>
@@ -58,7 +62,7 @@ export const MultipleMetricsOneCountryPerChart = () => {
 export const OneChartPerMetric = () => {
     const table = SynthesizeGDPTable({
         entityCount: 2,
-    }).selectAll()
+    })
     return (
         <svg width={bounds.width} height={bounds.height}>
             <FacetChart
@@ -67,6 +71,7 @@ export const OneChartPerMetric = () => {
                 manager={{
                     facetStrategy: FacetStrategy.column,
                     yColumnSlugs: table.numericColumnSlugs,
+                    selection: table.availableEntityNames,
                     table,
                 }}
             />

--- a/grapher/facetChart/FacetChart.test.ts
+++ b/grapher/facetChart/FacetChart.test.ts
@@ -6,8 +6,10 @@ import { ChartManager } from "grapher/chart/ChartManager"
 import { FacetStrategy } from "grapher/core/GrapherConstants"
 
 it("can create a new FacetChart", () => {
+    const table = SynthesizeGDPTable({ timeRange: [2000, 2010] })
     const manager: ChartManager = {
-        table: SynthesizeGDPTable({ timeRange: [2000, 2010] }).selectAll(),
+        table,
+        selection: table.availableEntityNames,
     }
     const chart = new FacetChart({ manager })
     expect(chart.series.length).toEqual(2)

--- a/grapher/footer/Footer.jsdom.test.tsx
+++ b/grapher/footer/Footer.jsdom.test.tsx
@@ -2,7 +2,7 @@
 
 import { mount } from "enzyme"
 import React from "react"
-import { Grapher } from "grapher/core/Grapher"
+import { Grapher, GrapherProgrammaticInterface } from "grapher/core/Grapher"
 import {
     SampleColumnSlugs,
     SynthesizeGDPTable,
@@ -10,8 +10,10 @@ import {
 import { DimensionProperty } from "grapher/core/GrapherConstants"
 
 const TestGrapherConfig = () => {
+    const table = SynthesizeGDPTable({ entityCount: 10 })
     return {
-        table: SynthesizeGDPTable({ entityCount: 10 }).selectSample(5),
+        table,
+        selectedEntityNames: table.sampleEntityName(5),
         dimensions: [
             {
                 slug: SampleColumnSlugs.GDP,
@@ -19,7 +21,7 @@ const TestGrapherConfig = () => {
                 variableId: SampleColumnSlugs.GDP as any,
             },
         ],
-    }
+    } as GrapherProgrammaticInterface
 }
 
 test("clicking the sources footer changes tabs", () => {

--- a/grapher/lineCharts/LineChart.stories.tsx
+++ b/grapher/lineCharts/LineChart.stories.tsx
@@ -16,14 +16,18 @@ export default {
 }
 
 export const SingleColumnMultiCountry = () => {
-    const table = SynthesizeGDPTable().selectAll()
+    const table = SynthesizeGDPTable()
     const bounds = new Bounds(0, 0, 500, 250)
     return (
         <div>
             <svg width={500} height={250}>
                 <LineChart
                     bounds={bounds}
-                    manager={{ table, yColumnSlugs: [SampleColumnSlugs.GDP] }}
+                    manager={{
+                        table,
+                        yColumnSlugs: [SampleColumnSlugs.GDP],
+                        selection: table.availableEntityNames,
+                    }}
                 />
             </svg>
             <div>With missing data:</div>
@@ -32,6 +36,7 @@ export const SingleColumnMultiCountry = () => {
                     bounds={bounds}
                     manager={{
                         table: table.dropRandomRows(50),
+                        selection: table.availableEntityNames,
                         yColumnSlugs: [SampleColumnSlugs.GDP],
                     }}
                 />
@@ -44,7 +49,7 @@ export const WithLogScaleAndNegativeAndZeroValues = () => {
     const table = SynthesizeFruitTableWithNonPositives({
         entityCount: 2,
         timeRange: [1900, 2000],
-    }).selectAll()
+    })
     const bounds = new Bounds(0, 0, 500, 250)
     const bounds2 = new Bounds(0, 270, 500, 250)
     return (
@@ -53,6 +58,7 @@ export const WithLogScaleAndNegativeAndZeroValues = () => {
                 bounds={bounds}
                 manager={{
                     table,
+                    selection: table.availableEntityNames,
                     yColumnSlugs: [SampleColumnSlugs.Fruit],
                 }}
             />
@@ -60,6 +66,7 @@ export const WithLogScaleAndNegativeAndZeroValues = () => {
                 bounds={bounds2}
                 manager={{
                     table,
+                    selection: table.availableEntityNames,
                     yColumnSlugs: [SampleColumnSlugs.Fruit],
                     yAxisConfig: { scaleType: ScaleType.log },
                 }}
@@ -72,12 +79,16 @@ export const WithoutCirclesOnPoints = () => {
     const table = SynthesizeGDPTable({
         entityCount: 6,
         timeRange: [1900, 2000],
-    }).selectAll()
+    })
     return (
         <div>
             <svg width={600} height={600}>
                 <LineChart
-                    manager={{ table, yColumnSlugs: [SampleColumnSlugs.GDP] }}
+                    manager={{
+                        table,
+                        yColumnSlugs: [SampleColumnSlugs.GDP],
+                        selection: table.availableEntityNames,
+                    }}
                 />
             </svg>
         </div>
@@ -96,12 +107,15 @@ export const WithAnnotations = () => {
                 fn: (row) => `${row.entityName} is a country`,
             },
         ])
-        .selectAll()
     return (
         <div>
             <svg width={600} height={600}>
                 <LineChart
-                    manager={{ table, yColumnSlugs: [SampleColumnSlugs.GDP] }}
+                    manager={{
+                        table,
+                        yColumnSlugs: [SampleColumnSlugs.GDP],
+                        selection: table.availableEntityNames,
+                    }}
                 />
             </svg>
         </div>
@@ -109,18 +123,24 @@ export const WithAnnotations = () => {
 }
 
 export const MultiColumnSingleCountry = () => {
-    const table = SynthesizeGDPTable().selectSample(1)
+    const table = SynthesizeGDPTable()
     const bounds = new Bounds(0, 0, 500, 250)
     return (
         <div>
             <svg width={500} height={250}>
-                <LineChart bounds={bounds} manager={{ table }} />
+                <LineChart
+                    bounds={bounds}
+                    manager={{ table, selection: table.sampleEntityName(1) }}
+                />
             </svg>
             <div>With missing data:</div>
             <svg width={500} height={250}>
                 <LineChart
                     bounds={bounds}
-                    manager={{ table: table.dropRandomRows(100) }}
+                    manager={{
+                        table: table.dropRandomRows(100),
+                        selection: table.sampleEntityName(1),
+                    }}
                 />
             </svg>
         </div>
@@ -128,11 +148,14 @@ export const MultiColumnSingleCountry = () => {
 }
 
 export const MultiColumnMultiCountry = () => {
-    const table = SynthesizeFruitTable({ entityCount: 5 }).selectAll()
+    const table = SynthesizeFruitTable({ entityCount: 5 })
     const bounds = new Bounds(0, 0, 500, 250)
     return (
         <svg width={500} height={250}>
-            <LineChart bounds={bounds} manager={{ table }} />
+            <LineChart
+                bounds={bounds}
+                manager={{ table, selection: table.availableEntityNames }}
+            />
         </svg>
     )
 }

--- a/grapher/lineCharts/LineChart.test.ts
+++ b/grapher/lineCharts/LineChart.test.ts
@@ -11,15 +11,16 @@ import { ScaleType } from "grapher/core/GrapherConstants"
 import { OwidTable } from "coreTable/OwidTable"
 
 it("can create a new chart", () => {
-    const manager = {
-        table: SynthesizeGDPTable({ timeRange: [2000, 2010] }),
+    const table = SynthesizeGDPTable({ timeRange: [2000, 2010] })
+    const manager: ChartManager = {
+        table,
         yColumnSlugs: [SampleColumnSlugs.GDP],
     }
     const chart = new LineChart({ manager })
 
     expect(chart.failMessage).toBeTruthy()
 
-    manager.table.selectAll()
+    manager.selection = table.availableEntityNames
 
     expect(chart.failMessage).toEqual("")
     expect(chart.series.length).toEqual(2)
@@ -35,11 +36,12 @@ it("can filter points with negative values when using a log scale", () => {
         },
         20,
         1
-    ).selectAll()
+    )
 
     const manager: ChartManager = {
         table,
         yColumnSlugs: [SampleColumnSlugs.Fruit],
+        selection: table.availableEntityNames,
     }
     const chart = new LineChart({ manager })
     expect(chart.series.length).toEqual(2)
@@ -58,8 +60,10 @@ it("can filter points with negative values when using a log scale", () => {
 })
 
 it("will combine entity and column name when we set multi country multi column", () => {
+    const table = SynthesizeGDPTable()
     const manager = {
-        table: SynthesizeGDPTable().selectAll(),
+        table,
+        selection: table.availableEntityNames,
     }
     const chart = new LineChart({ manager })
     expect(chart.series[0].seriesName).toContain(" - ")
@@ -71,10 +75,11 @@ it("can add custom colors", () => {
         time: [2000, 2000, 2001, 2001],
         gdp: [100, 200, 200, 300],
         entityColor: ["blue", "red", "blue", "red"],
-    }).selectAll()
+    })
     const manager = {
         yColumnSlugs: ["gdp"],
         table,
+        selection: table.availableEntityNames,
     }
     const chart = new LineChart({ manager })
     expect(chart.series.map((series) => series.color)).toEqual(["blue", "red"])

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -44,7 +44,11 @@ import {
 } from "./LineChartConstants"
 import { columnToLineChartSeriesArray } from "./LineChartUtils"
 import { OwidTable } from "coreTable/OwidTable"
-import { autoDetectYColumnSlugs, makeClipPath } from "grapher/chart/ChartUtils"
+import {
+    autoDetectYColumnSlugs,
+    makeClipPath,
+    makeSelectionArray,
+} from "grapher/chart/ChartUtils"
 
 const BLUR_COLOR = "#eee"
 
@@ -225,7 +229,9 @@ export class LineChart
     base: React.RefObject<SVGGElement> = React.createRef()
 
     transformTable(table: OwidTable) {
-        table = table.filterBySelectedOnly()
+        table = table.filterBySelectedOnly(
+            this.selectionArray.selectedEntityNames
+        )
 
         if (this.isLogScale)
             table = table.replaceNonPositiveCellsForLogScale(
@@ -275,6 +281,10 @@ export class LineChart
 
     @computed get maxLegendWidth() {
         return this.bounds.width / 3
+    }
+
+    @computed get selectionArray() {
+        return makeSelectionArray(this.manager)
     }
 
     seriesIsBlurred(series: LineChartSeries) {

--- a/grapher/scatterCharts/ScatterPlotChart.stories.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.stories.tsx
@@ -13,8 +13,10 @@ export default {
     component: ScatterPlotChart,
 }
 
+const table = SynthesizeGDPTable({ entityCount: 20 })
 const basicSetup: ScatterPlotManager = {
-    table: SynthesizeGDPTable({ entityCount: 20 }).selectAll(),
+    table,
+    selection: table.availableEntityNames,
     yColumnSlug: SampleColumnSlugs.GDP,
     xColumnSlug: SampleColumnSlugs.Population,
     yAxisConfig: {
@@ -25,11 +27,14 @@ const basicSetup: ScatterPlotManager = {
     },
 }
 
+const table2 = SynthesizeGDPTable({ entityCount: 20 }).filterByTargetTimes(
+    [2000],
+    0
+)
 const oneYear: ScatterPlotManager = {
     ...basicSetup,
-    table: SynthesizeGDPTable({ entityCount: 20 })
-        .selectAll()
-        .filterByTargetTimes([2000], 0),
+    selection: table2.availableEntityNames,
+    table: table2,
 }
 
 const oneYearWithSizeColumn = {
@@ -56,14 +61,17 @@ export const OneYearWithSizeColumn = () => {
 }
 
 export const WithComparisonLinesAndSelection = () => {
+    const table = SynthesizeGDPTable({ entityCount: 20 }).filterByTargetTimes(
+        [2000],
+        0
+    )
     return (
         <svg width={600} height={600}>
             <ScatterPlotChart
                 manager={{
                     ...oneYearWithComparisons,
-                    table: SynthesizeGDPTable({ entityCount: 20 })
-                        .filterByTargetTimes([2000], 0)
-                        .selectSample(5),
+                    table,
+                    selection: table.sampleEntityName(5),
                 }}
             />
         </svg>
@@ -109,7 +117,8 @@ export const LogScales = () => {
 
 export const LogScaleWithNonPositives = () => {
     const manager: ScatterPlotManager = {
-        table: SynthesizeFruitTableWithNonPositives().selectAll(),
+        table: SynthesizeFruitTableWithNonPositives(),
+        selection: table.availableEntityNames,
         yColumnSlug: SampleColumnSlugs.Fruit,
         xColumnSlug: SampleColumnSlugs.Vegetables,
         yAxisConfig: {
@@ -139,14 +148,14 @@ export const MultipleYearsWithConnectedLines = () => {
 }
 
 export const MultipleYearsWithConnectedLinesAndBackgroundLines = () => {
+    const table = SynthesizeGDPTable({ entityCount: 20 })
     return (
         <svg width={600} height={600}>
             <ScatterPlotChart
                 manager={{
                     ...basicSetup,
-                    table: SynthesizeGDPTable({ entityCount: 20 }).selectSample(
-                        2
-                    ),
+                    table,
+                    selection: table.sampleEntityName(2),
                 }}
             />
         </svg>

--- a/grapher/scatterCharts/ScatterPlotChart.test.ts
+++ b/grapher/scatterCharts/ScatterPlotChart.test.ts
@@ -41,12 +41,13 @@ it("can filter points with negative values when using a log scale", () => {
         },
         20,
         1
-    ).selectAll()
+    )
 
     const manager: ScatterPlotManager = {
         table,
         yColumnSlug: SampleColumnSlugs.Fruit,
         xColumnSlug: SampleColumnSlugs.Vegetables,
+        selection: table.availableEntityNames,
         yAxisConfig: {},
         xAxisConfig: {},
     }

--- a/grapher/slopeCharts/SlopeChart.tsx
+++ b/grapher/slopeCharts/SlopeChart.tsx
@@ -48,8 +48,12 @@ import {
 import { CoreColumn } from "coreTable/CoreTableColumns"
 import { OwidTable } from "coreTable/OwidTable"
 import { Color } from "coreTable/CoreTableConstants"
-import { autoDetectYColumnSlugs } from "grapher/chart/ChartUtils"
+import {
+    autoDetectYColumnSlugs,
+    makeSelectionArray,
+} from "grapher/chart/ChartUtils"
 import { ColorSchemeName } from "grapher/color/ColorConstants"
+import { SelectionArray } from "grapher/core/SelectionArray"
 
 @observer
 export class SlopeChart
@@ -114,7 +118,7 @@ export class SlopeChart
             return
         }
 
-        this.inputTable.toggleSelection(hoverKey)
+        this.selectionArray.toggleSelection(hoverKey)
     }
 
     @action.bound onLegendMouseOver(color: string) {
@@ -125,8 +129,12 @@ export class SlopeChart
         this.hoverColor = undefined
     }
 
+    @computed private get selectionArray() {
+        return makeSelectionArray(this.manager)
+    }
+
     @computed private get selectedEntityNames() {
-        return this.inputTable.selectedEntityNames
+        return this.selectionArray.selectedEntityNames
     }
 
     // When the color legend is clicked, toggle selection fo all associated keys
@@ -146,11 +154,11 @@ export class SlopeChart
             intersection(seriesNamesToToggle, this.selectedEntityNames)
                 .length === seriesNamesToToggle.length
         if (areAllSeriesActive)
-            this.inputTable.setSelectedEntities(
+            this.selectionArray.setSelectedEntities(
                 without(this.selectedEntityNames, ...seriesNamesToToggle)
             )
         else
-            this.inputTable.setSelectedEntities(
+            this.selectionArray.setSelectedEntities(
                 this.selectedEntityNames.concat(seriesNamesToToggle)
             )
     }

--- a/grapher/spreadsheet/Spreadsheet.stories.tsx
+++ b/grapher/spreadsheet/Spreadsheet.stories.tsx
@@ -7,7 +7,6 @@ import { Spreadsheet } from "./Spreadsheet"
 import { action, computed, observable } from "mobx"
 import { observer } from "mobx-react"
 import { Bounds } from "grapher/utils/Bounds"
-import { OwidTable } from "coreTable/OwidTable"
 import { ChartTypeName } from "grapher/core/GrapherConstants"
 import { ChartComponentClassMap } from "grapher/chart/ChartTypeMap"
 
@@ -20,9 +19,7 @@ const getRandomTable = () =>
     SynthesizeGDPTable({
         entityCount: 2,
         timeRange: [2020, 2024],
-    })
-        .dropColumns([SampleColumnSlugs.GDP, SampleColumnSlugs.Population])
-        .selectAll() as OwidTable
+    }).dropColumns([SampleColumnSlugs.GDP, SampleColumnSlugs.Population])
 
 @observer
 class Editor extends React.Component {

--- a/grapher/spreadsheet/Spreadsheet.tsx
+++ b/grapher/spreadsheet/Spreadsheet.tsx
@@ -18,10 +18,9 @@ export class Spreadsheet extends React.Component<{
 
     @action.bound private updateFromHot() {
         const newVersion = this.hotTableComponent.current?.hotInstance.getData() as Grid
-        if (newVersion && this.isChanged(newVersion))
-            this.manager.table = new OwidTable(
-                rowsFromGrid(newVersion)
-            ).selectAll()
+        if (newVersion && this.isChanged(newVersion)) {
+            this.manager.table = new OwidTable(rowsFromGrid(newVersion))
+        }
     }
 
     private isChanged(newVersion: Grid) {

--- a/grapher/stackedCharts/StackedAreaChart.stories.tsx
+++ b/grapher/stackedCharts/StackedAreaChart.stories.tsx
@@ -19,9 +19,10 @@ const table = SynthesizeGDPTable(
         timeRange: [1950, 2010],
     },
     seed
-).selectSample(5)
+)
 const entitiesChart: ChartManager = {
     table,
+    selection: table.sampleEntityName(5),
     yColumnSlugs: [SampleColumnSlugs.GDP],
 }
 
@@ -64,8 +65,10 @@ export const EntitiesAsSeriesWithMissingRowsNoInterpolation = () => (
     </svg>
 )
 
+const colTable = SynthesizeFruitTable()
 const columnsChart: ChartManager = {
-    table: SynthesizeFruitTable().selectSample(1),
+    table: colTable,
+    selection: colTable.sampleEntityName(1),
 }
 
 export const ColumnsAsSeries = () => (
@@ -80,14 +83,18 @@ export const ColumnsAsSeriesRelative = () => (
     </svg>
 )
 
-export const ColumnsAsSeriesWithMissingCells = () => (
-    <svg width={600} height={600}>
-        <StackedAreaChart
-            manager={{
-                table: SynthesizeFruitTable()
-                    .selectSample(1)
-                    .replaceRandomCells(200, [SampleColumnSlugs.Fruit]),
-            }}
-        />
-    </svg>
-)
+export const ColumnsAsSeriesWithMissingCells = () => {
+    const table = SynthesizeFruitTable().replaceRandomCells(200, [
+        SampleColumnSlugs.Fruit,
+    ])
+    return (
+        <svg width={600} height={600}>
+            <StackedAreaChart
+                manager={{
+                    selection: table.sampleEntityName(1),
+                    table,
+                }}
+            />
+        </svg>
+    )
+}

--- a/grapher/stackedCharts/StackedAreaChart.tsx
+++ b/grapher/stackedCharts/StackedAreaChart.tsx
@@ -464,7 +464,7 @@ export class StackedAreaChart
                 ? ColorSchemes[this.manager.baseColorScheme]
                 : null) ?? ColorSchemes.stackedAreaDefault
         const seriesCount = this.isEntitySeries
-            ? this.transformedTable.numSelectedEntities
+            ? this.selectionArray.numSelectedEntities
             : this.yColumns.length
         const baseColors = scheme.getColors(seriesCount)
         if (!this.isEntitySeries) baseColors.reverse() // I don't know why

--- a/grapher/stackedCharts/StackedBarChart.stories.tsx
+++ b/grapher/stackedCharts/StackedBarChart.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { StackedBarChart } from "./StackedBarChart"
 import {
+    SampleColumnSlugs,
     SynthesizeFruitTable,
     SynthesizeGDPTable,
 } from "coreTable/OwidTableSynthesizers"
@@ -11,18 +12,23 @@ export default {
 }
 
 export const ColumnsAsSeries = () => {
-    const table = SynthesizeFruitTable().selectSample(1)
+    const table = SynthesizeFruitTable()
+
     return (
         <svg width={600} height={600}>
-            <StackedBarChart manager={{ table }} />
+            <StackedBarChart
+                manager={{ table, selection: table.sampleEntityName(1) }}
+            />
         </svg>
     )
 }
 
 export const EntitiesAsSeries = () => {
+    const table = SynthesizeGDPTable({ entityCount: 5 })
     const manager = {
-        table: SynthesizeGDPTable({ entityCount: 5 }).selectAll(),
-        yColumnSlugs: ["Population"],
+        table,
+        selection: table.availableEntityNames,
+        yColumnSlugs: [SampleColumnSlugs.Population],
     }
 
     return (
@@ -33,11 +39,11 @@ export const EntitiesAsSeries = () => {
 }
 
 export const EntitiesAsSeriesWithMissingRows = () => {
+    const table = SynthesizeGDPTable({ entityCount: 5 }).dropRandomRows(30)
     const manager = {
-        table: SynthesizeGDPTable({ entityCount: 5 })
-            .selectAll()
-            .dropRandomRows(30),
-        yColumnSlugs: ["Population"],
+        table,
+        selection: table.availableEntityNames,
+        yColumnSlugs: [SampleColumnSlugs.Population],
     }
 
     return (

--- a/grapher/utils/Util.ts
+++ b/grapher/utils/Util.ts
@@ -1067,3 +1067,11 @@ export function sortNumeric<T>(
 // A predicate for filtering an array of nulls and undefineds that returns the correct type
 export const isPresent = <T>(t: T | undefined | null | void): t is T =>
     t !== undefined && t !== null
+
+export const mapBy = (arr: any[], key: string, value: string) => {
+    const map = new Map()
+    arr.forEach((val) => {
+        map.set(val[key], val[value])
+    })
+    return map
+}

--- a/site/globalEntityControl/GlobalEntitySelection.ts
+++ b/site/globalEntityControl/GlobalEntitySelection.ts
@@ -65,10 +65,10 @@ export function subscribeGrapherToGlobalEntitySelection(
             // This implements "override" mode only!
             if (mode === GlobalEntitySelectionModes.override) {
                 if (selectedEntities.length > 0)
-                    grapher.table.setSelectedEntitiesByCode(
+                    grapher.selection.setSelectedEntitiesByCode(
                         selectedEntities.map((entity) => entity.code)
                     )
-                else grapher.table.clearSelection()
+                else grapher.selection.clearSelection()
             }
         },
         { fireImmediately: true }


### PR DESCRIPTION
This moves—almost verbatim—the selection code from OwidTable to the new `SelectionArray` class ("Selection" is a dom class so just went with SelectionArray for now).

So Tables no longer have a notion of selection, which makes them simpler, and importantly allows us to keep selection order for color assignment. Selection is also pretty simple now too. And it's simpler for Explorer Country Picker.

One note: when writing tests, instead of:

```
{table: someTable.selectAll()}
```
You do have to pass in a selection separately like:

```
{table,
selection: ["USA"]}
```

