### PR TITLE
fix: `tableForSelection` only contains entities that can be selected

### DIFF
--- a/grapher/core/Grapher.jsdom.test.ts
+++ b/grapher/core/Grapher.jsdom.test.ts
@@ -917,3 +917,48 @@ it("considers map tolerance before using column tolerance", () => {
         grapher.transformedTable.filterByEntityNames(["Germany"]).numRows
     ).toEqual(1)
 })
+
+describe("tableForSelection", () => {
+    it("should include all available entities (LineChart)", () => {
+        const table = SynthesizeGDPTable({ entityNames: ["A", "B"] })
+
+        const grapher = new Grapher({ table })
+
+        expect(grapher.tableForSelection.availableEntityNames).toEqual([
+            "A",
+            "B",
+        ])
+    })
+
+    it("should not include entities that cannot be displayed (ScatterPlot)", () => {
+        const table = new OwidTable([
+            [
+                "entityId",
+                "entityName",
+                "entityCode",
+                "year",
+                "x",
+                "y",
+                "color",
+                "size",
+            ],
+            [1, "UK", "", 2000, 1, 1, null, null],
+            [1, "UK", "", 2001, null, 1, "Europe", 100],
+            [1, "UK", "", 2002, 1, null, null, null],
+            [1, "UK", "", 2003, null, null, null, null],
+            [2, "Barbados", "", 2000, null, null, null, null], // x, y value missing
+            [3, "USA", "", 2001, 2, 1, null, null], // excluded via excludedEntities
+            [4, "France", "", 2000, 0, null, null, null], // y value missing
+        ])
+
+        const grapher = new Grapher({
+            table,
+            type: ChartTypeName.ScatterPlot,
+            excludedEntities: [3],
+            xSlug: "x",
+            ySlugs: "y",
+        })
+
+        expect(grapher.tableForSelection.availableEntityNames).toEqual(["UK"])
+    })
+})

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -485,8 +485,22 @@ export class Grapher
         return this.tab === GrapherTabOption.map
     }
 
-    @computed private get tableForSelection() {
-        return this.inputTable // perform selection at root level
+    @computed get tableForSelection() {
+        // This table specifies which entities can be selected in the charts EntitySelectorModal.
+        // It should contain all entities that can be selected, and none more.
+        // Depending on the chart type, the criteria for being able to select an entity are
+        // different; e.g. for scatterplots, the entity needs to (1) not be excluded and
+        // (2) needs to have data for the x and y dimension.
+
+        if (this.isScatter || this.isSlopeChart)
+            // for scatter and slope charts, the `transformTable()` call takes care of removing
+            // all entities that cannot be selected
+            return this.tableAfterAuthorTimelineAndActiveChartTransform
+
+        // for other chart types, the `transformTable()` call would sometimes remove too many
+        // entities, and we want to use the inputTable instead (which should have exactly the
+        // entities where data is available)
+        return this.inputTable
     }
 
     // If an author sets a timeline filter run it early in the pipeline so to the charts it's as if the filtered times do not exist


### PR DESCRIPTION
Notion: [ScatterPlot allows selecting entities not plotted on the chart](https://www.notion.so/ScatterPlot-allows-selecting-entities-not-plotted-on-the-chart-dc862f57e6c549e3a7122db542ec6455)

Supersedes #850, and solves it in a simpler way.