### PR TITLE
CovidExplorer Query Params Fixes

### DIFF
--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -1,6 +1,9 @@
 import React from "react"
 import ReactDOM from "react-dom"
-import { GrapherInterface } from "grapher/core/GrapherInterface"
+import {
+    GrapherInterface,
+    GrapherQueryParams,
+} from "grapher/core/GrapherInterface"
 import { Grapher } from "grapher/core/Grapher"
 import {
     computed,
@@ -660,13 +663,20 @@ export class CovidExplorer
         new UrlBinder().bindToWindow(url)
     }
 
+    @computed private get paramsFromGrapher(): GrapherQueryParams {
+        return {
+            tab: this.grapher.tab,
+            time: this.grapher.timeParam,
+        }
+    }
+
     @computed get params() {
         return {
             ...this.writeableParams.toQueryParams,
+            ...this.paramsFromGrapher,
             country: EntityUrlBuilder.entitiesToQueryParam(
                 Array.from(this.selectionArray.selectedEntityCodes)
             ),
-            tab: this.grapher.tab,
         }
     }
 

--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -451,12 +451,6 @@ export class CovidExplorer
         }
     }
 
-    private perCapitaTitle(metric: MetricOptions) {
-        return this.constrainedParams.perCapita
-            ? " " + this.perCapitaOptions[perCapitaDivisorByMetric(metric)]
-            : ""
-    }
-
     @computed private get chartTitle() {
         const params = this.constrainedParams
 

--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -901,6 +901,7 @@ export const PerfTest = async () => {
     // table.dumpPipeline()
     // timer.tick("dumped pipelin")
 
+    const table = MegaCsvToCovidExplorerTable(megaCsv).appendEveryColumn()
     timer.tick("csv to covid explorer table with every possible column")
     // table.dumpPipeline()
     // timer.tick("dumped pipelin")

--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -666,6 +666,7 @@ export class CovidExplorer
             country: EntityUrlBuilder.entitiesToQueryParam(
                 Array.from(this.selectionArray.selectedEntityCodes)
             ),
+            tab: this.grapher.tab,
         }
     }
 

--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -9,7 +9,6 @@ import {
     IReactionDisposer,
     Lambda,
     reaction,
-    autorun,
 } from "mobx"
 import { observer } from "mobx-react"
 import { bind } from "decko"
@@ -58,7 +57,7 @@ import {
     ScaleType,
 } from "grapher/core/GrapherConstants"
 import { LegacyChartDimensionInterface } from "coreTable/LegacyVariableCode"
-import { queryParamsToStr } from "utils/client/url"
+import { queryParamsToStr, strToQueryParams } from "utils/client/url"
 import {
     fetchRequiredData,
     perCapitaDivisorByMetric,
@@ -620,6 +619,10 @@ export class CovidExplorer
             this
         )
 
+        grapher.populateFromQueryParams(
+            strToQueryParams(this.props.queryStr ?? "")
+        )
+
         this.selectionArray.setSelectedEntitiesByCode(
             Array.from(this.writeableParams.selectedCountryCodes.values())
         )
@@ -887,7 +890,6 @@ export const PerfTest = async () => {
     // table.dumpPipeline()
     // timer.tick("dumped pipelin")
 
-    const table = MegaCsvToCovidExplorerTable(megaCsv).appendEveryColumn()
     timer.tick("csv to covid explorer table with every possible column")
     // table.dumpPipeline()
     // timer.tick("dumped pipelin")

--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -87,6 +87,7 @@ import { CovidAnnotationColumnDefs } from "./CovidAnnotations"
 import { Timer } from "coreTable/CoreTableUtils"
 import { CountryPickerManager } from "grapher/controls/countryPicker/CountryPickerConstants"
 import { SelectionArray, SelectionManager } from "grapher/core/SelectionArray"
+import { EntityUrlBuilder } from "grapher/core/EntityUrlBuilder"
 
 interface BootstrapProps {
     containerNode: HTMLElement
@@ -663,7 +664,12 @@ export class CovidExplorer
     }
 
     @computed get params() {
-        return this.writeableParams.toQueryParams
+        return {
+            ...this.writeableParams.toQueryParams,
+            country: EntityUrlBuilder.entitiesToQueryParam(
+                Array.from(this.selectionArray.selectedEntityCodes)
+            ),
+        }
     }
 
     disposers: (IReactionDisposer | Lambda)[] = []


### PR DESCRIPTION
This PR fixes issues with the CovidExplorer URL:
- country param now reflects actual selection
- CovidExplorer URL now includes tab and year selection from the Grapher
- CovidExplorer now feeds its params to the Grapher

Unrelatedly, it also removes an unused `perCapitaTitle` function.
