### PR TITLE
Fix time in Atom feed

### DIFF
--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -604,8 +604,8 @@ export const getFullPost = async (
     path: postApi.slug, // kept for transitioning between legacy BPES (blog post as entry section) and future hierarchical paths
     title: decodeHTML(postApi.title.rendered),
     subtitle: postApi.meta.owid_subtitle_meta_field,
-    date: new Date(postApi.date),
-    modifiedDate: new Date(postApi.modified),
+    date: new Date(postApi.date_gmt),
+    modifiedDate: new Date(postApi.modified_gmt),
     authors: postApi.authors_name || [],
     content: excludeContent ? "" : postApi.content.rendered,
     excerpt: decodeHTML(postApi.excerpt.rendered),


### PR DESCRIPTION
**Before**
<img width="914" alt="Screenshot 2021-06-03 at 16 45 11" src="https://user-images.githubusercontent.com/13406362/120669621-e9fd6f80-c48f-11eb-9f5f-aa232b9b4cd3.png">

**After**
<img width="879" alt="Screenshot 2021-06-03 at 16 53 33" src="https://user-images.githubusercontent.com/13406362/120669644-eec22380-c48f-11eb-94cf-7a8e0888a7fd.png">


postApi's dates (date, modified, date_gmt, modified_gmt) are e.g. 2021-06-03T13:30:23, with no timezone offset. Parsing them with new Date() is understood as UTC given TZ=utc is defined in .env. This passes the dates as GMT / UTC.

Not entirely sure how Mailchimp uses the post time in their RSS campaigns but it's probably best to have the correct one, especially given our preflight process which is time sensitive (see [Automate immediate newsletter updates](https://www.notion.so/Automate-immediate-newsletter-updates-04f02909c1bc4eaa9700c258a9f57cfc))