### PR TITLE
Fix: replace non-numeric cells with errors for charts that don't support them

### DIFF
--- a/coreTable/CoreTableUtils.ts
+++ b/coreTable/CoreTableUtils.ts
@@ -14,6 +14,7 @@ import {
     ColumnSlug,
     CoreMatrix,
     Time,
+    CoreValueType,
 } from "./CoreTableConstants"
 import { ColumnTypeNames, CoreColumnDef } from "./CoreColumnDef"
 
@@ -491,15 +492,14 @@ export const renameColumnStore = (
     return newStore
 }
 
-export const replaceNonPositives = (
+export const replaceCells = (
     columnStore: CoreColumnStore,
-    slugs: ColumnSlug[]
+    columnSlugs: ColumnSlug[],
+    replaceFn: (val: CoreValueType) => CoreValueType
 ) => {
-    const newStore: CoreColumnStore = Object.assign({}, columnStore)
-    slugs.forEach((slug) => {
-        newStore[slug] = newStore[slug].map((val) =>
-            val <= 0 ? ErrorValueTypes.InvalidOnALogScale : val
-        )
+    const newStore: CoreColumnStore = { ...columnStore }
+    columnSlugs.forEach((slug) => {
+        newStore[slug] = newStore[slug].map(replaceFn)
     })
     return newStore
 }

--- a/coreTable/OwidTableSynthesizers.ts
+++ b/coreTable/OwidTableSynthesizers.ts
@@ -201,3 +201,18 @@ export const SynthesizeFruitTableWithNonPositives = (
         () => rand()
     )
 }
+
+const stringValues = ["NA", "inf", "..", "/", "-", "#VALUE!"]
+
+export const SynthesizeFruitTableWithStringValues = (
+    options?: Partial<SynthOptions>,
+    howMany = 20,
+    seed = Date.now()
+) => {
+    return SynthesizeFruitTable(options, seed).replaceRandomCells(
+        howMany,
+        [SampleColumnSlugs.Fruit, SampleColumnSlugs.Vegetables],
+        undefined,
+        () => sampleFrom(stringValues, 1, Date.now())[0]
+    )
+}

--- a/grapher/barCharts/DiscreteBarChart.test.ts
+++ b/grapher/barCharts/DiscreteBarChart.test.ts
@@ -4,16 +4,19 @@ import { DiscreteBarChart } from "./DiscreteBarChart"
 import {
     SampleColumnSlugs,
     SynthesizeFruitTable,
+    SynthesizeFruitTableWithStringValues,
     SynthesizeGDPTable,
 } from "coreTable/OwidTableSynthesizers"
 import {
     DEFAULT_BAR_COLOR,
     DiscreteBarChartManager,
+    DiscreteBarSeries,
 } from "./DiscreteBarChartConstants"
 import { ColorSchemeName } from "grapher/color/ColorConstants"
 import { SeriesStrategy } from "grapher/core/GrapherConstants"
 import { SelectionArray } from "grapher/selection/SelectionArray"
 import { OwidTable } from "coreTable/OwidTable"
+import { isNumber } from "grapher/utils/Util"
 
 it("can create a new bar chart", () => {
     const table = SynthesizeGDPTable({ timeRange: [2000, 2001] })
@@ -110,4 +113,23 @@ describe("barcharts with columns as the series", () => {
         expect(chart.formatValue(chart.series[0])).toEqual("1,002")
         expect(chart.formatValue(chart.series[1])).toEqual("1,000 (2019)")
     })
+})
+
+it("filters non-numeric values", () => {
+    const table = SynthesizeFruitTableWithStringValues(
+        {
+            entityCount: 2,
+            timeRange: [2000, 2001],
+        },
+        1,
+        1
+    )
+    const manager: DiscreteBarChartManager = {
+        table,
+        yColumnSlugs: [SampleColumnSlugs.Fruit],
+        selection: table.availableEntityNames,
+    }
+    const chart = new DiscreteBarChart({ manager })
+    expect(chart.series.length).toEqual(1)
+    expect(chart.series.every((series) => isNumber(series.value))).toBeTruthy()
 })

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -56,6 +56,8 @@ export class DiscreteBarChart
             this.selectionArray.selectedEntityNames
         )
 
+        table = table.replaceNonNumericCellsWithErrorValues(this.yColumnSlugs)
+
         if (this.isLogScale)
             table = table.replaceNonPositiveCellsForLogScale(this.yColumnSlugs)
 

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -56,6 +56,7 @@ export class DiscreteBarChart
             this.selectionArray.selectedEntityNames
         )
 
+        // TODO: remove this filter once we don't have mixed type columns in datasets
         table = table.replaceNonNumericCellsWithErrorValues(this.yColumnSlugs)
 
         if (this.isLogScale)

--- a/grapher/lineCharts/LineChart.test.ts
+++ b/grapher/lineCharts/LineChart.test.ts
@@ -4,6 +4,7 @@ import { LineChart } from "./LineChart"
 import {
     SampleColumnSlugs,
     SynthesizeFruitTableWithNonPositives,
+    SynthesizeFruitTableWithStringValues,
     SynthesizeGDPTable,
 } from "coreTable/OwidTableSynthesizers"
 import { ChartManager } from "grapher/chart/ChartManager"
@@ -58,6 +59,25 @@ it("can filter points with negative values when using a log scale", () => {
     expect(logChart.verticalAxis.domain[0]).toBeGreaterThan(0)
     expect(logChart.series.length).toEqual(2)
     expect(logChart.allPoints.length).toEqual(180)
+})
+
+it("filters non-numeric values", () => {
+    const table = SynthesizeFruitTableWithStringValues(
+        {
+            entityCount: 2,
+            timeRange: [1900, 2000],
+        },
+        20,
+        1
+    )
+    const manager: ChartManager = {
+        table,
+        yColumnSlugs: [SampleColumnSlugs.Fruit],
+        selection: table.availableEntityNames,
+    }
+    const chart = new LineChart({ manager })
+    expect(chart.series.length).toEqual(2)
+    expect(chart.allPoints.length).toEqual(180)
 })
 
 it("will combine entity and column name when we set multi country multi column", () => {

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -235,6 +235,8 @@ export class LineChart
             this.selectionArray.selectedEntityNames
         )
 
+        table = table.replaceNonNumericCellsWithErrorValues(this.yColumnSlugs)
+
         if (this.isLogScale)
             table = table.replaceNonPositiveCellsForLogScale(
                 this.manager.yColumnSlugs

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -235,6 +235,7 @@ export class LineChart
             this.selectionArray.selectedEntityNames
         )
 
+        // TODO: remove this filter once we don't have mixed type columns in datasets
         table = table.replaceNonNumericCellsWithErrorValues(this.yColumnSlugs)
 
         if (this.isLogScale)

--- a/grapher/slopeCharts/SlopeChart.test.ts
+++ b/grapher/slopeCharts/SlopeChart.test.ts
@@ -3,11 +3,13 @@
 import { SlopeChart } from "./SlopeChart"
 import {
     SampleColumnSlugs,
+    SynthesizeFruitTableWithStringValues,
     SynthesizeGDPTable,
 } from "coreTable/OwidTableSynthesizers"
 import { ChartManager } from "grapher/chart/ChartManager"
 import { DEFAULT_SLOPE_CHART_COLOR } from "./SlopeChartConstants"
 import { OwidTableSlugs } from "coreTable/OwidTableConstants"
+import { isNumber } from "grapher/utils/Util"
 
 const table = SynthesizeGDPTable({ timeRange: [2000, 2010] })
 const manager: ChartManager = {
@@ -28,4 +30,29 @@ it("slope charts can have different colors", () => {
     }
     const chart = new SlopeChart({ manager })
     expect(chart.series[0].color).not.toEqual(DEFAULT_SLOPE_CHART_COLOR)
+})
+
+it("filters non-numeric values", () => {
+    const table = SynthesizeFruitTableWithStringValues(
+        {
+            entityCount: 2,
+            timeRange: [2000, 2002],
+        },
+        1,
+        1
+    )
+    const manager: ChartManager = {
+        table,
+        yColumnSlugs: [SampleColumnSlugs.Fruit],
+        selection: table.availableEntityNames,
+    }
+    const chart = new SlopeChart({ manager })
+    expect(chart.series.length).toEqual(1)
+    expect(
+        chart.series.every((series) =>
+            series.values.every(
+                (value) => isNumber(value.x) && isNumber(value.y)
+            )
+        )
+    ).toBeTruthy()
 })

--- a/grapher/slopeCharts/SlopeChart.tsx
+++ b/grapher/slopeCharts/SlopeChart.tsx
@@ -69,6 +69,8 @@ export class SlopeChart
     transformTable(table: OwidTable) {
         if (!table.has(this.yColumnSlug)) return table
 
+        table = table.replaceNonNumericCellsWithErrorValues([this.yColumnSlug])
+
         return table
             .dropRowsWithErrorValuesForColumn(this.yColumnSlug)
             .interpolateColumnWithTolerance(this.yColumnSlug)

--- a/grapher/slopeCharts/SlopeChart.tsx
+++ b/grapher/slopeCharts/SlopeChart.tsx
@@ -69,6 +69,7 @@ export class SlopeChart
     transformTable(table: OwidTable) {
         if (!table.has(this.yColumnSlug)) return table
 
+        // TODO: remove this filter once we don't have mixed type columns in datasets
         table = table.replaceNonNumericCellsWithErrorValues([this.yColumnSlug])
 
         return table

--- a/grapher/stackedCharts/AbstractStackedChart.tsx
+++ b/grapher/stackedCharts/AbstractStackedChart.tsx
@@ -37,6 +37,8 @@ export class AbstactStackedChart
             this.selectionArray.selectedEntityNames
         )
 
+        table = table.replaceNonNumericCellsWithErrorValues(this.yColumnSlugs)
+
         if (!this.props.disableLinearInterpolation) {
             this.yColumnSlugs.forEach((slug) => {
                 table = table.interpolateColumnLinearly(slug)

--- a/grapher/stackedCharts/AbstractStackedChart.tsx
+++ b/grapher/stackedCharts/AbstractStackedChart.tsx
@@ -37,6 +37,7 @@ export class AbstactStackedChart
             this.selectionArray.selectedEntityNames
         )
 
+        // TODO: remove this filter once we don't have mixed type columns in datasets
         table = table.replaceNonNumericCellsWithErrorValues(this.yColumnSlugs)
 
         if (!this.props.disableLinearInterpolation) {

--- a/grapher/stackedCharts/StackedAreaChart.test.ts
+++ b/grapher/stackedCharts/StackedAreaChart.test.ts
@@ -4,12 +4,14 @@ import { StackedAreaChart } from "./StackedAreaChart"
 import {
     SampleColumnSlugs,
     SynthesizeFruitTable,
+    SynthesizeFruitTableWithStringValues,
     SynthesizeGDPTable,
 } from "coreTable/OwidTableSynthesizers"
 import { ChartManager } from "grapher/chart/ChartManager"
 import { observable } from "mobx"
 import { AxisConfig } from "grapher/axis/AxisConfig"
 import { SelectionArray } from "grapher/selection/SelectionArray"
+import { isNumber } from "grapher/utils/Util"
 
 class MockManager implements ChartManager {
     table = SynthesizeGDPTable({
@@ -80,4 +82,29 @@ it("can filter a series when there are no points", () => {
     })
 
     expect(chart.series.length).toEqual(1)
+})
+
+it("filters non-numeric values", () => {
+    const table = SynthesizeFruitTableWithStringValues(
+        {
+            entityCount: 2,
+            timeRange: [1900, 2000],
+        },
+        20,
+        1
+    )
+    const manager: ChartManager = {
+        table,
+        yColumnSlugs: [SampleColumnSlugs.Fruit],
+        selection: table.availableEntityNames,
+    }
+    const chart = new StackedAreaChart({ manager })
+    expect(chart.series.length).toEqual(2)
+    expect(
+        chart.series.every((series) =>
+            series.points.every(
+                (point) => isNumber(point.x) && isNumber(point.y)
+            )
+        )
+    ).toBeTruthy()
 })

--- a/grapher/stackedCharts/StackedBarChart.test.ts
+++ b/grapher/stackedCharts/StackedBarChart.test.ts
@@ -2,10 +2,12 @@
 
 import {
     SampleColumnSlugs,
+    SynthesizeFruitTableWithStringValues,
     SynthesizeGDPTable,
 } from "coreTable/OwidTableSynthesizers"
 import { ChartManager } from "grapher/chart/ChartManager"
 import { SelectionArray } from "grapher/selection/SelectionArray"
+import { isNumber } from "grapher/utils/Util"
 import { StackedBarChart } from "./StackedBarChart"
 
 it("can create a chart", () => {
@@ -76,4 +78,29 @@ describe("stackedbar chart with entities as series", () => {
         expect(chart.series.length).toEqual(5)
         expect(chart.series[0].points[0].y).toBeTruthy()
     })
+})
+
+it("filters non-numeric values", () => {
+    const table = SynthesizeFruitTableWithStringValues(
+        {
+            entityCount: 2,
+            timeRange: [1900, 2000],
+        },
+        20,
+        1
+    )
+    const manager: ChartManager = {
+        table,
+        yColumnSlugs: [SampleColumnSlugs.Fruit],
+        selection: table.availableEntityNames,
+    }
+    const chart = new StackedBarChart({ manager })
+    expect(chart.series.length).toEqual(2)
+    expect(
+        chart.series.every((series) =>
+            series.points.every(
+                (point) => isNumber(point.x) && isNumber(point.y)
+            )
+        )
+    ).toBeTruthy()
 })


### PR DESCRIPTION
Notion issue: https://www.notion.so/owid/StackedArea-LineChart-DiscreteBar-crash-when-data-contains-non-numeric-vaue-8b1b59ed3ae74d0fa40b004590c694cc