### PR TITLE
enhance(grapher): Offer a dropdown menu for facet strategy

### DIFF
--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -255,12 +255,14 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         if (manager.showAbsRelToggle)
             controls.push(<AbsRelToggle key="AbsRelToggle" manager={manager} />)
 
-        controls.push(
-            <FacetStrategyDropdown
-                key="FacetStrategyDropdown"
-                manager={manager}
-            />
-        )
+        if (manager.showFacets) {
+            controls.push(
+                <FacetStrategyDropdown
+                    key="FacetStrategyDropdown"
+                    manager={manager}
+                />
+            )
+        }
 
         if (this.isFaceted && manager.showFacetYRangeToggle)
             controls.push(

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -252,9 +252,6 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         if (manager.showZoomToggle)
             controls.push(<ZoomToggle key="ZoomToggle" manager={manager} />)
 
-        if (manager.showAbsRelToggle)
-            controls.push(<AbsRelToggle key="AbsRelToggle" manager={manager} />)
-
         if (manager.showFacets) {
             controls.push(
                 <FacetStrategyDropdown
@@ -264,7 +261,10 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
             )
         }
 
-        if (this.isFaceted && manager.showFacetYRangeToggle)
+        if (manager.showAbsRelToggle)
+            controls.push(<AbsRelToggle key="AbsRelToggle" manager={manager} />)
+
+        if (manager.showFacetYRangeToggle)
             controls.push(
                 <FacetYRangeToggle key="FacetYRangeToggle" manager={manager} />
             )

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -11,6 +11,7 @@ import {
 import {
     BASE_FONT_SIZE,
     ChartTypeName,
+    FacetStrategy,
     GrapherTabOption,
 } from "../core/GrapherConstants"
 import { MapChartManager } from "../mapCharts/MapChartConstants"
@@ -30,6 +31,8 @@ import {
     HighlightToggleManager,
     FacetYRangeToggle,
     FacetYRangeToggleManager,
+    FacetStrategyDropdown,
+    FacetStrategyDropdownManager,
 } from "../controls/Controls"
 import { ScaleSelector } from "../controls/ScaleSelector"
 import { AddEntityButton } from "../controls/AddEntityButton"
@@ -48,7 +51,8 @@ export interface CaptionedChartManager
         AbsRelToggleManager,
         FooterManager,
         HeaderManager,
-        FacetYRangeToggleManager {
+        FacetYRangeToggleManager,
+        FacetStrategyDropdownManager {
     containerElement?: HTMLDivElement
     tabBounds?: Bounds
     fontSize?: number
@@ -139,7 +143,10 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
     }
 
     @computed get isFaceted(): boolean {
-        return !this.isMapTab && !!this.manager.facetStrategy
+        const hasStrategy =
+            !!this.manager.facetStrategy &&
+            this.manager.facetStrategy !== FacetStrategy.together
+        return !this.isMapTab && hasStrategy
     }
 
     renderChart(): JSX.Element {
@@ -247,6 +254,13 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
 
         if (manager.showAbsRelToggle)
             controls.push(<AbsRelToggle key="AbsRelToggle" manager={manager} />)
+
+        controls.push(
+            <FacetStrategyDropdown
+                key="FacetStrategyDropdown"
+                manager={manager}
+            />
+        )
 
         if (this.isFaceted && manager.showFacetYRangeToggle)
             controls.push(

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -145,7 +145,7 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
     @computed get isFaceted(): boolean {
         const hasStrategy =
             !!this.manager.facetStrategy &&
-            this.manager.facetStrategy !== FacetStrategy.together
+            this.manager.facetStrategy !== FacetStrategy.none
         return !this.isMapTab && hasStrategy
     }
 

--- a/grapher/controls/Controls.scss
+++ b/grapher/controls/Controls.scss
@@ -13,6 +13,13 @@ $zindex-ControlsFooter: 2;
     color: $controls-color;
 }
 
+.FacetStrategyDropdown {
+    width: 160px;
+    font-family: "Lato";
+    font-size: 10px;
+    font-weight: bold;
+}
+
 @keyframes bounceIn {
     from,
     20%,

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { computed, action } from "mobx"
+import { computed, action, observable } from "mobx"
 import { observer } from "mobx-react"
 import {
     getQueryParams,
@@ -241,6 +241,7 @@ export class FilterSmallCountriesToggle extends React.Component<{
 export interface FacetStrategyDropdownManager {
     availableFacetStrategies?: FacetStrategy[]
     facet?: FacetStrategy
+    showFacets?: boolean
 }
 
 const FACET_DROPDOWN_CLASS = "FacetStrategyDropdown"
@@ -276,10 +277,10 @@ export class FacetStrategyDropdown extends React.Component<{
             <Select
                 className={FACET_DROPDOWN_CLASS}
                 classNamePrefix={FACET_DROPDOWN_CLASS}
-                options={this.options}
-                value={this.options.find(
-                    (option) => option.value === this.facet
+                defaultValue={this.options.find(
+                    (o) => o.value === FacetStrategy.together
                 )}
+                options={this.options}
                 onChange={this.onChange}
                 styles={styles}
             />

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { computed, action, observable } from "mobx"
+import { computed, action } from "mobx"
 import { observer } from "mobx-react"
 import {
     getQueryParams,
@@ -251,8 +251,8 @@ export class FacetStrategyDropdown extends React.Component<{
 }> {
     @computed get options(): { label: string; value: string }[] {
         const strategies = this.props.manager.availableFacetStrategies || [
-            FacetStrategy.together,
-            FacetStrategy.country,
+            FacetStrategy.none,
+            FacetStrategy.entity,
             FacetStrategy.column,
         ]
         return strategies.map((value) => {
@@ -262,7 +262,7 @@ export class FacetStrategyDropdown extends React.Component<{
     }
 
     @computed get facet(): FacetStrategy {
-        return this.props.manager.facet || FacetStrategy.together
+        return this.props.manager.facet || FacetStrategy.none
     }
 
     @action.bound onChange(
@@ -278,7 +278,7 @@ export class FacetStrategyDropdown extends React.Component<{
                 className={FACET_DROPDOWN_CLASS}
                 classNamePrefix={FACET_DROPDOWN_CLASS}
                 defaultValue={this.options.find(
-                    (o) => o.value === FacetStrategy.together
+                    (o) => o.value === FacetStrategy.none
                 )}
                 options={this.options}
                 onChange={this.onChange}
@@ -289,8 +289,8 @@ export class FacetStrategyDropdown extends React.Component<{
 }
 
 const facetStrategyLabels = {
-    [FacetStrategy.together]: "All together",
-    [FacetStrategy.country]: "Split by country",
+    [FacetStrategy.none]: "All together",
+    [FacetStrategy.entity]: "Split by country",
     [FacetStrategy.column]: "Split by metric",
 }
 

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -6,6 +6,7 @@ import {
     getWindowQueryParams,
     QueryParams,
 } from "../../clientUtils/urls/UrlUtils"
+import Select, { ValueType } from "react-select"
 import { TimelineComponent } from "../timeline/TimelineComponent"
 import { formatValue } from "../../clientUtils/formatValue"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
@@ -15,6 +16,7 @@ import { faExpand } from "@fortawesome/free-solid-svg-icons/faExpand"
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons/faExternalLinkAlt"
 import {
     FacetAxisRange,
+    FacetStrategy,
     GrapherTabOption,
     HighlightToggleConfig,
     RelatedQuestionsConfig,
@@ -24,6 +26,10 @@ import { ShareMenu, ShareMenuManager } from "./ShareMenu"
 import { TimelineController } from "../timeline/TimelineController"
 import { SelectionArray } from "../selection/SelectionArray"
 import { AxisConfig } from "../axis/AxisConfig"
+import {
+    asArray,
+    getStylesForTargetHeight,
+} from "../../clientUtils/react-select"
 
 export interface HighlightToggleManager {
     highlightToggle?: HighlightToggleConfig
@@ -230,6 +236,61 @@ export class FilterSmallCountriesToggle extends React.Component<{
             </label>
         )
     }
+}
+
+export interface FacetStrategyDropdownManager {
+    availableFacetStrategies?: FacetStrategy[]
+    facet?: FacetStrategy
+}
+
+const FACET_DROPDOWN_CLASS = "FacetStrategyDropdown"
+
+export class FacetStrategyDropdown extends React.Component<{
+    manager: FacetStrategyDropdownManager
+}> {
+    @computed get options(): { label: string; value: string }[] {
+        const strategies = this.props.manager.availableFacetStrategies || [
+            FacetStrategy.together,
+            FacetStrategy.country,
+            FacetStrategy.column,
+        ]
+        return strategies.map((value) => {
+            const label = facetStrategyLabels[value]
+            return { label, value }
+        })
+    }
+
+    @computed get facet(): FacetStrategy {
+        return this.props.manager.facet || FacetStrategy.together
+    }
+
+    @action.bound onChange(
+        selected: ValueType<{ label: string; value: string }>
+    ): void {
+        this.props.manager.facet = asArray(selected)[0].value as FacetStrategy
+    }
+
+    render(): JSX.Element {
+        const styles = getStylesForTargetHeight(24)
+        return (
+            <Select
+                className={FACET_DROPDOWN_CLASS}
+                classNamePrefix={FACET_DROPDOWN_CLASS}
+                options={this.options}
+                value={this.options.find(
+                    (option) => option.value === this.facet
+                )}
+                onChange={this.onChange}
+                styles={styles}
+            />
+        )
+    }
+}
+
+const facetStrategyLabels = {
+    [FacetStrategy.together]: "All together",
+    [FacetStrategy.country]: "Split by country",
+    [FacetStrategy.column]: "Split by metric",
 }
 
 export interface FooterControlsManager extends ShareMenuManager {

--- a/grapher/core/Grapher.stories.tsx
+++ b/grapher/core/Grapher.stories.tsx
@@ -116,7 +116,7 @@ export const NoMap = (): JSX.Element => {
 export const Faceting = (): JSX.Element => {
     const model = {
         type: ChartTypeName.StackedArea,
-        facet: FacetStrategy.country,
+        facet: FacetStrategy.entity,
         ...basics,
     }
     return <Grapher {...model} />

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -278,7 +278,6 @@ export class Grapher
     scatterPointLabelStrategy?: ScatterPointLabelStrategy = undefined
     @observable.ref compareEndPointsOnly?: boolean = undefined
     @observable.ref matchingEntitiesOnly?: boolean = undefined
-    @observable.ref showFacetYRangeToggle: boolean = true
 
     @observable.ref xAxis = new AxisConfig(undefined, this)
     @observable.ref yAxis = new AxisConfig(undefined, this)
@@ -1809,6 +1808,11 @@ export class Grapher
 
     @action.bound private toggleFacetVisibility(): void {
         this.showFacets = !this.showFacets
+    }
+
+    @computed get showFacetYRangeToggle(): boolean {
+        // don't offer to make the y range relative if the range is discrete
+        return this.facet !== FacetStrategy.none && !this.isStackedDiscreteBar
     }
 
     @computed get facet(): FacetStrategy {

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -251,7 +251,7 @@ export class Grapher
     @observable.ref timelineMaxTime?: Time = undefined
     @observable.ref addCountryMode = EntitySelectionMode.MultipleEntities
     @observable.ref highlightToggle?: HighlightToggleConfig = undefined
-    @observable.ref stackMode = StackMode.absolute
+    @observable.ref lastStackMode = StackMode.absolute
     @observable.ref hideLegend?: boolean = false
     @observable.ref logo?: LogoOption = undefined
     @observable.ref hideLogo?: boolean = undefined
@@ -1458,7 +1458,22 @@ export class Grapher
                 !this.areHandlesOnSameTime &&
                 this.yScaleType !== ScaleType.log
             )
+
+        if (this.facet === FacetStrategy.column) return false
+
         return !this.hideRelativeToggle
+    }
+
+    get stackMode(): StackMode {
+        // There's no point using relative stacking once you're split by metric,
+        // since every single bar is 100%
+        if (this.facet === FacetStrategy.column) return StackMode.absolute
+
+        return this.lastStackMode
+    }
+
+    set stackMode(mode: StackMode) {
+        this.lastStackMode = mode
     }
 
     // Filter data to what can be display on the map (across all times)

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -49,7 +49,6 @@ import {
     FacetStrategy,
     ThereWasAProblemLoadingThisChart,
     SeriesColorMap,
-    FacetAxisRange,
 } from "../core/GrapherConstants"
 import {
     LegacyChartDimensionInterface,
@@ -111,6 +110,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons/faExclamationTriangle"
 import {
     AbsRelToggleManager,
+    FacetStrategyDropdownManager,
     FooterControls,
     FooterControlsManager,
     HighlightToggleManager,
@@ -234,6 +234,7 @@ export class Grapher
         FooterControlsManager,
         DataTableManager,
         ScatterPlotManager,
+        FacetStrategyDropdownManager,
         MapChartManager {
     @observable.ref type = ChartTypeName.LineChart
     @observable.ref id?: number = undefined
@@ -1830,11 +1831,8 @@ export class Grapher
         return []
     }
 
-    @computed private get availableFacetStrategies(): (
-        | FacetStrategy
-        | undefined
-    )[] {
-        const strategies: (FacetStrategy | undefined)[] = [undefined]
+    @computed get availableFacetStrategies(): FacetStrategy[] {
+        const strategies: FacetStrategy[] = [FacetStrategy.together]
 
         if (this.hasMultipleYColumns) strategies.push(FacetStrategy.column)
 
@@ -1845,11 +1843,11 @@ export class Grapher
     }
 
     private disableAutoFaceting = true // turned off for now
-    @computed get facetStrategy(): FacetStrategy | undefined {
+    @computed get facetStrategy(): FacetStrategy {
         if (this.facet && this.availableFacetStrategies.includes(this.facet))
             return this.facet
 
-        if (this.disableAutoFaceting) return undefined
+        if (this.disableAutoFaceting) return FacetStrategy.together
 
         // Auto facet on SingleEntity charts with multiple selected entities
         if (
@@ -1866,7 +1864,7 @@ export class Grapher
         )
             return FacetStrategy.column
 
-        return undefined
+        return FacetStrategy.together
     }
 
     @action.bound randomSelection(num: number): void {

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -302,7 +302,7 @@ export class Grapher
     @observable.ref annotation?: Annotation = undefined
 
     @observable showFacets?: boolean = false
-    @observable lastFacet: FacetStrategy = FacetStrategy.together
+    @observable lastFacet: FacetStrategy = FacetStrategy.none
 
     owidDataset?: LegacyVariablesAndEntityKey = undefined // This is temporarily used for testing. Will be removed
     manuallyProvideData? = false // This will be removed.
@@ -1815,7 +1815,7 @@ export class Grapher
         if (this.showFacets) {
             return this.lastFacet
         }
-        return FacetStrategy.together
+        return FacetStrategy.none
     }
     set facet(strategy: FacetStrategy) {
         this.lastFacet = strategy
@@ -1847,12 +1847,12 @@ export class Grapher
     }
 
     @computed get availableFacetStrategies(): FacetStrategy[] {
-        const strategies: FacetStrategy[] = [FacetStrategy.together]
+        const strategies: FacetStrategy[] = [FacetStrategy.none]
 
         if (this.hasMultipleYColumns) strategies.push(FacetStrategy.column)
 
         if (this.selection.numSelectedEntities > 1)
-            strategies.push(FacetStrategy.country)
+            strategies.push(FacetStrategy.entity)
 
         return strategies
     }
@@ -1862,14 +1862,14 @@ export class Grapher
         if (this.facet && this.availableFacetStrategies.includes(this.facet))
             return this.facet
 
-        if (this.disableAutoFaceting) return FacetStrategy.together
+        if (this.disableAutoFaceting) return FacetStrategy.none
 
         // Auto facet on SingleEntity charts with multiple selected entities
         if (
             this.addCountryMode === EntitySelectionMode.SingleEntity &&
             this.selection.numSelectedEntities > 1
         )
-            return FacetStrategy.country
+            return FacetStrategy.entity
 
         // Auto facet when multiple slugs and multiple entities selected. todo: not sure if this is correct.
         if (
@@ -1879,7 +1879,7 @@ export class Grapher
         )
             return FacetStrategy.column
 
-        return FacetStrategy.together
+        return FacetStrategy.none
     }
 
     @action.bound randomSelection(num: number): void {
@@ -2130,7 +2130,7 @@ export class Grapher
         this.colorSlug = grapher.colorSlug
         this.sizeSlug = grapher.sizeSlug
         this.hasMapTab = grapher.hasMapTab
-        this.facet = FacetStrategy.together
+        this.facet = FacetStrategy.none
         this.hasChartTab = grapher.hasChartTab
         this.map = grapher.map
         this.yAxis.scaleType = grapher.yAxis.scaleType

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1849,10 +1849,13 @@ export class Grapher
     @computed get availableFacetStrategies(): FacetStrategy[] {
         const strategies: FacetStrategy[] = [FacetStrategy.none]
 
-        if (this.hasMultipleYColumns) strategies.push(FacetStrategy.column)
-
-        if (this.selection.numSelectedEntities > 1)
+        // It only ever makes sense to facet on metric or on entity. In cases like StackedDiscreteBar
+        // that could offer both, faceting by entity is strictly worse than the original together view.
+        if (this.hasMultipleYColumns) {
+            strategies.push(FacetStrategy.column)
+        } else if (this.selection.numSelectedEntities > 1) {
             strategies.push(FacetStrategy.entity)
+        }
 
         return strategies
     }

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -301,6 +301,9 @@ export class Grapher
     @observable relatedQuestions: RelatedQuestionsConfig[] = [] // todo: Persistables?
     @observable.ref annotation?: Annotation = undefined
 
+    @observable showFacets?: boolean = false
+    @observable lastFacet: FacetStrategy = FacetStrategy.together
+
     owidDataset?: LegacyVariablesAndEntityKey = undefined // This is temporarily used for testing. Will be removed
     manuallyProvideData? = false // This will be removed.
 
@@ -1732,7 +1735,7 @@ export class Grapher
             },
             {
                 combo: "f",
-                fn: (): void => this.toggleFacetStrategy(),
+                fn: (): void => this.toggleFacetVisibility(),
                 title: `Toggle Faceting`,
                 category: "Chart",
             },
@@ -1804,7 +1807,19 @@ export class Grapher
         this.facet = next(this.availableFacetStrategies, this.facet)
     }
 
-    @observable facet?: FacetStrategy
+    @action.bound private toggleFacetVisibility(): void {
+        this.showFacets = !this.showFacets
+    }
+
+    @computed get facet(): FacetStrategy {
+        if (this.showFacets) {
+            return this.lastFacet
+        }
+        return FacetStrategy.together
+    }
+    set facet(strategy: FacetStrategy) {
+        this.lastFacet = strategy
+    }
 
     @computed private get hasMultipleYColumns(): boolean {
         return this.yColumnSlugs.length > 1
@@ -2115,7 +2130,7 @@ export class Grapher
         this.colorSlug = grapher.colorSlug
         this.sizeSlug = grapher.sizeSlug
         this.hasMapTab = grapher.hasMapTab
-        this.facet = undefined
+        this.facet = FacetStrategy.together
         this.hasChartTab = grapher.hasChartTab
         this.map = grapher.map
         this.yAxis.scaleType = grapher.yAxis.scaleType

--- a/grapher/core/GrapherConstants.ts
+++ b/grapher/core/GrapherConstants.ts
@@ -38,8 +38,8 @@ export enum StackMode {
 export const BASE_FONT_SIZE = 16
 
 export enum FacetStrategy {
-    together = "together", // No facets
-    country = "country", // One chart for each country
+    none = "none", // No facets
+    entity = "entity", // One chart for each country/entity
     column = "column", // One chart for each Y column
 }
 

--- a/grapher/core/GrapherConstants.ts
+++ b/grapher/core/GrapherConstants.ts
@@ -38,6 +38,7 @@ export enum StackMode {
 export const BASE_FONT_SIZE = 16
 
 export enum FacetStrategy {
+    together = "together", // No facets
     country = "country", // One chart for each country
     column = "column", // One chart for each Y column
 }

--- a/grapher/facetChart/FacetChart.test.ts
+++ b/grapher/facetChart/FacetChart.test.ts
@@ -30,7 +30,7 @@ it("uses the transformed data for display in country mode", () => {
         selection: table.availableEntityNames,
         // simulate the transformation that is done by Grapher on the data
         transformedTable: table.filterByTimeRange(2002, 2008),
-        facetStrategy: FacetStrategy.country,
+        facetStrategy: FacetStrategy.entity,
         yAxis: new AxisConfig(),
     }
     const chart = new FacetChart({ manager })


### PR DESCRIPTION
Add a dropdown menu for faceting, which is enabled by pressing "f", allowing you to choose what faceting strategy to use, when there are multiple available.

See: https://www.notion.so/owid/Plot-entities-together-or-metrics-together-f47c2de5ca554294a78a540dc383597f

## This PR

- [x] Add a faceting dropdown control to the grapher
- [x] Update "f" hotkey to just show/hide faceting controls
- [x] Do not offer faceting by entity for StackedDiscreteBar
- [x] Fix interaction with relative control and faceting

## In a follow-up PR

- Turn the dropdown into the full hovering design