### PR TITLE
feat: stacked bars support relative mode

### DIFF
--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -74,6 +74,7 @@ export class EditorFeatures {
     @computed get relativeModeToggle() {
         return (
             this.grapher.isStackedArea ||
+            this.grapher.isStackedDiscreteBar ||
             this.grapher.isLineChart ||
             this.grapher.isScatter
         )

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -2260,7 +2260,12 @@ export class Grapher
         if (!this.canToggleRelativeMode) return false
         if (this.isScatter)
             return this.xOverrideTime === undefined && this.hasTimeline
-        return this.isStackedArea || this.isScatter || this.isLineChart
+        return (
+            this.isStackedArea ||
+            this.isStackedDiscreteBar ||
+            this.isScatter ||
+            this.isLineChart
+        )
     }
 
     @computed get showHighlightToggle() {

--- a/grapher/stackedCharts/StackedDiscreteBarChart.stories.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.stories.tsx
@@ -14,9 +14,28 @@ export const ColumnsAsSeries = () => {
     })
 
     return (
-        <svg width={600} height={600}>
+        <svg width={640} height={600}>
             <StackedDiscreteBarChart
                 manager={{ table, selection: table.sampleEntityName(5) }}
+            />
+        </svg>
+    )
+}
+
+export const ColumnsAsSeriesRelative = () => {
+    const table = SynthesizeFruitTable({
+        timeRange: [2000, 2001],
+        entityCount: 5,
+    })
+
+    return (
+        <svg width={640} height={600}>
+            <StackedDiscreteBarChart
+                manager={{
+                    table,
+                    selection: table.sampleEntityName(5),
+                    isRelativeMode: true,
+                }}
             />
         </svg>
     )

--- a/grapher/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.tsx
@@ -76,6 +76,12 @@ export class StackedDiscreteBarChart
             table = table.interpolateColumnWithTolerance(slug)
         })
 
+        if (this.manager.isRelativeMode) {
+            table = table.toPercentageFromEachColumnForEachEntityAndTime(
+                this.yColumnSlugs
+            )
+        }
+
         return table
     }
 

--- a/grapher/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.tsx
@@ -192,11 +192,19 @@ export class StackedDiscreteBarChart
                 })
             ),
         }))
-        return sortBy(items, (item) => {
-            const lastPoint = last(item.bars)?.point
-            if (!lastPoint) return 0
-            return lastPoint.valueOffset + lastPoint.value
-        }).reverse()
+
+        if (this.manager.isRelativeMode) {
+            // TODO: This is more of a stopgap to prevent the chart from being super jumpy in
+            // relative mode. Once we have an option to sort by a specific metric, that'll help.
+            // Until then, we're sorting by label to prevent any jumping.
+            return sortBy(items, (item) => item.label)
+        } else {
+            return sortBy(items, (item) => {
+                const lastPoint = last(item.bars)?.point
+                if (!lastPoint) return 0
+                return lastPoint.valueOffset + lastPoint.value
+            }).reverse()
+        }
     }
 
     @computed private get barHeight() {

--- a/grapher/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.tsx
@@ -176,22 +176,24 @@ export class StackedDiscreteBarChart
 
     @computed private get items(): Item[] {
         const entityNames = this.selectionArray.selectedEntityNames
-        const items = entityNames.map((entityName) => ({
-            label: entityName,
-            bars: excludeUndefined(
-                this.series.map((series) => {
-                    const point = series.points.find(
-                        (point) => point.position === entityName
-                    )
-                    if (!point) return undefined
-                    return {
-                        point,
-                        color: series.color,
-                        seriesName: series.seriesName,
-                    }
-                })
-            ),
-        }))
+        const items = entityNames
+            .map((entityName) => ({
+                label: entityName,
+                bars: excludeUndefined(
+                    this.series.map((series) => {
+                        const point = series.points.find(
+                            (point) => point.position === entityName
+                        )
+                        if (!point) return undefined
+                        return {
+                            point,
+                            color: series.color,
+                            seriesName: series.seriesName,
+                        }
+                    })
+                ),
+            }))
+            .filter((item) => item.bars.length)
 
         if (this.manager.isRelativeMode) {
             // TODO: This is more of a stopgap to prevent the chart from being super jumpy in


### PR DESCRIPTION
Notion: [Relative/100% stacked bar transform](https://www.notion.so/Relative-100-stacked-bar-transform-ca046c9723914361b092d32054768654)

Thankfully the table transform was already there, and then this was actually quite easy to do.

I decided to always order the bars by label (i.e. country name) when in relative mode, because otherwise it would be super jumpy. We can reconsider once we have some more clever ordering options.

I also fixed the bug [Max reported](https://owid.slack.com/archives/C46U9LXRR/p1620903248035500) where countries without data were showing up in the chart, even though they didn't have a bar. It's not totally related, but not totally unrelated either.