### PR TITLE
Fix line charts with projection

### DIFF
--- a/grapher/chart/ChartUtils.tsx
+++ b/grapher/chart/ChartUtils.tsx
@@ -25,11 +25,13 @@ export const getDefaultFailMessage = (manager: ChartManager): string => {
 }
 
 export const autoDetectSeriesStrategy = (
-    manager: ChartManager
+    manager: ChartManager,
+    hasNormalAndProjectedSeries?: boolean
 ): SeriesStrategy => {
     if (manager.seriesStrategy) return manager.seriesStrategy
 
-    return autoDetectYColumnSlugs(manager).length > 1
+    const columnThreshold = hasNormalAndProjectedSeries ? 2 : 1
+    return autoDetectYColumnSlugs(manager).length > columnThreshold
         ? SeriesStrategy.column
         : SeriesStrategy.entity
 }

--- a/grapher/chart/ChartUtils.tsx
+++ b/grapher/chart/ChartUtils.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Box } from "../../clientUtils/owidTypes"
 import { SeriesStrategy } from "../core/GrapherConstants"
+import { LineChartSeries } from "../lineCharts/LineChartConstants"
 import { SelectionArray } from "../selection/SelectionArray"
 import { ChartManager } from "./ChartManager"
 
@@ -22,6 +23,12 @@ export const getDefaultFailMessage = (manager: ChartManager): string => {
     const selection = makeSelectionArray(manager)
     if (!selection.hasSelection) return `No ${selection.entityType} selected`
     return ""
+}
+
+export const getSeriesKey = (series: LineChartSeries, suffix?: string) => {
+    return `${series.seriesName}-${series.color}-${
+        series.isProjection ? "projection" : ""
+    }${suffix ? "-" + suffix : ""}`
 }
 
 export const autoDetectSeriesStrategy = (

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -49,6 +49,7 @@ import {
     autoDetectSeriesStrategy,
     autoDetectYColumnSlugs,
     getDefaultFailMessage,
+    getSeriesKey,
     makeClipPath,
     makeSelectionArray,
 } from "../chart/ChartUtils"
@@ -165,9 +166,7 @@ class Lines extends React.Component<LinesProps> {
         return this.backgroundLines.map((series, index) => (
             <g key={index}>
                 <path
-                    key={`${series.seriesName}-${series.color}-${
-                        series.isProjection ? "projection" : ""
-                    }-line`}
+                    key={getSeriesKey(series, "line")}
                     strokeLinecap="round"
                     stroke="#ddd"
                     d={pointsToPath(
@@ -380,11 +379,7 @@ export class LineChart
                                 : series.color
                             return (
                                 <tr
-                                    key={`${series.seriesName}-${
-                                        series.color
-                                    }-${
-                                        series.isProjection ? "projection" : ""
-                                    }`}
+                                    key={getSeriesKey(series)}
                                     style={{ color: textColor }}
                                 >
                                     <td>
@@ -565,11 +560,7 @@ export class LineChart
 
                             return (
                                 <circle
-                                    key={`${series.seriesName}-${
-                                        series.color
-                                    }-${
-                                        series.isProjection ? "projection" : ""
-                                    }`}
+                                    key={getSeriesKey(series)}
                                     cx={horizontalAxis.place(value.x)}
                                     cy={verticalAxis.place(value.y)}
                                     r={4}

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -11,7 +11,6 @@ import {
     exposeInstanceOnWindow,
 } from "../../clientUtils/Util"
 import { computed, action, observable } from "mobx"
-import { some } from "lodash"
 import { observer } from "mobx-react"
 import { select } from "d3-selection"
 import { easeLinear } from "d3-ease"
@@ -642,8 +641,8 @@ export class LineChart
 
     @computed get seriesStrategy(): SeriesStrategy {
         const hasNormalAndProjectedSeries =
-            some(this.yColumns, (col) => col.isProjection) &&
-            some(this.yColumns, (col) => !col.isProjection)
+            this.yColumns.some((col) => col.isProjection) &&
+            this.yColumns.some((col) => !col.isProjection)
         return autoDetectSeriesStrategy(
             this.manager,
             hasNormalAndProjectedSeries

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -11,6 +11,7 @@ import {
     exposeInstanceOnWindow,
 } from "../../clientUtils/Util"
 import { computed, action, observable } from "mobx"
+import { some } from "lodash"
 import { observer } from "mobx-react"
 import { select } from "d3-selection"
 import { easeLinear } from "d3-ease"
@@ -165,7 +166,9 @@ class Lines extends React.Component<LinesProps> {
         return this.backgroundLines.map((series, index) => (
             <g key={index}>
                 <path
-                    key={`${series.seriesName}-${series.color}-line`}
+                    key={`${series.seriesName}-${series.color}-${
+                        series.isProjection ? "projection" : ""
+                    }-line`}
                     strokeLinecap="round"
                     stroke="#ddd"
                     d={pointsToPath(
@@ -378,7 +381,11 @@ export class LineChart
                                 : series.color
                             return (
                                 <tr
-                                    key={`${series.seriesName}-${series.color}`}
+                                    key={`${series.seriesName}-${
+                                        series.color
+                                    }-${
+                                        series.isProjection ? "projection" : ""
+                                    }`}
                                     style={{ color: textColor }}
                                 >
                                     <td>
@@ -559,7 +566,11 @@ export class LineChart
 
                             return (
                                 <circle
-                                    key={`${series.seriesName}-${series.color}`}
+                                    key={`${series.seriesName}-${
+                                        series.color
+                                    }-${
+                                        series.isProjection ? "projection" : ""
+                                    }`}
                                     cx={horizontalAxis.place(value.x)}
                                     cy={verticalAxis.place(value.y)}
                                     r={4}
@@ -630,7 +641,13 @@ export class LineChart
     }
 
     @computed get seriesStrategy(): SeriesStrategy {
-        return autoDetectSeriesStrategy(this.manager)
+        const hasNormalAndProjectedSeries =
+            some(this.yColumns, (col) => col.isProjection) &&
+            some(this.yColumns, (col) => !col.isProjection)
+        return autoDetectSeriesStrategy(
+            this.manager,
+            hasNormalAndProjectedSeries
+        )
     }
 
     @computed get isLogScale(): boolean {

--- a/grapher/lineCharts/LineChartUtils.ts
+++ b/grapher/lineCharts/LineChartUtils.ts
@@ -12,11 +12,7 @@ export const columnToLineChartSeriesArray = (
     return entityNames.map((entityName) => {
         let seriesName
         if (seriesStrategy === SeriesStrategy.entity) {
-            if (col.isProjection && col.displayName) {
-                seriesName = `${entityName} - ${col.displayName}`
-            } else {
-                seriesName = entityName
-            }
+            seriesName = entityName
         } else {
             if (canSelectMultipleEntities) {
                 seriesName = `${entityName} - ${col.displayName}`

--- a/grapher/lineCharts/LineChartUtils.ts
+++ b/grapher/lineCharts/LineChartUtils.ts
@@ -10,7 +10,7 @@ export const columnToLineChartSeriesArray = (
     const { isProjection, owidRowsByEntityName } = col
     const entityNames = Array.from(owidRowsByEntityName.keys())
     return entityNames.map((entityName) => {
-        let seriesName = ""
+        let seriesName
         if (seriesStrategy === SeriesStrategy.entity) {
             if (col.isProjection && col.displayName) {
                 seriesName = `${entityName} - ${col.displayName}`

--- a/grapher/lineCharts/LineChartUtils.ts
+++ b/grapher/lineCharts/LineChartUtils.ts
@@ -10,12 +10,20 @@ export const columnToLineChartSeriesArray = (
     const { isProjection, owidRowsByEntityName } = col
     const entityNames = Array.from(owidRowsByEntityName.keys())
     return entityNames.map((entityName) => {
-        const seriesName =
-            seriesStrategy === SeriesStrategy.entity
-                ? entityName
-                : canSelectMultipleEntities
-                ? `${entityName} - ${col.displayName}`
-                : col.displayName
+        let seriesName = ""
+        if (seriesStrategy === SeriesStrategy.entity) {
+            if (col.isProjection && col.displayName) {
+                seriesName = `${entityName} - ${col.displayName}`
+            } else {
+                seriesName = entityName
+            }
+        } else {
+            if (canSelectMultipleEntities) {
+                seriesName = `${entityName} - ${col.displayName}`
+            } else {
+                seriesName = col.displayName
+            }
+        }
         return {
             points: owidRowsByEntityName.get(entityName)!.map((row) => {
                 return {


### PR DESCRIPTION
This fixes the issue described in https://www.notion.so/owid/Broken-chart-ea6e5f3f9dcf49d4859b74dad585d6ca). The problem is that autoDetectSeriesStrategy checks if there is more than one variable involved and if so it sets the strategy to column. When there is a projection we have two variables but logically this is shown as one and entity is still the right strategy.

This is my first code commit so please let me know extensively what you think. It might also be that the entire approach is wrong, but this is what I came up with to resolve the issue :).