### PR TITLE
fix: single entity charts shouldn't show "add country" button

### DIFF
--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -2384,7 +2384,7 @@ export class Grapher
             return true
         if (
             this.addCountryMode === EntitySelectionMode.SingleEntity &&
-            this.facetStrategy
+            this.facetStrategy !== FacetStrategy.none
         )
             return true
 
@@ -2403,6 +2403,7 @@ export class Grapher
     @computed get canChangeEntity(): boolean {
         return (
             !this.isScatter &&
+            !this.canSelectMultipleEntities &&
             this.addCountryMode === EntitySelectionMode.SingleEntity &&
             this.numSelectableEntityNames > 1
         )


### PR DESCRIPTION
This resolves two issues:

- Colors on "change entity" charts not being applied (reported by both [Lucas](https://owid.slack.com/archives/C46U9LXRR/p1624631755004300) and [Charlie](https://owid.slack.com/archives/C46U9LXRR/p1624813310013700))
- Add country button showing up when it shouldn't (reported by [Charlie](https://owid.slack.com/archives/C46U9LXRR/p1624813310013700))