### PR TITLE
chore(deps): remove `asciify-string` and `google-trends-api` dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
         "@types/url-parse": "^1.4.3",
         "@types/webpack": "^4.41.25",
         "algoliasearch": "^4.2.0",
-        "asciify-string": "^0.1.1",
         "autoprefixer": "^10.0.0",
         "bcrypt": "^5.0.0",
         "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
         "fuzzyset": "^1.0.5",
         "fuzzysort": "^1.1.4",
         "glob": "^7.1.4",
-        "google-trends-api": "^4.9.0",
         "handsontable": "^8.1.0",
         "html-to-text": "^5.1.1",
         "js-base64": "^3.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4720,11 +4720,6 @@ ascii-table@0.0.9:
   resolved "https://registry.yarnpkg.com/ascii-table/-/ascii-table-0.0.9.tgz#06a6604d6a55d4bf41a9a47d9872d7a78da31e73"
   integrity sha1-BqZgTWpV1L9BqaR9mHLXp42jHnM=
 
-asciify-string@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/asciify-string/-/asciify-string-0.1.1.tgz#7e1702cd0a1d2c7ca2c0b81e784a3be9048a29de"
-  integrity sha1-fhcCzQodLHyiwLgeeEo76QSKKd4=
-
 asn1.js@^4.0.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10052,11 +10052,6 @@ good-listener@^1.2.2:
   dependencies:
     delegate "^3.1.2"
 
-google-trends-api@^4.9.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/google-trends-api/-/google-trends-api-4.9.0.tgz#907ad9f02df6c10596dfe887f5e16517b8510f60"
-  integrity sha512-ujOLHM98bE7Igy8YA4Lrb5naDpaY1wGt215zgHXPznCDwHmMjMK1FW8yW//dHQ9CKyG/HzaNBDfF7jEAUk8Kkw==
-
 got@^10.7.0:
   version "10.7.0"
   resolved "https://registry.yarnpkg.com/got/-/got-10.7.0.tgz#62889dbcd6cca32cd6a154cc2d0c6895121d091f"


### PR DESCRIPTION
I am almost certain that we don't need these two any more. They are certainly no longer being referenced anywhere.