### PR TITLE
Fix: Use isMissing instead of undefined column check

### DIFF
--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -477,7 +477,9 @@ export class CoreTable<
     // Todo: remove this. Generally this should not be called until the data is loaded. Even then, all calls should probably be made
     // on the column itself, and not tied tightly to the idea of a time column.
     @imemo get timeColumnFormatFunction() {
-        return this.timeColumn ? this.timeColumn.formatValue : formatYear
+        return !this.timeColumn.isMissing
+            ? this.timeColumn.formatValue
+            : formatYear
     }
 
     formatTime(value: any) {

--- a/coreTable/CoreTableColumns.ts
+++ b/coreTable/CoreTableColumns.ts
@@ -61,6 +61,10 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
         return val
     }
 
+    @imemo get isMissing(): boolean {
+        return this instanceof MissingColumn
+    }
+
     @imemo get unit() {
         return this.def.unit || this.display?.unit || ""
     }

--- a/coreTable/OwidTable.ts
+++ b/coreTable/OwidTable.ts
@@ -176,7 +176,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
 
     // Does a stable sort by time. You can refer to this table for fast time filtering.
     @imemo private get sortedByTime() {
-        if (!this.timeColumn) return this
+        if (this.timeColumn.isMissing) return this
         return this.sortBy([this.timeColumn.slug])
     }
 
@@ -352,7 +352,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         startTimeBound: TimeBound,
         columnSlugs: ColumnSlug[]
     ) {
-        if (!this.timeColumn) return this
+        if (this.timeColumn.isMissing) return this
         const timeColumnSlug = this.timeColumn.slug
         const newDefs = this.defs.map((def) => {
             if (columnSlugs.includes(def.slug))
@@ -499,10 +499,10 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         const tolerance = toleranceOverride ?? column.display.tolerance ?? 0
         const entityNameSlug = this.entityNameSlug
 
-        const timeColumnOfTable =
-            this.timeColumn ??
-            // CovidTable does not have a day or year column so we need to use time.
-            (this.get(OwidTableSlugs.time) as CoreColumn)
+        const timeColumnOfTable = !this.timeColumn.isMissing
+            ? this.timeColumn
+            : // CovidTable does not have a day or year column so we need to use time.
+              (this.get(OwidTableSlugs.time) as CoreColumn)
 
         const maybeTimeColumnOfValue =
             getOriginalTimeColumnSlug(this, columnSlug) ??
@@ -582,7 +582,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     ) {
         const indexMap = this.rowIndicesByEntityName
         const timeColumn = this.timeColumn
-        if (!timeColumn) return []
+        if (this.timeColumn.isMissing) return []
         const timeValues = timeColumn.allValues
         return entityNames
             .map((name) => {

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1106,9 +1106,9 @@ export class Grapher
     }
 
     @computed private get timeTitleSuffix() {
-        if (!this.table.timeColumn) return "" // Do not show year until data is loaded
-        const { startTime, endTime } = this
         const timeColumn = this.table.timeColumn
+        if (timeColumn.isMissing) return "" // Do not show year until data is loaded
+        const { startTime, endTime } = this
         const time =
             startTime === endTime
                 ? timeColumn.formatValue(startTime)
@@ -2070,7 +2070,8 @@ export class Grapher
 
     formatTime(value: Time) {
         const timeColumn = this.table.timeColumn
-        if (!timeColumn) return this.table.timeColumnFormatFunction(value)
+        if (timeColumn.isMissing)
+            return this.table.timeColumnFormatFunction(value)
         return isMobile()
             ? timeColumn.formatValueForMobile(value)
             : timeColumn.formatValue(value)

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -191,7 +191,7 @@ export class MapChart
     }
 
     @computed get failMessage() {
-        if (!this.mapColumn) return "Missing map column"
+        if (this.mapColumn.isMissing) return "Missing map column"
         return ""
     }
 
@@ -307,7 +307,7 @@ export class MapChart
             targetTime,
             formatTooltipValue,
         } = this
-        if (!mapColumn) return []
+        if (mapColumn.isMissing) return []
         if (targetTime === undefined) return []
 
         return mapColumn.owidRows

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -126,7 +126,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
         const { timeColumn } = this.inputTable
         const { renderSparkBars, barColor, tooltipTarget } = this
 
-        const displayTime = timeColumn
+        const displayTime = !timeColumn.isMissing
             ? timeColumn.formatValue(targetTime)
             : targetTime
         const displayDatumTime =

--- a/grapher/slopeCharts/SlopeChart.tsx
+++ b/grapher/slopeCharts/SlopeChart.tsx
@@ -301,7 +301,7 @@ export class SlopeChart
     }
 
     @computed get failMessage() {
-        if (!this.yColumn) return "Missing Y column"
+        if (this.yColumn.isMissing) return "Missing Y column"
         else if (isEmpty(this.series)) return "No matching data"
         return ""
     }
@@ -356,7 +356,7 @@ export class SlopeChart
         Color | undefined
     > {
         const { colorScale, colorColumn } = this
-        if (!colorColumn) return new Map()
+        if (colorColumn.isMissing) return new Map()
 
         const colorByEntity = new Map<SeriesName, Color | undefined>()
 


### PR DESCRIPTION
There are a bunch in the `CovidExplorer` that I didn't fix, let me know if I should.

Also, some of these checks may be redundant – I wasn't paying attention to that, just trying to get it to the previous state.

Also, no tests added, and it seems it might be a bit of an effort to design test cases for all?