### PR TITLE
chore: Make it well-defined how to run grapher without wordpress

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,15 +133,6 @@ Set up your `.env` file by copying the example:
 cp .env.example .env
 ```
 
-If you are operating a partial stack (grapher-only), you should also set these variables to be empty in your `.env` file:
-
-```
-WORDPRESS_DB_NAME=''
-WORDPRESS_API_URL=''
-```
-
-This disable any requirements on wordpress from Grapher.
-
 Then run the three development processes:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ Set up your `.env` file by copying the example:
 cp .env.example .env
 ```
 
+If you are operating a partial stack (grapher-only), you should also set these variables to be empty in your `.env` file:
+
+```
+WORDPRESS_DB_NAME=''
+WORDPRESS_API_URL=''
+```
+
+This disable any requirements on wordpress from Grapher.
+
 Then run the three development processes:
 
 ```sh

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -69,6 +69,8 @@ async function getLogsByChartId(chartId: number): Promise<ChartRevision[]> {
 const getReferencesByChartId = async (
     chartId: number
 ): Promise<PostReference[]> => {
+    if (!wpdb.isWordpressDBEnabled) return []
+
     const rows = await db.queryMysql(
         `
         SELECT config->"$.slug" AS slug

--- a/adminSiteServer/app.tsx
+++ b/adminSiteServer/app.tsx
@@ -115,53 +115,9 @@ export class OwidAdminApp {
         if (this.options.isDev) app.use("/", mockSiteRouter)
 
         // Give full error messages, including in production
-        app.use(
-            async (err: any, req: any, res: express.Response, next: any) => {
-                if (!res.headersSent) {
-                    res.status(err.status || 500)
-                    res.send({
-                        error: {
-                            message: err.stack || err,
-                            status: err.status || 500,
-                        },
-                    })
-                } else {
-                    res.write(
-                        JSON.stringify({
-                            error: {
-                                message: err.stack || err,
-                                status: err.status || 500,
-                            },
-                        })
-                    )
-                    res.end()
-                }
-            }
-        )
+        app.use(this.errorHandler)
 
-        try {
-            await db.getConnection()
-        } catch (err) {
-            if (!this.options.quiet) {
-                console.log(`Failed to connect to grapher mysql database.`)
-                console.error(err)
-                console.log(
-                    "Could not connect to Wordpress database. Continuing without DB..."
-                )
-            }
-        }
-
-        // The Grapher should be able to work without Wordpress being set up.
-        try {
-            await wpdb.singleton.connect()
-        } catch (error) {
-            if (!this.options.quiet) {
-                console.error(error)
-                console.log(
-                    "Could not connect to Wordpress database. Continuing without Wordpress..."
-                )
-            }
-        }
+        await this.connectToDatabases()
 
         this.server = await this.listenPromise(
             app,
@@ -184,11 +140,71 @@ export class OwidAdminApp {
         adminServerPort: number,
         adminServerHost: string
     ): Promise<http.Server> {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve) => {
             const server = app.listen(adminServerPort, adminServerHost, () => {
                 resolve(server)
             })
         })
+    }
+
+    errorHandler = async (err: any, req: any, res: express.Response) => {
+        if (!res.headersSent) {
+            res.status(err.status || 500)
+            res.send({
+                error: {
+                    message: err.stack || err,
+                    status: err.status || 500,
+                },
+            })
+        } else {
+            res.write(
+                JSON.stringify({
+                    error: {
+                        message: err.stack || err,
+                        status: err.status || 500,
+                    },
+                })
+            )
+            res.end()
+        }
+    }
+
+    connectToDatabases = async () => {
+        try {
+            await db.getConnection()
+        } catch (error) {
+            // grapher database is in fact required, but we will not fail now in case it
+            // comes online later
+            if (!this.options.quiet) {
+                console.error(error)
+                console.warn(
+                    "Could not connect to grapher database. Continuing without DB..."
+                )
+            }
+        }
+
+        if (wpdb.isWordpressDBEnabled) {
+            try {
+                await wpdb.singleton.connect()
+            } catch (error) {
+                if (!this.options.quiet) {
+                    console.error(error)
+                    console.warn(
+                        "Could not connect to Wordpress database. Continuing without Wordpress..."
+                    )
+                }
+            }
+        } else if (!this.options.quiet) {
+            console.log(
+                "WORDPRESS_DB_NAME is not configured -- continuing without Wordpress DB"
+            )
+        }
+
+        if (!wpdb.isWordpressAPIEnabled && !this.options.quiet) {
+            console.log(
+                "WORDPRESS_API_URL is not configured -- continuing without Wordpress API"
+            )
+        }
     }
 }
 

--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -41,6 +41,7 @@ import { MultiEmbedderTestPage } from "../site/multiembedder/MultiEmbedderTestPa
 import { bakeEmbedSnippet } from "../site/webpackUtils"
 import { JsonError } from "../clientUtils/owidTypes"
 import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants"
+import { isWordpressAPIEnabled } from "../db/wpdb"
 
 require("express-async-errors")
 
@@ -138,9 +139,13 @@ mockSiteRouter.get("/blog/page/:pageno", async (req, res) => {
     else throw new Error("invalid page number")
 })
 
-mockSiteRouter.get("/headerMenu.json", async (req, res) =>
+mockSiteRouter.get("/headerMenu.json", async (req, res) => {
+    if (!isWordpressAPIEnabled) {
+        res.status(404).send(await renderNotFoundPage())
+        return
+    }
     res.send(await renderMenuJson())
-)
+})
 
 mockSiteRouter.use(
     // Not all /app/uploads paths are going through formatting

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -6,7 +6,12 @@ import { renderToHtmlPage } from "../baker/siteRenderers"
 import { Post } from "../db/model/Post"
 import { urlToSlug, without } from "../clientUtils/Util"
 import { isPresent } from "../clientUtils/isPresent"
-import { getRelatedArticles, getRelatedCharts } from "../db/wpdb"
+import {
+    getRelatedArticles,
+    getRelatedCharts,
+    isWordpressAPIEnabled,
+    isWordpressDBEnabled,
+} from "../db/wpdb"
 import { getVariableData } from "../db/model/Variable"
 import * as fs from "fs-extra"
 import { deserializeJSONFromHTML } from "../clientUtils/serializers"
@@ -26,10 +31,14 @@ import { isPathRedirectedToExplorer } from "../explorerAdmin/ExplorerRedirects"
 const grapherConfigToHtmlPage = async (grapher: GrapherInterface) => {
     const postSlug = urlToSlug(grapher.originUrl || "")
     const post = postSlug ? await Post.bySlug(postSlug) : undefined
-    const relatedCharts = post ? await getRelatedCharts(post.id) : undefined
-    const relatedArticles = grapher.slug
-        ? await getRelatedArticles(grapher.slug)
-        : undefined
+    const relatedCharts =
+        post && isWordpressDBEnabled
+            ? await getRelatedCharts(post.id)
+            : undefined
+    const relatedArticles =
+        grapher.slug && isWordpressAPIEnabled
+            ? await getRelatedArticles(grapher.slug)
+            : undefined
 
     return renderToHtmlPage(
         <GrapherPage

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -441,9 +441,8 @@ export const getPosts = async (
     postTypes: string[] = [WP_PostType.Post, WP_PostType.Page],
     limit?: number
 ): Promise<any[]> => {
-    if (!isWordpressAPIEnabled) {
-        return []
-    }
+    if (!isWordpressAPIEnabled) return []
+
     const perPage = 50
     let posts: any[] = []
 
@@ -577,6 +576,8 @@ export const getRelatedArticles = async (
 export const getBlockContent = async (
     id: number
 ): Promise<string | undefined> => {
+    if (!isWordpressAPIEnabled) return undefined
+
     const query = `
     query getBlock($id: ID!) {
         wp_block(id: $id, idType: DATABASE_ID) {

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -302,6 +302,7 @@ let cachedEntries: CategoryWithEntries[] = []
 export const getEntriesByCategory = async (): Promise<
     CategoryWithEntries[]
 > => {
+    if (!isWordpressAPIEnabled) return []
     if (cachedEntries.length) return cachedEntries
 
     const first = 100
@@ -440,6 +441,9 @@ export const getPosts = async (
     postTypes: string[] = [WP_PostType.Post, WP_PostType.Page],
     limit?: number
 ): Promise<any[]> => {
+    if (!isWordpressAPIEnabled) {
+        return []
+    }
     const perPage = 50
     let posts: any[] = []
 

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -36,6 +36,9 @@ import { memoize } from "../clientUtils/Util"
 
 let knexInstance: Knex
 
+export const isWordpressAPIEnabled = WORDPRESS_URL.length > 0
+export const isWordpressDBEnabled = WORDPRESS_DB_NAME.length > 0
+
 class WPDB {
     private conn?: DatabaseConnection
 

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -489,6 +489,10 @@ export const getPostType = async (search: number | string): Promise<string> => {
 }
 
 export const getPostBySlug = async (slug: string): Promise<any[]> => {
+    if (!isWordpressAPIEnabled) {
+        throw new JsonError(`Need wordpress API to match slug ${slug}`, 404)
+    }
+
     try {
         const type = await getPostType(slug)
         const postArr = await apiQuery(

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -27,8 +27,7 @@ export const BAKED_GRAPHER_URL: string =
 export const ADMIN_BASE_URL: string =
     process.env.ADMIN_BASE_URL ??
     `http://${ADMIN_SERVER_HOST}:${ADMIN_SERVER_PORT}`
-export const WORDPRESS_URL: string =
-    process.env.WORDPRESS_URL ?? "https://owid.cloud"
+export const WORDPRESS_URL: string = process.env.WORDPRESS_URL ?? ""
 
 export const ALGOLIA_ID: string = process.env.ALGOLIA_ID ?? ""
 export const ALGOLIA_SEARCH_KEY: string = process.env.ALGOLIA_SEARCH_KEY ?? ""

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -54,8 +54,7 @@ export const BAKED_SITE_DIR: string =
 export const SECRET_KEY: string =
     serverSettings.SECRET_KEY ??
     "fejwiaof jewiafo jeioa fjieowajf isa fjidosajfgj"
-export const WORDPRESS_DB_NAME: string =
-    serverSettings.WORDPRESS_DB_NAME ?? DB_NAME
+export const WORDPRESS_DB_NAME: string = serverSettings.WORDPRESS_DB_NAME ?? ""
 export const WORDPRESS_DB_USER: string =
     serverSettings.WORDPRESS_DB_USER ?? DB_USER
 export const WORDPRESS_DB_PASS: string =
@@ -85,7 +84,7 @@ export const EMAIL_USE_TLS: boolean =
     serverSettings.EMAIL_USE_TLS !== "false" ?? true
 
 // Wordpress target setting
-export const WORDPRESS_DIR: string = serverSettings.WORDPRESS_DIR ?? ""
+export const WORDPRESS_DIR: string = serverSettings.WORDPRESS_DIR ?? "wordpress"
 export const HTTPS_ONLY: boolean = serverSettings.HTTPS_ONLY !== "false" ?? true
 
 // Node slack webhook to report errors to using express-error-slac


### PR DESCRIPTION
Currently, grapher fails to render some pages (e.g. `/grapher/:slug`) if you do not have a wordpress database dump set up and if you do not have a working wordpress API url with credentials.

This PR makes it well defined how to disable these two Wordpress integrations by blanking out specific config keys (`WORDPRESS_DB_NAME` and `WORDPRESS_API_URL`). When they are disabled, the site runs without them and does not attempt operations that would have failed. This makes rendering local charts much much faster.

For example, the http://localhost:3030/admin/test/embeds page rapidly renders all local charts after this change, whereas before they blocked on API calls to a Wordpress instance and were slower than the production site.