### PR TITLE
fix(grapher): allow saving/recovering stackMode config property

### DIFF
--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -248,7 +248,7 @@ export class Grapher
     @observable.ref timelineMaxTime?: Time = undefined
     @observable.ref addCountryMode = EntitySelectionMode.MultipleEntities
     @observable.ref highlightToggle?: HighlightToggleConfig = undefined
-    @observable.ref lastStackMode = StackMode.absolute
+    @observable.ref stackMode = StackMode.absolute
     @observable.ref hideLegend?: boolean = false
     @observable.ref logo?: LogoOption = undefined
     @observable.ref hideLogo?: boolean = undefined
@@ -1459,18 +1459,6 @@ export class Grapher
         if (this.facet === FacetStrategy.column) return false
 
         return !this.hideRelativeToggle
-    }
-
-    get stackMode(): StackMode {
-        // There's no point using relative stacking once you're split by metric,
-        // since every single bar is 100%
-        if (this.facet === FacetStrategy.column) return StackMode.absolute
-
-        return this.lastStackMode
-    }
-
-    set stackMode(mode: StackMode) {
-        this.lastStackMode = mode
     }
 
     // Filter data to what can be display on the map (across all times)


### PR DESCRIPTION
This reverts a part of https://github.com/owid/owid-grapher/commit/1581f9d2bdd39bb65d74d4a6973f4bddc6f6c32f.

It's a quick fix for a bug we have where `stackMode` is not being saved/recovered at all from config ([Slack report](https://owid.slack.com/archives/C46U9LXRR/p1624953280000400)). Since faceting is not surfaced to users, it seems harmless to revert.

The logic as it was written also wasn't quite right: charts can be stacked by either metric or entity, so that needs to be taken into account. But additionally, what gets stacked is determined by `seriesStrategy`, which doesn't have a consistent meaning from chart to chart.