### PR TITLE
Add return type annotations in grapher - part 1

### DIFF
--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -131,7 +131,9 @@ import { isNegativeInfinity, isPositiveInfinity } from "./TimeBounds"
 export type SVGElement = any
 export type VNode = any
 
-type NoUndefinedValues<T> = { [P in keyof T]: Required<NonNullable<T[P]>> }
+export type NoUndefinedValues<T> = {
+    [P in keyof T]: Required<NonNullable<T[P]>>
+}
 
 // d3 v6 changed the default minus sign used in d3-format to "−" (Unicode minus sign), which looks
 // nicer but can cause issues when copy-pasting values into a spreadsheet or script.

--- a/coreTable/CoreTableColumns.ts
+++ b/coreTable/CoreTableColumns.ts
@@ -48,7 +48,7 @@ interface ColumnSummary {
     deciles: { [decile: number]: PrimitiveType }
 }
 
-abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
+export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
     def: CoreColumnDef
     table: CoreTable
 

--- a/grapher/axis/.eslintrc.yaml
+++ b/grapher/axis/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -24,6 +24,11 @@ interface Tickmark {
     isFirstOrLastTick?: boolean
 }
 
+interface TickPlacement {
+    tick: number
+    bounds: Bounds
+    isHidden: boolean
+}
 abstract class AbstractAxis {
     config: AxisConfig
     @observable.ref domain: ValueRange
@@ -39,7 +44,7 @@ abstract class AbstractAxis {
         this.domain = [config.domain[0], config.domain[1]]
     }
 
-    @computed get hideAxis() {
+    @computed get hideAxis(): boolean {
         return this.config.hideAxis
     }
 
@@ -49,7 +54,7 @@ abstract class AbstractAxis {
     // Undefined values are ignored
     updateDomainPreservingUserSettings(
         domain: [number | undefined, number | undefined]
-    ) {
+    ): this {
         this.domain = [
             domain[0] !== undefined
                 ? Math.min(this.domain[0], domain[0])
@@ -61,11 +66,11 @@ abstract class AbstractAxis {
         return this
     }
 
-    @computed get fontSize() {
+    @computed get fontSize(): number {
         return this.config.fontSize
     }
 
-    @computed get scaleType() {
+    @computed get scaleType(): ScaleType {
         return this._scaleType ?? (this.config.scaleType || ScaleType.linear)
     }
 
@@ -73,7 +78,7 @@ abstract class AbstractAxis {
         this._scaleType = value
     }
 
-    @computed get label() {
+    @computed get label(): string {
         return this._label ?? this.config.label
     }
 
@@ -81,12 +86,12 @@ abstract class AbstractAxis {
         this._label = value
     }
 
-    @computed get canChangeScaleType() {
+    @computed get canChangeScaleType(): boolean | undefined {
         return this.config.canChangeScaleType
     }
 
     // todo: refactor. switch to a parent pattern?
-    _update(parentAxis: AbstractAxis) {
+    _update(parentAxis: AbstractAxis): this {
         this.formatColumn = parentAxis.formatColumn
         this.domain = parentAxis.domain.slice() as ValueRange
         this.hideFractionalTicks = parentAxis.hideFractionalTicks
@@ -105,25 +110,25 @@ abstract class AbstractAxis {
         return d3Scale().domain(this.domain).range(this.range)
     }
 
-    @computed get rangeSize() {
+    @computed get rangeSize(): number {
         return Math.abs(this.range[1] - this.range[0])
     }
 
-    @computed get rangeMax() {
+    @computed get rangeMax(): number {
         return Math.max(this.range[1], this.range[0])
     }
 
-    @computed get rangeMin() {
+    @computed get rangeMin(): number {
         return Math.min(this.range[1], this.range[0])
     }
 
     // When this is a log axis, only show so many grid lines because otherwise the chart would get
     // too overwhelming. Different for mobile because screens are usually smaller.
-    @computed private get maxLogLines() {
+    @computed private get maxLogLines(): number {
         return isMobile() ? 8 : 10
     }
 
-    getTickValues() {
+    getTickValues(): Tickmark[] {
         const { scaleType, d3_scale, maxLogLines } = this
 
         let ticks: Tickmark[]
@@ -156,7 +161,10 @@ abstract class AbstractAxis {
             //
             // -@MarcelGerber, 2020-08-07
             const tickCandidates = d3_scale.ticks(maxLogLines)
-            ticks = tickCandidates.map((value) => {
+            ticks = tickCandidates.map((value): {
+                value: number
+                priority: number
+            } => {
                 // 10^x
                 if (Math.fround(Math.log10(value)) % 1 === 0)
                     return { value, priority: 1 }
@@ -172,18 +180,24 @@ abstract class AbstractAxis {
             if (ticks.length > maxLogLines) {
                 if (ticks.length <= 2 * maxLogLines) {
                     // Convert all "in-between" lines to faint grid lines without labels
-                    ticks = ticks.map((tick) => {
-                        if (tick.priority === 3)
-                            tick = { ...tick, faint: true, gridLineOnly: true }
-                        return tick
-                    })
+                    ticks = ticks.map(
+                        (tick): Tickmark => {
+                            if (tick.priority === 3)
+                                tick = {
+                                    ...tick,
+                                    faint: true,
+                                    gridLineOnly: true,
+                                }
+                            return tick
+                        }
+                    )
                 } else {
                     // Remove some tickmarks again because the chart would get too overwhelming
                     // otherwise
                     for (let priority = 3; priority > 1; priority--) {
                         if (ticks.length > maxLogLines)
                             ticks = ticks.filter(
-                                (tick) => tick.priority < priority
+                                (tick): boolean => tick.priority < priority
                             )
                     }
                 }
@@ -191,13 +205,17 @@ abstract class AbstractAxis {
         } else {
             // Only use priority 2 here because we want the start / end ticks
             // to be priority 1
-            ticks = d3_scale
-                .ticks(6)
-                .map((tickValue) => ({ value: tickValue, priority: 2 }))
+            ticks = d3_scale.ticks(6).map((tickValue): {
+                value: number
+                priority: number
+            } => ({
+                value: tickValue,
+                priority: 2,
+            }))
         }
 
         if (this.hideFractionalTicks)
-            ticks = ticks.filter((t) => t.value % 1 === 0)
+            ticks = ticks.filter((t): boolean => t.value % 1 === 0)
 
         return uniq(ticks)
     }
@@ -226,7 +244,9 @@ abstract class AbstractAxis {
         // -@danielgavrilov, 2020-05-27
         const tickValues = this.getTickValues()
         const minDist = min(
-            rollingMap(tickValues, (a, b) => Math.abs(a.value - b.value))
+            rollingMap(tickValues, (a, b): number =>
+                Math.abs(a.value - b.value)
+            )
         )
         if (minDist === undefined) return {}
 
@@ -237,14 +257,14 @@ abstract class AbstractAxis {
         return {}
     }
 
-    getFormattedTicks() {
+    getFormattedTicks(): string[] {
         // todo: pass in first or last?
-        return this.getTickValues().map((tickmark) =>
+        return this.getTickValues().map((tickmark): string =>
             this.formatTick(tickmark.value)
         )
     }
 
-    place(value: number) {
+    place(value: number): number {
         if (!this.range) {
             console.error(
                 "Can't place value on scale without a defined output range"
@@ -257,15 +277,15 @@ abstract class AbstractAxis {
         return parseFloat(this.d3_scale(value).toFixed(1))
     }
 
-    @computed get tickFontSize() {
+    @computed get tickFontSize(): number {
         return 0.9 * this.fontSize
     }
 
-    protected doIntersect(bounds: Bounds, bounds2: Bounds) {
+    protected doIntersect(bounds: Bounds, bounds2: Bounds): boolean {
         return bounds.intersects(bounds2)
     }
 
-    @computed get ticks() {
+    @computed get ticks(): number[] {
         const { tickPlacements } = this
         for (let i = 0; i < tickPlacements.length; i++) {
             for (let j = i + 1; j < tickPlacements.length; j++) {
@@ -277,14 +297,16 @@ abstract class AbstractAxis {
         }
 
         return sortBy(
-            tickPlacements.filter((t) => !t.isHidden).map((t) => t.tick)
+            tickPlacements
+                .filter((t): boolean => !t.isHidden)
+                .map((t): number => t.tick)
         )
     }
 
     formatTick(
         tick: number,
         formattingOptionsOverride?: TickFormattingOptions
-    ) {
+    ): string {
         const tickFormattingOptions: TickFormattingOptions = {
             ...this.getTickFormattingOptions(),
             ...formattingOptionsOverride,
@@ -296,30 +318,34 @@ abstract class AbstractAxis {
     }
 
     // calculates coordinates for ticks, sorted by priority
-    @computed private get tickPlacements() {
-        return sortBy(this.baseTicks, (tick) => tick.priority).map((tick) => {
-            const bounds = Bounds.forText(
-                this.formatTick(tick.value, {
-                    isFirstOrLastTick: tick.isFirstOrLastTick,
-                }),
-                {
-                    fontSize: this.tickFontSize,
+    @computed private get tickPlacements(): TickPlacement[] {
+        return sortBy(this.baseTicks, (tick): number => tick.priority).map(
+            (tick): TickPlacement => {
+                const bounds = Bounds.forText(
+                    this.formatTick(tick.value, {
+                        isFirstOrLastTick: tick.isFirstOrLastTick,
+                    }),
+                    {
+                        fontSize: this.tickFontSize,
+                    }
+                )
+                return {
+                    tick: tick.value,
+                    bounds: bounds.extend(this.placeTick(tick.value, bounds)),
+                    isHidden: false,
                 }
-            )
-            return {
-                tick: tick.value,
-                bounds: bounds.extend(this.placeTick(tick.value, bounds)),
-                isHidden: false,
             }
-        })
+        )
     }
 
-    @computed get labelFontSize() {
+    @computed get labelFontSize(): number {
         return 0.7 * this.fontSize
     }
 
-    @computed protected get baseTicks() {
-        return this.getTickValues().filter((tick) => !tick.gridLineOnly)
+    @computed protected get baseTicks(): Tickmark[] {
+        return this.getTickValues().filter(
+            (tick): boolean => !tick.gridLineOnly
+        )
     }
 
     abstract get labelWidth(): number
@@ -345,21 +371,21 @@ const labelPadding = 5
 
 export class HorizontalAxis extends AbstractAxis {
     // todo: test/refactor
-    clone() {
+    clone(): HorizontalAxis {
         return new HorizontalAxis(this.config)._update(this)
     }
 
-    @computed get labelOffset() {
+    @computed get labelOffset(): number {
         return this.labelTextWrap
             ? this.labelTextWrap.height + labelPadding * 2
             : 0
     }
 
-    @computed get labelWidth() {
+    @computed get labelWidth(): number {
         return this.rangeSize
     }
 
-    @computed get height() {
+    @computed get height(): number {
         const { labelOffset } = this
         const firstFormattedTick = this.getFormattedTicks()[0]
         const fontSize = this.tickFontSize
@@ -373,8 +399,10 @@ export class HorizontalAxis extends AbstractAxis {
         )
     }
 
-    @computed protected get baseTicks() {
-        let ticks = this.getTickValues().filter((tick) => !tick.gridLineOnly)
+    @computed protected get baseTicks(): Tickmark[] {
+        let ticks = this.getTickValues().filter(
+            (tick): boolean => !tick.gridLineOnly
+        )
         const { domain } = this
 
         // Make sure the start and end values are present, if they're whole numbers
@@ -400,7 +428,10 @@ export class HorizontalAxis extends AbstractAxis {
         return uniq(ticks)
     }
 
-    protected placeTick(tickValue: number, bounds: Bounds) {
+    protected placeTick(
+        tickValue: number,
+        bounds: Bounds
+    ): { x: number; y: number } {
         const { labelOffset } = this
         return {
             x: this.place(tickValue) - bounds.width / 2,
@@ -409,30 +440,30 @@ export class HorizontalAxis extends AbstractAxis {
     }
 
     // Add some padding before checking for intersection
-    protected doIntersect(bounds: Bounds, bounds2: Bounds) {
+    protected doIntersect(bounds: Bounds, bounds2: Bounds): boolean {
         return bounds.intersects(bounds2.padWidth(-5))
     }
 }
 
 export class VerticalAxis extends AbstractAxis {
-    @computed get labelWidth() {
+    @computed get labelWidth(): number {
         return this.height
     }
 
     // todo: test/refactor
-    clone() {
+    clone(): VerticalAxis {
         return new VerticalAxis(this.config)._update(this)
     }
 
-    @computed get labelOffset() {
+    @computed get labelOffset(): number {
         return this.labelTextWrap ? this.labelTextWrap.height + 10 : 0
     }
 
-    @computed get width() {
+    @computed get width(): number {
         const { labelOffset } = this
         const longestTick = maxBy(
             this.getFormattedTicks(),
-            (tick) => tick.length
+            (tick): any => tick.length
         )
         return (
             Bounds.forText(longestTick, { fontSize: this.tickFontSize }).width +
@@ -441,11 +472,11 @@ export class VerticalAxis extends AbstractAxis {
         )
     }
 
-    @computed get height() {
+    @computed get height(): number {
         return this.rangeSize
     }
 
-    protected placeTick(tickValue: number) {
+    protected placeTick(tickValue: number): { y: number; x: number } {
         return {
             y: this.place(tickValue),
             // x placement doesn't really matter here, so we're using
@@ -471,40 +502,40 @@ export class DualAxis {
         this.props = props
     }
 
-    @computed get horizontalAxis() {
+    @computed get horizontalAxis(): HorizontalAxis {
         const axis = this.props.horizontalAxis.clone()
         axis.range = this.innerBounds.xRange()
         return axis
     }
 
-    @computed get verticalAxis() {
+    @computed get verticalAxis(): VerticalAxis {
         const axis = this.props.verticalAxis.clone()
         axis.range = this.innerBounds.yRange()
         return axis
     }
 
     // We calculate an initial height from the range of the input bounds
-    @computed private get horizontalAxisHeight() {
+    @computed private get horizontalAxisHeight(): number {
         const axis = this.props.horizontalAxis.clone()
         axis.range = [0, this.bounds.width]
         return axis.hideAxis ? 0 : axis.height
     }
 
     // We calculate an initial width from the range of the input bounds
-    @computed private get verticalAxisWidth() {
+    @computed private get verticalAxisWidth(): number {
         const axis = this.props.verticalAxis.clone()
         axis.range = [0, this.bounds.height]
         return axis.hideAxis ? 0 : axis.width
     }
 
     // Now we can determine the "true" inner bounds of the dual axis
-    @computed get innerBounds() {
+    @computed get innerBounds(): Bounds {
         return this.bounds
             .padBottom(this.horizontalAxisHeight)
             .padLeft(this.verticalAxisWidth)
     }
 
-    @computed get bounds() {
+    @computed get bounds(): Bounds {
         return this.props.bounds ?? DEFAULT_BOUNDS
     }
 }

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -161,10 +161,7 @@ abstract class AbstractAxis {
             //
             // -@MarcelGerber, 2020-08-07
             const tickCandidates = d3_scale.ticks(maxLogLines)
-            ticks = tickCandidates.map((value): {
-                value: number
-                priority: number
-            } => {
+            ticks = tickCandidates.map((value) => {
                 // 10^x
                 if (Math.fround(Math.log10(value)) % 1 === 0)
                     return { value, priority: 1 }
@@ -180,24 +177,22 @@ abstract class AbstractAxis {
             if (ticks.length > maxLogLines) {
                 if (ticks.length <= 2 * maxLogLines) {
                     // Convert all "in-between" lines to faint grid lines without labels
-                    ticks = ticks.map(
-                        (tick): Tickmark => {
-                            if (tick.priority === 3)
-                                tick = {
-                                    ...tick,
-                                    faint: true,
-                                    gridLineOnly: true,
-                                }
-                            return tick
-                        }
-                    )
+                    ticks = ticks.map((tick) => {
+                        if (tick.priority === 3)
+                            tick = {
+                                ...tick,
+                                faint: true,
+                                gridLineOnly: true,
+                            }
+                        return tick
+                    })
                 } else {
                     // Remove some tickmarks again because the chart would get too overwhelming
                     // otherwise
                     for (let priority = 3; priority > 1; priority--) {
                         if (ticks.length > maxLogLines)
                             ticks = ticks.filter(
-                                (tick): boolean => tick.priority < priority
+                                (tick) => tick.priority < priority
                             )
                     }
                 }
@@ -205,17 +200,14 @@ abstract class AbstractAxis {
         } else {
             // Only use priority 2 here because we want the start / end ticks
             // to be priority 1
-            ticks = d3_scale.ticks(6).map((tickValue): {
-                value: number
-                priority: number
-            } => ({
+            ticks = d3_scale.ticks(6).map((tickValue) => ({
                 value: tickValue,
                 priority: 2,
             }))
         }
 
         if (this.hideFractionalTicks)
-            ticks = ticks.filter((t): boolean => t.value % 1 === 0)
+            ticks = ticks.filter((t) => t.value % 1 === 0)
 
         return uniq(ticks)
     }
@@ -244,9 +236,7 @@ abstract class AbstractAxis {
         // -@danielgavrilov, 2020-05-27
         const tickValues = this.getTickValues()
         const minDist = min(
-            rollingMap(tickValues, (a, b): number =>
-                Math.abs(a.value - b.value)
-            )
+            rollingMap(tickValues, (a, b) => Math.abs(a.value - b.value))
         )
         if (minDist === undefined) return {}
 
@@ -297,9 +287,7 @@ abstract class AbstractAxis {
         }
 
         return sortBy(
-            tickPlacements
-                .filter((t): boolean => !t.isHidden)
-                .map((t): number => t.tick)
+            tickPlacements.filter((t) => !t.isHidden).map((t) => t.tick)
         )
     }
 
@@ -319,23 +307,21 @@ abstract class AbstractAxis {
 
     // calculates coordinates for ticks, sorted by priority
     @computed private get tickPlacements(): TickPlacement[] {
-        return sortBy(this.baseTicks, (tick): number => tick.priority).map(
-            (tick): TickPlacement => {
-                const bounds = Bounds.forText(
-                    this.formatTick(tick.value, {
-                        isFirstOrLastTick: tick.isFirstOrLastTick,
-                    }),
-                    {
-                        fontSize: this.tickFontSize,
-                    }
-                )
-                return {
-                    tick: tick.value,
-                    bounds: bounds.extend(this.placeTick(tick.value, bounds)),
-                    isHidden: false,
+        return sortBy(this.baseTicks, (tick) => tick.priority).map((tick) => {
+            const bounds = Bounds.forText(
+                this.formatTick(tick.value, {
+                    isFirstOrLastTick: tick.isFirstOrLastTick,
+                }),
+                {
+                    fontSize: this.tickFontSize,
                 }
+            )
+            return {
+                tick: tick.value,
+                bounds: bounds.extend(this.placeTick(tick.value, bounds)),
+                isHidden: false,
             }
-        )
+        })
     }
 
     @computed get labelFontSize(): number {
@@ -343,9 +329,7 @@ abstract class AbstractAxis {
     }
 
     @computed protected get baseTicks(): Tickmark[] {
-        return this.getTickValues().filter(
-            (tick): boolean => !tick.gridLineOnly
-        )
+        return this.getTickValues().filter((tick) => !tick.gridLineOnly)
     }
 
     abstract get labelWidth(): number
@@ -463,7 +447,7 @@ export class VerticalAxis extends AbstractAxis {
         const { labelOffset } = this
         const longestTick = maxBy(
             this.getFormattedTicks(),
-            (tick): any => tick.length
+            (tick) => tick.length
         )
         return (
             Bounds.forText(longestTick, { fontSize: this.tickFontSize }).width +

--- a/grapher/axis/AxisConfig.ts
+++ b/grapher/axis/AxisConfig.ts
@@ -39,7 +39,7 @@ export class AxisConfig
     @observable hideAxis = false
 
     // todo: test/refactor
-    updateFromObject(props?: AxisConfigInterface) {
+    updateFromObject(props?: AxisConfigInterface): void {
         if (props) extend(this, props)
     }
 
@@ -58,26 +58,26 @@ export class AxisConfig
         return obj
     }
 
-    @computed get fontSize() {
+    @computed get fontSize(): number {
         return this.fontSizeManager?.fontSize || BASE_FONT_SIZE
     }
 
     // A log scale domain cannot have values <= 0, so we double check here
-    @computed private get constrainedMin() {
+    @computed private get constrainedMin(): number {
         if (this.scaleType === ScaleType.log && (this.min ?? 0) <= 0)
             return Infinity
         return this.min ?? Infinity
     }
 
     // If the author has specified a min/max AND to remove points outside the domain, this should return true
-    shouldRemovePoint(value: number) {
+    shouldRemovePoint(value: number): boolean {
         if (!this.removePointsOutsideDomain) return false
         if (this.min !== undefined && value < this.min) return true
         if (this.max !== undefined && value > this.max) return true
         return false
     }
 
-    @computed private get constrainedMax() {
+    @computed private get constrainedMax(): number {
         if (this.scaleType === ScaleType.log && (this.max || 0) <= 0)
             return -Infinity
         return this.max ?? -Infinity
@@ -89,11 +89,11 @@ export class AxisConfig
 
     // Convert axis configuration to a finalized axis spec by supplying
     // any needed information calculated from the data
-    toHorizontalAxis() {
+    toHorizontalAxis(): HorizontalAxis {
         return new HorizontalAxis(this)
     }
 
-    toVerticalAxis() {
+    toVerticalAxis(): VerticalAxis {
         return new VerticalAxis(this)
     }
 }

--- a/grapher/axis/AxisViews.tsx
+++ b/grapher/axis/AxisViews.tsx
@@ -11,32 +11,36 @@ export class VerticalAxisGridLines extends React.Component<{
     verticalAxis: VerticalAxis
     bounds: Bounds
 }> {
-    render() {
+    render(): JSX.Element {
         const { bounds, verticalAxis } = this.props
         const axis = verticalAxis.clone()
         axis.range = bounds.yRange()
 
         return (
             <g className={classNames("AxisGridLines", "horizontalLines")}>
-                {axis.getTickValues().map((t, i) => {
-                    const color = t.faint
-                        ? "#eee"
-                        : t.value === 0
-                        ? "#ccc"
-                        : "#d3d3d3"
+                {axis.getTickValues().map(
+                    (t, i): JSX.Element => {
+                        const color = t.faint
+                            ? "#eee"
+                            : t.value === 0
+                            ? "#ccc"
+                            : "#d3d3d3"
 
-                    return (
-                        <line
-                            key={i}
-                            x1={bounds.left.toFixed(2)}
-                            y1={axis.place(t.value)}
-                            x2={bounds.right.toFixed(2)}
-                            y2={axis.place(t.value)}
-                            stroke={color}
-                            strokeDasharray={t.value !== 0 ? "3,2" : undefined}
-                        />
-                    )
-                })}
+                        return (
+                            <line
+                                key={i}
+                                x1={bounds.left.toFixed(2)}
+                                y1={axis.place(t.value)}
+                                x2={bounds.right.toFixed(2)}
+                                y2={axis.place(t.value)}
+                                stroke={color}
+                                strokeDasharray={
+                                    t.value !== 0 ? "3,2" : undefined
+                                }
+                            />
+                        )
+                    }
+                )}
             </g>
         )
     }
@@ -47,11 +51,11 @@ export class HorizontalAxisGridLines extends React.Component<{
     horizontalAxis: HorizontalAxis
     bounds?: Bounds
 }> {
-    @computed get bounds() {
+    @computed get bounds(): Bounds {
         return this.props.bounds ?? DEFAULT_BOUNDS
     }
 
-    render() {
+    render(): JSX.Element {
         const { horizontalAxis } = this.props
         const { bounds } = this
         const axis = horizontalAxis.clone()
@@ -59,25 +63,29 @@ export class HorizontalAxisGridLines extends React.Component<{
 
         return (
             <g className={classNames("AxisGridLines", "verticalLines")}>
-                {axis.getTickValues().map((t, i) => {
-                    const color = t.faint
-                        ? "#eee"
-                        : t.value === 0
-                        ? "#ccc"
-                        : "#d3d3d3"
+                {axis.getTickValues().map(
+                    (t, i): JSX.Element => {
+                        const color = t.faint
+                            ? "#eee"
+                            : t.value === 0
+                            ? "#ccc"
+                            : "#d3d3d3"
 
-                    return (
-                        <line
-                            key={i}
-                            x1={axis.place(t.value)}
-                            y1={bounds.bottom.toFixed(2)}
-                            x2={axis.place(t.value)}
-                            y2={bounds.top.toFixed(2)}
-                            stroke={color}
-                            strokeDasharray={t.value !== 0 ? "3,2" : undefined}
-                        />
-                    )
-                })}
+                        return (
+                            <line
+                                key={i}
+                                x1={axis.place(t.value)}
+                                y1={bounds.bottom.toFixed(2)}
+                                x2={axis.place(t.value)}
+                                y2={bounds.top.toFixed(2)}
+                                stroke={color}
+                                strokeDasharray={
+                                    t.value !== 0 ? "3,2" : undefined
+                                }
+                            />
+                        )
+                    }
+                )}
             </g>
         )
     }
@@ -91,7 +99,7 @@ interface DualAxisViewProps {
 
 @observer
 export class DualAxisComponent extends React.Component<DualAxisViewProps> {
-    render() {
+    render(): JSX.Element {
         const { dualAxis, showTickMarks } = this.props
         const { bounds, horizontalAxis, verticalAxis, innerBounds } = dualAxis
 
@@ -141,7 +149,7 @@ export class VerticalAxisComponent extends React.Component<{
     bounds: Bounds
     verticalAxis: VerticalAxis
 }> {
-    render() {
+    render(): JSX.Element {
         const { bounds, verticalAxis } = this.props
         const { ticks, labelTextWrap } = verticalAxis
         const textColor = "#666"
@@ -154,19 +162,23 @@ export class VerticalAxisComponent extends React.Component<{
                         bounds.left,
                         { transform: "rotate(-90)" }
                     )}
-                {ticks.map((tick, i) => (
-                    <text
-                        key={i}
-                        x={(bounds.left + verticalAxis.width - 5).toFixed(2)}
-                        y={verticalAxis.place(tick)}
-                        fill={textColor}
-                        dominantBaseline="middle"
-                        textAnchor="end"
-                        fontSize={verticalAxis.tickFontSize}
-                    >
-                        {verticalAxis.formatTick(tick)}
-                    </text>
-                ))}
+                {ticks.map(
+                    (tick, i): JSX.Element => (
+                        <text
+                            key={i}
+                            x={(bounds.left + verticalAxis.width - 5).toFixed(
+                                2
+                            )}
+                            y={verticalAxis.place(tick)}
+                            fill={textColor}
+                            dominantBaseline="middle"
+                            textAnchor="end"
+                            fontSize={verticalAxis.tickFontSize}
+                        >
+                            {verticalAxis.formatTick(tick)}
+                        </text>
+                    )
+                )}
             </g>
         )
     }
@@ -178,7 +190,7 @@ export class HorizontalAxisComponent extends React.Component<{
     axisPosition: number
     showTickMarks?: boolean
 }> {
-    @computed get scaleType() {
+    @computed get scaleType(): ScaleType {
         return this.props.axis.scaleType
     }
 
@@ -187,12 +199,12 @@ export class HorizontalAxisComponent extends React.Component<{
     }
 
     // for scale selector. todo: cleanup
-    @computed get bounds() {
+    @computed get bounds(): Bounds {
         const { bounds } = this.props
         return new Bounds(bounds.right, bounds.bottom - 30, 100, 100)
     }
 
-    render() {
+    render(): JSX.Element {
         const { bounds, axis, axisPosition, showTickMarks } = this.props
         const { ticks, labelTextWrap: label, labelOffset } = axis
         const textColor = "#666"
@@ -200,7 +212,9 @@ export class HorizontalAxisComponent extends React.Component<{
         const tickMarks = showTickMarks ? (
             <AxisTickMarks
                 tickMarkTopPosition={axisPosition}
-                tickMarkXPositions={ticks.map((tick) => axis.place(tick))}
+                tickMarkXPositions={ticks.map((tick): number =>
+                    axis.place(tick)
+                )}
                 color="#ccc"
             />
         ) : undefined
@@ -213,35 +227,38 @@ export class HorizontalAxisComponent extends React.Component<{
                         bounds.bottom - label.height
                     )}
                 {tickMarks}
-                {ticks.map((tick, i) => {
-                    const label = axis.formatTick(tick, {
-                        isFirstOrLastTick: i === 0 || i === ticks.length - 1,
-                    })
-                    const rawXPosition = axis.place(tick)
-                    // Ensure the first label does not exceed the chart viewing area
-                    const xPosition =
-                        i === 0
-                            ? Bounds.getRightShiftForMiddleAlignedTextIfNeeded(
-                                  label,
-                                  axis.tickFontSize,
-                                  rawXPosition
-                              ) + rawXPosition
-                            : rawXPosition
-                    const element = (
-                        <text
-                            key={i}
-                            x={xPosition}
-                            y={bounds.bottom - labelOffset}
-                            fill={textColor}
-                            textAnchor="middle"
-                            fontSize={axis.tickFontSize}
-                        >
-                            {label}
-                        </text>
-                    )
+                {ticks.map(
+                    (tick, i): JSX.Element => {
+                        const label = axis.formatTick(tick, {
+                            isFirstOrLastTick:
+                                i === 0 || i === ticks.length - 1,
+                        })
+                        const rawXPosition = axis.place(tick)
+                        // Ensure the first label does not exceed the chart viewing area
+                        const xPosition =
+                            i === 0
+                                ? Bounds.getRightShiftForMiddleAlignedTextIfNeeded(
+                                      label,
+                                      axis.tickFontSize,
+                                      rawXPosition
+                                  ) + rawXPosition
+                                : rawXPosition
+                        const element = (
+                            <text
+                                key={i}
+                                x={xPosition}
+                                y={bounds.bottom - labelOffset}
+                                fill={textColor}
+                                textAnchor="middle"
+                                fontSize={axis.tickFontSize}
+                            >
+                                {label}
+                            </text>
+                        )
 
-                    return element
-                })}
+                        return element
+                    }
+                )}
             </g>
         )
     }
@@ -252,21 +269,23 @@ export class AxisTickMarks extends React.Component<{
     tickMarkXPositions: number[]
     color: string
 }> {
-    render() {
+    render(): JSX.Element[] {
         const { tickMarkTopPosition, tickMarkXPositions, color } = this.props
         const tickSize = 4
         const tickBottom = tickMarkTopPosition + tickSize
-        return tickMarkXPositions.map((tickMarkPosition, index) => {
-            return (
-                <line
-                    key={index}
-                    x1={tickMarkPosition}
-                    y1={tickMarkTopPosition}
-                    x2={tickMarkPosition}
-                    y2={tickBottom}
-                    stroke={color}
-                />
-            )
-        })
+        return tickMarkXPositions.map(
+            (tickMarkPosition, index): JSX.Element => {
+                return (
+                    <line
+                        key={index}
+                        x1={tickMarkPosition}
+                        y1={tickMarkTopPosition}
+                        x2={tickMarkPosition}
+                        y2={tickBottom}
+                        stroke={color}
+                    />
+                )
+            }
+        )
     }
 }

--- a/grapher/axis/AxisViews.tsx
+++ b/grapher/axis/AxisViews.tsx
@@ -18,29 +18,25 @@ export class VerticalAxisGridLines extends React.Component<{
 
         return (
             <g className={classNames("AxisGridLines", "horizontalLines")}>
-                {axis.getTickValues().map(
-                    (t, i): JSX.Element => {
-                        const color = t.faint
-                            ? "#eee"
-                            : t.value === 0
-                            ? "#ccc"
-                            : "#d3d3d3"
+                {axis.getTickValues().map((t, i) => {
+                    const color = t.faint
+                        ? "#eee"
+                        : t.value === 0
+                        ? "#ccc"
+                        : "#d3d3d3"
 
-                        return (
-                            <line
-                                key={i}
-                                x1={bounds.left.toFixed(2)}
-                                y1={axis.place(t.value)}
-                                x2={bounds.right.toFixed(2)}
-                                y2={axis.place(t.value)}
-                                stroke={color}
-                                strokeDasharray={
-                                    t.value !== 0 ? "3,2" : undefined
-                                }
-                            />
-                        )
-                    }
-                )}
+                    return (
+                        <line
+                            key={i}
+                            x1={bounds.left.toFixed(2)}
+                            y1={axis.place(t.value)}
+                            x2={bounds.right.toFixed(2)}
+                            y2={axis.place(t.value)}
+                            stroke={color}
+                            strokeDasharray={t.value !== 0 ? "3,2" : undefined}
+                        />
+                    )
+                })}
             </g>
         )
     }
@@ -63,29 +59,25 @@ export class HorizontalAxisGridLines extends React.Component<{
 
         return (
             <g className={classNames("AxisGridLines", "verticalLines")}>
-                {axis.getTickValues().map(
-                    (t, i): JSX.Element => {
-                        const color = t.faint
-                            ? "#eee"
-                            : t.value === 0
-                            ? "#ccc"
-                            : "#d3d3d3"
+                {axis.getTickValues().map((t, i) => {
+                    const color = t.faint
+                        ? "#eee"
+                        : t.value === 0
+                        ? "#ccc"
+                        : "#d3d3d3"
 
-                        return (
-                            <line
-                                key={i}
-                                x1={axis.place(t.value)}
-                                y1={bounds.bottom.toFixed(2)}
-                                x2={axis.place(t.value)}
-                                y2={bounds.top.toFixed(2)}
-                                stroke={color}
-                                strokeDasharray={
-                                    t.value !== 0 ? "3,2" : undefined
-                                }
-                            />
-                        )
-                    }
-                )}
+                    return (
+                        <line
+                            key={i}
+                            x1={axis.place(t.value)}
+                            y1={bounds.bottom.toFixed(2)}
+                            x2={axis.place(t.value)}
+                            y2={bounds.top.toFixed(2)}
+                            stroke={color}
+                            strokeDasharray={t.value !== 0 ? "3,2" : undefined}
+                        />
+                    )
+                })}
             </g>
         )
     }
@@ -162,23 +154,19 @@ export class VerticalAxisComponent extends React.Component<{
                         bounds.left,
                         { transform: "rotate(-90)" }
                     )}
-                {ticks.map(
-                    (tick, i): JSX.Element => (
-                        <text
-                            key={i}
-                            x={(bounds.left + verticalAxis.width - 5).toFixed(
-                                2
-                            )}
-                            y={verticalAxis.place(tick)}
-                            fill={textColor}
-                            dominantBaseline="middle"
-                            textAnchor="end"
-                            fontSize={verticalAxis.tickFontSize}
-                        >
-                            {verticalAxis.formatTick(tick)}
-                        </text>
-                    )
-                )}
+                {ticks.map((tick, i) => (
+                    <text
+                        key={i}
+                        x={(bounds.left + verticalAxis.width - 5).toFixed(2)}
+                        y={verticalAxis.place(tick)}
+                        fill={textColor}
+                        dominantBaseline="middle"
+                        textAnchor="end"
+                        fontSize={verticalAxis.tickFontSize}
+                    >
+                        {verticalAxis.formatTick(tick)}
+                    </text>
+                ))}
             </g>
         )
     }
@@ -227,38 +215,35 @@ export class HorizontalAxisComponent extends React.Component<{
                         bounds.bottom - label.height
                     )}
                 {tickMarks}
-                {ticks.map(
-                    (tick, i): JSX.Element => {
-                        const label = axis.formatTick(tick, {
-                            isFirstOrLastTick:
-                                i === 0 || i === ticks.length - 1,
-                        })
-                        const rawXPosition = axis.place(tick)
-                        // Ensure the first label does not exceed the chart viewing area
-                        const xPosition =
-                            i === 0
-                                ? Bounds.getRightShiftForMiddleAlignedTextIfNeeded(
-                                      label,
-                                      axis.tickFontSize,
-                                      rawXPosition
-                                  ) + rawXPosition
-                                : rawXPosition
-                        const element = (
-                            <text
-                                key={i}
-                                x={xPosition}
-                                y={bounds.bottom - labelOffset}
-                                fill={textColor}
-                                textAnchor="middle"
-                                fontSize={axis.tickFontSize}
-                            >
-                                {label}
-                            </text>
-                        )
+                {ticks.map((tick, i) => {
+                    const label = axis.formatTick(tick, {
+                        isFirstOrLastTick: i === 0 || i === ticks.length - 1,
+                    })
+                    const rawXPosition = axis.place(tick)
+                    // Ensure the first label does not exceed the chart viewing area
+                    const xPosition =
+                        i === 0
+                            ? Bounds.getRightShiftForMiddleAlignedTextIfNeeded(
+                                  label,
+                                  axis.tickFontSize,
+                                  rawXPosition
+                              ) + rawXPosition
+                            : rawXPosition
+                    const element = (
+                        <text
+                            key={i}
+                            x={xPosition}
+                            y={bounds.bottom - labelOffset}
+                            fill={textColor}
+                            textAnchor="middle"
+                            fontSize={axis.tickFontSize}
+                        >
+                            {label}
+                        </text>
+                    )
 
-                        return element
-                    }
-                )}
+                    return element
+                })}
             </g>
         )
     }
@@ -273,19 +258,17 @@ export class AxisTickMarks extends React.Component<{
         const { tickMarkTopPosition, tickMarkXPositions, color } = this.props
         const tickSize = 4
         const tickBottom = tickMarkTopPosition + tickSize
-        return tickMarkXPositions.map(
-            (tickMarkPosition, index): JSX.Element => {
-                return (
-                    <line
-                        key={index}
-                        x1={tickMarkPosition}
-                        y1={tickMarkTopPosition}
-                        x2={tickMarkPosition}
-                        y2={tickBottom}
-                        stroke={color}
-                    />
-                )
-            }
-        )
+        return tickMarkXPositions.map((tickMarkPosition, index) => {
+            return (
+                <line
+                    key={index}
+                    x1={tickMarkPosition}
+                    y1={tickMarkTopPosition}
+                    x2={tickMarkPosition}
+                    y2={tickBottom}
+                    stroke={color}
+                />
+            )
+        })
     }
 }

--- a/grapher/barCharts/.eslintrc.yaml
+++ b/grapher/barCharts/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/barCharts/DiscreteBarChart.stories.tsx
+++ b/grapher/barCharts/DiscreteBarChart.stories.tsx
@@ -12,7 +12,7 @@ export default {
     component: DiscreteBarChart,
 }
 
-export const EntitiesAsSeries = () => {
+export const EntitiesAsSeries = (): JSX.Element => {
     const table = SynthesizeGDPTable({
         timeRange: [2009, 2010],
         entityCount: 10,
@@ -31,13 +31,13 @@ export const EntitiesAsSeries = () => {
     )
 }
 
-export const EntitiesAsSeriesWithTolerance = () => {
+export const EntitiesAsSeriesWithTolerance = (): JSX.Element => {
     const table = SynthesizeGDPTable({
         timeRange: [2009, 2011],
         entityCount: 10,
     })
         .rowFilter(
-            (row) => row.year === 2010 || Math.random() > 0.5,
+            (row): boolean => row.year === 2010 || Math.random() > 0.5,
             "Remove 50% of 2009 rows"
         )
         .interpolateColumnWithTolerance(SampleColumnSlugs.Population, 1)
@@ -59,7 +59,7 @@ export const EntitiesAsSeriesWithTolerance = () => {
     )
 }
 
-export const ColumnsAsSeries = () => {
+export const ColumnsAsSeries = (): JSX.Element => {
     const table = SynthesizeFruitTable({ entityCount: 1 })
     const manager: DiscreteBarChartManager = {
         table,

--- a/grapher/barCharts/DiscreteBarChart.test.ts
+++ b/grapher/barCharts/DiscreteBarChart.test.ts
@@ -10,7 +10,6 @@ import {
 import {
     DEFAULT_BAR_COLOR,
     DiscreteBarChartManager,
-    DiscreteBarSeries,
 } from "./DiscreteBarChartConstants"
 import { ColorSchemeName } from "../color/ColorConstants"
 import { SeriesStrategy } from "../core/GrapherConstants"

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -33,6 +33,11 @@ import {
 } from "./DiscreteBarChartConstants"
 import { OwidTable } from "../../coreTable/OwidTable"
 import { autoDetectYColumnSlugs, makeSelectionArray } from "../chart/ChartUtils"
+import { HorizontalAxis } from "../axis/Axis"
+import { SelectionArray } from "../selection/SelectionArray"
+import { CoreColumn } from "../../coreTable/CoreTableColumns"
+import { ColorScheme } from "../color/ColorScheme"
+import { Time } from "../../clientUtils/owidTypes"
 
 const labelToTextPadding = 10
 const labelToBarPadding = 5
@@ -46,7 +51,7 @@ export class DiscreteBarChart
     implements ChartInterface {
     base: React.RefObject<SVGGElement> = React.createRef()
 
-    transformTable(table: OwidTable) {
+    transformTable(table: OwidTable): OwidTable {
         if (!this.yColumnSlugs.length) return table
 
         table = table.filterByEntityNames(
@@ -68,41 +73,47 @@ export class DiscreteBarChart
         return table
     }
 
-    @computed get inputTable() {
+    @computed get inputTable(): OwidTable {
         return this.manager.table
     }
 
-    @computed get transformedTable() {
+    @computed get transformedTable(): OwidTable {
         return (
             this.manager.transformedTable ??
             this.transformTable(this.inputTable)
         )
     }
 
-    @computed private get manager() {
+    @computed private get manager(): DiscreteBarChartManager {
         return this.props.manager
     }
 
-    @computed private get targetTime() {
+    @computed private get targetTime(): Time | undefined {
         return this.manager.endTime
     }
 
-    @computed private get bounds() {
+    @computed private get bounds(): Bounds {
         return (this.props.bounds ?? DEFAULT_BOUNDS).padRight(10)
     }
 
-    @computed private get baseFontSize() {
+    @computed private get baseFontSize(): number {
         return this.manager.baseFontSize ?? BASE_FONT_SIZE
     }
 
-    @computed private get legendLabelStyle() {
+    @computed private get legendLabelStyle(): {
+        fontSize: number
+        fontWeight: number
+    } {
         return {
             fontSize: 0.75 * this.baseFontSize,
             fontWeight: 700,
         }
     }
 
-    @computed private get valueLabelStyle() {
+    @computed private get valueLabelStyle(): {
+        fontSize: number
+        fontWeight: number
+    } {
         return {
             fontSize: 0.75 * this.baseFontSize,
             fontWeight: 400,
@@ -110,22 +121,22 @@ export class DiscreteBarChart
     }
 
     // Account for the width of the legend
-    @computed private get legendWidth() {
+    @computed private get legendWidth(): number {
         const labels = this.series.map((series) => series.seriesName)
         const longestLabel = maxBy(labels, (d) => d.length)
         return Bounds.forText(longestLabel, this.legendLabelStyle).width
     }
 
-    @computed private get hasPositive() {
+    @computed private get hasPositive(): boolean {
         return this.series.some((d) => d.value >= 0)
     }
 
-    @computed private get hasNegative() {
+    @computed private get hasNegative(): boolean {
         return this.series.some((d) => d.value < 0)
     }
 
     // The amount of space we need to allocate for bar end labels on the right
-    @computed private get rightEndLabelWidth() {
+    @computed private get rightEndLabelWidth(): number {
         if (!this.hasPositive) return 0
 
         const positiveLabels = this.series
@@ -138,7 +149,7 @@ export class DiscreteBarChart
     // The amount of space we need to allocate for bar end labels on the left
     // These are only present if there are negative values
     // We pad this a little so it doesn't run directly up against the bar labels themselves
-    @computed private get leftEndLabelWidth() {
+    @computed private get leftEndLabelWidth(): number {
         if (!this.hasNegative) return 0
 
         const negativeLabels = this.series
@@ -151,7 +162,7 @@ export class DiscreteBarChart
         )
     }
 
-    @computed private get x0() {
+    @computed private get x0(): number {
         if (!this.isLogScale) return 0
 
         const minValue = min(this.series.map((d) => d.value))
@@ -176,11 +187,11 @@ export class DiscreteBarChart
         ]
     }
 
-    @computed private get yAxis() {
+    @computed private get yAxis(): AxisConfig {
         return this.manager.yAxis || new AxisConfig()
     }
 
-    @computed private get axis() {
+    @computed private get axis(): HorizontalAxis {
         // NB: We use the user's YAxis options here to make the XAxis
         const axis = this.yAxis.toHorizontalAxis()
         axis.updateDomainPreservingUserSettings(this.xDomainDefault)
@@ -191,31 +202,31 @@ export class DiscreteBarChart
         return axis
     }
 
-    @computed private get innerBounds() {
+    @computed private get innerBounds(): Bounds {
         return this.bounds
             .padLeft(this.legendWidth + this.leftEndLabelWidth)
             .padBottom(this.axis.height)
             .padRight(this.rightEndLabelWidth)
     }
 
-    @computed private get selectionArray() {
+    @computed private get selectionArray(): SelectionArray {
         return makeSelectionArray(this.manager)
     }
 
     // Leave space for extra bar at bottom to show "Add country" button
-    @computed private get totalBars() {
+    @computed private get totalBars(): number {
         return this.series.length
     }
 
-    @computed private get barHeight() {
+    @computed private get barHeight(): number {
         return (0.8 * this.innerBounds.height) / this.totalBars
     }
 
-    @computed private get barSpacing() {
+    @computed private get barSpacing(): number {
         return this.innerBounds.height / this.totalBars - this.barHeight
     }
 
-    @computed private get barPlacements() {
+    @computed private get barPlacements(): { x: number; width: number }[] {
         const { series, axis } = this
         return series.map((d) => {
             const isNegative = d.value < 0
@@ -228,7 +239,7 @@ export class DiscreteBarChart
         })
     }
 
-    @computed private get barWidths() {
+    @computed private get barWidths(): number[] {
         return this.barPlacements.map((b) => b.width)
     }
 
@@ -236,30 +247,30 @@ export class DiscreteBarChart
         return select(this.base.current).selectAll("g.bar > rect")
     }
 
-    private animateBarWidth() {
+    private animateBarWidth(): void {
         this.d3Bars()
             .transition()
             .attr("width", (_, i) => this.barWidths[i])
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         this.d3Bars().attr("width", 0)
         this.animateBarWidth()
         exposeInstanceOnWindow(this)
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(): void {
         // Animating the bar width after a render ensures there's no race condition, where the
         // initial animation (in componentDidMount) did override the now-changed bar width in
         // some cases. Updating the animation with the updated bar widths fixes that.
         this.animateBarWidth()
     }
 
-    @action.bound private onAddClick() {
+    @action.bound private onAddClick(): void {
         this.manager.isSelectingData = true
     }
 
-    render() {
+    render(): JSX.Element {
         if (this.failMessage)
             return (
                 <NoDataModal
@@ -376,7 +387,7 @@ export class DiscreteBarChart
         )
     }
 
-    @computed get failMessage() {
+    @computed get failMessage(): string {
         const column = this.yColumns[0]
 
         if (!column) return "No column to chart"
@@ -389,7 +400,7 @@ export class DiscreteBarChart
             : ""
     }
 
-    formatValue(series: DiscreteBarSeries) {
+    formatValue(series: DiscreteBarSeries): string {
         const column = this.yColumns[0] // todo: do we need to use the right column here?
         const { transformedTable } = this
 
@@ -404,11 +415,11 @@ export class DiscreteBarChart
         )
     }
 
-    @computed protected get yColumnSlugs() {
+    @computed protected get yColumnSlugs(): string[] {
         return autoDetectYColumnSlugs(this.manager)
     }
 
-    @computed private get seriesStrategy() {
+    @computed private get seriesStrategy(): SeriesStrategy {
         return (
             this.manager.seriesStrategy ??
             (this.yColumnSlugs.length > 1 &&
@@ -418,7 +429,7 @@ export class DiscreteBarChart
         )
     }
 
-    @computed protected get yColumns() {
+    @computed protected get yColumns(): CoreColumn[] {
         return this.transformedTable.getColumns(this.yColumnSlugs)
     }
 
@@ -456,7 +467,7 @@ export class DiscreteBarChart
         return sortBy(raw, (series) => series.row.value)
     }
 
-    @computed private get colorScheme() {
+    @computed private get colorScheme(): ColorScheme | undefined {
         // If this DiscreteBarChart stems from a LineChart, we want to match its (default) color
         // scheme OWID Distinct. Otherwise, use an all-blue color scheme (`undefined`) as default.
         const defaultColorScheme = this.manager.isLineChart
@@ -470,7 +481,7 @@ export class DiscreteBarChart
         )
     }
 
-    @computed private get valuesToColorsMap() {
+    @computed private get valuesToColorsMap(): Map<number, string> | undefined {
         const { manager, colorScheme, sortedRawSeries } = this
 
         return colorScheme?.getUniqValueColorMap(
@@ -479,7 +490,7 @@ export class DiscreteBarChart
         )
     }
 
-    @computed get series() {
+    @computed get series(): DiscreteBarSeries[] {
         const { manager, colorScheme } = this
 
         const series = this.sortedRawSeries
@@ -513,7 +524,7 @@ export class DiscreteBarChart
         return series
     }
 
-    @computed private get isLogScale() {
+    @computed private get isLogScale(): boolean {
         return this.yAxis.scaleType === ScaleType.log
     }
 }

--- a/grapher/bodyDiv/.eslintrc.yaml
+++ b/grapher/bodyDiv/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/bodyDiv/BodyDiv.tsx
+++ b/grapher/bodyDiv/BodyDiv.tsx
@@ -11,15 +11,15 @@ export class BodyDiv extends React.Component {
 
     el: HTMLDivElement
 
-    componentDidMount() {
+    componentDidMount(): void {
         document.body.appendChild(this.el)
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         document.body.removeChild(this.el)
     }
 
-    render() {
+    render(): any {
         return ReactDOM.createPortal(this.props.children, this.el)
     }
 }

--- a/grapher/captionedChart/.eslintrc.yaml
+++ b/grapher/captionedChart/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/captionedChart/CaptionedChart.stories.tsx
+++ b/grapher/captionedChart/CaptionedChart.stories.tsx
@@ -26,13 +26,13 @@ const manager: CaptionedChartManager = {
     currentTitle: "This is the Title",
     subtitle: "A Subtitle",
     note: "Here are some footer notes",
-    populateFromQueryParams: () => {},
+    populateFromQueryParams: (): void => {},
     isReady: true,
 }
 
-export const LineChart = () => <CaptionedChart manager={manager} />
+export const LineChart = (): JSX.Element => <CaptionedChart manager={manager} />
 
-export const StaticLineChartForExport = () => {
+export const StaticLineChartForExport = (): JSX.Element => {
     return (
         <StaticCaptionedChart
             manager={{
@@ -43,10 +43,10 @@ export const StaticLineChartForExport = () => {
     )
 }
 
-export const MapChart = () => (
+export const MapChart = (): JSX.Element => (
     <CaptionedChart manager={{ ...manager, tab: GrapherTabOption.map }} />
 )
-export const StackedArea = () => (
+export const StackedArea = (): JSX.Element => (
     <CaptionedChart
         manager={{
             ...manager,
@@ -55,7 +55,7 @@ export const StackedArea = () => (
         }}
     />
 )
-export const Scatter = () => (
+export const Scatter = (): JSX.Element => (
     <CaptionedChart
         manager={{
             ...manager,

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -35,6 +35,8 @@ import { faPencilAlt } from "@fortawesome/free-solid-svg-icons/faPencilAlt"
 import { FooterManager } from "../footer/FooterManager"
 import { HeaderManager } from "../header/HeaderManager"
 import { exposeInstanceOnWindow } from "../../clientUtils/Util"
+import { SelectionArray } from "../selection/SelectionArray"
+import { EntityName } from "../../coreTable/OwidTableConstants"
 
 export interface CaptionedChartManager
     extends ChartManager,
@@ -78,33 +80,33 @@ const PADDING_ABOVE_FOOTER = 25
 
 @observer
 export class CaptionedChart extends React.Component<CaptionedChartProps> {
-    @computed protected get manager() {
+    @computed protected get manager(): CaptionedChartManager {
         return this.props.manager
     }
 
-    @computed private get containerElement() {
+    @computed private get containerElement(): HTMLDivElement | undefined {
         return this.manager?.containerElement
     }
 
-    @computed private get maxWidth() {
+    @computed private get maxWidth(): number {
         return this.props.maxWidth ?? this.bounds.width - OUTSIDE_PADDING * 2
     }
 
-    @computed protected get header() {
+    @computed protected get header(): Header {
         return new Header({
             manager: this.manager,
             maxWidth: this.maxWidth,
         })
     }
 
-    @computed protected get footer() {
+    @computed protected get footer(): Footer {
         return new Footer({
             manager: this.manager,
             maxWidth: this.maxWidth,
         })
     }
 
-    @computed protected get chartHeight() {
+    @computed protected get chartHeight(): number {
         const controlsRowHeight = this.controls.length ? CONTROLS_ROW_HEIGHT : 0
         return (
             this.bounds.height -
@@ -116,23 +118,23 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
     }
 
     // todo: should we remove this and not make a distinction between map and chart tabs?
-    @computed protected get isMapTab() {
+    @computed protected get isMapTab(): boolean {
         return this.manager.tab === GrapherTabOption.map
     }
 
-    @computed protected get bounds() {
+    @computed protected get bounds(): Bounds {
         return this.props.bounds ?? this.manager.tabBounds ?? DEFAULT_BOUNDS
     }
 
     // The bounds for the middle chart part
-    @computed protected get boundsForChart() {
+    @computed protected get boundsForChart(): Bounds {
         return new Bounds(0, 0, this.bounds.width, this.chartHeight)
             .padWidth(OUTSIDE_PADDING)
             .padTop(this.isMapTab ? 0 : PADDING_BELOW_HEADER)
             .padBottom(OUTSIDE_PADDING)
     }
 
-    renderChart() {
+    renderChart(): JSX.Element {
         const { manager } = this
         const bounds = this.boundsForChart
 
@@ -163,15 +165,15 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         )
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         exposeInstanceOnWindow(this, "captionedChart")
     }
 
-    @action.bound startSelecting() {
+    @action.bound startSelecting(): void {
         this.manager.isSelectingData = true
     }
 
-    @computed get controls() {
+    @computed get controls(): JSX.Element[] {
         const manager = this.manager
         // Todo: we don't yet show any controls on Maps, but seems like we would want to.
         if (!manager.isReady || this.isMapTab) return []
@@ -254,11 +256,11 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         return controls
     }
 
-    @computed get selectionArray() {
+    @computed get selectionArray(): SelectionArray | EntityName[] | undefined {
         return this.manager.selection
     }
 
-    private renderControlsRow() {
+    private renderControlsRow(): JSX.Element | null {
         return this.controls.length ? (
             <div className="controlsRow">
                 <CollapsibleList>{this.controls}</CollapsibleList>
@@ -266,7 +268,7 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         ) : null
     }
 
-    private renderLoadingIndicator() {
+    private renderLoadingIndicator(): JSX.Element {
         return (
             <foreignObject {...this.boundsForChart.toProps()}>
                 <LoadingIndicator title={this.manager.whatAreWeWaitingFor} />
@@ -274,7 +276,7 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         )
     }
 
-    render() {
+    render(): JSX.Element {
         const { bounds, chartHeight, maxWidth } = this
         const { width } = bounds
 
@@ -326,19 +328,19 @@ export class StaticCaptionedChart extends CaptionedChart {
         super(props)
     }
 
-    @computed private get paddedBounds() {
+    @computed private get paddedBounds(): Bounds {
         return this.bounds.pad(OUTSIDE_PADDING)
     }
 
     // The bounds for the middle chart part
-    @computed protected get boundsForChart() {
+    @computed protected get boundsForChart(): Bounds {
         return this.paddedBounds
             .padTop(this.header.height)
             .padBottom(this.footer.height + PADDING_ABOVE_FOOTER)
             .padTop(this.isMapTab ? 0 : PADDING_BELOW_HEADER)
     }
 
-    render() {
+    render(): JSX.Element {
         const { bounds, paddedBounds } = this
         const { width, height } = bounds
 

--- a/grapher/captionedChart/Logos.tsx
+++ b/grapher/captionedChart/Logos.tsx
@@ -50,24 +50,24 @@ export class Logo {
         this.props = props
     }
 
-    @computed private get spec() {
+    @computed private get spec(): LogoAttributes {
         return this.props.logo !== undefined
             ? logos[this.props.logo]
             : logos.owid
     }
 
-    @computed private get scale() {
+    @computed private get scale(): number {
         return this.spec.targetHeight / this.spec.height
     }
 
-    @computed get width() {
+    @computed get width(): number {
         return this.spec.width * this.scale
     }
-    @computed get height() {
+    @computed get height(): number {
         return this.spec.height * this.scale
     }
 
-    renderSVG(targetX: number, targetY: number) {
+    renderSVG(targetX: number, targetY: number): JSX.Element {
         const { scale } = this
         const svg =
             (this.spec.svg.match(/<svg>(.*)<\/svg>/) || "")[1] || this.spec.svg
@@ -81,7 +81,7 @@ export class Logo {
         )
     }
 
-    renderHTML() {
+    renderHTML(): JSX.Element {
         const { spec } = this
         const props: React.HTMLAttributes<
             HTMLDivElement & HTMLAnchorElement

--- a/grapher/chart/.eslintrc.yaml
+++ b/grapher/chart/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/chart/ChartDimension.ts
+++ b/grapher/chart/ChartDimension.ts
@@ -16,6 +16,7 @@ import {
     deleteRuntimeAndUnchangedProps,
     updatePersistables,
 } from "../persistable/Persistable"
+import { CoreColumn } from "../../coreTable/CoreTableColumns"
 
 // A chart "dimension" represents a binding between a chart
 // and a particular variable that it requests as data
@@ -50,11 +51,11 @@ export class ChartDimension
         if (obj) this.updateFromObject(obj)
     }
 
-    @computed private get table() {
+    @computed private get table(): OwidTable {
         return this.manager.table
     }
 
-    updateFromObject(obj: LegacyChartDimensionInterface) {
+    updateFromObject(obj: LegacyChartDimensionInterface): void {
         if (obj.display) updatePersistables(this, { display: obj.display })
 
         this.targetYear = obj.targetYear
@@ -80,11 +81,11 @@ export class ChartDimension
     // Do not persist yet, until we migrate off VariableIds
     @observable slug?: ColumnSlug
 
-    @computed get column() {
+    @computed get column(): CoreColumn {
         return this.table.get(this.columnSlug)
     }
 
-    @computed get columnSlug() {
+    @computed get columnSlug(): string {
         return this.slug ?? this.variableId.toString()
     }
 }

--- a/grapher/chart/ChartInterface.ts
+++ b/grapher/chart/ChartInterface.ts
@@ -1,7 +1,7 @@
 import { Color } from "../../coreTable/CoreTableConstants"
 import { OwidTable } from "../../coreTable/OwidTable"
 import { SeriesName } from "../core/GrapherConstants"
-
+import { ColorScale } from "../color/ColorScale"
 // The idea of this interface is to try and start reusing more code across our Chart classes and make it easier
 // for a dev to work on a chart type they haven't touched before if they've worked with another that implements
 // this interface.
@@ -18,6 +18,8 @@ export interface ChartInterface {
 
     inputTable: OwidTable // Points to the OwidTable coming into the chart. All charts have an inputTable. Standardized as part of the interface as a development aid.
     transformedTable: OwidTable // Points to the OwidTable after the chart has transformed the input table. The chart may add a relative transform, for example. Standardized as part of the interface as a development aid.
+
+    colorScale?: ColorScale
 
     series: readonly ChartSeries[] // This points to the marks that the chart will render. They don't have to be placed yet. Standardized as part of the interface as a development aid.
     // Todo: should all charts additionally have a placedSeries: ChartPlacedSeries[] getter?

--- a/grapher/chart/ChartTypeSwitcher.tsx
+++ b/grapher/chart/ChartTypeSwitcher.tsx
@@ -5,10 +5,10 @@ import { ChartTypeName } from "../core/GrapherConstants"
 export class ChartTypeSwitcher extends React.Component<{
     onChange: (chartType: ChartTypeName) => void
 }> {
-    render() {
+    render(): JSX.Element {
         return (
             <select
-                onChange={(event) =>
+                onChange={(event): void =>
                     this.props.onChange(event.target.value as any)
                 }
             >

--- a/grapher/chart/ChartUtils.tsx
+++ b/grapher/chart/ChartUtils.tsx
@@ -5,14 +5,14 @@ import { LineChartSeries } from "../lineCharts/LineChartConstants"
 import { SelectionArray } from "../selection/SelectionArray"
 import { ChartManager } from "./ChartManager"
 
-export const autoDetectYColumnSlugs = (manager: ChartManager) => {
+export const autoDetectYColumnSlugs = (manager: ChartManager): string[] => {
     if (manager.yColumnSlugs && manager.yColumnSlugs.length)
         return manager.yColumnSlugs
     if (manager.yColumnSlug) return [manager.yColumnSlug]
     return manager.table.numericColumnSlugs
 }
 
-export const getDefaultFailMessage = (manager: ChartManager) => {
+export const getDefaultFailMessage = (manager: ChartManager): string => {
     if (manager.table.rootTable.isBlank) return `No table loaded yet.`
     if (manager.table.rootTable.entityNameColumn.isMissing)
         return `Table is missing an EntityName column.`
@@ -25,7 +25,10 @@ export const getDefaultFailMessage = (manager: ChartManager) => {
     return ""
 }
 
-export const getSeriesKey = (series: LineChartSeries, suffix?: string) => {
+export const getSeriesKey = (
+    series: LineChartSeries,
+    suffix?: string
+): string => {
     return `${series.seriesName}-${series.color}-${
         series.isProjection ? "projection" : ""
     }${suffix ? "-" + suffix : ""}`
@@ -34,7 +37,7 @@ export const getSeriesKey = (series: LineChartSeries, suffix?: string) => {
 export const autoDetectSeriesStrategy = (
     manager: ChartManager,
     hasNormalAndProjectedSeries?: boolean
-) => {
+): SeriesStrategy => {
     if (manager.seriesStrategy) return manager.seriesStrategy
 
     const columnThreshold = hasNormalAndProjectedSeries ? 2 : 1
@@ -43,7 +46,10 @@ export const autoDetectSeriesStrategy = (
         : SeriesStrategy.entity
 }
 
-export const makeClipPath = (renderUid: number, box: Box) => {
+export const makeClipPath = (
+    renderUid: number,
+    box: Box
+): { id: string; element: JSX.Element } => {
     const id = `boundsClip-${renderUid}`
     return {
         id: `url(#${id})`,
@@ -57,7 +63,7 @@ export const makeClipPath = (renderUid: number, box: Box) => {
     }
 }
 
-export const makeSelectionArray = (manager: ChartManager) =>
+export const makeSelectionArray = (manager: ChartManager): SelectionArray =>
     manager.selection instanceof SelectionArray
         ? manager.selection
         : new SelectionArray(manager.selection ?? [])

--- a/grapher/chart/DimensionSlot.ts
+++ b/grapher/chart/DimensionSlot.ts
@@ -4,6 +4,7 @@ import { Grapher } from "../core/Grapher"
 import { computed } from "mobx"
 import { DimensionProperty } from "../core/GrapherConstants"
 import { excludeUndefined, findIndex, sortBy } from "../../clientUtils/Util"
+import { ChartDimension } from "./ChartDimension"
 
 export class DimensionSlot {
     private grapher: Grapher
@@ -13,7 +14,7 @@ export class DimensionSlot {
         this.property = property
     }
 
-    @computed get name() {
+    @computed get name(): string {
         const names = {
             y: this.grapher.isDiscreteBar ? "X axis" : "Y axis",
             x: "X axis",
@@ -25,24 +26,24 @@ export class DimensionSlot {
         return (names as any)[this.property] || ""
     }
 
-    @computed get allowMultiple() {
+    @computed get allowMultiple(): boolean {
         return (
             this.property === DimensionProperty.y &&
             this.grapher.supportsMultipleYColumns
         )
     }
 
-    @computed get isOptional() {
+    @computed get isOptional(): boolean {
         return this.allowMultiple
     }
 
-    @computed get dimensions() {
+    @computed get dimensions(): ChartDimension[] {
         return this.grapher.dimensions.filter(
             (d) => d.property === this.property
         )
     }
 
-    @computed get dimensionsOrderedAsInPersistedSelection() {
+    @computed get dimensionsOrderedAsInPersistedSelection(): ChartDimension[] {
         const legacyConfig = this.grapher.legacyConfigAsAuthored
         const variableIDsInSelectionOrder = excludeUndefined(
             legacyConfig.selectedData?.map(

--- a/grapher/chart/Tippy.tsx
+++ b/grapher/chart/Tippy.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { default as OriginalTippy, TippyProps } from "@tippyjs/react"
 
-export const Tippy = (props: TippyProps) => (
+export const Tippy = (props: TippyProps): JSX.Element => (
     <OriginalTippy theme="light" {...props} />
 )

--- a/grapher/color/.eslintrc.yaml
+++ b/grapher/color/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/color/BinningStrategies.ts
+++ b/grapher/color/BinningStrategies.ts
@@ -22,7 +22,7 @@ function calcEqualIntervalStepSize(
     sortedValues: number[],
     binCount: number,
     minBinValue: number
-) {
+): number {
     if (!sortedValues.length) return 10
     const stepSizeInitial = (last(sortedValues)! - minBinValue) / binCount
     return roundSigFig(stepSizeInitial, 1)
@@ -42,7 +42,7 @@ interface GetBinMaximumsWithStrategyArgs {
 function normalizeBinValues(
     binValues: (number | undefined)[],
     minBinValue?: number
-) {
+): any {
     const values = uniq(excludeUndefined(binValues))
     return minBinValue !== undefined
         ? values.filter((v) => v > minBinValue)

--- a/grapher/color/ColorScale.test.ts
+++ b/grapher/color/ColorScale.test.ts
@@ -8,7 +8,7 @@ import { ColorScaleConfigInterface } from "./ColorScaleConfig"
 const createColorScaleFromTable = (
     colorValuePairs: { value: number; color?: string }[],
     colorScaleConfig: ColorScaleConfigInterface
-) => {
+): ColorScale => {
     const table = new CoreTable({
         colorValues: colorValuePairs.map((pair) => pair.value),
     })

--- a/grapher/color/ColorScaleBin.ts
+++ b/grapher/color/ColorScaleBin.ts
@@ -27,35 +27,35 @@ abstract class AbstractColorScaleBin<T extends BinProps> {
     constructor(props: T) {
         this.props = props
     }
-    get color() {
+    get color(): string {
         return this.props.color
     }
-    get label() {
+    get label(): string | undefined {
         return this.props.label
     }
 }
 
 export class NumericBin extends AbstractColorScaleBin<NumericBinProps> {
-    get min() {
+    get min(): number {
         return this.props.min
     }
-    get max() {
+    get max(): number {
         return this.props.max
     }
-    get minText() {
+    get minText(): string {
         return (this.props.isOpenLeft ? `<` : "") + this.props.displayMin
     }
-    get maxText() {
+    get maxText(): string {
         return (this.props.isOpenRight ? `>` : "") + this.props.displayMax
     }
-    get text() {
+    get text(): string {
         return this.props.label || ""
     }
-    get isHidden() {
+    get isHidden(): boolean {
         return false
     }
 
-    contains(value: string | number | undefined) {
+    contains(value: string | number | undefined): boolean {
         if (value === undefined) return false
 
         if (this.props.isOpenLeft) return value <= this.max
@@ -67,7 +67,7 @@ export class NumericBin extends AbstractColorScaleBin<NumericBinProps> {
         return value > this.min && value <= this.max
     }
 
-    equals(other: ColorScaleBin) {
+    equals(other: ColorScaleBin): boolean {
         return (
             other instanceof NumericBin &&
             this.min === other.min &&
@@ -77,28 +77,28 @@ export class NumericBin extends AbstractColorScaleBin<NumericBinProps> {
 }
 
 export class CategoricalBin extends AbstractColorScaleBin<CategoricalBinProps> {
-    get index() {
+    get index(): number {
         return this.props.index
     }
-    get value() {
+    get value(): string {
         return this.props.value
     }
-    get isHidden() {
+    get isHidden(): boolean | undefined {
         return this.props.isHidden
     }
 
-    get text() {
+    get text(): string {
         return this.props.label || this.props.value
     }
 
-    contains(value: string | number | undefined) {
+    contains(value: string | number | undefined): boolean {
         return (
             (value === undefined && this.props.value === "No data") ||
             (value !== undefined && value === this.props.value)
         )
     }
 
-    equals(other: ColorScaleBin) {
+    equals(other: ColorScaleBin): boolean {
         return (
             other instanceof CategoricalBin &&
             this.props.index === other.props.index

--- a/grapher/color/ColorScaleConfig.ts
+++ b/grapher/color/ColorScaleConfig.ts
@@ -83,7 +83,7 @@ export type ColorScaleConfigInterface = ColorScaleConfigDefaults
 export class ColorScaleConfig
     extends ColorScaleConfigDefaults
     implements Persistable {
-    updateFromObject(obj: any) {
+    updateFromObject(obj: any): void {
         extend(this, obj)
     }
 
@@ -109,7 +109,7 @@ export class ColorScaleConfig
         const customNumericColors: (Color | undefined)[] = []
         scale.colorScaleNumericBins
             ?.split(INTER_BIN_DELIMITER)
-            .forEach((bin) => {
+            .forEach((bin): void => {
                 const [value, color, ...label] = bin.split(
                     INTRA_BIN_DELIMITER
                 ) as (string | undefined)[]
@@ -138,7 +138,7 @@ export class ColorScaleConfig
         } = {}
         scale.colorScaleCategoricalBins
             ?.split(INTER_BIN_DELIMITER)
-            .forEach((bin) => {
+            .forEach((bin): void => {
                 const [value, color, ...label] = bin.split(
                     INTRA_BIN_DELIMITER
                 ) as (string | undefined)[]
@@ -204,7 +204,7 @@ export class ColorScaleConfig
             colorScaleLegendDescription: legendDescription,
             colorScaleNumericMinValue: customNumericMinValue,
             colorScaleNumericBins: (customNumericValues ?? [])
-                .map((value: any, index: number) =>
+                .map((value: any, index: number): string =>
                     [
                         value,
                         customNumericColors[index] ?? "",
@@ -214,7 +214,7 @@ export class ColorScaleConfig
                 .join(INTER_BIN_DELIMITER),
             colorScaleNoDataLabel: customCategoryLabels[NO_DATA_LABEL],
             colorScaleCategoricalBins: Object.keys(customCategoryColors ?? {})
-                .map((value) =>
+                .map((value): string =>
                     [
                         value,
                         customCategoryColors[value],

--- a/grapher/color/ColorScaleConfig.ts
+++ b/grapher/color/ColorScaleConfig.ts
@@ -204,7 +204,7 @@ export class ColorScaleConfig
             colorScaleLegendDescription: legendDescription,
             colorScaleNumericMinValue: customNumericMinValue,
             colorScaleNumericBins: (customNumericValues ?? [])
-                .map((value: any, index: number): string =>
+                .map((value: any, index: number) =>
                     [
                         value,
                         customNumericColors[index] ?? "",
@@ -214,7 +214,7 @@ export class ColorScaleConfig
                 .join(INTER_BIN_DELIMITER),
             colorScaleNoDataLabel: customCategoryLabels[NO_DATA_LABEL],
             colorScaleCategoricalBins: Object.keys(customCategoryColors ?? {})
-                .map((value): string =>
+                .map((value) =>
                     [
                         value,
                         customCategoryColors[value],

--- a/grapher/color/ColorScheme.ts
+++ b/grapher/color/ColorScheme.ts
@@ -23,7 +23,7 @@ export class ColorScheme implements ColorSchemeInterface {
         this.colorSets = []
         this.singleColorScale = !!singleColorScale
         this.isDistinct = !!isDistinct
-        colorSets.forEach((set): string[] => (this.colorSets[set.length] = set))
+        colorSets.forEach((set) => (this.colorSets[set.length] = set))
     }
 
     improviseGradientFromShorter(
@@ -65,12 +65,12 @@ export class ColorScheme implements ColorSchemeInterface {
 
         const prevColors = clone(colorSets)
             .reverse()
-            .find((set): boolean => set && set.length < numColors)
+            .find((set) => set && set.length < numColors)
         if (prevColors)
             return this.improviseGradientFromShorter(prevColors, numColors)
         else
             return this.improviseGradientFromLonger(
-                colorSets.find((set): boolean => !!set) as Color[],
+                colorSets.find((set) => !!set) as Color[],
                 numColors
             )
     }
@@ -112,9 +112,8 @@ export class ColorScheme implements ColorSchemeInterface {
         // We want to display same values using the same color, e.g. two values of 100 get the same shade of green
         // Therefore, we create a map from all possible (unique) values to the corresponding color
         const colorByValue = new Map<number, Color>()
-        uniqValues.forEach(
-            (value, index): Map<number, string> =>
-                colorByValue.set(value, colors[index])
+        uniqValues.forEach((value, index) =>
+            colorByValue.set(value, colors[index])
         )
         return colorByValue
     }
@@ -125,12 +124,12 @@ export class ColorScheme implements ColorSchemeInterface {
         customColorMap: Map<SeriesName, Color> = new Map(),
         seriesColorMap: SeriesColorMap = new Map()
     ): void {
-        seriesArr.forEach((series): void => {
+        seriesArr.forEach((series) => {
             const customColor = customColorMap.get(series.seriesName)
             if (customColor) seriesColorMap.set(series.seriesName, customColor)
         })
         this.updateColorMap(seriesArr, seriesColorMap, invertColorScheme)
-        seriesArr.forEach((series): void => {
+        seriesArr.forEach((series) => {
             series.color = seriesColorMap.get(series.seriesName)!
         })
     }
@@ -142,9 +141,9 @@ export class ColorScheme implements ColorSchemeInterface {
     ): void {
         // For names that don't have a color, assign one.
         seriesArr
-            .map((series): string => series.seriesName)
-            .filter((name): boolean => !seriesColorMap.has(name))
-            .forEach((name): void => {
+            .map((series) => series.seriesName)
+            .filter((name) => !seriesColorMap.has(name))
+            .forEach((name) => {
                 const availableColors = lastOfNonEmptyArray(
                     this.colorSets
                 ).slice()

--- a/grapher/color/ColorScheme.ts
+++ b/grapher/color/ColorScheme.ts
@@ -23,7 +23,7 @@ export class ColorScheme implements ColorSchemeInterface {
         this.colorSets = []
         this.singleColorScale = !!singleColorScale
         this.isDistinct = !!isDistinct
-        colorSets.forEach((set) => (this.colorSets[set.length] = set))
+        colorSets.forEach((set): string[] => (this.colorSets[set.length] = set))
     }
 
     improviseGradientFromShorter(
@@ -65,12 +65,12 @@ export class ColorScheme implements ColorSchemeInterface {
 
         const prevColors = clone(colorSets)
             .reverse()
-            .find((set) => set && set.length < numColors)
+            .find((set): boolean => set && set.length < numColors)
         if (prevColors)
             return this.improviseGradientFromShorter(prevColors, numColors)
         else
             return this.improviseGradientFromLonger(
-                colorSets.find((set) => !!set) as Color[],
+                colorSets.find((set): boolean => !!set) as Color[],
                 numColors
             )
     }
@@ -102,15 +102,19 @@ export class ColorScheme implements ColorSchemeInterface {
             : this.getGradientColors(numColors)
     }
 
-    getUniqValueColorMap(uniqValues: any[], inverseOrder?: boolean) {
+    getUniqValueColorMap(
+        uniqValues: any[],
+        inverseOrder?: boolean
+    ): Map<number, string> {
         const colors = this.getColors(uniqValues.length) || []
         if (inverseOrder) colors.reverse()
 
         // We want to display same values using the same color, e.g. two values of 100 get the same shade of green
         // Therefore, we create a map from all possible (unique) values to the corresponding color
         const colorByValue = new Map<number, Color>()
-        uniqValues.forEach((value, index) =>
-            colorByValue.set(value, colors[index])
+        uniqValues.forEach(
+            (value, index): Map<number, string> =>
+                colorByValue.set(value, colors[index])
         )
         return colorByValue
     }
@@ -120,13 +124,13 @@ export class ColorScheme implements ColorSchemeInterface {
         invertColorScheme = false,
         customColorMap: Map<SeriesName, Color> = new Map(),
         seriesColorMap: SeriesColorMap = new Map()
-    ) {
-        seriesArr.forEach((series) => {
+    ): void {
+        seriesArr.forEach((series): void => {
             const customColor = customColorMap.get(series.seriesName)
             if (customColor) seriesColorMap.set(series.seriesName, customColor)
         })
         this.updateColorMap(seriesArr, seriesColorMap, invertColorScheme)
-        seriesArr.forEach((series) => {
+        seriesArr.forEach((series): void => {
             series.color = seriesColorMap.get(series.seriesName)!
         })
     }
@@ -135,12 +139,12 @@ export class ColorScheme implements ColorSchemeInterface {
         seriesArr: ChartSeries[],
         seriesColorMap: SeriesColorMap,
         invertColorScheme = false
-    ) {
+    ): void {
         // For names that don't have a color, assign one.
         seriesArr
-            .map((series) => series.seriesName)
-            .filter((name) => !seriesColorMap.has(name))
-            .forEach((name) => {
+            .map((series): string => series.seriesName)
+            .filter((name): boolean => !seriesColorMap.has(name))
+            .forEach((name): void => {
                 const availableColors = lastOfNonEmptyArray(
                     this.colorSets
                 ).slice()
@@ -159,10 +163,11 @@ export class ColorScheme implements ColorSchemeInterface {
         name: string,
         colorSets: { [key: string]: Color[] },
         singleColorScale?: boolean
-    ) {
+    ): ColorScheme {
         const colorSetsArray: Color[][] = []
         Object.keys(colorSets).forEach(
-            (numColors) => (colorSetsArray[+numColors] = colorSets[numColors])
+            (numColors): string[] =>
+                (colorSetsArray[+numColors] = colorSets[numColors])
         )
         return new ColorScheme(name, colorSetsArray, singleColorScale)
     }

--- a/grapher/color/ColorSchemes.ts
+++ b/grapher/color/ColorSchemes.ts
@@ -3,7 +3,7 @@ import { CustomColorSchemes } from "./CustomSchemes"
 import { ColorBrewerSchemes } from "./ColorBrewerSchemes"
 import { ColorScheme } from "./ColorScheme"
 
-const initAllSchemes = () => {
+const initAllSchemes = (): { [key in ColorSchemeName]: ColorScheme } => {
     const schemes = [...ColorBrewerSchemes, ...CustomColorSchemes]
 
     // NB: Temporarily switch to any typing to build the ColorScheme map. Ideally it would just be an enum, but in TS in enums you can only have primitive values.

--- a/grapher/color/ColorUtils.ts
+++ b/grapher/color/ColorUtils.ts
@@ -3,7 +3,9 @@ import { rgb } from "d3-color"
 import { interpolate } from "d3-interpolate"
 import { difference, groupBy, minBy } from "../../clientUtils/Util"
 
-export const interpolateArray = (scaleArr: string[]) => {
+export const interpolateArray = (
+    scaleArr: string[]
+): ((t: number) => string) => {
     const N = scaleArr.length - 2 // -1 for spacings, -1 for number of interpolate fns
     const intervalWidth = 1 / N
     const intervals: Array<(t: number) => string> = []
@@ -12,7 +14,7 @@ export const interpolateArray = (scaleArr: string[]) => {
         intervals[i] = interpolate(rgb(scaleArr[i]), rgb(scaleArr[i + 1]))
     }
 
-    return (t: number) => {
+    return (t: number): string => {
         if (t < 0 || t > 1)
             throw new Error("Outside the allowed range of [0, 1]")
 
@@ -26,7 +28,7 @@ export const interpolateArray = (scaleArr: string[]) => {
 export function getLeastUsedColor(
     availableColors: Color[],
     usedColors: Color[]
-) {
+): any {
     // If there are unused colors, return the first available
     const unusedColors = difference(availableColors, usedColors)
     if (unusedColors.length > 0) return unusedColors[0]
@@ -35,8 +37,8 @@ export function getLeastUsedColor(
     // unused one.
     const colorCounts = Object.entries(
         groupBy(usedColors)
-    ).map(([color, arr]) => [color, arr.length])
-    const mostUnusedColor = minBy(colorCounts, ([, count]) => count) as [
+    ).map(([color, arr]): any[] => [color, arr.length])
+    const mostUnusedColor = minBy(colorCounts, ([, count]): any => count) as [
         string,
         number
     ]

--- a/grapher/color/ColorUtils.ts
+++ b/grapher/color/ColorUtils.ts
@@ -38,7 +38,7 @@ export function getLeastUsedColor(
     const colorCounts = Object.entries(
         groupBy(usedColors)
     ).map(([color, arr]): any[] => [color, arr.length])
-    const mostUnusedColor = minBy(colorCounts, ([, count]): any => count) as [
+    const mostUnusedColor = minBy(colorCounts, ([, count]) => count) as [
         string,
         number
     ]

--- a/grapher/controls/.eslintrc.yaml
+++ b/grapher/controls/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/controls/AddEntityButton.tsx
+++ b/grapher/controls/AddEntityButton.tsx
@@ -11,11 +11,11 @@ export interface AddEntityButtonManager {
 export class AddEntityButton extends React.Component<{
     manager: AddEntityButtonManager
 }> {
-    render() {
+    render(): JSX.Element {
         return (
             <button
                 className="addEntityButton clickable"
-                onClick={() =>
+                onClick={(): boolean =>
                     runInAction(
                         () => (this.props.manager.isSelectingData = true)
                     )

--- a/grapher/controls/CollapsibleList/CollapsibleList.sampleInput.tsx
+++ b/grapher/controls/CollapsibleList/CollapsibleList.sampleInput.tsx
@@ -7,11 +7,11 @@ import { range } from "../../../clientUtils/Util"
 class SampleCheckBox extends React.Component<{ id: number }> {
     @observable checked: boolean = false
 
-    @action.bound onToggle() {
+    @action.bound onToggle(): void {
         this.checked = !this.checked
     }
 
-    render() {
+    render(): JSX.Element {
         return (
             <label className="clickable">
                 <input

--- a/grapher/controls/CollapsibleList/CollapsibleList.stories.tsx
+++ b/grapher/controls/CollapsibleList/CollapsibleList.stories.tsx
@@ -7,11 +7,11 @@ export default {
     component: CollapsibleList,
 }
 
-export const CollapsibleListComponent = () => {
+export const CollapsibleListComponent = (): JSX.Element => {
     return <CollapsibleList>{collapsibleListSampleItems}</CollapsibleList>
 }
 
-export const MoreButtonComponent = () => {
+export const MoreButtonComponent = (): JSX.Element => {
     const options = [
         <div key="option1">option1</div>,
         <div key="option2">option2</div>,

--- a/grapher/controls/CollapsibleList/CollapsibleList.tsx
+++ b/grapher/controls/CollapsibleList/CollapsibleList.tsx
@@ -35,18 +35,18 @@ export class CollapsibleList extends React.Component {
         )
     }
 
-    private updateOuterContainerWidth() {
+    private updateOuterContainerWidth(): void {
         this.outerContainerWidth =
             this.outerContainerRef.current?.clientWidth ?? 0
     }
 
-    private calculateItemWidths() {
+    private calculateItemWidths(): void {
         this.outerContainerRef.current
             ?.querySelectorAll(".list-item.visible")
-            .forEach((item) => this.itemsWidths.push(item.clientWidth))
+            .forEach((item): number => this.itemsWidths.push(item.clientWidth))
     }
 
-    @action private updateNumItemsVisible() {
+    @action private updateNumItemsVisible(): void {
         const numItemsVisibleWithoutMoreButton = numItemsVisible(
             this.itemsWidths,
             this.outerContainerWidth
@@ -62,26 +62,26 @@ export class CollapsibleList extends React.Component {
                   )
     }
 
-    private get visibleItems() {
+    private get visibleItems(): ListChild[] {
         return this.children.slice(0, this.numItemsVisible)
     }
 
-    private get dropdownItems() {
+    private get dropdownItems(): ListChild[] {
         return this.numItemsVisible
             ? this.children.slice(this.numItemsVisible)
             : []
     }
 
-    @action private onResize = throttle(() => {
+    @action private onResize = throttle((): void => {
         this.updateItemVisibility()
     }, 100)
 
-    @action private updateItemVisibility() {
+    @action private updateItemVisibility(): void {
         this.updateOuterContainerWidth()
         this.updateNumItemsVisible()
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         window.addEventListener("resize", this.onResize)
 
         this.moreButtonWidth = this.moreButtonRef.current?.clientWidth ?? 0
@@ -89,19 +89,21 @@ export class CollapsibleList extends React.Component {
         this.updateItemVisibility()
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         window.removeEventListener("resize", this.onResize)
     }
 
-    render() {
+    render(): JSX.Element {
         return (
             <div className="collapsibleList" ref={this.outerContainerRef}>
                 <ul>
-                    {this.visibleItems.map((item) => (
-                        <li key={item.index} className="list-item visible">
-                            {item.child}
-                        </li>
-                    ))}
+                    {this.visibleItems.map(
+                        (item): JSX.Element => (
+                            <li key={item.index} className="list-item visible">
+                                {item.child}
+                            </li>
+                        )
+                    )}
                     <li
                         className="list-item moreButton"
                         ref={this.moreButtonRef}
@@ -112,14 +114,16 @@ export class CollapsibleList extends React.Component {
                         }}
                     >
                         <MoreButton
-                            options={this.dropdownItems.map((item) => (
-                                <li
-                                    key={item.index}
-                                    className="list-item dropdown"
-                                >
-                                    {item.child}
-                                </li>
-                            ))}
+                            options={this.dropdownItems.map(
+                                (item): JSX.Element => (
+                                    <li
+                                        key={item.index}
+                                        className="list-item dropdown"
+                                    >
+                                        {item.child}
+                                    </li>
+                                )
+                            )}
                         />
                     </li>
                 </ul>
@@ -131,7 +135,7 @@ export class CollapsibleList extends React.Component {
 export class MoreButton extends React.Component<{
     options: React.ReactElement[]
 }> {
-    render() {
+    render(): JSX.Element {
         const { options } = this.props
         return (
             <Tippy
@@ -157,7 +161,7 @@ export function numItemsVisible(
     itemWidths: number[],
     containerWidth: number,
     startingWidth: number = 0
-) {
+): number {
     let total = startingWidth
     for (let i = 0; i < itemWidths.length; i++) {
         if (total + itemWidths[i] > containerWidth) return i

--- a/grapher/controls/CommandPalette.stories.tsx
+++ b/grapher/controls/CommandPalette.stories.tsx
@@ -6,23 +6,23 @@ export default {
     component: CommandPalette,
 }
 
-export const WithCommands = () => {
+export const WithCommands = (): JSX.Element => {
     const demoCommands: Command[] = [
         {
             combo: "ctrl+o",
-            fn: () => {},
+            fn: (): void => {},
             title: "Open",
             category: "File",
         },
         {
             combo: "ctrl+s",
-            fn: () => {},
+            fn: (): void => {},
             title: "Save",
             category: "File",
         },
         {
             combo: "ctrl+c",
-            fn: () => {},
+            fn: (): void => {},
             title: "Copy",
             category: "Edit",
         },

--- a/grapher/controls/CommandPalette.tsx
+++ b/grapher/controls/CommandPalette.tsx
@@ -7,7 +7,7 @@ declare type keyboardCombo = string
 
 export interface Command {
     combo: keyboardCombo
-    fn: () => any
+    fn: () => void
     title?: string
     category?: string
 }
@@ -19,7 +19,7 @@ export class CommandPalette extends React.Component<{
     commands: Command[]
     display: "none" | "block"
 }> {
-    static togglePalette() {
+    static togglePalette(): void {
         const element = document.getElementsByClassName(
             CommandPaletteClassName
         )[0] as HTMLElement
@@ -28,7 +28,7 @@ export class CommandPalette extends React.Component<{
                 element.style.display === "none" ? "block" : "none"
     }
 
-    render() {
+    render(): JSX.Element {
         const style: any = {
             display: this.props.display,
         }
@@ -50,7 +50,9 @@ export class CommandPalette extends React.Component<{
                             <span className="commandCombo">
                                 {command.combo}
                             </span>
-                            <a onClick={() => command.fn()}>{command.title}</a>
+                            <a onClick={(): void => command.fn()}>
+                                {command.title}
+                            </a>
                         </div>
                     </div>
                 )

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -34,20 +34,20 @@ export interface HighlightToggleManager {
 export class HighlightToggle extends React.Component<{
     manager: HighlightToggleManager
 }> {
-    @computed private get manager() {
+    @computed private get manager(): HighlightToggleManager {
         return this.props.manager
     }
-    @computed private get highlight() {
+    @computed private get highlight(): HighlightToggleConfig | undefined {
         return this.props.manager.highlightToggle
     }
 
-    @computed private get highlightParams() {
+    @computed private get highlightParams(): QueryParams {
         return getQueryParams((this.highlight?.paramStr || "").substring(1))
     }
 
     @action.bound private onHighlightToggle(
         event: React.FormEvent<HTMLInputElement>
-    ) {
+    ): void {
         if (!event.currentTarget.checked) {
             this.manager.selectionArray?.clearSelection()
             return
@@ -60,16 +60,16 @@ export class HighlightToggle extends React.Component<{
         this.manager.populateFromQueryParams(params)
     }
 
-    private get isHighlightActive() {
+    private get isHighlightActive(): boolean {
         const params = getWindowQueryParams()
         let isActive = true
-        Object.keys(this.highlightParams).forEach((key) => {
+        Object.keys(this.highlightParams).forEach((key): void => {
             if (params[key] !== this.highlightParams[key]) isActive = false
         })
         return isActive
     }
 
-    render() {
+    render(): JSX.Element {
         const { highlight, isHighlightActive } = this
         return (
             <label className="clickable HighlightToggle">
@@ -93,21 +93,21 @@ export interface AbsRelToggleManager {
 export class AbsRelToggle extends React.Component<{
     manager: AbsRelToggleManager
 }> {
-    @action.bound onToggle() {
+    @action.bound onToggle(): void {
         this.manager.stackMode = this.isRelativeMode
             ? StackMode.absolute
             : StackMode.relative
     }
 
-    @computed get isRelativeMode() {
+    @computed get isRelativeMode(): boolean {
         return this.manager.stackMode === StackMode.relative
     }
 
-    @computed get manager() {
+    @computed get manager(): AbsRelToggleManager {
         return this.props.manager
     }
 
-    render() {
+    render(): JSX.Element {
         const label = this.manager.relativeToggleLabel ?? "Relative"
         return (
             <label className="clickable">
@@ -131,13 +131,13 @@ export interface ZoomToggleManager {
 export class ZoomToggle extends React.Component<{
     manager: ZoomToggleManager
 }> {
-    @action.bound onToggle() {
+    @action.bound onToggle(): void {
         this.props.manager.zoomToSelection = this.props.manager.zoomToSelection
             ? undefined
             : true
     }
 
-    render() {
+    render(): JSX.Element {
         const label = "Zoom to selection"
         return (
             <label className="clickable">
@@ -162,21 +162,21 @@ export interface SmallCountriesFilterManager {
 export class FilterSmallCountriesToggle extends React.Component<{
     manager: SmallCountriesFilterManager
 }> {
-    @action.bound private onChange() {
+    @action.bound private onChange(): void {
         this.manager.minPopulationFilter = this.manager.minPopulationFilter
             ? undefined
             : this.filterOption
     }
 
-    @computed private get manager() {
+    @computed private get manager(): SmallCountriesFilterManager {
         return this.props.manager
     }
 
-    @computed private get filterOption() {
+    @computed private get filterOption(): number {
         return this.manager.populationFilterOption ?? 1e6
     }
 
-    render() {
+    render(): JSX.Element {
         const label = `Hide countries < ${formatValue(
             this.filterOption,
             {}
@@ -213,48 +213,44 @@ export interface FooterControlsManager extends ShareMenuManager {
 export class FooterControls extends React.Component<{
     manager: FooterControlsManager
 }> {
-    @computed private get manager() {
+    @computed private get manager(): FooterControlsManager {
         return this.props.manager
     }
 
-    @action.bound onShareMenu() {
+    @action.bound onShareMenu(): void {
         this.manager.isShareMenuActive = !this.manager.isShareMenuActive
     }
 
-    @computed private get availableTabs() {
+    @computed private get availableTabs(): GrapherTabOption[] {
         return this.manager.availableTabs || []
     }
 
-    private _getTabsElement() {
+    private _getTabsElement(): JSX.Element {
         const { manager } = this
         return (
             <nav className="tabs">
                 <ul>
                     {this.availableTabs.map((tabName) => {
-                        return (
-                            tabName !== GrapherTabOption.download && (
-                                <li
-                                    key={tabName}
-                                    className={
-                                        "tab clickable" +
-                                        (tabName === manager.currentTab
-                                            ? " active"
-                                            : "")
-                                    }
+                        return tabName !== GrapherTabOption.download ? (
+                            <li
+                                key={tabName}
+                                className={
+                                    "tab clickable" +
+                                    (tabName === manager.currentTab
+                                        ? " active"
+                                        : "")
+                                }
+                            >
+                                <a
+                                    onClick={(): void => {
+                                        manager.currentTab = tabName
+                                    }}
+                                    data-track-note={"chart-click-" + tabName}
                                 >
-                                    <a
-                                        onClick={() =>
-                                            (manager.currentTab = tabName)
-                                        }
-                                        data-track-note={
-                                            "chart-click-" + tabName
-                                        }
-                                    >
-                                        {tabName}
-                                    </a>
-                                </li>
-                            )
-                        )
+                                    {tabName}
+                                </a>
+                            </li>
+                        ) : null
                     })}
                     <li
                         className={
@@ -267,7 +263,7 @@ export class FooterControls extends React.Component<{
                     >
                         <a
                             data-track-note="chart-click-download"
-                            onClick={() =>
+                            onClick={(): GrapherTabOption =>
                                 (manager.currentTab = GrapherTabOption.download)
                             }
                         >
@@ -301,7 +297,7 @@ export class FooterControls extends React.Component<{
         )
     }
 
-    render() {
+    render(): JSX.Element {
         const { manager } = this
         const {
             isShareMenuActive,

--- a/grapher/controls/EntitySelectorModal.tsx
+++ b/grapher/controls/EntitySelectorModal.tsx
@@ -21,7 +21,7 @@ class EntitySelectorMulti extends React.Component<{
     base: React.RefObject<HTMLDivElement> = React.createRef()
     dismissable: boolean = true
 
-    @computed get availableEntities() {
+    @computed get availableEntities(): string[] {
         return this.props.selectionArray.availableEntityNames
     }
 
@@ -29,23 +29,23 @@ class EntitySelectorMulti extends React.Component<{
         return new FuzzySearch(this.searchableEntities, "name")
     }
 
-    @computed private get searchableEntities() {
+    @computed private get searchableEntities(): SearchableEntity[] {
         return this.availableEntities.map((name) => {
             return { name } as SearchableEntity
         })
     }
 
-    @computed get searchResults() {
+    @computed get searchResults(): SearchableEntity[] {
         return this.searchInput
             ? this.fuzzy.search(this.searchInput)
-            : sortBy(this.searchableEntities, (result) => result.name)
+            : sortBy(this.searchableEntities, (result): any => result.name)
     }
 
-    @action.bound onClickOutside(e: MouseEvent) {
+    @action.bound onClickOutside(e: MouseEvent): void {
         if (this.dismissable) this.props.onDismiss()
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         // HACK (Mispy): The normal ways of doing this (stopPropagation etc) don't seem to work here
         this.base.current!.addEventListener("click", () => {
             this.dismissable = false
@@ -58,22 +58,24 @@ class EntitySelectorMulti extends React.Component<{
         if (!isTouchDevice()) this.searchField.focus()
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         document.removeEventListener("click", this.onClickOutside)
     }
 
-    @action.bound onSearchKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    @action.bound onSearchKeyDown(
+        e: React.KeyboardEvent<HTMLInputElement>
+    ): void {
         if (e.key === "Enter" && this.searchResults.length > 0) {
             this.props.selectionArray.selectEntity(this.searchResults[0].name)
             this.searchInput = ""
         } else if (e.key === "Escape") this.props.onDismiss()
     }
 
-    @action.bound onClear() {
+    @action.bound onClear(): void {
         this.props.selectionArray.clearSelection()
     }
 
-    render() {
+    render(): JSX.Element {
         const { selectionArray } = this.props
         const { searchResults, searchInput } = this
 
@@ -96,35 +98,37 @@ class EntitySelectorMulti extends React.Component<{
                                 type="search"
                                 placeholder="Search..."
                                 value={searchInput}
-                                onInput={(e) =>
-                                    (this.searchInput = e.currentTarget.value)
-                                }
+                                onInput={(e): void => {
+                                    this.searchInput = e.currentTarget.value
+                                }}
                                 onKeyDown={this.onSearchKeyDown}
-                                ref={(e) =>
+                                ref={(e): HTMLInputElement =>
                                     (this.searchField = e as HTMLInputElement)
                                 }
                             />
                             <ul>
-                                {searchResults.map((result) => {
-                                    return (
-                                        <li key={result.name}>
-                                            <label className="clickable">
-                                                <input
-                                                    type="checkbox"
-                                                    checked={selectionArray.selectedSet.has(
-                                                        result.name
-                                                    )}
-                                                    onChange={() =>
-                                                        selectionArray.toggleSelection(
+                                {searchResults.map(
+                                    (result): JSX.Element => {
+                                        return (
+                                            <li key={result.name}>
+                                                <label className="clickable">
+                                                    <input
+                                                        type="checkbox"
+                                                        checked={selectionArray.selectedSet.has(
                                                             result.name
-                                                        )
-                                                    }
-                                                />{" "}
-                                                {result.name}
-                                            </label>
-                                        </li>
-                                    )
-                                })}
+                                                        )}
+                                                        onChange={(): SelectionArray =>
+                                                            selectionArray.toggleSelection(
+                                                                result.name
+                                                            )
+                                                        }
+                                                    />{" "}
+                                                    {result.name}
+                                                </label>
+                                            </li>
+                                        )
+                                    }
+                                )}
                             </ul>
                         </div>
                         <div className="selectedData">
@@ -136,11 +140,11 @@ class EntitySelectorMulti extends React.Component<{
                                                 <input
                                                     type="checkbox"
                                                     checked={true}
-                                                    onChange={() =>
+                                                    onChange={(): void => {
                                                         selectionArray.deselectEntity(
                                                             name
                                                         )
-                                                    }
+                                                    }}
                                                 />{" "}
                                                 {name}
                                             </label>
@@ -178,7 +182,7 @@ class EntitySelectorSingle extends React.Component<{
     base: React.RefObject<HTMLDivElement> = React.createRef()
     dismissable: boolean = true
 
-    @computed private get availableEntities() {
+    @computed private get availableEntities(): { id: string; label: string }[] {
         const availableItems: { id: string; label: string }[] = []
         this.props.selectionArray.availableEntityNames.forEach((name) => {
             availableItems.push({
@@ -196,15 +200,15 @@ class EntitySelectorSingle extends React.Component<{
     @computed get searchResults(): { id: string; label: string }[] {
         return this.searchInput
             ? this.fuzzy.search(this.searchInput)
-            : sortBy(this.availableEntities, (result) => result.label)
+            : sortBy(this.availableEntities, (result): any => result.label)
     }
 
-    @action.bound onClickOutside(e: MouseEvent) {
+    @action.bound onClickOutside(e: MouseEvent): void {
         if (this.base && !this.base.current!.contains(e.target as Node))
             this.props.onDismiss()
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         // HACK (Mispy): The normal ways of doing this (stopPropagation etc) don't seem to work here
         this.base.current!.addEventListener("click", () => {
             this.dismissable = false
@@ -217,23 +221,25 @@ class EntitySelectorSingle extends React.Component<{
         if (!this.props.isMobile) this.searchField.focus()
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         document.removeEventListener("click", this.onClickOutside)
     }
 
-    @action.bound onSearchKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    @action.bound onSearchKeyDown(
+        e: React.KeyboardEvent<HTMLInputElement>
+    ): void {
         if (e.key === "Enter" && this.searchResults.length > 0) {
             this.onSelect(this.searchResults[0].label)
             this.searchInput = ""
         } else if (e.key === "Escape") this.props.onDismiss()
     }
 
-    @action.bound onSelect(entityName: string) {
+    @action.bound onSelect(entityName: string): void {
         this.props.selectionArray.setSelectedEntities([entityName])
         this.props.onDismiss()
     }
 
-    render() {
+    render(): JSX.Element {
         const { searchResults, searchInput } = this
 
         return (
@@ -252,26 +258,30 @@ class EntitySelectorSingle extends React.Component<{
                             type="search"
                             placeholder="Search..."
                             value={searchInput}
-                            onInput={(e) =>
-                                (this.searchInput = e.currentTarget.value)
-                            }
+                            onInput={(e): void => {
+                                this.searchInput = e.currentTarget.value
+                            }}
                             onKeyDown={this.onSearchKeyDown}
-                            ref={(e) =>
+                            ref={(e): HTMLInputElement =>
                                 (this.searchField = e as HTMLInputElement)
                             }
                         />
                         <ul>
-                            {searchResults.map((d) => {
-                                return (
-                                    <li
-                                        key={d.id}
-                                        className="clickable"
-                                        onClick={() => this.onSelect(d.id)}
-                                    >
-                                        {d.label}
-                                    </li>
-                                )
-                            })}
+                            {searchResults.map(
+                                (d): JSX.Element => {
+                                    return (
+                                        <li
+                                            key={d.id}
+                                            className="clickable"
+                                            onClick={(): void =>
+                                                this.onSelect(d.id)
+                                            }
+                                        >
+                                            {d.label}
+                                        </li>
+                                    )
+                                }
+                            )}
                         </ul>
                     </div>
                 </div>
@@ -287,7 +297,7 @@ export class EntitySelectorModal extends React.Component<{
     isMobile: boolean
     onDismiss: () => void
 }> {
-    render() {
+    render(): JSX.Element {
         return this.props.canChangeEntity ? (
             <EntitySelectorSingle {...this.props} />
         ) : (

--- a/grapher/controls/FuzzySearch.ts
+++ b/grapher/controls/FuzzySearch.ts
@@ -16,7 +16,7 @@ export class FuzzySearch<T> {
             .map((result: any) => this.datamap[result.target])
     }
 
-    single(input: string, target: string) {
+    single(input: string, target: string): Fuzzysort.Result | null {
         return fuzzysort.single(input, target)
     }
 

--- a/grapher/controls/ScaleSelector.stories.tsx
+++ b/grapher/controls/ScaleSelector.stories.tsx
@@ -12,6 +12,6 @@ class MockScaleSelectorManager implements ScaleSelectorManager {
     @observable scaleType = ScaleType.log
 }
 
-export const Default = () => (
+export const Default = (): JSX.Element => (
     <ScaleSelector manager={new MockScaleSelectorManager()} />
 )

--- a/grapher/controls/ScaleSelector.tsx
+++ b/grapher/controls/ScaleSelector.tsx
@@ -14,7 +14,7 @@ export class ScaleSelector extends React.Component<{
     manager?: ScaleSelectorManager
     prefix?: string
 }> {
-    @action.bound private onClick() {
+    @action.bound private onClick(): void {
         const manager = this.props.manager ?? {}
         manager.scaleType = next(
             [ScaleType.linear, ScaleType.log],
@@ -22,7 +22,7 @@ export class ScaleSelector extends React.Component<{
         )
     }
 
-    render() {
+    render(): JSX.Element {
         const { manager, prefix } = this.props
         const { scaleType } = manager ?? {}
         return (

--- a/grapher/controls/ShareMenu.tsx
+++ b/grapher/controls/ShareMenu.tsx
@@ -42,40 +42,40 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
         }
     }
 
-    @computed get manager() {
+    @computed get manager(): ShareMenuManager {
         return this.props.manager
     }
 
-    @computed get title() {
+    @computed get title(): string {
         return this.manager.currentTitle ?? ""
     }
 
-    @computed get isDisabled() {
+    @computed get isDisabled(): boolean {
         return !this.manager.slug
     }
 
-    @computed get canonicalUrl() {
+    @computed get canonicalUrl(): string | undefined {
         return this.manager.canonicalUrl
     }
 
-    @action.bound dismiss() {
+    @action.bound dismiss(): void {
         this.props.onDismiss()
     }
 
-    @action.bound onClickSomewhere() {
+    @action.bound onClickSomewhere(): void {
         if (this.dismissable) this.dismiss()
         else this.dismissable = true
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         document.addEventListener("click", this.onClickSomewhere)
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         document.removeEventListener("click", this.onClickSomewhere)
     }
 
-    @action.bound onEmbed() {
+    @action.bound onEmbed(): void {
         if (!this.canonicalUrl) return
 
         this.manager.addPopup(
@@ -84,7 +84,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
         this.dismiss()
     }
 
-    @action.bound async onNavigatorShare() {
+    @action.bound async onNavigatorShare(): Promise<void> {
         if (!this.canonicalUrl || !navigator.share) return
 
         const shareData = {
@@ -99,13 +99,13 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
         }
     }
 
-    @action.bound onCopy() {
+    @action.bound onCopy(): void {
         if (!this.canonicalUrl) return
 
         if (copy(this.canonicalUrl)) this.setState({ copied: true })
     }
 
-    @computed get twitterHref() {
+    @computed get twitterHref(): string {
         let href =
             "https://twitter.com/intent/tweet/?text=" +
             encodeURIComponent(this.title)
@@ -114,7 +114,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
         return href
     }
 
-    @computed get facebookHref() {
+    @computed get facebookHref(): string {
         let href =
             "https://www.facebook.com/dialog/share?app_id=1149943818390250&display=page"
         if (this.canonicalUrl)
@@ -122,7 +122,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
         return href
     }
 
-    render() {
+    render(): JSX.Element {
         const { twitterHref, facebookHref, isDisabled, manager } = this
         const { editUrl } = manager
 
@@ -201,28 +201,28 @@ class EmbedMenu extends React.Component<{
 }> {
     dismissable = true
 
-    @action.bound onClickSomewhere() {
+    @action.bound onClickSomewhere(): void {
         if (this.dismissable) this.manager.removePopup(EmbedMenu)
         else this.dismissable = true
     }
 
-    @computed get manager() {
+    @computed get manager(): ShareMenuManager {
         return this.props.manager
     }
 
-    @action.bound onClick() {
+    @action.bound onClick(): void {
         this.dismissable = false
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         document.addEventListener("click", this.onClickSomewhere)
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         document.removeEventListener("click", this.onClickSomewhere)
     }
 
-    render() {
+    render(): JSX.Element {
         const url = this.manager.embedUrl ?? this.manager.canonicalUrl
         return (
             <div className="embedMenu" onClick={this.onClick}>
@@ -230,7 +230,7 @@ class EmbedMenu extends React.Component<{
                 <p>Paste this into any HTML page:</p>
                 <textarea
                     readOnly={true}
-                    onFocus={(evt) => evt.currentTarget.select()}
+                    onFocus={(evt): void => evt.currentTarget.select()}
                     value={`<iframe src="${url}" loading="lazy" style="width: 100%; height: 600px; border: 0px none;"></iframe>`}
                 />
                 {this.manager.embedDialogAdditionalElements}

--- a/grapher/controls/SortIcon.tsx
+++ b/grapher/controls/SortIcon.tsx
@@ -12,7 +12,7 @@ export function SortIcon(props: {
     type?: "text" | "numeric"
     isActiveIcon?: boolean
     order: SortOrder
-}) {
+}): JSX.Element {
     const type = props.type ?? "numeric"
     const isActiveIcon = props.isActiveIcon ?? false
 

--- a/grapher/controls/VerticalScrollContainer.tsx
+++ b/grapher/controls/VerticalScrollContainer.tsx
@@ -104,7 +104,7 @@ function getShadowOpacity(
     maxOpacity: number,
     maxDistance: number,
     scrollDistance: number | undefined
-) {
+): number {
     const distance =
         scrollDistance !== undefined ? Math.min(scrollDistance, maxDistance) : 0
     return (distance / maxDistance) * maxOpacity
@@ -114,7 +114,7 @@ const ScrollingShadow = (props: {
     direction: "up" | "down"
     size: number
     opacity: number
-}) => {
+}): JSX.Element => {
     // "Eased" gradient
     // https://larsenwork.com/easing-gradients/
     const background = `linear-gradient(
@@ -162,7 +162,7 @@ function useScrollBounds<ElementType extends HTMLElement>(
         if (el) {
             let pendingUpdate = false
 
-            function onScroll() {
+            function onScroll(): void {
                 const { scrollTop, scrollHeight, offsetHeight } = el
                 onScrollTop(scrollTop)
                 onScrollBottom(scrollHeight - offsetHeight - scrollTop)
@@ -170,7 +170,7 @@ function useScrollBounds<ElementType extends HTMLElement>(
             }
             onScroll() // execute for first time to setState
 
-            const onScrollThrottled = () => {
+            const onScrollThrottled = (): void => {
                 if (!pendingUpdate) {
                     window.requestAnimationFrame(onScroll)
                     pendingUpdate = true
@@ -178,7 +178,7 @@ function useScrollBounds<ElementType extends HTMLElement>(
             }
 
             el.addEventListener("scroll", onScrollThrottled)
-            return () => {
+            return (): void => {
                 el.removeEventListener("scroll", onScrollThrottled)
             }
         }
@@ -199,7 +199,7 @@ interface ScrollLockOptions {
 function useScrollLock<ElementType extends HTMLElement>(
     ref: React.RefObject<ElementType>,
     opts?: Partial<ScrollLockOptions>
-) {
+): void {
     useEffect(() => {
         const el = ref.current
         const options: ScrollLockOptions = {
@@ -207,7 +207,7 @@ function useScrollLock<ElementType extends HTMLElement>(
             ...opts,
         }
         if (el) {
-            function onWheel(ev: MouseWheelEvent) {
+            function onWheel(ev: MouseWheelEvent): void {
                 const el = ref.current
                 if (el) {
                     const delta = ev.deltaY
@@ -221,7 +221,7 @@ function useScrollLock<ElementType extends HTMLElement>(
                         return
                     }
 
-                    function prevent() {
+                    function prevent(): void {
                         ev.stopPropagation()
                         ev.preventDefault()
                     }
@@ -244,7 +244,7 @@ function useScrollLock<ElementType extends HTMLElement>(
                 // We need to be in non-passive mode to be able to cancel the event
                 passive: false,
             })
-            return () => {
+            return (): void => {
                 if (el) {
                     el.removeEventListener("mousewheel", onWheel as any)
                 }

--- a/grapher/controls/entityPicker/EntityPicker.stories.tsx
+++ b/grapher/controls/entityPicker/EntityPicker.stories.tsx
@@ -15,7 +15,7 @@ import { computed, observable } from "mobx"
 import { SelectionArray } from "../../selection/SelectionArray"
 
 class PickerHolder extends React.Component {
-    render() {
+    render(): JSX.Element {
         return (
             <div
                 style={{
@@ -50,7 +50,7 @@ class SomeThingWithAPicker
     @observable entityPickerMetric?: ColumnSlug
     @observable entityPickerSort?: SortOrder
 
-    @computed get pickerColumnSlugs() {
+    @computed get pickerColumnSlugs(): string[] | undefined {
         return this.props.pickerSlugs
     }
 
@@ -61,7 +61,7 @@ class SomeThingWithAPicker
 
     requiredColumnSlugs = defaultSlugs
 
-    render() {
+    render(): JSX.Element {
         return (
             <PickerHolder>
                 <EntityPicker manager={this} />
@@ -75,7 +75,7 @@ export default {
     component: EntityPicker,
 }
 
-export const Empty = () => (
+export const Empty = (): JSX.Element => (
     <PickerHolder>
         <EntityPicker
             manager={{
@@ -85,13 +85,13 @@ export const Empty = () => (
     </PickerHolder>
 )
 
-export const WithChoices = () => <SomeThingWithAPicker />
+export const WithChoices = (): JSX.Element => <SomeThingWithAPicker />
 
-export const WithPickerMetricsChoices = () => (
+export const WithPickerMetricsChoices = (): JSX.Element => (
     <SomeThingWithAPicker pickerSlugs={defaultSlugs} />
 )
 
-export const WithExistingSelectionChoices = () => (
+export const WithExistingSelectionChoices = (): JSX.Element => (
     <SomeThingWithAPicker
         pickerSlugs={defaultSlugs}
         selection={["Japan", "Samoa"]}

--- a/grapher/controls/globalEntitySelector/GlobalEntitySelector.stories.tsx
+++ b/grapher/controls/globalEntitySelector/GlobalEntitySelector.stories.tsx
@@ -7,6 +7,6 @@ export default {
     component: GlobalEntitySelector,
 }
 
-export const WithNoGraphers = () => (
+export const WithNoGraphers = (): JSX.Element => (
     <GlobalEntitySelector selection={new SelectionArray()} />
 )

--- a/grapher/controls/globalEntitySelector/GlobalEntitySelector.tsx
+++ b/grapher/controls/globalEntitySelector/GlobalEntitySelector.tsx
@@ -47,7 +47,7 @@ const allEntities = sortBy(countries, (c) => c.name)
         },
     ])
 
-const Option = (props: any) => {
+const Option = (props: any): JSX.Element => {
     return (
         <div>
             <components.Option {...props}>
@@ -73,14 +73,14 @@ const SelectOptions: Props = {
     hideSelectedOptions: false,
     placeholder: "Add a country to all charts...",
     styles: {
-        placeholder: (base: any) => ({ ...base, whiteSpace: "nowrap" }),
-        valueContainer: (base: any) => ({
+        placeholder: (base: any): any => ({ ...base, whiteSpace: "nowrap" }),
+        valueContainer: (base: any): any => ({
             ...base,
             paddingTop: 0,
             paddingBottom: 0,
         }),
-        control: (base: any) => ({ ...base, minHeight: "initial" }),
-        dropdownIndicator: (base: any) => ({ ...base, padding: "0 5px" }),
+        control: (base: any): any => ({ ...base, minHeight: "initial" }),
+        dropdownIndicator: (base: any): any => ({ ...base, padding: "0 5px" }),
     },
 }
 
@@ -89,7 +89,7 @@ function SelectedItems(props: {
     emptyLabel: string
     canRemove?: boolean
     onRemove?: (item: EntityName) => void
-}) {
+}): JSX.Element {
     const canRemove = (props.canRemove ?? true) && props.onRemove !== undefined
     const onRemove = props.onRemove || noop
     const isEmpty = props.selectedEntityNames.length === 0
@@ -110,7 +110,7 @@ function SelectedItems(props: {
                             {canRemove && (
                                 <div
                                     className="remove-icon"
-                                    onClick={() => onRemove(entityName)}
+                                    onClick={(): void => onRemove(entityName)}
                                 >
                                     <FontAwesomeIcon icon={faTimes} />
                                 </div>
@@ -142,7 +142,7 @@ export class GlobalEntitySelector extends React.Component<{
 
     @observable.ref private optionGroups: GroupedOptionsType<any> = []
 
-    componentDidMount() {
+    componentDidMount(): void {
         this.onResize()
         window.addEventListener("resize", this.onResizeThrottled)
         this.disposers.push(
@@ -154,30 +154,30 @@ export class GlobalEntitySelector extends React.Component<{
         this.populateLocalEntity()
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         window.removeEventListener("resize", this.onResizeThrottled)
-        this.disposers.forEach((dispose) => dispose())
+        this.disposers.forEach((dispose): void => dispose())
     }
 
     private onResizeThrottled = throttle(this.onResize, 200)
-    @action.bound private onResize() {
+    @action.bound private onResize(): void {
         const container = this.refContainer.current
         if (container) this.isNarrow = container.offsetWidth <= 640
     }
 
-    @action.bound async populateLocalEntity() {
+    @action.bound async populateLocalEntity(): Promise<void> {
         try {
             const localCountryCode = await getCountryCodeFromNetlifyRedirect()
             if (!localCountryCode) return
 
             const country = allEntities.find(
-                (entity) => entity.code === localCountryCode
+                (entity): boolean => entity.code === localCountryCode
             )
             if (country) this.localEntityName = country.name
         } catch (err) {}
     }
 
-    @action.bound private prepareOptionGroups() {
+    @action.bound private prepareOptionGroups(): GroupedOptionsType<any> {
         let optionGroups: GroupedOptionsType<any> = []
         // We want to include the local country, but not if it's already selected, it adds
         // unnecessary duplication.
@@ -218,7 +218,7 @@ export class GlobalEntitySelector extends React.Component<{
         this.props.environment ?? "development"
     )
 
-    @action.bound private updateURL() {
+    @action.bound private updateURL(): void {
         setWindowUrl(
             setSelectedEntityNamesParam(
                 getWindowUrl(),
@@ -227,13 +227,13 @@ export class GlobalEntitySelector extends React.Component<{
         )
     }
 
-    @action.bound updateSelection(newSelectedEntities: string[]) {
+    @action.bound updateSelection(newSelectedEntities: string[]): void {
         this.selection.setSelectedEntities(newSelectedEntities)
         this.updateAllGraphersAndExplorersOnPage()
         this.updateURL()
     }
 
-    @action.bound private onChange(options: ValueType<any>) {
+    @action.bound private onChange(options: ValueType<any>): void {
         this.updateSelection(options.map((option: any) => option.label))
 
         this.analytics.logGlobalEntitySelector(
@@ -242,7 +242,7 @@ export class GlobalEntitySelector extends React.Component<{
         )
     }
 
-    @action.bound private updateAllGraphersAndExplorersOnPage() {
+    @action.bound private updateAllGraphersAndExplorersOnPage(): void {
         if (!this.props.graphersAndExplorersToUpdate) return
         Array.from(this.props.graphersAndExplorersToUpdate.values()).forEach(
             (value) => {
@@ -251,23 +251,23 @@ export class GlobalEntitySelector extends React.Component<{
         )
     }
 
-    @action.bound private onRemove(option: EntityName) {
+    @action.bound private onRemove(option: EntityName): void {
         this.selection.toggleSelection(option)
         this.updateAllGraphersAndExplorersOnPage()
         this.updateURL()
     }
 
-    @action.bound private onMenuOpen() {
+    @action.bound private onMenuOpen(): void {
         this.isOpen = true
     }
 
-    @action.bound private onMenuClose() {
+    @action.bound private onMenuClose(): void {
         this.isOpen = false
     }
 
     @action.bound private onButtonOpen(
         event: React.MouseEvent<HTMLButtonElement>
-    ) {
+    ): void {
         this.analytics.logGlobalEntitySelector(
             "open",
             event.currentTarget.innerText
@@ -277,7 +277,7 @@ export class GlobalEntitySelector extends React.Component<{
 
     @action.bound private onButtonClose(
         event: React.MouseEvent<HTMLButtonElement>
-    ) {
+    ): void {
         this.analytics.logGlobalEntitySelector(
             "close",
             event.currentTarget.innerText
@@ -285,11 +285,14 @@ export class GlobalEntitySelector extends React.Component<{
         this.onMenuClose()
     }
 
-    @computed private get selectedOptions() {
+    @computed private get selectedOptions(): {
+        label: string
+        value: string
+    }[] {
         return this.selection.selectedEntityNames.map(entityNameToOption)
     }
 
-    private renderNarrow() {
+    private renderNarrow(): JSX.Element {
         return (
             <>
                 <div
@@ -346,7 +349,7 @@ export class GlobalEntitySelector extends React.Component<{
         )
     }
 
-    private renderWide() {
+    private renderWide(): JSX.Element {
         return (
             <>
                 <div className="select-dropdown-container">
@@ -368,7 +371,7 @@ export class GlobalEntitySelector extends React.Component<{
         )
     }
 
-    render() {
+    render(): JSX.Element {
         return (
             <div
                 className={classnames("global-entity-control", {
@@ -389,7 +392,7 @@ export class GlobalEntitySelector extends React.Component<{
 export const hydrateGlobalEntitySelectorIfAny = (
     selection: SelectionArray,
     graphersAndExplorersToUpdate: Set<SelectionArray>
-) => {
+): void => {
     const element = document.querySelector(GLOBAL_ENTITY_SELECTOR_ELEMENT)
     if (!element) return
 
@@ -402,7 +405,9 @@ export const hydrateGlobalEntitySelectorIfAny = (
     )
 }
 
-const entityNameToOption = (label: EntityName) => ({
+const entityNameToOption = (
+    label: EntityName
+): { label: string; value: string } => ({
     label,
     value: label,
 })

--- a/grapher/core/.eslintrc.yaml
+++ b/grapher/core/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/core/EntityUrlBuilder.ts
+++ b/grapher/core/EntityUrlBuilder.ts
@@ -31,7 +31,7 @@ import {
 const V1_DELIMITER = "+"
 export const ENTITY_V2_DELIMITER = "~"
 
-const isV1Param = (encodedQueryParam: string) => {
+const isV1Param = (encodedQueryParam: string): boolean => {
     // No legacy entities have a v2Delimiter in their name,
     // so if a v2Delimiter is present we know it's a v2 link.
     return !decodeURIComponent(encodedQueryParam).includes(ENTITY_V2_DELIMITER)
@@ -157,7 +157,7 @@ export const getSelectedEntityNamesParam = (
 export const setSelectedEntityNamesParam = (
     url: Url,
     entityNames: EntityName[] | undefined
-) => {
+): Url => {
     return migrateSelectedEntityNamesParam(url).updateQueryParams({
         country: entityNames
             ? entityNamesToV2Param(entityNames.map(entityNameToCode))

--- a/grapher/core/Grapher.jsdom.test.ts
+++ b/grapher/core/Grapher.jsdom.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./GrapherConstants"
 import {
     GrapherInterface,
+    GrapherQueryParams,
     LegacyGrapherQueryParams,
 } from "../core/GrapherInterface"
 import {
@@ -30,7 +31,15 @@ import { MapConfig } from "../mapCharts/MapConfig"
 import { ColumnTypeNames } from "../../coreTable/CoreColumnDef"
 import { SelectionArray } from "../selection/SelectionArray"
 
-const TestGrapherConfig = () => {
+const TestGrapherConfig = (): {
+    table: OwidTable
+    selection: any[]
+    dimensions: {
+        slug: SampleColumnSlugs
+        property: DimensionProperty
+        variableId: any
+    }[]
+} => {
     const table = SynthesizeGDPTable({ entityCount: 10 })
     return {
         table,
@@ -200,7 +209,7 @@ describe("hasTimeline", () => {
     })
 })
 
-const getGrapher = () =>
+const getGrapher = (): Grapher =>
     new Grapher({
         dimensions: [
             {
@@ -230,7 +239,7 @@ const getGrapher = () =>
 function fromQueryParams(
     params: LegacyGrapherQueryParams,
     props?: Partial<GrapherInterface>
-) {
+): Grapher {
     const grapher = new Grapher(props)
     grapher.populateFromQueryParams(
         legacyToCurrentGrapherQueryParams(queryParamsToStr(params))
@@ -238,7 +247,9 @@ function fromQueryParams(
     return grapher
 }
 
-function toQueryParams(props?: Partial<GrapherInterface>) {
+function toQueryParams(
+    props?: Partial<GrapherInterface>
+): Partial<GrapherQueryParams> {
     const grapher = new Grapher({
         minTime: -5000,
         maxTime: 5000,

--- a/grapher/core/Grapher.stories.tsx
+++ b/grapher/core/Grapher.stories.tsx
@@ -45,9 +45,9 @@ const basics: GrapherProgrammaticInterface = {
     ],
 }
 
-export const Line = () => <Grapher {...basics} />
+export const Line = (): JSX.Element => <Grapher {...basics} />
 
-export const SlopeChart = () => {
+export const SlopeChart = (): JSX.Element => {
     const model = {
         type: ChartTypeName.SlopeChart,
         ...basics,
@@ -55,7 +55,7 @@ export const SlopeChart = () => {
     return <Grapher {...model} />
 }
 
-export const ScatterPlot = () => {
+export const ScatterPlot = (): JSX.Element => {
     const model = {
         type: ChartTypeName.ScatterPlot,
         ...basics,
@@ -63,7 +63,7 @@ export const ScatterPlot = () => {
     return <Grapher {...model} />
 }
 
-export const DiscreteBar = () => {
+export const DiscreteBar = (): JSX.Element => {
     const model = {
         type: ChartTypeName.DiscreteBar,
         ...basics,
@@ -71,7 +71,7 @@ export const DiscreteBar = () => {
     return <Grapher {...model} />
 }
 
-export const StackedBar = () => {
+export const StackedBar = (): JSX.Element => {
     const model = {
         type: ChartTypeName.StackedBar,
         ...basics,
@@ -79,7 +79,7 @@ export const StackedBar = () => {
     return <Grapher {...model} />
 }
 
-export const StackedArea = () => {
+export const StackedArea = (): JSX.Element => {
     const model = {
         type: ChartTypeName.StackedArea,
         ...basics,
@@ -87,7 +87,7 @@ export const StackedArea = () => {
     return <Grapher {...model} />
 }
 
-export const MapFirst = () => {
+export const MapFirst = (): JSX.Element => {
     const model = {
         ...basics,
         tab: GrapherTabOption.map,
@@ -95,7 +95,7 @@ export const MapFirst = () => {
     return <Grapher {...model} />
 }
 
-export const BlankGrapher = () => {
+export const BlankGrapher = (): JSX.Element => {
     const model = {
         type: ChartTypeName.WorldMap,
         tab: GrapherTabOption.map,
@@ -105,7 +105,7 @@ export const BlankGrapher = () => {
     return <Grapher {...model} />
 }
 
-export const NoMap = () => {
+export const NoMap = (): JSX.Element => {
     const model = {
         ...basics,
         hasMapTab: false,
@@ -113,7 +113,7 @@ export const NoMap = () => {
     return <Grapher {...model} />
 }
 
-export const Faceting = () => {
+export const Faceting = (): JSX.Element => {
     const model = {
         type: ChartTypeName.StackedArea,
         facet: FacetStrategy.country,
@@ -122,7 +122,7 @@ export const Faceting = () => {
     return <Grapher {...model} />
 }
 
-export const WithAuthorTimeFilter = () => {
+export const WithAuthorTimeFilter = (): JSX.Element => {
     const model: GrapherProgrammaticInterface = {
         ...basics,
         timelineMinTime: 1993,
@@ -133,7 +133,7 @@ export const WithAuthorTimeFilter = () => {
 
 @observer
 class PerfGrapher extends React.Component {
-    @action.bound loadBigTable() {
+    @action.bound loadBigTable(): void {
         this.table = SynthesizeGDPTable({
             entityCount: 200,
             timeRange: [1500, 2000],
@@ -142,13 +142,13 @@ class PerfGrapher extends React.Component {
 
     @observable.ref table = basics.table!
 
-    @action.bound private changeChartType(type: ChartTypeName) {
+    @action.bound private changeChartType(type: ChartTypeName): void {
         this.chartTypeName = type
     }
 
     @observable chartTypeName = ChartTypeName.LineChart
 
-    render() {
+    render(): JSX.Element {
         const key = Math.random() // I do this hack to force a rerender until can re-add the grapher model/grapher view that we used to have. @breck 10/29/2020
         return (
             <div>
@@ -169,4 +169,4 @@ class PerfGrapher extends React.Component {
     }
 }
 
-export const Perf = () => <PerfGrapher />
+export const Perf = (): JSX.Element => <PerfGrapher />

--- a/grapher/core/GrapherAnalytics.ts
+++ b/grapher/core/GrapherAnalytics.ts
@@ -2,7 +2,7 @@ import { findDOMParent } from "../../clientUtils/Util"
 
 const DEBUG = false
 
-declare var window: any
+declare let window: any
 
 // Docs on GA's event interface: https://developers.google.com/analytics/devguides/collection/analyticsjs/events
 interface GAEvent {
@@ -46,12 +46,12 @@ export class GrapherAnalytics {
     private version: string // Ideally the Git hash commit
     private isDev: boolean
 
-    logGrapherViewError(error: any, info: any) {
+    logGrapherViewError(error: any, info: any): void {
         this.logToAmplitude(EventNames.grapherViewError, { error, info })
         this.logToGA(Categories.GrapherError, EventNames.grapherViewError)
     }
 
-    logEntitiesNotFoundError(entities: string[]) {
+    logEntitiesNotFoundError(entities: string[]): void {
         this.logToAmplitude(EventNames.entitiesNotFound, { entities })
         this.logToGA(
             Categories.GrapherError,
@@ -60,11 +60,11 @@ export class GrapherAnalytics {
         )
     }
 
-    logGrapherTimelinePlay(slug?: string) {
+    logGrapherTimelinePlay(slug?: string): void {
         this.logToGA(Categories.GrapherUsage, EventNames.timelinePlay, slug)
     }
 
-    logGlobalEntitySelector(action: entityControlEvent, note?: string) {
+    logGlobalEntitySelector(action: entityControlEvent, note?: string): void {
         this.logToGA(Categories.GlobalEntitySelectorUsage, action, note)
     }
 
@@ -72,19 +72,19 @@ export class GrapherAnalytics {
         pickerSlug: string,
         action: countrySelectorEvent,
         note?: string
-    ) {
+    ): void {
         this.logToGA(`${pickerSlug}ExplorerCountrySelectorUsage`, action, note)
     }
 
-    logSiteClick(action: string = "unknown-action", label: string) {
+    logSiteClick(action: string = "unknown-action", label: string): void {
         this.logToGA(Categories.SiteClick, action, label)
     }
 
-    logKeyboardShortcut(shortcut: string, combo: string) {
+    logKeyboardShortcut(shortcut: string, combo: string): void {
         this.logToGA(Categories.KeyboardShortcut, shortcut, combo)
     }
 
-    startClickTracking() {
+    startClickTracking(): void {
         // Todo: add a Story and tests for this OR even better remove and use Google Tag Manager or similar fully SAAS tracking.
         // Todo: have different Attributes for Grapher charts vs Site.
         const dataTrackAttr = "data-track-note"
@@ -107,7 +107,7 @@ export class GrapherAnalytics {
         })
     }
 
-    protected logToAmplitude(name: string, props?: any) {
+    protected logToAmplitude(name: string, props?: any): void {
         const allProps = {
             context: {
                 siteVersion: this.version,
@@ -133,7 +133,7 @@ export class GrapherAnalytics {
         eventAction: string,
         eventLabel?: string,
         eventValue?: number
-    ) {
+    ): void {
         // Todo: send the Grapher (or site) version to Git
         const event: GAEvent = {
             hitType: "event",

--- a/grapher/core/GrapherUrlMigrations.ts
+++ b/grapher/core/GrapherUrlMigrations.ts
@@ -7,7 +7,7 @@ import {
 import { migrateSelectedEntityNamesParam } from "./EntityUrlBuilder"
 
 export const grapherUrlMigrations: UrlMigration[] = [
-    (url) => {
+    (url): Url => {
         const { year, time } = url.queryParams
         if (!year) return url
         return url.updateQueryParams({
@@ -18,7 +18,7 @@ export const grapherUrlMigrations: UrlMigration[] = [
     migrateSelectedEntityNamesParam,
 ]
 
-export const legacyToCurrentGrapherUrl = (url: Url) =>
+export const legacyToCurrentGrapherUrl = (url: Url): Url =>
     performUrlMigrations(grapherUrlMigrations, url)
 
 export const legacyToCurrentGrapherQueryParams = (

--- a/grapher/core/LegacyToOwidTable.ts
+++ b/grapher/core/LegacyToOwidTable.ts
@@ -212,7 +212,7 @@ export const legacyToOwidTableAndDimensions = (
     return { dimensions: newDimensions, table: joinedVariablesTable }
 }
 
-const fullJoinTables = (tables: OwidTable[]) =>
+const fullJoinTables = (tables: OwidTable[]): OwidTable =>
     tables.reduce((joinedTable, table) => joinedTable.fullJoin(table))
 
 const columnDefFromLegacyVariable = (
@@ -282,7 +282,7 @@ const timeColumnValuesFromLegacyVariable = (
         : yearsRaw
 }
 
-const convertLegacyYears = (years: number[], zeroDay: string) => {
+const convertLegacyYears = (years: number[], zeroDay: string): number[] => {
     // Only shift years if the variable zeroDay is different from EPOCH_DATE
     // When the dataset uses days (`yearIsDay == true`), the days are expressed as integer
     // days since the specified `zeroDay`, which can be different for different variables.
@@ -310,7 +310,7 @@ const annotationMapAndDefFromLegacyVariable = (
     return []
 }
 
-const annotationsToMap = (annotations: string) => {
+const annotationsToMap = (annotations: string): Map<string, string> => {
     // Todo: let's delete this and switch to traditional columns
     const entityAnnotationsMap = new Map<string, string>()
     const delimiter = ":"

--- a/grapher/core/LegacyVariableCode.ts
+++ b/grapher/core/LegacyVariableCode.ts
@@ -7,7 +7,7 @@ import {
     objectWithPersistablesToObject,
     deleteRuntimeAndUnchangedProps,
 } from "../persistable/Persistable"
-import { ColumnSlug, Integer, Time } from "../../coreTable/CoreTableConstants"
+import { ColumnSlug, Time } from "../../coreTable/CoreTableConstants"
 import { DimensionProperty } from "../core/GrapherConstants"
 import { OwidSource } from "../../coreTable/OwidSource"
 import {
@@ -43,11 +43,13 @@ class LegacyVariableDisplayConfigDefaults {
 export class LegacyVariableDisplayConfig
     extends LegacyVariableDisplayConfigDefaults
     implements Persistable {
-    updateFromObject(obj?: Partial<LegacyVariableDisplayConfigInterface>) {
+    updateFromObject(
+        obj?: Partial<LegacyVariableDisplayConfigInterface>
+    ): void {
         if (obj) updatePersistables(this, obj)
     }
 
-    toObject() {
+    toObject(): LegacyVariableDisplayConfigDefaults {
         return deleteRuntimeAndUnchangedProps(
             objectWithPersistablesToObject(this),
             new LegacyVariableDisplayConfigDefaults()

--- a/grapher/dataTable/.eslintrc.yaml
+++ b/grapher/dataTable/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/dataTable/DataTable.sample.ts
+++ b/grapher/dataTable/DataTable.sample.ts
@@ -2,7 +2,9 @@ import { Grapher } from "../core/Grapher"
 import { DimensionProperty, GrapherTabOption } from "../core/GrapherConstants"
 import { GrapherInterface } from "../core/GrapherInterface"
 
-export const childMortalityGrapher = (props: Partial<GrapherInterface> = {}) =>
+export const childMortalityGrapher = (
+    props: Partial<GrapherInterface> = {}
+): Grapher =>
     new Grapher({
         hasMapTab: true,
         tab: GrapherTabOption.map,
@@ -35,7 +37,9 @@ export const childMortalityGrapher = (props: Partial<GrapherInterface> = {}) =>
         },
     })
 
-export const IncompleteDataTable = (props: Partial<GrapherInterface> = {}) =>
+export const IncompleteDataTable = (
+    props: Partial<GrapherInterface> = {}
+): Grapher =>
     new Grapher({
         tab: GrapherTabOption.table,
         dimensions: [

--- a/grapher/dataTable/DataTable.stories.tsx
+++ b/grapher/dataTable/DataTable.stories.tsx
@@ -14,14 +14,14 @@ const table = SynthesizeGDPTable({
     entityCount: 7,
 })
 
-export const Default = () => {
+export const Default = (): JSX.Element => {
     const manager: DataTableManager = {
         table,
     }
     return <DataTable manager={manager} />
 }
 
-export const WithTimeRange = () => {
+export const WithTimeRange = (): JSX.Element => {
     const manager: DataTableManager = {
         table,
     }
@@ -30,7 +30,7 @@ export const WithTimeRange = () => {
     return <DataTable manager={manager} />
 }
 
-export const WithTolerance = () => {
+export const WithTolerance = (): JSX.Element => {
     const table = SynthesizeGDPTable(
         {
             timeRange: [2010, 2020],
@@ -68,12 +68,12 @@ export const WithTolerance = () => {
     )
 }
 
-export const FromLegacy = () => {
+export const FromLegacy = (): JSX.Element => {
     const grapher = childMortalityGrapher()
     return <DataTable manager={grapher} />
 }
 
-export const FromLegacyWithTimeRange = () => {
+export const FromLegacyWithTimeRange = (): JSX.Element => {
     const grapher = childMortalityGrapher({
         type: ChartTypeName.LineChart,
         tab: GrapherTabOption.chart,
@@ -83,7 +83,7 @@ export const FromLegacyWithTimeRange = () => {
     return <DataTable manager={grapher} />
 }
 
-export const IncompleteDataTableComponent = () => {
+export const IncompleteDataTableComponent = (): JSX.Element => {
     const grapher = IncompleteDataTable()
     grapher.timelineHandleTimeBounds = [2000, 2000]
     return <DataTable manager={grapher} />

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -26,6 +26,7 @@ import { BlankOwidTable, OwidTable } from "../../coreTable/OwidTable"
 import { CoreColumn } from "../../coreTable/CoreTableColumns"
 import { Bounds, DEFAULT_BOUNDS } from "../../clientUtils/Bounds"
 import { makeSelectionArray } from "../chart/ChartUtils"
+import { SelectionArray } from "../selection/SelectionArray"
 
 interface DataTableState {
     sort: DataTableSortState
@@ -55,7 +56,7 @@ const columnNameByType: Record<ColumnKey, string> = {
     deltaRatio: "Relative Change",
 }
 
-const inverseSortOrder = (order: SortOrder) =>
+const inverseSortOrder = (order: SortOrder): SortOrder =>
     order === SortOrder.asc ? SortOrder.desc : SortOrder.asc
 
 export interface DataTableManager {
@@ -107,29 +108,30 @@ export class DataTable extends React.Component<{
         }
     }
 
-    @computed get table() {
+    @computed get table(): OwidTable {
         return this.inputTable
     }
 
-    @computed get inputTable() {
+    @computed get inputTable(): OwidTable {
         return this.manager.table
     }
 
-    @computed get manager() {
+    @computed get manager(): DataTableManager {
         return this.props.manager || { table: BlankOwidTable() }
     }
 
-    @computed private get entityType() {
+    @computed private get entityType(): string {
         return this.table.entityType
     }
 
     @computed private get sortValueMapper(): (
         row: DataTableRow
-    ) => number | string | undefined {
+    ) => number | string {
         const { dimIndex, columnKey, order } = this.tableState.sort
-        if (dimIndex === ENTITY_DIM_INDEX) return (row) => row.entityName
+        if (dimIndex === ENTITY_DIM_INDEX)
+            return (row): string => row.entityName
 
-        return (row) => {
+        return (row): string | number => {
             const dv = row.dimensionValues[dimIndex] as DimensionValue
 
             let value: number | string | undefined
@@ -155,7 +157,7 @@ export class DataTable extends React.Component<{
         }
     }
 
-    @computed private get hasSubheaders() {
+    @computed private get hasSubheaders(): boolean {
         return this.displayDimensions.some(
             (header) => header.columns.length > 1
         )
@@ -164,7 +166,7 @@ export class DataTable extends React.Component<{
     @action.bound private updateSort(
         dimIndex: DimensionIndex,
         columnKey?: ColumnKey
-    ) {
+    ): void {
         const { sort } = this.tableState
         const order =
             sort.dimIndex === dimIndex && sort.columnKey === columnKey
@@ -178,7 +180,7 @@ export class DataTable extends React.Component<{
         this.storedState.sort.order = order
     }
 
-    private get entityHeader() {
+    private get entityHeader(): JSX.Element {
         const { sort } = this.tableState
         return (
             <ColumnHeader
@@ -186,7 +188,7 @@ export class DataTable extends React.Component<{
                 sortable={true}
                 sortedCol={sort.dimIndex === ENTITY_DIM_INDEX}
                 sortOrder={sort.order}
-                onClick={() => this.updateSort(ENTITY_DIM_INDEX)}
+                onClick={(): void => this.updateSort(ENTITY_DIM_INDEX)}
                 rowSpan={this.hasSubheaders ? 2 : 1}
                 headerText={capitalize(this.entityType)}
                 colType="entity"
@@ -195,7 +197,7 @@ export class DataTable extends React.Component<{
         )
     }
 
-    private get dimensionHeaders() {
+    private get dimensionHeaders(): JSX.Element[] {
         const { sort } = this.tableState
         return this.displayDimensions.map((dim, dimIndex) => {
             const actualColumn = dim.coreTableColumn
@@ -217,9 +219,11 @@ export class DataTable extends React.Component<{
                 sortable: dim.sortable,
                 sortedCol: dim.sortable && sort.dimIndex === dimIndex,
                 sortOrder: sort.order,
-                onClick: () =>
-                    dim.sortable &&
-                    this.updateSort(dimIndex, SingleValueKey.single),
+                onClick: (): void => {
+                    if (dim.sortable) {
+                        this.updateSort(dimIndex, SingleValueKey.single)
+                    }
+                },
                 rowSpan: this.hasSubheaders && dim.columns.length < 2 ? 2 : 1,
                 colSpan: dim.columns.length,
                 headerText: dimensionHeaderText,
@@ -231,7 +235,7 @@ export class DataTable extends React.Component<{
         })
     }
 
-    private get dimensionSubheaders() {
+    private get dimensionSubheaders(): JSX.Element[][] {
         const { sort } = this.tableState
         return this.displayDimensions.map((dim, dimIndex) =>
             dim.columns.map((column, i) => {
@@ -247,7 +251,9 @@ export class DataTable extends React.Component<{
                             sort.columnKey === column.key
                         }
                         sortOrder={sort.order}
-                        onClick={() => this.updateSort(dimIndex, column.key)}
+                        onClick={(): void =>
+                            this.updateSort(dimIndex, column.key)
+                        }
                         headerText={headerText}
                         colType="subdimension"
                         dataType="numeric"
@@ -259,7 +265,7 @@ export class DataTable extends React.Component<{
         )
     }
 
-    private get headerRow() {
+    private get headerRow(): JSX.Element {
         return (
             <React.Fragment>
                 <tr>
@@ -277,7 +283,7 @@ export class DataTable extends React.Component<{
         dv: DimensionValue | undefined,
         sorted: boolean,
         actualColumn: CoreColumn
-    ) {
+    ): JSX.Element {
         if (dv === undefined || !(column.key in dv))
             return <td key={key} className="dimension" />
 
@@ -319,7 +325,7 @@ export class DataTable extends React.Component<{
     private renderEntityRow(
         row: DataTableRow,
         dimensions: DataTableDimension[]
-    ) {
+    ): JSX.Element {
         const { sort } = this.tableState
         return (
             <tr key={row.entityName}>
@@ -350,17 +356,17 @@ export class DataTable extends React.Component<{
         )
     }
 
-    private get valueRows() {
+    private get valueRows(): JSX.Element[] {
         return this.sortedRows.map((row) =>
             this.renderEntityRow(row, this.displayDimensions)
         )
     }
 
-    @computed get bounds() {
+    @computed get bounds(): Bounds {
         return this.props.bounds ?? DEFAULT_BOUNDS
     }
 
-    render() {
+    render(): JSX.Element {
         return (
             <div
                 style={{
@@ -377,7 +383,7 @@ export class DataTable extends React.Component<{
         )
     }
 
-    @computed private get loadedWithData() {
+    @computed private get loadedWithData(): boolean {
         return this.columnsToShow.length > 0
     }
 
@@ -387,7 +393,7 @@ export class DataTable extends React.Component<{
      * If the user or the editor hasn't specified a start, auto-select a start time
      *  where AUTO_SELECTION_THRESHOLD_PERCENTAGE of the entities have values.
      */
-    @computed get autoSelectedStartTime() {
+    @computed get autoSelectedStartTime(): number | undefined {
         let autoSelectedStartTime: number | undefined = undefined
 
         if (
@@ -399,7 +405,7 @@ export class DataTable extends React.Component<{
 
         const numEntitiesInTable = this.entityNames.length
 
-        this.columnsToShow.forEach((column) => {
+        this.columnsToShow.forEach((column): boolean => {
             const numberOfEntitiesWithDataSortedByTime = sortBy(
                 Object.entries(countBy(column.uniqTimesAsc)),
                 (value) => parseInt(value[0])
@@ -427,7 +433,7 @@ export class DataTable extends React.Component<{
         return autoSelectedStartTime
     }
 
-    @computed private get columnsToShow() {
+    @computed private get columnsToShow(): CoreColumn[] {
         const slugs = this.manager.dataTableSlugs ?? []
         if (slugs.length)
             return slugs
@@ -447,11 +453,11 @@ export class DataTable extends React.Component<{
         )
     }
 
-    @computed private get selectionArray() {
+    @computed private get selectionArray(): SelectionArray {
         return makeSelectionArray(this.manager)
     }
 
-    @computed private get entityNames() {
+    @computed private get entityNames(): string[] {
         let tableForEntities = this.table
         if (this.manager.minPopulationFilter)
             tableForEntities = tableForEntities.filterByPopulationExcept(
@@ -465,7 +471,7 @@ export class DataTable extends React.Component<{
         )
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         exposeInstanceOnWindow(this, "dataTable")
     }
 
@@ -473,7 +479,7 @@ export class DataTable extends React.Component<{
         column: CoreColumn,
         value: number | string | undefined,
         formattingOverrides?: TickFormattingOptions
-    ) {
+    ): string | undefined {
         return value === undefined
             ? value
             : column.formatValueShort(value, {
@@ -483,7 +489,7 @@ export class DataTable extends React.Component<{
               })
     }
 
-    @computed get targetTimes() {
+    @computed get targetTimes(): number[] | undefined {
         const { startTime, endTime } = this.manager
         if (startTime === undefined || endTime === undefined) return undefined
 
@@ -651,7 +657,7 @@ export class DataTable extends React.Component<{
         }))
     }
 
-    @computed private get sortedRows() {
+    @computed private get sortedRows(): DataTableRow[] {
         const { order } = this.tableState.sort
         return orderBy(this.displayRows, this.sortValueMapper, [order])
     }
@@ -680,7 +686,7 @@ function ColumnHeader(props: {
     dataType: "text" | "numeric"
     subdimensionType?: ColumnKey
     lastSubdimension?: boolean
-}) {
+}): JSX.Element {
     const {
         sortable,
         sortedCol,
@@ -725,7 +731,10 @@ function ColumnHeader(props: {
     )
 }
 
-const makeClosestTimeNotice = (targetTime: string, closestTime: string) => (
+const makeClosestTimeNotice = (
+    targetTime: string,
+    closestTime: string
+): JSX.Element => (
     <Tippy
         content={
             <div className="closest-time-notice-tippy">
@@ -812,6 +821,6 @@ interface DataTableRow {
     dimensionValues: (DimensionValue | undefined)[] // TODO make it not undefined
 }
 
-function isDeltaColumn(columnKey?: ColumnKey) {
+function isDeltaColumn(columnKey?: ColumnKey): boolean {
     return columnKey === "delta" || columnKey === "deltaRatio"
 }

--- a/grapher/downloadTab/.eslintrc.yaml
+++ b/grapher/downloadTab/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/downloadTab/DownloadTab.stories.tsx
+++ b/grapher/downloadTab/DownloadTab.stories.tsx
@@ -6,7 +6,7 @@ export default {
     component: DownloadTab,
 }
 
-export const Default = () => {
+export const Default = (): JSX.Element => {
     return (
         <DownloadTab
             manager={{

--- a/grapher/facetChart/.eslintrc.yaml
+++ b/grapher/facetChart/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/facetChart/FacetChart.stories.tsx
+++ b/grapher/facetChart/FacetChart.stories.tsx
@@ -19,7 +19,7 @@ export default CSF
 
 const bounds = new Bounds(0, 0, 1000, 500)
 
-export const OneMetricOneCountryPerChart = () => {
+export const OneMetricOneCountryPerChart = (): JSX.Element => {
     const table = SynthesizeGDPTable({
         entityCount: 4,
     })
@@ -41,7 +41,7 @@ export const OneMetricOneCountryPerChart = () => {
     )
 }
 
-export const MultipleMetricsOneCountryPerChart = () => {
+export const MultipleMetricsOneCountryPerChart = (): JSX.Element => {
     const table = SynthesizeFruitTable({
         entityCount: 4,
     })
@@ -59,7 +59,7 @@ export const MultipleMetricsOneCountryPerChart = () => {
     )
 }
 
-export const OneChartPerMetric = () => {
+export const OneChartPerMetric = (): JSX.Element => {
     const table = SynthesizeGDPTable({
         entityCount: 2,
     })

--- a/grapher/facetChart/FacetChartUtils.tsx
+++ b/grapher/facetChart/FacetChartUtils.tsx
@@ -5,7 +5,7 @@ export const getFontSize = (
     count: number,
     baseFontSize = BASE_FONT_SIZE,
     min = 8
-) => {
+): number => {
     if (count === 2) return baseFontSize
     if (count < 5) return baseFontSize - 2
     if (count < 10) return baseFontSize - 4
@@ -14,7 +14,9 @@ export const getFontSize = (
     return min
 }
 
-export const getChartPadding = (count: number) => {
+export const getChartPadding = (
+    count: number
+): { rowPadding: number; columnPadding: number; outerPadding: number } => {
     if (count > 9) {
         return {
             rowPadding: 20,

--- a/grapher/footer/.eslintrc.yaml
+++ b/grapher/footer/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/footer/Footer.jsdom.test.tsx
+++ b/grapher/footer/Footer.jsdom.test.tsx
@@ -12,7 +12,7 @@ import { configure, mount } from "enzyme"
 import Adapter from "enzyme-adapter-react-16"
 configure({ adapter: new Adapter() })
 
-const TestGrapherConfig = () => {
+const TestGrapherConfig = (): GrapherProgrammaticInterface => {
     const table = SynthesizeGDPTable({ entityCount: 10 })
     return {
         table,

--- a/grapher/footer/Footer.stories.tsx
+++ b/grapher/footer/Footer.stories.tsx
@@ -13,4 +13,4 @@ const manager: FooterManager = {
     sourcesLine: "These are my sources",
 }
 
-export const Default = () => <Footer manager={manager} />
+export const Default = (): JSX.Element => <Footer manager={manager} />

--- a/grapher/footer/Footer.tsx
+++ b/grapher/footer/Footer.tsx
@@ -14,41 +14,41 @@ export class Footer extends React.Component<{
     manager: FooterManager
     maxWidth?: number
 }> {
-    @computed private get maxWidth() {
+    @computed private get maxWidth(): number {
         return this.props.maxWidth ?? DEFAULT_BOUNDS.width
     }
 
-    @computed private get manager() {
+    @computed private get manager(): FooterManager {
         return this.props.manager
     }
 
-    @computed private get sourcesText() {
+    @computed private get sourcesText(): string {
         const sourcesLine = this.manager.sourcesLine
         return sourcesLine ? `Source: ${sourcesLine}` : ""
     }
 
-    @computed private get noteText() {
+    @computed private get noteText(): string {
         return this.manager.note ? `Note: ${this.manager.note}` : ""
     }
 
-    @computed private get ccSvg() {
+    @computed private get ccSvg(): string {
         if (this.manager.hasOWIDLogo)
             return `<a style="fill: #777;" class="cclogo" href="http://creativecommons.org/licenses/by/4.0/deed.en_US" target="_blank">CC BY</a>`
 
         return `<a href="https://ourworldindata.org" target="_blank">Powered by ourworldindata.org</a>`
     }
 
-    @computed private get originUrlWithProtocol() {
+    @computed private get originUrlWithProtocol(): string {
         return this.manager.originUrlWithProtocol ?? "http://localhost"
     }
 
-    @computed private get finalUrl() {
+    @computed private get finalUrl(): string {
         const originUrl = this.originUrlWithProtocol
         const url = parseUrl(originUrl)
         return `https://${url.hostname}${url.pathname}`
     }
 
-    @computed private get finalUrlText() {
+    @computed private get finalUrlText(): string | undefined {
         const originUrl = this.originUrlWithProtocol
 
         // Make sure the link back to OWID is consistent
@@ -73,7 +73,7 @@ export class Footer extends React.Component<{
         return finalUrlText
     }
 
-    @computed private get licenseSvg() {
+    @computed private get licenseSvg(): string {
         const { finalUrl, finalUrlText, ccSvg } = this
         if (!finalUrlText) return ccSvg
 
@@ -87,11 +87,11 @@ export class Footer extends React.Component<{
         )
     }
 
-    @computed private get fontSize() {
+    @computed private get fontSize(): number {
         return 0.7 * (this.manager.fontSize ?? BASE_FONT_SIZE)
     }
 
-    @computed private get sources() {
+    @computed private get sources(): TextWrap {
         const { maxWidth, fontSize, sourcesText } = this
         return new TextWrap({
             maxWidth,
@@ -101,7 +101,7 @@ export class Footer extends React.Component<{
         })
     }
 
-    @computed private get note() {
+    @computed private get note(): TextWrap {
         const { maxWidth, fontSize, noteText } = this
         return new TextWrap({
             maxWidth,
@@ -111,7 +111,7 @@ export class Footer extends React.Component<{
         })
     }
 
-    @computed private get license() {
+    @computed private get license(): TextWrap {
         const { maxWidth, fontSize, licenseSvg } = this
         return new TextWrap({
             maxWidth: maxWidth * 3,
@@ -122,15 +122,15 @@ export class Footer extends React.Component<{
     }
 
     // Put the license stuff to the side if there's room
-    @computed private get isCompact() {
+    @computed private get isCompact(): boolean {
         return this.maxWidth - this.sources.width - 5 > this.license.width
     }
 
-    @computed private get paraMargin() {
+    @computed private get paraMargin(): number {
         return 2
     }
 
-    @computed get height() {
+    @computed get height(): number {
         if (this.manager.isMediaCard) return 0
 
         const { sources, note, license, isCompact, paraMargin } = this
@@ -141,11 +141,11 @@ export class Footer extends React.Component<{
         )
     }
 
-    @action.bound private onSourcesClick() {
+    @action.bound private onSourcesClick(): void {
         this.manager.currentTab = GrapherTabOption.sources
     }
 
-    renderStatic(targetX: number, targetY: number) {
+    renderStatic(targetX: number, targetY: number): JSX.Element | null {
         if (this.manager.isMediaCard) return null
 
         const { sources, note, license, maxWidth, isCompact, paraMargin } = this
@@ -175,7 +175,7 @@ export class Footer extends React.Component<{
     base: React.RefObject<HTMLDivElement> = React.createRef()
     @observable.ref tooltipTarget?: { x: number; y: number }
 
-    @action.bound private onMouseMove(e: MouseEvent) {
+    @action.bound private onMouseMove(e: MouseEvent): void {
         const cc = this.base.current!.querySelector(".cclogo")
         if (cc && cc.matches(":hover")) {
             const div = this.base.current as HTMLDivElement
@@ -184,15 +184,15 @@ export class Footer extends React.Component<{
         } else this.tooltipTarget = undefined
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         window.addEventListener("mousemove", this.onMouseMove)
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         window.removeEventListener("mousemove", this.onMouseMove)
     }
 
-    render() {
+    render(): JSX.Element {
         const { tooltipTarget } = this
 
         const license = (

--- a/grapher/header/.eslintrc.yaml
+++ b/grapher/header/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/header/Header.stories.tsx
+++ b/grapher/header/Header.stories.tsx
@@ -12,4 +12,4 @@ const manager: HeaderManager = {
     subtitle: "This is my chart subtitle",
 }
 
-export const Default = () => <Header manager={manager} />
+export const Default = (): JSX.Element => <Header manager={manager} />

--- a/grapher/header/Header.tsx
+++ b/grapher/header/Header.tsx
@@ -12,27 +12,27 @@ export class Header extends React.Component<{
     manager: HeaderManager
     maxWidth?: number
 }> {
-    @computed private get manager() {
+    @computed private get manager(): HeaderManager {
         return this.props.manager
     }
 
-    @computed private get fontSize() {
+    @computed private get fontSize(): number {
         return this.manager.fontSize ?? BASE_FONT_SIZE
     }
 
-    @computed private get maxWidth() {
+    @computed private get maxWidth(): number {
         return this.props.maxWidth ?? DEFAULT_BOUNDS.width
     }
 
-    @computed private get titleText() {
+    @computed private get titleText(): string {
         return this.manager.currentTitle ?? ""
     }
 
-    @computed private get subtitleText() {
+    @computed private get subtitleText(): string {
         return this.manager.subtitle ?? ""
     }
 
-    @computed get logo() {
+    @computed get logo(): Logo | undefined {
         const { manager } = this
         if (manager.hideLogo) return undefined
 
@@ -43,14 +43,14 @@ export class Header extends React.Component<{
         })
     }
 
-    @computed private get logoWidth() {
+    @computed private get logoWidth(): number {
         return this.logo ? this.logo.width : 0
     }
-    @computed private get logoHeight() {
+    @computed private get logoHeight(): number {
         return this.logo ? this.logo.height : 0
     }
 
-    @computed get title() {
+    @computed get title(): TextWrap {
         const { logoWidth } = this
         const maxWidth = this.maxWidth - logoWidth - 20
 
@@ -78,14 +78,14 @@ export class Header extends React.Component<{
 
     titleMarginBottom = 4
 
-    @computed get subtitleWidth() {
+    @computed get subtitleWidth(): number {
         // If the subtitle is entirely below the logo, we can go underneath it
         return this.title.height > this.logoHeight
             ? this.maxWidth
             : this.maxWidth - this.logoWidth - 10
     }
 
-    @computed get subtitle() {
+    @computed get subtitle(): TextWrap {
         return new TextWrap({
             maxWidth: this.subtitleWidth,
             fontSize: 0.8 * this.fontSize,
@@ -95,7 +95,7 @@ export class Header extends React.Component<{
         })
     }
 
-    @computed get height() {
+    @computed get height(): number {
         if (this.manager.isMediaCard) return 0
 
         return Math.max(
@@ -104,7 +104,7 @@ export class Header extends React.Component<{
         )
     }
 
-    renderStatic(x: number, y: number) {
+    renderStatic(x: number, y: number): JSX.Element | null {
         const { title, logo, subtitle, manager, maxWidth } = this
 
         if (manager.isMediaCard) return null
@@ -132,7 +132,7 @@ export class Header extends React.Component<{
         )
     }
 
-    render() {
+    render(): JSX.Element {
         const { manager } = this
 
         const titleStyle = {

--- a/grapher/lineCharts/.eslintrc.yaml
+++ b/grapher/lineCharts/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/lineCharts/LineChart.stories.tsx
+++ b/grapher/lineCharts/LineChart.stories.tsx
@@ -16,7 +16,7 @@ export default {
     component: LineChart,
 }
 
-export const SingleColumnMultiCountry = () => {
+export const SingleColumnMultiCountry = (): JSX.Element => {
     const table = SynthesizeGDPTable()
     const bounds = new Bounds(0, 0, 500, 250)
     return (
@@ -46,7 +46,7 @@ export const SingleColumnMultiCountry = () => {
     )
 }
 
-export const WithLogScaleAndNegativeAndZeroValues = () => {
+export const WithLogScaleAndNegativeAndZeroValues = (): JSX.Element => {
     const table = SynthesizeFruitTableWithNonPositives({
         entityCount: 2,
         timeRange: [1900, 2000],
@@ -76,7 +76,7 @@ export const WithLogScaleAndNegativeAndZeroValues = () => {
     )
 }
 
-export const WithoutCirclesOnPoints = () => {
+export const WithoutCirclesOnPoints = (): JSX.Element => {
     const table = SynthesizeGDPTable({
         entityCount: 6,
         timeRange: [1900, 2000],
@@ -96,7 +96,7 @@ export const WithoutCirclesOnPoints = () => {
     )
 }
 
-export const WithAnnotations = () => {
+export const WithAnnotations = (): JSX.Element => {
     let table = SynthesizeGDPTable({
         entityCount: 6,
         timeRange: [1900, 2000],
@@ -107,7 +107,7 @@ export const WithAnnotations = () => {
             slug: makeAnnotationsSlug(SampleColumnSlugs.GDP),
             values: table
                 .get(OwidTableSlugs.entityName)
-                .values.map((name) => `${name} is a country`),
+                .values.map((name): string => `${name} is a country`),
         },
     ])
     return (
@@ -125,7 +125,7 @@ export const WithAnnotations = () => {
     )
 }
 
-export const MultiColumnSingleCountry = () => {
+export const MultiColumnSingleCountry = (): JSX.Element => {
     const table = SynthesizeGDPTable()
     const bounds = new Bounds(0, 0, 500, 250)
     return (
@@ -150,7 +150,7 @@ export const MultiColumnSingleCountry = () => {
     )
 }
 
-export const MultiColumnMultiCountry = () => {
+export const MultiColumnMultiCountry = (): JSX.Element => {
     const table = SynthesizeFruitTable({ entityCount: 5 })
     const bounds = new Bounds(0, 0, 500, 250)
     return (

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -16,7 +16,7 @@ import { select } from "d3-selection"
 import { easeLinear } from "d3-ease"
 import { Bounds, DEFAULT_BOUNDS } from "../../clientUtils/Bounds"
 import { DualAxisComponent } from "../axis/AxisViews"
-import { DualAxis } from "../axis/Axis"
+import { DualAxis, HorizontalAxis, VerticalAxis } from "../axis/Axis"
 import { PointVector } from "../../clientUtils/PointVector"
 import {
     LineLegend,
@@ -40,6 +40,8 @@ import {
     LinesProps,
     LineChartSeries,
     LineChartManager,
+    LinePoint,
+    PlacedLineChartSeries,
 } from "./LineChartConstants"
 import { columnToLineChartSeriesArray } from "./LineChartUtils"
 import { OwidTable } from "../../coreTable/OwidTable"
@@ -52,6 +54,9 @@ import {
     makeSelectionArray,
 } from "../chart/ChartUtils"
 import { ColorScheme } from "../color/ColorScheme"
+import { SelectionArray } from "../selection/SelectionArray"
+import { CoreColumn } from "../../coreTable/CoreTableColumns"
+import { PrimitiveType } from "../../coreTable/CoreTableConstants"
 
 const BLUR_COLOR = "#eee"
 
@@ -59,11 +64,11 @@ const BLUR_COLOR = "#eee"
 class Lines extends React.Component<LinesProps> {
     base: React.RefObject<SVGGElement> = React.createRef()
 
-    @computed private get allValues() {
+    @computed private get allValues(): LinePoint[] {
         return flatten(this.props.placedSeries.map((series) => series.points))
     }
 
-    @action.bound private onCursorMove(ev: MouseEvent | TouchEvent) {
+    @action.bound private onCursorMove(ev: MouseEvent | TouchEvent): void {
         const { dualAxis } = this.props
         const { horizontalAxis } = dualAxis
 
@@ -80,11 +85,11 @@ class Lines extends React.Component<LinesProps> {
         this.props.onHover(hoverX)
     }
 
-    @action.bound private onCursorLeave() {
+    @action.bound private onCursorLeave(): void {
         this.props.onHover(undefined)
     }
 
-    @computed get bounds() {
+    @computed get bounds(): Bounds {
         const { horizontalAxis, verticalAxis } = this.props.dualAxis
         return Bounds.fromCorners(
             new PointVector(horizontalAxis.range[0], verticalAxis.range[0]),
@@ -92,7 +97,7 @@ class Lines extends React.Component<LinesProps> {
         )
     }
 
-    @computed private get focusedLines() {
+    @computed private get focusedLines(): PlacedLineChartSeries[] {
         const { focusedSeriesNames } = this.props
         // If nothing is focused, everything is
         if (!focusedSeriesNames.length) return this.props.placedSeries
@@ -101,7 +106,7 @@ class Lines extends React.Component<LinesProps> {
         )
     }
 
-    @computed private get backgroundLines() {
+    @computed private get backgroundLines(): PlacedLineChartSeries[] {
         const { focusedSeriesNames } = this.props
         return this.props.placedSeries.filter(
             (series) => !focusedSeriesNames.includes(series.seriesName)
@@ -110,7 +115,7 @@ class Lines extends React.Component<LinesProps> {
 
     // Don't display point markers if there are very many of them for performance reasons
     // Note that we're using circle elements instead of marker-mid because marker performance in Safari 10 is very poor for some reason
-    @computed private get hasMarkers() {
+    @computed private get hasMarkers(): boolean {
         if (this.props.hidePoints) return false
         return (
             sum(
@@ -121,11 +126,11 @@ class Lines extends React.Component<LinesProps> {
         )
     }
 
-    @computed private get strokeWidth() {
+    @computed private get strokeWidth(): number {
         return this.props.lineStrokeWidth ?? 1.5
     }
 
-    private renderFocusGroups() {
+    private renderFocusGroups(): JSX.Element[] {
         return this.focusedLines.map((series, index) => (
             <g key={index}>
                 <path
@@ -157,7 +162,7 @@ class Lines extends React.Component<LinesProps> {
         ))
     }
 
-    private renderBackgroundGroups() {
+    private renderBackgroundGroups(): JSX.Element[] {
         return this.backgroundLines.map((series, index) => (
             <g key={index}>
                 <path
@@ -178,7 +183,7 @@ class Lines extends React.Component<LinesProps> {
     }
 
     private container?: SVGElement
-    componentDidMount() {
+    componentDidMount(): void {
         const base = this.base.current as SVGGElement
         const container = base.closest("svg") as SVGElement
         container.addEventListener("mousemove", this.onCursorMove)
@@ -190,7 +195,7 @@ class Lines extends React.Component<LinesProps> {
         this.container = container
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         const { container } = this
         if (!container) return
 
@@ -202,7 +207,7 @@ class Lines extends React.Component<LinesProps> {
         container.removeEventListener("touchcancel", this.onCursorLeave)
     }
 
-    render() {
+    render(): JSX.Element {
         const { bounds } = this
 
         return (
@@ -231,7 +236,7 @@ export class LineChart
     implements ChartInterface, LineLegendManager {
     base: React.RefObject<SVGGElement> = React.createRef()
 
-    transformTable(table: OwidTable) {
+    transformTable(table: OwidTable): OwidTable {
         table = table.filterByEntityNames(
             this.selectionArray.selectedEntityNames
         )
@@ -247,18 +252,18 @@ export class LineChart
         return table
     }
 
-    @computed get inputTable() {
+    @computed get inputTable(): OwidTable {
         return this.manager.table
     }
 
-    @computed private get transformedTableFromGrapher() {
+    @computed private get transformedTableFromGrapher(): OwidTable {
         return (
             this.manager.transformedTable ??
             this.transformTable(this.inputTable)
         )
     }
 
-    @computed get transformedTable() {
+    @computed get transformedTable(): OwidTable {
         let table = this.transformedTableFromGrapher
         // The % growth transform cannot be applied in transformTable() because it will filter out
         // any rows before startHandleTimeBound and change the timeline bounds.
@@ -273,34 +278,34 @@ export class LineChart
     }
 
     @observable hoverX?: number
-    @action.bound onHover(hoverX: number | undefined) {
+    @action.bound onHover(hoverX: number | undefined): void {
         this.hoverX = hoverX
     }
 
-    @computed private get manager() {
+    @computed private get manager(): LineChartManager {
         return this.props.manager
     }
 
-    @computed get bounds() {
+    @computed get bounds(): Bounds {
         return this.props.bounds ?? DEFAULT_BOUNDS
     }
 
-    @computed get maxLegendWidth() {
+    @computed get maxLegendWidth(): number {
         return this.bounds.width / 3
     }
 
-    @computed get selectionArray() {
+    @computed get selectionArray(): SelectionArray {
         return makeSelectionArray(this.manager)
     }
 
-    seriesIsBlurred(series: LineChartSeries) {
+    seriesIsBlurred(series: LineChartSeries): boolean {
         return (
             this.isFocusMode &&
             !this.focusedSeriesNames.includes(series.seriesName)
         )
     }
 
-    @computed private get tooltip() {
+    @computed private get tooltip(): JSX.Element | undefined {
         const { hoverX, dualAxis, inputTable, formatColumn } = this
 
         if (hoverX === undefined) return undefined
@@ -434,24 +439,24 @@ export class LineChart
     defaultRightPadding = 1
 
     @observable hoveredSeriesName?: SeriesName
-    @action.bound onLegendClick() {
+    @action.bound onLegendClick(): void {
         if (this.manager.startSelectingWhenLineClicked)
             this.manager.isSelectingData = true
     }
 
-    @action.bound onLegendMouseOver(seriesName: SeriesName) {
+    @action.bound onLegendMouseOver(seriesName: SeriesName): void {
         this.hoveredSeriesName = seriesName
     }
 
-    @action.bound onLegendMouseLeave() {
+    @action.bound onLegendMouseLeave(): void {
         this.hoveredSeriesName = undefined
     }
 
-    @computed get focusedSeriesNames() {
+    @computed get focusedSeriesNames(): string[] {
         return this.hoveredSeriesName ? [this.hoveredSeriesName] : []
     }
 
-    @computed get isFocusMode() {
+    @computed get isFocusMode(): boolean {
         return this.focusedSeriesNames.length > 0
     }
 
@@ -461,12 +466,12 @@ export class LineChart
         SVGGElement | null,
         unknown
     >
-    componentDidMount() {
+    componentDidMount(): void {
         if (!this.manager.isExportingtoSvgOrPng) this.runFancyIntroAnimation()
         exposeInstanceOnWindow(this)
     }
 
-    private runFancyIntroAnimation() {
+    private runFancyIntroAnimation(): void {
         this.animSelection = select(this.base.current)
             .selectAll("clipPath > rect")
             .attr("width", 0)
@@ -478,15 +483,15 @@ export class LineChart
             .on("end", () => this.forceUpdate()) // Important in case bounds changes during transition
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         if (this.animSelection) this.animSelection.interrupt()
     }
 
-    @computed get renderUid() {
+    @computed get renderUid(): number {
         return guid()
     }
 
-    @computed get fontSize() {
+    @computed get fontSize(): number {
         return this.manager.baseFontSize ?? BASE_FONT_SIZE
     }
 
@@ -494,13 +499,13 @@ export class LineChart
         return this.bounds.right - (this.legendDimensions?.width || 0)
     }
 
-    @computed private get legendDimensions() {
+    @computed private get legendDimensions(): LineLegend | undefined {
         return this.manager.hideLegend
             ? undefined
             : new LineLegend({ manager: this })
     }
 
-    render() {
+    render(): JSX.Element {
         if (this.failMessage)
             return (
                 <NoDataModal
@@ -578,33 +583,36 @@ export class LineChart
         )
     }
 
-    @computed get failMessage() {
+    @computed get failMessage(): string {
         const message = getDefaultFailMessage(this.manager)
         if (message) return message
         if (!this.series.length) return "No matching data"
         return ""
     }
 
-    @computed private get yColumns() {
+    @computed private get yColumns(): CoreColumn[] {
         return this.yColumnSlugs.map((slug) => this.transformedTable.get(slug))
     }
 
-    @computed protected get yColumnSlugs() {
+    @computed protected get yColumnSlugs(): string[] {
         return autoDetectYColumnSlugs(this.manager)
     }
 
-    @computed private get formatColumn() {
+    @computed private get formatColumn(): CoreColumn {
         return this.yColumns[0]
     }
 
     // todo: for now just works with 1 y column
-    @computed private get annotationsMap() {
+    @computed private get annotationsMap(): Map<
+        PrimitiveType,
+        Set<PrimitiveType>
+    > {
         return this.inputTable
             .getAnnotationColumnForColumn(this.yColumnSlugs[0])
             ?.getUniqueValuesGroupedBy(this.inputTable.entityNameSlug)
     }
 
-    getAnnotationsForSeries(seriesName: SeriesName) {
+    getAnnotationsForSeries(seriesName: SeriesName): string | undefined {
         const annotationsMap = this.annotationsMap
         const annos = annotationsMap?.get(seriesName)
         return annos
@@ -632,7 +640,7 @@ export class LineChart
         )
     }
 
-    @computed get isLogScale() {
+    @computed get isLogScale(): boolean {
         return this.yAxisConfig.scaleType === ScaleType.log
     }
 
@@ -658,7 +666,7 @@ export class LineChart
         return arrOfSeries
     }
 
-    @computed get allPoints() {
+    @computed get allPoints(): LinePoint[] {
         return flatten(this.series.map((series) => series.points))
     }
 
@@ -719,11 +727,11 @@ export class LineChart
         })
     }
 
-    @computed get verticalAxis() {
+    @computed get verticalAxis(): VerticalAxis {
         return this.dualAxis.verticalAxis
     }
 
-    @computed private get horizontalAxisPart() {
+    @computed private get horizontalAxisPart(): HorizontalAxis {
         const { manager } = this
         const axisConfig =
             manager.xAxis ?? new AxisConfig(manager.xAxisConfig, this)
@@ -739,12 +747,12 @@ export class LineChart
         return axis
     }
 
-    @computed private get yAxisConfig() {
+    @computed private get yAxisConfig(): AxisConfig {
         const { manager } = this
         return manager.yAxis ?? new AxisConfig(manager.yAxisConfig, this)
     }
 
-    @computed private get verticalAxisPart() {
+    @computed private get verticalAxisPart(): VerticalAxis {
         const { manager } = this
         const axisConfig = this.yAxisConfig
         if (manager.hideYAxis) axisConfig.hideAxis = true

--- a/grapher/lineLegend/LineLegend.stories.tsx
+++ b/grapher/lineLegend/LineLegend.stories.tsx
@@ -54,7 +54,7 @@ const manager: LineLegendManager = {
     verticalAxis: dualAxis.verticalAxis,
 }
 
-export const TestCollisionDetection = () => {
+export const TestCollisionDetection = (): JSX.Element => {
     return (
         <svg width={600} height={400}>
             <LineLegend manager={manager} />

--- a/grapher/lineLegend/LineLegend.tsx
+++ b/grapher/lineLegend/LineLegend.tsx
@@ -49,7 +49,7 @@ interface PlacedSeries extends SizedSeries {
     totalLevels: number
 }
 
-function groupBounds(group: PlacedSeries[]) {
+function groupBounds(group: PlacedSeries[]): Bounds {
     const first = group[0]
     const last = group[group.length - 1]
     const height = last.bounds.bottom - first.bounds.top
@@ -57,7 +57,10 @@ function groupBounds(group: PlacedSeries[]) {
     return new Bounds(first.bounds.x, first.bounds.y, width, height)
 }
 
-function stackGroupVertically(group: PlacedSeries[], y: number) {
+function stackGroupVertically(
+    group: PlacedSeries[],
+    y: number
+): PlacedSeries[] {
     let currentY = y
     group.forEach((mark) => {
         mark.bounds = mark.bounds.extend({ y: currentY })
@@ -77,7 +80,7 @@ class Label extends React.Component<{
     onClick: () => void
     onMouseLeave?: () => void
 }> {
-    render() {
+    render(): JSX.Element {
         const {
             series,
             manager,
@@ -160,12 +163,12 @@ export interface LineLegendManager {
 export class LineLegend extends React.Component<{
     manager: LineLegendManager
 }> {
-    @computed private get fontSize() {
+    @computed private get fontSize(): number {
         return 0.75 * (this.manager.fontSize ?? BASE_FONT_SIZE)
     }
     leftPadding = 35
 
-    @computed private get maxWidth() {
+    @computed private get maxWidth(): number {
         return this.manager.maxLegendWidth ?? 300
     }
 
@@ -204,7 +207,7 @@ export class LineLegend extends React.Component<{
         })
     }
 
-    @computed get width() {
+    @computed get width(): number {
         if (this.sizedLabels.length === 0) return 0
         return max(this.sizedLabels.map((d) => d.width)) ?? 0
     }
@@ -219,13 +222,13 @@ export class LineLegend extends React.Component<{
         return this.manager.onLegendClick ?? noop
     }
 
-    @computed get isFocusMode() {
+    @computed get isFocusMode(): boolean {
         return this.sizedLabels.some((label) =>
             this.manager.focusedSeriesNames.includes(label.seriesName)
         )
     }
 
-    @computed get legendX() {
+    @computed get legendX(): number {
         return this.manager.legendX ?? 0
     }
 
@@ -270,7 +273,7 @@ export class LineLegend extends React.Component<{
         )
     }
 
-    @computed get standardPlacement() {
+    @computed get standardPlacement(): PlacedSeries[] {
         const { verticalAxis } = this.manager
 
         const groups: PlacedSeries[][] = cloneDeep(
@@ -341,7 +344,7 @@ export class LineLegend extends React.Component<{
     }
 
     // Overlapping placement, for when we really can't find a solution without overlaps.
-    @computed get overlappingPlacement() {
+    @computed get overlappingPlacement(): PlacedSeries[] {
         const series = cloneDeep(this.initialSeries)
         for (let i = 0; i < series.length; i++) {
             const m1 = series[i]
@@ -356,7 +359,7 @@ export class LineLegend extends React.Component<{
         return series
     }
 
-    @computed get placedSeries() {
+    @computed get placedSeries(): PlacedSeries[] {
         const nonOverlappingMinHeight =
             sumBy(this.initialSeries, (series) => series.bounds.height) +
             this.initialSeries.length * LEGEND_ITEM_MIN_SPACING
@@ -378,7 +381,7 @@ export class LineLegend extends React.Component<{
         return this.standardPlacement
     }
 
-    @computed private get backgroundSeries() {
+    @computed private get backgroundSeries(): PlacedSeries[] {
         const { focusedSeriesNames } = this.manager
         const { isFocusMode } = this
         return this.placedSeries.filter((mark) =>
@@ -388,7 +391,7 @@ export class LineLegend extends React.Component<{
         )
     }
 
-    @computed private get focusedSeries() {
+    @computed private get focusedSeries(): PlacedSeries[] {
         const { focusedSeriesNames } = this.manager
         const { isFocusMode } = this
         return this.placedSeries.filter((mark) =>
@@ -399,25 +402,25 @@ export class LineLegend extends React.Component<{
     }
 
     // Does this placement need line markers or is the position of the labels already clear?
-    @computed private get needsLines() {
+    @computed private get needsLines(): boolean {
         return this.placedSeries.some((series) => series.totalLevels > 1)
     }
 
-    private renderBackground() {
+    private renderBackground(): JSX.Element[] {
         return this.backgroundSeries.map((series, index) => (
             <Label
                 key={`background-${index}-` + series.seriesName}
                 series={series}
                 manager={this}
                 needsLines={this.needsLines}
-                onMouseOver={() => this.onMouseOver(series.seriesName)}
-                onClick={() => this.onClick(series.seriesName)}
+                onMouseOver={(): void => this.onMouseOver(series.seriesName)}
+                onClick={(): void => this.onClick(series.seriesName)}
             />
         ))
     }
 
     // All labels are focused by default, moved to background when mouseover of other label
-    private renderFocus() {
+    private renderFocus(): JSX.Element[] {
         return this.focusedSeries.map((series, index) => (
             <Label
                 key={`focus-${index}-` + series.seriesName}
@@ -425,18 +428,18 @@ export class LineLegend extends React.Component<{
                 manager={this}
                 isFocus={true}
                 needsLines={this.needsLines}
-                onMouseOver={() => this.onMouseOver(series.seriesName)}
-                onClick={() => this.onClick(series.seriesName)}
-                onMouseLeave={() => this.onMouseLeave(series.seriesName)}
+                onMouseOver={(): void => this.onMouseOver(series.seriesName)}
+                onClick={(): void => this.onClick(series.seriesName)}
+                onMouseLeave={(): void => this.onMouseLeave(series.seriesName)}
             />
         ))
     }
 
-    @computed get manager() {
+    @computed get manager(): LineLegendManager {
         return this.props.manager
     }
 
-    render() {
+    render(): JSX.Element {
         return (
             <g
                 className="LineLabels"

--- a/grapher/loadingIndicator/.eslintrc.yaml
+++ b/grapher/loadingIndicator/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/loadingIndicator/LoadingIndicator.stories.tsx
+++ b/grapher/loadingIndicator/LoadingIndicator.stories.tsx
@@ -6,7 +6,7 @@ export default {
     component: LoadingIndicator,
 }
 
-export const Default = () => {
+export const Default = (): JSX.Element => {
     return (
         <div>
             <LoadingIndicator />

--- a/grapher/loadingIndicator/LoadingIndicator.tsx
+++ b/grapher/loadingIndicator/LoadingIndicator.tsx
@@ -8,7 +8,7 @@ export const LoadingIndicator = (props: {
     bounds?: Bounds
     color?: string
     title?: string
-}) => {
+}): JSX.Element => {
     return (
         <div
             className="loading-indicator"

--- a/grapher/mapCharts/.eslintrc.yaml
+++ b/grapher/mapCharts/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/grapher/mapCharts/EntitiesOnTheMap.ts
+++ b/grapher/mapCharts/EntitiesOnTheMap.ts
@@ -2,7 +2,7 @@ import { EntityName } from "../../coreTable/OwidTableConstants"
 import { MapTopology } from "./MapTopology"
 
 let _cache: Set<string>
-export const isOnTheMap = (entityName: EntityName) => {
+export const isOnTheMap = (entityName: EntityName): boolean => {
     // Cache the result
     if (!_cache)
         _cache = new Set(

--- a/grapher/mapCharts/MapChart.stories.tsx
+++ b/grapher/mapCharts/MapChart.stories.tsx
@@ -7,7 +7,7 @@ export default {
     component: MapChart,
 }
 
-export const AutoColors = () => {
+export const AutoColors = (): JSX.Element => {
     const table = SynthesizeGDPTable({
         timeRange: [2000, 2010],
         entityCount: 200,

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -64,6 +64,7 @@ import {
 } from "../chart/ChartUtils"
 import { NoDataModal } from "../noDataModal/NoDataModal"
 import { ColorScaleConfig } from "../color/ColorScaleConfig"
+import { CoreColumn } from "../../coreTable/CoreTableColumns"
 
 const PROJECTION_CHOOSER_WIDTH = 110
 const PROJECTION_CHOOSER_HEIGHT = 22
@@ -84,7 +85,7 @@ const GeoFeatures: GeoFeature[] = (topojson.feature(
 
 // Get the svg path specification string for every feature
 const geoPathCache = new Map<MapProjectionName, string[]>()
-const geoPathsFor = (projectionName: MapProjectionName) => {
+const geoPathsFor = (projectionName: MapProjectionName): string[] => {
     if (geoPathCache.has(projectionName))
         return geoPathCache.get(projectionName)!
     const projectionGeo = MapProjectionGeos[projectionName]
@@ -112,7 +113,7 @@ const geoPathsFor = (projectionName: MapProjectionName) => {
 
 // Get the bounding box for every geographical feature
 const geoBoundsCache = new Map<MapProjectionName, Bounds[]>()
-const geoBoundsFor = (projectionName: MapProjectionName) => {
+const geoBoundsFor = (projectionName: MapProjectionName): Bounds[] => {
     if (geoBoundsCache.has(projectionName))
         return geoBoundsCache.get(projectionName)!
     const projectionGeo = MapProjectionGeos[projectionName]
@@ -139,7 +140,9 @@ const geoBoundsFor = (projectionName: MapProjectionName) => {
 
 // Bundle GeoFeatures with the calculated info needed to render them
 const renderFeaturesCache = new Map<MapProjectionName, RenderFeature[]>()
-const renderFeaturesFor = (projectionName: MapProjectionName) => {
+const renderFeaturesFor = (
+    projectionName: MapProjectionName
+): RenderFeature[] => {
     if (renderFeaturesCache.has(projectionName))
         return renderFeaturesCache.get(projectionName)!
     const geoBounds = geoBoundsFor(projectionName)
@@ -166,7 +169,7 @@ export class MapChart
     @observable focusEntity?: MapEntity
     @observable focusBracket?: MapBracket
 
-    transformTable(table: OwidTable) {
+    transformTable(table: OwidTable): OwidTable {
         if (!table.has(this.mapColumnSlug)) return table
         return this.dropNonMapEntities(table)
             .dropRowsWithErrorValuesForColumn(this.mapColumnSlug)
@@ -176,45 +179,45 @@ export class MapChart
             )
     }
 
-    private dropNonMapEntities(table: OwidTable) {
+    private dropNonMapEntities(table: OwidTable): OwidTable {
         const entityNamesToSelect = table.availableEntityNames.filter(
             isOnTheMap
         )
         return table.filterByEntityNames(entityNamesToSelect)
     }
 
-    @computed get inputTable() {
+    @computed get inputTable(): OwidTable {
         return this.manager.table
     }
 
-    @computed get transformedTable() {
+    @computed get transformedTable(): OwidTable {
         return (
             this.manager.transformedTable ??
             this.transformTable(this.inputTable)
         )
     }
 
-    @computed get failMessage() {
+    @computed get failMessage(): string {
         if (this.mapColumn.isMissing) return "Missing map column"
         return ""
     }
 
-    @computed get mapColumn() {
+    @computed get mapColumn(): CoreColumn {
         return this.transformedTable.get(this.mapColumnSlug)
     }
 
-    @computed get mapColumnSlug() {
+    @computed get mapColumnSlug(): string {
         return (
             this.manager.mapColumnSlug ??
             autoDetectYColumnSlugs(this.manager)[0]!
         )
     }
 
-    @computed private get targetTime() {
+    @computed private get targetTime(): number | undefined {
         return this.manager.endTime
     }
 
-    @computed get bounds() {
+    @computed get bounds(): Bounds {
         return this.props.bounds ?? DEFAULT_BOUNDS
     }
 

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -65,6 +65,7 @@ import {
 import { NoDataModal } from "../noDataModal/NoDataModal"
 import { ColorScaleConfig } from "../color/ColorScaleConfig"
 import { CoreColumn } from "../../coreTable/CoreTableColumns"
+import { SelectionArray } from "../selection/SelectionArray"
 
 const PROJECTION_CHOOSER_WIDTH = 110
 const PROJECTION_CHOOSER_HEIGHT = 22
@@ -222,7 +223,10 @@ export class MapChart
     }
 
     base: React.RefObject<SVGGElement> = React.createRef()
-    @action.bound onMapMouseOver(feature: GeoFeature, ev: React.MouseEvent) {
+    @action.bound onMapMouseOver(
+        feature: GeoFeature,
+        ev: React.MouseEvent
+    ): void {
         const series =
             feature.id === undefined
                 ? undefined
@@ -244,12 +248,12 @@ export class MapChart
             }
     }
 
-    @action.bound onMapMouseLeave() {
+    @action.bound onMapMouseLeave(): void {
         this.focusEntity = undefined
         this.tooltipTarget = undefined
     }
 
-    @computed get manager() {
+    @computed get manager(): MapChartManager {
         return this.props.manager
     }
 
@@ -260,16 +264,19 @@ export class MapChart
     }
 
     // Determine if we can go to line chart by clicking on a given map entity
-    private isEntityClickable(entityName?: EntityName) {
+    private isEntityClickable(entityName?: EntityName): boolean {
         if (!this.manager.mapIsClickable || !entityName) return false
         return this.entityNamesWithData.has(entityName)
     }
 
-    @computed private get selectionArray() {
+    @computed private get selectionArray(): SelectionArray {
         return makeSelectionArray(this.manager)
     }
 
-    @action.bound onClick(d: GeoFeature, ev: React.MouseEvent<SVGElement>) {
+    @action.bound onClick(
+        d: GeoFeature,
+        ev: React.MouseEvent<SVGElement>
+    ): void {
         const entityName = d.id as EntityName
         if (!this.isEntityClickable(entityName)) return
 
@@ -279,24 +286,24 @@ export class MapChart
         } else this.selectionArray.toggleSelection(entityName)
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         this.onMapMouseLeave()
         this.onLegendMouseLeave()
     }
 
-    @action.bound onLegendMouseOver(bracket: MapBracket) {
+    @action.bound onLegendMouseOver(bracket: MapBracket): void {
         this.focusBracket = bracket
     }
 
-    @action.bound onLegendMouseLeave() {
+    @action.bound onLegendMouseLeave(): void {
         this.focusBracket = undefined
     }
 
-    @computed get mapConfig() {
+    @computed get mapConfig(): MapConfig {
         return this.manager.mapConfig || new MapConfig()
     }
 
-    @action.bound onProjectionChange(value: MapProjectionName) {
+    @action.bound onProjectionChange(value: MapProjectionName): void {
         this.mapConfig.projection = value
     }
 
@@ -306,7 +313,7 @@ export class MapChart
         const customLabels = mapConfig.tooltipUseCustomLabels
             ? colorScale.customNumericLabels
             : []
-        return (d: number | string) => {
+        return (d: number | string): string => {
             if (isString(d)) return d
             else return customLabels[d] ?? mapColumn?.formatValueLong(d) ?? ""
         }
@@ -340,7 +347,7 @@ export class MapChart
             .filter(isPresent)
     }
 
-    @computed private get seriesMap() {
+    @computed private get seriesMap(): Map<SeriesName, ChoroplethSeries> {
         const map = new Map<SeriesName, ChoroplethSeries>()
         this.series.forEach((series) => {
             map.set(series.seriesName, series)
@@ -348,7 +355,7 @@ export class MapChart
         return map
     }
 
-    @computed get colorScaleColumn() {
+    @computed get colorScaleColumn(): CoreColumn {
         // Use the table before transform to build the legend.
         // Otherwise the legend jumps around as you slide the timeline handle.
         return this.dropNonMapEntities(this.inputTable).get(this.mapColumnSlug)
@@ -356,7 +363,7 @@ export class MapChart
 
     colorScale = new ColorScale(this)
 
-    @computed get colorScaleConfig() {
+    @computed get colorScaleConfig(): ColorScaleConfig {
         return (
             ColorScaleConfig.fromDSL(this.mapColumn.def) ??
             this.mapConfig.colorScale
@@ -366,7 +373,7 @@ export class MapChart
     defaultBaseColorScheme = ColorSchemeName.BuGn
     hasNoDataBin = true
 
-    componentDidMount() {
+    componentDidMount(): void {
         select(this.base.current)
             .selectAll("path")
             .attr("data-fill", function () {
@@ -385,7 +392,7 @@ export class MapChart
         exposeInstanceOnWindow(this)
     }
 
-    @computed get projectionChooserBounds() {
+    @computed get projectionChooserBounds(): Bounds {
         const { bounds } = this
         return new Bounds(
             bounds.width - PROJECTION_CHOOSER_WIDTH + 15 - 3,
@@ -395,23 +402,23 @@ export class MapChart
         )
     }
 
-    @computed get legendData() {
+    @computed get legendData(): ColorScaleBin[] {
         return this.colorScale.legendBins
     }
 
-    @computed get equalSizeBins() {
+    @computed get equalSizeBins(): boolean | undefined {
         return this.colorScale.config.equalSizeBins
     }
 
-    @computed get focusValue() {
+    @computed get focusValue(): string | number | undefined {
         return this.focusEntity?.series?.value
     }
 
-    @computed get fontSize() {
+    @computed get fontSize(): number {
         return this.manager.baseFontSize ?? BASE_FONT_SIZE
     }
 
-    @computed get numericLegendData() {
+    @computed get numericLegendData(): ColorScaleBin[] {
         if (
             this.hasCategorical ||
             !this.legendData.some(
@@ -431,17 +438,18 @@ export class MapChart
         return flatten([bin[bin.length - 1], bin.slice(0, -1)])
     }
 
-    @computed get hasNumeric() {
+    @computed get hasNumeric(): boolean {
         return this.numericLegendData.length > 1
     }
 
-    @computed get categoricalLegendData() {
+    @computed get categoricalLegendData(): CategoricalBin[] {
         return this.legendData.filter(
-            (bin) => bin instanceof CategoricalBin && !bin.isHidden
-        ) as CategoricalBin[]
+            (bin): bin is CategoricalBin =>
+                bin instanceof CategoricalBin && !bin.isHidden
+        )
     }
 
-    @computed get hasCategorical() {
+    @computed get hasCategorical(): boolean {
         return this.categoricalLegendData.length > 1
     }
 
@@ -457,7 +465,7 @@ export class MapChart
         return undefined
     }
 
-    @computed get categoricalFocusBracket() {
+    @computed get categoricalFocusBracket(): CategoricalBin | undefined {
         const { focusBracket, focusValue } = this
         const { categoricalLegendData } = this
         if (focusBracket && focusBracket instanceof CategoricalBin)
@@ -469,15 +477,15 @@ export class MapChart
         return undefined
     }
 
-    @computed get legendBounds() {
+    @computed get legendBounds(): Bounds {
         return this.bounds.padBottom(15)
     }
 
-    @computed get legendWidth() {
+    @computed get legendWidth(): number {
         return this.legendBounds.width * 0.8
     }
 
-    @computed get legendHeight() {
+    @computed get legendHeight(): number {
         return this.categoryLegendHeight + this.numericLegendHeight + 10
     }
 
@@ -489,13 +497,13 @@ export class MapChart
         return this.categoryLegend ? this.categoryLegend.height + 5 : 0
     }
 
-    @computed get categoryLegend() {
+    @computed get categoryLegend(): MapCategoricalColorLegend | undefined {
         return this.categoricalLegendData.length > 1
             ? new MapCategoricalColorLegend({ manager: this })
             : undefined
     }
 
-    @computed get numericLegend() {
+    @computed get numericLegend(): MapNumericColorLegend | undefined {
         return this.numericLegendData.length > 1
             ? new MapNumericColorLegend({ manager: this })
             : undefined
@@ -531,7 +539,7 @@ export class MapChart
         return 0
     }
 
-    renderMapLegend() {
+    renderMapLegend(): JSX.Element {
         const { numericLegend, categoryLegend } = this
 
         return (
@@ -542,7 +550,7 @@ export class MapChart
         )
     }
 
-    render() {
+    render(): JSX.Element {
         if (this.failMessage)
             return (
                 <NoDataModal
@@ -622,37 +630,40 @@ declare type SVGMouseEvent = React.MouseEvent<SVGElement>
 class ChoroplethMap extends React.Component<ChoroplethMapProps> {
     base: React.RefObject<SVGGElement> = React.createRef()
 
-    @computed private get uid() {
+    @computed private get uid(): number {
         return guid()
     }
 
-    @computed.struct private get bounds() {
+    @computed.struct private get bounds(): Bounds {
         return this.props.bounds
     }
 
-    @computed.struct private get choroplethData() {
+    @computed.struct private get choroplethData(): Map<
+        string,
+        ChoroplethSeries
+    > {
         return this.props.choroplethData
     }
 
-    @computed.struct private get defaultFill() {
+    @computed.struct private get defaultFill(): string {
         return this.props.defaultFill
     }
 
     // Combine bounding boxes to get the extents of the entire map
-    @computed private get mapBounds() {
+    @computed private get mapBounds(): Bounds {
         return Bounds.merge(geoBoundsFor(this.props.projection))
     }
 
-    @computed private get focusBracket() {
+    @computed private get focusBracket(): ColorScaleBin | undefined {
         return this.props.focusBracket
     }
 
-    @computed private get focusEntity() {
+    @computed private get focusEntity(): MapEntity | undefined {
         return this.props.focusEntity
     }
 
     // Check if a geo entity is currently focused, either directly or via the bracket
-    private hasFocus(id: string) {
+    private hasFocus(id: string): boolean {
         const { choroplethData, focusBracket, focusEntity } = this
         if (focusEntity && focusEntity.id === id) return true
         else if (!focusBracket) return false
@@ -662,12 +673,17 @@ class ChoroplethMap extends React.Component<ChoroplethMapProps> {
         else return false
     }
 
-    private isSelected(id: string) {
+    private isSelected(id: string): boolean | undefined {
         return this.choroplethData.get(id)!.isSelected
     }
 
     // Viewport for each projection, defined by center and width+height in fractional coordinates
-    @computed private get viewport() {
+    @computed private get viewport(): {
+        x: number
+        y: number
+        width: number
+        height: number
+    } {
         const viewports = {
             World: { x: 0.565, y: 0.5, width: 1, height: 1 },
             Europe: { x: 0.5, y: 0.22, width: 0.2, height: 0.2 },
@@ -682,7 +698,7 @@ class ChoroplethMap extends React.Component<ChoroplethMapProps> {
     }
 
     // Calculate what scaling should be applied to the untransformed map to match the current viewport to the container
-    @computed private get viewportScale() {
+    @computed private get viewportScale(): number {
         const { bounds, viewport, mapBounds } = this
         const viewportWidth = viewport.width * mapBounds.width
         const viewportHeight = viewport.height * mapBounds.height
@@ -692,7 +708,7 @@ class ChoroplethMap extends React.Component<ChoroplethMapProps> {
         )
     }
 
-    @computed private get matrixTransform() {
+    @computed private get matrixTransform(): string {
         const { bounds, mapBounds, viewport, viewportScale } = this
 
         // Calculate our reference dimensions. These values are independent of the current
@@ -717,14 +733,14 @@ class ChoroplethMap extends React.Component<ChoroplethMapProps> {
     }
 
     // Features that aren't part of the current projection (e.g. India if we're showing Africa)
-    @computed private get featuresOutsideProjection() {
+    @computed private get featuresOutsideProjection(): RenderFeature[] {
         return difference(
             renderFeaturesFor(this.props.projection),
             this.featuresInProjection
         )
     }
 
-    @computed private get featuresInProjection() {
+    @computed private get featuresInProjection(): RenderFeature[] {
         const { projection } = this.props
         const features = renderFeaturesFor(this.props.projection)
         if (projection === MapProjectionName.World) return features
@@ -738,11 +754,11 @@ class ChoroplethMap extends React.Component<ChoroplethMapProps> {
         )
     }
 
-    @computed private get featuresWithNoData() {
+    @computed private get featuresWithNoData(): RenderFeature[] {
         return difference(this.featuresInProjection, this.featuresWithData)
     }
 
-    @computed private get featuresWithData() {
+    @computed private get featuresWithData(): RenderFeature[] {
         return this.featuresInProjection.filter((feature) =>
             this.choroplethData.has(feature.id)
         )
@@ -755,7 +771,7 @@ class ChoroplethMap extends React.Component<ChoroplethMapProps> {
 
     @observable private hoverEnterFeature?: RenderFeature
     @observable private hoverNearbyFeature?: RenderFeature
-    @action.bound private onMouseMove(ev: React.MouseEvent<SVGGElement>) {
+    @action.bound private onMouseMove(ev: React.MouseEvent<SVGGElement>): void {
         if (ev.shiftKey) this.showSelectedStyle = true // Turn on highlight selection. To turn off, user can switch tabs.
         if (this.hoverEnterFeature) return
 
@@ -788,21 +804,21 @@ class ChoroplethMap extends React.Component<ChoroplethMapProps> {
     @action.bound private onMouseEnter(
         feature: RenderFeature,
         ev: SVGMouseEvent
-    ) {
+    ): void {
         this.hoverEnterFeature = feature
         this.props.onHover(feature.geo, ev)
     }
 
-    @action.bound private onMouseLeave() {
+    @action.bound private onMouseLeave(): void {
         this.hoverEnterFeature = undefined
         this.props.onHoverStop()
     }
 
-    @computed private get hoverFeature() {
+    @computed private get hoverFeature(): RenderFeature | undefined {
         return this.hoverEnterFeature || this.hoverNearbyFeature
     }
 
-    @action.bound private onClick(ev: React.MouseEvent<SVGGElement>) {
+    @action.bound private onClick(ev: React.MouseEvent<SVGGElement>): void {
         if (this.hoverFeature !== undefined)
             this.props.onClick(this.hoverFeature.geo, ev)
     }
@@ -812,7 +828,7 @@ class ChoroplethMap extends React.Component<ChoroplethMapProps> {
 
     // SVG layering is based on order of appearance in the element tree (later elements rendered on top)
     // The ordering here is quite careful
-    render() {
+    render(): JSX.Element {
         const {
             uid,
             bounds,
@@ -838,7 +854,7 @@ class ChoroplethMap extends React.Component<ChoroplethMapProps> {
                 className="ChoroplethMap"
                 clipPath={clipPath.id}
                 onMouseDown={
-                    (ev: SVGMouseEvent) =>
+                    (ev: SVGMouseEvent): void =>
                         ev.preventDefault() /* Without this, title may get selected while shift clicking */
                 }
                 onMouseMove={this.onMouseMove}
@@ -899,10 +915,10 @@ class ChoroplethMap extends React.Component<ChoroplethMapProps> {
                                         cursor="pointer"
                                         fill={defaultFill}
                                         fillOpacity={fillOpacity}
-                                        onClick={(ev: SVGMouseEvent) =>
+                                        onClick={(ev: SVGMouseEvent): void =>
                                             this.props.onClick(feature.geo, ev)
                                         }
-                                        onMouseEnter={(ev) =>
+                                        onMouseEnter={(ev): void =>
                                             this.onMouseEnter(feature, ev)
                                         }
                                         onMouseLeave={this.onMouseLeave}
@@ -951,10 +967,10 @@ class ChoroplethMap extends React.Component<ChoroplethMapProps> {
                                     cursor="pointer"
                                     fill={fill}
                                     fillOpacity={fillOpacity}
-                                    onClick={(ev: SVGMouseEvent) =>
+                                    onClick={(ev: SVGMouseEvent): void =>
                                         this.props.onClick(feature.geo, ev)
                                     }
-                                    onMouseEnter={(ev) =>
+                                    onMouseEnter={(ev): void =>
                                         this.onMouseEnter(feature, ev)
                                     }
                                     onMouseLeave={this.onMouseLeave}

--- a/grapher/mapCharts/MapColorLegends.tsx
+++ b/grapher/mapCharts/MapColorLegends.tsx
@@ -73,31 +73,31 @@ export interface MapLegendManager {
 class MapLegend extends React.Component<{
     manager: MapLegendManager
 }> {
-    @computed get manager() {
+    @computed get manager(): MapLegendManager {
         return this.props.manager
     }
 
-    @computed get legendX() {
+    @computed get legendX(): number {
         return this.manager.legendX ?? 0
     }
 
-    @computed get categoryLegendY() {
+    @computed get categoryLegendY(): number {
         return this.manager.categoryLegendY ?? 0
     }
 
-    @computed get numericLegendY() {
+    @computed get numericLegendY(): number {
         return this.manager.numericLegendY ?? 0
     }
 
-    @computed get legendWidth() {
+    @computed get legendWidth(): number {
         return this.manager.legendWidth ?? 200
     }
 
-    @computed get legendHeight() {
+    @computed get legendHeight(): number {
         return this.manager.legendHeight ?? 200
     }
 
-    @computed get fontSize() {
+    @computed get fontSize(): number {
         return this.manager.fontSize ?? BASE_FONT_SIZE
     }
 }
@@ -106,39 +106,39 @@ class MapLegend extends React.Component<{
 export class MapNumericColorLegend extends MapLegend {
     base: React.RefObject<SVGGElement> = React.createRef()
 
-    @computed get numericLegendData() {
+    @computed get numericLegendData(): ColorScaleBin[] {
         return this.manager.numericLegendData ?? []
     }
 
-    @computed get numericBins() {
+    @computed get numericBins(): NumericBin[] {
         return this.numericLegendData.filter(
-            (bin) => bin instanceof NumericBin
-        ) as NumericBin[]
+            (bin): bin is NumericBin => bin instanceof NumericBin
+        )
     }
     rectHeight = 10
 
-    @computed get tickFontSize() {
+    @computed get tickFontSize(): number {
         return 0.75 * this.fontSize
     }
 
     // NumericColorLegend wants to map a range to a width. However, sometimes we are given
     // data without a clear min/max. So we must fit these scurrilous bins into the width somehow.
-    @computed get minValue() {
+    @computed get minValue(): number {
         return min(this.numericBins.map((bin) => bin.min)) as number
     }
-    @computed get maxValue() {
+    @computed get maxValue(): number {
         return max(this.numericBins.map((bin) => bin.max)) as number
     }
-    @computed get rangeSize() {
+    @computed get rangeSize(): number {
         return this.maxValue - this.minValue
     }
-    @computed get categoryBinWidth() {
+    @computed get categoryBinWidth(): number {
         return Bounds.forText("No data", { fontSize: this.tickFontSize }).width
     }
-    @computed get categoryBinMargin() {
+    @computed get categoryBinMargin(): number {
         return this.rectHeight * 1.5
     }
-    @computed get totalCategoricalWidth() {
+    @computed get totalCategoricalWidth(): number {
         const { numericLegendData } = this
         const { categoryBinWidth, categoryBinMargin } = this
         const widths = numericLegendData.map((bin) =>
@@ -148,11 +148,11 @@ export class MapNumericColorLegend extends MapLegend {
         )
         return sum(widths)
     }
-    @computed get availableNumericWidth() {
+    @computed get availableNumericWidth(): number {
         return this.legendWidth - this.totalCategoricalWidth
     }
 
-    @computed get positionedBins() {
+    @computed get positionedBins(): PositionedBin[] {
         const {
             manager,
             rangeSize,
@@ -185,18 +185,18 @@ export class MapNumericColorLegend extends MapLegend {
                 width,
                 margin,
                 bin: bin,
-            } as PositionedBin
+            }
         })
     }
 
-    @computed get numericLabels() {
+    @computed get numericLabels(): NumericLabel[] {
         const { rectHeight, positionedBins, tickFontSize } = this
 
         const makeBoundaryLabel = (
             bin: PositionedBin,
             minOrMax: "min" | "max",
             text: string
-        ) => {
+        ): NumericLabel => {
             const labelBounds = Bounds.forText(text, { fontSize: tickFontSize })
             const x =
                 bin.x +
@@ -212,7 +212,7 @@ export class MapNumericColorLegend extends MapLegend {
             }
         }
 
-        const makeRangeLabel = (bin: PositionedBin) => {
+        const makeRangeLabel = (bin: PositionedBin): NumericLabel => {
             const labelBounds = Bounds.forText(bin.bin.text, {
                 fontSize: tickFontSize,
             })
@@ -279,13 +279,13 @@ export class MapNumericColorLegend extends MapLegend {
         return labels
     }
 
-    @computed get height() {
+    @computed get height(): number {
         return Math.abs(
             min(this.numericLabels.map((label) => label.bounds.y)) ?? 0
         )
     }
 
-    @computed get bounds() {
+    @computed get bounds(): Bounds {
         return new Bounds(
             this.legendX,
             this.numericLegendY,
@@ -294,7 +294,7 @@ export class MapNumericColorLegend extends MapLegend {
         )
     }
 
-    @action.bound onMouseMove(ev: MouseEvent | TouchEvent) {
+    @action.bound onMouseMove(ev: MouseEvent | TouchEvent): void {
         const { manager, base, positionedBins } = this
         const { numericFocusBracket } = manager
         const mouse = getRelativeMouse(base.current, ev)
@@ -327,12 +327,12 @@ export class MapNumericColorLegend extends MapLegend {
             manager.onLegendMouseOver(newFocusBracket)
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         document.documentElement.addEventListener("mousemove", this.onMouseMove)
         document.documentElement.addEventListener("touchmove", this.onMouseMove)
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         document.documentElement.removeEventListener(
             "mousemove",
             this.onMouseMove
@@ -343,7 +343,7 @@ export class MapNumericColorLegend extends MapLegend {
         )
     }
 
-    render() {
+    render(): JSX.Element {
         const {
             manager,
             numericLabels,
@@ -418,11 +418,11 @@ export class MapNumericColorLegend extends MapLegend {
 
 @observer
 export class MapCategoricalColorLegend extends MapLegend {
-    @computed get categoricalLegendData() {
+    @computed get categoricalLegendData(): CategoricalBin[] {
         return this.manager.categoricalLegendData ?? []
     }
 
-    @computed private get markLines() {
+    @computed private get markLines(): MarkLine[] {
         const manager = this.manager
         const scale = manager.scale ?? 1
         const rectSize = 12 * scale
@@ -475,11 +475,11 @@ export class MapCategoricalColorLegend extends MapLegend {
         return lines
     }
 
-    @computed get width() {
+    @computed get width(): number {
         return max(this.markLines.map((l) => l.totalWidth)) as number
     }
 
-    @computed get marks() {
+    @computed get marks(): CategoricalMark[] {
         const lines = this.markLines
 
         // Center each line
@@ -496,11 +496,11 @@ export class MapCategoricalColorLegend extends MapLegend {
         return flatten(lines.map((l) => l.marks))
     }
 
-    @computed get height() {
+    @computed get height(): number {
         return max(this.marks.map((mark) => mark.y + mark.rectSize)) as number
     }
 
-    render() {
+    render(): JSX.Element {
         const { manager, marks } = this
         const { categoricalFocusBracket } = manager
 
@@ -515,12 +515,12 @@ export class MapCategoricalColorLegend extends MapLegend {
                         return (
                             <g
                                 key={index}
-                                onMouseOver={() =>
+                                onMouseOver={(): void =>
                                     manager.onLegendMouseOver
                                         ? manager.onLegendMouseOver(mark.bin)
                                         : undefined
                                 }
-                                onMouseLeave={() =>
+                                onMouseLeave={(): void =>
                                     manager.onLegendMouseLeave
                                         ? manager.onLegendMouseLeave()
                                         : undefined

--- a/grapher/mapCharts/MapConfig.ts
+++ b/grapher/mapCharts/MapConfig.ts
@@ -13,7 +13,7 @@ import {
     maxTimeBoundFromJSONOrPositiveInfinity,
     maxTimeToJSON,
 } from "../../clientUtils/TimeBounds"
-import { trimObject } from "../../clientUtils/Util"
+import { trimObject, NoUndefinedValues } from "../../clientUtils/Util"
 
 // MapConfig holds the data and underlying logic needed by MapTab.
 // It wraps the map property on ChartConfig.
@@ -38,7 +38,7 @@ interface MapConfigWithLegacyInterface extends MapConfigInterface {
 }
 
 export class MapConfig extends MapConfigDefaults implements Persistable {
-    updateFromObject(obj: Partial<MapConfigWithLegacyInterface>) {
+    updateFromObject(obj: Partial<MapConfigWithLegacyInterface>): void {
         // Migrate variableIds to columnSlugs
         if (obj.variableId && !obj.columnSlug)
             obj.columnSlug = obj.variableId.toString()
@@ -53,7 +53,7 @@ export class MapConfig extends MapConfigDefaults implements Persistable {
             this.time = maxTimeBoundFromJSONOrPositiveInfinity(obj.time)
     }
 
-    toObject() {
+    toObject(): NoUndefinedValues<MapConfigWithLegacyInterface> {
         const obj = objectWithPersistablesToObject(
             this
         ) as MapConfigWithLegacyInterface

--- a/grapher/mapCharts/MapProjections.ts
+++ b/grapher/mapCharts/MapProjections.ts
@@ -2,7 +2,6 @@ import {
     geoPath,
     geoConicConformal,
     geoAzimuthalEqualArea,
-    GeoProjection,
     GeoPath,
 } from "d3-geo"
 import { geoRobinson, geoPatterson } from "d3-geo-projection"

--- a/grapher/mapCharts/MapTooltip.stories.tsx
+++ b/grapher/mapCharts/MapTooltip.stories.tsx
@@ -9,4 +9,6 @@ export default {
 }
 
 // todo: refactor TooltipView stuff so we can decouple from Grapher
-export const WithSparkChart = () => <Grapher {...legacyMapGrapher} />
+export const WithSparkChart = (): JSX.Element => (
+    <Grapher {...legacyMapGrapher} />
+)

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -12,7 +12,9 @@ import { SparkBarTimeSeriesValue } from "../sparkBars/SparkBarTimeSeriesValue"
 import { MapChartManager, ChoroplethSeries } from "./MapChartConstants"
 import { ColorScale } from "../color/ColorScale"
 import { Time } from "../../coreTable/CoreTableConstants"
-import { ChartTypeName, GrapherTabOption } from "../core/GrapherConstants"
+import { ChartTypeName } from "../core/GrapherConstants"
+import { OwidTable } from "../../coreTable/OwidTable"
+import { CoreColumn } from "../../coreTable/CoreTableColumns"
 
 interface MapTooltipProps {
     tooltipDatum?: ChoroplethSeries
@@ -25,9 +27,9 @@ interface MapTooltipProps {
 
 @observer
 export class MapTooltip extends React.Component<MapTooltipProps> {
-    private sparkBarsDatumXAccessor = (d: SparkBarsDatum) => d.time
+    private sparkBarsDatumXAccessor = (d: SparkBarsDatum): number => d.time
 
-    @computed private get sparkBarsToDisplay() {
+    @computed private get sparkBarsToDisplay(): number {
         return isMobile() ? 13 : 20
     }
 
@@ -35,26 +37,26 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
         return {
             data: this.sparkBarsData,
             x: this.sparkBarsDatumXAccessor,
-            y: (d: SparkBarsDatum) => d.value,
+            y: (d: SparkBarsDatum): number => d.value,
             xDomain: this.sparkBarsDomain,
         }
     }
 
-    @computed get inputTable() {
+    @computed get inputTable(): OwidTable {
         return this.props.manager.table
     }
 
-    @computed private get mapColumnSlug() {
+    @computed private get mapColumnSlug(): string | undefined {
         return this.props.manager.mapColumnSlug
     }
 
     // Uses the rootTable because if a target year is set, we filter the years at the grapher level.
     // Todo: might want to do all filtering a step below the Grapher level?
-    @computed private get sparkBarColumn() {
+    @computed private get sparkBarColumn(): CoreColumn {
         return this.inputTable.rootTable.get(this.mapColumnSlug)
     }
 
-    @computed private get sparkBarsData() {
+    @computed private get sparkBarsData(): SparkBarsDatum[] {
         const tooltipDatum = this.props.tooltipDatum
         if (!tooltipDatum) return []
 
@@ -83,25 +85,25 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
         return [start, end]
     }
 
-    @computed private get currentSparkBar() {
+    @computed private get currentSparkBar(): number | undefined {
         const lastVal = last(this.sparkBarsData)
         return lastVal ? this.sparkBarsDatumXAccessor(lastVal) : undefined
     }
 
     colorScale = this.props.colorScale ?? new ColorScale()
 
-    @computed private get renderSparkBars() {
+    @computed private get renderSparkBars(): boolean | undefined {
         return this.props.manager.mapIsClickable
     }
 
-    @computed private get darkestColorInColorScheme() {
+    @computed private get darkestColorInColorScheme(): string | undefined {
         const { colorScale } = this
         return colorScale.isColorSchemeInverted
             ? first(colorScale.baseColors)
             : last(colorScale.baseColors)
     }
 
-    @computed private get barColor() {
+    @computed private get barColor(): string | undefined {
         const { colorScale } = this
         return colorScale.singleColorScale &&
             !colorScale.customNumericColorsActive
@@ -109,7 +111,11 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
             : undefined
     }
 
-    @computed private get tooltipTarget() {
+    @computed private get tooltipTarget(): {
+        x: number
+        y: number
+        featureId: string
+    } {
         return (
             this.props.tooltipTarget ?? {
                 x: 0,
@@ -119,7 +125,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
         )
     }
 
-    render() {
+    render(): JSX.Element {
         const {
             tooltipDatum,
             isEntityClickable,

--- a/grapher/mapCharts/ProjectionChooser.tsx
+++ b/grapher/mapCharts/ProjectionChooser.tsx
@@ -19,12 +19,12 @@ export class ProjectionChooser extends React.Component<{
     value: string
     onChange: (value: MapProjectionName) => void
 }> {
-    @action.bound onChange(selected: ValueType<ProjectionChooserEntry>) {
+    @action.bound onChange(selected: ValueType<ProjectionChooserEntry>): void {
         const selectedValue = first(asArray(selected))?.value
         if (selectedValue) this.props.onChange(selectedValue)
     }
 
-    @computed get options() {
+    @computed get options(): { value: MapProjectionName; label: string }[] {
         return Object.values(MapProjectionName).map((projectName) => {
             return {
                 value: projectName,
@@ -33,7 +33,7 @@ export class ProjectionChooser extends React.Component<{
         })
     }
 
-    render() {
+    render(): JSX.Element {
         const { value } = this.props
 
         const style: React.CSSProperties = {

--- a/settings/.eslintrc.yaml
+++ b/settings/.eslintrc.yaml
@@ -1,0 +1,4 @@
+rules:
+    no-console: "off"
+    "@typescript-eslint/explicit-function-return-type": "warn"
+    "@typescript-eslint/explicit-module-boundary-types": "warn"

--- a/settings/findBaseDir.ts
+++ b/settings/findBaseDir.ts
@@ -7,7 +7,7 @@ import fs from "fs"
  * Here, we just traverse the directory tree upwards until we find a `package.json` file, which
  * should indicate that we have found the root directory of the `owid-grapher` repo.
  */
-export default function findProjectBaseDir(from: string) {
+export default function findProjectBaseDir(from: string): string | undefined {
     if (!fs.existsSync) return undefined // if fs.existsSync doesn't exist, we're probably running in the browser
 
     let dir = path.dirname(from)


### PR DESCRIPTION
Because grapher is such a big folder I am proceeding in increments of a few folders per PR inside grapher. This PR adds return type annotations for axis, chart, color and core folders. 

I try to do only primitive type annotations and leave adding new interface types for later but in Axis for TickPlacement it felt like a reasonable thing to add right away.

I also started accidentally working on MapChart.tsx and included this as well - will continue in a later PR