### PR TITLE
Embedded charts without query string get iframe-less embeds

### DIFF
--- a/baker/GrapherBakingUtils.test.ts
+++ b/baker/GrapherBakingUtils.test.ts
@@ -1,0 +1,70 @@
+import {
+    grapherSlugToExportFileKey,
+    grapherUrlToSlugAndQueryStr,
+} from "./GrapherBakingUtils"
+
+describe(grapherUrlToSlugAndQueryStr, () => {
+    it("can extract a slug", () => {
+        const grapherUrl = "https://ourworldindata.org/grapher/soil-lifespans"
+        const { slug, queryStr } = grapherUrlToSlugAndQueryStr(grapherUrl)
+        expect(slug).toEqual("soil-lifespans")
+        expect(queryStr).toEqual("")
+    })
+
+    it("can extract slug and queryStr", () => {
+        const grapherUrl =
+            "https://ourworldindata.org/grapher/soil-lifespans?tab=map"
+        const { slug, queryStr } = grapherUrlToSlugAndQueryStr(grapherUrl)
+        expect(slug).toEqual("soil-lifespans")
+        expect(queryStr).toEqual("?tab=map")
+    })
+
+    it("ignores empty query string", () => {
+        const grapherUrl = "https://ourworldindata.org/grapher/soil-lifespans?"
+        const { slug, queryStr } = grapherUrlToSlugAndQueryStr(grapherUrl)
+        expect(slug).toEqual("soil-lifespans")
+        expect(queryStr).toEqual("")
+    })
+
+    it("can handle slugs with uppercase letters", () => {
+        const grapherUrl =
+            "https://ourworldindata.org/grapher/real-gdp-per-capita-pennWT"
+        const { slug, queryStr } = grapherUrlToSlugAndQueryStr(grapherUrl)
+        expect(slug).toEqual("real-gdp-per-capita-pennWT")
+        expect(queryStr).toEqual("")
+    })
+})
+
+describe(grapherSlugToExportFileKey, () => {
+    it("can handle empty query string", () => {
+        const slug = "soil-lifespans"
+        const queryStr = ""
+        expect(grapherSlugToExportFileKey(slug, queryStr)).toEqual(
+            "soil-lifespans"
+        )
+    })
+
+    it("can handle undefined query string", () => {
+        const slug = "soil-lifespans"
+        const queryStr = undefined
+        expect(grapherSlugToExportFileKey(slug, queryStr)).toEqual(
+            "soil-lifespans"
+        )
+    })
+
+    it("can handle non-empty query string", () => {
+        const slug = "soil-lifespans"
+        const queryStr = "?tab=map"
+        expect(grapherSlugToExportFileKey(slug, queryStr)).toEqual(
+            "soil-lifespans-a42c8357c168ebd03c90930b9d3c439b"
+        )
+    })
+
+    it("can handle slugs with uppercase letters", () => {
+        const slug = "real-gdp-per-capita-pennWT"
+        const queryStr = ""
+        expect(grapherSlugToExportFileKey(slug, queryStr)).toEqual(
+            "real-gdp-per-capita-pennWT"
+        )
+    })
+})

--- a/urls/Url.test.ts
+++ b/urls/Url.test.ts
@@ -52,4 +52,9 @@ describe(Url, () => {
         expect(url.base).toBeUndefined()
         expect(url.pathname).toBeUndefined()
     })
+
+    it("Url with empty query string drops query string", () => {
+        const url = Url.fromURL("https://owid.cloud/?")
+        expect(url.fullUrl).toEqual("https://owid.cloud/")
+    })
 })

--- a/urls/Url.ts
+++ b/urls/Url.ts
@@ -9,7 +9,7 @@ import { excludeUndefined, omitUndefinedValues } from "../clientUtils/Util"
 
 const parseUrl = (url: string) => {
     const parsed = urlParseLib(url, {})
-    // The library returns an unparsed string for `query`, its types are quite right.
+    // The library returns an unparsed string for `query`, its types aren't quite right.
     const query = parsed.query.toString()
     return {
         ...parsed,
@@ -85,7 +85,10 @@ export class Url {
 
     get queryStr(): string {
         const { queryStr } = this.props
-        return queryStr !== undefined ? ensureQueryStrFormat(queryStr) : ""
+        // Drop a single trailing `?`, if there is one
+        return queryStr && queryStr !== "?"
+            ? ensureQueryStrFormat(queryStr)
+            : ""
     }
 
     get hash(): string {


### PR DESCRIPTION
Notion: https://www.notion.so/owid/Embedded-charts-without-query-strings-are-iframe-full-when-they-should-be-iframe-less-8a61cf7045884363a6247ac64af7574f

What I changed:
* `Url` drops a trailing `?` if the query string is empty
* Both `GrapherBakingUtils` and `GrapherImageBaker` use this Url class
* Also, they now have two common methods for extracting slug & queryStr from an embed URL, and combining these to a export filename. This way, the implementations can hopefully stay in sync in the future.
* I also added unit tests for these two util methods.