### PR TITLE
perf: way faster cartesian product using `fast-cartesian`

### DIFF
--- a/coreTable/CoreTableUtils.test.ts
+++ b/coreTable/CoreTableUtils.test.ts
@@ -19,6 +19,7 @@ import {
     concatColumnStores,
     guessColumnDefFromSlugAndRow,
     standardizeSlugs,
+    cartesianProduct,
 } from "./CoreTableUtils"
 import { ErrorValueTypes } from "./ErrorValues"
 
@@ -369,5 +370,23 @@ describe(concatColumnStores, () => {
                 ErrorValueTypes.MissingValuePlaceholder,
             ],
         })
+    })
+})
+
+describe(cartesianProduct, () => {
+    it("correctly calculates a cartesian product", () => {
+        const a = [1, 2, 3]
+        const b = ["a", "b"]
+
+        const product = cartesianProduct<string | number>(a, b)
+
+        expect(product).toEqual([
+            [1, "a"],
+            [1, "b"],
+            [2, "a"],
+            [2, "b"],
+            [3, "a"],
+            [3, "b"],
+        ])
     })
 })

--- a/coreTable/CoreTableUtils.ts
+++ b/coreTable/CoreTableUtils.ts
@@ -1,4 +1,5 @@
 import { dsvFormat } from "d3-dsv"
+import fastCartesian from "fast-cartesian"
 import {
     findIndexFast,
     first,
@@ -615,15 +616,8 @@ export const trimArray = (arr: any[]) => {
     return arr.slice(0, rightIndex + 1)
 }
 
-// https://gist.github.com/ssippe/1f92625532eef28be6974f898efb23ef
 export function cartesianProduct<T>(...allEntries: T[][]): T[][] {
-    return allEntries.reduce<T[][]>(
-        (results, entries) =>
-            results
-                .map((result) => entries.map((entry) => [...result, entry]))
-                .reduce((subResults, result) => [...subResults, ...result], []),
-        [[]]
-    )
+    return fastCartesian(allEntries)
 }
 
 const applyNewSortOrder = (arr: any[], newOrder: number[]) =>

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
         "express-async-errors": "^3.1.1",
         "express-error-slack": "^2.0.0",
         "express-rate-limit": "^5.1.3",
+        "fast-cartesian": "^5.1.0",
         "fibers": "^5.0.0",
         "file-loader": "^6.1.0",
         "filenamify": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8844,6 +8844,11 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
+fast-cartesian@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/fast-cartesian/-/fast-cartesian-5.1.0.tgz#496ff07b4d60d9e4ba6888d0f04a97b2115f4aca"
+  integrity sha512-sZqtZoSpvB64whoAfZYaHY2EMF4yX039MlXoL7UpXpy38OxaN2ZJcZbS1qu7hsEkPrrReqTi0EBrfx5bd+HNBQ==
+
 fast-deep-equal@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"


### PR DESCRIPTION
In my search for performance issues in `next`, I noticed that `cartesianProduct` took a very long time.
It is called by `table.complete`, which in turn is called in our various tolerance methods.

I switched the cartesian product code over to use https://github.com/ehmicky/fast-cartesian instead, and the results speak for themselves:
When switching from "log" to "linear" in http://localhost:3030/grapher/GDP-vs-agriculture-employment, `cartesianProduct` takes:
* 936ms before (with our custom implementation)
* 24.5ms after (with https://github.com/ehmicky/fast-cartesian)

We still would want to look for further optimizations in the future to make things faster, but that's a great first step already and we may need a fast cartesian product in the future, too!