### PR TITLE
enhance: determine facet properties from intermediate chart views

### DIFF
--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -29,6 +29,7 @@ interface TickPlacement {
     bounds: Bounds
     isHidden: boolean
 }
+
 abstract class AbstractAxis {
     config: AxisConfig
     @observable.ref domain: ValueRange

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -105,7 +105,7 @@ export class DiscreteBarChart
     }
 
     @computed private get isLogScale(): boolean {
-        return this.yAxis.scaleType === ScaleType.log
+        return this.yAxisConfig.scaleType === ScaleType.log
     }
 
     @computed private get bounds(): Bounds {
@@ -201,13 +201,13 @@ export class DiscreteBarChart
         ]
     }
 
-    @computed private get yAxis(): AxisConfig {
+    @computed private get yAxisConfig(): AxisConfig {
         return this.manager.yAxis || new AxisConfig()
     }
 
     @computed private get axis(): HorizontalAxis {
         // NB: We use the user's YAxis options here to make the XAxis
-        const axis = this.yAxis.toHorizontalAxis()
+        const axis = this.yAxisConfig.toHorizontalAxis()
         axis.updateDomainPreservingUserSettings(this.xDomainDefault)
 
         axis.formatColumn = this.yColumns[0] // todo: does this work for columns as series?

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -205,7 +205,7 @@ export class DiscreteBarChart
         return this.manager.yAxis || new AxisConfig()
     }
 
-    @computed private get axis(): HorizontalAxis {
+    @computed get yAxis(): HorizontalAxis {
         // NB: We use the user's YAxis options here to make the XAxis
         const axis = this.yAxisConfig.toHorizontalAxis()
         axis.updateDomainPreservingUserSettings(this.xDomainDefault)
@@ -219,7 +219,7 @@ export class DiscreteBarChart
     @computed private get innerBounds(): Bounds {
         return this.bounds
             .padLeft(this.legendWidth + this.leftValueLabelWidth)
-            .padBottom(this.axis.height)
+            .padBottom(this.yAxis.height)
             .padRight(this.rightValueLabelWidth)
     }
 
@@ -241,13 +241,15 @@ export class DiscreteBarChart
     }
 
     @computed private get barPlacements(): { x: number; width: number }[] {
-        const { series, axis } = this
+        const { series, yAxis } = this
         return series.map((d) => {
             const isNegative = d.value < 0
-            const barX = isNegative ? axis.place(d.value) : axis.place(this.x0)
+            const barX = isNegative
+                ? yAxis.place(d.value)
+                : yAxis.place(this.x0)
             const barWidth = isNegative
-                ? axis.place(this.x0) - barX
-                : axis.place(d.value) - barX
+                ? yAxis.place(this.x0) - barX
+                : yAxis.place(d.value) - barX
 
             return { x: barX, width: barWidth }
         })
@@ -293,7 +295,7 @@ export class DiscreteBarChart
         const {
             series,
             bounds,
-            axis,
+            yAxis,
             innerBounds,
             barHeight,
             barSpacing,
@@ -313,22 +315,22 @@ export class DiscreteBarChart
                 />
                 <HorizontalAxisComponent
                     bounds={bounds}
-                    axis={axis}
+                    axis={yAxis}
                     axisPosition={innerBounds.bottom}
                 />
                 <HorizontalAxisGridLines
-                    horizontalAxis={axis}
+                    horizontalAxis={yAxis}
                     bounds={innerBounds}
                 />
                 {series.map((series) => {
                     // Todo: add a "placedSeries" getter to get the transformed series, then just loop over the placedSeries and render a bar for each
                     const isNegative = series.value < 0
                     const barX = isNegative
-                        ? axis.place(series.value)
-                        : axis.place(this.x0)
+                        ? yAxis.place(series.value)
+                        : yAxis.place(this.x0)
                     const barWidth = isNegative
-                        ? axis.place(this.x0) - barX
-                        : axis.place(series.value) - barX
+                        ? yAxis.place(this.x0) - barX
+                        : yAxis.place(series.value) - barX
                     const valueLabel = this.formatValue(series)
                     const labelX = isNegative
                         ? barX -
@@ -373,7 +375,7 @@ export class DiscreteBarChart
                                 x={0}
                                 y={0}
                                 transform={`translate(${
-                                    axis.place(series.value) +
+                                    yAxis.place(series.value) +
                                     (isNegative
                                         ? -labelToBarPadding
                                         : labelToBarPadding)

--- a/grapher/chart/ChartInterface.ts
+++ b/grapher/chart/ChartInterface.ts
@@ -2,6 +2,7 @@ import { Color } from "../../coreTable/CoreTableConstants"
 import { OwidTable } from "../../coreTable/OwidTable"
 import { SeriesName } from "../core/GrapherConstants"
 import { ColorScale } from "../color/ColorScale"
+import { HorizontalAxis, VerticalAxis } from "../axis/Axis"
 // The idea of this interface is to try and start reusing more code across our Chart classes and make it easier
 // for a dev to work on a chart type they haven't touched before if they've worked with another that implements
 // this interface.
@@ -25,4 +26,7 @@ export interface ChartInterface {
     // Todo: should all charts additionally have a placedSeries: ChartPlacedSeries[] getter?
 
     transformTable: ChartTableTransformer
+
+    yAxis?: HorizontalAxis | VerticalAxis
+    xAxis?: HorizontalAxis | VerticalAxis
 }

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -19,11 +19,15 @@ import {
     FacetSeries,
     FacetChartProps,
     PlacedFacetSeries,
+    IntermediatePlacedFacetSeries,
 } from "./FacetChartConstants"
 import { OwidTable } from "../../coreTable/OwidTable"
 import { autoDetectYColumnSlugs, makeSelectionArray } from "../chart/ChartUtils"
 import { SelectionArray } from "../selection/SelectionArray"
 import { CoreColumn } from "../../coreTable/CoreTableColumns"
+import { extent } from "d3-array"
+import { excludeUndefined, flatten } from "../../clientUtils/Util"
+import { AxisConfigInterface } from "../axis/AxisConfigInterface"
 
 const facetBackgroundColor = "transparent" // we don't use color yet but may use it for background later
 
@@ -46,13 +50,25 @@ export class FacetChart
         )
     }
 
-    @computed get placedSeries(): PlacedFacetSeries[] {
+    /**
+     * Holds the intermediate render properties for chart views, as well as the intermediate chart
+     * views themselves.
+     *
+     * An example: a StackedArea has a Y axis domain that is the largest sum of all columns.
+     * In order to avoid replicating that logic here (stacking values), we initialize StackedArea
+     * instances, without rendering them. In a later method, we use those intermediate chart views to
+     * determine the final axes for facets, e.g. for a uniform axis, we would iterate through all
+     * instances to find the domain.
+     *
+     * @danielgavrilov, 2021-07-13
+     */
+    @computed get intermediatePlacedSeries(): IntermediatePlacedFacetSeries[] {
         const { manager, series } = this
-        const chartTypeName =
-            this.props.chartTypeName ?? ChartTypeName.LineChart
         const count = series.length
 
         const boundsArr = this.bounds.split(count, getChartPadding(count))
+
+        // Copy properties from manager to facets
         const {
             yColumnSlug,
             xColumnSlug,
@@ -61,6 +77,10 @@ export class FacetChart
             sizeColumnSlug,
             isRelativeMode,
         } = manager
+        const xAxisConfig =
+            this.manager.xAxisConfig ?? this.manager.xAxis?.toObject()
+        const yAxisConfig =
+            this.manager.yAxisConfig ?? this.manager.yAxis?.toObject()
 
         const baseFontSize = getFontSize(count, manager.baseFontSize)
         const lineStrokeWidth = count > 16 ? 1 : undefined
@@ -69,12 +89,16 @@ export class FacetChart
 
         return series.map((series, index) => {
             const bounds = boundsArr[index]
+            const chartTypeName =
+                series.chartTypeName ??
+                this.props.chartTypeName ??
+                ChartTypeName.LineChart
+            const ChartClass =
+                ChartComponentClassMap.get(chartTypeName) ?? DefaultChartClass
             const hideXAxis = false // row < rows - 1 // todo: figure out design issues here
             const hideYAxis = false // column > 0 // todo: figure out design issues here
             const hideLegend = false // !(column !== columns - 1) // todo: only show 1?
             const hidePoints = true
-            const xAxisConfig = undefined
-            const yAxisConfig = undefined
 
             const manager: ChartManager = {
                 table,
@@ -96,11 +120,64 @@ export class FacetChart
             }
             return {
                 bounds,
-                chartTypeName: series.chartTypeName ?? chartTypeName,
+                chartTypeName,
                 manager,
                 seriesName: series.seriesName,
-            } as PlacedFacetSeries
+                color: series.color,
+                chartInstance: new ChartClass({ manager }),
+            }
         })
+    }
+
+    @computed get placedSeries(): PlacedFacetSeries[] {
+        // Uniform X axis
+        const uniformXAxis = true
+        let xAxisConfig: AxisConfigInterface = {}
+        if (uniformXAxis) {
+            const [min, max] = extent(
+                excludeUndefined(
+                    flatten(
+                        this.intermediatePlacedSeries.map(
+                            (series) => series.chartInstance.xAxis?.domain
+                        )
+                    )
+                )
+            )
+            xAxisConfig = { min, max }
+        }
+        // Uniform Y axis
+        const uniformYAxis =
+            this.manager.yAxis?.facetAxisRange === FacetAxisRange.shared
+        let yAxisConfig: AxisConfigInterface = {}
+        if (uniformYAxis) {
+            const [min, max] = extent(
+                excludeUndefined(
+                    flatten(
+                        this.intermediatePlacedSeries.map(
+                            (series) => series.chartInstance.yAxis?.domain
+                        )
+                    )
+                )
+            )
+            yAxisConfig = { min, max }
+        }
+        // Overwrite properties (without mutating original)
+        return this.intermediatePlacedSeries.map((series) => ({
+            ...series,
+            manager: {
+                ...series.manager,
+                xAxisConfig: {
+                    ...series.manager.xAxisConfig,
+                    ...xAxisConfig,
+                },
+                yAxisConfig: {
+                    ...series.manager.yAxisConfig,
+                    ...yAxisConfig,
+                },
+            },
+            // delete property
+            chartInstance: undefined,
+        }))
     }
 
     @computed private get selectionArray(): SelectionArray {
@@ -111,34 +188,11 @@ export class FacetChart
         const table = this.transformedTable.filterByEntityNames(
             this.selectionArray.selectedEntityNames
         )
-        const sharedYDomain = table.domainFor(this.yColumnSlugs)
-        const scaleType = this.manager.yAxis?.scaleType
-        const sameXAxis = true
-        const xAxisConfig = sameXAxis
-            ? {
-                  max: table.maxTime,
-                  min: table.minTime,
-                  scaleType,
-              }
-            : undefined
-
         const hideLegend = this.manager.yColumnSlugs?.length === 1
-
         return this.selectionArray.selectedEntityNames.map((seriesName) => {
             const seriesTable = table.filterByEntityNames([seriesName])
-            const seriesYDomain = seriesTable.domainFor(this.yColumnSlugs)
-            const yAxisConfig =
-                this.manager.yAxis!.facetAxisRange == FacetAxisRange.shared
-                    ? {
-                          max: sharedYDomain[1],
-                          min: sharedYDomain[0],
-                          scaleType,
-                      }
-                    : {
-                          max: seriesYDomain[1],
-                          min: seriesYDomain[0],
-                          scaleType,
-                      }
+            // Only set overrides for this facet strategy.
+            // Default properties are set elsewhere.
             return {
                 seriesName,
                 color: facetBackgroundColor,
@@ -147,8 +201,6 @@ export class FacetChart
                     selection: [seriesName],
                     seriesStrategy: SeriesStrategy.column,
                     hideLegend,
-                    yAxisConfig,
-                    xAxisConfig,
                 },
             }
         })
@@ -156,13 +208,15 @@ export class FacetChart
 
     @computed private get columnFacets(): FacetSeries[] {
         return this.yColumns.map((col) => {
+            // Only set overrides for this facet strategy.
+            // Default properties are set elsewhere.
             return {
                 seriesName: col.displayName,
                 color: facetBackgroundColor,
                 manager: {
                     selection: this.selectionArray,
                     yColumnSlug: col.slug,
-                    yColumnSlugs: [col.slug], // In a column facet strategy, only have 1 yColumn per chart.
+                    yColumnSlugs: [col.slug],
                     seriesStrategy: SeriesStrategy.entity,
                 },
             }

--- a/grapher/facetChart/FacetChartConstants.ts
+++ b/grapher/facetChart/FacetChartConstants.ts
@@ -1,4 +1,4 @@
-import { ChartSeries } from "../chart/ChartInterface"
+import { ChartInterface, ChartSeries } from "../chart/ChartInterface"
 import { ChartManager } from "../chart/ChartManager"
 import { ChartTypeName } from "../core/GrapherConstants"
 import { Bounds } from "../../clientUtils/Bounds"
@@ -18,4 +18,8 @@ export interface PlacedFacetSeries extends FacetSeries {
     manager: ChartManager
     chartTypeName: ChartTypeName
     bounds: Bounds
+}
+
+export interface IntermediatePlacedFacetSeries extends PlacedFacetSeries {
+    chartInstance: ChartInterface
 }

--- a/grapher/facetChart/FacetChartConstants.ts
+++ b/grapher/facetChart/FacetChartConstants.ts
@@ -19,7 +19,3 @@ export interface PlacedFacetSeries extends FacetSeries {
     chartTypeName: ChartTypeName
     bounds: Bounds
 }
-
-export interface IntermediatePlacedFacetSeries extends PlacedFacetSeries {
-    chartInstance: ChartInterface
-}

--- a/grapher/facetChart/FacetChartConstants.ts
+++ b/grapher/facetChart/FacetChartConstants.ts
@@ -1,4 +1,4 @@
-import { ChartInterface, ChartSeries } from "../chart/ChartInterface"
+import { ChartSeries } from "../chart/ChartInterface"
 import { ChartManager } from "../chart/ChartManager"
 import { ChartTypeName } from "../core/GrapherConstants"
 import { Bounds } from "../../clientUtils/Bounds"

--- a/grapher/lineCharts/LineChart.test.ts
+++ b/grapher/lineCharts/LineChart.test.ts
@@ -57,7 +57,7 @@ it("can filter points with negative values when using a log scale", () => {
         },
     }
     const logChart = new LineChart({ manager: logScaleManager })
-    expect(logChart.verticalAxis.domain[0]).toBeGreaterThan(0)
+    expect(logChart.yAxis.domain[0]).toBeGreaterThan(0)
     expect(logChart.series.length).toEqual(2)
     expect(logChart.allPoints.length).toEqual(180)
 })

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -732,23 +732,6 @@ export class LineChart
         })
     }
 
-    // todo: Refactor
-    @computed private get dualAxis(): DualAxis {
-        return new DualAxis({
-            bounds: this.bounds.padRight(
-                this.legendDimensions
-                    ? this.legendDimensions.width
-                    : this.defaultRightPadding
-            ),
-            verticalAxis: this.verticalAxisPart,
-            horizontalAxis: this.horizontalAxisPart,
-        })
-    }
-
-    @computed get verticalAxis(): VerticalAxis {
-        return this.dualAxis.verticalAxis
-    }
-
     @computed private get horizontalAxisPart(): HorizontalAxis {
         const { manager } = this
         const axisConfig =
@@ -787,5 +770,25 @@ export class LineChart
         axis.label = ""
         axis.formatColumn = this.formatColumn
         return axis
+    }
+
+    @computed private get dualAxis(): DualAxis {
+        return new DualAxis({
+            bounds: this.bounds.padRight(
+                this.legendDimensions
+                    ? this.legendDimensions.width
+                    : this.defaultRightPadding
+            ),
+            verticalAxis: this.verticalAxisPart,
+            horizontalAxis: this.horizontalAxisPart,
+        })
+    }
+
+    @computed get yAxis(): VerticalAxis {
+        return this.dualAxis.verticalAxis
+    }
+
+    @computed get xAxis(): HorizontalAxis {
+        return this.dualAxis.horizontalAxis
     }
 }

--- a/grapher/lineLegend/LineLegend.stories.tsx
+++ b/grapher/lineLegend/LineLegend.stories.tsx
@@ -51,7 +51,7 @@ const manager: LineLegendManager = {
     ],
     legendX: 200,
     focusedSeriesNames: [],
-    verticalAxis: dualAxis.verticalAxis,
+    yAxis: dualAxis.verticalAxis,
 }
 
 export const TestCollisionDetection = (): JSX.Element => {

--- a/grapher/lineLegend/LineLegend.test.tsx
+++ b/grapher/lineLegend/LineLegend.test.tsx
@@ -22,7 +22,7 @@ const manager: LineLegendManager = {
     ],
     legendX: 200,
     focusedSeriesNames: [],
-    verticalAxis: new AxisConfig({ min: 0, max: 100 }).toVerticalAxis(),
+    yAxis: new AxisConfig({ min: 0, max: 100 }).toVerticalAxis(),
 }
 
 it("can create a new legend", () => {

--- a/grapher/lineLegend/LineLegend.tsx
+++ b/grapher/lineLegend/LineLegend.tsx
@@ -154,7 +154,7 @@ export interface LineLegendManager {
     onLegendClick?: (key: EntityName) => void
     onLegendMouseLeave?: () => void
     focusedSeriesNames: EntityName[]
-    verticalAxis: VerticalAxis
+    yAxis: VerticalAxis
     legendX?: number
 }
 
@@ -233,14 +233,13 @@ export class LineLegend extends React.Component<{
 
     // Naive initial placement of each mark at the target height, before collision detection
     @computed private get initialSeries(): PlacedSeries[] {
-        const { verticalAxis } = this.manager
+        const { yAxis } = this.manager
         const { legendX } = this
 
         return sortBy(
             this.sizedLabels.map((label) => {
                 // place vertically centered at Y value
-                const initialY =
-                    verticalAxis.place(label.yValue) - label.height / 2
+                const initialY = yAxis.place(label.yValue) - label.height / 2
                 const origBounds = new Bounds(
                     legendX,
                     initialY,
@@ -250,8 +249,8 @@ export class LineLegend extends React.Component<{
 
                 // ensure label doesn't go beyond the top or bottom of the chart
                 const y = Math.min(
-                    Math.max(initialY, verticalAxis.rangeMin),
-                    verticalAxis.rangeMax - label.height
+                    Math.max(initialY, yAxis.rangeMin),
+                    yAxis.rangeMax - label.height
                 )
                 const bounds = new Bounds(legendX, y, label.width, label.height)
 
@@ -268,12 +267,12 @@ export class LineLegend extends React.Component<{
 
                 // Ensure list is sorted by the visual position in ascending order
             }),
-            (label) => verticalAxis.place(label.yValue)
+            (label) => yAxis.place(label.yValue)
         )
     }
 
     @computed get standardPlacement(): PlacedSeries[] {
-        const { verticalAxis } = this.manager
+        const { yAxis } = this.manager
 
         const groups: PlacedSeries[][] = cloneDeep(
             this.initialSeries
@@ -302,12 +301,9 @@ export class LineLegend extends React.Component<{
                         overlapHeight *
                             (bottomGroup.length /
                                 (topGroup.length + bottomGroup.length))
-                    const overflowTop = Math.max(
-                        verticalAxis.rangeMin - targetY,
-                        0
-                    )
+                    const overflowTop = Math.max(yAxis.rangeMin - targetY, 0)
                     const overflowBottom = Math.max(
-                        targetY + newHeight - verticalAxis.rangeMax,
+                        targetY + newHeight - yAxis.rangeMax,
                         0
                     )
                     const newY = targetY + overflowTop - overflowBottom
@@ -365,8 +361,8 @@ export class LineLegend extends React.Component<{
             sumBy(this.initialSeries, (series) => series.bounds.height) +
             this.initialSeries.length * LEGEND_ITEM_MIN_SPACING
         const availableHeight = this.manager.canAddData
-            ? this.manager.verticalAxis.rangeSize - ADD_BUTTON_HEIGHT
-            : this.manager.verticalAxis.rangeSize
+            ? this.manager.yAxis.rangeSize - ADD_BUTTON_HEIGHT
+            : this.manager.yAxis.rangeSize
 
         // Need to be careful here – the controls overlay will automatically add padding if
         // needed to fit the floating 'Add country' button, therefore decreasing the space

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -458,6 +458,14 @@ export class ScatterPlotChart
         })
     }
 
+    @computed get yAxis(): VerticalAxis {
+        return this.dualAxis.verticalAxis
+    }
+
+    @computed get xAxis(): HorizontalAxis {
+        return this.dualAxis.horizontalAxis
+    }
+
     @computed private get comparisonLines():
         | ComparisonLineConfig[]
         | undefined {

--- a/grapher/stackedCharts/AbstractStackedChart.tsx
+++ b/grapher/stackedCharts/AbstractStackedChart.tsx
@@ -161,6 +161,14 @@ export class AbstactStackedChart<PositionType extends StackedPointPositionType>
         })
     }
 
+    @computed get yAxis(): VerticalAxis {
+        return this.dualAxis.verticalAxis
+    }
+
+    @computed get xAxis(): HorizontalAxis {
+        return this.dualAxis.horizontalAxis
+    }
+
     @computed private get horizontalAxisPart(): HorizontalAxis {
         const axisConfig =
             this.manager.xAxis || new AxisConfig(this.manager.xAxisConfig, this)

--- a/grapher/stackedCharts/StackedAreaChart.test.ts
+++ b/grapher/stackedCharts/StackedAreaChart.test.ts
@@ -76,9 +76,9 @@ describe("column charts", () => {
 it("use author axis settings unless relative mode", () => {
     const manager = new MockManager()
     const chart = new StackedAreaChart({ manager })
-    expect(chart.verticalAxis.domain[1]).toBeGreaterThan(100)
+    expect(chart.yAxis.domain[1]).toBeGreaterThan(100)
     manager.isRelativeMode = true
-    expect(chart.verticalAxis.domain).toEqual([0, 100])
+    expect(chart.yAxis.domain).toEqual([0, 100])
 })
 
 it("shows a failure message if there are columns but no series", () => {

--- a/grapher/stackedCharts/StackedAreaChart.tsx
+++ b/grapher/stackedCharts/StackedAreaChart.tsx
@@ -221,10 +221,6 @@ export class StackedAreaChart
         super(props)
     }
 
-    @computed get verticalAxis(): VerticalAxis {
-        return this.dualAxis.verticalAxis
-    }
-
     @computed get midpoints(): number[] {
         let prevY = 0
         return this.series.map((series) => {

--- a/grapher/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.tsx
@@ -195,13 +195,13 @@ export class StackedDiscreteBarChart
         return [this.bounds.left + this.labelWidth, this.bounds.right]
     }
 
-    @computed private get yAxis(): AxisConfig {
+    @computed private get yAxisConfig(): AxisConfig {
         return this.manager.yAxis || new AxisConfig()
     }
 
     @computed private get axis(): HorizontalAxis {
         // NB: We use the user's YAxis options here to make the XAxis
-        const axis = this.yAxis.toHorizontalAxis()
+        const axis = this.yAxisConfig.toHorizontalAxis()
         axis.updateDomainPreservingUserSettings(this.xDomainDefault)
 
         axis.formatColumn = this.yColumns[0] // todo: does this work for columns as series?

--- a/grapher/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.tsx
@@ -84,7 +84,7 @@ interface TooltipProps extends StackedBarChartContext {
 }
 
 interface StackedBarChartContext {
-    axis: HorizontalAxis
+    yAxis: HorizontalAxis
     targetTime?: number
     timeColumn: CoreColumn
     formatColumn: CoreColumn
@@ -199,7 +199,7 @@ export class StackedDiscreteBarChart
         return this.manager.yAxis || new AxisConfig()
     }
 
-    @computed private get axis(): HorizontalAxis {
+    @computed get yAxis(): HorizontalAxis {
         // NB: We use the user's YAxis options here to make the XAxis
         const axis = this.yAxisConfig.toHorizontalAxis()
         axis.updateDomainPreservingUserSettings(this.xDomainDefault)
@@ -213,7 +213,7 @@ export class StackedDiscreteBarChart
     @computed private get innerBounds(): Bounds {
         return this.bounds
             .padLeft(this.labelWidth)
-            .padBottom(this.axis.height)
+            .padBottom(this.yAxis.height)
             .padTop(this.legendPaddingTop)
             .padTop(this.legend.height)
     }
@@ -345,10 +345,10 @@ export class StackedDiscreteBarChart
                 />
             )
 
-        const { bounds, axis, innerBounds, barHeight, barSpacing } = this
+        const { bounds, yAxis, innerBounds, barHeight, barSpacing } = this
 
         const chartContext: StackedBarChartContext = {
-            axis,
+            yAxis,
             targetTime: this.manager.endTime,
             timeColumn: this.inputTable.timeColumn,
             formatColumn: this.formatColumn,
@@ -382,11 +382,11 @@ export class StackedDiscreteBarChart
                 />
                 <HorizontalAxisComponent
                     bounds={bounds}
-                    axis={axis}
+                    axis={yAxis}
                     axisPosition={innerBounds.bottom}
                 />
                 <HorizontalAxisGridLines
-                    horizontalAxis={axis}
+                    horizontalAxis={yAxis}
                     bounds={innerBounds}
                 />
                 <HorizontalCategoricalColorLegend manager={this} />
@@ -432,7 +432,7 @@ export class StackedDiscreteBarChart
                                                 x={0}
                                                 y={0}
                                                 transform={`translate(${
-                                                    axis.place(this.x0) -
+                                                    yAxis.place(this.x0) -
                                                     labelToBarPadding
                                                 }, 0)`}
                                                 fill="#555"
@@ -471,13 +471,13 @@ export class StackedDiscreteBarChart
         tooltipProps: TooltipProps
     }): JSX.Element {
         const { bar, chartContext, tooltipProps } = props
-        const { axis, formatColumn, focusSeriesName, barHeight } = chartContext
+        const { yAxis, formatColumn, focusSeriesName, barHeight } = chartContext
 
         const isFaint =
             focusSeriesName !== undefined && focusSeriesName !== bar.seriesName
-        const barX = axis.place(chartContext.x0 + bar.point.valueOffset)
+        const barX = yAxis.place(chartContext.x0 + bar.point.valueOffset)
         const barWidth =
-            axis.place(bar.point.value) - axis.place(chartContext.x0)
+            yAxis.place(bar.point.value) - yAxis.place(chartContext.x0)
 
         // Compute how many decimal places we should show.
         // Basically, this makes us show 2 significant digits, or no decimal places if the number


### PR DESCRIPTION
Notion: [Refactor chart transform flow to support facets](https://www.notion.so/Refactor-chart-transform-flow-to-support-facets-55a3a4183162465885a8bc2527f66ef4)

This also fixes:
- [yAxisMin explorer setting should be respected in facets](https://www.notion.so/yAxisMin-explorer-setting-should-be-respected-in-facets-f992da1cbd944de18301b3bd26915555)
    ...which is being worked on https://github.com/owid/owid-grapher/pull/946, this is an alternative way to fix it.
- [StackedArea axis is not uniform](https://owid.slack.com/archives/CQQUA2C2U/p1624358837039600)

This PR adds `xAxis` and `yAxis` to `ChartInterface`, and then also initializes chart classes (that aren't rendered) in the faceting logic, in order to determine the right axis props to pass. 

Effectively, it only fixes the "uniform Y axis" behaviour. I expect that the fix is a pattern we apply to other problems to come, especially around [Gridlines, axis labels, titles](https://www.notion.so/Gridlines-axis-labels-titles-066fcc51c1dc4a36b9593159b178cfc6), where we need to know how the axes would be rendered in order to allocate enough space and align all facets.

Initially I thought we might have to split up the chart classes, so that for example `LineChart` becomes:
- `LineChartTransform` containing the transforms & information we need to determine the facet properties 
- `LineChartReactComponent` that uses the information from the `LineChartTransform` to render the SVG

I think this is not necessary, we can leave the classes as they are, and execution-wise they'd be equivalent since `render()` is not called when instantiating a React class with `new`.

Not ready to merge, but ready for scrutinising this method of extracting information from provisional/intermediate views. 