### PR TITLE
Show helpful message on single-year ScatterPlot avg annual change

### DIFF
--- a/grapher/noDataModal/NoDataModal.scss
+++ b/grapher/noDataModal/NoDataModal.scss
@@ -4,6 +4,7 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
+    height: 100%;
 
     .action {
         background-color: $controls-color;

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -677,8 +677,16 @@ export class ScatterPlotChart
 
         if (this.yColumn.isMissing) return "Missing X axis variable"
 
-        if (isEmpty(this.allEntityNamesWithXAndY))
+        if (isEmpty(this.allEntityNamesWithXAndY)) {
+            if (
+                this.manager.isRelativeMode &&
+                this.manager.hasTimeline &&
+                this.manager.startTime === this.manager.endTime
+            ) {
+                return "Please select two points on the timeline below"
+            }
             return "No entities with data for both X and Y"
+        }
 
         if (isEmpty(this.series)) return "No matching data"
 

--- a/grapher/scatterCharts/ScatterPlotChartConstants.ts
+++ b/grapher/scatterCharts/ScatterPlotChartConstants.ts
@@ -27,6 +27,7 @@ export interface ScatterPlotManager extends ChartManager {
     hideLinesOutsideTolerance?: boolean
     startTime?: Time
     endTime?: Time
+    hasTimeline?: boolean
 }
 
 export interface ScatterTooltipProps {


### PR DESCRIPTION
Before:

<img width="853" alt="Screenshot 2020-11-24 at 22 27 47" src="https://user-images.githubusercontent.com/1308115/100158585-50338500-2ea4-11eb-819b-33367e3f94e6.png">

After:

<img width="853" alt="Screenshot 2020-11-24 at 22 27 31" src="https://user-images.githubusercontent.com/1308115/100158592-545fa280-2ea4-11eb-8926-7c6e5591d804.png">
