### PR TITLE
Embed dialog: correct URL, hideControls toggle, hideControls works

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -134,6 +134,8 @@ export class Explorer
     @observable entityPickerMetric? = this.initialPatchObject.pickerMetric
     @observable entityPickerSort? = this.initialPatchObject.pickerSort
 
+    @observable embedHideControls = true
+
     selection = new SelectionArray(
         this.explorerProgram.selection,
         undefined,
@@ -551,6 +553,38 @@ export class Explorer
             this.props.canonicalUrl ??
             (this.baseUrl ? this.baseUrl + this.encodedQueryString : undefined)
         )
+    }
+
+    @computed get embedUrl() {
+        const embedPatch = new Patch({
+            ...(this.patchObject as any),
+            hideControls: this.embedHideControls.toString(),
+        }).uriEncodedString
+        const embedPatchEncoded = embedPatch
+            ? `?${PATCH_QUERY_PARAM}=` + embedPatch
+            : ""
+
+        return this.baseUrl ? this.baseUrl + embedPatchEncoded : undefined
+    }
+
+    @computed get embedAdditionalElements() {
+        return () => {
+            const toggleHideControls = () =>
+                (this.embedHideControls = !this.embedHideControls)
+
+            return (
+                <div style={{ marginTop: ".5rem" }}>
+                    <label>
+                        <input
+                            type="checkbox"
+                            checked={this.embedHideControls}
+                            onChange={toggleHideControls}
+                        />{" "}
+                        Hide controls
+                    </label>
+                </div>
+            )
+        }
     }
 
     @computed get entityPickerTable() {

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -66,6 +66,7 @@ interface ExplorerProps extends SerializedGridProgram {
 interface ExplorerPatchObject extends GrapherQueryParams {
     pickerSort?: SortOrder
     pickerMetric?: ColumnSlug
+    hideControls?: string
 }
 
 const renderLivePreviewVersion = (props: ExplorerProps) => {
@@ -360,6 +361,7 @@ export class Explorer
                 : undefined,
             pickerSort: this.entityPickerSort,
             pickerMetric: this.entityPickerMetric,
+            hideControls: this.initialPatchObject.hideControls || undefined,
             ...decisionsPatchObject,
         }
 
@@ -417,7 +419,11 @@ export class Explorer
     @observable private isNarrow = isNarrow()
 
     @computed private get showExplorerControls() {
-        if (this.explorerProgram.hideControls) return false
+        if (
+            this.explorerProgram.hideControls ||
+            this.initialPatchObject.hideControls === "true"
+        )
+            return false
 
         return this.props.isEmbeddedInAnOwidPage ? false : true
     }

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -53,6 +53,7 @@ import { BlankOwidTable, OwidTable } from "../coreTable/OwidTable"
 import { GlobalEntityRegistry } from "../grapher/controls/globalEntityControl/GlobalEntityRegistry"
 import { Patch } from "../patch/Patch"
 import { setWindowQueryStr, strToQueryParams } from "../clientUtils/url"
+import { BAKED_BASE_URL } from "../settings/clientSettings"
 
 interface ExplorerProps extends SerializedGridProgram {
     grapherConfigs?: GrapherInterface[]
@@ -535,8 +536,15 @@ export class Explorer
         return `${EXPLORERS_ROUTE_FOLDER}/${this.props.slug}`
     }
 
+    @computed get baseUrl() {
+        return `${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${this.props.slug}`
+    }
+
     @computed get canonicalUrl() {
-        return (this.props.canonicalUrl ?? "") + this.encodedQueryString
+        return (
+            this.props.canonicalUrl ??
+            (this.baseUrl ? this.baseUrl + this.encodedQueryString : undefined)
+        )
     }
 
     @computed get entityPickerTable() {

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -134,7 +134,8 @@ export class Explorer
     @observable entityPickerMetric? = this.initialPatchObject.pickerMetric
     @observable entityPickerSort? = this.initialPatchObject.pickerSort
 
-    @observable embedHideControls = true
+    // only used for the checkbox at the bottom of the embed dialog
+    @observable embedDialogHideControls = true
 
     selection = new SelectionArray(
         this.explorerProgram.selection,
@@ -555,10 +556,10 @@ export class Explorer
         )
     }
 
-    @computed get embedUrl() {
+    @computed get embedDialogUrl() {
         const embedPatch = new Patch({
             ...(this.patchObject as any),
-            hideControls: this.embedHideControls.toString(),
+            hideControls: this.embedDialogHideControls.toString(),
         }).uriEncodedString
         const embedPatchEncoded = embedPatch
             ? `?${PATCH_QUERY_PARAM}=` + embedPatch
@@ -567,24 +568,23 @@ export class Explorer
         return this.baseUrl ? this.baseUrl + embedPatchEncoded : undefined
     }
 
-    @computed get embedAdditionalElements() {
-        return () => {
-            const toggleHideControls = () =>
-                (this.embedHideControls = !this.embedHideControls)
+    @action.bound embedDialogToggleHideControls() {
+        this.embedDialogHideControls = !this.embedDialogHideControls
+    }
 
-            return (
-                <div style={{ marginTop: ".5rem" }}>
-                    <label>
-                        <input
-                            type="checkbox"
-                            checked={this.embedHideControls}
-                            onChange={toggleHideControls}
-                        />{" "}
-                        Hide controls
-                    </label>
-                </div>
-            )
-        }
+    @computed get embedDialogAdditionalElements() {
+        return (
+            <div style={{ marginTop: ".5rem" }}>
+                <label>
+                    <input
+                        type="checkbox"
+                        checked={this.embedDialogHideControls}
+                        onChange={this.embedDialogToggleHideControls}
+                    />{" "}
+                    Hide controls
+                </label>
+            </div>
+        )
     }
 
     @computed get entityPickerTable() {

--- a/grapher/controls/ShareMenu.tsx
+++ b/grapher/controls/ShareMenu.tsx
@@ -15,7 +15,7 @@ export interface ShareMenuManager {
     currentTitle?: string
     canonicalUrl?: string
     embedUrl?: string
-    embedAdditionalElements?: () => React.ReactElement
+    embedDialogAdditionalElements?: React.ReactElement
     editUrl?: string
     addPopup: (popup: any) => void
     removePopup: (popup: any) => void
@@ -233,7 +233,7 @@ class EmbedMenu extends React.Component<{
                     onFocus={(evt) => evt.currentTarget.select()}
                     value={`<iframe src="${url}" loading="lazy" style="width: 100%; height: 600px; border: 0px none;"></iframe>`}
                 />
-                {this.manager.embedAdditionalElements?.()}
+                {this.manager.embedDialogAdditionalElements}
             </div>
         )
     }

--- a/grapher/controls/ShareMenu.tsx
+++ b/grapher/controls/ShareMenu.tsx
@@ -14,6 +14,8 @@ export interface ShareMenuManager {
     slug?: string
     currentTitle?: string
     canonicalUrl?: string
+    embedUrl?: string
+    embedAdditionalElements?: () => React.ReactElement
     editUrl?: string
     addPopup: (popup: any) => void
     removePopup: (popup: any) => void
@@ -221,7 +223,7 @@ class EmbedMenu extends React.Component<{
     }
 
     render() {
-        const url = this.manager.canonicalUrl
+        const url = this.manager.embedUrl ?? this.manager.canonicalUrl
         return (
             <div className="embedMenu" onClick={this.onClick}>
                 <h2>Embed</h2>
@@ -231,6 +233,7 @@ class EmbedMenu extends React.Component<{
                     onFocus={(evt) => evt.currentTarget.select()}
                     value={`<iframe src="${url}" loading="lazy" style="width: 100%; height: 600px; border: 0px none;"></iframe>`}
                 />
+                {this.manager.embedAdditionalElements?.()}
             </div>
         )
     }

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -197,6 +197,8 @@ export interface GrapherProgrammaticInterface extends GrapherInterface {
 
 export interface GrapherManager {
     canonicalUrl?: string
+    embedUrl?: string
+    embedAdditionalElements?: () => React.ReactElement
     selection?: SelectionArray
     editUrl?: string
 }
@@ -2096,6 +2098,14 @@ export class Grapher
             this.manager.canonicalUrl ??
             (this.baseUrl ? this.baseUrl + this.queryStr : undefined)
         )
+    }
+
+    @computed get embedUrl() {
+        return this.manager.embedUrl ?? this.canonicalUrl
+    }
+
+    @computed get embedAdditionalElements() {
+        return this.manager.embedAdditionalElements
     }
 
     @computed private get hasUserChangedTimeHandles() {

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -197,8 +197,8 @@ export interface GrapherProgrammaticInterface extends GrapherInterface {
 
 export interface GrapherManager {
     canonicalUrl?: string
-    embedUrl?: string
-    embedAdditionalElements?: () => React.ReactElement
+    embedDialogUrl?: string
+    embedDialogAdditionalElements?: React.ReactElement
     selection?: SelectionArray
     editUrl?: string
 }
@@ -2101,11 +2101,11 @@ export class Grapher
     }
 
     @computed get embedUrl() {
-        return this.manager.embedUrl ?? this.canonicalUrl
+        return this.manager.embedDialogUrl ?? this.canonicalUrl
     }
 
-    @computed get embedAdditionalElements() {
-        return this.manager.embedAdditionalElements
+    @computed get embedDialogAdditionalElements() {
+        return this.manager.embedDialogAdditionalElements
     }
 
     @computed private get hasUserChangedTimeHandles() {


### PR DESCRIPTION
Notion: https://www.notion.so/owid/Embed-code-missing-url-and-hideControls-param-d08ae86bd229421ba897afc9b2a944b9

This fixes 3 issues we had:
* the `hideControls=true` param (as part of the patch) works
* the embed dialog shows the correct URL, including the base URL
* the "Hide controls" toggle at the bottom of the embed dialog is restored (it's still not integrated in a super clean way, but I think it's better than before at least, and more extensible)

![image](https://user-images.githubusercontent.com/2641501/102779380-6abe2880-4394-11eb-9d5b-d4ab74501d82.png)
