### PR TITLE
chore: Drive dev environment with `make`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ DB_PASS=''
 DB_HOST='127.0.0.1'
 
 WORDPRESS_DB_NAME='wordpress'
+WORDPRESS_URL=http://owid.lndo.site
 
 # Overrides of anything else can go here.
 # See clientSettings.ts and serverSettings.ts for available settings.
+WORDPRESS_API_USER=
+WORDPRESS_API_PASS=

--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,12 @@ TZ=utc
 SECRET_KEY='fejwiaof jewiafo jeioa fjieowajf isa fjidosajfgj'
 
 # Database settings
-DB_NAME='owid'
+DB_NAME='grapher'
 DB_USER='root'
 DB_PASS=''
+DB_HOST='127.0.0.1'
+
+WORDPRESS_DB_NAME='wordpress'
 
 # Overrides of anything else can go here.
 # See clientSettings.ts and serverSettings.ts for available settings.

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ public/covidChartAndVariableMeta.json
 clientSettings.json
 serverSettings.json
 localBake/
-.db-snapshot-imported
+.full-snapshot-imported

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ public/covidChartAndVariableMeta.json
 clientSettings.json
 serverSettings.json
 localBake/
+.db-snapshot-imported

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ clientSettings.json
 serverSettings.json
 localBake/
 .full-snapshot-imported
+.admin-built
+.wordpress-built

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ help:
 	@echo '  make destroy            Destroy images and docker resources'
 	@echo
 
-start: check-node-version ../owid-content build-complete .env
+start: check-node-version ../owid-content build-complete .env wordpress/.env
 	@echo '==> Bringing up dev environment'
 	cd wordpress && lando start
 
@@ -74,8 +74,12 @@ import-full:
 	cd wordpress && lando refresh --with-chartdata
 
 .env:
-	@echo '==> Using .env.example to configure environment'
+	@echo '==> Using .env.example to configure grapher'
 	cp .env.example .env
+
+wordpress/.env:
+	@echo '==> Using wordpress/.env.example to configure wordpress'
+	cp wordpress/.env.example wordpress/.env
 
 deploy:
 	@echo '==> Beginning deploy to production'

--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,20 @@ NODE_VERSION = v12.13.1
 help:
 	@echo 'Available commands:'
 	@echo
-	@echo '  make start      Start the development environment'
-	@echo '  make stop       Stop the development environment'
-	@echo '  make destroy    Destroy images and docker resources'
+	@echo '  make start              Start the development environment'
+	@echo '  make stop               Stop the development environment'
+	@echo '  make import-grapher     Re-import the grapher database'
+	@echo '  make import-full        Re-import the full database (OWID staff only)'
+	@echo '  make mysql              Connect to dev MySQL database'
+	@echo '  make destroy            Destroy images and docker resources'
 	@echo
 
-start: check-node-version ../owid-content build-complete
+start: check-node-version ../owid-content build-complete .env
 	@echo '==> Bringing up dev environment'
 	cd wordpress && lando start
 
-	@make .db-snapshot-imported
+	# one-time setup of necessary databases
+	@make .full-snapshot-imported
 
 	@echo '==> Starting services in tmux'
 	@yarn startTmuxServer
@@ -32,7 +36,11 @@ stop:
 destroy:
 	@echo '==> Tearing down dev environment'
 	cd wordpress && lando destroy
-	rm -f .db-snapshot-imported
+
+	@make clean
+
+clean:
+	rm -f .grapher-snapshot-imported .wordpress-snapshot-imported
 
 check-node-version:
 	@echo '==> Checking node version'
@@ -47,15 +55,23 @@ mysql:
 	@echo '==> Checking out content in sibling directory'
 	git clone git@github.com:owid/owid-content $@
 
-build-complete:
+build-complete: .env
 	@echo '==> Installing dev packages'
 	yarn
 
-# avoid re-importing the db if we've done it once
-.db-snapshot-imported:
-	@make import-db
+.full-snapshot-imported:
+	@make import-full
+	# mark that we completed the import
 	touch $@
 
-import-db:
-	@echo '==> Importing a db snapshot'
+import-grapher:
+	@echo '==> Importing a grapher db snapshot'
 	./db/downloadAndCreateDatabase.sh
+
+import-full:
+	@echo '==> Importing full db snapshot'
+	cd wordpress && lando refresh --with-chartdata
+
+.env:
+	@echo '==> Using .env.example to configure environment'
+	cp .env.example .env

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ help:
 	@echo '  make import-grapher     Re-import the grapher database'
 	@echo '  make import-full        Re-import the full database (OWID staff only)'
 	@echo '  make mysql              Connect to dev MySQL database'
+	@echo '  make deploy             Build and deploy the live site'
 	@echo '  make destroy            Destroy images and docker resources'
 	@echo
 
@@ -75,3 +76,7 @@ import-full:
 .env:
 	@echo '==> Using .env.example to configure environment'
 	cp .env.example .env
+
+deploy:
+	@echo '==> Beginning deploy to production'
+	yarn buildAndDeploySite

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,7 @@ mysql:
 
 .wordpress-built: wordpress/composer.json wordpress/composer.lock
 	@echo '==> Building wordpress'
-	cd wordpress
-	lando build
+	cd wordpress && lando build
 	touch $@
 
 .full-snapshot-imported:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,60 @@
+#
+#  Makefile
+#
+#  Setup scripts that work even if nothing is installed.
+#
+
+.DUMMY: help start stop check-node build-complete
+
+NODE_VERSION = v12.13.1
+
+help:
+	@echo 'Available commands:'
+	@echo
+	@echo '  make start      Start the development environment'
+	@echo '  make stop       Stop the development environment'
+	@echo '  make destroy    Destroy images and docker resources'
+	@echo
+
+start: check-node-version ../owid-content build-complete
+	@echo '==> Bringing up dev environment'
+	cd wordpress && lando start
+
+	@make .db-snapshot-imported
+
+	@echo '==> Starting services in tmux'
+	@yarn startTmuxServer
+
+stop:
+	@echo '==> Stopping dev environment'
+	cd wordpress && lando stop
+
+destroy:
+	@echo '==> Tearing down dev environment'
+	cd wordpress && lando destroy
+
+check-node-version:
+	@echo '==> Checking node version'
+	@test "$(shell node --version)" = "$(NODE_VERSION)" || ( \
+		echo 'Expected node $(NODE_VERSION) -- did you use nvm to install it?' && false \
+	)
+
+mysql:
+	mysql -h 127.0.0.1 -u root
+
+../owid-content:
+	@echo '==> Checking out content in sibling directory'
+	git clone git@github.com:owid/owid-content $@
+
+build-complete:
+	@echo '==> Installing dev packages'
+	yarn
+
+# avoid re-importing the db if we've done it once
+.db-snapshot-imported:
+	@make import-db
+	touch $@
+
+import-db:
+	@echo '==> Importing a db snapshot'
+	./db/downloadAndCreateDatabase.sh

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,11 @@ start: check-node-version ../owid-content .env wordpress/.env
 	@make .full-snapshot-imported
 
 	@echo '==> Starting services in tmux'
-	@yarn startTmuxServer
+	tmux \
+		new-session -s dev -n admin 'yarn startSiteBack' \; \
+		new-window -n admin-webpack 'yarn startSiteFront' \; \
+		new-window -n wp-webpack 'cd wordpress && lando dev' \; \
+		new-window -n log 'cd wordpress && lando logs --follow'
 
 stop:
 	@echo '==> Stopping dev environment'

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ stop:
 destroy:
 	@echo '==> Tearing down dev environment'
 	cd wordpress && lando destroy
+	rm -f .db-snapshot-imported
 
 check-node-version:
 	@echo '==> Checking node version'

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ import-grapher:
 
 import-full:
 	@echo '==> Importing full db snapshot'
-	cd wordpress && lando refresh --with-chartdata --with-uploads
+	cd wordpress && lando refresh --with-chartdata
 
 .env:
 	@echo '==> Using .env.example to configure grapher'

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ start: check-node-version ../owid-content .env wordpress/.env
 
 	@echo '==> Starting services in tmux'
 	tmux \
-		new-session -s dev -n admin 'yarn startSiteBack' \; \
+		new-session -s dev -n admin-node 'yarn run tsc-watch -b --onSuccess="yarn startAdminServer"' \; \
 		new-window -n admin-webpack 'yarn startSiteFront' \; \
 		new-window -n wp-webpack 'cd wordpress && lando dev' \; \
 		new-window -n log 'cd wordpress && lando logs --follow'

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Instructions are for MacOS, please adapt for your platform.
 
 6. Spin up the environment:
 
-   You now have everything you need! You can spin up your environment with:
+    You now have everything you need! You can spin up your environment with:
 
     ```sh
     make start
@@ -97,8 +97,8 @@ You should then be able to browse to http://localhost:3030/admin/charts
 
 ### Inspecting the database
 
-- Command-line: `make mysql`
-- MacOS: [Sequel Ace](https://apps.apple.com/us/app/sequel-ace/id1518036000?mt=12) is our recommended free client
+-   Command-line: `make mysql`
+-   MacOS: [Sequel Ace](https://apps.apple.com/us/app/sequel-ace/id1518036000?mt=12) is our recommended free client
 
 We also have [**a rough sketch of the schema**](https://user-images.githubusercontent.com/1308115/64631358-d920e680-d3ee-11e9-90a7-b45d942a7259.png) as it was on November 2019 (there may be slight changes).
 

--- a/README.md
+++ b/README.md
@@ -95,10 +95,6 @@ These instructions are a little experimental, please give us feedback if they do
 
 You should then be able to browse to http://localhost:3030/admin/charts
 
-### Other platforms
-
-You will need: [MySQL 5.7](https://www.mysql.com/), [Node 12.13.1+](https://nodejs.org/en/) and [Yarn](https://yarnpkg.com/en/). Running `yarn` in the repo root will grab the remaining dependencies.
-
 ### Inspecting the database
 
 - Command-line: `make mysql`

--- a/README.md
+++ b/README.md
@@ -32,13 +32,7 @@ Instructions are for MacOS, please adapt for your platform.
 
 1. Install Homebrew first, follow the instructions here: <https://brew.sh/>
 
-2. Install Homebrew services:
-
-    ```sh
-    brew tap homebrew/services
-    ```
-
-3. Install nvm:
+2. Install nvm:
 
     ```sh
     brew update
@@ -46,13 +40,13 @@ Instructions are for MacOS, please adapt for your platform.
     source $(brew --prefix nvm)/nvm.sh
     ```
 
-4. Install Node 12.13.1+:
+3. Install Node 12.13.1+:
 
     ```sh
     nvm install 12.13.1
     ```
 
-5. Install lando:
+4. Install lando:
 
     ```sh
     brew install lando
@@ -60,12 +54,12 @@ Instructions are for MacOS, please adapt for your platform.
 
     For other platforms: https://docs.lando.dev/basics/installation.html
 
-6. Submit your ssh public key:
+5. Submit your ssh public key:
 
     Generate an SSH keypair and submit your key to existing developers for access to production servers. This will be used
     to pull a database snapshot.
 
-7. Spin up the environment:
+6. Spin up the environment:
 
    You now have everything you need! You can spin up your environment with:
 

--- a/db/downloadAndCreateDatabase.sh
+++ b/db/downloadAndCreateDatabase.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
+#
+#  downloadAndCreateDatabase.sh
+#
+#  Download and ingest the publicly shared subset of the production grapher 
+#  database, containing data for every published graph.
+#
 
 set -e
 
-MYSQL='mysql -h 127.0.0.1 -u root'
+DB_NAME=grapher
+MYSQL="mysql -h 127.0.0.1 -u root"
 
-$MYSQL -e "CREATE DATABASE owid;"
+# database should not exist for a fresh lando spin-up
+$MYSQL -e "CREATE DATABASE IF NOT EXISTS ${DB_NAME};"
+
 curl -Lo /tmp/owid_metadata.sql.gz https://files.ourworldindata.org/owid_metadata.sql.gz
-gunzip < /tmp/owid_metadata.sql.gz | $MYSQL -D owid
+gunzip < /tmp/owid_metadata.sql.gz | $MYSQL -D ${DB_NAME}
 curl -Lo /tmp/owid_chartdata.sql.gz https://files.ourworldindata.org/owid_chartdata.sql.gz
-gunzip < /tmp/owid_chartdata.sql.gz | $MYSQL -D owid
+gunzip < /tmp/owid_chartdata.sql.gz | $MYSQL -D ${DB_NAME}

--- a/db/downloadAndCreateDatabase.sh
+++ b/db/downloadAndCreateDatabase.sh
@@ -1,5 +1,11 @@
-mysql -e "CREATE DATABASE owid;"
+#!/bin/bash
+
+set -e
+
+MYSQL='mysql -h 127.0.0.1 -u root'
+
+$MYSQL -e "CREATE DATABASE owid;"
 curl -Lo /tmp/owid_metadata.sql.gz https://files.ourworldindata.org/owid_metadata.sql.gz
-gunzip < /tmp/owid_metadata.sql.gz | mysql -D owid
+gunzip < /tmp/owid_metadata.sql.gz | $MYSQL -D owid
 curl -Lo /tmp/owid_chartdata.sql.gz https://files.ourworldindata.org/owid_chartdata.sql.gz
-gunzip < /tmp/owid_chartdata.sql.gz | mysql -D owid
+gunzip < /tmp/owid_chartdata.sql.gz | $MYSQL -D owid

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "startDeployQueueServer": "node ./itsJustJavascript/baker/startDeployQueueServer.js",
         "startLando": "cd wordpress && lando start",
         "startStorybookServer": "start-storybook -c ./itsJustJavascript/.storybook -p 6006",
-        "startTmuxServer": "tmux new-session -s dev 'yarn startTscServer' \\; split-window 'yarn startAdminServer' \\; split-window 'yarn startWebpackServer' \\;",
+        "startTmuxServer": "tmux new-session -s dev -n admin 'tsc-watch -b --onSuccess \"yarn startAdminServer\"' \\; new-window -n webpack 'yarn startSiteFront' \\;",
         "startTscServer": "tsc -b -verbose -watch",
         "startWebpackServer": "webpack-dev-server --no-live-reload --config ./itsJustJavascript/webpack.config.js",
         "startSiteFront": "webpack-dev-server --config ./itsJustJavascript/webpack.config.js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "startDeployQueueServer": "node ./itsJustJavascript/baker/startDeployQueueServer.js",
         "startLando": "cd wordpress && lando start",
         "startStorybookServer": "start-storybook -c ./itsJustJavascript/.storybook -p 6006",
-        "startTmuxServer": "tmex dev \"yarn startTscServer\" \"yarn startAdminServer\" \"yarn startWebpackServer\"",
+        "startTmuxServer": "tmux new-session 'yarn startTscServer' \\; split-window 'yarn startAdminServer' \\; split-window 'yarn startWebpackServer' \\;",
         "startTscServer": "tsc -b -verbose -watch",
         "startWebpackServer": "webpack-dev-server --no-live-reload --config ./itsJustJavascript/webpack.config.js",
         "startSiteFront": "webpack-dev-server --config ./itsJustJavascript/webpack.config.js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "startDeployQueueServer": "node ./itsJustJavascript/baker/startDeployQueueServer.js",
         "startLando": "cd wordpress && lando start",
         "startStorybookServer": "start-storybook -c ./itsJustJavascript/.storybook -p 6006",
-        "startTmuxServer": "tmux new-session 'yarn startTscServer' \\; split-window 'yarn startAdminServer' \\; split-window 'yarn startWebpackServer' \\;",
+        "startTmuxServer": "tmux new-session -s dev 'yarn startTscServer' \\; split-window 'yarn startAdminServer' \\; split-window 'yarn startWebpackServer' \\;",
         "startTscServer": "tsc -b -verbose -watch",
         "startWebpackServer": "webpack-dev-server --no-live-reload --config ./itsJustJavascript/webpack.config.js",
         "startSiteFront": "webpack-dev-server --config ./itsJustJavascript/webpack.config.js",

--- a/wordpress/.lando.yml
+++ b/wordpress/.lando.yml
@@ -22,14 +22,6 @@ services:
     database:
         portforward: 3306
         healthcheck:
-    database-grapher:
-        type: mysql
-        creds:
-            user: grapher
-            password: grapher
-            database: grapher
-        portforward: 3307
-        healthcheck:
 events:
     pre-build:
         # post-start:

--- a/wordpress/.lando/scripts/refresh-dev.sh
+++ b/wordpress/.lando/scripts/refresh-dev.sh
@@ -5,9 +5,9 @@
 ##################################################
 
 # env variables are set by lando's env_file directive
-WORDPRESS_DB_HOST=$DB_HOST
-WORDPRESS_DB_NAME=$DB_NAME
-GRAPHER_DB_HOST=database-grapher
+WORDPRESS_DB_HOST=database
+WORDPRESS_DB_NAME=wordpress
+GRAPHER_DB_HOST=database
 GRAPHER_DB_NAME=grapher
 MYSQL="mysql -u root --default-character-set=utf8mb4"
 DL_FOLDER="."
@@ -59,7 +59,7 @@ done
 
 
 purge_db(){
-  $MYSQL -h $1 -e "DROP DATABASE $2;CREATE DATABASE $2"
+  $MYSQL -h $1 -e "DROP DATABASE IF EXISTS $2; CREATE DATABASE $2"
 }
 
 import_db(){

--- a/wordpress/.lando/scripts/refresh-dev.sh
+++ b/wordpress/.lando/scripts/refresh-dev.sh
@@ -19,7 +19,7 @@ SKIP_DB_DL=false
 
 usage()
 {
-  echo "Refreshes content. At the minimum, both Wordress and Grapher databases are cleared and populated after downloading the latest archives."
+  echo "Refreshes content. At the minimum, both Wordpress and Grapher databases are cleared and populated after downloading the latest archives."
   echo "The Grapher database is only populated with owid_metadata by default. Add --with-chartdata to have access to the full content."
   echo "Usage: refresh [options...]"
   echo ""
@@ -68,17 +68,17 @@ import_db(){
 
 # Wordpress DB
 if [ "${SKIP_DB_DL}" = false ]; then
-  echo "Downloading Wordress database (live_wordpress)"
+  echo "Downloading Wordpress database (live_wordpress)"
     ssh owid-live "sudo mysqldump --default-character-set=utf8mb4 live_wordpress -r /tmp/live_wordpress.sql && sudo gzip -f /tmp/live_wordpress.sql"
     rsync -hav --progress owid-live:/tmp/live_wordpress.sql.gz $DL_FOLDER
 fi
-echo "Importing Wordress database (live_wordpress)"
+echo "Importing Wordpress database (live_wordpress)"
 purge_db $WORDPRESS_DB_HOST $WORDPRESS_DB_NAME
 import_db $DL_FOLDER/live_wordpress.sql.gz $WORDPRESS_DB_HOST $WORDPRESS_DB_NAME
 
 # Wordpress uploads
 if [ "${WITH_UPLOADS}" = true ]; then
-  echo "Downloading Wordress uploads"
+  echo "Downloading Wordpress uploads"
   rsync -havz --delete --exclude=/.gitkeep --progress owid-live:live-data/wordpress/uploads/ web/app/uploads
 fi
 


### PR DESCRIPTION
Automate more of the development environment with `make`, heavily reusing existing `yarn` commands and `lando`. The idea is that the environment should come up cleanly right out of the box with minimal intervention.

- Run `make` for available commands
- `make start` brings up background services (nginx, mysql), does one-time db imports (grapher, wordpress), and runs foreground services in watch mode (admin, webpack)
- Reduces MySQL services from two to one in lando
- Unifies database settings to work out of the box with lando defaults
- Updates `.env.example` and copies `.env.example` to `.env` on first run