### PR TITLE
Unskip Map Tests

### DIFF
--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -457,7 +457,9 @@ export class Grapher
     @observable private selectedEntitiesInQueryParam: string[] = []
 
     @action.bound private setTimeFromTimeQueryParam(time: string) {
-        this.timelineHandleTimeBounds = getTimeDomainFromQueryString(time)
+        this.timelineHandleTimeBounds = getTimeDomainFromQueryString(time).map(
+            (time) => findClosestTime(this.times, time) ?? time
+        ) as TimeBounds
     }
 
     @computed private get isChartOrMapTab() {

--- a/grapher/core/GrapherWithChartTypes.jsdom.test.tsx
+++ b/grapher/core/GrapherWithChartTypes.jsdom.test.tsx
@@ -18,7 +18,7 @@ describe("grapher and map charts", () => {
         expect(grapher.times).toEqual([2000, 2010])
 
         // Todo: not actually clear what the desired behavior is here (we have a query string time not actually an available time.)
-        it.skip("sets correct time handles", () => {
+        it("sets correct time handles", () => {
             expect(grapher.startHandleTimeBound).toBe(2000)
             expect(grapher.endHandleTimeBound).toBe(2000)
         })


### PR DESCRIPTION
Tiny change -- makes it so that the timelineHandles use the closest data point to the query string `time` param instead of the param itself.