### PR TITLE
fix: show timeline on map tab even if chart is StackedArea, StackedBar or DiscreteBar

### DIFF
--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1090,11 +1090,16 @@ export class Grapher
     }
 
     @computed get hasTimeline() {
-        if (this.isStackedBar || this.isStackedArea || this.isDiscreteBar)
-            return false
         if (this.isOnOverlay) return false
         if (this.hideTimeline) return false
-        if (this.isOnMapTab && this.map.hideTimeline) return false
+
+        if (this.isOnMapTab) {
+            if (this.map.hideTimeline) return false
+        } else {
+            if (this.isStackedBar || this.isStackedArea || this.isDiscreteBar)
+                return false
+        }
+
         return this.times.length > 1
     }
 

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1087,12 +1087,15 @@ export class Grapher
         if (this.times.length <= 1) return false
 
         switch (this.tab) {
+            // the map tab has its own `hideTimeline` option
             case GrapherTabOption.map:
                 return !this.map.hideTimeline
 
+            // use the chart-level `hideTimeline` option for the table, too
             case GrapherTabOption.table:
                 return !this.hideTimeline
 
+            // StackedBar, StackedArea, and DiscreteBar charts never display a timeline
             case GrapherTabOption.chart:
                 return (
                     !this.hideTimeline &&
@@ -1103,6 +1106,7 @@ export class Grapher
                     )
                 )
 
+            // never show a timeline while we're showing one of these two overlays
             case GrapherTabOption.download:
             case GrapherTabOption.sources:
                 return false

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1090,17 +1090,30 @@ export class Grapher
     }
 
     @computed get hasTimeline() {
-        if (this.isOnOverlay) return false
-        if (this.hideTimeline) return false
+        // we don't have more than one distinct times in our data, so it doesn't make sense to show a timeline
+        if (this.times.length <= 1) return false
 
-        if (this.isOnMapTab) {
-            if (this.map.hideTimeline) return false
-        } else {
-            if (this.isStackedBar || this.isStackedArea || this.isDiscreteBar)
+        switch (this.tab) {
+            case GrapherTabOption.map:
+                return !this.map.hideTimeline
+
+            case GrapherTabOption.table:
+                return !this.hideTimeline
+
+            case GrapherTabOption.chart:
+                return (
+                    !this.hideTimeline &&
+                    !(
+                        this.isStackedBar ||
+                        this.isStackedArea ||
+                        this.isDiscreteBar
+                    )
+                )
+
+            case GrapherTabOption.download:
+            case GrapherTabOption.sources:
                 return false
         }
-
-        return this.times.length > 1
     }
 
     @computed private get areHandlesOnSameTime() {

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1082,15 +1082,8 @@ export class Grapher
         return text.trim()
     }
 
-    @computed private get isOnOverlay() {
-        return (
-            this.currentTab === GrapherTabOption.sources ||
-            this.currentTab === GrapherTabOption.download
-        )
-    }
-
-    @computed get hasTimeline() {
-        // we don't have more than one distinct times in our data, so it doesn't make sense to show a timeline
+    @computed get hasTimeline(): boolean {
+        // we don't have more than one distinct time point in our data, so it doesn't make sense to show a timeline
         if (this.times.length <= 1) return false
 
         switch (this.tab) {


### PR DESCRIPTION
Notion: https://www.notion.so/owid/Some-charts-are-missing-a-timeline-0cc1f7ec43a04762bb8a19558313a0f1

I _think_ this is the correct logic for the timeline.

For reference, [this is the old logic behind this.](https://github.com/owid/owid-grapher/blob/3ec3750084c76bf49b426f022cc7c86385692d6b/grapher/core/GrapherView.tsx#L472-L486)
I also tested this somewhat, and it seems to do the job.

And, if you can think of a way to make the method more expressive / easier to understand the nested logic, please go for it!