### PR TITLE
New: authors can now define column source information in Explorers

### DIFF
--- a/coreTable/CoreColumnDef.ts
+++ b/coreTable/CoreColumnDef.ts
@@ -48,6 +48,14 @@ export interface CoreColumnDef {
     growthRateGenerator?: () => number // A function for generating synthetic data for testing. Can probably combine with the above.
     display?: LegacyVariableDisplayConfigInterface // todo: move to OwidTable
     color?: Color // A column can have a color for use in charts.
+
+    // Source information:
+    sourceName?: string
+    sourceLink?: string
+    dataPublishedBy?: string
+    dataPublisherSource?: string
+    retrievedDate?: string
+    additionalInfo?: string
 }
 
 // todo: remove index param?

--- a/coreTable/CoreTableColumns.ts
+++ b/coreTable/CoreTableColumns.ts
@@ -30,6 +30,7 @@ import { LegacyVariableDisplayConfig } from "./LegacyVariableCode"
 import { getOriginalTimeColumnSlug } from "./OwidTableUtil"
 import { imemo } from "./CoreTableUtils"
 import moment from "moment"
+import { OwidSource } from "./OwidSource"
 
 interface ColumnSummary {
     numInvalidCells: number
@@ -371,6 +372,24 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
 
     @imemo get valuesAscending() {
         return sortNumeric(this.parsedValues.slice())
+    }
+
+    // todo: cleanup this method. figure out what source properties should be on CoreTable vs OwidTable.
+    get source(): OwidSource {
+        const { def } = this
+
+        // todo: flatten out source onto column def in Grapher backend, then can remove this.
+        const { source } = def as any
+        if (source) return source as OwidSource
+
+        return {
+            name: def.sourceName,
+            link: def.sourceLink,
+            dataPublishedBy: def.dataPublishedBy,
+            dataPublisherSource: def.dataPublisherSource,
+            retrievedDate: def.retrievedDate,
+            additionalInfo: def.additionalInfo,
+        } as OwidSource
     }
 
     // todo: remove. should not be on coretable

--- a/coreTable/OwidSource.ts
+++ b/coreTable/OwidSource.ts
@@ -1,5 +1,5 @@
 export interface OwidSource {
-    id: number
+    id?: number
 
     /**
      * Source name displayed on charts using this dataset. For academic papers, the name of the source should be "Authors (year)" e.g.

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1132,13 +1132,13 @@ export class Grapher
                 column.name === "Total population (Gapminder)"
             )
                 return false
-            return !!(column.def as OwidColumnDef).source
+            return !!column.source.name
         })
     }
 
     @computed private get defaultSourcesLine() {
         let sourceNames = this.columnsWithSources.map(
-            (column) => (column.def as OwidColumnDef)?.source?.name || ""
+            (column) => column.source.name ?? ""
         )
 
         // Shorten automatic source names for certain major sources

--- a/grapher/sourcesTab/SourcesTab.tsx
+++ b/grapher/sourcesTab/SourcesTab.tsx
@@ -1,4 +1,4 @@
-import { min, max, linkify } from "grapher/utils/Util"
+import { linkify } from "grapher/utils/Util"
 import * as React from "react"
 import { computed } from "mobx"
 import { observer } from "mobx-react"
@@ -30,12 +30,11 @@ export class SourcesTab extends React.Component<{
     }
 
     private renderSource(column: CoreColumn) {
-        const def = column.def as OwidColumnDef
-        const source = def.source!
-        const { table } = column
+        const { table, slug, source, def } = column
+        const { datasetId, coverage } = def as OwidColumnDef
 
         const editUrl = this.manager.showAdminControls
-            ? `${this.props.manager.adminBaseUrl}/admin/datasets/${def.datasetId}`
+            ? `${this.props.manager.adminBaseUrl}/admin/datasets/${datasetId}`
             : undefined
 
         const { minTime, maxTime } = column
@@ -46,7 +45,7 @@ export class SourcesTab extends React.Component<{
             )} – ${table.timeColumn?.formatValue(maxTime)}`
 
         return (
-            <div key={def.slug} className="datasource-wrapper">
+            <div key={slug} className="datasource-wrapper">
                 <h2>
                     {column.name}{" "}
                     {editUrl && (
@@ -67,10 +66,10 @@ export class SourcesTab extends React.Component<{
                                 />
                             </tr>
                         ) : null}
-                        {def.coverage ? (
+                        {coverage ? (
                             <tr>
                                 <td>Variable geographic coverage</td>
-                                <td>{def.coverage}</td>
+                                <td>{coverage}</td>
                             </tr>
                         ) : null}
                         {timespan ? (
@@ -140,10 +139,7 @@ export class SourcesTab extends React.Component<{
 
     render() {
         const { bounds } = this
-        // todo: cleanup the Owidcolumn typings
-        const cols = this.manager.columnsWithSources.filter(
-            (col) => (col.def as OwidColumnDef).source
-        )
+        const cols = this.manager.columnsWithSources.filter((col) => col.source)
 
         return (
             <div


### PR DESCRIPTION
Allows authors to directly put source info into an Explorer. It does not connect to Grapher backend so there would be some copy/pasting in the short-run. I think in the medium-run it makes sense to move all column definitions to Git.

![Screen Shot 2020-11-05 at 8 41 25 PM](https://user-images.githubusercontent.com/74692/98334592-486c7900-1fa7-11eb-98f4-aafb536fbf63.png)

I believe in Live we only have the ability to define a source for a dataset, and variables pull sources from the dataset they were uploaded with. So it's a little duplicative storing source info at the column level. But something we could do later.