### PR TITLE
Remove Timeline#snapTimes()

### DIFF
--- a/grapher/timeline/TimelineComponent.tsx
+++ b/grapher/timeline/TimelineComponent.tsx
@@ -134,8 +134,6 @@ export class TimelineComponent extends React.Component<{
             this.startTooltipVisible = false
             this.endTooltipVisible = false
         }
-
-        this.controller.snapTimes()
     }
 
     private mouseHoveringOverTimeline: boolean = false

--- a/grapher/timeline/TimelineController.ts
+++ b/grapher/timeline/TimelineController.ts
@@ -55,16 +55,6 @@ export class TimelineController {
         return (this.endTime - this.minTime) / (this.maxTime - this.minTime)
     }
 
-    snapTimes() {
-        const { startTime, endTime } = this
-        if (startTime === endTime) return
-
-        if (endTime - startTime > 1) return
-
-        // if handles within 1 time of each other, snap to closest time.
-        this.manager.startHandleTimeBound = this.manager.endHandleTimeBound
-    }
-
     getNextTime(time: number) {
         // Todo: speed up?
         return this.timesAsc[this.timesAsc.indexOf(time) + 1] ?? this.maxTime


### PR DESCRIPTION
I _think_ it was introduced when we had the timeline dragging freely without snapping. Now that it always snaps to available years, it's not necessary.

The fact that it snaps on `≤1` also causes this bug where you can't select a range that's only 1 time step apart: 

https://user-images.githubusercontent.com/1308115/103649389-48acd480-4f56-11eb-8095-91597c521afc.mov

Reported here: https://owid.slack.com/archives/C46U9LXRR/p1609849260000400