### PR TITLE
enhance(grapher): Improve UI for facet selection

### DIFF
--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -32,7 +32,10 @@ import { ColumnGrammar } from "./ColumnGrammar"
 import { DecisionMatrix } from "./ExplorerDecisionMatrix"
 import { CoreColumnDef } from "../coreTable/CoreColumnDef"
 import { PromiseCache } from "../clientUtils/PromiseCache"
-import { FacetAxisDomain } from "../grapher/core/GrapherConstants"
+import {
+    FacetAxisDomain,
+    FacetStrategy,
+} from "../grapher/core/GrapherConstants"
 
 export const EXPLORER_FILE_SUFFIX = ".explorer.tsv"
 
@@ -48,6 +51,7 @@ interface ExplorerGrapherInterface extends GrapherInterface {
     yScaleToggle?: boolean
     yAxisMin?: number
     facetYDomain?: FacetAxisDomain
+    selectedFacetStrategy?: FacetStrategy
 }
 
 const ExplorerRootDef: CellDef = {

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -32,10 +32,7 @@ import { ColumnGrammar } from "./ColumnGrammar"
 import { DecisionMatrix } from "./ExplorerDecisionMatrix"
 import { CoreColumnDef } from "../coreTable/CoreColumnDef"
 import { PromiseCache } from "../clientUtils/PromiseCache"
-import {
-    FacetAxisDomain,
-    FacetStrategy,
-} from "../grapher/core/GrapherConstants"
+import { FacetAxisDomain } from "../grapher/core/GrapherConstants"
 
 export const EXPLORER_FILE_SUFFIX = ".explorer.tsv"
 

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -51,7 +51,6 @@ interface ExplorerGrapherInterface extends GrapherInterface {
     yScaleToggle?: boolean
     yAxisMin?: number
     facetYDomain?: FacetAxisDomain
-    selectedFacetStrategy?: FacetStrategy
 }
 
 const ExplorerRootDef: CellDef = {

--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -144,6 +144,16 @@ export const GrapherGrammar: Grammar = {
             cssClass: "",
         })),
     },
+    selectedFacetStrategy: {
+        ...EnumCellDef,
+        keyword: "selectedFacetStrategy",
+        description: "Whether the chart should be faceted or not",
+        terminalOptions: Object.keys(FacetStrategy).map((keyword) => ({
+            keyword,
+            description: "",
+            cssClass: "",
+        })),
+    },
     baseColorScheme: {
         ...EnumCellDef,
         keyword: "baseColorScheme",

--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -148,7 +148,7 @@ export const GrapherGrammar: Grammar = {
         ...EnumCellDef,
         keyword: "selectedFacetStrategy",
         description: "Whether the chart should be faceted or not",
-        terminalOptions: Object.keys(FacetStrategy).map((keyword) => ({
+        terminalOptions: Object.values(FacetStrategy).map((keyword) => ({
             keyword,
             description: "",
             cssClass: "",

--- a/grapher/captionedChart/CaptionedChart.stories.tsx
+++ b/grapher/captionedChart/CaptionedChart.stories.tsx
@@ -1,6 +1,7 @@
 import { SynthesizeGDPTable } from "../../coreTable/OwidTableSynthesizers"
 import {
     ChartTypeName,
+    FacetStrategy,
     GrapherTabOption,
     SeriesStrategy,
 } from "../core/GrapherConstants"
@@ -28,6 +29,7 @@ const manager: CaptionedChartManager = {
     note: "Here are some footer notes",
     populateFromQueryParams: (): void => {},
     isReady: true,
+    availableFacetStrategies: [FacetStrategy.none],
 }
 
 export const LineChart = (): JSX.Element => <CaptionedChart manager={manager} />

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -255,7 +255,10 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         if (manager.showZoomToggle)
             controls.push(<ZoomToggle key="ZoomToggle" manager={manager} />)
 
-        if (manager.showFacets) {
+        if (
+            manager.showFacets &&
+            manager.availableFacetStrategies!.length > 1
+        ) {
             controls.push(
                 <FacetStrategyDropdown
                     key="FacetStrategyDropdown"

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -257,7 +257,7 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
 
         if (
             !manager.hideFacetControl &&
-            manager.availableFacetStrategies!.length > 1
+            manager.availableFacetStrategies.length > 1
         ) {
             controls.push(
                 <FacetStrategyDropdown

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -256,7 +256,7 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
             controls.push(<ZoomToggle key="ZoomToggle" manager={manager} />)
 
         if (
-            manager.showFacets &&
+            !manager.hideFacetControl &&
             manager.availableFacetStrategies!.length > 1
         ) {
             controls.push(

--- a/grapher/controls/Controls.scss
+++ b/grapher/controls/Controls.scss
@@ -13,11 +13,118 @@ $zindex-ControlsFooter: 2;
     color: $controls-color;
 }
 
+// FACET STRATEGY SELECTOR
+
+// the fake dropdown menu
 .FacetStrategyDropdown {
     width: 160px;
     font-family: "Lato";
-    font-size: 10px;
+    font-size: 12px;
     font-weight: bold;
+    border: 1px solid #afb7c1;
+    border-radius: 5px;
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
+// the chevron
+.FacetStrategyDropdown div {
+    float: right;
+}
+
+// the pop-up list of options
+.FacetStrategyFloat {
+    display: flex;
+}
+
+// one of those options
+.FacetStrategyOption {
+    padding: 4px;
+
+    position: static;
+    width: 96px;
+    height: 68px;
+    left: 4px;
+    top: 4px;
+
+    background: #ffffff;
+    margin: 0px 0px;
+}
+
+.FacetStrategyLabel {
+    position: static;
+    left: 4.17%;
+    right: 44.79%;
+    top: 5.88%;
+    bottom: 64.71%;
+
+    font-family: Lato;
+    font-style: normal;
+    font-weight: bold;
+    font-size: 12px;
+    line-height: 20px;
+
+    margin: 2px 0px;
+}
+
+.selected .FacetStrategyLabel {
+    color: #0073e6;
+}
+.FacetStrategyLabel {
+    color: #7d899c;
+}
+
+.FacetStrategyPreview-none-child {
+    position: absolute;
+    left: 0%;
+    right: 0%;
+    top: 0%;
+    bottom: 0%;
+
+    border-radius: 1px;
+}
+
+.FacetStrategyPreview-parent {
+    position: relative;
+    width: 100%;
+    height: 36px;
+}
+
+.FacetStrategyPreview-split-child {
+    float: left;
+    width: 28px;
+    height: 17px;
+    border-radius: 1px;
+}
+
+// set appropriate margins for our manual 3x2 grid
+.FacetStrategyPreview-split-child:nth-of-type(1),
+.FacetStrategyPreview-split-child:nth-of-type(2),
+.FacetStrategyPreview-split-child:nth-of-type(3) {
+    margin-bottom: 2px;
+}
+
+.FacetStrategyPreview-split-child:nth-of-type(1),
+.FacetStrategyPreview-split-child:nth-of-type(2),
+.FacetStrategyPreview-split-child:nth-of-type(4),
+.FacetStrategyPreview-split-child:nth-of-type(5) {
+    margin-right: 2px;
+}
+
+.selected .FacetStrategyPreview-none-child {
+    background: #d9eafb;
+}
+
+.FacetStrategyPreview-none-child {
+    background: #dde1e7;
+}
+
+.selected .FacetStrategyPreview-split-child {
+    background: #d9eafb;
+}
+
+.FacetStrategyPreview-split-child {
+    background: #dde1e7;
 }
 
 @keyframes bounceIn {

--- a/grapher/controls/Controls.scss
+++ b/grapher/controls/Controls.scss
@@ -25,6 +25,7 @@ $zindex-ControlsFooter: 2;
     border-radius: 5px;
     padding-left: 10px;
     padding-right: 10px;
+    cursor: pointer;
 }
 
 // the chevron

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -251,6 +251,7 @@ export class FacetStrategyDropdown extends React.Component<{
                 interactive={true}
                 trigger={"click"}
                 placement={"bottom"}
+                arrow={false}
             >
                 <div className="FacetStrategyDropdown">
                     {facetStrategyLabels[this.facetStrategy]}

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -6,7 +6,6 @@ import {
     getWindowQueryParams,
     QueryParams,
 } from "../../clientUtils/urls/UrlUtils"
-import Select, { ValueType } from "react-select"
 import { TimelineComponent } from "../timeline/TimelineComponent"
 import { formatValue } from "../../clientUtils/formatValue"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
@@ -14,6 +13,7 @@ import { faDownload } from "@fortawesome/free-solid-svg-icons/faDownload"
 import { faShareAlt } from "@fortawesome/free-solid-svg-icons/faShareAlt"
 import { faExpand } from "@fortawesome/free-solid-svg-icons/faExpand"
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons/faExternalLinkAlt"
+import { faChevronDown } from "@fortawesome/free-solid-svg-icons/faChevronDown"
 import {
     FacetAxisDomain,
     FacetStrategy,
@@ -26,10 +26,7 @@ import { ShareMenu, ShareMenuManager } from "./ShareMenu"
 import { TimelineController } from "../timeline/TimelineController"
 import { SelectionArray } from "../selection/SelectionArray"
 import { AxisConfig } from "../axis/AxisConfig"
-import {
-    asArray,
-    getStylesForTargetHeight,
-} from "../../clientUtils/react-select"
+import { Tippy } from "../chart/Tippy"
 
 export interface HighlightToggleManager {
     highlightToggle?: HighlightToggleConfig
@@ -238,7 +235,7 @@ export class FilterSmallCountriesToggle extends React.Component<{
 
 export interface FacetStrategyDropdownManager {
     availableFacetStrategies?: FacetStrategy[]
-    facet?: FacetStrategy
+    facetStrategy?: FacetStrategy
     showFacets?: boolean
 }
 
@@ -247,41 +244,68 @@ const FACET_DROPDOWN_CLASS = "FacetStrategyDropdown"
 export class FacetStrategyDropdown extends React.Component<{
     manager: FacetStrategyDropdownManager
 }> {
-    @computed get options(): { label: string; value: string }[] {
+    @computed get options(): JSX.Element {
         const strategies = this.props.manager.availableFacetStrategies || [
             FacetStrategy.none,
             FacetStrategy.entity,
             FacetStrategy.column,
         ]
-        return strategies.map((value) => {
+        const parts = strategies.map((value: FacetStrategy) => {
             const label = facetStrategyLabels[value]
-            return { label, value }
+            const selected = value == this.facetStrategy ? " selected" : ""
+            const children =
+                value === FacetStrategy.none ? (
+                    <div className="FacetStrategyPreview-none-child"></div>
+                ) : (
+                    <>
+                        <div className="FacetStrategyPreview-split-child"></div>
+                        <div className="FacetStrategyPreview-split-child"></div>
+                        <div className="FacetStrategyPreview-split-child"></div>
+                        <div className="FacetStrategyPreview-split-child"></div>
+                        <div className="FacetStrategyPreview-split-child"></div>
+                        <div className="FacetStrategyPreview-split-child"></div>
+                    </>
+                )
+            return (
+                <div
+                    className={"FacetStrategyOption" + selected}
+                    key={value.toString()}
+                >
+                    <a
+                        onClick={(): void => {
+                            this.props.manager.facetStrategy = value
+                        }}
+                    >
+                        <div className="FacetStrategyLabel">{label}</div>
+                        <div className={`FacetStrategyPreview-parent`}>
+                            {children}
+                        </div>
+                    </a>
+                </div>
+            )
         })
+        return <div className="FacetStrategyFloat">{parts}</div>
     }
 
-    @computed get facet(): FacetStrategy {
-        return this.props.manager.facet || FacetStrategy.none
-    }
-
-    @action.bound onChange(
-        selected: ValueType<{ label: string; value: string }>
-    ): void {
-        this.props.manager.facet = asArray(selected)[0].value as FacetStrategy
+    @computed get facetStrategy(): FacetStrategy {
+        return this.props.manager.facetStrategy || FacetStrategy.none
     }
 
     render(): JSX.Element {
-        const styles = getStylesForTargetHeight(24)
         return (
-            <Select
-                className={FACET_DROPDOWN_CLASS}
-                classNamePrefix={FACET_DROPDOWN_CLASS}
-                defaultValue={this.options.find(
-                    (o) => o.value === FacetStrategy.none
-                )}
-                options={this.options}
-                onChange={this.onChange}
-                styles={styles}
-            />
+            <Tippy
+                content={this.options}
+                interactive={true}
+                trigger={"click"}
+                placement={"bottom"}
+            >
+                <div className={FACET_DROPDOWN_CLASS}>
+                    {facetStrategyLabels[this.facetStrategy]}
+                    <div>
+                        <FontAwesomeIcon icon={faChevronDown} />
+                    </div>
+                </div>
+            </Tippy>
         )
     }
 }

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -239,24 +239,46 @@ export interface FacetStrategyDropdownManager {
     showFacets?: boolean
 }
 
-const FACET_DROPDOWN_CLASS = "FacetStrategyDropdown"
-
+// A drop-down button that, when clicked, shows a hovering visual display
+// indicating the faceting options.
 export class FacetStrategyDropdown extends React.Component<{
     manager: FacetStrategyDropdownManager
 }> {
-    @computed get options(): JSX.Element {
+    render(): JSX.Element {
+        return (
+            <Tippy
+                content={this.content}
+                interactive={true}
+                trigger={"click"}
+                placement={"bottom"}
+            >
+                <div className="FacetStrategyDropdown">
+                    {facetStrategyLabels[this.facetStrategy]}
+                    <div>
+                        <FontAwesomeIcon icon={faChevronDown} />
+                    </div>
+                </div>
+            </Tippy>
+        )
+    }
+
+    // A hovering visual display giving options to be selected from
+    @computed get content(): JSX.Element {
         const strategies = this.props.manager.availableFacetStrategies || [
             FacetStrategy.none,
             FacetStrategy.entity,
             FacetStrategy.column,
         ]
         const parts = strategies.map((value: FacetStrategy) => {
+            // There are only ever two strategies, none + (country OR entity).
             const label = facetStrategyLabels[value]
             const selected = value == this.facetStrategy ? " selected" : ""
             const children =
                 value === FacetStrategy.none ? (
+                    // a single solid block
                     <div className="FacetStrategyPreview-none-child"></div>
                 ) : (
+                    // a 3x2 grid of squares
                     <>
                         <div className="FacetStrategyPreview-split-child"></div>
                         <div className="FacetStrategyPreview-split-child"></div>
@@ -289,24 +311,6 @@ export class FacetStrategyDropdown extends React.Component<{
 
     @computed get facetStrategy(): FacetStrategy {
         return this.props.manager.facetStrategy || FacetStrategy.none
-    }
-
-    render(): JSX.Element {
-        return (
-            <Tippy
-                content={this.options}
-                interactive={true}
-                trigger={"click"}
-                placement={"bottom"}
-            >
-                <div className={FACET_DROPDOWN_CLASS}>
-                    {facetStrategyLabels[this.facetStrategy]}
-                    <div>
-                        <FontAwesomeIcon icon={faChevronDown} />
-                    </div>
-                </div>
-            </Tippy>
-        )
     }
 }
 

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -234,7 +234,7 @@ export class FilterSmallCountriesToggle extends React.Component<{
 }
 
 export interface FacetStrategyDropdownManager {
-    availableFacetStrategies?: FacetStrategy[]
+    availableFacetStrategies: FacetStrategy[]
     facetStrategy?: FacetStrategy
     showFacets?: boolean
 }

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -250,7 +250,7 @@ export class FacetStrategyDropdown extends React.Component<{
                 content={this.content}
                 interactive={true}
                 trigger={"click"}
-                placement={"bottom"}
+                placement={"bottom-start"}
                 arrow={false}
             >
                 <div className="FacetStrategyDropdown">

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -28,6 +28,7 @@ import { SelectionArray } from "../selection/SelectionArray"
 import { AxisConfig } from "../axis/AxisConfig"
 import { Tippy } from "../chart/Tippy"
 import { Bounds } from "../../clientUtils/Bounds"
+import classnames from "classnames"
 
 export interface HighlightToggleManager {
     highlightToggle?: HighlightToggleConfig
@@ -293,7 +294,6 @@ export class FacetStrategyDropdown extends React.Component<{
         const parts = this.strategies.map((value: FacetStrategy) => {
             // There are only ever two strategies, none + (country OR entity).
             const label = facetStrategyLabels[value]
-            const selected = value == this.facetStrategy ? " selected" : ""
             const children =
                 value === FacetStrategy.none ? (
                     // a single solid block
@@ -311,7 +311,10 @@ export class FacetStrategyDropdown extends React.Component<{
                 )
             return (
                 <div
-                    className={"FacetStrategyOption" + selected}
+                    className={classnames({
+                        FacetStrategyOption: true,
+                        selected: value === this.facetStrategy,
+                    })}
                     key={value.toString()}
                 >
                     <a

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -239,6 +239,7 @@ export interface FacetStrategyDropdownManager {
     availableFacetStrategies: FacetStrategy[]
     facetStrategy?: FacetStrategy
     hideFacetControl?: boolean
+    entityType?: string
 }
 
 // A drop-down button that, when clicked, shows a hovering visual display
@@ -259,13 +260,27 @@ export class FacetStrategyDropdown extends React.Component<{
                     className="FacetStrategyDropdown"
                     style={{ width: this.dropDownWidth }}
                 >
-                    {facetStrategyLabels[this.facetStrategy]}
+                    {this.facetStrategyLabels[this.facetStrategy]}
                     <div>
                         <FontAwesomeIcon icon={faChevronDown} />
                     </div>
                 </div>
             </Tippy>
         )
+    }
+
+    @computed get facetStrategyLabels(): { [key in FacetStrategy]: string } {
+        // arbitrary entity names can be too long for our current design; as a trade-off,
+        // we accept them only if they are not too long, otherwise we just use "item"
+        const entityType = this.props.manager.entityType ?? "country"
+        const entityLabel =
+            entityType.length > "country".length ? "item" : entityType
+
+        return {
+            [FacetStrategy.none]: "All together",
+            [FacetStrategy.entity]: `Split by ${entityLabel}`,
+            [FacetStrategy.column]: "Split by metric",
+        }
     }
 
     @computed get strategies(): FacetStrategy[] {
@@ -282,8 +297,9 @@ export class FacetStrategyDropdown extends React.Component<{
         const maxWidth = Math.max(
             ...this.strategies.map(
                 (s) =>
-                    Bounds.forText(facetStrategyLabels[s], { fontSize: 12 })
-                        .width
+                    Bounds.forText(this.facetStrategyLabels[s], {
+                        fontSize: 12,
+                    }).width
             )
         )
         return `${maxWidth + 45}px` // leave room for the chevron
@@ -292,8 +308,7 @@ export class FacetStrategyDropdown extends React.Component<{
     // A hovering visual display giving options to be selected from
     @computed get content(): JSX.Element {
         const parts = this.strategies.map((value: FacetStrategy) => {
-            // There are only ever two strategies, none + (country OR entity).
-            const label = facetStrategyLabels[value]
+            const label = this.facetStrategyLabels[value]
             const children =
                 value === FacetStrategy.none ? (
                     // a single solid block
@@ -336,12 +351,6 @@ export class FacetStrategyDropdown extends React.Component<{
     @computed get facetStrategy(): FacetStrategy {
         return this.props.manager.facetStrategy || FacetStrategy.none
     }
-}
-
-const facetStrategyLabels = {
-    [FacetStrategy.none]: "All together",
-    [FacetStrategy.entity]: "Split by country",
-    [FacetStrategy.column]: "Split by metric",
 }
 
 export interface FooterControlsManager extends ShareMenuManager {

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -236,7 +236,7 @@ export class FilterSmallCountriesToggle extends React.Component<{
 export interface FacetStrategyDropdownManager {
     availableFacetStrategies: FacetStrategy[]
     facetStrategy?: FacetStrategy
-    showFacets?: boolean
+    hideFacetControl?: boolean
 }
 
 // A drop-down button that, when clicked, shows a hovering visual display

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -27,6 +27,7 @@ import { TimelineController } from "../timeline/TimelineController"
 import { SelectionArray } from "../selection/SelectionArray"
 import { AxisConfig } from "../axis/AxisConfig"
 import { Tippy } from "../chart/Tippy"
+import { Bounds } from "../../clientUtils/Bounds"
 
 export interface HighlightToggleManager {
     highlightToggle?: HighlightToggleConfig
@@ -253,7 +254,10 @@ export class FacetStrategyDropdown extends React.Component<{
                 placement={"bottom-start"}
                 arrow={false}
             >
-                <div className="FacetStrategyDropdown">
+                <div
+                    className="FacetStrategyDropdown"
+                    style={{ width: this.dropDownWidth }}
+                >
                     {facetStrategyLabels[this.facetStrategy]}
                     <div>
                         <FontAwesomeIcon icon={faChevronDown} />
@@ -263,14 +267,30 @@ export class FacetStrategyDropdown extends React.Component<{
         )
     }
 
+    @computed get strategies(): FacetStrategy[] {
+        return (
+            this.props.manager.availableFacetStrategies || [
+                FacetStrategy.none,
+                FacetStrategy.entity,
+                FacetStrategy.column,
+            ]
+        )
+    }
+
+    @computed get dropDownWidth(): string {
+        const maxWidth = Math.max(
+            ...this.strategies.map(
+                (s) =>
+                    Bounds.forText(facetStrategyLabels[s], { fontSize: 12 })
+                        .width
+            )
+        )
+        return `${maxWidth + 45}px` // leave room for the chevron
+    }
+
     // A hovering visual display giving options to be selected from
     @computed get content(): JSX.Element {
-        const strategies = this.props.manager.availableFacetStrategies || [
-            FacetStrategy.none,
-            FacetStrategy.entity,
-            FacetStrategy.column,
-        ]
-        const parts = strategies.map((value: FacetStrategy) => {
+        const parts = this.strategies.map((value: FacetStrategy) => {
             // There are only ever two strategies, none + (country OR entity).
             const label = facetStrategyLabels[value]
             const selected = value == this.facetStrategy ? " selected" : ""

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -244,6 +244,7 @@ export interface FacetStrategyDropdownManager {
 
 // A drop-down button that, when clicked, shows a hovering visual display
 // indicating the faceting options.
+@observer
 export class FacetStrategyDropdown extends React.Component<{
     manager: FacetStrategyDropdownManager
 }> {

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -304,7 +304,7 @@ export class Grapher
     @observable hideFacetControl?: boolean = true
 
     // the desired faceting strategy, which might not be possible if we change the data
-    @observable selectedFacetStrategy: FacetStrategy = FacetStrategy.none
+    @observable selectedFacetStrategy?: FacetStrategy = undefined
 
     @observable sortBy?: SortBy
     @observable sortOrder?: SortOrder

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -302,7 +302,9 @@ export class Grapher
     @observable.ref annotation?: Annotation = undefined
 
     @observable showFacets?: boolean = false
-    @observable lastFacet: FacetStrategy = FacetStrategy.none
+
+    // the desired faceting strategy, which might not be possible if we change the data
+    @observable selectedFacetStrategy: FacetStrategy = FacetStrategy.none
 
     @observable sortBy?: SortBy
     @observable sortOrder?: SortOrder
@@ -1179,7 +1181,7 @@ export class Grapher
             .map((dim) => dim.column)
     }
 
-    @computed get yColumnSlugsInSelectionOrder() {
+    @computed get yColumnSlugsInSelectionOrder(): string[] {
         return this.selectedColumnSlugs?.length
             ? this.selectedColumnSlugs
             : this.yColumnSlugs
@@ -1472,7 +1474,7 @@ export class Grapher
                 this.yScaleType !== ScaleType.log
             )
 
-        if (this.facet === FacetStrategy.column) return false
+        if (this.facetStrategy === FacetStrategy.column) return false
 
         return !this.hideRelativeToggle
     }
@@ -1829,7 +1831,10 @@ export class Grapher
     }
 
     @action.bound private toggleFacetStrategy(): void {
-        this.facet = next(this.availableFacetStrategies, this.facet)
+        this.facetStrategy = next(
+            this.availableFacetStrategies,
+            this.facetStrategy
+        )
     }
 
     @action.bound private toggleFacetVisibility(): void {
@@ -1838,17 +1843,10 @@ export class Grapher
 
     @computed get showFacetYDomainToggle(): boolean {
         // don't offer to make the y range relative if the range is discrete
-        return this.facet !== FacetStrategy.none && !this.isStackedDiscreteBar
-    }
-
-    @computed get facet(): FacetStrategy {
-        if (this.showFacets) {
-            return this.lastFacet
-        }
-        return FacetStrategy.none
-    }
-    set facet(strategy: FacetStrategy) {
-        this.lastFacet = strategy
+        return (
+            this.facetStrategy !== FacetStrategy.none &&
+            !this.isStackedDiscreteBar
+        )
     }
 
     @computed get _sortConfig(): Readonly<SortConfig> {
@@ -1912,9 +1910,16 @@ export class Grapher
     }
 
     private disableAutoFaceting = true // turned off for now
+
+    // the actual facet setting used by a chart, potentially overriding selectedFacetStrategy
     @computed get facetStrategy(): FacetStrategy {
-        if (this.facet && this.availableFacetStrategies.includes(this.facet))
-            return this.facet
+        if (!this.showFacets) return FacetStrategy.none
+
+        if (
+            this.selectedFacetStrategy &&
+            this.availableFacetStrategies.includes(this.selectedFacetStrategy)
+        )
+            return this.selectedFacetStrategy
 
         if (this.disableAutoFaceting) return FacetStrategy.none
 
@@ -1934,6 +1939,10 @@ export class Grapher
             return FacetStrategy.column
 
         return FacetStrategy.none
+    }
+
+    set facetStrategy(facet: FacetStrategy) {
+        this.selectedFacetStrategy = facet
     }
 
     @action.bound randomSelection(num: number): void {
@@ -2184,7 +2193,7 @@ export class Grapher
         this.colorSlug = grapher.colorSlug
         this.sizeSlug = grapher.sizeSlug
         this.hasMapTab = grapher.hasMapTab
-        this.facet = FacetStrategy.none
+        this.selectedFacetStrategy = FacetStrategy.none
         this.hasChartTab = grapher.hasChartTab
         this.map = grapher.map
         this.yAxis.scaleType = grapher.yAxis.scaleType

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -301,7 +301,7 @@ export class Grapher
     @observable relatedQuestions: RelatedQuestionsConfig[] = [] // todo: Persistables?
     @observable.ref annotation?: Annotation = undefined
 
-    @observable showFacets?: boolean = false
+    @observable hideFacetControl?: boolean = true
 
     // the desired faceting strategy, which might not be possible if we change the data
     @observable selectedFacetStrategy: FacetStrategy = FacetStrategy.none
@@ -1762,7 +1762,7 @@ export class Grapher
             },
             {
                 combo: "f",
-                fn: (): void => this.toggleFacetVisibility(),
+                fn: (): void => this.toggleFacetControlVisibility(),
                 title: `Toggle Faceting`,
                 category: "Chart",
             },
@@ -1837,8 +1837,8 @@ export class Grapher
         )
     }
 
-    @action.bound private toggleFacetVisibility(): void {
-        this.showFacets = !this.showFacets
+    @action.bound private toggleFacetControlVisibility(): void {
+        this.hideFacetControl = !this.hideFacetControl
     }
 
     @computed get showFacetYDomainToggle(): boolean {
@@ -1913,8 +1913,6 @@ export class Grapher
 
     // the actual facet setting used by a chart, potentially overriding selectedFacetStrategy
     @computed get facetStrategy(): FacetStrategy {
-        if (!this.showFacets) return FacetStrategy.none
-
         if (
             this.selectedFacetStrategy &&
             this.availableFacetStrategies.includes(this.selectedFacetStrategy)

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1897,11 +1897,10 @@ export class Grapher
     @computed get availableFacetStrategies(): FacetStrategy[] {
         const strategies: FacetStrategy[] = [FacetStrategy.none]
 
-        // It only ever makes sense to facet on metric or on entity. In cases like StackedDiscreteBar
-        // that could offer both, faceting by entity is strictly worse than the original together view.
         if (this.hasMultipleYColumns) {
             strategies.push(FacetStrategy.column)
         }
+
         if (this.selection.numSelectedEntities > 1) {
             strategies.push(FacetStrategy.entity)
         }

--- a/grapher/core/GrapherInterface.ts
+++ b/grapher/core/GrapherInterface.ts
@@ -167,6 +167,8 @@ export const grapherKeysToSerialize = [
     "sortOrder",
     "sortColumnSlug",
     "excludedEntities",
+    "selectedFacetStrategy",
+    "hideFacetControl",
     "comparisonLines",
     "relatedQuestions",
 ]

--- a/grapher/core/schema.json
+++ b/grapher/core/schema.json
@@ -335,6 +335,10 @@
             "type": "string",
             "enum": ["x", "y", "year"]
         },
+        "selectedFacetStrategy": {
+            "type": "string",
+            "enum": ["none", "entity", "column"]
+        },
         "sourceDesc": {
             "type": "string"
         },


### PR DESCRIPTION
Convert the standard drop-down for selecting facets into a more visual and user friendly design. The expected behaviour is that:

- The "f" key enables the chart control, but only for charts that support faceting (e.g. not scatterplots)
- The control looks like a normal dropdown, but shows hovering options when you click on it
- You should have the option "All together" and either "Split by entity" or "Split by country", depending on the chart

Refactors the faceting variables in `Grapher.tsx` to make clear what the desired faceting strategy is vs the actual rendered strategy, which has to take into account what is actually possible given the data.

See: https://www.notion.so/owid/Plot-entities-together-or-metrics-together-f47c2de5ca554294a78a540dc383597f

## Todo

- [x] Basic hovering UI dialog for facet selection
- [x] Enable both types of faceting for the multi-country, multi-metric case
- [x] Remove tippy arrow
- [x] Left-align hovering UI with control
- [x] Grapher config key for strategy selection
- [x] Add cursor: pointer
- [x] Admin UI for strategy selection
- [x] Explorer setting for strategy selection
- [ ] ~~Harmonize dropdown to existing components~~
- [x] Shrink width to longest label
