### PR TITLE
style: improve spacing in Explorer mobile menu

### DIFF
--- a/explorer/ExplorerControls.scss
+++ b/explorer/ExplorerControls.scss
@@ -43,7 +43,10 @@ $chart-border-radius: 2px;
 
         .ControlOption {
             line-height: 1.3;
-            margin-bottom: 9px;
+        }
+
+        .ControlOption + .ControlOption {
+            margin-top: 8px;
         }
 
         .UnavailableOption {
@@ -74,7 +77,7 @@ $chart-border-radius: 2px;
         right: 0;
         z-index: 100;
         border-radius: 0;
-        padding-top: 8px;
+        padding-top: 10px;
 
         .HiddenControlHeader {
             // Remove hidden labels on mobile entirely
@@ -104,6 +107,7 @@ $chart-border-radius: 2px;
 
         padding-top: 0;
         padding-bottom: 0;
+        margin-right: 0;
 
         &.count {
             width: unset;
@@ -112,6 +116,14 @@ $chart-border-radius: 2px;
         .intervalDropdown {
             width: 100%;
         }
+    }
+
+    .ExplorerControl + .ExplorerControl {
+        padding-top: 15px;
+    }
+
+    .ExplorerDropdown {
+        width: 100%;
     }
 }
 

--- a/grapher/controls/entityPicker/EntityPicker.scss
+++ b/grapher/controls/entityPicker/EntityPicker.scss
@@ -250,10 +250,6 @@ $zindex-dropdown: 100;
         height: 35vh;
     }
 
-    .ControlHeader {
-        padding-top: 6px;
-    }
-
     .ExplorerFigure {
         min-height: 480px;
         @include full-width;


### PR DESCRIPTION
Before:

<img width="375" alt="Screenshot 2021-03-15 at 19 32 36" src="https://user-images.githubusercontent.com/1308115/111210651-66855e00-85c5-11eb-979f-bdb659a4c8fc.png">

After:

<img width="375" alt="Screenshot 2021-03-15 at 19 31 53" src="https://user-images.githubusercontent.com/1308115/111210664-6a18e500-85c5-11eb-8279-35f5e1c6bd86.png">
