### PR TITLE
fix(sources): sources tab and text no longer empty

### DIFF
--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -756,9 +756,7 @@ export class Grapher
     @computed get newSlugs() {
         const { xSlug, colorSlug, sizeSlug } = this
         const ySlugs = this.ySlugs ? this.ySlugs.split(" ") : []
-        return [...ySlugs, xSlug, colorSlug, sizeSlug].filter(
-            (slug) => slug
-        ) as ColumnSlug[]
+        return excludeUndefined([...ySlugs, xSlug, colorSlug, sizeSlug])
     }
 
     @computed private get loadingDimensions() {
@@ -1182,7 +1180,8 @@ export class Grapher
         return this.sourceDesc ?? this.defaultSourcesLine
     }
 
-    @computed get columnsWithSources() {
+    // All columns that are _currently_ part of the visualization
+    @computed get activeColumnSlugs() {
         const {
             yColumnSlugs,
             xColumnSlug,
@@ -1190,16 +1189,18 @@ export class Grapher
             colorColumnSlug,
         } = this
 
+        return excludeUndefined([
+            ...yColumnSlugs,
+            xColumnSlug,
+            sizeColumnSlug,
+            colorColumnSlug,
+        ])
+    }
+
+    @computed get columnsWithSources() {
         // Only use dimensions/columns that are actually part of the visualization
         // In Explorers, this also ensures that only columns which are currently in use will be shown in Sources tab
-        const columnSlugs = uniq(
-            excludeUndefined([
-                ...yColumnSlugs,
-                xColumnSlug,
-                sizeColumnSlug,
-                colorColumnSlug,
-            ])
-        )
+        const columnSlugs = uniq(this.activeColumnSlugs)
 
         // exclude some columns that are "too common" (they are used in most scatter plots for color & size)
         // todo: this sort of conditional we could do in a smarter editor, and not at runtime

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1183,14 +1183,38 @@ export class Grapher
     }
 
     @computed get columnsWithSources() {
-        return this.inputTable.getColumns(this.newSlugs).filter((column) => {
-            if (
-                column.name === "Countries Continents" ||
-                column.name === "Total population (Gapminder)"
+        const {
+            yColumnSlugs,
+            xColumnSlug,
+            sizeColumnSlug,
+            colorColumnSlug,
+        } = this
+
+        // Only use dimensions/columns that are actually part of the visualization
+        // In Explorers, this also ensures that only columns which are currently in use will be shown in Sources tab
+        const columnSlugs = uniq(
+            excludeUndefined([
+                ...yColumnSlugs,
+                xColumnSlug,
+                sizeColumnSlug,
+                colorColumnSlug,
+            ])
+        )
+
+        // exclude some columns that are "too common" (they are used in most scatter plots for color & size)
+        // todo: this sort of conditional we could do in a smarter editor, and not at runtime
+        const excludedColumnSlugs = [
+            "72", // "Total population (Gapminder, HYDE & UN)", usually used as "size" dimension in scatter plots
+            "123", // "Countries Continent", usually used as color in scatter plots, slope charts, etc.
+        ]
+
+        return this.inputTable
+            .getColumns(columnSlugs)
+            .filter(
+                (column) =>
+                    !!column.source.name &&
+                    !excludedColumnSlugs.includes(column.slug)
             )
-                return false // todo: this sort of conditional we could do in a smarter editor, and not at runtime
-            return !!column.source.name
-        })
     }
 
     @computed private get defaultSourcesLine() {


### PR DESCRIPTION
Notion: https://www.notion.so/owid/Source-tab-is-empty-and-no-source-below-charts-edc8f4b52be1473ba3792aa4351aaed7

This also fixes the exclusion of the variables "Countries Continent" and "Total population (Gapminder, HYDE & UN)", which wasn't working on live. That's a slight behavior change in the sources line (marked in red), but I think that's for the better:
![image](https://user-images.githubusercontent.com/2641501/102804789-876d5700-43ba-11eb-9f5f-538597ab1662.png)

(same in the Sources tab, where these two entries are now also absent)