### PR TITLE
fix: each grapher gets its own query params

### DIFF
--- a/explorer/Explorer.jsdom.test.tsx
+++ b/explorer/Explorer.jsdom.test.tsx
@@ -5,6 +5,7 @@ import { SampleExplorer } from "./Explorer.sample"
 
 import { configure, mount } from "enzyme"
 import Adapter from "enzyme-adapter-react-16"
+import { GrapherTabOption } from "../grapher/core/GrapherConstants"
 configure({ adapter: new Adapter() })
 
 describe(Explorer, () => {
@@ -19,9 +20,17 @@ describe(Explorer, () => {
         expect(element.text()).toContain("Kingdom")
     })
 
-    it("maintains changed params in url even if a user switches to a chart where the param is the default", () => {
+    it("each grapher has its own set of URL params/options are preserved even when the grapher changes", () => {
         const explorer = element.instance() as Explorer
-        expect(explorer.patchObject.stackMode).toEqual(undefined)
-        // todo: add more tests
+        expect(explorer.patchObject.tab).toBeUndefined()
+
+        explorer.onChangeChoice("Gas Radio")("All GHGs (CO₂eq)")
+
+        if (explorer.grapher) explorer.grapher.tab = GrapherTabOption.table
+        else throw Error("where's the grapher?")
+        expect(explorer.patchObject.tab).toEqual("table")
+
+        explorer.onChangeChoice("Gas Radio")("CO₂")
+        expect(explorer.patchObject.tab).toBeUndefined()
     })
 })

--- a/explorer/Explorer.sample.tsx
+++ b/explorer/Explorer.sample.tsx
@@ -1,13 +1,15 @@
 import React from "react"
 import { GrapherProgrammaticInterface } from "../grapher/core/Grapher"
-import { DimensionProperty } from "../grapher/core/GrapherConstants"
+import {
+    DimensionProperty,
+    GrapherTabOption,
+} from "../grapher/core/GrapherConstants"
 import { Explorer } from "./Explorer"
 
 const SampleExplorerProgram = `explorerTitle	CO₂ Data Explorer
 isPublished	false
 explorerSubtitle	Download the complete <i>Our World in Data</i> <a href="https://github.com/owid/co2-data">CO₂ and GHG Emissions Dataset</a>.
 subNavId	co2
-tab	chart
 time	earliest..latest
 selection	China	United States	India	United Kingdom	World
 Gas Radio	CO₂
@@ -54,6 +56,7 @@ export const SampleExplorer = () => {
                 property: DimensionProperty.y,
             },
         ],
+        tab: GrapherTabOption.chart,
         owidDataset: {
             variables: {
                 "142609": {

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -28,6 +28,7 @@ import {
     SlideShowManager,
 } from "../grapher/slideshowController/SlideShowController"
 import {
+    ExplorerChoice,
     ExplorerContainerId,
     EXPLORERS_PREVIEW_ROUTE,
     EXPLORERS_ROUTE_FOLDER,
@@ -375,16 +376,15 @@ export class Explorer
                     key={choice.title}
                     explorerSlug={this.explorerProgram.slug}
                     choice={choice}
-                    onChange={(value) => {
-                        this.explorerProgram.decisionMatrix.setValueCommand(
-                            choice.title,
-                            value
-                        )
-                        this.reactToUserChangingSelection()
-                    }}
+                    onChange={this.onChangeChoice(choice.title)}
                 />
             )
         )
+    }
+
+    onChangeChoice = (choiceTitle: string) => (value: string) => {
+        this.explorerProgram.decisionMatrix.setValueCommand(choiceTitle, value)
+        this.reactToUserChangingSelection()
     }
 
     private renderHeaderElement() {


### PR DESCRIPTION
Should fix [After changing an explorer to log scale, url doesn't revert when you change it back to linear](url) by giving each grapher its own query parameters.