### PR TITLE
Dev: reduce usage of dangerouslySetInnerHTML

### DIFF
--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -76,7 +76,6 @@ import {
 import {
     strToQueryParams,
     queryParamsToStr,
-    QueryParams,
 } from "utils/client/url"
 import { populationMap } from "coreTable/PopulationMap"
 import {

--- a/site/client/owid.entry.ts
+++ b/site/client/owid.entry.ts
@@ -37,22 +37,29 @@ window.GrapherPageUtils = GrapherPageUtils
 window.Grapher = Grapher
 window.Explorer = Explorer
 window.runChartsIndexPage = runChartsIndexPage
-window.runHeaderMenus = runHeaderMenus
 window.runSearchPage = runSearchPage
 window.runNotFoundPage = runNotFoundPage
-window.runSiteTools = runSiteTools
 window.runFeedbackPage = runFeedbackPage
 window.runDonateForm = runDonateForm
 window.runVariableCountryPage = runVariableCountryPage
 window.runCountryProfilePage = runCountryProfilePage
-window.runCookiePreferencesManager = runCookiePreferencesManager
-window.runBlocks = runBlocks
 window.runTableOfContents = runTableOfContents
 window.runRelatedCharts = runRelatedCharts
-window.runLightbox = runLightbox
-window.runCovid = runCovid
-window.runGlobalEntityControl = runGlobalEntityControl
-window.runFootnotes = runFootnotes
+
+window.siteFooterMain = () => {
+    runHeaderMenus()
+    runBlocks()
+    runLightbox()
+    runSiteTools()
+    runCookiePreferencesManager()
+    runCovid()
+    runFootnotes()
+
+    if (!document.querySelector(".ChartPage")) {
+        GrapherPageUtils.embedAll()
+        runGlobalEntityControl(GrapherPageUtils.globalEntitySelection)
+    }
+}
 
 const analytics = new Analytics(ENV)
 analytics.logPageLoad()

--- a/site/server/views/CountriesIndexPage.tsx
+++ b/site/server/views/CountriesIndexPage.tsx
@@ -39,7 +39,6 @@ export const CountriesIndexPage = (props: { countries: Country[] }) => {
                     </ul>
                 </main>
                 <SiteFooter />
-                {/* <script>{`window.runChartsIndexPage()`}</script> */}
             </body>
         </html>
     )

--- a/site/server/views/SiteFooter.tsx
+++ b/site/server/views/SiteFooter.tsx
@@ -239,19 +239,7 @@ export const SiteFooter = ({
                 <script src={webpack("owid.js", "site")} />
                 <script
                     dangerouslySetInnerHTML={{
-                        __html: `
-                runHeaderMenus();
-                runBlocks();
-                runLightbox();
-                runSiteTools();
-                runCookiePreferencesManager();
-                runCovid();
-                runFootnotes();
-                if (!document.querySelector(".ChartPage")) {
-                    GrapherPageUtils.embedAll();
-                    runGlobalEntityControl(GrapherPageUtils.globalEntitySelection);
-                }
-            `,
+                        __html: `siteFooterMain()`,
                     }}
                 />
             </footer>


### PR DESCRIPTION
Sometimes I'll do a "Find All References" and TypeScript will miss certain references that are in strings.

I'm wondering if we could move away from the pattern of using `dangerouslySetInnerHTML`, but I don't know enough about the webpack build and bundling process, etc, to know if that's too much of a pain.

Regardless I think it may be nice to reduce usage of untyped strings, and thought that this is one thing we could do.

Any other ideas?