### PR TITLE
Remove cookie notice from print version (updated)

### DIFF
--- a/site/client/CookieNotice.tsx
+++ b/site/client/CookieNotice.tsx
@@ -27,7 +27,7 @@ export const CookieNotice = ({
 
     return (
         <div
-            className={classnames("cookie-notice", "no-print", {
+            className={classnames("cookie-notice", {
                 open: mounted && (!accepted || outdated),
             })}
             data-test="cookie-notice"

--- a/site/client/css/components/cookie-notice.scss
+++ b/site/client/css/components/cookie-notice.scss
@@ -12,15 +12,25 @@
     z-index: $zindex-cookie-notice;
     box-shadow: 0 0 30px rgba(#fff, 0.3);
 
-    transition: transform 400ms ease, box-shadow 400ms ease;
-
     // when closed
-    transform: translate(0, 100%);
-    box-shadow: none;
+    display: none;
+
+    @keyframes slide-in {
+        0% {
+            opacity: 0; // prevent flickering when animation starts
+            transform: translate(0, 100%);
+        }
+        1% {
+            opacity: 1;
+        }
+        100% {
+            transform: translate(0, 0);
+        }
+    }
 
     &.open {
-        transform: translate(0, 0);
-        box-shadow: 0 0 30px rgba(#fff, 0.3);
+        display: block;
+        animation: 400ms ease slide-in forwards;
     }
 
     @include md-up {


### PR DESCRIPTION
Keeps the banner visible on print if not yet accepted.