### PR TITLE
fix: tolerance not applied on ScatterPlot with mixed time units

### DIFF
--- a/coreTable/OwidTable.ts
+++ b/coreTable/OwidTable.ts
@@ -43,7 +43,7 @@ import { TimeBound } from "../clientUtils/TimeBounds"
 import {
     getOriginalTimeColumnSlug,
     makeOriginalTimeSlugFromColumnSlug,
-    timeColumnSlugFromColumnDef,
+    timeColumnSlugOfValueColumn,
     toPercentageColumnDef,
 } from "./OwidTableUtil"
 import {
@@ -645,7 +645,6 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         if (!this.has(columnSlug)) return this
 
         const column = this.get(columnSlug)
-        const columnDef = column.def as OwidColumnDef
         const tolerance = toleranceOverride ?? column.tolerance ?? 0
 
         const timeColumnOfTable = !this.timeColumn.isMissing
@@ -655,7 +654,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
 
         const maybeTimeColumnOfValue =
             getOriginalTimeColumnSlug(this, columnSlug) ??
-            timeColumnSlugFromColumnDef(columnDef)
+            timeColumnSlugOfValueColumn(this, columnSlug)
         const timeColumnOfValue = this.get(maybeTimeColumnOfValue)
         const originalTimeSlug = makeOriginalTimeSlugFromColumnSlug(columnSlug)
 
@@ -710,11 +709,10 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         if (!this.has(columnSlug)) return this
 
         const column = this.get(columnSlug)
-        const columnDef = column?.def as OwidColumnDef
 
         const maybeTimeColumnSlug =
             getOriginalTimeColumnSlug(this, columnSlug) ??
-            timeColumnSlugFromColumnDef(columnDef)
+            timeColumnSlugOfValueColumn(this, columnSlug)
         const timeColumn =
             this.get(maybeTimeColumnSlug) ??
             (this.get(OwidTableSlugs.time) as CoreColumn) // CovidTable does not have a day or year column so we need to use time.

--- a/coreTable/OwidTableUtil.ts
+++ b/coreTable/OwidTableUtil.ts
@@ -1,12 +1,23 @@
 import { ColumnTypeNames, CoreColumnDef } from "./CoreColumnDef"
 import { CoreTable } from "./CoreTable"
+import { ColumnTypeMap } from "./CoreTableColumns"
 import { ColumnSlug } from "./CoreTableConstants"
+import { OwidTable } from "./OwidTable"
 import { OwidColumnDef, OwidTableSlugs } from "./OwidTableConstants"
 
-export function timeColumnSlugFromColumnDef(
-    def: OwidColumnDef
-): OwidTableSlugs.day | OwidTableSlugs.year {
-    return def.isDailyMeasurement ? OwidTableSlugs.day : OwidTableSlugs.year
+export function timeColumnSlugOfValueColumn(
+    table: OwidTable,
+    valueColumnSlug: ColumnSlug
+): ColumnSlug {
+    const def = table.get(valueColumnSlug).def as OwidColumnDef
+    if (def.isDailyMeasurement) {
+        return table.timeColumn instanceof ColumnTypeMap.Day
+            ? table.timeColumn.slug
+            : OwidTableSlugs.day
+    }
+    return table.timeColumn instanceof ColumnTypeMap.Year
+        ? table.timeColumn.slug
+        : OwidTableSlugs.year
 }
 
 export function makeOriginalTimeSlugFromColumnSlug(slug: ColumnSlug): string {

--- a/grapher/core/LegacyToOwidTable.ts
+++ b/grapher/core/LegacyToOwidTable.ts
@@ -56,15 +56,15 @@ export const legacyToOwidTableAndDimensions = (
         baseColumnDefs.set(def.slug, def)
     })
 
-    const colorColumnSlug =
+    const entityColorColumnSlug =
         entityColorMap.size > 0 || grapherConfig.selectedEntityColors
             ? OwidTableSlugs.entityColor
             : undefined
-    if (colorColumnSlug) {
-        baseColumnDefs.set(colorColumnSlug, {
-            slug: colorColumnSlug,
+    if (entityColorColumnSlug) {
+        baseColumnDefs.set(entityColorColumnSlug, {
+            slug: entityColorColumnSlug,
             type: ColumnTypeNames.Color,
-            name: colorColumnSlug,
+            name: entityColorColumnSlug,
         })
     }
 
@@ -142,8 +142,8 @@ export const legacyToOwidTableAndDimensions = (
             ] = entityNames.map((entityName) => annotationMap!.get(entityName))
         }
 
-        if (colorColumnSlug) {
-            columnStore[colorColumnSlug] = entityIds.map(
+        if (entityColorColumnSlug) {
+            columnStore[entityColorColumnSlug] = entityIds.map(
                 (entityId) =>
                     grapherConfig.selectedEntityColors?.[
                         entityMetaById[entityId].name


### PR DESCRIPTION
Notion: [ScatterPlot tolerance broken with mixed time units](https://www.notion.so/ScatterPlot-tolerance-broken-with-mixed-time-units-ed771026c1184fa9866f1f83cc9b30e1)

### TODO

- [x] Create a (failing) test case
- [ ] Fix the bug