### PR TITLE
fix(config): locate the correct `.env` file to use

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
         "nodemailer": "^6.2.1",
         "normalize.css": "^8.0.1",
         "optimize-css-assets-webpack-plugin": "^5.0.4",
+        "pkg-dir": "^5.0.0",
         "postcss": "^8.0.6",
         "postcss-loader": "^4.0.2",
         "prettier": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -160,7 +160,6 @@
         "nodemailer": "^6.2.1",
         "normalize.css": "^8.0.1",
         "optimize-css-assets-webpack-plugin": "^5.0.4",
-        "pkg-dir": "^5.0.0",
         "postcss": "^8.0.6",
         "postcss-loader": "^4.0.2",
         "prettier": "^2.1.2",

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -4,7 +4,18 @@
 // bundled and shipped out to our users.
 
 import dotenv from "dotenv"
-dotenv.config()
+import fs from "fs"
+
+// only run the below code if we're in a node environment
+if (fs.statSync !== undefined) {
+    const pkgDir = require("pkg-dir")
+
+    const baseDir = pkgDir.sync(__dirname)
+    if (baseDir === undefined)
+        throw new Error("could not locate base package.json")
+
+    dotenv.config({ path: `${baseDir}/.env` })
+}
 
 import { parseIntOrUndefined } from "../clientUtils/Util"
 

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -4,18 +4,10 @@
 // bundled and shipped out to our users.
 
 import dotenv from "dotenv"
-import fs from "fs"
+import findBaseDir from "./findBaseDir"
 
-// only run the below code if we're in a node environment
-if (fs.statSync !== undefined) {
-    const pkgDir = require("pkg-dir")
-
-    const baseDir = pkgDir.sync(__dirname)
-    if (baseDir === undefined)
-        throw new Error("could not locate base package.json")
-
-    dotenv.config({ path: `${baseDir}/.env` })
-}
+const baseDir = findBaseDir(__dirname)
+if (baseDir) dotenv.config({ path: `${baseDir}/.env` })
 
 import { parseIntOrUndefined } from "../clientUtils/Util"
 

--- a/settings/findBaseDir.ts
+++ b/settings/findBaseDir.ts
@@ -1,0 +1,25 @@
+import path from "path"
+import fs from "fs"
+
+/**
+ * With our code residing either in some src folder or in the `itsJustJavascript` folder, it's not
+ * always straightforward to know where to find a config file like `.env`.
+ * Here, we just traverse the directory tree upwards until we find a `package.json` file, which
+ * should indicate that we have found the root directory of the `owid-grapher` repo.
+ */
+export default function findProjectBaseDir(from: string) {
+    if (!fs.existsSync) return undefined // if fs.existsSync doesn't exist, we're probably running in the browser
+
+    let dir = path.dirname(from)
+
+    while (dir.length) {
+        if (fs.existsSync(path.resolve(dir, "package.json"))) return dir
+
+        const parentDir = path.resolve(dir, "..")
+        // break if we have reached the file system root
+        if (parentDir === dir) break
+        else dir = parentDir
+    }
+
+    return undefined
+}

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -3,14 +3,19 @@
 
 import path from "path"
 import dotenv from "dotenv"
-dotenv.config()
+import pkgDir from "pkg-dir"
+
+const baseDir = pkgDir.sync(__dirname)
+if (baseDir === undefined) throw new Error("could not locate base package.json")
+
+dotenv.config({ path: `${baseDir}/.env` })
 
 import * as clientSettings from "./clientSettings"
 import { parseIntOrUndefined } from "../clientUtils/Util"
 
 const serverSettings = process.env ?? {}
 
-export const BASE_DIR: string = path.resolve(__dirname, "../..")
+export const BASE_DIR: string = baseDir
 export const ENV: "development" | "production" = clientSettings.ENV
 
 export const ADMIN_SERVER_PORT: number = clientSettings.ADMIN_SERVER_PORT
@@ -45,7 +50,7 @@ export const DB_PORT: number =
     parseIntOrUndefined(serverSettings.DB_PORT) ?? 3306
 
 export const BAKED_SITE_DIR: string =
-    serverSettings.BAKED_SITE_DIR ?? `${BASE_DIR}/bakedSite` // Where the static build output goes
+    serverSettings.BAKED_SITE_DIR ?? path.resolve(BASE_DIR, "bakedSite") // Where the static build output goes
 export const SECRET_KEY: string =
     serverSettings.SECRET_KEY ??
     "fejwiaof jewiafo jeioa fjieowajf isa fjidosajfgj"

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -3,9 +3,9 @@
 
 import path from "path"
 import dotenv from "dotenv"
-import pkgDir from "pkg-dir"
+import findBaseDir from "./findBaseDir"
 
-const baseDir = pkgDir.sync(__dirname)
+const baseDir = findBaseDir(__dirname)
 if (baseDir === undefined) throw new Error("could not locate base package.json")
 
 dotenv.config({ path: `${baseDir}/.env` })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8979,6 +8979,14 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
 findup-sync@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-3.0.0.tgz#17b108f9ee512dfb7a5c7f3c8b27ea9e1a9c08d1"
@@ -12207,6 +12215,13 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -14129,6 +14144,13 @@ p-locate@^4.1.0:
   dependencies:
     p-limit "^2.2.0"
 
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
+
 p-map@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
@@ -14567,6 +14589,13 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+pkg-dir@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-5.0.0.tgz#a02d6aebe6ba133a928f74aec20bafdfe6b8e760"
+  integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
+  dependencies:
+    find-up "^5.0.0"
 
 pkg-up@3.1.0:
   version "3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8979,14 +8979,6 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-find-up@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
-  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
-  dependencies:
-    locate-path "^6.0.0"
-    path-exists "^4.0.0"
-
 findup-sync@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-3.0.0.tgz#17b108f9ee512dfb7a5c7f3c8b27ea9e1a9c08d1"
@@ -12215,13 +12207,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-locate-path@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
-  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
-  dependencies:
-    p-locate "^5.0.0"
-
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -14144,13 +14129,6 @@ p-locate@^4.1.0:
   dependencies:
     p-limit "^2.2.0"
 
-p-locate@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
-  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
-  dependencies:
-    p-limit "^3.0.2"
-
 p-map@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
@@ -14589,13 +14567,6 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
-
-pkg-dir@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-5.0.0.tgz#a02d6aebe6ba133a928f74aec20bafdfe6b8e760"
-  integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
-  dependencies:
-    find-up "^5.0.0"
 
 pkg-up@3.1.0:
   version "3.1.0"


### PR DESCRIPTION
This fixes the issue that [running the `exportMetadata` script resulted in an error message](https://owid.slack.com/archives/C01D295TM4K/p1616507884021000), and makes the config code more robust.

How this happened: When running `node itsJustJavascript/db/exportMetadata.ts`, dotenv was looking for a config file `itsJustJavascript/.env` - which doesn't exist.
This then meant that `ormconfig.js` simply used the default database settings (for Typeorm), and MySQL threw a not-very-helpful error message.

The fix now is that we're using `pkg-dir` to find our `package.json` file, and always use the `.env` file on that level. This makes it so that our settings code always uses the same config file, no matter whether it's run from `itsJustJavascript` or not.