### PR TITLE
feat: StackedDiscreteBarChart bars animate

### DIFF
--- a/clientUtils/BrowserUtil.ts
+++ b/clientUtils/BrowserUtil.ts
@@ -1,3 +1,4 @@
 // Taken from https://since1979.dev/respecting-prefers-reduced-motion-with-javascript-and-react/
 export const prefersReducedMotion = (): boolean =>
-    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    typeof window !== "undefined" &&
+    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches

--- a/clientUtils/BrowserUtil.ts
+++ b/clientUtils/BrowserUtil.ts
@@ -1,0 +1,3 @@
+// Taken from https://since1979.dev/respecting-prefers-reduced-motion-with-javascript-and-react/
+export const prefersReducedMotion = (): boolean =>
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches

--- a/grapher/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.tsx
@@ -46,6 +46,7 @@ import { HorizontalAxis } from "../axis/Axis"
 import { SelectionArray } from "../selection/SelectionArray"
 import { ColorScheme } from "../color/ColorScheme"
 import { Flipper, Flipped } from "react-flip-toolkit"
+import { prefersReducedMotion } from "../../clientUtils/BrowserUtil"
 
 const labelToBarPadding = 5
 
@@ -304,6 +305,8 @@ export class StackedDiscreteBarChart
 
         const { bounds, axis, innerBounds, barHeight, barSpacing } = this
 
+        const shouldAnimate = !prefersReducedMotion()
+
         let yOffset = innerBounds.top + barHeight / 2
 
         return (
@@ -348,6 +351,7 @@ export class StackedDiscreteBarChart
                                 flipId={label}
                                 translate
                                 spring={spring}
+                                shouldFlip={() => shouldAnimate}
                             >
                                 <g
                                     key={label}

--- a/grapher/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.tsx
@@ -45,6 +45,7 @@ import { isDarkColor } from "../color/ColorUtils"
 import { HorizontalAxis } from "../axis/Axis"
 import { SelectionArray } from "../selection/SelectionArray"
 import { ColorScheme } from "../color/ColorScheme"
+import { Flipper, Flipped } from "react-flip-toolkit"
 
 const labelToBarPadding = 5
 
@@ -325,63 +326,77 @@ export class StackedDiscreteBarChart
                     bounds={innerBounds}
                 />
                 <HorizontalCategoricalColorLegend manager={this} />
-                {this.items.map(({ label, bars }) => {
-                    // Using transforms for positioning to enable better (subpixel) transitions
-                    // Width transitions don't work well on iOS Safari – they get interrupted and
-                    // it appears very slow. Also be careful with negative bar charts.
-                    const tooltipProps = {
-                        label,
-                        bars,
-                        targetTime: this.manager.endTime,
-                        timeColumn: this.inputTable.timeColumn,
-                        formatColumn: this.formatColumn,
-                    }
+                <Flipper flipKey={this.items.map((i) => i.label)} element="g">
+                    {this.items.map(({ label, bars }) => {
+                        // Using transforms for positioning to enable better (subpixel) transitions
+                        // Width transitions don't work well on iOS Safari – they get interrupted and
+                        // it appears very slow. Also be careful with negative bar charts.
+                        const tooltipProps = {
+                            label,
+                            bars,
+                            targetTime: this.manager.endTime,
+                            timeColumn: this.inputTable.timeColumn,
+                            formatColumn: this.formatColumn,
+                        }
 
-                    const result = (
-                        <g
-                            key={label}
-                            className="bar"
-                            transform={`translate(0, ${yOffset})`}
-                        >
-                            <TippyIfInteractive
-                                lazy
-                                isInteractive={
-                                    !this.manager.isExportingtoSvgOrPng
-                                }
-                                hideOnClick={false}
-                                content={
-                                    <StackedDiscreteBarChart.Tooltip
-                                        {...tooltipProps}
-                                    />
-                                }
+                        // This custom spring is very gentle and doesn't wobble.
+                        const spring = { stiffness: 130, damping: 23 }
+
+                        const result = (
+                            <Flipped
+                                key={label}
+                                flipId={label}
+                                translate
+                                spring={spring}
                             >
-                                <text
-                                    x={0}
-                                    y={0}
-                                    transform={`translate(${
-                                        axis.place(this.x0) - labelToBarPadding
-                                    }, 0)`}
-                                    fill="#555"
-                                    dominantBaseline="middle"
-                                    textAnchor="end"
-                                    {...this.labelStyle}
+                                <g
+                                    key={label}
+                                    className="bar"
+                                    transform={`translate(0, ${yOffset})`}
                                 >
-                                    {label}
-                                </text>
-                            </TippyIfInteractive>
-                            {bars.map((bar) =>
-                                this.renderBar(bar, {
-                                    ...tooltipProps,
-                                    highlightedSeriesName: bar.seriesName,
-                                })
-                            )}
-                        </g>
-                    )
+                                    <TippyIfInteractive
+                                        lazy
+                                        isInteractive={
+                                            !this.manager.isExportingtoSvgOrPng
+                                        }
+                                        hideOnClick={false}
+                                        content={
+                                            <StackedDiscreteBarChart.Tooltip
+                                                {...tooltipProps}
+                                            />
+                                        }
+                                    >
+                                        <text
+                                            x={0}
+                                            y={0}
+                                            transform={`translate(${
+                                                axis.place(this.x0) -
+                                                labelToBarPadding
+                                            }, 0)`}
+                                            fill="#555"
+                                            dominantBaseline="middle"
+                                            textAnchor="end"
+                                            {...this.labelStyle}
+                                        >
+                                            {label}
+                                        </text>
+                                    </TippyIfInteractive>
+                                    {bars.map((bar) =>
+                                        this.renderBar(bar, {
+                                            ...tooltipProps,
+                                            highlightedSeriesName:
+                                                bar.seriesName,
+                                        })
+                                    )}
+                                </g>
+                            </Flipped>
+                        )
 
-                    yOffset += barHeight + barSpacing
+                        yOffset += barHeight + barSpacing
 
-                    return result
-                })}
+                        return result
+                    })}
+                </Flipper>
             </g>
         )
     }

--- a/grapher/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.tsx
@@ -339,8 +339,8 @@ export class StackedDiscreteBarChart
                             formatColumn: this.formatColumn,
                         }
 
-                        // This custom spring is very gentle and doesn't wobble.
-                        const spring = { stiffness: 130, damping: 23 }
+                        // This custom spring is quite gentle and doesn't wobble.
+                        const spring = { stiffness: 160, damping: 26 }
 
                         const result = (
                             <Flipped


### PR DESCRIPTION
Notion: [Animate reordering of bars](https://www.notion.so/Animate-reordering-of-bars-188ab2942abe43b48c9306e42b966f15)

Thankfully, this can be done pretty easily with `react-flip-toolkit`.
One caveat there is that we're only animating the order of bars, and not their respective width. Animating the bar width is a little more intricate (because we would also need to animate the axis, etc.)

This is also live on _tufte_. Try it out here:
* [COVID explorer](https://tufte-owid.netlify.app/explorers/coronavirus-data-explorer?Metric=People+vaccinated+%28by+dose%29&Interval=7-day+rolling+average&Relative+to+Population=true&Align+outbreaks=false&country=IND~USA~ITA~GBR~DEU~CAN)
* [Per capita electricity consumption by source](https://tufte-owid.netlify.app/grapher/per-capita-electricity-source-stacked?time=2020&country=OWID_WRL~CHN~IND~USA~JPN~DEU~GBR~BRA~FRA~CAN~SWE~ZAF)