### PR TITLE
enhance(grapher): add relative yaxis mode in facets

### DIFF
--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -22,6 +22,7 @@ import { ColorSchemeDropdown, ColorSchemeOption } from "./ColorSchemeDropdown"
 import { EditorColorScaleSection } from "./EditorColorScaleSection"
 import { ColorSchemeName } from "../grapher/color/ColorConstants"
 import { TimeBoundValue } from "../clientUtils/TimeBounds"
+import { FacetScaleMode } from "../grapher/core/GrapherConstants"
 @observer
 class ColorSchemeSelector extends React.Component<{ grapher: Grapher }> {
     @action.bound onChange(selected: ColorSchemeOption) {
@@ -307,6 +308,26 @@ export class EditorCustomizeTab extends React.Component<{
                                             (yAxisConfig.canChangeScaleType =
                                                 value || undefined)
                                         }
+                                    />
+                                </FieldsRow>
+                                <FieldsRow>
+                                    <Toggle
+                                        label={`Facets have uniform y-axis`}
+                                        value={
+                                            // default is absolute
+                                            [
+                                                FacetScaleMode.absolute,
+                                                undefined,
+                                            ].includes(
+                                                yAxisConfig.facetScaleMode
+                                            )
+                                        }
+                                        onValue={(value) => {
+                                            // remap absolute back to undefined
+                                            yAxisConfig.facetScaleMode = value
+                                                ? undefined
+                                                : FacetScaleMode.relative
+                                        }}
                                     />
                                 </FieldsRow>
                             </React.Fragment>

--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -22,7 +22,7 @@ import { ColorSchemeDropdown, ColorSchemeOption } from "./ColorSchemeDropdown"
 import { EditorColorScaleSection } from "./EditorColorScaleSection"
 import { ColorSchemeName } from "../grapher/color/ColorConstants"
 import { TimeBoundValue } from "../clientUtils/TimeBounds"
-import { FacetScaleMode } from "../grapher/core/GrapherConstants"
+import { FacetAxisRange } from "../grapher/core/GrapherConstants"
 @observer
 class ColorSchemeSelector extends React.Component<{ grapher: Grapher }> {
     @action.bound onChange(selected: ColorSchemeOption) {
@@ -314,19 +314,13 @@ export class EditorCustomizeTab extends React.Component<{
                                     <Toggle
                                         label={`Facets have uniform y-axis`}
                                         value={
-                                            // default is absolute
-                                            [
-                                                FacetScaleMode.absolute,
-                                                undefined,
-                                            ].includes(
-                                                yAxisConfig.facetScaleMode
-                                            )
+                                            yAxisConfig.facetAxisRange ===
+                                            FacetAxisRange.shared
                                         }
                                         onValue={(value) => {
-                                            // remap absolute back to undefined
-                                            yAxisConfig.facetScaleMode = value
-                                                ? undefined
-                                                : FacetScaleMode.relative
+                                            yAxisConfig.facetAxisRange = value
+                                                ? FacetAxisRange.shared
+                                                : FacetAxisRange.independent
                                         }}
                                     />
                                 </FieldsRow>

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -281,6 +281,7 @@ export class Explorer
             tableSlug,
             yScaleToggle,
             yAxisMin,
+            facetYRange,
         } = grapherConfigFromExplorer
 
         const hasGrapherId = grapherId && isNotErrorValue(grapherId)
@@ -300,6 +301,9 @@ export class Explorer
         grapher.reset()
         grapher.yAxis.canChangeScaleType = yScaleToggle
         grapher.yAxis.min = yAxisMin
+        if (facetYRange) {
+            grapher.yAxis.facetAxisRange = facetYRange
+        }
         grapher.updateFromObject(config)
 
         if (!hasGrapherId) {

--- a/explorer/ExplorerProgram.test.ts
+++ b/explorer/ExplorerProgram.test.ts
@@ -117,6 +117,14 @@ graphers
         expect(grapherConfig).toEqual({ title: "Foo", ySlugs: "gdp" })
     })
 
+    it("can set a facet y range", () => {
+        const grapherConfig = new ExplorerProgram(
+            "test",
+            `facetYRange\tindependent`
+        ).tuplesObject
+        expect(grapherConfig).toEqual({ facetYRange: "independent" })
+    })
+
     it("prefers inline data to url if it has both", () => {
         const program = new ExplorerProgram(
             "test",

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -32,6 +32,7 @@ import { ColumnGrammar } from "./ColumnGrammar"
 import { DecisionMatrix } from "./ExplorerDecisionMatrix"
 import { CoreColumnDef } from "../coreTable/CoreColumnDef"
 import { PromiseCache } from "../clientUtils/PromiseCache"
+import { FacetAxisRange } from "../grapher/core/GrapherConstants"
 
 export const EXPLORER_FILE_SUFFIX = ".explorer.tsv"
 
@@ -46,6 +47,7 @@ interface ExplorerGrapherInterface extends GrapherInterface {
     tableSlug?: string
     yScaleToggle?: boolean
     yAxisMin?: number
+    facetYRange?: FacetAxisRange
 }
 
 const ExplorerRootDef: CellDef = {
@@ -336,9 +338,11 @@ export class ExplorerProgram extends GridProgram {
         })
 
         const selectedGrapherRow = this.decisionMatrix.selectedRow
-        return selectedGrapherRow && Object.keys(selectedGrapherRow).length
-            ? { ...rootObject, ...selectedGrapherRow }
-            : rootObject
+        if (selectedGrapherRow && Object.keys(selectedGrapherRow).length) {
+            return { ...rootObject, ...selectedGrapherRow }
+        }
+
+        return rootObject
     }
 
     /**

--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -10,6 +10,7 @@ import {
 } from "../gridLang/GridLangConstants"
 import {
     ChartTypeName,
+    FacetAxisRange,
     FacetStrategy,
     GrapherTabOption,
 } from "../grapher/core/GrapherConstants"
@@ -129,6 +130,17 @@ export const GrapherGrammar: Grammar = {
         ...NumericCellDef,
         keyword: "yAxisMin",
         description: "Set the minimum value for the yAxis",
+    },
+    facetYRange: {
+        ...EnumCellDef,
+        keyword: "facetYRange",
+        description:
+            "Whether facets axes default to shared or independent range",
+        terminalOptions: Object.keys(FacetAxisRange).map((keyword) => ({
+            keyword,
+            description: "",
+            cssClass: "",
+        })),
     },
     baseColorScheme: {
         ...EnumCellDef,

--- a/grapher/axis/AxisConfig.ts
+++ b/grapher/axis/AxisConfig.ts
@@ -1,4 +1,8 @@
-import { BASE_FONT_SIZE, ScaleType } from "../core/GrapherConstants"
+import {
+    BASE_FONT_SIZE,
+    FacetScaleMode,
+    ScaleType,
+} from "../core/GrapherConstants"
 import { extend, trimObject } from "../../clientUtils/Util"
 import { observable, computed } from "mobx"
 import { HorizontalAxis, VerticalAxis } from "./Axis"
@@ -20,6 +24,7 @@ class AxisConfigDefaults {
     @observable.ref canChangeScaleType?: boolean = undefined
     @observable label: string = ""
     @observable.ref removePointsOutsideDomain?: boolean = undefined
+    @observable.ref facetScaleMode?: FacetScaleMode = undefined
 }
 
 export class AxisConfig
@@ -51,6 +56,7 @@ export class AxisConfig
             max: this.max,
             canChangeScaleType: this.canChangeScaleType,
             removePointsOutsideDomain: this.removePointsOutsideDomain,
+            facetScaleMode: this.facetScaleMode,
         })
 
         deleteRuntimeAndUnchangedProps(obj, new AxisConfigDefaults())

--- a/grapher/axis/AxisConfig.ts
+++ b/grapher/axis/AxisConfig.ts
@@ -1,6 +1,6 @@
 import {
     BASE_FONT_SIZE,
-    FacetScaleMode,
+    FacetAxisRange,
     ScaleType,
 } from "../core/GrapherConstants"
 import { extend, trimObject } from "../../clientUtils/Util"
@@ -24,7 +24,7 @@ class AxisConfigDefaults {
     @observable.ref canChangeScaleType?: boolean = undefined
     @observable label: string = ""
     @observable.ref removePointsOutsideDomain?: boolean = undefined
-    @observable.ref facetScaleMode?: FacetScaleMode = undefined
+    @observable.ref facetAxisRange: FacetAxisRange = FacetAxisRange.shared
 }
 
 export class AxisConfig
@@ -56,7 +56,7 @@ export class AxisConfig
             max: this.max,
             canChangeScaleType: this.canChangeScaleType,
             removePointsOutsideDomain: this.removePointsOutsideDomain,
-            facetScaleMode: this.facetScaleMode,
+            facetAxisRange: this.facetAxisRange,
         })
 
         deleteRuntimeAndUnchangedProps(obj, new AxisConfigDefaults())

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -28,6 +28,8 @@ import {
     SmallCountriesFilterManager,
     AbsRelToggleManager,
     HighlightToggleManager,
+    FacetYAxisToggle,
+    FacetYAxisToggleManager,
 } from "../controls/Controls"
 import { ScaleSelector } from "../controls/ScaleSelector"
 import { AddEntityButton } from "../controls/AddEntityButton"
@@ -45,7 +47,8 @@ export interface CaptionedChartManager
         HighlightToggleManager,
         AbsRelToggleManager,
         FooterManager,
-        HeaderManager {
+        HeaderManager,
+        FacetYAxisToggleManager {
     containerElement?: HTMLDivElement
     tabBounds?: Bounds
     fontSize?: number
@@ -61,6 +64,7 @@ export interface CaptionedChartManager
     showXScaleToggle?: boolean
     showZoomToggle?: boolean
     showAbsRelToggle?: boolean
+    showFacetYAxisToggle?: boolean
     showHighlightToggle?: boolean
     showChangeEntityButton?: boolean
     showAddEntityButton?: boolean
@@ -239,6 +243,11 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
 
         if (manager.showAbsRelToggle)
             controls.push(<AbsRelToggle key="AbsRelToggle" manager={manager} />)
+
+        if (manager.showFacetYAxisToggle || true)
+            controls.push(
+                <FacetYAxisToggle key="FacetYAxisToggle" manager={manager} />
+            )
 
         if (manager.showHighlightToggle)
             controls.push(

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -28,8 +28,8 @@ import {
     SmallCountriesFilterManager,
     AbsRelToggleManager,
     HighlightToggleManager,
-    FacetYAxisToggle,
-    FacetYAxisToggleManager,
+    FacetYRangeToggle,
+    FacetYRangeToggleManager,
 } from "../controls/Controls"
 import { ScaleSelector } from "../controls/ScaleSelector"
 import { AddEntityButton } from "../controls/AddEntityButton"
@@ -48,7 +48,7 @@ export interface CaptionedChartManager
         AbsRelToggleManager,
         FooterManager,
         HeaderManager,
-        FacetYAxisToggleManager {
+        FacetYRangeToggleManager {
     containerElement?: HTMLDivElement
     tabBounds?: Bounds
     fontSize?: number
@@ -64,7 +64,7 @@ export interface CaptionedChartManager
     showXScaleToggle?: boolean
     showZoomToggle?: boolean
     showAbsRelToggle?: boolean
-    showFacetYAxisToggle?: boolean
+    showFacetYRangeToggle?: boolean
     showHighlightToggle?: boolean
     showChangeEntityButton?: boolean
     showAddEntityButton?: boolean
@@ -248,9 +248,9 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         if (manager.showAbsRelToggle)
             controls.push(<AbsRelToggle key="AbsRelToggle" manager={manager} />)
 
-        if (this.isFaceted && manager.showFacetYAxisToggle)
+        if (this.isFaceted && manager.showFacetYRangeToggle)
             controls.push(
-                <FacetYAxisToggle key="FacetYAxisToggle" manager={manager} />
+                <FacetYRangeToggle key="FacetYRangeToggle" manager={manager} />
             )
 
         if (manager.showHighlightToggle)

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -138,6 +138,10 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
             .padBottom(OUTSIDE_PADDING)
     }
 
+    @computed get isFaceted(): boolean {
+        return !this.isMapTab && !!this.manager.facetStrategy
+    }
+
     renderChart(): JSX.Element {
         const { manager } = this
         const bounds = this.boundsForChart
@@ -151,7 +155,7 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
             ChartComponentClassMap.get(chartTypeName) ?? DefaultChartClass
 
         // Todo: make FacetChart a chart type name?
-        if (!this.isMapTab && manager.facetStrategy)
+        if (this.isFaceted)
             return (
                 <FacetChart
                     bounds={bounds}
@@ -244,7 +248,7 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         if (manager.showAbsRelToggle)
             controls.push(<AbsRelToggle key="AbsRelToggle" manager={manager} />)
 
-        if (manager.showFacetYAxisToggle || true)
+        if (this.isFaceted && manager.showFacetYAxisToggle)
             controls.push(
                 <FacetYAxisToggle key="FacetYAxisToggle" manager={manager} />
             )

--- a/grapher/chart/ChartManager.ts
+++ b/grapher/chart/ChartManager.ts
@@ -3,7 +3,7 @@ import { ColorScaleConfigInterface } from "../color/ColorScaleConfig"
 import {
     EntitySelectionMode,
     FacetStrategy,
-    FacetYAxisMode,
+    FacetScaleMode,
     SeriesColorMap,
     SeriesStrategy,
 } from "../core/GrapherConstants"
@@ -29,7 +29,7 @@ export interface ChartManager {
     startSelectingWhenLineClicked?: boolean // used by lineLabels
     isExportingtoSvgOrPng?: boolean
     isRelativeMode?: boolean
-    isFacetYAxisRelative?: boolean
+    isFacetYAxisAbsolute?: boolean
     comparisonLines?: ComparisonLineConfig[]
     hideLegend?: boolean
     tooltip?: TooltipProps

--- a/grapher/chart/ChartManager.ts
+++ b/grapher/chart/ChartManager.ts
@@ -28,7 +28,7 @@ export interface ChartManager {
     startSelectingWhenLineClicked?: boolean // used by lineLabels
     isExportingtoSvgOrPng?: boolean
     isRelativeMode?: boolean
-    isFacetYAxisAbsolute?: boolean
+    isFacetYAxisShared?: boolean
     comparisonLines?: ComparisonLineConfig[]
     hideLegend?: boolean
     tooltip?: TooltipProps

--- a/grapher/chart/ChartManager.ts
+++ b/grapher/chart/ChartManager.ts
@@ -28,7 +28,6 @@ export interface ChartManager {
     startSelectingWhenLineClicked?: boolean // used by lineLabels
     isExportingtoSvgOrPng?: boolean
     isRelativeMode?: boolean
-    isFacetYAxisShared?: boolean
     comparisonLines?: ComparisonLineConfig[]
     hideLegend?: boolean
     tooltip?: TooltipProps

--- a/grapher/chart/ChartManager.ts
+++ b/grapher/chart/ChartManager.ts
@@ -3,6 +3,7 @@ import { ColorScaleConfigInterface } from "../color/ColorScaleConfig"
 import {
     EntitySelectionMode,
     FacetStrategy,
+    FacetYAxisMode,
     SeriesColorMap,
     SeriesStrategy,
 } from "../core/GrapherConstants"
@@ -28,6 +29,7 @@ export interface ChartManager {
     startSelectingWhenLineClicked?: boolean // used by lineLabels
     isExportingtoSvgOrPng?: boolean
     isRelativeMode?: boolean
+    isFacetYAxisRelative?: boolean
     comparisonLines?: ComparisonLineConfig[]
     hideLegend?: boolean
     tooltip?: TooltipProps

--- a/grapher/chart/ChartManager.ts
+++ b/grapher/chart/ChartManager.ts
@@ -3,7 +3,6 @@ import { ColorScaleConfigInterface } from "../color/ColorScaleConfig"
 import {
     EntitySelectionMode,
     FacetStrategy,
-    FacetScaleMode,
     SeriesColorMap,
     SeriesStrategy,
 } from "../core/GrapherConstants"

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -14,7 +14,7 @@ import { faShareAlt } from "@fortawesome/free-solid-svg-icons/faShareAlt"
 import { faExpand } from "@fortawesome/free-solid-svg-icons/faExpand"
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons/faExternalLinkAlt"
 import {
-    FacetYAxisMode,
+    FacetScaleMode,
     GrapherTabOption,
     HighlightToggleConfig,
     RelatedQuestionsConfig,
@@ -125,7 +125,7 @@ export class AbsRelToggle extends React.Component<{
 }
 
 export interface FacetYAxisToggleManager {
-    facetYAxisMode?: FacetYAxisMode
+    facetYAxisMode?: FacetScaleMode
 }
 
 @observer
@@ -134,14 +134,13 @@ export class FacetYAxisToggle extends React.Component<{
 }> {
     @action.bound onToggle(): void {
         this.props.manager.facetYAxisMode = this.isAbsoluteMode
-            ? FacetYAxisMode.relative
-            : FacetYAxisMode.absolute
+            ? FacetScaleMode.relative
+            : FacetScaleMode.absolute
     }
 
     @computed get isAbsoluteMode(): boolean {
-        return (
-            !this.props.manager.facetYAxisMode ||
-            this.props.manager.facetYAxisMode === FacetYAxisMode.absolute
+        return [FacetScaleMode.absolute, undefined].includes(
+            this.props.manager.facetYAxisMode
         )
     }
 

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -14,6 +14,7 @@ import { faShareAlt } from "@fortawesome/free-solid-svg-icons/faShareAlt"
 import { faExpand } from "@fortawesome/free-solid-svg-icons/faExpand"
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons/faExternalLinkAlt"
 import {
+    FacetYAxisMode,
     GrapherTabOption,
     HighlightToggleConfig,
     RelatedQuestionsConfig,
@@ -118,6 +119,42 @@ export class AbsRelToggle extends React.Component<{
                     data-track-note="chart-abs-rel-toggle"
                 />{" "}
                 &nbsp;{label}
+            </label>
+        )
+    }
+}
+
+export interface FacetYAxisToggleManager {
+    facetYAxisMode?: FacetYAxisMode
+}
+
+@observer
+export class FacetYAxisToggle extends React.Component<{
+    manager: FacetYAxisToggleManager
+}> {
+    @action.bound onToggle(): void {
+        this.props.manager.facetYAxisMode = this.isAbsoluteMode
+            ? FacetYAxisMode.relative
+            : FacetYAxisMode.absolute
+    }
+
+    @computed get isAbsoluteMode(): boolean {
+        return (
+            !this.props.manager.facetYAxisMode ||
+            this.props.manager.facetYAxisMode === FacetYAxisMode.absolute
+        )
+    }
+
+    render(): JSX.Element {
+        return (
+            <label className="clickable">
+                <input
+                    type="checkbox"
+                    checked={this.isAbsoluteMode}
+                    onChange={this.onToggle}
+                    data-track-note="chart-facet-ymode-toggle"
+                />{" "}
+                &nbsp;Uniform y-axis
             </label>
         )
     }

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -14,7 +14,7 @@ import { faShareAlt } from "@fortawesome/free-solid-svg-icons/faShareAlt"
 import { faExpand } from "@fortawesome/free-solid-svg-icons/faExpand"
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons/faExternalLinkAlt"
 import {
-    FacetScaleMode,
+    FacetAxisRange,
     GrapherTabOption,
     HighlightToggleConfig,
     RelatedQuestionsConfig,
@@ -23,6 +23,7 @@ import {
 import { ShareMenu, ShareMenuManager } from "./ShareMenu"
 import { TimelineController } from "../timeline/TimelineController"
 import { SelectionArray } from "../selection/SelectionArray"
+import { AxisConfig } from "../axis/AxisConfig"
 
 export interface HighlightToggleManager {
     highlightToggle?: HighlightToggleConfig
@@ -124,23 +125,23 @@ export class AbsRelToggle extends React.Component<{
     }
 }
 
-export interface FacetYAxisToggleManager {
-    facetYAxisMode?: FacetScaleMode
+export interface FacetYRangeToggleManager {
+    yAxis?: AxisConfig
 }
 
 @observer
-export class FacetYAxisToggle extends React.Component<{
-    manager: FacetYAxisToggleManager
+export class FacetYRangeToggle extends React.Component<{
+    manager: FacetYRangeToggleManager
 }> {
     @action.bound onToggle(): void {
-        this.props.manager.facetYAxisMode = this.isAbsoluteMode
-            ? FacetScaleMode.relative
-            : FacetScaleMode.absolute
+        this.props.manager.yAxis!.facetAxisRange = this.isYRangeShared
+            ? FacetAxisRange.independent
+            : FacetAxisRange.shared
     }
 
-    @computed get isAbsoluteMode(): boolean {
-        return [FacetScaleMode.absolute, undefined].includes(
-            this.props.manager.facetYAxisMode
+    @computed get isYRangeShared(): boolean {
+        return (
+            this.props.manager.yAxis!.facetAxisRange === FacetAxisRange.shared
         )
     }
 
@@ -149,9 +150,9 @@ export class FacetYAxisToggle extends React.Component<{
             <label className="clickable">
                 <input
                     type="checkbox"
-                    checked={this.isAbsoluteMode}
+                    checked={this.isYRangeShared}
                     onChange={this.onToggle}
-                    data-track-note="chart-facet-ymode-toggle"
+                    data-track-note="chart-facet-yrange-toggle"
                 />{" "}
                 &nbsp;Uniform y-axis
             </label>

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1448,18 +1448,6 @@ export class Grapher
         return this.stackMode === StackMode.relative
     }
 
-    @computed get isFacetYAxisShared(): boolean {
-        return this.facetYScale === FacetAxisRange.shared
-    }
-
-    get facetYScale(): FacetAxisRange {
-        return this.yAxis.facetAxisRange
-    }
-
-    set facetYScale(mode: FacetAxisRange) {
-        this.yAxis.facetAxisRange = mode
-    }
-
     @computed get canToggleRelativeMode(): boolean {
         if (this.isLineChart)
             return (

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -49,7 +49,7 @@ import {
     FacetStrategy,
     ThereWasAProblemLoadingThisChart,
     SeriesColorMap,
-    FacetYAxisMode,
+    FacetScaleMode,
 } from "../core/GrapherConstants"
 import {
     LegacyChartDimensionInterface,
@@ -255,7 +255,6 @@ export class Grapher
     @observable.ref logo?: LogoOption = undefined
     @observable.ref hideLogo?: boolean = undefined
     @observable.ref hideRelativeToggle? = true
-    @observable.ref facetYAxisMode: FacetYAxisMode = FacetYAxisMode.absolute
     @observable.ref entityType = "country"
     @observable.ref entityTypePlural = "countries"
     @observable.ref hideTimeline?: boolean = undefined
@@ -547,6 +546,14 @@ export class Grapher
         return this.isOnMapTab
             ? new MapChart({ manager: this })
             : this.chartInstanceExceptMap
+    }
+
+    get facetYAxisMode(): FacetScaleMode {
+        return this.yAxis.facetScaleMode || FacetScaleMode.absolute
+    }
+
+    set facetYAxisMode(mode: FacetScaleMode) {
+        this.yAxis.facetScaleMode = mode
     }
 
     // When Map becomes a first-class chart instance, we should drop this
@@ -1449,8 +1456,8 @@ export class Grapher
         return this.stackMode === StackMode.relative
     }
 
-    @computed get isFacetYAxisRelative(): boolean {
-        return this.facetYAxisMode !== FacetYAxisMode.absolute
+    @computed get isFacetYAxisAbsolute(): boolean {
+        return this.facetYAxisMode === FacetScaleMode.absolute
     }
 
     @computed get canToggleRelativeMode(): boolean {

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -49,6 +49,7 @@ import {
     FacetStrategy,
     ThereWasAProblemLoadingThisChart,
     SeriesColorMap,
+    FacetYAxisMode,
 } from "../core/GrapherConstants"
 import {
     LegacyChartDimensionInterface,
@@ -254,6 +255,7 @@ export class Grapher
     @observable.ref logo?: LogoOption = undefined
     @observable.ref hideLogo?: boolean = undefined
     @observable.ref hideRelativeToggle? = true
+    @observable.ref facetYAxisMode: FacetYAxisMode = FacetYAxisMode.absolute
     @observable.ref entityType = "country"
     @observable.ref entityTypePlural = "countries"
     @observable.ref hideTimeline?: boolean = undefined
@@ -1444,6 +1446,10 @@ export class Grapher
     // to the lower bound year rather than creating an arrow chart
     @computed get isRelativeMode(): boolean {
         return this.stackMode === StackMode.relative
+    }
+
+    @computed get isFacetYAxisRelative(): boolean {
+        return this.facetYAxisMode !== FacetYAxisMode.absolute
     }
 
     @computed get canToggleRelativeMode(): boolean {

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -49,7 +49,7 @@ import {
     FacetStrategy,
     ThereWasAProblemLoadingThisChart,
     SeriesColorMap,
-    FacetScaleMode,
+    FacetAxisRange,
 } from "../core/GrapherConstants"
 import {
     LegacyChartDimensionInterface,
@@ -277,7 +277,7 @@ export class Grapher
     scatterPointLabelStrategy?: ScatterPointLabelStrategy = undefined
     @observable.ref compareEndPointsOnly?: boolean = undefined
     @observable.ref matchingEntitiesOnly?: boolean = undefined
-    @observable.ref showFacetYAxisToggle: boolean = true
+    @observable.ref showFacetYRangeToggle: boolean = true
 
     @observable.ref xAxis = new AxisConfig(undefined, this)
     @observable.ref yAxis = new AxisConfig(undefined, this)
@@ -546,14 +546,6 @@ export class Grapher
         return this.isOnMapTab
             ? new MapChart({ manager: this })
             : this.chartInstanceExceptMap
-    }
-
-    get facetYAxisMode(): FacetScaleMode {
-        return this.yAxis.facetScaleMode || FacetScaleMode.absolute
-    }
-
-    set facetYAxisMode(mode: FacetScaleMode) {
-        this.yAxis.facetScaleMode = mode
     }
 
     // When Map becomes a first-class chart instance, we should drop this
@@ -1456,8 +1448,16 @@ export class Grapher
         return this.stackMode === StackMode.relative
     }
 
-    @computed get isFacetYAxisAbsolute(): boolean {
-        return this.facetYAxisMode === FacetScaleMode.absolute
+    @computed get isFacetYAxisShared(): boolean {
+        return this.facetYScale === FacetAxisRange.shared
+    }
+
+    get facetYScale(): FacetAxisRange {
+        return this.yAxis.facetAxisRange
+    }
+
+    set facetYScale(mode: FacetAxisRange) {
+        this.yAxis.facetAxisRange = mode
     }
 
     @computed get canToggleRelativeMode(): boolean {

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -278,6 +278,7 @@ export class Grapher
     scatterPointLabelStrategy?: ScatterPointLabelStrategy = undefined
     @observable.ref compareEndPointsOnly?: boolean = undefined
     @observable.ref matchingEntitiesOnly?: boolean = undefined
+    @observable.ref showFacetYAxisToggle: boolean = true
 
     @observable.ref xAxis = new AxisConfig(undefined, this)
     @observable.ref yAxis = new AxisConfig(undefined, this)

--- a/grapher/core/GrapherConstants.ts
+++ b/grapher/core/GrapherConstants.ts
@@ -42,6 +42,11 @@ export enum FacetStrategy {
     column = "column", // One chart for each Y column
 }
 
+export enum FacetYAxisMode {
+    relative = "relative", // all facets have their own y range
+    absolute = "absolute", // all facets share the same y range
+}
+
 export enum SeriesStrategy {
     column = "column", // One line per column
     entity = "entity", // One line per entity

--- a/grapher/core/GrapherConstants.ts
+++ b/grapher/core/GrapherConstants.ts
@@ -42,9 +42,9 @@ export enum FacetStrategy {
     column = "column", // One chart for each Y column
 }
 
-export enum FacetScaleMode {
-    relative = "relative", // all facets have their own y range
-    absolute = "absolute", // all facets share the same y range
+export enum FacetAxisRange {
+    independent = "independent", // all facets have their own y range
+    shared = "shared", // all facets share the same y range
 }
 
 export enum SeriesStrategy {

--- a/grapher/core/GrapherConstants.ts
+++ b/grapher/core/GrapherConstants.ts
@@ -42,7 +42,7 @@ export enum FacetStrategy {
     column = "column", // One chart for each Y column
 }
 
-export enum FacetYAxisMode {
+export enum FacetScaleMode {
     relative = "relative", // all facets have their own y range
     absolute = "absolute", // all facets share the same y range
 }

--- a/grapher/facetChart/FacetChart.stories.tsx
+++ b/grapher/facetChart/FacetChart.stories.tsx
@@ -8,6 +8,7 @@ import {
 import { Bounds } from "../../clientUtils/Bounds"
 import { ChartTypeName, FacetStrategy } from "../core/GrapherConstants"
 import { Meta } from "@storybook/react"
+import { AxisConfig } from "../axis/AxisConfig"
 
 // See https://storybook.js.org/docs/react/essentials/controls for Control Types
 const CSF: Meta = {
@@ -28,6 +29,7 @@ export const OneMetricOneCountryPerChart = (): JSX.Element => {
         selection: table.availableEntityNames,
         yColumnSlug: SampleColumnSlugs.GDP,
         xColumnSlug: SampleColumnSlugs.Population,
+        yAxis: new AxisConfig(),
     }
 
     return (
@@ -53,6 +55,7 @@ export const MultipleMetricsOneCountryPerChart = (): JSX.Element => {
                 manager={{
                     selection: table.availableEntityNames,
                     table,
+                    yAxis: new AxisConfig(),
                 }}
             />
         </svg>

--- a/grapher/facetChart/FacetChart.test.ts
+++ b/grapher/facetChart/FacetChart.test.ts
@@ -4,12 +4,14 @@ import { FacetChart } from "./FacetChart"
 import { SynthesizeGDPTable } from "../../coreTable/OwidTableSynthesizers"
 import { ChartManager } from "../chart/ChartManager"
 import { FacetStrategy } from "../core/GrapherConstants"
+import { AxisConfig } from "../axis/AxisConfig"
 
 it("can create a new FacetChart", () => {
     const table = SynthesizeGDPTable({ timeRange: [2000, 2010] })
     const manager: ChartManager = {
         table,
         selection: table.availableEntityNames,
+        yAxis: new AxisConfig(),
     }
     const chart = new FacetChart({ manager })
 
@@ -29,6 +31,7 @@ it("uses the transformed data for display in country mode", () => {
         // simulate the transformation that is done by Grapher on the data
         transformedTable: table.filterByTimeRange(2002, 2008),
         facetStrategy: FacetStrategy.country,
+        yAxis: new AxisConfig(),
     }
     const chart = new FacetChart({ manager })
 

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -59,7 +59,7 @@ export class FacetChart
             colorColumnSlug,
             sizeColumnSlug,
             isRelativeMode,
-            isFacetYAxisAbsolute,
+            isFacetYAxisShared,
         } = manager
 
         const baseFontSize = getFontSize(count, manager.baseFontSize)
@@ -92,7 +92,7 @@ export class FacetChart
                 colorColumnSlug,
                 sizeColumnSlug,
                 isRelativeMode,
-                isFacetYAxisAbsolute,
+                isFacetYAxisShared,
                 ...series.manager,
             }
             return {
@@ -128,7 +128,7 @@ export class FacetChart
         return this.selectionArray.selectedEntityNames.map((seriesName) => {
             const seriesTable = table.filterByEntityNames([seriesName])
             const seriesYDomain = seriesTable.domainFor(this.yColumnSlugs)
-            const yAxisConfig = this.manager.isFacetYAxisAbsolute
+            const yAxisConfig = this.manager.isFacetYAxisShared
                 ? {
                       max: sharedYDomain[1],
                       min: sharedYDomain[0],

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -4,6 +4,7 @@ import { Bounds, DEFAULT_BOUNDS } from "../../clientUtils/Bounds"
 import { computed } from "mobx"
 import {
     ChartTypeName,
+    FacetAxisRange,
     FacetStrategy,
     SeriesStrategy,
 } from "../core/GrapherConstants"
@@ -59,7 +60,6 @@ export class FacetChart
             colorColumnSlug,
             sizeColumnSlug,
             isRelativeMode,
-            isFacetYAxisShared,
         } = manager
 
         const baseFontSize = getFontSize(count, manager.baseFontSize)
@@ -92,7 +92,6 @@ export class FacetChart
                 colorColumnSlug,
                 sizeColumnSlug,
                 isRelativeMode,
-                isFacetYAxisShared,
                 ...series.manager,
             }
             return {
@@ -128,17 +127,18 @@ export class FacetChart
         return this.selectionArray.selectedEntityNames.map((seriesName) => {
             const seriesTable = table.filterByEntityNames([seriesName])
             const seriesYDomain = seriesTable.domainFor(this.yColumnSlugs)
-            const yAxisConfig = this.manager.isFacetYAxisShared
-                ? {
-                      max: sharedYDomain[1],
-                      min: sharedYDomain[0],
-                      scaleType,
-                  }
-                : {
-                      max: seriesYDomain[1],
-                      min: seriesYDomain[0],
-                      scaleType,
-                  }
+            const yAxisConfig =
+                this.manager.yAxis!.facetAxisRange == FacetAxisRange.shared
+                    ? {
+                          max: sharedYDomain[1],
+                          min: sharedYDomain[0],
+                          scaleType,
+                      }
+                    : {
+                          max: seriesYDomain[1],
+                          min: seriesYDomain[0],
+                          scaleType,
+                      }
             return {
                 seriesName,
                 color: facetBackgroundColor,

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -59,7 +59,7 @@ export class FacetChart
             colorColumnSlug,
             sizeColumnSlug,
             isRelativeMode,
-            isFacetYAxisRelative,
+            isFacetYAxisAbsolute,
         } = manager
 
         const baseFontSize = getFontSize(count, manager.baseFontSize)
@@ -92,7 +92,7 @@ export class FacetChart
                 colorColumnSlug,
                 sizeColumnSlug,
                 isRelativeMode,
-                isFacetYAxisRelative,
+                isFacetYAxisAbsolute,
                 ...series.manager,
             }
             return {
@@ -114,7 +114,7 @@ export class FacetChart
         )
         const yDomain = table.domainFor(this.yColumnSlugs)
         const scaleType = this.manager.yAxis?.scaleType
-        const sameYAxis = !this.manager.isFacetYAxisRelative
+        const sameYAxis = this.manager.isFacetYAxisAbsolute
         const yAxisConfig = sameYAxis
             ? {
                   max: yDomain[1],

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -112,16 +112,8 @@ export class FacetChart
         const table = this.transformedTable.filterByEntityNames(
             this.selectionArray.selectedEntityNames
         )
-        const yDomain = table.domainFor(this.yColumnSlugs)
+        const sharedYDomain = table.domainFor(this.yColumnSlugs)
         const scaleType = this.manager.yAxis?.scaleType
-        const sameYAxis = this.manager.isFacetYAxisAbsolute
-        const yAxisConfig = sameYAxis
-            ? {
-                  max: yDomain[1],
-                  min: yDomain[0],
-                  scaleType,
-              }
-            : undefined
         const sameXAxis = true
         const xAxisConfig = sameXAxis
             ? {
@@ -135,12 +127,18 @@ export class FacetChart
 
         return this.selectionArray.selectedEntityNames.map((seriesName) => {
             const seriesTable = table.filterByEntityNames([seriesName])
-            const relativeYDomain = seriesTable.domainFor(this.yColumnSlugs)
-            const relativeYAxisConfig = {
-                max: relativeYDomain[1],
-                min: relativeYDomain[0],
-                scaleType,
-            }
+            const seriesYDomain = seriesTable.domainFor(this.yColumnSlugs)
+            const yAxisConfig = this.manager.isFacetYAxisAbsolute
+                ? {
+                      max: sharedYDomain[1],
+                      min: sharedYDomain[0],
+                      scaleType,
+                  }
+                : {
+                      max: seriesYDomain[1],
+                      min: seriesYDomain[0],
+                      scaleType,
+                  }
             return {
                 seriesName,
                 color: facetBackgroundColor,
@@ -149,7 +147,7 @@ export class FacetChart
                     selection: [seriesName],
                     seriesStrategy: SeriesStrategy.column,
                     hideLegend,
-                    yAxisConfig: yAxisConfig || relativeYAxisConfig,
+                    yAxisConfig,
                     xAxisConfig,
                 },
             }

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -112,7 +112,7 @@ export class FacetChart
         )
         const yDomain = table.domainFor(this.yColumnSlugs)
         const scaleType = this.manager.yAxis?.scaleType
-        const sameYAxis = true
+        const sameYAxis = false
         const yAxisConfig = sameYAxis
             ? {
                   max: yDomain[1],
@@ -132,15 +132,22 @@ export class FacetChart
         const hideLegend = this.manager.yColumnSlugs?.length === 1
 
         return this.selectionArray.selectedEntityNames.map((seriesName) => {
+            const seriesTable = table.filterByEntityNames([seriesName])
+            const relativeYDomain = seriesTable.domainFor(this.yColumnSlugs)
+            const relativeYAxisConfig = {
+                max: relativeYDomain[1],
+                min: relativeYDomain[0],
+                scaleType,
+            }
             return {
                 seriesName,
                 color: facetBackgroundColor,
                 manager: {
-                    table: table.filterByEntityNames([seriesName]),
+                    table: seriesTable,
                     selection: [seriesName],
                     seriesStrategy: SeriesStrategy.column,
                     hideLegend,
-                    yAxisConfig,
+                    yAxisConfig: yAxisConfig || relativeYAxisConfig,
                     xAxisConfig,
                 },
             }

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -59,6 +59,7 @@ export class FacetChart
             colorColumnSlug,
             sizeColumnSlug,
             isRelativeMode,
+            isFacetYAxisRelative,
         } = manager
 
         const baseFontSize = getFontSize(count, manager.baseFontSize)
@@ -91,6 +92,7 @@ export class FacetChart
                 colorColumnSlug,
                 sizeColumnSlug,
                 isRelativeMode,
+                isFacetYAxisRelative,
                 ...series.manager,
             }
             return {
@@ -112,7 +114,7 @@ export class FacetChart
         )
         const yDomain = table.domainFor(this.yColumnSlugs)
         const scaleType = this.manager.yAxis?.scaleType
-        const sameYAxis = false
+        const sameYAxis = !this.manager.isFacetYAxisRelative
         const yAxisConfig = sameYAxis
             ? {
                   max: yDomain[1],


### PR DESCRIPTION
Currently, many charts support facets by typing `f` when viewing. The y-axis of every facet has the same range, so that you can compare scale across entities.

This PR adds a "Uniform y-axis" toggle when in facet mode which allows you to switch to relative y-axis mode, good for comparing the shape across entities. The default mode can be set to relative by an author, set via the "Facets have uniform y-axis" checkbox in the "Customize" tab. This controls the `yAxis.facetAxisRange` grapher config key.

See: https://www.notion.so/owid/Adjusted-vs-uniform-y-axis-scale-b88534934da04681b753742627d24ced