### PR TITLE
fix(explorer): dropdowns are completely in view on mobile

### DIFF
--- a/explorer/client/ExplorerControls.tsx
+++ b/explorer/client/ExplorerControls.tsx
@@ -61,6 +61,7 @@ export class ExplorerControlPanel extends React.Component<{
     comment?: string
     onChange: (value: string) => void
     hideTitle?: boolean
+    isMobile: boolean
 }> {
     renderOption(option: ControlOption, index: number) {
         const {
@@ -130,7 +131,8 @@ export class ExplorerControlPanel extends React.Component<{
                 className="intervalDropdown"
                 classNamePrefix="intervalDropdown"
                 isDisabled={options.length < 2}
-                menuPlacement="auto"
+                // menuPlacement="auto" doesn't work perfectly well on mobile, with fixed position
+                menuPlacement={this.props.isMobile ? "top" : "auto"}
                 options={options}
                 value={
                     options.find(
@@ -143,6 +145,7 @@ export class ExplorerControlPanel extends React.Component<{
                 }}
                 styles={styles}
                 isSearchable={false}
+                menuPosition={this.props.isMobile ? "fixed" : "absolute"}
             />
         )
     }

--- a/explorer/client/ExplorerShell.tsx
+++ b/explorer/client/ExplorerShell.tsx
@@ -23,6 +23,7 @@ export class ExplorerShell extends React.Component<{
     headerElement: JSX.Element
     params: ExplorerQueryParams
     isEmbed: boolean
+    onResize?: (isMobile: boolean) => void
 }> {
     get keyboardShortcuts(): Command[] {
         return []
@@ -39,6 +40,8 @@ export class ExplorerShell extends React.Component<{
     @action.bound onResize() {
         this.isMobile = this._isMobile()
         this.chartBounds = this.getChartBounds()
+
+        this.props.onResize?.(this.isMobile)
     }
 
     private _isMobile() {

--- a/explorer/client/SwitcherExplorer.tsx
+++ b/explorer/client/SwitcherExplorer.tsx
@@ -57,6 +57,8 @@ export class SwitcherExplorer extends React.Component<{
     @observable private _grapher?: Grapher = undefined
     @observable availableEntities: string[] = []
 
+    @observable private isMobile = false
+
     private get explorerRuntime() {
         return this.props.program.explorerRuntime
     }
@@ -159,6 +161,7 @@ export class SwitcherExplorer extends React.Component<{
                 onChange={(value) => {
                     this.switcherRuntime.setValue(group.title, value)
                 }}
+                isMobile={this.isMobile}
             />
         ))
     }
@@ -183,6 +186,10 @@ export class SwitcherExplorer extends React.Component<{
         return false
     }
 
+    @action.bound onShellResize(isMobile: boolean) {
+        this.isMobile = isMobile
+    }
+
     render() {
         return (
             <ExplorerShell
@@ -193,6 +200,7 @@ export class SwitcherExplorer extends React.Component<{
                 grapher={this._grapher!}
                 params={this.explorerRuntime}
                 isEmbed={this.isEmbed}
+                onResize={this.onShellResize}
             />
         )
     }

--- a/explorer/covidExplorer/CovidExplorer.tsx
+++ b/explorer/covidExplorer/CovidExplorer.tsx
@@ -233,6 +233,7 @@ export class CovidExplorer extends React.Component<{
                     options={options}
                     onChange={this.changeMetric}
                     isCheckbox={false}
+                    isMobile={this.isMobile}
                 />
                 <ExplorerControlPanel
                     title="Metric"
@@ -242,6 +243,7 @@ export class CovidExplorer extends React.Component<{
                     onChange={this.changeMetric}
                     options={optionsColumn2}
                     isCheckbox={false}
+                    isMobile={this.isMobile}
                 />
             </>
         )
@@ -304,6 +306,7 @@ export class CovidExplorer extends React.Component<{
                     this.renderControlsThenUpdateChart()
                 }}
                 explorerSlug="covid"
+                isMobile={this.isMobile}
             />
         )
     }
@@ -333,6 +336,7 @@ export class CovidExplorer extends React.Component<{
                     this.props.params.perCapita = value === "true"
                     this.renderControlsThenUpdateChart()
                 }}
+                isMobile={this.isMobile}
             />
         )
     }
@@ -359,6 +363,7 @@ export class CovidExplorer extends React.Component<{
                 }}
                 comment={this.constrainedParams.trajectoryColumnOption.name}
                 explorerSlug="covid"
+                isMobile={this.isMobile}
             />
         )
     }


### PR DESCRIPTION
Note: This PR is against _master_

Notion: https://www.notion.so/owid/Dropdowns-in-explorer-controls-overlay-mobile-should-scroll-0ca3cf675adc4a81b41409534fb847a5

This is a quick fix for the problem that the Interval dropdown in the Covid explorer, as well as the dropdowns in the CO2, cannot be fully used on mobile, since not all of the dropdown options cannot be reached and the dropdowns don't scroll.
Since we're facing the same issue on `next` still, I will make sure that this fix also makes its way into `next`!

Live on **hans**.

### Before
![image](https://user-images.githubusercontent.com/2641501/106357376-092f9900-6306-11eb-8e73-36d85c37d3b5.png)

### After
![image](https://user-images.githubusercontent.com/2641501/106357593-3cbef300-6307-11eb-896c-86bb09a94692.png)
