### PR TITLE
Revert to using entity codes instead of entity names

### DIFF
--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -16,6 +16,7 @@ import fromPairs from "lodash/fromPairs"
 import groupBy from "lodash/groupBy"
 import has from "lodash/has"
 import identity from "lodash/identity"
+import invert from "lodash/invert"
 import isEmpty from "lodash/isEmpty"
 import isEqual from "lodash/isEqual"
 import isNumber from "lodash/isNumber"
@@ -75,6 +76,7 @@ export {
     groupBy,
     has,
     identity,
+    invert,
     isEmpty,
     isEqual,
     isNumber,

--- a/explorer/Explorer.jsdom.test.tsx
+++ b/explorer/Explorer.jsdom.test.tsx
@@ -35,7 +35,7 @@ describe(Explorer, () => {
     })
 
     it("recovers country selection from URL params", () => {
-        const element = mount(SampleExplorer({ queryStr: "?country=IRL" }))
+        const element = mount(SampleExplorer({ queryStr: "?selection=IRL" }))
         const explorer = element.instance() as Explorer
         expect(explorer.selection.selectedEntityNames).toEqual(["Ireland"])
     })

--- a/explorer/Explorer.jsdom.test.tsx
+++ b/explorer/Explorer.jsdom.test.tsx
@@ -35,9 +35,7 @@ describe(Explorer, () => {
     })
 
     it("recovers country selection from URL params", () => {
-        const element = mount(
-            SampleExplorer({ queryStr: "?selection=Ireland" })
-        )
+        const element = mount(SampleExplorer({ queryStr: "?country=IRL" }))
         const explorer = element.instance() as Explorer
         expect(explorer.selection.selectedEntityNames).toEqual(["Ireland"])
     })

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -56,7 +56,7 @@ import {
 } from "./urlMigrations/ExplorerUrlMigrations"
 import { setWindowUrl, Url } from "../clientUtils/urls/Url"
 import { ExplorerPageUrlMigrationSpec } from "./urlMigrations/ExplorerPageUrlMigrationSpec"
-import { setCountryQueryParam } from "../grapher/core/EntityUrlBuilder"
+import { setSelectedEntityNamesParam } from "../grapher/core/EntityUrlBuilder"
 
 export interface ExplorerProps extends SerializedGridProgram {
     grapherConfigs?: GrapherInterface[]
@@ -188,7 +188,7 @@ export class Explorer
         let url = Url.fromQueryParams(this.initialQueryParams)
 
         if (this.props.selection?.hasSelection) {
-            url = setCountryQueryParam(
+            url = setSelectedEntityNamesParam(
                 url,
                 this.props.selection.selectedEntityNames
             )
@@ -378,7 +378,7 @@ export class Explorer
             })
         )
 
-        url = setCountryQueryParam(
+        url = setSelectedEntityNamesParam(
             url,
             this.selection.hasSelection
                 ? this.selection.selectedEntityNames

--- a/explorer/urlMigrations/ExplorerUrlMigrations.test.ts
+++ b/explorer/urlMigrations/ExplorerUrlMigrations.test.ts
@@ -24,7 +24,7 @@ describe("legacyToGridCovidExplorer", () => {
         ]
 
     const legacyUrl = Url.fromURL(
-        "https://ourworldindata.org/coronavirus-data-explorer?country=ESP~MKD"
+        "https://ourworldindata.org/coronavirus-data-explorer?country=ESP~MKD~North+America"
     )
     const baseQueryStr = "country=SWE~MKD&yScale=log&year=0"
     const migratedUrl = migration.migrateUrl(legacyUrl, baseQueryStr)
@@ -41,8 +41,7 @@ describe("legacyToGridCovidExplorer", () => {
     })
 
     it("migrates country param correctly", () => {
-        expect(migratedQueryParams.country).toBeUndefined()
-        expect(migratedQueryParams.selection).toEqual("Spain~North Macedonia")
+        expect(migratedQueryParams.country).toEqual("ESP~MKD~North America")
     })
 
     it("migrates year param correctly", () => {
@@ -68,7 +67,7 @@ describe("co2 explorer", () => {
             Fuel: "Coal",
             Gas: "CO₂",
             "Relative to world total": "true",
-            selection: "China~United States~India~United Kingdom~World",
+            country: "China~United States~India~United Kingdom~World",
             stackMode: "absolute",
             tab: "chart",
             time: "earliest..latest",
@@ -90,7 +89,7 @@ describe("energy explorer", () => {
             Metric: "Per capita generation",
             "Select a source": "Fossil fuels",
             "Total or Breakdown": "Select a source",
-            selection:
+            country:
                 "United States~United Kingdom~China~World~India~Brazil~South Africa",
             tab: "chart",
             time: "earliest..latest",

--- a/explorer/urlMigrations/ExplorerUrlMigrations.test.ts
+++ b/explorer/urlMigrations/ExplorerUrlMigrations.test.ts
@@ -41,7 +41,8 @@ describe("legacyToGridCovidExplorer", () => {
     })
 
     it("migrates country param correctly", () => {
-        expect(migratedQueryParams.country).toEqual("ESP~MKD~North America")
+        expect(migratedQueryParams.country).toBeUndefined()
+        expect(migratedQueryParams.selection).toEqual("ESP~MKD~North America")
     })
 
     it("migrates year param correctly", () => {
@@ -67,7 +68,7 @@ describe("co2 explorer", () => {
             Fuel: "Coal",
             Gas: "CO₂",
             "Relative to world total": "true",
-            country: "China~United States~India~United Kingdom~World",
+            selection: "China~United States~India~United Kingdom~World",
             stackMode: "absolute",
             tab: "chart",
             time: "earliest..latest",
@@ -89,7 +90,7 @@ describe("energy explorer", () => {
             Metric: "Per capita generation",
             "Select a source": "Fossil fuels",
             "Total or Breakdown": "Select a source",
-            country:
+            selection:
                 "United States~United Kingdom~China~World~India~Brazil~South Africa",
             tab: "chart",
             time: "earliest..latest",

--- a/grapher/controls/globalEntitySelector/GlobalEntitySelector.tsx
+++ b/grapher/controls/globalEntitySelector/GlobalEntitySelector.tsx
@@ -23,7 +23,7 @@ import { WorldEntityName } from "../../core/GrapherConstants"
 import { GLOBAL_ENTITY_SELECTOR_ELEMENT } from "./GlobalEntitySelectorConstants"
 import { SelectionArray } from "../../selection/SelectionArray"
 import { EntityName } from "../../../coreTable/OwidTableConstants"
-import { setCountryQueryParam } from "../../core/EntityUrlBuilder"
+import { setSelectedEntityNamesParam } from "../../core/EntityUrlBuilder"
 import { getWindowUrl, setWindowUrl } from "../../../clientUtils/urls/Url"
 
 enum GlobalEntitySelectionModes {
@@ -220,7 +220,7 @@ export class GlobalEntitySelector extends React.Component<{
 
     @action.bound private updateURL() {
         setWindowUrl(
-            setCountryQueryParam(
+            setSelectedEntityNamesParam(
                 getWindowUrl(),
                 this.selection.selectedEntityNames
             )

--- a/grapher/core/EntityCodes.ts
+++ b/grapher/core/EntityCodes.ts
@@ -1,4 +1,7 @@
-export const LegacyEntityCodesToEntityNames: any = {
+import { invert } from "../../clientUtils/Util"
+import { EntityName } from "../../coreTable/OwidTableConstants"
+
+export const entityCodesToEntityNames: Record<string, string> = {
     ABW: "Aruba",
     AFG: "Afghanistan",
     AGO: "Angola",
@@ -288,4 +291,14 @@ export const LegacyEntityCodesToEntityNames: any = {
     ZAF: "South Africa",
     ZMB: "Zambia",
     ZWE: "Zimbabwe",
+}
+
+export const entityNamesToEntityCodes = invert(entityCodesToEntityNames)
+
+export const codeToEntityName = (codeOrEntityName: string): EntityName => {
+    return entityCodesToEntityNames[codeOrEntityName] ?? codeOrEntityName
+}
+
+export const entityNameToCode = (entityName: EntityName): string => {
+    return entityNamesToEntityCodes[entityName] ?? entityName
 }

--- a/grapher/core/EntityUrlBuilder.test.ts
+++ b/grapher/core/EntityUrlBuilder.test.ts
@@ -3,8 +3,8 @@
 import { Url } from "../../clientUtils/urls/Url"
 import {
     ENTITY_V2_DELIMITER,
-    getCountryQueryParam,
-    setCountryQueryParam,
+    getSelectedEntityNamesParam,
+    setSelectedEntityNamesParam,
 } from "./EntityUrlBuilder"
 
 const encodeTests = [
@@ -66,14 +66,16 @@ const encodeTests = [
 encodeTests.forEach((testCase) => {
     it(`correctly encodes url strings`, () => {
         expect(
-            setCountryQueryParam(Url.fromQueryStr(""), testCase.entities)
+            setSelectedEntityNamesParam(Url.fromQueryStr(""), testCase.entities)
                 .queryStr
         ).toEqual(testCase.outputQueryStr)
     })
 
     it(`correctly decodes url strings`, () => {
         expect(
-            getCountryQueryParam(Url.fromQueryStr(testCase.inputQueryStr))
+            getSelectedEntityNamesParam(
+                Url.fromQueryStr(testCase.inputQueryStr)
+            )
         ).toEqual(testCase.entities)
     })
 })
@@ -97,7 +99,7 @@ describe("legacyLinks", () => {
     legacyLinks.forEach((testCase) => {
         it(`correctly decodes legacy url strings`, () => {
             expect(
-                getCountryQueryParam(Url.fromQueryStr(testCase.queryStr))
+                getSelectedEntityNamesParam(Url.fromQueryStr(testCase.queryStr))
             ).toEqual(testCase.entities)
         })
     })
@@ -114,7 +116,7 @@ describe("facebook", () => {
     facebookLinks.forEach((testCase) => {
         it(`correctly decodes Facebook altered links`, () => {
             expect(
-                getCountryQueryParam(Url.fromQueryStr(testCase.queryStr))
+                getSelectedEntityNamesParam(Url.fromQueryStr(testCase.queryStr))
             ).toEqual(testCase.entities)
         })
     })
@@ -131,7 +133,7 @@ describe("it can handle legacy urls with dimension in selection key", () => {
         ].join(ENTITY_V2_DELIMITER),
     })
 
-    const results = getCountryQueryParam(url)
+    const results = getSelectedEntityNamesParam(url)
 
     expect(results).toEqual([
         "United States",

--- a/grapher/core/EntityUrlBuilder.test.ts
+++ b/grapher/core/EntityUrlBuilder.test.ts
@@ -11,12 +11,12 @@ const encodeTests = [
     {
         entities: ["United States", "United Kingdom"],
         inputQueryStr: "?country=USA~GBR",
-        outputQueryStr: "?country=USA~GBR",
+        outputQueryStr: "?selection=USA~GBR",
     },
     {
         entities: ["YouTube", "Google+"],
         inputQueryStr: "?country=YouTube~Google%2B",
-        outputQueryStr: "?country=YouTube~Google%2B",
+        outputQueryStr: "?selection=YouTube~Google%2B",
     },
     {
         entities: [
@@ -27,29 +27,29 @@ const encodeTests = [
         inputQueryStr:
             "?country=Bogebakken%20(Denmark)%3B%204300%20-%203800%20BCE~British%20Columbia%20(30%20sites)%3B%203500%20BCE%20-%201674%20CE~Brittany%3B%206000%20BCE",
         outputQueryStr:
-            "?country=Bogebakken+%28Denmark%29%3B+4300+-+3800+BCE~British+Columbia+%2830+sites%29%3B+3500+BCE+-+1674+CE~Brittany%3B+6000+BCE",
+            "?selection=Bogebakken+%28Denmark%29%3B+4300+-+3800+BCE~British+Columbia+%2830+sites%29%3B+3500+BCE+-+1674+CE~Brittany%3B+6000+BCE",
     },
     {
         entities: ["British Columbia (30 sites); 3500 BCE - 1674 CE"],
         inputQueryStr:
             "?country=~British%20Columbia%20(30%20sites)%3B%203500%20BCE%20-%201674%20CE",
         outputQueryStr:
-            "?country=~British+Columbia+%2830+sites%29%3B+3500+BCE+-+1674+CE",
+            "?selection=~British+Columbia+%2830+sites%29%3B+3500+BCE+-+1674+CE",
     },
     {
         entities: ["Caribbean small states"],
         inputQueryStr: "?country=~Caribbean%20small%20states",
-        outputQueryStr: "?country=~Caribbean+small+states",
+        outputQueryStr: "?selection=~Caribbean+small+states",
     },
     {
         entities: ["North America"],
         inputQueryStr: "?country=~North%20America",
-        outputQueryStr: "?country=~North+America",
+        outputQueryStr: "?selection=~North+America",
     },
     {
         entities: [],
         inputQueryStr: "?country=",
-        outputQueryStr: "?country=",
+        outputQueryStr: "?selection=",
     },
     {
         entities: [
@@ -59,7 +59,7 @@ const encodeTests = [
         inputQueryStr:
             "?country=Men%20and%20Women%20Ages%2065%2B~Australia%20%26%20New%20Zealand%20%2B%20(Total)",
         outputQueryStr:
-            "?country=Men+and+Women+Ages+65%2B~Australia+%26+New+Zealand+%2B+%28Total%29",
+            "?selection=Men+and+Women+Ages+65%2B~Australia+%26+New+Zealand+%2B+%28Total%29",
     },
 ]
 

--- a/grapher/core/EntityUrlBuilder.test.ts
+++ b/grapher/core/EntityUrlBuilder.test.ts
@@ -11,12 +11,12 @@ const encodeTests = [
     {
         entities: ["United States", "United Kingdom"],
         inputQueryStr: "?country=USA~GBR",
-        outputQueryStr: "?selection=United+States~United+Kingdom",
+        outputQueryStr: "?country=USA~GBR",
     },
     {
         entities: ["YouTube", "Google+"],
         inputQueryStr: "?country=YouTube~Google%2B",
-        outputQueryStr: "?selection=YouTube~Google%2B",
+        outputQueryStr: "?country=YouTube~Google%2B",
     },
     {
         entities: [
@@ -27,29 +27,29 @@ const encodeTests = [
         inputQueryStr:
             "?country=Bogebakken%20(Denmark)%3B%204300%20-%203800%20BCE~British%20Columbia%20(30%20sites)%3B%203500%20BCE%20-%201674%20CE~Brittany%3B%206000%20BCE",
         outputQueryStr:
-            "?selection=Bogebakken+%28Denmark%29%3B+4300+-+3800+BCE~British+Columbia+%2830+sites%29%3B+3500+BCE+-+1674+CE~Brittany%3B+6000+BCE",
+            "?country=Bogebakken+%28Denmark%29%3B+4300+-+3800+BCE~British+Columbia+%2830+sites%29%3B+3500+BCE+-+1674+CE~Brittany%3B+6000+BCE",
     },
     {
         entities: ["British Columbia (30 sites); 3500 BCE - 1674 CE"],
         inputQueryStr:
             "?country=~British%20Columbia%20(30%20sites)%3B%203500%20BCE%20-%201674%20CE",
         outputQueryStr:
-            "?selection=~British+Columbia+%2830+sites%29%3B+3500+BCE+-+1674+CE",
+            "?country=~British+Columbia+%2830+sites%29%3B+3500+BCE+-+1674+CE",
     },
     {
         entities: ["Caribbean small states"],
         inputQueryStr: "?country=~Caribbean%20small%20states",
-        outputQueryStr: "?selection=~Caribbean+small+states",
+        outputQueryStr: "?country=~Caribbean+small+states",
     },
     {
         entities: ["North America"],
         inputQueryStr: "?country=~North%20America",
-        outputQueryStr: "?selection=~North+America",
+        outputQueryStr: "?country=~North+America",
     },
     {
         entities: [],
         inputQueryStr: "?country=",
-        outputQueryStr: "?selection=",
+        outputQueryStr: "?country=",
     },
     {
         entities: [
@@ -59,7 +59,7 @@ const encodeTests = [
         inputQueryStr:
             "?country=Men%20and%20Women%20Ages%2065%2B~Australia%20%26%20New%20Zealand%20%2B%20(Total)",
         outputQueryStr:
-            "?selection=Men+and+Women+Ages+65%2B~Australia+%26+New+Zealand+%2B+%28Total%29",
+            "?country=Men+and+Women+Ages+65%2B~Australia+%26+New+Zealand+%2B+%28Total%29",
     },
 ]
 

--- a/grapher/core/EntityUrlBuilder.ts
+++ b/grapher/core/EntityUrlBuilder.ts
@@ -76,7 +76,7 @@ const migrateEncodedLegacyCountryParam = (countryParam: string) => {
     return entityNamesToDecodedQueryParam(entityNames)
 }
 
-export const migrateCountryQueryParam = (url: Url) => {
+export const migrateSelectedEntityNamesParam = (url: Url) => {
     // need to use still-encoded URL params because we need to
     // distinguish between `+` and `%20` in legacy URLs
     const { country } = url.encodedQueryParams
@@ -87,17 +87,19 @@ export const migrateCountryQueryParam = (url: Url) => {
     })
 }
 
-export const getCountryQueryParam = (url: Url): EntityName[] | undefined => {
-    return migrateCountryQueryParam(url)
+export const getSelectedEntityNamesParam = (
+    url: Url
+): EntityName[] | undefined => {
+    return migrateSelectedEntityNamesParam(url)
         .queryParams.selection?.split(ENTITY_V2_DELIMITER)
         .filter((entityName) => entityName)
 }
 
-export const setCountryQueryParam = (
+export const setSelectedEntityNamesParam = (
     url: Url,
     entityNames: EntityName[] | undefined
 ) => {
-    return migrateCountryQueryParam(url).updateQueryParams({
+    return migrateSelectedEntityNamesParam(url).updateQueryParams({
         selection: entityNames
             ? entityNamesToDecodedQueryParam(entityNames)
             : undefined,

--- a/grapher/core/EntityUrlBuilder.ts
+++ b/grapher/core/EntityUrlBuilder.ts
@@ -127,12 +127,34 @@ const migrateLegacyDimensionPairs: UrlMigration = (url) => {
 }
 
 /*
+ * Migration #3: Rename the `country` param to `selection`.
+ *
+ * Implemented: March 2021
+ *
+ * Most of our charts have countries as entities, but some don't. Using selection= is more general
+ * than country=.
+ *
+ */
+
+const migrateCountryToSelection: UrlMigration = (url) => {
+    const { country, selection } = url.queryParams
+    if (selection === undefined && country !== undefined) {
+        return url.updateQueryParams({
+            country: undefined,
+            selection: country,
+        })
+    }
+    return url
+}
+
+/*
  * Combining all migrations
  */
 
 const urlMigrations: UrlMigration[] = [
     migrateV1Delimited,
     migrateLegacyDimensionPairs,
+    migrateCountryToSelection,
 ]
 
 export const migrateSelectedEntityNamesParam: UrlMigration = (
@@ -148,9 +170,9 @@ export const migrateSelectedEntityNamesParam: UrlMigration = (
 export const getSelectedEntityNamesParam = (
     url: Url
 ): EntityName[] | undefined => {
-    const { country } = migrateSelectedEntityNamesParam(url).queryParams
-    return country !== undefined
-        ? entityNamesFromV2Param(country).map(codeToEntityName)
+    const { selection } = migrateSelectedEntityNamesParam(url).queryParams
+    return selection !== undefined
+        ? entityNamesFromV2Param(selection).map(codeToEntityName)
         : undefined
 }
 
@@ -159,7 +181,7 @@ export const setSelectedEntityNamesParam = (
     entityNames: EntityName[] | undefined
 ) => {
     return migrateSelectedEntityNamesParam(url).updateQueryParams({
-        country: entityNames
+        selection: entityNames
             ? entityNamesToV2Param(entityNames.map(entityNameToCode))
             : undefined,
     })

--- a/grapher/core/EntityUrlBuilder.ts
+++ b/grapher/core/EntityUrlBuilder.ts
@@ -89,8 +89,6 @@ const migrateV1Delimited: UrlMigration = (url) => {
  * We dropped this feature in March 2021 in order to simplify the selection-handling logic, and it
  * was also, in most cases, not desirable to present users with variable-entity options.
  *
- * We will likely re-introduce this in the future, architected better and with the option of which
- *
  */
 
 const LegacyDimensionRegex = /\-\d+$/

--- a/grapher/core/EntityUrlBuilder.ts
+++ b/grapher/core/EntityUrlBuilder.ts
@@ -1,19 +1,105 @@
 import { EntityName } from "../../coreTable/OwidTableConstants"
 import { Url } from "../../clientUtils/urls/Url"
-import { LegacyEntityCodesToEntityNames } from "./LegacyEntityCodesToEntityNames"
+import { codeToEntityName, entityNameToCode } from "./EntityCodes"
+import {
+    performUrlMigrations,
+    UrlMigration,
+} from "../../clientUtils/urls/UrlMigration"
+
+/*
+ * Migration #1: Switch from + to ~ delimited entities.
+ *
+ * Implemented: May 2020
+ *
+ * See PR discussion on how we decided on ~ (tilde): https://github.com/owid/owid-grapher/pull/446
+ * And the initial issue (Facebook rewriting our URLs): https://github.com/owid/owid-grapher/issues/397
+ *
+ * In short:
+ *
+ * Facebook replaces `%20` in URLs with `+`. Before this migration we encoded
+ * ["North America", "South America"] → "North%20America+South%20America".
+ * Facebook would turn this into "North+America+South+America" making the delimiters and spaces
+ * ambiguous.
+ *
+ * We chose ~ (tilde) because no entities existed in the database that contain that symbol, so the
+ * existence of that symbol could be used to detect legacy URLs.
+ *
+ */
 
 // Todo: ensure EntityName never contains the v2Delimiter
 
 const V1_DELIMITER = "+"
 export const ENTITY_V2_DELIMITER = "~"
 
+const isV1Param = (encodedQueryParam: string) => {
+    // No legacy entities have a v2Delimiter in their name,
+    // so if a v2Delimiter is present we know it's a v2 link.
+    return !decodeURIComponent(encodedQueryParam).includes(ENTITY_V2_DELIMITER)
+}
+
+const entityNamesFromV1EncodedParam = (
+    encodedQueryParam: string
+): EntityName[] => {
+    // need to use still-encoded URL params because we need to
+    // distinguish between `+` and `%20` in legacy URLs
+    return encodedQueryParam.split(V1_DELIMITER).map(decodeURIComponent)
+}
+
+const entityNamesToV2Param = (entityNames: EntityName[]): string => {
+    // Always include a v2Delimiter in a v2 link. When decoding we will drop any empty strings.
+    if (entityNames.length === 1) return ENTITY_V2_DELIMITER + entityNames[0]
+    return entityNames.join(ENTITY_V2_DELIMITER)
+}
+
+const entityNamesFromV2Param = (queryParam: string): EntityName[] => {
+    // Facebook turns %20 into +. v2 links will never contain a +, so we can safely replace all of them with %20.
+    return queryParam.split(ENTITY_V2_DELIMITER).filter((item) => item)
+}
+
+const migrateV1Delimited: UrlMigration = (url) => {
+    const { country } = url.encodedQueryParams
+    if (country !== undefined && isV1Param(country)) {
+        return url.updateQueryParams({
+            country: entityNamesToV2Param(
+                entityNamesFromV1EncodedParam(country)
+            ),
+        })
+    }
+    return url
+}
+
+/*
+ * Migration #2: Drop dimension keys from selected entities.
+ *
+ * Implemented: March 2021
+ *
+ * When plotting multiple variables on a chart, it used to be possible to pick which
+ * variable-entity pairs get plotted.
+ *
+ * For example, if you had a line chart with 3 variables: Energy consumption from Coal, Oil and Gas,
+ * then you (as a user) could select individual variable-entity pairs to plot:
+ *
+ * - France - Coal ("FRA-0")
+ * - France - Oil ("FRA-1")
+ * - France - Gas ("FRA-2")
+ * - ...
+ *
+ * The index of the dimension was appended to the entity (e.g. 0 for Coal).
+ *
+ * We dropped this feature in March 2021 in order to simplify the selection-handling logic, and it
+ * was also, in most cases, not desirable to present users with variable-entity options.
+ *
+ * We will likely re-introduce this in the future, architected better and with the option of which
+ *
+ */
+
 const LegacyDimensionRegex = /\-\d+$/
 
-const dropLegacyDimensionInEntityNames = (
+const injectEntityNamesInLegacyDimension = (
     entityNames: EntityName[]
 ): EntityName[] => {
-    // If an entity has the old name-dimension encoding, removing the dimension part and add it as a new selection. So USA-1 becomes USA.
-    // This is only run against the old `country` params
+    // If an entity has the old name-dimension encoding, removing the dimension part and add it as
+    // a new selection. So USA-1 becomes USA.
     const newNames: EntityName[] = []
     entityNames.forEach((entityName) => {
         newNames.push(entityName)
@@ -28,71 +114,46 @@ const dropLegacyDimensionInEntityNames = (
     return newNames
 }
 
-const codeToEntityName = (codeOrEntityName: string) => {
-    return LegacyEntityCodesToEntityNames[codeOrEntityName] ?? codeOrEntityName
+const migrateLegacyDimensionPairs: UrlMigration = (url) => {
+    const { country } = url.queryParams
+    if (country) {
+        return url.updateQueryParams({
+            country: entityNamesToV2Param(
+                injectEntityNamesInLegacyDimension(
+                    entityNamesFromV2Param(country)
+                )
+            ),
+        })
+    }
+    return url
 }
 
-const entityNamesToDecodedQueryParam = (entityNames: EntityName[]): string => {
-    // Always include a v2Delimiter in a v2 link. When decoding we will drop any empty strings.
-    if (entityNames.length === 1) return ENTITY_V2_DELIMITER + entityNames[0]
-    return entityNames.join(ENTITY_V2_DELIMITER)
-}
-
-const isV1Link = (queryParam: string) => {
-    // No legacy entities have a v2Delimiter in their name, so if a v2Delimiter is present we know it's a v2 link.
-    return !decodeURIComponent(queryParam).includes(ENTITY_V2_DELIMITER)
-}
-
-const decodeV1Link = (queryParam: string): EntityName[] => {
-    return queryParam.split(V1_DELIMITER).map(decodeURIComponent)
-}
-
-const decodeV2Link = (queryParam: string): EntityName[] => {
-    // Facebook turns %20 into +. v2 links will never contain a +, so we can safely replace all of them with %20.
-    return decodeURIComponent(queryParam.replace(/\+/g, "%20"))
-        .split(ENTITY_V2_DELIMITER)
-        .filter((item) => item)
-}
-
-const encodedQueryParamToEntityNames = (queryParam = ""): EntityName[] => {
-    // First preserve handling of the old v1 country=USA+FRA style links. If a link does not
-    // include a v2Delimiter and includes a + we assume it's a v1 link. Unfortunately link sharing
-    // with v1 links did not work on Facebook because FB would replace %20 with "+".
-    if (queryParam === "") return []
-    return isV1Link(queryParam)
-        ? decodeV1Link(queryParam)
-        : decodeV2Link(queryParam)
-}
-
-/**
- * Old URLs may contain the selected entities by code or by their full name. In addition, some old urls contain a selection+dimension index combo. This methods
- * migrates those old urls.
- * Important: Only ever pass not-yet-decoded URI params in here, otherwise the migration will give wrong results for legacy URLs.
+/*
+ * Combining all migrations
  */
-const migrateEncodedLegacyCountryParam = (countryParam: string) => {
-    const entityNames = dropLegacyDimensionInEntityNames(
-        encodedQueryParamToEntityNames(countryParam)
-    ).map(codeToEntityName)
-    return entityNamesToDecodedQueryParam(entityNames)
+
+const urlMigrations: UrlMigration[] = [
+    migrateV1Delimited,
+    migrateLegacyDimensionPairs,
+]
+
+export const migrateSelectedEntityNamesParam: UrlMigration = (
+    url: Url
+): Url => {
+    return performUrlMigrations(urlMigrations, url)
 }
 
-export const migrateSelectedEntityNamesParam = (url: Url) => {
-    // need to use still-encoded URL params because we need to
-    // distinguish between `+` and `%20` in legacy URLs
-    const { country } = url.encodedQueryParams
-    if (country === undefined) return url
-    return url.updateQueryParams({
-        country: undefined,
-        selection: migrateEncodedLegacyCountryParam(country),
-    })
-}
+/*
+ * Accessors
+ */
 
 export const getSelectedEntityNamesParam = (
     url: Url
 ): EntityName[] | undefined => {
-    return migrateSelectedEntityNamesParam(url)
-        .queryParams.selection?.split(ENTITY_V2_DELIMITER)
-        .filter((entityName) => entityName)
+    const { country } = migrateSelectedEntityNamesParam(url).queryParams
+    return country !== undefined
+        ? entityNamesFromV2Param(country).map(codeToEntityName)
+        : undefined
 }
 
 export const setSelectedEntityNamesParam = (
@@ -100,8 +161,8 @@ export const setSelectedEntityNamesParam = (
     entityNames: EntityName[] | undefined
 ) => {
     return migrateSelectedEntityNamesParam(url).updateQueryParams({
-        selection: entityNames
-            ? entityNamesToDecodedQueryParam(entityNames)
+        country: entityNames
+            ? entityNamesToV2Param(entityNames.map(entityNameToCode))
             : undefined,
     })
 }

--- a/grapher/core/Grapher.jsdom.test.ts
+++ b/grapher/core/Grapher.jsdom.test.ts
@@ -129,7 +129,7 @@ it("can generate a url with country selection even if there is no entity code", 
     const grapher = new Grapher(config)
     expect(grapher.queryStr).toBe("")
     grapher.selection.selectAll()
-    expect(grapher.queryStr).toContain("Afghanistan")
+    expect(grapher.queryStr).toContain("AFG")
 
     const config2 = {
         ...legacyConfig,
@@ -139,7 +139,7 @@ it("can generate a url with country selection even if there is no entity code", 
     const grapher2 = new Grapher(config2)
     expect(grapher2.queryStr).toBe("")
     grapher2.selection.selectAll()
-    expect(grapher2.queryStr).toContain("Afghanistan")
+    expect(grapher2.queryStr).toContain("AFG")
 })
 
 it("stackedbars should not have timelines", () => {

--- a/grapher/core/Grapher.jsdom.test.ts
+++ b/grapher/core/Grapher.jsdom.test.ts
@@ -22,7 +22,7 @@ import {
 } from "../../coreTable/OwidTableSynthesizers"
 import { orderBy } from "../../clientUtils/Util"
 import { legacyToCurrentGrapherQueryParams } from "./GrapherUrlMigrations"
-import { setCountryQueryParam } from "./EntityUrlBuilder"
+import { setSelectedEntityNamesParam } from "./EntityUrlBuilder"
 import { queryParamsToStr } from "../../clientUtils/urls/UrlUtils"
 import { Url } from "../../clientUtils/urls/Url"
 
@@ -350,7 +350,9 @@ describe("urls", () => {
             selectedEntityNames: ["usa", "canada"],
             addCountryMode: EntitySelectionMode.Disabled,
         })
-        const url = setCountryQueryParam(Url.fromQueryParams({}), ["usa"])
+        const url = setSelectedEntityNamesParam(Url.fromQueryParams({}), [
+            "usa",
+        ])
         grapher.populateFromQueryParams(url.queryParams)
         expect(grapher.selection.selectedEntityNames).toEqual(["usa", "canada"])
     })

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -82,7 +82,10 @@ import {
     LegacyGrapherInterface,
 } from "../core/GrapherInterface"
 import { DimensionSlot } from "../chart/DimensionSlot"
-import { getCountryQueryParam, setCountryQueryParam } from "./EntityUrlBuilder"
+import {
+    getSelectedEntityNamesParam,
+    setSelectedEntityNamesParam,
+} from "./EntityUrlBuilder"
 import { MapProjectionName } from "../mapCharts/MapProjections"
 import { LogoOption } from "../captionedChart/Logos"
 import { AxisConfig, FontSizeManager } from "../axis/AxisConfig"
@@ -461,7 +464,9 @@ export class Grapher
         if (region !== undefined)
             this.map.projection = region as MapProjectionName
 
-        const selection = getCountryQueryParam(Url.fromQueryParams(params))
+        const selection = getSelectedEntityNamesParam(
+            Url.fromQueryParams(params)
+        )
 
         if (this.addCountryMode !== EntitySelectionMode.Disabled && selection)
             this.selection.setSelectedEntities(selection)
@@ -2055,7 +2060,7 @@ export class Grapher
         params.endpointsOnly = this.compareEndPointsOnly ? "1" : "0"
         params.time = this.timeParam
         params.region = this.map.projection
-        return setCountryQueryParam(
+        return setSelectedEntityNamesParam(
             Url.fromQueryParams(params),
             this.selectedEntitiesIfDifferentThanAuthors
         ).queryParams

--- a/grapher/core/GrapherUrlMigrations.test.ts
+++ b/grapher/core/GrapherUrlMigrations.test.ts
@@ -9,7 +9,7 @@ describe(legacyToCurrentGrapherQueryParams, () => {
         const currentQueryParams = legacyToCurrentGrapherQueryParams(queryStr)
 
         expect(currentQueryParams).toEqual({
-            country: "~East Asia & Pacific",
+            selection: "~East Asia & Pacific",
             tab: "chart",
         })
     })
@@ -22,7 +22,7 @@ describe(legacyToCurrentGrapherQueryParams, () => {
         )
 
         expect(currentQueryParams).toEqual({
-            country: "~East Asia & Pacific",
+            selection: "~East Asia & Pacific",
             tab: "chart",
         })
     })

--- a/grapher/core/GrapherUrlMigrations.test.ts
+++ b/grapher/core/GrapherUrlMigrations.test.ts
@@ -9,7 +9,7 @@ describe(legacyToCurrentGrapherQueryParams, () => {
         const currentQueryParams = legacyToCurrentGrapherQueryParams(queryStr)
 
         expect(currentQueryParams).toEqual({
-            selection: "~East Asia & Pacific",
+            country: "~East Asia & Pacific",
             tab: "chart",
         })
     })
@@ -22,7 +22,7 @@ describe(legacyToCurrentGrapherQueryParams, () => {
         )
 
         expect(currentQueryParams).toEqual({
-            selection: "~East Asia & Pacific",
+            country: "~East Asia & Pacific",
             tab: "chart",
         })
     })

--- a/grapher/core/GrapherUrlMigrations.ts
+++ b/grapher/core/GrapherUrlMigrations.ts
@@ -4,7 +4,7 @@ import {
     UrlMigration,
     performUrlMigrations,
 } from "../../clientUtils/urls/UrlMigration"
-import { migrateCountryQueryParam } from "./EntityUrlBuilder"
+import { migrateSelectedEntityNamesParam } from "./EntityUrlBuilder"
 
 export const grapherUrlMigrations: UrlMigration[] = [
     (url) => {
@@ -15,7 +15,7 @@ export const grapherUrlMigrations: UrlMigration[] = [
             time: time ?? year,
         })
     },
-    migrateCountryQueryParam,
+    migrateSelectedEntityNamesParam,
 ]
 
 export const legacyToCurrentGrapherUrl = (url: Url) =>

--- a/site/SearchResults.tsx
+++ b/site/SearchResults.tsx
@@ -11,7 +11,7 @@ import { EmbedChart } from "./EmbedChart"
 import { BAKED_GRAPHER_URL } from "../settings/clientSettings"
 import { uniq, capitalize } from "../clientUtils/Util"
 import { Country } from "../clientUtils/countries"
-import { setCountryQueryParam } from "../grapher/core/EntityUrlBuilder"
+import { setSelectedEntityNamesParam } from "../grapher/core/EntityUrlBuilder"
 import { Url } from "../clientUtils/urls/Url"
 
 class ChartResult extends React.Component<{
@@ -27,7 +27,7 @@ class ChartResult extends React.Component<{
         const { entities } = this
         if (!entities.length) return hit.slug
         else
-            return setCountryQueryParam(
+            return setSelectedEntityNamesParam(
                 Url.fromURL(hit.slug).updateQueryParams({
                     tab: "chart",
                 }),
@@ -155,7 +155,7 @@ export class SearchResults extends React.Component<{
 
         if (!bestChartEntities.length) return bestChartHit.slug
         else
-            return setCountryQueryParam(
+            return setSelectedEntityNamesParam(
                 Url.fromURL(bestChartHit.slug).updateQueryParams({
                     tab: "chart",
                 }),

--- a/site/blocks/ProminentLink.tsx
+++ b/site/blocks/ProminentLink.tsx
@@ -4,9 +4,9 @@ import { observer } from "mobx-react"
 import { computed } from "mobx"
 import { union, getAttributesOfHTMLElement } from "../../clientUtils/Util"
 import {
-    getCountryQueryParam,
-    migrateCountryQueryParam,
-    setCountryQueryParam,
+    getSelectedEntityNamesParam,
+    migrateSelectedEntityNamesParam,
+    setSelectedEntityNamesParam,
 } from "../../grapher/core/EntityUrlBuilder"
 import { SelectionArray } from "../../grapher/selection/SelectionArray"
 import { Url } from "../../clientUtils/urls/Url"
@@ -21,13 +21,13 @@ class ProminentLink extends React.Component<{
     globalEntitySelection?: SelectionArray
 }> {
     @computed get originalUrl(): Url {
-        return migrateCountryQueryParam(
+        return migrateSelectedEntityNamesParam(
             Url.fromURL(this.props.originalAnchorAttributes.href)
         )
     }
 
     @computed private get originalSelectedEntities(): EntityName[] {
-        return getCountryQueryParam(this.originalUrl) ?? []
+        return getSelectedEntityNamesParam(this.originalUrl) ?? []
     }
 
     @computed private get entitiesInGlobalEntitySelection(): EntityName[] {
@@ -39,7 +39,7 @@ class ProminentLink extends React.Component<{
             this.originalSelectedEntities,
             this.entitiesInGlobalEntitySelection
         )
-        return setCountryQueryParam(this.originalUrl, newEntityList)
+        return setSelectedEntityNamesParam(this.originalUrl, newEntityList)
     }
 
     render() {

--- a/site/multiembedder/MultiEmbedder.tsx
+++ b/site/multiembedder/MultiEmbedder.tsx
@@ -21,8 +21,8 @@ import {
 import { getWindowUrl, Url } from "../../clientUtils/urls/Url"
 import { SelectionArray } from "../../grapher/selection/SelectionArray"
 import {
-    getCountryQueryParam,
-    migrateCountryQueryParam,
+    getSelectedEntityNamesParam,
+    migrateSelectedEntityNamesParam,
 } from "../../grapher/core/EntityUrlBuilder"
 import { hydrateGlobalEntitySelectorIfAny } from "../../grapher/controls/globalEntitySelector/GlobalEntitySelector"
 
@@ -246,8 +246,8 @@ class MultiEmbedder {
             }),
             getWindowUrl(),
         ]
-            .map(migrateCountryQueryParam)
-            .map(getCountryQueryParam)
+            .map(migrateSelectedEntityNamesParam)
+            .map(getSelectedEntityNamesParam)
 
         this.selection = new SelectionArray(
             windowEntityNames ?? defaultEntityNames


### PR DESCRIPTION
Notion issue: [Revert back to using entity codes instead of entity names](https://www.notion.so/Revert-back-to-using-country-instead-of-selection-8963b354600649d898fb941e7d58c872)

- Use codes instead of names (`selection=USA` instead of `selection=United+States`)

I just made the changes in the query param accessors (now renamed to `getSelectedEntityNamesParam` and `setSelectedEntityNamesParam`). 

Ideally, in the future we'd move the _codes → names_ transformations outside the codebase, so they can be updated by authors (maybe using the chart data entity map as before? maybe an API?), but for now this is enough to preserve the URLs on live.