### PR TITLE
fix(colorScale): don't remove outliers if that would mean we end up with only one distinct value

### DIFF
--- a/grapher/color/ColorScale.ts
+++ b/grapher/color/ColorScale.ts
@@ -229,9 +229,15 @@ export class ColorScale {
         if (!sortedNumericValues.length) return []
         const sampleMean = mean(sortedNumericValues) as number
         const sampleDeviation = deviation(sortedNumericValues) as number
-        return sortedNumericValues.filter(
+        const withoutOutliers = sortedNumericValues.filter(
             (d) => Math.abs(d - sampleMean) <= sampleDeviation * 2
         )
+
+        if (deviation(withoutOutliers) === 0) {
+            // if after removing outliers we end up in a state where the std. dev. is 0, i.e. we only
+            // have one distinct value, then we actually want to _keep_ the outliers in
+            return sortedNumericValues
+        } else return withoutOutliers
     }
 
     /** Sorted numeric values passed onto the binning algorithms */


### PR DESCRIPTION
This fixes a recurring issue that was [reported in Slack](https://owid.slack.com/archives/C46U9LXRR/p1608119235000600) multiple times in the last few days, where the color scale outlier detection would remove all values except for 0 and the authors couldn't assign map brackets etc.

I'm going to merge this in already so this can go live, but please take a quick look at it to see if this all makes sense.
Also, it looks like we don't currently have tests for `ColorScale` methods? This would really benefit from tests...

**Before:**
![image](https://user-images.githubusercontent.com/2641501/102353507-6fa46600-3fa9-11eb-8725-43d3a4931e9e.png)

**After:**
![image](https://user-images.githubusercontent.com/2641501/102353563-8c409e00-3fa9-11eb-8e14-0f56ea61bf21.png)
