### PR TITLE
Improve perf by dropping unnecessary columns before transforming the table further

### DIFF
--- a/coreTable/CoreTable.test.ts
+++ b/coreTable/CoreTable.test.ts
@@ -355,6 +355,19 @@ describe("column operations", () => {
         expect(table.dropColumns(["year"]).columnSlugs).toEqual(["country"])
     })
 
+    it("can keep only a certain set of columns", () => {
+        const rows = [
+            { country: "USA", year: 1999, gdp: 10001 },
+            { country: "Germany", year: 2000, gdp: 20002 },
+        ]
+        const table = new CoreTable(rows)
+        expect(table.columnSlugs).toEqual(["country", "year", "gdp"])
+        expect(table.keepOnlyColumns(["country", "gdp"]).columnSlugs).toEqual([
+            "country",
+            "gdp",
+        ])
+    })
+
     it("can transform columns", () => {
         const rows = [
             { country: "USA", year: 1999 },

--- a/coreTable/CoreTable.test.ts
+++ b/coreTable/CoreTable.test.ts
@@ -355,14 +355,14 @@ describe("column operations", () => {
         expect(table.dropColumns(["year"]).columnSlugs).toEqual(["country"])
     })
 
-    it("can keep only a certain set of columns", () => {
+    it("can select a set of columns", () => {
         const rows = [
             { country: "USA", year: 1999, gdp: 10001 },
             { country: "Germany", year: 2000, gdp: 20002 },
         ]
         const table = new CoreTable(rows)
         expect(table.columnSlugs).toEqual(["country", "year", "gdp"])
-        expect(table.keepOnlyColumns(["country", "gdp"]).columnSlugs).toEqual([
+        expect(table.select(["country", "gdp"]).columnSlugs).toEqual([
             "country",
             "gdp",
         ])

--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -931,7 +931,11 @@ export class CoreTable<
 
     appendRows(rows: ROW_TYPE[], opDescription: string) {
         return this.concat(
-            [new (this.constructor as any)(rows, this.defs) as CoreTable],
+            [
+                new (this.constructor as any)(rows, this.defs, {
+                    parent: this.parent,
+                }) as CoreTable,
+            ],
             opDescription
         )
     }

--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -974,32 +974,18 @@ export class CoreTable<
 
     select(slugs: ColumnSlug[]) {
         const columnsToKeep = new Set(slugs)
-        const defs = this.columnsAsArray
-            .filter((col) => columnsToKeep.has(col.slug))
-            .map((col) => col.def) as COL_DEF_TYPE[]
-        return this.transform(
-            this.columnStore,
-            defs,
-            `Kept columns '${slugs}'`,
-            TransformType.FilterColumns
-        )
-    }
-
-    keepOnlyColumns(slugs: ColumnSlug[]) {
-        const columnsToKeep = new Set(slugs)
-        const newStore = {
-            ...this.columnStore,
-        }
+        const newStore = { ...this.columnStore }
         const defs = this.columnsAsArray
             .filter((col) => columnsToKeep.has(col.slug))
             .map((col) => col.def) as COL_DEF_TYPE[]
         Object.keys(newStore).forEach((slug) => {
             if (!columnsToKeep.has(slug)) delete newStore[slug]
         })
+
         return this.transform(
-            newStore,
+            this.columnStore,
             defs,
-            `Kept only columns '${slugs}'`,
+            `Kept columns '${slugs}'`,
             TransformType.FilterColumns
         )
     }

--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -974,16 +974,19 @@ export class CoreTable<
 
     select(slugs: ColumnSlug[]) {
         const columnsToKeep = new Set(slugs)
-        const newStore = { ...this.columnStore }
+        const newStore: CoreColumnStore = {}
         const defs = this.columnsAsArray
             .filter((col) => columnsToKeep.has(col.slug))
             .map((col) => col.def) as COL_DEF_TYPE[]
-        Object.keys(newStore).forEach((slug) => {
-            if (!columnsToKeep.has(slug)) delete newStore[slug]
-        })
+
+        Object.keys(this.columnStore)
+            .filter((slug) => columnsToKeep.has(slug))
+            .forEach((slug) => {
+                newStore[slug] = this.columnStore[slug]
+            })
 
         return this.transform(
-            this.columnStore,
+            newStore,
             defs,
             `Kept columns '${slugs}'`,
             TransformType.FilterColumns

--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -985,6 +985,25 @@ export class CoreTable<
         )
     }
 
+    keepOnlyColumns(slugs: ColumnSlug[]) {
+        const columnsToKeep = new Set(slugs)
+        const newStore = {
+            ...this.columnStore,
+        }
+        const defs = this.columnsAsArray
+            .filter((col) => columnsToKeep.has(col.slug))
+            .map((col) => col.def) as COL_DEF_TYPE[]
+        Object.keys(newStore).forEach((slug) => {
+            if (!columnsToKeep.has(slug)) delete newStore[slug]
+        })
+        return this.transform(
+            newStore,
+            defs,
+            `Kept only columns '${slugs}'`,
+            TransformType.FilterColumns
+        )
+    }
+
     dropColumns(slugs: ColumnSlug[], message?: string) {
         const columnsToDrop = new Set(slugs)
         const newStore = {

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -610,7 +610,7 @@ export class Explorer
     }
 
     @computed get entityPickerTable() {
-        return this.grapher?.table
+        return this.grapher?.tableAfterAuthorTimelineFilter
     }
 
     @computed get pickerColumnSlugs() {
@@ -623,7 +623,7 @@ export class Explorer
             ColumnTypeNames.EntityId,
             ColumnTypeNames.EntityCode,
         ])
-        return this.grapher?.table.columnsAsArray
+        return this.entityPickerTable?.columnsAsArray
             .filter(
                 (col) => !doNotShowThese.has(col.def.type as ColumnTypeNames)
             )

--- a/grapher/core/Grapher.jsdom.test.ts
+++ b/grapher/core/Grapher.jsdom.test.ts
@@ -275,13 +275,14 @@ describe("currentTitle", () => {
         expect(grapher.currentTitle).toContain("2009")
     })
 
-    it("can generate a title when all you have is a table", () => {
+    it("can generate a title when all you have is a table and ySlug", () => {
         const table = SynthesizeGDPTable(
             { entityCount: 2, timeRange: [2000, 2010] },
             1
         )
         const grapher = new Grapher({
             table,
+            ySlugs: "GDP",
         })
 
         expect(grapher.currentTitle).toContain("GDP")
@@ -296,6 +297,7 @@ describe("authors can use maxTime", () => {
             type: ChartTypeName.DiscreteBar,
             selectedEntityNames: table.availableEntityNames,
             maxTime: 2005,
+            ySlugs: "GDP",
         })
         const chart = grapher.chartInstance
         expect(chart.failMessage).toBeFalsy()

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -488,7 +488,7 @@ export class Grapher
     }
 
     // If an author sets a timeline filter run it early in the pipeline so to the charts it's as if the filtered times do not exist
-    @computed private get tableAfterAuthorTimelineFilter() {
+    @computed get tableAfterAuthorTimelineFilter() {
         const table = this.inputTable
         if (
             this.timelineMinTime === undefined &&

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -139,6 +139,7 @@ import {
     EntityId,
     EntityName,
     OwidColumnDef,
+    OwidTableSlugs,
 } from "../../coreTable/OwidTableConstants"
 import { BlankOwidTable, OwidTable } from "../../coreTable/OwidTable"
 import * as Mousetrap from "mousetrap"
@@ -502,13 +503,9 @@ export class Grapher
     }
 
     @computed private get tableAfterAuthorTimelineAndColumnFilter() {
-        return this.tableAfterAuthorTimelineFilter.keepOnlyColumns([
-            ...this.activeColumnSlugs,
-            this.inputTable.timeColumn.slug,
-            this.inputTable.entityNameSlug,
-            this.inputTable.entityIdColumn.slug,
-            this.inputTable.entityCodeColumn.slug,
-        ])
+        return this.tableAfterAuthorTimelineFilter.select(
+            this.columnSlugsNecessaryForCurrentView
+        )
     }
 
     // Convenience method for debugging
@@ -1199,7 +1196,7 @@ export class Grapher
         return this.sourceDesc ?? this.defaultSourcesLine
     }
 
-    // All columns that are _currently_ part of the visualization
+    // Columns that are used as a dimension in the currently active view
     @computed get activeColumnSlugs() {
         const {
             yColumnSlugs,
@@ -1213,6 +1210,19 @@ export class Grapher
             xColumnSlug,
             sizeColumnSlug,
             colorColumnSlug,
+        ])
+    }
+
+    // All columns that are necessary for the current view, including meta columns like entityName
+    // and time
+    @computed get columnSlugsNecessaryForCurrentView() {
+        return excludeUndefined([
+            ...this.activeColumnSlugs,
+            this.inputTable.timeColumn.slug,
+            this.inputTable.entityNameSlug,
+            this.inputTable.entityIdColumn.slug,
+            this.inputTable.entityCodeColumn.slug,
+            OwidTableSlugs.entityColor,
         ])
     }
 

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -502,7 +502,7 @@ export class Grapher
         )
     }
 
-    @computed private get tableAfterAuthorTimelineAndColumnFilter() {
+    @computed get tableAfterAuthorTimelineAndColumnFilter() {
         return this.tableAfterAuthorTimelineFilter.select(
             this.columnSlugsNecessaryForCurrentView
         )

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -501,6 +501,16 @@ export class Grapher
         )
     }
 
+    @computed private get tableAfterAuthorTimelineAndColumnFilter() {
+        return this.tableAfterAuthorTimelineFilter.keepOnlyColumns([
+            ...this.activeColumnSlugs,
+            this.inputTable.timeColumn.slug,
+            this.inputTable.entityNameSlug,
+            this.inputTable.entityIdColumn.slug,
+            this.inputTable.entityCodeColumn.slug,
+        ])
+    }
+
     // Convenience method for debugging
     windowQueryParams(str = location.search) {
         return strToQueryParams(str)
@@ -508,7 +518,7 @@ export class Grapher
 
     @computed
     private get tableAfterAuthorTimelineAndActiveChartTransform(): OwidTable {
-        const table = this.tableAfterAuthorTimelineFilter
+        const table = this.tableAfterAuthorTimelineAndColumnFilter
         if (!this.isReady || !this.isChartOrMapTab) return table
         return this.chartInstance.transformTable(table)
     }
@@ -533,7 +543,7 @@ export class Grapher
     }
 
     @computed get table() {
-        return this.tableAfterAuthorTimelineFilter
+        return this.tableAfterAuthorTimelineAndColumnFilter
     }
 
     @computed


### PR DESCRIPTION
Notion: [Switching to Map view is slow](https://www.notion.so/Switching-to-Map-view-is-slow-71ed38f1a82d48d88d73cc6b55ef5cfa)

The main thing that makes switching to the map tab slow is that we need to apply 4 `FilterMask`s, and every one of them needs to be applied to ~80000 rows × ~100 columns for the Covid explorer.
To display any given chart, though, we don't need much more than 4 or 5 columns.

So what I'm doing in here is that I drop most columns as early on as possible, only keeping those that we need to display the current chart. This seems to work quite nicely.

This all is still a bit rough around the edges, though, and we (I) probably want to test it more, too.

TODOs:
* [x] Fix failing tests
* [x] Test this with a whole lot of charts and explorers, to see that there's nothing going wrong anywhere
* [ ] Decide what we should do with csv downloads - currently, the csv download only includes "active" columns, i.e. (derived) columns which are used in the current visualization
* [x] Take out the `FilterMask` logging/timing code
* [x] Squash commits and find better names for them :)
* [x] Add tests for `activeColumnSlugs`, or for the whole transform? (e.g. a test case that has a massive amount of unused columns, and then check that only the necessary columns are being kept)
