### PR TITLE
fix Bugsnag integration

### DIFF
--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1480,27 +1480,25 @@ export class Grapher
         containerNode: Element
     ): Grapher | null {
         const grapherInstanceRef = React.createRef<Grapher>()
+
+        let ErrorBoundary = React.Fragment // use React.Fragment as a sort of default error boundary if Bugsnag is not available
+        if (Bugsnag && (Bugsnag as any)._client) {
+            ErrorBoundary = Bugsnag.getPlugin("react").createErrorBoundary(
+                React
+            )
+        }
+
         const setBoundsFromContainerAndRender = (): void => {
             const props: GrapherProgrammaticInterface = {
                 ...config,
                 bounds: Bounds.fromRect(containerNode.getBoundingClientRect()),
             }
-            if (Bugsnag && (Bugsnag as any)._client) {
-                const ErrorBoundary = Bugsnag.getPlugin(
-                    "react"
-                ).createErrorBoundary(React)
-                ReactDOM.render(
-                    <ErrorBoundary>
-                        <Grapher ref={grapherInstanceRef} {...props} />
-                    </ErrorBoundary>,
-                    containerNode
-                )
-            } else {
-                ReactDOM.render(
-                    <Grapher ref={grapherInstanceRef} {...props} />,
-                    containerNode
-                )
-            }
+            ReactDOM.render(
+                <ErrorBoundary>
+                    <Grapher ref={grapherInstanceRef} {...props} />
+                </ErrorBoundary>,
+                containerNode
+            )
         }
 
         setBoundsFromContainerAndRender()

--- a/site/covid/CovidTable.tsx
+++ b/site/covid/CovidTable.tsx
@@ -231,12 +231,10 @@ export class CovidTable extends React.Component<CovidTableProps> {
         }
     }
 
-    @computed get countryColors(): Record<string, string> {
+    @computed get countryColors(): Map<string, string> {
         const locations = uniq((this.data || []).map((d) => d.location))
         const colors = schemeCategory10
-        return Object.fromEntries(
-            locations.map((l, i) => [l, colors[i % colors.length]])
-        )
+        return new Map(locations.map((l, i) => [l, colors[i % colors.length]]))
     }
 
     @action.bound onShowMore() {

--- a/site/covid/CovidTableColumns.tsx
+++ b/site/covid/CovidTableColumns.tsx
@@ -57,7 +57,7 @@ export interface CovidTableCellSpec {
         "data" | "xDomain" | "x" | "currentX" | "highlightedX" | "onHover"
     >
     totalTestsBarScale: ScaleLinear<number, number>
-    countryColors: Record<string, string>
+    countryColors: Map<string, string>
     baseRowSpan: number
 }
 
@@ -477,8 +477,9 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                         <div
                             className="bar"
                             style={{
-                                backgroundColor:
-                                    props.countryColors[props.datum.location],
+                                backgroundColor: props.countryColors.get(
+                                    props.datum.location
+                                ),
                                 width: `${
                                     props.totalTestsBarScale(
                                         props.datum.latestWithTests.tests

--- a/site/covid/CovidTableRow.tsx
+++ b/site/covid/CovidTableRow.tsx
@@ -15,7 +15,7 @@ import {
 export interface CovidTableTransform {
     dateRange: DateRange
     totalTestsBarScale: ScaleLinear<number, number>
-    countryColors: Record<string, string>
+    countryColors: Map<string, string>
 }
 
 export interface CovidTableRowProps {


### PR DESCRIPTION
Okay, so one thing that's contained in here is just a fix for one of the issues we detected using Bugsnag, namely that we use `Object.fromEntries` which doesn't have super-good browser support yet.

But in working on this I discovered a way bigger issue with our Bugsnag, namely that it reloaded the Grapher every time the window size changed 😧 

https://user-images.githubusercontent.com/2641501/127222317-69d9d94f-b60a-4407-88d6-199822c4af62.mp4

To make matters worse, in Android Chrome there's a window resize event happening for many scrolls, since the address bar is shown/hidden on scroll.

This probably happened because every call to `Bugsnag.getPlugin("react").createErrorBoundary(React)` returns a new reference to a Bugsnag error boundary, and `setBoundsFromContainerAndRender` is called on every window size change which would then lead to a complete re-render.
What I did here should fix that, and seems to do so.