### PR TITLE
fix: `tableForSelection` only contains entities that can be selected (for ScatterPlotChart, SlopeChart)

### DIFF
--- a/grapher/chart/ChartInterface.ts
+++ b/grapher/chart/ChartInterface.ts
@@ -18,6 +18,7 @@ export interface ChartInterface {
 
     inputTable: OwidTable // Points to the OwidTable coming into the chart. All charts have an inputTable. Standardized as part of the interface as a development aid.
     transformedTable: OwidTable // Points to the OwidTable after the chart has transformed the input table. The chart may add a relative transform, for example. Standardized as part of the interface as a development aid.
+    tableForSelection?: OwidTable // A table that contains all entities that can be selected, and none more. It is used to populate the EntitySelectorModal. If it is not set, `inputTable` will be used instead.
 
     series: ChartSeries[] // This points to the marks that the chart will render. They don't have to be placed yet. Standardized as part of the interface as a development aid.
     // Todo: should all charts additionally have a placedSeries: ChartPlacedSeries[] getter?

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -485,7 +485,7 @@ export class Grapher
     }
 
     @computed private get tableForSelection() {
-        return this.inputTable // perform selection at root level
+        return this.chartInstanceExceptMap.tableForSelection ?? this.inputTable
     }
 
     // If an author sets a timeline filter run it early in the pipeline so to the charts it's as if the filtered times do not exist

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -514,7 +514,7 @@ export class Grapher
     }
 
     @computed
-    private get tableAfterAuthorTimelineAndActiveChartTransform(): OwidTable {
+    get tableAfterAuthorTimelineAndActiveChartTransform(): OwidTable {
         const table = this.tableAfterAuthorTimelineAndColumnFilter
         if (!this.isReady || !this.isChartOrMapTab) return table
         return this.chartInstance.transformTable(table)

--- a/grapher/scatterCharts/ScatterPlotChart.test.ts
+++ b/grapher/scatterCharts/ScatterPlotChart.test.ts
@@ -1003,6 +1003,6 @@ describe("tableForSelection availableEntities", () => {
 
         const chart = new ScatterPlotChart({ manager })
 
-        expect(chart.tableForSelection.availableEntityNames).toEqual(["UK"])
+        expect(chart.tableForSelection?.availableEntityNames).toEqual(["UK"])
     })
 })

--- a/grapher/scatterCharts/ScatterPlotChart.test.ts
+++ b/grapher/scatterCharts/ScatterPlotChart.test.ts
@@ -1003,6 +1003,6 @@ describe("tableForSelection availableEntities", () => {
 
         const chart = new ScatterPlotChart({ manager })
 
-        expect(chart.tableForSelection?.availableEntityNames).toEqual(["UK"])
+        expect(chart.tableForSelection.availableEntityNames).toEqual(["UK"])
     })
 })

--- a/grapher/scatterCharts/ScatterPlotChart.test.ts
+++ b/grapher/scatterCharts/ScatterPlotChart.test.ts
@@ -954,3 +954,55 @@ describe("addCountryMode", () => {
         expect(chart.transformedTable.numRows).toEqual(1)
     })
 })
+
+describe("tableForSelection availableEntities", () => {
+    it("tableForSelection should not include entities that cannot be displayed", () => {
+        const table = new OwidTable(
+            [
+                [
+                    "entityId",
+                    "entityName",
+                    "entityCode",
+                    "year",
+                    "x",
+                    "y",
+                    "color",
+                    "size",
+                ],
+                [1, "UK", "", 2000, 1, 1, null, null],
+                [1, "UK", "", 2001, null, 1, "Europe", 100],
+                [1, "UK", "", 2002, 1, null, null, null],
+                [1, "UK", "", 2003, null, null, null, null],
+                [2, "Barbados", "", 2000, null, null, null, null], // x, y value missing
+                [3, "USA", "", 2001, 2, 1, null, null], // excluded via excludedEntities
+                [4, "France", "", 2000, 0, null, null, null], // y value missing
+            ],
+            [
+                { slug: "x", type: ColumnTypeNames.Numeric },
+                { slug: "y", type: ColumnTypeNames.Numeric },
+                {
+                    slug: "color",
+                    type: ColumnTypeNames.String,
+                    display: { tolerance: 1 },
+                },
+                {
+                    slug: "size",
+                    type: ColumnTypeNames.Numeric,
+                },
+            ]
+        )
+
+        const manager: ScatterPlotManager = {
+            xColumnSlug: "x",
+            yColumnSlug: "y",
+            colorColumnSlug: "color",
+            sizeColumnSlug: "size",
+            excludedEntities: [3],
+            table,
+        }
+
+        const chart = new ScatterPlotChart({ manager })
+
+        expect(chart.tableForSelection.availableEntityNames).toEqual(["UK"])
+    })
+})

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -216,10 +216,14 @@ export class ScatterPlotChart
         return this.manager.table
     }
 
+    @computed private get transformedTableBeforeTimeFilterAndAvgAnnualChange() {
+        return this.transformTable(this.inputTable)
+    }
+
     @computed private get transformedTableFromGrapher() {
         return (
             this.manager.transformedTable ??
-            this.transformTable(this.inputTable)
+            this.transformedTableBeforeTimeFilterAndAvgAnnualChange
         )
     }
 
@@ -254,6 +258,10 @@ export class ScatterPlotChart
             ])
         }
         return table
+    }
+
+    @computed get tableForSelection() {
+        return this.transformedTableBeforeTimeFilterAndAvgAnnualChange
     }
 
     @computed private get manager() {

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -261,6 +261,11 @@ export class ScatterPlotChart
     }
 
     @computed get tableForSelection() {
+        // we want to use a table for entity selection that contains all entities that can be
+        // displayed, and no more.
+        // thus, we use the table that already has excludedEntities, tolerance, and
+        // timeDomainStart/End "filters" applied, but is not restricted to the current timeline
+        // yet (we cannot use `transformedTable` for this reason).
         return this.transformedTableBeforeTimeFilterAndAvgAnnualChange
     }
 

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -216,14 +216,10 @@ export class ScatterPlotChart
         return this.manager.table
     }
 
-    @computed private get transformedTableBeforeTimeFilterAndAvgAnnualChange() {
-        return this.transformTable(this.inputTable)
-    }
-
     @computed private get transformedTableFromGrapher() {
         return (
             this.manager.transformedTable ??
-            this.transformedTableBeforeTimeFilterAndAvgAnnualChange
+            this.transformTable(this.inputTable)
         )
     }
 
@@ -266,7 +262,7 @@ export class ScatterPlotChart
         // thus, we use the table that already has excludedEntities, tolerance, and
         // timeDomainStart/End "filters" applied, but is not restricted to the current timeline
         // yet (we cannot use `transformedTable` for this reason).
-        return this.transformedTableBeforeTimeFilterAndAvgAnnualChange
+        return this.manager.tableAfterAuthorTimelineAndActiveChartTransform
     }
 
     @computed private get manager() {

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -262,7 +262,10 @@ export class ScatterPlotChart
         // thus, we use the table that already has excludedEntities, tolerance, and
         // timeDomainStart/End "filters" applied, but is not restricted to the current timeline
         // yet (we cannot use `transformedTable` for this reason).
-        return this.manager.tableAfterAuthorTimelineAndActiveChartTransform
+        return (
+            this.manager.tableAfterAuthorTimelineAndActiveChartTransform ??
+            this.transformedTableFromGrapher // we need this for tests to run correctly (when there is no Grapher instance)
+        )
     }
 
     @computed private get manager() {

--- a/grapher/scatterCharts/ScatterPlotChartConstants.ts
+++ b/grapher/scatterCharts/ScatterPlotChartConstants.ts
@@ -22,6 +22,7 @@ export interface ScatterPlotManager extends ChartManager {
     addCountryMode?: EntitySelectionMode
     xOverrideTime?: Time | undefined
     tableAfterAuthorTimelineAndActiveChartTransformAndPopulationFilter?: OwidTable
+    tableAfterAuthorTimelineAndActiveChartTransform?: OwidTable
     excludedEntities?: EntityId[]
     backgroundSeriesLimit?: number
     hideLinesOutsideTolerance?: boolean

--- a/grapher/slopeCharts/SlopeChart.tsx
+++ b/grapher/slopeCharts/SlopeChart.tsx
@@ -340,6 +340,10 @@ export class SlopeChart
         )
     }
 
+    @computed get tableForSelection() {
+        return this.transformedTable
+    }
+
     @computed get inputTable() {
         return this.manager.table
     }


### PR DESCRIPTION
Notion: [ScatterPlot allows selecting entities not plotted on the chart](https://www.notion.so/ScatterPlot-allows-selecting-entities-not-plotted-on-the-chart-dc862f57e6c549e3a7122db542ec6455)

This PR is live on _tufte_.

This PR fixes that problem, by (optionally) moving `tableForSelection` to the chart instance, and using that one to populate the `EntitySelectorModal`. If a chart-level `tableForSelection` is not present, we fall back to using `inputTable`, as it was before.

Chart comparison links:
* Scatter plot 1: https://tufte.owid.cloud/admin/test/embeds?ids=245
* Scatter plot 2: https://tufte.owid.cloud/admin/test/embeds?ids=4185
* Slope chart: https://tufte.owid.cloud/admin/test/embeds?ids=414
* all other chart types except for scatterplots and slope charts should be unaffected