### PR TITLE
fix: plot line series in pre-v3 order (first column is on top)

### DIFF
--- a/grapher/chart/ChartInterface.ts
+++ b/grapher/chart/ChartInterface.ts
@@ -19,7 +19,7 @@ export interface ChartInterface {
     inputTable: OwidTable // Points to the OwidTable coming into the chart. All charts have an inputTable. Standardized as part of the interface as a development aid.
     transformedTable: OwidTable // Points to the OwidTable after the chart has transformed the input table. The chart may add a relative transform, for example. Standardized as part of the interface as a development aid.
 
-    series: ChartSeries[] // This points to the marks that the chart will render. They don't have to be placed yet. Standardized as part of the interface as a development aid.
+    series: readonly ChartSeries[] // This points to the marks that the chart will render. They don't have to be placed yet. Standardized as part of the interface as a development aid.
     // Todo: should all charts additionally have a placedSeries: ChartPlacedSeries[] getter?
 
     transformTable: ChartTableTransformer

--- a/grapher/lineCharts/LineChart.test.ts
+++ b/grapher/lineCharts/LineChart.test.ts
@@ -156,3 +156,29 @@ describe("colors", () => {
         expect(newSeries[0].color).toEqual(series[1].color)
     })
 })
+
+it("reverses order of plotted series to plot the first one over the others", () => {
+    const table = new OwidTable(
+        {
+            entityName: ["usa", "usa"],
+            year: [2000, 2001],
+            gdp: [100, 200],
+            pop: [100, 200],
+        },
+        [
+            { slug: "gdp", color: "green" },
+            { slug: "pop", color: "red" },
+        ]
+    )
+
+    const manager: ChartManager = {
+        yColumnSlugs: ["gdp", "pop"],
+        table: table,
+        selection: ["usa"],
+        seriesStrategy: SeriesStrategy.column,
+    }
+    const chart = new LineChart({ manager })
+
+    expect(chart.placedSeries).toHaveLength(2)
+    expect(chart.placedSeries[0].seriesName).toEqual("pop")
+})

--- a/grapher/lineCharts/LineChart.test.ts
+++ b/grapher/lineCharts/LineChart.test.ts
@@ -166,8 +166,8 @@ it("reverses order of plotted series to plot the first one over the others", () 
             pop: [100, 200],
         },
         [
-            { slug: "gdp", color: "green" },
-            { slug: "pop", color: "red" },
+            { slug: "gdp", color: "green", type: ColumnTypeNames.Numeric },
+            { slug: "pop", color: "red", type: ColumnTypeNames.Numeric },
         ]
     )
 

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -659,7 +659,7 @@ export class LineChart
         const { dualAxis } = this
         const { horizontalAxis, verticalAxis } = dualAxis
 
-        return this.series.map((series) => {
+        return this.series.reverse().map((series) => {
             return {
                 ...series,
                 placedPoints: series.points.map(

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -629,7 +629,7 @@ export class LineChart
         return this.yAxisConfig.scaleType === ScaleType.log
     }
 
-    @computed get series(): LineChartSeries[] {
+    @computed get series(): readonly LineChartSeries[] {
         const arrOfSeries: LineChartSeries[] = flatten(
             this.yColumns.map((col) =>
                 columnToLineChartSeriesArray(
@@ -659,18 +659,21 @@ export class LineChart
         const { dualAxis } = this
         const { horizontalAxis, verticalAxis } = dualAxis
 
-        return this.series.reverse().map((series) => {
-            return {
-                ...series,
-                placedPoints: series.points.map(
-                    (point) =>
-                        new PointVector(
-                            Math.round(horizontalAxis.place(point.x)),
-                            Math.round(verticalAxis.place(point.y))
-                        )
-                ),
-            }
-        })
+        return this.series
+            .slice()
+            .reverse()
+            .map((series) => {
+                return {
+                    ...series,
+                    placedPoints: series.points.map(
+                        (point) =>
+                            new PointVector(
+                                Math.round(horizontalAxis.place(point.x)),
+                                Math.round(verticalAxis.place(point.y))
+                            )
+                    ),
+                }
+            })
     }
 
     // Order of the legend items on a line chart should visually correspond


### PR DESCRIPTION
Notion: [LineChart: Overlay lines by order of variables (first should be on top)](https://www.notion.so/LineChart-Overlay-lines-by-order-of-variables-first-should-be-on-top-f865d1eb540b4a2da6aeb3fffb424252)

This is the ordering that was used in `pre-v3`. 

For now it's not possible to reorder in Admin, but at least this fixes the issue for past charts.