### PR TITLE
Points-only (disconnected) ScatterPlot

### DIFF
--- a/grapher/scatterCharts/ScatterPlotChart.test.ts
+++ b/grapher/scatterCharts/ScatterPlotChart.test.ts
@@ -8,7 +8,11 @@ import {
     SynthesizeGDPTable,
 } from "../../coreTable/OwidTableSynthesizers"
 import { ScatterPlotManager } from "./ScatterPlotChartConstants"
-import { ScaleType, ScatterPointLabelStrategy } from "../core/GrapherConstants"
+import {
+    EntitySelectionMode,
+    ScaleType,
+    ScatterPointLabelStrategy,
+} from "../core/GrapherConstants"
 import { OwidTable } from "../../coreTable/OwidTable"
 import { ErrorValueTypes } from "../../coreTable/ErrorValues"
 import { ColumnTypeNames } from "../../coreTable/CoreColumnDef"
@@ -889,5 +893,64 @@ describe("x/y tolerance", () => {
                 year: 2008,
             }),
         ])
+    })
+})
+
+describe("addCountryMode", () => {
+    const table = new OwidTable(
+        [
+            ["entityId", "entityName", "entityCode", "year", "x", "y"],
+            [1, "UK", "", 2000, 1, 1],
+            [2, "USA", "", 2000, 2, 2],
+        ],
+        [
+            {
+                slug: "x",
+                type: ColumnTypeNames.Numeric,
+            },
+            {
+                slug: "y",
+                type: ColumnTypeNames.Numeric,
+            },
+        ]
+    )
+
+    const manager: ScatterPlotManager = {
+        xColumnSlug: "x",
+        yColumnSlug: "y",
+        colorColumnSlug: "color",
+        sizeColumnSlug: "size",
+        table,
+        selection: ["UK"],
+    }
+
+    it("doesn't filter any data for MultipleEntities mode", () => {
+        const chart = new ScatterPlotChart({
+            manager: {
+                ...manager,
+                addCountryMode: EntitySelectionMode.MultipleEntities,
+            },
+        })
+        expect(chart.transformedTable.numRows).toEqual(2)
+    })
+
+    it("filters unselected data for SingleEntity mode", () => {
+        const chart = new ScatterPlotChart({
+            manager: {
+                ...manager,
+                addCountryMode: EntitySelectionMode.SingleEntity,
+            },
+        })
+        expect(chart.transformedTable.numRows).toEqual(1)
+    })
+
+    it("filters unselected data for Disabled mode", () => {
+        const chart = new ScatterPlotChart({
+            manager: {
+                ...manager,
+                addCountryMode: EntitySelectionMode.Disabled,
+            },
+        })
+        expect(chart.transformedTable.numRows).toEqual(1)
     })
 })

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -477,7 +477,7 @@ export class ScatterPlotChart
         )
     }
 
-    @computed private get hideLines() {
+    @computed private get hideConnectedScatterLines() {
         return !!this.manager.hideConnectedScatterLines
     }
 
@@ -486,7 +486,7 @@ export class ScatterPlotChart
             dualAxis,
             focusedEntityNames,
             hoveredSeriesNames,
-            hideLines,
+            hideConnectedScatterLines,
             manager,
             series,
             sizeDomain,
@@ -497,7 +497,7 @@ export class ScatterPlotChart
         return (
             <ScatterPointsWithLabels
                 noDataModalManager={manager}
-                hideLines={hideLines}
+                hideConnectedScatterLines={hideConnectedScatterLines}
                 seriesArray={series}
                 dualAxis={dualAxis}
                 colorScale={!colorColumn.isMissing ? colorScale : undefined}

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -87,7 +87,10 @@ export class ScatterPlotChart
             addCountryMode,
         } = this.manager
 
-        if (addCountryMode === EntitySelectionMode.Disabled) {
+        if (
+            addCountryMode === EntitySelectionMode.Disabled ||
+            addCountryMode === EntitySelectionMode.SingleEntity
+        ) {
             table = table.filterByEntityNames(
                 this.selectionArray.selectedEntityNames
             )

--- a/grapher/scatterCharts/ScatterPlotChartConstants.ts
+++ b/grapher/scatterCharts/ScatterPlotChartConstants.ts
@@ -114,6 +114,6 @@ export interface ScatterPointsWithLabelsProps {
     onMouseOver: (series: ScatterSeries) => void
     onMouseLeave: () => void
     onClick: () => void
-    hideLines: boolean
+    hideConnectedScatterLines: boolean
     noDataModalManager: NoDataModalManager
 }

--- a/grapher/scatterCharts/ScatterUtils.ts
+++ b/grapher/scatterCharts/ScatterUtils.ts
@@ -18,15 +18,24 @@ export const labelPriority = (label: ScatterLabel) => {
     return priority
 }
 
+const FONT_SIZE_WHEN_HIDDEN_LINES = 12
+
 // Create the start year label for a series
 export const makeStartLabel = (
     series: ScatterRenderSeries,
-    isSubtleForeground: boolean
+    isSubtleForeground: boolean,
+    hideConnectedScatterLines: boolean
 ): ScatterLabel | undefined => {
     // No room to label the year if it's a single point
     if (!series.isForeground || series.points.length <= 1) return undefined
 
-    const fontSize = series.isForeground ? (isSubtleForeground ? 8 : 9) : 7
+    const fontSize = hideConnectedScatterLines
+        ? FONT_SIZE_WHEN_HIDDEN_LINES
+        : series.isForeground
+        ? isSubtleForeground
+            ? 8
+            : 9
+        : 7
     const firstValue = series.points[0]
     const nextValue = series.points[1]
     const nextSegment = nextValue.position.subtract(firstValue.position)
@@ -68,7 +77,8 @@ export const makeStartLabel = (
 // Positioned using normals of the line segments
 export const makeMidLabels = (
     series: ScatterRenderSeries,
-    isSubtleForeground: boolean
+    isSubtleForeground: boolean,
+    hideConnectedScatterLines: boolean
 ): ScatterLabel[] => {
     if (
         !series.isForeground ||
@@ -77,7 +87,13 @@ export const makeMidLabels = (
     )
         return []
 
-    const fontSize = series.isForeground ? (isSubtleForeground ? 8 : 9) : 7
+    const fontSize = hideConnectedScatterLines
+        ? FONT_SIZE_WHEN_HIDDEN_LINES
+        : series.isForeground
+        ? isSubtleForeground
+            ? 8
+            : 9
+        : 7
     const fontWeight = 400
 
     return series.points.slice(1, -1).map((v, i) => {
@@ -145,19 +161,16 @@ export const makeMidLabels = (
 export const makeEndLabel = (
     series: ScatterRenderSeries,
     isSubtleForeground: boolean,
-    hideLines: boolean
+    hideConnectedScatterLines: boolean
 ): ScatterLabel => {
     const lastValue = last(series.points) as ScatterRenderPoint
     const lastPos = lastValue.position
-    const fontSize = hideLines
-        ? series.isForeground
-            ? isSubtleForeground
-                ? 8
-                : 9
-            : 7
+    const fontSize = hideConnectedScatterLines
+        ? FONT_SIZE_WHEN_HIDDEN_LINES
         : lastValue.fontSize *
           (series.isForeground ? (isSubtleForeground ? 1.2 : 1.3) : 1.1)
-    const fontWeight = series.isForeground ? 700 : 400
+    const fontWeight =
+        series.isForeground && !hideConnectedScatterLines ? 700 : 400
 
     let offsetVector = PointVector.up
     if (series.points.length > 1) {
@@ -190,7 +203,10 @@ export const makeEndLabel = (
         })
 
     return {
-        text: hideLines && series.isForeground ? lastValue.label : series.text,
+        text:
+            hideConnectedScatterLines && series.isForeground
+                ? lastValue.label
+                : series.text,
         fontSize,
         fontWeight,
         color: lastValue.color,


### PR DESCRIPTION
Notion issue: [Plot points for ScatterPlot when connecting lines are hidden](https://www.notion.so/Plot-points-for-ScatterPlot-when-connecting-lines-are-hidden-56b03ae1e9284a53b5c66c4b59b57f9b)

`TimeScatter` was used for this, but [now it's gone](https://staging.owid.cloud/admin/test/embeds?ids=4334) (left is _live_, right is _next_):

<img width="1371" alt="Screenshot 2021-03-08 at 16 46 33" src="https://user-images.githubusercontent.com/1308115/110352491-e5aaed00-802d-11eb-82d0-414eac2363cb.png">

---

With this PR, ScatterPlots with hidden connecting lines (`hideConnectedScatterLines
`) do plot points:

<img width="706" alt="Screenshot 2021-03-08 at 16 48 39" src="https://user-images.githubusercontent.com/1308115/110352829-4afede00-802e-11eb-8fdf-6efd9af03a9a.png">

### Todo

- [x] Migrate all existing ScatterPlots from `SingleEntity` to `MultipleEntities` selection mode. In the past the `SingleEntity` selection mode had no effect on ScatterPlot.