### PR TITLE
fix(admin): use correct asset path

### DIFF
--- a/adminSiteServer/IndexPage.tsx
+++ b/adminSiteServer/IndexPage.tsx
@@ -27,20 +27,24 @@ export const IndexPage = (props: {
                     rel="stylesheet"
                 />
                 <link
-                    href={webpackUrl("commons.css")}
+                    href={webpackUrl("commons.css", undefined, "/admin")}
                     rel="stylesheet"
                     type="text/css"
                 />
                 <link
-                    href={webpackUrl("admin.css")}
+                    href={webpackUrl("admin.css", undefined, "/admin")}
                     rel="stylesheet"
                     type="text/css"
                 />
             </head>
             <body>
                 <div id="app"></div>
-                <script src={webpackUrl("commons.js")}></script>
-                <script src={webpackUrl("admin.js")}></script>
+                <script
+                    src={webpackUrl("commons.js", undefined, "/admin")}
+                ></script>
+                <script
+                    src={webpackUrl("admin.js", undefined, "/admin")}
+                ></script>
                 <script
                     type="text/javascript"
                     dangerouslySetInnerHTML={{ __html: script }}

--- a/adminSiteServer/app.tsx
+++ b/adminSiteServer/app.tsx
@@ -9,6 +9,7 @@ import {
     ADMIN_SERVER_HOST,
     ADMIN_SERVER_PORT,
     ENV,
+    SLACK_ERRORS_WEBHOOK_URL,
 } from "../settings/serverSettings"
 import * as db from "../db/db"
 import * as wpdb from "../db/wpdb"
@@ -19,7 +20,7 @@ import { apiRouter } from "./apiRouter"
 import { testPageRouter } from "./testPageRouter"
 import { adminRouter } from "./adminRouter"
 import { renderToHtmlPage } from "./serverUtil"
-import { SLACK_ERRORS_WEBHOOK_URL } from "../settings/serverSettings"
+
 import { publicApiRouter } from "./publicApiRouter"
 import { mockSiteRouter } from "./mockSiteRouter"
 import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants"
@@ -49,7 +50,7 @@ app.use("/api", publicApiRouter.router)
 app.use("/admin/api", apiRouter.router)
 app.use("/admin/test", testPageRouter)
 
-app.use("/admin/build", express.static("itsJustJavascript/webpack"))
+app.use("/admin/assets", express.static("itsJustJavascript/webpack"))
 app.use("/admin/storybook", express.static(".storybook/build"))
 app.use("/admin", adminRouter)
 

--- a/site/webpackUtils.tsx
+++ b/site/webpackUtils.tsx
@@ -23,7 +23,7 @@ export const webpackUrl = (
                     )
                     .toString("utf8")
             )
-        return urljoin(baseUrl, "/", "assets", manifest[assetName])
+        return urljoin(baseUrl, "/assets", manifest[assetName])
     }
 
     return urljoin(WEBPACK_DEV_URL, assetName)


### PR DESCRIPTION
Even with #784, the admin site is still not working since it is loading its assets from the wrong path.
In fact, back before `itsJustJavascript`, there were two different methods to determine where to load an asset from: https://github.com/owid/owid-grapher/blob/57bf84c10266421cbff9bd6aa5474c4345d1bc48/utils/server/staticGen.tsx and https://github.com/owid/owid-grapher/blob/57bf84c10266421cbff9bd6aa5474c4345d1bc48/adminSite/server/utils/webpack.ts. One was for the admin server, the other for the actual site.

In this PR, I'm changing the URL where admin assets are delivered from `/admin/build` to `/admin/assets`, and can then just use `baseUrl: "/admin"` to load the correct one. I notice this is certainly not the cleanest solution, but it works and that's what we need most at the moment.

### What still doesn't work

The embed test pages, i.e. `/admin/test/embeds`, still don't know where to load their respective assets from.