### PR TITLE
fix: `authorsVersion` selection doesn't reflect grapher selection

### DIFF
--- a/grapher/core/Grapher.jsdom.test.ts
+++ b/grapher/core/Grapher.jsdom.test.ts
@@ -28,6 +28,7 @@ import { Url } from "../../clientUtils/urls/Url"
 import { OwidTable } from "../../coreTable/OwidTable"
 import { MapConfig } from "../mapCharts/MapConfig"
 import { ColumnTypeNames } from "../../coreTable/CoreColumnDef"
+import { SelectionArray } from "../selection/SelectionArray"
 
 const TestGrapherConfig = () => {
     const table = SynthesizeGDPTable({ entityCount: 10 })
@@ -112,6 +113,21 @@ it("can apply legacy chart dimension settings", () => {
     const col = grapher.yColumns[0]!
     expect(col.unit).toEqual(unit)
     expect(col.displayName).toEqual(name)
+})
+
+it("correctly identifies changes to passed-in selection", () => {
+    const selection = new SelectionArray()
+    const grapher = new Grapher({
+        ...legacyConfig,
+        manager: { selection },
+    })
+
+    expect(grapher.changedParams).toEqual({})
+    expect(selection.selectedEntityNames).toEqual(["Iceland", "Afghanistan"])
+
+    selection.deselectEntity("Afghanistan")
+
+    expect(grapher.changedParams).toEqual({ country: "~ISL" })
 })
 
 it("can fallback to a ycolumn if a map variableId does not exist", () => {

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -31,7 +31,6 @@ import {
     debounce,
     isInIFrame,
     differenceObj,
-    intersection,
 } from "../../clientUtils/Util"
 import {
     ChartTypeName,
@@ -2125,6 +2124,7 @@ export class Grapher
     @computed private get authorsVersion() {
         return new Grapher({
             ...this.legacyConfigAsAuthored,
+            manager: undefined,
             manuallyProvideData: true,
             queryStr: "",
         })


### PR DESCRIPTION
Notion: [canonicalUrl of embedded chart is wrong, doesn't include selected entities](https://www.notion.so/canonicalUrl-of-embedded-chart-is-wrong-doesn-t-include-selected-entities-4f78411d424b4c64a73c1fa1ad409ee5)

This fixes the canonical URL of embedded charts being wrong, but ideally
we fix this in a nicer way at some point.

Let's put this on our list of pain points, maybe. I feel like `SelectionArray` should really be immutable, even though I somewhat understand why we want/need it to be mutable.