### PR TITLE
Restore CovidExplorer Datatables

### DIFF
--- a/coreTable/OwidTableConstants.ts
+++ b/coreTable/OwidTableConstants.ts
@@ -38,7 +38,6 @@ export interface OwidColumnDef extends CoreColumnDef {
     coverage?: string
     datasetId?: string
     datasetName?: string
-    display?: LegacyVariableDisplayConfigInterface
     source?: OwidSource
     isDailyMeasurement?: boolean // todo: remove after mysql time refactor
     annotationsColumnSlug?: ColumnSlug

--- a/coreTable/OwidTableConstants.ts
+++ b/coreTable/OwidTableConstants.ts
@@ -7,7 +7,11 @@ import {
     Time,
     Year,
 } from "./CoreTableConstants"
-import { LegacyVariableId, OwidSource } from "./LegacyVariableCode"
+import {
+    LegacyVariableDisplayConfigInterface,
+    LegacyVariableId,
+    OwidSource,
+} from "./LegacyVariableCode"
 
 export enum OwidTableSlugs {
     entityName = "entityName",
@@ -34,6 +38,7 @@ export interface OwidColumnDef extends CoreColumnDef {
     coverage?: string
     datasetId?: string
     datasetName?: string
+    display?: LegacyVariableDisplayConfigInterface
     source?: OwidSource
     isDailyMeasurement?: boolean // todo: remove after mysql time refactor
     annotationsColumnSlug?: ColumnSlug

--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -879,9 +879,10 @@ export class CovidExplorer
             this.colorScales[params.colorStrategy]
         )
 
-        grapher.dataTableColumnSlugsToShow = covidTableWithAdditionalColumnsAndFilters.columnSlugsToShowInDataTable(
-            params
-        )
+        grapher.dataTableColumnSlugsToShow = [this.yColumn.slug]
+        // grapher.dataTableColumnSlugsToShow = covidTableWithAdditionalColumnsAndFilters.columnSlugsToShowInDataTable(
+        //     params
+        // )
 
         grapher.id = this.sourceChartId
         grapher.baseQueryString = queryParamsToStr(this.params)

--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -22,7 +22,11 @@ import {
     isPresent,
 } from "grapher/utils/Util"
 import { ExplorerControlPanel } from "explorer/client/ExplorerControls"
-import { allAvailableQueryStringCombos, CovidQueryParams } from "./CovidParams"
+import {
+    allAvailableQueryStringCombos,
+    columnDisplayName,
+    CovidQueryParams,
+} from "./CovidParams"
 import { CovidExplorerTable } from "./CovidExplorerTable"
 import { BAKED_BASE_URL } from "settings"
 import moment from "moment"
@@ -453,31 +457,11 @@ export class CovidExplorer
     }
 
     @computed private get chartTitle() {
-        let title = ""
         const params = this.constrainedParams
-        const interval = params.interval
 
         if (params.yColumn || params.xColumn)
             return startCase(`${this.yColumn.name} by ${this.xColumn?.name}`)
-
-        const isCumulative = interval === IntervalOptions.total
-        const freq = params.intervalTitle
-        if (params.cfrMetric)
-            title = `Case fatality rate of the ongoing COVID-19 pandemic`
-        else if (params.positiveTestRate)
-            title = `The share of ${
-                isCumulative ? "" : "daily "
-            }COVID-19 tests that are positive`
-        else if (params.testsPerCaseMetric)
-            title = `${
-                isCumulative ? `Cumulative tests` : `Tests`
-            } conducted per confirmed case of COVID-19`
-        else if (params.testsMetric) title = `${freq} COVID-19 tests`
-        else if (params.deathsMetric)
-            title = `${freq} confirmed COVID-19 deaths`
-        else if (params.casesMetric) title = `${freq} confirmed COVID-19 cases`
-
-        return title + this.perCapitaTitle(params.metricName)
+        else return columnDisplayName(params)
     }
 
     @computed private get weekSubtitle() {

--- a/explorer/covidExplorer/CovidExplorerTable.ts
+++ b/explorer/covidExplorer/CovidExplorerTable.ts
@@ -176,6 +176,10 @@ export class CovidExplorerTable extends OwidTable {
     }
 
     columnSlugsToShowInDataTable(params: CovidConstrainedQueryParams) {
+        const multiMetricTable = params.tableMetrics
+            ? params.tableMetrics.length > 0
+            : false
+
         return this.paramsForDataTableColumns(params).map(
             (params) =>
                 makeColumnDefFromParams(params, this.columnDefTemplates).slug

--- a/explorer/covidExplorer/CovidExplorerTable.ts
+++ b/explorer/covidExplorer/CovidExplorerTable.ts
@@ -176,10 +176,6 @@ export class CovidExplorerTable extends OwidTable {
     }
 
     columnSlugsToShowInDataTable(params: CovidConstrainedQueryParams) {
-        const multiMetricTable = params.tableMetrics
-            ? params.tableMetrics.length > 0
-            : false
-
         return this.paramsForDataTableColumns(params).map(
             (params) =>
                 makeColumnDefFromParams(params, this.columnDefTemplates).slug

--- a/explorer/covidExplorer/CovidParams.ts
+++ b/explorer/covidExplorer/CovidParams.ts
@@ -475,7 +475,7 @@ export const makeColumnDefFromParams = (
 
     const display = def.display || {}
     display.name = columnDisplayName(params)
-    display.unit = def.display?.unit ?? ""
+    display.unit = def.display?.unit
     def.display = display
 
     // Show decimal places for rolling average & per capita variables

--- a/explorer/covidExplorer/MegaCsv.ts
+++ b/explorer/covidExplorer/MegaCsv.ts
@@ -67,7 +67,7 @@ export const MegaCsvToCovidExplorerTable = (
     )
         .updateColumnsToHideInDataTable()
         .loadColumnDefTemplatesFromGrapherBackend(
-            metaDataFromGrapherBackend.variables
+            metaDataFromGrapherBackend?.variables
         )
 }
 

--- a/explorer/covidExplorer/MegaCsv.ts
+++ b/explorer/covidExplorer/MegaCsv.ts
@@ -57,7 +57,6 @@ export const MegaCsvToCovidExplorerTable = (
     )
 
     const tableWithRows = addGroups(coreTable)
-
     return new CovidExplorerTable(
         tableWithRows.columnStore,
         tableWithRows.defs,
@@ -67,7 +66,9 @@ export const MegaCsvToCovidExplorerTable = (
         }
     )
         .updateColumnsToHideInDataTable()
-        .loadColumnDefTemplatesFromGrapherBackend(metaDataFromGrapherBackend)
+        .loadColumnDefTemplatesFromGrapherBackend(
+            metaDataFromGrapherBackend.variables
+        )
 }
 
 const addGroups = (coreTable: CoreTable) => {

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -205,6 +205,7 @@ export class DataTable extends React.Component<{
                 actualColumn.displayName !== ""
                     ? actualColumn.displayName
                     : actualColumn.name
+
             const dimensionHeaderText = (
                 <React.Fragment>
                     <span className="name">{upperFirst(columnName)}</span>

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -452,7 +452,7 @@ export class DataTable extends React.Component<{
     }
 
     @computed private get entityNames() {
-        let tableForEntities = this.table.rootTable
+        let tableForEntities = this.table
         if (this.manager.minPopulationFilter)
             tableForEntities = tableForEntities.filterByPopulationExcept(
                 this.manager.minPopulationFilter,


### PR DESCRIPTION
Variety of fixes for the CovidExplorer DataTables.
This adds back titles, units, data, and source grapher data.

Still need to restore MultiMetric DataTables, but need to repair CovidExplorer query params first.