### PR TITLE
fix(grapher): Facet graphs controlled by the timeline

### DIFF
--- a/grapher/facetChart/FacetChart.test.ts
+++ b/grapher/facetChart/FacetChart.test.ts
@@ -12,7 +12,29 @@ it("can create a new FacetChart", () => {
         selection: table.availableEntityNames,
     }
     const chart = new FacetChart({ manager })
+
+    // default to country facets
     expect(chart.series.length).toEqual(2)
+
+    // switch to column facets
     manager.facetStrategy = FacetStrategy.column
     expect(chart.series.length).toEqual(3)
+})
+
+it("uses the transformed data for display in country mode", () => {
+    const table = SynthesizeGDPTable({ timeRange: [2000, 2010] })
+    const manager: ChartManager = {
+        table,
+        selection: table.availableEntityNames,
+        // simulate the transformation that is done by Grapher on the data
+        transformedTable: table.filterByTimeRange(2002, 2008),
+        facetStrategy: FacetStrategy.country,
+    }
+    const chart = new FacetChart({ manager })
+
+    // we should be using the transformed table
+    chart.series.forEach((s) => {
+        expect(s.manager.table!.minTime).toEqual(2002)
+        expect(s.manager.table!.maxTime).toEqual(2008)
+    })
 })

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -64,7 +64,7 @@ export class FacetChart
         const baseFontSize = getFontSize(count, manager.baseFontSize)
         const lineStrokeWidth = count > 16 ? 1 : undefined
 
-        const table = this.inputTable
+        const table = this.transformedTable
 
         return series.map((series, index) => {
             const bounds = boundsArr[index]
@@ -107,7 +107,7 @@ export class FacetChart
     }
 
     @computed private get countryFacets(): FacetSeries[] {
-        const table = this.inputTable.filterByEntityNames(
+        const table = this.transformedTable.filterByEntityNames(
             this.selectionArray.selectedEntityNames
         )
         const yDomain = table.domainFor(this.yColumnSlugs)
@@ -136,7 +136,7 @@ export class FacetChart
                 seriesName,
                 color: facetBackgroundColor,
                 manager: {
-                    table: this.inputTable.filterByEntityNames([seriesName]),
+                    table: table.filterByEntityNames([seriesName]),
                     selection: [seriesName],
                     seriesStrategy: SeriesStrategy.column,
                     hideLegend,


### PR DESCRIPTION
Currently, facet charts totally ignore the timeline control. This is because they are generated from the `inputTable` before transformations, which include filtering the data to only the selected range.

This fix builds the facet charts instead from the `transformedData` that has been correctly filtered this way.