### PR TITLE
Fix ScatterPlot uses wrong time column 

### DIFF
--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -414,7 +414,14 @@ export class CoreTable<
     // But we can have charts with multiple time columns. Ideally each place that needs access to the timeColumn, would get the specific column
     // and not the first time column from the table.
     @imemo get timeColumn() {
-        // For now, return a day column first if present. But see note above about removing this method.
+        // "time" is the canonical time column slug.
+        // See LegacyToOwidTable where this column is injected for all Graphers.
+        const maybeTimeColumn = this.get(OwidTableSlugs.time)
+        if (maybeTimeColumn instanceof ColumnTypeMap.Time)
+            return maybeTimeColumn
+        // If a valid "time" column doesn't exist, find _some_ time column to use.
+        // This is somewhat unreliable and currently only used to infer the time
+        // column on explorers.
         return (
             this.columnsAsArray.find(
                 (col) => col instanceof ColumnTypeMap.Day
@@ -428,7 +435,7 @@ export class CoreTable<
             this.columnsAsArray.find(
                 (col) => col instanceof ColumnTypeMap.Quarter
             ) ??
-            this.get(OwidTableSlugs.time)
+            maybeTimeColumn
         )
     }
 

--- a/coreTable/CoreTableColumns.ts
+++ b/coreTable/CoreTableColumns.ts
@@ -724,6 +724,7 @@ export const ColumnTypeMap = {
     Date: DateColumn,
     Year: YearColumn,
     Quarter: QuarterColumn,
+    Time: TimeColumn,
     Boolean: BooleanColumn,
     Currency: CurrencyColumn,
     Percentage: PercentageColumn,

--- a/coreTable/OwidTable.test.ts
+++ b/coreTable/OwidTable.test.ts
@@ -8,7 +8,7 @@ import {
 import { BlankOwidTable, OwidTable } from "./OwidTable"
 import { ColumnTypeNames } from "./CoreColumnDef"
 import { ErrorValueTypes } from "./ErrorValues"
-import { OwidColumnDef } from "./OwidTableConstants"
+import { OwidColumnDef, OwidTableSlugs } from "./OwidTableConstants"
 
 const sampleRows = [
     {
@@ -102,12 +102,44 @@ it("can group data by entity and time", () => {
     expect(timeValues.filter((value) => isNaN(value as number))).toEqual([])
 })
 
-it("prefers a day column when both year and day are in the chart", () => {
-    const csv = `entityName,entityCode,entityId,pop,year,day
-usa,usa,1,322,2000,2`
+describe("timeColumn", () => {
+    it("uses 'time' as the canonical timeColumn", () => {
+        const columnStore = {
+            [OwidTableSlugs.entityName]: ["usa"],
+            [OwidTableSlugs.time]: [2000],
+            year: [2000],
+            day: ["2000-01-01"],
+            x: [0],
+        }
+        const colDefs: OwidColumnDef[] = [
+            {
+                slug: "year",
+                type: ColumnTypeNames.Year,
+            },
+            {
+                slug: "day",
+                type: ColumnTypeNames.Day,
+            },
+            {
+                slug: OwidTableSlugs.time,
+                type: ColumnTypeNames.Year,
+            },
+            {
+                slug: "x",
+                type: ColumnTypeNames.Numeric,
+            },
+        ]
+        const table = new OwidTable(columnStore, colDefs)
+        expect(table.timeColumn.slug).toEqual(OwidTableSlugs.time)
+    })
 
-    const table = new OwidTable(csv)
-    expect(table.timeColumn!.slug).toBe("day")
+    it("prefers a day column when both year and day are in the chart", () => {
+        const csv = `entityName,entityCode,entityId,pop,year,day
+    usa,usa,1,322,2000,2`
+
+        const table = new OwidTable(csv)
+        expect(table.timeColumn!.slug).toBe("day")
+    })
 })
 
 it("can get the latest values for an entity", () => {

--- a/coreTable/OwidTable.ts
+++ b/coreTable/OwidTable.ts
@@ -127,10 +127,6 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         return this.sortedByTime.get(this.timeColumn.slug).values
     }
 
-    @imemo get hasDayColumn() {
-        return this.has(OwidTableSlugs.day)
-    }
-
     @imemo get rowIndicesByEntityName() {
         return this.rowIndex([this.entityNameSlug])
     }

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1240,11 +1240,16 @@ export class Grapher
             )
         )
 
+        const originalTimeSlugs = this.activeColumnSlugs.map(
+            (slug) => this.inputTable.get(slug).originalTimeColumnSlug
+        )
+
         // not all of these columns might actually exist in our inputTable, so we intersect them with
         // the actually-existing column slugs below
         const maybeRequiredColumnSlugs = excludeUndefined([
             ...this.activeColumnSlugs,
             ...annotationSlugs,
+            ...originalTimeSlugs,
             this.inputTable.timeColumn.slug,
             this.inputTable.entityNameSlug,
             this.inputTable.entityIdColumn.slug,

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -162,6 +162,7 @@ import {
 } from "../../settings/clientSettings"
 import { legacyToCurrentGrapherQueryParams } from "./GrapherUrlMigrations"
 import { Url } from "../../clientUtils/urls/Url"
+import { ColumnTypeMap } from "../../coreTable/CoreTableColumns"
 
 declare const window: any
 
@@ -2210,26 +2211,26 @@ export class Grapher
     }
 
     @computed get timeParam() {
-        const formatAsDay = this.table.hasDayColumn
-        if (
-            this.isOnMapTab &&
-            this.map.time !== undefined &&
-            this.hasUserChangedMapTimeHandle
-        )
-            return timeBoundToTimeBoundString(this.map.time, formatAsDay)
+        const { timeColumn } = this.table
+        const formatTime = (t: Time) =>
+            timeBoundToTimeBoundString(
+                t,
+                timeColumn instanceof ColumnTypeMap.Day
+            )
+
+        if (this.isOnMapTab) {
+            return this.map.time !== undefined &&
+                this.hasUserChangedMapTimeHandle
+                ? formatTime(this.map.time)
+                : undefined
+        }
+
         if (!this.hasUserChangedTimeHandles) return undefined
 
-        const [startHandleTime, rightHandleTime] = this.timelineHandleTimeBounds
-        const startTimeBoundString = timeBoundToTimeBoundString(
-            startHandleTime,
-            formatAsDay
+        const [startTime, endTime] = this.timelineHandleTimeBounds.map(
+            formatTime
         )
-        return startHandleTime === rightHandleTime
-            ? startTimeBoundString
-            : `${startTimeBoundString}..${timeBoundToTimeBoundString(
-                  rightHandleTime,
-                  formatAsDay
-              )}`
+        return startTime === endTime ? startTime : `${startTime}..${endTime}`
     }
 
     msPerTick = DEFAULT_MS_PER_TICK


### PR DESCRIPTION
Notion: [Fix ScatterPlot uses wrong time column](https://www.notion.so/Fix-ScatterPlot-using-wrong-time-column-190a88cd3cbf47e7aff2ea6622086f59). 

There were two problems:

- The `timeColumn` was inferred to be the first column of time type. This meant that an `originalTime` column could end up the inferred time column for the whole table.
- We started dropping `originalTime` columns in https://github.com/owid/owid-grapher/pull/830.

