### PR TITLE
Return to requested protected page before login

### DIFF
--- a/adminSite/server/utils/authentication.tsx
+++ b/adminSite/server/utils/authentication.tsx
@@ -93,7 +93,7 @@ export async function authCloudflareSSOMiddleware(
         sameSite: "lax",
         secure: ENV === "production",
     })
-    return res.redirect("/admin")
+    return res.redirect(req.query.next ?? "/admin")
 }
 
 export async function logOut(

--- a/adminSite/server/utils/authentication.tsx
+++ b/adminSite/server/utils/authentication.tsx
@@ -9,7 +9,7 @@ import { CLOUDFLARE_AUD, SECRET_KEY, SESSION_COOKIE_AGE } from "serverSettings"
 import { JsonError } from "utils/server/serverUtil"
 import fetch from "node-fetch"
 import { Secret, verify } from "jsonwebtoken"
-import { ENV } from "settings"
+import { ADMIN_BASE_URL, ENV } from "settings"
 
 export type CurrentUser = User
 
@@ -93,7 +93,17 @@ export async function authCloudflareSSOMiddleware(
         sameSite: "lax",
         secure: ENV === "production",
     })
-    return res.redirect(req.query.next ?? "/admin")
+
+    // Prevents redirect to external URLs
+    let redirectTo = "/admin"
+    if (req.query.next) {
+        try {
+            redirectTo = new URL(req.query.next, ADMIN_BASE_URL).pathname
+        } catch (err) {
+            console.error(err)
+        }
+    }
+    return res.redirect(redirectTo)
 }
 
 export async function logOut(

--- a/wordpress/web/app/plugins/owid/src/authentication.php
+++ b/wordpress/web/app/plugins/owid/src/authentication.php
@@ -96,7 +96,7 @@ add_action('login_init', function () {
         // This prevents clearing the auth cookies we just set, which
         // would lead to an infinite redirection loop.
         $_REQUEST['reauth'] = 0;
-        wp_redirect(admin_url());
+        wp_redirect($_REQUEST["redirect_to"] ?? admin_url());
     }
 });
 
@@ -115,7 +115,6 @@ add_action('wp_logout', function () {
  * query parameter), it is protected by Cloudflare. Logging out then prompts the
  * user to log in, which we don't want. This filter changes the logout URL to
  * point it to a custom page, where the logout is performed.
- * custom page.
  */
 add_filter(
     'logout_url',


### PR DESCRIPTION
With no active session, attempting to access a protected page redirects the user to the login page.

This PR uses the `redirect_to` (wordpress) and `next` (grapher) query parameters to redirect the user to the previously requested page upon successful login.

See https://www.notion.so/80f7bd92d1dd40aab3a9dea9858a7dd6