### PR TITLE
style(grapher): Add return type annotations

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,9 @@
 bakedSite/**
 .eslintrc.js
 itsJustJavascript/**
+devtools/**
+jest.config.js
+knexfile.ts
+ormconfig.js
+postcss.config.js
+public/detect-country.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,30 +20,29 @@ module.exports = {
     ],
     rules: {
         // These rules are only preliminary to ease the migration from tslint, many of them might make sense to have enabled!
-        "@typescript-eslint/camelcase": "off",
-        "@typescript-eslint/explicit-function-return-type": "off",
-        "@typescript-eslint/explicit-module-boundary-types": "off",
-        "@typescript-eslint/no-empty-function": "off",
+        "@typescript-eslint/explicit-function-return-type": "off", // This rule is enabled on a folder by folder basis and should be enabled project wide soon
+        "@typescript-eslint/explicit-module-boundary-types": "off", // This rule is enabled on a folder by folder basis and should be enabled project wide soon
+        "@typescript-eslint/no-empty-function": "warn",
         "@typescript-eslint/no-empty-interface": "warn",
-        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-explicit-any": "off", // TODO: enable this rule
         "@typescript-eslint/no-for-in-array": "warn",
-        "@typescript-eslint/no-inferrable-types": "off",
-        "@typescript-eslint/no-namespace": "off",
-        "@typescript-eslint/no-non-null-assertion": "off",
-        "@typescript-eslint/no-this-alias": "off",
+        "@typescript-eslint/no-inferrable-types": "off", // If this is on the ESLint automatic fixing removes type annotations in assignments like "somenumber: number = 4"
+        "@typescript-eslint/no-namespace": "warn",
+        "@typescript-eslint/no-non-null-assertion": "off", // TODO: enable this rule
+        "@typescript-eslint/no-this-alias": "warn",
         "@typescript-eslint/no-unused-vars": "warn",
-        "@typescript-eslint/no-use-before-define": "off",
-        "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/no-use-before-define": "off", // This was useful in the past with var and variable hoisting changing depending on scope but AFAIK typescript deals with this in a sane way and we can leave this off
+        "@typescript-eslint/no-var-requires": "warn",
         "@typescript-eslint/restrict-plus-operands": "warn",
         "no-console": ["warn", { allow: ["warn", "error"] }],
-        "no-var": "off",
+        "no-var": "warn",
         "prefer-const": ["warn", { destructuring: "all" }],
-        "react/display-name": "off",
+        "react/display-name": "warn",
         "react/jsx-key": "warn",
         "react/jsx-no-target-blank": ["warn", { allowReferrer: true }],
-        "react/no-render-return-value": "off",
-        "react/no-unescaped-entities": "off",
-        "react/prop-types": "off",
+        "react/no-render-return-value": "warn",
+        "react/no-unescaped-entities": "off", // This rule is overly noisy in JSX blocks when quotes are used for little gain
+        "react/prop-types": "warn",
     },
     settings: {
         react: {

--- a/adminSiteClient/.eslintrc.yaml
+++ b/adminSiteClient/.eslintrc.yaml
@@ -1,0 +1,2 @@
+rules:
+    no-console: "off"

--- a/adminSiteClient/Admin.tsx
+++ b/adminSiteClient/Admin.tsx
@@ -41,7 +41,7 @@ export class Admin {
 
     @observable currentRequests: Promise<Response>[] = []
 
-    @computed get showLoadingIndicator() {
+    @computed get showLoadingIndicator(): boolean {
         return this.loadingIndicatorSetting === "default"
             ? this.currentRequests.length > 0
             : this.loadingIndicatorSetting === "loading"
@@ -50,7 +50,7 @@ export class Admin {
     @observable loadingIndicatorSetting: "loading" | "off" | "default" =
         "default"
 
-    start(containerNode: HTMLElement, gitCmsBranchName: string) {
+    start(containerNode: HTMLElement, gitCmsBranchName: string): void {
         ReactDOM.render(
             <AdminApp admin={this} gitCmsBranchName={gitCmsBranchName} />,
             containerNode
@@ -61,12 +61,16 @@ export class Admin {
         return urljoin(this.basePath, path)
     }
 
-    goto(path: string) {
+    goto(path: string): void {
         this.url(path)
     }
 
     // Make a request with no error or response handling
-    async rawRequest(path: string, data: string | File, method: HTTPMethod) {
+    async rawRequest(
+        path: string,
+        data: string | File,
+        method: HTTPMethod
+    ): Promise<Response> {
         const headers: any = {}
         const isFile = data instanceof File
         if (!isFile) {
@@ -89,7 +93,7 @@ export class Admin {
         data: Json | File,
         method: HTTPMethod,
         opts: { onFailure?: "show" | "continue" } = {}
-    ) {
+    ): Promise<Json> {
         const onFailure = opts.onFailure || "show"
 
         let targetPath = path
@@ -133,15 +137,15 @@ export class Admin {
         return json
     }
 
-    @action.bound private setErrorMessage(message: any) {
+    @action.bound private setErrorMessage(message: any): void {
         this.errorMessage = message
     }
 
-    @action.bound private addRequest(request: Promise<Response>) {
+    @action.bound private addRequest(request: Promise<Response>): void {
         this.currentRequests.push(request)
     }
 
-    @action.bound private removeRequest(request: Promise<Response>) {
+    @action.bound private removeRequest(request: Promise<Response>): void {
         this.currentRequests = this.currentRequests.filter(
             (req) => req !== request
         )

--- a/adminSiteClient/AdminApp.tsx
+++ b/adminSiteClient/AdminApp.tsx
@@ -38,7 +38,7 @@ import { AdminLayout } from "./AdminLayout"
 
 @observer
 class AdminErrorMessage extends React.Component<{ admin: Admin }> {
-    render() {
+    render(): JSX.Element | null {
         const { admin } = this.props
         const error = admin.errorMessage
 
@@ -80,7 +80,7 @@ class AdminErrorMessage extends React.Component<{ admin: Admin }> {
 
 @observer
 class AdminLoader extends React.Component<{ admin: Admin }> {
-    render() {
+    render(): JSX.Element | null {
         const { admin } = this.props
         return admin.showLoadingIndicator ? <LoadingBlocker /> : null
     }
@@ -95,7 +95,7 @@ export class AdminApp extends React.Component<{
         return { admin: this.props.admin }
     }
 
-    render() {
+    render(): JSX.Element {
         const { admin, gitCmsBranchName } = this.props
 
         return (

--- a/adminSiteClient/AdminLayout.tsx
+++ b/adminSiteClient/AdminLayout.tsx
@@ -25,29 +25,29 @@ export class AdminLayout extends React.Component<{
     @observable private showFAQ: boolean = false
     @observable private showSidebar: boolean = false
 
-    @action.bound onToggleFAQ() {
+    @action.bound onToggleFAQ(): void {
         this.showFAQ = !this.showFAQ
     }
 
-    @action.bound onToggleSidebar() {
+    @action.bound onToggleSidebar(): void {
         this.showSidebar = !this.showSidebar
     }
 
-    @action.bound private setInitialSidebarState(value: boolean) {
+    @action.bound private setInitialSidebarState(value: boolean): void {
         this.showSidebar = value
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         this.setInitialSidebarState(!this.props.noSidebar)
         this.componentDidUpdate()
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(): void {
         if (this.props.title)
             document.title = this.props.title + " - owid-admin"
     }
 
-    @computed get environmentSpan() {
+    @computed get environmentSpan(): JSX.Element {
         const { admin } = this.context
         if (admin.settings.ENV === "development") {
             return <span className="dev">dev</span>
@@ -58,7 +58,7 @@ export class AdminLayout extends React.Component<{
         }
     }
 
-    render() {
+    render(): JSX.Element {
         const { admin } = this.context
         const { showFAQ: isFAQ, showSidebar, environmentSpan } = this
 

--- a/adminSiteClient/AdminSidebar.tsx
+++ b/adminSiteClient/AdminSidebar.tsx
@@ -16,7 +16,7 @@ import { faNewspaper } from "@fortawesome/free-solid-svg-icons/faNewspaper"
 import { faBook } from "@fortawesome/free-solid-svg-icons/faBook"
 import { faSatelliteDish } from "@fortawesome/free-solid-svg-icons/faSatelliteDish"
 
-export const AdminSidebar = () => (
+export const AdminSidebar = (): JSX.Element => (
     <aside className="AdminSidebar">
         <ul className="sidebar-menu">
             <li className="header">SITE</li>

--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -144,7 +144,7 @@ export class ChartEditor {
     }
 
     // Load index of datasets and variables for the given namespace
-    async loadNamespace(namespace: string) {
+    async loadNamespace(namespace: string): Promise<void> {
         const data = await this.manager.admin.getJSON(
             `/api/editorData/${namespace}.json`
         )
@@ -153,7 +153,9 @@ export class ChartEditor {
         )
     }
 
-    async saveGrapher({ onError }: { onError?: () => void } = {}) {
+    async saveGrapher({ onError }: { onError?: () => void } = {}): Promise<
+        void
+    > {
         const { grapher, isNewGrapher } = this
         const currentGrapherObject = {
             ...this.grapher.object,
@@ -198,7 +200,7 @@ export class ChartEditor {
         }
     }
 
-    async saveAsNewGrapher() {
+    async saveAsNewGrapher(): Promise<void> {
         const currentGrapherObject = this.grapher.object
 
         const chartJson = { ...currentGrapherObject }
@@ -219,7 +221,7 @@ export class ChartEditor {
             )
     }
 
-    publishGrapher() {
+    publishGrapher(): void {
         const url = `${BAKED_GRAPHER_URL}/${this.grapher.displaySlug}`
 
         if (window.confirm(`Publish chart at ${url}?`)) {
@@ -230,7 +232,7 @@ export class ChartEditor {
         }
     }
 
-    unpublishGrapher() {
+    unpublishGrapher(): void {
         const message =
             this.references && this.references.length > 0
                 ? "WARNING: This chart might be referenced from public posts, please double check before unpublishing. Remove chart anyway?"

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -13,7 +13,7 @@ import { Prompt, Redirect } from "react-router-dom"
 import { Bounds } from "../clientUtils/Bounds"
 import { capitalize } from "../clientUtils/Util"
 import { Grapher } from "../grapher/core/Grapher"
-
+import { Admin } from "./Admin"
 import {
     ChartEditor,
     EditorDatabase,
@@ -47,7 +47,7 @@ import {
 @observer
 class TabBinder extends React.Component<{ editor: ChartEditor }> {
     dispose!: IReactionDisposer
-    componentDidMount() {
+    componentDidMount(): void {
         //window.addEventListener("hashchange", this.onHashChange)
         this.onHashChange()
 
@@ -56,16 +56,16 @@ class TabBinder extends React.Component<{ editor: ChartEditor }> {
         })
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         //window.removeEventListener("hashchange", this.onHashChange)
         this.dispose()
     }
 
-    render() {
+    render(): null {
         return null
     }
 
-    @action.bound onHashChange() {
+    @action.bound onHashChange(): void {
         const match = window.location.hash.match(/#(.+?)-tab/)
         if (match) {
             const tab = match[1]
@@ -99,7 +99,7 @@ export class ChartEditorPage
 
     @observable simulateVisionDeficiency?: VisionDeficiency
 
-    async fetchGrapher() {
+    async fetchGrapher(): Promise<void> {
         const { grapherId, grapherConfig } = this.props
         const { admin } = this.context
         const json =
@@ -111,11 +111,11 @@ export class ChartEditorPage
 
     @observable private _isDbSet = false
     @observable private _isGrapherSet = false
-    @computed get isReady() {
+    @computed get isReady(): boolean {
         return this._isDbSet && this._isGrapherSet
     }
 
-    @action.bound private loadGrapherJson(json: any) {
+    @action.bound private loadGrapherJson(json: any): void {
         this.grapherElement = (
             <Grapher
                 {...{
@@ -133,18 +133,18 @@ export class ChartEditorPage
         this._isGrapherSet = true
     }
 
-    @action.bound private setDb(json: any) {
+    @action.bound private setDb(json: any): void {
         this.database = new EditorDatabase(json)
         this._isDbSet = true
     }
 
-    async fetchData() {
+    async fetchData(): Promise<void> {
         const { admin } = this.context
         const json = await admin.getJSON(`/api/editorData/namespaces.json`)
         this.setDb(json)
     }
 
-    async fetchLogs() {
+    async fetchLogs(): Promise<void> {
         const { grapherId } = this.props
         const { admin } = this.context
         const json =
@@ -154,7 +154,7 @@ export class ChartEditorPage
         runInAction(() => (this.logs = json.logs))
     }
 
-    async fetchRefs() {
+    async fetchRefs(): Promise<void> {
         const { grapherId } = this.props
         const { admin } = this.context
         const json =
@@ -166,7 +166,7 @@ export class ChartEditorPage
         runInAction(() => (this.references = json.references || []))
     }
 
-    async fetchRedirects() {
+    async fetchRedirects(): Promise<void> {
         const { grapherId } = this.props
         const { admin } = this.context
         const json =
@@ -176,17 +176,17 @@ export class ChartEditorPage
         runInAction(() => (this.redirects = json.redirects))
     }
 
-    @computed get admin() {
+    @computed get admin(): Admin {
         return this.context.admin
     }
 
-    @computed get editor() {
+    @computed get editor(): ChartEditor | undefined {
         if (!this.isReady) return undefined
 
         return new ChartEditor({ manager: this })
     }
 
-    @action.bound refresh() {
+    @action.bound refresh(): void {
         this.fetchGrapher()
         this.fetchData()
         this.fetchLogs()
@@ -195,7 +195,7 @@ export class ChartEditorPage
     }
 
     dispose!: IReactionDisposer
-    componentDidMount() {
+    componentDidMount(): void {
         this.refresh()
 
         this.dispose = reaction(
@@ -213,15 +213,15 @@ export class ChartEditorPage
 
     // This funny construction allows the "new chart" link to work by forcing an update
     // even if the props don't change
-    componentWillReceiveProps() {
+    UNSAFE_componentWillReceiveProps(): void {
         setTimeout(() => this.refresh(), 0)
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         this.dispose()
     }
 
-    render() {
+    render(): JSX.Element {
         return (
             <AdminLayout noSidebar>
                 <main className="ChartEditorPage">
@@ -233,7 +233,7 @@ export class ChartEditorPage
         )
     }
 
-    renderReady(editor: ChartEditor) {
+    renderReady(editor: ChartEditor): JSX.Element {
         const { grapher, availableTabs, previewMode } = editor
 
         return (

--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -46,7 +46,8 @@ class VariableEditable {
     @observable unit: string = ""
     @observable shortUnit: string = ""
     @observable description: string = ""
-    @observable display = new LegacyVariableDisplayConfig()
+    @observable
+    display: LegacyVariableDisplayConfig = new LegacyVariableDisplayConfig()
 
     constructor(json: any) {
         for (const key in this) {
@@ -67,10 +68,10 @@ class VariableEditRow extends React.Component<{
     @observable.ref private grapher?: Grapher
     @observable private newVariable!: VariableEditable
 
-    componentWillMount() {
-        this.componentWillReceiveProps()
+    UNSAFE_componentWillMount() {
+        this.UNSAFE_componentWillReceiveProps()
     }
-    componentWillReceiveProps() {
+    UNSAFE_componentWillReceiveProps() {
         this.newVariable = new VariableEditable(this.props.variable)
     }
 
@@ -397,10 +398,10 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
     @observable timesUpdated: number = 0
 
     // Store the original dataset to determine when it is modified
-    componentWillMount() {
-        this.componentWillReceiveProps()
+    UNSAFE_componentWillMount() {
+        this.UNSAFE_componentWillReceiveProps()
     }
-    componentWillReceiveProps() {
+    UNSAFE_componentWillReceiveProps() {
         this.newDataset = new DatasetEditable(this.props.dataset)
         this.isDeleted = false
     }
@@ -737,9 +738,9 @@ export class DatasetEditPage extends React.Component<{ datasetId: number }> {
     }
 
     componentDidMount() {
-        this.componentWillReceiveProps()
+        this.UNSAFE_componentWillReceiveProps()
     }
-    componentWillReceiveProps() {
+    UNSAFE_componentWillReceiveProps() {
         this.getData()
     }
 }

--- a/adminSiteClient/SourceEditPage.tsx
+++ b/adminSiteClient/SourceEditPage.tsx
@@ -49,10 +49,10 @@ class SourceEditor extends React.Component<{ source: SourcePageData }> {
     @observable isDeleted: boolean = false
 
     // Store the original source to determine when it is modified
-    componentWillMount() {
-        this.componentWillReceiveProps()
+    UNSAFE_componentWillMount() {
+        this.UNSAFE_componentWillReceiveProps()
     }
-    componentWillReceiveProps() {
+    UNSAFE_componentWillReceiveProps() {
         this.newSource = new SourceEditable(this.props.source)
         this.isDeleted = false
     }
@@ -185,9 +185,9 @@ export class SourceEditPage extends React.Component<{ sourceId: number }> {
     }
 
     componentDidMount() {
-        this.componentWillReceiveProps()
+        this.UNSAFE_componentWillReceiveProps()
     }
-    componentWillReceiveProps() {
+    UNSAFE_componentWillReceiveProps() {
         this.getData()
     }
 }

--- a/adminSiteClient/TagEditPage.tsx
+++ b/adminSiteClient/TagEditPage.tsx
@@ -44,10 +44,10 @@ class TagEditor extends React.Component<{ tag: TagPageData }> {
     @observable isDeleted: boolean = false
 
     // Store the original tag to determine when it is modified
-    componentWillMount() {
-        this.componentWillReceiveProps(this.props)
+    UNSAFE_componentWillMount() {
+        this.UNSAFE_componentWillReceiveProps(this.props)
     }
-    componentWillReceiveProps(nextProps: any) {
+    UNSAFE_componentWillReceiveProps(nextProps: any) {
         this.newtag = new TagEditable(nextProps.tag)
         this.isDeleted = false
     }
@@ -231,7 +231,7 @@ export class TagEditPage extends React.Component<{ tagId: number }> {
     componentDidMount() {
         this.getData(this.props.tagId)
     }
-    componentWillReceiveProps(nextProps: any) {
+    UNSAFE_componentWillReceiveProps(nextProps: any) {
         this.getData(nextProps.tagId)
     }
 }

--- a/adminSiteClient/VariableEditPage.tsx
+++ b/adminSiteClient/VariableEditPage.tsx
@@ -57,10 +57,10 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
     @observable isDeleted: boolean = false
 
     // Store the original dataset to determine when it is modified
-    componentWillMount() {
-        this.componentWillReceiveProps()
+    UNSAFE_componentWillMount() {
+        this.UNSAFE_componentWillReceiveProps()
     }
-    componentWillReceiveProps() {
+    UNSAFE_componentWillReceiveProps() {
         this.newVariable = new VariableEditable(this.props.variable)
         this.isDeleted = false
     }
@@ -340,9 +340,9 @@ export class VariableEditPage extends React.Component<{ variableId: number }> {
     }
 
     componentDidMount() {
-        this.componentWillReceiveProps()
+        this.UNSAFE_componentWillReceiveProps()
     }
-    componentWillReceiveProps() {
+    UNSAFE_componentWillReceiveProps() {
         this.getData()
     }
 }

--- a/adminSiteClient/admin.entry.ts
+++ b/adminSiteClient/admin.entry.ts
@@ -3,5 +3,5 @@ import "adminSiteClient/admin.scss"
 import "explorerAdmin/ExplorerCreatePage.scss"
 import "handsontable/dist/handsontable.full.css"
 
-declare var window: any
+declare let window: any
 window.Admin = require("./Admin").Admin

--- a/adminSiteServer/.eslintrc.yaml
+++ b/adminSiteServer/.eslintrc.yaml
@@ -1,0 +1,2 @@
+rules:
+    no-console: "off"

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -1300,7 +1300,7 @@ apiRouter.get("/posts/:postId.json", async (req: Request, res: Response) => {
         .knexTable(Post.table)
         .where({ id: postId })
         .select("*")
-        .first()) as PostRow
+        .first()) as PostRow | undefined
     return camelCaseProperties(post)
 })
 

--- a/baker/.eslintrc.yaml
+++ b/baker/.eslintrc.yaml
@@ -1,0 +1,2 @@
+rules:
+    no-console: "off"

--- a/clientUtils/.eslintrc.yaml
+++ b/clientUtils/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/clientUtils/Bounds.ts
+++ b/clientUtils/Bounds.ts
@@ -11,24 +11,24 @@ export class Bounds {
     static textBoundsCache: { [key: string]: Bounds } = {}
     static ctx: CanvasRenderingContext2D
 
-    static fromProps(props: Box) {
+    static fromProps(props: Box): Bounds {
         const { x, y, width, height } = props
         return new Bounds(x, y, width, height)
     }
 
-    static fromBBox(bbox: Box) {
+    static fromBBox(bbox: Box): Bounds {
         return this.fromProps(bbox)
     }
 
-    static fromRect(rect: ClientRect) {
+    static fromRect(rect: ClientRect): Bounds {
         return new Bounds(rect.left, rect.top, rect.width, rect.height)
     }
 
-    static fromElement(el: HTMLElement) {
+    static fromElement(el: HTMLElement): Bounds {
         return Bounds.fromRect(el.getBoundingClientRect())
     }
 
-    static fromCorners(p1: PointVector, p2: PointVector) {
+    static fromCorners(p1: PointVector, p2: PointVector): Bounds {
         const x1 = Math.min(p1.x, p2.x)
         const x2 = Math.max(p1.x, p2.x)
         const y1 = Math.min(p1.y, p2.y)
@@ -38,7 +38,7 @@ export class Bounds {
     }
 
     // Merge a collection of bounding boxes into a single encompassing Bounds
-    static merge(boundsList: Bounds[]) {
+    static merge(boundsList: Bounds[]): Bounds {
         let x1 = Infinity,
             y1 = Infinity,
             x2 = -Infinity,
@@ -59,7 +59,7 @@ export class Bounds {
         label: string,
         fontSize: number,
         xPosition: number
-    ) {
+    ): number {
         const bounds = Bounds.forText(label, {
             fontSize,
         })
@@ -67,7 +67,7 @@ export class Bounds {
         return overflow < 0 ? Math.abs(overflow) : 0
     }
 
-    static empty() {
+    static empty(): Bounds {
         return new Bounds(0, 0, 0, 0)
     }
 
@@ -85,7 +85,7 @@ export class Bounds {
             fontWeight?: number
             fontFamily?: string
         } = {}
-    ) {
+    ): Bounds {
         // Collapse contiguous spaces into one
         str = str.replace(/ +/g, " ")
         const key = `${str}-${fontSize}`
@@ -122,45 +122,45 @@ export class Bounds {
         this.height = Math.max(height, 0)
     }
 
-    get left() {
+    get left(): number {
         return this.x
     }
-    get top() {
+    get top(): number {
         return this.y
     }
-    get right() {
+    get right(): number {
         return this.x + this.width
     }
-    get bottom() {
+    get bottom(): number {
         return this.y + this.height
     }
-    get centerX() {
+    get centerX(): number {
         return this.x + this.width / 2
     }
-    get centerY() {
+    get centerY(): number {
         return this.y + this.height / 2
     }
-    get centerPos() {
+    get centerPos(): PointVector {
         return new PointVector(this.centerX, this.centerY)
     }
-    get area() {
+    get area(): number {
         return this.width * this.height
     }
 
-    get topLeft() {
+    get topLeft(): PointVector {
         return new PointVector(this.left, this.top)
     }
-    get topRight() {
+    get topRight(): PointVector {
         return new PointVector(this.right, this.top)
     }
-    get bottomLeft() {
+    get bottomLeft(): PointVector {
         return new PointVector(this.left, this.bottom)
     }
-    get bottomRight() {
+    get bottomRight(): PointVector {
         return new PointVector(this.right, this.bottom)
     }
 
-    padLeft(amount: number) {
+    padLeft(amount: number): Bounds {
         return new Bounds(
             this.x + amount,
             this.y,
@@ -169,15 +169,15 @@ export class Bounds {
         )
     }
 
-    padRight(amount: number) {
+    padRight(amount: number): Bounds {
         return new Bounds(this.x, this.y, this.width - amount, this.height)
     }
 
-    padBottom(amount: number) {
+    padBottom(amount: number): Bounds {
         return new Bounds(this.x, this.y, this.width, this.height - amount)
     }
 
-    padTop(amount: number) {
+    padTop(amount: number): Bounds {
         return new Bounds(
             this.x,
             this.y + amount,
@@ -186,7 +186,7 @@ export class Bounds {
         )
     }
 
-    padWidth(amount: number) {
+    padWidth(amount: number): Bounds {
         return new Bounds(
             this.x + amount,
             this.y,
@@ -195,7 +195,7 @@ export class Bounds {
         )
     }
 
-    padHeight(amount: number) {
+    padHeight(amount: number): Bounds {
         return new Bounds(
             this.x,
             this.y + amount,
@@ -204,15 +204,15 @@ export class Bounds {
         )
     }
 
-    fromLeft(amount: number) {
+    fromLeft(amount: number): Bounds {
         return this.padRight(this.width - amount)
     }
 
-    fromBottom(amount: number) {
+    fromBottom(amount: number): Bounds {
         return this.padTop(this.height - amount)
     }
 
-    pad(amount: number) {
+    pad(amount: number): Bounds {
         return new Bounds(
             this.x + amount,
             this.y + amount,
@@ -221,11 +221,16 @@ export class Bounds {
         )
     }
 
-    extend(props: { x?: number; y?: number; width?: number; height?: number }) {
+    extend(props: {
+        x?: number
+        y?: number
+        width?: number
+        height?: number
+    }): Bounds {
         return Bounds.fromProps({ ...this, ...props })
     }
 
-    scale(scale: number) {
+    scale(scale: number): Bounds {
         return new Bounds(
             this.x * scale,
             this.y * scale,
@@ -234,7 +239,7 @@ export class Bounds {
         )
     }
 
-    intersects(otherBounds: Bounds) {
+    intersects(otherBounds: Bounds): boolean {
         const r1 = this
         const r2 = otherBounds
 
@@ -255,14 +260,14 @@ export class Bounds {
         ]
     }
 
-    boundedPoint(p: PointVector) {
+    boundedPoint(p: PointVector): PointVector {
         return new PointVector(
             Math.max(Math.min(p.x, this.right), this.left),
             Math.max(Math.min(p.y, this.bottom), this.top)
         )
     }
 
-    containsPoint(x: number, y: number) {
+    containsPoint(x: number, y: number): boolean {
         return (
             x >= this.left &&
             x <= this.right &&
@@ -271,11 +276,11 @@ export class Bounds {
         )
     }
 
-    contains(p: PointVector) {
+    contains(p: PointVector): boolean {
         return this.containsPoint(p.x, p.y)
     }
 
-    encloses(bounds: Bounds) {
+    encloses(bounds: Bounds): boolean {
         return (
             this.containsPoint(bounds.left, bounds.top) &&
             this.containsPoint(bounds.left, bounds.bottom) &&
@@ -308,7 +313,7 @@ export class Bounds {
         return [this.left, this.right]
     }
 
-    split(pieces: number, padding: SplitBoundsPadding = {}) {
+    split(pieces: number, padding: SplitBoundsPadding = {}): Bounds[] {
         // Splits a rectangle into smaller rectangles.
         // The Facet Storybook has a visual demo of how this works.
         // I form the smallest possible square and then fill that up. This always goes left to right, top down.
@@ -341,7 +346,7 @@ export class Bounds {
         return [this.bottom, this.top]
     }
 
-    equals(bounds: Bounds) {
+    equals(bounds: Bounds): boolean {
         return (
             this.x === bounds.x &&
             this.y === bounds.y &&
@@ -352,7 +357,7 @@ export class Bounds {
 
     // Calculate squared distance between a given point and the closest border of the bounds
     // If the point is within the bounds, returns 0
-    private distanceToPointSq(p: PointVector) {
+    private distanceToPointSq(p: PointVector): number {
         if (this.contains(p)) return 0
 
         const cx = Math.max(Math.min(p.x, this.x + this.width), this.x)
@@ -360,7 +365,7 @@ export class Bounds {
         return (p.x - cx) * (p.x - cx) + (p.y - cy) * (p.y - cy)
     }
 
-    distanceToPoint(p: PointVector) {
+    distanceToPoint(p: PointVector): number {
         return Math.sqrt(this.distanceToPointSq(p))
     }
 }

--- a/clientUtils/PointVector.ts
+++ b/clientUtils/PointVector.ts
@@ -17,23 +17,23 @@ export class PointVector {
         this.y = y
     }
 
-    subtract(v: PointVector) {
+    subtract(v: PointVector): PointVector {
         return new PointVector(this.x - v.x, this.y - v.y)
     }
 
-    add(v: PointVector) {
+    add(v: PointVector): PointVector {
         return new PointVector(this.x + v.x, this.y + v.y)
     }
 
-    times(n: number) {
+    times(n: number): PointVector {
         return new PointVector(this.x * n, this.y * n)
     }
 
-    get magnitude() {
+    get magnitude(): number {
         return Math.sqrt(this.x ** 2 + this.y ** 2)
     }
 
-    normalize() {
+    normalize(): PointVector {
         const magnitude = this.magnitude
         if (magnitude > 1e-5)
             return new PointVector(this.x / magnitude, this.y / magnitude)
@@ -48,22 +48,22 @@ export class PointVector {
         ]
     }
 
-    toString() {
+    toString(): string {
         return `PointVector<${this.x}, ${this.y}>`
     }
 
     static up = new PointVector(0, -1)
     static zero = new PointVector(0, 0)
 
-    static distanceSq(a: PointVector, b: PointVector) {
+    static distanceSq(a: PointVector, b: PointVector): number {
         return (b.x - a.x) ** 2 + (b.y - a.y) ** 2
     }
 
-    static distance(a: PointVector, b: PointVector) {
+    static distance(a: PointVector, b: PointVector): number {
         return Math.sqrt(PointVector.distanceSq(a, b))
     }
 
-    static angle(a: PointVector, b: PointVector) {
+    static angle(a: PointVector, b: PointVector): number {
         return (
             Math.acos(
                 Math.max(
@@ -74,7 +74,7 @@ export class PointVector {
         )
     }
 
-    private static dot(lhs: PointVector, rhs: PointVector) {
+    private static dot(lhs: PointVector, rhs: PointVector): number {
         return lhs.x * rhs.x + lhs.y * rhs.y
     }
 
@@ -83,7 +83,7 @@ export class PointVector {
         p: PointVector,
         v: PointVector,
         w: PointVector
-    ) {
+    ): number {
         const l2 = PointVector.distanceSq(v, w)
         if (l2 === 0) return PointVector.distanceSq(p, v)
 

--- a/clientUtils/PromiseCache.test.ts
+++ b/clientUtils/PromiseCache.test.ts
@@ -1,6 +1,6 @@
 import { PromiseCache } from "./PromiseCache"
 
-const wait = (ms: number) =>
+const wait = (ms: number): Promise<void> =>
     new Promise((resolve) => {
         setTimeout(resolve, ms)
     })

--- a/clientUtils/PromiseSwitcher.test.ts
+++ b/clientUtils/PromiseSwitcher.test.ts
@@ -1,11 +1,11 @@
 import { PromiseSwitcher } from "./PromiseSwitcher"
 
-const delayResolve = (result: any, ms: number = 10) =>
+const delayResolve = (result: any, ms: number = 10): Promise<void> =>
     new Promise((resolve) => {
         setTimeout(() => resolve(result), ms)
     })
 
-const delayReject = (error: any, ms: number = 10) =>
+const delayReject = (error: any, ms: number = 10): Promise<void> =>
     new Promise((_, reject) => {
         setTimeout(() => reject(error), ms)
     })

--- a/clientUtils/PromiseSwitcher.ts
+++ b/clientUtils/PromiseSwitcher.ts
@@ -46,7 +46,7 @@ export class PromiseSwitcher<Result> {
         }
     }
 
-    clear() {
+    clear(): void {
         this.pendingPromise = undefined
     }
 }

--- a/clientUtils/TimeBounds.ts
+++ b/clientUtils/TimeBounds.ts
@@ -26,8 +26,10 @@ enum TimeBoundValueStr {
     unboundedRight = "latest",
 }
 
-export const timeFromTimebounds = (timeBound: TimeBound, fallbackTime: Time) =>
-    Math.abs(timeBound) !== Infinity ? timeBound : fallbackTime
+export const timeFromTimebounds = (
+    timeBound: TimeBound,
+    fallbackTime: Time
+): number => (Math.abs(timeBound) !== Infinity ? timeBound : fallbackTime)
 
 const hasAnInfinity = (timeBound: TimeBound): timeBound is TimeBoundValue =>
     isNegativeInfinity(timeBound) || isPositiveInfinity(timeBound)
@@ -40,7 +42,7 @@ export const isPositiveInfinity = (
     timeBound: TimeBound
 ): timeBound is TimeBoundValue => timeBound === TimeBoundValue.positiveInfinity
 
-const formatTimeBound = (timeBound: TimeBound) => {
+const formatTimeBound = (timeBound: TimeBound): string => {
     if (isNegativeInfinity(timeBound)) return TimeBoundValueStr.unboundedLeft
     if (isPositiveInfinity(timeBound)) return TimeBoundValueStr.unboundedRight
     return `${timeBound}`
@@ -57,7 +59,7 @@ const parseTimeBound = (str: string): TimeBound | undefined => {
 }
 
 // Use this to not repeat logic
-const fromJSON = (value: TimeBound | string | undefined) =>
+const fromJSON = (value: TimeBound | string | undefined): number | undefined =>
     isString(value) ? parseTimeBound(value) : value
 
 const toJSON = (bound: TimeBound | undefined): string | number | undefined => {
@@ -84,7 +86,7 @@ const reISODate = new RegExp(`^(${reISODateComponent.source})$`)
 export const timeBoundToTimeBoundString = (
     timeBound: TimeBound,
     isDate: boolean
-) => {
+): string => {
     if (hasAnInfinity(timeBound)) return formatTimeBound(timeBound)
     return isDate
         ? formatDay(timeBound, { format: "YYYY-MM-DD" })
@@ -96,7 +98,7 @@ const parseTimeURIComponent = (param: string): TimeBound | undefined =>
         ? diffDateISOStringInDays(param, EPOCH_DATE)
         : parseTimeBound(param)
 
-const upgradeLegacyTimeString = (time: string) => {
+const upgradeLegacyTimeString = (time: string): string => {
     // In the past we supported unbounded time parameters like time=2015.. which would be
     // equivalent to time=2015..latest. We don't actively generate these kinds of URL any
     // more because URLs ending with dots are not interpreted correctly by many services

--- a/clientUtils/Util.test.ts
+++ b/clientUtils/Util.test.ts
@@ -23,7 +23,7 @@ import {
     getClosestTimePairs,
     differenceObj,
 } from "./Util"
-import { SortOrder, ScaleType } from "./owidTypes"
+import { SortOrder } from "./owidTypes"
 
 describe(findClosestTime, () => {
     describe("without tolerance", () => {
@@ -178,9 +178,12 @@ describe(formatDay, () => {
 })
 
 describe(retryPromise, () => {
-    function resolveAfterNthRetry(nth: number, message: string = "success") {
+    function resolveAfterNthRetry(
+        nth: number,
+        message = "success"
+    ): () => Promise<string> {
         let retried = 0
-        return () =>
+        return (): Promise<string> =>
             new Promise((resolve, reject) =>
                 retried++ >= nth ? resolve(message) : reject()
             )

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -131,7 +131,9 @@ import { isNegativeInfinity, isPositiveInfinity } from "./TimeBounds"
 export type SVGElement = any
 export type VNode = any
 
-type NoUndefinedValues<T> = { [P in keyof T]: Required<NonNullable<T[P]>> }
+export type NoUndefinedValues<T> = {
+    [P in keyof T]: Required<NonNullable<T[P]>>
+}
 
 // d3 v6 changed the default minus sign used in d3-format to "−" (Unicode minus sign), which looks
 // nicer but can cause issues when copy-pasting values into a spreadsheet or script.
@@ -148,7 +150,7 @@ export const d3Format = formatLocale({
 export const getRelativeMouse = (
     node: SVGElement,
     event: TouchEvent | { clientX: number; clientY: number }
-) => {
+): PointVector => {
     const isTouchEvent = !!(event as TouchEvent).targetTouches
     const eventOwner = isTouchEvent
         ? (event as TouchEvent).targetTouches[0]
@@ -173,7 +175,7 @@ export const getRelativeMouse = (
 }
 
 // Purely for local development time
-const isStorybook = () =>
+const isStorybook = (): boolean =>
     window.location.host.startsWith("localhost:6006") &&
     document.title === "Storybook"
 
@@ -182,7 +184,7 @@ export const exposeInstanceOnWindow = (
     component: any,
     name = "chart",
     alsoOnTopWindow?: boolean
-) => {
+): void => {
     if (typeof window === "undefined") return
     const win = window as any
     win[name] = component
@@ -192,7 +194,7 @@ export const exposeInstanceOnWindow = (
 }
 
 // Make an arbitrary string workable as a css class name
-export const makeSafeForCSS = (name: string) =>
+export const makeSafeForCSS = (name: string): string =>
     name.replace(/[^a-z0-9]/g, (str) => {
         const char = str.charCodeAt(0)
         if (char === 32) return "-"
@@ -212,7 +214,7 @@ export function formatDay(
     return moment.utc(EPOCH_DATE).add(dayAsYear, "days").format(format)
 }
 
-export const formatYear = (year: number) => {
+export const formatYear = (year: number): string => {
     if (isNaN(year)) {
         console.warn(`Invalid year '${year}'`)
         return ""
@@ -223,7 +225,7 @@ export const formatYear = (year: number) => {
         : year.toString()
 }
 
-export const roundSigFig = (num: number, sigfigs: number = 1) => {
+export const roundSigFig = (num: number, sigfigs: number = 1): number => {
     if (num === 0) return 0
     const magnitude = Math.floor(Math.log10(Math.abs(num)))
     return round(num, -magnitude + sigfigs - 1)
@@ -255,19 +257,19 @@ export const lastOfNonEmptyArray = <T>(arr: T[]): T => {
 interface ObjectLiteral {
     [key: string]: any
 }
-export const mapToObjectLiteral = (map: Map<string, any>) =>
+export const mapToObjectLiteral = (map: Map<string, any>): ObjectLiteral =>
     Array.from(map).reduce((objLit, [key, value]) => {
         objLit[key.toString()] = value
         return objLit
     }, {} as ObjectLiteral)
 
-export function next<T>(set: T[], current: T) {
+export function next<T>(set: T[], current: T): T {
     let nextIndex = set.indexOf(current) + 1
     nextIndex = nextIndex === -1 ? 0 : nextIndex
     return set[nextIndex === set.length ? 0 : nextIndex]
 }
 
-export const previous = <T>(set: T[], current: T) => {
+export const previous = <T>(set: T[], current: T): T => {
     const nextIndex = set.indexOf(current) - 1
     return set[nextIndex < 0 ? set.length - 1 : nextIndex]
 }
@@ -315,7 +317,7 @@ const cagrFromPoints = (
     startPoint: Point,
     endPoint: Point,
     property: "x" | "y"
-) => {
+): number => {
     const elapsed = endPoint.timeValue - startPoint.timeValue
     if (!elapsed) return 0
     return cagr(startPoint[property]!, endPoint[property]!, elapsed)
@@ -325,7 +327,7 @@ export const cagr = (
     startValue: number,
     endValue: number,
     yearsElapsed: number
-) => {
+): number => {
     const ratio = endValue / startValue
     return (
         Math.sign(ratio) *
@@ -334,7 +336,7 @@ export const cagr = (
     )
 }
 
-export const makeAnnotationsSlug = (columnSlug: string) =>
+export const makeAnnotationsSlug = (columnSlug: string): string =>
     `${columnSlug}-annotations`
 
 // Todo: add unit tests
@@ -364,7 +366,7 @@ export const relativeMinAndMax = (
     return [minChange, maxChange]
 }
 
-export const isVisible = (elm: HTMLElement | null) => {
+export const isVisible = (elm: HTMLElement | null): boolean => {
     if (!elm || !elm.getBoundingClientRect) return false
     const rect = elm.getBoundingClientRect()
     const viewHeight = Math.max(
@@ -375,8 +377,9 @@ export const isVisible = (elm: HTMLElement | null) => {
 }
 
 // Take an arbitrary string and turn it into a nice url slug
-export const slugify = (str: string) => slugifySameCase(str.toLowerCase())
-export const slugifySameCase = (str: string) =>
+export const slugify = (str: string): string =>
+    slugifySameCase(str.toLowerCase())
+export const slugifySameCase = (str: string): string =>
     str
         .replace(/\s*\*.+\*/, "")
         .replace(/[^\w- ]+/g, "")
@@ -386,10 +389,10 @@ export const slugifySameCase = (str: string) =>
 // Unique number for this execution context
 // Useful for coordinating between embeds to avoid conflicts in their ids
 let _guid = 0
-export const guid = () => ++_guid
+export const guid = (): number => ++_guid
 
 // Take an array of points and make it into an SVG path specification string
-export const pointsToPath = (points: Array<[number, number]>) => {
+export const pointsToPath = (points: Array<[number, number]>): string => {
     let path = ""
     for (let i = 0; i < points.length; i++) {
         if (i === 0) path += `M${points[i][0]} ${points[i][1]}`
@@ -407,7 +410,7 @@ export const sortedFindClosestIndex = (
     startIndex: number = 0,
     // non-inclusive end
     endIndex: number = array.length
-) => {
+): number => {
     if (startIndex >= endIndex) return -1
 
     if (value < array[startIndex]) return startIndex
@@ -443,12 +446,12 @@ export const sortedFindClosest = (
     return index !== -1 ? array[index] : undefined
 }
 
-export const isMobile = () =>
+export const isMobile = (): boolean =>
     typeof window === "undefined"
         ? false
         : !!window?.navigator?.userAgent.toLowerCase().includes("mobi")
 
-export const isTouchDevice = () => !!("ontouchstart" in window)
+export const isTouchDevice = (): boolean => !!("ontouchstart" in window)
 
 // General type reperesenting arbitrary json data; basically a non-nullable 'any'
 export interface Json {
@@ -456,22 +459,23 @@ export interface Json {
 }
 
 // Escape a function for storage in a csv cell
-export const csvEscape = (value: any) => {
+export const csvEscape = (value: any): any => {
     const valueStr = toString(value)
     return valueStr.includes(",") ? `"${value.replace(/\"/g, '""')}"` : value
 }
 
-export const arrToCsvRow = (arr: string[]) =>
+export const arrToCsvRow = (arr: string[]): string =>
     arr.map((x) => csvEscape(x)).join(",") + "\n"
 
-export const urlToSlug = (url: string) =>
+export const urlToSlug = (url: string): string =>
     last(
         parseUrl(url)
             .pathname.split("/")
             .filter((x) => x)
     ) as string
 
-export const sign = (num: number) => (num > 0 ? 1 : num < 0 ? -1 : 0)
+export const sign = (num: number): 0 | 1 | -1 =>
+    num > 0 ? 1 : num < 0 ? -1 : 0
 
 // Removes all undefineds from an object.
 export const trimObject = <Obj>(
@@ -525,7 +529,7 @@ export const getCountryCodeFromNetlifyRedirect = async (): Promise<
         req.send()
     })
 
-export const stripHTML = (html: string) => striptags(html)
+export const stripHTML = (html: string): string => striptags(html)
 
 // Math.rand doesn't have between nor seed. Lodash's Random doesn't take a seed, making it bad for testing.
 // So we have our own *very* psuedo-RNG.
@@ -546,7 +550,7 @@ export const sampleFrom = <T>(
 
 // A seeded array shuffle
 // https://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
-const shuffleArray = (array: any[], seed = Date.now()) => {
+const shuffleArray = (array: any[], seed = Date.now()): any[] => {
     const rand = getRandomNumberGenerator(0, 100, seed)
     const clonedArr = array.slice()
     for (let index = clonedArr.length - 1; index > 0; index--) {
@@ -559,7 +563,7 @@ const shuffleArray = (array: any[], seed = Date.now()) => {
     return clonedArr
 }
 
-export const makeGrid = (pieces: number) => {
+export const makeGrid = (pieces: number): { columns: number; rows: number } => {
     const columns = Math.ceil(Math.sqrt(pieces))
     const rows = Math.ceil(pieces / columns)
     return {
@@ -629,7 +633,7 @@ const valuesAtTimes = (
     valueByTime: Map<number, string | number>,
     targetTimes: Time[],
     tolerance = 0
-) => {
+): { time: number | undefined; value: string | number | undefined }[] => {
     const times = Array.from(valueByTime.keys())
     return targetTimes.map((targetTime) => {
         const time = findClosestTime(times, targetTime, tolerance)
@@ -666,7 +670,9 @@ export const valuesByEntityWithinTimes = (
     )
 }
 
-export const getStartEndValues = (values: DataValue[]) => [
+export const getStartEndValues = (
+    values: DataValue[]
+): (DataValue | undefined)[] => [
     minBy(values, (dv) => dv.time),
     maxBy(values, (dv) => dv.time),
 ]
@@ -674,14 +680,14 @@ export const getStartEndValues = (values: DataValue[]) => [
 const MS_PER_DAY = 1000 * 60 * 60 * 24
 
 // From https://stackoverflow.com/a/15289883
-export function dateDiffInDays(a: Date, b: Date) {
+export function dateDiffInDays(a: Date, b: Date): number {
     // Discard the time and time-zone information.
     const utca = Date.UTC(a.getFullYear(), a.getMonth(), a.getDate())
     const utcb = Date.UTC(b.getFullYear(), b.getMonth(), b.getDate())
     return Math.floor((utca - utcb) / MS_PER_DAY)
 }
 
-export const diffDateISOStringInDays = (a: string, b: string) =>
+export const diffDateISOStringInDays = (a: string, b: string): number =>
     moment.utc(a).diff(moment.utc(b), "days")
 
 export const addDays = (date: Date, days: number): Date => {
@@ -693,7 +699,7 @@ export const addDays = (date: Date, days: number): Date => {
 export async function retryPromise<T>(
     promiseGetter: () => Promise<T>,
     maxRetries: number = 3
-) {
+): Promise<T> {
     let retried = 0
     let lastError
     while (retried++ < maxRetries) {
@@ -706,7 +712,7 @@ export async function retryPromise<T>(
     throw lastError
 }
 
-export function parseIntOrUndefined(s: string | undefined) {
+export function parseIntOrUndefined(s: string | undefined): number | undefined {
     if (s === undefined) return undefined
     const value = parseInt(s)
     return isNaN(value) ? undefined : value
@@ -718,7 +724,7 @@ export const anyToString = (value: any): string =>
 // Scroll Helpers
 // Borrowed from: https://github.com/JedWatson/react-select/blob/32ad5c040b/packages/react-select/src/utils.js
 
-function isDocumentElement(el: HTMLElement) {
+function isDocumentElement(el: HTMLElement): boolean {
     return [document.documentElement, document.body].indexOf(el) > -1
 }
 
@@ -756,7 +762,7 @@ export function scrollIntoViewIfNeeded(
     }
 }
 
-export function rollingMap<T, U>(array: T[], mapper: (a: T, b: T) => U) {
+export function rollingMap<T, U>(array: T[], mapper: (a: T, b: T) => U): U[] {
     const result: U[] = []
     if (array.length <= 1) return result
     for (let i = 0; i < array.length - 1; i++) {
@@ -792,7 +798,7 @@ export function keyMap<Key, Value>(
     return result
 }
 
-export const linkify = (str: string) => linkifyHtml(str)
+export const linkify = (str: string): string => linkifyHtml(str)
 
 export const oneOf = <T>(value: any, options: T[], defaultOption: T): T => {
     for (const option of options) {
@@ -801,7 +807,7 @@ export const oneOf = <T>(value: any, options: T[], defaultOption: T): T => {
     return defaultOption
 }
 
-export const intersectionOfSets = <T>(sets: Set<T>[]) => {
+export const intersectionOfSets = <T>(sets: Set<T>[]): Set<T> => {
     if (!sets.length) return new Set<T>()
     const intersection = new Set<T>(sets[0])
 
@@ -830,7 +836,7 @@ export function sortByUndefinedLast<T>(
     array: T[],
     accessor: (t: T) => string | number | undefined,
     order: SortOrder = SortOrder.asc
-) {
+): any {
     const sorted = sortBy(array, (value) => {
         const mapped = accessor(value)
         if (mapped === undefined) {
@@ -841,7 +847,9 @@ export function sortByUndefinedLast<T>(
     return order === SortOrder.asc ? sorted : sorted.reverse()
 }
 
-export function getAttributesOfHTMLElement(el: HTMLElement) {
+export function getAttributesOfHTMLElement(
+    el: HTMLElement
+): { [key: string]: string } {
     const attributes: { [key: string]: string } = {}
     for (let i = 0; i < el.attributes.length; i++) {
         const attr = el.attributes.item(i)
@@ -854,7 +862,7 @@ export const mapNullToUndefined = <T>(
     array: (T | undefined | null)[]
 ): (T | undefined)[] => array.map((v) => (v === null ? undefined : v))
 
-export const lowerCaseFirstLetterUnlessAbbreviation = (str: string) =>
+export const lowerCaseFirstLetterUnlessAbbreviation = (str: string): string =>
     str.charAt(1).match(/[A-Z]/)
         ? str
         : str.charAt(0).toLowerCase() + str.slice(1)
@@ -872,15 +880,15 @@ export const sortNumeric = <T>(
 ): T[] =>
     arr.sort(
         sortOrder === SortOrder.asc
-            ? (a: T, b: T) => sortByFn(a) - sortByFn(b)
-            : (a: T, b: T) => sortByFn(b) - sortByFn(a)
+            ? (a: T, b: T): number => sortByFn(a) - sortByFn(b)
+            : (a: T, b: T): number => sortByFn(b) - sortByFn(a)
     )
 
 export const mapBy = <T>(
     arr: T[],
     keyAccessor: (t: T) => any,
     valueAccessor: (t: T) => any
-) => {
+): Map<any, any> => {
     const map = new Map()
     arr.forEach((val) => {
         map.set(keyAccessor(val), valueAccessor(val))
@@ -894,7 +902,7 @@ export const findIndexFast = (
     predicate: (value: any, index: number) => boolean,
     fromIndex = 0,
     toIndex = array.length
-) => {
+): number => {
     let index = fromIndex
     while (index < toIndex) {
         if (predicate(array[index], index)) return index
@@ -907,7 +915,7 @@ export const logMe = (
     target: any,
     propertyName: string,
     descriptor: TypedPropertyDescriptor<any>
-) => {
+): TypedPropertyDescriptor<any> => {
     const originalMethod = descriptor.value
     descriptor.value = function (...args: any[]) {
         console.log(`Running ${propertyName} with '${args}'`)
@@ -927,7 +935,7 @@ export function getClosestTimePairs(
     sortedTimesA: Time[],
     sortedTimesB: Time[],
     maxDiff: Integer = Infinity
-) {
+): [number, number][] {
     if (sortedTimesA.length === 0 || sortedTimesB.length === 0) return []
 
     const decidedPairs: [Time, Time][] = []
@@ -1028,7 +1036,7 @@ export const differenceObj = <
 >(
     obj: A,
     defaultObj: B
-) => {
+): Partial<A> => {
     const result: Partial<A> = {}
     for (const key in obj) {
         if (defaultObj[key] !== obj[key]) {

--- a/clientUtils/countries.ts
+++ b/clientUtils/countries.ts
@@ -1512,10 +1512,10 @@ export const countries: Country[] = allCountriesSortedByCode.filter(
     (country) => !country.filter
 )
 
-export const getCountry = (slug: string) =>
+export const getCountry = (slug: string): Country | undefined =>
     countries.find((c) => c.slug === slug)
 
-export const getCountryDetectionRedirects = () =>
+export const getCountryDetectionRedirects = (): string[] =>
     countries
         .filter((country) => country.iso3166 && country.code)
         .map(

--- a/clientUtils/react-select.tsx
+++ b/clientUtils/react-select.tsx
@@ -25,43 +25,43 @@ export const getStylesForTargetHeight = (
         menu,
     } = props
     return {
-        container: (base: React.CSSProperties) => ({
+        container: (base: React.CSSProperties): any => ({
             ...base,
             ...container,
         }),
-        control: (base: React.CSSProperties) => ({
+        control: (base: React.CSSProperties): any => ({
             ...base,
             minHeight: "initial",
             ...control,
         }),
-        valueContainer: (base: React.CSSProperties) => ({
+        valueContainer: (base: React.CSSProperties): any => ({
             ...base,
             height: `${targetHeight - 1 - 1}px`,
             padding: "0 4px",
             flexWrap: "nowrap",
             ...valueContainer,
         }),
-        singleValue: (base: React.CSSProperties) => ({
+        singleValue: (base: React.CSSProperties): any => ({
             ...base,
             ...singleValue,
         }),
-        clearIndicator: (base: React.CSSProperties) => ({
+        clearIndicator: (base: React.CSSProperties): any => ({
             ...base,
             padding: `${(targetHeight - 20 - 1 - 1) / 2}px`,
             ...clearIndicator,
         }),
-        dropdownIndicator: (base: React.CSSProperties) => ({
+        dropdownIndicator: (base: React.CSSProperties): any => ({
             ...base,
             padding: `${(targetHeight - 20 - 1 - 1) / 2}px`,
             ...dropdownIndicator,
         }),
-        option: (base: React.CSSProperties) => ({
+        option: (base: React.CSSProperties): any => ({
             ...base,
             paddingTop: "5px",
             paddingBottom: "5px",
             ...option,
         }),
-        menu: (base: React.CSSProperties) => ({
+        menu: (base: React.CSSProperties): any => ({
             ...base,
             zIndex: 10000,
             ...menu,

--- a/clientUtils/search.ts
+++ b/clientUtils/search.ts
@@ -2,7 +2,7 @@ import { flatten } from "./Util"
 import chunk from "chunk-text"
 import { fromString } from "html-to-text"
 
-export const htmlToPlaintext = (html: string) =>
+export const htmlToPlaintext = (html: string): string =>
     fromString(html, {
         tables: true,
         ignoreHref: true,
@@ -11,10 +11,13 @@ export const htmlToPlaintext = (html: string) =>
         ignoreImage: true,
     })
 
-export const chunkWords = (text: string, maxChunkLength: number) =>
+export const chunkWords = (text: string, maxChunkLength: number): string[] =>
     chunk(text, maxChunkLength)
 
-export const chunkSentences = (text: string, maxChunkLength: number) => {
+export const chunkSentences = (
+    text: string,
+    maxChunkLength: number
+): string[] => {
     // See https://stackoverflow.com/a/25736082/1983739
     // Not perfect, just works in most cases
     const sentenceRegex = /(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\?|\n)\s/g
@@ -52,7 +55,10 @@ export const chunkSentences = (text: string, maxChunkLength: number) => {
 
 // Chunks a given bit of text into an array of fragments less than or equal to maxChunkLength in size
 // These chunks will honor sentence boundaries where possible
-export const chunkParagraphs = (text: string, maxChunkLength: number) => {
+export const chunkParagraphs = (
+    text: string,
+    maxChunkLength: number
+): string[] => {
     const paragraphs = flatten(
         text
             .split("\n\n")

--- a/clientUtils/serializers.ts
+++ b/clientUtils/serializers.ts
@@ -3,14 +3,14 @@ const jsonCommentDelimiter = "\n//EMBEDDED_JSON\n"
 export const serializeJSONForHTML = (
     obj: any,
     delimiter = jsonCommentDelimiter
-) =>
+): string =>
     `${delimiter}${
         obj === undefined ? "" : JSON.stringify(obj, null, 2)
     }${delimiter}`
 export const deserializeJSONFromHTML = (
     html: string,
     delimiter = jsonCommentDelimiter
-) => {
+): any => {
     const json = html.split(delimiter)[1]
     return json === undefined || json === "" ? undefined : JSON.parse(json)
 }

--- a/clientUtils/string.ts
+++ b/clientUtils/string.ts
@@ -3,10 +3,10 @@ const URL_REGEX = /[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9
 export const findUrlsInText = (str: string): string[] =>
     str.match(URL_REGEX) || []
 
-const snakeToCamel = (str: string) =>
+const snakeToCamel = (str: string): string =>
     str.replace(/(\_\w)/g, (char) => char[1].toUpperCase())
 
-export const camelCaseProperties = (obj: any) => {
+export const camelCaseProperties = (obj: any): any => {
     const newObj: any = {}
     for (const key in obj) {
         newObj[snakeToCamel(key)] = obj[key]

--- a/coreTable/.eslintrc.yaml
+++ b/coreTable/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -28,6 +28,7 @@ import {
     InputType,
     CoreMatrix,
     TableSlug,
+    JsTypes,
 } from "./CoreTableConstants"
 import { ColumnTypeNames, CoreColumnDef } from "./CoreColumnDef"
 import {
@@ -58,9 +59,14 @@ import {
     truncate,
     replaceCells,
 } from "./CoreTableUtils"
-import { ErrorValueTypes, isNotErrorValue } from "./ErrorValues"
+import {
+    ErrorValueTypes,
+    isNotErrorValue,
+    DroppedForTesting,
+} from "./ErrorValues"
 import { OwidTableSlugs } from "./OwidTableConstants"
 import { applyTransforms } from "./Transforms"
+import { Transform } from "node:stream"
 
 interface AdvancedOptions {
     tableDescription?: string
@@ -134,7 +140,7 @@ export class CoreTable<
 
     // A method currently used just in debugging but may be useful in the author backend.
     // If your charts look funny, a good thing to check is if the autodetected columns are wrong.
-    get autodetectedColumnDefs() {
+    get autodetectedColumnDefs(): CoreTable {
         const providedSlugs = new Set(
             this.inputColumnDefs.map((def) => def.slug)
         )
@@ -143,7 +149,7 @@ export class CoreTable<
         )
     }
 
-    @imemo get transformCategory() {
+    @imemo get transformCategory(): TransformType {
         const { advancedOptions, inputType } = this
         if (advancedOptions.transformCategory)
             return advancedOptions.transformCategory
@@ -172,7 +178,7 @@ export class CoreTable<
         return originalInput as CoreColumnStore
     }
 
-    @imemo get columnStore() {
+    @imemo get columnStore(): CoreColumnStore {
         const {
             inputColumnStore,
             valuesFromColumnDefs,
@@ -209,7 +215,7 @@ export class CoreTable<
             : columnStore
     }
 
-    private get blankColumnStore() {
+    private get blankColumnStore(): CoreColumnStore {
         const columnsObject: CoreColumnStore = {}
         this.columnSlugs.forEach((slug) => {
             columnsObject[slug] = []
@@ -217,7 +223,7 @@ export class CoreTable<
         return columnsObject
     }
 
-    @imemo private get delimitedAsColumnStore() {
+    @imemo private get delimitedAsColumnStore(): CoreColumnStore {
         const { originalInput, _numericColumnSlugs } = this
         const parsed = parseDelimited(
             originalInput as string,
@@ -232,11 +238,11 @@ export class CoreTable<
         return rowsToColumnStore(renamedRows ? renamedRows.rows : parsed)
     }
 
-    get tableSlug() {
+    get tableSlug(): string | undefined {
         return this.advancedOptions.tableSlug
     }
 
-    private get inputColumnsToParsedColumnStore() {
+    private get inputColumnsToParsedColumnStore(): CoreColumnStore {
         const { inputColumnStore, colsToParse } = this
         const columnsObject: CoreColumnStore = {}
         if (!colsToParse.length) return columnsObject
@@ -264,7 +270,7 @@ export class CoreTable<
         return columnsObject
     }
 
-    private get colsToParse() {
+    private get colsToParse(): CoreColumn[] {
         const { inputType, columnsAsArray, inputColumnStore } = this
         const firstInputRow = makeRowFromColumnStore(0, inputColumnStore)
         if (inputType === InputType.Delimited) {
@@ -304,11 +310,11 @@ export class CoreTable<
         )
     }
 
-    toOneDimensionalArray() {
+    toOneDimensionalArray(): any {
         return flatten(this.toTypedMatrix().slice(1))
     }
 
-    private setColumn(def: COL_DEF_TYPE) {
+    private setColumn(def: COL_DEF_TYPE): void {
         const { type, slug } = def
         const ColumnType = (type && ColumnTypeMap[type]) || ColumnTypeMap.String
         this._columns.set(slug, new ColumnType(this, def))
@@ -340,48 +346,51 @@ export class CoreTable<
             : 0
     }
 
-    @imemo get rows() {
+    @imemo get rows(): ROW_TYPE[] {
         return columnStoreToRows(this.columnStore) as ROW_TYPE[]
     }
 
-    @imemo get indices() {
+    @imemo get indices(): number[] {
         return range(0, this.numRows)
     }
 
-    *[Symbol.iterator]() {
+    *[Symbol.iterator](): Generator<CoreRow, void, unknown> {
         const { columnStore, numRows } = this
         for (let index = 0; index < numRows; index++) {
             yield makeRowFromColumnStore(index, columnStore)
         }
     }
 
-    getTimesAtIndices(indices: number[]) {
+    getTimesAtIndices(indices: number[]): number[] {
         if (!indices.length) return []
         return this.getValuesAtIndices(this.timeColumn!.slug, indices) as Time[]
     }
 
-    getValuesAtIndices(columnSlug: ColumnSlug, indices: number[]) {
+    getValuesAtIndices(
+        columnSlug: ColumnSlug,
+        indices: number[]
+    ): CoreValueType[] {
         const values = this.get(columnSlug).valuesIncludingErrorValues
         return indices.map((index) => values[index])
     }
 
-    @imemo get firstRow() {
+    @imemo get firstRow(): ROW_TYPE {
         return makeRowFromColumnStore(0, this.columnStore) as ROW_TYPE
     }
 
-    @imemo get lastRow() {
+    @imemo get lastRow(): ROW_TYPE {
         return makeRowFromColumnStore(
             this.numRows - 1,
             this.columnStore
         ) as ROW_TYPE
     }
 
-    @imemo get numRows() {
+    @imemo get numRows(): number {
         const firstColValues = Object.values(this.columnStore)[0]
         return firstColValues ? firstColValues.length : 0
     }
 
-    @imemo get numColumns() {
+    @imemo get numColumns(): number {
         return this.columnSlugs.length
     }
 
@@ -398,12 +407,14 @@ export class CoreTable<
         )
     }
 
-    has(columnSlug: ColumnSlug | undefined) {
+    has(columnSlug: ColumnSlug | undefined): boolean {
         if (columnSlug === undefined) return false
         return this._columns.has(columnSlug)
     }
 
-    getFirstColumnWithType(columnTypeName: ColumnTypeNames) {
+    getFirstColumnWithType(
+        columnTypeName: ColumnTypeNames
+    ): CoreColumn | undefined {
         return this.columnsAsArray.find(
             (col) => col.def.type === columnTypeName
         )
@@ -413,7 +424,7 @@ export class CoreTable<
     // TODO: remove this. Currently we use this to get the right day/year time formatting. For now a chart is either a "day chart" or a "year chart".
     // But we can have charts with multiple time columns. Ideally each place that needs access to the timeColumn, would get the specific column
     // and not the first time column from the table.
-    @imemo get timeColumn() {
+    @imemo get timeColumn(): CoreColumn {
         // "time" is the canonical time column slug.
         // See LegacyToOwidTable where this column is injected for all Graphers.
         const maybeTimeColumn = this.get(OwidTableSlugs.time)
@@ -440,7 +451,7 @@ export class CoreTable<
     }
 
     // todo: should be on owidtable
-    @imemo get entityNameColumn() {
+    @imemo get entityNameColumn(): CoreColumn {
         return (
             this.getFirstColumnWithType(ColumnTypeNames.EntityName) ??
             this.get(OwidTableSlugs.entityName)
@@ -448,35 +459,35 @@ export class CoreTable<
     }
 
     // todo: should be on owidtable
-    @imemo get entityNameSlug() {
+    @imemo get entityNameSlug(): string {
         return this.entityNameColumn.slug
     }
 
     // Todo: remove this. Generally this should not be called until the data is loaded. Even then, all calls should probably be made
     // on the column itself, and not tied tightly to the idea of a time column.
-    @imemo get timeColumnFormatFunction() {
+    @imemo get timeColumnFormatFunction(): (year: number) => string {
         return !this.timeColumn.isMissing
             ? this.timeColumn.formatValue
             : formatYear
     }
 
-    formatTime(value: any) {
+    formatTime(value: any): string {
         return this.timeColumnFormatFunction(value)
     }
 
-    @imemo private get columnsWithParseErrors() {
+    @imemo private get columnsWithParseErrors(): CoreColumn[] {
         return this.columnsAsArray.filter((col) => col.numErrorValues)
     }
 
-    @imemo get numColumnsWithErrorValues() {
+    @imemo get numColumnsWithErrorValues(): number {
         return this.columnsWithParseErrors.length
     }
 
-    @imemo get numErrorValues() {
+    @imemo get numErrorValues(): number {
         return sum(this.columnsAsArray.map((col) => col.numErrorValues))
     }
 
-    @imemo get numValidCells() {
+    @imemo get numValidCells(): number {
         return sum(this.columnsAsArray.map((col) => col.numValues))
     }
 
@@ -493,7 +504,7 @@ export class CoreTable<
      * So `table.rowIndex(["country", "population"]).get("USA 100")` would return [0].
      *
      */
-    rowIndex(columnSlugs: ColumnSlug[]) {
+    rowIndex(columnSlugs: ColumnSlug[]): Map<string, number[]> {
         const index = new Map<string, number[]>()
         const keyFn = makeKeyFn(this.columnStore, columnSlugs)
         this.indices.forEach((rowIndex) => {
@@ -517,7 +528,7 @@ export class CoreTable<
     protected valueIndex(
         indexColumnSlug: ColumnSlug,
         valueColumnSlug: ColumnSlug
-    ) {
+    ): Map<PrimitiveType, PrimitiveType> {
         const indexCol = this.get(indexColumnSlug)
         const valueCol = this.get(valueColumnSlug)
         const indexValues = indexCol.valuesIncludingErrorValues
@@ -537,7 +548,7 @@ export class CoreTable<
         return map
     }
 
-    grep(searchStringOrRegex: string | RegExp) {
+    grep(searchStringOrRegex: string | RegExp): this {
         return this.rowFilter((row) => {
             const line = Object.values(row).join(" ")
             return typeof searchStringOrRegex === "string"
@@ -546,7 +557,7 @@ export class CoreTable<
         }, `Kept rows that matched '${searchStringOrRegex.toString()}'`)
     }
 
-    get opposite() {
+    get opposite(): this {
         const { parent } = this
         const { filterMask } = this.advancedOptions
         if (!filterMask || !parent) return this
@@ -559,7 +570,7 @@ export class CoreTable<
         )
     }
 
-    @imemo get oppositeColumns() {
+    @imemo get oppositeColumns(): this {
         if (this.isRoot) return this
         const columnsToDrop = new Set(this.columnSlugs)
         const defs = this.parent!.columnsAsArray.filter(
@@ -573,7 +584,7 @@ export class CoreTable<
         )
     }
 
-    grepColumns(searchStringOrRegex: string | RegExp) {
+    grepColumns(searchStringOrRegex: string | RegExp): this {
         const columnsToDrop = this.columnSlugs.filter((slug) => {
             return typeof searchStringOrRegex === "string"
                 ? !slug.includes(searchStringOrRegex)
@@ -591,7 +602,7 @@ export class CoreTable<
     rowFilter(
         predicate: (row: ROW_TYPE, index: number) => boolean,
         opName: string
-    ) {
+    ): this {
         return this.transform(
             this.columnStore,
             this.defs,
@@ -605,7 +616,7 @@ export class CoreTable<
         columnSlug: ColumnSlug,
         predicate: (value: CoreValueType, index: number) => boolean,
         opName: string
-    ) {
+    ): this {
         return this.transform(
             this.columnStore,
             this.defs,
@@ -618,7 +629,7 @@ export class CoreTable<
         )
     }
 
-    sortBy(slugs: ColumnSlug[]) {
+    sortBy(slugs: ColumnSlug[]): this {
         return this.transform(
             sortColumnStore(this.columnStore, slugs),
             this.defs,
@@ -627,7 +638,7 @@ export class CoreTable<
         )
     }
 
-    sortColumns(slugs: ColumnSlug[]) {
+    sortColumns(slugs: ColumnSlug[]): this {
         const first = this.getColumns(slugs)
         const rest = this.columnsAsArray.filter((col) => !first.includes(col))
         return this.transform(
@@ -638,7 +649,7 @@ export class CoreTable<
         )
     }
 
-    reverse() {
+    reverse(): this {
         return this.transform(
             reverseColumnStore(this.columnStore),
             this.defs,
@@ -648,7 +659,7 @@ export class CoreTable<
     }
 
     // Assumes table is sorted by columnSlug. Returns an array representing the starting index of each new group.
-    protected groupBoundaries(columnSlug: ColumnSlug) {
+    protected groupBoundaries(columnSlug: ColumnSlug): number[] {
         const values = this.get(columnSlug).valuesIncludingErrorValues
         const arr: number[] = []
         let last: CoreValueType
@@ -667,45 +678,45 @@ export class CoreTable<
         return arr
     }
 
-    @imemo get defs() {
+    @imemo get defs(): COL_DEF_TYPE[] {
         return this.columnsAsArray.map((col) => col.def) as COL_DEF_TYPE[]
     }
 
-    @imemo get columnNames() {
+    @imemo get columnNames(): string[] {
         return this.columnsAsArray.map((col) => col.name)
     }
 
-    @imemo get columnTypes() {
+    @imemo get columnTypes(): (ColumnTypeNames | undefined)[] {
         return this.columnsAsArray.map((col) => col.def.type)
     }
 
-    @imemo get columnJsTypes() {
+    @imemo get columnJsTypes(): JsTypes[] {
         return this.columnsAsArray.map((col) => col.jsType)
     }
 
-    @imemo get columnSlugs() {
+    @imemo get columnSlugs(): string[] {
         return Array.from(this._columns.keys())
     }
 
-    @imemo get numericColumnSlugs() {
+    @imemo get numericColumnSlugs(): string[] {
         return this._numericColumnSlugs
     }
 
-    private get _numericColumnSlugs() {
+    private get _numericColumnSlugs(): string[] {
         return this._columnsAsArray
             .filter((col) => col instanceof ColumnTypeMap.Numeric)
             .map((col) => col.slug)
     }
 
-    private get _columnsAsArray() {
+    private get _columnsAsArray(): CoreColumn[] {
         return Array.from(this._columns.values())
     }
 
-    @imemo get columnsAsArray() {
+    @imemo get columnsAsArray(): CoreColumn[] {
         return this._columnsAsArray
     }
 
-    getColumns(slugs: ColumnSlug[]) {
+    getColumns(slugs: ColumnSlug[]): CoreColumn[] {
         return slugs.map((slug) => this.get(slug))
     }
 
@@ -717,7 +728,7 @@ export class CoreTable<
         return [min(mins), max(maxes)]
     }
 
-    private extract(slugs = this.columnSlugs) {
+    private extract(slugs = this.columnSlugs): any[][] {
         return this.rows.map((row) =>
             slugs.map((slug) =>
                 isNotErrorValue(row[slug]) ? row[slug] : undefined
@@ -725,27 +736,27 @@ export class CoreTable<
         )
     }
 
-    private get isRoot() {
+    private get isRoot(): boolean {
         return !this.parent
     }
 
-    dump(rowLimit = 30) {
+    dump(rowLimit = 30): void {
         this.dumpPipeline()
         this.dumpColumns()
         this.dumpRows(rowLimit)
     }
 
-    dumpPipeline() {
+    dumpPipeline(): void {
         // eslint-disable-next-line no-console
         console.table(this.ancestors.map((tb) => tb.explanation))
     }
 
-    dumpColumns() {
+    dumpColumns(): void {
         // eslint-disable-next-line no-console
         console.table(this.explainColumns)
     }
 
-    rowsFrom(start: number, end: number) {
+    rowsFrom(start: number, end: number): any {
         if (start >= this.numRows) return []
         if (end > this.numRows) end = this.numRows
         return range(start, end).map((index) =>
@@ -753,17 +764,17 @@ export class CoreTable<
         )
     }
 
-    dumpRows(rowLimit = 30) {
+    dumpRows(rowLimit = 30): void {
         // eslint-disable-next-line no-console
         console.table(this.rowsFrom(0, rowLimit), this.columnSlugs)
     }
 
-    dumpInputTable() {
+    dumpInputTable(): void {
         // eslint-disable-next-line no-console
         console.table(this.inputAsTable)
     }
 
-    @imemo private get inputType() {
+    @imemo private get inputType(): InputType {
         const { originalInput } = this
         if (typeof originalInput === "string") return InputType.Delimited
         if (Array.isArray(originalInput))
@@ -773,7 +784,10 @@ export class CoreTable<
         return InputType.ColumnStore
     }
 
-    @imemo private get inputColumnStoreToRows() {
+    @imemo private get inputColumnStoreToRows(): Record<
+        string,
+        CoreValueType
+    >[] {
         return columnStoreToRows(this.inputColumnStore)
     }
 
@@ -814,7 +828,7 @@ export class CoreTable<
         return this.parent ? [...this.parent.ancestors, this] : [this]
     }
 
-    @imemo private get numColsToParse() {
+    @imemo private get numColsToParse(): number {
         return this.colsToParse.length
     }
 
@@ -852,11 +866,11 @@ export class CoreTable<
     }
 
     // Output a pretty table for consles
-    toAlignedTextTable(options?: AlignedTextTableOptions) {
+    toAlignedTextTable(options?: AlignedTextTableOptions): string {
         return toAlignedTextTable(this.columnSlugs, this.rows, options)
     }
 
-    toMarkdownTable() {
+    toMarkdownTable(): string {
         return toMarkdownTable(this.columnSlugs, this.rows)
     }
 
@@ -864,15 +878,15 @@ export class CoreTable<
         delimiter: string = ",",
         columnSlugs = this.columnSlugs,
         rows = this.rows
-    ) {
+    ): string {
         return toDelimited(delimiter, columnSlugs, rows)
     }
 
-    toTsv() {
+    toTsv(): string {
         return this.toDelimited("\t")
     }
 
-    toCsvWithColumnNames() {
+    toCsvWithColumnNames(): string {
         const delimiter = ","
         const header =
             this.columnsAsArray
@@ -890,7 +904,7 @@ export class CoreTable<
     }
 
     // Get all the columns that only have 1 value
-    get constantColumns() {
+    get constantColumns(): CoreColumn[] {
         return this.columnsAsArray.filter((col) => col.isConstant)
     }
 
@@ -901,11 +915,11 @@ export class CoreTable<
         )
     }
 
-    findRows(query: CoreQuery) {
+    findRows(query: CoreQuery): ROW_TYPE[] {
         return this.rowsAt(this.findRowsIndices(query))
     }
 
-    findRowsIndices(query: CoreQuery) {
+    findRowsIndices(query: CoreQuery): any {
         const slugs = Object.keys(query)
         if (!slugs.length) return this.indices
         const arrs = this.getColumns(slugs).map((col) =>
@@ -914,11 +928,11 @@ export class CoreTable<
         return intersection(...arrs)
     }
 
-    indexOf(row: ROW_TYPE) {
+    indexOf(row: ROW_TYPE): any {
         return this.findRowsIndices(row)[0] ?? -1
     }
 
-    where(query: CoreQuery) {
+    where(query: CoreQuery): this {
         const rows = this.findRows(query)
         const queryDescription = Object.entries(query)
             .map(([col, value]) => `${col}=${value}`)
@@ -932,14 +946,14 @@ export class CoreTable<
         )
     }
 
-    appendRows(rows: ROW_TYPE[], opDescription: string) {
+    appendRows(rows: ROW_TYPE[], opDescription: string): this {
         return this.concat(
             [new (this.constructor as any)(rows, this.defs) as CoreTable],
             opDescription
         )
     }
 
-    limit(howMany: number, offset: number = 0) {
+    limit(howMany: number, offset: number = 0): this {
         const start = offset
         const end = offset + howMany
         return this.transform(
@@ -954,7 +968,7 @@ export class CoreTable<
         )
     }
 
-    updateDefs(fn: (def: COL_DEF_TYPE) => COL_DEF_TYPE) {
+    updateDefs(fn: (def: COL_DEF_TYPE) => COL_DEF_TYPE): this {
         return this.transform(
             this.columnStore,
             this.defs.map(fn),
@@ -963,7 +977,7 @@ export class CoreTable<
         )
     }
 
-    limitColumns(howMany: number, offset: number = 0) {
+    limitColumns(howMany: number, offset: number = 0): this {
         const slugs = this.columnSlugs.slice(offset, howMany + offset)
         return this.dropColumns(
             slugs,
@@ -971,7 +985,7 @@ export class CoreTable<
         )
     }
 
-    select(slugs: ColumnSlug[]) {
+    select(slugs: ColumnSlug[]): this {
         const columnsToKeep = new Set(slugs)
         const newStore: CoreColumnStore = {}
         const defs = this.columnsAsArray
@@ -992,7 +1006,7 @@ export class CoreTable<
         )
     }
 
-    dropColumns(slugs: ColumnSlug[], message?: string) {
+    dropColumns(slugs: ColumnSlug[], message?: string): this {
         const columnsToDrop = new Set(slugs)
         const newStore = {
             ...this.columnStore,
@@ -1011,7 +1025,7 @@ export class CoreTable<
         )
     }
 
-    @imemo get duplicateRowIndices() {
+    @imemo get duplicateRowIndices(): number[] {
         const keyFn = makeKeyFn(this.columnStore, this.columnSlugs)
         const dupeSet = new Set()
         const dupeIndices: number[] = []
@@ -1023,11 +1037,11 @@ export class CoreTable<
         return dupeIndices
     }
 
-    dropDuplicateRows() {
+    dropDuplicateRows(): this {
         return this.dropRowsAt(this.duplicateRowIndices)
     }
 
-    isRowEmpty(index: number) {
+    isRowEmpty(index: number): boolean {
         const { columnStore } = this
         return (
             this.columnSlugs
@@ -1037,7 +1051,7 @@ export class CoreTable<
         )
     }
 
-    dropEmptyRows() {
+    dropEmptyRows(): this {
         return this.dropRowsAt(
             this.indices
                 .map((index) => (this.isRowEmpty(index) ? index : null))
@@ -1045,12 +1059,12 @@ export class CoreTable<
         )
     }
 
-    renameColumn(oldSlug: ColumnSlug, newSlug: ColumnSlug) {
+    renameColumn(oldSlug: ColumnSlug, newSlug: ColumnSlug): this {
         return this.renameColumns({ [oldSlug]: newSlug })
     }
 
     // Todo: improve typings. After renaming a column the row interface should change. Applies to some other methods as well.
-    renameColumns(columnRenameMap: { [columnSlug: string]: ColumnSlug }) {
+    renameColumns(columnRenameMap: { [columnSlug: string]: ColumnSlug }): this {
         const oldSlugs = Object.keys(columnRenameMap)
         const newSlugs = Object.values(columnRenameMap)
 
@@ -1075,7 +1089,7 @@ export class CoreTable<
         )
     }
 
-    dropRowsAt(indices: number[], message?: string) {
+    dropRowsAt(indices: number[], message?: string): this {
         return this.transform(
             this.columnStore,
             this.defs,
@@ -1086,7 +1100,7 @@ export class CoreTable<
     }
 
     // for testing. Preserves ordering.
-    dropRandomRows(howMany = 1, seed = Date.now()) {
+    dropRandomRows(howMany: number = 1, seed: number = Date.now()): this {
         if (!howMany) return this // todo: clone?
         const indexesToDrop = getDropIndexes(this.numRows, howMany, seed)
         return this.dropRowsAt(
@@ -1095,7 +1109,7 @@ export class CoreTable<
         )
     }
 
-    replaceNonPositiveCellsForLogScale(columnSlugs: ColumnSlug[] = []) {
+    replaceNonPositiveCellsForLogScale(columnSlugs: ColumnSlug[] = []): this {
         return this.transform(
             replaceCells(this.columnStore, columnSlugs, (val) =>
                 val <= 0 ? ErrorValueTypes.InvalidOnALogScale : val
@@ -1108,7 +1122,7 @@ export class CoreTable<
         )
     }
 
-    replaceNonNumericCellsWithErrorValues(columnSlugs: ColumnSlug[]) {
+    replaceNonNumericCellsWithErrorValues(columnSlugs: ColumnSlug[]): this {
         return this.transform(
             replaceCells(this.columnStore, columnSlugs, (val) =>
                 !isNumber(val) ? ErrorValueTypes.NaNButShouldBeNumber : val
@@ -1125,9 +1139,9 @@ export class CoreTable<
         howMany = 1,
         columnSlugs: ColumnSlug[] = [],
         seed = Date.now(),
-        replacementGenerator: () => any = () =>
+        replacementGenerator: () => any = (): DroppedForTesting =>
             ErrorValueTypes.DroppedForTesting
-    ) {
+    ): this {
         return this.transform(
             replaceRandomCellsInColumnStore(
                 this.columnStore,
@@ -1144,7 +1158,10 @@ export class CoreTable<
         )
     }
 
-    dropRandomPercent(dropHowMuch = 1, seed = Date.now()) {
+    dropRandomPercent(
+        dropHowMuch: number = 1,
+        seed: number = Date.now()
+    ): this {
         return this.dropRandomRows(
             Math.floor((dropHowMuch / 100) * this.numRows),
             seed
@@ -1155,7 +1172,7 @@ export class CoreTable<
         columnSlug: ColumnSlug,
         value: PrimitiveType,
         opName?: string
-    ) {
+    ): this {
         return this.columnFilter(
             columnSlug,
             (colValue) => colValue > value,
@@ -1163,7 +1180,7 @@ export class CoreTable<
         )
     }
 
-    filterNegativesForLogScale(columnSlug: ColumnSlug) {
+    filterNegativesForLogScale(columnSlug: ColumnSlug): this {
         return this.isGreaterThan(
             columnSlug,
             0,
@@ -1171,7 +1188,7 @@ export class CoreTable<
         )
     }
 
-    filterNegatives(slug: ColumnSlug) {
+    filterNegatives(slug: ColumnSlug): this {
         return this.columnFilter(
             slug,
             (value) => value >= 0,
@@ -1179,7 +1196,7 @@ export class CoreTable<
         )
     }
 
-    appendColumns(defs: COL_DEF_TYPE[]) {
+    appendColumns(defs: COL_DEF_TYPE[]): this {
         return this.transform(
             this.columnStore,
             this.defs.concat(defs),
@@ -1190,7 +1207,7 @@ export class CoreTable<
         )
     }
 
-    duplicateColumn(slug: ColumnSlug, overrides: COL_DEF_TYPE) {
+    duplicateColumn(slug: ColumnSlug, overrides: COL_DEF_TYPE): this {
         return this.transform(
             {
                 ...this.columnStore,
@@ -1210,7 +1227,7 @@ export class CoreTable<
     transpose(
         by: ColumnSlug,
         columnTypeNameForNewColumns = ColumnTypeNames.Numeric
-    ) {
+    ): this {
         const newColumnSlugs = [by, ...this.get(by).uniqValues]
         const newColumnDefs = newColumnSlugs.map((slug) => {
             if (slug === by) return { slug }
@@ -1230,14 +1247,14 @@ export class CoreTable<
         )
     }
 
-    columnIntersection(tables: CoreTable[]) {
+    columnIntersection(tables: CoreTable[]): string[] {
         return intersection(
             this.columnSlugs,
             ...tables.map((table) => table.columnSlugs)
         )
     }
 
-    private intersectingRowIndices(tables: CoreTable[]) {
+    private intersectingRowIndices(tables: CoreTable[]): number[] {
         const columnSlugs = this.columnIntersection(tables)
         if (!columnSlugs.length) return []
         const thisIndex = this.rowIndex(columnSlugs)
@@ -1251,7 +1268,7 @@ export class CoreTable<
         return Array.from(keys).map((key) => thisIndex.get(key)![0]) // Only include first match if many b/c we are treating tables as sets here
     }
 
-    intersection(tables: CoreTable[]) {
+    intersection(tables: CoreTable[]): this {
         return this.transform(
             this.columnStore,
             this.defs,
@@ -1265,7 +1282,7 @@ export class CoreTable<
         )
     }
 
-    difference(tables: CoreTable[]) {
+    difference(tables: CoreTable[]): this {
         return this.transform(
             this.columnStore,
             this.defs,
@@ -1279,11 +1296,11 @@ export class CoreTable<
         )
     }
 
-    appendColumnsIfNew(defs: COL_DEF_TYPE[]) {
+    appendColumnsIfNew(defs: COL_DEF_TYPE[]): this {
         return this.appendColumns(defs.filter((def) => !this.has(def.slug)))
     }
 
-    toMatrix() {
+    toMatrix(): any[][] {
         const slugs = this.columnSlugs
         const rows = this.rows.map((row) =>
             slugs.map((slug) =>
@@ -1294,13 +1311,13 @@ export class CoreTable<
     }
 
     // Same as toMatrix, but preserves error types
-    toTypedMatrix() {
+    toTypedMatrix(): any[][] {
         const slugs = this.columnSlugs
         const rows = this.rows.map((row) => slugs.map((slug) => row[slug]))
         return [this.columnSlugs, ...rows]
     }
 
-    defToObject() {
+    defToObject(): any {
         const output: any = {}
         this.columnsAsArray.forEach((col) => {
             output[col.slug] = col.def
@@ -1308,7 +1325,7 @@ export class CoreTable<
         return output
     }
 
-    toJs() {
+    toJs(): { columns: any; rows: ROW_TYPE[] } {
         return {
             columns: this.defToObject(),
             rows: this.rows,
@@ -1319,7 +1336,7 @@ export class CoreTable<
         destinationTable: CoreTable,
         sourceTable: CoreTable,
         by?: ColumnSlug[]
-    ) {
+    ): COL_DEF_TYPE[] {
         by =
             by ??
             intersection(sourceTable.columnSlugs, destinationTable.columnSlugs)
@@ -1356,7 +1373,7 @@ export class CoreTable<
         return defsToAdd
     }
 
-    concat(tables: CoreTable[], message = `Combined tables`) {
+    concat(tables: CoreTable[], message: string = `Combined tables`): this {
         const all = [this, ...tables] as CoreTable[]
         const defs = flatten(all.map((table) => table.defs)) as COL_DEF_TYPE[]
         const uniqDefs = uniqBy(defs, (def) => def.slug)
@@ -1415,7 +1432,7 @@ export class CoreTable<
         return rightTable.leftJoin(this, by) as any // todo: change parent?
     }
 
-    innerJoin(rightTable: CoreTable, by?: ColumnSlug[]) {
+    innerJoin(rightTable: CoreTable, by?: ColumnSlug[]): this {
         const defs = this.join(this, rightTable, by)
         const newValues = defs.map((def) => def.values)
         const rowsToDrop: number[] = []
@@ -1434,11 +1451,11 @@ export class CoreTable<
             .dropDuplicateRows()
     }
 
-    union(tables: CoreTable[]) {
+    union(tables: CoreTable[]): this {
         return this.concat(tables).dropDuplicateRows()
     }
 
-    indexBy(slug: ColumnSlug) {
+    indexBy(slug: ColumnSlug): Map<CoreValueType, number[]> {
         const map = new Map<CoreValueType, number[]>()
         this.get(slug).values.map((value, index) => {
             if (!map.has(value)) map.set(value, [])
@@ -1447,7 +1464,7 @@ export class CoreTable<
         return map
     }
 
-    groupBy(by: ColumnSlug) {
+    groupBy(by: ColumnSlug): this[] {
         const index = this.indexBy(by)
         return Array.from(index.keys()).map((groupName) =>
             this.transform(
@@ -1460,7 +1477,7 @@ export class CoreTable<
         )
     }
 
-    reduce(reductionMap: ReductionMap) {
+    reduce(reductionMap: ReductionMap): this {
         const lastRow = { ...this.lastRow }
         Object.keys(reductionMap).forEach((slug: keyof ROW_TYPE) => {
             const prop = reductionMap[slug]
@@ -1503,14 +1520,14 @@ class FilterMask {
         }
     }
 
-    inverse() {
+    inverse(): FilterMask {
         return new FilterMask(
             this.numRows,
             this.mask.map((bit) => !bit)
         )
     }
 
-    apply(columnStore: CoreColumnStore) {
+    apply(columnStore: CoreColumnStore): CoreColumnStore {
         const columnsObject: CoreColumnStore = {}
         Object.keys(columnStore).forEach((slug) => {
             columnsObject[slug] = columnStore[slug].filter(
@@ -1527,7 +1544,7 @@ class FilterMask {
  *
  * todo: define all column def property types
  */
-export const columnDefinitionsFromDelimited = <T>(delimited: string) =>
+export const columnDefinitionsFromDelimited = <T>(delimited: string): T[] =>
     new CoreTable<T>(delimited.trim()).columnFilter(
         "slug",
         (value) => !!value,

--- a/coreTable/CoreTableColumns.ts
+++ b/coreTable/CoreTableColumns.ts
@@ -15,7 +15,14 @@ import {
 } from "../clientUtils/Util"
 import { isPresent } from "../clientUtils/isPresent"
 import { CoreTable } from "./CoreTable"
-import { ColumnSlug, Time, PrimitiveType, JsTypes } from "./CoreTableConstants"
+import {
+    CoreRow,
+    ColumnSlug,
+    Time,
+    PrimitiveType,
+    JsTypes,
+    CoreValueType,
+} from "./CoreTableConstants"
 import { ColumnTypeNames, CoreColumnDef } from "./CoreColumnDef"
 import { EntityName, LegacyOwidRow } from "./OwidTableConstants" // todo: remove. Should not be on CoreTable
 import { ErrorValue, ErrorValueTypes } from "./ErrorValues"
@@ -24,6 +31,7 @@ import { imemo } from "./CoreTableUtils"
 import moment from "moment"
 import { OwidSource } from "./OwidSource"
 import { formatValue, TickFormattingOptions } from "../clientUtils/formatValue"
+import { LegacyVariableDisplayConfigInterface } from "../clientUtils/LegacyVariableDisplayConfigInterface"
 
 interface ColumnSummary {
     numErrorValues: number
@@ -40,7 +48,7 @@ interface ColumnSummary {
     deciles: { [decile: number]: PrimitiveType }
 }
 
-abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
+export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
     def: CoreColumnDef
     table: CoreTable
 
@@ -51,7 +59,7 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
 
     abstract jsType: JsTypes
 
-    parse(val: any) {
+    parse(val: any): any {
         return val
     }
 
@@ -59,24 +67,24 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
         return this instanceof MissingColumn
     }
 
-    get sum() {
+    get sum(): number | undefined {
         return this.summary.sum
     }
 
-    get median() {
+    get median(): PrimitiveType | undefined {
         return this.summary.median
     }
 
-    get max() {
+    get max(): PrimitiveType | undefined {
         return this.summary.max
     }
 
-    get min() {
+    get min(): PrimitiveType | undefined {
         return this.summary.min
     }
 
     // todo: switch to a lib and/or add tests for this. handle non numerics better.
-    @imemo get summary() {
+    @imemo get summary(): Partial<ColumnSummary> {
         const { numErrorValues, numValues, numUniqs } = this
         const basicSummary: Partial<ColumnSummary> = {
             numErrorValues,
@@ -138,24 +146,24 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
 
     // todo: migrate from unitConversionFactor to computed columns instead. then delete this.
     // note: unitConversionFactor is used >400 times in charts and >800 times in variables!!!
-    @imemo get unitConversionFactor() {
-        return this.display.conversionFactor ?? 1
+    @imemo get unitConversionFactor(): number {
+        return this.display?.conversionFactor ?? 1
     }
 
-    @imemo get isAllIntegers() {
+    @imemo get isAllIntegers(): boolean {
         return false
     }
 
-    @imemo get tolerance() {
-        return this.display.tolerance ?? this.def.tolerance ?? 0
+    @imemo get tolerance(): number {
+        return this.display?.tolerance ?? this.def.tolerance ?? 0
     }
 
-    @imemo get domain() {
+    @imemo get domain(): [JS_TYPE, JS_TYPE] {
         return [this.minValue, this.maxValue]
     }
 
-    @imemo get display() {
-        return this.def.display || {}
+    @imemo get display(): LegacyVariableDisplayConfigInterface | undefined {
+        return this.def.display
     }
 
     abstract formatValue(value: any, options?: TickFormattingOptions): string
@@ -189,7 +197,7 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
     }
 
     @imemo get numDecimalPlaces(): number {
-        return this.display.numDecimalPlaces ?? 2
+        return this.display?.numDecimalPlaces ?? 2
     }
 
     @imemo get unit(): string | undefined {
@@ -198,7 +206,7 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
 
     @imemo get shortUnit(): string | undefined {
         const shortUnit =
-            this.display.shortUnit ?? this.def.shortUnit ?? undefined
+            this.display?.shortUnit ?? this.def.shortUnit ?? undefined
         if (shortUnit !== undefined) return shortUnit
 
         const unit = this.unit
@@ -213,7 +221,9 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
 
     // Returns a map where the key is a series slug such as "name" and the value is a set
     // of all the unique values that this column has for that particular series.
-    getUniqueValuesGroupedBy(indexColumnSlug: ColumnSlug) {
+    getUniqueValuesGroupedBy(
+        indexColumnSlug: ColumnSlug
+    ): Map<PrimitiveType, Set<PrimitiveType>> {
         const map = new Map<PrimitiveType, Set<PrimitiveType>>()
         const values = this.values
         const indexValues = this.table.getValuesAtIndices(
@@ -227,34 +237,34 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
         return map
     }
 
-    @imemo get description() {
+    @imemo get description(): string | undefined {
         return this.def.description
     }
 
-    @imemo get isEmpty() {
+    @imemo get isEmpty(): boolean {
         return this.valuesIncludingErrorValues.length === 0
     }
 
-    @imemo get name() {
+    @imemo get name(): string {
         return this.def.name ?? this.def.slug
     }
 
-    @imemo get displayName() {
+    @imemo get displayName(): string {
         return this.display?.name ?? this.name ?? ""
     }
 
     // todo: is the isString necessary?
-    @imemo get sortedUniqNonEmptyStringVals() {
+    @imemo get sortedUniqNonEmptyStringVals(): JS_TYPE[] {
         return Array.from(
             new Set(this.values.filter(isString).filter((i) => i))
         ).sort()
     }
 
-    @imemo get slug() {
+    @imemo get slug(): string {
         return this.def.slug
     }
 
-    @imemo get valuesToIndices() {
+    @imemo get valuesToIndices(): Map<any, number[]> {
         const map = new Map<any, number[]>()
         this.valuesIncludingErrorValues.forEach((value, index) => {
             if (!map.has(value)) map.set(value, [])
@@ -263,7 +273,7 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
         return map
     }
 
-    indicesWhere(value: JS_TYPE | JS_TYPE[]) {
+    indicesWhere(value: JS_TYPE | JS_TYPE[]): any {
         const queries = Array.isArray(value) ? value : [value]
         return union(
             ...queries
@@ -273,7 +283,7 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
     }
 
     // We approximate whether a column is parsed simply by looking at the first row.
-    needsParsing(value: any) {
+    needsParsing(value: any): boolean {
         // Never parse computeds. The computed should return the correct JS type. Ideally we can provide some error messaging around this.
         if (this.def.transform) return false
 
@@ -285,15 +295,15 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
         return true
     }
 
-    @imemo get isProjection() {
+    @imemo get isProjection(): boolean {
         return !!this.display?.isProjection
     }
 
-    @imemo get uniqValues() {
+    @imemo get uniqValues(): JS_TYPE[] {
         return uniq(this.values)
     }
 
-    @imemo get uniqValuesAsSet() {
+    @imemo get uniqValuesAsSet(): Set<JS_TYPE> {
         return new Set(this.uniqValues)
     }
 
@@ -302,12 +312,12 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
      * Normally you want just the valid values, like `[45000, 50000, ...]`. But sometimes you
      * need the ErrorValues too like `[45000, DivideByZeroError, 50000,...]`
      */
-    @imemo get valuesIncludingErrorValues() {
+    @imemo get valuesIncludingErrorValues(): CoreValueType[] {
         const { table, slug } = this
         return table.has(slug) ? table.columnStore[slug] : []
     }
 
-    @imemo get validRowIndices() {
+    @imemo get validRowIndices(): number[] {
         return this.valuesIncludingErrorValues
             .map((value, index) =>
                 (value as any) instanceof ErrorValue ? null : index
@@ -315,20 +325,20 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
             .filter(isPresent)
     }
 
-    @imemo get values() {
+    @imemo get values(): JS_TYPE[] {
         const values = this.valuesIncludingErrorValues
         return this.validRowIndices.map((index) => values[index]) as JS_TYPE[]
     }
 
-    @imemo get originalTimeColumnSlug() {
+    @imemo get originalTimeColumnSlug(): string {
         return getOriginalTimeColumnSlug(this.table, this.slug)
     }
 
-    @imemo get originalTimeColumn() {
+    @imemo get originalTimeColumn(): CoreColumn {
         return this.table.get(this.originalTimeColumnSlug)
     }
 
-    @imemo get originalTimes() {
+    @imemo get originalTimes(): number[] {
         const { originalTimeColumnSlug } = this
         if (!originalTimeColumnSlug) return []
         return this.table.getValuesAtIndices(
@@ -341,32 +351,32 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
      * True if the column has only 1 unique value. ErrorValues are counted as values, so
      * something like [DivideByZeroError, 2, 2] would not be constant.
      */
-    @imemo get isConstant() {
+    @imemo get isConstant(): boolean {
         return new Set(this.valuesIncludingErrorValues).size === 1
     }
 
-    @imemo get minValue() {
+    @imemo get minValue(): JS_TYPE {
         return this.valuesAscending[0]
     }
 
-    @imemo get maxValue() {
+    @imemo get maxValue(): JS_TYPE {
         return last(this.valuesAscending)!
     }
 
-    @imemo get numErrorValues() {
+    @imemo get numErrorValues(): number {
         return this.valuesIncludingErrorValues.length - this.numValues
     }
 
     // Number of correctly parsed values
-    @imemo get numValues() {
+    @imemo get numValues(): number {
         return this.values.length
     }
 
-    @imemo get numUniqs() {
+    @imemo get numUniqs(): number {
         return this.uniqValues.length
     }
 
-    @imemo get valuesAscending() {
+    @imemo get valuesAscending(): JS_TYPE[] {
         const values = this.values.slice()
         return this.jsType === "string" ? values.sort() : sortNumeric(values)
     }
@@ -400,7 +410,7 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
     }
 
     // todo: remove. should not be on coretable
-    @imemo get maxTime() {
+    @imemo get maxTime(): Time {
         return last(this.uniqTimesAsc) as Time
     }
 
@@ -415,7 +425,7 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
     }
 
     // todo: remove? Should not be on CoreTable
-    @imemo private get allEntityNames() {
+    @imemo private get allEntityNames(): EntityName[] {
         return this.table.getValuesAtIndices(
             this.table.entityNameSlug,
             this.validRowIndices
@@ -438,7 +448,7 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
     }
 
     // todo: remove? Should not be on CoreTable
-    @imemo get owidRowsByEntityName() {
+    @imemo get owidRowsByEntityName(): Map<EntityName, CoreRow[]> {
         const map = new Map<EntityName, LegacyOwidRow<JS_TYPE>[]>()
         this.owidRows.forEach((row) => {
             if (!map.has(row.entityName)) map.set(row.entityName, [])
@@ -448,7 +458,7 @@ abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
     }
 
     // todo: remove? Should not be on CoreTable
-    @imemo get valueByEntityNameAndTime() {
+    @imemo get valueByEntityNameAndTime(): Map<EntityName, Map<Time, JS_TYPE>> {
         const valueByEntityNameAndTime = new Map<
             EntityName,
             Map<Time, JS_TYPE>
@@ -469,7 +479,7 @@ export type CoreColumn = AbstractCoreColumn<any>
 export class MissingColumn extends AbstractCoreColumn<any> {
     jsType = JsTypes.string
 
-    formatValue() {
+    formatValue(): string {
         return ""
     }
 }
@@ -477,11 +487,11 @@ export class MissingColumn extends AbstractCoreColumn<any> {
 class StringColumn extends AbstractCoreColumn<string> {
     jsType = JsTypes.string
 
-    formatValue(value: any) {
+    formatValue(value: any): string {
         return anyToString(value)
     }
 
-    parse(val: any) {
+    parse(val: any): any {
         if (val === null) return ErrorValueTypes.NullButShouldBeString
         if (val === undefined) return ErrorValueTypes.UndefinedButShouldBeString
         return val.toString() || ""
@@ -496,18 +506,18 @@ class ColorColumn extends CategoricalColumn {}
 class BooleanColumn extends AbstractCoreColumn<boolean> {
     jsType = JsTypes.boolean
 
-    formatValue(value: any) {
+    formatValue(value: any): "true" | "false" {
         return value ? "true" : "false"
     }
 
-    parse(val: any) {
+    parse(val: any): boolean {
         return !!val
     }
 }
 abstract class AbstractNumericColumn extends AbstractCoreColumn<number> {
     jsType = JsTypes.number
 
-    formatValue(value: number, options?: TickFormattingOptions) {
+    formatValue(value: number, options?: TickFormattingOptions): string {
         if (isNumber(value)) {
             return formatValue(value, {
                 numDecimalPlaces: this.numDecimalPlaces,
@@ -520,7 +530,7 @@ abstract class AbstractNumericColumn extends AbstractCoreColumn<number> {
     formatValueShortWithAbbreviations(
         value: number,
         options?: TickFormattingOptions
-    ) {
+    ): string {
         return super.formatValueShortWithAbbreviations(value, {
             shortNumberPrefixes: true,
             // do not set a unit
@@ -528,7 +538,7 @@ abstract class AbstractNumericColumn extends AbstractCoreColumn<number> {
         })
     }
 
-    formatValueShort(value: number, options?: TickFormattingOptions) {
+    formatValueShort(value: number, options?: TickFormattingOptions): string {
         return super.formatValueShort(value, {
             ...omitUndefinedValues({
                 unit: this.shortUnit,
@@ -537,7 +547,7 @@ abstract class AbstractNumericColumn extends AbstractCoreColumn<number> {
         })
     }
 
-    formatValueLong(value: number, options?: TickFormattingOptions) {
+    formatValueLong(value: number, options?: TickFormattingOptions): string {
         return super.formatValueLong(value, {
             ...omitUndefinedValues({
                 unit: this.unit,
@@ -546,7 +556,7 @@ abstract class AbstractNumericColumn extends AbstractCoreColumn<number> {
         })
     }
 
-    @imemo get isAllIntegers() {
+    @imemo get isAllIntegers(): boolean {
         return this.values.every((val) => val % 1 === 0)
     }
 
@@ -564,7 +574,7 @@ abstract class AbstractNumericColumn extends AbstractCoreColumn<number> {
         return res
     }
 
-    protected _parse(val: any) {
+    protected _parse(val: any): number {
         return parseFloat(val)
     }
 }
@@ -573,20 +583,20 @@ class NumericColumn extends AbstractNumericColumn {}
 class NumericCategoricalColumn extends AbstractNumericColumn {}
 
 class IntegerColumn extends NumericColumn {
-    formatValue(value: any, options?: TickFormattingOptions) {
+    formatValue(value: any, options?: TickFormattingOptions): string {
         return super.formatValue(value, {
             numDecimalPlaces: 0,
             ...options,
         })
     }
 
-    protected _parse(val: any) {
+    protected _parse(val: any): number {
         return parseInt(val)
     }
 }
 
 class CurrencyColumn extends NumericColumn {
-    formatValue(value: any, options?: TickFormattingOptions) {
+    formatValue(value: any, options?: TickFormattingOptions): string {
         return super.formatValue(value, {
             numDecimalPlaces: 0,
             unit: "$",
@@ -596,7 +606,7 @@ class CurrencyColumn extends NumericColumn {
 }
 // Expects 50% to be 50
 class PercentageColumn extends NumericColumn {
-    formatValue(value: number, options?: TickFormattingOptions) {
+    formatValue(value: number, options?: TickFormattingOptions): string {
         return super.formatValue(value, {
             numberPrefixes: false,
             unit: "%",
@@ -610,7 +620,7 @@ class PercentageColumn extends NumericColumn {
 class RelativePercentageColumn extends PercentageColumn {}
 
 class PercentChangeOverTimeColumn extends PercentageColumn {
-    formatValue(value: number, options?: TickFormattingOptions) {
+    formatValue(value: number, options?: TickFormattingOptions): string {
         return super.formatValue(value, {
             showPlus: true,
             ...options,
@@ -636,29 +646,29 @@ abstract class TimeColumn extends AbstractCoreColumn<number> {
 }
 
 class YearColumn extends TimeColumn {
-    formatValue(value: number) {
+    formatValue(value: number): string {
         // Include BCE
         return formatYear(value)
     }
 }
 
 class DayColumn extends TimeColumn {
-    formatValue(value: number) {
+    formatValue(value: number): string {
         return formatDay(value)
     }
 
-    formatValueForMobile(value: number) {
+    formatValueForMobile(value: number): string {
         return formatDay(value, { format: "MMM D, 'YY" })
     }
 
-    formatForCsv(value: number) {
+    formatForCsv(value: number): string {
         return formatDay(value, { format: "YYYY-MM-DD" })
     }
 }
 
 const dateToTimeCache = new Map<string, Time>() // Cache for performance
 class DateColumn extends DayColumn {
-    parse(val: any) {
+    parse(val: any): number {
         // skip parsing if a date is a number, it's already been parsed
         if (typeof val === "number") return val
         if (!dateToTimeCache.has(val))
@@ -689,18 +699,18 @@ class QuarterColumn extends TimeColumn {
         return ErrorValueTypes.InvalidQuarterValue
     }
 
-    private static numToQuarter(value: number) {
+    private static numToQuarter(value: number): number[] {
         const year = Math.floor(value / 4)
         const quarter = (Math.abs(value) % 4) + 1
         return [year, quarter]
     }
 
-    formatValue(value: number) {
+    formatValue(value: number): string {
         const [year, quarter] = QuarterColumn.numToQuarter(value)
         return `Q${quarter}/${year}`
     }
 
-    formatForCsv(value: number) {
+    formatForCsv(value: number): string {
         const [year, quarter] = QuarterColumn.numToQuarter(value)
         return `${year}-Q${quarter}`
     }

--- a/coreTable/CoreTablePrinters.ts
+++ b/coreTable/CoreTablePrinters.ts
@@ -11,7 +11,7 @@ export const toAlignedTextTable = (
     headerSlugs: string[],
     rows: any[],
     options: AlignedTextTableOptions = {}
-) => {
+): string => {
     const {
         alignRight = true,
         maxCharactersPerColumn = 20,
@@ -68,7 +68,7 @@ export const toMarkdownTable = (
     slugs: string[],
     rows: any[],
     formatFn?: CellFormatter
-) =>
+): string =>
     [
         slugs,
         slugs.map(() => "-"),
@@ -88,7 +88,7 @@ export const toDelimited = (
     rows: any[],
     cellFn?: CellFormatter,
     rowDelimiter = "\n"
-) => {
+): string => {
     const skipHeaderRow = 1
     const header = columnSlugs.map((columnName, index) =>
         cellFn ? cellFn(columnName, 0, index) : columnName

--- a/coreTable/CoreTableUtils.test.ts
+++ b/coreTable/CoreTableUtils.test.ts
@@ -179,11 +179,11 @@ describe(linearInterpolation, () => {
     })
 })
 
-describe("immutable memoization", () => {
+describe("immutable memoization", (): void => {
     class WeatherForecast {
         conditions = "rainy"
 
-        @imemo get forecast() {
+        @imemo get forecast(): string {
             return this.conditions
         }
     }

--- a/coreTable/ErrorValues.ts
+++ b/coreTable/ErrorValues.ts
@@ -8,16 +8,16 @@
  * For a good read on the "Errors are values" pattern: https://blog.golang.org/errors-are-values
  */
 export abstract class ErrorValue {
-    toString() {
+    toString(): string {
         return ""
     }
-    toErrorString() {
+    toErrorString(): string {
         return this.constructor.name
     }
 }
 
 class NaNButShouldBeNumber extends ErrorValue {}
-class DroppedForTesting extends ErrorValue {}
+export class DroppedForTesting extends ErrorValue {}
 class InvalidOnALogScale extends ErrorValue {}
 class UndefinedButShouldBeNumber extends ErrorValue {}
 class NullButShouldBeNumber extends ErrorValue {}
@@ -25,10 +25,10 @@ class BlankButShouldBeNumber extends ErrorValue {}
 class UndefinedButShouldBeString extends ErrorValue {}
 class NullButShouldBeString extends ErrorValue {}
 class NotAParseableNumberButShouldBeNumber extends ErrorValue {}
-class DivideByZeroError extends ErrorValue {}
+export class DivideByZeroError extends ErrorValue {}
 class NoValueWithinTolerance extends ErrorValue {}
 class NoMatchingValueAfterJoin extends ErrorValue {}
-class ValueTooLow extends ErrorValue {}
+export class ValueTooLow extends ErrorValue {}
 class NoValueToCompareAgainst extends ErrorValue {}
 class FilteredValue extends ErrorValue {}
 class NoValueForInterpolation extends ErrorValue {}

--- a/coreTable/OwidTable.test.ts
+++ b/coreTable/OwidTable.test.ts
@@ -557,7 +557,7 @@ describe("tolerance", () => {
         ]
     )
 
-    function applyTolerance(table: OwidTable) {
+    function applyTolerance(table: OwidTable): OwidTable {
         return table.interpolateColumnWithTolerance("gdp", 1)
     }
 

--- a/coreTable/OwidTable.ts
+++ b/coreTable/OwidTable.ts
@@ -27,6 +27,7 @@ import {
     TransformType,
     CoreColumnStore,
     Color,
+    CoreValueType,
 } from "./CoreTableConstants"
 import { ColumnTypeNames } from "./CoreColumnDef"
 import { CoreTable } from "./CoreTable"
@@ -60,16 +61,16 @@ import { CoreColumn, ColumnTypeMap } from "./CoreTableColumns"
 export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     entityType = "Country"
 
-    @imemo get availableEntityNames() {
+    @imemo get availableEntityNames(): any[] {
         return Array.from(this.availableEntityNameSet)
     }
 
-    @imemo get availableEntityNameSet() {
+    @imemo get availableEntityNameSet(): Set<any> {
         return new Set(this.entityNameColumn.uniqValues)
     }
 
     // todo: can we remove at some point?
-    @imemo get entityIdToNameMap() {
+    @imemo get entityIdToNameMap(): Map<number, string> {
         return this.valueIndex(
             this.entityIdColumn.slug,
             this.entityNameColumn.slug
@@ -77,7 +78,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     }
 
     // todo: can we remove at some point?
-    @imemo get entityCodeToNameMap() {
+    @imemo get entityCodeToNameMap(): Map<string, string> {
         return this.valueIndex(
             this.entityCodeColumn.slug,
             this.entityNameColumn.slug
@@ -85,7 +86,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     }
 
     // todo: can we remove at some point?
-    @imemo get entityNameToIdMap() {
+    @imemo get entityNameToIdMap(): Map<string, number> {
         return this.valueIndex(
             this.entityNameColumn.slug,
             this.entityIdColumn.slug
@@ -93,32 +94,32 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     }
 
     // todo: can we remove at some point?
-    @imemo get entityNameToCodeMap() {
+    @imemo get entityNameToCodeMap(): Map<string, string> {
         return this.valueIndex(
             this.entityNameColumn.slug,
             this.entityCodeColumn.slug
         ) as Map<string, string>
     }
 
-    @imemo get maxTime() {
+    @imemo get maxTime(): number | undefined {
         return last(this.allTimes)
     }
 
-    @imemo get entityIdColumn() {
+    @imemo get entityIdColumn(): CoreColumn {
         return (
             this.getFirstColumnWithType(ColumnTypeNames.EntityId) ??
             this.get(OwidTableSlugs.entityId)
         )
     }
 
-    @imemo get entityCodeColumn() {
+    @imemo get entityCodeColumn(): CoreColumn {
         return (
             this.getFirstColumnWithType(ColumnTypeNames.EntityCode) ??
             this.get(OwidTableSlugs.entityCode)
         )
     }
 
-    @imemo get minTime() {
+    @imemo get minTime(): Time {
         return this.allTimes[0]
     }
 
@@ -126,24 +127,24 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         return this.sortedByTime.get(this.timeColumn.slug).values
     }
 
-    @imemo get rowIndicesByEntityName() {
+    @imemo get rowIndicesByEntityName(): Map<string, number[]> {
         return this.rowIndex([this.entityNameSlug])
     }
 
-    getAnnotationColumnSlug(columnDef: OwidColumnDef) {
+    getAnnotationColumnSlug(columnDef: OwidColumnDef): string | undefined {
         return isEmpty(columnDef?.annotationsColumnSlug)
             ? makeAnnotationsSlug(columnDef.slug)
             : columnDef.annotationsColumnSlug
     }
 
     // todo: instead of this we should probably make annotations another property on charts—something like "annotationsColumnSlugs"
-    getAnnotationColumnForColumn(columnSlug: ColumnSlug) {
+    getAnnotationColumnForColumn(columnSlug: ColumnSlug): CoreColumn {
         const def = this.get(columnSlug).def as OwidColumnDef
         const slug = this.getAnnotationColumnSlug(def)
         return this.get(slug)
     }
 
-    getTimesUniqSortedAscForColumns(columnSlugs: ColumnSlug[]) {
+    getTimesUniqSortedAscForColumns(columnSlugs: ColumnSlug[]): number[] {
         // todo: should be easy to speed up if necessary.
         return sortNumeric(
             uniq(
@@ -172,7 +173,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         return [min(mins), max(maxes)]
     }
 
-    filterByEntityNames(names: EntityName[]) {
+    filterByEntityNames(names: EntityName[]): this {
         const namesSet = new Set(names)
         return this.columnFilter(
             this.entityNameSlug,
@@ -182,7 +183,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     }
 
     // Does a stable sort by time. You can refer to this table for fast time filtering.
-    @imemo private get sortedByTime() {
+    @imemo private get sortedByTime(): this {
         if (this.timeColumn.isMissing) return this
         return this.sortBy([this.timeColumn.slug])
     }
@@ -202,7 +203,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         )
     }
 
-    filterByTargetTimes(targetTimes: Time[], tolerance = 0) {
+    filterByTargetTimes(targetTimes: Time[], tolerance = 0): this {
         const timeColumn = this.timeColumn!
         const timeValues = timeColumn.valuesIncludingErrorValues
         const entityNameToIndices = this.rowIndicesByEntityName
@@ -232,7 +233,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         )
     }
 
-    dropRowsWithErrorValuesForColumn(slug: ColumnSlug) {
+    dropRowsWithErrorValuesForColumn(slug: ColumnSlug): this {
         return this.columnFilter(
             slug,
             (value) => isNotErrorValue(value),
@@ -242,7 +243,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
 
     // TODO rewrite with column ops
     // TODO move to CoreTable
-    dropRowsWithErrorValuesForAnyColumn(slugs: ColumnSlug[]) {
+    dropRowsWithErrorValuesForAnyColumn(slugs: ColumnSlug[]): this {
         return this.rowFilter(
             (row) => slugs.every((slug) => isNotErrorValue(row[slug])),
             `Drop rows with empty or ErrorValues in any column: ${slugs.join(
@@ -253,7 +254,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
 
     // TODO rewrite with column ops
     // TODO move to CoreTable
-    dropRowsWithErrorValuesForAllColumns(slugs: ColumnSlug[]) {
+    dropRowsWithErrorValuesForAllColumns(slugs: ColumnSlug[]): this {
         return this.rowFilter(
             (row) => slugs.some((slug) => isNotErrorValue(row[slug])),
             `Drop rows with empty or ErrorValues in every column: ${slugs.join(
@@ -262,7 +263,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         )
     }
 
-    private sumsByTime(columnSlug: ColumnSlug) {
+    private sumsByTime(columnSlug: ColumnSlug): Map<number, number> {
         const timeValues = this.timeColumn.values
         const values = this.get(columnSlug).values as number[]
         const map = new Map<number, number>()
@@ -354,7 +355,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     toTotalGrowthForEachColumnComparedToStartTime(
         startTimeBound: TimeBound,
         columnSlugs: ColumnSlug[]
-    ) {
+    ): this {
         if (this.timeColumn.isMissing) return this
         const timeColumnSlug = this.timeColumn.slug
         const newDefs = this.defs.map((def) => {
@@ -530,7 +531,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     }
 
     // Return slugs that would be good to chart
-    @imemo get suggestedYColumnSlugs() {
+    @imemo get suggestedYColumnSlugs(): string[] {
         const skips = new Set<ColumnSlug>([
             OwidTableSlugs.entityId,
             OwidTableSlugs.time,
@@ -541,7 +542,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     }
 
     // Give our users a clean CSV of each Grapher. Assumes an Owid Table with entityName.
-    toPrettyCsv() {
+    toPrettyCsv(): string {
         return this.dropColumns([
             OwidTableSlugs.entityId,
             OwidTableSlugs.time,
@@ -551,18 +552,18 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
             .toCsvWithColumnNames()
     }
 
-    @imemo get entityNameColorIndex() {
+    @imemo get entityNameColorIndex(): Map<EntityName, Color> {
         return this.valueIndex(
             this.entityNameSlug,
             OwidTableSlugs.entityColor
         ) as Map<EntityName, Color>
     }
 
-    getColorForEntityName(entityName: EntityName) {
+    getColorForEntityName(entityName: EntityName): Color | undefined {
         return this.entityNameColorIndex.get(entityName)
     }
 
-    @imemo get columnDisplayNameToColorMap() {
+    @imemo get columnDisplayNameToColorMap(): Map<string, Color> {
         return new Map(
             this.columnsAsArray
                 .filter((col) => col.def.color)
@@ -576,7 +577,10 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
 
     // This assumes the table is sorted where the times for entity names go in asc order.
     // The whole table does not have to be sorted by time.
-    getLatestValueForEntity(entityName: EntityName, columnSlug: ColumnSlug) {
+    getLatestValueForEntity(
+        entityName: EntityName,
+        columnSlug: ColumnSlug
+    ): CoreValueType | undefined {
         const indices = this.rowIndicesByEntityName.get(entityName)
         if (!indices) return undefined
         const values = this.get(columnSlug).valuesIncludingErrorValues
@@ -606,7 +610,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         timeColumnSlug: ColumnSlug,
         interpolation: InterpolationProvider<K>,
         context: K
-    ) {
+    ): { values: number[]; times: number[] } {
         const groupBoundaries = withAllRows.groupBoundaries(this.entityNameSlug)
         const newValues = withAllRows
             .get(columnSlug)
@@ -636,7 +640,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     interpolateColumnWithTolerance(
         columnSlug: ColumnSlug,
         toleranceOverride?: number
-    ) {
+    ): this {
         // If the column doesn't exist, return the table unchanged.
         if (!this.has(columnSlug)) return this
 
@@ -701,7 +705,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     interpolateColumnLinearly(
         columnSlug: ColumnSlug,
         extrapolate: boolean = false
-    ) {
+    ): this {
         // If the column doesn't exist, return the table unchanged.
         if (!this.has(columnSlug)) return this
 
@@ -902,7 +906,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         entityNames: EntityName[],
         targetTime: Time,
         tolerance: Integer
-    ) {
+    ): number[] {
         const indexMap = this.rowIndicesByEntityName
         const timeColumn = this.timeColumn
         if (this.timeColumn.isMissing) return []
@@ -922,7 +926,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
             .filter(isPresent)
     }
 
-    filterByPopulationExcept(minPop: number, entityNames: string[] = []) {
+    filterByPopulationExcept(minPop: number, entityNames: string[] = []): this {
         const set = new Set(entityNames)
         return this.columnFilter(
             this.entityNameSlug,
@@ -946,11 +950,11 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         })
     }
 
-    sampleEntityName(howMany = 1) {
+    sampleEntityName(howMany = 1): any[] {
         return this.availableEntityNames.slice(0, howMany)
     }
 
-    get isBlank() {
+    get isBlank(): boolean {
         return (
             this.tableDescription.startsWith(BLANK_TABLE_MESSAGE) &&
             !this.numRows
@@ -964,7 +968,7 @@ const BLANK_TABLE_MESSAGE = `Table is empty.`
 export const BlankOwidTable = (
     tableSlug = `blankOwidTable`,
     extraTableDescription = ""
-) =>
+): OwidTable =>
     new OwidTable(
         undefined,
         [

--- a/coreTable/OwidTableSynthesizers.ts
+++ b/coreTable/OwidTableSynthesizers.ts
@@ -20,7 +20,7 @@ interface SynthOptions {
 const SynthesizeOwidTable = (
     options?: Partial<SynthOptions>,
     seed = Date.now()
-) => {
+): OwidTable => {
     const finalOptions: SynthOptions = {
         entityNames: [],
         entityCount: 2,
@@ -70,7 +70,7 @@ const SynthesizeOwidTable = (
 export const SynthesizeNonCountryTable = (
     options?: Partial<SynthOptions>,
     seed = Date.now()
-) =>
+): OwidTable =>
     SynthesizeOwidTable(
         {
             entityNames: ["Fire", "Earthquake", "Tornado"],
@@ -104,7 +104,7 @@ export const SynthesizeGDPTable = (
     options?: Partial<SynthOptions>,
     seed = Date.now(),
     display?: LegacyVariableDisplayConfigInterface
-) =>
+): OwidTable =>
     SynthesizeOwidTable(
         {
             columnDefs: [
@@ -142,7 +142,17 @@ export const SynthesizeGDPTable = (
         seed
     )
 
-const SynthSource = (name: string) => {
+const SynthSource = (
+    name: string
+): {
+    id: number
+    name: string
+    dataPublishedBy: string
+    dataPublisherSource: string
+    link: string
+    retrievedDate: string
+    additionalInfo: string
+} => {
     return {
         id: name.charCodeAt(0) + name.charCodeAt(1) + name.charCodeAt(2),
         name: `${name} Almanac`,
@@ -157,7 +167,7 @@ const SynthSource = (name: string) => {
 export const SynthesizeFruitTable = (
     options?: Partial<SynthOptions>,
     seed = Date.now()
-) =>
+): OwidTable =>
     SynthesizeOwidTable(
         {
             columnDefs: [
@@ -193,7 +203,7 @@ export const SynthesizeFruitTableWithNonPositives = (
     options?: Partial<SynthOptions>,
     howManyNonPositives = 20,
     seed = Date.now()
-) => {
+): OwidTable => {
     const rand = getRandomNumberGenerator(-1000, 0)
     return SynthesizeFruitTable(
         options,
@@ -212,7 +222,7 @@ export const SynthesizeFruitTableWithStringValues = (
     options?: Partial<SynthOptions>,
     howMany = 20,
     seed = Date.now()
-) => {
+): OwidTable => {
     return SynthesizeFruitTable(options, seed).replaceRandomCells(
         howMany,
         [SampleColumnSlugs.Fruit, SampleColumnSlugs.Vegetables],

--- a/coreTable/OwidTableUtil.ts
+++ b/coreTable/OwidTableUtil.ts
@@ -3,11 +3,13 @@ import { CoreTable } from "./CoreTable"
 import { ColumnSlug } from "./CoreTableConstants"
 import { OwidColumnDef, OwidTableSlugs } from "./OwidTableConstants"
 
-export function timeColumnSlugFromColumnDef(def: OwidColumnDef) {
+export function timeColumnSlugFromColumnDef(
+    def: OwidColumnDef
+): OwidTableSlugs.day | OwidTableSlugs.year {
     return def.isDailyMeasurement ? OwidTableSlugs.day : OwidTableSlugs.year
 }
 
-export function makeOriginalTimeSlugFromColumnSlug(slug: ColumnSlug) {
+export function makeOriginalTimeSlugFromColumnSlug(slug: ColumnSlug): string {
     return `${slug}-originalTime`
 }
 

--- a/db/.eslintrc.yaml
+++ b/db/.eslintrc.yaml
@@ -1,0 +1,4 @@
+rules:
+    no-console: "off"
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/db/DatabaseConnection.ts
+++ b/db/DatabaseConnection.ts
@@ -34,7 +34,7 @@ export class DatabaseConnection {
         this.config = config
     }
 
-    async connect() {
+    async connect(): Promise<void> {
         this.pool = mysql.createPool(this.config)
         await this.getConnection()
     }
@@ -86,7 +86,7 @@ export class DatabaseConnection {
         return (await this.query(queryStr, params))[0]
     }
 
-    end() {
+    end(): void {
         this.pool.end()
     }
 }

--- a/db/cleanup.ts
+++ b/db/cleanup.ts
@@ -1,9 +1,10 @@
 type Handler = () => any
 const handlers: Handler[] = []
 
-export const cleanup = async () => await Promise.all(handlers)
+export const cleanup = async (): Promise<Handler[]> =>
+    await Promise.all(handlers)
 
-export const exit = async () => {
+export const exit = async (): Promise<never> => {
     try {
         await cleanup()
         process.exit(0)
@@ -13,7 +14,7 @@ export const exit = async () => {
     }
 }
 
-export const registerExitHandler = (fn: Handler) => handlers.push(fn)
+export const registerExitHandler = (fn: Handler): number => handlers.push(fn)
 
 process.on("SIGINT", exit)
 process.on("SIGTERM", exit)

--- a/db/contentGraph.test.ts
+++ b/db/contentGraph.test.ts
@@ -8,15 +8,15 @@ const slugs = [
     "life-expectancy",
 ]
 
-const getIframe = (slug: string) => {
+const getIframe = (slug: string): string => {
     return `<iframe src="http://ourworldindata.org/grapher/${slug}?tab=chart&stackMode=absolute&region=World" loading="lazy" style="width: 100%; height: 600px; border: 0px none;"></iframe>`
 }
 
-const getLink = (slug: string) => {
+const getLink = (slug: string): string => {
     return `<a href=\"https:\/\/ourworldindata.org\/grapher\/${slug}\">here<\/a>`
 }
 
-const getContent = (slugs: string[]) => {
+const getContent = (slugs: string[]): string => {
     return `
     <p>Sed lacinia vehicula commodo. Praesent vehicula ipsum nec justo vulputate, at
     pellentesque nisi lacinia. Mauris dapibus non orci ut blandit. Maecenas nibh

--- a/db/csv.ts
+++ b/db/csv.ts
@@ -46,7 +46,7 @@ export class CSVStreamParser {
         this.parser = parser
     }
 
-    private update() {
+    private update(): void {
         if (!this.rowResolve || !this.rowReject) return
 
         if (this.error) {

--- a/db/db.ts
+++ b/db/db.ts
@@ -74,14 +74,14 @@ export const mysqlFirst = async (
     return (await queryMysql(queryStr, params))[0]
 }
 
-export const closeTypeOrmAndKnexConnections = async () => {
+export const closeTypeOrmAndKnexConnections = async (): Promise<void> => {
     if (typeormConnection) await typeormConnection.close()
     if (knexInstance) await knexInstance.destroy()
 }
 
 let knexInstance: Knex
 
-export const knex = () => {
+export const knex = (): Knex<any, any[]> => {
     if (knexInstance) return knexInstance
 
     knexInstance = Knex({
@@ -108,6 +108,44 @@ export const knex = () => {
     return knexInstance
 }
 
-export const knexTable = (table: string) => knex().table(table)
+export const knexTable = (
+    table: string
+): Knex.QueryBuilder<
+    Record<string, unknown>,
+    | {
+          _base: unknown
+          _hasSelection: false
+          _keys: never
+          _aliases: Record<string, unknown>
+          _single: false
+          _intersectProps: Record<string, unknown>
 
-export const knexRaw = (str: string) => knex().raw(str)
+          _unionProps: never
+      }[]
+    | (
+          | {
+                _base: unknown
+                _hasSelection: boolean
+                _keys: string
+                _aliases: Record<string, unknown>
+
+                _single: boolean
+                _intersectProps: Record<string, unknown>
+
+                _unionProps: unknown
+            }
+          | {
+                _base: unknown
+                _hasSelection: false
+                _keys: never
+                _aliases: Record<string, unknown>
+
+                _single: false
+                _intersectProps: Record<string, unknown>
+
+                _unionProps: never
+            }
+      )[]
+> => knex().table(table)
+
+export const knexRaw = (str: string): Knex.Raw<any> => knex().raw(str)

--- a/db/execWrapper.ts
+++ b/db/execWrapper.ts
@@ -37,7 +37,7 @@ export const execFormatted = async (
     cmd: string,
     args: string[],
     verbose = true
-) => {
+): Promise<ExecReturn> => {
     const formatCmd = util.format(cmd, ...args.map((word) => quote([word])))
     if (verbose) console.log(formatCmd)
     return await execWrapper(formatCmd, { silent: !verbose })

--- a/db/exportChartData.ts
+++ b/db/exportChartData.ts
@@ -16,7 +16,7 @@ import { execWrapper } from "./execWrapper"
 const argv = parseArgs(process.argv.slice(2))
 const filePath = argv._[0] || "/tmp/owid_chartdata.sql"
 
-const dataExport = async () => {
+const dataExport = async (): Promise<void> => {
     await db.getConnection()
 
     const variablesToExportQuery = `

--- a/db/exportChartDataNamespace.ts
+++ b/db/exportChartDataNamespace.ts
@@ -23,12 +23,10 @@ if (!namespacesArg) {
 
 const namespaces: string[] = namespacesArg.split(",")
 
-async function dataExport() {
+async function dataExport(): Promise<void> {
     await db.getConnection()
 
-    const tmpFilename: string = `/tmp/owid_chartdata_${namespaces.join(
-        ","
-    )}.sql`
+    const tmpFilename = `/tmp/owid_chartdata_${namespaces.join(",")}.sql`
 
     // This will also retrieve variables that are not in the specified namespace
     // but are used in a chart that has at least one variable from the specified

--- a/db/exportMetadata.ts
+++ b/db/exportMetadata.ts
@@ -29,7 +29,7 @@ const excludeTables = [
     "data_values",
 ]
 
-async function dataExport() {
+async function dataExport(): Promise<void> {
     await db.getConnection()
 
     console.log(`Exporting database structure and metadata to ${filePath}...`)

--- a/db/hashers.ts
+++ b/db/hashers.ts
@@ -4,17 +4,17 @@ export class BCryptHasher {
     private algorithm = "bcrypt"
     private iterations = 12
 
-    private async salt() {
+    private async salt(): Promise<string> {
         return bcrypt.genSalt(this.iterations)
     }
 
-    async encode(password: string) {
+    async encode(password: string): Promise<string> {
         const salt = await this.salt()
         const key = await bcrypt.hash(password, salt)
         return `${this.algorithm}$${key}`
     }
 
-    async verify(password: string, hashToken: string) {
+    async verify(password: string, hashToken: string): Promise<boolean> {
         const hashPassword = hashToken.substring(
             this.algorithm.length + 1,
             hashToken.length

--- a/db/importVDemDataset.ts
+++ b/db/importVDemDataset.ts
@@ -18,7 +18,7 @@ const VARIABLE_START_COLUMN = 7
 
 // TODO design a more long-term import api so these scripts are less fragile
 
-async function importCodebook() {
+async function importCodebook(): Promise<void> {
     const codebookXLS = XLSX.readFile(CODEBOOK_FILE)
     const sheet = codebookXLS.Sheets[codebookXLS.SheetNames[0]]
     const codebookCSV = XLSX.utils.sheet_to_csv(sheet)
@@ -179,7 +179,7 @@ async function importCodebook() {
     })
 }
 
-async function importData() {
+async function importData(): Promise<void> {
     const input = fs.createReadStream(DATA_FILE, "utf8")
 
     // Calculated from running first column through country standardizer
@@ -444,7 +444,7 @@ async function importData() {
         let valueRows: any[][] = []
         let insertCounter = 0
 
-        async function insertRows() {
+        async function insertRows(): Promise<void> {
             insertCounter += valueRows.length
             console.log(insertCounter)
             await t.execute(
@@ -508,7 +508,7 @@ async function importData() {
     })
 }
 
-async function main() {
+async function main(): Promise<void> {
     await db.getConnection()
     try {
         //    await importCodebook()

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -82,7 +82,7 @@ export class Chart extends BaseEntity {
         return await Chart.findOne({ id: slugsById[slug] })
     }
 
-    static async setTags(chartId: number, tagIds: number[]) {
+    static async setTags(chartId: number, tagIds: number[]): Promise<void> {
         await db.transaction(async (t) => {
             const tagRows = tagIds.map((tagId) => [tagId, chartId])
             await t.execute(`DELETE FROM chart_tags WHERE chartId=?`, [chartId])
@@ -108,7 +108,9 @@ export class Chart extends BaseEntity {
         })
     }
 
-    static async assignTagsForCharts(charts: { id: number; tags: any[] }[]) {
+    static async assignTagsForCharts(
+        charts: { id: number; tags: any[] }[]
+    ): Promise<void> {
         const chartTags = await db.queryMysql(`
             SELECT ct.chartId, ct.tagId, t.name as tagName FROM chart_tags ct
             JOIN charts c ON c.id=ct.chartId
@@ -134,7 +136,7 @@ export class Chart extends BaseEntity {
             row.config = JSON.parse(row.config)
         }
 
-        return rows
+        return rows as ChartRow[] // This cast might be a lie?
     }
 }
 

--- a/db/model/Dataset.ts
+++ b/db/model/Dataset.ts
@@ -34,7 +34,7 @@ export class Dataset extends BaseEntity {
     createdByUser!: User
 
     // Export dataset variables to CSV (not including metadata)
-    static async writeCSV(datasetId: number, stream: Writable) {
+    static async writeCSV(datasetId: number, stream: Writable): Promise<void> {
         const csvHeader = ["Entity", "Year"]
         const variables = await db.queryMysql(
             `SELECT name, id FROM variables v WHERE v.datasetId=? ORDER BY v.columnOrder ASC, v.id ASC`,
@@ -86,7 +86,7 @@ export class Dataset extends BaseEntity {
         stream.end()
     }
 
-    static async setTags(datasetId: number, tagIds: number[]) {
+    static async setTags(datasetId: number, tagIds: number[]): Promise<void> {
         await db.transaction(async (t) => {
             const tagRows = tagIds.map((tagId) => [tagId, datasetId])
             await t.execute(`DELETE FROM dataset_tags WHERE datasetId=?`, [
@@ -109,11 +109,11 @@ export class Dataset extends BaseEntity {
         return csv
     }
 
-    get filename() {
+    get filename(): string {
         return filenamify(this.name)
     }
 
-    get slug() {
+    get slug(): string {
         return slugify(this.name)
     }
 

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -8,10 +8,12 @@ export namespace Post {
     export const select = <K extends keyof PostRow>(
         ...args: K[]
     ): { from: (query: QueryBuilder) => Promise<Pick<PostRow, K>[]> } => ({
-        from: (query) => query.select(...args) as any,
+        from: (query): any => query.select(...args) as any,
     })
 
-    export const tagsByPostId = async () => {
+    export const tagsByPostId = async (): Promise<
+        Map<number, { id: number; name: string }[]>
+    > => {
         const postTags = await db.queryMysql(`
             SELECT pt.post_id AS postId, pt.tag_id AS tagId, t.name as tagName FROM post_tags pt
             JOIN posts p ON p.id=pt.post_id

--- a/db/model/User.ts
+++ b/db/model/User.ts
@@ -35,7 +35,7 @@ export class User extends BaseEntity {
     @OneToMany(() => Dataset, (dataset) => dataset.createdByUser)
     createdDatasets!: Dataset[]
 
-    async setPassword(password: string) {
+    async setPassword(password: string): Promise<void> {
         const h = new BCryptHasher()
         this.password = await h.encode(password)
     }

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -102,7 +102,7 @@ export async function getVariableData(variableIds: number[]): Promise<any> {
 export async function writeVariableCSV(
     variableIds: number[],
     stream: Writable
-) {
+): Promise<void> {
     const variableQuery: Promise<
         { id: number; name: string }[]
     > = db.queryMysql(

--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -9,7 +9,7 @@ import { PostRow } from "../clientUtils/owidTypes"
 
 const zeroDateString = "0000-00-00 00:00:00"
 
-const syncPostsToGrapher = async () => {
+const syncPostsToGrapher = async (): Promise<void> => {
     const rows = await wpdb.singleton.query(
         "select * from wp_posts where (post_type='page' or post_type='post') AND post_status != 'trash'"
     )
@@ -54,7 +54,7 @@ const syncPostsToGrapher = async () => {
     })
 }
 
-const main = async () => {
+const main = async (): Promise<void> => {
     try {
         await syncPostsToGrapher()
     } finally {

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -41,7 +41,20 @@ class WPDB {
 
     private knex(
         tableName?: string | Knex.Raw | Knex.QueryBuilder | undefined
-    ) {
+    ): Knex.QueryBuilder<
+        Record<string, unknown>,
+        {
+            _base: any
+            _hasSelection: false
+            _keys: never
+            _aliases: Record<string, unknown>
+
+            _single: false
+            _intersectProps: Record<string, unknown>
+
+            _unionProps: never
+        }[]
+    > {
         if (!knexInstance) {
             knexInstance = Knex({
                 client: "mysql",
@@ -60,11 +73,11 @@ class WPDB {
         return knexInstance(tableName)
     }
 
-    private async destroyKnex() {
+    private async destroyKnex(): Promise<void> {
         if (knexInstance) await knexInstance.destroy()
     }
 
-    async connect() {
+    async connect(): Promise<void> {
         this.conn = new DatabaseConnection({
             host: WORDPRESS_DB_HOST,
             port: WORDPRESS_DB_PORT,
@@ -79,7 +92,7 @@ class WPDB {
         })
     }
 
-    async end() {
+    async end(): Promise<void> {
         if (this.conn) this.conn.end()
         this.destroyKnex()
     }
@@ -112,7 +125,10 @@ export const ENTRIES_CATEGORY_ID = 44
  * every query. So it is the caller's responsibility to throw (if necessary) on
  * "faux 404".
  */
-const graphqlQuery = async (query: string, variables: any = {}) => {
+const graphqlQuery = async (
+    query: string,
+    variables: any = {}
+): Promise<any> => {
     const response = await fetch(WP_GRAPHQL_ENDPOINT, {
         method: "POST",
         headers: {
@@ -253,14 +269,24 @@ export const getDocumentsInfo = async (
     }
 }
 
-const getEntryNode = ({ slug, title, excerpt, kpi }: EntryNode) => ({
+const getEntryNode = ({
+    slug,
+    title,
+    excerpt,
+    kpi,
+}: EntryNode): {
+    slug: string
+    title: string
+    excerpt: string
+    kpi: string
+} => ({
     slug,
     title: decodeHTML(title),
     excerpt: excerpt === null ? "" : decodeHTML(excerpt),
     kpi,
 })
 
-const isEntryInSubcategories = (entry: EntryNode, subcategories: any) => {
+const isEntryInSubcategories = (entry: EntryNode, subcategories: any): any => {
     return subcategories.some((subcategory: any) => {
         return subcategory.pages.nodes.some(
             (node: EntryNode) => entry.slug === node.slug
@@ -374,14 +400,17 @@ export const getPageType = async (post: FullPost): Promise<PageType> => {
     return isEntry ? PageType.Entry : PageType.Standard
 }
 
-export const getPermalinks = async () => ({
+export const getPermalinks = async (): Promise<{
     // Strip trailing slashes, and convert __ into / to allow custom subdirs like /about/media-coverage
-    get: (ID: number, postName: string) =>
+    get: (ID: number, postName: string) => string
+}> => ({
+    // Strip trailing slashes, and convert __ into / to allow custom subdirs like /about/media-coverage
+    get: (ID: number, postName: string): string =>
         postName.replace(/\/+$/g, "").replace(/--/g, "/").replace(/__/g, "/"),
 })
 
 let cachedFeaturedImages: Map<number, string> | undefined
-export const getFeaturedImages = async () => {
+export const getFeaturedImages = async (): Promise<Map<number, string>> => {
     if (cachedFeaturedImages) return cachedFeaturedImages
 
     const rows = await singleton.query(
@@ -398,7 +427,7 @@ export const getFeaturedImages = async () => {
 }
 
 // page => pages, post => posts
-const getEndpointSlugFromType = (type: string) => `${type}s`
+const getEndpointSlugFromType = (type: string): string => `${type}s`
 
 // Limit not supported with multiple post types:
 // When passing multiple post types, the limit is applied to the resulting array
@@ -514,7 +543,9 @@ export const getRelatedCharts = async (
         ORDER BY title ASC
     `)
 
-export const getRelatedArticles = async (chartSlug: string) => {
+export const getRelatedArticles = async (
+    chartSlug: string
+): Promise<PostReference[] | undefined> => {
     const graph = await getContentGraph()
 
     const chartRecord = await graph.find(GraphType.Chart, chartSlug)

--- a/explorerAdmin/.eslintrc.yaml
+++ b/explorerAdmin/.eslintrc.yaml
@@ -1,0 +1,2 @@
+rules:
+    no-console: "off"

--- a/grapher/axis/.eslintrc.yaml
+++ b/grapher/axis/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/axis/AxisConfig.ts
+++ b/grapher/axis/AxisConfig.ts
@@ -39,7 +39,7 @@ export class AxisConfig
     @observable hideAxis = false
 
     // todo: test/refactor
-    updateFromObject(props?: AxisConfigInterface) {
+    updateFromObject(props?: AxisConfigInterface): void {
         if (props) extend(this, props)
     }
 
@@ -58,26 +58,26 @@ export class AxisConfig
         return obj
     }
 
-    @computed get fontSize() {
+    @computed get fontSize(): number {
         return this.fontSizeManager?.fontSize || BASE_FONT_SIZE
     }
 
     // A log scale domain cannot have values <= 0, so we double check here
-    @computed private get constrainedMin() {
+    @computed private get constrainedMin(): number {
         if (this.scaleType === ScaleType.log && (this.min ?? 0) <= 0)
             return Infinity
         return this.min ?? Infinity
     }
 
     // If the author has specified a min/max AND to remove points outside the domain, this should return true
-    shouldRemovePoint(value: number) {
+    shouldRemovePoint(value: number): boolean {
         if (!this.removePointsOutsideDomain) return false
         if (this.min !== undefined && value < this.min) return true
         if (this.max !== undefined && value > this.max) return true
         return false
     }
 
-    @computed private get constrainedMax() {
+    @computed private get constrainedMax(): number {
         if (this.scaleType === ScaleType.log && (this.max || 0) <= 0)
             return -Infinity
         return this.max ?? -Infinity
@@ -89,11 +89,11 @@ export class AxisConfig
 
     // Convert axis configuration to a finalized axis spec by supplying
     // any needed information calculated from the data
-    toHorizontalAxis() {
+    toHorizontalAxis(): HorizontalAxis {
         return new HorizontalAxis(this)
     }
 
-    toVerticalAxis() {
+    toVerticalAxis(): VerticalAxis {
         return new VerticalAxis(this)
     }
 }

--- a/grapher/axis/AxisViews.tsx
+++ b/grapher/axis/AxisViews.tsx
@@ -11,7 +11,7 @@ export class VerticalAxisGridLines extends React.Component<{
     verticalAxis: VerticalAxis
     bounds: Bounds
 }> {
-    render() {
+    render(): JSX.Element {
         const { bounds, verticalAxis } = this.props
         const axis = verticalAxis.clone()
         axis.range = bounds.yRange()
@@ -47,11 +47,11 @@ export class HorizontalAxisGridLines extends React.Component<{
     horizontalAxis: HorizontalAxis
     bounds?: Bounds
 }> {
-    @computed get bounds() {
+    @computed get bounds(): Bounds {
         return this.props.bounds ?? DEFAULT_BOUNDS
     }
 
-    render() {
+    render(): JSX.Element {
         const { horizontalAxis } = this.props
         const { bounds } = this
         const axis = horizontalAxis.clone()
@@ -91,7 +91,7 @@ interface DualAxisViewProps {
 
 @observer
 export class DualAxisComponent extends React.Component<DualAxisViewProps> {
-    render() {
+    render(): JSX.Element {
         const { dualAxis, showTickMarks } = this.props
         const { bounds, horizontalAxis, verticalAxis, innerBounds } = dualAxis
 
@@ -141,7 +141,7 @@ export class VerticalAxisComponent extends React.Component<{
     bounds: Bounds
     verticalAxis: VerticalAxis
 }> {
-    render() {
+    render(): JSX.Element {
         const { bounds, verticalAxis } = this.props
         const { ticks, labelTextWrap } = verticalAxis
         const textColor = "#666"
@@ -178,7 +178,7 @@ export class HorizontalAxisComponent extends React.Component<{
     axisPosition: number
     showTickMarks?: boolean
 }> {
-    @computed get scaleType() {
+    @computed get scaleType(): ScaleType {
         return this.props.axis.scaleType
     }
 
@@ -187,12 +187,12 @@ export class HorizontalAxisComponent extends React.Component<{
     }
 
     // for scale selector. todo: cleanup
-    @computed get bounds() {
+    @computed get bounds(): Bounds {
         const { bounds } = this.props
         return new Bounds(bounds.right, bounds.bottom - 30, 100, 100)
     }
 
-    render() {
+    render(): JSX.Element {
         const { bounds, axis, axisPosition, showTickMarks } = this.props
         const { ticks, labelTextWrap: label, labelOffset } = axis
         const textColor = "#666"
@@ -200,7 +200,9 @@ export class HorizontalAxisComponent extends React.Component<{
         const tickMarks = showTickMarks ? (
             <AxisTickMarks
                 tickMarkTopPosition={axisPosition}
-                tickMarkXPositions={ticks.map((tick) => axis.place(tick))}
+                tickMarkXPositions={ticks.map((tick): number =>
+                    axis.place(tick)
+                )}
                 color="#ccc"
             />
         ) : undefined
@@ -252,7 +254,7 @@ export class AxisTickMarks extends React.Component<{
     tickMarkXPositions: number[]
     color: string
 }> {
-    render() {
+    render(): JSX.Element[] {
         const { tickMarkTopPosition, tickMarkXPositions, color } = this.props
         const tickSize = 4
         const tickBottom = tickMarkTopPosition + tickSize

--- a/grapher/barCharts/.eslintrc.yaml
+++ b/grapher/barCharts/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/barCharts/DiscreteBarChart.stories.tsx
+++ b/grapher/barCharts/DiscreteBarChart.stories.tsx
@@ -12,7 +12,7 @@ export default {
     component: DiscreteBarChart,
 }
 
-export const EntitiesAsSeries = () => {
+export const EntitiesAsSeries = (): JSX.Element => {
     const table = SynthesizeGDPTable({
         timeRange: [2009, 2010],
         entityCount: 10,
@@ -31,13 +31,13 @@ export const EntitiesAsSeries = () => {
     )
 }
 
-export const EntitiesAsSeriesWithTolerance = () => {
+export const EntitiesAsSeriesWithTolerance = (): JSX.Element => {
     const table = SynthesizeGDPTable({
         timeRange: [2009, 2011],
         entityCount: 10,
     })
         .rowFilter(
-            (row) => row.year === 2010 || Math.random() > 0.5,
+            (row): boolean => row.year === 2010 || Math.random() > 0.5,
             "Remove 50% of 2009 rows"
         )
         .interpolateColumnWithTolerance(SampleColumnSlugs.Population, 1)
@@ -59,7 +59,7 @@ export const EntitiesAsSeriesWithTolerance = () => {
     )
 }
 
-export const ColumnsAsSeries = () => {
+export const ColumnsAsSeries = (): JSX.Element => {
     const table = SynthesizeFruitTable({ entityCount: 1 })
     const manager: DiscreteBarChartManager = {
         table,

--- a/grapher/bodyDiv/.eslintrc.yaml
+++ b/grapher/bodyDiv/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/bodyDiv/BodyDiv.tsx
+++ b/grapher/bodyDiv/BodyDiv.tsx
@@ -11,15 +11,15 @@ export class BodyDiv extends React.Component {
 
     el: HTMLDivElement
 
-    componentDidMount() {
+    componentDidMount(): void {
         document.body.appendChild(this.el)
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         document.body.removeChild(this.el)
     }
 
-    render() {
+    render(): any {
         return ReactDOM.createPortal(this.props.children, this.el)
     }
 }

--- a/grapher/captionedChart/.eslintrc.yaml
+++ b/grapher/captionedChart/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/captionedChart/CaptionedChart.stories.tsx
+++ b/grapher/captionedChart/CaptionedChart.stories.tsx
@@ -26,13 +26,13 @@ const manager: CaptionedChartManager = {
     currentTitle: "This is the Title",
     subtitle: "A Subtitle",
     note: "Here are some footer notes",
-    populateFromQueryParams: () => {},
+    populateFromQueryParams: (): void => {},
     isReady: true,
 }
 
-export const LineChart = () => <CaptionedChart manager={manager} />
+export const LineChart = (): JSX.Element => <CaptionedChart manager={manager} />
 
-export const StaticLineChartForExport = () => {
+export const StaticLineChartForExport = (): JSX.Element => {
     return (
         <StaticCaptionedChart
             manager={{
@@ -43,10 +43,10 @@ export const StaticLineChartForExport = () => {
     )
 }
 
-export const MapChart = () => (
+export const MapChart = (): JSX.Element => (
     <CaptionedChart manager={{ ...manager, tab: GrapherTabOption.map }} />
 )
-export const StackedArea = () => (
+export const StackedArea = (): JSX.Element => (
     <CaptionedChart
         manager={{
             ...manager,
@@ -55,7 +55,7 @@ export const StackedArea = () => (
         }}
     />
 )
-export const Scatter = () => (
+export const Scatter = (): JSX.Element => (
     <CaptionedChart
         manager={{
             ...manager,

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -35,6 +35,8 @@ import { faPencilAlt } from "@fortawesome/free-solid-svg-icons/faPencilAlt"
 import { FooterManager } from "../footer/FooterManager"
 import { HeaderManager } from "../header/HeaderManager"
 import { exposeInstanceOnWindow } from "../../clientUtils/Util"
+import { SelectionArray } from "../selection/SelectionArray"
+import { EntityName } from "../../coreTable/OwidTableConstants"
 
 export interface CaptionedChartManager
     extends ChartManager,
@@ -78,33 +80,33 @@ const PADDING_ABOVE_FOOTER = 25
 
 @observer
 export class CaptionedChart extends React.Component<CaptionedChartProps> {
-    @computed protected get manager() {
+    @computed protected get manager(): CaptionedChartManager {
         return this.props.manager
     }
 
-    @computed private get containerElement() {
+    @computed private get containerElement(): HTMLDivElement | undefined {
         return this.manager?.containerElement
     }
 
-    @computed private get maxWidth() {
+    @computed private get maxWidth(): number {
         return this.props.maxWidth ?? this.bounds.width - OUTSIDE_PADDING * 2
     }
 
-    @computed protected get header() {
+    @computed protected get header(): Header {
         return new Header({
             manager: this.manager,
             maxWidth: this.maxWidth,
         })
     }
 
-    @computed protected get footer() {
+    @computed protected get footer(): Footer {
         return new Footer({
             manager: this.manager,
             maxWidth: this.maxWidth,
         })
     }
 
-    @computed protected get chartHeight() {
+    @computed protected get chartHeight(): number {
         const controlsRowHeight = this.controls.length ? CONTROLS_ROW_HEIGHT : 0
         return (
             this.bounds.height -
@@ -116,23 +118,23 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
     }
 
     // todo: should we remove this and not make a distinction between map and chart tabs?
-    @computed protected get isMapTab() {
+    @computed protected get isMapTab(): boolean {
         return this.manager.tab === GrapherTabOption.map
     }
 
-    @computed protected get bounds() {
+    @computed protected get bounds(): Bounds {
         return this.props.bounds ?? this.manager.tabBounds ?? DEFAULT_BOUNDS
     }
 
     // The bounds for the middle chart part
-    @computed protected get boundsForChart() {
+    @computed protected get boundsForChart(): Bounds {
         return new Bounds(0, 0, this.bounds.width, this.chartHeight)
             .padWidth(OUTSIDE_PADDING)
             .padTop(this.isMapTab ? 0 : PADDING_BELOW_HEADER)
             .padBottom(OUTSIDE_PADDING)
     }
 
-    renderChart() {
+    renderChart(): JSX.Element {
         const { manager } = this
         const bounds = this.boundsForChart
 
@@ -163,15 +165,15 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         )
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         exposeInstanceOnWindow(this, "captionedChart")
     }
 
-    @action.bound startSelecting() {
+    @action.bound startSelecting(): void {
         this.manager.isSelectingData = true
     }
 
-    @computed get controls() {
+    @computed get controls(): JSX.Element[] {
         const manager = this.manager
         // Todo: we don't yet show any controls on Maps, but seems like we would want to.
         if (!manager.isReady || this.isMapTab) return []
@@ -254,11 +256,11 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         return controls
     }
 
-    @computed get selectionArray() {
+    @computed get selectionArray(): SelectionArray | EntityName[] | undefined {
         return this.manager.selection
     }
 
-    private renderControlsRow() {
+    private renderControlsRow(): JSX.Element | null {
         return this.controls.length ? (
             <div className="controlsRow">
                 <CollapsibleList>{this.controls}</CollapsibleList>
@@ -266,7 +268,7 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         ) : null
     }
 
-    private renderLoadingIndicator() {
+    private renderLoadingIndicator(): JSX.Element {
         return (
             <foreignObject {...this.boundsForChart.toProps()}>
                 <LoadingIndicator title={this.manager.whatAreWeWaitingFor} />
@@ -274,7 +276,7 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         )
     }
 
-    render() {
+    render(): JSX.Element {
         const { bounds, chartHeight, maxWidth } = this
         const { width } = bounds
 
@@ -326,19 +328,19 @@ export class StaticCaptionedChart extends CaptionedChart {
         super(props)
     }
 
-    @computed private get paddedBounds() {
+    @computed private get paddedBounds(): Bounds {
         return this.bounds.pad(OUTSIDE_PADDING)
     }
 
     // The bounds for the middle chart part
-    @computed protected get boundsForChart() {
+    @computed protected get boundsForChart(): Bounds {
         return this.paddedBounds
             .padTop(this.header.height)
             .padBottom(this.footer.height + PADDING_ABOVE_FOOTER)
             .padTop(this.isMapTab ? 0 : PADDING_BELOW_HEADER)
     }
 
-    render() {
+    render(): JSX.Element {
         const { bounds, paddedBounds } = this
         const { width, height } = bounds
 

--- a/grapher/captionedChart/Logos.tsx
+++ b/grapher/captionedChart/Logos.tsx
@@ -50,24 +50,24 @@ export class Logo {
         this.props = props
     }
 
-    @computed private get spec() {
+    @computed private get spec(): LogoAttributes {
         return this.props.logo !== undefined
             ? logos[this.props.logo]
             : logos.owid
     }
 
-    @computed private get scale() {
+    @computed private get scale(): number {
         return this.spec.targetHeight / this.spec.height
     }
 
-    @computed get width() {
+    @computed get width(): number {
         return this.spec.width * this.scale
     }
-    @computed get height() {
+    @computed get height(): number {
         return this.spec.height * this.scale
     }
 
-    renderSVG(targetX: number, targetY: number) {
+    renderSVG(targetX: number, targetY: number): JSX.Element {
         const { scale } = this
         const svg =
             (this.spec.svg.match(/<svg>(.*)<\/svg>/) || "")[1] || this.spec.svg
@@ -81,7 +81,7 @@ export class Logo {
         )
     }
 
-    renderHTML() {
+    renderHTML(): JSX.Element {
         const { spec } = this
         const props: React.HTMLAttributes<
             HTMLDivElement & HTMLAnchorElement

--- a/grapher/chart/.eslintrc.yaml
+++ b/grapher/chart/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/chart/ChartDimension.ts
+++ b/grapher/chart/ChartDimension.ts
@@ -16,6 +16,7 @@ import {
     deleteRuntimeAndUnchangedProps,
     updatePersistables,
 } from "../persistable/Persistable"
+import { CoreColumn } from "../../coreTable/CoreTableColumns"
 
 // A chart "dimension" represents a binding between a chart
 // and a particular variable that it requests as data
@@ -50,11 +51,11 @@ export class ChartDimension
         if (obj) this.updateFromObject(obj)
     }
 
-    @computed private get table() {
+    @computed private get table(): OwidTable {
         return this.manager.table
     }
 
-    updateFromObject(obj: LegacyChartDimensionInterface) {
+    updateFromObject(obj: LegacyChartDimensionInterface): void {
         if (obj.display) updatePersistables(this, { display: obj.display })
 
         this.targetYear = obj.targetYear
@@ -80,11 +81,11 @@ export class ChartDimension
     // Do not persist yet, until we migrate off VariableIds
     @observable slug?: ColumnSlug
 
-    @computed get column() {
+    @computed get column(): CoreColumn {
         return this.table.get(this.columnSlug)
     }
 
-    @computed get columnSlug() {
+    @computed get columnSlug(): string {
         return this.slug ?? this.variableId.toString()
     }
 }

--- a/grapher/chart/ChartInterface.ts
+++ b/grapher/chart/ChartInterface.ts
@@ -1,7 +1,7 @@
 import { Color } from "../../coreTable/CoreTableConstants"
 import { OwidTable } from "../../coreTable/OwidTable"
 import { SeriesName } from "../core/GrapherConstants"
-
+import { ColorScale } from "../color/ColorScale"
 // The idea of this interface is to try and start reusing more code across our Chart classes and make it easier
 // for a dev to work on a chart type they haven't touched before if they've worked with another that implements
 // this interface.
@@ -18,6 +18,8 @@ export interface ChartInterface {
 
     inputTable: OwidTable // Points to the OwidTable coming into the chart. All charts have an inputTable. Standardized as part of the interface as a development aid.
     transformedTable: OwidTable // Points to the OwidTable after the chart has transformed the input table. The chart may add a relative transform, for example. Standardized as part of the interface as a development aid.
+
+    colorScale?: ColorScale
 
     series: readonly ChartSeries[] // This points to the marks that the chart will render. They don't have to be placed yet. Standardized as part of the interface as a development aid.
     // Todo: should all charts additionally have a placedSeries: ChartPlacedSeries[] getter?

--- a/grapher/chart/ChartTypeSwitcher.tsx
+++ b/grapher/chart/ChartTypeSwitcher.tsx
@@ -5,10 +5,10 @@ import { ChartTypeName } from "../core/GrapherConstants"
 export class ChartTypeSwitcher extends React.Component<{
     onChange: (chartType: ChartTypeName) => void
 }> {
-    render() {
+    render(): JSX.Element {
         return (
             <select
-                onChange={(event) =>
+                onChange={(event): void =>
                     this.props.onChange(event.target.value as any)
                 }
             >

--- a/grapher/chart/ChartUtils.tsx
+++ b/grapher/chart/ChartUtils.tsx
@@ -4,14 +4,14 @@ import { SeriesStrategy } from "../core/GrapherConstants"
 import { SelectionArray } from "../selection/SelectionArray"
 import { ChartManager } from "./ChartManager"
 
-export const autoDetectYColumnSlugs = (manager: ChartManager) => {
+export const autoDetectYColumnSlugs = (manager: ChartManager): string[] => {
     if (manager.yColumnSlugs && manager.yColumnSlugs.length)
         return manager.yColumnSlugs
     if (manager.yColumnSlug) return [manager.yColumnSlug]
     return manager.table.numericColumnSlugs
 }
 
-export const getDefaultFailMessage = (manager: ChartManager) => {
+export const getDefaultFailMessage = (manager: ChartManager): string => {
     if (manager.table.rootTable.isBlank) return `No table loaded yet.`
     if (manager.table.rootTable.entityNameColumn.isMissing)
         return `Table is missing an EntityName column.`
@@ -24,7 +24,7 @@ export const getDefaultFailMessage = (manager: ChartManager) => {
     return ""
 }
 
-export const autoDetectSeriesStrategy = (manager: ChartManager) => {
+export const autoDetectSeriesStrategy = (manager: ChartManager): SeriesStrategy => {
     if (manager.seriesStrategy) return manager.seriesStrategy
 
     return autoDetectYColumnSlugs(manager).length > 1
@@ -32,7 +32,10 @@ export const autoDetectSeriesStrategy = (manager: ChartManager) => {
         : SeriesStrategy.entity
 }
 
-export const makeClipPath = (renderUid: number, box: Box) => {
+export const makeClipPath = (
+    renderUid: number,
+    box: Box
+): { id: string; element: JSX.Element } => {
     const id = `boundsClip-${renderUid}`
     return {
         id: `url(#${id})`,
@@ -46,7 +49,7 @@ export const makeClipPath = (renderUid: number, box: Box) => {
     }
 }
 
-export const makeSelectionArray = (manager: ChartManager) =>
+export const makeSelectionArray = (manager: ChartManager): SelectionArray =>
     manager.selection instanceof SelectionArray
         ? manager.selection
         : new SelectionArray(manager.selection ?? [])

--- a/grapher/chart/ChartUtils.tsx
+++ b/grapher/chart/ChartUtils.tsx
@@ -24,7 +24,9 @@ export const getDefaultFailMessage = (manager: ChartManager): string => {
     return ""
 }
 
-export const autoDetectSeriesStrategy = (manager: ChartManager): SeriesStrategy => {
+export const autoDetectSeriesStrategy = (
+    manager: ChartManager
+): SeriesStrategy => {
     if (manager.seriesStrategy) return manager.seriesStrategy
 
     return autoDetectYColumnSlugs(manager).length > 1

--- a/grapher/chart/DimensionSlot.ts
+++ b/grapher/chart/DimensionSlot.ts
@@ -4,6 +4,7 @@ import { Grapher } from "../core/Grapher"
 import { computed } from "mobx"
 import { DimensionProperty } from "../core/GrapherConstants"
 import { excludeUndefined, findIndex, sortBy } from "../../clientUtils/Util"
+import { ChartDimension } from "./ChartDimension"
 
 export class DimensionSlot {
     private grapher: Grapher
@@ -13,7 +14,7 @@ export class DimensionSlot {
         this.property = property
     }
 
-    @computed get name() {
+    @computed get name(): string {
         const names = {
             y: this.grapher.isDiscreteBar ? "X axis" : "Y axis",
             x: "X axis",
@@ -25,24 +26,24 @@ export class DimensionSlot {
         return (names as any)[this.property] || ""
     }
 
-    @computed get allowMultiple() {
+    @computed get allowMultiple(): boolean {
         return (
             this.property === DimensionProperty.y &&
             this.grapher.supportsMultipleYColumns
         )
     }
 
-    @computed get isOptional() {
+    @computed get isOptional(): boolean {
         return this.allowMultiple
     }
 
-    @computed get dimensions() {
+    @computed get dimensions(): ChartDimension[] {
         return this.grapher.dimensions.filter(
             (d) => d.property === this.property
         )
     }
 
-    @computed get dimensionsOrderedAsInPersistedSelection() {
+    @computed get dimensionsOrderedAsInPersistedSelection(): ChartDimension[] {
         const legacyConfig = this.grapher.legacyConfigAsAuthored
         const variableIDsInSelectionOrder = excludeUndefined(
             legacyConfig.selectedData?.map(

--- a/grapher/chart/Tippy.tsx
+++ b/grapher/chart/Tippy.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { default as OriginalTippy, TippyProps } from "@tippyjs/react"
 
-export const Tippy = (props: TippyProps) => (
+export const Tippy = (props: TippyProps): JSX.Element => (
     <OriginalTippy theme="light" {...props} />
 )

--- a/grapher/color/.eslintrc.yaml
+++ b/grapher/color/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/color/BinningStrategies.ts
+++ b/grapher/color/BinningStrategies.ts
@@ -22,7 +22,7 @@ function calcEqualIntervalStepSize(
     sortedValues: number[],
     binCount: number,
     minBinValue: number
-) {
+): number {
     if (!sortedValues.length) return 10
     const stepSizeInitial = (last(sortedValues)! - minBinValue) / binCount
     return roundSigFig(stepSizeInitial, 1)
@@ -42,7 +42,7 @@ interface GetBinMaximumsWithStrategyArgs {
 function normalizeBinValues(
     binValues: (number | undefined)[],
     minBinValue?: number
-) {
+): any {
     const values = uniq(excludeUndefined(binValues))
     return minBinValue !== undefined
         ? values.filter((v) => v > minBinValue)

--- a/grapher/color/ColorScale.test.ts
+++ b/grapher/color/ColorScale.test.ts
@@ -8,7 +8,7 @@ import { ColorScaleConfigInterface } from "./ColorScaleConfig"
 const createColorScaleFromTable = (
     colorValuePairs: { value: number; color?: string }[],
     colorScaleConfig: ColorScaleConfigInterface
-) => {
+): ColorScale => {
     const table = new CoreTable({
         colorValues: colorValuePairs.map((pair) => pair.value),
     })

--- a/grapher/color/ColorScaleBin.ts
+++ b/grapher/color/ColorScaleBin.ts
@@ -27,35 +27,35 @@ abstract class AbstractColorScaleBin<T extends BinProps> {
     constructor(props: T) {
         this.props = props
     }
-    get color() {
+    get color(): string {
         return this.props.color
     }
-    get label() {
+    get label(): string | undefined {
         return this.props.label
     }
 }
 
 export class NumericBin extends AbstractColorScaleBin<NumericBinProps> {
-    get min() {
+    get min(): number {
         return this.props.min
     }
-    get max() {
+    get max(): number {
         return this.props.max
     }
-    get minText() {
+    get minText(): string {
         return (this.props.isOpenLeft ? `<` : "") + this.props.displayMin
     }
-    get maxText() {
+    get maxText(): string {
         return (this.props.isOpenRight ? `>` : "") + this.props.displayMax
     }
-    get text() {
+    get text(): string {
         return this.props.label || ""
     }
-    get isHidden() {
+    get isHidden(): boolean {
         return false
     }
 
-    contains(value: string | number | undefined) {
+    contains(value: string | number | undefined): boolean {
         if (value === undefined) return false
 
         if (this.props.isOpenLeft) return value <= this.max
@@ -67,7 +67,7 @@ export class NumericBin extends AbstractColorScaleBin<NumericBinProps> {
         return value > this.min && value <= this.max
     }
 
-    equals(other: ColorScaleBin) {
+    equals(other: ColorScaleBin): boolean {
         return (
             other instanceof NumericBin &&
             this.min === other.min &&
@@ -77,28 +77,28 @@ export class NumericBin extends AbstractColorScaleBin<NumericBinProps> {
 }
 
 export class CategoricalBin extends AbstractColorScaleBin<CategoricalBinProps> {
-    get index() {
+    get index(): number {
         return this.props.index
     }
-    get value() {
+    get value(): string {
         return this.props.value
     }
-    get isHidden() {
+    get isHidden(): boolean | undefined {
         return this.props.isHidden
     }
 
-    get text() {
+    get text(): string {
         return this.props.label || this.props.value
     }
 
-    contains(value: string | number | undefined) {
+    contains(value: string | number | undefined): boolean {
         return (
             (value === undefined && this.props.value === "No data") ||
             (value !== undefined && value === this.props.value)
         )
     }
 
-    equals(other: ColorScaleBin) {
+    equals(other: ColorScaleBin): boolean {
         return (
             other instanceof CategoricalBin &&
             this.props.index === other.props.index

--- a/grapher/color/ColorScaleConfig.ts
+++ b/grapher/color/ColorScaleConfig.ts
@@ -83,7 +83,7 @@ export type ColorScaleConfigInterface = ColorScaleConfigDefaults
 export class ColorScaleConfig
     extends ColorScaleConfigDefaults
     implements Persistable {
-    updateFromObject(obj: any) {
+    updateFromObject(obj: any): void {
         extend(this, obj)
     }
 
@@ -109,7 +109,7 @@ export class ColorScaleConfig
         const customNumericColors: (Color | undefined)[] = []
         scale.colorScaleNumericBins
             ?.split(INTER_BIN_DELIMITER)
-            .forEach((bin) => {
+            .forEach((bin): void => {
                 const [value, color, ...label] = bin.split(
                     INTRA_BIN_DELIMITER
                 ) as (string | undefined)[]
@@ -138,7 +138,7 @@ export class ColorScaleConfig
         } = {}
         scale.colorScaleCategoricalBins
             ?.split(INTER_BIN_DELIMITER)
-            .forEach((bin) => {
+            .forEach((bin): void => {
                 const [value, color, ...label] = bin.split(
                     INTRA_BIN_DELIMITER
                 ) as (string | undefined)[]

--- a/grapher/color/ColorScheme.ts
+++ b/grapher/color/ColorScheme.ts
@@ -102,7 +102,10 @@ export class ColorScheme implements ColorSchemeInterface {
             : this.getGradientColors(numColors)
     }
 
-    getUniqValueColorMap(uniqValues: any[], inverseOrder?: boolean) {
+    getUniqValueColorMap(
+        uniqValues: any[],
+        inverseOrder?: boolean
+    ): Map<number, string> {
         const colors = this.getColors(uniqValues.length) || []
         if (inverseOrder) colors.reverse()
 
@@ -120,7 +123,7 @@ export class ColorScheme implements ColorSchemeInterface {
         invertColorScheme = false,
         customColorMap: Map<SeriesName, Color> = new Map(),
         seriesColorMap: SeriesColorMap = new Map()
-    ) {
+    ): void {
         seriesArr.forEach((series) => {
             const customColor = customColorMap.get(series.seriesName)
             if (customColor) seriesColorMap.set(series.seriesName, customColor)
@@ -135,7 +138,7 @@ export class ColorScheme implements ColorSchemeInterface {
         seriesArr: ChartSeries[],
         seriesColorMap: SeriesColorMap,
         invertColorScheme = false
-    ) {
+    ): void {
         // For names that don't have a color, assign one.
         seriesArr
             .map((series) => series.seriesName)
@@ -159,10 +162,11 @@ export class ColorScheme implements ColorSchemeInterface {
         name: string,
         colorSets: { [key: string]: Color[] },
         singleColorScale?: boolean
-    ) {
+    ): ColorScheme {
         const colorSetsArray: Color[][] = []
         Object.keys(colorSets).forEach(
-            (numColors) => (colorSetsArray[+numColors] = colorSets[numColors])
+            (numColors): string[] =>
+                (colorSetsArray[+numColors] = colorSets[numColors])
         )
         return new ColorScheme(name, colorSetsArray, singleColorScale)
     }

--- a/grapher/color/ColorSchemes.ts
+++ b/grapher/color/ColorSchemes.ts
@@ -3,7 +3,7 @@ import { CustomColorSchemes } from "./CustomSchemes"
 import { ColorBrewerSchemes } from "./ColorBrewerSchemes"
 import { ColorScheme } from "./ColorScheme"
 
-const initAllSchemes = () => {
+const initAllSchemes = (): { [key in ColorSchemeName]: ColorScheme } => {
     const schemes = [...ColorBrewerSchemes, ...CustomColorSchemes]
 
     // NB: Temporarily switch to any typing to build the ColorScheme map. Ideally it would just be an enum, but in TS in enums you can only have primitive values.

--- a/grapher/color/ColorUtils.ts
+++ b/grapher/color/ColorUtils.ts
@@ -3,7 +3,9 @@ import { rgb } from "d3-color"
 import { interpolate } from "d3-interpolate"
 import { difference, groupBy, minBy } from "../../clientUtils/Util"
 
-export const interpolateArray = (scaleArr: string[]) => {
+export const interpolateArray = (
+    scaleArr: string[]
+): ((t: number) => string) => {
     const N = scaleArr.length - 2 // -1 for spacings, -1 for number of interpolate fns
     const intervalWidth = 1 / N
     const intervals: Array<(t: number) => string> = []
@@ -12,7 +14,7 @@ export const interpolateArray = (scaleArr: string[]) => {
         intervals[i] = interpolate(rgb(scaleArr[i]), rgb(scaleArr[i + 1]))
     }
 
-    return (t: number) => {
+    return (t: number): string => {
         if (t < 0 || t > 1)
             throw new Error("Outside the allowed range of [0, 1]")
 
@@ -26,7 +28,7 @@ export const interpolateArray = (scaleArr: string[]) => {
 export function getLeastUsedColor(
     availableColors: Color[],
     usedColors: Color[]
-) {
+): any {
     // If there are unused colors, return the first available
     const unusedColors = difference(availableColors, usedColors)
     if (unusedColors.length > 0) return unusedColors[0]
@@ -35,7 +37,7 @@ export function getLeastUsedColor(
     // unused one.
     const colorCounts = Object.entries(
         groupBy(usedColors)
-    ).map(([color, arr]) => [color, arr.length])
+    ).map(([color, arr]): any[] => [color, arr.length])
     const mostUnusedColor = minBy(colorCounts, ([, count]) => count) as [
         string,
         number

--- a/grapher/controls/.eslintrc.yaml
+++ b/grapher/controls/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/controls/AddEntityButton.tsx
+++ b/grapher/controls/AddEntityButton.tsx
@@ -11,11 +11,11 @@ export interface AddEntityButtonManager {
 export class AddEntityButton extends React.Component<{
     manager: AddEntityButtonManager
 }> {
-    render() {
+    render(): JSX.Element {
         return (
             <button
                 className="addEntityButton clickable"
-                onClick={() =>
+                onClick={(): boolean =>
                     runInAction(
                         () => (this.props.manager.isSelectingData = true)
                     )

--- a/grapher/controls/CollapsibleList/CollapsibleList.sampleInput.tsx
+++ b/grapher/controls/CollapsibleList/CollapsibleList.sampleInput.tsx
@@ -7,11 +7,11 @@ import { range } from "../../../clientUtils/Util"
 class SampleCheckBox extends React.Component<{ id: number }> {
     @observable checked: boolean = false
 
-    @action.bound onToggle() {
+    @action.bound onToggle(): void {
         this.checked = !this.checked
     }
 
-    render() {
+    render(): JSX.Element {
         return (
             <label className="clickable">
                 <input

--- a/grapher/controls/CollapsibleList/CollapsibleList.stories.tsx
+++ b/grapher/controls/CollapsibleList/CollapsibleList.stories.tsx
@@ -7,11 +7,11 @@ export default {
     component: CollapsibleList,
 }
 
-export const CollapsibleListComponent = () => {
+export const CollapsibleListComponent = (): JSX.Element => {
     return <CollapsibleList>{collapsibleListSampleItems}</CollapsibleList>
 }
 
-export const MoreButtonComponent = () => {
+export const MoreButtonComponent = (): JSX.Element => {
     const options = [
         <div key="option1">option1</div>,
         <div key="option2">option2</div>,

--- a/grapher/controls/CollapsibleList/CollapsibleList.tsx
+++ b/grapher/controls/CollapsibleList/CollapsibleList.tsx
@@ -35,18 +35,18 @@ export class CollapsibleList extends React.Component {
         )
     }
 
-    private updateOuterContainerWidth() {
+    private updateOuterContainerWidth(): void {
         this.outerContainerWidth =
             this.outerContainerRef.current?.clientWidth ?? 0
     }
 
-    private calculateItemWidths() {
+    private calculateItemWidths(): void {
         this.outerContainerRef.current
             ?.querySelectorAll(".list-item.visible")
-            .forEach((item) => this.itemsWidths.push(item.clientWidth))
+            .forEach((item): number => this.itemsWidths.push(item.clientWidth))
     }
 
-    @action private updateNumItemsVisible() {
+    @action private updateNumItemsVisible(): void {
         const numItemsVisibleWithoutMoreButton = numItemsVisible(
             this.itemsWidths,
             this.outerContainerWidth
@@ -62,26 +62,26 @@ export class CollapsibleList extends React.Component {
                   )
     }
 
-    private get visibleItems() {
+    private get visibleItems(): ListChild[] {
         return this.children.slice(0, this.numItemsVisible)
     }
 
-    private get dropdownItems() {
+    private get dropdownItems(): ListChild[] {
         return this.numItemsVisible
             ? this.children.slice(this.numItemsVisible)
             : []
     }
 
-    @action private onResize = throttle(() => {
+    @action private onResize = throttle((): void => {
         this.updateItemVisibility()
     }, 100)
 
-    @action private updateItemVisibility() {
+    @action private updateItemVisibility(): void {
         this.updateOuterContainerWidth()
         this.updateNumItemsVisible()
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         window.addEventListener("resize", this.onResize)
 
         this.moreButtonWidth = this.moreButtonRef.current?.clientWidth ?? 0
@@ -89,19 +89,21 @@ export class CollapsibleList extends React.Component {
         this.updateItemVisibility()
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         window.removeEventListener("resize", this.onResize)
     }
 
-    render() {
+    render(): JSX.Element {
         return (
             <div className="collapsibleList" ref={this.outerContainerRef}>
                 <ul>
-                    {this.visibleItems.map((item) => (
-                        <li key={item.index} className="list-item visible">
-                            {item.child}
-                        </li>
-                    ))}
+                    {this.visibleItems.map(
+                        (item): JSX.Element => (
+                            <li key={item.index} className="list-item visible">
+                                {item.child}
+                            </li>
+                        )
+                    )}
                     <li
                         className="list-item moreButton"
                         ref={this.moreButtonRef}
@@ -112,14 +114,16 @@ export class CollapsibleList extends React.Component {
                         }}
                     >
                         <MoreButton
-                            options={this.dropdownItems.map((item) => (
-                                <li
-                                    key={item.index}
-                                    className="list-item dropdown"
-                                >
-                                    {item.child}
-                                </li>
-                            ))}
+                            options={this.dropdownItems.map(
+                                (item): JSX.Element => (
+                                    <li
+                                        key={item.index}
+                                        className="list-item dropdown"
+                                    >
+                                        {item.child}
+                                    </li>
+                                )
+                            )}
                         />
                     </li>
                 </ul>
@@ -131,7 +135,7 @@ export class CollapsibleList extends React.Component {
 export class MoreButton extends React.Component<{
     options: React.ReactElement[]
 }> {
-    render() {
+    render(): JSX.Element {
         const { options } = this.props
         return (
             <Tippy
@@ -157,7 +161,7 @@ export function numItemsVisible(
     itemWidths: number[],
     containerWidth: number,
     startingWidth: number = 0
-) {
+): number {
     let total = startingWidth
     for (let i = 0; i < itemWidths.length; i++) {
         if (total + itemWidths[i] > containerWidth) return i

--- a/grapher/controls/CommandPalette.stories.tsx
+++ b/grapher/controls/CommandPalette.stories.tsx
@@ -6,23 +6,23 @@ export default {
     component: CommandPalette,
 }
 
-export const WithCommands = () => {
+export const WithCommands = (): JSX.Element => {
     const demoCommands: Command[] = [
         {
             combo: "ctrl+o",
-            fn: () => {},
+            fn: (): void => {},
             title: "Open",
             category: "File",
         },
         {
             combo: "ctrl+s",
-            fn: () => {},
+            fn: (): void => {},
             title: "Save",
             category: "File",
         },
         {
             combo: "ctrl+c",
-            fn: () => {},
+            fn: (): void => {},
             title: "Copy",
             category: "Edit",
         },

--- a/grapher/controls/CommandPalette.tsx
+++ b/grapher/controls/CommandPalette.tsx
@@ -7,7 +7,7 @@ declare type keyboardCombo = string
 
 export interface Command {
     combo: keyboardCombo
-    fn: () => any
+    fn: () => void
     title?: string
     category?: string
 }
@@ -19,7 +19,7 @@ export class CommandPalette extends React.Component<{
     commands: Command[]
     display: "none" | "block"
 }> {
-    static togglePalette() {
+    static togglePalette(): void {
         const element = document.getElementsByClassName(
             CommandPaletteClassName
         )[0] as HTMLElement
@@ -28,7 +28,7 @@ export class CommandPalette extends React.Component<{
                 element.style.display === "none" ? "block" : "none"
     }
 
-    render() {
+    render(): JSX.Element {
         const style: any = {
             display: this.props.display,
         }
@@ -50,7 +50,9 @@ export class CommandPalette extends React.Component<{
                             <span className="commandCombo">
                                 {command.combo}
                             </span>
-                            <a onClick={() => command.fn()}>{command.title}</a>
+                            <a onClick={(): void => command.fn()}>
+                                {command.title}
+                            </a>
                         </div>
                     </div>
                 )

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -34,20 +34,20 @@ export interface HighlightToggleManager {
 export class HighlightToggle extends React.Component<{
     manager: HighlightToggleManager
 }> {
-    @computed private get manager() {
+    @computed private get manager(): HighlightToggleManager {
         return this.props.manager
     }
-    @computed private get highlight() {
+    @computed private get highlight(): HighlightToggleConfig | undefined {
         return this.props.manager.highlightToggle
     }
 
-    @computed private get highlightParams() {
+    @computed private get highlightParams(): QueryParams {
         return getQueryParams((this.highlight?.paramStr || "").substring(1))
     }
 
     @action.bound private onHighlightToggle(
         event: React.FormEvent<HTMLInputElement>
-    ) {
+    ): void {
         if (!event.currentTarget.checked) {
             this.manager.selectionArray?.clearSelection()
             return
@@ -60,16 +60,16 @@ export class HighlightToggle extends React.Component<{
         this.manager.populateFromQueryParams(params)
     }
 
-    private get isHighlightActive() {
+    private get isHighlightActive(): boolean {
         const params = getWindowQueryParams()
         let isActive = true
-        Object.keys(this.highlightParams).forEach((key) => {
+        Object.keys(this.highlightParams).forEach((key): void => {
             if (params[key] !== this.highlightParams[key]) isActive = false
         })
         return isActive
     }
 
-    render() {
+    render(): JSX.Element {
         const { highlight, isHighlightActive } = this
         return (
             <label className="clickable HighlightToggle">
@@ -93,21 +93,21 @@ export interface AbsRelToggleManager {
 export class AbsRelToggle extends React.Component<{
     manager: AbsRelToggleManager
 }> {
-    @action.bound onToggle() {
+    @action.bound onToggle(): void {
         this.manager.stackMode = this.isRelativeMode
             ? StackMode.absolute
             : StackMode.relative
     }
 
-    @computed get isRelativeMode() {
+    @computed get isRelativeMode(): boolean {
         return this.manager.stackMode === StackMode.relative
     }
 
-    @computed get manager() {
+    @computed get manager(): AbsRelToggleManager {
         return this.props.manager
     }
 
-    render() {
+    render(): JSX.Element {
         const label = this.manager.relativeToggleLabel ?? "Relative"
         return (
             <label className="clickable">
@@ -131,13 +131,13 @@ export interface ZoomToggleManager {
 export class ZoomToggle extends React.Component<{
     manager: ZoomToggleManager
 }> {
-    @action.bound onToggle() {
+    @action.bound onToggle(): void {
         this.props.manager.zoomToSelection = this.props.manager.zoomToSelection
             ? undefined
             : true
     }
 
-    render() {
+    render(): JSX.Element {
         const label = "Zoom to selection"
         return (
             <label className="clickable">
@@ -162,21 +162,21 @@ export interface SmallCountriesFilterManager {
 export class FilterSmallCountriesToggle extends React.Component<{
     manager: SmallCountriesFilterManager
 }> {
-    @action.bound private onChange() {
+    @action.bound private onChange(): void {
         this.manager.minPopulationFilter = this.manager.minPopulationFilter
             ? undefined
             : this.filterOption
     }
 
-    @computed private get manager() {
+    @computed private get manager(): SmallCountriesFilterManager {
         return this.props.manager
     }
 
-    @computed private get filterOption() {
+    @computed private get filterOption(): number {
         return this.manager.populationFilterOption ?? 1e6
     }
 
-    render() {
+    render(): JSX.Element {
         const label = `Hide countries < ${formatValue(
             this.filterOption,
             {}
@@ -213,48 +213,44 @@ export interface FooterControlsManager extends ShareMenuManager {
 export class FooterControls extends React.Component<{
     manager: FooterControlsManager
 }> {
-    @computed private get manager() {
+    @computed private get manager(): FooterControlsManager {
         return this.props.manager
     }
 
-    @action.bound onShareMenu() {
+    @action.bound onShareMenu(): void {
         this.manager.isShareMenuActive = !this.manager.isShareMenuActive
     }
 
-    @computed private get availableTabs() {
+    @computed private get availableTabs(): GrapherTabOption[] {
         return this.manager.availableTabs || []
     }
 
-    private _getTabsElement() {
+    private _getTabsElement(): JSX.Element {
         const { manager } = this
         return (
             <nav className="tabs">
                 <ul>
                     {this.availableTabs.map((tabName) => {
-                        return (
-                            tabName !== GrapherTabOption.download && (
-                                <li
-                                    key={tabName}
-                                    className={
-                                        "tab clickable" +
-                                        (tabName === manager.currentTab
-                                            ? " active"
-                                            : "")
-                                    }
+                        return tabName !== GrapherTabOption.download ? (
+                            <li
+                                key={tabName}
+                                className={
+                                    "tab clickable" +
+                                    (tabName === manager.currentTab
+                                        ? " active"
+                                        : "")
+                                }
+                            >
+                                <a
+                                    onClick={(): void => {
+                                        manager.currentTab = tabName
+                                    }}
+                                    data-track-note={"chart-click-" + tabName}
                                 >
-                                    <a
-                                        onClick={() =>
-                                            (manager.currentTab = tabName)
-                                        }
-                                        data-track-note={
-                                            "chart-click-" + tabName
-                                        }
-                                    >
-                                        {tabName}
-                                    </a>
-                                </li>
-                            )
-                        )
+                                    {tabName}
+                                </a>
+                            </li>
+                        ) : null
                     })}
                     <li
                         className={
@@ -267,7 +263,7 @@ export class FooterControls extends React.Component<{
                     >
                         <a
                             data-track-note="chart-click-download"
-                            onClick={() =>
+                            onClick={(): GrapherTabOption =>
                                 (manager.currentTab = GrapherTabOption.download)
                             }
                         >
@@ -301,7 +297,7 @@ export class FooterControls extends React.Component<{
         )
     }
 
-    render() {
+    render(): JSX.Element {
         const { manager } = this
         const {
             isShareMenuActive,

--- a/grapher/controls/EntitySelectorModal.tsx
+++ b/grapher/controls/EntitySelectorModal.tsx
@@ -21,7 +21,7 @@ class EntitySelectorMulti extends React.Component<{
     base: React.RefObject<HTMLDivElement> = React.createRef()
     dismissable: boolean = true
 
-    @computed get availableEntities() {
+    @computed get availableEntities(): string[] {
         return this.props.selectionArray.availableEntityNames
     }
 
@@ -29,23 +29,23 @@ class EntitySelectorMulti extends React.Component<{
         return new FuzzySearch(this.searchableEntities, "name")
     }
 
-    @computed private get searchableEntities() {
+    @computed private get searchableEntities(): SearchableEntity[] {
         return this.availableEntities.map((name) => {
             return { name } as SearchableEntity
         })
     }
 
-    @computed get searchResults() {
+    @computed get searchResults(): SearchableEntity[] {
         return this.searchInput
             ? this.fuzzy.search(this.searchInput)
-            : sortBy(this.searchableEntities, (result) => result.name)
+            : sortBy(this.searchableEntities, (result): any => result.name)
     }
 
-    @action.bound onClickOutside(e: MouseEvent) {
+    @action.bound onClickOutside(e: MouseEvent): void {
         if (this.dismissable) this.props.onDismiss()
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         // HACK (Mispy): The normal ways of doing this (stopPropagation etc) don't seem to work here
         this.base.current!.addEventListener("click", () => {
             this.dismissable = false
@@ -58,22 +58,24 @@ class EntitySelectorMulti extends React.Component<{
         if (!isTouchDevice()) this.searchField.focus()
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         document.removeEventListener("click", this.onClickOutside)
     }
 
-    @action.bound onSearchKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    @action.bound onSearchKeyDown(
+        e: React.KeyboardEvent<HTMLInputElement>
+    ): void {
         if (e.key === "Enter" && this.searchResults.length > 0) {
             this.props.selectionArray.selectEntity(this.searchResults[0].name)
             this.searchInput = ""
         } else if (e.key === "Escape") this.props.onDismiss()
     }
 
-    @action.bound onClear() {
+    @action.bound onClear(): void {
         this.props.selectionArray.clearSelection()
     }
 
-    render() {
+    render(): JSX.Element {
         const { selectionArray } = this.props
         const { searchResults, searchInput } = this
 
@@ -96,35 +98,37 @@ class EntitySelectorMulti extends React.Component<{
                                 type="search"
                                 placeholder="Search..."
                                 value={searchInput}
-                                onInput={(e) =>
-                                    (this.searchInput = e.currentTarget.value)
-                                }
+                                onInput={(e): void => {
+                                    this.searchInput = e.currentTarget.value
+                                }}
                                 onKeyDown={this.onSearchKeyDown}
-                                ref={(e) =>
+                                ref={(e): HTMLInputElement =>
                                     (this.searchField = e as HTMLInputElement)
                                 }
                             />
                             <ul>
-                                {searchResults.map((result) => {
-                                    return (
-                                        <li key={result.name}>
-                                            <label className="clickable">
-                                                <input
-                                                    type="checkbox"
-                                                    checked={selectionArray.selectedSet.has(
-                                                        result.name
-                                                    )}
-                                                    onChange={() =>
-                                                        selectionArray.toggleSelection(
+                                {searchResults.map(
+                                    (result): JSX.Element => {
+                                        return (
+                                            <li key={result.name}>
+                                                <label className="clickable">
+                                                    <input
+                                                        type="checkbox"
+                                                        checked={selectionArray.selectedSet.has(
                                                             result.name
-                                                        )
-                                                    }
-                                                />{" "}
-                                                {result.name}
-                                            </label>
-                                        </li>
-                                    )
-                                })}
+                                                        )}
+                                                        onChange={(): SelectionArray =>
+                                                            selectionArray.toggleSelection(
+                                                                result.name
+                                                            )
+                                                        }
+                                                    />{" "}
+                                                    {result.name}
+                                                </label>
+                                            </li>
+                                        )
+                                    }
+                                )}
                             </ul>
                         </div>
                         <div className="selectedData">
@@ -136,11 +140,11 @@ class EntitySelectorMulti extends React.Component<{
                                                 <input
                                                     type="checkbox"
                                                     checked={true}
-                                                    onChange={() =>
+                                                    onChange={(): void => {
                                                         selectionArray.deselectEntity(
                                                             name
                                                         )
-                                                    }
+                                                    }}
                                                 />{" "}
                                                 {name}
                                             </label>
@@ -178,7 +182,7 @@ class EntitySelectorSingle extends React.Component<{
     base: React.RefObject<HTMLDivElement> = React.createRef()
     dismissable: boolean = true
 
-    @computed private get availableEntities() {
+    @computed private get availableEntities(): { id: string; label: string }[] {
         const availableItems: { id: string; label: string }[] = []
         this.props.selectionArray.availableEntityNames.forEach((name) => {
             availableItems.push({
@@ -196,15 +200,15 @@ class EntitySelectorSingle extends React.Component<{
     @computed get searchResults(): { id: string; label: string }[] {
         return this.searchInput
             ? this.fuzzy.search(this.searchInput)
-            : sortBy(this.availableEntities, (result) => result.label)
+            : sortBy(this.availableEntities, (result): any => result.label)
     }
 
-    @action.bound onClickOutside(e: MouseEvent) {
+    @action.bound onClickOutside(e: MouseEvent): void {
         if (this.base && !this.base.current!.contains(e.target as Node))
             this.props.onDismiss()
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         // HACK (Mispy): The normal ways of doing this (stopPropagation etc) don't seem to work here
         this.base.current!.addEventListener("click", () => {
             this.dismissable = false
@@ -217,23 +221,25 @@ class EntitySelectorSingle extends React.Component<{
         if (!this.props.isMobile) this.searchField.focus()
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         document.removeEventListener("click", this.onClickOutside)
     }
 
-    @action.bound onSearchKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    @action.bound onSearchKeyDown(
+        e: React.KeyboardEvent<HTMLInputElement>
+    ): void {
         if (e.key === "Enter" && this.searchResults.length > 0) {
             this.onSelect(this.searchResults[0].label)
             this.searchInput = ""
         } else if (e.key === "Escape") this.props.onDismiss()
     }
 
-    @action.bound onSelect(entityName: string) {
+    @action.bound onSelect(entityName: string): void {
         this.props.selectionArray.setSelectedEntities([entityName])
         this.props.onDismiss()
     }
 
-    render() {
+    render(): JSX.Element {
         const { searchResults, searchInput } = this
 
         return (
@@ -252,26 +258,30 @@ class EntitySelectorSingle extends React.Component<{
                             type="search"
                             placeholder="Search..."
                             value={searchInput}
-                            onInput={(e) =>
-                                (this.searchInput = e.currentTarget.value)
-                            }
+                            onInput={(e): void => {
+                                this.searchInput = e.currentTarget.value
+                            }}
                             onKeyDown={this.onSearchKeyDown}
-                            ref={(e) =>
+                            ref={(e): HTMLInputElement =>
                                 (this.searchField = e as HTMLInputElement)
                             }
                         />
                         <ul>
-                            {searchResults.map((d) => {
-                                return (
-                                    <li
-                                        key={d.id}
-                                        className="clickable"
-                                        onClick={() => this.onSelect(d.id)}
-                                    >
-                                        {d.label}
-                                    </li>
-                                )
-                            })}
+                            {searchResults.map(
+                                (d): JSX.Element => {
+                                    return (
+                                        <li
+                                            key={d.id}
+                                            className="clickable"
+                                            onClick={(): void =>
+                                                this.onSelect(d.id)
+                                            }
+                                        >
+                                            {d.label}
+                                        </li>
+                                    )
+                                }
+                            )}
                         </ul>
                     </div>
                 </div>
@@ -287,7 +297,7 @@ export class EntitySelectorModal extends React.Component<{
     isMobile: boolean
     onDismiss: () => void
 }> {
-    render() {
+    render(): JSX.Element {
         return this.props.canChangeEntity ? (
             <EntitySelectorSingle {...this.props} />
         ) : (

--- a/grapher/controls/FuzzySearch.ts
+++ b/grapher/controls/FuzzySearch.ts
@@ -16,7 +16,7 @@ export class FuzzySearch<T> {
             .map((result: any) => this.datamap[result.target])
     }
 
-    single(input: string, target: string) {
+    single(input: string, target: string): Fuzzysort.Result | null {
         return fuzzysort.single(input, target)
     }
 

--- a/grapher/controls/ScaleSelector.stories.tsx
+++ b/grapher/controls/ScaleSelector.stories.tsx
@@ -12,6 +12,6 @@ class MockScaleSelectorManager implements ScaleSelectorManager {
     @observable scaleType = ScaleType.log
 }
 
-export const Default = () => (
+export const Default = (): JSX.Element => (
     <ScaleSelector manager={new MockScaleSelectorManager()} />
 )

--- a/grapher/controls/ScaleSelector.tsx
+++ b/grapher/controls/ScaleSelector.tsx
@@ -14,7 +14,7 @@ export class ScaleSelector extends React.Component<{
     manager?: ScaleSelectorManager
     prefix?: string
 }> {
-    @action.bound private onClick() {
+    @action.bound private onClick(): void {
         const manager = this.props.manager ?? {}
         manager.scaleType = next(
             [ScaleType.linear, ScaleType.log],
@@ -22,7 +22,7 @@ export class ScaleSelector extends React.Component<{
         )
     }
 
-    render() {
+    render(): JSX.Element {
         const { manager, prefix } = this.props
         const { scaleType } = manager ?? {}
         return (

--- a/grapher/controls/ShareMenu.tsx
+++ b/grapher/controls/ShareMenu.tsx
@@ -42,40 +42,40 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
         }
     }
 
-    @computed get manager() {
+    @computed get manager(): ShareMenuManager {
         return this.props.manager
     }
 
-    @computed get title() {
+    @computed get title(): string {
         return this.manager.currentTitle ?? ""
     }
 
-    @computed get isDisabled() {
+    @computed get isDisabled(): boolean {
         return !this.manager.slug
     }
 
-    @computed get canonicalUrl() {
+    @computed get canonicalUrl(): string | undefined {
         return this.manager.canonicalUrl
     }
 
-    @action.bound dismiss() {
+    @action.bound dismiss(): void {
         this.props.onDismiss()
     }
 
-    @action.bound onClickSomewhere() {
+    @action.bound onClickSomewhere(): void {
         if (this.dismissable) this.dismiss()
         else this.dismissable = true
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         document.addEventListener("click", this.onClickSomewhere)
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         document.removeEventListener("click", this.onClickSomewhere)
     }
 
-    @action.bound onEmbed() {
+    @action.bound onEmbed(): void {
         if (!this.canonicalUrl) return
 
         this.manager.addPopup(
@@ -84,7 +84,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
         this.dismiss()
     }
 
-    @action.bound async onNavigatorShare() {
+    @action.bound async onNavigatorShare(): Promise<void> {
         if (!this.canonicalUrl || !navigator.share) return
 
         const shareData = {
@@ -99,13 +99,13 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
         }
     }
 
-    @action.bound onCopy() {
+    @action.bound onCopy(): void {
         if (!this.canonicalUrl) return
 
         if (copy(this.canonicalUrl)) this.setState({ copied: true })
     }
 
-    @computed get twitterHref() {
+    @computed get twitterHref(): string {
         let href =
             "https://twitter.com/intent/tweet/?text=" +
             encodeURIComponent(this.title)
@@ -114,7 +114,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
         return href
     }
 
-    @computed get facebookHref() {
+    @computed get facebookHref(): string {
         let href =
             "https://www.facebook.com/dialog/share?app_id=1149943818390250&display=page"
         if (this.canonicalUrl)
@@ -122,7 +122,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
         return href
     }
 
-    render() {
+    render(): JSX.Element {
         const { twitterHref, facebookHref, isDisabled, manager } = this
         const { editUrl } = manager
 
@@ -201,28 +201,28 @@ class EmbedMenu extends React.Component<{
 }> {
     dismissable = true
 
-    @action.bound onClickSomewhere() {
+    @action.bound onClickSomewhere(): void {
         if (this.dismissable) this.manager.removePopup(EmbedMenu)
         else this.dismissable = true
     }
 
-    @computed get manager() {
+    @computed get manager(): ShareMenuManager {
         return this.props.manager
     }
 
-    @action.bound onClick() {
+    @action.bound onClick(): void {
         this.dismissable = false
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         document.addEventListener("click", this.onClickSomewhere)
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         document.removeEventListener("click", this.onClickSomewhere)
     }
 
-    render() {
+    render(): JSX.Element {
         const url = this.manager.embedUrl ?? this.manager.canonicalUrl
         return (
             <div className="embedMenu" onClick={this.onClick}>
@@ -230,7 +230,7 @@ class EmbedMenu extends React.Component<{
                 <p>Paste this into any HTML page:</p>
                 <textarea
                     readOnly={true}
-                    onFocus={(evt) => evt.currentTarget.select()}
+                    onFocus={(evt): void => evt.currentTarget.select()}
                     value={`<iframe src="${url}" loading="lazy" style="width: 100%; height: 600px; border: 0px none;"></iframe>`}
                 />
                 {this.manager.embedDialogAdditionalElements}

--- a/grapher/controls/SortIcon.tsx
+++ b/grapher/controls/SortIcon.tsx
@@ -12,7 +12,7 @@ export function SortIcon(props: {
     type?: "text" | "numeric"
     isActiveIcon?: boolean
     order: SortOrder
-}) {
+}): JSX.Element {
     const type = props.type ?? "numeric"
     const isActiveIcon = props.isActiveIcon ?? false
 

--- a/grapher/controls/VerticalScrollContainer.tsx
+++ b/grapher/controls/VerticalScrollContainer.tsx
@@ -104,7 +104,7 @@ function getShadowOpacity(
     maxOpacity: number,
     maxDistance: number,
     scrollDistance: number | undefined
-) {
+): number {
     const distance =
         scrollDistance !== undefined ? Math.min(scrollDistance, maxDistance) : 0
     return (distance / maxDistance) * maxOpacity
@@ -114,7 +114,7 @@ const ScrollingShadow = (props: {
     direction: "up" | "down"
     size: number
     opacity: number
-}) => {
+}): JSX.Element => {
     // "Eased" gradient
     // https://larsenwork.com/easing-gradients/
     const background = `linear-gradient(
@@ -162,7 +162,7 @@ function useScrollBounds<ElementType extends HTMLElement>(
         if (el) {
             let pendingUpdate = false
 
-            function onScroll() {
+            function onScroll(): void {
                 const { scrollTop, scrollHeight, offsetHeight } = el
                 onScrollTop(scrollTop)
                 onScrollBottom(scrollHeight - offsetHeight - scrollTop)
@@ -170,7 +170,7 @@ function useScrollBounds<ElementType extends HTMLElement>(
             }
             onScroll() // execute for first time to setState
 
-            const onScrollThrottled = () => {
+            const onScrollThrottled = (): void => {
                 if (!pendingUpdate) {
                     window.requestAnimationFrame(onScroll)
                     pendingUpdate = true
@@ -178,7 +178,7 @@ function useScrollBounds<ElementType extends HTMLElement>(
             }
 
             el.addEventListener("scroll", onScrollThrottled)
-            return () => {
+            return (): void => {
                 el.removeEventListener("scroll", onScrollThrottled)
             }
         }
@@ -199,7 +199,7 @@ interface ScrollLockOptions {
 function useScrollLock<ElementType extends HTMLElement>(
     ref: React.RefObject<ElementType>,
     opts?: Partial<ScrollLockOptions>
-) {
+): void {
     useEffect(() => {
         const el = ref.current
         const options: ScrollLockOptions = {
@@ -207,7 +207,7 @@ function useScrollLock<ElementType extends HTMLElement>(
             ...opts,
         }
         if (el) {
-            function onWheel(ev: MouseWheelEvent) {
+            function onWheel(ev: MouseWheelEvent): void {
                 const el = ref.current
                 if (el) {
                     const delta = ev.deltaY
@@ -221,7 +221,7 @@ function useScrollLock<ElementType extends HTMLElement>(
                         return
                     }
 
-                    function prevent() {
+                    function prevent(): void {
                         ev.stopPropagation()
                         ev.preventDefault()
                     }
@@ -244,7 +244,7 @@ function useScrollLock<ElementType extends HTMLElement>(
                 // We need to be in non-passive mode to be able to cancel the event
                 passive: false,
             })
-            return () => {
+            return (): void => {
                 if (el) {
                     el.removeEventListener("mousewheel", onWheel as any)
                 }

--- a/grapher/controls/entityPicker/EntityPicker.stories.tsx
+++ b/grapher/controls/entityPicker/EntityPicker.stories.tsx
@@ -15,7 +15,7 @@ import { computed, observable } from "mobx"
 import { SelectionArray } from "../../selection/SelectionArray"
 
 class PickerHolder extends React.Component {
-    render() {
+    render(): JSX.Element {
         return (
             <div
                 style={{
@@ -50,7 +50,7 @@ class SomeThingWithAPicker
     @observable entityPickerMetric?: ColumnSlug
     @observable entityPickerSort?: SortOrder
 
-    @computed get pickerColumnSlugs() {
+    @computed get pickerColumnSlugs(): string[] | undefined {
         return this.props.pickerSlugs
     }
 
@@ -61,7 +61,7 @@ class SomeThingWithAPicker
 
     requiredColumnSlugs = defaultSlugs
 
-    render() {
+    render(): JSX.Element {
         return (
             <PickerHolder>
                 <EntityPicker manager={this} />
@@ -75,7 +75,7 @@ export default {
     component: EntityPicker,
 }
 
-export const Empty = () => (
+export const Empty = (): JSX.Element => (
     <PickerHolder>
         <EntityPicker
             manager={{
@@ -85,13 +85,13 @@ export const Empty = () => (
     </PickerHolder>
 )
 
-export const WithChoices = () => <SomeThingWithAPicker />
+export const WithChoices = (): JSX.Element => <SomeThingWithAPicker />
 
-export const WithPickerMetricsChoices = () => (
+export const WithPickerMetricsChoices = (): JSX.Element => (
     <SomeThingWithAPicker pickerSlugs={defaultSlugs} />
 )
 
-export const WithExistingSelectionChoices = () => (
+export const WithExistingSelectionChoices = (): JSX.Element => (
     <SomeThingWithAPicker
         pickerSlugs={defaultSlugs}
         selection={["Japan", "Samoa"]}

--- a/grapher/controls/globalEntitySelector/GlobalEntitySelector.stories.tsx
+++ b/grapher/controls/globalEntitySelector/GlobalEntitySelector.stories.tsx
@@ -7,6 +7,6 @@ export default {
     component: GlobalEntitySelector,
 }
 
-export const WithNoGraphers = () => (
+export const WithNoGraphers = (): JSX.Element => (
     <GlobalEntitySelector selection={new SelectionArray()} />
 )

--- a/grapher/controls/globalEntitySelector/GlobalEntitySelector.tsx
+++ b/grapher/controls/globalEntitySelector/GlobalEntitySelector.tsx
@@ -47,7 +47,7 @@ const allEntities = sortBy(countries, (c) => c.name)
         },
     ])
 
-const Option = (props: any) => {
+const Option = (props: any): JSX.Element => {
     return (
         <div>
             <components.Option {...props}>
@@ -73,14 +73,14 @@ const SelectOptions: Props = {
     hideSelectedOptions: false,
     placeholder: "Add a country to all charts...",
     styles: {
-        placeholder: (base: any) => ({ ...base, whiteSpace: "nowrap" }),
-        valueContainer: (base: any) => ({
+        placeholder: (base: any): any => ({ ...base, whiteSpace: "nowrap" }),
+        valueContainer: (base: any): any => ({
             ...base,
             paddingTop: 0,
             paddingBottom: 0,
         }),
-        control: (base: any) => ({ ...base, minHeight: "initial" }),
-        dropdownIndicator: (base: any) => ({ ...base, padding: "0 5px" }),
+        control: (base: any): any => ({ ...base, minHeight: "initial" }),
+        dropdownIndicator: (base: any): any => ({ ...base, padding: "0 5px" }),
     },
 }
 
@@ -89,7 +89,7 @@ function SelectedItems(props: {
     emptyLabel: string
     canRemove?: boolean
     onRemove?: (item: EntityName) => void
-}) {
+}): JSX.Element {
     const canRemove = (props.canRemove ?? true) && props.onRemove !== undefined
     const onRemove = props.onRemove || noop
     const isEmpty = props.selectedEntityNames.length === 0
@@ -110,7 +110,7 @@ function SelectedItems(props: {
                             {canRemove && (
                                 <div
                                     className="remove-icon"
-                                    onClick={() => onRemove(entityName)}
+                                    onClick={(): void => onRemove(entityName)}
                                 >
                                     <FontAwesomeIcon icon={faTimes} />
                                 </div>
@@ -142,7 +142,7 @@ export class GlobalEntitySelector extends React.Component<{
 
     @observable.ref private optionGroups: GroupedOptionsType<any> = []
 
-    componentDidMount() {
+    componentDidMount(): void {
         this.onResize()
         window.addEventListener("resize", this.onResizeThrottled)
         this.disposers.push(
@@ -154,30 +154,30 @@ export class GlobalEntitySelector extends React.Component<{
         this.populateLocalEntity()
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         window.removeEventListener("resize", this.onResizeThrottled)
-        this.disposers.forEach((dispose) => dispose())
+        this.disposers.forEach((dispose): void => dispose())
     }
 
     private onResizeThrottled = throttle(this.onResize, 200)
-    @action.bound private onResize() {
+    @action.bound private onResize(): void {
         const container = this.refContainer.current
         if (container) this.isNarrow = container.offsetWidth <= 640
     }
 
-    @action.bound async populateLocalEntity() {
+    @action.bound async populateLocalEntity(): Promise<void> {
         try {
             const localCountryCode = await getCountryCodeFromNetlifyRedirect()
             if (!localCountryCode) return
 
             const country = allEntities.find(
-                (entity) => entity.code === localCountryCode
+                (entity): boolean => entity.code === localCountryCode
             )
             if (country) this.localEntityName = country.name
         } catch (err) {}
     }
 
-    @action.bound private prepareOptionGroups() {
+    @action.bound private prepareOptionGroups(): GroupedOptionsType<any> {
         let optionGroups: GroupedOptionsType<any> = []
         // We want to include the local country, but not if it's already selected, it adds
         // unnecessary duplication.
@@ -218,7 +218,7 @@ export class GlobalEntitySelector extends React.Component<{
         this.props.environment ?? "development"
     )
 
-    @action.bound private updateURL() {
+    @action.bound private updateURL(): void {
         setWindowUrl(
             setSelectedEntityNamesParam(
                 getWindowUrl(),
@@ -227,13 +227,13 @@ export class GlobalEntitySelector extends React.Component<{
         )
     }
 
-    @action.bound updateSelection(newSelectedEntities: string[]) {
+    @action.bound updateSelection(newSelectedEntities: string[]): void {
         this.selection.setSelectedEntities(newSelectedEntities)
         this.updateAllGraphersAndExplorersOnPage()
         this.updateURL()
     }
 
-    @action.bound private onChange(options: ValueType<any>) {
+    @action.bound private onChange(options: ValueType<any>): void {
         this.updateSelection(options.map((option: any) => option.label))
 
         this.analytics.logGlobalEntitySelector(
@@ -242,7 +242,7 @@ export class GlobalEntitySelector extends React.Component<{
         )
     }
 
-    @action.bound private updateAllGraphersAndExplorersOnPage() {
+    @action.bound private updateAllGraphersAndExplorersOnPage(): void {
         if (!this.props.graphersAndExplorersToUpdate) return
         Array.from(this.props.graphersAndExplorersToUpdate.values()).forEach(
             (value) => {
@@ -251,23 +251,23 @@ export class GlobalEntitySelector extends React.Component<{
         )
     }
 
-    @action.bound private onRemove(option: EntityName) {
+    @action.bound private onRemove(option: EntityName): void {
         this.selection.toggleSelection(option)
         this.updateAllGraphersAndExplorersOnPage()
         this.updateURL()
     }
 
-    @action.bound private onMenuOpen() {
+    @action.bound private onMenuOpen(): void {
         this.isOpen = true
     }
 
-    @action.bound private onMenuClose() {
+    @action.bound private onMenuClose(): void {
         this.isOpen = false
     }
 
     @action.bound private onButtonOpen(
         event: React.MouseEvent<HTMLButtonElement>
-    ) {
+    ): void {
         this.analytics.logGlobalEntitySelector(
             "open",
             event.currentTarget.innerText
@@ -277,7 +277,7 @@ export class GlobalEntitySelector extends React.Component<{
 
     @action.bound private onButtonClose(
         event: React.MouseEvent<HTMLButtonElement>
-    ) {
+    ): void {
         this.analytics.logGlobalEntitySelector(
             "close",
             event.currentTarget.innerText
@@ -285,11 +285,14 @@ export class GlobalEntitySelector extends React.Component<{
         this.onMenuClose()
     }
 
-    @computed private get selectedOptions() {
+    @computed private get selectedOptions(): {
+        label: string
+        value: string
+    }[] {
         return this.selection.selectedEntityNames.map(entityNameToOption)
     }
 
-    private renderNarrow() {
+    private renderNarrow(): JSX.Element {
         return (
             <>
                 <div
@@ -346,7 +349,7 @@ export class GlobalEntitySelector extends React.Component<{
         )
     }
 
-    private renderWide() {
+    private renderWide(): JSX.Element {
         return (
             <>
                 <div className="select-dropdown-container">
@@ -368,7 +371,7 @@ export class GlobalEntitySelector extends React.Component<{
         )
     }
 
-    render() {
+    render(): JSX.Element {
         return (
             <div
                 className={classnames("global-entity-control", {
@@ -389,7 +392,7 @@ export class GlobalEntitySelector extends React.Component<{
 export const hydrateGlobalEntitySelectorIfAny = (
     selection: SelectionArray,
     graphersAndExplorersToUpdate: Set<SelectionArray>
-) => {
+): void => {
     const element = document.querySelector(GLOBAL_ENTITY_SELECTOR_ELEMENT)
     if (!element) return
 
@@ -402,7 +405,9 @@ export const hydrateGlobalEntitySelectorIfAny = (
     )
 }
 
-const entityNameToOption = (label: EntityName) => ({
+const entityNameToOption = (
+    label: EntityName
+): { label: string; value: string } => ({
     label,
     value: label,
 })

--- a/grapher/core/.eslintrc.yaml
+++ b/grapher/core/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/core/EntityUrlBuilder.ts
+++ b/grapher/core/EntityUrlBuilder.ts
@@ -31,7 +31,7 @@ import {
 const V1_DELIMITER = "+"
 export const ENTITY_V2_DELIMITER = "~"
 
-const isV1Param = (encodedQueryParam: string) => {
+const isV1Param = (encodedQueryParam: string): boolean => {
     // No legacy entities have a v2Delimiter in their name,
     // so if a v2Delimiter is present we know it's a v2 link.
     return !decodeURIComponent(encodedQueryParam).includes(ENTITY_V2_DELIMITER)
@@ -157,7 +157,7 @@ export const getSelectedEntityNamesParam = (
 export const setSelectedEntityNamesParam = (
     url: Url,
     entityNames: EntityName[] | undefined
-) => {
+): Url => {
     return migrateSelectedEntityNamesParam(url).updateQueryParams({
         country: entityNames
             ? entityNamesToV2Param(entityNames.map(entityNameToCode))

--- a/grapher/core/Grapher.jsdom.test.ts
+++ b/grapher/core/Grapher.jsdom.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./GrapherConstants"
 import {
     GrapherInterface,
+    GrapherQueryParams,
     LegacyGrapherQueryParams,
 } from "../core/GrapherInterface"
 import {
@@ -30,7 +31,15 @@ import { MapConfig } from "../mapCharts/MapConfig"
 import { ColumnTypeNames } from "../../coreTable/CoreColumnDef"
 import { SelectionArray } from "../selection/SelectionArray"
 
-const TestGrapherConfig = () => {
+const TestGrapherConfig = (): {
+    table: OwidTable
+    selection: any[]
+    dimensions: {
+        slug: SampleColumnSlugs
+        property: DimensionProperty
+        variableId: any
+    }[]
+} => {
     const table = SynthesizeGDPTable({ entityCount: 10 })
     return {
         table,
@@ -200,7 +209,7 @@ describe("hasTimeline", () => {
     })
 })
 
-const getGrapher = () =>
+const getGrapher = (): Grapher =>
     new Grapher({
         dimensions: [
             {
@@ -230,7 +239,7 @@ const getGrapher = () =>
 function fromQueryParams(
     params: LegacyGrapherQueryParams,
     props?: Partial<GrapherInterface>
-) {
+): Grapher {
     const grapher = new Grapher(props)
     grapher.populateFromQueryParams(
         legacyToCurrentGrapherQueryParams(queryParamsToStr(params))
@@ -238,7 +247,9 @@ function fromQueryParams(
     return grapher
 }
 
-function toQueryParams(props?: Partial<GrapherInterface>) {
+function toQueryParams(
+    props?: Partial<GrapherInterface>
+): Partial<GrapherQueryParams> {
     const grapher = new Grapher({
         minTime: -5000,
         maxTime: 5000,

--- a/grapher/core/Grapher.stories.tsx
+++ b/grapher/core/Grapher.stories.tsx
@@ -45,9 +45,9 @@ const basics: GrapherProgrammaticInterface = {
     ],
 }
 
-export const Line = () => <Grapher {...basics} />
+export const Line = (): JSX.Element => <Grapher {...basics} />
 
-export const SlopeChart = () => {
+export const SlopeChart = (): JSX.Element => {
     const model = {
         type: ChartTypeName.SlopeChart,
         ...basics,
@@ -55,7 +55,7 @@ export const SlopeChart = () => {
     return <Grapher {...model} />
 }
 
-export const ScatterPlot = () => {
+export const ScatterPlot = (): JSX.Element => {
     const model = {
         type: ChartTypeName.ScatterPlot,
         ...basics,
@@ -63,7 +63,7 @@ export const ScatterPlot = () => {
     return <Grapher {...model} />
 }
 
-export const DiscreteBar = () => {
+export const DiscreteBar = (): JSX.Element => {
     const model = {
         type: ChartTypeName.DiscreteBar,
         ...basics,
@@ -71,7 +71,7 @@ export const DiscreteBar = () => {
     return <Grapher {...model} />
 }
 
-export const StackedBar = () => {
+export const StackedBar = (): JSX.Element => {
     const model = {
         type: ChartTypeName.StackedBar,
         ...basics,
@@ -79,7 +79,7 @@ export const StackedBar = () => {
     return <Grapher {...model} />
 }
 
-export const StackedArea = () => {
+export const StackedArea = (): JSX.Element => {
     const model = {
         type: ChartTypeName.StackedArea,
         ...basics,
@@ -87,7 +87,7 @@ export const StackedArea = () => {
     return <Grapher {...model} />
 }
 
-export const MapFirst = () => {
+export const MapFirst = (): JSX.Element => {
     const model = {
         ...basics,
         tab: GrapherTabOption.map,
@@ -95,7 +95,7 @@ export const MapFirst = () => {
     return <Grapher {...model} />
 }
 
-export const BlankGrapher = () => {
+export const BlankGrapher = (): JSX.Element => {
     const model = {
         type: ChartTypeName.WorldMap,
         tab: GrapherTabOption.map,
@@ -105,7 +105,7 @@ export const BlankGrapher = () => {
     return <Grapher {...model} />
 }
 
-export const NoMap = () => {
+export const NoMap = (): JSX.Element => {
     const model = {
         ...basics,
         hasMapTab: false,
@@ -113,7 +113,7 @@ export const NoMap = () => {
     return <Grapher {...model} />
 }
 
-export const Faceting = () => {
+export const Faceting = (): JSX.Element => {
     const model = {
         type: ChartTypeName.StackedArea,
         facet: FacetStrategy.country,
@@ -122,7 +122,7 @@ export const Faceting = () => {
     return <Grapher {...model} />
 }
 
-export const WithAuthorTimeFilter = () => {
+export const WithAuthorTimeFilter = (): JSX.Element => {
     const model: GrapherProgrammaticInterface = {
         ...basics,
         timelineMinTime: 1993,
@@ -133,7 +133,7 @@ export const WithAuthorTimeFilter = () => {
 
 @observer
 class PerfGrapher extends React.Component {
-    @action.bound loadBigTable() {
+    @action.bound loadBigTable(): void {
         this.table = SynthesizeGDPTable({
             entityCount: 200,
             timeRange: [1500, 2000],
@@ -142,13 +142,13 @@ class PerfGrapher extends React.Component {
 
     @observable.ref table = basics.table!
 
-    @action.bound private changeChartType(type: ChartTypeName) {
+    @action.bound private changeChartType(type: ChartTypeName): void {
         this.chartTypeName = type
     }
 
     @observable chartTypeName = ChartTypeName.LineChart
 
-    render() {
+    render(): JSX.Element {
         const key = Math.random() // I do this hack to force a rerender until can re-add the grapher model/grapher view that we used to have. @breck 10/29/2020
         return (
             <div>
@@ -169,4 +169,4 @@ class PerfGrapher extends React.Component {
     }
 }
 
-export const Perf = () => <PerfGrapher />
+export const Perf = (): JSX.Element => <PerfGrapher />

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -10,6 +10,7 @@ import {
     IReactionDisposer,
 } from "mobx"
 import { bind } from "decko"
+import { ColorScale } from "../color/ColorScale"
 import {
     uniqWith,
     isEqual,
@@ -32,6 +33,7 @@ import {
     isInIFrame,
     differenceObj,
 } from "../../clientUtils/Util"
+import { QueryParams } from "../../clientUtils/urls/UrlUtils"
 import {
     ChartTypeName,
     GrapherTabOption,
@@ -160,7 +162,8 @@ import {
 } from "../../settings/clientSettings"
 import { legacyToCurrentGrapherQueryParams } from "./GrapherUrlMigrations"
 import { Url } from "../../clientUtils/urls/Url"
-import { ColumnTypeMap } from "../../coreTable/CoreTableColumns"
+import { ColumnTypeMap, CoreColumn } from "../../coreTable/CoreTableColumns"
+import { ChartInterface } from "../chart/ChartInterface"
 
 declare const window: any
 
@@ -319,13 +322,15 @@ export class Grapher
      * But currently some Grapher features depend on knowing how the current state is different than the "authored state".
      * So when an Explorer updates the grapher, it also needs to update this "original state".
      */
-    @action.bound setAuthoredVersion(config: Partial<LegacyGrapherInterface>) {
+    @action.bound setAuthoredVersion(
+        config: Partial<LegacyGrapherInterface>
+    ): void {
         this.legacyConfigAsAuthored = config
     }
 
     @action.bound updateAuthoredVersion(
         config: Partial<LegacyGrapherInterface>
-    ) {
+    ): void {
         this.legacyConfigAsAuthored = {
             ...this.legacyConfigAsAuthored,
             ...config,
@@ -359,7 +364,7 @@ export class Grapher
         this.checkVisibility = throttle(this.checkVisibility, 400)
     }
 
-    toObject() {
+    toObject(): GrapherInterface {
         const obj: GrapherInterface = objectWithPersistablesToObject(
             this,
             grapherKeysToSerialize
@@ -384,14 +389,14 @@ export class Grapher
         return obj
     }
 
-    @action.bound downloadData() {
+    @action.bound downloadData(): void {
         if (this.manuallyProvideData) {
         } else if (this.owidDataset)
             this._receiveLegacyDataAndApplySelection(this.owidDataset)
         else this.downloadLegacyDataFromOwidVariableIds()
     }
 
-    @action.bound updateFromObject(obj?: GrapherProgrammaticInterface) {
+    @action.bound updateFromObject(obj?: GrapherProgrammaticInterface): void {
         if (!obj) return
 
         // we can remove when we purge current graphers which have this set.
@@ -411,7 +416,7 @@ export class Grapher
             this.setDimensionsFromConfigs(obj.dimensions)
     }
 
-    @action.bound populateFromQueryParams(params: GrapherQueryParams) {
+    @action.bound populateFromQueryParams(params: GrapherQueryParams): void {
         // Set tab if specified
         const tab = params.tab
         if (tab) {
@@ -472,21 +477,21 @@ export class Grapher
             this.selection.setSelectedEntities(selection)
     }
 
-    @action.bound private setTimeFromTimeQueryParam(time: string) {
+    @action.bound private setTimeFromTimeQueryParam(time: string): void {
         this.timelineHandleTimeBounds = getTimeDomainFromQueryString(time).map(
             (time) => findClosestTime(this.times, time) ?? time
         ) as TimeBounds
     }
 
-    @computed private get isChartOrMapTab() {
+    @computed private get isChartOrMapTab(): boolean {
         return this.tab === GrapherTabOption.chart || this.isOnMapTab
     }
 
-    @computed private get isOnMapTab() {
+    @computed private get isOnMapTab(): boolean {
         return this.tab === GrapherTabOption.map
     }
 
-    @computed get tableForSelection() {
+    @computed get tableForSelection(): OwidTable {
         // This table specifies which entities can be selected in the charts EntitySelectorModal.
         // It should contain all entities that can be selected, and none more.
         // Depending on the chart type, the criteria for being able to select an entity are
@@ -505,7 +510,7 @@ export class Grapher
     }
 
     // If an author sets a timeline filter run it early in the pipeline so to the charts it's as if the filtered times do not exist
-    @computed get tableAfterAuthorTimelineFilter() {
+    @computed get tableAfterAuthorTimelineFilter(): OwidTable {
         const table = this.inputTable
         if (
             this.timelineMinTime === undefined &&
@@ -519,7 +524,7 @@ export class Grapher
     }
 
     // Convenience method for debugging
-    windowQueryParams(str = location.search) {
+    windowQueryParams(str = location.search): QueryParams {
         return strToQueryParams(str)
     }
 
@@ -530,7 +535,7 @@ export class Grapher
         return this.chartInstance.transformTable(table)
     }
 
-    @computed get chartInstance() {
+    @computed get chartInstance(): ChartInterface {
         // Note: when timeline handles on a LineChart are collapsed into a single handle, the
         // LineChart turns into a DiscreteBar.
 
@@ -540,7 +545,7 @@ export class Grapher
     }
 
     // When Map becomes a first-class chart instance, we should drop this
-    @computed get chartInstanceExceptMap() {
+    @computed get chartInstanceExceptMap(): ChartInterface {
         const chartTypeName = this
             .typeExceptWhenLineChartAndSingleTimeThenWillBeBarChart
 
@@ -549,12 +554,12 @@ export class Grapher
         return new ChartClass({ manager: this })
     }
 
-    @computed get table() {
+    @computed get table(): OwidTable {
         return this.tableAfterAuthorTimelineFilter
     }
 
     @computed
-    get tableAfterAuthorTimelineAndActiveChartTransformAndPopulationFilter() {
+    get tableAfterAuthorTimelineAndActiveChartTransformAndPopulationFilter(): OwidTable {
         const table = this.tableAfterAuthorTimelineAndActiveChartTransform
         // todo: could make these separate memoized computeds to speed up
         // todo: add cross filtering. 1 dimension at a time.
@@ -567,7 +572,7 @@ export class Grapher
     }
 
     @computed
-    private get tableAfterAllTransformsAndFilters() {
+    private get tableAfterAllTransformsAndFilters(): OwidTable {
         const { startTime, endTime } = this
         const table = this
             .tableAfterAuthorTimelineAndActiveChartTransformAndPopulationFilter
@@ -593,7 +598,7 @@ export class Grapher
         return table.filterByTimeRange(startTime, endTime)
     }
 
-    @computed get transformedTable() {
+    @computed get transformedTable(): OwidTable {
         return this.tableAfterAllTransformsAndFilters
     }
 
@@ -603,29 +608,29 @@ export class Grapher
     @observable isPlaying = false
     @observable.ref isSelectingData = false
 
-    private get isStaging() {
+    private get isStaging(): boolean {
         if (typeof location === undefined) return false
         return location.host.includes("staging")
     }
 
-    @computed get editUrl() {
+    @computed get editUrl(): string | undefined {
         if (!this.showAdminControls && !this.isDev && !this.isStaging)
             return undefined
         return `${this.adminBaseUrl}/admin/${
-            this.manager.editUrl ?? `charts/${this.id}/edit`
+            this.manager?.editUrl ?? `charts/${this.id}/edit`
         }`
     }
 
     private populationFilterToggleOption = 1e6
     // Make the default filter toggle option reflect what is initially loaded.
-    @computed get populationFilterOption() {
+    @computed get populationFilterOption(): number {
         if (this.minPopulationFilter)
             this.populationFilterToggleOption = this.minPopulationFilter
         return this.populationFilterToggleOption
     }
 
     // Checks if the data 1) is about countries and 2) has countries with less than the filter option. Used to partly determine whether to show the filter control.
-    @computed private get hasCountriesSmallerThanFilterOption() {
+    @computed private get hasCountriesSmallerThanFilterOption(): boolean {
         return this.inputTable.availableEntityNames.some(
             (entityName) =>
                 populationMap[entityName] &&
@@ -639,7 +644,7 @@ export class Grapher
     /**
      * Whether the chart is rendered in an Admin context (e.g. on owid.cloud).
      */
-    @computed get useAdminAPI() {
+    @computed get useAdminAPI(): boolean {
         if (typeof window === "undefined") return false
         return window.admin !== undefined
     }
@@ -648,13 +653,14 @@ export class Grapher
      * Whether the user viewing the chart is an admin and we should show admin controls,
      * like the "Edit" option in the share menu.
      */
-    @computed get showAdminControls() {
+    @computed get showAdminControls(): boolean {
         // This cookie is set by visiting ourworldindata.org/identifyadmin on the static site.
         // There is an iframe on owid.cloud to trigger a visit to that page.
         return !!Cookies.get(CookieKey.isAdmin)
     }
 
-    @action.bound private async downloadLegacyDataFromOwidVariableIds() {
+    @action.bound
+    private async downloadLegacyDataFromOwidVariableIds(): Promise<void> {
         if (this.variableIds.length === 0)
             // No data to download
             return
@@ -677,14 +683,14 @@ export class Grapher
         }
     }
 
-    @action.bound receiveLegacyData(json: LegacyVariablesAndEntityKey) {
+    @action.bound receiveLegacyData(json: LegacyVariablesAndEntityKey): void {
         this._receiveLegacyDataAndApplySelection(json)
     }
 
     @action.bound private _setInputTable(
         json: LegacyVariablesAndEntityKey,
         legacyConfig: Partial<LegacyGrapherInterface>
-    ) {
+    ): void {
         const { dimensions, table } = legacyToOwidTableAndDimensions(
             json,
             legacyConfig
@@ -697,14 +703,14 @@ export class Grapher
 
         this.appendNewEntitySelectionOptions()
 
-        if (this.manager.selection && this.manager.selection.hasSelection) {
+        if (this.manager?.selection?.hasSelection) {
             // Selection is managed externally, do nothing.
         } else if (this.selection.hasSelection) {
             // User has changed the selection, use theris
         } else this.applyOriginalSelectionAsAuthored()
     }
 
-    @action rebuildInputOwidTable() {
+    @action rebuildInputOwidTable(): void {
         if (!this.legacyVariableDataJson) return
         this._setInputTable(
             this.legacyVariableDataJson,
@@ -716,13 +722,13 @@ export class Grapher
 
     @action.bound private _receiveLegacyDataAndApplySelection(
         json: LegacyVariablesAndEntityKey
-    ) {
+    ): void {
         this.legacyVariableDataJson = json
 
         this.rebuildInputOwidTable()
     }
 
-    @action.bound appendNewEntitySelectionOptions() {
+    @action.bound appendNewEntitySelectionOptions(): void {
         const { selection } = this
         const currentEntities = selection.availableEntityNameSet
         const missingEntities = this.availableEntities.filter(
@@ -731,7 +737,7 @@ export class Grapher
         selection.addAvailableEntityNames(missingEntities)
     }
 
-    @action.bound private applyOriginalSelectionAsAuthored() {
+    @action.bound private applyOriginalSelectionAsAuthored(): void {
         if (this.selectedEntityNames.length)
             this.selection.setSelectedEntities(this.selectedEntityNames)
         else if (this.selectedEntityIds.length)
@@ -740,7 +746,7 @@ export class Grapher
 
     @observable private _baseFontSize = BASE_FONT_SIZE
 
-    @computed get baseFontSize() {
+    @computed get baseFontSize(): number {
         if (this.isMediaCard) return 24
         else if (this.isExportingtoSvgOrPng) return 18
         return this._baseFontSize
@@ -751,11 +757,11 @@ export class Grapher
     }
 
     // Ready to go iff we have retrieved data for every variable associated with the chart
-    @computed get isReady() {
+    @computed get isReady(): boolean {
         return this.whatAreWeWaitingFor === ""
     }
 
-    @computed get whatAreWeWaitingFor() {
+    @computed get whatAreWeWaitingFor(): string {
         const { newSlugs, inputTable, dimensions } = this
         if (newSlugs.length || dimensions.length === 0) {
             const missingColumns = newSlugs.filter(
@@ -773,19 +779,19 @@ export class Grapher
     }
 
     // If we are using new slugs and not dimensions, Grapher is ready.
-    @computed get newSlugs() {
+    @computed get newSlugs(): string[] {
         const { xSlug, colorSlug, sizeSlug } = this
         const ySlugs = this.ySlugs ? this.ySlugs.split(" ") : []
         return excludeUndefined([...ySlugs, xSlug, colorSlug, sizeSlug])
     }
 
-    @computed private get loadingDimensions() {
+    @computed private get loadingDimensions(): ChartDimension[] {
         return this.dimensions.filter(
             (dim) => !this.inputTable.has(dim.columnSlug)
         )
     }
 
-    @computed get isInIFrame() {
+    @computed get isInIFrame(): boolean {
         return isInIFrame()
     }
 
@@ -843,13 +849,13 @@ export class Grapher
         return findClosestTime(this.times, this.endHandleTimeBound)
     }
 
-    @computed private get onlySingleTimeSelectionPossible() {
+    @computed private get onlySingleTimeSelectionPossible(): boolean {
         return (
             this.isDiscreteBar || this.isStackedDiscreteBar || this.isOnMapTab
         )
     }
 
-    @computed get shouldLinkToOwid() {
+    @computed get shouldLinkToOwid(): boolean {
         if (
             this.props.isEmbeddedInAnOwidPage ||
             this.isExportingtoSvgOrPng ||
@@ -860,17 +866,17 @@ export class Grapher
         return true
     }
 
-    @computed.struct private get variableIds() {
+    @computed.struct private get variableIds(): number[] {
         return uniq(this.dimensions.map((d) => d.variableId))
     }
 
-    @computed private get dataFileName() {
+    @computed private get dataFileName(): string {
         return `${this.variableIds.join("+")}.json?v=${
             this.isEditor ? undefined : this.cacheTag
         }`
     }
 
-    @computed get dataUrl() {
+    @computed get dataUrl(): string {
         return `${this.bakedGrapherURL ?? ""}/data/variables/${
             this.dataFileName
         }`
@@ -878,14 +884,14 @@ export class Grapher
 
     externalCsvLink = ""
 
-    @computed get hasOWIDLogo() {
+    @computed get hasOWIDLogo(): boolean {
         return (
             !this.hideLogo && (this.logo === undefined || this.logo === "owid")
         )
     }
 
     // todo: did this name get botched in a merge?
-    @computed get hasFatalErrors() {
+    @computed get hasFatalErrors(): boolean {
         return this.relatedQuestions.some(
             (question) => !!getErrorMessageRelatedQuestionUrl(question)
         )
@@ -893,17 +899,17 @@ export class Grapher
 
     disposers: IReactionDisposer[] = []
 
-    @bind dispose() {
+    @bind dispose(): void {
         this.disposers.forEach((dispose) => dispose())
     }
 
-    @computed get fontSize() {
+    @computed get fontSize(): number {
         return this.baseFontSize
     }
 
     // todo: can we remove this?
     // I believe these states can only occur during editing.
-    @action.bound private ensureValidConfigWhenEditing() {
+    @action.bound private ensureValidConfigWhenEditing(): void {
         this.disposers.push(
             reaction(
                 () => this.variableIds,
@@ -924,7 +930,7 @@ export class Grapher
         this.disposers.push(...disposers)
     }
 
-    @computed private get validDimensions() {
+    @computed private get validDimensions(): ChartDimension[] {
         const { dimensions } = this
         const validProperties = this.dimensionSlots.map((d) => d.property)
         let validDimensions = dimensions.filter((dim) =>
@@ -948,21 +954,21 @@ export class Grapher
     }
 
     // todo: do we need this?
-    @computed get originUrlWithProtocol() {
+    @computed get originUrlWithProtocol(): string {
         let url = this.originUrl
         if (!url.startsWith("http")) url = `https://${url}`
         return url
     }
 
-    @computed get overlayTab() {
+    @computed get overlayTab(): GrapherTabOption | undefined {
         return this.overlay
     }
 
-    @computed get currentTab() {
+    @computed get currentTab(): GrapherTabOption {
         return this.overlay ? this.overlay : this.tab
     }
 
-    set currentTab(desiredTab) {
+    set currentTab(desiredTab: GrapherTabOption) {
         if (
             desiredTab === GrapherTabOption.chart ||
             desiredTab === GrapherTabOption.map ||
@@ -1001,7 +1007,7 @@ export class Grapher
     }
 
     // Get the dimension slots appropriate for this type of chart
-    @computed get dimensionSlots() {
+    @computed get dimensionSlots(): DimensionSlot[] {
         const xAxis = new DimensionSlot(this, DimensionProperty.x)
         const yAxis = new DimensionSlot(this, DimensionProperty.y)
         const color = new DimensionSlot(this, DimensionProperty.color)
@@ -1013,18 +1019,18 @@ export class Grapher
         return [yAxis]
     }
 
-    @computed.struct get filledDimensions() {
+    @computed.struct get filledDimensions(): ChartDimension[] {
         return this.isReady ? this.dimensions : []
     }
 
-    @action.bound addDimension(config: LegacyChartDimensionInterface) {
+    @action.bound addDimension(config: LegacyChartDimensionInterface): void {
         this.dimensions.push(new ChartDimension(config, this))
     }
 
     @action.bound setDimensionsForProperty(
         property: DimensionProperty,
         newConfigs: LegacyChartDimensionInterface[]
-    ) {
+    ): void {
         let newDimensions: ChartDimension[] = []
         this.dimensionSlots.forEach((slot) => {
             if (slot.property === property)
@@ -1038,17 +1044,17 @@ export class Grapher
 
     @action.bound setDimensionsFromConfigs(
         configs: LegacyChartDimensionInterface[]
-    ) {
+    ): void {
         this.dimensions = configs.map(
             (config) => new ChartDimension(config, this)
         )
     }
 
-    @computed get displaySlug() {
+    @computed get displaySlug(): string {
         return this.slug ?? slugify(this.displayTitle)
     }
 
-    @computed get availableTabs() {
+    @computed get availableTabs(): GrapherTabOption[] {
         return [
             this.hasChartTab && GrapherTabOption.chart,
             this.hasMapTab && GrapherTabOption.map,
@@ -1058,7 +1064,7 @@ export class Grapher
         ].filter(identity) as GrapherTabOption[]
     }
 
-    @computed get currentTitle() {
+    @computed get currentTitle(): string {
         let text = this.displayTitle
         const selectedEntityNames = this.selection.selectedEntityNames
         const showTitleAnnotation = !this.hideTitleAnnotation
@@ -1119,7 +1125,7 @@ export class Grapher
         }
     }
 
-    @computed private get areHandlesOnSameTime() {
+    @computed private get areHandlesOnSameTime(): boolean {
         const times = this.tableAfterAuthorTimelineFilter.timeColumn.uniqValues
         const [start, end] = this.timelineHandleTimeBounds.map((time) =>
             findClosestTime(times, time)
@@ -1127,7 +1133,7 @@ export class Grapher
         return start === end
     }
 
-    @computed get mapColumnSlug() {
+    @computed get mapColumnSlug(): string {
         const mapColumnSlug = this.map.columnSlug
         // If there's no mapColumnSlug or there is one but it's not in the dimensions array, use the first ycolumn
         if (
@@ -1138,16 +1144,16 @@ export class Grapher
         return mapColumnSlug
     }
 
-    getColumnForProperty(property: DimensionProperty) {
+    getColumnForProperty(property: DimensionProperty): CoreColumn | undefined {
         return this.dimensions.find((dim) => dim.property === property)?.column
     }
 
-    getSlugForProperty(property: DimensionProperty) {
+    getSlugForProperty(property: DimensionProperty): string | undefined {
         return this.dimensions.find((dim) => dim.property === property)
             ?.columnSlug
     }
 
-    @computed get yColumns() {
+    @computed get yColumns(): CoreColumn[] {
         return this.filledDimensions
             .filter((dim) => dim.property === DimensionProperty.y)
             .map((dim) => dim.column)
@@ -1159,7 +1165,7 @@ export class Grapher
             : this.yColumnSlugs
     }
 
-    @computed get yColumnSlugs() {
+    @computed get yColumnSlugs(): string[] {
         return this.ySlugs
             ? this.ySlugs.split(" ")
             : this.dimensions
@@ -1167,35 +1173,35 @@ export class Grapher
                   .map((dim) => dim.columnSlug)
     }
 
-    @computed get yColumnSlug() {
+    @computed get yColumnSlug(): string | undefined {
         return this.ySlugs
             ? this.ySlugs.split(" ")[0]
             : this.getSlugForProperty(DimensionProperty.y)
     }
 
-    @computed get xColumnSlug() {
+    @computed get xColumnSlug(): string | undefined {
         return this.xSlug ?? this.getSlugForProperty(DimensionProperty.x)
     }
 
-    @computed get sizeColumnSlug() {
+    @computed get sizeColumnSlug(): string | undefined {
         return this.sizeSlug ?? this.getSlugForProperty(DimensionProperty.size)
     }
 
-    @computed get colorColumnSlug() {
+    @computed get colorColumnSlug(): string | undefined {
         return (
             this.colorSlug ?? this.getSlugForProperty(DimensionProperty.color)
         )
     }
 
-    @computed get yScaleType() {
+    @computed get yScaleType(): ScaleType | undefined {
         return this.yAxis.scaleType
     }
 
-    @computed get xScaleType() {
+    @computed get xScaleType(): ScaleType | undefined {
         return this.xAxis.scaleType
     }
 
-    @computed private get timeTitleSuffix() {
+    @computed private get timeTitleSuffix(): string {
         const timeColumn = this.table.timeColumn
         if (timeColumn.isMissing) return "" // Do not show year until data is loaded
         const { startTime, endTime } = this
@@ -1211,12 +1217,12 @@ export class Grapher
         return ", " + time
     }
 
-    @computed get sourcesLine() {
+    @computed get sourcesLine(): string {
         return this.sourceDesc ?? this.defaultSourcesLine
     }
 
     // Columns that are used as a dimension in the currently active view
-    @computed get activeColumnSlugs() {
+    @computed get activeColumnSlugs(): string[] {
         const {
             yColumnSlugs,
             xColumnSlug,
@@ -1232,7 +1238,7 @@ export class Grapher
         ])
     }
 
-    @computed get columnsWithSources() {
+    @computed get columnsWithSources(): CoreColumn[] {
         // Only use dimensions/columns that are actually part of the visualization
         // In Explorers, this also ensures that only columns which are currently in use will be shown in Sources tab
         const columnSlugs = uniq(this.activeColumnSlugs)
@@ -1253,7 +1259,7 @@ export class Grapher
             )
     }
 
-    @computed private get defaultSourcesLine() {
+    @computed private get defaultSourcesLine(): string {
         let sourceNames = this.columnsWithSources.map(
             (column) => column.source.name ?? ""
         )
@@ -1273,7 +1279,7 @@ export class Grapher
         return uniq(sourceNames).join(", ")
     }
 
-    @computed private get axisDimensions() {
+    @computed private get axisDimensions(): ChartDimension[] {
         return this.filledDimensions.filter(
             (dim) =>
                 dim.property === DimensionProperty.y ||
@@ -1282,13 +1288,13 @@ export class Grapher
     }
 
     // todo: remove when we remove dimensions
-    @computed private get yColumnsFromDimensionsOrSlugsOrAuto() {
+    @computed private get yColumnsFromDimensionsOrSlugsOrAuto(): CoreColumn[] {
         return this.yColumns.length
             ? this.yColumns
             : this.table.getColumns(autoDetectYColumnSlugs(this))
     }
 
-    @computed private get defaultTitle() {
+    @computed private get defaultTitle(): string {
         const yColumns = this.yColumnsFromDimensionsOrSlugsOrAuto
 
         if (this.isScatter)
@@ -1311,66 +1317,67 @@ export class Grapher
         return yColumns.map((col) => col.displayName).join(", ")
     }
 
-    @computed get displayTitle() {
+    @computed get displayTitle(): string {
         return this.title ?? this.defaultTitle
     }
 
     // Returns an object ready to be serialized to JSON
-    @computed get object() {
+    @computed get object(): GrapherInterface {
         return this.toObject()
     }
 
-    @computed get typeExceptWhenLineChartAndSingleTimeThenWillBeBarChart() {
+    @computed
+    get typeExceptWhenLineChartAndSingleTimeThenWillBeBarChart(): ChartTypeName {
         // Switch to bar chart if a single year is selected. Todo: do we want to do this?
         return this.isLineChartThatTurnedIntoDiscreteBar
             ? ChartTypeName.DiscreteBar
             : this.type
     }
 
-    @computed get isLineChart() {
+    @computed get isLineChart(): boolean {
         return this.type === ChartTypeName.LineChart
     }
-    @computed get isScatter() {
+    @computed get isScatter(): boolean {
         return this.type === ChartTypeName.ScatterPlot
     }
-    @computed get isTimeScatter() {
+    @computed get isTimeScatter(): boolean {
         return this.type === ChartTypeName.TimeScatter
     }
-    @computed get isStackedArea() {
+    @computed get isStackedArea(): boolean {
         return this.type === ChartTypeName.StackedArea
     }
-    @computed get isSlopeChart() {
+    @computed get isSlopeChart(): boolean {
         return this.type === ChartTypeName.SlopeChart
     }
-    @computed get isDiscreteBar() {
+    @computed get isDiscreteBar(): boolean {
         return this.type === ChartTypeName.DiscreteBar
     }
-    @computed get isStackedBar() {
+    @computed get isStackedBar(): boolean {
         return this.type === ChartTypeName.StackedBar
     }
     @computed get isStackedDiscreteBar() {
         return this.type === ChartTypeName.StackedDiscreteBar
     }
 
-    @computed get isLineChartThatTurnedIntoDiscreteBar() {
+    @computed get isLineChartThatTurnedIntoDiscreteBar(): boolean {
         return this.isLineChart && this.areHandlesOnSameTime
     }
 
-    @computed get activeColorScale() {
-        const chart = this.chartInstance as any
+    @computed get activeColorScale(): ColorScale | undefined {
+        const chart = this.chartInstance
         return chart.colorScale
     }
 
-    @computed get activeColorScaleExceptMap() {
-        const chart = this.chartInstanceExceptMap as any
+    @computed get activeColorScaleExceptMap(): ColorScale | undefined {
+        const chart = this.chartInstanceExceptMap
         return chart.colorScale
     }
 
-    @computed get supportsMultipleYColumns() {
+    @computed get supportsMultipleYColumns(): boolean {
         return !(this.isScatter || this.isTimeScatter || this.isSlopeChart)
     }
 
-    @computed private get xDimension() {
+    @computed private get xDimension(): ChartDimension | undefined {
         return this.filledDimensions.find(
             (d) => d.property === DimensionProperty.x
         )
@@ -1380,8 +1387,8 @@ export class Grapher
     // todo: remove this. Should be done as a simple column transform at the data level.
     // Possible to override the x axis dimension to target a special year
     // In case you want to graph say, education in the past and democracy today https://ourworldindata.org/grapher/correlation-between-education-and-democracy
-    @computed get xOverrideTime() {
-        return this.xDimension && this.xDimension.targetYear
+    @computed get xOverrideTime(): number | undefined {
+        return this.xDimension?.targetYear
     }
 
     // todo: this is only relevant for scatter plots. move to scatter plot class?
@@ -1389,31 +1396,31 @@ export class Grapher
         this.xDimension!.targetYear = value
     }
 
-    @computed get idealBounds() {
+    @computed get idealBounds(): Bounds {
         return this.isMediaCard
             ? new Bounds(0, 0, 1200, 630)
             : new Bounds(0, 0, 850, 600)
     }
 
-    @computed get hasYDimension() {
+    @computed get hasYDimension(): boolean {
         return this.dimensions.some((d) => d.property === DimensionProperty.y)
     }
 
-    get staticSVG() {
+    get staticSVG(): string {
         return ReactDOMServer.renderToStaticMarkup(
             <StaticCaptionedChart manager={this} bounds={this.idealBounds} />
         )
     }
 
-    @computed get mapConfig() {
+    @computed get mapConfig(): MapConfig {
         return this.map
     }
 
-    @computed get cacheTag() {
+    @computed get cacheTag(): string {
         return this.version.toString()
     }
 
-    @computed get mapIsClickable() {
+    @computed get mapIsClickable(): boolean {
         return (
             this.hasChartTab &&
             (this.isLineChart || this.isScatter) &&
@@ -1421,7 +1428,7 @@ export class Grapher
         )
     }
 
-    @computed get relativeToggleLabel() {
+    @computed get relativeToggleLabel(): string {
         if (this.isScatter || this.isTimeScatter) return "Average annual change"
         else if (this.isLineChart) return "Relative change"
         return "Relative"
@@ -1429,11 +1436,11 @@ export class Grapher
 
     // NB: The timeline scatterplot in relative mode calculates changes relative
     // to the lower bound year rather than creating an arrow chart
-    @computed get isRelativeMode() {
+    @computed get isRelativeMode(): boolean {
         return this.stackMode === StackMode.relative
     }
 
-    @computed get canToggleRelativeMode() {
+    @computed get canToggleRelativeMode(): boolean {
         if (this.isLineChart)
             return (
                 !this.hideRelativeToggle &&
@@ -1453,8 +1460,8 @@ export class Grapher
     static renderGrapherIntoContainer(
         config: GrapherProgrammaticInterface,
         containerNode: Element
-    ) {
-        const setBoundsFromContainerAndRender = () => {
+    ): void {
+        const setBoundsFromContainerAndRender = (): void => {
             const props: GrapherProgrammaticInterface = {
                 ...config,
                 bounds: Bounds.fromRect(containerNode.getBoundingClientRect()),
@@ -1469,7 +1476,9 @@ export class Grapher
         )
     }
 
-    static renderSingleGrapherOnGrapherPage(jsonConfig: GrapherInterface) {
+    static renderSingleGrapherOnGrapherPage(
+        jsonConfig: GrapherInterface
+    ): void {
         const container = document.getElementsByTagName("figure")[0]
 
         try {
@@ -1489,27 +1498,27 @@ export class Grapher
         }
     }
 
-    @computed get isMobile() {
+    @computed get isMobile(): boolean {
         return isMobile()
     }
 
-    @computed private get bounds() {
+    @computed private get bounds(): Bounds {
         return this.props.bounds ?? DEFAULT_BOUNDS
     }
 
-    @computed private get isPortrait() {
+    @computed private get isPortrait(): boolean {
         return this.bounds.width < this.bounds.height && this.bounds.width < 850
     }
 
-    @computed private get widthForDeviceOrientation() {
+    @computed private get widthForDeviceOrientation(): number {
         return this.isPortrait ? 400 : 680
     }
 
-    @computed private get heightForDeviceOrientation() {
+    @computed private get heightForDeviceOrientation(): number {
         return this.isPortrait ? 640 : 480
     }
 
-    @computed private get useIdealBounds() {
+    @computed private get useIdealBounds(): boolean {
         const {
             isEditor,
             isExportingtoSvgOrPng,
@@ -1544,7 +1553,7 @@ export class Grapher
     }
 
     // If we have a big screen to be in, we can define our own aspect ratio and sit in the center
-    @computed private get scaleToFitIdeal() {
+    @computed private get scaleToFitIdeal(): number {
         return Math.min(
             (this.bounds.width * 0.95) / this.widthForDeviceOrientation,
             (this.bounds.height * 0.95) / this.heightForDeviceOrientation
@@ -1553,18 +1562,18 @@ export class Grapher
 
     // These are the final render dimensions
     // Todo: add explanation around why isExporting removes 5 px
-    @computed private get renderWidth() {
+    @computed private get renderWidth(): number {
         return this.useIdealBounds
             ? this.widthForDeviceOrientation * this.scaleToFitIdeal
             : this.bounds.width - (this.isExportingtoSvgOrPng ? 0 : 5)
     }
-    @computed private get renderHeight() {
+    @computed private get renderHeight(): number {
         return this.useIdealBounds
             ? this.heightForDeviceOrientation * this.scaleToFitIdeal
             : this.bounds.height - (this.isExportingtoSvgOrPng ? 0 : 5)
     }
 
-    @computed get tabBounds() {
+    @computed get tabBounds(): Bounds {
         const bounds = new Bounds(0, 0, this.renderWidth, this.renderHeight)
         return this.isExportingtoSvgOrPng
             ? bounds
@@ -1575,35 +1584,35 @@ export class Grapher
 
     base: React.RefObject<HTMLDivElement> = React.createRef()
 
-    @computed get containerElement() {
+    @computed get containerElement(): HTMLDivElement | undefined {
         return this.base.current || undefined
     }
 
     @observable private hasBeenVisible = false
     @observable private uncaughtError?: Error
 
-    @action.bound setError(err: Error) {
+    @action.bound setError(err: Error): void {
         this.uncaughtError = err
     }
 
-    @action.bound clearErrors() {
+    @action.bound clearErrors(): void {
         this.uncaughtError = undefined
     }
 
     // todo: clean up this popup stuff
-    addPopup(vnode: VNode) {
+    addPopup(vnode: VNode): void {
         this.popups = this.popups.concat([vnode])
     }
 
-    removePopup(vnodeType: any) {
+    removePopup(vnodeType: any): void {
         this.popups = this.popups.filter((d) => !(d.type === vnodeType))
     }
 
-    @computed private get isOnTableTab() {
+    @computed private get isOnTableTab(): boolean {
         return this.tab === GrapherTabOption.table
     }
 
-    private renderPrimaryTab() {
+    private renderPrimaryTab(): JSX.Element | undefined {
         if (this.isChartOrMapTab) return <CaptionedChart manager={this} />
 
         const { tabBounds } = this
@@ -1621,7 +1630,7 @@ export class Grapher
         return undefined
     }
 
-    private renderOverlayTab() {
+    private renderOverlayTab(): JSX.Element | undefined {
         const bounds = this.tabBounds
         if (this.overlayTab === GrapherTabOption.sources)
             return (
@@ -1634,26 +1643,26 @@ export class Grapher
         return undefined
     }
 
-    private get commandPalette() {
+    private get commandPalette(): JSX.Element | null {
         return this.props.enableKeyboardShortcuts ? (
             <CommandPalette commands={this.keyboardShortcuts} display="none" />
         ) : null
     }
 
-    formatTimeFn(time: Time) {
+    formatTimeFn(time: Time): string {
         return this.inputTable.timeColumnFormatFunction(time)
     }
 
-    @action.bound private toggleTabCommand() {
+    @action.bound private toggleTabCommand(): void {
         this.currentTab = next(this.availableTabs, this.currentTab)
     }
 
-    @action.bound private togglePlayingCommand() {
+    @action.bound private togglePlayingCommand(): void {
         this.timelineController.togglePlay()
     }
 
     selection =
-        this.manager.selection ??
+        this.manager?.selection ??
         new SelectionArray(
             this.props.selectedEntityNames ?? [],
             this.props.table?.availableEntities ?? []
@@ -1665,25 +1674,28 @@ export class Grapher
 
     private get keyboardShortcuts(): Command[] {
         const temporaryFacetTestCommands = range(0, 10).map((num) => {
-            return { combo: `${num}`, fn: () => this.randomSelection(num) }
+            return {
+                combo: `${num}`,
+                fn: (): void => this.randomSelection(num),
+            }
         })
         const shortcuts = [
             ...temporaryFacetTestCommands,
             {
                 combo: "t",
-                fn: () => this.toggleTabCommand(),
+                fn: (): void => this.toggleTabCommand(),
                 title: "Toggle tab",
                 category: "Navigation",
             },
             {
                 combo: "?",
-                fn: () => CommandPalette.togglePalette(),
+                fn: (): void => CommandPalette.togglePalette(),
                 title: `Toggle Help`,
                 category: "Navigation",
             },
             {
                 combo: "a",
-                fn: () =>
+                fn: (): void | SelectionArray =>
                     this.selection.hasSelection
                         ? this.selection.clearSelection()
                         : this.selection.selectAll(),
@@ -1694,41 +1706,41 @@ export class Grapher
             },
             {
                 combo: "f",
-                fn: () => this.toggleFilterAllCommand(),
+                fn: (): void => this.toggleFilterAllCommand(),
                 title: "Hide unselected",
                 category: "Selection",
             },
             {
                 combo: "p",
-                fn: () => this.togglePlayingCommand(),
+                fn: (): void => this.togglePlayingCommand(),
                 title: this.isPlaying ? `Pause` : `Play`,
                 category: "Timeline",
             },
             {
                 combo: "f",
-                fn: () => this.toggleFacetStrategy(),
+                fn: (): void => this.toggleFacetStrategy(),
                 title: `Toggle Faceting`,
                 category: "Chart",
             },
             {
                 combo: "l",
-                fn: () => this.toggleYScaleTypeCommand(),
+                fn: (): void => this.toggleYScaleTypeCommand(),
                 title: "Toggle Y log/linear",
                 category: "Chart",
             },
             {
                 combo: "esc",
-                fn: () => this.clearErrors(),
+                fn: (): void => this.clearErrors(),
             },
             {
                 combo: "z",
-                fn: () => this.toggleTimelineCommand(),
+                fn: (): void => this.toggleTimelineCommand(),
                 title: "Latest/Earliest/All period",
                 category: "Timeline",
             },
             {
                 combo: "shift+o",
-                fn: () => this.clearQueryParams(),
+                fn: (): void => this.clearQueryParams(),
                 title: "Reset to original",
                 category: "Navigation",
             },
@@ -1755,32 +1767,32 @@ export class Grapher
 
     @observable slideShow?: SlideShowController<any>
 
-    @action.bound private toggleTimelineCommand() {
+    @action.bound private toggleTimelineCommand(): void {
         // Todo: add tests for this
         this.setTimeFromTimeQueryParam(
             next(["latest", "earliest", ".."], this.timeParam!)
         )
     }
 
-    @action.bound private toggleFilterAllCommand() {
+    @action.bound private toggleFilterAllCommand(): void {
         this.minPopulationFilter =
             this.minPopulationFilter === 2e9 ? undefined : 2e9
     }
 
-    @action.bound private toggleYScaleTypeCommand() {
+    @action.bound private toggleYScaleTypeCommand(): void {
         this.yAxis.scaleType = next(
             [ScaleType.linear, ScaleType.log],
             this.yAxis.scaleType
         )
     }
 
-    @action.bound private toggleFacetStrategy() {
+    @action.bound private toggleFacetStrategy(): void {
         this.facet = next(this.availableFacetStrategies, this.facet)
     }
 
     @observable facet?: FacetStrategy
 
-    @computed private get hasMultipleYColumns() {
+    @computed private get hasMultipleYColumns(): boolean {
         return this.yColumnSlugs.length > 1
     }
 
@@ -1805,7 +1817,10 @@ export class Grapher
         return []
     }
 
-    @computed private get availableFacetStrategies() {
+    @computed private get availableFacetStrategies(): (
+        | FacetStrategy
+        | undefined
+    )[] {
         const strategies: (FacetStrategy | undefined)[] = [undefined]
 
         if (this.hasMultipleYColumns) strategies.push(FacetStrategy.column)
@@ -1817,7 +1832,7 @@ export class Grapher
     }
 
     private disableAutoFaceting = true // turned off for now
-    @computed get facetStrategy() {
+    @computed get facetStrategy(): FacetStrategy | undefined {
         if (this.facet && this.availableFacetStrategies.includes(this.facet))
             return this.facet
 
@@ -1841,7 +1856,7 @@ export class Grapher
         return undefined
     }
 
-    @action.bound randomSelection(num: number) {
+    @action.bound randomSelection(num: number): void {
         // Continent, Population, GDP PC, GDP, PopDens, UN, Language, etc.
         this.clearErrors()
         const currentSelection = this.selection.selectedEntityNames.length
@@ -1851,7 +1866,7 @@ export class Grapher
         )
     }
 
-    private renderError() {
+    private renderError(): JSX.Element {
         return (
             <div
                 title={this.uncaughtError?.message}
@@ -1891,7 +1906,7 @@ export class Grapher
         )
     }
 
-    render() {
+    render(): JSX.Element | undefined {
         const { isExportingtoSvgOrPng, isPortrait } = this
         // TODO how to handle errors in exports?
         // TODO tidy this up
@@ -1919,7 +1934,7 @@ export class Grapher
         )
     }
 
-    private renderReady() {
+    private renderReady(): JSX.Element {
         return (
             <>
                 {this.hasBeenVisible && this.renderPrimaryTab()}
@@ -1945,12 +1960,12 @@ export class Grapher
     }
 
     // Chart should only render SVG when it's on the screen
-    @action.bound private checkVisibility() {
+    @action.bound private checkVisibility(): void {
         if (!this.hasBeenVisible && isVisible(this.base.current))
             this.hasBeenVisible = true
     }
 
-    @action.bound private setBaseFontSize() {
+    @action.bound private setBaseFontSize(): void {
         const { renderWidth } = this
         if (renderWidth <= 400) this.baseFontSize = 14
         else if (renderWidth < 1080) this.baseFontSize = 16
@@ -1959,10 +1974,10 @@ export class Grapher
 
     // Binds chart properties to global window title and URL. This should only
     // ever be invoked from top-level JavaScript.
-    private bindToWindow() {
+    private bindToWindow(): void {
         // There is a surprisingly considerable performance overhead to updating the url
         // while animating, so we debounce to allow e.g. smoother timelines
-        const pushParams = () =>
+        const pushParams = (): void =>
             setWindowQueryStr(queryParamsToStr(this.changedParams))
         const debouncedPushParams = debounce(pushParams, 100)
 
@@ -1974,7 +1989,7 @@ export class Grapher
         autorun(() => (document.title = this.currentTitle))
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         window.addEventListener("scroll", this.checkVisibility)
         this.setBaseFontSize()
         this.checkVisibility()
@@ -1984,7 +1999,7 @@ export class Grapher
     }
 
     private _shortcutsBound = false
-    private bindKeyboardShortcuts() {
+    private bindKeyboardShortcuts(): void {
         if (this._shortcutsBound) return
         this.keyboardShortcuts.forEach((shortcut) => {
             Mousetrap.bind(shortcut.combo, () => {
@@ -1999,7 +2014,7 @@ export class Grapher
         this._shortcutsBound = true
     }
 
-    private unbindKeyboardShortcuts() {
+    private unbindKeyboardShortcuts(): void {
         if (!this._shortcutsBound) return
         this.keyboardShortcuts.forEach((shortcut) => {
             Mousetrap.unbind(shortcut.combo)
@@ -2007,35 +2022,35 @@ export class Grapher
         this._shortcutsBound = false
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         this.unbindKeyboardShortcuts()
         window.removeEventListener("scroll", this.checkVisibility)
         this.dispose()
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(): void {
         this.setBaseFontSize()
         this.checkVisibility()
     }
 
-    componentDidCatch(error: Error, info: any) {
+    componentDidCatch(error: Error, info: any): void {
         this.setError(error)
         this.analytics.logGrapherViewError(error, info)
     }
 
     @observable isShareMenuActive = false
 
-    @computed get hasRelatedQuestion() {
+    @computed get hasRelatedQuestion(): boolean {
         if (!this.relatedQuestions.length) return false
         const question = this.relatedQuestions[0]
         return !!question && !!question.text && !!question.url
     }
 
-    @computed private get footerControlsLines() {
+    @computed private get footerControlsLines(): number {
         return this.hasTimeline ? 2 : 1
     }
 
-    @computed get footerControlsHeight() {
+    @computed get footerControlsHeight(): number {
         const footerRowHeight = 32 // todo: cleanup. needs to keep in sync with grapher.scss' $footerRowHeight
         return (
             this.footerControlsLines * footerRowHeight +
@@ -2043,7 +2058,7 @@ export class Grapher
         )
     }
 
-    @action.bound clearQueryParams() {
+    @action.bound clearQueryParams(): void {
         const { authorsVersion } = this
         this.tab = authorsVersion.tab
         this.xAxis.scaleType = authorsVersion.xAxis.scaleType
@@ -2063,7 +2078,7 @@ export class Grapher
     // Todo: come up with a more general pattern?
     // The idea here is to reset the Grapher to a blank slate, so that if you updateFromObject and the object contains some blanks, those blanks
     // won't overwrite defaults (like type == LineChart). RAII would probably be better, but this works for now.
-    @action.bound reset() {
+    @action.bound reset(): void {
         const grapher = new Grapher()
         this.title = grapher.title
         this.subtitle = grapher.subtitle
@@ -2126,12 +2141,12 @@ export class Grapher
 
     // Autocomputed url params to reflect difference between current grapher state
     // and original config state
-    @computed.struct get changedParams() {
+    @computed.struct get changedParams(): Partial<GrapherQueryParams> {
         return differenceObj(this.allParams, this.authorsVersion.allParams)
     }
 
     // If you want to compare current state against the published grapher.
-    @computed private get authorsVersion() {
+    @computed private get authorsVersion(): Grapher {
         return new Grapher({
             ...this.legacyConfigAsAuthored,
             manager: undefined,
@@ -2140,37 +2155,39 @@ export class Grapher
         })
     }
 
-    @computed get queryStr() {
+    @computed get queryStr(): string {
         return queryParamsToStr(this.changedParams)
     }
 
-    @computed get baseUrl() {
+    @computed get baseUrl(): string | undefined {
         return this.isPublished
             ? `${this.bakedGrapherURL ?? "/grapher"}/${this.displaySlug}`
             : undefined
     }
 
-    @computed private get manager() {
-        return this.props.manager ?? {}
+    @computed private get manager(): GrapherManager | undefined {
+        return this.props.manager
     }
 
     // Get the full url representing the canonical location of this grapher state
-    @computed get canonicalUrl() {
+    @computed get canonicalUrl(): string | undefined {
         return (
-            this.manager.canonicalUrl ??
+            this.manager?.canonicalUrl ??
             (this.baseUrl ? this.baseUrl + this.queryStr : undefined)
         )
     }
 
-    @computed get embedUrl() {
-        return this.manager.embedDialogUrl ?? this.canonicalUrl
+    @computed get embedUrl(): string | undefined {
+        return this.manager?.embedDialogUrl ?? this.canonicalUrl
     }
 
-    @computed get embedDialogAdditionalElements() {
-        return this.manager.embedDialogAdditionalElements
+    @computed get embedDialogAdditionalElements():
+        | React.ReactElement
+        | undefined {
+        return this.manager?.embedDialogAdditionalElements
     }
 
-    @computed private get hasUserChangedTimeHandles() {
+    @computed private get hasUserChangedTimeHandles(): boolean {
         const authorsVersion = this.authorsVersion
         return (
             this.minTime !== authorsVersion.minTime ||
@@ -2178,11 +2195,11 @@ export class Grapher
         )
     }
 
-    @computed private get hasUserChangedMapTimeHandle() {
+    @computed private get hasUserChangedMapTimeHandle(): boolean {
         return this.map.time !== this.authorsVersion.map.time
     }
 
-    @computed get timeParam() {
+    @computed get timeParam(): string | undefined {
         const { timeColumn } = this.table
         const formatTime = (t: Time) =>
             timeBoundToTimeBoundString(
@@ -2209,26 +2226,26 @@ export class Grapher
 
     timelineController = new TimelineController(this)
 
-    onPlay() {
+    onPlay(): void {
         this.analytics.logGrapherTimelinePlay(this.slug)
     }
 
     // todo: restore this behavior??
-    onStartPlayOrDrag() {
+    onStartPlayOrDrag(): void {
         this.debounceMode = true
         this.useTimelineDomains = true
     }
 
-    onStopPlayOrDrag() {
+    onStopPlayOrDrag(): void {
         this.debounceMode = false
         this.useTimelineDomains = false
     }
 
-    @computed get disablePlay() {
+    @computed get disablePlay(): boolean {
         return this.isSlopeChart
     }
 
-    formatTime(value: Time) {
+    formatTime(value: Time): string {
         const timeColumn = this.table.timeColumn
         if (timeColumn.isMissing)
             return this.table.timeColumnFormatFunction(value)
@@ -2237,26 +2254,26 @@ export class Grapher
             : timeColumn.formatValue(value)
     }
 
-    @computed get showSmallCountriesFilterToggle() {
+    @computed get showSmallCountriesFilterToggle(): boolean {
         return this.isScatter && this.hasCountriesSmallerThanFilterOption
     }
 
-    @computed get showYScaleToggle() {
+    @computed get showYScaleToggle(): boolean | undefined {
         if (this.isRelativeMode) return false
         if (this.isStackedArea || this.isStackedBar) return false // We currently do not have these charts with log scale
         return this.yAxis.canChangeScaleType
     }
 
-    @computed get showXScaleToggle() {
+    @computed get showXScaleToggle(): boolean | undefined {
         if (this.isRelativeMode) return false
         return this.xAxis.canChangeScaleType
     }
 
-    @computed get showZoomToggle() {
+    @computed get showZoomToggle(): boolean {
         return this.isScatter && this.selection.hasSelection
     }
 
-    @computed get showAbsRelToggle() {
+    @computed get showAbsRelToggle(): boolean {
         if (!this.canToggleRelativeMode) return false
         if (this.isScatter)
             return this.xOverrideTime === undefined && this.hasTimeline
@@ -2268,15 +2285,15 @@ export class Grapher
         )
     }
 
-    @computed get showHighlightToggle() {
+    @computed get showHighlightToggle(): boolean {
         return this.isScatter && !!this.highlightToggle
     }
 
-    @computed get showChangeEntityButton() {
+    @computed get showChangeEntityButton(): boolean {
         return !this.hideEntityControls && this.canChangeEntity
     }
 
-    @computed get showAddEntityButton() {
+    @computed get showAddEntityButton(): boolean {
         return (
             !this.hideEntityControls &&
             this.canSelectMultipleEntities &&
@@ -2287,7 +2304,7 @@ export class Grapher
         )
     }
 
-    @computed get showSelectEntitiesButton() {
+    @computed get showSelectEntitiesButton(): boolean {
         return (
             !this.hideEntityControls &&
             this.addCountryMode !== EntitySelectionMode.Disabled &&
@@ -2297,7 +2314,7 @@ export class Grapher
         )
     }
 
-    @computed get canSelectMultipleEntities() {
+    @computed get canSelectMultipleEntities(): boolean {
         if (this.numSelectableEntityNames < 2) return false
         if (this.addCountryMode === EntitySelectionMode.MultipleEntities)
             return true
@@ -2315,11 +2332,11 @@ export class Grapher
     // A user may have added time or other filters that would filter out all rows from certain entities, but
     // we may still want to show those entities as available in a picker. We also do not want to do things like
     // hide the Add Entity button as the user drags the timeline.
-    @computed private get numSelectableEntityNames() {
+    @computed private get numSelectableEntityNames(): number {
         return this.selection.numAvailableEntityNames
     }
 
-    @computed get canChangeEntity() {
+    @computed get canChangeEntity(): boolean {
         return (
             !this.isScatter &&
             this.addCountryMode === EntitySelectionMode.SingleEntity &&
@@ -2327,7 +2344,7 @@ export class Grapher
         )
     }
 
-    @computed get startSelectingWhenLineClicked() {
+    @computed get startSelectingWhenLineClicked(): boolean {
         return this.showAddEntityButton
     }
 

--- a/grapher/core/GrapherAnalytics.ts
+++ b/grapher/core/GrapherAnalytics.ts
@@ -2,7 +2,7 @@ import { findDOMParent } from "../../clientUtils/Util"
 
 const DEBUG = false
 
-declare var window: any
+declare let window: any
 
 // Docs on GA's event interface: https://developers.google.com/analytics/devguides/collection/analyticsjs/events
 interface GAEvent {
@@ -46,12 +46,12 @@ export class GrapherAnalytics {
     private version: string // Ideally the Git hash commit
     private isDev: boolean
 
-    logGrapherViewError(error: any, info: any) {
+    logGrapherViewError(error: any, info: any): void {
         this.logToAmplitude(EventNames.grapherViewError, { error, info })
         this.logToGA(Categories.GrapherError, EventNames.grapherViewError)
     }
 
-    logEntitiesNotFoundError(entities: string[]) {
+    logEntitiesNotFoundError(entities: string[]): void {
         this.logToAmplitude(EventNames.entitiesNotFound, { entities })
         this.logToGA(
             Categories.GrapherError,
@@ -60,11 +60,11 @@ export class GrapherAnalytics {
         )
     }
 
-    logGrapherTimelinePlay(slug?: string) {
+    logGrapherTimelinePlay(slug?: string): void {
         this.logToGA(Categories.GrapherUsage, EventNames.timelinePlay, slug)
     }
 
-    logGlobalEntitySelector(action: entityControlEvent, note?: string) {
+    logGlobalEntitySelector(action: entityControlEvent, note?: string): void {
         this.logToGA(Categories.GlobalEntitySelectorUsage, action, note)
     }
 
@@ -72,19 +72,19 @@ export class GrapherAnalytics {
         pickerSlug: string,
         action: countrySelectorEvent,
         note?: string
-    ) {
+    ): void {
         this.logToGA(`${pickerSlug}ExplorerCountrySelectorUsage`, action, note)
     }
 
-    logSiteClick(action: string = "unknown-action", label: string) {
+    logSiteClick(action: string = "unknown-action", label: string): void {
         this.logToGA(Categories.SiteClick, action, label)
     }
 
-    logKeyboardShortcut(shortcut: string, combo: string) {
+    logKeyboardShortcut(shortcut: string, combo: string): void {
         this.logToGA(Categories.KeyboardShortcut, shortcut, combo)
     }
 
-    startClickTracking() {
+    startClickTracking(): void {
         // Todo: add a Story and tests for this OR even better remove and use Google Tag Manager or similar fully SAAS tracking.
         // Todo: have different Attributes for Grapher charts vs Site.
         const dataTrackAttr = "data-track-note"
@@ -107,7 +107,7 @@ export class GrapherAnalytics {
         })
     }
 
-    protected logToAmplitude(name: string, props?: any) {
+    protected logToAmplitude(name: string, props?: any): void {
         const allProps = {
             context: {
                 siteVersion: this.version,
@@ -133,7 +133,7 @@ export class GrapherAnalytics {
         eventAction: string,
         eventLabel?: string,
         eventValue?: number
-    ) {
+    ): void {
         // Todo: send the Grapher (or site) version to Git
         const event: GAEvent = {
             hitType: "event",

--- a/grapher/core/GrapherUrlMigrations.ts
+++ b/grapher/core/GrapherUrlMigrations.ts
@@ -7,7 +7,7 @@ import {
 import { migrateSelectedEntityNamesParam } from "./EntityUrlBuilder"
 
 export const grapherUrlMigrations: UrlMigration[] = [
-    (url) => {
+    (url): Url => {
         const { year, time } = url.queryParams
         if (!year) return url
         return url.updateQueryParams({
@@ -18,7 +18,7 @@ export const grapherUrlMigrations: UrlMigration[] = [
     migrateSelectedEntityNamesParam,
 ]
 
-export const legacyToCurrentGrapherUrl = (url: Url) =>
+export const legacyToCurrentGrapherUrl = (url: Url): Url =>
     performUrlMigrations(grapherUrlMigrations, url)
 
 export const legacyToCurrentGrapherQueryParams = (

--- a/grapher/core/LegacyToOwidTable.ts
+++ b/grapher/core/LegacyToOwidTable.ts
@@ -212,7 +212,7 @@ export const legacyToOwidTableAndDimensions = (
     return { dimensions: newDimensions, table: joinedVariablesTable }
 }
 
-const fullJoinTables = (tables: OwidTable[]) =>
+const fullJoinTables = (tables: OwidTable[]): OwidTable =>
     tables.reduce((joinedTable, table) => joinedTable.fullJoin(table))
 
 const columnDefFromLegacyVariable = (
@@ -282,7 +282,7 @@ const timeColumnValuesFromLegacyVariable = (
         : yearsRaw
 }
 
-const convertLegacyYears = (years: number[], zeroDay: string) => {
+const convertLegacyYears = (years: number[], zeroDay: string): number[] => {
     // Only shift years if the variable zeroDay is different from EPOCH_DATE
     // When the dataset uses days (`yearIsDay == true`), the days are expressed as integer
     // days since the specified `zeroDay`, which can be different for different variables.
@@ -310,7 +310,7 @@ const annotationMapAndDefFromLegacyVariable = (
     return []
 }
 
-const annotationsToMap = (annotations: string) => {
+const annotationsToMap = (annotations: string): Map<string, string> => {
     // Todo: let's delete this and switch to traditional columns
     const entityAnnotationsMap = new Map<string, string>()
     const delimiter = ":"

--- a/grapher/core/LegacyVariableCode.ts
+++ b/grapher/core/LegacyVariableCode.ts
@@ -7,7 +7,7 @@ import {
     objectWithPersistablesToObject,
     deleteRuntimeAndUnchangedProps,
 } from "../persistable/Persistable"
-import { ColumnSlug, Integer, Time } from "../../coreTable/CoreTableConstants"
+import { ColumnSlug, Time } from "../../coreTable/CoreTableConstants"
 import { DimensionProperty } from "../core/GrapherConstants"
 import { OwidSource } from "../../coreTable/OwidSource"
 import {
@@ -43,11 +43,13 @@ class LegacyVariableDisplayConfigDefaults {
 export class LegacyVariableDisplayConfig
     extends LegacyVariableDisplayConfigDefaults
     implements Persistable {
-    updateFromObject(obj?: Partial<LegacyVariableDisplayConfigInterface>) {
+    updateFromObject(
+        obj?: Partial<LegacyVariableDisplayConfigInterface>
+    ): void {
         if (obj) updatePersistables(this, obj)
     }
 
-    toObject() {
+    toObject(): LegacyVariableDisplayConfigDefaults {
         return deleteRuntimeAndUnchangedProps(
             objectWithPersistablesToObject(this),
             new LegacyVariableDisplayConfigDefaults()

--- a/grapher/core/grapher.entry.ts
+++ b/grapher/core/grapher.entry.ts
@@ -9,5 +9,5 @@ mobxFormatters(Mobx)
 //Mobx.useStrict(true)
 
 import { Grapher } from "../core/Grapher"
-declare var window: any
+declare let window: any
 window.Grapher = Grapher

--- a/grapher/dataTable/.eslintrc.yaml
+++ b/grapher/dataTable/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/dataTable/DataTable.sample.ts
+++ b/grapher/dataTable/DataTable.sample.ts
@@ -2,7 +2,9 @@ import { Grapher } from "../core/Grapher"
 import { DimensionProperty, GrapherTabOption } from "../core/GrapherConstants"
 import { GrapherInterface } from "../core/GrapherInterface"
 
-export const childMortalityGrapher = (props: Partial<GrapherInterface> = {}) =>
+export const childMortalityGrapher = (
+    props: Partial<GrapherInterface> = {}
+): Grapher =>
     new Grapher({
         hasMapTab: true,
         tab: GrapherTabOption.map,
@@ -35,7 +37,9 @@ export const childMortalityGrapher = (props: Partial<GrapherInterface> = {}) =>
         },
     })
 
-export const IncompleteDataTable = (props: Partial<GrapherInterface> = {}) =>
+export const IncompleteDataTable = (
+    props: Partial<GrapherInterface> = {}
+): Grapher =>
     new Grapher({
         tab: GrapherTabOption.table,
         dimensions: [

--- a/grapher/dataTable/DataTable.stories.tsx
+++ b/grapher/dataTable/DataTable.stories.tsx
@@ -14,14 +14,14 @@ const table = SynthesizeGDPTable({
     entityCount: 7,
 })
 
-export const Default = () => {
+export const Default = (): JSX.Element => {
     const manager: DataTableManager = {
         table,
     }
     return <DataTable manager={manager} />
 }
 
-export const WithTimeRange = () => {
+export const WithTimeRange = (): JSX.Element => {
     const manager: DataTableManager = {
         table,
     }
@@ -30,7 +30,7 @@ export const WithTimeRange = () => {
     return <DataTable manager={manager} />
 }
 
-export const WithTolerance = () => {
+export const WithTolerance = (): JSX.Element => {
     const table = SynthesizeGDPTable(
         {
             timeRange: [2010, 2020],
@@ -68,12 +68,12 @@ export const WithTolerance = () => {
     )
 }
 
-export const FromLegacy = () => {
+export const FromLegacy = (): JSX.Element => {
     const grapher = childMortalityGrapher()
     return <DataTable manager={grapher} />
 }
 
-export const FromLegacyWithTimeRange = () => {
+export const FromLegacyWithTimeRange = (): JSX.Element => {
     const grapher = childMortalityGrapher({
         type: ChartTypeName.LineChart,
         tab: GrapherTabOption.chart,
@@ -83,7 +83,7 @@ export const FromLegacyWithTimeRange = () => {
     return <DataTable manager={grapher} />
 }
 
-export const IncompleteDataTableComponent = () => {
+export const IncompleteDataTableComponent = (): JSX.Element => {
     const grapher = IncompleteDataTable()
     grapher.timelineHandleTimeBounds = [2000, 2000]
     return <DataTable manager={grapher} />

--- a/grapher/downloadTab/.eslintrc.yaml
+++ b/grapher/downloadTab/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/downloadTab/DownloadTab.stories.tsx
+++ b/grapher/downloadTab/DownloadTab.stories.tsx
@@ -6,7 +6,7 @@ export default {
     component: DownloadTab,
 }
 
-export const Default = () => {
+export const Default = (): JSX.Element => {
     return (
         <DownloadTab
             manager={{

--- a/grapher/facetChart/.eslintrc.yaml
+++ b/grapher/facetChart/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/facetChart/FacetChart.stories.tsx
+++ b/grapher/facetChart/FacetChart.stories.tsx
@@ -19,7 +19,7 @@ export default CSF
 
 const bounds = new Bounds(0, 0, 1000, 500)
 
-export const OneMetricOneCountryPerChart = () => {
+export const OneMetricOneCountryPerChart = (): JSX.Element => {
     const table = SynthesizeGDPTable({
         entityCount: 4,
     })
@@ -41,7 +41,7 @@ export const OneMetricOneCountryPerChart = () => {
     )
 }
 
-export const MultipleMetricsOneCountryPerChart = () => {
+export const MultipleMetricsOneCountryPerChart = (): JSX.Element => {
     const table = SynthesizeFruitTable({
         entityCount: 4,
     })
@@ -59,7 +59,7 @@ export const MultipleMetricsOneCountryPerChart = () => {
     )
 }
 
-export const OneChartPerMetric = () => {
+export const OneChartPerMetric = (): JSX.Element => {
     const table = SynthesizeGDPTable({
         entityCount: 2,
     })

--- a/grapher/facetChart/FacetChartUtils.tsx
+++ b/grapher/facetChart/FacetChartUtils.tsx
@@ -5,7 +5,7 @@ export const getFontSize = (
     count: number,
     baseFontSize = BASE_FONT_SIZE,
     min = 8
-) => {
+): number => {
     if (count === 2) return baseFontSize
     if (count < 5) return baseFontSize - 2
     if (count < 10) return baseFontSize - 4
@@ -14,7 +14,9 @@ export const getFontSize = (
     return min
 }
 
-export const getChartPadding = (count: number) => {
+export const getChartPadding = (
+    count: number
+): { rowPadding: number; columnPadding: number; outerPadding: number } => {
     if (count > 9) {
         return {
             rowPadding: 20,

--- a/grapher/footer/.eslintrc.yaml
+++ b/grapher/footer/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/footer/Footer.jsdom.test.tsx
+++ b/grapher/footer/Footer.jsdom.test.tsx
@@ -12,7 +12,7 @@ import { configure, mount } from "enzyme"
 import Adapter from "enzyme-adapter-react-16"
 configure({ adapter: new Adapter() })
 
-const TestGrapherConfig = () => {
+const TestGrapherConfig = (): GrapherProgrammaticInterface => {
     const table = SynthesizeGDPTable({ entityCount: 10 })
     return {
         table,

--- a/grapher/footer/Footer.stories.tsx
+++ b/grapher/footer/Footer.stories.tsx
@@ -13,4 +13,4 @@ const manager: FooterManager = {
     sourcesLine: "These are my sources",
 }
 
-export const Default = () => <Footer manager={manager} />
+export const Default = (): JSX.Element => <Footer manager={manager} />

--- a/grapher/footer/Footer.tsx
+++ b/grapher/footer/Footer.tsx
@@ -14,41 +14,41 @@ export class Footer extends React.Component<{
     manager: FooterManager
     maxWidth?: number
 }> {
-    @computed private get maxWidth() {
+    @computed private get maxWidth(): number {
         return this.props.maxWidth ?? DEFAULT_BOUNDS.width
     }
 
-    @computed private get manager() {
+    @computed private get manager(): FooterManager {
         return this.props.manager
     }
 
-    @computed private get sourcesText() {
+    @computed private get sourcesText(): string {
         const sourcesLine = this.manager.sourcesLine
         return sourcesLine ? `Source: ${sourcesLine}` : ""
     }
 
-    @computed private get noteText() {
+    @computed private get noteText(): string {
         return this.manager.note ? `Note: ${this.manager.note}` : ""
     }
 
-    @computed private get ccSvg() {
+    @computed private get ccSvg(): string {
         if (this.manager.hasOWIDLogo)
             return `<a style="fill: #777;" class="cclogo" href="http://creativecommons.org/licenses/by/4.0/deed.en_US" target="_blank">CC BY</a>`
 
         return `<a href="https://ourworldindata.org" target="_blank">Powered by ourworldindata.org</a>`
     }
 
-    @computed private get originUrlWithProtocol() {
+    @computed private get originUrlWithProtocol(): string {
         return this.manager.originUrlWithProtocol ?? "http://localhost"
     }
 
-    @computed private get finalUrl() {
+    @computed private get finalUrl(): string {
         const originUrl = this.originUrlWithProtocol
         const url = parseUrl(originUrl)
         return `https://${url.hostname}${url.pathname}`
     }
 
-    @computed private get finalUrlText() {
+    @computed private get finalUrlText(): string | undefined {
         const originUrl = this.originUrlWithProtocol
 
         // Make sure the link back to OWID is consistent
@@ -73,7 +73,7 @@ export class Footer extends React.Component<{
         return finalUrlText
     }
 
-    @computed private get licenseSvg() {
+    @computed private get licenseSvg(): string {
         const { finalUrl, finalUrlText, ccSvg } = this
         if (!finalUrlText) return ccSvg
 
@@ -87,11 +87,11 @@ export class Footer extends React.Component<{
         )
     }
 
-    @computed private get fontSize() {
+    @computed private get fontSize(): number {
         return 0.7 * (this.manager.fontSize ?? BASE_FONT_SIZE)
     }
 
-    @computed private get sources() {
+    @computed private get sources(): TextWrap {
         const { maxWidth, fontSize, sourcesText } = this
         return new TextWrap({
             maxWidth,
@@ -101,7 +101,7 @@ export class Footer extends React.Component<{
         })
     }
 
-    @computed private get note() {
+    @computed private get note(): TextWrap {
         const { maxWidth, fontSize, noteText } = this
         return new TextWrap({
             maxWidth,
@@ -111,7 +111,7 @@ export class Footer extends React.Component<{
         })
     }
 
-    @computed private get license() {
+    @computed private get license(): TextWrap {
         const { maxWidth, fontSize, licenseSvg } = this
         return new TextWrap({
             maxWidth: maxWidth * 3,
@@ -122,15 +122,15 @@ export class Footer extends React.Component<{
     }
 
     // Put the license stuff to the side if there's room
-    @computed private get isCompact() {
+    @computed private get isCompact(): boolean {
         return this.maxWidth - this.sources.width - 5 > this.license.width
     }
 
-    @computed private get paraMargin() {
+    @computed private get paraMargin(): number {
         return 2
     }
 
-    @computed get height() {
+    @computed get height(): number {
         if (this.manager.isMediaCard) return 0
 
         const { sources, note, license, isCompact, paraMargin } = this
@@ -141,11 +141,11 @@ export class Footer extends React.Component<{
         )
     }
 
-    @action.bound private onSourcesClick() {
+    @action.bound private onSourcesClick(): void {
         this.manager.currentTab = GrapherTabOption.sources
     }
 
-    renderStatic(targetX: number, targetY: number) {
+    renderStatic(targetX: number, targetY: number): JSX.Element | null {
         if (this.manager.isMediaCard) return null
 
         const { sources, note, license, maxWidth, isCompact, paraMargin } = this
@@ -175,7 +175,7 @@ export class Footer extends React.Component<{
     base: React.RefObject<HTMLDivElement> = React.createRef()
     @observable.ref tooltipTarget?: { x: number; y: number }
 
-    @action.bound private onMouseMove(e: MouseEvent) {
+    @action.bound private onMouseMove(e: MouseEvent): void {
         const cc = this.base.current!.querySelector(".cclogo")
         if (cc && cc.matches(":hover")) {
             const div = this.base.current as HTMLDivElement
@@ -184,15 +184,15 @@ export class Footer extends React.Component<{
         } else this.tooltipTarget = undefined
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         window.addEventListener("mousemove", this.onMouseMove)
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         window.removeEventListener("mousemove", this.onMouseMove)
     }
 
-    render() {
+    render(): JSX.Element {
         const { tooltipTarget } = this
 
         const license = (

--- a/grapher/header/.eslintrc.yaml
+++ b/grapher/header/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/header/Header.stories.tsx
+++ b/grapher/header/Header.stories.tsx
@@ -12,4 +12,4 @@ const manager: HeaderManager = {
     subtitle: "This is my chart subtitle",
 }
 
-export const Default = () => <Header manager={manager} />
+export const Default = (): JSX.Element => <Header manager={manager} />

--- a/grapher/header/Header.tsx
+++ b/grapher/header/Header.tsx
@@ -12,27 +12,27 @@ export class Header extends React.Component<{
     manager: HeaderManager
     maxWidth?: number
 }> {
-    @computed private get manager() {
+    @computed private get manager(): HeaderManager {
         return this.props.manager
     }
 
-    @computed private get fontSize() {
+    @computed private get fontSize(): number {
         return this.manager.fontSize ?? BASE_FONT_SIZE
     }
 
-    @computed private get maxWidth() {
+    @computed private get maxWidth(): number {
         return this.props.maxWidth ?? DEFAULT_BOUNDS.width
     }
 
-    @computed private get titleText() {
+    @computed private get titleText(): string {
         return this.manager.currentTitle ?? ""
     }
 
-    @computed private get subtitleText() {
+    @computed private get subtitleText(): string {
         return this.manager.subtitle ?? ""
     }
 
-    @computed get logo() {
+    @computed get logo(): Logo | undefined {
         const { manager } = this
         if (manager.hideLogo) return undefined
 
@@ -43,14 +43,14 @@ export class Header extends React.Component<{
         })
     }
 
-    @computed private get logoWidth() {
+    @computed private get logoWidth(): number {
         return this.logo ? this.logo.width : 0
     }
-    @computed private get logoHeight() {
+    @computed private get logoHeight(): number {
         return this.logo ? this.logo.height : 0
     }
 
-    @computed get title() {
+    @computed get title(): TextWrap {
         const { logoWidth } = this
         const maxWidth = this.maxWidth - logoWidth - 20
 
@@ -78,14 +78,14 @@ export class Header extends React.Component<{
 
     titleMarginBottom = 4
 
-    @computed get subtitleWidth() {
+    @computed get subtitleWidth(): number {
         // If the subtitle is entirely below the logo, we can go underneath it
         return this.title.height > this.logoHeight
             ? this.maxWidth
             : this.maxWidth - this.logoWidth - 10
     }
 
-    @computed get subtitle() {
+    @computed get subtitle(): TextWrap {
         return new TextWrap({
             maxWidth: this.subtitleWidth,
             fontSize: 0.8 * this.fontSize,
@@ -95,7 +95,7 @@ export class Header extends React.Component<{
         })
     }
 
-    @computed get height() {
+    @computed get height(): number {
         if (this.manager.isMediaCard) return 0
 
         return Math.max(
@@ -104,7 +104,7 @@ export class Header extends React.Component<{
         )
     }
 
-    renderStatic(x: number, y: number) {
+    renderStatic(x: number, y: number): JSX.Element | null {
         const { title, logo, subtitle, manager, maxWidth } = this
 
         if (manager.isMediaCard) return null
@@ -132,7 +132,7 @@ export class Header extends React.Component<{
         )
     }
 
-    render() {
+    render(): JSX.Element {
         const { manager } = this
 
         const titleStyle = {

--- a/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -84,27 +84,27 @@ export interface HorizontalColorLegendManager {
 class HorizontalColorLegend extends React.Component<{
     manager: HorizontalColorLegendManager
 }> {
-    @computed get manager() {
+    @computed get manager(): HorizontalColorLegendManager {
         return this.props.manager
     }
 
-    @computed get legendX() {
+    @computed get legendX(): number {
         return this.manager.legendX ?? 0
     }
 
-    @computed get categoryLegendY() {
+    @computed get categoryLegendY(): number {
         return this.manager.categoryLegendY ?? 0
     }
 
-    @computed get numericLegendY() {
+    @computed get numericLegendY(): number {
         return this.manager.numericLegendY ?? 0
     }
 
-    @computed get legendWidth() {
+    @computed get legendWidth(): number {
         return this.manager.legendWidth ?? 200
     }
 
-    @computed get legendHeight() {
+    @computed get legendHeight(): number {
         return this.manager.legendHeight ?? 200
     }
 
@@ -113,7 +113,7 @@ class HorizontalColorLegend extends React.Component<{
         return this.manager.legendAlign ?? LegendAlign.center
     }
 
-    @computed get fontSize() {
+    @computed get fontSize(): number {
         return this.manager.fontSize ?? BASE_FONT_SIZE
     }
 }
@@ -122,39 +122,39 @@ class HorizontalColorLegend extends React.Component<{
 export class HorizontalNumericColorLegend extends HorizontalColorLegend {
     base: React.RefObject<SVGGElement> = React.createRef()
 
-    @computed get numericLegendData() {
+    @computed get numericLegendData(): ColorScaleBin[] {
         return this.manager.numericLegendData ?? []
     }
 
-    @computed get numericBins() {
+    @computed get numericBins(): NumericBin[] {
         return this.numericLegendData.filter(
-            (bin) => bin instanceof NumericBin
-        ) as NumericBin[]
+            (bin): bin is NumericBin => bin instanceof NumericBin
+        )
     }
     rectHeight = 10
 
-    @computed get tickFontSize() {
+    @computed get tickFontSize(): number {
         return 0.75 * this.fontSize
     }
 
     // NumericColorLegend wants to map a range to a width. However, sometimes we are given
     // data without a clear min/max. So we must fit these scurrilous bins into the width somehow.
-    @computed get minValue() {
+    @computed get minValue(): number {
         return min(this.numericBins.map((bin) => bin.min)) as number
     }
-    @computed get maxValue() {
+    @computed get maxValue(): number {
         return max(this.numericBins.map((bin) => bin.max)) as number
     }
-    @computed get rangeSize() {
+    @computed get rangeSize(): number {
         return this.maxValue - this.minValue
     }
-    @computed get categoryBinWidth() {
+    @computed get categoryBinWidth(): number {
         return Bounds.forText("No data", { fontSize: this.tickFontSize }).width
     }
-    @computed get categoryBinMargin() {
+    @computed get categoryBinMargin(): number {
         return this.rectHeight * 1.5
     }
-    @computed get totalCategoricalWidth() {
+    @computed get totalCategoricalWidth(): number {
         const { numericLegendData } = this
         const { categoryBinWidth, categoryBinMargin } = this
         const widths = numericLegendData.map((bin) =>
@@ -164,11 +164,11 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
         )
         return sum(widths)
     }
-    @computed get availableNumericWidth() {
+    @computed get availableNumericWidth(): number {
         return this.legendWidth - this.totalCategoricalWidth
     }
 
-    @computed get positionedBins() {
+    @computed get positionedBins(): PositionedBin[] {
         const {
             manager,
             rangeSize,
@@ -201,18 +201,18 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                 width,
                 margin,
                 bin: bin,
-            } as PositionedBin
+            }
         })
     }
 
-    @computed get numericLabels() {
+    @computed get numericLabels(): NumericLabel[] {
         const { rectHeight, positionedBins, tickFontSize } = this
 
         const makeBoundaryLabel = (
             bin: PositionedBin,
             minOrMax: "min" | "max",
             text: string
-        ) => {
+        ): NumericLabel => {
             const labelBounds = Bounds.forText(text, { fontSize: tickFontSize })
             const x =
                 bin.x +
@@ -228,7 +228,7 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
             }
         }
 
-        const makeRangeLabel = (bin: PositionedBin) => {
+        const makeRangeLabel = (bin: PositionedBin): NumericLabel => {
             const labelBounds = Bounds.forText(bin.bin.text, {
                 fontSize: tickFontSize,
             })
@@ -295,13 +295,13 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
         return labels
     }
 
-    @computed get height() {
+    @computed get height(): number {
         return Math.abs(
             min(this.numericLabels.map((label) => label.bounds.y)) ?? 0
         )
     }
 
-    @computed get bounds() {
+    @computed get bounds(): Bounds {
         return new Bounds(
             this.legendX,
             this.numericLegendY,
@@ -310,7 +310,7 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
         )
     }
 
-    @action.bound onMouseMove(ev: MouseEvent | TouchEvent) {
+    @action.bound onMouseMove(ev: MouseEvent | TouchEvent): void {
         const { manager, base, positionedBins } = this
         const { numericFocusBracket } = manager
         const mouse = getRelativeMouse(base.current, ev)
@@ -343,12 +343,12 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
             manager.onLegendMouseOver(newFocusBracket)
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         document.documentElement.addEventListener("mousemove", this.onMouseMove)
         document.documentElement.addEventListener("touchmove", this.onMouseMove)
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         document.documentElement.removeEventListener(
             "mousemove",
             this.onMouseMove
@@ -359,7 +359,7 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
         )
     }
 
-    render() {
+    render(): JSX.Element {
         const {
             manager,
             numericLabels,
@@ -434,11 +434,11 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
 
 @observer
 export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
-    @computed get categoricalLegendData() {
+    @computed get categoricalLegendData(): CategoricalBin[] {
         return this.manager.categoricalLegendData ?? []
     }
 
-    @computed private get markLines() {
+    @computed private get markLines(): MarkLine[] {
         const manager = this.manager
         const scale = manager.scale ?? 1
         const rectSize = 12 * scale
@@ -491,11 +491,11 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
         return lines
     }
 
-    @computed get width() {
+    @computed get width(): number {
         return max(this.markLines.map((l) => l.totalWidth)) as number
     }
 
-    @computed get marks() {
+    @computed get marks(): CategoricalMark[] {
         const lines = this.markLines
         const align = this.legendAlign
 
@@ -518,11 +518,11 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
         return flatten(lines.map((l) => l.marks))
     }
 
-    @computed get height() {
+    @computed get height(): number {
         return max(this.marks.map((mark) => mark.y + mark.rectSize)) as number
     }
 
-    render() {
+    render(): JSX.Element {
         const { manager, marks } = this
 
         return (
@@ -532,12 +532,12 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
                         return (
                             <g
                                 key={index}
-                                onMouseOver={() =>
+                                onMouseOver={(): void =>
                                     manager.onLegendMouseOver
                                         ? manager.onLegendMouseOver(mark.bin)
                                         : undefined
                                 }
-                                onMouseLeave={() =>
+                                onMouseLeave={(): void =>
                                     manager.onLegendMouseLeave
                                         ? manager.onLegendMouseLeave()
                                         : undefined

--- a/grapher/lineCharts/.eslintrc.yaml
+++ b/grapher/lineCharts/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/lineCharts/LineChart.stories.tsx
+++ b/grapher/lineCharts/LineChart.stories.tsx
@@ -16,7 +16,7 @@ export default {
     component: LineChart,
 }
 
-export const SingleColumnMultiCountry = () => {
+export const SingleColumnMultiCountry = (): JSX.Element => {
     const table = SynthesizeGDPTable()
     const bounds = new Bounds(0, 0, 500, 250)
     return (
@@ -46,7 +46,7 @@ export const SingleColumnMultiCountry = () => {
     )
 }
 
-export const WithLogScaleAndNegativeAndZeroValues = () => {
+export const WithLogScaleAndNegativeAndZeroValues = (): JSX.Element => {
     const table = SynthesizeFruitTableWithNonPositives({
         entityCount: 2,
         timeRange: [1900, 2000],
@@ -76,7 +76,7 @@ export const WithLogScaleAndNegativeAndZeroValues = () => {
     )
 }
 
-export const WithoutCirclesOnPoints = () => {
+export const WithoutCirclesOnPoints = (): JSX.Element => {
     const table = SynthesizeGDPTable({
         entityCount: 6,
         timeRange: [1900, 2000],
@@ -96,7 +96,7 @@ export const WithoutCirclesOnPoints = () => {
     )
 }
 
-export const WithAnnotations = () => {
+export const WithAnnotations = (): JSX.Element => {
     let table = SynthesizeGDPTable({
         entityCount: 6,
         timeRange: [1900, 2000],
@@ -107,7 +107,7 @@ export const WithAnnotations = () => {
             slug: makeAnnotationsSlug(SampleColumnSlugs.GDP),
             values: table
                 .get(OwidTableSlugs.entityName)
-                .values.map((name) => `${name} is a country`),
+                .values.map((name): string => `${name} is a country`),
         },
     ])
     return (
@@ -125,7 +125,7 @@ export const WithAnnotations = () => {
     )
 }
 
-export const MultiColumnSingleCountry = () => {
+export const MultiColumnSingleCountry = (): JSX.Element => {
     const table = SynthesizeGDPTable()
     const bounds = new Bounds(0, 0, 500, 250)
     return (
@@ -150,7 +150,7 @@ export const MultiColumnSingleCountry = () => {
     )
 }
 
-export const MultiColumnMultiCountry = () => {
+export const MultiColumnMultiCountry = (): JSX.Element => {
     const table = SynthesizeFruitTable({ entityCount: 5 })
     const bounds = new Bounds(0, 0, 500, 250)
     return (

--- a/grapher/lineLegend/LineLegend.stories.tsx
+++ b/grapher/lineLegend/LineLegend.stories.tsx
@@ -54,7 +54,7 @@ const manager: LineLegendManager = {
     verticalAxis: dualAxis.verticalAxis,
 }
 
-export const TestCollisionDetection = () => {
+export const TestCollisionDetection = (): JSX.Element => {
     return (
         <svg width={600} height={400}>
             <LineLegend manager={manager} />

--- a/grapher/lineLegend/LineLegend.tsx
+++ b/grapher/lineLegend/LineLegend.tsx
@@ -49,7 +49,7 @@ interface PlacedSeries extends SizedSeries {
     totalLevels: number
 }
 
-function groupBounds(group: PlacedSeries[]) {
+function groupBounds(group: PlacedSeries[]): Bounds {
     const first = group[0]
     const last = group[group.length - 1]
     const height = last.bounds.bottom - first.bounds.top
@@ -57,7 +57,10 @@ function groupBounds(group: PlacedSeries[]) {
     return new Bounds(first.bounds.x, first.bounds.y, width, height)
 }
 
-function stackGroupVertically(group: PlacedSeries[], y: number) {
+function stackGroupVertically(
+    group: PlacedSeries[],
+    y: number
+): PlacedSeries[] {
     let currentY = y
     group.forEach((mark) => {
         mark.bounds = mark.bounds.extend({ y: currentY })
@@ -77,7 +80,7 @@ class Label extends React.Component<{
     onClick: () => void
     onMouseLeave?: () => void
 }> {
-    render() {
+    render(): JSX.Element {
         const {
             series,
             manager,
@@ -160,12 +163,12 @@ export interface LineLegendManager {
 export class LineLegend extends React.Component<{
     manager: LineLegendManager
 }> {
-    @computed private get fontSize() {
+    @computed private get fontSize(): number {
         return 0.75 * (this.manager.fontSize ?? BASE_FONT_SIZE)
     }
     leftPadding = 35
 
-    @computed private get maxWidth() {
+    @computed private get maxWidth(): number {
         return this.manager.maxLegendWidth ?? 300
     }
 
@@ -204,7 +207,7 @@ export class LineLegend extends React.Component<{
         })
     }
 
-    @computed get width() {
+    @computed get width(): number {
         if (this.sizedLabels.length === 0) return 0
         return max(this.sizedLabels.map((d) => d.width)) ?? 0
     }
@@ -219,13 +222,13 @@ export class LineLegend extends React.Component<{
         return this.manager.onLegendClick ?? noop
     }
 
-    @computed get isFocusMode() {
+    @computed get isFocusMode(): boolean {
         return this.sizedLabels.some((label) =>
             this.manager.focusedSeriesNames.includes(label.seriesName)
         )
     }
 
-    @computed get legendX() {
+    @computed get legendX(): number {
         return this.manager.legendX ?? 0
     }
 
@@ -270,7 +273,7 @@ export class LineLegend extends React.Component<{
         )
     }
 
-    @computed get standardPlacement() {
+    @computed get standardPlacement(): PlacedSeries[] {
         const { verticalAxis } = this.manager
 
         const groups: PlacedSeries[][] = cloneDeep(
@@ -341,7 +344,7 @@ export class LineLegend extends React.Component<{
     }
 
     // Overlapping placement, for when we really can't find a solution without overlaps.
-    @computed get overlappingPlacement() {
+    @computed get overlappingPlacement(): PlacedSeries[] {
         const series = cloneDeep(this.initialSeries)
         for (let i = 0; i < series.length; i++) {
             const m1 = series[i]
@@ -356,7 +359,7 @@ export class LineLegend extends React.Component<{
         return series
     }
 
-    @computed get placedSeries() {
+    @computed get placedSeries(): PlacedSeries[] {
         const nonOverlappingMinHeight =
             sumBy(this.initialSeries, (series) => series.bounds.height) +
             this.initialSeries.length * LEGEND_ITEM_MIN_SPACING
@@ -378,7 +381,7 @@ export class LineLegend extends React.Component<{
         return this.standardPlacement
     }
 
-    @computed private get backgroundSeries() {
+    @computed private get backgroundSeries(): PlacedSeries[] {
         const { focusedSeriesNames } = this.manager
         const { isFocusMode } = this
         return this.placedSeries.filter((mark) =>
@@ -388,7 +391,7 @@ export class LineLegend extends React.Component<{
         )
     }
 
-    @computed private get focusedSeries() {
+    @computed private get focusedSeries(): PlacedSeries[] {
         const { focusedSeriesNames } = this.manager
         const { isFocusMode } = this
         return this.placedSeries.filter((mark) =>
@@ -399,25 +402,25 @@ export class LineLegend extends React.Component<{
     }
 
     // Does this placement need line markers or is the position of the labels already clear?
-    @computed private get needsLines() {
+    @computed private get needsLines(): boolean {
         return this.placedSeries.some((series) => series.totalLevels > 1)
     }
 
-    private renderBackground() {
+    private renderBackground(): JSX.Element[] {
         return this.backgroundSeries.map((series, index) => (
             <Label
                 key={`background-${index}-` + series.seriesName}
                 series={series}
                 manager={this}
                 needsLines={this.needsLines}
-                onMouseOver={() => this.onMouseOver(series.seriesName)}
-                onClick={() => this.onClick(series.seriesName)}
+                onMouseOver={(): void => this.onMouseOver(series.seriesName)}
+                onClick={(): void => this.onClick(series.seriesName)}
             />
         ))
     }
 
     // All labels are focused by default, moved to background when mouseover of other label
-    private renderFocus() {
+    private renderFocus(): JSX.Element[] {
         return this.focusedSeries.map((series, index) => (
             <Label
                 key={`focus-${index}-` + series.seriesName}
@@ -425,18 +428,18 @@ export class LineLegend extends React.Component<{
                 manager={this}
                 isFocus={true}
                 needsLines={this.needsLines}
-                onMouseOver={() => this.onMouseOver(series.seriesName)}
-                onClick={() => this.onClick(series.seriesName)}
-                onMouseLeave={() => this.onMouseLeave(series.seriesName)}
+                onMouseOver={(): void => this.onMouseOver(series.seriesName)}
+                onClick={(): void => this.onClick(series.seriesName)}
+                onMouseLeave={(): void => this.onMouseLeave(series.seriesName)}
             />
         ))
     }
 
-    @computed get manager() {
+    @computed get manager(): LineLegendManager {
         return this.props.manager
     }
 
-    render() {
+    render(): JSX.Element {
         return (
             <g
                 className="LineLabels"

--- a/grapher/loadingIndicator/.eslintrc.yaml
+++ b/grapher/loadingIndicator/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/loadingIndicator/LoadingIndicator.stories.tsx
+++ b/grapher/loadingIndicator/LoadingIndicator.stories.tsx
@@ -6,7 +6,7 @@ export default {
     component: LoadingIndicator,
 }
 
-export const Default = () => {
+export const Default = (): JSX.Element => {
     return (
         <div>
             <LoadingIndicator />

--- a/grapher/loadingIndicator/LoadingIndicator.tsx
+++ b/grapher/loadingIndicator/LoadingIndicator.tsx
@@ -8,7 +8,7 @@ export const LoadingIndicator = (props: {
     bounds?: Bounds
     color?: string
     title?: string
-}) => {
+}): JSX.Element => {
     return (
         <div
             className="loading-indicator"

--- a/grapher/mapCharts/.eslintrc.yaml
+++ b/grapher/mapCharts/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/mapCharts/EntitiesOnTheMap.ts
+++ b/grapher/mapCharts/EntitiesOnTheMap.ts
@@ -2,7 +2,7 @@ import { EntityName } from "../../coreTable/OwidTableConstants"
 import { MapTopology } from "./MapTopology"
 
 let _cache: Set<string>
-export const isOnTheMap = (entityName: EntityName) => {
+export const isOnTheMap = (entityName: EntityName): boolean => {
     // Cache the result
     if (!_cache)
         _cache = new Set(

--- a/grapher/mapCharts/MapChart.stories.tsx
+++ b/grapher/mapCharts/MapChart.stories.tsx
@@ -7,7 +7,7 @@ export default {
     component: MapChart,
 }
 
-export const AutoColors = () => {
+export const AutoColors = (): JSX.Element => {
     const table = SynthesizeGDPTable({
         timeRange: [2000, 2010],
         entityCount: 200,

--- a/grapher/mapCharts/MapConfig.ts
+++ b/grapher/mapCharts/MapConfig.ts
@@ -13,7 +13,7 @@ import {
     maxTimeBoundFromJSONOrPositiveInfinity,
     maxTimeToJSON,
 } from "../../clientUtils/TimeBounds"
-import { trimObject } from "../../clientUtils/Util"
+import { trimObject, NoUndefinedValues } from "../../clientUtils/Util"
 
 // MapConfig holds the data and underlying logic needed by MapTab.
 // It wraps the map property on ChartConfig.
@@ -38,7 +38,7 @@ interface MapConfigWithLegacyInterface extends MapConfigInterface {
 }
 
 export class MapConfig extends MapConfigDefaults implements Persistable {
-    updateFromObject(obj: Partial<MapConfigWithLegacyInterface>) {
+    updateFromObject(obj: Partial<MapConfigWithLegacyInterface>): void {
         // Migrate variableIds to columnSlugs
         if (obj.variableId && !obj.columnSlug)
             obj.columnSlug = obj.variableId.toString()
@@ -53,7 +53,7 @@ export class MapConfig extends MapConfigDefaults implements Persistable {
             this.time = maxTimeBoundFromJSONOrPositiveInfinity(obj.time)
     }
 
-    toObject() {
+    toObject(): NoUndefinedValues<MapConfigWithLegacyInterface> {
         const obj = objectWithPersistablesToObject(
             this
         ) as MapConfigWithLegacyInterface

--- a/grapher/mapCharts/MapProjections.ts
+++ b/grapher/mapCharts/MapProjections.ts
@@ -2,7 +2,6 @@ import {
     geoPath,
     geoConicConformal,
     geoAzimuthalEqualArea,
-    GeoProjection,
     GeoPath,
 } from "d3-geo"
 import { geoRobinson, geoPatterson } from "d3-geo-projection"

--- a/grapher/mapCharts/MapTooltip.stories.tsx
+++ b/grapher/mapCharts/MapTooltip.stories.tsx
@@ -9,4 +9,6 @@ export default {
 }
 
 // todo: refactor TooltipView stuff so we can decouple from Grapher
-export const WithSparkChart = () => <Grapher {...legacyMapGrapher} />
+export const WithSparkChart = (): JSX.Element => (
+    <Grapher {...legacyMapGrapher} />
+)

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -12,7 +12,9 @@ import { SparkBarTimeSeriesValue } from "../sparkBars/SparkBarTimeSeriesValue"
 import { MapChartManager, ChoroplethSeries } from "./MapChartConstants"
 import { ColorScale } from "../color/ColorScale"
 import { Time } from "../../coreTable/CoreTableConstants"
-import { ChartTypeName, GrapherTabOption } from "../core/GrapherConstants"
+import { ChartTypeName } from "../core/GrapherConstants"
+import { OwidTable } from "../../coreTable/OwidTable"
+import { CoreColumn } from "../../coreTable/CoreTableColumns"
 
 interface MapTooltipProps {
     tooltipDatum?: ChoroplethSeries
@@ -25,9 +27,9 @@ interface MapTooltipProps {
 
 @observer
 export class MapTooltip extends React.Component<MapTooltipProps> {
-    private sparkBarsDatumXAccessor = (d: SparkBarsDatum) => d.time
+    private sparkBarsDatumXAccessor = (d: SparkBarsDatum): number => d.time
 
-    @computed private get sparkBarsToDisplay() {
+    @computed private get sparkBarsToDisplay(): number {
         return isMobile() ? 13 : 20
     }
 
@@ -35,26 +37,26 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
         return {
             data: this.sparkBarsData,
             x: this.sparkBarsDatumXAccessor,
-            y: (d: SparkBarsDatum) => d.value,
+            y: (d: SparkBarsDatum): number => d.value,
             xDomain: this.sparkBarsDomain,
         }
     }
 
-    @computed get inputTable() {
+    @computed get inputTable(): OwidTable {
         return this.props.manager.table
     }
 
-    @computed private get mapColumnSlug() {
+    @computed private get mapColumnSlug(): string | undefined {
         return this.props.manager.mapColumnSlug
     }
 
     // Uses the rootTable because if a target year is set, we filter the years at the grapher level.
     // Todo: might want to do all filtering a step below the Grapher level?
-    @computed private get sparkBarColumn() {
+    @computed private get sparkBarColumn(): CoreColumn {
         return this.inputTable.rootTable.get(this.mapColumnSlug)
     }
 
-    @computed private get sparkBarsData() {
+    @computed private get sparkBarsData(): SparkBarsDatum[] {
         const tooltipDatum = this.props.tooltipDatum
         if (!tooltipDatum) return []
 
@@ -83,25 +85,25 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
         return [start, end]
     }
 
-    @computed private get currentSparkBar() {
+    @computed private get currentSparkBar(): number | undefined {
         const lastVal = last(this.sparkBarsData)
         return lastVal ? this.sparkBarsDatumXAccessor(lastVal) : undefined
     }
 
     colorScale = this.props.colorScale ?? new ColorScale()
 
-    @computed private get renderSparkBars() {
+    @computed private get renderSparkBars(): boolean | undefined {
         return this.props.manager.mapIsClickable
     }
 
-    @computed private get darkestColorInColorScheme() {
+    @computed private get darkestColorInColorScheme(): string | undefined {
         const { colorScale } = this
         return colorScale.isColorSchemeInverted
             ? first(colorScale.baseColors)
             : last(colorScale.baseColors)
     }
 
-    @computed private get barColor() {
+    @computed private get barColor(): string | undefined {
         const { colorScale } = this
         return colorScale.singleColorScale &&
             !colorScale.customNumericColorsActive
@@ -109,7 +111,11 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
             : undefined
     }
 
-    @computed private get tooltipTarget() {
+    @computed private get tooltipTarget(): {
+        x: number
+        y: number
+        featureId: string
+    } {
         return (
             this.props.tooltipTarget ?? {
                 x: 0,
@@ -119,7 +125,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
         )
     }
 
-    render() {
+    render(): JSX.Element {
         const {
             tooltipDatum,
             isEntityClickable,

--- a/grapher/mapCharts/ProjectionChooser.tsx
+++ b/grapher/mapCharts/ProjectionChooser.tsx
@@ -19,12 +19,12 @@ export class ProjectionChooser extends React.Component<{
     value: string
     onChange: (value: MapProjectionName) => void
 }> {
-    @action.bound onChange(selected: ValueType<ProjectionChooserEntry>) {
+    @action.bound onChange(selected: ValueType<ProjectionChooserEntry>): void {
         const selectedValue = first(asArray(selected))?.value
         if (selectedValue) this.props.onChange(selectedValue)
     }
 
-    @computed get options() {
+    @computed get options(): { value: MapProjectionName; label: string }[] {
         return Object.values(MapProjectionName).map((projectName) => {
             return {
                 value: projectName,
@@ -33,7 +33,7 @@ export class ProjectionChooser extends React.Component<{
         })
     }
 
-    render() {
+    render(): JSX.Element {
         const { value } = this.props
 
         const style: React.CSSProperties = {

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -148,7 +148,7 @@ export class ScatterPlotChart
 
         if (this.colorColumnSlug) {
             const tolerance =
-                table.get(this.colorColumnSlug)?.display.tolerance ?? Infinity
+                table.get(this.colorColumnSlug)?.display?.tolerance ?? Infinity
             table = table.interpolateColumnWithTolerance(
                 this.colorColumnSlug,
                 tolerance

--- a/settings/.eslintrc.yaml
+++ b/settings/.eslintrc.yaml
@@ -1,0 +1,4 @@
+rules:
+    no-console: "off"
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/settings/findBaseDir.ts
+++ b/settings/findBaseDir.ts
@@ -7,7 +7,7 @@ import fs from "fs"
  * Here, we just traverse the directory tree upwards until we find a `package.json` file, which
  * should indicate that we have found the root directory of the `owid-grapher` repo.
  */
-export default function findProjectBaseDir(from: string) {
+export default function findProjectBaseDir(from: string): string | undefined {
     if (!fs.existsSync) return undefined // if fs.existsSync doesn't exist, we're probably running in the browser
 
     let dir = path.dirname(from)


### PR DESCRIPTION
This PR re-enables several TS lint rules project wide. 

The two warnings that create the most noise are explicit function return type and explicit module boundary types. These are disabled on the project level for now.

For three folders these two warnings have been enabled (with a per-directory .eslint.yaml file): db, clientUtils and coreTable. In these, almost all return type annotations have been added (sans a few that need new interface types).

As is, running eslint as a command line app on the entire grapher directory sans wordpress (this is not directly included and thus gives an error when run this way) leads to 260 warnings of various minor things scattered in the codebase. I think these could be fixed slowly as we go.

There are two further big steps that I would like to do after this PR: 
1. add return type annotations for all the other folders, probably in 2-3 additional PRs (~3500 lines to annotate)
2. turn on no-explicit-any and fix all occurences (replacing any with at least unknown or more specific types where possible)
3. maybe turn on no-non-null-assertions as well as this can easily be a cause for subtle bugs but is of course sometimes justified as the TS codebase can't be fully annotated with correct nullability tracking