### PR TITLE
fix(explorer): dropdowns can be wider & higher to fit more options

### DIFF
--- a/explorer/ExplorerControls.scss
+++ b/explorer/ExplorerControls.scss
@@ -130,7 +130,7 @@ $chart-border-radius: 2px;
 .ExplorerDropdown {
     font-size: 13px;
     font-weight: 400;
-    width: 150px;
+    width: 200px;
     max-width: 100%;
 }
 

--- a/explorer/ExplorerControls.tsx
+++ b/explorer/ExplorerControls.tsx
@@ -140,6 +140,7 @@ export class ExplorerControlPanel extends React.Component<{
                 }}
                 styles={styles}
                 isSearchable={options.length > 20}
+                maxMenuHeight={350}
             />
         )
     }


### PR DESCRIPTION
This is a quick fix for one potential that Charlie brought up on Slack: [With the Covid explorer metric dropdown scrolling now, it can be easy to miss the lower options](https://owid.slack.com/archives/CV5RY8F1B/p1617121725009500?thread_ts=1617116752.008000&cid=CV5RY8F1B)

## Before
![image](https://user-images.githubusercontent.com/2641501/113303831-bec89980-9301-11eb-8b5d-51fe64ab35c8.png)

## After
### Wide desktop screen
![image](https://user-images.githubusercontent.com/2641501/113303894-d011a600-9301-11eb-8973-4f4cc1cab4f5.png)

### iPad size, landscape
![image](https://user-images.githubusercontent.com/2641501/113303999-e6b7fd00-9301-11eb-939c-69a7a6da5e1f.png)

### iPhone X size
![image](https://user-images.githubusercontent.com/2641501/113304120-018a7180-9302-11eb-820f-49ea01bca0c7.png)
