### PR TITLE
feat: allow setting a custom link to download CSV in explorers

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -283,6 +283,8 @@ export class Explorer
         grapher.downloadData()
         grapher.slug = this.explorerProgram.slug
         if (!hasGrapherId) grapher.id = 0
+        if (this.downloadDataLink)
+            grapher.externalCsvLink = this.downloadDataLink
     }
 
     @action.bound private setTableBySlug(tableSlug?: TableSlug) {
@@ -454,6 +456,10 @@ export class Explorer
             this.explorerProgram.hideControls ||
             this.initialQueryParams.hideControls === "true"
         )
+    }
+
+    @computed private get downloadDataLink(): string | undefined {
+        return this.explorerProgram.downloadDataLink
     }
 
     @observable private grapherContainerRef: React.RefObject<

--- a/explorer/ExplorerGrammar.ts
+++ b/explorer/ExplorerGrammar.ts
@@ -91,6 +91,13 @@ export const ExplorerGrammar: Grammar = {
         description:
             "Create a Google Sheet, share it with the OWID Group, then put the link here.",
     },
+    downloadDataLink: {
+        ...UrlCellDef,
+        keyword: "downloadDataLink",
+        valuePlaceholder: "https://example.com/data.csv",
+        description:
+            "An optional URL for the download button in the Download tab. If blank, the Explorer will instead generate a CSV from the data it has available.",
+    },
     isPublished: {
         ...BooleanCellDef,
         keyword: "isPublished",

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -150,6 +150,10 @@ export class ExplorerProgram extends GridProgram {
         return this.getLineValue(ExplorerGrammar.hideControls.keyword)
     }
 
+    get downloadDataLink() {
+        return this.getLineValue(ExplorerGrammar.downloadDataLink.keyword)
+    }
+
     get isPublished() {
         return (
             this.getLineValue(ExplorerGrammar.isPublished.keyword) ===


### PR DESCRIPTION
Notion: [Change CSV download to point to GitHub CSV again](https://www.notion.so/Change-CSV-download-to-point-to-GitHub-CSV-again-6567d913fe624b11b9c792fead4ae5c5)

After this is deployed, we need to set a `downloadDataLink` in the Explorer config.