### PR TITLE
Turn single-year line charts into bar charts based on non-filtered input table

### DIFF
--- a/grapher/core/Grapher.jsdom.test.ts
+++ b/grapher/core/Grapher.jsdom.test.ts
@@ -348,6 +348,14 @@ describe("line chart to bar chart and bar chart race", () => {
         grapher.timelineController.play(1)
         expect(grapher.startHandleTimeBound).toEqual(grapher.endHandleTimeBound)
     })
+
+    it("turns into a bar chart when constrained start & end handles are equal", () => {
+        grapher.startHandleTimeBound = 5000
+        grapher.endHandleTimeBound = Infinity
+        expect(
+            grapher.typeExceptWhenLineChartAndSingleTimeThenWillBeBarChart
+        ).toEqual(ChartTypeName.DiscreteBar)
+    })
 })
 
 describe("urls", () => {

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1114,7 +1114,10 @@ export class Grapher
     }
 
     @computed private get areHandlesOnSameTime() {
-        const [start, end] = this.timelineHandleTimeBounds
+        const times = this.tableAfterAuthorTimelineFilter.timeColumn.uniqValues
+        const [start, end] = this.timelineHandleTimeBounds.map((time) =>
+            findClosestTime(times, time)
+        )
         return start === end
     }
 


### PR DESCRIPTION
Hopefully takes care of:

- [Prevent single-year line charts](https://www.notion.so/Prevent-single-year-line-charts-f53b72f326114d8a8975ecc184d242bf)
- [Fix existing single-year line charts (manually)](https://www.notion.so/Fix-existing-single-year-line-charts-manually-4e6b39e7a659434d8d4df8833f886ada)