### PR TITLE
fix: x-axis lin/log toggle hidden while "Average annual change" enabled

### DIFF
--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -2237,6 +2237,7 @@ export class Grapher
     }
 
     @computed get showXScaleToggle() {
+        if (this.isRelativeMode) return false
         return this.xAxis.canChangeScaleType
     }
 


### PR DESCRIPTION
Notion: [ScatterPlot: Disable log/lin switch for "average annual change" chart](https://www.notion.so/ScatterPlot-Disable-log-lin-switch-for-average-annual-change-chart-a31ae16898654fde85c89e2881fb8c7e)

This one's easy.