### PR TITLE
fix: EntitySelectorMulti sorts entities

### DIFF
--- a/grapher/controls/EntitySelectorModal.tsx
+++ b/grapher/controls/EntitySelectorModal.tsx
@@ -38,7 +38,7 @@ class EntitySelectorMulti extends React.Component<{
     @computed get searchResults() {
         return this.searchInput
             ? this.fuzzy.search(this.searchInput)
-            : this.searchableEntities
+            : sortBy(this.searchableEntities, (result) => result.name)
     }
 
     @action.bound onClickOutside(e: MouseEvent) {


### PR DESCRIPTION
Notion: https://www.notion.so/owid/Sort-countries-by-name-in-selection-dialog-416a238ed8bc40809422e4e2585fa1c3

This is quick fix.
We should probably put up an `EntitySelectorModal` cleanup on the list of things to do after Operation Merge is finished, because the split between `EntitySelectorSingle` and `EntitySelectorMulti` really is not great.
The fact that single was already sorted and multi was not is probably just one artifact of that split.