### PR TITLE
fix(explorer): `toConstrainedOptions` logic improved

### DIFF
--- a/explorer/ExplorerDecisionMatrix.ts
+++ b/explorer/ExplorerDecisionMatrix.ts
@@ -117,7 +117,13 @@ export class DecisionMatrix {
     toConstrainedOptions(): ExplorerChoiceParams {
         const settings = { ...this.currentParams }
         this.choiceNames.forEach((choiceName) => {
-            if (!this.isOptionAvailable(choiceName, settings[choiceName])) {
+            if (
+                !this.isOptionAvailable(
+                    choiceName,
+                    settings[choiceName],
+                    settings
+                )
+            ) {
                 settings[choiceName] = this.firstAvailableOptionForChoice(
                     choiceName,
                     settings

--- a/explorer/ExplorerProgram.test.ts
+++ b/explorer/ExplorerProgram.test.ts
@@ -391,6 +391,23 @@ france,Life expectancy`
         expect(decisionMatrix.selectedRow.grapherId).toEqual(2)
     })
 
+    it("allows to change 'Relative to population' after 'Interval' has been forcibly set to another choice", () => {
+        const decisionMatrix = new DecisionMatrix(
+            `${grapherIdKeyword},Metric Dropdown,Interval Dropdown,Relative to population Checkbox
+1,Cases,Daily,true
+2,Cases,Weekly,true
+3,Cases,Cumulative,true
+4,Cases,Cumulative,false
+5,Tests,Cumulative,true
+6,Tests,Cumulative,false`
+        )
+
+        decisionMatrix.setValueCommand("Metric", "Tests")
+        expect(decisionMatrix.selectedRow.grapherId).toEqual(5)
+        decisionMatrix.setValueCommand("Relative to population", "false")
+        expect(decisionMatrix.selectedRow.grapherId).toEqual(6)
+    })
+
     describe("subtables", () => {
         it("can detect header frontier", () => {
             const subtableFrontierCell = new ExplorerProgram(

--- a/explorer/ExplorerProgram.test.ts
+++ b/explorer/ExplorerProgram.test.ts
@@ -367,12 +367,10 @@ france,Life expectancy`
         ).toEqual(true)
     })
 
-    // TODO: figure out why setValueCommand does not seem to be equivalent to a user interacting
-    // with the UI.
     // See logic in setValueCommand for an explanation of the logic we want to test here.
-    it.skip("overwrite unavailable option with new option, if more than 1 option is available", () => {
+    it("overwrite unavailable option with new option, if more than 1 option is available", () => {
         const decisionMatrix = new DecisionMatrix(
-            `${grapherIdKeyword},Metric,Interval,Relative to population,Align outbreaks
+            `${grapherIdKeyword},Metric Dropdown,Interval Dropdown,Relative to population Checkbox,Align outbreaks Checkbox
 1,Cases,Daily,true,false
 2,Cases,Daily,true,true
 3,Cases,Weekly,true,true
@@ -388,7 +386,7 @@ france,Life expectancy`
         decisionMatrix.setValueCommand("Metric", "Tests")
         expect(decisionMatrix.selectedRow.grapherId).toEqual(7)
         decisionMatrix.setValueCommand("Metric", "Cases")
-        expect(decisionMatrix.selectedRow.grapherId).toEqual(2)
+        expect(decisionMatrix.selectedRow.grapherId).toEqual(1)
     })
 
     it("allows to change 'Relative to population' after 'Interval' has been forcibly set to another choice", () => {


### PR DESCRIPTION
Notion: [Explorer setting unreachable?](https://www.notion.so/Explorer-setting-unreachable-0e8d5d6565ee43f7bf779dedae523911)

In `constrainedOptions`, the logic checked left-to-right which options are available, but wasn't taking into account the choices we made in previous loop iterations already.

Also, I re-enabled the broken test case from #818. Turns out that the column names absolutely need to contain the choice type (Dropdown, Radio, Checkbox), otherwise they won't even get parsed.