### PR TITLE
Color scales for grid explorers

### DIFF
--- a/adminSiteClient/EditorColorScaleSection.tsx
+++ b/adminSiteClient/EditorColorScaleSection.tsx
@@ -27,11 +27,9 @@ import {
     BindString,
 } from "./Forms"
 import { ColorSchemeOption, ColorSchemeDropdown } from "./ColorSchemeDropdown"
-import {
-    BinningStrategy,
-    binningStrategyLabels,
-} from "../grapher/color/BinningStrategies"
+import { binningStrategyLabels } from "../grapher/color/BinningStrategies"
 import { ColorSchemeName } from "../grapher/color/ColorConstants"
+import { BinningStrategy } from "../grapher/color/BinningStrategy"
 
 interface EditorColorScaleSectionFeatures {
     visualScaling: boolean

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -129,6 +129,8 @@ import { queryParamsToStr, strToQueryParams } from "./url"
 export type SVGElement = any
 export type VNode = any
 
+type NoUndefinedValues<T> = { [P in keyof T]: Required<NonNullable<T[P]>> }
+
 // d3 v6 changed the default minus sign used in d3-format to "−" (Unicode minus sign), which looks
 // nicer but can cause issues when copy-pasting values into a spreadsheet or script.
 // For that reason we change that back to a plain old hyphen.
@@ -470,15 +472,18 @@ export const urlToSlug = (url: string) =>
 export const sign = (num: number) => (num > 0 ? 1 : num < 0 ? -1 : 0)
 
 // Removes all undefineds from an object.
-export const trimObject = (obj: any = {}, trimStringEmptyStrings = false) => {
+export const trimObject = <Obj>(
+    obj: Obj,
+    trimStringEmptyStrings = false
+): NoUndefinedValues<Obj> => {
     const clone: any = {}
-    Object.keys(obj).forEach((key) => {
-        const val = obj[key]
+    for (const key in obj) {
+        const val = obj[key] as any
         if (isObject(val) && isEmpty(val)) {
             // Drop empty objects
         } else if (trimStringEmptyStrings && val === "") {
         } else if (val !== undefined) clone[key] = obj[key]
-    })
+    }
     return clone
 }
 
@@ -989,8 +994,6 @@ export function getClosestTimePairs(
 
     return decidedPairs
 }
-
-type NoUndefinedValues<T> = { [P in keyof T]: Required<NonNullable<T[P]>> }
 
 export const omitUndefinedValues = <T>(object: T): NoUndefinedValues<T> => {
     const result: any = {}

--- a/coreTable/CoreColumnDef.ts
+++ b/coreTable/CoreColumnDef.ts
@@ -34,9 +34,12 @@ export interface ColumnColorScale {
     colorScaleScheme?: string
     colorScaleInvert?: boolean
     colorScaleBinningStrategy?: string
+    colorScaleEqualSizeBins?: boolean
+    colorScaleNumericMinValue?: number
     colorScaleNumericBins?: string
     colorScaleCategoricalBins?: string
     colorScaleNoDataLabel?: string
+    colorScaleLegendDescription?: string
 }
 
 export interface CoreColumnDef extends ColumnColorScale {

--- a/coreTable/CoreColumnDef.ts
+++ b/coreTable/CoreColumnDef.ts
@@ -36,6 +36,7 @@ export interface ColumnColorScale {
     colorScaleBinningStrategy?: string
     colorScaleNumericBins?: string
     colorScaleCategoricalBins?: string
+    colorScaleNoDataLabel?: string
 }
 
 export interface CoreColumnDef extends ColumnColorScale {

--- a/coreTable/CoreColumnDef.ts
+++ b/coreTable/CoreColumnDef.ts
@@ -29,20 +29,31 @@ export enum ColumnTypeNames {
     Quarter = "Quarter",
 }
 
-export interface CoreColumnDef {
+export interface ColumnColorScale {
+    // Color scales
+    colorScaleScheme?: string
+    colorScaleInvert?: boolean
+    colorScaleBinningStrategy?: string
+    colorScaleNumericBins?: string
+    colorScaleCategoricalBins?: string
+}
+
+export interface CoreColumnDef extends ColumnColorScale {
     // Core
     slug: ColumnSlug
     type?: ColumnTypeNames
 
     // Computational
     transform?: string // Code that maps to a CoreTable transform
-    color?: Color // A column can have a color for use in charts.
     tolerance?: number // If set, some charts can use this for an interpolation strategy.
 
     // Column information used for display only
     name?: string // The display name for the column
     description?: string
     note?: string // Any internal notes the author wants to record for display in admin interfaces
+
+    // Color
+    color?: Color // A column can have a fixed color for use in charts where the columns are series
 
     // Source information used for display only
     sourceName?: string

--- a/devTools/graphersToGit/.gitignore
+++ b/devTools/graphersToGit/.gitignore
@@ -1,2 +1,3 @@
 *.json
 *.txt
+*.tsv

--- a/devTools/graphersToGit/tasks.ts
+++ b/devTools/graphersToGit/tasks.ts
@@ -13,11 +13,15 @@ import { LegacyGrapherInterface } from "../../grapher/core/GrapherInterface"
 import { CoreTable } from "../../coreTable/CoreTable"
 import parseArgs from "minimist"
 import { ChartTypeName } from "../../grapher/core/GrapherConstants"
+import { ColorScaleConfig } from "../../grapher/color/ColorScaleConfig"
+import { closeTypeOrmAndKnexConnections } from "../../db/db"
 
 const GRAPHER_DUMP_LOCATION = __dirname + "/graphers.json"
 const GRAPHER_TRIMMED_LOCATION = __dirname + "/graphers-trimmed.json"
 const GRAPHER_SELECTIONS_LOCATION = __dirname + "/graphers-selections.txt"
 const GRAPHER_COLOR_SCALES_LOCATION = __dirname + "/graphers-colorscales.json"
+const GRAPHER_ALL_COLOR_SCALES_LOCATION =
+    __dirname + "/graphers-colorscales.tsv"
 const GRAPHER_MAP_COLOR_SCALES_LOCATION =
     __dirname + "/graphers-mapcolorscales.json"
 
@@ -69,7 +73,7 @@ const dumpGraphers = async () => {
         JSON.stringify(mapToObjectLiteral(graphersById), null, 2),
         "utf8"
     )
-    db.end()
+    closeTypeOrmAndKnexConnections()
 }
 
 // If an author changes the map variable then removes that variable, we don't remove it from map config.
@@ -100,23 +104,38 @@ const graphersWithMapVariableIdsButNoMatchingDimension = async () => {
 const dumpColorScales = async () => {
     const hits: any[] = []
     const mapHits: any[] = []
+    const allColorScales: any[] = []
     eachGrapher((config) => {
         const { colorScale, map, id } = config
         const link = `https://ourworldindata.org/grapher/${config.slug}`
 
-        if (map?.colorScale)
+        if (map?.colorScale) {
             mapHits.push({
                 link,
                 id,
                 colorScale: map.colorScale,
             })
+            allColorScales.push({
+                id,
+                link,
+                notes: "From map",
+                ...new ColorScaleConfig(map.colorScale).toDSL(),
+            })
+        }
 
-        if (colorScale)
+        if (colorScale && colorScale.binningStrategy !== "equalInterval") {
             hits.push({
                 link,
                 id,
                 colorScale,
             })
+            allColorScales.push({
+                id,
+                link,
+                notes: "",
+                ...new ColorScaleConfig(colorScale).toDSL(),
+            })
+        }
     }, trimmedGraphers())
     fs.writeFileSync(
         GRAPHER_COLOR_SCALES_LOCATION,
@@ -126,6 +145,12 @@ const dumpColorScales = async () => {
     fs.writeFileSync(
         GRAPHER_MAP_COLOR_SCALES_LOCATION,
         JSON.stringify(mapHits, null, 2),
+        "utf8"
+    )
+
+    fs.writeFileSync(
+        GRAPHER_ALL_COLOR_SCALES_LOCATION,
+        new CoreTable(allColorScales).toTsv(),
         "utf8"
     )
 }
@@ -182,7 +207,7 @@ const dumpComplexSelections = async () => {
             }),
         "utf8"
     )
-    db.end()
+    closeTypeOrmAndKnexConnections()
 }
 
 const getArgsOrErrorMessage = () => {

--- a/explorer/ColumnGrammar.ts
+++ b/explorer/ColumnGrammar.ts
@@ -1,11 +1,15 @@
 import { ColumnTypeNames } from "../coreTable/CoreColumnDef"
 import { AvailableTransforms } from "../coreTable/Transforms"
+import { BinningStrategy } from "../grapher/color/BinningStrategy"
+import { ColorSchemeName } from "../grapher/color/ColorConstants"
 import {
     Grammar,
     SlugDeclarationCellDef,
     StringCellDef,
     IntegerCellDef,
     UrlCellDef,
+    BooleanCellDef,
+    EnumCellDef,
 } from "../gridLang/GridLangConstants"
 
 export const ColumnGrammar: Grammar = {
@@ -102,5 +106,40 @@ export const ColumnGrammar: Grammar = {
         keyword: "additionalInfo",
         description:
             "Describe the dataset and the methodology used in its construction. This can be as long and detailed as you like.",
+    },
+    colorScaleScheme: {
+        ...EnumCellDef,
+        keyword: "colorScaleScheme",
+        terminalOptions: Object.values(ColorSchemeName).map((keyword) => ({
+            keyword,
+            description: "",
+            cssClass: "",
+        })),
+        description: "The color scheme to use",
+    },
+    colorScaleInvert: {
+        ...BooleanCellDef,
+        keyword: "colorScaleInvert",
+        description: "Invert the color scale?",
+    },
+    colorScaleBinningStrategy: {
+        ...EnumCellDef,
+        keyword: "colorScaleBinningStrategy",
+        terminalOptions: Object.values(BinningStrategy).map((keyword) => ({
+            keyword,
+            description: "",
+            cssClass: "",
+        })),
+        description: "The binning strategy to use",
+    },
+    colorScaleNumericBins: {
+        ...StringCellDef,
+        keyword: "colorScaleNumericBins",
+        description: "Custom numeric bins",
+    },
+    colorScaleCategoricalBins: {
+        ...StringCellDef,
+        keyword: "colorScaleCategoricalBins",
+        description: "Custom categorical bins",
     },
 } as const

--- a/explorer/ColumnGrammar.ts
+++ b/explorer/ColumnGrammar.ts
@@ -132,6 +132,11 @@ export const ColumnGrammar: Grammar = {
         })),
         description: "The binning strategy to use",
     },
+    colorScaleNoDataLabel: {
+        ...StringCellDef,
+        keyword: "colorScaleNoDataLabel",
+        description: "Custom label for the 'No data' bin",
+    },
     colorScaleNumericBins: {
         ...StringCellDef,
         keyword: "colorScaleNumericBins",

--- a/explorer/ColumnGrammar.ts
+++ b/explorer/ColumnGrammar.ts
@@ -157,11 +157,19 @@ export const ColumnGrammar: Grammar = {
     colorScaleNumericBins: {
         ...StringCellDef,
         keyword: "colorScaleNumericBins",
-        description: "Custom numeric bins",
+        description: [
+            "Custom numeric bins",
+            "  Format: [binMax],[color],[label]; [binMax],[color],[label]; ...",
+            "  Example: 0.1,#ccc,example label; 0.2,,; 0.3,,prev has no label",
+        ].join("\n"),
     },
     colorScaleCategoricalBins: {
         ...StringCellDef,
         keyword: "colorScaleCategoricalBins",
-        description: "Custom categorical bins",
+        description: [
+            "Custom categorical bins",
+            "  Format: [data value],[color],[label]; [data value],[color],[label]; ...",
+            "  Example: one,#ccc,uno; two,,dos",
+        ].join("\n"),
     },
 } as const

--- a/explorer/ColumnGrammar.ts
+++ b/explorer/ColumnGrammar.ts
@@ -10,6 +10,7 @@ import {
     UrlCellDef,
     BooleanCellDef,
     EnumCellDef,
+    NumericCellDef,
 } from "../gridLang/GridLangConstants"
 
 export const ColumnGrammar: Grammar = {
@@ -136,6 +137,22 @@ export const ColumnGrammar: Grammar = {
         ...StringCellDef,
         keyword: "colorScaleNoDataLabel",
         description: "Custom label for the 'No data' bin",
+    },
+    colorScaleLegendDescription: {
+        ...StringCellDef,
+        keyword: "colorScaleLegendDescription",
+        description: "Legend title for ScatterPlot",
+    },
+    colorScaleEqualSizeBins: {
+        ...BooleanCellDef,
+        keyword: "colorScaleEqualSizeBins",
+        description: "Disable visual scaling of the bins based on values?",
+    },
+    colorScaleNumericMinValue: {
+        ...NumericCellDef,
+        keyword: "colorScaleNumericMinValue",
+        description:
+            "Minimum value of the first bin (leaving blank will infer the minimum from the data)",
     },
     colorScaleNumericBins: {
         ...StringCellDef,

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -376,7 +376,7 @@ export class Explorer
                 new Patch(decisionsPatchObject).uriEncodedString
             )
 
-        const explorerPatchObject = {
+        const explorerPatchObject: ExplorerPatchObject = {
             ...this.grapher.changedParams,
             selection: this.selection.hasSelection
                 ? this.selection.selectedEntityNames

--- a/explorer/ExplorerGrammar.ts
+++ b/explorer/ExplorerGrammar.ts
@@ -66,13 +66,13 @@ export const ExplorerGrammar: Grammar = {
     },
     columns: {
         ...SlugDeclarationCellDef,
+        keyword: "columns",
+        description:
+            "Include all your column definitions for a table here. If you do not provide a column definition for every column in your table one will be generated for you by the machine (sometimes times incorrectly).",
         headerCellDef: {
             ...SubTableHeaderCellDef,
             grammar: ColumnGrammar,
         },
-        keyword: "columns",
-        description:
-            "Include all your column definitions for a table here. If you do not provide a column definition for every column in your table one will be generated for you by the machine (sometimes times incorrectly).",
     },
     graphers: {
         ...SlugDeclarationCellDef,

--- a/explorer/ExplorerGrammar.ts
+++ b/explorer/ExplorerGrammar.ts
@@ -68,7 +68,7 @@ export const ExplorerGrammar: Grammar = {
         ...SlugDeclarationCellDef,
         keyword: "columns",
         description:
-            "Include all your column definitions for a table here. If you do not provide a column definition for every column in your table one will be generated for you by the machine (sometimes times incorrectly).",
+            "Include all your column definitions for a table here. If you do not provide a column definition for every column in your table one will be generated for you by the machine (sometimes incorrectly).",
         headerCellDef: {
             ...SubTableHeaderCellDef,
             grammar: ColumnGrammar,

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -668,7 +668,7 @@ export const makeFullPath = (slug: string) =>
 
 const trimAndParseObject = (config: any, grammar: Grammar) => {
     // Trim empty properties. Prevents things like clearing "type" which crashes Grapher. The call to grapher.reset will automatically clear things like title, subtitle, if not set.
-    const trimmedRow = trimObject(config, true)
+    const trimmedRow = trimObject(config, true) as any
 
     // parse types
     Object.keys(trimmedRow).forEach((key) => {

--- a/grapher/chart/ChartUtils.tsx
+++ b/grapher/chart/ChartUtils.tsx
@@ -1,7 +1,7 @@
-import { SeriesStrategy } from "../core/GrapherConstants"
-import { Box } from "../../clientUtils/owidTypes"
-import { SelectionArray } from "../selection/SelectionArray"
 import React from "react"
+import { Box } from "../../clientUtils/owidTypes"
+import { SeriesStrategy } from "../core/GrapherConstants"
+import { SelectionArray } from "../selection/SelectionArray"
 import { ChartManager } from "./ChartManager"
 
 export const autoDetectYColumnSlugs = (manager: ChartManager) => {

--- a/grapher/color/BinningStrategies.test.ts
+++ b/grapher/color/BinningStrategies.test.ts
@@ -1,6 +1,7 @@
 #! /usr/bin/env jest
 
-import { getBinMaximums, BinningStrategy } from "./BinningStrategies"
+import { getBinMaximums } from "./BinningStrategies"
+import { BinningStrategy } from "./BinningStrategy"
 
 describe(getBinMaximums, () => {
     it("returns no bins for empty array", () => {

--- a/grapher/color/BinningStrategies.ts
+++ b/grapher/color/BinningStrategies.ts
@@ -8,15 +8,7 @@ import {
     roundSigFig,
     first,
 } from "../../clientUtils/Util"
-
-export enum BinningStrategy {
-    equalInterval = "equalInterval",
-    quantiles = "quantiles",
-    ckmeans = "ckmeans",
-    // The `manual` option is ignored in the algorithms below,
-    // but it is stored and handled by the chart.
-    manual = "manual",
-}
+import { BinningStrategy } from "./BinningStrategy"
 
 /** Human-readable labels for the binning strategies */
 export const binningStrategyLabels: Record<BinningStrategy, string> = {

--- a/grapher/color/BinningStrategy.ts
+++ b/grapher/color/BinningStrategy.ts
@@ -1,0 +1,8 @@
+export enum BinningStrategy {
+    equalInterval = "equalInterval",
+    quantiles = "quantiles",
+    ckmeans = "ckmeans",
+    // The `manual` option is ignored in the algorithms below,
+    // but it is stored and handled by the chart.
+    manual = "manual",
+}

--- a/grapher/color/ColorScale.test.ts
+++ b/grapher/color/ColorScale.test.ts
@@ -1,7 +1,7 @@
 #! /usr/bin/env jest
 
 import { CoreTable } from "../../coreTable/CoreTable"
-import { BinningStrategy } from "./BinningStrategies"
+import { BinningStrategy } from "./BinningStrategy"
 import { ColorScale } from "./ColorScale"
 import { ColorScaleConfigInterface } from "./ColorScaleConfig"
 

--- a/grapher/color/ColorScale.ts
+++ b/grapher/color/ColorScale.ts
@@ -13,9 +13,10 @@ import {
 import { Color } from "../../coreTable/CoreTableConstants"
 import { ColorSchemes } from "../color/ColorSchemes"
 import { ColorScaleBin, NumericBin, CategoricalBin } from "./ColorScaleBin"
-import { BinningStrategy, getBinMaximums } from "./BinningStrategies"
-import { CoreColumn } from "../../coreTable/CoreTableColumns"
 import { ColorSchemeName } from "./ColorConstants"
+import { CoreColumn } from "../../coreTable/CoreTableColumns"
+import { getBinMaximums } from "./BinningStrategies"
+import { BinningStrategy } from "./BinningStrategy"
 
 const NO_DATA_LABEL = "No data"
 

--- a/grapher/color/ColorScale.ts
+++ b/grapher/color/ColorScale.ts
@@ -18,7 +18,7 @@ import { CoreColumn } from "../../coreTable/CoreTableColumns"
 import { getBinMaximums } from "./BinningStrategies"
 import { BinningStrategy } from "./BinningStrategy"
 
-const NO_DATA_LABEL = "No data"
+export const NO_DATA_LABEL = "No data"
 
 export interface ColorScaleManager {
     colorScaleConfig?: ColorScaleConfigInterface

--- a/grapher/color/ColorScaleBin.ts
+++ b/grapher/color/ColorScaleBin.ts
@@ -42,17 +42,11 @@ export class NumericBin extends AbstractColorScaleBin<NumericBinProps> {
     get max() {
         return this.props.max
     }
-    get color() {
-        return this.props.color
-    }
     get minText() {
         return (this.props.isOpenLeft ? `<` : "") + this.props.displayMin
     }
     get maxText() {
         return (this.props.isOpenRight ? `>` : "") + this.props.displayMax
-    }
-    get label() {
-        return this.props.label
     }
     get text() {
         return this.props.label || ""

--- a/grapher/color/ColorScaleConfig.test.ts
+++ b/grapher/color/ColorScaleConfig.test.ts
@@ -1,7 +1,117 @@
-#! /usr/bin/env jest
+#! yarn testJest
 
+import { BinningStrategy } from "./BinningStrategy"
+import { ColorSchemeName } from "./ColorConstants"
+import { NO_DATA_LABEL } from "./ColorScale"
 import { ColorScaleConfig } from "./ColorScaleConfig"
 
 it("can serialize for saving", () => {
     expect(new ColorScaleConfig().toObject()).toEqual({})
+})
+
+describe("fromDSL", () => {
+    const colorScale = ColorScaleConfig.fromDSL({
+        colorScaleScheme: ColorSchemeName.Magma,
+        colorScaleInvert: true,
+        // colorScaleBinningStrategy: undefined,
+        colorScaleEqualSizeBins: true,
+        colorScaleNumericMinValue: 0.5,
+        colorScaleNumericBins: "1,#ddd,One;2,#eee,Two",
+        colorScaleCategoricalBins: "one,#ddd,uno;two,#eee,dos",
+        colorScaleNoDataLabel: "Datas missing",
+        colorScaleLegendDescription: "Legend",
+    })!
+
+    it("handles comprehensive test case", () => {
+        expect(colorScale.baseColorScheme).toEqual(ColorSchemeName.Magma)
+        expect(colorScale.colorSchemeInvert).toBeTruthy()
+        expect(colorScale.equalSizeBins).toBeTruthy()
+        expect(colorScale.customNumericMinValue).toEqual(0.5)
+        expect(colorScale.customCategoryLabels).toEqual({
+            one: "uno",
+            two: "dos",
+            [NO_DATA_LABEL]: "Datas missing",
+        })
+        expect(colorScale.customCategoryColors).toEqual({
+            one: "#ddd",
+            two: "#eee",
+        })
+        expect(colorScale.legendDescription).toEqual("Legend")
+    })
+
+    it("handles a custom binning strategy", () => {
+        const colorScale = ColorScaleConfig.fromDSL({
+            colorScaleBinningStrategy: BinningStrategy.quantiles,
+        })
+        expect(colorScale?.binningStrategy).toEqual(BinningStrategy.quantiles)
+    })
+
+    it("automatically infers binningStrategy if custom colors (numeric)", () => {
+        const numericScale = ColorScaleConfig.fromDSL({
+            colorScaleNumericBins: "1;2;3",
+        })!
+        expect(numericScale.binningStrategy).toEqual(BinningStrategy.manual)
+        expect(numericScale.customNumericValues).toEqual([1, 2, 3])
+        expect(numericScale.customNumericColorsActive).toBeTruthy()
+    })
+
+    it("automatically infers binningStrategy if custom colors (categorical)", () => {
+        const categoricalScale = ColorScaleConfig.fromDSL({
+            colorScaleCategoricalBins: "1,,One;2,,Two;3,,Three",
+        })!
+        expect(categoricalScale.binningStrategy).toEqual(BinningStrategy.manual)
+        expect(categoricalScale.customCategoryLabels).toEqual({
+            1: "One",
+            2: "Two",
+            3: "Three",
+        })
+    })
+
+    it("handles omitting color and/or label from custom numeric bins", () => {
+        const colorScale = ColorScaleConfig.fromDSL({
+            colorScaleNumericBins: "1;2;3",
+        })!
+        expect(colorScale.customNumericValues).toEqual([1, 2, 3])
+        expect(colorScale.customNumericLabels).toEqual([
+            undefined,
+            undefined,
+            undefined,
+        ])
+        expect(colorScale.customNumericColors).toEqual([
+            undefined,
+            undefined,
+            undefined,
+        ])
+        const colorScale2 = ColorScaleConfig.fromDSL({
+            colorScaleNumericBins: "1,#ddd;2,#eee;3,#fff",
+        })!
+        expect(colorScale2.customNumericValues).toEqual([1, 2, 3])
+        expect(colorScale2.customNumericColors).toEqual([
+            "#ddd",
+            "#eee",
+            "#fff",
+        ])
+        expect(colorScale2.customNumericLabels).toEqual([
+            undefined,
+            undefined,
+            undefined,
+        ])
+        const colorScale3 = ColorScaleConfig.fromDSL({
+            colorScaleNumericBins: "1,,One;2,,Two;3,,Three",
+        })!
+        expect(colorScale3.customNumericValues).toEqual([1, 2, 3])
+        expect(colorScale3.customNumericColors).toEqual([
+            undefined,
+            undefined,
+            undefined,
+        ])
+        expect(colorScale3.customNumericLabels).toEqual(["One", "Two", "Three"])
+    })
+
+    it("handles commas in labels", () => {
+        const colorScale = ColorScaleConfig.fromDSL({
+            colorScaleNumericBins: "1,#ccc,a,label,with,commas",
+        })!
+        expect(colorScale.customNumericLabels).toEqual(["a,label,with,commas"])
+    })
 })

--- a/grapher/color/ColorScaleConfig.test.ts
+++ b/grapher/color/ColorScaleConfig.test.ts
@@ -114,4 +114,21 @@ describe("fromDSL", () => {
         })!
         expect(colorScale.customNumericLabels).toEqual(["a,label,with,commas"])
     })
+
+    it("trims whitespace in bin definitions", () => {
+        const colorScale = ColorScaleConfig.fromDSL({
+            colorScaleNumericBins: "1, #ccc, a label that may, have spaces  ",
+            colorScaleCategoricalBins: "one, , a label that may, have spaces  ",
+        })!
+        expect(colorScale.customNumericLabels).toEqual([
+            "a label that may, have spaces",
+        ])
+        expect(colorScale.customNumericColors).toEqual(["#ccc"])
+        expect(colorScale.customCategoryLabels).toEqual({
+            one: "a label that may, have spaces",
+        })
+        expect(colorScale.customCategoryColors).toEqual({
+            one: undefined,
+        })
+    })
 })

--- a/grapher/color/ColorScaleConfig.ts
+++ b/grapher/color/ColorScaleConfig.ts
@@ -1,14 +1,15 @@
 import { observable } from "mobx"
 import { Color } from "../../coreTable/CoreTableConstants"
-import { BinningStrategy } from "./BinningStrategies"
+import { ColumnColorScale } from "../../coreTable/CoreColumnDef"
 import {
     deleteRuntimeAndUnchangedProps,
     objectWithPersistablesToObject,
     Persistable,
     updatePersistables,
 } from "../persistable/Persistable"
-import { extend, trimObject } from "../../clientUtils/Util"
+import { extend, isEmpty, trimObject } from "../../clientUtils/Util"
 import { ColorSchemeName } from "./ColorConstants"
+import { BinningStrategy } from "./BinningStrategy"
 
 export class ColorScaleConfigDefaults {
     // Color scheme
@@ -95,4 +96,82 @@ export class ColorScaleConfig
         super()
         updatePersistables(this, obj)
     }
+
+    static fromDSL(scale: ColumnColorScale) {
+        const colorSchemeInvert = scale.colorScaleInvert
+        const baseColorScheme = scale.colorScaleScheme as ColorSchemeName
+
+        const customNumericValues: number[] = []
+        const customNumericLabels: string[] = []
+        const customNumericColors: Color[] = []
+        scale.colorScaleNumericBins?.split(INTER_BIN_DELIMITER).map((bin) => {
+            const [color, value, ...label] = bin.split(INTRA_BIN_DELIMITER)
+            customNumericValues.push(parseFloat(value))
+            customNumericLabels.push(label.join(INTRA_BIN_DELIMITER))
+            customNumericColors.push(color)
+        })
+
+        const customCategoryColors: {
+            [key: string]: string | undefined
+        } = {}
+
+        const customCategoryLabels: {
+            [key: string]: string | undefined
+        } = {}
+        scale.colorScaleCategoricalBins
+            ?.split(INTER_BIN_DELIMITER)
+            .map((bin) => {
+                const [color, value, ...label] = bin.split(INTRA_BIN_DELIMITER)
+                customCategoryColors[value] = color
+                customCategoryLabels[value] = label.join(INTRA_BIN_DELIMITER)
+            })
+        const trimmed = trimObject({
+            colorSchemeInvert,
+            baseColorScheme,
+            customNumericColors,
+            customNumericLabels,
+            customNumericValues,
+        })
+        return isEmpty(trimmed) ? undefined : trimmed
+    }
+
+    toDSL(): ColumnColorScale {
+        const {
+            baseColorScheme,
+            binningStrategy,
+            colorSchemeInvert,
+            customNumericValues,
+            customNumericColors,
+            customNumericLabels,
+            customCategoryLabels,
+            customCategoryColors,
+        } = this.toObject()
+
+        return trimObject({
+            colorScaleScheme: baseColorScheme,
+            colorScaleInvert: colorSchemeInvert,
+            colorScaleBinningStrategy: binningStrategy,
+            colorScaleNumericBins: (customNumericValues ?? [])
+                .map((value: any, index: number) =>
+                    [
+                        customNumericColors[index] ?? "",
+                        value,
+                        customNumericLabels[index],
+                    ].join(INTRA_BIN_DELIMITER)
+                )
+                .join(INTER_BIN_DELIMITER),
+            colorScaleCategoricalBins: Object.keys(customCategoryColors ?? {})
+                .map((value) =>
+                    [
+                        customCategoryColors[value],
+                        value,
+                        customCategoryLabels[value],
+                    ].join(INTRA_BIN_DELIMITER)
+                )
+                .join(INTER_BIN_DELIMITER),
+        })
+    }
 }
+
+const INTER_BIN_DELIMITER = ";"
+const INTRA_BIN_DELIMITER = ";"

--- a/grapher/color/ColorScaleConfig.ts
+++ b/grapher/color/ColorScaleConfig.ts
@@ -116,7 +116,12 @@ export class ColorScaleConfig
             )
         })
 
+        // TODO: once Grammar#parse() is called for all values, we can remove parseFloat() here
+        // See issue: https://www.notion.so/owid/ColumnGrammar-parse-function-does-not-get-applied-67b578b8af7642c5859a1db79c8d5712
         const customNumericMinValue = scale.colorScaleNumericMinValue
+            ? parseFloat(scale.colorScaleNumericMinValue as any)
+            : undefined
+
         const customNumericColorsActive = customNumericColors.length > 0
 
         const customCategoryColors: {

--- a/grapher/color/ColorScaleConfig.ts
+++ b/grapher/color/ColorScaleConfig.ts
@@ -127,9 +127,19 @@ export class ColorScaleConfig
                 customCategoryColors[value] = color
                 customCategoryLabels[value] = label.join(INTRA_BIN_DELIMITER)
             })
+
+        // Use user-defined binning strategy, otherwise set to manual if user has
+        // defined custom bins
+        const binningStrategy = scale.colorScaleBinningStrategy
+            ? (scale.colorScaleBinningStrategy as BinningStrategy)
+            : customNumericValues.length > 0 || !isEmpty(customCategoryColors)
+            ? BinningStrategy.manual
+            : undefined
+
         const trimmed: Partial<ColorScaleConfig> = trimObject({
             colorSchemeInvert,
             baseColorScheme,
+            binningStrategy,
             customNumericColors,
             customNumericLabels,
             customNumericValues,

--- a/grapher/color/ColorScaleConfig.ts
+++ b/grapher/color/ColorScaleConfig.ts
@@ -107,14 +107,19 @@ export class ColorScaleConfig
         const customNumericValues: number[] = []
         const customNumericLabels: (string | undefined)[] = []
         const customNumericColors: (Color | undefined)[] = []
-        scale.colorScaleNumericBins?.split(INTER_BIN_DELIMITER).map((bin) => {
-            const [value, color, ...label] = bin.split(INTRA_BIN_DELIMITER)
-            customNumericValues.push(parseFloat(value))
-            customNumericColors.push(color || undefined)
-            customNumericLabels.push(
-                label.join(INTRA_BIN_DELIMITER) || undefined
-            )
-        })
+        scale.colorScaleNumericBins
+            ?.split(INTER_BIN_DELIMITER)
+            .forEach((bin) => {
+                const [value, color, ...label] = bin.split(
+                    INTRA_BIN_DELIMITER
+                ) as (string | undefined)[]
+                if (!value) return
+                customNumericValues.push(parseFloat(value))
+                customNumericColors.push(color?.trim() || undefined)
+                customNumericLabels.push(
+                    label.join(INTRA_BIN_DELIMITER).trim() || undefined
+                )
+            })
 
         // TODO: once Grammar#parse() is called for all values, we can remove parseFloat() here
         // See issue: https://www.notion.so/owid/ColumnGrammar-parse-function-does-not-get-applied-67b578b8af7642c5859a1db79c8d5712
@@ -132,11 +137,14 @@ export class ColorScaleConfig
         } = {}
         scale.colorScaleCategoricalBins
             ?.split(INTER_BIN_DELIMITER)
-            .map((bin) => {
-                const [value, color, ...label] = bin.split(INTRA_BIN_DELIMITER)
-                customCategoryColors[value] = color || undefined
+            .forEach((bin) => {
+                const [value, color, ...label] = bin.split(
+                    INTRA_BIN_DELIMITER
+                ) as (string | undefined)[]
+                if (!value) return
+                customCategoryColors[value] = color?.trim() || undefined
                 customCategoryLabels[value] =
-                    label.join(INTRA_BIN_DELIMITER) || undefined
+                    label.join(INTRA_BIN_DELIMITER).trim() || undefined
             })
         if (scale.colorScaleNoDataLabel) {
             customCategoryLabels[NO_DATA_LABEL] = scale.colorScaleNoDataLabel

--- a/grapher/color/ColorScaleConfig.ts
+++ b/grapher/color/ColorScaleConfig.ts
@@ -86,8 +86,10 @@ export class ColorScaleConfig
         extend(this, obj)
     }
 
-    toObject() {
-        const obj = objectWithPersistablesToObject(this)
+    toObject(): ColorScaleConfigInterface {
+        const obj: ColorScaleConfigInterface = objectWithPersistablesToObject(
+            this
+        )
         deleteRuntimeAndUnchangedProps(obj, new ColorScaleConfigDefaults())
         return trimObject(obj)
     }
@@ -97,7 +99,7 @@ export class ColorScaleConfig
         updatePersistables(this, obj)
     }
 
-    static fromDSL(scale: ColumnColorScale) {
+    static fromDSL(scale: ColumnColorScale): ColorScaleConfig | undefined {
         const colorSchemeInvert = scale.colorScaleInvert
         const baseColorScheme = scale.colorScaleScheme as ColorSchemeName
 
@@ -125,14 +127,15 @@ export class ColorScaleConfig
                 customCategoryColors[value] = color
                 customCategoryLabels[value] = label.join(INTRA_BIN_DELIMITER)
             })
-        const trimmed = trimObject({
+        const trimmed: Partial<ColorScaleConfig> = trimObject({
             colorSchemeInvert,
             baseColorScheme,
             customNumericColors,
             customNumericLabels,
             customNumericValues,
         })
-        return isEmpty(trimmed) ? undefined : trimmed
+
+        return isEmpty(trimmed) ? undefined : new ColorScaleConfig(trimmed)
     }
 
     toDSL(): ColumnColorScale {
@@ -147,7 +150,7 @@ export class ColorScaleConfig
             customCategoryColors,
         } = this.toObject()
 
-        return trimObject({
+        const columnColorScale: ColumnColorScale = {
             colorScaleScheme: baseColorScheme,
             colorScaleInvert: colorSchemeInvert,
             colorScaleBinningStrategy: binningStrategy,
@@ -169,9 +172,11 @@ export class ColorScaleConfig
                     ].join(INTRA_BIN_DELIMITER)
                 )
                 .join(INTER_BIN_DELIMITER),
-        })
+        }
+
+        return trimObject(columnColorScale)
     }
 }
 
 const INTER_BIN_DELIMITER = ";"
-const INTRA_BIN_DELIMITER = ";"
+const INTRA_BIN_DELIMITER = ","

--- a/grapher/color/ColorScaleConfig.ts
+++ b/grapher/color/ColorScaleConfig.ts
@@ -10,6 +10,7 @@ import {
 import { extend, isEmpty, trimObject } from "../../clientUtils/Util"
 import { ColorSchemeName } from "./ColorConstants"
 import { BinningStrategy } from "./BinningStrategy"
+import { NO_DATA_LABEL } from "./ColorScale"
 
 export class ColorScaleConfigDefaults {
     // Color scheme
@@ -116,7 +117,6 @@ export class ColorScaleConfig
         const customCategoryColors: {
             [key: string]: string | undefined
         } = {}
-
         const customCategoryLabels: {
             [key: string]: string | undefined
         } = {}
@@ -127,12 +127,15 @@ export class ColorScaleConfig
                 customCategoryColors[value] = color
                 customCategoryLabels[value] = label.join(INTRA_BIN_DELIMITER)
             })
+        if (scale.colorScaleNoDataLabel) {
+            customCategoryLabels[NO_DATA_LABEL] = scale.colorScaleNoDataLabel
+        }
 
         // Use user-defined binning strategy, otherwise set to manual if user has
         // defined custom bins
         const binningStrategy = scale.colorScaleBinningStrategy
             ? (scale.colorScaleBinningStrategy as BinningStrategy)
-            : customNumericValues.length > 0 || !isEmpty(customCategoryColors)
+            : scale.colorScaleNumericBins || scale.colorScaleCategoricalBins
             ? BinningStrategy.manual
             : undefined
 

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -63,6 +63,7 @@ import {
     makeSelectionArray,
 } from "../chart/ChartUtils"
 import { NoDataModal } from "../noDataModal/NoDataModal"
+import { ColorScaleConfig } from "../color/ColorScaleConfig"
 
 const PROJECTION_CHOOSER_WIDTH = 110
 const PROJECTION_CHOOSER_HEIGHT = 22
@@ -351,7 +352,10 @@ export class MapChart
     colorScale = new ColorScale(this)
 
     @computed get colorScaleConfig() {
-        return this.mapConfig.colorScale
+        return (
+            ColorScaleConfig.fromDSL(this.mapColumn.def) ??
+            this.mapConfig.colorScale
+        )
     }
 
     defaultBaseColorScheme = ColorSchemeName.BuGn

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -62,6 +62,7 @@ import {
     defaultIfErrorValue,
     isNotErrorValue,
 } from "../../coreTable/ErrorValues"
+import { ColorScaleConfig } from "../color/ColorScaleConfig"
 
 @observer
 export class ScatterPlotChart
@@ -617,7 +618,10 @@ export class ScatterPlotChart
     }
 
     @computed get colorScaleConfig() {
-        return this.manager.colorScale
+        return (
+            ColorScaleConfig.fromDSL(this.yColumn.def) ??
+            this.manager.colorScale
+        )
     }
 
     defaultBaseColorScheme = ColorSchemeName.continents

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -619,7 +619,7 @@ export class ScatterPlotChart
 
     @computed get colorScaleConfig() {
         return (
-            ColorScaleConfig.fromDSL(this.yColumn.def) ??
+            ColorScaleConfig.fromDSL(this.colorColumn.def) ??
             this.manager.colorScale
         )
     }

--- a/grapher/verticalColorLegend/VerticalColorLegend.tsx
+++ b/grapher/verticalColorLegend/VerticalColorLegend.tsx
@@ -22,6 +22,8 @@ export interface VerticalColorLegendManager {
 
 interface LegendItem {
     label?: string
+    minText?: string
+    maxText?: string
     color: Color
 }
 
@@ -74,10 +76,15 @@ export class VerticalColorLegend extends React.Component<{
 
         return manager.legendItems
             .map((series) => {
+                let label = series.label
+                // infer label for numeric bins
+                if (!label && series.minText && series.maxText) {
+                    label = `${series.minText} – ${series.maxText}`
+                }
                 const textWrap = new TextWrap({
                     maxWidth: this.maxLegendWidth,
                     fontSize,
-                    text: series.label ?? "",
+                    text: label ?? "",
                 })
                 return {
                     textWrap,

--- a/gridLang/GridProgram.test.ts
+++ b/gridLang/GridProgram.test.ts
@@ -15,6 +15,10 @@ describe(GridProgram, () => {
         expect(
             program.setLineValue("title", "good morning").getLineValue("title")
         ).toEqual("good morning")
+
+        const rows = program.numRows
+        expect(program.appendLine("foo\tbar").numRows).toEqual(rows + 1)
+        expect(program.patch({ foo: "bat" }).getLineValue("foo")).toEqual("bat")
     })
 
     it("can find rows", () => {

--- a/gridLang/GridProgram.ts
+++ b/gridLang/GridProgram.ts
@@ -131,6 +131,15 @@ export class GridProgram {
         )
     }
 
+    get numRows() {
+        return this.lines.length
+    }
+
+    patch(obj: any) {
+        Object.keys(obj).forEach((key) => this.setLineValue(key, obj[key]))
+        return this
+    }
+
     grepFirst(key: string, position = Origin) {
         for (const next of this.ring(position)) {
             if (this.getCellContents(next) === key) return next
@@ -212,6 +221,11 @@ export class GridProgram {
     deleteLine(row?: number) {
         if (row === undefined) return this
         this.lines.splice(row, 1)
+        return this
+    }
+
+    appendLine(line: string) {
+        this.lines.push(line)
         return this
     }
 


### PR DESCRIPTION
Some additions to the work on #715.

- New `colorScale` columns:
    
    <img width="1208" alt="Screenshot 2021-01-27 at 20 05 51" src="https://user-images.githubusercontent.com/1308115/106047708-dace7580-60db-11eb-9a8c-05345556aab1.png">
    <img width="968" alt="Screenshot 2021-01-27 at 20 13 24" src="https://user-images.githubusercontent.com/1308115/106047959-28e37900-60dc-11eb-8089-3635d4108a2c.png">

- Tests for color bins DSL

- `VerticalColorLegend` now infers its numeric bin labels – we no longer have to specify them all by hand. This was necessary to implement because color scales are defined on column level, so it's the same definition for both Map and ScatterPlot.
    
    <img width="141" alt="Screenshot 2021-01-27 at 20 15 55" src="https://user-images.githubusercontent.com/1308115/106048272-9394b480-60dc-11eb-8d26-9b0c8e0ca599.png">

    (It's not ideal with the `<` and `>` but maybe we can figure that out another time)

---

@breck7 I didn't merge the last commit in #715: https://github.com/owid/owid-grapher/pull/715/commits/f8bca6641a375a00f3beaef352c530673a171127

It had some conflicts I wasn't sure how to resolve and just left it for later. Do you think it should be merged? I can try to merge again, or we can leave it as a low priority task. 