### PR TITLE
fix: legend label alignment in png exports

### DIFF
--- a/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -421,8 +421,11 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                         key={index}
                         x={this.legendX + label.bounds.x}
                         y={bottomY + label.bounds.y}
+                        // we can't use dominant-baseline to do proper alignment since our svg-to-png library Sharp
+                        // doesn't support that (https://github.com/lovell/sharp/issues/1996), so we'll have to make
+                        // do with some rough positioning.
+                        dy=".75em"
                         fontSize={label.fontSize}
-                        dominantBaseline="hanging"
                     >
                         {label.text}
                     </text>
@@ -559,8 +562,11 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
                                         this.categoryLegendY +
                                         mark.label.bounds.y
                                     }
+                                    // we can't use dominant-baseline to do proper alignment since our svg-to-png library Sharp
+                                    // doesn't support that (https://github.com/lovell/sharp/issues/1996), so we'll have to make
+                                    // do with some rough positioning.
+                                    dy=".75em"
                                     fontSize={mark.label.fontSize}
-                                    dominantBaseline="hanging"
                                 >
                                     {mark.label.text}
                                 </text>

--- a/grapher/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.tsx
@@ -402,8 +402,9 @@ export class StackedDiscreteBarChart
         const barLabel = formatColumn.formatValueShort(point.value, {
             numDecimalPlaces: Math.max(0, -magnitude + 2),
         })
+        const labelFontSize = 0.7 * this.baseFontSize
         const labelBounds = Bounds.forText(barLabel, {
-            fontSize: 0.7 * this.baseFontSize,
+            fontSize: labelFontSize,
         })
         // Check that we have enough space to show the bar label
         const showLabelInsideBar =
@@ -440,7 +441,7 @@ export class StackedDiscreteBarChart
                             height={barHeight}
                             fill={labelColor}
                             opacity={isFaint ? 0 : 1}
-                            fontSize="0.7em"
+                            fontSize={labelFontSize}
                             textAnchor="middle"
                             dominantBaseline="middle"
                         >


### PR DESCRIPTION
Notion: [HorizontalLegend become offset when converting SVG → PNG](https://www.notion.so/HorizontalLegend-become-offset-when-converting-SVG-PNG-2f7ef11b178141abbe035bee4f19f6c2)

## Before
![image](https://user-images.githubusercontent.com/2641501/121083276-85b81400-c7df-11eb-94ce-5ff89b61bcb8.png)


## After
![image](https://user-images.githubusercontent.com/2641501/121083133-55707580-c7df-11eb-9a56-68f473461d61.png)

Note that Lato and Playfair Display are installed on `owid-live`, but not on `owid-staging` - that's why the above image is rendered using the wrong fonts.
You may also notice that the bar labels, and other stuff, isn't aligned correctly in the above image. That's because, you guessed it, they also use `dominant-baseline`, which isn't supported by Sharp.
