### PR TITLE
WIP: unfinished attempt to fix cookie notice

### DIFF
--- a/site/CookieNotice.tsx
+++ b/site/CookieNotice.tsx
@@ -3,15 +3,13 @@ import { useEffect, useState } from "react"
 import classnames from "classnames"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faCheck } from "@fortawesome/free-solid-svg-icons/faCheck"
-import { Action, getTodayDate } from "./CookiePreferencesManager"
+import { Action } from "./CookiePreferencesManager"
 
 export const CookieNotice = ({
-    accepted,
-    outdated,
+    show,
     dispatch,
 }: {
-    accepted: boolean
-    outdated: boolean
+    show: boolean
     dispatch: any
 }) => {
     const [mounted, setMounted] = useState(false)
@@ -25,7 +23,7 @@ export const CookieNotice = ({
     return (
         <div
             className={classnames("cookie-notice", {
-                open: mounted && (!accepted || outdated),
+                open: mounted && show,
             })}
             data-test="cookie-notice"
         >
@@ -47,7 +45,6 @@ export const CookieNotice = ({
                             onClick={() =>
                                 dispatch({
                                     type: Action.Accept,
-                                    payload: { date: getTodayDate() },
                                 })
                             }
                             data-test="accept"

--- a/site/CookiePreferencesManager.test.ts
+++ b/site/CookiePreferencesManager.test.ts
@@ -3,12 +3,12 @@
 import {
     PreferenceType,
     parseRawCookieValue,
-    parseDate,
+    parseId,
     parsePreferences,
     updatePreference,
     getPreferenceValue,
     serializeState,
-    arePreferencesOutdated,
+    isPolicyOutdated,
 } from "./CookiePreferencesManager"
 
 describe("cookie preferences", () => {
@@ -18,7 +18,7 @@ describe("cookie preferences", () => {
             value: true,
         },
     ]
-    const date = 20201009
+    const policyId = 20201009
     const serializedState = "a:1-20201009"
     it("parses raw cookie value", () => {
         expect(parseRawCookieValue()).toBeUndefined()
@@ -32,16 +32,16 @@ describe("cookie preferences", () => {
         expect(parseRawCookieValue("x:1-20201009")).toBeUndefined()
         expect(parseRawCookieValue(serializedState)).toEqual({
             preferences,
-            date,
+            policyId,
         })
     })
     it("parses date", () => {
-        expect(parseDate()).toBeUndefined()
-        expect(parseDate("")).toBeUndefined()
-        expect(parseDate("abcd")).toBeUndefined()
-        expect(parseDate("2020")).toBeUndefined()
-        expect(parseDate("20201032")).toBeUndefined()
-        expect(parseDate("20201001")).toEqual(20201001)
+        expect(parseId()).toBeUndefined()
+        expect(parseId("")).toBeUndefined()
+        expect(parseId("abcd")).toBeUndefined()
+        expect(parseId("2020")).toBeUndefined()
+        expect(parseId("20201032")).toBeUndefined()
+        expect(parseId("20201001")).toEqual(20201001)
     })
 
     it("parses preferences", () => {
@@ -76,13 +76,15 @@ describe("cookie preferences", () => {
     })
 
     it("serializes state", () => {
-        expect(serializeState({ preferences, date })).toEqual(serializedState)
+        expect(serializeState({ preferences, policyId })).toEqual(
+            serializedState
+        )
     })
 
     it("checks if preferences are outdated", () => {
-        expect(arePreferencesOutdated(date - 1, date)).toEqual(true)
-        expect(arePreferencesOutdated(date, date)).toEqual(false)
-        expect(arePreferencesOutdated(date + 1, date)).toEqual(false)
-        expect(arePreferencesOutdated(undefined, date)).toEqual(false)
+        expect(isPolicyOutdated(policyId - 1, policyId)).toEqual(true)
+        expect(isPolicyOutdated(policyId, policyId)).toEqual(false)
+        expect(isPolicyOutdated(policyId + 1, policyId)).toEqual(false)
+        expect(isPolicyOutdated(undefined, policyId)).toEqual(false)
     })
 })

--- a/site/blocks/CookiePreferences.tsx
+++ b/site/blocks/CookiePreferences.tsx
@@ -1,11 +1,9 @@
-import moment from "moment"
 import * as React from "react"
 import * as ReactDOM from "react-dom"
 import {
     Action,
-    DATE_FORMAT,
+    CookiePreferencesDispatch,
     getPreferenceValue,
-    getTodayDate,
     Preference,
     PreferenceType,
 } from "../../site/CookiePreferencesManager"
@@ -67,12 +65,14 @@ const CookiePreference = ({
 
 export const CookiePreferences = ({
     preferences,
-    date,
+    acceptedPolicyId,
+    currentPolicyId,
     dispatch,
 }: {
     preferences: Preference[]
-    date?: number
-    dispatch: any
+    acceptedPolicyId?: number
+    currentPolicyId: number
+    dispatch: React.Dispatch<CookiePreferencesDispatch>
 }) => {
     const cookiePreferencesDomSlot = document.querySelector(
         ".wp-block-cookie-preferences"
@@ -103,25 +103,20 @@ export const CookiePreferences = ({
                         type: Action.TogglePreference,
                         payload: {
                             preferenceType: PreferenceType.Analytics,
-                            date: getTodayDate(),
+                            policyId: currentPolicyId,
                         },
                     })
                 }
             >
                 We use these cookies to monitor and improve website performance.
             </CookiePreference>
-            {date ? (
-                <div className="last-updated">
-                    Preferences last updated:{" "}
-                    {moment(date, DATE_FORMAT).format("LL")}
-                </div>
-            ) : (
+            {acceptedPolicyId === undefined && (
                 <button
                     className="owid-button"
                     onClick={() =>
                         dispatch({
                             type: Action.Accept,
-                            payload: { date: getTodayDate() },
+                            payload: { policyId: currentPolicyId },
                         })
                     }
                     data-test="accept"


### PR DESCRIPTION
The cookie policy implementation uses "date policy was accepted" to decide whether to show or hide the policy, by comparing it to the "date policy was last updated". 

This has issues:

- A policy update doesn't happen instantaneously at the beginning of a day, so if people accept the policy on a day, they may have accepted the old one. This means we should set the "policy last updated" date at least one day in the future. This brings up another issue:
- We use non-UTC dates, so users in more western timezones might be a day behind. This results in them not being able to get the banner away, because for them the condition holds even after accepting: "last accepted date" < "last policy update date".

I've attempted to fix this by using the policy date as an identifier, and storing that in the cookie. But have not finished this, and have still not gotten my head around the whole implementation. At the moment I'm also on an old laptop which doesn't have Wordpress set up to test this.

So I've left it half-finished. 🏳️  We can update the policy date with these bugs in place for now. 