### PR TITLE
feat: display total values in StackedDiscreteBarChart

### DIFF
--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -618,6 +618,20 @@ export class EditorCustomizeTab extends React.Component<{
                         </FieldsRow>
                     </Section>
                 )}
+                {features.canHideTotalValueLabel && (
+                    <Section name="Display">
+                        <FieldsRow>
+                            <Toggle
+                                label={`Hide total value label`}
+                                value={!!grapher.hideTotalValueLabel}
+                                onValue={(value) =>
+                                    (grapher.hideTotalValueLabel =
+                                        value || false)
+                                }
+                            />
+                        </FieldsRow>
+                    </Section>
+                )}
                 {features.comparisonLine && (
                     <ComparisonLineSection editor={this.props.editor} />
                 )}

--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -95,4 +95,8 @@ export class EditorFeatures {
     @computed get canSortByColumn() {
         return this.grapher.isStackedDiscreteBar
     }
+
+    @computed get canHideTotalValueLabel() {
+        return this.grapher.isStackedDiscreteBar
+    }
 }

--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -180,4 +180,10 @@ export const GrapherGrammar: Grammar = {
             "Show chart in absolute (default) or relative mode. Only works for some chart types.",
         terminalOptions: toTerminalOptions(Object.values(StackMode)),
     },
+    hideTotalValueLabel: {
+        ...BooleanCellDef,
+        keyword: "hideTotalValueLabel",
+        description:
+            "Hide the total value that is normally displayed to the right of the bars in a stacked bar chart.",
+    },
 } as const

--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -139,7 +139,7 @@ export const GrapherGrammar: Grammar = {
         keyword: "facetYDomain",
         description:
             "Whether facets axes default to shared or independent domain",
-        terminalOptions: Object.keys(FacetAxisDomain).map((keyword) => ({
+        terminalOptions: Object.values(FacetAxisDomain).map((keyword) => ({
             keyword,
             description: "",
             cssClass: "",
@@ -175,7 +175,7 @@ export const GrapherGrammar: Grammar = {
         ...EnumCellDef,
         keyword: "sortBy",
         description: "Specify what to sort the entities by",
-        terminalOptions: Object.keys(SortBy).map((keyword) => ({
+        terminalOptions: Object.values(SortBy).map((keyword) => ({
             keyword,
             description: "",
             cssClass: "",
@@ -185,7 +185,7 @@ export const GrapherGrammar: Grammar = {
         ...EnumCellDef,
         keyword: "sortOrder",
         description: "Whether to sort entities ascending or descending",
-        terminalOptions: Object.keys(SortOrder).map((keyword) => ({
+        terminalOptions: Object.values(SortOrder).map((keyword) => ({
             keyword,
             description: "",
             cssClass: "",
@@ -202,7 +202,7 @@ export const GrapherGrammar: Grammar = {
         keyword: "stackMode",
         description:
             "Show chart in absolute (default) or relative mode. Only works for some chart types.",
-        terminalOptions: Object.keys(StackMode).map((keyword) => ({
+        terminalOptions: Object.values(StackMode).map((keyword) => ({
             keyword,
             description: "",
             cssClass: "",

--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -7,7 +7,7 @@ import {
     BooleanCellDef,
     EnumCellDef,
     NumericCellDef,
-    JSONObjectCellDef,
+    CellDef,
 } from "../gridLang/GridLangConstants"
 import {
     ChartTypeName,
@@ -18,6 +18,14 @@ import {
 } from "../grapher/core/GrapherConstants"
 import { ColorSchemes } from "../grapher/color/ColorSchemes"
 import { SortBy, SortOrder } from "../clientUtils/owidTypes"
+
+const toTerminalOptions = (keywords: string[]): CellDef[] => {
+    return keywords.map((keyword) => ({
+        keyword,
+        cssClass: "",
+        description: "",
+    }))
+}
 
 export const GrapherGrammar: Grammar = {
     title: {
@@ -41,11 +49,7 @@ export const GrapherGrammar: Grammar = {
         ...StringCellDef,
         keyword: "type",
         description: `The type of chart to show such as LineChart or ScatterPlot.`,
-        terminalOptions: Object.values(ChartTypeName).map((keyword) => ({
-            keyword,
-            description: "",
-            cssClass: "",
-        })),
+        terminalOptions: toTerminalOptions(Object.values(ChartTypeName)),
     },
     grapherId: {
         ...IntegerCellDef,
@@ -66,11 +70,7 @@ export const GrapherGrammar: Grammar = {
         ...EnumCellDef,
         keyword: "tab",
         description: "Which tab to show by default",
-        terminalOptions: Object.values(GrapherTabOption).map((keyword) => ({
-            keyword,
-            description: "",
-            cssClass: "",
-        })),
+        terminalOptions: toTerminalOptions(Object.values(GrapherTabOption)),
     },
     hasChartTab: {
         ...BooleanCellDef,
@@ -107,11 +107,7 @@ export const GrapherGrammar: Grammar = {
         ...EnumCellDef,
         description: "Facet by column or entities",
         keyword: "facet",
-        terminalOptions: Object.values(FacetStrategy).map((keyword) => ({
-            keyword,
-            description: "",
-            cssClass: "",
-        })),
+        terminalOptions: toTerminalOptions(Object.values(FacetStrategy)),
     },
     hideTitleAnnotation: {
         ...BooleanCellDef,
@@ -139,32 +135,20 @@ export const GrapherGrammar: Grammar = {
         keyword: "facetYDomain",
         description:
             "Whether facets axes default to shared or independent domain",
-        terminalOptions: Object.values(FacetAxisDomain).map((keyword) => ({
-            keyword,
-            description: "",
-            cssClass: "",
-        })),
+        terminalOptions: toTerminalOptions(Object.values(FacetAxisDomain)),
     },
     selectedFacetStrategy: {
         ...EnumCellDef,
         keyword: "selectedFacetStrategy",
         description: "Whether the chart should be faceted or not",
-        terminalOptions: Object.values(FacetStrategy).map((keyword) => ({
-            keyword,
-            description: "",
-            cssClass: "",
-        })),
+        terminalOptions: toTerminalOptions(Object.values(FacetStrategy)),
     },
     baseColorScheme: {
         ...EnumCellDef,
         keyword: "baseColorScheme",
         description:
             "The default color scheme if no color overrides are specified",
-        terminalOptions: Object.keys(ColorSchemes).map((keyword) => ({
-            keyword,
-            description: "",
-            cssClass: "",
-        })),
+        terminalOptions: toTerminalOptions(Object.keys(ColorSchemes)),
     },
     note: {
         ...StringCellDef,
@@ -175,21 +159,13 @@ export const GrapherGrammar: Grammar = {
         ...EnumCellDef,
         keyword: "sortBy",
         description: "Specify what to sort the entities by",
-        terminalOptions: Object.values(SortBy).map((keyword) => ({
-            keyword,
-            description: "",
-            cssClass: "",
-        })),
+        terminalOptions: toTerminalOptions(Object.values(SortBy)),
     },
     sortOrder: {
         ...EnumCellDef,
         keyword: "sortOrder",
         description: "Whether to sort entities ascending or descending",
-        terminalOptions: Object.values(SortOrder).map((keyword) => ({
-            keyword,
-            description: "",
-            cssClass: "",
-        })),
+        terminalOptions: toTerminalOptions(Object.values(SortOrder)),
     },
     sortColumnSlug: {
         ...SlugDeclarationCellDef,
@@ -202,10 +178,6 @@ export const GrapherGrammar: Grammar = {
         keyword: "stackMode",
         description:
             "Show chart in absolute (default) or relative mode. Only works for some chart types.",
-        terminalOptions: Object.values(StackMode).map((keyword) => ({
-            keyword,
-            description: "",
-            cssClass: "",
-        })),
+        terminalOptions: toTerminalOptions(Object.values(StackMode)),
     },
 } as const

--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -14,6 +14,7 @@ import {
     FacetAxisDomain,
     FacetStrategy,
     GrapherTabOption,
+    StackMode,
 } from "../grapher/core/GrapherConstants"
 import { ColorSchemes } from "../grapher/color/ColorSchemes"
 import { SortBy, SortOrder } from "../clientUtils/owidTypes"
@@ -191,9 +192,20 @@ export const GrapherGrammar: Grammar = {
         })),
     },
     sortColumnSlug: {
-        ...EnumCellDef,
+        ...SlugDeclarationCellDef,
         keyword: "sortColumnSlug",
         description:
             "This setting is only respected when `sortBy` is set to `column`",
+    },
+    stackMode: {
+        ...EnumCellDef,
+        keyword: "stackMode",
+        description:
+            "Show chart in absolute (default) or relative mode. Only works for some chart types.",
+        terminalOptions: Object.keys(StackMode).map((keyword) => ({
+            keyword,
+            description: "",
+            cssClass: "",
+        })),
     },
 } as const

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -280,6 +280,7 @@ export class Grapher
     scatterPointLabelStrategy?: ScatterPointLabelStrategy = undefined
     @observable.ref compareEndPointsOnly?: boolean = undefined
     @observable.ref matchingEntitiesOnly?: boolean = undefined
+    @observable.ref hideTotalValueLabel?: boolean = undefined // Hides the total value label that is normally displayed for stacked bar charts
 
     @observable.ref xAxis = new AxisConfig(undefined, this)
     @observable.ref yAxis = new AxisConfig(undefined, this)

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -2207,6 +2207,7 @@ export class Grapher
         this.sortBy = grapher.sortBy
         this.sortOrder = grapher.sortOrder
         this.sortColumnSlug = grapher.sortColumnSlug
+        this.stackMode = grapher.stackMode
     }
 
     debounceMode = false

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -280,7 +280,8 @@ export class Grapher
     scatterPointLabelStrategy?: ScatterPointLabelStrategy = undefined
     @observable.ref compareEndPointsOnly?: boolean = undefined
     @observable.ref matchingEntitiesOnly?: boolean = undefined
-    @observable.ref hideTotalValueLabel?: boolean = undefined // Hides the total value label that is normally displayed for stacked bar charts
+    /** Hides the total value label that is normally displayed for stacked bar charts */
+    @observable.ref hideTotalValueLabel?: boolean = undefined
 
     @observable.ref xAxis = new AxisConfig(undefined, this)
     @observable.ref yAxis = new AxisConfig(undefined, this)

--- a/grapher/core/GrapherInterface.ts
+++ b/grapher/core/GrapherInterface.ts
@@ -70,6 +70,7 @@ export interface GrapherInterface extends SortConfig {
     scatterPointLabelStrategy?: ScatterPointLabelStrategy
     compareEndPointsOnly?: boolean
     matchingEntitiesOnly?: boolean
+    hideTotalValueLabel?: boolean
     excludedEntities?: number[]
     selectedEntityNames?: EntityName[]
     selectedEntityColors?: { [entityName: string]: string }
@@ -157,6 +158,7 @@ export const grapherKeysToSerialize = [
     "scatterPointLabelStrategy",
     "compareEndPointsOnly",
     "matchingEntitiesOnly",
+    "hideTotalValueLabel",
     "xAxis",
     "yAxis",
     "colorScale",

--- a/grapher/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.tsx
@@ -59,6 +59,7 @@ const labelToBarPadding = 5
 
 export interface StackedDiscreteBarChartManager extends ChartManager {
     endTime?: Time
+    hideTotalValueLabel?: boolean
 }
 
 interface Item {
@@ -181,7 +182,7 @@ export class StackedDiscreteBarChart
     }
 
     @computed get showTotalValueLabel(): boolean {
-        return !this.manager.isRelativeMode
+        return !this.manager.isRelativeMode && !this.manager.hideTotalValueLabel
     }
 
     // The amount of space we need to allocate for total value labels on the right

--- a/grapher/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.tsx
@@ -282,6 +282,17 @@ export class StackedDiscreteBarChart
         return sortedItems
     }
 
+    @computed private get placedItems(): PlacedItem[] {
+        const { innerBounds, barHeight, barSpacing } = this
+
+        const topYOffset = innerBounds.top + barHeight / 2
+
+        return this.sortedItems.map((d, i) => ({
+            yPosition: topYOffset + (barHeight + barSpacing) * i,
+            ...d,
+        }))
+    }
+
     @computed private get barHeight(): number {
         return (0.8 * this.innerBounds.height) / this.items.length
     }
@@ -378,12 +389,6 @@ export class StackedDiscreteBarChart
             isInteractive: !this.manager.isExportingtoSvgOrPng,
         }
 
-        const yOffset = innerBounds.top + barHeight / 2
-        const placedItems = this.sortedItems.map((d, i) => ({
-            yPosition: yOffset + (barHeight + barSpacing) * i,
-            ...d,
-        }))
-
         const handlePositionUpdate = (d: PlacedItem) => ({
             translateY: [d.yPosition],
             timing: { duration: 350, ease: easeQuadOut },
@@ -410,7 +415,7 @@ export class StackedDiscreteBarChart
                 />
                 <HorizontalCategoricalColorLegend manager={this} />
                 <NodeGroup
-                    data={placedItems}
+                    data={this.placedItems}
                     keyAccessor={(d: PlacedItem) => d.label}
                     start={handlePositionUpdate}
                     update={handlePositionUpdate}


### PR DESCRIPTION
Notion: [Show total value next to bars](https://www.notion.so/Show-total-value-next-to-bars-b3bc132511b04e9ba42264daf50176f8)

This PR is live on _tufte_. Check out https://tufte.owid.cloud/admin/test/embeds?type=StackedDiscreteBar for a nice comparison to _live_, or check the [Covid explorer](https://tufte-owid.netlify.app/explorers/coronavirus-data-explorer?Metric=People+vaccinated+%28by+dose%29&Interval=7-day+rolling+average&Relative+to+Population=true&Align+outbreaks=false&country=IND~USA~ITA~GBR~DEU~CAN).

I opted to not introduce another new option here, and to always display the total value if `!manager.isRelativeMode`. That is, for charts where the underlying data is already relative (i.e. the underlying data adds up to 100% for each entity), the authors can hide the total value by enabling relative mode (it's a little icky at the moment):

https://user-images.githubusercontent.com/2641501/127343024-6e0ae093-b62b-41d6-ba82-eb2b21746c1f.mp4

At least at this point in time, we don't have any other stacked bar charts where we would want to disable showing the total value, and I found it to not be worth it to introduce a custom setting just for stacked bar charts. Let me know what you think.