### PR TITLE
fix: site search updates preview chart when query changes

### DIFF
--- a/site/GrapherFigureView.tsx
+++ b/site/GrapherFigureView.tsx
@@ -32,8 +32,11 @@ export class GrapherFigureView extends React.Component<{ grapher: Grapher }> {
             bounds: this.bounds,
         }
         return (
+            // They key= in here makes it so that the chart is re-loaded when the slug changes.
+            // This is especially important for SearchResults, where the preview chart can change as
+            // the search query changes.
             <figure data-grapher-src ref={this.base}>
-                {this.bounds && <Grapher {...props} />}
+                {this.bounds && <Grapher key={props.slug} {...props} />}
             </figure>
         )
     }


### PR DESCRIPTION
Notion: https://www.notion.so/owid/Site-search-doesn-t-update-preview-chart-efd05ff4249240c2abe6afdfe905d325

This is an easy fix for the site search not updating when the query changes, and I hope it is a nice one too.