### PR TITLE
Decouple baking of Grapher and Wordpress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ public/covidChartAndVariableMeta.json
 clientSettings.json
 serverSettings.json
 serverSettings.json
+localBake/

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -145,7 +145,7 @@ export const bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers =
     const newSlugs = []
     await fs.mkdirp(bakedSiteDir + "/grapher")
     const progressBar = new ProgressBar(
-        "BakeGrapherPageVarPngAndSVGIfChanged [:bar] :current/:total :elapseds :name\n",
+        "BakeGrapherPageVarPngAndSVGIfChanged [:bar] :current/:total :elapseds :rate/s :etas :name\n",
         {
             width: 20,
             total: rows.length + 1,

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -369,7 +369,7 @@ export class SiteBaker {
         await this.bakePosts()
     }
 
-    async bakeNonWordpressPages() {
+    private async _bakeNonWordpressPages() {
         await bakeCountries(this)
         await this.bakeSpecialPages()
         await this.bakeCountryProfiles()
@@ -383,11 +383,21 @@ export class SiteBaker {
         await this.bakeGrapherToExplorerRedirects()
     }
 
+    async bakeNonWordpressPages() {
+        this.progressBar = new ProgressBar(
+            "BakeAll [:bar] :current/:total :elapseds :name\n",
+            {
+                total: 5,
+            }
+        )
+        await this._bakeNonWordpressPages()
+    }
+
     async bakeAll() {
         // Ensure caches are correctly initialized
         this.flushCache()
         await this.bakeWordpressPages()
-        await this.bakeNonWordpressPages()
+        await this._bakeNonWordpressPages()
         this.flushCache()
     }
 

--- a/baker/buildLocalBake.ts
+++ b/baker/buildLocalBake.ts
@@ -2,20 +2,24 @@
 
 import parseArgs from "minimist"
 import { SiteBaker } from "./SiteBaker"
+import * as fs from "fs-extra"
+import { normalize } from "path"
 
-const bakeDomainToFolder = async (baseUrl: string, dir: string) => {
+const bakeDomainToFolder = async (
+    baseUrl = "http://localhost:3000/",
+    dir = "localBake"
+) => {
+    dir = normalize(dir)
+    fs.mkdirp(dir)
     const baker = new SiteBaker(dir, baseUrl)
-    console.log(`Baking site with baseUrl '${baseUrl}' to dir '${dir}'`)
-    await baker.bakeAll()
+    console.log(
+        `Baking site sans Wordpress with baseUrl '${baseUrl}' to dir '${dir}'`
+    )
+    await baker.bakeNonWordpressPages()
 }
 
 const args = parseArgs(process.argv.slice(2))
 const theArgs = args._
-if (theArgs.length !== 2) {
-    console.error(
-        `Usage: yarn buildLocalBake http://owid.org /home/user/owid.org`
-    )
-    process.exit()
-}
-
+// Usage: yarn buildLocalBake http://localhost:3000/ localBake
+// todo: can we just make all paths relative? why do we need absolute baked base url?
 bakeDomainToFolder(theArgs[0], theArgs[1])

--- a/baker/countryProfiles.tsx
+++ b/baker/countryProfiles.tsx
@@ -209,4 +209,6 @@ export const bakeCountries = async (baker: SiteBaker) => {
         const html = await countryProfilePage(country.slug, baker.baseUrl)
         await baker.writeFile(path, html)
     }
+
+    baker.progressBar.tick({ name: "✅ baked countries" })
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "scripts": {
         "buildAndDeploySite": "node ./itsJustJavascript/baker/buildAndDeploySite.js",
         "buildCoverage": "jest --coverage=true --coverageProvider=v8",
-        "buildLocalBake": "node ./itsJustJavascript/baker/bakeLocal.js",
+        "buildLocalBake": "node ./itsJustJavascript/baker/buildLocalBake.js",
         "buildStorybook": "build-storybook -c ./itsJustJavascript/.storybook -o .storybook/build",
         "buildTsc": "tsc -b -verbose",
         "buildWebpack": "rm -rf itsJustJavascript/webpack && ENV=production webpack --config ./itsJustJavascript/webpack.config.js -p --progress",


### PR DESCRIPTION
Just split the body of "bakeAll" into 2 methods for baking Wordpress parts of site and the rest. that way you can dive in and debug the Grapher parts of the bake (which are slow and have a lot of room for improvement) without having to have the wordpress part running.
