### PR TITLE
fix(persistable): don't delete `Infinity` from object

### DIFF
--- a/grapher/persistable/Persistable.test.ts
+++ b/grapher/persistable/Persistable.test.ts
@@ -128,3 +128,14 @@ it("can handle an array of persistables", () => {
     })
     expect(game.relatedGames![0].players).toEqual(2)
 })
+
+it("can handle Infinity", () => {
+    const game = new GameBoyGame({
+        players: Infinity,
+    })
+    const persisted = deleteRuntimeAndUnchangedProps(
+        game,
+        new GameBoyGame({ players: -Infinity })
+    )
+    expect(persisted).toEqual({ players: Infinity })
+})

--- a/grapher/persistable/Persistable.ts
+++ b/grapher/persistable/Persistable.ts
@@ -1,4 +1,5 @@
 import { toJS } from "mobx"
+import { isEqual } from "../../clientUtils/Util"
 
 // Any classes that the user can edit, save, and then rehydrate should implement this interface
 export interface Persistable {
@@ -68,9 +69,9 @@ export function deleteRuntimeAndUnchangedProps<T>(
             return
         }
 
-        const currentValue = JSON.stringify(obj[key])
-        const defaultValue = JSON.stringify(defaultObj[key])
-        if (currentValue === defaultValue) {
+        const currentValue = obj[key]
+        const defaultValue = defaultObj[key]
+        if (isEqual(currentValue, defaultValue)) {
             // Don't persist any values that weren't changed from the default
             delete obj[key]
         }


### PR DESCRIPTION
Notion: [Cannot save chart with `minTime=Infinity` config](https://www.notion.so/Cannot-save-chart-with-minTime-Infinity-config-02c50abd4c6d45c488073442a2046ee9)

I tested this by logging the output of the old and new method, and made sure that the differences are restricted to `minTime` and `maxTime` in my testing. So this should fix the issue and shouldn't negatively impact anything else - fingers crossed!