### PR TITLE
New ScatterPlot interpolation: a value can belong only to a single point

### DIFF
--- a/coreTable/CoreTableUtils.ts
+++ b/coreTable/CoreTableUtils.ts
@@ -271,7 +271,7 @@ export function toleranceInterpolation(
         ) {
             nextNonBlankIndex = findIndexFast(
                 valuesSortedByTimeAsc,
-                (val) => isNotErrorValueOrEmptyCell(val),
+                isNotErrorValueOrEmptyCell,
                 index + 1,
                 end
             )

--- a/coreTable/OwidTable.ts
+++ b/coreTable/OwidTable.ts
@@ -165,26 +165,13 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         return [min(mins), max(maxes)]
     }
 
-    // TO-DISCUSS
-    // Do we want to have two separate functions, or possibly a parameter: "any" | "all"?
-    // Do we want to access the column methods, or do it like this through the columnStore?
-    timeDomainForIntersection(
+    originalTimeDomainFor(
         slugs: ColumnSlug[]
     ): [Time | undefined, Time | undefined] {
-        let minTime: Time | undefined = undefined
-        let maxTime: Time | undefined = undefined
-        const { columnStore, timeColumn } = this
-        for (let index = 0; index < this.numRows; index++) {
-            if (
-                // The difference between above and this is .every() vs .some()
-                slugs.every((slug) => isNotErrorValue(columnStore[slug][index]))
-            ) {
-                const time = columnStore[timeColumn.slug][index] as Time
-                if (minTime === undefined || minTime > time) minTime = time
-                if (maxTime === undefined || maxTime < time) maxTime = time
-            }
-        }
-        return [minTime, maxTime]
+        const cols = this.getColumns(slugs)
+        const mins = cols.map((col) => min(col.originalTimes))
+        const maxes = cols.map((col) => max(col.originalTimes))
+        return [min(mins), max(maxes)]
     }
 
     filterByEntityNames(names: EntityName[]) {
@@ -716,7 +703,9 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
                 maxDiff
             )
             const timeAtoTimeB = new Map(timePairs)
-            const pairedTimesInA = Array.from(timeAtoTimeB.keys()) as Time[]
+            const pairedTimesInA = sortNumeric(
+                Array.from(timeAtoTimeB.keys())
+            ) as Time[]
 
             for (let index = startIndex; index < endIndex; index++) {
                 const currentTime = times[index]

--- a/coreTable/OwidTable.ts
+++ b/coreTable/OwidTable.ts
@@ -14,6 +14,9 @@ import {
     groupBy,
     isNumber,
     isEmpty,
+    getClosestTimePairs,
+    sortedFindClosest,
+    pairs,
 } from "grapher/utils/Util"
 import {
     ColumnSlug,
@@ -162,6 +165,28 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         return [min(mins), max(maxes)]
     }
 
+    // TO-DISCUSS
+    // Do we want to have two separate functions, or possibly a parameter: "any" | "all"?
+    // Do we want to access the column methods, or do it like this through the columnStore?
+    timeDomainForIntersection(
+        slugs: ColumnSlug[]
+    ): [Time | undefined, Time | undefined] {
+        let minTime: Time | undefined = undefined
+        let maxTime: Time | undefined = undefined
+        const { columnStore, timeColumn } = this
+        for (let index = 0; index < this.numRows; index++) {
+            if (
+                // The difference between above and this is .every() vs .some()
+                slugs.every((slug) => isNotErrorValue(columnStore[slug][index]))
+            ) {
+                const time = columnStore[timeColumn.slug][index] as Time
+                if (minTime === undefined || minTime > time) minTime = time
+                if (maxTime === undefined || maxTime < time) maxTime = time
+            }
+        }
+        return [minTime, maxTime]
+    }
+
     filterByEntityNames(names: EntityName[]) {
         const namesSet = new Set(names)
         return this.columnFilter(
@@ -230,6 +255,8 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         )
     }
 
+    // TODO rewrite with column ops
+    // TODO move to CoreTable
     dropRowsWithErrorValuesForAnyColumn(slugs: ColumnSlug[]) {
         return this.rowFilter(
             (row) => slugs.every((slug) => isNotErrorValue(row[slug])),
@@ -239,6 +266,8 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         )
     }
 
+    // TODO rewrite with column ops
+    // TODO move to CoreTable
     dropRowsWithErrorValuesForAllColumns(slugs: ColumnSlug[]) {
         return this.rowFilter(
             (row) => slugs.some((slug) => isNotErrorValue(row[slug])),
@@ -611,6 +640,152 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
                 },
             ],
             `Interpolated values in column ${columnSlug} linearly`,
+            TransformType.UpdateColumnDefs
+        )
+    }
+
+    interpolateColumnsByClosestTimeMatch(
+        columnSlugA: ColumnSlug,
+        columnSlugB: ColumnSlug
+    ): this {
+        if (!this.has(columnSlugA) || !this.has(columnSlugB)) return this
+
+        const columnA = this.get(columnSlugA)
+        const columnB = this.get(columnSlugB)
+
+        const toleranceA = columnA.display.tolerance ?? 0
+        const toleranceB = columnB.display.tolerance ?? 0
+
+        // If the columns are of mismatching time types, then we can't do any time matching.
+        // This can happen when we have a ScatterPlot with days in one column, and a column with
+        // xOverrideYear.
+        // We also don't need to do any time matching when the tolerance of both columns is 0.
+        if (
+            this.timeColumn.isMissing ||
+            this.timeColumn.slug !== columnA.originalTimeColumnSlug ||
+            this.timeColumn.slug !== columnB.originalTimeColumnSlug ||
+            // Check for a non-zero, non-undefined tolerance
+            (toleranceA === 0 && toleranceB === 0)
+        ) {
+            return this
+        }
+
+        const maxDiff = Math.max(toleranceA, toleranceB)
+
+        const withAllRows = this.complete([
+            this.entityNameSlug,
+            this.timeColumn.slug,
+        ]).sortBy([this.entityNameSlug, this.timeColumn.slug])
+
+        // Existing columns
+        const valuesA = withAllRows.get(columnA.slug).valuesIncludingErrorValues
+        const valuesB = withAllRows.get(columnB.slug).valuesIncludingErrorValues
+        const times = withAllRows.timeColumn
+            .valuesIncludingErrorValues as Time[]
+
+        // New columns
+        const newValuesA = new Array(times.length).fill(
+            ErrorValueTypes.NoValueWithinTolerance
+        )
+        const newValuesB = new Array(times.length).fill(
+            ErrorValueTypes.NoValueWithinTolerance
+        )
+        const newTimesA = new Array(times.length).fill(
+            ErrorValueTypes.NoValueWithinTolerance
+        )
+        const newTimesB = new Array(times.length).fill(
+            ErrorValueTypes.NoValueWithinTolerance
+        )
+
+        const groupBoundaries = withAllRows.groupBoundaries(this.entityNameSlug)
+
+        pairs(groupBoundaries).forEach(([startIndex, endIndex]) => {
+            const availableTimesA = []
+            const availableTimesB = []
+
+            for (let index = startIndex; index < endIndex; index++) {
+                if (isNotErrorValue(valuesA[index]))
+                    availableTimesA.push(times[index])
+                if (isNotErrorValue(valuesB[index]))
+                    availableTimesB.push(times[index])
+            }
+
+            const timePairs = getClosestTimePairs(
+                availableTimesA,
+                availableTimesB,
+                maxDiff
+            )
+            const timeAtoTimeB = new Map(timePairs)
+            const pairedTimesInA = Array.from(timeAtoTimeB.keys()) as Time[]
+
+            for (let index = startIndex; index < endIndex; index++) {
+                const currentTime = times[index]
+
+                const candidateTimeA = sortedFindClosest(
+                    pairedTimesInA,
+                    currentTime
+                )
+
+                if (candidateTimeA === undefined) continue
+
+                const candidateIndexA = times.indexOf(
+                    candidateTimeA,
+                    startIndex
+                )
+
+                if (Math.abs(currentTime - candidateTimeA) > toleranceA)
+                    continue
+
+                const candidateTimeB = timeAtoTimeB.get(candidateTimeA)
+
+                if (
+                    candidateTimeB === undefined ||
+                    Math.abs(currentTime - candidateTimeB) > toleranceB
+                ) {
+                    continue
+                }
+
+                const candidateIndexB = times.indexOf(
+                    candidateTimeB,
+                    startIndex
+                )
+
+                newValuesA[index] = valuesA[candidateIndexA]
+                newValuesB[index] = valuesB[candidateIndexB]
+                newTimesA[index] = times[candidateIndexA]
+                newTimesB[index] = times[candidateIndexB]
+            }
+        })
+
+        const originalTimeColumnASlug = makeOriginalTimeSlugFromColumnSlug(
+            columnA.slug
+        )
+        const originalTimeColumnBSlug = makeOriginalTimeSlugFromColumnSlug(
+            columnB.slug
+        )
+
+        const columnStore = {
+            ...withAllRows.columnStore,
+            [columnA.slug]: newValuesA,
+            [columnB.slug]: newValuesB,
+            [originalTimeColumnASlug]: newTimesA,
+            [originalTimeColumnBSlug]: newTimesB,
+        }
+
+        return withAllRows.transform(
+            columnStore,
+            [
+                ...withAllRows.defs,
+                {
+                    ...withAllRows.timeColumn.def,
+                    slug: originalTimeColumnASlug,
+                },
+                {
+                    ...withAllRows.timeColumn.def,
+                    slug: originalTimeColumnBSlug,
+                },
+            ],
+            `Interpolated values`,
             TransformType.UpdateColumnDefs
         )
     }

--- a/coreTable/OwidTableUtil.ts
+++ b/coreTable/OwidTableUtil.ts
@@ -15,6 +15,6 @@ export function getOriginalTimeColumnSlug(
     slug: ColumnSlug
 ): ColumnSlug | undefined {
     const originalTimeSlug = makeOriginalTimeSlugFromColumnSlug(slug)
-    if (table.columnSlugs.includes(originalTimeSlug)) return originalTimeSlug
+    if (table.has(originalTimeSlug)) return originalTimeSlug
     return table.timeColumn?.slug
 }

--- a/coreTable/OwidTableUtil.ts
+++ b/coreTable/OwidTableUtil.ts
@@ -13,8 +13,8 @@ export function makeOriginalTimeSlugFromColumnSlug(slug: ColumnSlug) {
 export function getOriginalTimeColumnSlug(
     table: CoreTable,
     slug: ColumnSlug
-): ColumnSlug | undefined {
+): ColumnSlug {
     const originalTimeSlug = makeOriginalTimeSlugFromColumnSlug(slug)
     if (table.has(originalTimeSlug)) return originalTimeSlug
-    return table.timeColumn?.slug
+    return table.timeColumn.slug
 }

--- a/grapher/scatterCharts/ScatterPlotChart.test.ts
+++ b/grapher/scatterCharts/ScatterPlotChart.test.ts
@@ -19,7 +19,7 @@ import { ContinentColors } from "grapher/color/ColorConstants"
 import { OwidTableSlugs } from "coreTable/OwidTableConstants"
 import { Color } from "coreTable/CoreTableConstants"
 import { makeOriginalTimeSlugFromColumnSlug } from "coreTable/OwidTableUtil"
-import { uniq } from "grapher/utils/Util"
+import { uniq, uniqBy } from "grapher/utils/Util"
 
 it("can create a new chart", () => {
     const manager: ScatterPlotManager = {
@@ -103,11 +103,6 @@ it("can filter points with negative values when using a log scale", () => {
     expect(logChart.series.length).toEqual(2)
     expect(logChart.allPoints.length).toEqual(180)
 })
-
-// it("default point color if no color column", () => {
-//     const chart = new ScatterPlotChart({ manager: { table: new OwidTable() } })
-//     expect(chart.colorScale.getColor("Italy")).toEqual("#959595")
-// })
 
 describe("interpolation defaults", () => {
     const table = new OwidTable(
@@ -706,5 +701,133 @@ describe("scatter plot with xOverrideTime", () => {
         expect(chart.allPoints.map((p) => p.time.x)).toEqual(
             expect.arrayContaining([2000, 2001, 2003])
         )
+    })
+})
+
+describe("x/y tolerance", () => {
+    const table = new OwidTable(
+        [
+            [
+                "entityId",
+                "entityName",
+                "entityCode",
+                "year",
+                "x",
+                "y",
+                "color",
+                "size",
+            ],
+            [1, "UK", "", 2000, 0, null, "Europe", 100],
+            [1, "UK", "", 2001, null, null, null, null],
+            [1, "UK", "", 2002, null, null, null, null],
+            [1, "UK", "", 2003, null, 3, null, null],
+            [1, "UK", "", 2004, null, null, null, null],
+            [1, "UK", "", 2005, 5, null, null, null],
+            [1, "UK", "", 2006, 6, 6, null, null],
+            [1, "UK", "", 2007, null, 7, null, null],
+            [1, "UK", "", 2008, 8, null, null, null],
+            [1, "UK", "", 2009, null, null, null, null],
+            [1, "UK", "", 2010, null, null, "Europe", 100],
+            // should be removed because it has no X/Y values
+            [2, "USA", "", 2020, null, null, "North America", 0],
+        ],
+        [
+            {
+                slug: "x",
+                type: ColumnTypeNames.Numeric,
+                display: { tolerance: 3 },
+            },
+            {
+                slug: "y",
+                type: ColumnTypeNames.Numeric,
+                display: { tolerance: 3 },
+            },
+            {
+                slug: "color",
+                type: ColumnTypeNames.String,
+                display: { tolerance: 10 },
+            },
+            {
+                slug: "size",
+                type: ColumnTypeNames.Numeric,
+            },
+        ]
+    )
+
+    const manager: ScatterPlotManager = {
+        xColumnSlug: "x",
+        yColumnSlug: "y",
+        colorColumnSlug: "color",
+        sizeColumnSlug: "size",
+        table,
+    }
+
+    const chart = new ScatterPlotChart({ manager })
+
+    const transformedTable = chart.transformedTable
+
+    it("removes rows without X or Y value", () => {
+        expect(transformedTable.get("year").values).toEqual([
+            2003,
+            2004,
+            2005,
+            2006,
+            2007,
+            2008,
+        ])
+    })
+
+    it("applies tolerance on color & size before filtering rows", () => {
+        expect(
+            uniq(transformedTable.get("color").valuesIncludingErrorValues)
+        ).toEqual(["Europe"])
+        expect(
+            uniq(transformedTable.get("size").valuesIncludingErrorValues)
+        ).toEqual([100])
+    })
+
+    it("matches rows correctly", () => {
+        const xTimeSlug = makeOriginalTimeSlugFromColumnSlug("x")
+        const yTimeSlug = makeOriginalTimeSlugFromColumnSlug("y")
+
+        const rows = transformedTable.rows
+        expect(rows.length).toEqual(6)
+
+        const uniqRows = uniqBy(
+            rows,
+            (row) => `${row[xTimeSlug]}-${row[yTimeSlug]}`
+        )
+        expect(uniqRows).toEqual([
+            expect.objectContaining({
+                color: "Europe",
+                entityName: "UK",
+                size: 100,
+                x: 5,
+                [xTimeSlug]: 2005,
+                y: 3,
+                [yTimeSlug]: 2003,
+                year: 2003,
+            }),
+            expect.objectContaining({
+                color: "Europe",
+                entityName: "UK",
+                size: 100,
+                x: 6,
+                [xTimeSlug]: 2006,
+                y: 6,
+                [yTimeSlug]: 2006,
+                year: 2006,
+            }),
+            expect.objectContaining({
+                color: "Europe",
+                entityName: "UK",
+                size: 100,
+                x: 8,
+                [xTimeSlug]: 2008,
+                y: 7,
+                [yTimeSlug]: 2007,
+                year: 2008,
+            }),
+        ])
     })
 })

--- a/grapher/scatterCharts/ScatterPlotChart.test.ts
+++ b/grapher/scatterCharts/ScatterPlotChart.test.ts
@@ -575,9 +575,11 @@ describe("series transformations", () => {
             {
                 slug: "x",
                 type: ColumnTypeNames.Numeric,
-                display: { tolerance: 1 },
             },
-            { slug: "y", type: ColumnTypeNames.Numeric },
+            {
+                slug: "y",
+                type: ColumnTypeNames.Numeric,
+            },
             { slug: "color", type: ColumnTypeNames.String },
             {
                 slug: "size",
@@ -599,7 +601,6 @@ describe("series transformations", () => {
         const ukSeries = chart.series.find((s) => s.seriesName === "UK")!
         expect(ukSeries.points.map((p) => p.timeValue)).toEqual([
             2001,
-            2002,
             2003,
             2004,
         ])

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -181,6 +181,12 @@ export class ScatterPlotChart
                 "Drop rows with non-number values in Y column"
             )
 
+        // The tolerance application might lead to some data being dropped for some years.
+        // For example, if X times are [2000, 2005, 2010], and Y times are [2005], then for all 3
+        // rows we have the same match [[2005, 2005], [2005, 2005], [2005, 2005]].
+        // This means we can drop 2000 and 2010 from the timeline.
+        // It might not make a huge difference here, but it makes a difference when there are more
+        // entities covering different time periods.
         const [
             originalTimeDomainStart,
             originalTimeDomainEnd,

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -149,10 +149,7 @@ export class ScatterPlotChart
 
         // We want to "chop off" any rows outside the time domain for X and Y to avoid creating
         // leading and trailing timeline times that don't really exist in the dataset.
-        const [
-            timeDomainStart,
-            timeDomainEnd,
-        ] = table.timeDomainForIntersection([
+        const [timeDomainStart, timeDomainEnd] = table.timeDomainFor([
             this.xColumnSlug,
             this.yColumnSlug,
         ])
@@ -183,6 +180,15 @@ export class ScatterPlotChart
                 isNumber,
                 "Drop rows with non-number values in Y column"
             )
+
+        const [
+            originalTimeDomainStart,
+            originalTimeDomainEnd,
+        ] = table.originalTimeDomainFor([this.xColumnSlug, this.yColumnSlug])
+        table = table.filterByTimeRange(
+            originalTimeDomainStart ?? -Infinity,
+            originalTimeDomainEnd ?? Infinity
+        )
 
         return table
     }

--- a/grapher/selection/SelectionArray.ts
+++ b/grapher/selection/SelectionArray.ts
@@ -38,7 +38,11 @@ export class SelectionArray {
     }
 
     private mapBy(col: keyof Entity, val: keyof Entity) {
-        return mapBy(this.availableEntities, col, val)
+        return mapBy(
+            this.availableEntities,
+            (v) => v[col],
+            (v) => v[val]
+        )
     }
 
     @computed get entityNameToIdMap() {

--- a/grapher/utils/Util.test.ts
+++ b/grapher/utils/Util.test.ts
@@ -23,6 +23,7 @@ import {
     findClosestTimeIndex,
     intersection,
     splitArrayIntoGroupsOfN,
+    getClosestTimePairs,
 } from "grapher/utils/Util"
 import { strToQueryParams } from "utils/client/url"
 import { SortOrder } from "coreTable/CoreTableConstants"
@@ -402,5 +403,79 @@ describe(splitArrayIntoGroupsOfN, () => {
         expect(splitArrayIntoGroupsOfN([0, 1, 2, 3, 4, 5, 6], 5).length).toBe(2)
         expect(splitArrayIntoGroupsOfN([0, 1, 2, 3, 4, 5, 6], 7).length).toBe(1)
         expect(splitArrayIntoGroupsOfN([0, 1, 2, 3, 4, 5, 6], 9).length).toBe(1)
+    })
+})
+
+describe(getClosestTimePairs, () => {
+    it("case 1", () => {
+        expect(getClosestTimePairs([0, 4], [3, 4])).toEqual(
+            expect.arrayContaining([
+                [0, 3],
+                [4, 4],
+            ])
+        )
+    })
+
+    it("case 2", () => {
+        expect(getClosestTimePairs([0, 5, 6, 8], [3, 7])).toEqual(
+            expect.arrayContaining([
+                [5, 3],
+                [6, 7],
+            ])
+        )
+    })
+
+    it("case 3", () => {
+        expect(getClosestTimePairs([0, 1, 2], [2])).toEqual(
+            expect.arrayContaining([[2, 2]])
+        )
+    })
+
+    it("case 4", () => {
+        expect(getClosestTimePairs([0, 1], [2])).toEqual(
+            expect.arrayContaining([[1, 2]])
+        )
+    })
+
+    it("case 5", () => {
+        expect(getClosestTimePairs([5, 6], [1])).toEqual(
+            expect.arrayContaining([[5, 1]])
+        )
+    })
+
+    it("case 6", () => {
+        expect(getClosestTimePairs([0, 1], [2, 3])).toEqual(
+            expect.arrayContaining([[1, 2]])
+        )
+    })
+
+    it("case 7", () => {
+        expect(getClosestTimePairs([2, 3], [0, 1])).toEqual(
+            expect.arrayContaining([[2, 1]])
+        )
+    })
+
+    it("case 8", () => {
+        expect(getClosestTimePairs([0, 4], [3])).toEqual(
+            expect.arrayContaining([[4, 3]])
+        )
+    })
+
+    describe("with maxDiff", () => {
+        it("case 1", () => {
+            expect(getClosestTimePairs([0, 1], [2, 3], 1)).toEqual([[1, 2]])
+        })
+
+        it("case 2", () => {
+            expect(getClosestTimePairs([0, 1], [3, 4], 1)).toEqual([])
+        })
+
+        it("case 3", () => {
+            expect(getClosestTimePairs([2, 3], [0], 2)).toEqual([[2, 0]])
+        })
+
+        it("case 4", () => {
+            expect(getClosestTimePairs([2, 3], [0], 1)).toEqual([])
+        })
     })
 })

--- a/grapher/utils/Util.ts
+++ b/grapher/utils/Util.ts
@@ -1003,10 +1003,14 @@ export function sortNumeric<T>(
 export const isPresent = <T>(t: T | undefined | null | void): t is T =>
     t !== undefined && t !== null
 
-export const mapBy = <T>(arr: T[], key: keyof T, value: keyof T) => {
+export const mapBy = <T>(
+    arr: T[],
+    keyAccessor: (t: T) => any,
+    valueAccessor: (t: T) => any
+) => {
     const map = new Map()
     arr.forEach((val) => {
-        map.set(val[key], val[value])
+        map.set(keyAccessor(val), valueAccessor(val))
     })
     return map
 }

--- a/grapher/utils/Util.ts
+++ b/grapher/utils/Util.ts
@@ -469,15 +469,21 @@ export function pointsToPath(points: Array<[number, number]>) {
 // Based on https://stackoverflow.com/a/30245398/1983739
 // In case of tie returns higher value
 // todo: add unit tests
-export function sortedFindClosestIndex(array: number[], value: number) {
-    if (array.length === 0) return -1
+export function sortedFindClosestIndex(
+    array: number[],
+    value: number,
+    startIndex: number = 0,
+    // non-inclusive end
+    endIndex: number = array.length
+) {
+    if (startIndex >= endIndex) return -1
 
-    if (value < array[0]) return 0
+    if (value < array[startIndex]) return startIndex
 
-    if (value > array[array.length - 1]) return array.length - 1
+    if (value > array[endIndex - 1]) return endIndex - 1
 
-    let lo = 0
-    let hi = array.length - 1
+    let lo = startIndex
+    let hi = endIndex - 1
 
     while (lo <= hi) {
         const mid = Math.round((hi + lo) / 2)


### PR DESCRIPTION
The tolerance used to be applied independently to X and Y column, which meant e.g. a constant Y value from a single year would be used as X changes over time, creating some "staircases":

Before:

<img width="1616" alt="Screenshot 2020-11-12 at 16 38 04" src="https://user-images.githubusercontent.com/1308115/99288335-58038180-2833-11eb-8056-ae9fcf0969a1.png">

Now:

<img width="1473" alt="Screenshot 2020-11-16 at 17 48 51" src="https://user-images.githubusercontent.com/1308115/99288794-0ad3df80-2834-11eb-97f1-f6f7fb79f1bb.png">

Related discussion on Slack: https://owid.slack.com/archives/C01D295TM4K/p1605193993004700

To-do:
- [x] Resolve `TODO` and `TO-DISCUSS` 
- [x] Add ScatterPlot tests
- ~~Drop any duplicate points? This needs to happen after the timeline filter. But it needs to minimize the difference between `timeValue` and `time.x`.~~ The `endPointsOnly` transform also gets more complex if we drop duplicates, so I decided to leave duplicates unless they cause problems. No problems spotted so far...
