### PR TITLE
feat: animate stacked bar charts using `react-move`

### DIFF
--- a/grapher/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.tsx
@@ -73,7 +73,7 @@ interface Bar {
 interface TooltipProps extends StackedBarChartContext {
     label: string
     bars: Bar[]
-    highlightedSeriesName: string | null
+    highlightedSeriesName: string | undefined
 }
 
 interface StackedBarChartContext {
@@ -394,7 +394,9 @@ export class StackedDiscreteBarChart
                                             content={
                                                 <StackedDiscreteBarChart.Tooltip
                                                     {...tooltipProps}
-                                                    highlightedSeriesName={null}
+                                                    highlightedSeriesName={
+                                                        undefined
+                                                    }
                                                 />
                                             }
                                         >

--- a/grapher/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.tsx
@@ -60,6 +60,10 @@ interface Item {
     bars: Bar[]
 }
 
+interface PlacedItem extends Item {
+    yPosition: number
+}
+
 interface Bar {
     color: Color
     seriesName: string
@@ -328,6 +332,15 @@ export class StackedDiscreteBarChart
         }
 
         const yOffset = innerBounds.top + barHeight / 2
+        const placedItems = this.items.map((d, i) => ({
+            yPosition: yOffset + (barHeight + barSpacing) * i,
+            ...d,
+        }))
+
+        const handlePositionUpdate = (d: PlacedItem) => ({
+            translateY: [d.yPosition],
+            timing: { duration: 350, ease: easeQuadOut },
+        })
 
         return (
             <g ref={this.base} className="StackedDiscreteBarChart">
@@ -350,23 +363,15 @@ export class StackedDiscreteBarChart
                 />
                 <HorizontalCategoricalColorLegend manager={this} />
                 <NodeGroup
-                    data={this.items.map((d) => ({
-                        bounds: this.innerBounds,
-                        ...d,
-                    }))}
-                    keyAccessor={(d: Item) => d.label}
-                    start={(d: Item, i: number) => ({
-                        translateY: yOffset + (barHeight + barSpacing) * i,
-                    })}
-                    update={(d: Item, i: number) => ({
-                        translateY: [yOffset + (barHeight + barSpacing) * i],
-                        timing: { duration: 300, ease: easeQuadOut },
-                    })}
+                    data={placedItems}
+                    keyAccessor={(d: PlacedItem) => d.label}
+                    start={handlePositionUpdate}
+                    update={handlePositionUpdate}
                 >
                     {(nodes) => (
                         <g>
                             {nodes.map(({ data, state }) => {
-                                const { label, bars } = data as Item
+                                const { label, bars } = data as PlacedItem
                                 const tooltipProps = {
                                     ...chartContext,
                                     label,

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
         "react-color": "^2.18.1",
         "react-dom": "^16.13.1",
         "react-flip-toolkit": "^7.0.9",
+        "react-move": "^6.5.0",
         "react-recaptcha": "^2.3.10",
         "react-router-dom": "^5.0.1",
         "react-select": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1161,10 +1161,10 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.0", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
-  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.5", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.0", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -7407,6 +7407,11 @@ d3-shape@2:
   resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-2.0.0.tgz#055edb1d170cfe31ab2da8968deee940b56623e6"
   integrity sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==
 
+d3-timer@^1.0.9:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.10.tgz#dfe76b8a91748831b13b6d9c793ffbd508dd9de5"
+  integrity sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==
+
 d3-transition@2:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-2.0.0.tgz#366ef70c22ef88d1e34105f507516991a291c94c"
@@ -12441,6 +12446,13 @@ jwt-decode@^3.0.0:
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
   integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
 
+kapellmeister@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/kapellmeister/-/kapellmeister-3.0.1.tgz#419b715cd221acda3db79892caedf63e1c9f7d25"
+  integrity sha512-S7+gYcziMREv8RxG46138mb1O4Xf9II/bCxEJPYkhlZ7PgGWTlicgsyNad/DGc5oEAlWGLXE5ExLbTDVvJmgDA==
+  dependencies:
+    d3-timer "^1.0.9"
+
 keep-func-props@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/keep-func-props/-/keep-func-props-3.0.1.tgz#2aa8b6f421a7e979b071dbfe747d2003a135ee34"
@@ -16282,6 +16294,15 @@ react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-move@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/react-move/-/react-move-6.5.0.tgz#4b337d75987f9266426193f80e982604d49e97ff"
+  integrity sha512-tl8zwCqtXXWfmrUJGnkyPMNhx8DUTy1NugEuPW/JTMp2TGSEC819aMXGYMG8FWFzV9I6jy4kbgoZJnBpmZRktA==
+  dependencies:
+    "@babel/runtime" "^7.14.5"
+    kapellmeister "^3.0.1"
+    prop-types "^15.7.2"
 
 react-popper-tooltip@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
Notion: [Animate reordering of bars](https://www.notion.so/Animate-reordering-of-bars-188ab2942abe43b48c9306e42b966f15)

After the last attempt using `react-flip-toolkit` [failed due to browser issues](https://github.com/owid/owid-grapher/pull/955), I decided to reimplement it using `react-move`.

Live on _tufte_, e.g. here: https://tufte-owid.netlify.app/grapher/per-capita-energy-stacked