### PR TITLE
Use `readonly` in many places to enforce immutability

### DIFF
--- a/adminSiteClient/Colorpicker.tsx
+++ b/adminSiteClient/Colorpicker.tsx
@@ -21,7 +21,9 @@ export class Colorpicker extends React.Component<ColorpickerProps> {
 
     render() {
         const scheme = ColorSchemes["owid-distinct"]
-        const availableColors: string[] = lastOfNonEmptyArray(scheme.colorSets)
+        const availableColors: string[] = lastOfNonEmptyArray(
+            scheme.colorSets
+        ).slice()
 
         return (
             <SketchPicker

--- a/clientUtils/Bounds.ts
+++ b/clientUtils/Bounds.ts
@@ -38,7 +38,7 @@ export class Bounds {
     }
 
     // Merge a collection of bounding boxes into a single encompassing Bounds
-    static merge(boundsList: Bounds[]) {
+    static merge(boundsList: readonly Bounds[]) {
         let x1 = Infinity,
             y1 = Infinity,
             x2 = -Infinity,

--- a/clientUtils/LegacyVariableDisplayConfigInterface.ts
+++ b/clientUtils/LegacyVariableDisplayConfigInterface.ts
@@ -1,19 +1,19 @@
 // DEPRECATED. DO NOT USE.
 
 export interface LegacyVariableDisplayConfigInterface {
-    name?: string
-    unit?: string
-    shortUnit?: string
-    isProjection?: boolean
-    conversionFactor?: number
-    numDecimalPlaces?: number
-    tolerance?: number
-    yearIsDay?: boolean
-    zeroDay?: string
-    entityAnnotationsMap?: string
-    includeInTable?: boolean
-    tableDisplay?: LegacyVariableDataTableConfigInteface
-    color?: string
+    readonly name?: string
+    readonly unit?: string
+    readonly shortUnit?: string
+    readonly isProjection?: boolean
+    readonly conversionFactor?: number
+    readonly numDecimalPlaces?: number
+    readonly tolerance?: number
+    readonly yearIsDay?: boolean
+    readonly zeroDay?: string
+    readonly entityAnnotationsMap?: string
+    readonly includeInTable?: boolean
+    readonly tableDisplay?: LegacyVariableDataTableConfigInteface
+    readonly color?: string
 }
 
 // todo: flatten onto the above

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -235,19 +235,19 @@ export const defaultTo = <T, K>(
     defaultValue: K
 ): T | K => value ?? defaultValue
 
-export const first = <T>(arr: T[]): T | undefined => arr[0]
+export const first = <T>(arr: readonly T[]): T | undefined => arr[0]
 
-export const last = <T>(arr: T[]): T | undefined => arr[arr.length - 1]
+export const last = <T>(arr: readonly T[]): T | undefined => arr[arr.length - 1]
 
-export const excludeUndefined = <T>(arr: (T | undefined)[]): T[] =>
+export const excludeUndefined = <T>(arr: readonly (T | undefined)[]): T[] =>
     arr.filter((x) => x !== undefined) as T[]
 
-export const firstOfNonEmptyArray = <T>(arr: T[]): T => {
+export const firstOfNonEmptyArray = <T>(arr: readonly T[]): T => {
     if (arr.length < 1) throw new Error("array is empty")
     return first(arr) as T
 }
 
-export const lastOfNonEmptyArray = <T>(arr: T[]): T => {
+export const lastOfNonEmptyArray = <T>(arr: readonly T[]): T => {
     if (arr.length < 1) throw new Error("array is empty")
     return last(arr) as T
 }
@@ -261,20 +261,20 @@ export const mapToObjectLiteral = (map: Map<string, any>) =>
         return objLit
     }, {} as ObjectLiteral)
 
-export function next<T>(set: T[], current: T) {
+export function next<T>(set: readonly T[], current: T) {
     let nextIndex = set.indexOf(current) + 1
     nextIndex = nextIndex === -1 ? 0 : nextIndex
     return set[nextIndex === set.length ? 0 : nextIndex]
 }
 
-export const previous = <T>(set: T[], current: T) => {
+export const previous = <T>(set: readonly T[], current: T) => {
     const nextIndex = set.indexOf(current) - 1
     return set[nextIndex < 0 ? set.length - 1 : nextIndex]
 }
 
 // Calculate the extents of a set of numbers, with safeguards for log scales
 export const domainExtent = (
-    numValues: number[],
+    numValues: readonly number[],
     scaleType: ScaleType,
     maxValueMultiplierForPadding = 1
 ): [number, number] => {
@@ -339,7 +339,7 @@ export const makeAnnotationsSlug = (columnSlug: string) =>
 
 // Todo: add unit tests
 export const relativeMinAndMax = (
-    points: Point[],
+    points: readonly Point[],
     property: "x" | "y"
 ): [number, number] => {
     let minChange = 0
@@ -402,7 +402,7 @@ export const pointsToPath = (points: Array<[number, number]>) => {
 // In case of tie returns higher value
 // todo: add unit tests
 export const sortedFindClosestIndex = (
-    array: number[],
+    array: readonly number[],
     value: number,
     startIndex: number = 0,
     // non-inclusive end
@@ -434,7 +434,7 @@ export const sortedFindClosestIndex = (
 }
 
 export const sortedFindClosest = (
-    array: number[],
+    array: readonly number[],
     value: number,
     startIndex?: number,
     endIndex?: number
@@ -461,7 +461,7 @@ export const csvEscape = (value: any) => {
     return valueStr.includes(",") ? `"${value.replace(/\"/g, '""')}"` : value
 }
 
-export const arrToCsvRow = (arr: string[]) =>
+export const arrToCsvRow = (arr: readonly string[]) =>
     arr.map((x) => csvEscape(x)).join(",") + "\n"
 
 export const urlToSlug = (url: string) =>
@@ -539,14 +539,14 @@ export const getRandomNumberGenerator = (
 }
 
 export const sampleFrom = <T>(
-    collection: T[],
+    collection: readonly T[],
     howMany: number,
     seed: number
 ): T[] => shuffleArray(collection, seed).slice(0, howMany)
 
 // A seeded array shuffle
 // https://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
-const shuffleArray = (array: any[], seed = Date.now()) => {
+const shuffleArray = (array: readonly any[], seed = Date.now()) => {
     const rand = getRandomNumberGenerator(0, 100, seed)
     const clonedArr = array.slice()
     for (let index = clonedArr.length - 1; index > 0; index--) {
@@ -569,7 +569,7 @@ export const makeGrid = (pieces: number) => {
 }
 
 export const findClosestTimeIndex = (
-    times: Time[],
+    times: readonly Time[],
     targetTime: Time,
     tolerance?: number
 ): Time | undefined => {
@@ -599,7 +599,7 @@ export const findClosestTimeIndex = (
 }
 
 export const findClosestTime = (
-    times: Time[],
+    times: readonly Time[],
     targetTime: Time,
     tolerance?: number
 ): Time | undefined => {
@@ -627,7 +627,7 @@ interface DataValue {
 
 const valuesAtTimes = (
     valueByTime: Map<number, string | number>,
-    targetTimes: Time[],
+    targetTimes: readonly Time[],
     tolerance = 0
 ) => {
     const times = Array.from(valueByTime.keys())
@@ -643,7 +643,7 @@ const valuesAtTimes = (
 
 export const valuesByEntityAtTimes = (
     valueByEntityAndTime: Map<string, Map<number, string | number>>,
-    targetTimes: Time[],
+    targetTimes: readonly Time[],
     tolerance = 0
 ): Map<string, DataValue[]> =>
     es6mapValues(valueByEntityAndTime, (valueByTime) =>
@@ -652,7 +652,7 @@ export const valuesByEntityAtTimes = (
 
 export const valuesByEntityWithinTimes = (
     valueByEntityAndTimes: Map<string, Map<number, string | number>>,
-    range: (number | undefined)[]
+    range: readonly (number | undefined)[]
 ): Map<string, DataValue[]> => {
     const start = range[0] !== undefined ? range[0] : -Infinity
     const end = range[1] !== undefined ? range[1] : Infinity
@@ -666,7 +666,7 @@ export const valuesByEntityWithinTimes = (
     )
 }
 
-export const getStartEndValues = (values: DataValue[]) => [
+export const getStartEndValues = (values: readonly DataValue[]) => [
     minBy(values, (dv) => dv.time),
     maxBy(values, (dv) => dv.time),
 ]
@@ -756,7 +756,10 @@ export function scrollIntoViewIfNeeded(
     }
 }
 
-export function rollingMap<T, U>(array: T[], mapper: (a: T, b: T) => U) {
+export function rollingMap<T, U>(
+    array: readonly T[],
+    mapper: (a: T, b: T) => U
+) {
     const result: U[] = []
     if (array.length <= 1) return result
     for (let i = 0; i < array.length - 1; i++) {
@@ -765,7 +768,10 @@ export function rollingMap<T, U>(array: T[], mapper: (a: T, b: T) => U) {
     return result
 }
 
-export function groupMap<T, K>(array: T[], accessor: (v: T) => K): Map<K, T[]> {
+export function groupMap<T, K>(
+    array: readonly T[],
+    accessor: (v: T) => K
+): Map<K, T[]> {
     const result = new Map<K, T[]>()
     array.forEach((item) => {
         const key = accessor(item)
@@ -779,7 +785,7 @@ export function groupMap<T, K>(array: T[], accessor: (v: T) => K): Map<K, T[]> {
 }
 
 export function keyMap<Key, Value>(
-    array: Value[],
+    array: readonly Value[],
     accessor: (v: Value) => Key
 ): Map<Key, Value> {
     const result = new Map<Key, Value>()
@@ -794,7 +800,11 @@ export function keyMap<Key, Value>(
 
 export const linkify = (str: string) => linkifyHtml(str)
 
-export const oneOf = <T>(value: any, options: T[], defaultOption: T): T => {
+export const oneOf = <T>(
+    value: any,
+    options: readonly T[],
+    defaultOption: T
+): T => {
     for (const option of options) {
         if (value === option) return option
     }
@@ -816,7 +826,7 @@ export const intersectionOfSets = <T>(sets: Set<T>[]) => {
 }
 
 // ES6 is now significantly faster than lodash's intersection
-export const intersection = <T>(...arrs: T[][]): T[] => {
+export const intersection = <T>(...arrs: (readonly T[])[]): readonly T[] => {
     if (arrs.length === 0) return []
     if (arrs.length === 1) return arrs[0]
     if (arrs.length === 2) {
@@ -827,7 +837,7 @@ export const intersection = <T>(...arrs: T[][]): T[] => {
 }
 
 export function sortByUndefinedLast<T>(
-    array: T[],
+    array: readonly T[],
     accessor: (t: T) => string | number | undefined,
     order: SortOrder = SortOrder.asc
 ) {
@@ -851,7 +861,7 @@ export function getAttributesOfHTMLElement(el: HTMLElement) {
 }
 
 export const mapNullToUndefined = <T>(
-    array: (T | undefined | null)[]
+    array: readonly (T | undefined | null)[]
 ): (T | undefined)[] => array.map((v) => (v === null ? undefined : v))
 
 export const lowerCaseFirstLetterUnlessAbbreviation = (str: string) =>
@@ -877,7 +887,7 @@ export const sortNumeric = <T>(
     )
 
 export const mapBy = <T>(
-    arr: T[],
+    arr: readonly T[],
     keyAccessor: (t: T) => any,
     valueAccessor: (t: T) => any
 ) => {
@@ -890,7 +900,7 @@ export const mapBy = <T>(
 
 // Adapted from lodash baseFindIndex which is ~2x as fast as the wrapped findIndex
 export const findIndexFast = (
-    array: any[],
+    array: readonly any[],
     predicate: (value: any, index: number) => boolean,
     fromIndex = 0,
     toIndex = array.length
@@ -916,7 +926,10 @@ export const logMe = (
     return descriptor
 }
 
-export const splitArrayIntoGroupsOfN = (arr: any[], maxPerGroup: number) => {
+export const splitArrayIntoGroupsOfN = (
+    arr: readonly any[],
+    maxPerGroup: number
+) => {
     const result: any[] = []
     for (let index = 0; index < arr.length; index += maxPerGroup)
         result.push(arr.slice(index, index + maxPerGroup))
@@ -924,8 +937,8 @@ export const splitArrayIntoGroupsOfN = (arr: any[], maxPerGroup: number) => {
 }
 
 export function getClosestTimePairs(
-    sortedTimesA: Time[],
-    sortedTimesB: Time[],
+    sortedTimesA: readonly Time[],
+    sortedTimesB: readonly Time[],
     maxDiff: Integer = Infinity
 ) {
     if (sortedTimesA.length === 0 || sortedTimesB.length === 0) return []

--- a/clientUtils/countries.ts
+++ b/clientUtils/countries.ts
@@ -1,16 +1,16 @@
 export interface Country {
-    name: string
-    code: string
-    slug: string
-    iso3166?: string
-    variantNames?: string[]
+    readonly name: string
+    readonly code: string
+    readonly slug: string
+    readonly iso3166?: string
+    readonly variantNames?: string[]
 }
 
 interface FilterableCountry extends Country {
     filter?: boolean
 }
 
-const allCountriesSortedByCode: FilterableCountry[] = [
+const allCountriesSortedByCode: readonly FilterableCountry[] = [
     {
         name: "Aruba",
         code: "ABW",
@@ -1508,7 +1508,7 @@ const allCountriesSortedByCode: FilterableCountry[] = [
     },
 ]
 
-export const countries: Country[] = allCountriesSortedByCode.filter(
+export const countries: readonly Country[] = allCountriesSortedByCode.filter(
     (country) => !country.filter
 )
 

--- a/clientUtils/formatValue.ts
+++ b/clientUtils/formatValue.ts
@@ -1,21 +1,21 @@
 import { d3Format } from "./Util"
 
 export interface TickFormattingOptions {
-    numDecimalPlaces?: number
-    unit?: string
-    noTrailingZeroes?: boolean
-    noSpaceUnit?: boolean
-    numberPrefixes?: boolean
-    shortNumberPrefixes?: boolean
-    showPlus?: boolean
-    isFirstOrLastTick?: boolean
+    readonly numDecimalPlaces?: number
+    readonly unit?: string
+    readonly noTrailingZeroes?: boolean
+    readonly noSpaceUnit?: boolean
+    readonly numberPrefixes?: boolean
+    readonly shortNumberPrefixes?: boolean
+    readonly showPlus?: boolean
+    readonly isFirstOrLastTick?: boolean
 }
 
 // todo: Should this be numberSuffixes instead of Prefixes?
 // todo: we should have unit tests for this one. lot's of great features but hard to see how to use all of them.
 export function formatValue(
     value: number,
-    options: TickFormattingOptions
+    options: Readonly<TickFormattingOptions>
 ): string {
     const noTrailingZeroes = options.noTrailingZeroes ?? true
     const numberPrefixes =

--- a/clientUtils/urls/UrlMigration.ts
+++ b/clientUtils/urls/UrlMigration.ts
@@ -3,7 +3,7 @@ import { Url } from "./Url"
 export type UrlMigration = (url: Url) => Url
 
 export const performUrlMigrations = (
-    migrations: UrlMigration[],
+    migrations: readonly UrlMigration[],
     url: Url
 ): Url => {
     return migrations.reduce((url, migration) => migration(url), url)

--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -86,10 +86,10 @@ export class CoreTable<
     private originalInput: CoreTableInputOption
     private advancedOptions: AdvancedOptions
 
-    private inputColumnDefs: COL_DEF_TYPE[]
+    private inputColumnDefs: readonly COL_DEF_TYPE[]
     constructor(
         input: CoreTableInputOption = [],
-        inputColumnDefs: COL_DEF_TYPE[] | string = [],
+        inputColumnDefs: readonly COL_DEF_TYPE[] | string = [],
         advancedOptions: AdvancedOptions = {}
     ) {
         const start = Date.now() // Perf aid
@@ -355,12 +355,12 @@ export class CoreTable<
         }
     }
 
-    getTimesAtIndices(indices: number[]) {
+    getTimesAtIndices(indices: readonly number[]) {
         if (!indices.length) return []
         return this.getValuesAtIndices(this.timeColumn!.slug, indices) as Time[]
     }
 
-    getValuesAtIndices(columnSlug: ColumnSlug, indices: number[]) {
+    getValuesAtIndices(columnSlug: ColumnSlug, indices: readonly number[]) {
         const values = this.get(columnSlug).valuesIncludingErrorValues
         return indices.map((index) => values[index])
     }
@@ -486,7 +486,7 @@ export class CoreTable<
      * So `table.rowIndex(["country", "population"]).get("USA 100")` would return [0].
      *
      */
-    rowIndex(columnSlugs: ColumnSlug[]) {
+    rowIndex(columnSlugs: readonly ColumnSlug[]) {
         const index = new Map<string, number[]>()
         const keyFn = makeKeyFn(this.columnStore, columnSlugs)
         this.indices.forEach((rowIndex) => {
@@ -611,7 +611,7 @@ export class CoreTable<
         )
     }
 
-    sortBy(slugs: ColumnSlug[]) {
+    sortBy(slugs: readonly ColumnSlug[]) {
         return this.transform(
             sortColumnStore(this.columnStore, slugs),
             this.defs,
@@ -620,7 +620,7 @@ export class CoreTable<
         )
     }
 
-    sortColumns(slugs: ColumnSlug[]) {
+    sortColumns(slugs: readonly ColumnSlug[]) {
         const first = this.getColumns(slugs)
         const rest = this.columnsAsArray.filter((col) => !first.includes(col))
         return this.transform(
@@ -698,12 +698,12 @@ export class CoreTable<
         return this._columnsAsArray
     }
 
-    getColumns(slugs: ColumnSlug[]) {
+    getColumns(slugs: readonly ColumnSlug[]) {
         return slugs.map((slug) => this.get(slug))
     }
 
     // Get the min and max for multiple columns at once
-    domainFor(slugs: ColumnSlug[]): ValueRange {
+    domainFor(slugs: readonly ColumnSlug[]): ValueRange {
         const cols = this.getColumns(slugs)
         const mins = cols.map((col) => col.minValue)
         const maxes = cols.map((col) => col.maxValue)
@@ -887,7 +887,7 @@ export class CoreTable<
         return this.columnsAsArray.filter((col) => col.isConstant)
     }
 
-    rowsAt(indices: number[]): ROW_TYPE[] {
+    rowsAt(indices: readonly number[]): ROW_TYPE[] {
         const { columnStore } = this
         return indices.map(
             (index) => makeRowFromColumnStore(index, columnStore) as ROW_TYPE
@@ -968,7 +968,7 @@ export class CoreTable<
         )
     }
 
-    select(slugs: ColumnSlug[]) {
+    select(slugs: readonly ColumnSlug[]) {
         const columnsToKeep = new Set(slugs)
         const newStore: CoreColumnStore = {}
         const defs = this.columnsAsArray
@@ -989,7 +989,7 @@ export class CoreTable<
         )
     }
 
-    dropColumns(slugs: ColumnSlug[], message?: string) {
+    dropColumns(slugs: readonly ColumnSlug[], message?: string) {
         const columnsToDrop = new Set(slugs)
         const newStore = {
             ...this.columnStore,
@@ -1072,7 +1072,7 @@ export class CoreTable<
         )
     }
 
-    dropRowsAt(indices: number[], message?: string) {
+    dropRowsAt(indices: readonly number[], message?: string) {
         return this.transform(
             this.columnStore,
             this.defs,
@@ -1092,7 +1092,9 @@ export class CoreTable<
         )
     }
 
-    replaceNonPositiveCellsForLogScale(columnSlugs: ColumnSlug[] = []) {
+    replaceNonPositiveCellsForLogScale(
+        columnSlugs: readonly ColumnSlug[] = []
+    ) {
         return this.transform(
             replaceCells(this.columnStore, columnSlugs, (val) =>
                 val <= 0 ? ErrorValueTypes.InvalidOnALogScale : val
@@ -1105,7 +1107,7 @@ export class CoreTable<
         )
     }
 
-    replaceNonNumericCellsWithErrorValues(columnSlugs: ColumnSlug[]) {
+    replaceNonNumericCellsWithErrorValues(columnSlugs: readonly ColumnSlug[]) {
         return this.transform(
             replaceCells(this.columnStore, columnSlugs, (val) =>
                 !isNumber(val) ? ErrorValueTypes.NaNButShouldBeNumber : val
@@ -1120,7 +1122,7 @@ export class CoreTable<
 
     replaceRandomCells(
         howMany = 1,
-        columnSlugs: ColumnSlug[] = [],
+        columnSlugs: readonly ColumnSlug[] = [],
         seed = Date.now(),
         replacementGenerator: () => any = () =>
             ErrorValueTypes.DroppedForTesting
@@ -1227,14 +1229,14 @@ export class CoreTable<
         )
     }
 
-    columnIntersection(tables: CoreTable[]) {
+    columnIntersection(tables: readonly CoreTable[]) {
         return intersection(
             this.columnSlugs,
             ...tables.map((table) => table.columnSlugs)
         )
     }
 
-    private intersectingRowIndices(tables: CoreTable[]) {
+    private intersectingRowIndices(tables: readonly CoreTable[]) {
         const columnSlugs = this.columnIntersection(tables)
         if (!columnSlugs.length) return []
         const thisIndex = this.rowIndex(columnSlugs)
@@ -1248,7 +1250,7 @@ export class CoreTable<
         return Array.from(keys).map((key) => thisIndex.get(key)![0]) // Only include first match if many b/c we are treating tables as sets here
     }
 
-    intersection(tables: CoreTable[]) {
+    intersection(tables: readonly CoreTable[]) {
         return this.transform(
             this.columnStore,
             this.defs,
@@ -1262,7 +1264,7 @@ export class CoreTable<
         )
     }
 
-    difference(tables: CoreTable[]) {
+    difference(tables: readonly CoreTable[]) {
         return this.transform(
             this.columnStore,
             this.defs,
@@ -1315,7 +1317,7 @@ export class CoreTable<
     private join(
         destinationTable: CoreTable,
         sourceTable: CoreTable,
-        by?: ColumnSlug[]
+        by?: readonly ColumnSlug[]
     ) {
         by =
             by ??
@@ -1353,7 +1355,7 @@ export class CoreTable<
         return defsToAdd
     }
 
-    concat(tables: CoreTable[], message = `Combined tables`) {
+    concat(tables: readonly CoreTable[], message = `Combined tables`) {
         const all = [this, ...tables] as CoreTable[]
         const defs = flatten(all.map((table) => table.defs)) as COL_DEF_TYPE[]
         const uniqDefs = uniqBy(defs, (def) => def.slug)
@@ -1368,7 +1370,7 @@ export class CoreTable<
         )
     }
 
-    complete(columnSlugs: ColumnSlug[]): this {
+    complete(columnSlugs: readonly ColumnSlug[]): this {
         const index = this.rowIndex(columnSlugs)
         const cols = this.getColumns(columnSlugs)
         const product = cartesianProduct(...cols.map((col) => col.uniqValues))
@@ -1406,7 +1408,7 @@ export class CoreTable<
             .dropDuplicateRows()
     }
 
-    union(tables: CoreTable[]) {
+    union(tables: readonly CoreTable[]) {
         return this.concat(tables).dropDuplicateRows()
     }
 
@@ -1458,11 +1460,11 @@ interface ReductionMap {
 type ReductionTypes = keyof CoreColumn
 
 class FilterMask {
-    private mask: boolean[]
+    private mask: readonly boolean[]
     private numRows: number
     constructor(
         numRows: number,
-        input: boolean[] | number[],
+        input: readonly boolean[] | readonly number[],
         keepThese = true
     ) {
         this.numRows = numRows

--- a/coreTable/CoreTableConstants.ts
+++ b/coreTable/CoreTableConstants.ts
@@ -81,7 +81,7 @@ export type CoreValueType = PrimitiveType | ErrorValue
  * }
  */
 export type CoreColumnStore = {
-    [columnSlug: string]: CoreValueType[]
+    [columnSlug: string]: readonly CoreValueType[]
 }
 
 export type CoreTableInputOption =
@@ -95,7 +95,7 @@ export interface CoreQuery {
     [columnSlug: string]: PrimitiveType | PrimitiveType[]
 }
 
-type CoreVector = any[]
+type CoreVector = readonly any[]
 
 /**
  * This is just an array of arrays where the first array is the header and the rest are rows. An example is:
@@ -105,4 +105,4 @@ type CoreVector = any[]
  * Having this type is just to provide a common unique name for the basic structure used by HandsOnTable
  * and some other popular JS data libraries.
  */
-export type CoreMatrix = CoreVector[]
+export type CoreMatrix = readonly CoreVector[]

--- a/coreTable/CoreTablePrinters.ts
+++ b/coreTable/CoreTablePrinters.ts
@@ -8,8 +8,8 @@ export interface AlignedTextTableOptions {
 
 // Output a pretty table for consles
 export const toAlignedTextTable = (
-    headerSlugs: string[],
-    rows: any[],
+    headerSlugs: readonly string[],
+    rows: readonly any[],
     options: AlignedTextTableOptions = {}
 ) => {
     const {
@@ -84,8 +84,8 @@ export const toMarkdownTable = (
 
 export const toDelimited = (
     delimiter: string,
-    columnSlugs: string[],
-    rows: any[],
+    columnSlugs: readonly string[],
+    rows: readonly any[],
     cellFn?: CellFormatter,
     rowDelimiter = "\n"
 ) => {

--- a/coreTable/CoreTableUtils.ts
+++ b/coreTable/CoreTableUtils.ts
@@ -83,7 +83,7 @@ export const makeAutoTypeFn = (numericSlugs?: ColumnSlug[]) => {
 
 // Removes whitespace and non-word characters from column slugs if any exist.
 // The original names are moved to the name property on the column def.
-export const standardizeSlugs = (rows: CoreRow[]) => {
+export const standardizeSlugs = (rows: readonly CoreRow[]) => {
     const firstRow = rows[0] ?? {}
     const colsToRename = Object.keys(firstRow)
         .map((name) => {
@@ -333,7 +333,7 @@ export function interpolateRowValuesWithTolerance<
     TimeSlug extends ColumnSlug,
     Row extends { [key in TimeSlug]?: Time } & { [key in ValueSlug]?: any }
 >(
-    rowsSortedByTimeAsc: Row[],
+    rowsSortedByTimeAsc: readonly Row[],
     valueSlug: ValueSlug,
     timeSlug: TimeSlug,
     timeTolerance: number
@@ -353,7 +353,7 @@ export function interpolateRowValuesWithTolerance<
 // A dumb function for making a function that makes a key for a row given certain columns.
 export const makeKeyFn = (
     columnStore: CoreColumnStore,
-    columnSlugs: ColumnSlug[]
+    columnSlugs: readonly ColumnSlug[]
 ) => (rowIndex: number) =>
     // toString() handles `undefined` and `null` values, which can be in the table.
     columnSlugs.map((slug) => toString(columnStore[slug][rowIndex])).join(" ")
@@ -382,7 +382,7 @@ export const imemo = (
 
 export const appendRowsToColumnStore = (
     columnStore: CoreColumnStore,
-    rows: CoreRow[]
+    rows: readonly CoreRow[]
 ) => {
     const slugs = Object.keys(columnStore)
     const newColumnStore = columnStore
@@ -402,7 +402,7 @@ const getColumnStoreLength = (store: CoreColumnStore) => {
 }
 
 export const concatColumnStores = (
-    stores: CoreColumnStore[],
+    stores: readonly CoreColumnStore[],
     slugsToKeep?: ColumnSlug[]
 ) => {
     if (!stores.length) return {}
@@ -425,7 +425,7 @@ export const concatColumnStores = (
     return newColumnStore
 }
 
-export const rowsToColumnStore = (rows: CoreRow[]) => {
+export const rowsToColumnStore = (rows: readonly CoreRow[]) => {
     const columnsObject: CoreColumnStore = {}
     if (!rows.length) return columnsObject
 
@@ -436,7 +436,7 @@ export const rowsToColumnStore = (rows: CoreRow[]) => {
 }
 
 const guessColumnDefsFromRows = (
-    rows: CoreRow[],
+    rows: readonly CoreRow[],
     definedSlugs: Map<ColumnSlug, any>
 ) => {
     if (!rows[0]) return []
@@ -479,8 +479,8 @@ export const autodetectColumnDefs = (
 
 // Convenience method when you are replacing columns
 export const replaceDef = <ColumnDef extends CoreColumnDef>(
-    defs: ColumnDef[],
-    newDefs: ColumnDef[]
+    defs: readonly ColumnDef[],
+    newDefs: readonly ColumnDef[]
 ) =>
     defs.map((def) => {
         const newDef = newDefs.find((newDef) => newDef.slug === def.slug)
@@ -510,7 +510,7 @@ export const renameColumnStore = (
 
 export const replaceCells = (
     columnStore: CoreColumnStore,
-    columnSlugs: ColumnSlug[],
+    columnSlugs: readonly ColumnSlug[],
     replaceFn: (val: CoreValueType) => CoreValueType
 ) => {
     const newStore: CoreColumnStore = { ...columnStore }
@@ -530,7 +530,7 @@ export const getDropIndexes = (
 export const replaceRandomCellsInColumnStore = (
     columnStore: CoreColumnStore,
     howMany = 1,
-    columnSlugs: ColumnSlug[] = [],
+    columnSlugs: readonly ColumnSlug[] = [],
     seed = Date.now(),
     replacementGenerator: () => any = () => ErrorValueTypes.DroppedForTesting
 ) => {
@@ -605,12 +605,12 @@ export const parseDelimited = (
 export const detectDelimiter = (str: string) =>
     str.includes("\t") ? "\t" : str.includes(",") ? "," : " "
 
-export const rowsToMatrix = (rows: any[]): CoreMatrix | undefined =>
+export const rowsToMatrix = (rows: readonly any[]): CoreMatrix | undefined =>
     rows.length
         ? [Object.keys(rows[0]), ...rows.map((row) => Object.values(row))]
         : undefined
 
-const isRowEmpty = (row: any[]) => row.every(isCellEmpty)
+const isRowEmpty = (row: readonly any[]) => row.every(isCellEmpty)
 
 export const isCellEmpty = (cell: any) =>
     cell === null || cell === undefined || cell === ""
@@ -624,7 +624,7 @@ export const trimEmptyRows = (matrix: CoreMatrix): CoreMatrix => {
     return trimAt === undefined ? matrix : matrix.slice(0, trimAt)
 }
 
-export const trimArray = (arr: any[]) => {
+export const trimArray = (arr: readonly any[]) => {
     let rightIndex: number
     for (rightIndex = arr.length - 1; rightIndex >= 0; rightIndex--) {
         if (!isCellEmpty(arr[rightIndex])) break
@@ -636,12 +636,12 @@ export function cartesianProduct<T>(...allEntries: T[][]): T[][] {
     return fastCartesian(allEntries)
 }
 
-const applyNewSortOrder = (arr: any[], newOrder: number[]) =>
+const applyNewSortOrder = (arr: readonly any[], newOrder: readonly number[]) =>
     newOrder.map((index) => arr[index])
 
 export const sortColumnStore = (
     columnStore: CoreColumnStore,
-    slugs: ColumnSlug[]
+    slugs: readonly ColumnSlug[]
 ) => {
     const firstCol = Object.values(columnStore)[0]
     if (!firstCol) return {}
@@ -656,7 +656,7 @@ export const sortColumnStore = (
 
 const makeSortByFn = (
     columnStore: CoreColumnStore,
-    columnSlugs: ColumnSlug[]
+    columnSlugs: readonly ColumnSlug[]
 ) => {
     const numSlugs = columnSlugs.length
     return (indexA: number, indexB: number) => {

--- a/coreTable/OwidTableConstants.ts
+++ b/coreTable/OwidTableConstants.ts
@@ -50,7 +50,7 @@ export const OwidEntityCodeColumnDef = {
     type: ColumnTypeNames.EntityCode,
 }
 
-export const StandardOwidColumnDefs: OwidColumnDef[] = [
+export const StandardOwidColumnDefs: readonly OwidColumnDef[] = [
     OwidEntityNameColumnDef,
     OwidEntityIdColumnDef,
     OwidEntityCodeColumnDef,

--- a/coreTable/OwidTableSynthesizers.ts
+++ b/coreTable/OwidTableSynthesizers.ts
@@ -12,9 +12,9 @@ import { OwidColumnDef, OwidTableSlugs } from "./OwidTableConstants"
 
 interface SynthOptions {
     entityCount: number
-    entityNames: string[]
+    entityNames: readonly string[]
     timeRange: TimeRange
-    columnDefs: OwidColumnDef[]
+    columnDefs: readonly OwidColumnDef[]
 }
 
 const SynthesizeOwidTable = (

--- a/coreTable/Transforms.ts
+++ b/coreTable/Transforms.ts
@@ -9,8 +9,8 @@ import { ErrorValue, ErrorValueTypes, isNotErrorValue } from "./ErrorValues"
 // for each missing value from the first year to the last year, preserving the position of
 // the existing values.
 export const insertMissingValuePlaceholders = (
-    values: number[],
-    times: number[]
+    values: readonly number[],
+    times: readonly number[]
 ) => {
     const startTime = times[0]
     const endTime = times[times.length - 1]
@@ -33,7 +33,7 @@ export const insertMissingValuePlaceholders = (
 
 // todo: add the precision param to ensure no floating point effects
 export function computeRollingAverage(
-    numbers: (number | undefined | null | ErrorValue)[],
+    numbers: readonly (number | undefined | null | ErrorValue)[],
     windowSize: number,
     align: "right" | "center" = "right"
 ) {
@@ -288,7 +288,7 @@ export const AvailableTransforms = Object.keys(availableTransforms)
 
 export const applyTransforms = (
     columnStore: CoreColumnStore,
-    defs: CoreColumnDef[]
+    defs: readonly CoreColumnDef[]
 ) => {
     defs.forEach((def) => {
         const words = def.transform!.split(" ")

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -68,7 +68,7 @@ import { PromiseCache } from "../clientUtils/PromiseCache"
 import { PromiseSwitcher } from "../clientUtils/PromiseSwitcher"
 
 export interface ExplorerProps extends SerializedGridProgram {
-    grapherConfigs?: GrapherInterface[]
+    grapherConfigs?: readonly GrapherInterface[]
     queryStr?: string
     isEmbeddedInAnOwidPage?: boolean
     isInStandalonePage?: boolean
@@ -110,7 +110,7 @@ export class Explorer
     // caution: do a ctrl+f to find untyped usages
     static renderSingleExplorerOnExplorerPage(
         program: ExplorerProps,
-        grapherConfigs: GrapherInterface[],
+        grapherConfigs: readonly GrapherInterface[],
         urlMigrationSpec?: ExplorerPageUrlMigrationSpec
     ) {
         const props: ExplorerProps = {

--- a/explorer/ExplorerConstants.ts
+++ b/explorer/ExplorerConstants.ts
@@ -17,7 +17,7 @@ export const ExplorerControlTypeRegex = new RegExp(
 export interface ExplorerChoice {
     title: string
     displayTitle?: string
-    options: ExplorerChoiceOption[]
+    options: readonly ExplorerChoiceOption[]
     value: string
     type: ExplorerControlType
 }
@@ -73,5 +73,5 @@ export interface ExplorersRouteResponse {
     errorMessage?: string
     needsPull: boolean
     gitCmsBranchName: string
-    explorers: SerializedGridProgram[]
+    explorers: readonly SerializedGridProgram[]
 }

--- a/explorer/ExplorerDecisionMatrix.ts
+++ b/explorer/ExplorerDecisionMatrix.ts
@@ -55,7 +55,7 @@ const dropColumnTypes = (delimited: string): string => {
 }
 
 const makeCheckBoxOption = (
-    options: ExplorerChoiceOption[],
+    options: readonly ExplorerChoiceOption[],
     choiceName: string
 ) => {
     const checked = options.some(

--- a/explorer/urlMigrations/ExplorerUrlMigrations.ts
+++ b/explorer/urlMigrations/ExplorerUrlMigrations.ts
@@ -24,7 +24,7 @@ export const explorerUrlMigrationsById: Record<
     legacyToGridCovidExplorer: legacyCovidMigrationSpec,
 }
 
-const explorerUrlMigrations: UrlMigration[] = [
+const explorerUrlMigrations: readonly UrlMigration[] = [
     // NOTE: The order of migrations matters!
     co2UrlMigration,
     energyUrlMigration,

--- a/explorerAdmin/ExplorerAdminServer.tsx
+++ b/explorerAdmin/ExplorerAdminServer.tsx
@@ -234,7 +234,7 @@ export class ExplorerAdminServer {
 
     private async bakeExplorersToDir(
         directory: string,
-        explorers: ExplorerProgram[] = []
+        explorers: readonly ExplorerProgram[] = []
     ) {
         for (const explorer of explorers) {
             await this.write(

--- a/explorerAdmin/ExplorersListPage.tsx
+++ b/explorerAdmin/ExplorersListPage.tsx
@@ -157,7 +157,7 @@ class ExplorerRow extends React.Component<{
 
 @observer
 class ExplorerList extends React.Component<{
-    explorers: ExplorerProgram[]
+    explorers: readonly ExplorerProgram[]
     searchHighlight?: (text: string) => any
     indexPage: ExplorersIndexPage
     gitCmsBranchName: string

--- a/grapher/axis/AxisConfig.ts
+++ b/grapher/axis/AxisConfig.ts
@@ -10,7 +10,7 @@ import { AxisConfigInterface } from "./AxisConfigInterface"
 import { ScaleSelectorManager } from "../controls/ScaleSelector"
 
 export interface FontSizeManager {
-    fontSize: number
+    readonly fontSize: number
 }
 
 class AxisConfigDefaults {

--- a/grapher/axis/AxisViews.tsx
+++ b/grapher/axis/AxisViews.tsx
@@ -249,7 +249,7 @@ export class HorizontalAxisComponent extends React.Component<{
 
 export class AxisTickMarks extends React.Component<{
     tickMarkTopPosition: number
-    tickMarkXPositions: number[]
+    tickMarkXPositions: readonly number[]
     color: string
 }> {
     render() {

--- a/grapher/barCharts/DiscreteBarChart.test.ts
+++ b/grapher/barCharts/DiscreteBarChart.test.ts
@@ -10,7 +10,6 @@ import {
 import {
     DEFAULT_BAR_COLOR,
     DiscreteBarChartManager,
-    DiscreteBarSeries,
 } from "./DiscreteBarChartConstants"
 import { ColorSchemeName } from "../color/ColorConstants"
 import { SeriesStrategy } from "../core/GrapherConstants"
@@ -50,8 +49,9 @@ describe("barcharts with columns as the series", () => {
     expect(chart.series.length).toEqual(2)
 
     it("can add colors to columns as series", () => {
-        manager.baseColorScheme = ColorSchemeName.Reds
-        const chart = new DiscreteBarChart({ manager })
+        const chart = new DiscreteBarChart({
+            manager: { ...manager, baseColorScheme: ColorSchemeName.Reds },
+        })
         expect(chart.series[0].color).not.toEqual(DEFAULT_BAR_COLOR)
     })
 

--- a/grapher/barCharts/DiscreteBarChartConstants.ts
+++ b/grapher/barCharts/DiscreteBarChartConstants.ts
@@ -3,14 +3,14 @@ import { Time } from "../../coreTable/CoreTableConstants"
 import { ChartSeries } from "../chart/ChartInterface"
 
 export interface DiscreteBarSeries extends ChartSeries {
-    value: number
-    time: Time
+    readonly value: number
+    readonly time: Time
 }
 
 export interface DiscreteBarChartManager extends ChartManager {
-    showYearLabels?: boolean
-    endTime?: Time
-    isLineChart?: boolean
+    readonly showYearLabels?: boolean
+    readonly endTime?: Time
+    readonly isLineChart?: boolean
 }
 
 export const DEFAULT_BAR_COLOR = "#2E5778"

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -44,31 +44,31 @@ export interface CaptionedChartManager
         AbsRelToggleManager,
         FooterManager,
         HeaderManager {
-    containerElement?: HTMLDivElement
-    tabBounds?: Bounds
-    fontSize?: number
-    tab?: GrapherTabOption
-    type?: ChartTypeName
-    typeExceptWhenLineChartAndSingleTimeThenWillBeBarChart?: ChartTypeName
-    isReady?: boolean
-    whatAreWeWaitingFor?: string
-    entityType?: string
-    entityTypePlural?: string
-    showSmallCountriesFilterToggle?: boolean
-    showYScaleToggle?: boolean
-    showXScaleToggle?: boolean
-    showZoomToggle?: boolean
-    showAbsRelToggle?: boolean
-    showHighlightToggle?: boolean
-    showChangeEntityButton?: boolean
-    showAddEntityButton?: boolean
-    showSelectEntitiesButton?: boolean
+    readonly containerElement?: HTMLDivElement
+    readonly tabBounds?: Bounds
+    readonly fontSize?: number
+    readonly tab?: GrapherTabOption
+    readonly type?: ChartTypeName
+    readonly typeExceptWhenLineChartAndSingleTimeThenWillBeBarChart?: ChartTypeName
+    readonly isReady?: boolean
+    readonly whatAreWeWaitingFor?: string
+    readonly entityType?: string
+    readonly entityTypePlural?: string
+    readonly showSmallCountriesFilterToggle?: boolean
+    readonly showYScaleToggle?: boolean
+    readonly showXScaleToggle?: boolean
+    readonly showZoomToggle?: boolean
+    readonly showAbsRelToggle?: boolean
+    readonly showHighlightToggle?: boolean
+    readonly showChangeEntityButton?: boolean
+    readonly showAddEntityButton?: boolean
+    readonly showSelectEntitiesButton?: boolean
 }
 
 interface CaptionedChartProps {
-    manager: CaptionedChartManager
-    bounds?: Bounds
-    maxWidth?: number
+    readonly manager: CaptionedChartManager
+    readonly bounds?: Bounds
+    readonly maxWidth?: number
 }
 
 const OUTSIDE_PADDING = 15

--- a/grapher/chart/ChartDimension.ts
+++ b/grapher/chart/ChartDimension.ts
@@ -33,7 +33,7 @@ class ChartDimensionDefaults implements LegacyChartDimensionInterface {
 
 // todo: remove when we remove dimensions
 export interface LegacyDimensionsManager {
-    table: OwidTable
+    readonly table: OwidTable
 }
 
 export class ChartDimension

--- a/grapher/chart/ChartInterface.ts
+++ b/grapher/chart/ChartInterface.ts
@@ -7,8 +7,8 @@ import { SeriesName } from "../core/GrapherConstants"
 // this interface.
 
 export interface ChartSeries {
-    seriesName: SeriesName
-    color: Color
+    readonly seriesName: SeriesName
+    readonly color: Color
 }
 
 export type ChartTableTransformer = (inputTable: OwidTable) => OwidTable

--- a/grapher/chart/ChartManager.ts
+++ b/grapher/chart/ChartManager.ts
@@ -18,53 +18,53 @@ import { SelectionArray } from "../selection/SelectionArray"
 // The possible options common across our chart types. Not all of these apply to every chart type, so there is room to create a better type hierarchy.
 
 export interface ChartManager {
-    baseFontSize?: number
+    readonly baseFontSize?: number
 
-    table: OwidTable
-    transformedTable?: OwidTable
+    readonly table: OwidTable
+    readonly transformedTable?: OwidTable
 
-    isSelectingData?: boolean
-    startSelectingWhenLineClicked?: boolean // used by lineLabels
-    isExportingtoSvgOrPng?: boolean
-    isRelativeMode?: boolean
-    comparisonLines?: ComparisonLineConfig[]
-    hideLegend?: boolean
-    tooltip?: TooltipProps
-    useTimelineDomains?: boolean
-    baseColorScheme?: ColorSchemeName
-    invertColorScheme?: boolean
-    compareEndPointsOnly?: boolean
-    zoomToSelection?: boolean
-    matchingEntitiesOnly?: boolean
+    readonly startSelectingWhenLineClicked?: boolean // used by lineLabels
+    readonly isExportingtoSvgOrPng?: boolean
+    readonly isRelativeMode?: boolean
+    readonly comparisonLines?: readonly ComparisonLineConfig[]
+    readonly hideLegend?: boolean
+    readonly tooltip?: TooltipProps
+    readonly useTimelineDomains?: boolean
+    readonly baseColorScheme?: ColorSchemeName
+    readonly invertColorScheme?: boolean
+    readonly zoomToSelection?: boolean
+    readonly matchingEntitiesOnly?: boolean
 
-    colorScale?: ColorScaleConfigInterface
+    readonly colorScale?: ColorScaleConfigInterface
 
-    yAxis?: AxisConfig // Remove? Just pass interfaces?
-    xAxis?: AxisConfig
-    yAxisConfig?: AxisConfigInterface
-    xAxisConfig?: AxisConfigInterface
+    readonly yAxis?: AxisConfig // Remove? Just pass interfaces?
+    readonly xAxis?: AxisConfig
+    readonly yAxisConfig?: AxisConfigInterface
+    readonly xAxisConfig?: AxisConfigInterface
 
-    addCountryMode?: EntitySelectionMode
+    readonly addCountryMode?: EntitySelectionMode
 
-    yColumnSlug?: ColumnSlug
-    yColumnSlugs?: ColumnSlug[]
-    xColumnSlug?: ColumnSlug
-    sizeColumnSlug?: ColumnSlug
-    colorColumnSlug?: ColumnSlug
+    readonly yColumnSlug?: ColumnSlug
+    readonly yColumnSlugs?: readonly ColumnSlug[]
+    readonly xColumnSlug?: ColumnSlug
+    readonly sizeColumnSlug?: ColumnSlug
+    readonly colorColumnSlug?: ColumnSlug
 
-    selection?: SelectionArray | EntityName[]
-    selectedColumnSlugs?: ColumnSlug[]
+    readonly selection?: SelectionArray | readonly EntityName[]
+    readonly selectedColumnSlugs?: readonly ColumnSlug[]
 
     // If you want to use auto-assigned colors, but then have them preserved across selection and chart changes
-    seriesColorMap?: SeriesColorMap
+    readonly seriesColorMap?: SeriesColorMap
 
-    hidePoints?: boolean // for line options
-    lineStrokeWidth?: number
+    readonly hidePoints?: boolean // for line options
+    readonly lineStrokeWidth?: number
 
-    hideXAxis?: boolean
-    hideYAxis?: boolean
+    readonly hideXAxis?: boolean
+    readonly hideYAxis?: boolean
 
-    facetStrategy?: FacetStrategy // todo: make a strategy? a column prop? etc
+    readonly facetStrategy?: FacetStrategy // todo: make a strategy? a column prop? etc
+    readonly seriesStrategy?: SeriesStrategy
 
-    seriesStrategy?: SeriesStrategy
+    isSelectingData?: boolean
+    compareEndPointsOnly?: boolean
 }

--- a/grapher/color/BinningStrategies.ts
+++ b/grapher/color/BinningStrategies.ts
@@ -19,7 +19,7 @@ export const binningStrategyLabels: Record<BinningStrategy, string> = {
 }
 
 function calcEqualIntervalStepSize(
-    sortedValues: number[],
+    sortedValues: readonly number[],
     binCount: number,
     minBinValue: number
 ) {
@@ -30,7 +30,7 @@ function calcEqualIntervalStepSize(
 
 interface GetBinMaximumsWithStrategyArgs {
     binningStrategy: BinningStrategy
-    sortedValues: number[]
+    sortedValues: readonly number[]
     binCount: number
     /** `minBinValue` is only used in the `equalInterval` binning strategy. */
     minBinValue?: number
@@ -40,7 +40,7 @@ interface GetBinMaximumsWithStrategyArgs {
 // This also means the first bin can both start and end at the same value – the minimum
 // value. This is why we uniq() and why we remove any values <= minimum value.
 function normalizeBinValues(
-    binValues: (number | undefined)[],
+    binValues: readonly (number | undefined)[],
     minBinValue?: number
 ) {
     const values = uniq(excludeUndefined(binValues))

--- a/grapher/color/BinningStrategies.ts
+++ b/grapher/color/BinningStrategies.ts
@@ -1,5 +1,5 @@
-import { ckmeans } from "simple-statistics"
 import { range, quantile } from "d3-array"
+import { ckmeans } from "simple-statistics"
 
 import {
     excludeUndefined,
@@ -57,7 +57,7 @@ export function getBinMaximums(args: GetBinMaximumsWithStrategyArgs): number[] {
 
     if (binningStrategy === BinningStrategy.ckmeans) {
         const clusters = ckmeans(
-            sortedValues,
+            sortedValues.slice(),
             binCount > valueCount ? valueCount : binCount
         )
         return normalizeBinValues(clusters.map(last), minBinValue)

--- a/grapher/color/ColorBrewerSchemes.ts
+++ b/grapher/color/ColorBrewerSchemes.ts
@@ -60,7 +60,7 @@ const ColorBrewerSchemeIndex: {
 
 const brewerKeys = Object.keys(colorbrewer) as ColorSchemeName[]
 
-export const ColorBrewerSchemes: ColorSchemeInterface[] = brewerKeys
+export const ColorBrewerSchemes: readonly ColorSchemeInterface[] = brewerKeys
     .filter((brewerName) => ColorBrewerSchemeIndex[brewerName])
     .map((brewerName) => {
         const props = ColorBrewerSchemeIndex[brewerName]!

--- a/grapher/color/ColorConstants.ts
+++ b/grapher/color/ColorConstants.ts
@@ -12,7 +12,7 @@ export const ContinentColors = {
 
 export interface ColorSchemeInterface {
     name: string
-    colorSets: Color[][] // Different color sets depending on how many distinct colors you want
+    colorSets: readonly (readonly Color[])[] // Different color sets depending on how many distinct colors you want
     singleColorScale?: boolean
     isDistinct?: boolean
     displayName?: string

--- a/grapher/color/ColorScaleBin.ts
+++ b/grapher/color/ColorScaleBin.ts
@@ -1,25 +1,25 @@
 import { Color } from "../../coreTable/CoreTableConstants"
 
 interface BinProps {
-    color: Color
-    label?: string
+    readonly color: Color
+    readonly label?: string
 }
 
 interface NumericBinProps extends BinProps {
-    isFirst: boolean
-    isOpenLeft: boolean
-    isOpenRight: boolean
-    min: number
-    max: number
-    displayMin: string
-    displayMax: string
+    readonly isFirst: boolean
+    readonly isOpenLeft: boolean
+    readonly isOpenRight: boolean
+    readonly min: number
+    readonly max: number
+    readonly displayMin: string
+    readonly displayMax: string
 }
 
 interface CategoricalBinProps extends BinProps {
-    index: number
-    value: string
-    label: string
-    isHidden?: boolean
+    readonly index: number
+    readonly value: string
+    readonly label: string
+    readonly isHidden?: boolean
 }
 
 abstract class AbstractColorScaleBin<T extends BinProps> {

--- a/grapher/color/ColorUtils.ts
+++ b/grapher/color/ColorUtils.ts
@@ -3,7 +3,7 @@ import { rgb } from "d3-color"
 import { interpolate } from "d3-interpolate"
 import { difference, groupBy, minBy } from "../../clientUtils/Util"
 
-export const interpolateArray = (scaleArr: string[]) => {
+export const interpolateArray = (scaleArr: readonly string[]) => {
     const N = scaleArr.length - 2 // -1 for spacings, -1 for number of interpolate fns
     const intervalWidth = 1 / N
     const intervals: Array<(t: number) => string> = []
@@ -24,8 +24,8 @@ export const interpolateArray = (scaleArr: string[]) => {
 }
 
 export function getLeastUsedColor(
-    availableColors: Color[],
-    usedColors: Color[]
+    availableColors: readonly Color[],
+    usedColors: readonly Color[]
 ) {
     // If there are unused colors, return the first available
     const unusedColors = difference(availableColors, usedColors)

--- a/grapher/controls/CollapsibleList/CollapsibleList.tsx
+++ b/grapher/controls/CollapsibleList/CollapsibleList.tsx
@@ -154,7 +154,7 @@ export class MoreButton extends React.Component<{
  * Returns the number of items that can fit in the container
  */
 export function numItemsVisible(
-    itemWidths: number[],
+    itemWidths: readonly number[],
     containerWidth: number,
     startingWidth: number = 0
 ) {

--- a/grapher/controls/CommandPalette.tsx
+++ b/grapher/controls/CommandPalette.tsx
@@ -16,7 +16,7 @@ const CommandPaletteClassName = "CommandPalette"
 
 @observer
 export class CommandPalette extends React.Component<{
-    commands: Command[]
+    commands: readonly Command[]
     display: "none" | "block"
 }> {
     static togglePalette() {

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -24,9 +24,9 @@ import { TimelineController } from "../timeline/TimelineController"
 import { SelectionArray } from "../selection/SelectionArray"
 
 export interface HighlightToggleManager {
-    highlightToggle?: HighlightToggleConfig
-    selectionArray?: SelectionArray
-    populateFromQueryParams: (obj: QueryParams) => void
+    readonly highlightToggle?: HighlightToggleConfig
+    readonly selectionArray?: SelectionArray
+    readonly populateFromQueryParams: (obj: QueryParams) => void
 }
 
 // Todo: Add tests and stories
@@ -85,8 +85,8 @@ export class HighlightToggle extends React.Component<{
 }
 
 export interface AbsRelToggleManager {
+    readonly relativeToggleLabel?: string
     stackMode?: StackMode
-    relativeToggleLabel?: string
 }
 
 @observer
@@ -154,7 +154,7 @@ export class ZoomToggle extends React.Component<{
 }
 
 export interface SmallCountriesFilterManager {
-    populationFilterOption?: number
+    readonly populationFilterOption?: number
     minPopulationFilter?: number
 }
 
@@ -196,17 +196,17 @@ export class FilterSmallCountriesToggle extends React.Component<{
 }
 
 export interface FooterControlsManager extends ShareMenuManager {
-    isShareMenuActive?: boolean
-    isSelectingData?: boolean
-    availableTabs?: GrapherTabOption[]
+    readonly isSelectingData?: boolean
+    readonly availableTabs?: GrapherTabOption[]
+    readonly isInIFrame?: boolean
+    readonly canonicalUrl?: string
+    readonly hasTimeline?: boolean
+    readonly hasRelatedQuestion?: boolean
+    readonly relatedQuestions: readonly RelatedQuestionsConfig[]
+    readonly footerControlsHeight?: number
+    readonly timelineController?: TimelineController
     currentTab?: GrapherTabOption
-    isInIFrame?: boolean
-    canonicalUrl?: string
-    hasTimeline?: boolean
-    hasRelatedQuestion?: boolean
-    relatedQuestions: RelatedQuestionsConfig[]
-    footerControlsHeight?: number
-    timelineController?: TimelineController
+    isShareMenuActive?: boolean
 }
 
 @observer

--- a/grapher/controls/FuzzySearch.ts
+++ b/grapher/controls/FuzzySearch.ts
@@ -5,7 +5,7 @@ export class FuzzySearch<T> {
     strings: (Fuzzysort.Prepared | undefined)[]
     datamap: any
 
-    constructor(data: T[], key: string) {
+    constructor(data: readonly T[], key: string) {
         this.datamap = keyBy(data, key)
         this.strings = data.map((d: any) => fuzzysort.prepare(d[key]))
     }

--- a/grapher/controls/ShareMenu.tsx
+++ b/grapher/controls/ShareMenu.tsx
@@ -11,14 +11,14 @@ import { faCopy } from "@fortawesome/free-solid-svg-icons/faCopy"
 import { faEdit } from "@fortawesome/free-solid-svg-icons/faEdit"
 
 export interface ShareMenuManager {
-    slug?: string
-    currentTitle?: string
-    canonicalUrl?: string
-    embedUrl?: string
-    embedDialogAdditionalElements?: React.ReactElement
-    editUrl?: string
-    addPopup: (popup: any) => void
-    removePopup: (popup: any) => void
+    readonly slug?: string
+    readonly currentTitle?: string
+    readonly canonicalUrl?: string
+    readonly embedUrl?: string
+    readonly embedDialogAdditionalElements?: React.ReactElement
+    readonly editUrl?: string
+    readonly addPopup: (popup: any) => void
+    readonly removePopup: (popup: any) => void
 }
 
 interface ShareMenuProps {

--- a/grapher/controls/globalEntitySelector/GlobalEntitySelector.tsx
+++ b/grapher/controls/globalEntitySelector/GlobalEntitySelector.tsx
@@ -85,7 +85,7 @@ const SelectOptions: Props = {
 }
 
 function SelectedItems(props: {
-    selectedEntityNames: EntityName[]
+    selectedEntityNames: readonly EntityName[]
     emptyLabel: string
     canRemove?: boolean
     onRemove?: (item: EntityName) => void
@@ -227,7 +227,7 @@ export class GlobalEntitySelector extends React.Component<{
         )
     }
 
-    @action.bound updateSelection(newSelectedEntities: string[]) {
+    @action.bound updateSelection(newSelectedEntities: readonly string[]) {
         this.selection.setSelectedEntities(newSelectedEntities)
         this.updateAllGraphersAndExplorersOnPage()
         this.updateURL()

--- a/grapher/core/EntityUrlBuilder.ts
+++ b/grapher/core/EntityUrlBuilder.ts
@@ -45,7 +45,7 @@ const entityNamesFromV1EncodedParam = (
     return encodedQueryParam.split(V1_DELIMITER).map(decodeURIComponent)
 }
 
-const entityNamesToV2Param = (entityNames: EntityName[]): string => {
+const entityNamesToV2Param = (entityNames: readonly EntityName[]): string => {
     // Always include a v2Delimiter in a v2 link. When decoding we will drop any empty strings.
     if (entityNames.length === 1) return ENTITY_V2_DELIMITER + entityNames[0]
     return entityNames.join(ENTITY_V2_DELIMITER)
@@ -94,7 +94,7 @@ const migrateV1Delimited: UrlMigration = (url) => {
 const LegacyDimensionRegex = /\-\d+$/
 
 const injectEntityNamesInLegacyDimension = (
-    entityNames: EntityName[]
+    entityNames: readonly EntityName[]
 ): EntityName[] => {
     // If an entity has the old name-dimension encoding, removing the dimension part and add it as
     // a new selection. So USA-1 becomes USA.
@@ -130,7 +130,7 @@ const migrateLegacyDimensionPairs: UrlMigration = (url) => {
  * Combining all migrations
  */
 
-const urlMigrations: UrlMigration[] = [
+const urlMigrations: readonly UrlMigration[] = [
     migrateV1Delimited,
     migrateLegacyDimensionPairs,
 ]
@@ -156,7 +156,7 @@ export const getSelectedEntityNamesParam = (
 
 export const setSelectedEntityNamesParam = (
     url: Url,
-    entityNames: EntityName[] | undefined
+    entityNames: readonly EntityName[] | undefined
 ) => {
     return migrateSelectedEntityNamesParam(url).updateQueryParams({
         country: entityNames

--- a/grapher/core/Grapher.jsdom.test.ts
+++ b/grapher/core/Grapher.jsdom.test.ts
@@ -842,7 +842,9 @@ describe("identifies and drops unnecessary table columns", () => {
 
     it("correctly identifies columnSlugsNecessaryForCurrentView", () => {
         expect(grapher.columnSlugsNecessaryForCurrentView.length).toEqual(9)
-        expect(grapher.columnSlugsNecessaryForCurrentView.sort()).toEqual([
+        expect(
+            grapher.columnSlugsNecessaryForCurrentView.slice().sort()
+        ).toEqual([
             "child_mortality",
             "continent",
             "entityColor",

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -182,32 +182,33 @@ const DEFAULT_MS_PER_TICK = 100
 
 // Exactly the same as GrapherInterface, but contains options that developers want but authors won't be touching.
 export interface GrapherProgrammaticInterface extends GrapherInterface {
-    owidDataset?: LegacyVariablesAndEntityKey // This is temporarily used for testing. Will be removed
+    readonly owidDataset?: LegacyVariablesAndEntityKey // This is temporarily used for testing. Will be removed
+    readonly hideEntityControls?: boolean
+    readonly queryStr?: string
+    readonly isMediaCard?: boolean
+    readonly bounds?: Bounds
+    readonly table?: OwidTable
+    readonly bakedGrapherURL?: string
+    readonly adminBaseUrl?: string
+    readonly env?: string
+
+    readonly getGrapherInstance?: (instance: Grapher) => void
+
+    readonly enableKeyboardShortcuts?: boolean
+    readonly bindUrlToWindow?: boolean
+    readonly isEmbeddedInAnOwidPage?: boolean
+
+    readonly manager?: GrapherManager
+
     manuallyProvideData?: boolean // This will be removed.
-    hideEntityControls?: boolean
-    queryStr?: string
-    isMediaCard?: boolean
-    bounds?: Bounds
-    table?: OwidTable
-    bakedGrapherURL?: string
-    adminBaseUrl?: string
-    env?: string
-
-    getGrapherInstance?: (instance: Grapher) => void
-
-    enableKeyboardShortcuts?: boolean
-    bindUrlToWindow?: boolean
-    isEmbeddedInAnOwidPage?: boolean
-
-    manager?: GrapherManager
 }
 
 export interface GrapherManager {
-    canonicalUrl?: string
-    embedDialogUrl?: string
-    embedDialogAdditionalElements?: React.ReactElement
-    selection?: SelectionArray
-    editUrl?: string
+    readonly canonicalUrl?: string
+    readonly embedDialogUrl?: string
+    readonly embedDialogAdditionalElements?: React.ReactElement
+    readonly selection?: SelectionArray
+    readonly editUrl?: string
 }
 
 @observer
@@ -1028,7 +1029,7 @@ export class Grapher
 
     @action.bound setDimensionsForProperty(
         property: DimensionProperty,
-        newConfigs: LegacyChartDimensionInterface[]
+        newConfigs: readonly LegacyChartDimensionInterface[]
     ) {
         let newDimensions: ChartDimension[] = []
         this.dimensionSlots.forEach((slot) => {
@@ -1042,7 +1043,7 @@ export class Grapher
     }
 
     @action.bound setDimensionsFromConfigs(
-        configs: LegacyChartDimensionInterface[]
+        configs: readonly LegacyChartDimensionInterface[]
     ) {
         this.dimensions = configs.map(
             (config) => new ChartDimension(config, this)

--- a/grapher/core/GrapherAnalytics.ts
+++ b/grapher/core/GrapherAnalytics.ts
@@ -49,7 +49,7 @@ export class GrapherAnalytics {
         this.logToGA(Categories.GrapherError, EventNames.grapherViewError)
     }
 
-    logEntitiesNotFoundError(entities: string[]) {
+    logEntitiesNotFoundError(entities: readonly string[]) {
         this.logToAmplitude(EventNames.entitiesNotFound, { entities })
         this.logToGA(
             Categories.GrapherError,

--- a/grapher/core/GrapherUrlMigrations.ts
+++ b/grapher/core/GrapherUrlMigrations.ts
@@ -6,7 +6,7 @@ import {
 } from "../../clientUtils/urls/UrlMigration"
 import { migrateSelectedEntityNamesParam } from "./EntityUrlBuilder"
 
-export const grapherUrlMigrations: UrlMigration[] = [
+export const grapherUrlMigrations: readonly UrlMigration[] = [
     (url) => {
         const { year, time } = url.queryParams
         if (!year) return url

--- a/grapher/core/LegacyToOwidTable.test.ts
+++ b/grapher/core/LegacyToOwidTable.test.ts
@@ -398,10 +398,22 @@ describe("creating a table from legacy", () => {
 
     it("can apply legacy unit conversion factors", () => {
         const varSet = getLegacyVarSet()
-        varSet.variables["3512"].display!.conversionFactor = 100
+        const newVarSet = {
+            ...varSet,
+            variables: {
+                ...varSet.variables,
+                "3512": {
+                    ...varSet.variables["3512"],
+                    display: {
+                        ...varSet.variables["3512"].display,
+                        conversionFactor: 100,
+                    },
+                },
+            },
+        }
         expect(
             legacyToOwidTableAndDimensions(
-                varSet,
+                newVarSet,
                 getLegacyGrapherConfig()
             ).table.get("3512")!.values
         ).toEqual([550, 420, 1260])

--- a/grapher/core/LegacyToOwidTable.ts
+++ b/grapher/core/LegacyToOwidTable.ts
@@ -27,9 +27,12 @@ import { OwidTable } from "../../coreTable/OwidTable"
 import { EPOCH_DATE } from "../../clientUtils/owidTypes"
 
 export const legacyToOwidTableAndDimensions = (
-    json: LegacyVariablesAndEntityKey,
-    grapherConfig: Partial<LegacyGrapherInterface>
-): { dimensions: LegacyChartDimensionInterface[]; table: OwidTable } => {
+    json: Readonly<LegacyVariablesAndEntityKey>,
+    grapherConfig: Readonly<Partial<LegacyGrapherInterface>>
+): {
+    dimensions: readonly LegacyChartDimensionInterface[]
+    table: OwidTable
+} => {
     // Entity meta map
 
     const entityMetaById: { [id: string]: LegacyEntityMeta } = json.entityKey
@@ -128,7 +131,7 @@ export const legacyToOwidTableAndDimensions = (
             )
         }
 
-        const columnStore: { [key: string]: any[] } = {
+        const columnStore: { [key: string]: readonly any[] } = {
             [OwidTableSlugs.entityId]: entityIds,
             [OwidTableSlugs.entityCode]: entityCodes,
             [OwidTableSlugs.entityName]: entityNames,
@@ -212,7 +215,7 @@ export const legacyToOwidTableAndDimensions = (
     return { dimensions: newDimensions, table: joinedVariablesTable }
 }
 
-const fullJoinTables = (tables: OwidTable[]) =>
+const fullJoinTables = (tables: readonly OwidTable[]) =>
     tables.reduce((joinedTable, table) => joinedTable.fullJoin(table))
 
 const columnDefFromLegacyVariable = (
@@ -269,7 +272,7 @@ const timeColumnDefFromLegacyVariable = (
 
 const timeColumnValuesFromLegacyVariable = (
     variable: LegacyVariableConfig
-): number[] => {
+): readonly number[] => {
     const { display, years } = variable
     const yearsNeedTransform =
         display &&
@@ -282,7 +285,7 @@ const timeColumnValuesFromLegacyVariable = (
         : yearsRaw
 }
 
-const convertLegacyYears = (years: number[], zeroDay: string) => {
+const convertLegacyYears = (years: readonly number[], zeroDay: string) => {
     // Only shift years if the variable zeroDay is different from EPOCH_DATE
     // When the dataset uses days (`yearIsDay == true`), the days are expressed as integer
     // days since the specified `zeroDay`, which can be different for different variables.

--- a/grapher/core/LegacyVariableCode.ts
+++ b/grapher/core/LegacyVariableCode.ts
@@ -7,7 +7,7 @@ import {
     objectWithPersistablesToObject,
     deleteRuntimeAndUnchangedProps,
 } from "../persistable/Persistable"
-import { ColumnSlug, Integer, Time } from "../../coreTable/CoreTableConstants"
+import { ColumnSlug, Time } from "../../coreTable/CoreTableConstants"
 import { DimensionProperty } from "../core/GrapherConstants"
 import { OwidSource } from "../../coreTable/OwidSource"
 import {
@@ -17,11 +17,11 @@ import {
 import { LegacyVariableId } from "../../clientUtils/owidTypes"
 
 export interface LegacyChartDimensionInterface {
-    property: DimensionProperty
-    targetYear?: Time
-    display?: LegacyVariableDisplayConfigInterface
-    variableId: LegacyVariableId
-    slug?: ColumnSlug
+    readonly property: DimensionProperty
+    readonly targetYear?: Time
+    readonly display?: LegacyVariableDisplayConfigInterface
+    readonly variableId: LegacyVariableId
+    readonly slug?: ColumnSlug
 }
 
 class LegacyVariableDisplayConfigDefaults {
@@ -61,25 +61,25 @@ export class LegacyVariableDisplayConfig
 }
 
 export interface LegacyVariableConfig {
-    id: number
-    name?: string
-    description?: string
-    unit?: string
-    display?: LegacyVariableDisplayConfigInterface
-    shortUnit?: string
-    datasetName?: string
-    datasetId?: string
-    coverage?: string
-    source?: OwidSource
-    years?: number[]
-    entities?: number[]
-    values?: (string | number)[]
+    readonly id: number
+    readonly name?: string
+    readonly description?: string
+    readonly unit?: string
+    readonly display?: LegacyVariableDisplayConfigInterface
+    readonly shortUnit?: string
+    readonly datasetName?: string
+    readonly datasetId?: string
+    readonly coverage?: string
+    readonly source?: OwidSource
+    readonly years?: readonly number[]
+    readonly entities?: readonly number[]
+    readonly values?: readonly (string | number)[]
 }
 
 export interface LegacyEntityMeta {
-    id: number
-    name: string
-    code: string
+    readonly id: number
+    readonly name: string
+    readonly code: string
 }
 
 declare interface LegacyEntityKey {
@@ -87,8 +87,8 @@ declare interface LegacyEntityKey {
 }
 
 export interface LegacyVariablesAndEntityKey {
-    variables: {
+    readonly variables: {
         [id: string]: LegacyVariableConfig
     }
-    entityKey: LegacyEntityKey
+    readonly entityKey: LegacyEntityKey
 }

--- a/grapher/dataTable/DataTable.stories.tsx
+++ b/grapher/dataTable/DataTable.stories.tsx
@@ -24,9 +24,9 @@ export const Default = () => {
 export const WithTimeRange = () => {
     const manager: DataTableManager = {
         table,
+        startTime: 1950,
+        endTime: 2000,
     }
-    manager.startTime = 1950
-    manager.endTime = 2000
     return <DataTable manager={manager} />
 }
 

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -59,11 +59,11 @@ const inverseSortOrder = (order: SortOrder) =>
     order === SortOrder.asc ? SortOrder.desc : SortOrder.asc
 
 export interface DataTableManager {
-    table: OwidTable
-    endTime?: Time
-    startTime?: Time
-    minPopulationFilter?: number
-    dataTableSlugs?: ColumnSlug[]
+    readonly table: OwidTable
+    readonly endTime?: Time
+    readonly startTime?: Time
+    readonly minPopulationFilter?: number
+    readonly dataTableSlugs?: ColumnSlug[]
 }
 
 @observer
@@ -318,7 +318,7 @@ export class DataTable extends React.Component<{
 
     private renderEntityRow(
         row: DataTableRow,
-        dimensions: DataTableDimension[]
+        dimensions: readonly DataTableDimension[]
     ) {
         const { sort } = this.tableState
         return (
@@ -751,7 +751,7 @@ enum TargetTimeMode {
 }
 
 interface Dimension {
-    columns: DimensionColumn[]
+    columns: readonly DimensionColumn[]
     valueByEntity: Map<string, DimensionValue>
     sourceColumn: CoreColumn
 }
@@ -802,14 +802,14 @@ type DimensionValue = SingleValue | RangeValue
 type ColumnKey = SingleValueKey | RangeValueKey
 
 interface DataTableDimension {
-    columns: DataTableColumn[]
+    columns: readonly DataTableColumn[]
     coreTableColumn: CoreColumn
     sortable: boolean
 }
 
 interface DataTableRow {
     entityName: EntityName
-    dimensionValues: (DimensionValue | undefined)[] // TODO make it not undefined
+    dimensionValues: readonly (DimensionValue | undefined)[] // TODO make it not undefined
 }
 
 function isDeltaColumn(columnKey?: ColumnKey) {

--- a/grapher/downloadTab/DownloadTab.tsx
+++ b/grapher/downloadTab/DownloadTab.tsx
@@ -10,18 +10,18 @@ import classNames from "classnames"
 import { BlankOwidTable, OwidTable } from "../../coreTable/OwidTable"
 
 export interface DownloadTabManager {
-    idealBounds?: Bounds
-    staticSVG: string
-    displaySlug: string
-    baseUrl?: string
-    queryStr?: string
-    table?: OwidTable
-    externalCsvLink?: string // Todo: we can ditch this once rootTable === externalCsv (currently not quite the case for Covid Explorer)
+    readonly idealBounds?: Bounds
+    readonly staticSVG: string
+    readonly displaySlug: string
+    readonly baseUrl?: string
+    readonly queryStr?: string
+    readonly table?: OwidTable
+    readonly externalCsvLink?: string // Todo: we can ditch this once rootTable === externalCsv (currently not quite the case for Covid Explorer)
 }
 
 interface DownloadTabProps {
-    bounds?: Bounds
-    manager: DownloadTabManager
+    readonly bounds?: Bounds
+    readonly manager: DownloadTabManager
 }
 
 declare var Blob: any

--- a/grapher/facetChart/FacetChart.test.ts
+++ b/grapher/facetChart/FacetChart.test.ts
@@ -11,8 +11,15 @@ it("can create a new FacetChart", () => {
         table,
         selection: table.availableEntityNames,
     }
+
     const chart = new FacetChart({ manager })
     expect(chart.series.length).toEqual(2)
-    manager.facetStrategy = FacetStrategy.column
-    expect(chart.series.length).toEqual(3)
+
+    const facetChart = new FacetChart({
+        manager: {
+            ...manager,
+            facetStrategy: FacetStrategy.column,
+        },
+    })
+    expect(facetChart.series.length).toEqual(3)
 })

--- a/grapher/facetChart/FacetChartConstants.ts
+++ b/grapher/facetChart/FacetChartConstants.ts
@@ -4,18 +4,18 @@ import { ChartTypeName } from "../core/GrapherConstants"
 import { Bounds } from "../../clientUtils/Bounds"
 
 export interface FacetChartProps {
-    bounds?: Bounds
-    chartTypeName?: ChartTypeName
-    manager: ChartManager
+    readonly bounds?: Bounds
+    readonly chartTypeName?: ChartTypeName
+    readonly manager: ChartManager
 }
 
 export interface FacetSeries extends ChartSeries {
-    manager: Partial<ChartManager>
-    chartTypeName?: ChartTypeName
+    readonly manager: Partial<ChartManager>
+    readonly chartTypeName?: ChartTypeName
 }
 
 export interface PlacedFacetSeries extends FacetSeries {
-    manager: ChartManager
-    chartTypeName: ChartTypeName
-    bounds: Bounds
+    readonly manager: ChartManager
+    readonly chartTypeName: ChartTypeName
+    readonly bounds: Bounds
 }

--- a/grapher/footer/FooterManager.ts
+++ b/grapher/footer/FooterManager.ts
@@ -2,14 +2,14 @@ import { TooltipProps } from "../tooltip/TooltipProps"
 import { Bounds } from "../../clientUtils/Bounds"
 
 export interface FooterManager {
-    fontSize?: number
-    sourcesLine?: string
-    note?: string
-    hasOWIDLogo?: boolean
-    shouldLinkToOwid?: boolean
-    originUrlWithProtocol?: string
-    isMediaCard?: boolean
+    readonly fontSize?: number
+    readonly sourcesLine?: string
+    readonly note?: string
+    readonly hasOWIDLogo?: boolean
+    readonly shouldLinkToOwid?: boolean
+    readonly originUrlWithProtocol?: string
+    readonly isMediaCard?: boolean
+    readonly tooltip?: TooltipProps
+    readonly tabBounds?: Bounds
     currentTab?: string
-    tooltip?: TooltipProps
-    tabBounds?: Bounds
 }

--- a/grapher/header/HeaderManager.ts
+++ b/grapher/header/HeaderManager.ts
@@ -1,13 +1,13 @@
 import { Bounds } from "../../clientUtils/Bounds"
 
 export interface HeaderManager {
-    fontSize?: number
-    currentTitle?: string
-    subtitle?: string
-    hideLogo?: boolean
-    shouldLinkToOwid?: boolean
-    isMediaCard?: boolean
-    logo?: string
-    canonicalUrl?: string
-    tabBounds?: Bounds
+    readonly fontSize?: number
+    readonly currentTitle?: string
+    readonly subtitle?: string
+    readonly hideLogo?: boolean
+    readonly shouldLinkToOwid?: boolean
+    readonly isMediaCard?: boolean
+    readonly logo?: string
+    readonly canonicalUrl?: string
+    readonly tabBounds?: Bounds
 }

--- a/grapher/lineCharts/LineChart.test.ts
+++ b/grapher/lineCharts/LineChart.test.ts
@@ -23,12 +23,19 @@ it("can create a new chart", () => {
 
     expect(chart.failMessage).toBeTruthy()
 
-    manager.selection = table.availableEntityNames
+    const chartWithoutError = new LineChart({
+        manager: {
+            ...manager,
+            selection: table.availableEntityNames,
+        },
+    })
 
-    expect(chart.failMessage).toEqual("")
-    expect(chart.series.length).toEqual(2)
-    expect(chart.placedSeries.length).toEqual(2)
-    expect(chart.placedSeries[0].placedPoints[0].x).toBeGreaterThan(0)
+    expect(chartWithoutError.failMessage).toEqual("")
+    expect(chartWithoutError.series.length).toEqual(2)
+    expect(chartWithoutError.placedSeries.length).toEqual(2)
+    expect(chartWithoutError.placedSeries[0].placedPoints[0].x).toBeGreaterThan(
+        0
+    )
 })
 
 it("can filter points with negative values when using a log scale", () => {

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -40,6 +40,7 @@ import {
     LinesProps,
     LineChartSeries,
     LineChartManager,
+    PlacedLineChartSeries,
 } from "./LineChartConstants"
 import { columnToLineChartSeriesArray } from "./LineChartUtils"
 import { OwidTable } from "../../coreTable/OwidTable"
@@ -51,6 +52,8 @@ import {
     makeSelectionArray,
 } from "../chart/ChartUtils"
 import { ColorScheme } from "../color/ColorScheme"
+import { CoreColumn } from "../../coreTable/CoreTableColumns"
+import { ColumnSlug } from "../../coreTable/CoreTableConstants"
 
 const BLUR_COLOR = "#eee"
 
@@ -91,7 +94,7 @@ class Lines extends React.Component<LinesProps> {
         )
     }
 
-    @computed private get focusedLines() {
+    @computed private get focusedLines(): readonly PlacedLineChartSeries[] {
         const { focusedSeriesNames } = this.props
         // If nothing is focused, everything is
         if (!focusedSeriesNames.length) return this.props.placedSeries
@@ -100,7 +103,7 @@ class Lines extends React.Component<LinesProps> {
         )
     }
 
-    @computed private get backgroundLines() {
+    @computed private get backgroundLines(): readonly PlacedLineChartSeries[] {
         const { focusedSeriesNames } = this.props
         return this.props.placedSeries.filter(
             (series) => !focusedSeriesNames.includes(series.seriesName)
@@ -109,7 +112,7 @@ class Lines extends React.Component<LinesProps> {
 
     // Don't display point markers if there are very many of them for performance reasons
     // Note that we're using circle elements instead of marker-mid because marker performance in Safari 10 is very poor for some reason
-    @computed private get hasMarkers() {
+    @computed private get hasMarkers(): boolean {
         if (this.props.hidePoints) return false
         return (
             sum(
@@ -120,7 +123,7 @@ class Lines extends React.Component<LinesProps> {
         )
     }
 
-    @computed private get strokeWidth() {
+    @computed private get strokeWidth(): number {
         return this.props.lineStrokeWidth ?? 1.5
     }
 
@@ -292,7 +295,7 @@ export class LineChart
         return makeSelectionArray(this.manager)
     }
 
-    seriesIsBlurred(series: LineChartSeries) {
+    seriesIsBlurred(series: LineChartSeries): boolean {
         return (
             this.isFocusMode &&
             !this.focusedSeriesNames.includes(series.seriesName)
@@ -433,16 +436,16 @@ export class LineChart
     defaultRightPadding = 1
 
     @observable hoveredSeriesName?: SeriesName
-    @action.bound onLegendClick() {
+    @action.bound onLegendClick(): void {
         if (this.manager.startSelectingWhenLineClicked)
             this.manager.isSelectingData = true
     }
 
-    @action.bound onLegendMouseOver(seriesName: SeriesName) {
+    @action.bound onLegendMouseOver(seriesName: SeriesName): void {
         this.hoveredSeriesName = seriesName
     }
 
-    @action.bound onLegendMouseLeave() {
+    @action.bound onLegendMouseLeave(): void {
         this.hoveredSeriesName = undefined
     }
 
@@ -450,7 +453,7 @@ export class LineChart
         return this.hoveredSeriesName ? [this.hoveredSeriesName] : []
     }
 
-    @computed get isFocusMode() {
+    @computed get isFocusMode(): boolean {
         return this.focusedSeriesNames.length > 0
     }
 
@@ -481,11 +484,11 @@ export class LineChart
         if (this.animSelection) this.animSelection.interrupt()
     }
 
-    @computed get renderUid() {
+    @computed get renderUid(): number {
         return guid()
     }
 
-    @computed get fontSize() {
+    @computed get fontSize(): number {
         return this.manager.baseFontSize ?? BASE_FONT_SIZE
     }
 
@@ -493,7 +496,7 @@ export class LineChart
         return this.bounds.right - (this.legendDimensions?.width || 0)
     }
 
-    @computed private get legendDimensions() {
+    @computed private get legendDimensions(): LineLegend | undefined {
         return this.manager.hideLegend
             ? undefined
             : new LineLegend({ manager: this })
@@ -584,11 +587,11 @@ export class LineChart
         return ""
     }
 
-    @computed private get yColumns() {
+    @computed private get yColumns(): readonly CoreColumn[] {
         return this.yColumnSlugs.map((slug) => this.transformedTable.get(slug))
     }
 
-    @computed protected get yColumnSlugs() {
+    @computed protected get yColumnSlugs(): readonly ColumnSlug[] {
         return autoDetectYColumnSlugs(this.manager)
     }
 
@@ -630,7 +633,7 @@ export class LineChart
     }
 
     @computed get series(): readonly LineChartSeries[] {
-        const arrOfSeries: LineChartSeries[] = flatten(
+        const arrOfSeries: readonly LineChartSeries[] = flatten(
             this.yColumns.map((col) =>
                 columnToLineChartSeriesArray(
                     col,
@@ -640,7 +643,7 @@ export class LineChart
             )
         )
 
-        this.colorScheme.assignColors(
+        return this.colorScheme.assignColors(
             arrOfSeries,
             this.manager.invertColorScheme,
             this.seriesStrategy === SeriesStrategy.entity
@@ -648,14 +651,13 @@ export class LineChart
                 : this.inputTable.columnDisplayNameToColorMap,
             this.manager.seriesColorMap
         )
-        return arrOfSeries
     }
 
     @computed get allPoints() {
         return flatten(this.series.map((series) => series.points))
     }
 
-    @computed get placedSeries() {
+    @computed get placedSeries(): readonly PlacedLineChartSeries[] {
         const { dualAxis } = this
         const { horizontalAxis, verticalAxis } = dualAxis
 
@@ -678,7 +680,7 @@ export class LineChart
 
     // Order of the legend items on a line chart should visually correspond
     // to the order of the lines as the approach the legend
-    @computed get labelSeries(): LineLabelSeries[] {
+    @computed get labelSeries(): readonly LineLabelSeries[] {
         // If there are any projections, ignore non-projection legends
         // Bit of a hack
         let seriesToShow = this.series

--- a/grapher/lineCharts/LineChartConstants.ts
+++ b/grapher/lineCharts/LineChartConstants.ts
@@ -6,31 +6,31 @@ import { TimeBound } from "../../clientUtils/TimeBounds"
 import { ChartSeries } from "../chart/ChartInterface"
 
 export interface LinePoint {
-    x: number
-    y: number
+    readonly x: number
+    readonly y: number
 }
 
 export interface LineChartSeries extends ChartSeries {
-    isProjection?: boolean
-    points: LinePoint[]
+    readonly isProjection?: boolean
+    readonly points: readonly LinePoint[]
 }
 
 export interface PlacedLineChartSeries extends LineChartSeries {
-    placedPoints: PointVector[]
+    readonly placedPoints: readonly PointVector[]
 }
 
 export interface LinesProps {
-    dualAxis: DualAxis
-    placedSeries: PlacedLineChartSeries[]
-    focusedSeriesNames: SeriesName[]
-    onHover: (hoverX: number | undefined) => void
-    hidePoints?: boolean
-    lineStrokeWidth?: number
+    readonly dualAxis: DualAxis
+    readonly placedSeries: readonly PlacedLineChartSeries[]
+    readonly focusedSeriesNames: readonly SeriesName[]
+    readonly onHover: (hoverX: number | undefined) => void
+    readonly hidePoints?: boolean
+    readonly lineStrokeWidth?: number
 }
 
 export interface LineChartManager extends ChartManager {
-    hidePoints?: boolean
-    lineStrokeWidth?: number
-    startHandleTimeBound?: TimeBound
-    canSelectMultipleEntities?: boolean
+    readonly hidePoints?: boolean
+    readonly lineStrokeWidth?: number
+    readonly startHandleTimeBound?: TimeBound
+    readonly canSelectMultipleEntities?: boolean
 }

--- a/grapher/lineLegend/LineLegend.tsx
+++ b/grapher/lineLegend/LineLegend.tsx
@@ -27,29 +27,29 @@ const MARKER_MARGIN = 4
 const ADD_BUTTON_HEIGHT = 30
 
 export interface LineLabelSeries extends ChartSeries {
-    label: string
-    yValue: number
-    annotation?: string
-    yRange?: [number, number]
+    readonly label: string
+    readonly yValue: number
+    readonly annotation?: string
+    readonly yRange?: readonly [number, number]
 }
 
 interface SizedSeries extends LineLabelSeries {
-    textWrap: TextWrap
-    annotationTextWrap?: TextWrap
-    width: number
-    height: number
+    readonly textWrap: TextWrap
+    readonly annotationTextWrap?: TextWrap
+    readonly width: number
+    readonly height: number
 }
 
 interface PlacedSeries extends SizedSeries {
-    origBounds: Bounds
+    readonly origBounds: Bounds
     bounds: Bounds
-    isOverlap: boolean
     repositions: number
     level: number
     totalLevels: number
+    isOverlap: boolean
 }
 
-function groupBounds(group: PlacedSeries[]) {
+function groupBounds(group: readonly PlacedSeries[]) {
     const first = group[0]
     const last = group[group.length - 1]
     const height = last.bounds.bottom - first.bounds.top
@@ -57,7 +57,7 @@ function groupBounds(group: PlacedSeries[]) {
     return new Bounds(first.bounds.x, first.bounds.y, width, height)
 }
 
-function stackGroupVertically(group: PlacedSeries[], y: number) {
+function stackGroupVertically(group: readonly PlacedSeries[], y: number) {
     let currentY = y
     group.forEach((mark) => {
         mark.bounds = mark.bounds.extend({ y: currentY })
@@ -141,19 +141,19 @@ class Label extends React.Component<{
 }
 
 export interface LineLegendManager {
-    startSelectingWhenLineClicked?: boolean
-    canAddData?: boolean
-    isSelectingData?: boolean
-    entityType?: string
-    labelSeries: LineLabelSeries[]
-    maxLegendWidth?: number
-    fontSize?: number
-    onLegendMouseOver?: (key: EntityName) => void
-    onLegendClick?: (key: EntityName) => void
-    onLegendMouseLeave?: () => void
-    focusedSeriesNames: EntityName[]
-    verticalAxis: VerticalAxis
-    legendX?: number
+    readonly startSelectingWhenLineClicked?: boolean
+    readonly canAddData?: boolean
+    readonly isSelectingData?: boolean
+    readonly entityType?: string
+    readonly labelSeries: readonly LineLabelSeries[]
+    readonly maxLegendWidth?: number
+    readonly fontSize?: number
+    readonly onLegendMouseOver?: (key: EntityName) => void
+    readonly onLegendClick?: (key: EntityName) => void
+    readonly onLegendMouseLeave?: () => void
+    readonly focusedSeriesNames: readonly EntityName[]
+    readonly verticalAxis: VerticalAxis
+    readonly legendX?: number
 }
 
 @observer
@@ -230,7 +230,7 @@ export class LineLegend extends React.Component<{
     }
 
     // Naive initial placement of each mark at the target height, before collision detection
-    @computed private get initialSeries(): PlacedSeries[] {
+    @computed private get initialSeries(): readonly PlacedSeries[] {
         const { verticalAxis } = this.manager
         const { legendX } = this
 
@@ -270,7 +270,7 @@ export class LineLegend extends React.Component<{
         )
     }
 
-    @computed get standardPlacement() {
+    @computed get standardPlacement(): readonly PlacedSeries[] {
         const { verticalAxis } = this.manager
 
         const groups: PlacedSeries[][] = cloneDeep(
@@ -341,7 +341,7 @@ export class LineLegend extends React.Component<{
     }
 
     // Overlapping placement, for when we really can't find a solution without overlaps.
-    @computed get overlappingPlacement() {
+    @computed get overlappingPlacement(): readonly PlacedSeries[] {
         const series = cloneDeep(this.initialSeries)
         for (let i = 0; i < series.length; i++) {
             const m1 = series[i]
@@ -356,7 +356,7 @@ export class LineLegend extends React.Component<{
         return series
     }
 
-    @computed get placedSeries() {
+    @computed get placedSeries(): readonly PlacedSeries[] {
         const nonOverlappingMinHeight =
             sumBy(this.initialSeries, (series) => series.bounds.height) +
             this.initialSeries.length * LEGEND_ITEM_MIN_SPACING
@@ -378,7 +378,7 @@ export class LineLegend extends React.Component<{
         return this.standardPlacement
     }
 
-    @computed private get backgroundSeries() {
+    @computed private get backgroundSeries(): readonly PlacedSeries[] {
         const { focusedSeriesNames } = this.manager
         const { isFocusMode } = this
         return this.placedSeries.filter((mark) =>
@@ -388,7 +388,7 @@ export class LineLegend extends React.Component<{
         )
     }
 
-    @computed private get focusedSeries() {
+    @computed private get focusedSeries(): readonly PlacedSeries[] {
         const { focusedSeriesNames } = this.manager
         const { isFocusMode } = this
         return this.placedSeries.filter((mark) =>

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -77,7 +77,7 @@ interface MapChartProps {
 }
 
 // Get the underlying geographical topology elements we're going to display
-const GeoFeatures: GeoFeature[] = (topojson.feature(
+const GeoFeatures: readonly GeoFeature[] = (topojson.feature(
     MapTopology as any,
     MapTopology.objects.world as any
 ) as any).features

--- a/grapher/mapCharts/MapChartConstants.ts
+++ b/grapher/mapCharts/MapChartConstants.ts
@@ -12,8 +12,8 @@ export type GeoFeature = GeoJSON.Feature<GeoJSON.GeometryObject>
 export type MapBracket = ColorScaleBin
 
 export interface MapEntity {
-    id: string | number | undefined
-    series:
+    readonly id: string | number | undefined
+    readonly series:
         | ChoroplethSeries
         | {
               value: string
@@ -21,38 +21,38 @@ export interface MapEntity {
 }
 
 export interface ChoroplethSeries extends ChartSeries {
-    value: number | string
-    displayValue: string
-    time: number
-    isSelected?: boolean
-    highlightFillColor: Color
+    readonly value: number | string
+    readonly displayValue: string
+    readonly time: number
+    readonly isSelected?: boolean
+    readonly highlightFillColor: Color
 }
 
 export interface ChoroplethMapProps {
-    choroplethData: Map<SeriesName, ChoroplethSeries>
-    bounds: Bounds
-    projection: MapProjectionName
-    defaultFill: string
-    focusBracket?: MapBracket
-    focusEntity?: MapEntity
-    onClick: (d: GeoFeature, ev: React.MouseEvent<SVGElement>) => void
-    onHover: (d: GeoFeature, ev: React.MouseEvent<SVGElement>) => void
-    onHoverStop: () => void
+    readonly choroplethData: Map<SeriesName, ChoroplethSeries>
+    readonly bounds: Bounds
+    readonly projection: MapProjectionName
+    readonly defaultFill: string
+    readonly focusBracket?: MapBracket
+    readonly focusEntity?: MapEntity
+    readonly onClick: (d: GeoFeature, ev: React.MouseEvent<SVGElement>) => void
+    readonly onHover: (d: GeoFeature, ev: React.MouseEvent<SVGElement>) => void
+    readonly onHoverStop: () => void
 }
 
 export interface RenderFeature {
-    id: string
-    geo: GeoFeature
-    path: string
-    bounds: Bounds
-    center: PointVector
+    readonly id: string
+    readonly geo: GeoFeature
+    readonly path: string
+    readonly bounds: Bounds
+    readonly center: PointVector
 }
 
 export interface MapChartManager extends ChartManager {
-    mapColumnSlug?: ColumnSlug
-    mapIsClickable?: boolean
+    readonly mapColumnSlug?: ColumnSlug
+    readonly mapIsClickable?: boolean
+    readonly type?: ChartTypeName // Used to determine the "Click to select" text in MapTooltip
+    readonly mapConfig?: MapConfig
+    readonly endTime?: Time
     currentTab?: string // Used to switch to chart tab on map click
-    type?: ChartTypeName // Used to determine the "Click to select" text in MapTooltip
-    mapConfig?: MapConfig
-    endTime?: Time
 }

--- a/grapher/mapCharts/MapColorLegends.tsx
+++ b/grapher/mapCharts/MapColorLegends.tsx
@@ -19,17 +19,17 @@ import {
 import { BASE_FONT_SIZE } from "../core/GrapherConstants"
 
 interface PositionedBin {
-    x: number
-    width: number
-    margin: number
-    bin: ColorScaleBin
+    readonly x: number
+    readonly width: number
+    readonly margin: number
+    readonly bin: ColorScaleBin
 }
 
 interface NumericLabel {
-    text: string
-    fontSize: number
+    readonly text: string
+    readonly fontSize: number
+    readonly priority?: boolean
     bounds: Bounds
-    priority?: boolean
     hidden: boolean
 }
 
@@ -37,36 +37,36 @@ const FOCUS_BORDER_COLOR = "#111"
 
 interface CategoricalMark {
     x: number
-    y: number
-    rectSize: number
-    label: {
+    readonly y: number
+    readonly rectSize: number
+    readonly label: {
         text: string
         bounds: Bounds
         fontSize: number
     }
-    bin: CategoricalBin
+    readonly bin: CategoricalBin
 }
 
 interface MarkLine {
-    totalWidth: number
-    marks: CategoricalMark[]
+    readonly totalWidth: number
+    readonly marks: readonly CategoricalMark[]
 }
 
 export interface MapLegendManager {
-    fontSize?: number
-    legendX?: number
-    categoryLegendY?: number
-    numericLegendY?: number
-    legendWidth?: number
-    legendHeight?: number
-    scale?: number
-    categoricalLegendData?: CategoricalBin[]
-    categoricalFocusBracket?: CategoricalBin
-    numericLegendData?: ColorScaleBin[]
-    numericFocusBracket?: ColorScaleBin
-    equalSizeBins?: boolean
-    onLegendMouseLeave?: () => void
-    onLegendMouseOver?: (d: CategoricalBin) => void
+    readonly fontSize?: number
+    readonly legendX?: number
+    readonly categoryLegendY?: number
+    readonly numericLegendY?: number
+    readonly legendWidth?: number
+    readonly legendHeight?: number
+    readonly scale?: number
+    readonly categoricalLegendData?: readonly CategoricalBin[]
+    readonly categoricalFocusBracket?: CategoricalBin
+    readonly numericLegendData?: readonly ColorScaleBin[]
+    readonly numericFocusBracket?: ColorScaleBin
+    readonly equalSizeBins?: boolean
+    readonly onLegendMouseLeave?: () => void
+    readonly onLegendMouseOver?: (d: CategoricalBin) => void
 }
 
 @observer

--- a/grapher/noDataModal/NoDataModal.tsx
+++ b/grapher/noDataModal/NoDataModal.tsx
@@ -7,10 +7,10 @@ import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus"
 import { faExchangeAlt } from "@fortawesome/free-solid-svg-icons/faExchangeAlt"
 
 export interface NoDataModalManager {
-    canChangeEntity?: boolean
-    canAddData?: boolean
+    readonly canChangeEntity?: boolean
+    readonly canAddData?: boolean
+    readonly entityType?: string
     isSelectingData?: boolean
-    entityType?: string
 }
 
 @observer

--- a/grapher/persistable/Persistable.ts
+++ b/grapher/persistable/Persistable.ts
@@ -9,7 +9,7 @@ export interface Persistable {
 // Todo: see if there's a better way to do this with Mobx
 export function objectWithPersistablesToObject<T>(
     objWithPersistables: T,
-    keysToSerialize: string[] = []
+    keysToSerialize: readonly string[] = []
 ): T {
     const obj = toJS(objWithPersistables) as any
     const keysSet = new Set(keysToSerialize)

--- a/grapher/scatterCharts/ComparisonLine.tsx
+++ b/grapher/scatterCharts/ComparisonLine.tsx
@@ -17,7 +17,7 @@ export interface ComparisonLineConfig {
 @observer
 export class ComparisonLine extends React.Component<{
     dualAxis: DualAxis
-    comparisonLine: ComparisonLineConfig
+    comparisonLine: Readonly<ComparisonLineConfig>
 }> {
     private renderUid = guid()
 

--- a/grapher/scatterCharts/ConnectedScatterLegend.tsx
+++ b/grapher/scatterCharts/ConnectedScatterLegend.tsx
@@ -5,11 +5,11 @@ import { TextWrap } from "../text/TextWrap"
 import { BASE_FONT_SIZE } from "../core/GrapherConstants"
 
 export interface ConnectedScatterLegendManager {
-    sidebarWidth: number
-    displayStartTime: string
-    displayEndTime: string
-    fontSize?: number
-    compareEndPointsOnly?: boolean
+    readonly sidebarWidth: number
+    readonly displayStartTime: string
+    readonly displayEndTime: string
+    readonly fontSize?: number
+    readonly compareEndPointsOnly?: boolean
 }
 
 export class ConnectedScatterLegend {

--- a/grapher/scatterCharts/MultiColorPolyline.tsx
+++ b/grapher/scatterCharts/MultiColorPolyline.tsx
@@ -5,19 +5,19 @@ import { observer } from "mobx-react"
 import { last } from "../../clientUtils/Util"
 
 interface MultiColorPolylinePoint {
-    x: number
-    y: number
-    color: string
+    readonly x: number
+    readonly y: number
+    readonly color: string
 }
 
 interface Point {
-    x: number
-    y: number
+    readonly x: number
+    readonly y: number
 }
 
 interface Segment {
-    points: Point[]
-    color: string
+    readonly points: Point[]
+    readonly color: string
 }
 
 function getMidpoint(a: Point, b: Point) {
@@ -35,7 +35,7 @@ function toPoint(point: MultiColorPolylinePoint): Point {
 }
 
 export function getSegmentsFromPoints(
-    points: MultiColorPolylinePoint[]
+    points: readonly MultiColorPolylinePoint[]
 ): Segment[] {
     const segments: Segment[] = []
     points.forEach((currentPoint) => {
@@ -62,7 +62,7 @@ export function getSegmentsFromPoints(
     return segments
 }
 
-function toSvgPoints(points: Point[]): string {
+function toSvgPoints(points: readonly Point[]): string {
     return points.map((p) => `${p.x.toFixed(2)},${p.y.toFixed(2)}`).join(" ")
 }
 
@@ -70,7 +70,7 @@ type MultiColorPolylineProps = Omit<
     React.SVGProps<SVGPolylineElement>,
     "fill" | "stroke" | "points" | "strokeLinecap"
 > & {
-    points: MultiColorPolylinePoint[]
+    points: readonly MultiColorPolylinePoint[]
 }
 
 @observer

--- a/grapher/scatterCharts/ScatterPlotChart.test.ts
+++ b/grapher/scatterCharts/ScatterPlotChart.test.ts
@@ -56,14 +56,17 @@ it("doesn't show 'No data' bin when there is no color column", () => {
 })
 
 it("can remove points outside domain", () => {
-    const manager: ScatterPlotManager = {
-        table: SynthesizeFruitTable(undefined, 2),
-    }
-    const chart = new ScatterPlotChart({ manager })
+    const table = SynthesizeFruitTable(undefined, 2)
+    const chart = new ScatterPlotChart({ manager: { table } })
     const initialCount = chart.allPoints.length
-    manager.xAxisConfig = { removePointsOutsideDomain: true, max: 1100 }
-    expect(chart.allPoints.length).toBeGreaterThan(0)
-    expect(chart.allPoints.length).toBeLessThan(initialCount)
+    const chartWithRemovedPoints = new ScatterPlotChart({
+        manager: {
+            table,
+            xAxisConfig: { removePointsOutsideDomain: true, max: 1100 },
+        },
+    })
+    expect(chartWithRemovedPoints.allPoints.length).toBeGreaterThan(0)
+    expect(chartWithRemovedPoints.allPoints.length).toBeLessThan(initialCount)
 })
 
 it("can filter points with negative values when using a log scale", () => {

--- a/grapher/scatterCharts/ScatterPlotChartConstants.ts
+++ b/grapher/scatterCharts/ScatterPlotChartConstants.ts
@@ -17,58 +17,58 @@ import { ChartSeries } from "../chart/ChartInterface"
 import { OwidTable } from "../../coreTable/OwidTable"
 
 export interface ScatterPlotManager extends ChartManager {
-    hideConnectedScatterLines?: boolean
-    scatterPointLabelStrategy?: ScatterPointLabelStrategy
-    addCountryMode?: EntitySelectionMode
-    xOverrideTime?: Time | undefined
-    tableAfterAuthorTimelineAndActiveChartTransformAndPopulationFilter?: OwidTable
-    excludedEntities?: EntityId[]
-    backgroundSeriesLimit?: number
-    hideLinesOutsideTolerance?: boolean
-    startTime?: Time
-    endTime?: Time
-    hasTimeline?: boolean
+    readonly hideConnectedScatterLines?: boolean
+    readonly scatterPointLabelStrategy?: ScatterPointLabelStrategy
+    readonly addCountryMode?: EntitySelectionMode
+    readonly xOverrideTime?: Time | undefined
+    readonly tableAfterAuthorTimelineAndActiveChartTransformAndPopulationFilter?: OwidTable
+    readonly excludedEntities?: readonly EntityId[]
+    readonly backgroundSeriesLimit?: number
+    readonly hideLinesOutsideTolerance?: boolean
+    readonly startTime?: Time
+    readonly endTime?: Time
+    readonly hasTimeline?: boolean
 }
 
 export interface ScatterTooltipProps {
-    yColumn: CoreColumn
-    xColumn: CoreColumn
-    series: ScatterSeries
-    maxWidth: number
-    fontSize: number
-    x: number
-    y: number
+    readonly yColumn: CoreColumn
+    readonly xColumn: CoreColumn
+    readonly series: ScatterSeries
+    readonly maxWidth: number
+    readonly fontSize: number
+    readonly x: number
+    readonly y: number
 }
 
 export interface ScatterSeries extends ChartSeries {
-    label: string
-    size: number
-    points: SeriesPoint[]
-    isScaleColor?: boolean
+    readonly label: string
+    readonly size: number
+    readonly points: readonly SeriesPoint[]
+    readonly isScaleColor?: boolean
 }
 
 export interface SeriesPoint {
-    x: number
-    y: number
-    size: number
-    entityName?: EntityName
-    label: string
-    color?: number | Color
-    timeValue: Time
-    time: {
-        x: number
-        y: number
-        span?: [number, number]
+    readonly x: number
+    readonly y: number
+    readonly size: number
+    readonly entityName?: EntityName
+    readonly label: string
+    readonly color?: number | Color
+    readonly timeValue: Time
+    readonly time: {
+        readonly x: number
+        readonly y: number
+        readonly span?: [number, number]
     }
 }
 
 export interface ScatterRenderPoint {
-    position: PointVector
-    color: Color
-    size: number
-    fontSize: number
-    label: string
-    time: {
+    readonly position: PointVector
+    readonly color: Color
+    readonly size: number
+    readonly fontSize: number
+    readonly label: string
+    readonly time: {
         x: number
         y: number
     }
@@ -77,43 +77,43 @@ export interface ScatterRenderPoint {
 export const ScatterLabelFontFamily = "Arial, sans-serif"
 
 export interface ScatterRenderSeries extends ChartSeries {
-    displayKey: string
-    size: number
-    points: ScatterRenderPoint[]
-    text: string
-    isHover?: boolean
-    isFocus?: boolean
-    isForeground?: boolean
+    readonly displayKey: string
+    readonly size: number
+    readonly points: readonly ScatterRenderPoint[]
+    readonly text: string
+    readonly isHover?: boolean
+    readonly isFocus?: boolean
+    readonly isForeground?: boolean
+    readonly startLabel?: ScatterLabel
+    readonly midLabels: readonly ScatterLabel[]
+    readonly endLabel?: ScatterLabel
+    readonly allLabels: readonly ScatterLabel[]
     offsetVector: PointVector
-    startLabel?: ScatterLabel
-    midLabels: ScatterLabel[]
-    endLabel?: ScatterLabel
-    allLabels: ScatterLabel[]
 }
 
 export interface ScatterLabel {
-    text: string
-    fontSize: number
-    fontWeight: number
-    color: Color
+    readonly text: string
+    readonly fontSize: number
+    readonly fontWeight: number
+    readonly color: Color
+    readonly series: ScatterRenderSeries
+    readonly isStart?: boolean
+    readonly isMid?: boolean
+    readonly isEnd?: boolean
     bounds: Bounds
-    series: ScatterRenderSeries
     isHidden?: boolean
-    isStart?: boolean
-    isMid?: boolean
-    isEnd?: boolean
 }
 
 export interface ScatterPointsWithLabelsProps {
-    seriesArray: ScatterSeries[]
-    hoveredSeriesNames: SeriesName[]
-    focusedSeriesNames: SeriesName[]
-    dualAxis: DualAxis
-    colorScale?: ColorScale
-    sizeDomain: [number, number]
-    onMouseOver: (series: ScatterSeries) => void
-    onMouseLeave: () => void
-    onClick: () => void
-    hideConnectedScatterLines: boolean
-    noDataModalManager: NoDataModalManager
+    readonly seriesArray: readonly ScatterSeries[]
+    readonly hoveredSeriesNames: readonly SeriesName[]
+    readonly focusedSeriesNames: readonly SeriesName[]
+    readonly dualAxis: DualAxis
+    readonly colorScale?: ColorScale
+    readonly sizeDomain: [number, number]
+    readonly onMouseOver: (series: ScatterSeries) => void
+    readonly onMouseLeave: () => void
+    readonly onClick: () => void
+    readonly hideConnectedScatterLines: boolean
+    readonly noDataModalManager: NoDataModalManager
 }

--- a/grapher/scatterCharts/ScatterPointsWithLabels.tsx
+++ b/grapher/scatterCharts/ScatterPointsWithLabels.tsx
@@ -149,38 +149,34 @@ export class ScatterPointsWithLabels extends React.Component<
         )
     }
 
-    @computed private get renderSeries(): ScatterRenderSeries[] {
+    @computed private get renderSeries(): readonly ScatterRenderSeries[] {
         // Draw the largest points first so that smaller ones can sit on top of them
-        const renderData = this.initialRenderSeries
-
-        for (const series of renderData) {
-            series.isHover = this.hoveredSeriesNames.includes(series.seriesName)
-            series.isFocus = this.focusedSeriesNames.includes(series.seriesName)
-            series.isForeground = series.isHover || series.isFocus
-            if (series.isHover) series.size += 1
-        }
-
-        for (const series of renderData) {
-            series.startLabel = makeStartLabel(
+        const renderData = this.initialRenderSeries.map((series) => ({
+            ...series,
+            isHover: this.hoveredSeriesNames.includes(series.seriesName),
+            isFocus: this.focusedSeriesNames.includes(series.seriesName),
+            isForeground: series.isHover || series.isFocus,
+            size: series.isHover ? series.size + 1 : series.size,
+            startLabel: makeStartLabel(
                 series,
                 this.isSubtleForeground,
                 this.hideConnectedScatterLines
-            )
-            series.midLabels = makeMidLabels(
+            ),
+            midLabels: makeMidLabels(
                 series,
                 this.isSubtleForeground,
                 this.hideConnectedScatterLines
-            )
-            series.endLabel = makeEndLabel(
+            ),
+            endLabel: makeEndLabel(
                 series,
                 this.isSubtleForeground,
                 this.hideConnectedScatterLines
-            )
-            series.allLabels = [series.startLabel]
+            ),
+            allLabels: [series.startLabel]
                 .concat(series.midLabels)
                 .concat([series.endLabel])
-                .filter((x) => x) as ScatterLabel[]
-        }
+                .filter((x) => x) as ScatterLabel[],
+        }))
 
         const labels = flatten(renderData.map((series) => series.allLabels))
 
@@ -201,13 +197,15 @@ export class ScatterPointsWithLabels extends React.Component<
         return renderData
     }
 
-    private hideUnselectedLabels(labelsByPriority: ScatterLabel[]) {
+    private hideUnselectedLabels(labelsByPriority: readonly ScatterLabel[]) {
         labelsByPriority
             .filter((label) => !label.series.isFocus && !label.series.isHover)
             .forEach((label) => (label.isHidden = true))
     }
 
-    private hideCollidingLabelsByPriority(labelsByPriority: ScatterLabel[]) {
+    private hideCollidingLabelsByPriority(
+        labelsByPriority: readonly ScatterLabel[]
+    ) {
         for (let i = 0; i < labelsByPriority.length; i++) {
             const higherPriorityLabel = labelsByPriority[i]
             if (higherPriorityLabel.isHidden) continue
@@ -249,7 +247,7 @@ export class ScatterPointsWithLabels extends React.Component<
 
     // todo: move this to bounds class with a test
     private moveLabelsInsideChartBounds(
-        labels: ScatterLabel[],
+        labels: readonly ScatterLabel[],
         bounds: Bounds
     ) {
         for (const label of labels) {

--- a/grapher/selection/SelectionArray.ts
+++ b/grapher/selection/SelectionArray.ts
@@ -16,8 +16,8 @@ interface Entity {
 
 export class SelectionArray {
     constructor(
-        selectedEntityNames: EntityName[] = [],
-        availableEntities: Entity[] = [],
+        selectedEntityNames: readonly EntityName[] = [],
+        availableEntities: readonly Entity[] = [],
         entityType = "country"
     ) {
         this.selectedEntityNames = selectedEntityNames.slice()
@@ -81,22 +81,24 @@ export class SelectionArray {
     }
 
     // Clears and sets selected entities
-    @action.bound setSelectedEntities(entityNames: EntityName[]) {
+    @action.bound setSelectedEntities(entityNames: readonly EntityName[]) {
         this.clearSelection()
         return this.addToSelection(entityNames)
     }
 
-    @action.bound addToSelection(entityNames: EntityName[]) {
+    @action.bound addToSelection(entityNames: readonly EntityName[]) {
         this.selectedEntityNames = this.selectedEntityNames.concat(entityNames)
         return this
     }
 
-    @action.bound addAvailableEntityNames(entities: Entity[]) {
+    @action.bound addAvailableEntityNames(entities: readonly Entity[]) {
         this.availableEntities.push(...entities)
         return this
     }
 
-    @action.bound setSelectedEntitiesByCode(entityCodes: EntityCode[]) {
+    @action.bound setSelectedEntitiesByCode(
+        entityCodes: readonly EntityCode[]
+    ) {
         const map = this.entityCodeToNameMap
         const codesInData = entityCodes.filter((code) => map.has(code))
         return this.setSelectedEntities(
@@ -104,7 +106,9 @@ export class SelectionArray {
         )
     }
 
-    @action.bound setSelectedEntitiesByEntityId(entityIds: EntityId[]) {
+    @action.bound setSelectedEntitiesByEntityId(
+        entityIds: readonly EntityId[]
+    ) {
         const map = this.entityIdToNameMap
         return this.setSelectedEntities(entityIds.map((id) => map.get(id)!))
     }

--- a/grapher/slideshowController/SlideShowController.tsx
+++ b/grapher/slideshowController/SlideShowController.tsx
@@ -1,13 +1,13 @@
 import { action } from "mobx"
 
 export interface SlideShowManager<SlideData> {
-    setSlide: (slide: SlideData) => void
+    readonly setSlide: (slide: SlideData) => void
 }
 
 // A "slide" is just a query string.
 export class SlideShowController<SlideData> {
     constructor(
-        slides: SlideData[] = [],
+        slides: readonly SlideData[] = [],
         currentIndex = 0,
         manager?: SlideShowManager<SlideData>
     ) {
@@ -15,7 +15,7 @@ export class SlideShowController<SlideData> {
         this.slides = slides
         this.manager = manager
     }
-    private slides: SlideData[]
+    private slides: readonly SlideData[]
     private currentIndex: number
     private manager?: SlideShowManager<SlideData>
 

--- a/grapher/slopeCharts/SlopeChart.tsx
+++ b/grapher/slopeCharts/SlopeChart.tsx
@@ -50,6 +50,7 @@ import { OwidTable } from "../../coreTable/OwidTable"
 import { Color } from "../../coreTable/CoreTableConstants"
 import { autoDetectYColumnSlugs, makeSelectionArray } from "../chart/ChartUtils"
 import { ColorSchemeName } from "../color/ColorConstants"
+import { EntityName } from "../../coreTable/OwidTableConstants"
 
 @observer
 export class SlopeChart
@@ -135,7 +136,7 @@ export class SlopeChart
         return makeSelectionArray(this.manager)
     }
 
-    @computed private get selectedEntityNames() {
+    @computed private get selectedEntityNames(): readonly EntityName[] {
         return this.selectionArray.selectedEntityNames
     }
 
@@ -166,7 +167,7 @@ export class SlopeChart
     }
 
     // Colors on the legend for which every matching group is focused
-    @computed get focusColors() {
+    @computed get focusColors(): readonly Color[] {
         const { colorsInUse } = this
         return colorsInUse.filter((color) => {
             const matchingSeriesNames = this.series
@@ -684,7 +685,7 @@ class LabelledSlopes extends React.Component<LabelledSlopesProps> {
         return flatten(this.props.seriesArr.map((g) => g.values))
     }
 
-    @computed private get xDomainDefault(): [number, number] {
+    @computed private get xDomainDefault(): readonly [number, number] {
         return domainExtent(
             this.allValues.map((v) => v.x),
             ScaleType.linear
@@ -695,18 +696,18 @@ class LabelledSlopes extends React.Component<LabelledSlopesProps> {
         return this.manager.yAxis?.scaleType || ScaleType.linear
     }
 
-    @computed private get yDomainDefault(): [number, number] {
+    @computed private get yDomainDefault(): readonly [number, number] {
         return domainExtent(
             this.allValues.map((v) => v.y),
             this.yScaleType || ScaleType.linear
         )
     }
 
-    @computed private get xDomain(): [number, number] {
+    @computed private get xDomain(): readonly [number, number] {
         return this.xDomainDefault
     }
 
-    @computed private get yDomain(): [number, number] {
+    @computed private get yDomain(): readonly [number, number] {
         const domain = this.manager.yAxis?.domain || [Infinity, -Infinity]
         const domainDefault = this.yDomainDefault
         return [
@@ -748,7 +749,7 @@ class LabelledSlopes extends React.Component<LabelledSlopesProps> {
                   column: yColumn,
               }).width
         return scaleLinear()
-            .domain(xDomain)
+            .domain(xDomain.slice())
             .range(bounds.padWidth(padding).xRange())
     }
 
@@ -756,7 +757,7 @@ class LabelledSlopes extends React.Component<LabelledSlopesProps> {
         return this.bounds.width / 5
     }
 
-    @computed private get initialSlopeData() {
+    @computed private get initialSlopeData(): readonly SlopeProps[] {
         const {
             data,
             isPortrait,
@@ -866,20 +867,20 @@ class LabelledSlopes extends React.Component<LabelledSlopesProps> {
         })
     }
 
-    @computed get backgroundGroups() {
+    @computed get backgroundGroups(): readonly SlopeProps[] {
         return this.slopeData.filter(
             (group) => !(group.isHovered || group.isFocused)
         )
     }
 
-    @computed get foregroundGroups() {
+    @computed get foregroundGroups(): readonly SlopeProps[] {
         return this.slopeData.filter(
             (group) => !!(group.isHovered || group.isFocused)
         )
     }
 
     // Get the final slope data with hover focusing and collision detection
-    @computed get slopeData(): SlopeProps[] {
+    @computed get slopeData(): readonly SlopeProps[] {
         const { focusedSeriesNames, hoveredSeriesNames } = this
         let slopeData = this.labelAccountedSlopeData
 
@@ -1011,7 +1012,7 @@ class LabelledSlopes extends React.Component<LabelledSlopesProps> {
             .attr("stroke-dashoffset", "0%")
     }
 
-    renderGroups(groups: SlopeProps[]) {
+    renderGroups(groups: readonly SlopeProps[]) {
         const { isLayerMode } = this
 
         return groups.map((slope) => (

--- a/grapher/slopeCharts/SlopeChartConstants.ts
+++ b/grapher/slopeCharts/SlopeChartConstants.ts
@@ -6,55 +6,55 @@ import { TextWrap } from "../text/TextWrap"
 import { Bounds } from "../../clientUtils/Bounds"
 
 export interface SlopeChartValue {
-    x: number
-    y: number
+    readonly x: number
+    readonly y: number
 }
 
 export interface SlopeChartSeries extends ChartSeries {
-    size: number
-    values: SlopeChartValue[]
+    readonly size: number
+    readonly values: readonly SlopeChartValue[]
 }
 
 export const DEFAULT_SLOPE_CHART_COLOR = "#ff7f0e"
 
 export interface SlopeProps extends ChartSeries {
-    isLayerMode: boolean
-    x1: number
-    y1: number
-    x2: number
-    y2: number
-    size: number
-    hasLeftLabel: boolean
-    hasRightLabel: boolean
-    labelFontSize: number
-    leftLabelBounds: Bounds
-    rightLabelBounds: Bounds
-    leftValueStr: string
-    rightValueStr: string
-    leftLabel: TextWrap
-    rightLabel: TextWrap
-    isFocused: boolean
-    isHovered: boolean
-    leftValueWidth: number
-    rightValueWidth: number
+    readonly isLayerMode: boolean
+    readonly x1: number
+    readonly y1: number
+    readonly x2: number
+    readonly y2: number
+    readonly size: number
+    readonly hasLeftLabel: boolean
+    readonly hasRightLabel: boolean
+    readonly labelFontSize: number
+    readonly leftLabelBounds: Bounds
+    readonly rightLabelBounds: Bounds
+    readonly leftValueStr: string
+    readonly rightValueStr: string
+    readonly leftLabel: TextWrap
+    readonly rightLabel: TextWrap
+    readonly isFocused: boolean
+    readonly isHovered: boolean
+    readonly leftValueWidth: number
+    readonly rightValueWidth: number
 }
 
 export interface LabelledSlopesProps {
-    manager: ChartManager
-    yColumn: CoreColumn
-    bounds: Bounds
-    seriesArr: SlopeChartSeries[]
-    focusKeys: string[]
-    hoverKeys: string[]
-    onMouseOver: (slopeProps: SlopeProps) => void
-    onMouseLeave: () => void
-    onClick: () => void
+    readonly manager: ChartManager
+    readonly yColumn: CoreColumn
+    readonly bounds: Bounds
+    readonly seriesArr: readonly SlopeChartSeries[]
+    readonly focusKeys: readonly string[]
+    readonly hoverKeys: readonly string[]
+    readonly onMouseOver: (slopeProps: SlopeProps) => void
+    readonly onMouseLeave: () => void
+    readonly onClick: () => void
 }
 
 export interface SlopeAxisProps {
-    bounds: Bounds
-    orient: "left" | "right"
-    column: CoreColumn
-    scale: any
-    scaleType: ScaleType
+    readonly bounds: Bounds
+    readonly orient: "left" | "right"
+    readonly column: CoreColumn
+    readonly scale: any
+    readonly scaleType: ScaleType
 }

--- a/grapher/sourcesTab/SourcesTab.tsx
+++ b/grapher/sourcesTab/SourcesTab.tsx
@@ -11,9 +11,9 @@ import { OwidColumnDef } from "../../coreTable/OwidTableConstants"
 const formatText = (s: string) => linkify(s).replace(/(?:\r\n|\r|\n)/g, "<br/>")
 
 export interface SourcesTabManager {
-    adminBaseUrl?: string
-    columnsWithSources: CoreColumn[]
-    showAdminControls?: boolean
+    readonly adminBaseUrl?: string
+    readonly columnsWithSources: readonly CoreColumn[]
+    readonly showAdminControls?: boolean
 }
 
 @observer

--- a/grapher/sparkBars/SparkBars.tsx
+++ b/grapher/sparkBars/SparkBars.tsx
@@ -14,21 +14,21 @@ enum BarState {
 }
 
 export interface SparkBarsProps<T> {
-    data: T[]
-    x: (d: T) => number
-    y: (d: T) => number | undefined
-    xDomain: [number, number]
-    currentX?: number
-    highlightedX?: number
-    renderValue?: (d: T | undefined) => JSX.Element | undefined
-    onHover?: (d: T | undefined, index: number | undefined) => void
-    className?: string
-    color?: string
+    readonly data: readonly T[]
+    readonly x: (d: T) => number
+    readonly y: (d: T) => number | undefined
+    readonly xDomain: [number, number]
+    readonly currentX?: number
+    readonly highlightedX?: number
+    readonly renderValue?: (d: T | undefined) => JSX.Element | undefined
+    readonly onHover?: (d: T | undefined, index: number | undefined) => void
+    readonly className?: string
+    readonly color?: string
 }
 
 export interface SparkBarsDatum {
-    time: number
-    value: number
+    readonly time: number
+    readonly value: number
 }
 
 @observer
@@ -67,7 +67,7 @@ export class SparkBars<T> extends React.Component<SparkBarsProps<T>> {
         return BarState.normal
     }
 
-    @computed get bars(): (T | undefined)[] {
+    @computed get bars(): readonly (T | undefined)[] {
         const indexed = keyBy(this.props.data, this.props.x)
         const [start, end] = this.props.xDomain
         const result = []

--- a/grapher/spreadsheet/Spreadsheet.stories.tsx
+++ b/grapher/spreadsheet/Spreadsheet.stories.tsx
@@ -14,6 +14,7 @@ import {
 } from "../chart/ChartTypeMap"
 import { OwidTableSlugs } from "../../coreTable/OwidTableConstants"
 import { ChartTypeSwitcher } from "../chart/ChartTypeSwitcher"
+import { ColumnSlug } from "../../coreTable/CoreTableConstants"
 
 export default {
     title: "Spreadsheet",
@@ -41,7 +42,7 @@ class Editor extends React.Component {
         this.table = getRandomTable()
     }
 
-    @computed get yColumnSlugs() {
+    @computed get yColumnSlugs(): readonly ColumnSlug[] {
         return this.table.suggestedYColumnSlugs
     }
 

--- a/grapher/stackedCharts/AbstractStackedChart.tsx
+++ b/grapher/stackedCharts/AbstractStackedChart.tsx
@@ -17,7 +17,7 @@ import {
 import { computed } from "mobx"
 import { observer } from "mobx-react"
 import React from "react"
-import { StackedSeries } from "./StackedConstants"
+import { StackedPoint, StackedSeries } from "./StackedConstants"
 import { OwidTable } from "../../coreTable/OwidTable"
 import {
     autoDetectSeriesStrategy,
@@ -26,11 +26,12 @@ import {
 } from "../chart/ChartUtils"
 import { easeLinear, scaleOrdinal, select } from "d3"
 import { ColorSchemes } from "../color/ColorSchemes"
+import { CoreColumn } from "../../coreTable/CoreTableColumns"
 
 export interface AbstactStackedChartProps {
-    bounds?: Bounds
-    manager: ChartManager
-    disableLinearInterpolation?: boolean // just for testing
+    readonly bounds?: Bounds
+    readonly manager: ChartManager
+    readonly disableLinearInterpolation?: boolean // just for testing
 }
 
 @observer
@@ -186,7 +187,7 @@ export class AbstactStackedChart
         return axis
     }
 
-    @computed private get yColumnsInSelectionOrder() {
+    @computed private get yColumnsInSelectionOrder(): readonly CoreColumn[] {
         // For stacked charts, we want the first selected series to be on top, so we reverse the order of the stacks.
         const slugsInSelectionOrder = this.manager.selectedColumnSlugs?.length
             ? this.manager.selectedColumnSlugs
@@ -223,7 +224,7 @@ export class AbstactStackedChart
             : this.columnsAsSeries
     }
 
-    @computed protected get allStackedPoints() {
+    @computed protected get allStackedPoints(): readonly StackedPoint[] {
         return flatten(this.series.map((series) => series.points))
     }
 
@@ -268,7 +269,7 @@ export class AbstactStackedChart
         return this.series.map((series) => series.color)
     }
 
-    @computed get unstackedSeries() {
+    @computed get unstackedSeries(): readonly StackedSeries[] {
         return this.rawSeries
             .filter((series) => series.rows.length)
             .map((series) => {
@@ -284,11 +285,11 @@ export class AbstactStackedChart
                         }
                     }),
                     color: this.getColorForSeries(seriesName),
-                } as StackedSeries
+                }
             })
     }
 
-    @computed get series() {
+    @computed get series(): readonly StackedSeries[] {
         return this.unstackedSeries
     }
 }

--- a/grapher/stackedCharts/StackedAreaChart.tsx
+++ b/grapher/stackedCharts/StackedAreaChart.tsx
@@ -30,10 +30,10 @@ import { stackSeries, withZeroesAsInterpolatedPoints } from "./StackedUtils"
 import { makeClipPath } from "../chart/ChartUtils"
 
 interface AreasProps extends React.SVGAttributes<SVGGElement> {
-    dualAxis: DualAxis
-    seriesArr: StackedSeries[]
-    focusedSeriesNames: SeriesName[]
-    onHover: (hoverIndex: number | undefined) => void
+    readonly dualAxis: DualAxis
+    readonly seriesArr: readonly StackedSeries[]
+    readonly focusedSeriesNames: readonly SeriesName[]
+    readonly onHover: (hoverIndex: number | undefined) => void
 }
 
 const BLUR_COLOR = "#ddd"
@@ -453,7 +453,7 @@ export class StackedAreaChart
             : 0
     }
 
-    @computed get series() {
+    @computed get series(): readonly StackedSeries[] {
         return stackSeries(withZeroesAsInterpolatedPoints(this.unstackedSeries))
     }
 }

--- a/grapher/stackedCharts/StackedConstants.ts
+++ b/grapher/stackedCharts/StackedConstants.ts
@@ -1,14 +1,13 @@
-import { Color } from "../../coreTable/CoreTableConstants"
 import { ChartSeries } from "../chart/ChartInterface"
 
 export interface StackedPoint {
-    x: number
-    y: number
+    readonly x: number
+    readonly y: number
+    readonly fake?: boolean
     yOffset: number
-    fake?: boolean
 }
 
 export interface StackedSeries extends ChartSeries {
-    points: StackedPoint[]
-    isProjection?: boolean
+    readonly points: readonly StackedPoint[]
+    readonly isProjection?: boolean
 }

--- a/grapher/stackedCharts/StackedUtils.ts
+++ b/grapher/stackedCharts/StackedUtils.ts
@@ -3,7 +3,7 @@ import { StackedSeries } from "./StackedConstants"
 
 // This method shift up the Y Values of a Series with Points in place.
 // Todo: use a lib?
-export const stackSeries = (seriesArr: StackedSeries[]) => {
+export const stackSeries = (seriesArr: readonly StackedSeries[]) => {
     seriesArr.forEach((series, seriesIndex) => {
         if (!seriesIndex) return // The first series does not need to be shifted
         series.points.forEach((point, pointIndex) => {
@@ -17,7 +17,7 @@ export const stackSeries = (seriesArr: StackedSeries[]) => {
 
 // Adds a Y = 0 value for each missing x value (where X is usually Time)
 export const withZeroesAsInterpolatedPoints = (
-    seriesArr: StackedSeries[]
+    seriesArr: readonly StackedSeries[]
 ): StackedSeries[] => {
     const allXValuesSorted = sortNumeric(
         uniq(

--- a/grapher/timeline/TimelineController.ts
+++ b/grapher/timeline/TimelineController.ts
@@ -3,15 +3,15 @@ import { TimeBound, TimeBoundValue } from "../../clientUtils/TimeBounds"
 import { findClosestTime, last } from "../../clientUtils/Util"
 
 export interface TimelineManager {
-    disablePlay?: boolean
-    formatTimeFn?: (time: Time) => string
-    isPlaying?: boolean
+    readonly disablePlay?: boolean
+    readonly formatTimeFn?: (time: Time) => string
+    readonly times: readonly Time[]
+    readonly msPerTick?: number
+    readonly onPlay?: () => void
     userHasSetTimeline?: boolean
-    times: Time[]
+    isPlaying?: boolean
     startHandleTimeBound: TimeBound
     endHandleTimeBound: TimeBound
-    msPerTick?: number
-    onPlay?: () => void
 }
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))

--- a/grapher/tooltip/TooltipProps.ts
+++ b/grapher/tooltip/TooltipProps.ts
@@ -4,12 +4,12 @@ export interface TooltipManager {
 }
 
 export interface TooltipProps {
-    x: number
-    y: number
-    offsetX?: number
-    offsetY?: number
-    offsetYDirection?: "upward" | "downward"
-    style?: React.CSSProperties
-    children?: React.ReactNode
-    tooltipManager: TooltipManager
+    readonly x: number
+    readonly y: number
+    readonly offsetX?: number
+    readonly offsetY?: number
+    readonly offsetYDirection?: "upward" | "downward"
+    readonly style?: React.CSSProperties
+    readonly children?: React.ReactNode
+    readonly tooltipManager: TooltipManager
 }

--- a/grapher/verticalColorLegend/VerticalColorLegend.tsx
+++ b/grapher/verticalColorLegend/VerticalColorLegend.tsx
@@ -7,31 +7,31 @@ import { BASE_FONT_SIZE } from "../core/GrapherConstants"
 import { Color } from "../../coreTable/CoreTableConstants"
 
 export interface VerticalColorLegendManager {
-    maxLegendWidth?: number
-    fontSize?: number
-    legendItems: LegendItem[]
-    title?: string
-    onLegendMouseOver?: (color: string) => void
-    onLegendClick?: (color: string) => void
-    onLegendMouseLeave?: () => void
-    legendX?: number
-    legendY?: number
-    activeColors: Color[]
-    focusColors?: Color[]
+    readonly maxLegendWidth?: number
+    readonly fontSize?: number
+    readonly legendItems: readonly LegendItem[]
+    readonly title?: string
+    readonly onLegendMouseOver?: (color: string) => void
+    readonly onLegendClick?: (color: string) => void
+    readonly onLegendMouseLeave?: () => void
+    readonly legendX?: number
+    readonly legendY?: number
+    readonly activeColors: readonly Color[]
+    readonly focusColors?: readonly Color[]
 }
 
 interface LegendItem {
-    label?: string
-    minText?: string
-    maxText?: string
-    color: Color
+    readonly label?: string
+    readonly minText?: string
+    readonly maxText?: string
+    readonly color: Color
 }
 
 interface SizedLegendSeries {
-    textWrap: TextWrap
-    color: Color
-    width: number
-    height: number
+    readonly textWrap: TextWrap
+    readonly color: Color
+    readonly width: number
+    readonly height: number
 }
 
 @observer

--- a/gridLang/GrammarUtils.ts
+++ b/gridLang/GrammarUtils.ts
@@ -1,4 +1,4 @@
-export const isBlankLine = (line: string[] | undefined) =>
+export const isBlankLine = (line: readonly string[] | undefined) =>
     line === undefined ? true : line.join("") === ""
 
 // Todo: figure out Matrix cell type and whether we need the double check
@@ -7,7 +7,7 @@ export const isEmpty = (value: any) => value === "" || value === undefined
 // Adapted from: https://github.com/dcporter/didyoumean.js/blob/master/didYouMean-1.2.1.js
 export const didYouMean = (
     str = "",
-    options: string[] = [],
+    options: readonly string[] = [],
     caseSensitive = false,
     threshold = 0.4,
     thresholdAbsolute = 20

--- a/gridLang/GridLangConstants.ts
+++ b/gridLang/GridLangConstants.ts
@@ -15,34 +15,34 @@ export type Grammar = { [keywordSlug: string]: CellDef }
 
 // A CellDef is a tuple: part keyword and the other half is the contents. The contents can be 1 cell, a list of cells, and/or a subtable.
 export interface CellDef {
-    keyword: string
-    cssClass: string
-    description: string
-    grammar?: Grammar
-    headerCellDef?: CellDef
-    terminalOptions?: CellDef[]
-    catchAllCellDef?: CellDef // Only used by vertical grammars, this cell def, if present, will be used if a keyword is unrecognized during parsing.
-    regex?: RegExp // A validation regex a value must pass. todo: seems like this is overloaded and used for testing keywords and contents.
-    requirementsDescription?: string
-    valuePlaceholder?: string
-    positionalCellDefs?: readonly CellDef[] // Additional cell types as positional arguments.
-    isHorizontalList?: boolean // a list type, such as "colors\tred\torange\tgreen"
-    parse?: (value: any) => any
+    readonly keyword: string
+    readonly cssClass: string
+    readonly description: string
+    readonly grammar?: Grammar
+    readonly headerCellDef?: CellDef
+    readonly terminalOptions?: CellDef[]
+    readonly catchAllCellDef?: CellDef // Only used by vertical grammars, this cell def, if present, will be used if a keyword is unrecognized during parsing.
+    readonly regex?: RegExp // A validation regex a value must pass. todo: seems like this is overloaded and used for testing keywords and contents.
+    readonly requirementsDescription?: string
+    readonly valuePlaceholder?: string
+    readonly positionalCellDefs?: readonly CellDef[] // Additional cell types as positional arguments.
+    readonly isHorizontalList?: boolean // a list type, such as "colors\tred\torange\tgreen"
+    readonly parse?: (value: any) => any
 }
 
 export interface ParsedCell {
-    errorMessage?: string
-    cssClasses?: string[]
-    optionKeywords?: string[]
-    comment?: string
-    cellDef?: CellDef
-    placeholder?: string
-    contents?: any
+    readonly errorMessage?: string
+    readonly cssClasses?: string[]
+    readonly optionKeywords?: string[]
+    readonly comment?: string
+    readonly cellDef?: CellDef
+    readonly placeholder?: string
+    readonly contents?: any
 }
 
 export interface CellPosition {
-    row: CellCoordinate
-    column: CellCoordinate
+    readonly row: CellCoordinate
+    readonly column: CellCoordinate
 }
 
 export const Origin: CellPosition = {

--- a/site/CountriesIndexPage.tsx
+++ b/site/CountriesIndexPage.tsx
@@ -10,7 +10,7 @@ interface Country {
 }
 
 export const CountriesIndexPage = (props: {
-    countries: Country[]
+    countries: readonly Country[]
     baseUrl: string
 }) => {
     const { countries, baseUrl } = props


### PR DESCRIPTION
Prompted by https://github.com/owid/owid-grapher/pull/856, I thought I would try out what happens if we turn every array to be `readonly`. 

As I said there:

> Every `@computed` getter returning an object or an array is prone to this type of errors right? Because it's memoized, any changes are persisted when it's retrieved again.
> 
> I wonder if we should (strive to, from now on) use types `Readonly` and `ReadonlyArray` in these computeds so that TypeScript prevents these problems?

I didn't run into any more bugs like in #856 in this PR so far, but I only went through parts of LineChart and ScatterPlot so far.

To me it seems like a good idea to default to `readonly` unless we need a mutable array, but we would need to write a whole lot of `readonly`s to do that. What do you think? 