### PR TITLE
Fix: custom dimension colors in admin

### DIFF
--- a/adminSite/client/ChartEditor.ts
+++ b/adminSite/client/ChartEditor.ts
@@ -155,7 +155,10 @@ export class ChartEditor {
 
     async saveGrapher({ onError }: { onError?: () => void } = {}) {
         const { grapher, isNewGrapher } = this
-        const currentGrapherObject = this.grapher.object
+        const currentGrapherObject = {
+            ...this.grapher.object,
+            selectedData: this.grapher.legacyConfigAsAuthored.selectedData,
+        }
 
         // Chart title and slug may be autocalculated from data, in which case they won't be in props
         // But the server will need to know what we calculated in order to do its job

--- a/adminSite/client/DimensionCard.tsx
+++ b/adminSite/client/DimensionCard.tsx
@@ -8,6 +8,7 @@ import {
     EditableListItem,
     BindAutoString,
     BindAutoFloat,
+    ColorBox,
 } from "./Forms"
 import { Link } from "./Link"
 import { faChevronDown } from "@fortawesome/free-solid-svg-icons/faChevronDown"
@@ -16,6 +17,7 @@ import { faExchangeAlt } from "@fortawesome/free-solid-svg-icons/faExchangeAlt"
 import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { DimensionProperty } from "grapher/core/GrapherConstants"
+import { OwidTable } from "coreTable/OwidTable"
 
 @observer
 export class DimensionCard extends React.Component<{
@@ -25,6 +27,10 @@ export class DimensionCard extends React.Component<{
     onRemove?: () => void
 }> {
     @observable.ref isExpanded: boolean = false
+
+    @computed get table(): OwidTable {
+        return this.props.editor.grapher.table
+    }
 
     @computed get hasExpandedOptions(): boolean {
         return (
@@ -41,6 +47,15 @@ export class DimensionCard extends React.Component<{
     @action.bound onIsProjection(value: boolean) {
         this.props.dimension.display.isProjection = value
         this.updateTables()
+    }
+
+    @action.bound onColor(color: string | undefined) {
+        this.props.dimension.display.color = color
+        this.updateTables()
+    }
+
+    @computed get color() {
+        return this.props.dimension.column.def.color
     }
 
     private get tableDisplaySettings() {
@@ -105,6 +120,7 @@ export class DimensionCard extends React.Component<{
                             </span>
                         )}
                     </div>
+                    <ColorBox color={this.color} onColor={this.onColor} />
                     <div>
                         <Link
                             to={`/variables/${dimension.variableId}`}

--- a/coreTable/LegacyToOwidTable.ts
+++ b/coreTable/LegacyToOwidTable.ts
@@ -90,9 +90,9 @@ export const legacyToOwidTableAndDimensions = (
 
         // Value column
         const valueColumnDef = columnDefFromLegacyVariable(variable)
-        const valueColumnColor = columnColorMap.get(
-            dimension.variableId.toString()
-        )
+        const valueColumnColor =
+            dimension.display?.color ??
+            columnColorMap.get(dimension.variableId.toString())
         // Ensure the column slug is unique by copying it from the dimensions
         // (there can be two columns of the same variable with different targetTimes)
         valueColumnDef.slug = dimension.slug

--- a/coreTable/LegacyVariableCode.ts
+++ b/coreTable/LegacyVariableCode.ts
@@ -39,6 +39,7 @@ class LegacyVariableDisplayConfigDefaults {
     @observable entityAnnotationsMap?: string = undefined
     @observable includeInTable?: boolean = true
     @observable tableDisplay?: LegacyVariableTableDisplayConfig
+    @observable color?: string = undefined
 }
 
 export type LegacyVariableDisplayConfigInterface = LegacyVariableDisplayConfigDefaults

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -293,9 +293,7 @@ export class Grapher
 
     @observable.ref inputTable: OwidTable
 
-    @observable.ref private legacyConfigAsAuthored: Partial<
-        LegacyGrapherInterface
-    > = {}
+    @observable.ref legacyConfigAsAuthored: Partial<LegacyGrapherInterface> = {}
 
     @computed get dataTableSlugs(): ColumnSlug[] {
         return this.tableSlugs ? this.tableSlugs.split(" ") : this.newSlugs


### PR DESCRIPTION
Dimension-level colors can now be edited in the admin. Can't merge until I finish column re-ordering early tomorrow.
![image](https://user-images.githubusercontent.com/11683872/100176072-a0f3af80-2e9d-11eb-9971-2e8c5c7c4c92.png)
