### PR TITLE
fix(admin): AdminIndexPage displays correct chart type for line charts

### DIFF
--- a/adminSite/client/ChartList.tsx
+++ b/adminSite/client/ChartList.tsx
@@ -12,29 +12,36 @@ import { AdminAppContext, AdminAppContextType } from "./AdminAppContext"
 import { BAKED_GRAPHER_URL } from "settings"
 import { ChartTypeName } from "grapher/core/GrapherConstants"
 import { startCase } from "grapher/utils/Util"
+import { GrapherInterface } from "grapher/core/GrapherInterface"
 
+// These properties are coming from OldChart.ts
 export interface ChartListItem {
-    id: number
-    slug: string
-    title: string
-    tab: string
-    hasChartTab: boolean
-    hasMapTab: boolean
-    isPublished: boolean
+    // the first few entries mirror GrapherInterface, so take the types from there
+    id: GrapherInterface["id"]
+    title: GrapherInterface["title"]
+    slug: GrapherInterface["slug"]
+    type: GrapherInterface["type"]
+    internalNotes: GrapherInterface["internalNotes"]
+    variantName: GrapherInterface["variantName"]
+    isPublished: GrapherInterface["isPublished"]
+    tab: GrapherInterface["tab"]
+    hasChartTab: GrapherInterface["hasChartTab"]
+    hasMapTab: GrapherInterface["hasMapTab"]
+
     isStarred: boolean
-    variantName: string
-    internalNotes: string
-    type: ChartTypeName
     lastEditedAt: string
     lastEditedBy: string
     publishedAt: string
     publishedBy: string
+    isExplorable: boolean
+
     tags: Tag[]
 }
 
 function showChartType(chart: ChartListItem) {
-    const displayType = ChartTypeName[chart.type]
-        ? startCase(ChartTypeName[chart.type])
+    const chartType = chart.type ?? ChartTypeName.LineChart
+    const displayType = ChartTypeName[chartType]
+        ? startCase(ChartTypeName[chartType])
         : "Unknown"
 
     if (chart.tab === "map") {
@@ -93,12 +100,12 @@ class ChartRow extends React.Component<{
                 <td style={{ minWidth: "180px" }}>
                     {chart.isPublished ? (
                         <a href={`${BAKED_GRAPHER_URL}/${chart.slug}`}>
-                            {highlight(chart.title)}
+                            {highlight(chart.title ?? "")}
                         </a>
                     ) : (
                         <span>
                             <span style={{ color: "red" }}>Draft: </span>{" "}
-                            {highlight(chart.title)}
+                            {highlight(chart.title ?? "")}
                         </span>
                     )}{" "}
                     {chart.variantName ? (

--- a/adminSite/server/apiRouter.ts
+++ b/adminSite/server/apiRouter.ts
@@ -40,8 +40,6 @@ import { enqueueChange, getDeploys } from "deploy/queue"
 import { FunctionalRouter } from "./utils/FunctionalRouter"
 import { addExplorerApiRoutes } from "explorer/admin/ExplorerBaker"
 import { addGitCmsApiRoutes } from "gitCms/server"
-import { ChartTypeName, GrapherTabOption } from "grapher/core/GrapherConstants"
-import { Grapher } from "grapher/core/Grapher"
 
 const apiRouter = new FunctionalRouter()
 
@@ -313,24 +311,15 @@ async function saveGrapher(
 apiRouter.get("/charts.json", async (req: Request, res: Response) => {
     const limit =
         req.query.limit !== undefined ? parseInt(req.query.limit) : 10000
-    const charts = await db
-        .query(
-            `
+    const charts = await db.query(
+        `
         SELECT ${OldChart.listFields} FROM charts
         JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
         LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
         ORDER BY charts.lastEditedAt DESC LIMIT ?
     `,
-            [limit]
-        )
-        .then((charts) =>
-            charts.map((chart: any) => {
-                // These fields are left out in some Grapher configs, so we populate with the default values here
-                chart.type ??= ChartTypeName.LineChart
-                chart.tab ??= GrapherTabOption.chart
-                return chart
-            })
-        )
+        [limit]
+    )
 
     await Chart.assignTagsForCharts(charts)
 

--- a/adminSite/server/apiRouter.ts
+++ b/adminSite/server/apiRouter.ts
@@ -40,6 +40,8 @@ import { enqueueChange, getDeploys } from "deploy/queue"
 import { FunctionalRouter } from "./utils/FunctionalRouter"
 import { addExplorerApiRoutes } from "explorer/admin/ExplorerBaker"
 import { addGitCmsApiRoutes } from "gitCms/server"
+import { ChartTypeName, GrapherTabOption } from "grapher/core/GrapherConstants"
+import { Grapher } from "grapher/core/Grapher"
 
 const apiRouter = new FunctionalRouter()
 
@@ -311,21 +313,28 @@ async function saveGrapher(
 apiRouter.get("/charts.json", async (req: Request, res: Response) => {
     const limit =
         req.query.limit !== undefined ? parseInt(req.query.limit) : 10000
-    const charts = await db.query(
-        `
+    const charts = await db
+        .query(
+            `
         SELECT ${OldChart.listFields} FROM charts
         JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
         LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
         ORDER BY charts.lastEditedAt DESC LIMIT ?
     `,
-        [limit]
-    )
+            [limit]
+        )
+        .then((charts) =>
+            charts.map((chart: any) => {
+                // These fields are left out in some Grapher configs, so we populate with the default values here
+                chart.type ??= ChartTypeName.LineChart
+                chart.tab ??= GrapherTabOption.chart
+                return chart
+            })
+        )
 
     await Chart.assignTagsForCharts(charts)
 
-    return {
-        charts: charts,
-    }
+    return { charts }
 })
 
 apiRouter.get(


### PR DESCRIPTION
This is not really a regression on `next` but is already to be seen on live: On the admin landing page, some line charts display a type of "Unknown" in the type column.
This happens because `Grapher.tsx` strips off all default values, and the default value for the chart type is `LineChart`. Therefore the `charts.json` response includes `type: null` for those charts.

If there's a better way to fix this please let me know :)

![image](https://user-images.githubusercontent.com/2641501/98607069-b20ebf00-22e8-11eb-8b82-620c69049cac.png)

