### PR TITLE
fix: stacked discrete bar chart handles mising values for some columns

### DIFF
--- a/grapher/stackedCharts/StackedAreaChart.tsx
+++ b/grapher/stackedCharts/StackedAreaChart.tsx
@@ -26,7 +26,7 @@ import {
     AbstactStackedChartProps,
 } from "../stackedCharts/AbstractStackedChart"
 import { StackedSeries } from "./StackedConstants"
-import { stackSeries, withZeroesAsInterpolatedPoints } from "./StackedUtils"
+import { stackSeries, withMissingValuesAsZeroes } from "./StackedUtils"
 import { makeClipPath } from "../chart/ChartUtils"
 import { Time } from "../../clientUtils/owidTypes"
 
@@ -455,6 +455,6 @@ export class StackedAreaChart
     }
 
     @computed get series() {
-        return stackSeries(withZeroesAsInterpolatedPoints(this.unstackedSeries))
+        return stackSeries(withMissingValuesAsZeroes(this.unstackedSeries))
     }
 }

--- a/grapher/stackedCharts/StackedBarChart.tsx
+++ b/grapher/stackedCharts/StackedBarChart.tsx
@@ -24,7 +24,7 @@ import {
 import { StackedPoint, StackedSeries } from "./StackedConstants"
 import { VerticalAxis } from "../axis/Axis"
 import { ColorSchemeName } from "../color/ColorConstants"
-import { stackSeries, withZeroesAsInterpolatedPoints } from "./StackedUtils"
+import { stackSeries, withMissingValuesAsZeroes } from "./StackedUtils"
 import { makeClipPath } from "../chart/ChartUtils"
 import { Time } from "../../clientUtils/owidTypes"
 
@@ -485,6 +485,6 @@ export class StackedBarChart
     defaultBaseColorScheme = ColorSchemeName.stackedAreaDefault
 
     @computed get series() {
-        return stackSeries(withZeroesAsInterpolatedPoints(this.unstackedSeries))
+        return stackSeries(withMissingValuesAsZeroes(this.unstackedSeries))
     }
 }

--- a/grapher/stackedCharts/StackedDiscreteBarChart.test.ts
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.test.ts
@@ -53,12 +53,90 @@ it("can display a StackedDiscreteBar chart in relative mode", () => {
     expect(chart.failMessage).toEqual("")
     expect(chart.series.length).toEqual(2)
     expect(chart.series[0].points).toEqual([
-        { position: "France", value: 40, valueOffset: 0, time: 2000 },
-        { position: "Spain", value: 30, valueOffset: 0, time: 2000 },
+        {
+            position: "France",
+            value: 40,
+            valueOffset: 0,
+            time: 2000,
+            fake: false,
+        },
+        {
+            position: "Spain",
+            value: 30,
+            valueOffset: 0,
+            time: 2000,
+            fake: false,
+        },
     ])
     expect(chart.series[1].points).toEqual([
-        { position: "France", value: 60, valueOffset: 40, time: 2000 },
-        { position: "Spain", value: 70, valueOffset: 30, time: 2000 },
+        {
+            position: "France",
+            value: 60,
+            valueOffset: 40,
+            time: 2000,
+            fake: false,
+        },
+        {
+            position: "Spain",
+            value: 70,
+            valueOffset: 30,
+            time: 2000,
+            fake: false,
+        },
+    ])
+})
+
+it("can display a chart with missing variable data for some entities", () => {
+    const csv = `coal,gas,year,entityName
+    20,,2000,France
+    ,14,2000,Spain`
+    const table = new OwidTable(csv, [
+        { slug: "coal", type: ColumnTypeNames.Numeric },
+        { slug: "gas", type: ColumnTypeNames.Numeric },
+        { slug: "year", type: ColumnTypeNames.Year },
+    ])
+
+    const manager: ChartManager = {
+        table,
+        selection: table.availableEntityNames,
+        yColumnSlugs: ["coal", "gas"],
+    }
+    const chart = new StackedDiscreteBarChart({ manager })
+
+    // Check that our absolute values get properly transformed into percentages
+    expect(chart.failMessage).toEqual("")
+    expect(chart.series.length).toEqual(2)
+    expect(chart.series[0].points).toEqual([
+        {
+            position: "France",
+            value: 20,
+            valueOffset: 0,
+            time: 2000,
+            fake: false,
+        },
+        {
+            position: "Spain",
+            value: 0,
+            valueOffset: 0,
+            time: 0,
+            fake: true,
+        },
+    ])
+    expect(chart.series[1].points).toEqual([
+        {
+            position: "France",
+            value: 0,
+            valueOffset: 20,
+            time: 0,
+            fake: true,
+        },
+        {
+            position: "Spain",
+            value: 14,
+            valueOffset: 0,
+            time: 2000,
+            fake: false,
+        },
     ])
 })
 

--- a/grapher/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.tsx
@@ -21,7 +21,10 @@ import { AxisConfig } from "../axis/AxisConfig"
 import { ChartInterface } from "../chart/ChartInterface"
 import { OwidTable } from "../../coreTable/OwidTable"
 import { autoDetectYColumnSlugs, makeSelectionArray } from "../chart/ChartUtils"
-import { stackSeries } from "../stackedCharts/StackedUtils"
+import {
+    stackSeries,
+    withZeroesAsInterpolatedPoints,
+} from "../stackedCharts/StackedUtils"
 import { ChartManager } from "../chart/ChartManager"
 import { Color, Time } from "../../clientUtils/owidTypes"
 import { StackedPoint, StackedSeries } from "./StackedConstants"
@@ -471,7 +474,7 @@ export class StackedDiscreteBarChart
                             highlightedSeriesName !== undefined &&
                             !isHighlighted
                         const shouldShowTimeNotice =
-                            bar.point.value !== undefined &&
+                            !bar.point.fake &&
                             bar.point.time !== props.targetTime
                         hasTimeNotice ||= shouldShowTimeNotice
 
@@ -513,7 +516,7 @@ export class StackedDiscreteBarChart
                                         whiteSpace: "nowrap",
                                     }}
                                 >
-                                    {bar.point.value === undefined
+                                    {bar.point.fake
                                         ? "No data"
                                         : props.formatColumn.formatValueShort(
                                               bar.point.value,
@@ -637,6 +640,6 @@ export class StackedDiscreteBarChart
     }
 
     @computed get series(): readonly StackedSeries<EntityName>[] {
-        return stackSeries(this.unstackedSeries)
+        return stackSeries(withZeroesAsInterpolatedPoints(this.unstackedSeries))
     }
 }

--- a/grapher/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.tsx
@@ -23,7 +23,7 @@ import { OwidTable } from "../../coreTable/OwidTable"
 import { autoDetectYColumnSlugs, makeSelectionArray } from "../chart/ChartUtils"
 import {
     stackSeries,
-    withZeroesAsInterpolatedPoints,
+    withMissingValuesAsZeroes,
 } from "../stackedCharts/StackedUtils"
 import { ChartManager } from "../chart/ChartManager"
 import { Color, Time } from "../../clientUtils/owidTypes"
@@ -640,6 +640,6 @@ export class StackedDiscreteBarChart
     }
 
     @computed get series(): readonly StackedSeries<EntityName>[] {
-        return stackSeries(withZeroesAsInterpolatedPoints(this.unstackedSeries))
+        return stackSeries(withMissingValuesAsZeroes(this.unstackedSeries))
     }
 }

--- a/grapher/stackedCharts/StackedUtils.test.ts
+++ b/grapher/stackedCharts/StackedUtils.test.ts
@@ -1,6 +1,6 @@
 #! /usr/bin/env jest
 
-import { stackSeries, withZeroesAsInterpolatedPoints } from "./StackedUtils"
+import { stackSeries, withMissingValuesAsZeroes } from "./StackedUtils"
 
 const seriesArr = [
     {
@@ -20,12 +20,12 @@ const seriesArr = [
 
 it("can add fake points", () => {
     expect(seriesArr[1].points[1]).toEqual(undefined)
-    const series = withZeroesAsInterpolatedPoints(seriesArr)
+    const series = withMissingValuesAsZeroes(seriesArr)
     expect(series[1].points[1].position).toEqual(2002)
 })
 
 it("can stack series", () => {
     expect(seriesArr[1].points[0].valueOffset).toEqual(0)
-    const series = stackSeries(withZeroesAsInterpolatedPoints(seriesArr))
+    const series = stackSeries(withMissingValuesAsZeroes(seriesArr))
     expect(series[1].points[0].valueOffset).toEqual(10)
 })

--- a/grapher/stackedCharts/StackedUtils.ts
+++ b/grapher/stackedCharts/StackedUtils.ts
@@ -19,7 +19,7 @@ export const stackSeries = <PositionType extends StackedPointPositionType>(
 }
 
 // Adds a Y = 0 value for each missing x value (where X is usually Time)
-export const withZeroesAsInterpolatedPoints = <
+export const withMissingValuesAsZeroes = <
     PositionType extends StackedPointPositionType
 >(
     seriesArr: readonly StackedSeries<PositionType>[]


### PR DESCRIPTION
Fixes the issues that [Hannah reported](https://owid.slack.com/archives/C46U9LXRR/p1622146853049900) for this chart: https://ourworldindata.org/grapher/per-capita-co2-by-fuel

In [`stackSeries`](https://github.com/owid/owid-grapher/blob/62d1a56ac0929a06fb92d161d30f61a0f41368bf/grapher/stackedCharts/StackedUtils.ts#L6-L19), we were assuming that all series had the same number of points (one for every entity we have), which wasn't the case if some variable had missing data for one entity.

I'm not in love with the whole `fake` point thing, and think we should introduce another `NoDataAvailableStackedPoint` or something instead. But that's something for another time.