### PR TITLE
VS Code Devcontainer setup for easier development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,6 @@ FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:dev-${VARIANT}
 
 RUN apt-get update \
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends default-mysql-client \
+    && apt-get -y install --no-install-recommends default-mysql-client tmux bc \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+ARG VARIANT=12
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:dev-${VARIANT}
+
+RUN apt-get update \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends default-mysql-client \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,9 +16,6 @@
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [3000, 27017],
 
-    // Use 'postCreateCommand' to run commands after the container is created.
-    // "postCreateCommand": "yarn install",
-
     // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "node",
     "postCreateCommand": "sudo chown node node_modules"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+// Update the VARIANT arg in docker-compose.yml to pick a Node.js version: 10, 12, 14
+{
+    "name": "OWID Grapher devcontainer",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "app",
+    "workspaceFolder": "/workspace",
+
+    // Set *default* container specific settings.json values on container create.
+    // "settings": {
+    //     "terminal.integrated.shell.linux": "/bin/bash"
+    // },
+
+    // Add the IDs of extensions you want installed when the container is created.
+    "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"],
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [3000, 27017],
+
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "yarn install",
+
+    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "node",
+    "postCreateCommand": "sudo chown node node_modules"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,54 @@
+version: "3"
+
+services:
+    app:
+        build:
+            context: .
+            dockerfile: Dockerfile
+            args:
+                # [Choice] Node.js version: 14, 12, 10
+                VARIANT: 12
+                # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
+                #USER_UID: 1000
+                #USER_GID: 1000
+        volumes:
+            - ..:/workspace:cached
+            - try-node-node_modules:/workspace/node_modules
+
+        # Overrides default command so things don't shut down after the process ends.
+        command: sleep infinity
+
+        # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+        network_mode: service:db
+
+        depends_on:
+            - db
+
+        environment:
+            MYSQL_HOST: db
+            MYSQL_PWD: node
+
+        # Uncomment the next line to use a non-root user for all processes.
+        # user: node
+
+        # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+        # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+    db:
+        image: mysql:5.7
+        restart: unless-stopped
+        volumes:
+            - owid-data:/data/db
+
+        environment:
+            MYSQL_ROOT_PASSWORD: superuser
+            MYSQL_USER: node
+            MYSQL_PASSWORD: node
+            MYSQL_DATABASE: owid
+
+        # Add "forwardPorts": ["27017"] to **devcontainer.json** to forward MongoDB locally.
+        # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+volumes:
+    owid-data:
+    try-node-node_modules:

--- a/.github/workflows/prettify.yml
+++ b/.github/workflows/prettify.yml
@@ -16,7 +16,7 @@ jobs:
             - name: Clone repository
               uses: actions/checkout@v2
               with:
-                  ref: ${{ github.head_ref }}
+                  ref: ${{ github.ref }}
 
             # Use Node version specified in .nvmrc
             # https://github.com/actions/setup-node/issues/32#issuecomment-525791142

--- a/README.md
+++ b/README.md
@@ -14,7 +14,27 @@ The owid-grapher visualization frontend code can run isomorphically under node t
 
 ## Initial development setup
 
-### macOS
+### VS Code Devcontainer
+
+One option for development that does not require a local node and mysql setup is to use VS Code, Docker, and the the [VS Code Devcontainers extension](https://code.visualstudio.com/docs/remote/containers). To proceed this this method of development, install VS Code, Docker and the VS Code Devcontainers extension, the open the project in VS Code, type `CTLR + Shift + P` to get the command panel and run the `Remote Containers: Reopen in container` command. This may take a few minutes to download the base containers and build the app container (all files involved can be found in the [./.devcontainers](./.devcontainers) folder).
+
+After this all you have to do is one run to install the currently required node version and run the database setup script as described below (the terminal in VS Code is now running in the development container with Node and the mysql client installed).
+
+1. Install the exact node version used for development
+
+    ```sh
+    nvm install 12.13.1
+    ```
+
+2. Install all dependecies
+
+    ```sh
+    yarn
+    ```
+
+3. Continue below in the [Import the latest data extract](#import-the-latest-data-extract) section to set up the database
+
+### Local macOS development
 
 1. Install Homebrew first, follow the instructions here: <https://brew.sh/>
 

--- a/package.json
+++ b/package.json
@@ -229,6 +229,7 @@
         "pretty-quick": "^3.0.0",
         "source-map-support": "^0.5.12",
         "storybook": "^6.1.21",
+        "tmex": "^1.0.8",
         "tsc-watch": "^4.2.9",
         "xhr-mock": "^2.5.1"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -18592,6 +18592,11 @@ tippy.js@^6.2.0:
   dependencies:
     "@popperjs/core" "^2.3.2"
 
+tmex@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/tmex/-/tmex-1.0.8.tgz#a6fc022c5765dec4a99591b3a75d075c85748ca7"
+  integrity sha512-PBaw29ZrGkKIGEtlSFXshDEFQsbU+zTCwhyKJti3B4PrJVtV87ezu2UwWgW97tZZrNw8KHXvliDnk4GHUMVuYg==
+
 tmp-promise@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.2.tgz#6e933782abff8b00c3119d63589ca1fb9caaa62a"


### PR DESCRIPTION
I created an alternative to the setup described in this repo that installs mysql and node locally for development. This alternative uses VS Code, Docker, and the [VS Code Devcontainer extension](https://code.visualstudio.com/docs/remote/containers) to make it very fast to get started as both the editing environment with node and mysql both run in containers managed with a docker-compose file but all of that hidden by VS code.

The setup seems to work for me but on my somewhat underpowered laptop I have some issues running the application for a longer time in dev mode. I'll test this more on a more powerful machine.

The readme instructions are just a draft for now. Please let me know into how much detail this should go and how much this should take for granted that people are familiar with these concepts vs spelling them out in the readme.

It would also be great if someone else could test this setup and let me know if there are any issues.