### PR TITLE
fix: hide timeline for Source or Download tabs

### DIFF
--- a/grapher/core/Grapher.jsdom.test.ts
+++ b/grapher/core/Grapher.jsdom.test.ts
@@ -207,6 +207,17 @@ describe("hasTimeline", () => {
         grapher.tab = GrapherTabOption.table
         expect(grapher.hasTimeline).toBeTruthy()
     })
+
+    it("source and download tabs do not have a timeline", () => {
+        const grapher = new Grapher(legacyConfig)
+        grapher.type = ChartTypeName.LineChart
+
+        grapher.currentTab = GrapherTabOption.sources
+        expect(grapher.hasTimeline).toBeFalsy()
+
+        grapher.currentTab = GrapherTabOption.download
+        expect(grapher.hasTimeline).toBeFalsy()
+    })
 })
 
 const getGrapher = (): Grapher =>

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1098,7 +1098,7 @@ export class Grapher
         // we don't have more than one distinct time point in our data, so it doesn't make sense to show a timeline
         if (this.times.length <= 1) return false
 
-        switch (this.tab) {
+        switch (this.currentTab) {
             // the map tab has its own `hideTimeline` option
             case GrapherTabOption.map:
                 return !this.map.hideTimeline


### PR DESCRIPTION
When you click on the Source or Download tabs of a chart, the timeline currently stays rendered, despite logic that is meant to hide it.

This is because the check is done on `this.tab`, but actually Source and Download are overlays on the tab; when you click on them, `this.tab` stays at wherever it was last.

This fix runs the same check, but on `this.currentTab` instead, which picks up any overlay (such as Source or Download) if they are available. This has the effect of correctly hiding the timeline when the user clicks on those tabs.

See: https://www.notion.so/owid/Hide-timeline-on-Sources-and-Download-tabs-8766e5c1c13f431b978b8d579b92ff65
