### PR TITLE
Fix link tracking

### DIFF
--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -1037,3 +1037,15 @@ export const differenceObj = <
     }
     return result
 }
+
+export const getDOMParent = (
+    el: HTMLElement,
+    condition: (el: HTMLElement) => boolean
+): HTMLElement | null => {
+    let current: HTMLElement | null = el
+    while (current) {
+        if (condition(current)) return current
+        current = current.parentElement
+    }
+    return null
+}

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -1038,7 +1038,7 @@ export const differenceObj = <
     return result
 }
 
-export const getDOMParent = (
+export const findDOMParent = (
     el: HTMLElement,
     condition: (el: HTMLElement) => boolean
 ): HTMLElement | null => {

--- a/explorer/ExplorerControls.tsx
+++ b/explorer/ExplorerControls.tsx
@@ -87,9 +87,6 @@ export class ExplorerControlPanel extends React.Component<{
                             ? AVAILABLE_OPTION_CLASS
                             : UNAVAILABLE_OPTION_CLASS
                     )}
-                    data-track-note={`${
-                        explorerSlug ?? "explorer"
-                    }-click-${title.toLowerCase()}`}
                 >
                     <input
                         onChange={() => this.customOnChange(onChangeValue)}
@@ -98,6 +95,9 @@ export class ExplorerControlPanel extends React.Component<{
                         name={title}
                         checked={checked}
                         value={currentValue}
+                        data-track-note={`${
+                            explorerSlug ?? "explorer"
+                        }-click-${title.toLowerCase()}`}
                     />{" "}
                     {label}
                 </label>

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -241,11 +241,11 @@ export class FooterControls extends React.Component<{
                                             ? " active"
                                             : "")
                                     }
-                                    onClick={() =>
-                                        (manager.currentTab = tabName)
-                                    }
                                 >
                                     <a
+                                        onClick={() =>
+                                            (manager.currentTab = tabName)
+                                        }
                                         data-track-note={
                                             "chart-click-" + tabName
                                         }
@@ -263,13 +263,14 @@ export class FooterControls extends React.Component<{
                                 ? " active"
                                 : "")
                         }
-                        data-track-note="chart-click-download"
-                        onClick={() =>
-                            (manager.currentTab = GrapherTabOption.download)
-                        }
                         title="Download as .png or .svg"
                     >
-                        <a>
+                        <a
+                            data-track-note="chart-click-download"
+                            onClick={() =>
+                                (manager.currentTab = GrapherTabOption.download)
+                            }
+                        >
                             <FontAwesomeIcon icon={faDownload} /> Download
                         </a>
                     </li>

--- a/grapher/core/GrapherAnalytics.ts
+++ b/grapher/core/GrapherAnalytics.ts
@@ -1,3 +1,5 @@
+import { getDOMParent } from "../../clientUtils/Util"
+
 const DEBUG = false
 
 declare var window: any
@@ -88,8 +90,11 @@ export class GrapherAnalytics {
         const dataTrackAttr = "data-track-note"
         document.addEventListener("click", async (ev) => {
             const targetElement = ev.target as HTMLElement
-            const trackedAttr = targetElement.getAttribute(dataTrackAttr)
-            if (!trackedAttr) return
+            const trackedElement = getDOMParent(
+                targetElement,
+                (el: HTMLElement) => el.getAttribute(dataTrackAttr) !== null
+            )
+            if (!trackedElement) return
 
             // Note that browsers will cancel all pending requests once a user
             // navigates away from a page. An earlier implementation had a

--- a/grapher/core/GrapherAnalytics.ts
+++ b/grapher/core/GrapherAnalytics.ts
@@ -74,12 +74,8 @@ export class GrapherAnalytics {
         this.logToGA(`${pickerSlug}ExplorerCountrySelectorUsage`, action, note)
     }
 
-    logSiteClick(text: string, note?: string, href?: string) {
-        this.logToGA(
-            Categories.SiteClick,
-            note || href || "unknown-category",
-            text
-        )
+    logSiteClick(action: string = "unknown-action", label: string) {
+        this.logToGA(Categories.SiteClick, action, label)
     }
 
     logKeyboardShortcut(shortcut: string, combo: string) {
@@ -100,9 +96,8 @@ export class GrapherAnalytics {
             // timeout to send the event before navigating, but it broke
             // CMD+CLICK for opening a new tab.
             this.logSiteClick(
-                targetElement.innerText,
-                trackedAttr || undefined,
-                targetElement.getAttribute("href") || undefined
+                trackedElement.getAttribute(dataTrackAttr) || undefined,
+                trackedElement.innerText
             )
         })
     }

--- a/grapher/core/GrapherAnalytics.ts
+++ b/grapher/core/GrapherAnalytics.ts
@@ -1,4 +1,4 @@
-import { getDOMParent } from "../../clientUtils/Util"
+import { findDOMParent } from "../../clientUtils/Util"
 
 const DEBUG = false
 
@@ -90,7 +90,7 @@ export class GrapherAnalytics {
         const dataTrackAttr = "data-track-note"
         document.addEventListener("click", async (ev) => {
             const targetElement = ev.target as HTMLElement
-            const trackedElement = getDOMParent(
+            const trackedElement = findDOMParent(
                 targetElement,
                 (el: HTMLElement) => el.getAttribute(dataTrackAttr) !== null
             )

--- a/site/AmazonMenu.tsx
+++ b/site/AmazonMenu.tsx
@@ -3,7 +3,7 @@
 
 import * as React from "react"
 import { bind } from "decko"
-import { getDOMParent } from "../clientUtils/Util"
+import { findDOMParent } from "../clientUtils/Util"
 
 interface Position {
     x: number
@@ -16,7 +16,7 @@ const DELAY = 400
 const TOLERANCE_PX = 20
 
 const getSubmenuId = (targetEl: HTMLElement): string | null => {
-    const listItem = getDOMParent(targetEl, (el: HTMLElement) =>
+    const listItem = findDOMParent(targetEl, (el: HTMLElement) =>
         el.matches(`[${ATTRIBUTE}]`)
     )
     return listItem ? listItem.getAttribute(ATTRIBUTE) : null

--- a/site/AmazonMenu.tsx
+++ b/site/AmazonMenu.tsx
@@ -3,6 +3,7 @@
 
 import * as React from "react"
 import { bind } from "decko"
+import { getDOMParent } from "../clientUtils/Util"
 
 interface Position {
     x: number
@@ -14,20 +15,8 @@ const MOUSE_LOCS_TRACKED = 3
 const DELAY = 400
 const TOLERANCE_PX = 20
 
-const getParent = (
-    el: HTMLElement,
-    condition: (el: HTMLElement) => boolean
-): HTMLElement | null => {
-    let current: HTMLElement | null = el
-    while (current) {
-        if (condition(current)) return current
-        current = current.parentElement
-    }
-    return null
-}
-
 const getSubmenuId = (targetEl: HTMLElement): string | null => {
-    const listItem = getParent(targetEl, (el: HTMLElement) =>
+    const listItem = getDOMParent(targetEl, (el: HTMLElement) =>
         el.matches(`[${ATTRIBUTE}]`)
     )
     return listItem ? listItem.getAttribute(ATTRIBUTE) : null

--- a/site/NewsletterSubscription.tsx
+++ b/site/NewsletterSubscription.tsx
@@ -152,8 +152,8 @@ export const NewsletterSubscriptionForm = ({
                     disabled={!isSubmittable}
                     onClick={() =>
                         analytics.logSiteClick(
-                            `Subscribe [${context ?? "other-contexts"}]`,
-                            "newsletter-subscribe"
+                            "newsletter-subscribe",
+                            `Subscribe [${context ?? "other-contexts"}]`
                         )
                     }
                 >

--- a/site/SiteHeaderMenus.tsx
+++ b/site/SiteHeaderMenus.tsx
@@ -81,7 +81,7 @@ class Header extends React.Component<{
     @action.bound scheduleOpenTimeout(delay: number) {
         this.dropdownOpenTimeoutId = window.setTimeout(() => {
             this.setOpen(true)
-            analytics.logSiteClick("Articles by topic", "header-open-menu")
+            analytics.logSiteClick("header-open-menu", "Articles by topic")
         }, delay)
         this.clearCloseTimeout()
     }

--- a/site/blocks/CookiePreferences.tsx
+++ b/site/blocks/CookiePreferences.tsx
@@ -44,8 +44,8 @@ const CookiePreference = ({
     const onChange = () => {
         toggleConsent()
         analytics.logSiteClick(
-            `${consent ? "Refuse" : "Accept"} ${name}`,
-            ANALYTICS_ACTION
+            ANALYTICS_ACTION,
+            `${consent ? "Refuse" : "Accept"} ${name}`
         )
     }
 

--- a/site/owid.entry.ts
+++ b/site/owid.entry.ts
@@ -88,35 +88,4 @@ new SmoothScroll('a[href*="#"][data-smooth-scroll]', {
     popstate: false,
 })
 
-const dataTrackAttr = "data-track-note"
-
-const getParent = (
-    el: HTMLElement,
-    condition: (el: HTMLElement) => boolean
-): HTMLElement | null => {
-    let current: HTMLElement | null = el
-    while (current) {
-        if (condition(current)) return current
-        current = current.parentElement
-    }
-    return null
-}
-
-document.addEventListener("click", async (ev) => {
-    const targetElement = ev.target as HTMLElement
-    const trackedElement = getParent(
-        targetElement,
-        (el: HTMLElement) => el.getAttribute(dataTrackAttr) !== null
-    )
-    if (trackedElement) {
-        // Note that browsers will cancel all pending requests once a user
-        // navigates away from a page. An earlier implementation had a
-        // timeout to send the event before navigating, but it broke
-        // CMD+CLICK for opening a new tab.
-        analytics.logSiteClick(
-            trackedElement.innerText,
-            trackedElement.getAttribute("href") || undefined,
-            trackedElement.getAttribute(dataTrackAttr) || undefined
-        )
-    }
-})
+analytics.startClickTracking()


### PR DESCRIPTION
This fixes a couple of issues related to link tracking:
- [Tracking event sent twice when click on label of explorer controls (checkbox)](https://www.notion.so/Tracking-event-sent-twice-when-click-on-label-of-explorer-controls-checkbox-5c5862be61c24335b2951d239ec93c71)
- [Use `data-track-note` and not href as the event action](https://www.notion.so/Use-data-track-note-and-not-href-as-the-event-action-ca02c0042ae443b79296cff6a5f288e9)