### PR TITLE
Remove CovidExplorer MegaCSV aggregates before processing

### DIFF
--- a/explorer/covidExplorer/CovidExplorerTable.ts
+++ b/explorer/covidExplorer/CovidExplorerTable.ts
@@ -13,6 +13,7 @@ import {
     fetchJSON,
     max,
     sum,
+    uniq,
 } from "grapher/utils/Util"
 import moment from "moment"
 import { csv } from "d3-fetch"
@@ -262,9 +263,21 @@ export class CovidExplorerTable {
 
     static async fetchAndParseData(): Promise<CovidGrapherRow[]> {
         const rawData = (await csv(covidDataPath)) as any
-        const filtered: CovidGrapherRow[] = rawData
-            .map(CovidExplorerTable.parseCovidRow)
-            .filter((row: CovidGrapherRow) => row.location !== "International")
+        const rows: CovidGrapherRow[] = rawData.map(
+            CovidExplorerTable.parseCovidRow
+        )
+
+        const continents = uniq(rows.map((row) => row.continent)).filter(
+            (v) => v
+        )
+        const locationsToDrop = new Set([
+            "International",
+            "European Union",
+            ...continents,
+        ])
+        const filtered = rows.filter(
+            (row) => !locationsToDrop.has(row.location)
+        )
 
         const latestDate = max(filtered.map((row) => row.date))
 


### PR DESCRIPTION
The current CovidExplorer creates its own client-side generated aggregates. 

In `next`, we will use the CSV aggregates.

In order to enable us to launch the new aggregates-included CSV for the Next explorer, without duplicating aggregates on the current explorer, it seems easiest/best to drop them on the current CovidExplorer and continue generating them the old way.