### PR TITLE
fix(admin): test embeds page works again

### DIFF
--- a/adminSiteServer/IndexPage.tsx
+++ b/adminSiteServer/IndexPage.tsx
@@ -27,24 +27,20 @@ export const IndexPage = (props: {
                     rel="stylesheet"
                 />
                 <link
-                    href={webpackUrl("commons.css", undefined, "/admin")}
+                    href={webpackUrl("commons.css", "/admin")}
                     rel="stylesheet"
                     type="text/css"
                 />
                 <link
-                    href={webpackUrl("admin.css", undefined, "/admin")}
+                    href={webpackUrl("admin.css", "/admin")}
                     rel="stylesheet"
                     type="text/css"
                 />
             </head>
             <body>
                 <div id="app"></div>
-                <script
-                    src={webpackUrl("commons.js", undefined, "/admin")}
-                ></script>
-                <script
-                    src={webpackUrl("admin.js", undefined, "/admin")}
-                ></script>
+                <script src={webpackUrl("commons.js", "/admin")}></script>
+                <script src={webpackUrl("admin.js", "/admin")}></script>
                 <script
                     type="text/javascript"
                     dangerouslySetInnerHTML={{ __html: script }}

--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -17,12 +17,14 @@ import {
     countryProfileCountryPage,
 } from "../baker/siteRenderers"
 import { grapherSlugToHtmlPage } from "../baker/GrapherBaker"
-import { BAKED_BASE_URL, BAKED_GRAPHER_URL } from "../settings/serverSettings"
 import {
+    BAKED_BASE_URL,
+    BAKED_GRAPHER_URL,
     WORDPRESS_DIR,
     BASE_DIR,
     BAKED_SITE_DIR,
 } from "../settings/serverSettings"
+
 import * as db from "../db/db"
 import { expectInt, renderToHtmlPage } from "./serverUtil"
 import {
@@ -80,7 +82,7 @@ mockSiteRouter.get(
 )
 
 mockSiteRouter.get("/grapher/embedCharts.js", async (req, res) =>
-    res.send(bakeEmbedSnippet())
+    res.send(bakeEmbedSnippet(BAKED_BASE_URL))
 )
 
 mockSiteRouter.get("/grapher/latest", async (req, res) => {

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -7,10 +7,14 @@ import * as cheerio from "cheerio"
 import ProgressBar = require("progress")
 import * as wpdb from "../db/wpdb"
 import * as db from "../db/db"
-import { BLOG_POSTS_PER_PAGE } from "../settings/serverSettings"
+import {
+    BLOG_POSTS_PER_PAGE,
+    BASE_DIR,
+    WORDPRESS_DIR,
+} from "../settings/serverSettings"
 import { extractFormattingOptions } from "./formatting"
 import { LongFormPage } from "../site/LongFormPage"
-import { BASE_DIR, WORDPRESS_DIR } from "../settings/serverSettings"
+
 import {
     renderToHtmlPage,
     renderFrontPage,
@@ -322,7 +326,7 @@ export class SiteBaker {
 
         await fs.writeFile(
             `${this.bakedSiteDir}/grapher/embedCharts.js`,
-            bakeEmbedSnippet()
+            bakeEmbedSnippet(this.baseUrl)
         )
         this.stage(`${this.bakedSiteDir}/grapher/embedCharts.js`)
         this.progressBar.tick({ name: "✅ baked assets" })

--- a/site/Head.tsx
+++ b/site/Head.tsx
@@ -54,8 +54,8 @@ export const Head = (props: {
                 href="https://fonts.googleapis.com/css?family=Lato:300,400,400i,700,700i|Playfair+Display:400,700&display=swap"
                 rel="stylesheet"
             />
-            <link rel="stylesheet" href={webpackUrl("commons.css")} />
-            <link rel="stylesheet" href={webpackUrl("owid.css")} />
+            <link rel="stylesheet" href={webpackUrl("commons.css", baseUrl)} />
+            <link rel="stylesheet" href={webpackUrl("owid.css", baseUrl)} />
             {props.children}
         </head>
     )

--- a/site/SiteFooter.tsx
+++ b/site/SiteFooter.tsx
@@ -230,8 +230,8 @@ export const SiteFooter = (props: SiteFooterProps) => (
             </div>
             <div className="site-tools" />
             <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,fetch" />
-            <script src={webpackUrl("commons.js")} />
-            <script src={webpackUrl("owid.js")} />
+            <script src={webpackUrl("commons.js", props.baseUrl)} />
+            <script src={webpackUrl("owid.js", props.baseUrl)} />
             <script
                 dangerouslySetInnerHTML={{
                     __html: `window.runSiteFooterScripts()`, // todo: gotta be a better way.

--- a/site/webpackUtils.tsx
+++ b/site/webpackUtils.tsx
@@ -46,10 +46,11 @@ const checkReady = () => {
         window.MultiEmbedderSingleton.embedAll()
 }
 
-const coreScripts = ['https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,fetch', '${webpackUrl(
-    "commons.js",
-    baseUrl
-)}', '${webpackUrl("owid.js", baseUrl)}']
+const coreScripts = [
+    'https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,fetch',
+    '${webpackUrl("commons.js", baseUrl)}',
+    '${webpackUrl("owid.js", baseUrl)}'
+]
 
 coreScripts.forEach(url => {
     const script = document.createElement('script')

--- a/site/webpackUtils.tsx
+++ b/site/webpackUtils.tsx
@@ -10,8 +10,8 @@ const WEBPACK_OUTPUT_PATH =
 let manifest: { [key: string]: string }
 export const webpackUrl = (
     assetName: string,
-    isProduction = ENV === "production",
-    baseUrl = ""
+    baseUrl = "",
+    isProduction = ENV === "production"
 ) => {
     if (isProduction) {
         // Read the real asset name from the manifest in case it has a hashed filename
@@ -23,7 +23,8 @@ export const webpackUrl = (
                     )
                     .toString("utf8")
             )
-        return urljoin(baseUrl, "/assets", manifest[assetName])
+        if (baseUrl) return urljoin(baseUrl, "/assets", manifest[assetName])
+        else return urljoin("/", "assets", manifest[assetName])
     }
 
     return urljoin(WEBPACK_DEV_URL, assetName)
@@ -35,7 +36,7 @@ export const bakeEmbedSnippet = (
 const link = document.createElement('link')
 link.type = 'text/css'
 link.rel = 'stylesheet'
-link.href = '${webpackUrl("commons.css", undefined, baseUrl)}'
+link.href = '${webpackUrl("commons.css", baseUrl)}'
 document.head.appendChild(link)
 
 let loadedScripts = 0;
@@ -47,9 +48,8 @@ const checkReady = () => {
 
 const coreScripts = ['https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,fetch', '${webpackUrl(
     "commons.js",
-    undefined,
     baseUrl
-)}', '${webpackUrl("owid.js", undefined, baseUrl)}']
+)}', '${webpackUrl("owid.js", baseUrl)}']
 
 coreScripts.forEach(url => {
     const script = document.createElement('script')

--- a/site/webpackUtils.tsx
+++ b/site/webpackUtils.tsx
@@ -29,11 +29,13 @@ export const webpackUrl = (
     return urljoin(WEBPACK_DEV_URL, assetName)
 }
 
-export const bakeEmbedSnippet = () => `const embedSnippet = () => {
+export const bakeEmbedSnippet = (
+    baseUrl: string
+) => `const embedSnippet = () => {
 const link = document.createElement('link')
 link.type = 'text/css'
 link.rel = 'stylesheet'
-link.href = '${webpackUrl("commons.css")}'
+link.href = '${webpackUrl("commons.css", undefined, baseUrl)}'
 document.head.appendChild(link)
 
 let loadedScripts = 0;
@@ -44,8 +46,10 @@ const checkReady = () => {
 }
 
 const coreScripts = ['https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,fetch', '${webpackUrl(
-    "commons.js"
-)}', '${webpackUrl("owid.js")}']
+    "commons.js",
+    undefined,
+    baseUrl
+)}', '${webpackUrl("owid.js", undefined, baseUrl)}']
 
 coreScripts.forEach(url => {
     const script = document.createElement('script')


### PR DESCRIPTION
So, the "Test embeds" page wasn't working since the asset URL was relative to the wrong server. The same problem also happened to the "Preview post" and "Preview explorer" pages.
These should now all be fixed, since _almost_ all of them are now using absolute paths rather than relative ones.