### PR TITLE
Add edge case test: row & column delimiter used in key & value

### DIFF
--- a/explorer/client/Patch.test.ts
+++ b/explorer/client/Patch.test.ts
@@ -2,14 +2,24 @@
 
 import {
     DEFAULT_COLUMN_DELIMITER,
+    DEFAULT_ROW_DELIMITER,
     objectFromPatch,
     objectToPatch,
 } from "./Patch"
 
+const specialCharacters = "!*'();:@&=+$,/?#[]-_.~|\"\\"
+
 it("can create a patch", () => {
     const tests = [
-        { object: { foo: "bar" }, patch: `foo${DEFAULT_COLUMN_DELIMITER}bar` },
         { patch: "", object: {} },
+        { object: { foo: "bar" }, patch: `foo${DEFAULT_COLUMN_DELIMITER}bar` },
+        {
+            object: {
+                [`a${DEFAULT_COLUMN_DELIMITER}${specialCharacters}${DEFAULT_ROW_DELIMITER}c`]: `a${DEFAULT_COLUMN_DELIMITER}${specialCharacters}${DEFAULT_ROW_DELIMITER}b`,
+                [`${DEFAULT_COLUMN_DELIMITER}${DEFAULT_ROW_DELIMITER}`]: specialCharacters,
+            },
+            patch: `a${DEFAULT_COLUMN_DELIMITER}${specialCharacters}${DEFAULT_ROW_DELIMITER}c${DEFAULT_COLUMN_DELIMITER}${`a${DEFAULT_COLUMN_DELIMITER}${specialCharacters}${DEFAULT_ROW_DELIMITER}b`}${DEFAULT_ROW_DELIMITER}${`${DEFAULT_COLUMN_DELIMITER}${DEFAULT_ROW_DELIMITER}`}${DEFAULT_COLUMN_DELIMITER}${specialCharacters}`,
+        },
     ]
     tests.forEach((test) => {
         expect(objectToPatch(test.object)).toEqual(test.patch)


### PR DESCRIPTION
Sorry for the messiness, there's probably a better way to write up that test case