### PR TITLE
fix(admin): test page shows charts that only have implicit `hasChartTab`

### DIFF
--- a/adminSiteServer/testPageRouter.tsx
+++ b/adminSiteServer/testPageRouter.tsx
@@ -99,11 +99,11 @@ async function propsFromQueryParams(
                     `(
                         config->"$.type" = "LineChart"
                         OR config->"$.type" IS NULL
-                    ) AND config->"$.hasChartTab" IS TRUE`
+                    ) AND COALESCE(config->"$.hasChartTab", TRUE) IS TRUE`
                 )
             } else {
                 query = query.andWhere(
-                    `config->"$.type" = :type AND config->"$.hasChartTab" IS TRUE`,
+                    `config->"$.type" = :type AND COALESCE(config->"$.hasChartTab", TRUE) IS TRUE`,
                     { type: params.type }
                 )
             }
@@ -185,7 +185,9 @@ async function propsFromQueryParams(
     if (tab === GrapherTabOption.map) {
         query = query.andWhere(`config->"$.hasMapTab" IS TRUE`)
     } else if (tab === GrapherTabOption.chart) {
-        query = query.andWhere(`config->"$.hasChartTab" IS TRUE`)
+        query = query.andWhere(
+            `COALESCE(config->"$.hasChartTab", TRUE) IS TRUE`
+        )
     }
 
     // Exclude charts that have the "Private" tag assigned, unless `includePrivate` is passed.


### PR DESCRIPTION
When I was going to https://owid.cloud/admin/test/embeds?type=StackedDiscreteBar, I found that that page was lying to us 😢 
While there are at least 4 StackedDiscreteBar charts out there, it was showing none.

This is because the `hasChartTab` option gets stripped out from the configuration if it has the default config (`true`), and we didn't consider that in the SQL query we build.
I added a `COALESCE` to all of these, and now it works again!