### PR TITLE
fix(grapher): Facets use a chart y min if available

### DIFF
--- a/grapher/facetChart/FacetChart.test.ts
+++ b/grapher/facetChart/FacetChart.test.ts
@@ -41,3 +41,23 @@ it("uses the transformed data for display in country mode", () => {
         expect(s.manager.table!.maxTime).toEqual(2008)
     })
 })
+
+it("uses a shared y min if one is available", () => {
+    const table = SynthesizeGDPTable({ timeRange: [2000, 2010] })
+    const manager: ChartManager = {
+        table,
+        selection: table.availableEntityNames,
+        // simulate the transformation that is done by Grapher on the data
+        transformedTable: table.filterByTimeRange(2002, 2008),
+        facetStrategy: FacetStrategy.entity,
+        yAxis: new AxisConfig(),
+    }
+    manager.yAxis!.min = -100
+
+    const chart = new FacetChart({ manager })
+
+    // we should be using the transformed table
+    chart.series.forEach((s) => {
+        expect(s.manager.yAxisConfig!.min).toBe(-100)
+    })
+})

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -157,7 +157,10 @@ export class FacetChart
     }
 
     @computed private get columnFacets(): FacetSeries[] {
-        return this.yColumns.map((col) => {
+        const yAxis = new AxisConfig()
+        yAxis.min = this.manager.yAxis!.min
+
+        return this.yColumns.map((col: CoreColumn) => {
             return {
                 seriesName: col.displayName,
                 color: facetBackgroundColor,
@@ -166,6 +169,7 @@ export class FacetChart
                     yColumnSlug: col.slug,
                     yColumnSlugs: [col.slug], // In a column facet strategy, only have 1 yColumn per chart.
                     seriesStrategy: SeriesStrategy.entity,
+                    yAxis,
                 },
             }
         })

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -24,6 +24,7 @@ import { OwidTable } from "../../coreTable/OwidTable"
 import { autoDetectYColumnSlugs, makeSelectionArray } from "../chart/ChartUtils"
 import { SelectionArray } from "../selection/SelectionArray"
 import { CoreColumn } from "../../coreTable/CoreTableColumns"
+import { AxisConfig } from "../axis/AxisConfig"
 
 const facetBackgroundColor = "transparent" // we don't use color yet but may use it for background later
 
@@ -67,7 +68,7 @@ export class FacetChart
 
         const table = this.transformedTable
 
-        return series.map((series, index) => {
+        return series.map((series: FacetSeries, index: number) => {
             const bounds = boundsArr[index]
             const hideXAxis = false // row < rows - 1 // todo: figure out design issues here
             const hideYAxis = false // column > 0 // todo: figure out design issues here
@@ -121,6 +122,7 @@ export class FacetChart
                   scaleType,
               }
             : undefined
+        const yAxisMin = this.manager.yAxis!.min
 
         const hideLegend = this.manager.yColumnSlugs?.length === 1
 
@@ -131,12 +133,12 @@ export class FacetChart
                 this.manager.yAxis!.facetAxisRange == FacetAxisRange.shared
                     ? {
                           max: sharedYDomain[1],
-                          min: sharedYDomain[0],
+                          min: yAxisMin ?? sharedYDomain[0],
                           scaleType,
                       }
                     : {
                           max: seriesYDomain[1],
-                          min: seriesYDomain[0],
+                          min: yAxisMin ?? seriesYDomain[0],
                           scaleType,
                       }
             return {


### PR DESCRIPTION
For example, in the Covid explorer, the min is set to zero on all axes, but the facets did not share this minimum.

Now facets share the one y min when it is configured.

See: https://www.notion.so/owid/yAxisMin-explorer-setting-should-be-respected-in-facets-f992da1cbd944de18301b3bd26915555

## TODO

- [x] Use shared y min for country strategy
- [x] Use shared y min for column strategy
- [ ] Fix uniform mode for column strategy
- [ ] Use min(shared y min, detected y min) in uniform mode