### PR TITLE
fix: make country selection top-to-bottom, left-to-right

### DIFF
--- a/grapher/controls/EntitySelectorModal.scss
+++ b/grapher/controls/EntitySelectorModal.scss
@@ -106,7 +106,6 @@ $zindex-EntitySelector: 30;
 
     li {
         list-style-type: none;
-        flex: 1 0 15em;
         margin-bottom: 0.3em;
     }
 

--- a/grapher/controls/EntitySelectorModal.scss
+++ b/grapher/controls/EntitySelectorModal.scss
@@ -93,9 +93,10 @@ $zindex-EntitySelector: 30;
         width: 100%;
     }
 
-    .searchResults ul {
-        display: flex;
-        flex-wrap: wrap;
+    @media (min-width: 800px) {
+        .searchResults ul {
+            column-count: 2;
+        }
     }
 
     ul {


### PR DESCRIPTION
Switch from flex box for entity selector to using ul columns with a media query.

This is because countries were spilling left-to-right before top-to-bottom, a highly unintuitive sort order for people to look through. A media query approach was taken because flexbox columns would only solve this if the container had fixed height.

See: https://www.notion.so/owid/List-countries-vertically-instead-of-by-rows-in-grapher-country-selector-ad9fbd8b86c04e61bf58b68dd5e1bade