### PR TITLE
Fix(grapher): Hide time series that are all 0 in stacked area charts

### DIFF
--- a/grapher/stackedCharts/AbstractStackedChart.tsx
+++ b/grapher/stackedCharts/AbstractStackedChart.tsx
@@ -264,10 +264,18 @@ export class AbstactStackedChart<PositionType extends StackedPointPositionType>
     @computed get seriesColors() {
         return this.series.map((series) => series.color)
     }
+    get showAll0Series(): boolean {
+        return true
+    }
 
     @computed get unstackedSeries(): readonly StackedSeries<PositionType>[] {
         return this.rawSeries
-            .filter((series) => series.rows.length)
+            .filter(
+                (series) =>
+                    series.rows.length &&
+                    (this.showAll0Series ||
+                        series.rows.some((row) => row.value !== 0))
+            )
             .map((series) => {
                 const { isProjection, seriesName, rows } = series
                 return {

--- a/grapher/stackedCharts/AbstractStackedChart.tsx
+++ b/grapher/stackedCharts/AbstractStackedChart.tsx
@@ -264,7 +264,9 @@ export class AbstactStackedChart<PositionType extends StackedPointPositionType>
     @computed get seriesColors() {
         return this.series.map((series) => series.color)
     }
-    get showAll0Series(): boolean {
+
+    /** Whether we want to display series with only zeroes. Defaults to true but e.g. StackedArea charts want to set this to false */
+    get showAllZeroSeries(): boolean {
         return true
     }
 
@@ -273,7 +275,7 @@ export class AbstactStackedChart<PositionType extends StackedPointPositionType>
             .filter(
                 (series) =>
                     series.rows.length &&
-                    (this.showAll0Series ||
+                    (this.showAllZeroSeries ||
                         series.rows.some((row) => row.value !== 0))
             )
             .map((series) => {

--- a/grapher/stackedCharts/StackedAreaChart.tsx
+++ b/grapher/stackedCharts/StackedAreaChart.tsx
@@ -447,6 +447,9 @@ export class StackedAreaChart
             </g>
         )
     }
+    get showAll0Series() {
+        return false
+    }
 
     @computed get legendX(): number {
         return this.legendDimensions

--- a/grapher/stackedCharts/StackedAreaChart.tsx
+++ b/grapher/stackedCharts/StackedAreaChart.tsx
@@ -447,7 +447,8 @@ export class StackedAreaChart
             </g>
         )
     }
-    get showAll0Series() {
+    /** Whether we want to display series with only zeroes (inherited). False for this class, true for others */
+    get showAllZeroSeries() {
         return false
     }
 


### PR DESCRIPTION
This fixes https://www.notion.so/owid/Do-not-plot-series-with-value-0-on-StackedArea-5b877f8c58854445a4631f9999b9b813 , in particular the vaccination chart by company