### PR TITLE
Add support for more "last updated" tags

### DIFF
--- a/baker/formatWordpressPost.tsx
+++ b/baker/formatWordpressPost.tsx
@@ -192,7 +192,7 @@ export const formatWordpressPost = async (
         )
     })
 
-    const dataTokenRegex = /{{([A-Z_]+)}}/gm
+    const dataTokenRegex = /{{([a-zA-Z]+)}}/gm
 
     html = html.replace(dataTokenRegex, (_, token) => {
         return ReactDOMServer.renderToString(<DataToken token={token} />)

--- a/baker/formatting.test.ts
+++ b/baker/formatting.test.ts
@@ -3,6 +3,7 @@
 import {
     extractDataValuesConfiguration,
     parseFormattingOptions,
+    parseKeyValueArgs,
 } from "./formatting"
 
 it("parses formatting options", () => {
@@ -13,6 +14,15 @@ it("parses formatting options", () => {
         isTrue: true,
         isAlsoTrue: true,
         isFalse: false,
+    })
+})
+
+it("parses LastUpdated options", () => {
+    const lastUpdatedOptions =
+        "timestampUrl:https://covid.ourworldindata.org/data/internal/timestamp/owid-covid-data-last-updated-timestamp-root.txt"
+    expect(parseKeyValueArgs(lastUpdatedOptions)).toStrictEqual({
+        timestampUrl:
+            "https://covid.ourworldindata.org/data/internal/timestamp/owid-covid-data-last-updated-timestamp-root.txt",
     })
 })
 

--- a/baker/formatting.tsx
+++ b/baker/formatting.tsx
@@ -95,12 +95,14 @@ export const parseKeyValueArgs = (text: string): KeyValueProps => {
         .filter((s) => s && s.length > 0)
         // populate options object
         .forEach((option: string) => {
-            const [name, value] = option.split(":") as [
+            const optionRegex = /([^:]+):?(.*)/
+            const [, name, value] = option.match(optionRegex) as [
+                any,
                 string,
-                string | undefined
+                string
             ]
             let parsedValue
-            if (value === undefined || value === "true") parsedValue = true
+            if (value === "" || value === "true") parsedValue = true
             else if (value === "false") parsedValue = false
             else parsedValue = value
             options[name] = parsedValue

--- a/baker/formatting.tsx
+++ b/baker/formatting.tsx
@@ -93,8 +93,9 @@ export const parseKeyValueArgs = (text: string): KeyValueProps => {
     text.split(/\s+/)
         // filter out empty strings
         .filter((s) => s && s.length > 0)
-        // populate options object
         .forEach((option: string) => {
+            // using regex instead of split(":") to handle ":" in value
+            // e.g. {{LastUpdated timestampUrl:https://...}}
             const optionRegex = /([^:]+):?(.*)/
             const [, name, value] = option.match(optionRegex) as [
                 any,

--- a/site/DataToken.tsx
+++ b/site/DataToken.tsx
@@ -2,12 +2,15 @@ import * as React from "react"
 
 export const DataToken_name = "DataToken"
 
-export const DataToken = ({ token }: { token: string }) => (
+export const DataToken = ({ token, ...restProps }: { token: string }) => (
     <span>
         <script
             data-type={DataToken_name}
             type="component/props"
             data-token={token}
+            dangerouslySetInnerHTML={{
+                __html: JSON.stringify(restProps),
+            }}
         ></script>
     </span>
 )

--- a/site/covid/LastUpdated.tsx
+++ b/site/covid/LastUpdated.tsx
@@ -3,7 +3,7 @@ import dayjs, { Dayjs } from "dayjs"
 import relativeTime from "dayjs/plugin/relativeTime"
 dayjs.extend(relativeTime)
 
-export const CovidLastUpdated = () => {
+export const LastUpdated = () => {
     const [date, setDate] = useState<null | Dayjs>(null)
 
     useEffect(() => {

--- a/site/covid/LastUpdated.tsx
+++ b/site/covid/LastUpdated.tsx
@@ -3,14 +3,16 @@ import dayjs, { Dayjs } from "dayjs"
 import relativeTime from "dayjs/plugin/relativeTime"
 dayjs.extend(relativeTime)
 
-export const LastUpdated = () => {
-    const [date, setDate] = useState<null | Dayjs>(null)
+export interface LastUpdatedTokenProps {
+    timestampUrl?: string
+}
 
+export const LastUpdated = ({ timestampUrl }: LastUpdatedTokenProps) => {
+    const [date, setDate] = useState<null | Dayjs>(null)
     useEffect(() => {
         const fetchTimeStamp = async () => {
-            const response = await fetch(
-                "https://covid.ourworldindata.org/data/owid-covid-data-last-updated-timestamp.txt"
-            )
+            if (!timestampUrl) return
+            const response = await fetch(timestampUrl)
             if (!response.ok) return
             const timestamp = await response.text()
             setDate(

--- a/site/runDataTokens.tsx
+++ b/site/runDataTokens.tsx
@@ -1,14 +1,14 @@
 import React from "react"
 import ReactDOM from "react-dom"
 import { DataToken_name } from "../site/DataToken"
-import { CovidLastUpdated } from "./covid/CovidLastUpdated"
+import { LastUpdated } from "./covid/LastUpdated"
 
 interface ComponentDictionary {
     [key: string]: any
 }
 
 const dictionary: ComponentDictionary = {
-    COVID_LAST_UPDATED: CovidLastUpdated,
+    LastUpdated,
 }
 
 export const runDataTokens = () => {

--- a/site/runDataTokens.tsx
+++ b/site/runDataTokens.tsx
@@ -19,9 +19,14 @@ export const runDataTokens = () => {
         const token = dataToken.getAttribute("data-token")
         if (!token) return
 
+        const componentProps = JSON.parse(dataToken.innerHTML)
+
         const Component = dictionary[token]
         if (!Component) return
 
-        ReactDOM.render(<Component />, dataToken.parentElement)
+        ReactDOM.render(
+            <Component {...componentProps} />,
+            dataToken.parentElement
+        )
     })
 }


### PR DESCRIPTION
Until now, only /coronavirus had a client-side refreshed "Last updated" tag ({{COVID_LAST_UPDATED}}).

This adds support for a more generic {{LastUpdated timestampUrl:https://...}} tag, where the timestamp url is provided as an attribute. 

List of currently available timestamps (COVID only): 
- public: https://github.com/owid/covid-19-data/tree/master/public/data/internal/timestamp
- internal: https://www.notion.so/owid/e4b94a243b834804aca76734917857a5?v=ec20b4bceaf44d31aa8e2e9c5f6bd3d2