### PR TITLE
fix: DiscreteBarChart and LineChart colors consistent

### DIFF
--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -458,15 +458,15 @@ export class DiscreteBarChart
 
     @computed private get colorScheme() {
         // If this DiscreteBarChart stems from a LineChart, we want to match its (default) color
-        // scheme OWID Distinct. Otherwise, use an all-blue color scheme (`null`) as default.
+        // scheme OWID Distinct. Otherwise, use an all-blue color scheme (`undefined`) as default.
         const defaultColorScheme = this.manager.isLineChart
             ? ColorSchemes["owid-distinct"]
-            : null
+            : undefined
 
         return (
             (this.manager.baseColorScheme
                 ? ColorSchemes[this.manager.baseColorScheme]
-                : null) ?? defaultColorScheme
+                : undefined) ?? defaultColorScheme
         )
     }
 

--- a/grapher/barCharts/DiscreteBarChartConstants.ts
+++ b/grapher/barCharts/DiscreteBarChartConstants.ts
@@ -10,6 +10,7 @@ export interface DiscreteBarSeries extends ChartSeries {
 export interface DiscreteBarChartManager extends ChartManager {
     showYearLabels?: boolean
     endTime?: Time
+    isLineChart?: boolean
 }
 
 export const DEFAULT_BAR_COLOR = "#2E5778"


### PR DESCRIPTION
Notion: [Bar charts - all bars are blue](https://www.notion.so/Bar-charts-all-bars-are-blue-1fdd648e33764370a1a05c90833fefe8)

This PR is live on _tufte_.

In fixing this, I decided to (slightly) differentiate the of behaviour DiscreteBarCharts depending on whether they are a collapsed line chart or a "real" DiscreteBarChart.

A collapsed line chart turned bar chart now:
* uses OWID Distinct as its default color scheme (like LineCharts do)
  * rationale: a line chart loaded with a single-year selection immediately has colored bars, rather than starting out with blue ones
* uses `colorScheme.assignColors()` to assign colors to entities, to keep colors consistent when it turns into a line chart again (and also when entities in the bar chart reorder)
  * rationale:
    * the colors stay the same when the bar chart turns into a line chart
    * when changing the year shown in the line chart, the colors identify the entity, not its position in the bar chart


On the other hand, a "real" bar chart _still_:
* uses `null` as its default color scheme, resulting in all-blue charts
  * rationale: I found changing all existing bar charts to use OWID Distinct could introduce a new distraction, where one could think the color represents another dimension. The all-blue default color scheme prevents this and makes bars more equal.
* uses `colorScheme.getUniqValueColorMap()` to assign colors to values
  * rationale: If we used `assignColors()` for normal bar charts, too, then this wonderful chart would look less wonderful:
![image](https://user-images.githubusercontent.com/2641501/114456593-53be7300-9bdd-11eb-87ce-d73f1ae5b641.png)


Your mileage may vary, and I'm happy to re-evaluate the logic I decided on (and hopefully simplify it!)