### PR TITLE
Formatting data in text

### DIFF
--- a/adminSiteClient/DimensionCard.tsx
+++ b/adminSiteClient/DimensionCard.tsx
@@ -16,9 +16,9 @@ import { faChevronUp } from "@fortawesome/free-solid-svg-icons/faChevronUp"
 import { faExchangeAlt } from "@fortawesome/free-solid-svg-icons/faExchangeAlt"
 import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { DimensionProperty } from "../grapher/core/GrapherConstants"
 import { OwidTable } from "../coreTable/OwidTable"
 import { faArrowsAltV } from "@fortawesome/free-solid-svg-icons/faArrowsAltV"
+import { DimensionProperty } from "../clientUtils/owidTypes"
 
 @observer
 export class DimensionCard extends React.Component<{

--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -12,7 +12,6 @@ import {
 import {
     EntitySelectionMode,
     ChartTypeName,
-    DimensionProperty,
     WorldEntityName,
 } from "../grapher/core/GrapherConstants"
 import { Toggle, SelectField, EditableList, FieldsRow, Section } from "./Forms"
@@ -20,8 +19,11 @@ import { ChartEditor } from "./ChartEditor"
 import { VariableSelector } from "./VariableSelector"
 import { DimensionCard } from "./DimensionCard"
 import { DimensionSlot } from "../grapher/chart/DimensionSlot"
-import { LegacyVariableId } from "../clientUtils/owidTypes"
-import { ColumnSlug } from "../coreTable/CoreTableConstants"
+import {
+    ColumnSlug,
+    DimensionProperty,
+    LegacyVariableId,
+} from "../clientUtils/owidTypes"
 import { ChartDimension } from "../grapher/chart/ChartDimension"
 
 @observer

--- a/adminSiteClient/VariableEditPage.tsx
+++ b/adminSiteClient/VariableEditPage.tsx
@@ -21,12 +21,9 @@ import { GrapherFigureView } from "../site/GrapherFigureView"
 import { ChartList, ChartListItem } from "./ChartList"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext"
 import { Base64 } from "js-base64"
-import {
-    DimensionProperty,
-    GrapherTabOption,
-} from "../grapher/core/GrapherConstants"
+import { GrapherTabOption } from "../grapher/core/GrapherConstants"
 import { GrapherInterface } from "../grapher/core/GrapherInterface"
-import { EPOCH_DATE } from "../clientUtils/owidTypes"
+import { DimensionProperty, EPOCH_DATE } from "../clientUtils/owidTypes"
 
 interface VariablePageData extends Omit<LegacyVariableConfig, "source"> {
     datasetNamespace: string

--- a/clientUtils/LegacyVariableDisplayConfigInterface.ts
+++ b/clientUtils/LegacyVariableDisplayConfigInterface.ts
@@ -1,5 +1,12 @@
 // DEPRECATED. DO NOT USE.
 
+import {
+    ColumnSlug,
+    DimensionProperty,
+    LegacyVariableId,
+    Time,
+} from "./owidTypes"
+
 export interface LegacyVariableDisplayConfigInterface {
     name?: string
     unit?: string
@@ -20,4 +27,12 @@ export interface LegacyVariableDisplayConfigInterface {
 export interface LegacyVariableDataTableConfigInteface {
     hideAbsoluteChange?: boolean
     hideRelativeChange?: boolean
+}
+
+export interface LegacyChartDimensionInterface {
+    property: DimensionProperty
+    targetYear?: Time
+    display?: LegacyVariableDisplayConfigInterface
+    variableId: LegacyVariableId
+    slug?: ColumnSlug
 }

--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -248,3 +248,14 @@ export interface Annotation {
     entityName?: string
     year?: number
 }
+
+export enum DimensionProperty {
+    y = "y",
+    x = "x",
+    size = "size",
+    color = "color",
+    table = "table",
+}
+
+// see CoreTableConstants.ts
+export type ColumnSlug = string // a url friendly name for a column in a table. cannot have spaces

--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -92,6 +92,7 @@ export interface KeyValueProps {
 export interface DataValueQueryArgs {
     variableId?: number
     entityId?: number
+    chartId?: number
     year?: number
 }
 
@@ -108,6 +109,7 @@ export interface DataValueResult {
 }
 
 export interface DataValueProps extends DataValueResult {
+    formattedValue?: string
     template: string
 }
 

--- a/coreTable/CoreColumnDef.ts
+++ b/coreTable/CoreColumnDef.ts
@@ -1,5 +1,6 @@
 import { LegacyVariableDisplayConfigInterface } from "../clientUtils/LegacyVariableDisplayConfigInterface"
-import { ColumnSlug, CoreValueType, Color } from "./CoreTableConstants"
+import { ColumnSlug } from "../clientUtils/owidTypes"
+import { CoreValueType, Color } from "./CoreTableConstants"
 
 export enum ColumnTypeNames {
     Numeric = "Numeric",

--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -15,7 +15,6 @@ import {
 import { isPresent } from "../clientUtils/isPresent"
 import { CoreColumn, ColumnTypeMap, MissingColumn } from "./CoreTableColumns"
 import {
-    ColumnSlug,
     CoreColumnStore,
     CoreRow,
     CoreTableInputOption,
@@ -66,6 +65,7 @@ import {
 } from "./ErrorValues"
 import { OwidTableSlugs } from "./OwidTableConstants"
 import { applyTransforms } from "./Transforms"
+import { ColumnSlug } from "../clientUtils/owidTypes"
 
 interface AdvancedOptions {
     tableDescription?: string

--- a/coreTable/CoreTableColumns.ts
+++ b/coreTable/CoreTableColumns.ts
@@ -17,7 +17,6 @@ import { isPresent } from "../clientUtils/isPresent"
 import { CoreTable } from "./CoreTable"
 import {
     CoreRow,
-    ColumnSlug,
     Time,
     PrimitiveType,
     JsTypes,
@@ -32,6 +31,7 @@ import moment from "moment"
 import { OwidSource } from "./OwidSource"
 import { formatValue, TickFormattingOptions } from "../clientUtils/formatValue"
 import { LegacyVariableDisplayConfigInterface } from "../clientUtils/LegacyVariableDisplayConfigInterface"
+import { ColumnSlug } from "../clientUtils/owidTypes"
 
 interface ColumnSummary {
     numErrorValues: number

--- a/coreTable/CoreTableConstants.ts
+++ b/coreTable/CoreTableConstants.ts
@@ -1,7 +1,6 @@
 import { ErrorValue } from "./ErrorValues"
 
 export type TableSlug = string // a url friendly name for a table
-export type ColumnSlug = string // a url friendly name for a column in a table. cannot have spaces
 export type ColumnSlugs = string // slugs cannot have spaces, so this is a space delimited array of ColumnSlugs
 
 export type Integer = number

--- a/coreTable/CoreTableUtils.ts
+++ b/coreTable/CoreTableUtils.ts
@@ -12,7 +12,6 @@ import {
 import {
     CoreColumnStore,
     CoreRow,
-    ColumnSlug,
     CoreMatrix,
     Time,
     CoreValueType,
@@ -25,6 +24,7 @@ import {
     OwidEntityNameColumnDef,
     OwidTableSlugs,
 } from "./OwidTableConstants"
+import { ColumnSlug } from "../clientUtils/owidTypes"
 
 export const columnStoreToRows = (
     columnStore: CoreColumnStore

--- a/coreTable/OwidTable.ts
+++ b/coreTable/OwidTable.ts
@@ -21,7 +21,6 @@ import {
 } from "../clientUtils/Util"
 import { isPresent } from "../clientUtils/isPresent"
 import {
-    ColumnSlug,
     Integer,
     Time,
     TransformType,
@@ -54,6 +53,7 @@ import {
     InterpolationProvider,
 } from "./CoreTableUtils"
 import { CoreColumn, ColumnTypeMap } from "./CoreTableColumns"
+import { ColumnSlug } from "../clientUtils/owidTypes"
 
 // An OwidTable is a subset of Table. An OwidTable always has EntityName, EntityCode, EntityId, and Time columns,
 // and value column(s). Whether or not we need in the long run is uncertain and it may just be a stepping stone

--- a/coreTable/OwidTableConstants.ts
+++ b/coreTable/OwidTableConstants.ts
@@ -1,5 +1,4 @@
 import {
-    ColumnSlug,
     CoreRow,
     Integer,
     PrimitiveType,
@@ -8,6 +7,7 @@ import {
 } from "./CoreTableConstants"
 import { ColumnTypeNames, CoreColumnDef } from "./CoreColumnDef"
 import { OwidSource } from "./OwidSource"
+import { ColumnSlug } from "../clientUtils/owidTypes"
 
 export enum OwidTableSlugs {
     entityName = "entityName",

--- a/coreTable/OwidTableSynthesizers.ts
+++ b/coreTable/OwidTableSynthesizers.ts
@@ -4,11 +4,12 @@ import {
     range,
 } from "../clientUtils/Util"
 import { countries } from "../clientUtils/countries"
-import { ColumnSlug, TimeRange } from "./CoreTableConstants"
+import { TimeRange } from "./CoreTableConstants"
 import { ColumnTypeNames } from "./CoreColumnDef"
 import { LegacyVariableDisplayConfigInterface } from "../clientUtils/LegacyVariableDisplayConfigInterface"
 import { OwidTable } from "./OwidTable"
 import { OwidColumnDef, OwidTableSlugs } from "./OwidTableConstants"
+import { ColumnSlug } from "../clientUtils/owidTypes"
 
 interface SynthOptions {
     entityCount: number

--- a/coreTable/OwidTableUtil.ts
+++ b/coreTable/OwidTableUtil.ts
@@ -1,6 +1,6 @@
+import { ColumnSlug } from "../clientUtils/owidTypes"
 import { ColumnTypeNames, CoreColumnDef } from "./CoreColumnDef"
 import { CoreTable } from "./CoreTable"
-import { ColumnSlug } from "./CoreTableConstants"
 import { OwidColumnDef, OwidTableSlugs } from "./OwidTableConstants"
 
 export function timeColumnSlugFromColumnDef(

--- a/coreTable/Transforms.ts
+++ b/coreTable/Transforms.ts
@@ -1,10 +1,5 @@
 import { flatten } from "../clientUtils/Util"
-import {
-    ColumnSlug,
-    CoreColumnStore,
-    Time,
-    CoreValueType,
-} from "./CoreTableConstants"
+import { CoreColumnStore, Time, CoreValueType } from "./CoreTableConstants"
 import { CoreColumnDef } from "./CoreColumnDef"
 import {
     ErrorValue,
@@ -14,6 +9,7 @@ import {
     ValueTooLow,
     DivideByZeroError,
 } from "./ErrorValues"
+import { ColumnSlug } from "../clientUtils/owidTypes"
 
 // In Grapher we return just the years for which we have values for. This puts MissingValuePlaceholder
 // in the spots where we are missing values (added to make computing rolling windows easier).

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -1,11 +1,15 @@
 import * as lodash from "lodash"
 import { Writable } from "stream"
 import * as db from "../db"
-import { LegacyVariableDisplayConfigInterface } from "../../clientUtils/LegacyVariableDisplayConfigInterface"
+import {
+    LegacyChartDimensionInterface,
+    LegacyVariableDisplayConfigInterface,
+} from "../../clientUtils/LegacyVariableDisplayConfigInterface"
 import { arrToCsvRow } from "../../clientUtils/Util"
 import {
     DataValueQueryArgs,
     DataValueResult,
+    LegacyVariableId,
 } from "../../clientUtils/owidTypes"
 
 export namespace Variable {
@@ -226,4 +230,31 @@ export const getDataValue = async ({
         unit: row.unit,
         entityName: row.entityName,
     }
+}
+
+export const getLegacyChartDimensionConfigForVariable = async (
+    variableId: LegacyVariableId,
+    chartId: number
+): Promise<LegacyChartDimensionInterface | undefined> => {
+    const row = await db.mysqlFirst(
+        `SELECT config->"$.dimensions" as dimensions from charts WHERE id=?`,
+        [chartId]
+    )
+    if (!row.dimensions) return
+    const dimensions = JSON.parse(row.dimensions)
+    return dimensions.find(
+        (dimension: LegacyChartDimensionInterface) =>
+            dimension.variableId === variableId
+    )
+}
+
+export const getLegacyVariableDisplayConfig = async (
+    variableId: LegacyVariableId
+): Promise<LegacyVariableDisplayConfigInterface | undefined> => {
+    const row = await db.mysqlFirst(
+        `SELECT display from variables WHERE id=?`,
+        [variableId]
+    )
+    if (!row.display) return
+    return JSON.parse(row.display)
 }

--- a/explorer/Explorer.sample.tsx
+++ b/explorer/Explorer.sample.tsx
@@ -1,9 +1,7 @@
 import React from "react"
+import { DimensionProperty } from "../clientUtils/owidTypes"
 import { GrapherProgrammaticInterface } from "../grapher/core/Grapher"
-import {
-    DimensionProperty,
-    GrapherTabOption,
-} from "../grapher/core/GrapherConstants"
+import { GrapherTabOption } from "../grapher/core/GrapherConstants"
 import { Explorer, ExplorerProps } from "./Explorer"
 
 const SampleExplorerOfGraphersProgram = `explorerTitle	CO₂ Data Explorer

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -11,7 +11,7 @@ import {
 } from "../explorer/ExplorerControls"
 import ReactDOM from "react-dom"
 import { ExplorerProgram } from "../explorer/ExplorerProgram"
-import { SerializedGridProgram } from "../clientUtils/owidTypes"
+import { ColumnSlug, SerializedGridProgram } from "../clientUtils/owidTypes"
 import {
     Grapher,
     GrapherManager,
@@ -43,11 +43,7 @@ import {
 } from "./ExplorerConstants"
 import { EntityPickerManager } from "../grapher/controls/entityPicker/EntityPickerConstants"
 import { SelectionArray } from "../grapher/selection/SelectionArray"
-import {
-    ColumnSlug,
-    SortOrder,
-    TableSlug,
-} from "../coreTable/CoreTableConstants"
+import { SortOrder, TableSlug } from "../coreTable/CoreTableConstants"
 import { isNotErrorValue } from "../coreTable/ErrorValues"
 import { Bounds, DEFAULT_BOUNDS } from "../clientUtils/Bounds"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"

--- a/explorer/ExplorerConstants.ts
+++ b/explorer/ExplorerConstants.ts
@@ -1,5 +1,5 @@
-import { SerializedGridProgram } from "../clientUtils/owidTypes"
-import { ColumnSlug, SortOrder } from "../coreTable/CoreTableConstants"
+import { ColumnSlug, SerializedGridProgram } from "../clientUtils/owidTypes"
+import { SortOrder } from "../coreTable/CoreTableConstants"
 import { GrapherQueryParams } from "../grapher/core/GrapherInterface"
 
 export enum ExplorerControlType {

--- a/grapher/chart/ChartDimension.test.ts
+++ b/grapher/chart/ChartDimension.test.ts
@@ -4,7 +4,7 @@
 
 import { ChartDimension } from "./ChartDimension"
 import { BlankOwidTable } from "../../coreTable/OwidTable"
-import { DimensionProperty } from "../core/GrapherConstants"
+import { DimensionProperty } from "../../clientUtils/owidTypes"
 
 it("can serialize for saving", () => {
     expect(

--- a/grapher/chart/ChartDimension.ts
+++ b/grapher/chart/ChartDimension.ts
@@ -3,20 +3,21 @@
 
 import { observable, computed } from "mobx"
 import { trimObject } from "../../clientUtils/Util"
-import { DimensionProperty } from "../core/GrapherConstants"
 import { OwidTable } from "../../coreTable/OwidTable"
+import { LegacyVariableDisplayConfig } from "../core/LegacyVariableCode"
 import {
-    LegacyChartDimensionInterface,
-    LegacyVariableDisplayConfig,
-} from "../core/LegacyVariableCode"
-import { LegacyVariableId } from "../../clientUtils/owidTypes"
-import { ColumnSlug, Time } from "../../coreTable/CoreTableConstants"
+    ColumnSlug,
+    DimensionProperty,
+    LegacyVariableId,
+} from "../../clientUtils/owidTypes"
+import { Time } from "../../coreTable/CoreTableConstants"
 import {
     Persistable,
     deleteRuntimeAndUnchangedProps,
     updatePersistables,
 } from "../persistable/Persistable"
 import { CoreColumn } from "../../coreTable/CoreTableColumns"
+import { LegacyChartDimensionInterface } from "../../clientUtils/LegacyVariableDisplayConfigInterface"
 
 // A chart "dimension" represents a binding between a chart
 // and a particular variable that it requests as data

--- a/grapher/chart/ChartManager.ts
+++ b/grapher/chart/ChartManager.ts
@@ -9,12 +9,11 @@ import {
 import { ComparisonLineConfig } from "../scatterCharts/ComparisonLine"
 import { TooltipProps } from "../tooltip/TooltipProps"
 import { OwidTable } from "../../coreTable/OwidTable"
-import { ColumnSlug } from "../../coreTable/CoreTableConstants"
 import { AxisConfigInterface } from "../axis/AxisConfigInterface"
 import { ColorSchemeName } from "../color/ColorConstants"
 import { EntityName } from "../../coreTable/OwidTableConstants"
 import { SelectionArray } from "../selection/SelectionArray"
-import { Annotation } from "../../clientUtils/owidTypes"
+import { Annotation, ColumnSlug } from "../../clientUtils/owidTypes"
 
 // The possible options common across our chart types. Not all of these apply to every chart type, so there is room to create a better type hierarchy.
 

--- a/grapher/chart/DimensionSlot.ts
+++ b/grapher/chart/DimensionSlot.ts
@@ -2,9 +2,9 @@
 
 import { Grapher } from "../core/Grapher"
 import { computed } from "mobx"
-import { DimensionProperty } from "../core/GrapherConstants"
 import { excludeUndefined, findIndex, sortBy } from "../../clientUtils/Util"
 import { ChartDimension } from "./ChartDimension"
+import { DimensionProperty } from "../../clientUtils/owidTypes"
 
 export class DimensionSlot {
     private grapher: Grapher

--- a/grapher/controls/entityPicker/EntityPicker.stories.tsx
+++ b/grapher/controls/entityPicker/EntityPicker.stories.tsx
@@ -5,7 +5,7 @@ import {
     SampleColumnSlugs,
     SynthesizeGDPTable,
 } from "../../../coreTable/OwidTableSynthesizers"
-import { ColumnSlug, SortOrder } from "../../../coreTable/CoreTableConstants"
+import { SortOrder } from "../../../coreTable/CoreTableConstants"
 import {
     EntityName,
     OwidTableSlugs,
@@ -13,6 +13,7 @@ import {
 import { EntityPickerManager } from "./EntityPickerConstants"
 import { computed, observable } from "mobx"
 import { SelectionArray } from "../../selection/SelectionArray"
+import { ColumnSlug } from "../../../clientUtils/owidTypes"
 
 class PickerHolder extends React.Component {
     render(): JSX.Element {

--- a/grapher/controls/entityPicker/EntityPicker.tsx
+++ b/grapher/controls/entityPicker/EntityPicker.tsx
@@ -21,7 +21,7 @@ import {
 } from "../../../clientUtils/Util"
 import { VerticalScrollContainer } from "../../controls/VerticalScrollContainer"
 import { SortIcon } from "../../controls/SortIcon"
-import { ColumnSlug, SortOrder } from "../../../coreTable/CoreTableConstants"
+import { SortOrder } from "../../../coreTable/CoreTableConstants"
 import {
     getStylesForTargetHeight,
     asArray,
@@ -35,6 +35,7 @@ import { EntityPickerManager } from "./EntityPickerConstants"
 import { CoreColumnDef } from "../../../coreTable/CoreColumnDef"
 import { OwidTable } from "../../../coreTable/OwidTable"
 import { SelectionArray } from "../../selection/SelectionArray"
+import { ColumnSlug } from "../../../clientUtils/owidTypes"
 
 const toggleSort = (order: SortOrder): SortOrder =>
     order === SortOrder.desc ? SortOrder.asc : SortOrder.desc

--- a/grapher/controls/entityPicker/EntityPickerConstants.ts
+++ b/grapher/controls/entityPicker/EntityPickerConstants.ts
@@ -1,5 +1,6 @@
+import { ColumnSlug } from "../../../clientUtils/owidTypes"
 import { CoreColumnDef } from "../../../coreTable/CoreColumnDef"
-import { ColumnSlug, SortOrder } from "../../../coreTable/CoreTableConstants"
+import { SortOrder } from "../../../coreTable/CoreTableConstants"
 import { OwidTable } from "../../../coreTable/OwidTable"
 import { GrapherAnalytics } from "../../core/GrapherAnalytics"
 import { SelectionArray } from "../../selection/SelectionArray"

--- a/grapher/core/Grapher.jsdom.test.ts
+++ b/grapher/core/Grapher.jsdom.test.ts
@@ -2,7 +2,6 @@
 import { Grapher } from "../core/Grapher"
 import {
     ChartTypeName,
-    DimensionProperty,
     EntitySelectionMode,
     GrapherTabOption,
     ScaleType,
@@ -30,6 +29,7 @@ import { OwidTable } from "../../coreTable/OwidTable"
 import { MapConfig } from "../mapCharts/MapConfig"
 import { ColumnTypeNames } from "../../coreTable/CoreColumnDef"
 import { SelectionArray } from "../selection/SelectionArray"
+import { DimensionProperty } from "../../clientUtils/owidTypes"
 
 const TestGrapherConfig = (): {
     table: OwidTable

--- a/grapher/core/Grapher.stories.tsx
+++ b/grapher/core/Grapher.stories.tsx
@@ -6,7 +6,6 @@ import {
 } from "../../coreTable/OwidTableSynthesizers"
 import {
     ChartTypeName,
-    DimensionProperty,
     FacetStrategy,
     GrapherTabOption,
 } from "./GrapherConstants"
@@ -14,6 +13,7 @@ import { BlankOwidTable } from "../../coreTable/OwidTable"
 import { action, observable } from "mobx"
 import { observer } from "mobx-react"
 import { ChartTypeSwitcher } from "../chart/ChartTypeSwitcher"
+import { DimensionProperty } from "../../clientUtils/owidTypes"
 
 export default {
     title: "Grapher",

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -39,7 +39,6 @@ import {
     GrapherTabOption,
     ScaleType,
     StackMode,
-    DimensionProperty,
     EntitySelectionMode,
     HighlightToggleConfig,
     ScatterPointLabelStrategy,
@@ -51,10 +50,7 @@ import {
     SeriesColorMap,
     FacetAxisRange,
 } from "../core/GrapherConstants"
-import {
-    LegacyChartDimensionInterface,
-    LegacyVariablesAndEntityKey,
-} from "./LegacyVariableCode"
+import { LegacyVariablesAndEntityKey } from "./LegacyVariableCode"
 import * as Cookies from "js-cookie"
 import {
     ChartDimension,
@@ -100,11 +96,7 @@ import {
     deleteRuntimeAndUnchangedProps,
     updatePersistables,
 } from "../persistable/Persistable"
-import {
-    ColumnSlug,
-    ColumnSlugs,
-    Time,
-} from "../../coreTable/CoreTableConstants"
+import { ColumnSlugs, Time } from "../../coreTable/CoreTableConstants"
 import { isOnTheMap } from "../mapCharts/EntitiesOnTheMap"
 import { ChartManager } from "../chart/ChartManager"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
@@ -163,9 +155,14 @@ import {
 } from "../../settings/clientSettings"
 import { legacyToCurrentGrapherQueryParams } from "./GrapherUrlMigrations"
 import { Url } from "../../clientUtils/urls/Url"
-import { Annotation } from "../../clientUtils/owidTypes"
+import {
+    Annotation,
+    ColumnSlug,
+    DimensionProperty,
+} from "../../clientUtils/owidTypes"
 import { ColumnTypeMap, CoreColumn } from "../../coreTable/CoreTableColumns"
 import { ChartInterface } from "../chart/ChartInterface"
+import { LegacyChartDimensionInterface } from "../../clientUtils/LegacyVariableDisplayConfigInterface"
 
 declare const window: any
 

--- a/grapher/core/GrapherConstants.ts
+++ b/grapher/core/GrapherConstants.ts
@@ -90,14 +90,6 @@ export enum ScatterPointLabelStrategy {
     y = "y",
 }
 
-export enum DimensionProperty {
-    y = "y",
-    x = "x",
-    size = "size",
-    color = "color",
-    table = "table",
-}
-
 // todo: remove
 export interface EntitySelection {
     entityId: number

--- a/grapher/core/GrapherInterface.ts
+++ b/grapher/core/GrapherInterface.ts
@@ -10,20 +10,17 @@ import {
     FacetStrategy,
 } from "./GrapherConstants"
 import { AxisConfigInterface } from "../axis/AxisConfigInterface"
-import { LegacyChartDimensionInterface } from "./LegacyVariableCode"
 import { TimeBound } from "../../clientUtils/TimeBounds"
 import { ComparisonLineConfig } from "../scatterCharts/ComparisonLine"
 import { LogoOption } from "../captionedChart/Logos"
 import { ColorScaleConfigInterface } from "../color/ColorScaleConfig"
 import { MapConfigInterface } from "../mapCharts/MapConfig"
-import {
-    ColumnSlug,
-    ColumnSlugs,
-    Time,
-} from "../../coreTable/CoreTableConstants"
+import { ColumnSlugs, Time } from "../../coreTable/CoreTableConstants"
 import { EntityId, EntityName } from "../../coreTable/OwidTableConstants"
 import { ColorSchemeName } from "../color/ColorConstants"
 import { QueryParams } from "../../clientUtils/urls/UrlUtils"
+import { LegacyChartDimensionInterface } from "../../clientUtils/LegacyVariableDisplayConfigInterface"
+import { ColumnSlug } from "../../clientUtils/owidTypes"
 
 // This configuration represents the entire persistent state of a grapher
 // Ideally, this is also all of the interaction state: when a grapher is saved and loaded again

--- a/grapher/core/GrapherWithChartTypes.jsdom.test.tsx
+++ b/grapher/core/GrapherWithChartTypes.jsdom.test.tsx
@@ -1,5 +1,6 @@
 #! /usr/bin/env jest
 
+import { DimensionProperty } from "../../clientUtils/owidTypes"
 import {
     SynthesizeGDPTable,
     SampleColumnSlugs,
@@ -7,7 +8,7 @@ import {
 import { Grapher, GrapherProgrammaticInterface } from "../core/Grapher"
 import { MapChart } from "../mapCharts/MapChart"
 import { legacyMapGrapher } from "../mapCharts/MapChart.sample"
-import { ChartTypeName, DimensionProperty } from "./GrapherConstants"
+import { ChartTypeName } from "./GrapherConstants"
 
 describe("grapher and map charts", () => {
     describe("map time tolerance plus query string works with a map chart", () => {

--- a/grapher/core/LegacyToOwidTable.test.ts
+++ b/grapher/core/LegacyToOwidTable.test.ts
@@ -1,6 +1,6 @@
 #! /usr/bin/env jest
 
-import { ChartTypeName, DimensionProperty } from "../core/GrapherConstants"
+import { ChartTypeName } from "../core/GrapherConstants"
 import { LegacyGrapherInterface } from "../core/GrapherInterface"
 import { ColumnTypeMap } from "../../coreTable/CoreTableColumns"
 import { ErrorValueTypes } from "../../coreTable/ErrorValues"
@@ -10,6 +10,7 @@ import {
     OwidTableSlugs,
     StandardOwidColumnDefs,
 } from "../../coreTable/OwidTableConstants"
+import { DimensionProperty } from "../../clientUtils/owidTypes"
 
 describe(legacyToOwidTableAndDimensions, () => {
     const legacyVariableConfig: LegacyVariablesAndEntityKey = {

--- a/grapher/core/LegacyToOwidTable.ts
+++ b/grapher/core/LegacyToOwidTable.ts
@@ -1,7 +1,7 @@
 // todo: Remove this file when we've migrated OWID data and OWID charts to next version
 
 import { ChartTypeName } from "../core/GrapherConstants"
-import { Color, ColumnSlug } from "../../coreTable/CoreTableConstants"
+import { Color } from "../../coreTable/CoreTableConstants"
 import { ColumnTypeNames, CoreColumnDef } from "../../coreTable/CoreColumnDef"
 import { LegacyGrapherInterface } from "../core/GrapherInterface"
 import {
@@ -15,7 +15,6 @@ import {
     LegacyVariablesAndEntityKey,
     LegacyEntityMeta,
     LegacyVariableConfig,
-    LegacyChartDimensionInterface,
 } from "./LegacyVariableCode"
 import {
     StandardOwidColumnDefs,
@@ -24,7 +23,8 @@ import {
     EntityId,
 } from "../../coreTable/OwidTableConstants"
 import { OwidTable } from "../../coreTable/OwidTable"
-import { EPOCH_DATE } from "../../clientUtils/owidTypes"
+import { ColumnSlug, EPOCH_DATE } from "../../clientUtils/owidTypes"
+import { LegacyChartDimensionInterface } from "../../clientUtils/LegacyVariableDisplayConfigInterface"
 
 export const legacyToOwidTableAndDimensions = (
     json: LegacyVariablesAndEntityKey,

--- a/grapher/core/LegacyVariableCode.ts
+++ b/grapher/core/LegacyVariableCode.ts
@@ -7,22 +7,11 @@ import {
     objectWithPersistablesToObject,
     deleteRuntimeAndUnchangedProps,
 } from "../persistable/Persistable"
-import { ColumnSlug, Time } from "../../coreTable/CoreTableConstants"
-import { DimensionProperty } from "../core/GrapherConstants"
 import { OwidSource } from "../../coreTable/OwidSource"
 import {
     LegacyVariableDataTableConfigInteface,
     LegacyVariableDisplayConfigInterface,
 } from "../../clientUtils/LegacyVariableDisplayConfigInterface"
-import { LegacyVariableId } from "../../clientUtils/owidTypes"
-
-export interface LegacyChartDimensionInterface {
-    property: DimensionProperty
-    targetYear?: Time
-    display?: LegacyVariableDisplayConfigInterface
-    variableId: LegacyVariableId
-    slug?: ColumnSlug
-}
 
 class LegacyVariableDisplayConfigDefaults {
     @observable name?: string = undefined

--- a/grapher/dataTable/DataTable.sample.ts
+++ b/grapher/dataTable/DataTable.sample.ts
@@ -1,5 +1,6 @@
+import { DimensionProperty } from "../../clientUtils/owidTypes"
 import { Grapher } from "../core/Grapher"
-import { DimensionProperty, GrapherTabOption } from "../core/GrapherConstants"
+import { GrapherTabOption } from "../core/GrapherConstants"
 import { GrapherInterface } from "../core/GrapherInterface"
 
 export const childMortalityGrapher = (

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -4,7 +4,7 @@ import { observer } from "mobx-react"
 import classnames from "classnames"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons/faInfoCircle"
-import { SortOrder, ColumnSlug, Time } from "../../coreTable/CoreTableConstants"
+import { SortOrder, Time } from "../../coreTable/CoreTableConstants"
 import { EntityName, OwidTableSlugs } from "../../coreTable/OwidTableConstants"
 import { TickFormattingOptions } from "../../clientUtils/formatValue"
 import {
@@ -27,6 +27,7 @@ import { CoreColumn } from "../../coreTable/CoreTableColumns"
 import { Bounds, DEFAULT_BOUNDS } from "../../clientUtils/Bounds"
 import { makeSelectionArray } from "../chart/ChartUtils"
 import { SelectionArray } from "../selection/SelectionArray"
+import { ColumnSlug } from "../../clientUtils/owidTypes"
 
 interface DataTableState {
     sort: DataTableSortState

--- a/grapher/footer/Footer.jsdom.test.tsx
+++ b/grapher/footer/Footer.jsdom.test.tsx
@@ -6,10 +6,10 @@ import {
     SampleColumnSlugs,
     SynthesizeGDPTable,
 } from "../../coreTable/OwidTableSynthesizers"
-import { DimensionProperty } from "../core/GrapherConstants"
 
 import { configure, mount } from "enzyme"
 import Adapter from "enzyme-adapter-react-16"
+import { DimensionProperty } from "../../clientUtils/owidTypes"
 configure({ adapter: new Adapter() })
 
 const TestGrapherConfig = (): GrapherProgrammaticInterface => {

--- a/grapher/mapCharts/MapChart.sample.ts
+++ b/grapher/mapCharts/MapChart.sample.ts
@@ -1,5 +1,6 @@
+import { DimensionProperty } from "../../clientUtils/owidTypes"
 import { GrapherProgrammaticInterface } from "../core/Grapher"
-import { GrapherTabOption, DimensionProperty } from "../core/GrapherConstants"
+import { GrapherTabOption } from "../core/GrapherConstants"
 
 export const legacyMapGrapher: GrapherProgrammaticInterface = {
     hasMapTab: true,

--- a/grapher/mapCharts/MapChartConstants.ts
+++ b/grapher/mapCharts/MapChartConstants.ts
@@ -4,9 +4,10 @@ import { PointVector } from "../../clientUtils/PointVector"
 import { MapProjectionName } from "./MapProjections"
 import { ChartManager } from "../chart/ChartManager"
 import { MapConfig } from "./MapConfig"
-import { Color, ColumnSlug, Time } from "../../coreTable/CoreTableConstants"
+import { Color, Time } from "../../coreTable/CoreTableConstants"
 import { ChartTypeName, SeriesName } from "../core/GrapherConstants"
 import { ChartSeries } from "../chart/ChartInterface"
+import { ColumnSlug } from "../../clientUtils/owidTypes"
 
 export type GeoFeature = GeoJSON.Feature<GeoJSON.GeometryObject>
 export type MapBracket = ColorScaleBin

--- a/grapher/mapCharts/MapConfig.ts
+++ b/grapher/mapCharts/MapConfig.ts
@@ -1,8 +1,7 @@
 import { observable } from "mobx"
 import { MapProjectionName } from "./MapProjections"
 import { ColorScaleConfig } from "../color/ColorScaleConfig"
-import { ColumnSlug } from "../../coreTable/CoreTableConstants"
-import { LegacyVariableId } from "../../clientUtils/owidTypes"
+import { ColumnSlug, LegacyVariableId } from "../../clientUtils/owidTypes"
 import {
     Persistable,
     updatePersistables,

--- a/site/DataValue.tsx
+++ b/site/DataValue.tsx
@@ -5,7 +5,7 @@ export const DATA_VALUE = "DataValue"
 
 export const processTemplate = (props: DataValueProps) => {
     return props.template
-        .replace("%value", props.value.toString())
+        .replace("%value", props.formattedValue || props.value.toString())
         .replace("%year", props.year.toString() || "")
         .replace("%unit", props.unit || "")
         .replace("%entity", props.entityName || "")

--- a/site/GrapherPage.jsdom.test.tsx
+++ b/site/GrapherPage.jsdom.test.tsx
@@ -4,10 +4,13 @@ import * as React from "react"
 import { GrapherPage } from "./GrapherPage"
 import { SiteHeader } from "./SiteHeader"
 import { SiteFooter } from "./SiteFooter"
-import { PostRow, RelatedChart } from "../clientUtils/owidTypes"
+import {
+    DimensionProperty,
+    PostRow,
+    RelatedChart,
+} from "../clientUtils/owidTypes"
 import { ChartListItemVariant } from "./ChartListItemVariant"
 import { GrapherInterface } from "../grapher/core/GrapherInterface"
-import { DimensionProperty } from "../grapher/core/GrapherConstants"
 
 import { configure, shallow, ShallowWrapper } from "enzyme"
 import Adapter from "enzyme-adapter-react-16"


### PR DESCRIPTION
Follow up to #908.

This PR adds formatting (conversion, unit) to values extracted from the DB and inserted into the text.

E.g. 5998.350483 with a conversion factor of 1000000 and a unit of "tonnes" becomes "6 billion tonnes":

<img width="590" alt="Screenshot 2021-06-17 at 18 22 50" src="https://user-images.githubusercontent.com/13406362/122436389-12f62800-cf99-11eb-98b4-5c8ea379c4e4.png">

Formatting rules are derived from the Grapher display configurations, stored at the variable and chart level.

Limitations:
- the general approach is quite convoluted and uses legacy code
- use cases limited to the [Pilot chart from dynamic text experiment](https://www.notion.so/owid/Pilot-chart-from-dynamic-text-580a7d0ad84546d3b83499d3581269f0#f69fd796d1d2451587a635ff462f1b14)

