### PR TITLE
test: fix GitCms test on CI

### DIFF
--- a/gitCms/GitCms.test.ts
+++ b/gitCms/GitCms.test.ts
@@ -47,10 +47,7 @@ describe("client/server integration tests", () => {
             commitMessage: "created file",
         })
 
-        // todo: this test is failing in CI. Maybe a race condition? Not sure. Commenting it out for now.
-        expect(response).toBeTruthy()
-        // if (!response.success) console.log(JSON.stringify(response)) // Dump for easier debugging in CI
-        // expect(response.success).toBeTruthy()
+        expect(response.success).toBeTruthy()
     })
 
     it("fails write gracefully when given a bad path", async () => {
@@ -88,10 +85,7 @@ describe("client/server integration tests", () => {
     it("can delete a file", async () => {
         const response = await client.deleteRemoteFile({ filepath })
 
-        // todo: this test is failing in CI. Maybe a race condition? Not sure. Commenting it out for now.
-        expect(response).toBeTruthy()
-        // if (!response.success) console.log(JSON.stringify(response)) // Dump for easier debugging in CI
-        // expect(response.success).toBeTruthy()
+        expect(response.success).toBeTruthy()
     })
 
     it("can fail delete gracefully", async () => {

--- a/gitCms/GitCmsServer.ts
+++ b/gitCms/GitCmsServer.ts
@@ -71,6 +71,11 @@ export class GitCmsServer {
         const { baseDir } = this
         if (!existsSync(baseDir)) mkdirSync(baseDir)
         await this.git.init()
+
+        // Needed since git won't let you commit if there's no user name config present (i.e. CI), even if you always
+        // specify `author=` in every command. See https://stackoverflow.com/q/29685337/10670163 for example.
+        await this.git.addConfig("user.name", GIT_DEFAULT_USERNAME)
+        await this.git.addConfig("user.email", GIT_DEFAULT_EMAIL)
     }
 
     private async commitFile(


### PR DESCRIPTION
It wasn't running correctly since git _always_ needs `user.name` and `user.email` set in some config somewhere, even if it's always passed as `--author=` arg for every command.
Thus, we now set it in the repo-local config.

See https://stackoverflow.com/q/29685337/10670163 for example, which is about just this issue.

cc @breck7 