### PR TITLE
Recover Explorer selection from URL params on load

### DIFF
--- a/explorer/Explorer.jsdom.test.tsx
+++ b/explorer/Explorer.jsdom.test.tsx
@@ -1,4 +1,4 @@
-#! /usr/bin/env jest
+#! yarn testJest
 
 import { Explorer } from "./Explorer"
 import { SampleExplorer } from "./Explorer.sample"
@@ -32,5 +32,13 @@ describe(Explorer, () => {
 
         explorer.onChangeChoice("Gas Radio")("CO₂")
         expect(explorer.patchObject.tab).toBeUndefined()
+    })
+
+    it("recovers country selection from URL params", () => {
+        const element = mount(
+            SampleExplorer({ uriEncodedPatch: "selection~Ireland" })
+        )
+        const explorer = element.instance() as Explorer
+        expect(explorer.selection.selectedEntityNames).toEqual(["Ireland"])
     })
 })

--- a/explorer/Explorer.sample.tsx
+++ b/explorer/Explorer.sample.tsx
@@ -4,7 +4,7 @@ import {
     DimensionProperty,
     GrapherTabOption,
 } from "../grapher/core/GrapherConstants"
-import { Explorer } from "./Explorer"
+import { Explorer, ExplorerProps } from "./Explorer"
 
 const SampleExplorerProgram = `explorerTitle	CO₂ Data Explorer
 isPublished	false
@@ -45,7 +45,7 @@ graphers
 	4224	Nitrous oxide	Production-based		Per country
 	4244	Nitrous oxide	Production-based		Per capita`
 
-export const SampleExplorer = () => {
+export const SampleExplorer = (props?: Partial<ExplorerProps>) => {
     const title = "AlphaBeta"
     const first = {
         id: 488,
@@ -86,6 +86,7 @@ export const SampleExplorer = () => {
             slug="test-slug"
             program={SampleExplorerProgram}
             grapherConfigs={grapherConfigs}
+            {...props}
         />
     )
 }

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -241,8 +241,9 @@ export class Explorer
                 preChangeQueryParams
             )
 
-        const persistedParams =
-            grapher.id && this.persistedQueryParamsByGrapher.get(grapher.id)
+        const persistedParams = grapher.id
+            ? this.persistedQueryParamsByGrapher.get(grapher.id)
+            : preChangeQueryParams
 
         const grapherConfig =
             grapherId && hasGrapherId ? this.grapherConfigs.get(grapherId)! : {}


### PR DESCRIPTION
Notion issue: https://www.notion.so/owid/selection-param-not-correctly-decoded-by-Explorer-518f9a5fdf2e46d7a8ca20146eb06321

@shaahmad Does that the one-line change for `persistedParams` look reasonable? Not sure if it might break something else, it was a shot in the dark 🎯