### PR TITLE
fix: CovidExplorer spuriously selects Align outbreaks

### DIFF
--- a/explorer/ExplorerDecisionMatrix.ts
+++ b/explorer/ExplorerDecisionMatrix.ts
@@ -136,16 +136,27 @@ export class DecisionMatrix {
     }
 
     @action.bound setValueCommand(choiceName: ChoiceName, value: ChoiceValue) {
-        const currentInvalidState = this.diffBetweenUserSettingsAndConstrained
         this._setValue(choiceName, value)
-        const newInvalidState = this.diffBetweenUserSettingsAndConstrained
-        Object.keys(currentInvalidState).forEach((key) => {
-            /**
-             * The user navigated to an invalid state. Then they made a change in the new state, but the old invalid props were still set. At this
-             * point, we should delete the old invalid props. We only want to allow the user to go back 1, not a full undo/redo history.
-             */
-            if (currentInvalidState[key] === newInvalidState[key]) {
-                this._setValue(key, currentInvalidState[key])
+        const invalidState = this.diffBetweenUserSettingsAndConstrained
+        Object.keys(invalidState).forEach((key) => {
+            // If a user navigates to a state where an option previously selected is not available,
+            // then persist the new option, as long as it isn't the only one available.
+            //
+            // For example, if the user navigates from metric:Cases interval:Weekly, to
+            // metric:Vaccinations, if interval:Weekly is not available for Vaccinations but other
+            // (more than one) intervals are available, we will persist whichever we happen to end
+            // up on.
+            //
+            // But if the user navigates from metric:Cases perCapita:true, to
+            // metric:Share of positive tests, then the only available perCapita option is false,
+            // but it isn't persisted, because the user has no other options. It's non-sensical to
+            // ask for "Share of positive tests per capita", so qualitatively it's a different
+            // metric, and the perCapita can just be ignored.
+            //
+            // We assume in every case where the user has only a single option available (therefore
+            // has no choice) the option should not be persisted.
+            if (this.availableChoiceOptions[key].length > 1) {
+                this._setValue(key, invalidState[key])
             }
         })
     }
@@ -188,6 +199,16 @@ export class DecisionMatrix {
                 .uniqValues.filter((cell) => !isCellEmpty(cell)) as string[]
         })
         return choiceMap
+    }
+
+    @computed private get availableChoiceOptions(): ChoiceMap {
+        const result: ChoiceMap = {}
+        this.choiceNames.forEach((choiceName) => {
+            result[choiceName] = this.allChoiceOptions[
+                choiceName
+            ].filter((option) => this.isOptionAvailable(choiceName, option))
+        })
+        return result
     }
 
     private firstAvailableOptionForChoice(

--- a/explorer/ExplorerProgram.test.ts
+++ b/explorer/ExplorerProgram.test.ts
@@ -367,6 +367,28 @@ france,Life expectancy`
         ).toEqual(true)
     })
 
+    it("something", () => {
+        const decisionMatrix = new DecisionMatrix(
+            `${grapherIdKeyword},Metric,Interval,Relative to population,Align outbreaks
+1,Cases,Daily,true,false
+2,Cases,Daily,true,true
+3,Cases,Cumulative,true,true
+4,Cases,Cumulative,false,false
+5,Cases,Cumulative,true,false
+6,Tests,Daily,false,false
+7,Tests,Cumulative,false,false`
+        )
+        decisionMatrix.setValueCommand("Metric", "Cases")
+        decisionMatrix.setValueCommand("Interval", "Daily")
+        expect(decisionMatrix.selectedRow.grapherId).toEqual(1)
+        decisionMatrix.setValueCommand("Metric", "Tests")
+        expect(decisionMatrix.selectedRow.grapherId).toEqual(6)
+        decisionMatrix.setValueCommand("Interval", "Cumulative")
+        expect(decisionMatrix.selectedRow.grapherId).toEqual(7)
+        decisionMatrix.setValueCommand("Metric", "Cases")
+        expect(decisionMatrix.selectedRow.grapherId).toEqual(3)
+    })
+
     describe("subtables", () => {
         it("can detect header frontier", () => {
             const subtableFrontierCell = new ExplorerProgram(

--- a/explorer/ExplorerProgram.test.ts
+++ b/explorer/ExplorerProgram.test.ts
@@ -367,26 +367,28 @@ france,Life expectancy`
         ).toEqual(true)
     })
 
-    it("something", () => {
+    // TODO: figure out why setValueCommand does not seem to be equivalent to a user interacting
+    // with the UI.
+    // See logic in setValueCommand for an explanation of the logic we want to test here.
+    it.skip("overwrite unavailable option with new option, if more than 1 option is available", () => {
         const decisionMatrix = new DecisionMatrix(
             `${grapherIdKeyword},Metric,Interval,Relative to population,Align outbreaks
 1,Cases,Daily,true,false
 2,Cases,Daily,true,true
-3,Cases,Cumulative,true,true
-4,Cases,Cumulative,false,false
-5,Cases,Cumulative,true,false
-6,Tests,Daily,false,false
-7,Tests,Cumulative,false,false`
+3,Cases,Weekly,true,true
+4,Cases,Cumulative,true,true
+5,Cases,Cumulative,false,false
+6,Cases,Cumulative,true,false
+7,Tests,Daily,false,false
+8,Tests,Cumulative,false,false`
         )
         decisionMatrix.setValueCommand("Metric", "Cases")
-        decisionMatrix.setValueCommand("Interval", "Daily")
-        expect(decisionMatrix.selectedRow.grapherId).toEqual(1)
+        decisionMatrix.setValueCommand("Interval", "Weekly")
+        expect(decisionMatrix.selectedRow.grapherId).toEqual(3)
         decisionMatrix.setValueCommand("Metric", "Tests")
-        expect(decisionMatrix.selectedRow.grapherId).toEqual(6)
-        decisionMatrix.setValueCommand("Interval", "Cumulative")
         expect(decisionMatrix.selectedRow.grapherId).toEqual(7)
         decisionMatrix.setValueCommand("Metric", "Cases")
-        expect(decisionMatrix.selectedRow.grapherId).toEqual(3)
+        expect(decisionMatrix.selectedRow.grapherId).toEqual(2)
     })
 
     describe("subtables", () => {


### PR DESCRIPTION
Notion issue: [ "Align outbreaks" setting is not remembered when switching away from a view where it is disabled](https://www.notion.so/Align-outbreaks-setting-is-not-remembered-when-switching-away-from-a-view-where-it-is-disabled-5d2e20a8e7d74cf386bc49168d260647)

⚠️ That test case I've added doesn't actually reproduce the issue, it passes before and after. I spent an hour trying to figure it out but didn't get anywhere, and this is a Low priority issue so didn't think it was worth continuing.

Meanwhile, the fix actually works if you try to reproduce it in the browser. There was a bug in `toConstrainedParams` – the choice params are built-up sequentially (e.g. for COVID that's metric, interval, population ...), and for each param this function ensures there's a valid state, or it changes the param to the `firstAvailableOptionForChoice`. But the changes to each param weren't while this was built up sequentially, instead it was always using `currentParams`, so it lead to returning `undefined` in some cases (e.g. `{ "Align outbreaks": undefined }`). This creates problems I didn't manage to understand.