### PR TITLE
enhance: Shrink explorer title to reduce wasted space

### DIFF
--- a/explorer/Explorer.scss
+++ b/explorer/Explorer.scss
@@ -30,8 +30,8 @@ html.IsInIframe #ExplorerContainer {
     justify-content: space-around;
 
     .ExplorerTitle {
-        font-size: max(16px, min(1.5vw, 19px));
-        line-height: max(18px, min(1.7vw, 23px));
+        font-size: clamp(16px, 1.5vw, 19px);
+        line-height: clamp(18px, 1.7vw, 23px);
         font-weight: bold;
         font-family: "Lato";
     }

--- a/explorer/Explorer.scss
+++ b/explorer/Explorer.scss
@@ -30,10 +30,10 @@ html.IsInIframe #ExplorerContainer {
     justify-content: space-around;
 
     .ExplorerTitle {
-        font-size: 28px;
+        font-size: 19px;
         font-weight: bold;
-        line-height: 32px;
-        font-family: "Playfair Display";
+        line-height: 23px;
+        font-family: "Lato";
     }
 
     .ExplorerSubtitle {

--- a/explorer/Explorer.scss
+++ b/explorer/Explorer.scss
@@ -30,9 +30,9 @@ html.IsInIframe #ExplorerContainer {
     justify-content: space-around;
 
     .ExplorerTitle {
-        font-size: 19px;
+        font-size: max(16px, min(1.5vw, 19px));
+        line-height: max(18px, min(1.7vw, 23px));
         font-weight: bold;
-        line-height: 23px;
         font-family: "Lato";
     }
 


### PR DESCRIPTION
In a previous design, the title could take more space because there were more controls to the right of it. Now that there are fewer, there is blank space left.

This change reduces the title so as to remove the need for blank space in the panel to its right.

See: https://www.notion.so/owid/Condense-explorer-title-d5bbac463dd54470a60cac48c1c2dee2