### PR TITLE
Remove redundant esnext.asynciterable in tsconfig

### DIFF
--- a/tsconfig.client.json
+++ b/tsconfig.client.json
@@ -12,7 +12,7 @@
         "experimentalDecorators": true,
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
-        "lib": ["dom", "es2020", "esnext.asynciterable"],
+        "lib": ["dom", "es2020"],
         "baseUrl": ".",
         "plugins": [],
         "keyofStringsOnly": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,
         "forceConsistentCasingInFileNames": true,
-        "lib": ["dom", "es2020", "esnext.asynciterable"],
+        "lib": ["dom", "es2020"],
         "baseUrl": ".",
         "plugins": [],
         "keyofStringsOnly": true,


### PR DESCRIPTION
Having [recently bumped the es version in tsconfigs](https://github.com/owid/owid-grapher/commit/467c48765931c32f79bde6bc5161868a2d9522a8) (from es7 to es2020), I believe `esnext.asynciterable` is now redundant as it was made part of ES2018 (see https://developer.mozilla.org/en-US/docs/Archive/Web/JavaScript/ECMAScript_Next_support_in_Mozilla). 