### PR TITLE
Embed cleanup

### DIFF
--- a/adminSite/client/DatasetEditPage.tsx
+++ b/adminSite/client/DatasetEditPage.tsx
@@ -152,7 +152,10 @@ class VariableEditRow extends React.Component<{
     dispose!: IReactionDisposer
     dispose2!: IReactionDisposer
     componentDidMount() {
-        this.grapher = new Grapher({ ...this.grapherConfig, isEmbed: true })
+        this.grapher = new Grapher({
+            ...this.grapherConfig,
+            isEmbeddedInAnOwidPage: true,
+        })
 
         this.dispose2 = when(
             () => this.grapher !== undefined && this.grapher.isReady,

--- a/baker/GrapherImageBaker.tsx
+++ b/baker/GrapherImageBaker.tsx
@@ -22,7 +22,7 @@ export async function bakeGraphersToPngs(
     optimizeSvgs = false
 ) {
     const grapher = new Grapher({ ...jsonConfig, manuallyProvideData: true })
-    grapher.isExporting = true
+    grapher.isExportingtoSvgOrPng = true
     grapher.receiveLegacyData(vardata)
     const outPath = path.join(outDir, grapher.slug as string)
 
@@ -88,7 +88,7 @@ export async function bakeGrapherToSvg(
         manuallyProvideData: true,
         queryStr,
     })
-    grapher.isExporting = true
+    grapher.isExportingtoSvgOrPng = true
     const { width, height } = grapher.idealBounds
     const outPath = `${outDir}/${slug}${queryStr ? "-" + md5(queryStr) : ""}_v${
         jsonConfig.version
@@ -157,7 +157,7 @@ export async function grapherToSVG(
     vardata: any
 ): Promise<string> {
     const grapher = new Grapher({ ...jsonConfig, manuallyProvideData: true })
-    grapher.isExporting = true
+    grapher.isExportingtoSvgOrPng = true
     grapher.receiveLegacyData(vardata)
     return grapher.staticSVG
 }

--- a/explorer/admin/ExplorerBaker.tsx
+++ b/explorer/admin/ExplorerBaker.tsx
@@ -29,6 +29,7 @@ import simpleGit from "simple-git"
 import { GitCommit } from "gitCms/GitTypes"
 import { slugify } from "grapher/utils/Util"
 import { GrapherInterface } from "grapher/core/GrapherInterface"
+import { Grapher } from "grapher/core/Grapher"
 
 const git = simpleGit({
     baseDir: GIT_CMS_DIR,
@@ -187,7 +188,7 @@ export const renderExplorerPage = async (program: ExplorerProgram) => {
     const grapherConfigs: GrapherInterface[] = grapherConfigRows.map((row) => {
         const config = JSON.parse(row.config)
         config.id = row.id // Ensure each grapher has an id
-        return config
+        return new Grapher(config).toObject()
     })
 
     return renderToHtmlPage(

--- a/explorer/admin/ExplorerPage.tsx
+++ b/explorer/admin/ExplorerPage.tsx
@@ -4,7 +4,7 @@ import { Head } from "site/server/views/Head"
 import { SiteHeader } from "site/server/views/SiteHeader"
 import { SiteFooter } from "site/server/views/SiteFooter"
 import { LoadingIndicator } from "grapher/loadingIndicator/LoadingIndicator"
-import { EmbedDetector } from "site/server/views/EmbedDetector"
+import { IFrameDetector } from "site/server/views/IframeDetector"
 import { SiteSubnavigation } from "site/server/views/SiteSubnavigation"
 import ExplorerContent from "./ExplorerContent"
 import {
@@ -15,6 +15,7 @@ import {
 import { ExplorerProgram } from "explorer/client/ExplorerProgram"
 import { GrapherInterface } from "grapher/core/GrapherInterface"
 import { serializeJSONForHTML } from "utils/serializers"
+import { GRAPHER_PAGE_BODY_CLASS } from "grapher/core/GrapherConstants"
 
 interface ExplorerPageSettings {
     program: ExplorerProgram
@@ -56,9 +57,9 @@ window.Explorer.renderSingleExplorerOnExplorerPage(explorerProgram, grapherConfi
                 pageTitle={explorerTitle}
                 imageUrl={`${settings.BAKED_BASE_URL}/${thumbnail} `}
             >
-                <EmbedDetector />
+                <IFrameDetector />
             </Head>
-            <body className="ChartPage">
+            <body className={GRAPHER_PAGE_BODY_CLASS}>
                 <SiteHeader hideAlertBanner={hideAlertBanner || false} />
                 {subNav}
                 <main id={ExplorerContainerId}>

--- a/explorer/client/Explorer.scss
+++ b/explorer/client/Explorer.scss
@@ -4,14 +4,14 @@ $explorer-grid-gap: 10px;
 $explorer-min-width-first-col: 200px;
 $explorer-padding: 0.5rem;
 
-#explorerContainer {
+#ExplorerContainer {
     min-height: $placeholder-height;
     width: 100%;
     position: relative;
     padding: $explorer-padding;
 }
 
-html.iframe #explorerContainer {
+html.IsInIframe #ExplorerContainer {
     height: 100vh;
     min-height: auto !important;
     max-height: none;
@@ -62,7 +62,7 @@ html.iframe #explorerContainer {
     }
 }
 
-html.iframe .Explorer,
+html.IsInIframe .Explorer,
 .Explorer.is-embed {
     height: 100%;
     min-height: auto !important;
@@ -72,7 +72,7 @@ html.iframe .Explorer,
     padding: 0;
 }
 
-html.iframe .ExplorerFigure,
+html.IsInIframe .ExplorerFigure,
 .is-embed .ExplorerFigure {
     min-height: auto !important;
     max-height: none;
@@ -123,7 +123,7 @@ html.iframe .ExplorerFigure,
         // Remove chart from layout calculation.
         // Since grid/flex layouts size to their contents, having the chart dictate that leads to
         // a very slow adaptations to resizing.
-        .chart {
+        .GrapherComponent {
             position: absolute;
         }
     }

--- a/explorer/client/Explorer.tsx
+++ b/explorer/client/Explorer.tsx
@@ -509,8 +509,7 @@ export class Explorer
                 <div className="ExplorerFigure" ref={this.grapherContainerRef}>
                     <Grapher
                         bounds={this.grapherBounds}
-                        isEmbed={true}
-                        enableKeyboardShortcuts={true}
+                        isInStandalonePage={true}
                         selectionArray={this.selection}
                         ref={this.grapherRef}
                     />

--- a/explorer/client/Explorer.tsx
+++ b/explorer/client/Explorer.tsx
@@ -52,7 +52,8 @@ import { setWindowQueryStr } from "utils/client/url"
 interface ExplorerProps extends SerializedGridProgram {
     grapherConfigs?: GrapherInterface[]
     patch?: string
-    isEmbed?: boolean // todo: what specifically does this mean? Does it mean IFF in an iframe? Or does it mean in an iframe OR hoisted?
+    isEmbeddedInAnOwidPage?: boolean
+    isInStandalonePage?: boolean
 }
 
 interface ExplorerPatchObject extends GrapherQueryParams {
@@ -90,10 +91,11 @@ export class Explorer
         program: ExplorerProps,
         grapherConfigs: GrapherInterface[]
     ) {
-        const props = {
+        const props: ExplorerProps = {
             ...program,
             grapherConfigs,
-            isEmbed: false,
+            isEmbeddedInAnOwidPage: false,
+            isInStandalonePage: true,
         }
 
         if (window.location.href.includes(EXPLORERS_PREVIEW_ROUTE)) {
@@ -154,7 +156,7 @@ export class Explorer
         window.addEventListener("resize", this.onResizeThrottled)
         this.onResize() // call resize for the first time to initialize chart
 
-        if (!this.props.isEmbed) this.bindToWindow()
+        if (this.props.isInStandalonePage) this.bindToWindow()
         else GlobalEntityRegistry.add(this)
     }
 
@@ -405,7 +407,7 @@ export class Explorer
     @computed private get showExplorerControls() {
         if (this.explorerProgram.hideControls) return false
 
-        return this.props.isEmbed ? false : true
+        return this.props.isEmbeddedInAnOwidPage ? false : true
     }
 
     @observable private grapherContainerRef: React.RefObject<
@@ -497,7 +499,7 @@ export class Explorer
                     Explorer: true,
                     "mobile-explorer": this.isNarrow,
                     HideControls: !showExplorerControls,
-                    "is-embed": this.props.isEmbed,
+                    "is-embed": this.props.isEmbeddedInAnOwidPage,
                 })}
             >
                 {showHeaderElement && this.renderHeaderElement()}
@@ -509,7 +511,8 @@ export class Explorer
                 <div className="ExplorerFigure" ref={this.grapherContainerRef}>
                     <Grapher
                         bounds={this.grapherBounds}
-                        isInStandalonePage={true}
+                        enableKeyboardShortcuts={true}
+                        isInAnExplorer={true}
                         selectionArray={this.selection}
                         ref={this.grapherRef}
                     />

--- a/explorer/client/ExplorerConstants.ts
+++ b/explorer/client/ExplorerConstants.ts
@@ -36,7 +36,7 @@ export const EMBEDDED_EXPLORER_GRAPHER_CONFIGS =
 
 export const EXPLORER_EMBEDDED_FIGURE_SELECTOR = "data-explorer-src"
 
-export const ExplorerContainerId = "explorerContainer"
+export const ExplorerContainerId = "ExplorerContainer"
 
 export const ExplorersRoute = "allExplorersForAdminListPage.json"
 export const ExplorersRouteGrapherConfigs =

--- a/grapher/captionedChart/Logos.tsx
+++ b/grapher/captionedChart/Logos.tsx
@@ -2,7 +2,11 @@ import * as React from "react"
 import { computed } from "mobx"
 import { OWID_LOGO_SVG, CORE_LOGO_SVG, GV_LOGO_SVG } from "./LogosSVG"
 
-export type LogoOption = "owid" | "core+owid" | "gv+owid"
+export enum LogoOption {
+    owid = "owid",
+    "core+owid" = "core+owid",
+    "gv+owid" = "gv+owid",
+}
 
 interface LogoAttributes {
     svg: string
@@ -35,7 +39,7 @@ const logos: Record<LogoOption, LogoAttributes> = {
 }
 
 interface LogoProps {
-    logo: LogoOption | undefined
+    logo?: LogoOption
     isLink: boolean
     fontSize: number
 }
@@ -46,13 +50,13 @@ export class Logo {
         this.props = props
     }
 
-    @computed get spec() {
+    @computed private get spec() {
         return this.props.logo !== undefined
             ? logos[this.props.logo]
             : logos.owid
     }
 
-    @computed get scale(): number {
+    @computed private get scale() {
         return this.spec.targetHeight / this.spec.height
     }
 
@@ -78,24 +82,15 @@ export class Logo {
     }
 
     renderHTML() {
+        const { spec } = this
         const props: React.HTMLAttributes<
             HTMLDivElement & HTMLAnchorElement
         > = {
             className: "logo",
-            dangerouslySetInnerHTML: { __html: this.spec.svg },
-            style: { height: `${this.spec.targetHeight}px` },
+            dangerouslySetInnerHTML: { __html: spec.svg },
+            style: { height: `${spec.targetHeight}px` },
         }
-        if (this.props.isLink || !this.spec.url) {
-            return <div {...props} />
-        } else {
-            return (
-                <a
-                    {...props}
-                    href={this.spec.url}
-                    target="_blank"
-                    rel="noopener"
-                />
-            )
-        }
+        if (this.props.isLink || !spec.url) return <div {...props} />
+        return <a {...props} href={spec.url} target="_blank" rel="noopener" />
     }
 }

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -200,7 +200,7 @@ export interface FooterControlsManager extends ShareMenuManager {
     isSelectingData?: boolean
     availableTabs?: GrapherTabOption[]
     currentTab?: GrapherTabOption
-    isEmbed?: boolean
+    isInIFrame?: boolean
     canonicalUrl?: string
     hasTimeline?: boolean
     hasRelatedQuestion?: boolean
@@ -282,7 +282,7 @@ export class FooterControls extends React.Component<{
                             <FontAwesomeIcon icon={faShareAlt} />
                         </a>
                     </li>
-                    {manager.isEmbed && (
+                    {manager.isInIFrame && (
                         <li className="clickable icon">
                             <a
                                 title="Open chart in new tab"

--- a/grapher/controls/EntitySelectorModal.scss
+++ b/grapher/controls/EntitySelectorModal.scss
@@ -139,7 +139,7 @@ $zindex-EntitySelector: 30;
     }
 }
 
-.chart.portrait .EntitySelectorMulti {
+.GrapherComponent.GrapherPortraitClass .EntitySelectorMulti {
     .selectedData {
         min-width: 50%;
     }

--- a/grapher/controls/ShareMenu.scss
+++ b/grapher/controls/ShareMenu.scss
@@ -82,6 +82,6 @@ $zindex-embedMenu: 12;
     height: 80%;
 }
 
-.chart.mobile .ShareMenu .btn-embed {
+.GrapherComponent.mobile .ShareMenu .btn-embed {
     display: none;
 }

--- a/grapher/core/Grapher.stories.tsx
+++ b/grapher/core/Grapher.stories.tsx
@@ -122,14 +122,6 @@ export const Faceting = () => {
     return <Grapher {...model} />
 }
 
-export const WithKeyboardShortcutsAndOtherNonEmbedBehavior = () => {
-    const model: GrapherProgrammaticInterface = {
-        ...basics,
-        isEmbed: false,
-    }
-    return <Grapher {...model} />
-}
-
 export const WithAuthorTimeFilter = () => {
     const model: GrapherProgrammaticInterface = {
         ...basics,

--- a/grapher/core/GrapherConstants.ts
+++ b/grapher/core/GrapherConstants.ts
@@ -13,6 +13,10 @@ export enum ChartTypeName {
 
 export const GRAPHER_EMBEDDED_FIGURE_ATTR = "data-grapher-src"
 
+export const GRAPHER_PAGE_BODY_CLASS = "StandaloneGrapherOrExplorerPage"
+
+export const GRAPHER_IS_IN_IFRAME_CLASS = "IsInIframe"
+
 export enum CookieKey {
     isAdmin = "isAdmin",
 }

--- a/grapher/core/grapher.scss
+++ b/grapher/core/grapher.scss
@@ -13,14 +13,14 @@ $zindex-chart: 1;
 $zindex-tab: 1;
 $zindex-Tooltip: 20;
 
-.chart,
-.chart p,
-.chart ul,
-.chart ol {
+.GrapherComponent,
+.GrapherComponent p,
+.GrapherComponent ul,
+.GrapherComponent ol {
     font-family: $sans-serif-font-stack;
 }
 
-.chart {
+.GrapherComponent {
     display: inline-block;
     border-bottom: none;
     border-radius: 2px;
@@ -123,7 +123,7 @@ $zindex-Tooltip: 20;
     }
 }
 
-.chart.export {
+.GrapherComponent.isExportingToSvgOrPng {
     padding: 0 !important;
 }
 

--- a/grapher/footer/Footer.tsx
+++ b/grapher/footer/Footer.tsx
@@ -53,22 +53,24 @@ export class Footer extends React.Component<{
 
         // Make sure the link back to OWID is consistent
         // And don't show the full url if there isn't enough room
-        if (originUrl && originUrl.toLowerCase().match(/^https?:\/\/./)) {
-            const url = parseUrl(originUrl)
-            const finalUrlText = `${url.hostname}${url.pathname}`.replace(
-                "ourworldindata.org",
-                "OurWorldInData.org"
-            )
-            if (
-                this.manager.isNativeEmbed ||
-                Bounds.forText(finalUrlText, { fontSize: this.fontSize })
-                    .width >
-                    0.7 * this.maxWidth
-            )
-                return undefined
-            return finalUrlText
-        }
-        return undefined
+        if (
+            !originUrl ||
+            !originUrl.toLowerCase().match(/^https?:\/\/./) ||
+            this.manager.shouldLinkToOwid
+        )
+            return undefined
+
+        const url = parseUrl(originUrl)
+        const finalUrlText = `${url.hostname}${url.pathname}`.replace(
+            "ourworldindata.org",
+            "OurWorldInData.org"
+        )
+        if (
+            Bounds.forText(finalUrlText, { fontSize: this.fontSize }).width >
+            0.7 * this.maxWidth
+        )
+            return undefined
+        return finalUrlText
     }
 
     @computed private get licenseSvg() {

--- a/grapher/footer/FooterManager.ts
+++ b/grapher/footer/FooterManager.ts
@@ -6,7 +6,7 @@ export interface FooterManager {
     sourcesLine?: string
     note?: string
     hasOWIDLogo?: boolean
-    isNativeEmbed?: boolean
+    shouldLinkToOwid?: boolean
     originUrlWithProtocol?: string
     isMediaCard?: boolean
     currentTab?: string

--- a/grapher/header/Header.tsx
+++ b/grapher/header/Header.tsx
@@ -38,7 +38,7 @@ export class Header extends React.Component<{
 
         return new Logo({
             logo: manager.logo as any,
-            isLink: !manager.isNativeEmbed,
+            isLink: !!manager.shouldLinkToOwid,
             fontSize: this.fontSize,
         })
     }

--- a/grapher/header/HeaderManager.ts
+++ b/grapher/header/HeaderManager.ts
@@ -5,7 +5,7 @@ export interface HeaderManager {
     currentTitle?: string
     subtitle?: string
     hideLogo?: boolean
-    isNativeEmbed?: boolean
+    shouldLinkToOwid?: boolean
     isMediaCard?: boolean
     logo?: string
     canonicalUrl?: string

--- a/grapher/sourcesTab/SourcesTab.scss
+++ b/grapher/sourcesTab/SourcesTab.scss
@@ -53,6 +53,6 @@
     margin-top: 0.3em;
 }
 
-.chart.narrow .datasource-wrapper {
+.GrapherComponent.narrow .datasource-wrapper {
     padding: 0;
 }

--- a/site/client/EmbedChart.tsx
+++ b/site/client/EmbedChart.tsx
@@ -14,15 +14,15 @@ import { deserializeJSONFromHTML } from "utils/serializers"
 
 @observer
 export class EmbedChart extends React.Component<{ src: string }> {
-    @computed get configUrl(): string {
+    @computed private get configUrl() {
         return splitURLintoPathAndQueryString(this.props.src).path
     }
-    @computed get queryStr(): string | undefined {
+    @computed private get queryStr() {
         return splitURLintoPathAndQueryString(this.props.src).queryString
     }
-    @observable grapher?: Grapher
+    @observable private grapher?: Grapher
 
-    async loadConfig() {
+    private async loadConfig() {
         const { configUrl } = this
         const resp = await fetch(configUrl)
         if (this.configUrl !== configUrl) {
@@ -35,13 +35,13 @@ export class EmbedChart extends React.Component<{ src: string }> {
         runInAction(() => {
             this.grapher = new Grapher({
                 ...config,
-                isEmbed: true,
+                isEmbeddedInAnOwidPage: true,
                 queryStr: this.queryStr,
             })
         })
     }
 
-    dispose?: IReactionDisposer
+    private dispose?: IReactionDisposer
     componentDidMount() {
         this.dispose = autorun(() => this.props.src && this.loadConfig())
     }

--- a/site/client/css/pages/chart.scss
+++ b/site/client/css/pages/chart.scss
@@ -1,4 +1,4 @@
-.ChartPage main figure[data-grapher-src],
+.StandaloneGrapherOrExplorerPage main figure[data-grapher-src],
 #fallback {
     display: flex;
     align-items: center;
@@ -7,10 +7,10 @@
     margin: 0 auto;
     width: 100%;
 
-    // Defined in chart.authorWidth & chart.authorHeight (the landscape values)
-    $author-width: 680px;
-    $author-height: 480px;
-    $ideal-ratio: $author-width / $author-height;
+    // The landscape values)
+    $orientation-width: 680px;
+    $orientation-height: 480px;
+    $ideal-ratio: $orientation-width / $orientation-height;
 
     $max-width: 1250px; // The rough max-width across all pages on the site
     $max-height: $max-width / $ideal-ratio;
@@ -31,7 +31,7 @@
 
     // At this point, the ratio-preserving sizing kicks in, so we want to mirror that in the CSS
     // to avoid using unnecessary space.
-    @media (min-width: $author-width) {
+    @media (min-width: $orientation-width) {
         // We no longer use the full height
         max-height: #{1 / $ideal-ratio * 100}vw;
     }
@@ -61,13 +61,13 @@
     border: 1px solid #ccc;
 }
 
-.ChartPage .site-subnavigation {
+.StandaloneGrapherOrExplorerPage .site-subnavigation {
     padding-left: 1rem;
     margin: 0 auto;
     max-width: $max-width-covid-data-explorer;
 }
 
-.ChartPage main {
+.StandaloneGrapherOrExplorerPage main {
     .related-research-data {
         @include block-spacing;
         margin-top: $vertical-spacing;
@@ -94,7 +94,7 @@
     }
 }
 
-html.iframe .ChartPage {
+html.IsInIframe .StandaloneGrapherOrExplorerPage {
     background-color: inherit;
 
     > main {

--- a/site/client/figures/MultiEmbedder.tsx
+++ b/site/client/figures/MultiEmbedder.tsx
@@ -31,8 +31,8 @@ class EmbeddedFigure {
         if (this._isLoaded) return
         this._isLoaded = true
 
-        const common = {
-            isEmbed: true,
+        const common: GrapherProgrammaticInterface = {
+            isEmbeddedInAnOwidPage: true,
             queryStr: this.props.queryStr,
         }
 

--- a/site/client/owid.entry.ts
+++ b/site/client/owid.entry.ts
@@ -27,7 +27,10 @@ import { hydrateGlobalEntityControlIfAny } from "grapher/controls/globalEntityCo
 import { runFootnotes } from "site/client/Footnote"
 import { Explorer } from "explorer/client/Explorer"
 import { ENV } from "settings"
-import { CookieKey } from "grapher/core/GrapherConstants"
+import {
+    CookieKey,
+    GRAPHER_PAGE_BODY_CLASS,
+} from "grapher/core/GrapherConstants"
 import { Grapher } from "grapher/core/Grapher"
 import { MultiEmbedderSingleton } from "./figures/MultiEmbedder"
 import { CoreTable } from "coreTable/CoreTable"
@@ -56,7 +59,7 @@ window.runSiteFooterScripts = () => {
     runCookiePreferencesManager()
     runCovid()
     runFootnotes()
-    if (!document.querySelector(".ChartPage")) {
+    if (!document.querySelector(`.${GRAPHER_PAGE_BODY_CLASS}`)) {
         MultiEmbedderSingleton.embedAll()
         hydrateGlobalEntityControlIfAny()
     }

--- a/site/client/runVariableCountryPage.tsx
+++ b/site/client/runVariableCountryPage.tsx
@@ -36,7 +36,7 @@ class ClientVariableCountryPage extends React.Component<{
     componentDidMount() {
         this.grapher = new Grapher({
             ...this.grapherConfig,
-            isEmbed: true,
+            isEmbeddedInAnOwidPage: true,
         })
     }
 

--- a/site/server/views/EmbedDetector.tsx
+++ b/site/server/views/EmbedDetector.tsx
@@ -1,9 +1,0 @@
-import * as React from "react"
-
-export const EmbedDetector = () => (
-    <script
-        dangerouslySetInnerHTML={{
-            __html: `if (window != window.top) document.documentElement.classList.add('iframe')`,
-        }}
-    />
-)

--- a/site/server/views/GrapherPage.tsx
+++ b/site/server/views/GrapherPage.tsx
@@ -13,8 +13,9 @@ import { Post } from "db/model/Post"
 import { RelatedChart } from "site/client/blocks/RelatedCharts/RelatedCharts"
 import { ChartListItemVariant } from "./ChartListItemVariant"
 import { LoadingIndicator } from "grapher/loadingIndicator/LoadingIndicator"
-import { EmbedDetector } from "./EmbedDetector"
+import { IFrameDetector } from "./IframeDetector"
 import { serializeJSONForHTML } from "utils/serializers"
+import { GRAPHER_PAGE_BODY_CLASS } from "grapher/core/GrapherConstants"
 
 export const GrapherPage = (props: {
     grapher: GrapherInterface
@@ -51,7 +52,7 @@ window.Grapher.renderSingleGrapherOnGrapherPage(jsonConfig)`
             >
                 <meta property="og:image:width" content="850" />
                 <meta property="og:image:height" content="600" />
-                <EmbedDetector />
+                <IFrameDetector />
                 <noscript>
                     <style>{`
                     figure { display: none !important; }
@@ -66,7 +67,7 @@ window.Grapher.renderSingleGrapherOnGrapherPage(jsonConfig)`
                     crossOrigin="anonymous"
                 />
             </Head>
-            <body className="ChartPage">
+            <body className={GRAPHER_PAGE_BODY_CLASS}>
                 <SiteHeader />
                 <main>
                     <figure data-grapher-src={`/grapher/${grapher.slug}`}>

--- a/site/server/views/IframeDetector.tsx
+++ b/site/server/views/IframeDetector.tsx
@@ -1,0 +1,10 @@
+import { GRAPHER_IS_IN_IFRAME_CLASS } from "grapher/core/GrapherConstants"
+import * as React from "react"
+
+export const IFrameDetector = () => (
+    <script
+        dangerouslySetInnerHTML={{
+            __html: `if (window != window.top) document.documentElement.classList.add('${GRAPHER_IS_IN_IFRAME_CLASS}')`,
+        }}
+    />
+)


### PR DESCRIPTION
Just trying to cleanup the "isEmbed" style properties a bit, and remove any general css classes like "chart" and "iframe". Ideally we can get our SCSS and TypeScript linking to the same identifiers at some point.

