### PR TITLE
Serialize all choice params in Explorer URL

### DIFF
--- a/explorer/Explorer.jsdom.test.tsx
+++ b/explorer/Explorer.jsdom.test.tsx
@@ -39,4 +39,16 @@ describe(Explorer, () => {
         const explorer = element.instance() as Explorer
         expect(explorer.selection.selectedEntityNames).toEqual(["Ireland"])
     })
+
+    it("serializes all choice params in URL", () => {
+        const element = mount(SampleExplorer())
+        const explorer = element.instance() as Explorer
+        expect(explorer.queryParams).toMatchObject({
+            Accounting: "Production-based",
+            Count: "Per country",
+            Fuel: "Total",
+            Gas: "CO₂",
+            "Relative to world total": "false",
+        })
+    })
 })

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -349,13 +349,9 @@ export class Explorer
         )
     }
 
-    @computed get changedChoiceParams(): Partial<ExplorerChoiceParams> {
+    @computed private get currentChoiceParams(): ExplorerChoiceParams {
         const { decisionMatrix } = this.explorerProgram
-        const currentParams: Readonly<ExplorerChoiceParams> =
-            decisionMatrix.currentParams
-        const defaultParams: Readonly<ExplorerChoiceParams> = this
-            .explorerProgram.clone.decisionMatrix.currentParams
-        return differenceObj(currentParams, defaultParams)
+        return decisionMatrix.currentParams
     }
 
     @computed get queryParams(): ExplorerFullQueryParams {
@@ -365,7 +361,7 @@ export class Explorer
             localStorage.setItem(
                 UNSAVED_EXPLORER_PREVIEW_QUERYPARAMS +
                     this.explorerProgram.slug,
-                JSON.stringify(this.changedChoiceParams)
+                JSON.stringify(this.currentChoiceParams)
             )
 
         let url = Url.fromQueryParams(
@@ -374,7 +370,7 @@ export class Explorer
                 pickerSort: this.entityPickerSort,
                 pickerMetric: this.entityPickerMetric,
                 hideControls: this.initialQueryParams.hideControls || undefined,
-                ...this.changedChoiceParams,
+                ...this.currentChoiceParams,
             })
         )
 


### PR DESCRIPTION
Notion issue: [Include all choice params in Explorer URL](https://www.notion.so/Include-all-choice-params-in-Explorer-URL-87b675a53a01460899edcc61b149b99a).

> Is it a good idea to include all Explorer params (metric, interval, align outbreaks, etc) in the URL every time, regardless whether they are set to their default value?
> That way, if we change the default, which is highly likely, we won’t end up with unexpected views.
> This is the behaviour of the current (live) CovidExplorer.
> On the Next explorer, we omit params that are set to their defaults. This can be problematic if we change the default view (which we do every now and then).

> An example: I want to embed a cases, daily, per million chart.
> Because all these are defaults, they’re not in the URL. If we change the defaults, you will get a completely different chart in your embed.