### PR TITLE
fix(csv): csv download no longer contains pretty-printed numbers

### DIFF
--- a/coreTable/CoreTableColumns.test.ts
+++ b/coreTable/CoreTableColumns.test.ts
@@ -4,6 +4,17 @@ import { ErrorValueTypes } from "./ErrorValues"
 import { OwidTable } from "./OwidTable"
 
 describe(ColumnTypeNames.Quarter, () => {
+    const col = new ColumnTypeMap.Numeric(new OwidTable(), { slug: "test" })
+
+    it("should format correctly for csv", () => {
+        const testValue = 12345678.9
+        const parsed = col.parse(testValue) as number
+        const csvFormatted = col.formatForCsv(parsed)
+        expect(csvFormatted).toEqual("12345678.9")
+    })
+})
+
+describe(ColumnTypeNames.Quarter, () => {
     const col = new ColumnTypeMap.Quarter(new OwidTable(), { slug: "test" })
 
     it("should parse and format values correctly", () => {
@@ -26,5 +37,12 @@ describe(ColumnTypeNames.Quarter, () => {
             if (formattedStr !== undefined && typeof parsed === "number")
                 expect(col.formatValue(parsed)).toEqual(formattedStr)
         }
+    })
+
+    it("should format correctly for csv", () => {
+        const inStr = "2020-Q1"
+        const parsed = col.parse(inStr) as number
+        const csvFormatted = col.formatForCsv(parsed)
+        expect(csvFormatted).toEqual("2020-Q1")
     })
 })

--- a/coreTable/CoreTableColumns.ts
+++ b/coreTable/CoreTableColumns.ts
@@ -191,7 +191,7 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
 
     // A method for formatting for CSV
     formatForCsv(value: JS_TYPE): string {
-        return csvEscape(this.formatValue(value))
+        return csvEscape(anyToString(value))
     }
 
     @imemo get numDecimalPlaces(): number {

--- a/coreTable/OwidTable.test.ts
+++ b/coreTable/OwidTable.test.ts
@@ -134,7 +134,7 @@ it("can synth numerics", () => {
 })
 
 const basicTableCsv = `entityName,entityCode,entityId,gdp,pop
-iceland,ice,1,123,3
+iceland,ice,1,123123456.2,3
 usa,us,2,23,
 france,fr,3,23,4`
 
@@ -150,7 +150,7 @@ it("can export a clean csv", () => {
     const table = new OwidTable(basicTableCsv)
     expect(table.toPrettyCsv()).toEqual(`Entity,Code,gdp,pop
 france,fr,23,4
-iceland,ice,123,3
+iceland,ice,123123456.2,3
 usa,us,23,`)
 })
 
@@ -160,7 +160,7 @@ it("can handle columns with commas", () => {
     expect(table.toPrettyCsv())
         .toEqual(`Entity,Code,"Gross, Domestic, Product",pop
 france,fr,23,4
-iceland,ice,123,3
+iceland,ice,123123456.2,3
 usa,us,23,`)
 })
 


### PR DESCRIPTION
Notion: https://www.notion.so/owid/CSV-download-includes-human-formatted-numbers-451fab4d3aea4870bbb746af99b3343c

I just hope we _never_ have to apply some formatting to CSV-downloaded numbers 🤞, and there's not some rogue column type that needs formatValue in some way?
I at least checked that the unit conversion factor is respected in the value contained in the csv.

For reference, this was probably broken in https://github.com/owid/owid-grapher/commit/30e7773b65b62d48538d07a2560a7ae4369473ee