### PR TITLE
fix: collapsible list measures item widths correctly

### DIFF
--- a/grapher/controls/CollapsibleList/CollapsibleList.scss
+++ b/grapher/controls/CollapsibleList/CollapsibleList.scss
@@ -4,11 +4,12 @@
     ul {
         list-style: none;
         > .list-item {
-            &.visible,
-            &.moreButton {
-                display: inline-block;
+            display: inline-block;
 
-                padding-left: 15px;
+            padding-left: 15px;
+
+            &.hidden {
+                visibility: hidden;
             }
         }
     }

--- a/grapher/controls/CollapsibleList/CollapsibleList.tsx
+++ b/grapher/controls/CollapsibleList/CollapsibleList.tsx
@@ -39,8 +39,9 @@ export class CollapsibleList extends React.Component {
     }
 
     private calculateItemWidths(): void {
+        this.itemsWidths = []
         this.outerContainerRef.current
-            ?.querySelectorAll(".list-item.visible")
+            ?.querySelectorAll(".list-item.visible, .list-item.hidden")
             .forEach((item): number => this.itemsWidths.push(item.clientWidth))
     }
 
@@ -130,6 +131,14 @@ export class CollapsibleList extends React.Component {
                             )}
                         />
                     </li>
+                    {/* Invisibly render dropdown items such that we can measure their clientWidth, too */}
+                    {this.dropdownItems.map(
+                        (item): JSX.Element => (
+                            <li key={item.index} className="list-item hidden">
+                                {item.child}
+                            </li>
+                        )
+                    )}
                 </ul>
             </div>
         )

--- a/grapher/controls/CollapsibleList/CollapsibleList.tsx
+++ b/grapher/controls/CollapsibleList/CollapsibleList.tsx
@@ -66,9 +66,7 @@ export class CollapsibleList extends React.Component {
     }
 
     private get dropdownItems(): ListChild[] {
-        return this.numItemsVisible
-            ? this.children.slice(this.numItemsVisible)
-            : []
+        return this.children.slice(this.numItemsVisible)
     }
 
     @action private onResize = throttle((): void => {


### PR DESCRIPTION
Notion: [Mobx reaches max update depth](https://www.notion.so/Mobx-reaches-max-update-depth-61049a64ac6d4443aeb1e859c50b1bb3)

While looking into this, I noticed that the code in `CollapsibleList` was entirely broken in some way:
In every call to `calculateItemWidths`, we were calculating the widths of all _visible_ elements and appended them to the end of the ever-growing `this.itemsWidths`.

To fix this and to also measure the width of items that are not visible, we now mount all dropdown items after the More button with `visibility: hidden` to have access to their `clientWidth`.
This results in `calculateItemWidths` always calculating the width of all children, i.e. `this.itemsWidths` is always up to date for all children.
Let me know if you know of a way of measuring the width without mounting the element :) But if there is none, then I think this is a good solution. And it certainly solves the warning messages in test runs.