### PR TITLE
chore: polyfill IntersectionObserver & URLSearchParams

### DIFF
--- a/site/SiteFooter.tsx
+++ b/site/SiteFooter.tsx
@@ -238,7 +238,7 @@ export const SiteFooter = (props: SiteFooterProps) => (
                 </div>
             </div>
             <div className="site-tools" />
-            <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,fetch" />
+            <script src="https://polyfill.io/v3/polyfill.min.js?features=es6,fetch,URL,IntersectionObserver,IntersectionObserverEntry" />
             <script src={webpackUrl("commons.js", props.baseUrl)} />
             <script src={webpackUrl("owid.js", props.baseUrl)} />
             <script

--- a/site/multiembedder/MultiEmbedder.tsx
+++ b/site/multiembedder/MultiEmbedder.tsx
@@ -61,6 +61,10 @@ class MultiEmbedder {
                     rootMargin: "200%",
                 }
             )
+        } else {
+            console.warn(
+                "IntersectionObserver not available; interactive embeds won't load on this page"
+            )
         }
     }
 

--- a/site/webpackUtils.tsx
+++ b/site/webpackUtils.tsx
@@ -47,7 +47,7 @@ const checkReady = () => {
 }
 
 const coreScripts = [
-    'https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,fetch',
+    'https://polyfill.io/v3/polyfill.min.js?features=es6,fetch,URL,IntersectionObserver,IntersectionObserverEntry',
     '${webpackUrl("commons.js", baseUrl)}',
     '${webpackUrl("owid.js", baseUrl)}'
 ]


### PR DESCRIPTION
This PR is live on _tufte_.

Since we're already using `polyfill.io` anyway, we might as well be using to polyfill these two :)

This gives us basic compatibility (i.e. there might be other issues) with:
* Firefox >= 52 ([explorer embeds are not great in Firefox < 59, though](https://user-images.githubusercontent.com/2641501/119222982-4a3afb80-baf7-11eb-9d35-51c705293cd8.png))
* Chrome >= 58
* Safari >= 11.0