### PR TITLE
fix: CoreTable#complete() does not append missing rows

### DIFF
--- a/adminSiteServer/testPageRouter.tsx
+++ b/adminSiteServer/testPageRouter.tsx
@@ -12,14 +12,18 @@ import {
     BAKED_GRAPHER_URL,
     BAKED_BASE_URL,
 } from "../settings/serverSettings"
-import * as querystring from "querystring"
-import * as lodash from "lodash"
-import * as url from "url"
 import { excludeUndefined, parseIntOrUndefined } from "../clientUtils/Util"
 import { grapherToSVG } from "../baker/GrapherImageBaker"
-import { EntitySelectionMode } from "../grapher/core/GrapherConstants"
+import {
+    ChartTypeName,
+    EntitySelectionMode,
+    GrapherTabOption,
+    StackMode,
+} from "../grapher/core/GrapherConstants"
+import { Url } from "../clientUtils/urls/Url"
 
 const IS_LIVE = ADMIN_BASE_URL === "https://owid.cloud"
+const DEFAULT_COMPARISON_URL = "https://ourworldindata.org"
 
 const testPageRouter = Router()
 
@@ -28,12 +32,249 @@ interface ChartItem {
     slug: string
 }
 
+function parseStringArrayOrUndefined(param: string | undefined): string[] {
+    if (param === undefined) return []
+    return param.split(",")
+}
+
+function parseIntArrayOrUndefined(param: string | undefined): number[] {
+    return excludeUndefined(
+        parseStringArrayOrUndefined(param).map(parseIntOrUndefined)
+    )
+}
+
+interface EmbedTestPageQueryParams {
+    readonly originalUrl: string
+    readonly comparisonUrl?: string
+    readonly perPage?: string
+    readonly page?: string
+    readonly random?: string
+    readonly tab?: GrapherTabOption
+    readonly type?: ChartTypeName
+    readonly logLinear?: string
+    readonly comparisonLines?: string
+    readonly stackMode?: StackMode
+    readonly relativeToggle?: string
+    readonly categoricalLegend?: string
+    readonly mixedTimeTypes?: string
+    readonly addCountryMode?: EntitySelectionMode
+    readonly includePrivate?: string
+    readonly ids?: string
+    readonly datasetIds?: string
+    readonly namespace?: string
+    readonly namespaces?: string
+}
+
+async function propsFromQueryParams(
+    params: EmbedTestPageQueryParams
+): Promise<EmbedTestPageProps> {
+    const page = params.page
+        ? expectInt(params.page)
+        : params.random
+        ? Math.floor(1 + Math.random() * 180) // Sample one of 180 pages. Some charts won't ever get picked but good enough.
+        : 1
+    const perPage = parseIntOrUndefined(params.perPage) ?? 20
+    const ids = parseIntArrayOrUndefined(params.ids)
+    const datasetIds = parseIntArrayOrUndefined(params.datasetIds)
+    const namespaces =
+        parseStringArrayOrUndefined(params.namespaces) ??
+        (params.namespace ? [params.namespace] : [])
+
+    let query = Chart.createQueryBuilder("charts")
+        .where("publishedAt IS NOT NULL")
+        .limit(perPage)
+        .offset(perPage * (page - 1))
+        .orderBy("id", "ASC")
+
+    let tab = params.tab
+
+    if (params.type) {
+        if (params.type === ChartTypeName.WorldMap) {
+            query = query.andWhere(`config->"$.hasMapTab" IS TRUE`)
+            tab = tab || GrapherTabOption.map
+        } else {
+            if (params.type === "LineChart") {
+                query = query.andWhere(
+                    `(
+                        config->"$.type" = "LineChart"
+                        OR config->"$.type" IS NULL
+                    ) AND config->"$.hasChartTab" IS TRUE`
+                )
+            } else {
+                query = query.andWhere(
+                    `config->"$.type" = :type AND config->"$.hasChartTab" IS TRUE`,
+                    { type: params.type }
+                )
+            }
+            tab = tab || GrapherTabOption.chart
+        }
+    }
+
+    if (params.logLinear) {
+        query = query.andWhere(
+            `config->'$.yAxis.canChangeScaleType' IS TRUE OR config->>'$.xAxis.canChangeScaleType' IS TRUE`
+        )
+        tab = GrapherTabOption.chart
+    }
+
+    if (params.comparisonLines) {
+        query = query.andWhere(`config->'$.comparisonLines[0].yEquals' != ''`)
+        tab = GrapherTabOption.chart
+    }
+
+    if (params.stackMode) {
+        query = query.andWhere(`config->'$.stackMode' = :stackMode`, {
+            stackMode: params.stackMode,
+        })
+        tab = GrapherTabOption.chart
+    }
+
+    if (params.relativeToggle) {
+        query = query.andWhere(`config->'$.hideRelativeToggle' IS FALSE`)
+        tab = GrapherTabOption.chart
+    }
+
+    if (params.categoricalLegend) {
+        // This is more of a heuristic, since this query can potentially include charts that don't
+        // have a visible categorial legend, and can leave out some that have one.
+        // But in practice it seems to work reasonably well.
+        query = query.andWhere(
+            `json_length(config->'$.map.colorScale.customCategoryColors') > 1`
+        )
+        tab = GrapherTabOption.map
+    }
+
+    if (params.mixedTimeTypes) {
+        query = query.andWhere(
+            `
+            (
+                SELECT COUNT(DISTINCT CASE
+                    WHEN variables.display->"$.yearIsDay" IS NULL
+                    THEN "year"
+                    ELSE "day"
+                END) as timeTypeCount
+                FROM variables
+                JOIN chart_dimensions ON chart_dimensions.variableId = variables.id
+                WHERE chart_dimensions.chartId = charts.id
+            ) >= 2
+        `
+        )
+    }
+
+    if (params.addCountryMode) {
+        const mode = params.addCountryMode
+        if (mode === EntitySelectionMode.MultipleEntities) {
+            query = query.andWhere(
+                `config->'$.addCountryMode' IS NULL OR config->'$.addCountryMode' = :mode`,
+                {
+                    mode: EntitySelectionMode.MultipleEntities,
+                }
+            )
+        } else {
+            query = query.andWhere(`config->'$.addCountryMode' = :mode`, {
+                mode,
+            })
+        }
+    }
+
+    if (ids.length > 0) {
+        query = query.andWhere(`charts.id IN (${params.ids})`)
+    }
+
+    if (tab === GrapherTabOption.map) {
+        query = query.andWhere(`config->"$.hasMapTab" IS TRUE`)
+    } else if (tab === GrapherTabOption.chart) {
+        query = query.andWhere(`config->"$.hasChartTab" IS TRUE`)
+    }
+
+    // Exclude charts that have the "Private" tag assigned, unless `includePrivate` is passed.
+    // The data for these charts is not included in the public database dump used to populate
+    // staging and local, so they are not comparable.
+    if (params.includePrivate === undefined) {
+        query.andWhere(`
+            NOT EXISTS(
+                SELECT *
+                FROM tags
+                JOIN chart_tags ON chart_tags.tagId = tags.id
+                WHERE chart_tags.chartId = charts.id
+                AND tags.name = 'Private'
+            )
+        `)
+    }
+
+    if (datasetIds.length > 0) {
+        const datasetIds = params.datasetIds
+        query.andWhere(
+            `
+            EXISTS(
+                SELECT *
+                FROM variables
+                INNER JOIN chart_dimensions ON chart_dimensions.variableId = variables.id
+                WHERE variables.datasetId IN (:datasetIds)
+                AND chart_dimensions.chartId = charts.id
+            )
+        `,
+            { datasetIds }
+        )
+    }
+
+    if (namespaces.length > 0) {
+        query.andWhere(
+            `
+            EXISTS(
+                SELECT *
+                FROM datasets
+                INNER JOIN variables ON variables.datasetId = datasets.id
+                INNER JOIN chart_dimensions ON chart_dimensions.variableId = variables.id
+                WHERE datasets.namespace IN (:namespaces)
+                AND chart_dimensions.chartId = charts.id
+            )
+        `,
+            { namespaces: namespaces }
+        )
+    }
+
+    const charts: ChartItem[] = (await query.getMany()).map((c) => ({
+        id: c.id,
+        slug: c.config.slug,
+    }))
+
+    if (tab) {
+        charts.forEach((c) => (c.slug += `?tab=${tab}`))
+    }
+
+    const count = await query.getCount()
+    const numPages = Math.ceil(count / perPage)
+
+    const originalUrl = Url.fromURL(params.originalUrl)
+    const prevPageUrl =
+        page > 1
+            ? originalUrl.updateQueryParams({ page: (page - 1).toString() })
+                  .fullUrl
+            : undefined
+    const nextPageUrl =
+        page < numPages
+            ? originalUrl.updateQueryParams({ page: (page + 1).toString() })
+                  .fullUrl
+            : undefined
+
+    return {
+        prevPageUrl: prevPageUrl,
+        nextPageUrl: nextPageUrl,
+        charts: charts,
+        currentPage: page,
+        totalPages: numPages,
+        comparisonUrl: params.comparisonUrl ?? "https://ourworldindata.org",
+    }
+}
+
 interface EmbedTestPageProps {
     prevPageUrl?: string
     nextPageUrl?: string
     currentPage?: number
     totalPages?: number
     charts: ChartItem[]
+    comparisonUrl: string
 }
 
 function EmbedTestPage(props: EmbedTestPageProps) {
@@ -105,7 +346,7 @@ function EmbedTestPage(props: EmbedTestPageProps) {
             <body>
                 <div className="row">
                     <div className="side-by-side">
-                        <h3>ourworldindata.org</h3>
+                        <h3>{props.comparisonUrl}</h3>
                         {!IS_LIVE && <h3>{BAKED_BASE_URL}</h3>}
                     </div>
                 </div>
@@ -116,7 +357,7 @@ function EmbedTestPage(props: EmbedTestPageProps) {
                         </div>
                         <div className="side-by-side">
                             <iframe
-                                src={`https://ourworldindata.org/grapher/${chart.slug}`}
+                                src={`${props.comparisonUrl}/grapher/${chart.slug}`}
                                 loading="lazy"
                             />
                             {!IS_LIVE && (
@@ -145,217 +386,11 @@ function EmbedTestPage(props: EmbedTestPageProps) {
 }
 
 testPageRouter.get("/embeds", async (req, res) => {
-    const numPerPage = parseIntOrUndefined(req.query.perPage) ?? 20
-    const page = req.query.page
-        ? expectInt(req.query.page)
-        : req.query.random
-        ? Math.floor(1 + Math.random() * 180) // Sample one of 180 pages. Some charts won't ever get picked but good enough.
-        : 1
-
-    let query = Chart.createQueryBuilder("charts")
-        .where("publishedAt IS NOT NULL")
-        .limit(numPerPage)
-        .offset(numPerPage * (page - 1))
-        .orderBy("id", "ASC")
-
-    let tab = req.query.tab
-
-    if (req.query.type) {
-        if (req.query.type === "ChoroplethMap") {
-            query = query.andWhere(`config->"$.hasMapTab" IS TRUE`)
-            tab = tab || "map"
-        } else {
-            if (req.query.type === "LineChart") {
-                query = query.andWhere(
-                    `(
-                        config->"$.type" = "LineChart"
-                        OR config->"$.type" IS NULL
-                    ) AND config->"$.hasChartTab" IS TRUE`
-                )
-            } else {
-                query = query.andWhere(
-                    `config->"$.type" = :type AND config->"$.hasChartTab" IS TRUE`,
-                    { type: req.query.type }
-                )
-            }
-            tab = tab || "chart"
-        }
-    }
-
-    if (req.query.logLinear) {
-        query = query.andWhere(
-            `config->'$.yAxis.canChangeScaleType' IS TRUE OR config->>'$.xAxis.canChangeScaleType' IS TRUE`
-        )
-        tab = "chart"
-    }
-
-    if (req.query.comparisonLines) {
-        query = query.andWhere(`config->'$.comparisonLines[0].yEquals' != ''`)
-        tab = "chart"
-    }
-
-    if (req.query.stackMode) {
-        query = query.andWhere(`config->'$.stackMode' = 'relative'`)
-        tab = "chart"
-    }
-
-    if (req.query.relativeToggle) {
-        query = query.andWhere(`config->'$.hideRelativeToggle' IS FALSE`)
-        tab = "chart"
-    }
-
-    if (req.query.categoricalLegend) {
-        // This is more of a heuristic, since this query can potentially include charts that don't
-        // have a visible categorial legend, and can leave out some that have one.
-        // But in practice it seems to work reasonably well.
-        query = query.andWhere(
-            `json_length(config->'$.map.colorScale.customCategoryColors') > 1`
-        )
-        tab = "map"
-    }
-
-    if (req.query.mixedTimeTypes) {
-        query = query.andWhere(
-            `
-            (
-                SELECT COUNT(DISTINCT CASE
-                    WHEN variables.display->"$.yearIsDay" IS NULL
-                    THEN "year"
-                    ELSE "day"
-                END) as timeTypeCount
-                FROM variables
-                JOIN chart_dimensions ON chart_dimensions.variableId = variables.id
-                WHERE chart_dimensions.chartId = charts.id
-            ) >= 2
-        `
-        )
-    }
-
-    if (req.query.addCountryMode) {
-        const mode = req.query.addCountryMode
-        if (mode === "multiple") {
-            query = query.andWhere(
-                `config->'$.addCountryMode' IS NULL OR config->'$.addCountryMode' = :mode`,
-                {
-                    mode: EntitySelectionMode.MultipleEntities,
-                }
-            )
-        } else if (mode === "single") {
-            query = query.andWhere(`config->'$.addCountryMode' = :mode`, {
-                mode: EntitySelectionMode.SingleEntity,
-            })
-        } else if (mode === "disabled") {
-            query = query.andWhere(`config->'$.addCountryMode' = :mode`, {
-                mode: EntitySelectionMode.Disabled,
-            })
-        }
-    }
-
-    if (req.query.ids) {
-        query = query.andWhere(`charts.id IN (${req.query.ids})`)
-    }
-
-    if (tab === "map") {
-        query = query.andWhere(`config->"$.hasMapTab" IS TRUE`)
-    } else if (tab === "chart") {
-        query = query.andWhere(`config->"$.hasChartTab" IS TRUE`)
-    }
-
-    // Exclude charts that have the "Private" tag assigned, unless `includePrivate` is passed.
-    // The data for these charts is not included in the public database dump used to populate
-    // staging and local, so they are not comparable.
-    if (req.query.includePrivate === undefined) {
-        query.andWhere(`
-            NOT EXISTS(
-                SELECT *
-                FROM tags
-                JOIN chart_tags ON chart_tags.tagId = tags.id
-                WHERE chart_tags.chartId = charts.id
-                AND tags.name = 'Private'
-            )
-        `)
-    }
-
-    if (req.query.datasetIds) {
-        const datasetIds = excludeUndefined(
-            req.query.datasetIds.split(",").map(parseIntOrUndefined)
-        )
-        query.andWhere(
-            `
-            EXISTS(
-                SELECT *
-                FROM variables
-                INNER JOIN chart_dimensions ON chart_dimensions.variableId = variables.id
-                WHERE variables.datasetId IN (:datasetIds)
-                AND chart_dimensions.chartId = charts.id
-            )
-        `,
-            { datasetIds }
-        )
-    }
-
-    const namespaces = req.query.namespaces
-        ? req.query.namespaces.split(",")
-        : req.query.namespace
-        ? [req.query.namespace]
-        : []
-
-    if (namespaces.length > 0) {
-        query.andWhere(
-            `
-            EXISTS(
-                SELECT *
-                FROM datasets
-                INNER JOIN variables ON variables.datasetId = datasets.id
-                INNER JOIN chart_dimensions ON chart_dimensions.variableId = variables.id
-                WHERE datasets.namespace IN (:namespaces)
-                AND chart_dimensions.chartId = charts.id
-            )
-        `,
-            { namespaces: namespaces }
-        )
-    }
-
-    const charts: ChartItem[] = (await query.getMany()).map((c) => ({
-        id: c.id,
-        slug: c.config.slug,
-    }))
-
-    if (tab) {
-        charts.forEach((c) => (c.slug += `?tab=${tab}`))
-    }
-
-    const count = await query.getCount()
-    const numPages = Math.ceil(count / numPerPage)
-
-    const prevPageUrl =
-        page > 1
-            ? (url.parse(req.originalUrl).pathname as string) +
-              "?" +
-              querystring.stringify(
-                  lodash.extend({}, req.query, { page: page - 1 })
-              )
-            : undefined
-    const nextPageUrl =
-        page < numPages
-            ? (url.parse(req.originalUrl).pathname as string) +
-              "?" +
-              querystring.stringify(
-                  lodash.extend({}, req.query, { page: page + 1 })
-              )
-            : undefined
-
-    res.send(
-        renderToHtmlPage(
-            <EmbedTestPage
-                prevPageUrl={prevPageUrl}
-                nextPageUrl={nextPageUrl}
-                charts={charts}
-                currentPage={page}
-                totalPages={numPages}
-            />
-        )
-    )
+    const props = await propsFromQueryParams({
+        ...req.query,
+        originalUrl: req.originalUrl,
+    })
+    res.send(renderToHtmlPage(<EmbedTestPage {...props} />))
 })
 
 testPageRouter.get("/embeds/:id", async (req, res) => {
@@ -372,7 +407,14 @@ testPageRouter.get("/embeds/:id", async (req, res) => {
                 }`,
             },
         ]
-        res.send(renderToHtmlPage(<EmbedTestPage charts={charts} />))
+        res.send(
+            renderToHtmlPage(
+                <EmbedTestPage
+                    charts={charts}
+                    comparisonUrl={DEFAULT_COMPARISON_URL}
+                />
+            )
+        )
     } else {
         res.send("Could not find chart ID")
     }
@@ -424,7 +466,9 @@ function PreviewTestPage(props: { charts: any[] }) {
     )
 }
 
-function EmbedVariantsTestPage(props: EmbedTestPageProps) {
+function EmbedVariantsTestPage(
+    props: Omit<EmbedTestPageProps, "comparisonUrl">
+) {
     const style = `
         html, body {
             height: 100%;

--- a/adminSiteServer/testPageRouter.tsx
+++ b/adminSiteServer/testPageRouter.tsx
@@ -21,6 +21,7 @@ import {
     StackMode,
 } from "../grapher/core/GrapherConstants"
 import { Url } from "../clientUtils/urls/Url"
+import { queryParamsToStr } from "../clientUtils/urls/UrlUtils"
 
 const IS_LIVE = ADMIN_BASE_URL === "https://owid.cloud"
 const DEFAULT_COMPARISON_URL = "https://ourworldindata.org"
@@ -353,7 +354,14 @@ function EmbedTestPage(props: EmbedTestPageProps) {
                 {props.charts.map((chart) => (
                     <div key={chart.slug} className="row">
                         <div className="chart-id">
-                            <a href={`?ids=${chart.id}`}>{chart.id}</a>
+                            <a
+                                href={queryParamsToStr({
+                                    ids: chart.id.toString(),
+                                    comparisonUrl: props.comparisonUrl,
+                                })}
+                            >
+                                {chart.id}
+                            </a>
                         </div>
                         <div className="side-by-side">
                             <iframe

--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -934,11 +934,7 @@ export class CoreTable<
 
     appendRows(rows: ROW_TYPE[], opDescription: string) {
         return this.concat(
-            [
-                new (this.constructor as any)(rows, this.defs, {
-                    parent: this.parent,
-                }) as CoreTable,
-            ],
+            [new (this.constructor as any)(rows, this.defs) as CoreTable],
             opDescription
         )
     }
@@ -1375,6 +1371,31 @@ export class CoreTable<
         )
     }
 
+    /**
+     * Ensure a row exists for all values in columnSlug1 × columnSlug2 × ...
+     *
+     * For example, if we have a table:
+     *
+     *   ```
+     *   entityName, year, …
+     *   UK, 2000, …
+     *   UK, 2005, …
+     *   USA, 2003, …
+     *   ```
+     *
+     * After `complete(["entityName", "year"])`, we'd get:
+     *
+     *   ```
+     *   entityName, year, …
+     *   UK, 2000, …
+     *   UK, 2003, …
+     *   UK, 2005, …
+     *   USA, 2000, …
+     *   USA, 2003, …
+     *   USA, 2005, …
+     *   ```
+     *
+     */
     complete(columnSlugs: ColumnSlug[]): this {
         const index = this.rowIndex(columnSlugs)
         const cols = this.getColumns(columnSlugs)

--- a/coreTable/OwidTable.ts
+++ b/coreTable/OwidTable.ts
@@ -757,8 +757,8 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         const columnA = this.get(columnSlugA)
         const columnB = this.get(columnSlugB)
 
-        const toleranceA = columnA.display.tolerance ?? 0
-        const toleranceB = columnB.display.tolerance ?? 0
+        const toleranceA = columnA.tolerance ?? 0
+        const toleranceB = columnB.tolerance ?? 0
 
         // If the columns are of mismatching time types, then we can't do any time matching.
         // This can happen when we have a ScatterPlot with days in one column, and a column with
@@ -768,7 +768,6 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
             this.timeColumn.isMissing ||
             this.timeColumn.slug !== columnA.originalTimeColumnSlug ||
             this.timeColumn.slug !== columnB.originalTimeColumnSlug ||
-            // Check for a non-zero, non-undefined tolerance
             (toleranceA === 0 && toleranceB === 0)
         ) {
             return this

--- a/grapher/core/Grapher.jsdom.test.ts
+++ b/grapher/core/Grapher.jsdom.test.ts
@@ -931,3 +931,51 @@ describe("tableForSelection", () => {
         expect(grapher.tableForSelection.availableEntityNames).toEqual(["UK"])
     })
 })
+
+it("handles tolerance when there are gaps in ScatterPlot data", () => {
+    const table = new OwidTable(
+        [
+            ["entityName", "year", "x", "y"],
+            ["usa", 1998, 1, 1],
+            ["uk", 1999, 0, 0],
+            ["uk", 2000, 0, 0],
+            ["uk", 2001, 0, 0],
+            ["usa", 2002, 2, 2],
+        ],
+        [
+            {
+                slug: "x",
+                type: ColumnTypeNames.Numeric,
+                tolerance: 1,
+            },
+            {
+                slug: "y",
+                type: ColumnTypeNames.Numeric,
+                tolerance: 1,
+            },
+        ]
+    )
+
+    const grapher = new Grapher({
+        table,
+        type: ChartTypeName.ScatterPlot,
+        xSlug: "x",
+        ySlugs: "y",
+        minTime: 1999,
+        maxTime: 1999,
+    })
+
+    expect(
+        grapher.transformedTable.filterByEntityNames(["usa"]).get("x").values
+    ).toEqual([1])
+
+    grapher.timelineHandleTimeBounds = [2000, 2000]
+    expect(
+        grapher.transformedTable.filterByEntityNames(["usa"]).get("x").values
+    ).toEqual([])
+
+    grapher.timelineHandleTimeBounds = [2001, 2001]
+    expect(
+        grapher.transformedTable.filterByEntityNames(["usa"]).get("x").values
+    ).toEqual([2])
+})

--- a/grapher/core/Grapher.jsdom.test.ts
+++ b/grapher/core/Grapher.jsdom.test.ts
@@ -27,6 +27,7 @@ import { queryParamsToStr } from "../../clientUtils/urls/UrlUtils"
 import { Url } from "../../clientUtils/urls/Url"
 import { OwidTable } from "../../coreTable/OwidTable"
 import { MapConfig } from "../mapCharts/MapConfig"
+import { ColumnTypeNames } from "../../coreTable/CoreColumnDef"
 
 const TestGrapherConfig = () => {
     const table = SynthesizeGDPTable({ entityCount: 10 })
@@ -852,6 +853,7 @@ it("considers map tolerance before using column tolerance", () => {
         [
             {
                 slug: "gdp",
+                type: ColumnTypeNames.Numeric,
                 tolerance: 2,
             },
         ]
@@ -867,28 +869,22 @@ it("considers map tolerance before using column tolerance", () => {
 
     expect(grapher.timelineHandleTimeBounds[1]).toEqual(2002)
     expect(
-        grapher.transformedTable.filterByEntityNames(["Germany"]).numRows
-    ).toEqual(0)
+        grapher.transformedTable.filterByEntityNames(["Germany"]).get("gdp")
+            .values
+    ).toEqual([])
 
     grapher.map.time = 2001
     expect(
-        grapher.transformedTable.filterByEntityNames(["Germany"]).numRows
-    ).toEqual(1)
-
-    const grapherColumnTolerance = new Grapher({
-        table,
-        type: ChartTypeName.WorldMap,
-        ySlugs: "gdp",
-        tab: GrapherTabOption.map,
-        map: new MapConfig({ columnSlug: "gdp", time: 2002 }),
-    })
+        grapher.transformedTable.filterByEntityNames(["Germany"]).get("gdp")
+            .values
+    ).toEqual([2])
 
     grapher.map.time = 2002
     grapher.map.timeTolerance = undefined
-
     expect(
-        grapher.transformedTable.filterByEntityNames(["Germany"]).numRows
-    ).toEqual(1)
+        grapher.transformedTable.filterByEntityNames(["Germany"]).get("gdp")
+            .values
+    ).toEqual([2])
 })
 
 describe("tableForSelection", () => {


### PR DESCRIPTION
- Adds a new `comparisonUrl` param to embed test pages, so for example you can compare _local_ vs _jefferson_, instead of always _local_ vs _live_. Example: http://localhost:3030/admin/test/embeds?ids=306&comparisonUrl=https://jefferson-owid.netlify.app

- Fixes `complete()` being a noop in certain cases. Added a ScatterPlot test case that was affected by this. 

- There was a map test case that I got wrong some time ago, now fixed

- Makes performance on charts that apply tolerance much worse