### PR TITLE
Allow empty deploy commits

### DIFF
--- a/site/server/SiteBaker.tsx
+++ b/site/server/SiteBaker.tsx
@@ -630,11 +630,11 @@ export class SiteBaker {
 
         if (authorEmail && authorName && commitMsg) {
             await this.silentExec(
-                `cd ${BAKED_SITE_DIR} && git add -A . && git commit --author='${authorName} <${authorEmail}>' -a -m '${commitMsg}' && git push origin master`
+                `cd ${BAKED_SITE_DIR} && git add -A . && git commit --allow-empty --author='${authorName} <${authorEmail}>' -a -m '${commitMsg}' && git push origin master`
             )
         } else {
             await this.silentExec(
-                `cd ${BAKED_SITE_DIR} && git add -A . && git commit -a -m '${commitMsg}' && git push origin master`
+                `cd ${BAKED_SITE_DIR} && git add -A . && git commit --allow-empty -a -m '${commitMsg}' && git push origin master`
             )
         }
     }


### PR DESCRIPTION
This would hopefully prevent the daily deploy errors we get, while preserving a full log of deploys (even empty ones) in the git repo.

Notion issue: https://www.notion.so/owid/Empty-serverUtil-Error-from-empty-deploy-2b91b1b5fd964ce59d67890d5a7ccf54