### PR TITLE
fix: set CovidExplorer boolean URL params to 'false' if omitted

### DIFF
--- a/explorer/urlMigrations/ExplorerUrlMigrations.test.ts
+++ b/explorer/urlMigrations/ExplorerUrlMigrations.test.ts
@@ -52,6 +52,32 @@ describe("legacyToGridCovidExplorer", () => {
     it("preserves old query params", () => {
         expect(migratedQueryParams.yScale).toEqual("log")
     })
+
+    it("sets boolean options to 'false' if omitted in legacy URL", () => {
+        const legacyUrl = Url.fromURL(
+            "https://ourworldindata.org/coronavirus-data-explorer?casesMetric=true"
+        )
+        const baseQueryStr = "deathsMetric=true&perCapita=true&aligned=true"
+        const migratedUrl = migration.migrateUrl(legacyUrl, baseQueryStr)
+        const migratedQueryParams = migratedUrl.queryParams
+
+        expect(migratedQueryParams["Metric"]).toEqual("Confirmed cases")
+        expect(migratedQueryParams["Relative to Population"]).toEqual("false")
+        expect(migratedQueryParams["Align outbreaks"]).toEqual("false")
+    })
+
+    it("sets default view for legacy URL without params", () => {
+        const legacyUrl = Url.fromURL(
+            "https://ourworldindata.org/coronavirus-data-explorer"
+        )
+        const baseQueryStr = "casesMetric=true&interval=daily&perCapita=true"
+        const migratedUrl = migration.migrateUrl(legacyUrl, baseQueryStr)
+        const migratedQueryParams = migratedUrl.queryParams
+
+        expect(migratedQueryParams["Metric"]).toEqual("Confirmed cases")
+        expect(migratedQueryParams["Relative to Population"]).toEqual("true")
+        expect(migratedQueryParams["Align outbreaks"]).toEqual("false")
+    })
 })
 
 describe("co2 explorer", () => {

--- a/explorer/urlMigrations/LegacyCovidUrlMigration.ts
+++ b/explorer/urlMigrations/LegacyCovidUrlMigration.ts
@@ -58,11 +58,14 @@ const covidIntervalFromLegacyQueryParams = (queryParams: QueryParams) => {
     return undefined
 }
 
+const boolParamToString = (bool: boolean | string | undefined) =>
+    bool ? "true" : "false"
+
 const legacyToCurrentCovidQueryParams = (
     queryParams: QueryParams,
     baseQueryParams: QueryParams = {}
 ): QueryParams => {
-    const { aligned, perCapita, ...restQueryParams } = omit(
+    const restQueryParams = omit(
         {
             ...baseQueryParams,
             ...queryParams,
@@ -77,8 +80,12 @@ const legacyToCurrentCovidQueryParams = (
         "interval",
         "smoothing",
         "totalFreq",
-        "dailyFreq"
+        "dailyFreq",
+        "aligned",
+        "perCapita"
     )
+
+    const urlContainsMetric = !!covidMetricFromLegacyQueryParams(queryParams)
 
     const explorerQueryParams: QueryParams = {
         Metric:
@@ -87,8 +94,12 @@ const legacyToCurrentCovidQueryParams = (
         Interval:
             covidIntervalFromLegacyQueryParams(queryParams) ??
             covidIntervalFromLegacyQueryParams(baseQueryParams),
-        "Align outbreaks": aligned ? "true" : "false",
-        "Relative to Population": perCapita ? "true" : "false",
+        "Align outbreaks": urlContainsMetric
+            ? boolParamToString(queryParams.aligned)
+            : boolParamToString(baseQueryParams.aligned),
+        "Relative to Population": urlContainsMetric
+            ? boolParamToString(queryParams.perCapita)
+            : boolParamToString(baseQueryParams.perCapita),
     }
 
     return {


### PR DESCRIPTION
Notion: [All old Explorer URLs and embeds have perCapita enabled](https://www.notion.so/All-old-Explorer-URLs-and-embeds-have-perCapita-enabled-4926b84936634812b5682b585995c71e)