### PR TITLE
feat: support setting Grapher `note` in Explorer config

### DIFF
--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -141,4 +141,9 @@ export const GrapherGrammar: Grammar = {
             cssClass: "",
         })),
     },
+    note: {
+        ...StringCellDef,
+        keyword: "note",
+        description: "Chart footnote",
+    },
 } as const


### PR DESCRIPTION
This is a "footnote" in the Grapher chart. (Hannah asked about this on [Slack](https://owid.slack.com/archives/C5BDCB2R3/p1621951911077100).)