### PR TITLE
fix: if a map displays two legends, don't overlay them over one another

### DIFF
--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -496,17 +496,23 @@ export class MapChart
         return 0
     }
 
-    @computed get legendY(): number {
+    @computed get legendYNumeric(): number {
         const {
-            bounds,
             numericLegend,
-            categoryLegend,
+            numericLegendHeight,
+            bounds,
             categoryLegendHeight,
         } = this
+
         if (numericLegend)
             return (
-                bounds.bottom - categoryLegendHeight - numericLegend!.height - 4
+                bounds.bottom - categoryLegendHeight - numericLegendHeight - 4
             )
+        return 0
+    }
+
+    @computed get legendYCategorical(): number {
+        const { categoryLegend, bounds, categoryLegendHeight } = this
 
         if (categoryLegend) return bounds.bottom - categoryLegendHeight
         return 0

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -496,7 +496,14 @@ export class MapChart
         return 0
     }
 
-    @computed get legendYNumeric(): number {
+    @computed get categoryLegendY(): number {
+        const { categoryLegend, bounds, categoryLegendHeight } = this
+
+        if (categoryLegend) return bounds.bottom - categoryLegendHeight
+        return 0
+    }
+
+    @computed get numericLegendY(): number {
         const {
             numericLegend,
             numericLegendHeight,
@@ -508,13 +515,6 @@ export class MapChart
             return (
                 bounds.bottom - categoryLegendHeight - numericLegendHeight - 4
             )
-        return 0
-    }
-
-    @computed get legendYCategorical(): number {
-        const { categoryLegend, bounds, categoryLegendHeight } = this
-
-        if (categoryLegend) return bounds.bottom - categoryLegendHeight
         return 0
     }
 

--- a/grapher/mapCharts/MapColorLegends.tsx
+++ b/grapher/mapCharts/MapColorLegends.tsx
@@ -55,7 +55,8 @@ interface MarkLine {
 export interface MapLegendManager {
     fontSize?: number
     legendX?: number
-    legendY?: number
+    legendYCategorical?: number
+    legendYNumeric?: number
     legendWidth?: number
     legendHeight?: number
     scale?: number
@@ -80,8 +81,12 @@ class MapLegend extends React.Component<{
         return this.manager.legendX ?? 0
     }
 
-    @computed get legendY() {
-        return this.manager.legendY ?? 0
+    @computed get legendYCategorical() {
+        return this.manager.legendYCategorical ?? 0
+    }
+
+    @computed get legendYNumeric() {
+        return this.manager.legendYNumeric ?? 0
     }
 
     @computed get legendWidth() {
@@ -283,7 +288,7 @@ export class MapNumericColorLegend extends MapLegend {
     @computed get bounds() {
         return new Bounds(
             this.legendX,
-            this.legendY,
+            this.legendYNumeric,
             this.legendWidth,
             this.legendHeight
         )
@@ -350,7 +355,7 @@ export class MapNumericColorLegend extends MapLegend {
         //Bounds.debug([this.bounds])
 
         const borderColor = "#333"
-        const bottomY = this.legendY + height
+        const bottomY = this.legendYNumeric + height
 
         return (
             <g ref={this.base} className="numericColorLegend">
@@ -523,7 +528,7 @@ export class MapCategoricalColorLegend extends MapLegend {
                             >
                                 <rect
                                     x={this.legendX + mark.x}
-                                    y={this.legendY + mark.y}
+                                    y={this.legendYCategorical + mark.y}
                                     width={mark.rectSize}
                                     height={mark.rectSize}
                                     fill={mark.bin.color}
@@ -533,7 +538,10 @@ export class MapCategoricalColorLegend extends MapLegend {
                                 ,
                                 <text
                                     x={this.legendX + mark.label.bounds.x}
-                                    y={this.legendY + mark.label.bounds.y}
+                                    y={
+                                        this.legendYCategorical +
+                                        mark.label.bounds.y
+                                    }
                                     fontSize={mark.label.fontSize}
                                     dominantBaseline="hanging"
                                 >

--- a/grapher/mapCharts/MapColorLegends.tsx
+++ b/grapher/mapCharts/MapColorLegends.tsx
@@ -55,8 +55,8 @@ interface MarkLine {
 export interface MapLegendManager {
     fontSize?: number
     legendX?: number
-    legendYCategorical?: number
-    legendYNumeric?: number
+    categoryLegendY?: number
+    numericLegendY?: number
     legendWidth?: number
     legendHeight?: number
     scale?: number
@@ -81,12 +81,12 @@ class MapLegend extends React.Component<{
         return this.manager.legendX ?? 0
     }
 
-    @computed get legendYCategorical() {
-        return this.manager.legendYCategorical ?? 0
+    @computed get categoryLegendY() {
+        return this.manager.categoryLegendY ?? 0
     }
 
-    @computed get legendYNumeric() {
-        return this.manager.legendYNumeric ?? 0
+    @computed get numericLegendY() {
+        return this.manager.numericLegendY ?? 0
     }
 
     @computed get legendWidth() {
@@ -288,7 +288,7 @@ export class MapNumericColorLegend extends MapLegend {
     @computed get bounds() {
         return new Bounds(
             this.legendX,
-            this.legendYNumeric,
+            this.numericLegendY,
             this.legendWidth,
             this.legendHeight
         )
@@ -355,7 +355,7 @@ export class MapNumericColorLegend extends MapLegend {
         //Bounds.debug([this.bounds])
 
         const borderColor = "#333"
-        const bottomY = this.legendYNumeric + height
+        const bottomY = this.numericLegendY + height
 
         return (
             <g ref={this.base} className="numericColorLegend">
@@ -528,7 +528,7 @@ export class MapCategoricalColorLegend extends MapLegend {
                             >
                                 <rect
                                     x={this.legendX + mark.x}
-                                    y={this.legendYCategorical + mark.y}
+                                    y={this.categoryLegendY + mark.y}
                                     width={mark.rectSize}
                                     height={mark.rectSize}
                                     fill={mark.bin.color}
@@ -539,7 +539,7 @@ export class MapCategoricalColorLegend extends MapLegend {
                                 <text
                                     x={this.legendX + mark.label.bounds.x}
                                     y={
-                                        this.legendYCategorical +
+                                        this.categoryLegendY +
                                         mark.label.bounds.y
                                     }
                                     fontSize={mark.label.fontSize}


### PR DESCRIPTION
This fixes special snowflake charts like this one http://localhost:3030/grapher/yaws-status-and-case-numbers, which display both a categorical and a numeric legend.

This fix is very ugly, but somehow `legendY` needs to know whether the requesting legend is a numeric or categorical one. And it works.
Please let me know if you can think of a better way to solve this issue, I'm all ears.

## Before
![image](https://user-images.githubusercontent.com/2641501/98043392-6dd17980-1e25-11eb-8de4-6bb9d6e5c278.png)


## After
![image](https://user-images.githubusercontent.com/2641501/98043347-5f835d80-1e25-11eb-8c24-f30aa810f360.png)