### PR TITLE
feat: JSON table support for Explorer (in columnStore format)

### DIFF
--- a/clientUtils/PromiseCache.test.ts
+++ b/clientUtils/PromiseCache.test.ts
@@ -1,0 +1,50 @@
+import { PromiseCache } from "./PromiseCache"
+
+const wait = (ms: number) =>
+    new Promise((resolve) => {
+        setTimeout(resolve, ms)
+    })
+
+it("reuses existing promise", async () => {
+    const cache = new PromiseCache(async () => {
+        await wait(10)
+    })
+    const firstPromise = cache.get("key")
+    const secondPromise = cache.get("key")
+    expect(firstPromise).toBe(secondPromise)
+    await firstPromise
+    const thirdPromise = cache.get("key")
+    expect(thirdPromise).toBe(firstPromise)
+})
+
+it("promise is discarded if it rejects", async () => {
+    const cache = new PromiseCache(async () => {
+        await wait(10)
+        throw new Error("Failed")
+    })
+
+    const firstPromise = cache.get("key")
+    const secondPromise = cache.get("key")
+    expect(firstPromise).toBe(secondPromise)
+    expect(cache.has("key")).toBeTruthy()
+
+    try {
+        await firstPromise
+        fail()
+    } catch (error) {}
+
+    expect(cache.has("key")).toBeFalsy()
+
+    try {
+        await cache.get("key")
+        fail()
+    } catch (error) {}
+
+    const thirdPromise = cache.get("key")
+    expect(thirdPromise).not.toBe(firstPromise)
+
+    try {
+        await thirdPromise
+        fail()
+    } catch (error) {}
+})

--- a/clientUtils/PromiseCache.ts
+++ b/clientUtils/PromiseCache.ts
@@ -1,0 +1,36 @@
+/**
+ * Prevents creating multiple promises for a single key.
+ *
+ * If an existing promise for a key is pending, that promise will be returned without
+ * creating a new one.
+ *
+ * If a promise throws an error, it will be discarded, and a new one created the next
+ * time a key is requested.
+ *
+ * For now it only supports primitive value keys, but we can extend it if necessary.
+ */
+export class PromiseCache<Key extends string | number | undefined, Result> {
+    constructor(private createPromiseFromKey: (key: Key) => Promise<Result>) {}
+
+    private promisesByKey = new Map<Key, Promise<Result>>()
+
+    get(key: Key): Promise<Result> {
+        if (!this.promisesByKey.has(key)) {
+            this.promisesByKey.set(
+                key,
+                // Make sure to attach .catch() _before_ adding it to the cache.
+                // Otherwise external logic would be able to attach a catch() that
+                // could make this one unreachable.
+                this.createPromiseFromKey(key).catch((error) => {
+                    this.promisesByKey.delete(key)
+                    throw error
+                })
+            )
+        }
+        return this.promisesByKey.get(key)!
+    }
+
+    has(key: Key): boolean {
+        return this.promisesByKey.has(key)
+    }
+}

--- a/clientUtils/PromiseSwitcher.test.ts
+++ b/clientUtils/PromiseSwitcher.test.ts
@@ -1,0 +1,67 @@
+import { PromiseSwitcher } from "./PromiseSwitcher"
+
+const delayResolve = (result: any, ms: number = 10) =>
+    new Promise((resolve) => {
+        setTimeout(() => resolve(result), ms)
+    })
+
+const delayReject = (error: any, ms: number = 10) =>
+    new Promise((_, reject) => {
+        setTimeout(() => reject(error), ms)
+    })
+
+it("handles fulfilling single promise", async () => {
+    const onResolve = jest.fn(() => undefined)
+    const selector = new PromiseSwitcher({ onResolve })
+    await selector.set(Promise.resolve("done"))
+    expect(onResolve).toBeCalledWith("done")
+    await selector.set(Promise.resolve("done"))
+    expect(onResolve).toBeCalledTimes(2)
+})
+
+it("selecting a new promise while one is pending discards the pending promise", async () => {
+    const onResolve = jest.fn(() => undefined)
+    const selector = new PromiseSwitcher({ onResolve })
+    selector.set(delayResolve("first"))
+    await selector.set(Promise.resolve("second"))
+    expect(onResolve).toHaveBeenCalledTimes(1)
+    expect(onResolve).toHaveBeenCalledWith("second")
+})
+
+it("handles promise rejections", async () => {
+    const onResolve = jest.fn(() => undefined)
+    const onReject = jest.fn(() => undefined)
+    const selector = new PromiseSwitcher({ onResolve, onReject })
+
+    await selector.set(Promise.reject("error"))
+    expect(onReject).toHaveBeenCalledWith("error")
+
+    selector.set(delayResolve("success"))
+    await selector.set(Promise.reject("error 2"))
+    expect(onResolve).not.toHaveBeenCalled()
+    expect(onReject).toHaveBeenCalledTimes(2)
+})
+
+it("handles clearing pending promise", async () => {
+    const onResolve = jest.fn(() => undefined)
+    const onReject = jest.fn(() => undefined)
+    const selector = new PromiseSwitcher({ onResolve, onReject })
+
+    const resolve = delayResolve("done")
+    selector.set(resolve)
+    selector.clear()
+    await resolve
+
+    expect(onResolve).not.toHaveBeenCalled()
+    expect(onReject).not.toHaveBeenCalled()
+
+    const reject = delayReject("error")
+    selector.set(reject)
+    selector.clear()
+    try {
+        await reject
+    } catch (error) {}
+
+    expect(onResolve).not.toHaveBeenCalled()
+    expect(onReject).not.toHaveBeenCalled()
+})

--- a/clientUtils/PromiseSwitcher.ts
+++ b/clientUtils/PromiseSwitcher.ts
@@ -1,0 +1,52 @@
+interface PromiseSelectorArg<Result> {
+    onResolve?: (result: Result) => void
+    onReject?: (error: any) => void
+}
+
+/**
+ * An alternative to cancellable promises. Allows set()-ing a single promise,
+ * discarding the results of any previous ones, regardless whether they
+ * resolve or reject.
+ *
+ * The problem it solves:
+ *
+ * 1. User interacts with UI
+ * 2. Request sent to fetch required data: `getViewData().then((data) => updateView(data))`
+ * 3. But now what if the user navigates away? When the promise completes, it will
+ *    update the view regardless.
+ *
+ * In order to solve this, we use `switcher = PromiseSwitcher({ onResolve: updateView })`
+ * And then send off requests with `switcher.set(getViewData())`
+ * If set() is called with a new Promise while the previous is still pending, the
+ * pending promise is ignored – it doesn't call `onResolve` or `onReject`.
+ *
+ */
+export class PromiseSwitcher<Result> {
+    private pendingPromise: Promise<Result> | undefined
+
+    private onResolve?: (result: Result) => void
+    private onReject?: (error: any) => void
+
+    constructor(arg: PromiseSelectorArg<Result>) {
+        this.onResolve = arg.onResolve
+        this.onReject = arg.onReject
+    }
+
+    async set(promise: Promise<Result>): Promise<void> {
+        this.pendingPromise = promise
+        try {
+            const result = await promise
+            if (this.pendingPromise === promise) {
+                this.onResolve?.(result)
+            }
+        } catch (error) {
+            if (this.pendingPromise === promise) {
+                this.onReject?.(error)
+            }
+        }
+    }
+
+    clear() {
+        this.pendingPromise = undefined
+    }
+}

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -778,6 +778,20 @@ export function groupMap<T, K>(array: T[], accessor: (v: T) => K): Map<K, T[]> {
     return result
 }
 
+export function keyMap<Key, Value>(
+    array: Value[],
+    accessor: (v: Value) => Key
+): Map<Key, Value> {
+    const result = new Map<Key, Value>()
+    array.forEach((item) => {
+        const key = accessor(item)
+        if (!result.has(key)) {
+            result.set(key, item)
+        }
+    })
+    return result
+}
+
 export const linkify = (str: string) => linkifyHtml(str)
 
 export const oneOf = <T>(value: any, options: T[], defaultOption: T): T => {

--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -283,12 +283,7 @@ export class CoreTable<
             )
         }
 
-        if (
-            inputType === InputType.ColumnStore ||
-            this.parent ||
-            !firstInputRow
-        )
-            return []
+        if (this.parent || !firstInputRow) return []
         // The default behavior is to assume some missing or bad data in user data, so we always parse the full input the first time we load
         // user data, with the exception of columns that have values passed directly.
         // Todo: measure the perf hit and add a parameter to opt out of this this if you know the data is complete?

--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -99,9 +99,7 @@ export class CoreTable<
         this.parent = parent as this
         this.inputColumnDefs =
             typeof inputColumnDefs === "string"
-                ? (columnDefinitionsFromDelimited(
-                      inputColumnDefs
-                  ) as COL_DEF_TYPE[])
+                ? columnDefinitionsFromDelimited<COL_DEF_TYPE>(inputColumnDefs)
                 : inputColumnDefs
 
         // If any values were passed in, copy those to column store now and then remove them from column definitions.
@@ -1498,8 +1496,8 @@ class FilterMask {
  *
  * todo: define all column def property types
  */
-const columnDefinitionsFromDelimited = (delimited: string) =>
-    new CoreTable(delimited.trim()).columnFilter(
+export const columnDefinitionsFromDelimited = <T>(delimited: string) =>
+    new CoreTable<T>(delimited.trim()).columnFilter(
         "slug",
         (value) => !!value,
         "Keep only column defs with a slug"

--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -68,6 +68,7 @@ interface AdvancedOptions {
     parent?: CoreTable
     filterMask?: FilterMask
     tableSlug?: TableSlug
+    skipParsing?: boolean
 }
 
 // The complex generic with default here just enables you to optionally specify a more
@@ -281,7 +282,9 @@ export class CoreTable<
             )
         }
 
-        if (this.parent || !firstInputRow) return []
+        if (this.advancedOptions.skipParsing || this.parent || !firstInputRow)
+            return []
+
         // The default behavior is to assume some missing or bad data in user data, so we always parse the full input the first time we load
         // user data, with the exception of columns that have values passed directly.
         // Todo: measure the perf hit and add a parameter to opt out of this this if you know the data is complete?

--- a/coreTable/CoreTableColumns.ts
+++ b/coreTable/CoreTableColumns.ts
@@ -744,6 +744,7 @@ export const ColumnTypeMap = {
 // Keep this in. This is used as a compile-time check that ColumnTypeMap covers all
 // column names defined in ColumnTypeNames, since that is quite difficult to ensure
 // otherwise without losing inferred type information.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const _ColumnTypeMap: {
     [key in ColumnTypeNames]: unknown
 } = ColumnTypeMap

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -265,11 +265,7 @@ export class Explorer
 
     private futureGrapherTable = new PromiseSwitcher<OwidTable>({
         onResolve: (table) => this.setGrapherTable(table),
-        onReject: (error) =>
-            this.grapher?.setError(
-                error,
-                <p>Failed to load dataset, please try refreshing the page.</p>
-            ),
+        onReject: (error) => this.grapher?.setError(error),
     })
 
     tableLoader = new PromiseCache((slug: TableSlug | undefined) =>

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -19,7 +19,6 @@ import {
 } from "../grapher/core/Grapher"
 import {
     debounce,
-    differenceObj,
     exposeInstanceOnWindow,
     isInIFrame,
     omitUndefinedValues,

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -302,19 +302,21 @@ export class Explorer
         grapher.yAxis.min = yAxisMin
         grapher.updateFromObject(config)
 
-        // Clear any error messages, they are likely to be related to dataset loading.
-        this.grapher?.clearErrors()
-        // Set a table immediately. A BlankTable shows a loading animation.
-        this.setGrapherTable(
-            BlankOwidTable(tableSlug, `Loading table '${tableSlug}'`)
-        )
-        this.futureGrapherTable.set(this.tableLoader.get(tableSlug))
+        if (!hasGrapherId) {
+            // Clear any error messages, they are likely to be related to dataset loading.
+            this.grapher?.clearErrors()
+            // Set a table immediately. A BlankTable shows a loading animation.
+            this.setGrapherTable(
+                BlankOwidTable(tableSlug, `Loading table '${tableSlug}'`)
+            )
+            this.futureGrapherTable.set(this.tableLoader.get(tableSlug))
+            grapher.id = 0
+        }
 
         // Download data if this is a Grapher ID inside the Explorer specification
         grapher.downloadData()
-
         grapher.slug = this.explorerProgram.slug
-        if (!hasGrapherId) grapher.id = 0
+
         if (this.downloadDataLink)
             grapher.externalCsvLink = this.downloadDataLink
     }

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -6,7 +6,11 @@ import {
     EXPLORERS_ROUTE_FOLDER,
 } from "./ExplorerConstants"
 import { CoreTable } from "../coreTable/CoreTable"
-import { CoreMatrix, TableSlug } from "../coreTable/CoreTableConstants"
+import {
+    CoreMatrix,
+    CoreTableInputOption,
+    TableSlug,
+} from "../coreTable/CoreTableConstants"
 import { ExplorerGrammar } from "./ExplorerGrammar"
 import {
     CellDef,
@@ -327,8 +331,10 @@ export class ExplorerProgram extends GridProgram {
         const tableDef = this.getTableDef(tableSlug)!
         const response = await fetch(url)
         if (!response.ok) throw new Error(response.statusText)
-        const text = await response.text()
-        const table = new OwidTable(text, tableDef.columnDefinitions, {
+        const input: CoreTableInputOption = url.endsWith(".json")
+            ? await response.json()
+            : await response.text()
+        const table = new OwidTable(input, tableDef.columnDefinitions, {
             tableDescription: `Loaded from ${url}`,
         })
         return table

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -346,9 +346,9 @@ export class ExplorerProgram extends GridProgram {
 
     /**
      * A static method so that all explorers on the page share requests,
-     * and no dupliicate requests are sent.
+     * and no duplicate requests are sent.
      */
-    private static tableLoadRequestsByUrl = new PromiseCache(
+    private static tableDataLoader = new PromiseCache(
         async (url: string): Promise<CoreTableInputOption> => {
             const response = await fetch(url)
             if (!response.ok) throw new Error(response.statusText)
@@ -375,7 +375,7 @@ export class ExplorerProgram extends GridProgram {
                 }
             ).dropEmptyRows()
         } else if (tableDef.url) {
-            const input = await ExplorerProgram.tableLoadRequestsByUrl.get(
+            const input = await ExplorerProgram.tableDataLoader.get(
                 tableDef.url
             )
             return new OwidTable(input, tableDef.columnDefinitions, {

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -5,7 +5,10 @@ import {
     ExplorerChoiceParams,
     EXPLORERS_ROUTE_FOLDER,
 } from "./ExplorerConstants"
-import { CoreTable } from "../coreTable/CoreTable"
+import {
+    columnDefinitionsFromDelimited,
+    CoreTable,
+} from "../coreTable/CoreTable"
 import {
     CoreMatrix,
     CoreTableInputOption,
@@ -27,6 +30,8 @@ import { GrapherInterface } from "../grapher/core/GrapherInterface"
 import { GrapherGrammar } from "./GrapherGrammar"
 import { ColumnGrammar } from "./ColumnGrammar"
 import { DecisionMatrix } from "./ExplorerDecisionMatrix"
+import { CoreColumnDef } from "../coreTable/CoreColumnDef"
+import { PromiseCache } from "../clientUtils/PromiseCache"
 
 export const EXPLORER_FILE_SUFFIX = ".explorer.tsv"
 
@@ -207,6 +212,26 @@ export class ExplorerProgram extends GridProgram {
             }).length
     }
 
+    get tableSlugs(): (TableSlug | undefined)[] {
+        return this.lines
+            .filter((line) => line.startsWith(ExplorerGrammar.table.keyword))
+            .map((line) => line.split(this.cellDelimiter)[2])
+    }
+
+    get columnDefsByTableSlug(): Map<TableSlug | undefined, CoreColumnDef[]> {
+        const result = new Map<TableSlug | undefined, CoreColumnDef[]>()
+        this.tableSlugs.forEach((tableSlug) => {
+            const tableDef = this.getTableDef(tableSlug)
+            if (tableDef && tableDef.columnDefinitions) {
+                result.set(
+                    tableSlug,
+                    columnDefinitionsFromDelimited(tableDef.columnDefinitions)
+                )
+            }
+        })
+        return result
+    }
+
     async replaceTableWithInlineDataAndAutofilledColumnDefsCommand(
         tableSlug?: string
     ) {
@@ -221,7 +246,7 @@ export class ExplorerProgram extends GridProgram {
             clone.deleteLine(colDefRow)
         }
 
-        const table = await clone.tryFetchTableForTableSlugIfItHasUrl(tableSlug)
+        const table = await clone.constructTable(tableSlug)
 
         const tableDefRow = clone.getRowMatchingWords(
             ExplorerGrammar.table.keyword,
@@ -257,9 +282,7 @@ export class ExplorerProgram extends GridProgram {
 
     async autofillMissingColumnDefinitionsForTableCommand(tableSlug?: string) {
         const clone = this.clone
-        const remoteTable = await clone.tryFetchTableForTableSlugIfItHasUrl(
-            tableSlug
-        )
+        const remoteTable = await clone.constructTable(tableSlug)
         const existingTableDef = this.getTableDef(tableSlug)
         const table =
             remoteTable ||
@@ -308,10 +331,6 @@ export class ExplorerProgram extends GridProgram {
         return clone
     }
 
-    getUrlForTableSlug(tableSlug?: TableSlug) {
-        return this.getTableDef(tableSlug)?.url
-    }
-
     get grapherConfig(): ExplorerGrapherInterface {
         const rootObject = trimAndParseObject(this.tuplesObject, GrapherGrammar)
 
@@ -325,19 +344,46 @@ export class ExplorerProgram extends GridProgram {
             : rootObject
     }
 
-    async tryFetchTableForTableSlugIfItHasUrl(tableSlug?: TableSlug) {
-        const url = this.getUrlForTableSlug(tableSlug)
-        if (!url) return undefined
-        const tableDef = this.getTableDef(tableSlug)!
-        const response = await fetch(url)
-        if (!response.ok) throw new Error(response.statusText)
-        const input: CoreTableInputOption = url.endsWith(".json")
-            ? await response.json()
-            : await response.text()
-        const table = new OwidTable(input, tableDef.columnDefinitions, {
-            tableDescription: `Loaded from ${url}`,
-        })
-        return table
+    /**
+     * A static method so that all explorers on the page share requests,
+     * and no dupliicate requests are sent.
+     */
+    private static tableLoadRequestsByUrl = new PromiseCache(
+        async (url: string): Promise<CoreTableInputOption> => {
+            const response = await fetch(url)
+            if (!response.ok) throw new Error(response.statusText)
+            const tableInput: CoreTableInputOption = url.endsWith(".json")
+                ? await response.json()
+                : await response.text()
+            return tableInput
+        }
+    )
+
+    async constructTable(tableSlug?: TableSlug): Promise<OwidTable> {
+        const tableDef = this.getTableDef(tableSlug)
+        if (!tableDef) {
+            throw new Error(`Table definitions not found for '${tableSlug}'`)
+        }
+
+        if (tableDef.inlineData) {
+            return new OwidTable(
+                tableDef.inlineData,
+                tableDef.columnDefinitions,
+                {
+                    tableDescription: `Loaded '${tableSlug}' from inline data`,
+                    tableSlug: tableSlug,
+                }
+            ).dropEmptyRows()
+        } else if (tableDef.url) {
+            const input = await ExplorerProgram.tableLoadRequestsByUrl.get(
+                tableDef.url
+            )
+            return new OwidTable(input, tableDef.columnDefinitions, {
+                tableDescription: `Loaded from ${tableDef.url}`,
+            })
+        }
+
+        throw new Error(`No data for table '${tableSlug}'`)
     }
 
     getTableDef(tableSlug?: TableSlug): TableDef | undefined {

--- a/grapher/controls/entityPicker/EntityPicker.tsx
+++ b/grapher/controls/entityPicker/EntityPicker.tsx
@@ -16,7 +16,6 @@ import {
     last,
     max,
     isNumber,
-    sortBy,
     sortByUndefinedLast,
     first,
 } from "../../../clientUtils/Util"
@@ -116,15 +115,12 @@ export class EntityPicker extends React.Component<{
     }
 
     @computed private get metricOptions() {
-        return sortBy(
-            this.pickerColumnDefs.map((col) => {
-                return {
-                    label: col.name || col.slug,
-                    value: col.slug,
-                }
-            }),
-            "label"
-        )
+        return this.pickerColumnDefs.map((col) => {
+            return {
+                label: col.name || col.slug,
+                value: col.slug,
+            }
+        })
     }
 
     @computed private get activePickerMetricColumn() {

--- a/grapher/controls/entityPicker/EntityPickerConstants.ts
+++ b/grapher/controls/entityPicker/EntityPickerConstants.ts
@@ -1,3 +1,4 @@
+import { CoreColumnDef } from "../../../coreTable/CoreColumnDef"
 import { ColumnSlug, SortOrder } from "../../../coreTable/CoreTableConstants"
 import { OwidTable } from "../../../coreTable/OwidTable"
 import { GrapherAnalytics } from "../../core/GrapherAnalytics"
@@ -6,10 +7,13 @@ import { SelectionArray } from "../../selection/SelectionArray"
 export interface EntityPickerManager {
     entityPickerMetric?: ColumnSlug
     entityPickerSort?: SortOrder
+    setEntityPicker?: (options: { metric?: string; sort?: SortOrder }) => void
     requiredColumnSlugs?: ColumnSlug[] // If this param is provided, and an entity does not have a value for 1+, it will show as unavailable.
-    pickerColumnSlugs?: ColumnSlug[] // These are the columns that can be used for sorting entities.
-    analytics?: GrapherAnalytics
+    entityPickerColumnDefs?: CoreColumnDef[]
     entityPickerTable?: OwidTable
+    entityPickerTableIsLoading?: boolean
+    grapherTable?: OwidTable
     selection: SelectionArray
+    analytics?: GrapherAnalytics
     analyticsNamespace?: string
 }

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1583,7 +1583,7 @@ export class Grapher
         this.userFacingErrorSuggestion = userFacingErrorSuggestion
     }
 
-    @action.bound private clearErrors() {
+    @action.bound clearErrors() {
         this.uncaughtError = undefined
         this.userFacingErrorSuggestion = undefined
     }

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1573,19 +1573,13 @@ export class Grapher
 
     @observable private hasBeenVisible = false
     @observable private uncaughtError?: Error
-    @observable private userFacingErrorSuggestion?: JSX.Element // optionally provide the user with something helpful to self-troubleshoot
 
-    @action.bound setError(
-        err: Error,
-        userFacingErrorSuggestion?: JSX.Element
-    ) {
+    @action.bound setError(err: Error) {
         this.uncaughtError = err
-        this.userFacingErrorSuggestion = userFacingErrorSuggestion
     }
 
     @action.bound clearErrors() {
         this.uncaughtError = undefined
-        this.userFacingErrorSuggestion = undefined
     }
 
     // todo: clean up this popup stuff
@@ -1880,7 +1874,11 @@ export class Grapher
                     </a>
                     .
                 </p>
-                {this.userFacingErrorSuggestion}
+                {this.uncaughtError && this.uncaughtError.message && (
+                    <pre style={{ fontSize: "11px" }}>
+                        Error: {this.uncaughtError.message}
+                    </pre>
+                )}
             </div>
         )
     }

--- a/grapher/core/LegacyToOwidTable.ts
+++ b/grapher/core/LegacyToOwidTable.ts
@@ -155,7 +155,10 @@ export const legacyToOwidTableAndDimensions = (
 
         let variableTable = new OwidTable(
             columnStore,
-            Array.from(columnDefs.values())
+            Array.from(columnDefs.values()),
+            // Because database columns can contain mixed types, we want to avoid
+            // parsing for Grapher data until we fix that.
+            { skipParsing: true }
         )
 
         // If there is a targetTime set on the dimension, we need to perform the join on the

--- a/grapher/lineCharts/LineChart.test.ts
+++ b/grapher/lineCharts/LineChart.test.ts
@@ -11,6 +11,7 @@ import { ChartManager } from "../chart/ChartManager"
 import { ScaleType, SeriesStrategy } from "../core/GrapherConstants"
 import { OwidTable } from "../../coreTable/OwidTable"
 import { SelectionArray } from "../selection/SelectionArray"
+import { ColumnTypeNames } from "../../coreTable/CoreColumnDef"
 
 it("can create a new chart", () => {
     const table = SynthesizeGDPTable({ timeRange: [2000, 2010] })
@@ -120,7 +121,7 @@ describe("colors", () => {
                 gdp: [100, 200],
                 entityColor: ["blue", "blue"],
             },
-            [{ slug: "gdp", color: "green" }]
+            [{ slug: "gdp", color: "green", type: ColumnTypeNames.Numeric }]
         )
 
         const manager: ChartManager = {


### PR DESCRIPTION
Work in progress, should be [live on playfair](http://playfair-owid.netlify.app/explorers/coronavirus-data-explorer-json?zoomToSelection=true&time=2020-03-01..latest&country=USA~GBR~CAN~DEU~ITA~IND&region=World&pickerMetric=location&pickerSort=asc&Metric=Confirmed+cases&Interval=7-day+rolling+average&Align+outbreaks=false&Relative+to+Population=true) at some point.