### PR TITLE
fix(admin): always show "Tolerance" input in DimensionCard

### DIFF
--- a/adminSiteClient/DimensionCard.tsx
+++ b/adminSiteClient/DimensionCard.tsx
@@ -199,16 +199,12 @@ export class DimensionCard extends React.Component<{
                             onBlur={this.updateTables}
                         />
                         {this.tableDisplaySettings}
-                        {(grapher.isScatter ||
-                            grapher.isDiscreteBar ||
-                            grapher.isLineChart) && (
-                            <BindAutoFloat
-                                field="tolerance"
-                                store={dimension.display}
-                                auto={column.tolerance}
-                                onBlur={this.updateTables}
-                            />
-                        )}
+                        <BindAutoFloat
+                            field="tolerance"
+                            store={dimension.display}
+                            auto={column.tolerance}
+                            onBlur={this.updateTables}
+                        />
                         {grapher.isLineChart && (
                             <Toggle
                                 label="Is projection"


### PR DESCRIPTION
Quite a lot of charts support tolerance now.

The field in `DimensionCard` was hidden for some charts, this PR makes it always shown. 