### PR TITLE
Move xScale log lin toggle to controls row.

### DIFF
--- a/grapher/axis/AxisConfig.ts
+++ b/grapher/axis/AxisConfig.ts
@@ -7,6 +7,7 @@ import {
     Persistable,
 } from "grapher/persistable/Persistable"
 import { AxisConfigInterface } from "./AxisConfigInterface"
+import { ScaleSelectorManager } from "grapher/controls/ScaleSelector"
 
 export interface FontSizeManager {
     fontSize: number
@@ -23,7 +24,7 @@ class AxisConfigDefaults {
 
 export class AxisConfig
     extends AxisConfigDefaults
-    implements AxisConfigInterface, Persistable {
+    implements AxisConfigInterface, Persistable, ScaleSelectorManager {
     // todo: test/refactor
     constructor(
         props?: AxisConfigInterface,

--- a/grapher/axis/AxisViews.tsx
+++ b/grapher/axis/AxisViews.tsx
@@ -4,10 +4,6 @@ import { observer } from "mobx-react"
 import { Bounds, DEFAULT_BOUNDS } from "grapher/utils/Bounds"
 import { VerticalAxis, HorizontalAxis, DualAxis } from "./Axis"
 import classNames from "classnames"
-import {
-    ScaleSelector,
-    ScaleSelectorManager,
-} from "grapher/controls/ScaleSelector"
 import { ScaleType } from "grapher/core/GrapherConstants"
 
 @observer
@@ -91,7 +87,6 @@ interface DualAxisViewProps {
     dualAxis: DualAxis
     highlightValue?: { x: number; y: number }
     showTickMarks?: boolean
-    isInteractive?: boolean
 }
 
 @observer
@@ -99,8 +94,6 @@ export class DualAxisComponent extends React.Component<DualAxisViewProps> {
     render() {
         const { dualAxis, showTickMarks } = this.props
         const { bounds, horizontalAxis, verticalAxis, innerBounds } = dualAxis
-
-        const maxX = undefined // {grapher.tabBounds.width} todo
 
         const verticalGridlines = verticalAxis.hideGridlines ? null : (
             <VerticalAxisGridLines
@@ -125,12 +118,10 @@ export class DualAxisComponent extends React.Component<DualAxisViewProps> {
 
         const horizontalAxisComponent = horizontalAxis.hideAxis ? null : (
             <HorizontalAxisComponent
-                maxX={maxX}
                 bounds={bounds}
                 axisPosition={innerBounds.bottom}
                 axis={horizontalAxis}
                 showTickMarks={showTickMarks}
-                isInteractive={false} // Todo! Renable xAxis scale type toggle. this.props.isInteractive
             />
         )
 
@@ -181,33 +172,18 @@ export class VerticalAxisComponent extends React.Component<{
     }
 }
 
-export class HorizontalAxisComponent
-    extends React.Component<{
-        bounds: Bounds
-        axis: HorizontalAxis
-        axisPosition: number
-        maxX?: number
-        showTickMarks?: boolean
-        isInteractive?: boolean
-    }>
-    implements ScaleSelectorManager {
-    @computed private get controls() {
-        const showControls =
-            this.props.isInteractive && this.props.axis.canChangeScaleType
-        if (!showControls) return undefined
-        return <ScaleSelector manager={this} />
-    }
-
+export class HorizontalAxisComponent extends React.Component<{
+    bounds: Bounds
+    axis: HorizontalAxis
+    axisPosition: number
+    showTickMarks?: boolean
+}> {
     @computed get scaleType() {
         return this.props.axis.scaleType
     }
 
     set scaleType(scaleType: ScaleType) {
         this.props.axis.config.scaleType = scaleType
-    }
-
-    @computed get maxX() {
-        return this.props.maxX
     }
 
     // for scale selector. todo: cleanup
@@ -266,7 +242,6 @@ export class HorizontalAxisComponent
 
                     return element
                 })}
-                {this.controls}
             </g>
         )
     }

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -283,8 +283,6 @@ export class DiscreteBarChart
 
         let yOffset = innerBounds.top + barHeight / 2
 
-        const maxX = bounds.width + 40 // This is only used to shift the ScaleSelector left if it exceeds the container. Hard coded for now but could be improved
-
         return (
             <g ref={this.base} className="DiscreteBarChart">
                 <rect
@@ -296,9 +294,7 @@ export class DiscreteBarChart
                     fill="rgba(255,255,255,0)"
                 />
                 <HorizontalAxisComponent
-                    maxX={maxX}
                     bounds={bounds}
-                    isInteractive={!this.manager.isStaticSvg}
                     axis={axis}
                     axisPosition={innerBounds.bottom}
                 />

--- a/grapher/captionedChart/CaptionedChart.stories.tsx
+++ b/grapher/captionedChart/CaptionedChart.stories.tsx
@@ -37,7 +37,7 @@ export const StaticLineChartForExport = () => {
         <StaticCaptionedChart
             manager={{
                 ...manager,
-                isStaticSvg: true,
+                isExportingtoSvgOrPng: true,
             }}
         />
     )

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -52,7 +52,6 @@ export interface CaptionedChartManager
     typeExceptWhenLineChartAndSingleTimeThenWillBeBarChart?: ChartTypeName
     isReady?: boolean
     whatAreWeWaitingFor?: string
-    isStaticSvg?: boolean
     entityType?: string
     entityTypePlural?: string
     showSmallCountriesFilterToggle?: boolean

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -57,6 +57,7 @@ export interface CaptionedChartManager
     entityTypePlural?: string
     showSmallCountriesFilterToggle?: boolean
     showYScaleToggle?: boolean
+    showXScaleToggle?: boolean
     showZoomToggle?: boolean
     showAbsRelToggle?: boolean
     showHighlightToggle?: boolean
@@ -176,11 +177,26 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         // Todo: we don't yet show any controls on Maps, but seems like we would want to.
         if (!manager.isReady || this.isMapTab) return []
 
+        const { showYScaleToggle, showXScaleToggle } = manager
+
         const controls: JSX.Element[] = []
 
-        if (manager.showYScaleToggle)
+        if (showYScaleToggle)
             controls.push(
-                <ScaleSelector key="scaleSelector" manager={manager.yAxis!} />
+                <ScaleSelector
+                    key="scaleSelector"
+                    manager={manager.yAxis!}
+                    prefix={showXScaleToggle ? "Y: " : ""}
+                />
+            )
+
+        if (showXScaleToggle)
+            controls.push(
+                <ScaleSelector
+                    key="scaleSelector"
+                    manager={manager.xAxis!}
+                    prefix={"X: "}
+                />
             )
 
         if (manager.showSelectEntitiesButton)

--- a/grapher/chart/ChartManager.ts
+++ b/grapher/chart/ChartManager.ts
@@ -25,7 +25,7 @@ export interface ChartManager {
 
     isSelectingData?: boolean
     startSelectingWhenLineClicked?: boolean // used by lineLabels
-    isStaticSvg?: boolean
+    isExportingtoSvgOrPng?: boolean
     isRelativeMode?: boolean
     comparisonLines?: ComparisonLineConfig[]
     hideLegend?: boolean

--- a/grapher/controls/ScaleSelector.scss
+++ b/grapher/controls/ScaleSelector.scss
@@ -1,8 +1,4 @@
 .toggleSwitch {
-    &:not(.inline) {
-        position: absolute;
-    }
-
     text-transform: uppercase;
     cursor: pointer;
     font-weight: bold;

--- a/grapher/controls/ScaleSelector.stories.tsx
+++ b/grapher/controls/ScaleSelector.stories.tsx
@@ -5,7 +5,6 @@ import {
 } from "grapher/controls/ScaleSelector"
 import { ScaleType } from "grapher/core/GrapherConstants"
 import { observable } from "mobx"
-import { Bounds } from "grapher/utils/Bounds"
 
 export default {
     title: "ScaleSelector",
@@ -14,22 +13,8 @@ export default {
 
 class MockScaleSelectorManager implements ScaleSelectorManager {
     @observable scaleType = ScaleType.log
-    bounds?: Bounds
-    maxX?: number
 }
 
 export const Default = () => (
     <ScaleSelector manager={new MockScaleSelectorManager()} />
 )
-
-export const StayInBounds = () => {
-    const manager = new MockScaleSelectorManager()
-    manager.bounds = new Bounds(190, 0, 100, 100)
-    manager.maxX = 200
-    return (
-        <svg width={200} height={200} style={{ position: "relative" }}>
-            <rect width="100%" height="100%" fill="green" />
-            <ScaleSelector manager={manager} />
-        </svg>
-    )
-}

--- a/grapher/controls/ScaleSelector.tsx
+++ b/grapher/controls/ScaleSelector.tsx
@@ -1,81 +1,34 @@
 import * as React from "react"
-import { computed, action } from "mobx"
+import { action } from "mobx"
 import { observer } from "mobx-react"
 import { ScaleType } from "grapher/core/GrapherConstants"
 import classNames from "classnames"
 import { next } from "grapher/utils/Util"
-import { Bounds } from "grapher/utils/Bounds"
 
 export interface ScaleSelectorManager {
-    bounds?: Bounds
-    maxX?: number // If set, the scale toggle will shift left if it exceeds this number
     scaleType?: ScaleType
 }
 
 @observer
 export class ScaleSelector extends React.Component<{
-    manager: ScaleSelectorManager
+    manager?: ScaleSelectorManager
+    prefix?: string
 }> {
-    @computed get manager() {
-        return this.props.manager
-    }
-
-    @computed private get isInline() {
-        return this.manager.bounds === undefined
-    }
-
-    @computed get maxX() {
-        return this.manager.maxX || 0
-    }
-
-    @computed get scaleType() {
-        return this.manager.scaleType ?? ScaleType.linear
-    }
-
-    @action.bound onClick() {
-        this.manager.scaleType = next(
+    @action.bound private onClick() {
+        const manager = this.props.manager ?? {}
+        manager.scaleType = next(
             [ScaleType.linear, ScaleType.log],
-            this.scaleType
+            manager.scaleType ?? ScaleType.linear
         )
-    }
-
-    private componentWidth = 95
-
-    private getLeftShiftIfNeeded(xPosition: number) {
-        if (!this.maxX) return 0
-        const overflow = this.maxX - (xPosition + this.componentWidth)
-        let shiftLeft = 0
-        if (overflow < 0) shiftLeft = Math.abs(overflow)
-        return shiftLeft
     }
 
     render() {
-        if (this.isInline) return this.renderToggle()
-        const bounds = this.manager.bounds!
-        return (
-            <foreignObject
-                id="horizontal-scale-selector"
-                y={bounds.y}
-                x={bounds.x - this.getLeftShiftIfNeeded(bounds.x)}
-                width={1}
-                height={1}
-                style={{ overflow: "visible" }}
-            >
-                {this.renderToggle()}
-            </foreignObject>
-        )
-    }
-
-    renderToggle() {
-        const { scaleType } = this
+        const { manager, prefix } = this.props
+        const { scaleType } = manager ?? {}
         return (
             <span
                 onClick={this.onClick}
-                className={classNames([
-                    "clickable",
-                    "toggleSwitch",
-                    { inline: this.isInline },
-                ])}
+                className={classNames(["clickable", "toggleSwitch"])}
             >
                 <span
                     data-track-note="chart-toggle-scale"
@@ -84,7 +37,7 @@ export class ScaleSelector extends React.Component<{
                         (scaleType === ScaleType.linear ? "activeToggle" : "")
                     }
                 >
-                    Linear
+                    {prefix}Linear
                 </span>
                 <span
                     data-track-note="chart-toggle-scale"
@@ -93,7 +46,7 @@ export class ScaleSelector extends React.Component<{
                         (scaleType === ScaleType.log ? "activeToggle" : "")
                     }
                 >
-                    Log
+                    {prefix}Log
                 </span>
             </span>
         )

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -2169,6 +2169,10 @@ export class Grapher
         return this.yAxis.canChangeScaleType
     }
 
+    @computed get showXScaleToggle() {
+        return this.xAxis.canChangeScaleType
+    }
+
     @computed get showZoomToggle() {
         return this.isScatter && this.selection.hasSelection
     }

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -573,10 +573,6 @@ export class Grapher
     @observable isPlaying = false
     @observable.ref isSelectingData = false
 
-    @computed get isStaticSvg() {
-        return this.isExportingtoSvgOrPng
-    }
-
     private get isStaging() {
         if (typeof location === undefined) return false
         return location.host.includes("staging")

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -524,11 +524,7 @@ export class LineChart
         return (
             <g ref={this.base} className="LineChart">
                 {clipPath.element}
-                <DualAxisComponent
-                    isInteractive={!manager.isStaticSvg}
-                    dualAxis={dualAxis}
-                    showTickMarks={true}
-                />
+                <DualAxisComponent dualAxis={dualAxis} showTickMarks={true} />
                 <g clipPath={clipPath.id}>
                     {comparisonLines.map((line, index) => (
                         <ComparisonLine

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -461,7 +461,7 @@ export class LineChart
         unknown
     >
     componentDidMount() {
-        if (!this.manager.isStaticSvg) this.runFancyIntroAnimation()
+        if (!this.manager.isExportingtoSvgOrPng) this.runFancyIntroAnimation()
         exposeInstanceOnWindow(this)
     }
 

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -546,17 +546,12 @@ export class ScatterPlotChart
             sidebarWidth,
             tooltipSeries,
             comparisonLines,
-            manager,
             legendDimensions,
         } = this
 
         return (
             <g className="ScatterPlot">
-                <DualAxisComponent
-                    isInteractive={!manager.isStaticSvg}
-                    dualAxis={dualAxis}
-                    showTickMarks={false}
-                />
+                <DualAxisComponent dualAxis={dualAxis} showTickMarks={false} />
                 {comparisonLines &&
                     comparisonLines.map((line, i) => (
                         <ComparisonLine

--- a/grapher/stackedCharts/StackedAreaChart.tsx
+++ b/grapher/stackedCharts/StackedAreaChart.tsx
@@ -419,7 +419,7 @@ export class StackedAreaChart
                 />
             )
 
-        const { manager, bounds, dualAxis, renderUid, series } = this
+        const { bounds, dualAxis, renderUid, series } = this
 
         const showLegend = !this.manager.hideLegend
 
@@ -432,11 +432,7 @@ export class StackedAreaChart
         return (
             <g ref={this.base} className="StackedArea">
                 {clipPath.element}
-                <DualAxisComponent
-                    isInteractive={!manager.isStaticSvg}
-                    dualAxis={dualAxis}
-                    showTickMarks={true}
-                />
+                <DualAxisComponent dualAxis={dualAxis} showTickMarks={true} />
                 <g clipPath={clipPath.id}>
                     {showLegend && <LineLegend manager={this} />}
                     <Areas


### PR DESCRIPTION
Some may say UX is better; some may say it's a slight regression; but 99% of our charts don't have and xScale toggle, and we can always iterate later if we want.

The current implementation was as simple as could be and yet still a decently complex 100 lines interweaved in a few classes (You have to do collision detection amongst other things). Other more important things for now :).

Before/after
![Screen Shot 2020-11-25 at 6 01 43 PM](https://user-images.githubusercontent.com/74692/100307220-62b3ca00-2f49-11eb-91c5-2e843316c1fa.png)
