### PR TITLE
chore: Prune and annotate the JSON schema

### DIFF
--- a/grapher/core/schema.json
+++ b/grapher/core/schema.json
@@ -12,7 +12,8 @@
             "properties": {
                 "legendOrientation": {
                     "type": ["string", "null"],
-                    "enum": ["portrait", "landscape", null]
+                    "enum": ["portrait", "landscape", null],
+                    "description": "DELETE: never used in code"
                 },
                 "projection": {
                     "type": ["string", "null"],
@@ -28,7 +29,8 @@
                     ]
                 },
                 "isColorblind": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "DELETE: never used in code"
                 },
                 "defaultProjection": {
                     "type": "string",
@@ -40,14 +42,17 @@
                         "NortAmerica",
                         "SouthAmerica",
                         "Oceania"
-                    ]
+                    ],
+                    "description": "DELETE: never used in code"
                 },
                 "timelineMode": {
                     "type": ["string", "null"],
-                    "enum": ["slider", "timeline", "buttons", null]
+                    "enum": ["slider", "timeline", "buttons", null],
+                    "description": "DELETE: never used in code"
                 },
                 "minYear": {
-                    "type": ["integer"]
+                    "type": ["integer"],
+                    "description": "DELETE: never used in code"
                 },
                 "timeRanges": {
                     "type": "array",
@@ -60,7 +65,10 @@
                                         "type": "string",
                                         "enum": ["last"]
                                     },
-                                    { "type": "number", "minimum": 0 }
+                                    {
+                                        "type": "number",
+                                        "minimum": 0
+                                    }
                                 ]
                             },
                             "interval": {
@@ -74,7 +82,9 @@
                                         "type": "string",
                                         "enum": ["first"]
                                     },
-                                    { "type": "number" }
+                                    {
+                                        "type": "number"
+                                    }
                                 ]
                             },
                             "year": {
@@ -83,17 +93,22 @@
                                         "type": "string",
                                         "enum": ["last"]
                                     },
-                                    { "type": "number", "minimum": 0 }
+                                    {
+                                        "type": "number",
+                                        "minimum": 0
+                                    }
                                 ]
                             }
                         },
                         "additionalProperties": false
-                    }
+                    },
+                    "description": "DELETE: never used in code"
                 },
                 "legendStepSize": {
                     "type": "integer",
                     "maximum": 32767,
-                    "minimum": 0
+                    "minimum": 0,
+                    "description": "DELETE: never used in code"
                 },
                 "hideTimeline": {
                     "type": "boolean"
@@ -110,7 +125,9 @@
                         "customCategoryColors": {
                             "type": ["object", "array"],
                             "patternProperties": {
-                                ".*": { "type": "string" }
+                                ".*": {
+                                    "type": "string"
+                                }
                             },
                             "items": {}
                         },
@@ -122,9 +139,10 @@
                         },
                         "customHiddenCategories": {
                             "type": ["object", "array"],
-
                             "patternProperties": {
-                                ".*": { "type": "boolean" }
+                                ".*": {
+                                    "type": "boolean"
+                                }
                             },
                             "items": {}
                         },
@@ -168,7 +186,9 @@
                         "customCategoryLabels": {
                             "type": ["object", "array"],
                             "patternProperties": {
-                                ".*": { "type": "string" }
+                                ".*": {
+                                    "type": "string"
+                                }
                             },
                             "items": {}
                         }
@@ -185,7 +205,10 @@
                             "type": "string",
                             "enum": ["latest"]
                         },
-                        { "type": "number", "minimum": 0 }
+                        {
+                            "type": "number",
+                            "minimum": 0
+                        }
                     ]
                 },
                 "maxYear": {
@@ -194,25 +217,32 @@
                             "type": "string",
                             "enum": ["latest"]
                         },
-                        { "type": "number", "minimum": 0 }
-                    ]
+                        {
+                            "type": "number",
+                            "minimum": 0
+                        }
+                    ],
+                    "description": "DELETE: never used in code"
                 },
                 "colorSchemeName": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "DELETE: never used in code"
                 },
                 "tooltipUseCustomLabels": {
                     "type": "boolean"
                 },
                 "targetYearMode": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "DELETE: never used in code"
                 },
                 "mode": {
                     "type": "string",
-                    "enum": ["specific"]
+                    "enum": ["specific"],
+                    "description": "DEPRECATE: this field has not been used in 1y or more"
                 },
                 "time": {
                     "type": ["string", "integer"],
-
+                    "description": "Select a specific time to be displayed.",
                     "maximum": 32767,
                     "minimum": 0
                 },
@@ -223,10 +253,10 @@
                 },
                 "timeInterval": {
                     "type": "integer",
-                    "$comment": "TODO: This property is used only if 13 very old charts"
+                    "$comment": "TODO: This property is used only if 13 very old charts",
+                    "description": "DELETE: never used in code"
                 }
             },
-
             "additionalProperties": false
         },
         "maxTime": {
@@ -235,7 +265,10 @@
                     "type": "string",
                     "enum": ["latest"]
                 },
-                { "type": "number", "minimum": 0 }
+                {
+                    "type": "number",
+                    "minimum": 0
+                }
             ]
         },
         "subtitle": {
@@ -250,7 +283,6 @@
         "baseColorScheme": {
             "type": "string"
         },
-
         "yAxis": {
             "type": "object",
             "properties": {
@@ -281,14 +313,17 @@
                     "type": "boolean"
                 },
                 "labelDistance": {
-                    "type": "number"
+                    "type": "number",
+                    "description": "DELETE: never used in code"
                 },
                 "facetAxisRange": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "DEPRECATE: this field has not been used in 1y or more"
                 },
                 "numDecimalPlaces": {
                     "type": "integer",
-                    "minimum": 0
+                    "minimum": 0,
+                    "description": "DEPRECATE: this field has not been used in 1y or more"
                 }
             },
             "additionalProperties": false
@@ -322,29 +357,35 @@
         },
         "lastEditedAt": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "DELETE: never used in code"
         },
         "margins": {
             "type": "object",
             "properties": {
                 "top": {
                     "type": ["string", "integer"],
-                    "minimum": 0
+                    "minimum": 0,
+                    "description": "DEPRECATE: this field has not been used in 1y or more"
                 },
                 "left": {
                     "type": ["string", "integer"],
-                    "minimum": 0
+                    "minimum": 0,
+                    "description": "DEPRECATE: this field has not been used in 1y or more"
                 },
                 "right": {
                     "type": ["string", "integer"],
-                    "minimum": 0
+                    "minimum": 0,
+                    "description": "DEPRECATE: this field has not been used in 1y or more"
                 },
                 "bottom": {
                     "type": ["string", "integer"],
-                    "minimum": 0
+                    "minimum": 0,
+                    "description": "DEPRECATE: this field has not been used in 1y or more"
                 }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "description": "DELETE: never used in code"
         },
         "hasChartTab": {
             "type": "boolean"
@@ -391,7 +432,9 @@
                 "customCategoryColors": {
                     "type": "object",
                     "patternProperties": {
-                        ".*": { "type": "string" }
+                        ".*": {
+                            "type": "string"
+                        }
                     }
                 },
                 "baseColorScheme": {
@@ -400,7 +443,9 @@
                 "customHiddenCategories": {
                     "type": "object",
                     "patternProperties": {
-                        ".*": { "type": "boolean" }
+                        ".*": {
+                            "type": "boolean"
+                        }
                     }
                 },
                 "binningStrategy": {
@@ -601,7 +646,9 @@
         "selectedEntityColors": {
             "type": "object",
             "patternProperties": {
-                ".*": { "type": "string" }
+                ".*": {
+                    "type": "string"
+                }
             }
         },
         "relatedQuestions": {
@@ -623,7 +670,8 @@
             "type": "string"
         },
         "isAutoTitle": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "DELETE: never used in code"
         },
         "type": {
             "type": "string",
@@ -653,7 +701,9 @@
                     "type": "string",
                     "enum": ["latest", "earliest"]
                 },
-                { "type": "number" }
+                {
+                    "type": "number"
+                }
             ]
         },
         "hideTitleAnnotation": {
@@ -698,11 +748,13 @@
                 "labelDistance": {
                     "type": "integer",
                     "maximum": 32767,
-                    "minimum": -327681
+                    "minimum": -327681,
+                    "description": "DELETE: never used in code"
                 },
                 "numDecimalPlaces": {
                     "type": "integer",
-                    "minimum": 0
+                    "minimum": 0,
+                    "description": "DEPRECATE: this field has not been used in 1y or more"
                 }
             },
             "additionalProperties": false
@@ -712,7 +764,8 @@
             "minimum": 0
         },
         "isExplorable": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "DELETE: never used in code"
         },
         "hideConnectedScatterLines": {
             "type": "boolean"

--- a/grapher/core/schema.json
+++ b/grapher/core/schema.json
@@ -10,11 +10,6 @@
         "map": {
             "type": "object",
             "properties": {
-                "legendOrientation": {
-                    "type": ["string", "null"],
-                    "enum": ["portrait", "landscape", null],
-                    "description": "DELETE: never used in code"
-                },
                 "projection": {
                     "type": ["string", "null"],
                     "enum": [
@@ -27,88 +22,6 @@
                         "Oceania",
                         null
                     ]
-                },
-                "isColorblind": {
-                    "type": "boolean",
-                    "description": "DELETE: never used in code"
-                },
-                "defaultProjection": {
-                    "type": "string",
-                    "enum": [
-                        "World",
-                        "Europe",
-                        "Africa",
-                        "Asia",
-                        "NortAmerica",
-                        "SouthAmerica",
-                        "Oceania"
-                    ],
-                    "description": "DELETE: never used in code"
-                },
-                "timelineMode": {
-                    "type": ["string", "null"],
-                    "enum": ["slider", "timeline", "buttons", null],
-                    "description": "DELETE: never used in code"
-                },
-                "minYear": {
-                    "type": ["integer"],
-                    "description": "DELETE: never used in code"
-                },
-                "timeRanges": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "endYear": {
-                                "oneOf": [
-                                    {
-                                        "type": "string",
-                                        "enum": ["last"]
-                                    },
-                                    {
-                                        "type": "number",
-                                        "minimum": 0
-                                    }
-                                ]
-                            },
-                            "interval": {
-                                "type": "integer",
-                                "maximum": 32767,
-                                "minimum": 0
-                            },
-                            "startYear": {
-                                "oneOf": [
-                                    {
-                                        "type": "string",
-                                        "enum": ["first"]
-                                    },
-                                    {
-                                        "type": "number"
-                                    }
-                                ]
-                            },
-                            "year": {
-                                "oneOf": [
-                                    {
-                                        "type": "string",
-                                        "enum": ["last"]
-                                    },
-                                    {
-                                        "type": "number",
-                                        "minimum": 0
-                                    }
-                                ]
-                            }
-                        },
-                        "additionalProperties": false
-                    },
-                    "description": "DELETE: never used in code"
-                },
-                "legendStepSize": {
-                    "type": "integer",
-                    "maximum": 32767,
-                    "minimum": 0,
-                    "description": "DELETE: never used in code"
                 },
                 "hideTimeline": {
                     "type": "boolean"
@@ -211,34 +124,8 @@
                         }
                     ]
                 },
-                "maxYear": {
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "enum": ["latest"]
-                        },
-                        {
-                            "type": "number",
-                            "minimum": 0
-                        }
-                    ],
-                    "description": "DELETE: never used in code"
-                },
-                "colorSchemeName": {
-                    "type": "string",
-                    "description": "DELETE: never used in code"
-                },
                 "tooltipUseCustomLabels": {
                     "type": "boolean"
-                },
-                "targetYearMode": {
-                    "type": "string",
-                    "description": "DELETE: never used in code"
-                },
-                "mode": {
-                    "type": "string",
-                    "enum": ["specific"],
-                    "description": "DEPRECATE: this field has not been used in 1y or more"
                 },
                 "time": {
                     "type": ["string", "integer"],
@@ -250,11 +137,6 @@
                     "type": "integer",
                     "maximum": 2147483647,
                     "minimum": 0
-                },
-                "timeInterval": {
-                    "type": "integer",
-                    "$comment": "TODO: This property is used only if 13 very old charts",
-                    "description": "DELETE: never used in code"
                 }
             },
             "additionalProperties": false
@@ -312,13 +194,8 @@
                 "canChangeScaleType": {
                     "type": "boolean"
                 },
-                "labelDistance": {
-                    "type": "number",
-                    "description": "DELETE: never used in code"
-                },
                 "facetAxisRange": {
-                    "type": "string",
-                    "description": "DEPRECATE: this field has not been used in 1y or more"
+                    "type": "string"
                 },
                 "numDecimalPlaces": {
                     "type": "integer",
@@ -354,38 +231,6 @@
         },
         "matchingEntitiesOnly": {
             "type": "boolean"
-        },
-        "lastEditedAt": {
-            "type": "string",
-            "format": "date-time",
-            "description": "DELETE: never used in code"
-        },
-        "margins": {
-            "type": "object",
-            "properties": {
-                "top": {
-                    "type": ["string", "integer"],
-                    "minimum": 0,
-                    "description": "DEPRECATE: this field has not been used in 1y or more"
-                },
-                "left": {
-                    "type": ["string", "integer"],
-                    "minimum": 0,
-                    "description": "DEPRECATE: this field has not been used in 1y or more"
-                },
-                "right": {
-                    "type": ["string", "integer"],
-                    "minimum": 0,
-                    "description": "DEPRECATE: this field has not been used in 1y or more"
-                },
-                "bottom": {
-                    "type": ["string", "integer"],
-                    "minimum": 0,
-                    "description": "DEPRECATE: this field has not been used in 1y or more"
-                }
-            },
-            "additionalProperties": false,
-            "description": "DELETE: never used in code"
         },
         "hasChartTab": {
             "type": "boolean"
@@ -669,10 +514,6 @@
         "title": {
             "type": "string"
         },
-        "isAutoTitle": {
-            "type": "boolean",
-            "description": "DELETE: never used in code"
-        },
         "type": {
             "type": "string",
             "enum": [
@@ -745,12 +586,6 @@
                 "canChangeScaleType": {
                     "type": "boolean"
                 },
-                "labelDistance": {
-                    "type": "integer",
-                    "maximum": 32767,
-                    "minimum": -327681,
-                    "description": "DELETE: never used in code"
-                },
                 "numDecimalPlaces": {
                     "type": "integer",
                     "minimum": 0,
@@ -762,10 +597,6 @@
         "timelineMaxTime": {
             "type": "integer",
             "minimum": 0
-        },
-        "isExplorable": {
-            "type": "boolean",
-            "description": "DELETE: never used in code"
         },
         "hideConnectedScatterLines": {
             "type": "boolean"


### PR DESCRIPTION
Remove fields that do not exist in our codebase and auto-annotate as deprecated fields that have not been used in the past year.

See Jupyter notebook for details of auto-annotation/marking for deletion: https://gist.github.com/larsyencken/9f157a3db5a4d5dcd26262d5e72a51c5