### PR TITLE
fix: reset colorSlug and sizeSlug when switching Explorer views

### DIFF
--- a/explorer/Explorer.jsdom.test.tsx
+++ b/explorer/Explorer.jsdom.test.tsx
@@ -1,16 +1,17 @@
 #! yarn testJest
 
 import { Explorer } from "./Explorer"
-import { SampleExplorer } from "./Explorer.sample"
+import { SampleExplorerOfGraphers } from "./Explorer.sample"
 
 import { configure, mount } from "enzyme"
 import Adapter from "enzyme-adapter-react-16"
 import { GrapherTabOption } from "../grapher/core/GrapherConstants"
+
 configure({ adapter: new Adapter() })
 
 describe(Explorer, () => {
     const title = "AlphaBeta"
-    const element = mount(SampleExplorer())
+    const element = mount(SampleExplorerOfGraphers())
     it("renders", () => {
         expect(element.find(".ExplorerHeaderBox").text()).toContain(
             "CO₂ Data Explorer"
@@ -35,13 +36,15 @@ describe(Explorer, () => {
     })
 
     it("recovers country selection from URL params", () => {
-        const element = mount(SampleExplorer({ queryStr: "?country=IRL" }))
+        const element = mount(
+            SampleExplorerOfGraphers({ queryStr: "?country=IRL" })
+        )
         const explorer = element.instance() as Explorer
         expect(explorer.selection.selectedEntityNames).toEqual(["Ireland"])
     })
 
     it("serializes all choice params in URL", () => {
-        const element = mount(SampleExplorer())
+        const element = mount(SampleExplorerOfGraphers())
         const explorer = element.instance() as Explorer
         expect(explorer.queryParams).toMatchObject({
             Accounting: "Production-based",

--- a/explorer/Explorer.jsdom.test.tsx
+++ b/explorer/Explorer.jsdom.test.tsx
@@ -1,7 +1,10 @@
 #! yarn testJest
 
 import { Explorer } from "./Explorer"
-import { SampleExplorerOfGraphers } from "./Explorer.sample"
+import {
+    SampleExplorerOfGraphers,
+    SampleInlineDataExplorer,
+} from "./Explorer.sample"
 
 import { configure, mount } from "enzyme"
 import Adapter from "enzyme-adapter-react-16"
@@ -53,5 +56,34 @@ describe(Explorer, () => {
             Gas: "CO₂",
             "Relative to world total": "false",
         })
+    })
+})
+
+describe("inline data explorer", () => {
+    const element = mount(SampleInlineDataExplorer())
+    const explorer = element.instance() as Explorer
+
+    it("renders", () => {
+        expect(element.find(".ExplorerHeaderBox").text()).toContain(
+            "Sample Explorer"
+        )
+        expect(explorer.queryParams).toMatchObject({
+            Test: "Scatter",
+        })
+        expect(explorer.grapher?.xSlug).toEqual("x")
+        expect(explorer.grapher?.ySlugs).toEqual("y")
+        expect(explorer.grapher?.colorSlug).toEqual("color")
+        expect(explorer.grapher?.sizeSlug).toEqual("size")
+    })
+
+    it("clears column slugs that don't exist in current row", () => {
+        explorer.onChangeChoice("Test")("Line")
+        expect(explorer.queryParams).toMatchObject({
+            Test: "Line",
+        })
+        expect(explorer.grapher?.xSlug).toEqual(undefined)
+        expect(explorer.grapher?.ySlugs).toEqual("y")
+        expect(explorer.grapher?.colorSlug).toEqual(undefined)
+        expect(explorer.grapher?.sizeSlug).toEqual(undefined)
     })
 })

--- a/explorer/Explorer.sample.tsx
+++ b/explorer/Explorer.sample.tsx
@@ -90,3 +90,34 @@ export const SampleExplorerOfGraphers = (props?: Partial<ExplorerProps>) => {
         />
     )
 }
+
+const SampleInlineDataExplorerProgram = `explorerTitle	Sample Explorer
+selection	Argentina
+graphers
+	Test Radio	xSlug	ySlugs	colorSlug	sizeSlug	type
+	Scatter	x	y	color	size	ScatterPlot
+	Line		y			LineChart
+
+columns
+	slug	type	name
+	Country	EntityName	Country
+	Quarter	Quarter	Quarter
+	x	Numeric	x
+	y	Numeric	y
+	color	Numeric	color
+	size	Numeric	size
+
+table
+	Country	Year	x	y	color	size
+	Argentina	2020	1	1	1	1
+	Argentina	2021	1	1	1	1`
+
+export const SampleInlineDataExplorer = (props?: Partial<ExplorerProps>) => {
+    return (
+        <Explorer
+            slug="test-slug-inline-data"
+            program={SampleInlineDataExplorerProgram}
+            {...props}
+        />
+    )
+}

--- a/explorer/Explorer.sample.tsx
+++ b/explorer/Explorer.sample.tsx
@@ -6,7 +6,7 @@ import {
 } from "../grapher/core/GrapherConstants"
 import { Explorer, ExplorerProps } from "./Explorer"
 
-const SampleExplorerProgram = `explorerTitle	CO₂ Data Explorer
+const SampleExplorerOfGraphersProgram = `explorerTitle	CO₂ Data Explorer
 isPublished	false
 explorerSubtitle	Download the complete <i>Our World in Data</i> <a href="https://github.com/owid/co2-data">CO₂ and GHG Emissions Dataset</a>.
 subNavId	co2
@@ -45,7 +45,7 @@ graphers
 	4224	Nitrous oxide	Production-based		Per country
 	4244	Nitrous oxide	Production-based		Per capita`
 
-export const SampleExplorer = (props?: Partial<ExplorerProps>) => {
+export const SampleExplorerOfGraphers = (props?: Partial<ExplorerProps>) => {
     const title = "AlphaBeta"
     const first = {
         id: 488,
@@ -84,7 +84,7 @@ export const SampleExplorer = (props?: Partial<ExplorerProps>) => {
     return (
         <Explorer
             slug="test-slug"
-            program={SampleExplorerProgram}
+            program={SampleExplorerOfGraphersProgram}
             grapherConfigs={grapherConfigs}
             {...props}
         />

--- a/explorer/Explorer.stories.tsx
+++ b/explorer/Explorer.stories.tsx
@@ -1,9 +1,9 @@
 import { Explorer } from "../explorer/Explorer"
-import { SampleExplorer } from "./Explorer.sample"
+import { SampleExplorerOfGraphers } from "./Explorer.sample"
 
 export default {
     title: "Explorer",
     component: Explorer,
 }
 
-export const Sample = () => SampleExplorer()
+export const Sample = () => SampleExplorerOfGraphers()

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -2077,6 +2077,8 @@ export class Grapher
         this.type = grapher.type
         this.ySlugs = grapher.ySlugs
         this.xSlug = grapher.xSlug
+        this.colorSlug = grapher.colorSlug
+        this.sizeSlug = grapher.sizeSlug
         this.hasMapTab = grapher.hasMapTab
         this.facet = undefined
         this.hasChartTab = grapher.hasChartTab


### PR DESCRIPTION
Notion: [Infinite loading state in Covid explorer](https://www.notion.so/Infinite-loading-state-in-Covid-explorer-3190f56ec06542acbf5866d5b7f18c74)

When Explorer is switched from a row with `columnSlug` to one without, the `colorSlug` is not being cleared on the underlying Grapher. 

This is one (fragile) way to fix it. Still need to add a test.