### PR TITLE
fix: always display marker for singular data point in line chart

### DIFF
--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -118,11 +118,8 @@ class Lines extends React.Component<LinesProps> {
     @computed private get hasMarkers(): boolean {
         if (this.props.hidePoints) return false
         return (
-            sum(
-                this.props.placedSeries.map(
-                    (series) => series.placedPoints.length
-                )
-            ) < 500
+            sum(this.focusedLines.map((series) => series.placedPoints.length)) <
+            500
         )
     }
 
@@ -131,35 +128,45 @@ class Lines extends React.Component<LinesProps> {
     }
 
     private renderFocusGroups(): JSX.Element[] {
-        return this.focusedLines.map((series, index) => (
-            <g key={index}>
-                <path
-                    stroke={series.color}
-                    strokeLinecap="round"
-                    d={pointsToPath(
-                        series.placedPoints.map((value) => [
-                            value.x,
-                            value.y,
-                        ]) as [number, number][]
+        return this.focusedLines.map((series, index) => {
+            // If the series only contains one point, then we will always want to show a marker/circle
+            // because we can't draw a line.
+            const showMarkers =
+                (this.hasMarkers || series.placedPoints.length === 1) &&
+                !series.isProjection
+
+            return (
+                <g key={index}>
+                    <path
+                        stroke={series.color}
+                        strokeLinecap="round"
+                        d={pointsToPath(
+                            series.placedPoints.map((value) => [
+                                value.x,
+                                value.y,
+                            ]) as [number, number][]
+                        )}
+                        fill="none"
+                        strokeWidth={this.strokeWidth}
+                        strokeDasharray={
+                            series.isProjection ? "1,4" : undefined
+                        }
+                    />
+                    {showMarkers && (
+                        <g fill={series.color}>
+                            {series.placedPoints.map((value, index) => (
+                                <circle
+                                    key={index}
+                                    cx={value.x}
+                                    cy={value.y}
+                                    r={2}
+                                />
+                            ))}
+                        </g>
                     )}
-                    fill="none"
-                    strokeWidth={this.strokeWidth}
-                    strokeDasharray={series.isProjection ? "1,4" : undefined}
-                />
-                {this.hasMarkers && !series.isProjection && (
-                    <g fill={series.color}>
-                        {series.placedPoints.map((value, index) => (
-                            <circle
-                                key={index}
-                                cx={value.x}
-                                cy={value.y}
-                                r={2}
-                            />
-                        ))}
-                    </g>
-                )}
-            </g>
-        ))
+                </g>
+            )
+        })
     }
 
     private renderBackgroundGroups(): JSX.Element[] {


### PR DESCRIPTION
Notion: [Single data points being hidden can be misleading in line charts](https://www.notion.so/Single-data-points-being-hidden-can-be-misleading-in-line-charts-7c4317eafefb4ba281c48d8f75801280)

This also changes it so that circles can be shown on hover over a line, when they weren't shown before. This can make it clearer how many observations we have, as you can see in the video below.

https://user-images.githubusercontent.com/2641501/122206994-ed3a2780-cea1-11eb-88be-d7b25561fa37.mp4

