### PR TITLE
fix: introduce new transform type `UpdateColumnDefsAndApply`

### DIFF
--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -70,7 +70,7 @@ const TransformsRequiringCompute = new Set([
     TransformType.AppendRows,
     TransformType.AppendColumns,
     TransformType.UpdateRows,
-    TransformType.UpdateColumnDefs,
+    TransformType.UpdateColumnDefsAndApply,
 ])
 
 interface AdvancedOptions {

--- a/coreTable/CoreTableConstants.ts
+++ b/coreTable/CoreTableConstants.ts
@@ -41,6 +41,7 @@ export enum TransformType {
     SortColumns = "SortColumns",
     AppendColumns = "AppendColumns", // This will run column transform fns.
     UpdateColumnDefs = "UpdateColumnDefs", // do not use for updates that add a column transform fn.
+    UpdateColumnDefsAndApply = "UpdateColumnDefsAndApply", // use this for updates that add a column transform fn.
     RenameColumns = "RenameColumns",
     InverseFilterColumns = "InverseFilterColumns",
 }

--- a/coreTable/OwidTable.ts
+++ b/coreTable/OwidTable.ts
@@ -301,7 +301,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
             {
                 parent: this,
                 tableDescription: `Transformed ${columnSlug} column to be % contribution of each entity for that time`,
-                transformCategory: TransformType.UpdateColumnDefs,
+                transformCategory: TransformType.UpdateColumnDefsAndApply,
             }
         )
     }


### PR DESCRIPTION
Turns out, [that change](https://github.com/owid/owid-grapher/commit/fb9a851a5d2cfadc29d07453760f23fed7d84365) broke [relative mode](https://tufte.owid.cloud/admin/test/embeds?ids=619) again.

As a quick stopgap, this introduces a new transform type `UpdateColumnDefsAndApply` (naming up for debate) that recomputes values, whereas the "standard" `UpdateColumnDefs` one doesn't.

Without this fix `toPercentageFromEachColumnForEachEntityAndTime` is broken.