### PR TITLE
Fix: Use % axes for ScatterPlot 'average annual change' transform

### DIFF
--- a/coreTable/CoreTableColumns.ts
+++ b/coreTable/CoreTableColumns.ts
@@ -31,6 +31,7 @@ import { getOriginalTimeColumnSlug } from "./OwidTableUtil"
 import { imemo } from "./CoreTableUtils"
 import moment from "moment"
 import { OwidSource } from "./OwidSource"
+import { bind } from "decko"
 
 interface ColumnSummary {
     numErrorValues: number
@@ -186,7 +187,8 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
         return this.formatValue(value)
     }
 
-    formatForTick(value: any, options?: TickFormattingOptions) {
+    // Needs to be bound to instance to pass it to Axis without creating an intermediate function
+    @bind formatForTick(value: any, options?: TickFormattingOptions) {
         return this.formatValueShort(value, options)
     }
 

--- a/grapher/axis/Axis.test.ts
+++ b/grapher/axis/Axis.test.ts
@@ -27,7 +27,7 @@ it("can assign a column to an axis", () => {
     })
     const table = SynthesizeGDPTable()
     const axis = new HorizontalAxis(axisConfig)
-    axis.formatColumn = table.get("GDP")
+    axis.tickFormatter = table.get("GDP").formatForTick
     axis.clone()
 
     const ticks = axis.getTickValues()

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -29,7 +29,7 @@ abstract class AbstractAxis {
     @observable tickFormatter?: (
         value: any,
         options?: TickFormattingOptions
-    ) => string = anyToString
+    ) => string
     @observable hideFractionalTicks = false
     @observable hideGridlines = false
     @observable.struct range: ValueRange = [0, 0]
@@ -291,9 +291,8 @@ abstract class AbstractAxis {
             ...this.getTickFormattingOptions(),
             ...formattingOptionsOverride,
         }
-        return this.tickFormatter
-            ? this.tickFormatter(tick, tickFormattingOptions)
-            : tick.toString()
+        const tickFormatter = this.tickFormatter ?? anyToString
+        return tickFormatter(tick, tickFormattingOptions)
     }
 
     // calculates coordinates for ticks, sorted by priority

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -185,7 +185,7 @@ export class DiscreteBarChart
         const axis = this.yAxis.toHorizontalAxis()
         axis.updateDomainPreservingUserSettings(this.xDomainDefault)
 
-        axis.formatColumn = this.yColumns[0] // todo: does this work for columns as series?
+        axis.tickFormatter = first(this.yColumns)?.formatForTick
         axis.range = this.xRange
         axis.label = ""
         return axis

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -712,7 +712,7 @@ export class LineChart
             this.transformedTable.timeDomainFor(this.yColumnSlugs)
         )
         axis.scaleType = ScaleType.linear
-        axis.formatColumn = this.inputTable.timeColumn
+        axis.tickFormatter = this.inputTable.timeColumn.formatForTick
         axis.hideFractionalTicks = true
         axis.hideGridlines = true
         return axis
@@ -737,7 +737,7 @@ export class LineChart
         ])
         axis.hideFractionalTicks = yColumn.isAllIntegers // all y axis points are integral, don't show fractional ticks in that case
         axis.label = ""
-        axis.formatColumn = yColumn
+        axis.tickFormatter = yColumn.formatForTick
         return axis
     }
 }

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -18,6 +18,7 @@ import {
     cagr,
     dropWhile,
     sampleFrom,
+    formatValue,
 } from "grapher/utils/Util"
 import { observer } from "mobx-react"
 import { Bounds, DEFAULT_BOUNDS } from "grapher/utils/Bounds"
@@ -753,11 +754,16 @@ export class ScatterPlotChart
         const axisConfig = this.yAxisConfig
 
         const axis = axisConfig.toVerticalAxis()
-        axis.formatColumn = this.yColumn
         const label = axisConfig.label || this.yColumn?.displayName || ""
         axis.scaleType = this.yScaleType
 
         if (manager.isRelativeMode) {
+            axis.tickFormatter = (value, options) =>
+                formatValue(value, {
+                    unit: "%",
+                    showPlus: true,
+                    ...options,
+                })
             axis.domain = yDomainDefault // Overwrite user's min/max
             if (label && label.length > 1) {
                 axis.label = `Average annual change in ${lowerCaseFirstLetterUnlessAbbreviation(
@@ -765,6 +771,7 @@ export class ScatterPlotChart
                 )}`
             }
         } else {
+            axis.tickFormatter = this.yColumn.formatForTick
             axis.updateDomainPreservingUserSettings(yDomainDefault)
             axis.label = label
         }
@@ -789,9 +796,14 @@ export class ScatterPlotChart
         const { xDomainDefault, manager, xAxisLabelBase } = this
         const { xAxisConfig } = this
         const axis = xAxisConfig.toHorizontalAxis()
-        axis.formatColumn = this.xColumn
         axis.scaleType = this.xScaleType
         if (manager.isRelativeMode) {
+            axis.tickFormatter = (value, options) =>
+                formatValue(value, {
+                    unit: "%",
+                    showPlus: true,
+                    ...options,
+                })
             axis.domain = xDomainDefault // Overwrite user's min/max
             const label = xAxisConfig.label || xAxisLabelBase
             if (label && label.length > 1) {
@@ -800,6 +812,7 @@ export class ScatterPlotChart
                 )}`
             }
         } else {
+            axis.tickFormatter = this.xColumn.formatForTick
             axis.updateDomainPreservingUserSettings(xDomainDefault)
             const label = xAxisConfig.label || xAxisLabelBase
             if (label) axis.label = label

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -29,6 +29,7 @@ import {
     EntitySelectionMode,
     ScatterPointLabelStrategy,
     SeriesName,
+    TickFormattingOptions,
 } from "grapher/core/GrapherConstants"
 import { Color, Time } from "coreTable/CoreTableConstants"
 import {
@@ -749,6 +750,16 @@ export class ScatterPlotChart
         return this.domainDefault("y")
     }
 
+    readonly relativeAxisTickFormatter: (
+        value: any,
+        options?: TickFormattingOptions
+    ) => string = (value, options) =>
+        formatValue(value, {
+            unit: "%",
+            showPlus: true,
+            ...options,
+        })
+
     @computed private get verticalAxisPart() {
         const { manager, yDomainDefault } = this
         const axisConfig = this.yAxisConfig
@@ -758,12 +769,7 @@ export class ScatterPlotChart
         axis.scaleType = this.yScaleType
 
         if (manager.isRelativeMode) {
-            axis.tickFormatter = (value, options) =>
-                formatValue(value, {
-                    unit: "%",
-                    showPlus: true,
-                    ...options,
-                })
+            axis.tickFormatter = this.relativeAxisTickFormatter
             axis.domain = yDomainDefault // Overwrite user's min/max
             if (label && label.length > 1) {
                 axis.label = `Average annual change in ${lowerCaseFirstLetterUnlessAbbreviation(
@@ -798,12 +804,7 @@ export class ScatterPlotChart
         const axis = xAxisConfig.toHorizontalAxis()
         axis.scaleType = this.xScaleType
         if (manager.isRelativeMode) {
-            axis.tickFormatter = (value, options) =>
-                formatValue(value, {
-                    unit: "%",
-                    showPlus: true,
-                    ...options,
-                })
+            axis.tickFormatter = this.relativeAxisTickFormatter
             axis.domain = xDomainDefault // Overwrite user's min/max
             const label = xAxisConfig.label || xAxisLabelBase
             if (label && label.length > 1) {

--- a/grapher/stackedCharts/AbstractStackedChart.tsx
+++ b/grapher/stackedCharts/AbstractStackedChart.tsx
@@ -147,7 +147,7 @@ export class AbstactStackedChart
         axis.updateDomainPreservingUserSettings(
             this.transformedTable.timeDomainFor(this.yColumnSlugs)
         )
-        axis.formatColumn = this.inputTable.timeColumn
+        axis.tickFormatter = this.inputTable.timeColumn.formatForTick
         axis.hideFractionalTicks = true
         axis.hideGridlines = true
         return axis
@@ -166,7 +166,7 @@ export class AbstactStackedChart
         // Use user settings for axis, unless relative mode
         if (this.manager.isRelativeMode) axis.domain = [0, 100]
         else axis.updateDomainPreservingUserSettings([0, max(yValues) ?? 100]) // Stacked area chart must have its own y domain)
-        axis.formatColumn = this.yColumns[0]
+        axis.tickFormatter = this.yColumns[0].formatForTick
         return axis
     }
 


### PR DESCRIPTION
Instead of passing a column to the axis, it passes a formatting function only.

The slightly worrying thing with this is that the `.formatForTick` method needs to be bound to the instance. Right now only one exists, but I can see how it could go wrong if we change its definition.

Anything clever we can do, or should I create an intermediate arrow function every time?

```ts
axis.formatTick = (value, options) => column.formatForTick(value, options)
// instead of the current:
axis.formatTick = column.formatForTick
```