### PR TITLE
fix(stacked): don't do extrapolation of variables

### DIFF
--- a/coreTable/CoreTableUtils.test.ts
+++ b/coreTable/CoreTableUtils.test.ts
@@ -143,7 +143,23 @@ describe(toleranceInterpolation, () => {
 })
 
 describe(linearInterpolation, () => {
-    it("interpolates", () => {
+    it("interpolates, with extrapolation", () => {
+        const values = [
+            4,
+            ErrorValueTypes.MissingValuePlaceholder,
+            ErrorValueTypes.MissingValuePlaceholder,
+            1,
+            ErrorValueTypes.MissingValuePlaceholder,
+        ]
+        const timesAsc = [0, 1, 2, 3, 4]
+        linearInterpolation(values, timesAsc, {
+            extrapolateAtStart: true,
+            extrapolateAtEnd: true,
+        })
+        expect(values).toEqual([4, 3, 2, 1, 1])
+    })
+
+    it("interpolates, without extrapolation", () => {
         const values = [
             4,
             ErrorValueTypes.MissingValuePlaceholder,
@@ -153,7 +169,13 @@ describe(linearInterpolation, () => {
         ]
         const timesAsc = [0, 1, 2, 3, 4]
         linearInterpolation(values, timesAsc, {})
-        expect(values).toEqual([4, 3, 2, 1, 1])
+        expect(values).toEqual([
+            4,
+            3,
+            2,
+            1,
+            ErrorValueTypes.NoValueForInterpolation,
+        ])
     })
 })
 

--- a/coreTable/OwidTable.test.ts
+++ b/coreTable/OwidTable.test.ts
@@ -424,8 +424,49 @@ describe("linear interpolation", () => {
         ]
     )
 
-    it("applies interpolation", () => {
-        const interpolatedTable = table.interpolateColumnLinearly("gdp")
+    it("applies interpolation without extrapolation", () => {
+        const interpolatedTable = table.interpolateColumnLinearly("gdp", false)
+
+        expect(interpolatedTable.get("gdp").valuesIncludingErrorValues).toEqual(
+            [
+                // France
+                10,
+                0,
+                2,
+                4,
+                6,
+                8,
+                ErrorValueTypes.NoValueForInterpolation,
+                // UK
+                2,
+                2.25,
+                2.5,
+                2.75,
+                3,
+                ErrorValueTypes.NoValueForInterpolation,
+                ErrorValueTypes.NoValueForInterpolation,
+            ]
+        )
+
+        // Check that not only the gdp values are correct but also the other fields
+        expect(interpolatedTable.rows).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    entityName: "france",
+                    gdp: 2,
+                    year: 2002,
+                }),
+            ])
+        )
+        expect(
+            interpolatedTable.rows.filter(
+                (row) => row.year !== undefined && isNaN(row.year)
+            ).length
+        ).toEqual(0)
+    })
+
+    it("applies interpolation with extrapolation", () => {
+        const interpolatedTable = table.interpolateColumnLinearly("gdp", true)
 
         expect(interpolatedTable.get("gdp").valuesIncludingErrorValues).toEqual(
             [

--- a/coreTable/OwidTable.ts
+++ b/coreTable/OwidTable.ts
@@ -701,7 +701,10 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         )
     }
 
-    interpolateColumnLinearly(columnSlug: ColumnSlug) {
+    interpolateColumnLinearly(
+        columnSlug: ColumnSlug,
+        extrapolate: boolean = false
+    ) {
         // If the column doesn't exist, return the table unchanged.
         if (!this.has(columnSlug)) return this
 
@@ -726,7 +729,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
             columnSlug,
             timeColumn.slug,
             linearInterpolation,
-            {}
+            { extrapolateAtStart: extrapolate, extrapolateAtEnd: extrapolate }
         )
 
         const columnStore = {

--- a/grapher/stackedCharts/AbstractStackedChart.tsx
+++ b/grapher/stackedCharts/AbstractStackedChart.tsx
@@ -43,19 +43,20 @@ export class AbstactStackedChart
         )
 
         // TODO: remove this filter once we don't have mixed type columns in datasets
-        table = table.replaceNonNumericCellsWithErrorValues(this.yColumnSlugs)
-
-        // Drop rows for which no valid data points exist for any display column, so
-        // we don't interpolate these values and display a misleading chart
-        // Important: needs to be run after replaceNonNumericCellsWithErrorValues, so
-        // undefined and empty values are already replaced with error values
-        table = table.dropRowsWithErrorValuesForAllColumns(this.yColumnSlugs)
+        table = table
+            .replaceNonNumericCellsWithErrorValues(this.yColumnSlugs)
+            .dropRowsWithErrorValuesForAllColumns(this.yColumnSlugs)
 
         if (!this.props.disableLinearInterpolation) {
             this.yColumnSlugs.forEach((slug) => {
                 table = table.interpolateColumnLinearly(slug)
             })
         }
+
+        // Drop rows for which no valid data points exist for any display column
+        // after interpolation, which most likely means they lie at the start/end
+        // of the time range and were not extrapolated
+        table = table.dropRowsWithErrorValuesForAnyColumn(this.yColumnSlugs)
 
         if (this.manager.isRelativeMode) {
             table = this.isEntitySeries

--- a/grapher/stackedCharts/StackedAreaChart.test.ts
+++ b/grapher/stackedCharts/StackedAreaChart.test.ts
@@ -83,7 +83,7 @@ it("can filter a series when there are no points", () => {
         },
     })
 
-    expect(chart.series.length).toEqual(1)
+    expect(chart.series.length).toEqual(0)
 })
 
 it("filters non-numeric values", () => {

--- a/grapher/stackedCharts/StackedAreaChart.tsx
+++ b/grapher/stackedCharts/StackedAreaChart.tsx
@@ -454,10 +454,6 @@ export class StackedAreaChart
     }
 
     @computed get series() {
-        if (this.props.disableLinearInterpolation)
-            return stackSeries(
-                withZeroesAsInterpolatedPoints(this.unstackedSeries)
-            )
-        else return stackSeries(this.unstackedSeries)
+        return stackSeries(withZeroesAsInterpolatedPoints(this.unstackedSeries))
     }
 }

--- a/grapher/stackedCharts/StackedUtils.ts
+++ b/grapher/stackedCharts/StackedUtils.ts
@@ -37,7 +37,7 @@ export const withZeroesAsInterpolatedPoints = (
                     x,
                     y,
                     yOffset: 0,
-                    fake: !!point,
+                    fake: !point,
                 }
             }),
         }


### PR DESCRIPTION
Notion: https://www.notion.so/owid/Don-t-extrapolate-StackedArea-charts-at-start-end-where-some-variables-are-missing-values-70131dff17494705a042bc92e9dd7eb1

Prevents misleading stacked area charts where a variable was extrapolated (by simply copying over the closest known value) when they were not defined.

The behavior is different depending on whether we have a column-based series or an entity-based one.
For entity-based series, it is still showing the "full" time range, but showing "No data" for entities that are not present:
![image](https://user-images.githubusercontent.com/2641501/106109178-806bfe00-6149-11eb-8cd0-ecfbcd2ebcd8.png)

On the other hand, for column-based series it is only showing the time range where all columns have values:
![image](https://user-images.githubusercontent.com/2641501/106109306-ab565200-6149-11eb-9c9f-8927a27ab6e3.png)

(Here, "Fossil fuels and cement" has data before 1850, but it is not shown since there's no earlier data available for "Land use change").