### PR TITLE
fix(map): ProjectChooser no longer obstructs map

### DIFF
--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -585,7 +585,7 @@ export class MapChart
                     y={projectionChooserBounds.top}
                     width={projectionChooserBounds.width}
                     height={projectionChooserBounds.height}
-                    style={{ overflow: "visible", height: "100%" }}
+                    style={{ overflow: "visible", height: "100%", pointerEvents: "none" }}
                 >
                     <ProjectionChooser
                         value={projection}

--- a/grapher/mapCharts/ProjectionChooser.tsx
+++ b/grapher/mapCharts/ProjectionChooser.tsx
@@ -38,6 +38,7 @@ export class ProjectionChooser extends React.Component<{
 
         const style: React.CSSProperties = {
             fontSize: "0.75rem",
+            pointerEvents: "auto",
         }
 
         return (


### PR DESCRIPTION
The original fix of stretching the `foreignObject` to 100% height meant that the `ProjectionChooser` was invisibly obstructing Fiji and New Zealand which then wouldn't respond to mouse-over or click events:

![2021-03-25 21 15 44](https://user-images.githubusercontent.com/48054020/112544856-6f3d1780-8daf-11eb-86db-52ef4bf05424.gif)

I couldn't see any way to fix this by doing something else on Firefox, so this PR disables the pointer events on the obstructing parent and re-enables them on the child `div`, which gives the "intended" behaviour.

CAVEAT: I haven't been able to test this on iOS or Android with touch events, but (all macOS) Safari 11, Firefox 86 and Microsoft Edge 89 work as expected.