### PR TITLE
fix(admin): "Invert colors" for discrete bar charts doesn't invert the whole chart series

### DIFF
--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -475,19 +475,22 @@ export class DiscreteBarChart
 
     @computed get series() {
         const { valuesToColorsMap, seriesColorMap } = this
-        return this.sortedRawSeries.reverse().map((rawSeries) => {
-            const { row, seriesName, color } = rawSeries
-            const series: DiscreteBarSeries = {
-                ...row,
-                seriesName,
-                color:
-                    color ??
-                    seriesColorMap.get(seriesName) ?? // This provides line chart colors if it was a line chart in a prior life
-                    valuesToColorsMap?.get(row.value) ??
-                    DEFAULT_BAR_COLOR,
-            }
-            return series
-        })
+        return this.sortedRawSeries
+            .slice() // we need to clone/slice here so `.reverse()` doesn't modify `this.sortedRawSeries` in-place
+            .reverse()
+            .map((rawSeries) => {
+                const { row, seriesName, color } = rawSeries
+                const series: DiscreteBarSeries = {
+                    ...row,
+                    seriesName,
+                    color:
+                        color ??
+                        seriesColorMap.get(seriesName) ?? // This provides line chart colors if it was a line chart in a prior life
+                        valuesToColorsMap?.get(row.value) ??
+                        DEFAULT_BAR_COLOR,
+                }
+                return series
+            })
     }
 
     @computed private get isLogScale() {

--- a/grapher/color/ColorScheme.ts
+++ b/grapher/color/ColorScheme.ts
@@ -141,7 +141,9 @@ export class ColorScheme implements ColorSchemeInterface {
             .map((series) => series.seriesName)
             .filter((name) => !seriesColorMap.has(name))
             .forEach((name) => {
-                const availableColors = lastOfNonEmptyArray(this.colorSets)
+                const availableColors = lastOfNonEmptyArray(
+                    this.colorSets
+                ).slice()
                 if (invertColorScheme) availableColors.reverse()
                 const usedColors = Array.from(seriesColorMap.values()).filter(
                     isPresent


### PR DESCRIPTION
Notion: ["Invert colors" reverses the order of bars](https://www.notion.so/Invert-colors-reverses-the-order-of-bars-9cd6aee7477948a0a7762e22be3a1376)

The `.reverse()` call here modified `this.sortedRawSeries` in place, which meant that it was... sorted the other way round. When it was then accessed to assign the new colors after "Invert colors" has been toggled, its order was wrong.

I also found another occurence where we were inadvertently modifying a "static" array in-place in `ColorScheme.ts`, and fixed it even though it doesn't seem to be causing any trouble currently.