### PR TITLE
fix(play): line chart plays as line chart, not discrete bar chart

### DIFF
--- a/grapher/core/Grapher.jsdom.test.ts
+++ b/grapher/core/Grapher.jsdom.test.ts
@@ -344,9 +344,16 @@ describe("line chart to bar chart and bar chart race", () => {
         })
     })
 
-    it("turns into a bar chart race when playing a line chart", () => {
+    it("turns into a line chart race when playing a line chart that currently shows as a bar chart", () => {
+        grapher.startHandleTimeBound = -Infinity
+        grapher.endHandleTimeBound = -Infinity
         grapher.timelineController.play(1)
-        expect(grapher.startHandleTimeBound).toEqual(grapher.endHandleTimeBound)
+        expect(grapher.startHandleTimeBound).not.toEqual(
+            grapher.endHandleTimeBound
+        )
+        expect(
+            grapher.typeExceptWhenLineChartAndSingleTimeThenWillBeBarChart
+        ).toEqual(ChartTypeName.LineChart)
     })
 
     it("turns into a bar chart when constrained start & end handles are equal", () => {

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -786,11 +786,7 @@ export class Grapher
     }
 
     @computed get startHandleTimeBound(): TimeBound {
-        if (
-            this.isDiscreteBarOrLineChartTransformedIntoDiscreteBar ||
-            this.isOnMapTab
-        )
-            return this.endHandleTimeBound
+        if (this.onlySingleTimeSelectionPossible) return this.endHandleTimeBound
         return this.timelineHandleTimeBounds[0]
     }
 
@@ -805,10 +801,7 @@ export class Grapher
     }
 
     set endHandleTimeBound(newValue: TimeBound) {
-        if (
-            this.isOnMapTab ||
-            this.isDiscreteBarOrLineChartTransformedIntoDiscreteBar
-        )
+        if (this.onlySingleTimeSelectionPossible)
             this.timelineHandleTimeBounds = [newValue, newValue]
         else
             this.timelineHandleTimeBounds = [
@@ -832,12 +825,8 @@ export class Grapher
         return findClosestTime(this.times, this.endHandleTimeBound)
     }
 
-    @computed private get isDiscreteBarOrLineChartTransformedIntoDiscreteBar() {
-        return (
-            this.typeExceptWhenLineChartAndSingleTimeThenWillBeBarChart ===
-                ChartTypeName.DiscreteBar ||
-            (this.type === ChartTypeName.LineChart && this.isPlaying)
-        )
+    @computed private get onlySingleTimeSelectionPossible() {
+        return this.type === ChartTypeName.DiscreteBar || this.isOnMapTab
     }
 
     @computed get shouldLinkToOwid() {


### PR DESCRIPTION
Notion: [LineChart animations should be playing a line chart, not bar chart](https://www.notion.so/LineChart-animations-should-be-playing-a-line-chart-not-bar-chart-2c2cd73bf8bf4c249b3d82cc0739da4d)

Both line charts and scatter plots now always play in time-range mode, even if the chart starts out in single year mode (i.e. single-year discrete bar chart, or single-year scatter). This detection didn't quite work before.

In `TimelineController`, there's already a `rangeMode` that can later be used to switch between the two modes - single-year and multi-year playing.