### PR TITLE
fix(admin): enable editing of buckets for map charts

### DIFF
--- a/adminSite/client/EditorMapTab.tsx
+++ b/adminSite/client/EditorMapTab.tsx
@@ -19,6 +19,7 @@ import { LegacyVariableId } from "coreTable/LegacyVariableCode"
 import { MapConfig } from "grapher/mapCharts/MapConfig"
 import { ChartDimension } from "grapher/chart/ChartDimension"
 import { ColorScale } from "grapher/color/ColorScale"
+import { MapChart } from "grapher/mapCharts/MapChart"
 
 @observer
 class VariableSection extends React.Component<{
@@ -146,10 +147,8 @@ export class EditorMapTab extends React.Component<{ editor: ChartEditor }> {
     render() {
         const { grapher } = this
         const mapConfig = grapher.map
-
-        const colorScale = new ColorScale({
-            colorScaleConfig: mapConfig.colorScale,
-        })
+        const mapChart = new MapChart({ manager: this.grapher })
+        const colorScale = mapChart.colorScale
 
         const isReady =
             !!mapConfig.columnSlug && grapher.table.has(mapConfig.columnSlug)


### PR DESCRIPTION
For https://www.notion.so/owid/Admin-Manual-map-buckets-not-shown-b6151aa52365429ba4d77b590135c0d0

This seems very brittle, but also seems to work.
If there's a better way to do this please let me know, because this doesn't feel like it's the right way.