### PR TITLE
Faceting axis & layout improvements

### DIFF
--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -23,7 +23,7 @@ import { ColorSchemeDropdown, ColorSchemeOption } from "./ColorSchemeDropdown"
 import { EditorColorScaleSection } from "./EditorColorScaleSection"
 import { ColorSchemeName } from "../grapher/color/ColorConstants"
 import { TimeBoundValue } from "../clientUtils/TimeBounds"
-import { FacetAxisRange } from "../grapher/core/GrapherConstants"
+import { FacetAxisDomain } from "../grapher/core/GrapherConstants"
 import Select, { ValueType } from "react-select"
 import { SortOrder, SortBy, SortConfig } from "../clientUtils/owidTypes"
 import { asArray } from "../clientUtils/react-select"
@@ -421,13 +421,13 @@ export class EditorCustomizeTab extends React.Component<{
                                     <Toggle
                                         label={`Facets have uniform y-axis`}
                                         value={
-                                            yAxisConfig.facetAxisRange ===
-                                            FacetAxisRange.shared
+                                            yAxisConfig.facetDomain ===
+                                            FacetAxisDomain.shared
                                         }
                                         onValue={(value) => {
-                                            yAxisConfig.facetAxisRange = value
-                                                ? FacetAxisRange.shared
-                                                : FacetAxisRange.independent
+                                            yAxisConfig.facetDomain = value
+                                                ? FacetAxisDomain.shared
+                                                : FacetAxisDomain.independent
                                         }}
                                     />
                                 </FieldsRow>

--- a/clientUtils/Bounds.test.ts
+++ b/clientUtils/Bounds.test.ts
@@ -10,7 +10,7 @@ it("can report the center", () => {
 
 it("can split a bounds into correct number of pieces", () => {
     const bounds = new Bounds(0, 0, 100, 100)
-    const quads = bounds.grid(4, 1)
+    const quads = bounds.grid({ rows: 2, columns: 2 })
     expect(quads.length).toEqual(4)
     const first = quads[0]
     const second = quads[1]
@@ -38,7 +38,10 @@ it("can split a bounds into correct number of pieces", () => {
 
 it("can split with padding between charts", () => {
     const bounds = new Bounds(10, 10, 100, 100)
-    const quads = bounds.grid(4, 1, { rowPadding: 20, columnPadding: 20 })
+    const quads = bounds.grid(
+        { rows: 2, columns: 2 },
+        { rowPadding: 20, columnPadding: 20 }
+    )
     expect(quads.length).toEqual(4)
     const second = quads[1]
     const third = quads[2]

--- a/clientUtils/Bounds.test.ts
+++ b/clientUtils/Bounds.test.ts
@@ -10,7 +10,7 @@ it("can report the center", () => {
 
 it("can split a bounds into correct number of pieces", () => {
     const bounds = new Bounds(0, 0, 100, 100)
-    const quads = bounds.grid(4)
+    const quads = bounds.grid(4, 1)
     expect(quads.length).toEqual(4)
     const first = quads[0]
     const second = quads[1]
@@ -38,7 +38,7 @@ it("can split a bounds into correct number of pieces", () => {
 
 it("can split with padding between charts", () => {
     const bounds = new Bounds(10, 10, 100, 100)
-    const quads = bounds.grid(4, { rowPadding: 20, columnPadding: 20 })
+    const quads = bounds.grid(4, 1, { rowPadding: 20, columnPadding: 20 })
     expect(quads.length).toEqual(4)
     const second = quads[1]
     const third = quads[2]

--- a/clientUtils/Bounds.test.ts
+++ b/clientUtils/Bounds.test.ts
@@ -1,6 +1,7 @@
 #! /usr/bin/env jest
 
 import { Bounds } from "./Bounds"
+import { Position } from "./owidTypes"
 
 it("can report the center", () => {
     const bounds = new Bounds(0, 0, 100, 100)
@@ -11,6 +12,7 @@ it("can split a bounds into correct number of pieces", () => {
     const bounds = new Bounds(0, 0, 100, 100)
     const quads = bounds.grid(4)
     expect(quads.length).toEqual(4)
+    const first = quads[0]
     const second = quads[1]
     const third = quads[2]
     const fourth = quads[3]
@@ -19,6 +21,19 @@ it("can split a bounds into correct number of pieces", () => {
     expect(third.bounds.y).toEqual(50)
     expect(third.bounds.x).toEqual(0)
     expect(fourth.bounds.height).toEqual(50)
+
+    expect(Array.from(first.edges.values())).toEqual(
+        expect.arrayContaining([Position.left, Position.top])
+    )
+    expect(Array.from(second.edges.values())).toEqual(
+        expect.arrayContaining([Position.top, Position.right])
+    )
+    expect(Array.from(third.edges.values())).toEqual(
+        expect.arrayContaining([Position.left, Position.bottom])
+    )
+    expect(Array.from(fourth.edges.values())).toEqual(
+        expect.arrayContaining([Position.bottom, Position.right])
+    )
 })
 
 it("can split with padding between charts", () => {
@@ -33,4 +48,18 @@ it("can split with padding between charts", () => {
     expect(third.bounds.y).toEqual(70)
     expect(third.bounds.x).toEqual(10)
     expect(fourth.bounds.height).toEqual(40)
+})
+
+it("can pad & expand by position", () => {
+    const bounds = new Bounds(10, 10, 100, 100)
+
+    const pad = { top: 5, bottom: 10, left: 20, right: 50 }
+    const paddedBounds = bounds.pad(pad)
+    expect(paddedBounds.x).toEqual(30)
+    expect(paddedBounds.y).toEqual(15)
+    expect(paddedBounds.width).toEqual(30)
+    expect(paddedBounds.height).toEqual(85)
+
+    const expandedBounds = paddedBounds.expand(pad)
+    expect(expandedBounds.equals(bounds)).toBeTruthy()
 })

--- a/clientUtils/Bounds.ts
+++ b/clientUtils/Bounds.ts
@@ -1,7 +1,7 @@
-import { isNumber, mapValues, range, GridParameters } from "./Util"
+import { isNumber, mapValues, range } from "./Util"
 import { PointVector } from "./PointVector"
 import pixelWidth from "string-pixel-width"
-import { Box, Position, PositionMap } from "./owidTypes"
+import { Box, GridParameters, Position, PositionMap } from "./owidTypes"
 
 // Important utility class for all visualizations
 // Since we want to be able to render charts headlessly and functionally, we

--- a/clientUtils/Bounds.ts
+++ b/clientUtils/Bounds.ts
@@ -1,7 +1,12 @@
 import { isNumber, makeGrid, mapValues, range } from "./Util"
 import { PointVector } from "./PointVector"
 import pixelWidth from "string-pixel-width"
-import { Box, Position, PositionMap } from "./owidTypes"
+import {
+    Box,
+    IDEAL_CHART_ASPECT_RATIO,
+    Position,
+    PositionMap,
+} from "./owidTypes"
 
 // Important utility class for all visualizations
 // Since we want to be able to render charts headlessly and functionally, we
@@ -321,7 +326,11 @@ export class Bounds {
         return [this.left, this.right]
     }
 
-    grid(pieces: number, padding: SplitBoundsPadding = {}): GridBounds[] {
+    grid(
+        pieces: number,
+        idealAspectRatio: number = IDEAL_CHART_ASPECT_RATIO,
+        padding: SplitBoundsPadding = {}
+    ): GridBounds[] {
         // Splits a rectangle into smaller rectangles.
         // The Facet Storybook has a visual demo of how this works.
         // I form the smallest possible square and then fill that up. This always goes left to right, top down.
@@ -330,7 +339,12 @@ export class Bounds {
         // NB: The off-by-one-pixel scenarios have NOT yet been unit tested. Karma points for the person who adds those tests and makes
         // any required adjustments.
         const { columnPadding = 0, rowPadding = 0, outerPadding = 0 } = padding
-        const { columns, rows } = makeGrid(pieces)
+        const containerAspectRatio = this.width / this.height
+        const { columns, rows } = makeGrid(
+            pieces,
+            containerAspectRatio,
+            idealAspectRatio
+        )
         const contentWidth =
             this.width - columnPadding * (columns - 1) - outerPadding * 2
         const contentHeight =

--- a/clientUtils/Bounds.ts
+++ b/clientUtils/Bounds.ts
@@ -229,7 +229,7 @@ export class Bounds {
         )
     }
 
-    extend(props: {
+    set(props: {
         x?: number
         y?: number
         width?: number

--- a/clientUtils/Bounds.ts
+++ b/clientUtils/Bounds.ts
@@ -1,12 +1,7 @@
-import { isNumber, makeGrid, mapValues, range } from "./Util"
+import { isNumber, mapValues, range, GridParameters } from "./Util"
 import { PointVector } from "./PointVector"
 import pixelWidth from "string-pixel-width"
-import {
-    Box,
-    IDEAL_CHART_ASPECT_RATIO,
-    Position,
-    PositionMap,
-} from "./owidTypes"
+import { Box, Position, PositionMap } from "./owidTypes"
 
 // Important utility class for all visualizations
 // Since we want to be able to render charts headlessly and functionally, we
@@ -327,31 +322,20 @@ export class Bounds {
     }
 
     grid(
-        pieces: number,
-        idealAspectRatio: number = IDEAL_CHART_ASPECT_RATIO,
+        gridParams: GridParameters,
         padding: SplitBoundsPadding = {}
     ): GridBounds[] {
-        // Splits a rectangle into smaller rectangles.
-        // The Facet Storybook has a visual demo of how this works.
-        // I form the smallest possible square and then fill that up. This always goes left to right, top down.
-        // So when we don't have a round number we first add a column, then a row, etc, until we reach the next square.
-        // In the future we may want to position these bounds in custom ways, but this only does basic splitting for now.
-        // NB: The off-by-one-pixel scenarios have NOT yet been unit tested. Karma points for the person who adds those tests and makes
-        // any required adjustments.
+        const { columns, rows } = gridParams
         const { columnPadding = 0, rowPadding = 0, outerPadding = 0 } = padding
-        const containerAspectRatio = this.width / this.height
-        const { columns, rows } = makeGrid(
-            pieces,
-            containerAspectRatio,
-            idealAspectRatio
-        )
+
         const contentWidth =
             this.width - columnPadding * (columns - 1) - outerPadding * 2
         const contentHeight =
             this.height - rowPadding * (rows - 1) - outerPadding * 2
         const boxWidth = Math.floor(contentWidth / columns)
         const boxHeight = Math.floor(contentHeight / rows)
-        return range(0, pieces).map((index: number) => {
+
+        return range(0, rows * columns).map((index: number) => {
             const col = index % columns
             const row = Math.floor(index / columns)
             const edges = new Set<Position>()

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -571,12 +571,22 @@ const shuffleArray = <T>(array: T[], seed = Date.now()): T[] => {
     return clonedArr
 }
 
-export const makeGrid = (pieces: number): { columns: number; rows: number } => {
-    const columns = Math.ceil(Math.sqrt(pieces))
-    const rows = Math.ceil(pieces / columns)
+export const makeGrid = (
+    n: number,
+    containerAspectRatio: number,
+    idealAspectRatio: number
+): { columns: number; rows: number } => {
+    // See Observable notebook: https://observablehq.com/@danielgavrilov/pack-rectangles-of-a-preferred-aspect-ratio
+    // Also Desmos graph: https://www.desmos.com/calculator/tmajzuq5tm
+    const ratio = containerAspectRatio / idealAspectRatio
+    // prefer vertical grid for count=2
+    if (n === 2 && ratio < 2) return { rows: 2, columns: 1 }
+    // otherwise, optimize for closest to the ideal aspect ratio
+    const columns = Math.min(Math.round(Math.sqrt(n * ratio)), n)
+    const rows = Math.ceil(n / columns)
     return {
-        columns,
         rows,
+        columns,
     }
 }
 

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -115,7 +115,7 @@ import {
     ScaleType,
     VerticalAlign,
     HorizontalAlign,
-    IDEAL_CHART_ASPECT_RATIO,
+    IDEAL_PLOT_ASPECT_RATIO,
     GridParameters,
 } from "./owidTypes"
 import { PointVector } from "./PointVector"
@@ -576,7 +576,7 @@ const shuffleArray = <T>(array: T[], seed = Date.now()): T[] => {
 export const getIdealGridParams = ({
     count,
     containerAspectRatio,
-    idealAspectRatio = IDEAL_CHART_ASPECT_RATIO,
+    idealAspectRatio = IDEAL_PLOT_ASPECT_RATIO,
 }: {
     count: number
     containerAspectRatio: number

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -116,6 +116,7 @@ import {
     VerticalAlign,
     HorizontalAlign,
     IDEAL_CHART_ASPECT_RATIO,
+    GridParameters,
 } from "./owidTypes"
 import { PointVector } from "./PointVector"
 import { isNegativeInfinity, isPositiveInfinity } from "./TimeBounds"
@@ -570,11 +571,6 @@ const shuffleArray = <T>(array: T[], seed = Date.now()): T[] => {
         ]
     }
     return clonedArr
-}
-
-export interface GridParameters {
-    rows: number
-    columns: number
 }
 
 export const getIdealGridParams = ({

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -83,6 +83,7 @@ export {
     pick,
     range,
     reverse,
+    round,
     sample,
     sampleSize,
     sortBy,

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -115,6 +115,7 @@ import {
     ScaleType,
     VerticalAlign,
     HorizontalAlign,
+    IDEAL_CHART_ASPECT_RATIO,
 } from "./owidTypes"
 import { PointVector } from "./PointVector"
 import { isNegativeInfinity, isPositiveInfinity } from "./TimeBounds"
@@ -571,19 +572,28 @@ const shuffleArray = <T>(array: T[], seed = Date.now()): T[] => {
     return clonedArr
 }
 
-export const makeGrid = (
-    n: number,
-    containerAspectRatio: number,
-    idealAspectRatio: number
-): { columns: number; rows: number } => {
+export interface GridParameters {
+    rows: number
+    columns: number
+}
+
+export const getIdealGridParams = ({
+    count,
+    containerAspectRatio,
+    idealAspectRatio = IDEAL_CHART_ASPECT_RATIO,
+}: {
+    count: number
+    containerAspectRatio: number
+    idealAspectRatio?: number
+}): GridParameters => {
     // See Observable notebook: https://observablehq.com/@danielgavrilov/pack-rectangles-of-a-preferred-aspect-ratio
     // Also Desmos graph: https://www.desmos.com/calculator/tmajzuq5tm
     const ratio = containerAspectRatio / idealAspectRatio
     // prefer vertical grid for count=2
-    if (n === 2 && ratio < 2) return { rows: 2, columns: 1 }
+    if (count === 2 && ratio < 2) return { rows: 2, columns: 1 }
     // otherwise, optimize for closest to the ideal aspect ratio
-    const columns = Math.min(Math.round(Math.sqrt(n * ratio)), n)
-    const rows = Math.ceil(n / columns)
+    const columns = Math.min(Math.round(Math.sqrt(count * ratio)), count)
+    const rows = Math.ceil(count / columns)
     return {
         rows,
         columns,

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -1080,3 +1080,7 @@ export const dyFromAlign = (align: VerticalAlign): string => {
     if (align === VerticalAlign.bottom) return ".71em"
     return "0"
 }
+
+export const values = <Obj>(obj: Obj): Obj[keyof Obj][] => {
+    return Object.values(obj)
+}

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -106,7 +106,15 @@ import { formatLocale } from "d3-format"
 import striptags from "striptags"
 import parseUrl from "url-parse"
 import linkifyHtml from "linkifyjs/html"
-import { SortOrder, Integer, Time, EPOCH_DATE, ScaleType } from "./owidTypes"
+import {
+    SortOrder,
+    Integer,
+    Time,
+    EPOCH_DATE,
+    ScaleType,
+    VerticalAlign,
+    HorizontalAlign,
+} from "./owidTypes"
 import { PointVector } from "./PointVector"
 import { isNegativeInfinity, isPositiveInfinity } from "./TimeBounds"
 
@@ -1057,4 +1065,18 @@ export const wrapInDiv = (el: Element, classes?: string[]): Element => {
     el.parentNode.insertBefore(wrapper, el)
     wrapper.appendChild(el)
     return wrapper
+}
+
+export const textAnchorFromAlign = (
+    align: HorizontalAlign
+): "start" | "middle" | "end" => {
+    if (align === HorizontalAlign.center) return "middle"
+    if (align === HorizontalAlign.right) return "end"
+    return "start"
+}
+
+export const dyFromAlign = (align: VerticalAlign): string => {
+    if (align === VerticalAlign.middle) return ".32em"
+    if (align === VerticalAlign.bottom) return ".71em"
+    return "0"
 }

--- a/clientUtils/formatValue.ts
+++ b/clientUtils/formatValue.ts
@@ -8,7 +8,6 @@ export interface TickFormattingOptions {
     numberPrefixes?: boolean
     shortNumberPrefixes?: boolean
     showPlus?: boolean
-    isFirstOrLastTick?: boolean
 }
 
 // todo: Should this be numberSuffixes instead of Prefixes?

--- a/clientUtils/formatValue.ts
+++ b/clientUtils/formatValue.ts
@@ -53,6 +53,13 @@ export function formatValue(
                 noSpaceUnit: shortNumberPrefixes,
                 numDecimalPlaces: 2,
             })
+    } else if (!isNoSpaceUnit && shortNumberPrefixes && absValue >= 1e3) {
+        output = formatValue(value / 1e3, {
+            ...options,
+            unit: "k",
+            noSpaceUnit: true,
+            numDecimalPlaces: 2,
+        })
     } else {
         const targetDigits = Math.pow(10, -numDecimalPlaces)
 

--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -1,6 +1,8 @@
 // todo: remove when we ditch Year and YearIsDay
 export const EPOCH_DATE = "2020-01-21"
 
+export const IDEAL_CHART_ASPECT_RATIO: number = 1.41667
+
 export interface Box {
     x: number
     y: number

--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -1,7 +1,8 @@
 // todo: remove when we ditch Year and YearIsDay
 export const EPOCH_DATE = "2020-01-21"
 
-export const IDEAL_CHART_ASPECT_RATIO: number = 1.41667
+/** The "plot" is a chart without any header, footer or controls */
+export const IDEAL_PLOT_ASPECT_RATIO: number = 1.8
 
 export interface Box {
     x: number

--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -293,3 +293,8 @@ export enum VerticalAlign {
     middle = "middle",
     bottom = "bottom",
 }
+
+export interface GridParameters {
+    rows: number
+    columns: number
+}

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -279,7 +279,7 @@ export class Explorer
             tableSlug,
             yScaleToggle,
             yAxisMin,
-            facetYRange,
+            facetYDomain,
         } = grapherConfigFromExplorer
 
         const hasGrapherId = grapherId && isNotErrorValue(grapherId)
@@ -299,8 +299,8 @@ export class Explorer
         grapher.reset()
         grapher.yAxis.canChangeScaleType = yScaleToggle
         grapher.yAxis.min = yAxisMin
-        if (facetYRange) {
-            grapher.yAxis.facetAxisRange = facetYRange
+        if (facetYDomain) {
+            grapher.yAxis.facetDomain = facetYDomain
         }
         grapher.updateFromObject(config)
 

--- a/explorer/ExplorerProgram.test.ts
+++ b/explorer/ExplorerProgram.test.ts
@@ -117,12 +117,12 @@ graphers
         expect(grapherConfig).toEqual({ title: "Foo", ySlugs: "gdp" })
     })
 
-    it("can set a facet y range", () => {
+    it("can set a facet y domain", () => {
         const grapherConfig = new ExplorerProgram(
             "test",
-            `facetYRange\tindependent`
+            `facetYDomain\tindependent`
         ).tuplesObject
-        expect(grapherConfig).toEqual({ facetYRange: "independent" })
+        expect(grapherConfig).toEqual({ facetYDomain: "independent" })
     })
 
     it("prefers inline data to url if it has both", () => {

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -32,7 +32,7 @@ import { ColumnGrammar } from "./ColumnGrammar"
 import { DecisionMatrix } from "./ExplorerDecisionMatrix"
 import { CoreColumnDef } from "../coreTable/CoreColumnDef"
 import { PromiseCache } from "../clientUtils/PromiseCache"
-import { FacetAxisRange } from "../grapher/core/GrapherConstants"
+import { FacetAxisDomain } from "../grapher/core/GrapherConstants"
 
 export const EXPLORER_FILE_SUFFIX = ".explorer.tsv"
 
@@ -47,7 +47,7 @@ interface ExplorerGrapherInterface extends GrapherInterface {
     tableSlug?: string
     yScaleToggle?: boolean
     yAxisMin?: number
-    facetYRange?: FacetAxisRange
+    facetYDomain?: FacetAxisDomain
 }
 
 const ExplorerRootDef: CellDef = {

--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -11,7 +11,7 @@ import {
 } from "../gridLang/GridLangConstants"
 import {
     ChartTypeName,
-    FacetAxisRange,
+    FacetAxisDomain,
     FacetStrategy,
     GrapherTabOption,
 } from "../grapher/core/GrapherConstants"
@@ -133,12 +133,12 @@ export const GrapherGrammar: Grammar = {
         keyword: "yAxisMin",
         description: "Set the minimum value for the yAxis",
     },
-    facetYRange: {
+    facetYDomain: {
         ...EnumCellDef,
-        keyword: "facetYRange",
+        keyword: "facetYDomain",
         description:
-            "Whether facets axes default to shared or independent range",
-        terminalOptions: Object.keys(FacetAxisRange).map((keyword) => ({
+            "Whether facets axes default to shared or independent domain",
+        terminalOptions: Object.keys(FacetAxisDomain).map((keyword) => ({
             keyword,
             description: "",
             cssClass: "",

--- a/grapher/axis/Axis.test.ts
+++ b/grapher/axis/Axis.test.ts
@@ -104,3 +104,15 @@ it("creates compact labels", () => {
         tickLabels.every((tickLabel) => tickLabel.formattedValue.endsWith("k"))
     ).toBeTruthy()
 })
+
+it("a single-value domain plots to lower or upper end of range", () => {
+    const config: AxisConfigInterface = {
+        min: 0,
+        max: 0,
+    }
+    const axis = new AxisConfig(config).toVerticalAxis()
+    axis.range = [0, 500]
+    expect(axis.place(-1)).toEqual(0)
+    expect(axis.place(0)).toEqual(0)
+    expect(axis.place(1)).toEqual(500)
+})

--- a/grapher/axis/Axis.test.ts
+++ b/grapher/axis/Axis.test.ts
@@ -16,7 +16,6 @@ it("can create an axis", () => {
 
     const ticks = axis.getTickValues()
     expect(ticks.length).toBeGreaterThan(1)
-    expect(axis.getFormattedTicks().length).toEqual(ticks.length)
 })
 
 it("can assign a column to an axis", () => {

--- a/grapher/axis/Axis.test.ts
+++ b/grapher/axis/Axis.test.ts
@@ -4,6 +4,7 @@ import { HorizontalAxis } from "../axis/Axis"
 import { ScaleType } from "../core/GrapherConstants"
 import { SynthesizeGDPTable } from "../../coreTable/OwidTableSynthesizers"
 import { AxisConfig } from "./AxisConfig"
+import { AxisConfigInterface } from "./AxisConfigInterface"
 
 it("can create an axis", () => {
     const axisConfig = new AxisConfig({
@@ -14,6 +15,7 @@ it("can create an axis", () => {
     const axis = new HorizontalAxis(axisConfig)
     expect(axis.domain).toEqual([0, 100])
 
+    axis.range = [0, 200]
     const ticks = axis.getTickValues()
     expect(ticks.length).toBeGreaterThan(1)
 })
@@ -27,8 +29,78 @@ it("can assign a column to an axis", () => {
     const table = SynthesizeGDPTable()
     const axis = new HorizontalAxis(axisConfig)
     axis.formatColumn = table.get("GDP")
-    axis.clone()
+    axis.range = [0, 200]
 
     const ticks = axis.getTickValues()
     expect(ticks.length).toBeGreaterThan(1)
+})
+
+it("respects minSize unless hidden", () => {
+    const config: AxisConfigInterface = {
+        min: 0,
+        max: 100,
+    }
+    const { size } = new AxisConfig(config).toHorizontalAxis()
+    const configWithMinSize: AxisConfigInterface = {
+        ...config,
+        minSize: size + 10,
+    }
+    const axisWithMinSize = new AxisConfig(configWithMinSize).toHorizontalAxis()
+    expect(axisWithMinSize.size).toEqual(size + 10)
+
+    const hiddenAxis = new AxisConfig({
+        ...configWithMinSize,
+        hideAxis: true,
+    }).toHorizontalAxis()
+    expect(hiddenAxis.size).toEqual(0)
+})
+
+it("respects maxTicks parameter", () => {
+    const config: AxisConfigInterface = {
+        min: 0,
+        max: 100,
+        maxTicks: 10,
+    }
+    const axis = new AxisConfig(config).toVerticalAxis()
+    axis.range = [0, 500]
+
+    const axisWithLessTicks = new AxisConfig({
+        ...config,
+        maxTicks: 1,
+    }).toVerticalAxis()
+
+    expect(axis.getTickValues().length).toBeGreaterThan(
+        axisWithLessTicks.getTickValues().length
+    )
+})
+
+it("respects nice parameter", () => {
+    const config: AxisConfigInterface = {
+        min: 0.0001,
+        max: 99.9999,
+        maxTicks: 2,
+        nice: true,
+    }
+    const axis = new AxisConfig(config).toVerticalAxis()
+    axis.range = [0, 300]
+    const tickValues = axis.getTickValues()
+    expect(tickValues[0].value).toEqual(0)
+    expect(tickValues[tickValues.length - 1].value).toEqual(100)
+})
+
+it("creates compact labels", () => {
+    const config: AxisConfigInterface = {
+        min: 1000,
+        max: 4000,
+        maxTicks: 3,
+        compactLabels: true,
+    }
+    const axis = new AxisConfig(config).toVerticalAxis()
+    axis.range = [0, 500]
+    axis.formatColumn = SynthesizeGDPTable().get("GDP")
+    const { tickLabels } = axis
+    expect(tickLabels.length).toBeGreaterThan(0)
+    expect(
+        tickLabels.every((tickLabel) => tickLabel.formattedValue.endsWith("k"))
+    ).toBeTruthy()
 })

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -210,13 +210,13 @@ abstract class AbstractAxis {
             // * priority 3 (lowest) to all other ("in-between") values (e.g. 70, 300)
             //
             // We then decide depending on the number of tick candidates what to do:
-            // * if we have less than `totalTicks`, just show all
-            // * if we have betwenn `totalTicks` and `2 * totalTicks`, show all "in-between" lines
+            // * if we have less than `maxLabelledTicks`, just show all
+            // * if we have between `maxLabelledTicks` and `maxTicks`, show all "in-between" lines
             //   as faint grid lines without labels to give the chart that log paper look.
             //   We also show all priority 1 and 2 lines with labels, because there aren't too many
             //   of them.
             // * otherwise, remove priority 3 and, if necessary, priority 2 labels until we're below
-            //   `totalTicks` labels overall
+            //   `maxLabelledTicks` labels overall
             //
             // -@MarcelGerber, 2020-08-07
             const tickCandidates = d3_scale.ticks(maxTicks)

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -408,6 +408,7 @@ export class HorizontalAxis extends AbstractAxis {
     }
 
     @computed get height(): number {
+        if (this.hideAxis) return 0
         const { labelOffset, labelPadding } = this
         const maxTickHeight = max(this.tickLabels.map((tick) => tick.height))
         const height = maxTickHeight
@@ -502,6 +503,7 @@ export class VerticalAxis extends AbstractAxis {
     }
 
     @computed get width(): number {
+        if (this.hideAxis) return 0
         const { labelOffset, labelPadding } = this
         const maxTickWidth = max(this.tickLabels.map((tick) => tick.width))
         const width =
@@ -571,14 +573,14 @@ export class DualAxis {
     @computed private get horizontalAxisHeight(): number {
         const axis = this.props.horizontalAxis.clone()
         axis.range = [0, this.bounds.width]
-        return axis.hideAxis ? 0 : axis.height
+        return axis.height
     }
 
     // We calculate an initial width from the range of the input bounds
     @computed private get verticalAxisWidth(): number {
         const axis = this.props.verticalAxis.clone()
         axis.range = [0, this.bounds.height]
-        return axis.hideAxis ? 0 : axis.width
+        return axis.width
     }
 
     // Now we can determine the "true" inner bounds of the dual axis

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -1,6 +1,13 @@
 import { scaleLog, scaleLinear, ScaleLinear, ScaleLogarithmic } from "d3-scale"
 import { observable, computed } from "mobx"
-import { rollingMap, min, uniq, sortBy, max } from "../../clientUtils/Util"
+import {
+    rollingMap,
+    min,
+    uniq,
+    sortBy,
+    max,
+    numberMagnitude,
+} from "../../clientUtils/Util"
 import { Bounds, DEFAULT_BOUNDS } from "../../clientUtils/Bounds"
 import { TextWrap } from "../text/TextWrap"
 import { AxisConfig } from "./AxisConfig"
@@ -302,8 +309,8 @@ abstract class AbstractAxis {
         )
         if (minDist !== undefined) {
             // Find the decimal places required to reach the first non-zero digit
-            const dp = Math.ceil(-Math.log10(minDist))
-            if (isFinite(dp) && dp >= 0) {
+            const dp = -numberMagnitude(minDist) + 1
+            if (dp >= 0) {
                 options.numDecimalPlaces = dp
             }
         }

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -297,9 +297,8 @@ abstract class AbstractAxis {
         // See: https://github.com/d3/d3-array/blob/master/README.md#ticks
         //
         // -@danielgavrilov, 2020-05-27
-        const tickValues = this.getTickValues()
         const minDist = min(
-            rollingMap(tickValues, (a, b) => Math.abs(a.value - b.value))
+            rollingMap(this.baseTicks, (a, b) => Math.abs(a.value - b.value))
         )
         if (minDist !== undefined) {
             // Find the decimal places required to reach the first non-zero digit

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -102,6 +102,10 @@ abstract class AbstractAxis {
         return this.config.fontSize
     }
 
+    @computed private get maxTicks(): number {
+        return this.config.maxTicks
+    }
+
     @computed get scaleType(): ScaleType {
         return this._scaleType ?? (this.config.scaleType || ScaleType.linear)
     }
@@ -161,7 +165,9 @@ abstract class AbstractAxis {
         // a reasonable lower bound is. A maximum of 10 ticks arbitrarily chosen.
         // NOTE: This setting is used between both log & linear axes, check both when tweaking.
         // -@danielgavrilov, 2021-06-15
-        return Math.ceil(Math.min(10, this.rangeSize / (this.fontSize * 1.65)))
+        return Math.ceil(
+            Math.min(this.maxTicks, this.rangeSize / (this.fontSize * 1.65))
+        )
     }
 
     getTickValues(): Tickmark[] {

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -77,15 +77,15 @@ abstract class AbstractAxis {
     abstract placeTickLabel(value: number): TickLabelPlacement
 
     @computed get hideAxis(): boolean {
-        return this.config.hideAxis
+        return this.config.hideAxis ?? false
     }
 
     @computed get labelPadding(): number {
-        return this.config.labelPadding
+        return this.config.labelPadding ?? 5
     }
 
     @computed get nice(): boolean {
-        return this.config.nice
+        return this.config.nice ?? false
     }
 
     @computed get fontSize(): number {
@@ -93,7 +93,7 @@ abstract class AbstractAxis {
     }
 
     @computed private get maxTicks(): number {
-        return this.config.maxTicks
+        return this.config.maxTicks ?? 6
     }
 
     @computed get canChangeScaleType(): boolean | undefined {
@@ -101,7 +101,7 @@ abstract class AbstractAxis {
     }
 
     @computed get scaleType(): ScaleType {
-        return this._scaleType ?? (this.config.scaleType || ScaleType.linear)
+        return this._scaleType ?? this.config.scaleType ?? ScaleType.linear
     }
 
     set scaleType(value: ScaleType) {

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -266,6 +266,10 @@ abstract class AbstractAxis {
     }
 
     private getTickFormattingOptions(): TickFormattingOptions {
+        const options: TickFormattingOptions = {}
+        if (this.config.compactLabels) {
+            options.shortNumberPrefixes = true
+        }
         // The chart's tick formatting function is used by default to format axis ticks. This means
         // that the chart's `numDecimalPlaces` is also used by default to format the axis ticks.
         //
@@ -291,13 +295,14 @@ abstract class AbstractAxis {
         const minDist = min(
             rollingMap(tickValues, (a, b) => Math.abs(a.value - b.value))
         )
-        if (minDist === undefined) return {}
-
-        // Find the decimal places required to reach the first non-zero digit
-        const dp = Math.ceil(-Math.log10(minDist))
-        if (isFinite(dp) && dp >= 0) return { numDecimalPlaces: dp }
-
-        return {}
+        if (minDist !== undefined) {
+            // Find the decimal places required to reach the first non-zero digit
+            const dp = Math.ceil(-Math.log10(minDist))
+            if (isFinite(dp) && dp >= 0) {
+                options.numDecimalPlaces = dp
+            }
+        }
+        return options
     }
 
     getFormattedTicks(): string[] {

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -320,6 +320,15 @@ abstract class AbstractAxis {
         } else if (this.scaleType === ScaleType.log && value <= 0) {
             console.error(`Can't have ${value} which is <= 0 on a log scale`)
             return value
+        } else if (this.domain[0] === this.domain[1]) {
+            // When the domain is a single value, the D3 scale will by default place
+            // the value at the middle of the range.
+            // We instead want to place it at the end, in order to avoid an axis
+            // domain line being plotted in the middle of a chart (most of the time
+            // this occurs, the domain is [0, 0]).
+            //
+            // -@danielgavrilov, 2021-08-02
+            return value > this.domain[0] ? this.range[1] : this.range[0]
         }
         return parseFloat(this.d3_scale(value).toFixed(1))
     }

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -70,8 +70,13 @@ abstract class AbstractAxis {
         this.domain = [config.domain[0], config.domain[1]]
     }
 
-    abstract get position(): Position
+    /**
+     * The orthogonal size of the axis.
+     * For horizontal axes, this is the height.
+     * For vertical axes, this is the width.
+     */
     abstract get size(): number
+    abstract get position(): Position
     abstract get labelWidth(): number
 
     abstract placeTickLabel(value: number): TickLabelPlacement

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -226,7 +226,7 @@ abstract class AbstractAxis {
             //   `maxLabelledTicks` labels overall
             //
             // -@MarcelGerber, 2020-08-07
-            const tickCandidates = d3_scale.ticks(maxTicks)
+            const tickCandidates = d3_scale.ticks(maxLabelledTicks)
             ticks = tickCandidates.map((value) => {
                 // 10^x
                 if (Math.fround(Math.log10(value)) % 1 === 0)

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -175,7 +175,7 @@ abstract class AbstractAxis {
     /** The number of ticks we should _aim_ to show, not necessarily a strict target. */
     @computed private get totalTicksTarget(): number {
         // Chose 1.8 here by trying a bunch of different faceted charts and figuring out what
-        // a reasonable lower bound is. A maximum of 10 ticks arbitrarily chosen.
+        // a reasonable lower bound is.
         // NOTE: This setting is used between both log & linear axes, check both when tweaking.
         // -@danielgavrilov, 2021-06-15
         return Math.round(

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -76,6 +76,10 @@ abstract class AbstractAxis {
         return this.config.labelPadding
     }
 
+    @computed get nice(): boolean {
+        return this.config.nice
+    }
+
     // This will expand the domain but never shrink.
     // This will change the min unless the user's min setting is less
     // This will change the max unless the user's max setting is greater
@@ -135,7 +139,8 @@ abstract class AbstractAxis {
         | ScaleLogarithmic<number, number> {
         const d3Scale =
             this.scaleType === ScaleType.log ? scaleLog : scaleLinear
-        return d3Scale().domain(this.domain).range(this.range)
+        const scale = d3Scale().domain(this.domain).range(this.range)
+        return this.nice ? scale.nice(this.totalTicksTarget) : scale
     }
 
     @computed get rangeSize(): number {

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -250,13 +250,10 @@ abstract class AbstractAxis {
         } else {
             // Only use priority 2 here because we want the start / end ticks
             // to be priority 1
-            // Show a maximum of 6 ticks to match previous behaviour
-            ticks = d3_scale
-                .ticks(Math.min(6, this.totalTicksTarget))
-                .map((tickValue) => ({
-                    value: tickValue,
-                    priority: 2,
-                }))
+            ticks = d3_scale.ticks(this.totalTicksTarget).map((tickValue) => ({
+                value: tickValue,
+                priority: 2,
+            }))
         }
 
         if (this.hideFractionalTicks)

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -152,11 +152,11 @@ abstract class AbstractAxis {
 
     /** The number of ticks we should _aim_ to show, not necessarily a strict target. */
     @computed private get totalTicksTarget(): number {
-        // Chose 1.5 here by trying a bunch of different faceted charts and figuring out what
+        // Chose 1.65 here by trying a bunch of different faceted charts and figuring out what
         // a reasonable lower bound is. A maximum of 10 ticks arbitrarily chosen.
         // NOTE: This setting is used between both log & linear axes, check both when tweaking.
         // -@danielgavrilov, 2021-06-15
-        return Math.ceil(Math.min(10, this.rangeSize / (this.fontSize * 1.5)))
+        return Math.ceil(Math.min(10, this.rangeSize / (this.fontSize * 1.65)))
     }
 
     getTickValues(): Tickmark[] {

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -347,8 +347,10 @@ abstract class AbstractAxis {
                 if (t1 === t2 || t1.isHidden || t2.isHidden) continue
                 if (
                     doIntersect(
-                        boundsFromLabelPlacement(t1),
-                        boundsFromLabelPlacement(t2)
+                        // Expand bounds slightly so that labels aren't
+                        // too close together.
+                        boundsFromLabelPlacement(t1).expand(3),
+                        boundsFromLabelPlacement(t2).expand(3)
                     )
                 )
                     t2.isHidden = true

--- a/grapher/axis/AxisConfig.ts
+++ b/grapher/axis/AxisConfig.ts
@@ -30,6 +30,7 @@ class AxisConfigDefaults implements AxisConfigInterface {
     @observable.ref facetAxisRange: FacetAxisRange = FacetAxisRange.shared
     @observable.ref nice: boolean = false
     @observable.ref maxTicks: number = 10
+    @observable.ref compactLabels: boolean = false
 }
 
 export class AxisConfig
@@ -65,6 +66,7 @@ export class AxisConfig
             labelPadding: this.labelPadding,
             nice: this.nice,
             maxTicks: this.maxTicks,
+            compactLabels: this.compactLabels,
         })
 
         deleteRuntimeAndUnchangedProps(obj, new AxisConfigDefaults())

--- a/grapher/axis/AxisConfig.ts
+++ b/grapher/axis/AxisConfig.ts
@@ -1,6 +1,6 @@
 import {
     BASE_FONT_SIZE,
-    FacetAxisRange,
+    FacetAxisDomain,
     ScaleType,
 } from "../core/GrapherConstants"
 import { extend, trimObject } from "../../clientUtils/Util"
@@ -29,7 +29,7 @@ class AxisConfigDefaults implements AxisConfigInterface {
     @observable.ref maxTicks?: number = undefined
     @observable.ref compactLabels?: boolean = undefined
     @observable.ref scaleType?: ScaleType = ScaleType.linear
-    @observable.ref facetAxisRange?: FacetAxisRange = FacetAxisRange.shared
+    @observable.ref facetDomain?: FacetAxisDomain = FacetAxisDomain.shared
     @observable.ref label: string = ""
 }
 
@@ -66,7 +66,7 @@ export class AxisConfig
             compactLabels: this.compactLabels,
             scaleType: this.scaleType,
             label: this.label ? this.label : undefined,
-            facetAxisRange: this.facetAxisRange,
+            facetDomain: this.facetDomain,
         })
 
         deleteRuntimeAndUnchangedProps(obj, new AxisConfigDefaults())

--- a/grapher/axis/AxisConfig.ts
+++ b/grapher/axis/AxisConfig.ts
@@ -20,17 +20,17 @@ export interface FontSizeManager {
 class AxisConfigDefaults implements AxisConfigInterface {
     @observable.ref min?: number = undefined
     @observable.ref max?: number = undefined
-    @observable.ref scaleType?: ScaleType = ScaleType.linear
     @observable.ref canChangeScaleType?: boolean = undefined
-    @observable label: string = ""
     @observable.ref removePointsOutsideDomain?: boolean = undefined
     @observable.ref minSize?: number = undefined
-    @observable.ref hideAxis: boolean = false
-    @observable.ref labelPadding: number = 5
-    @observable.ref facetAxisRange: FacetAxisRange = FacetAxisRange.shared
-    @observable.ref nice: boolean = false
-    @observable.ref maxTicks: number = 6
-    @observable.ref compactLabels: boolean = false
+    @observable.ref hideAxis?: boolean = undefined
+    @observable.ref labelPadding?: number = undefined
+    @observable.ref nice?: boolean = undefined
+    @observable.ref maxTicks?: number = undefined
+    @observable.ref compactLabels?: boolean = undefined
+    @observable.ref scaleType?: ScaleType = ScaleType.linear
+    @observable.ref facetAxisRange?: FacetAxisRange = FacetAxisRange.shared
+    @observable.ref label: string = ""
 }
 
 export class AxisConfig
@@ -54,19 +54,19 @@ export class AxisConfig
 
     toObject(): AxisConfigInterface {
         const obj = trimObject({
-            scaleType: this.scaleType,
-            label: this.label ? this.label : undefined,
             min: this.min,
             max: this.max,
             canChangeScaleType: this.canChangeScaleType,
             removePointsOutsideDomain: this.removePointsOutsideDomain,
-            facetAxisRange: this.facetAxisRange,
             minSize: this.minSize,
             hideAxis: this.hideAxis,
             labelPadding: this.labelPadding,
             nice: this.nice,
             maxTicks: this.maxTicks,
             compactLabels: this.compactLabels,
+            scaleType: this.scaleType,
+            label: this.label ? this.label : undefined,
+            facetAxisRange: this.facetAxisRange,
         })
 
         deleteRuntimeAndUnchangedProps(obj, new AxisConfigDefaults())

--- a/grapher/axis/AxisConfig.ts
+++ b/grapher/axis/AxisConfig.ts
@@ -28,6 +28,7 @@ class AxisConfigDefaults {
     @observable.ref hideAxis: boolean = false
     @observable.ref labelPadding: number = 5
     @observable.ref facetAxisRange: FacetAxisRange = FacetAxisRange.shared
+    @observable.ref nice: boolean = false
 }
 
 export class AxisConfig
@@ -61,6 +62,7 @@ export class AxisConfig
             minSize: this.minSize,
             hideAxis: this.hideAxis,
             labelPadding: this.labelPadding,
+            nice: this.nice,
         })
 
         deleteRuntimeAndUnchangedProps(obj, new AxisConfigDefaults())

--- a/grapher/axis/AxisConfig.ts
+++ b/grapher/axis/AxisConfig.ts
@@ -25,7 +25,7 @@ class AxisConfigDefaults {
     @observable label: string = ""
     @observable.ref removePointsOutsideDomain?: boolean = undefined
     @observable.ref minSize?: number = undefined
-    @observable.ref hideAxis?: boolean = undefined
+    @observable.ref hideAxis: boolean = false
     @observable.ref labelPadding: number = 5
     @observable.ref facetAxisRange: FacetAxisRange = FacetAxisRange.shared
 }
@@ -43,7 +43,6 @@ export class AxisConfig
     }
 
     private fontSizeManager?: FontSizeManager
-    @observable hideAxis = false
 
     // todo: test/refactor
     updateFromObject(props?: AxisConfigInterface): void {

--- a/grapher/axis/AxisConfig.ts
+++ b/grapher/axis/AxisConfig.ts
@@ -29,7 +29,7 @@ class AxisConfigDefaults implements AxisConfigInterface {
     @observable.ref labelPadding: number = 5
     @observable.ref facetAxisRange: FacetAxisRange = FacetAxisRange.shared
     @observable.ref nice: boolean = false
-    @observable.ref maxTicks: number = 10
+    @observable.ref maxTicks: number = 6
     @observable.ref compactLabels: boolean = false
 }
 

--- a/grapher/axis/AxisConfig.ts
+++ b/grapher/axis/AxisConfig.ts
@@ -17,7 +17,7 @@ export interface FontSizeManager {
     fontSize: number
 }
 
-class AxisConfigDefaults {
+class AxisConfigDefaults implements AxisConfigInterface {
     @observable.ref min?: number = undefined
     @observable.ref max?: number = undefined
     @observable.ref scaleType?: ScaleType = ScaleType.linear
@@ -29,6 +29,7 @@ class AxisConfigDefaults {
     @observable.ref labelPadding: number = 5
     @observable.ref facetAxisRange: FacetAxisRange = FacetAxisRange.shared
     @observable.ref nice: boolean = false
+    @observable.ref maxTicks: number = 10
 }
 
 export class AxisConfig
@@ -63,6 +64,7 @@ export class AxisConfig
             hideAxis: this.hideAxis,
             labelPadding: this.labelPadding,
             nice: this.nice,
+            maxTicks: this.maxTicks,
         })
 
         deleteRuntimeAndUnchangedProps(obj, new AxisConfigDefaults())

--- a/grapher/axis/AxisConfigInterface.ts
+++ b/grapher/axis/AxisConfigInterface.ts
@@ -34,4 +34,9 @@ export interface AxisConfigInterface {
      * See: https://github.com/d3/d3-scale#continuous_ticks
      */
     maxTicks?: number
+
+    /**
+     * Whether to use short labels, e.g. "5k" instead of "5,000".
+     */
+    compactLabels?: boolean
 }

--- a/grapher/axis/AxisConfigInterface.ts
+++ b/grapher/axis/AxisConfigInterface.ts
@@ -22,4 +22,10 @@ export interface AxisConfigInterface {
      * - an axis label and an axis tick
      */
     labelPadding?: number
+
+    /**
+     * Extend scale to start & end on "nicer" round values.
+     * See: https://github.com/d3/d3-scale#continuous_nice
+     */
+    nice?: boolean
 }

--- a/grapher/axis/AxisConfigInterface.ts
+++ b/grapher/axis/AxisConfigInterface.ts
@@ -1,4 +1,4 @@
-import { FacetAxisRange, ScaleType } from "../core/GrapherConstants"
+import { FacetAxisDomain, ScaleType } from "../core/GrapherConstants"
 
 // Represents the actual entered configuration state in the editor
 export interface AxisConfigInterface {
@@ -13,7 +13,7 @@ export interface AxisConfigInterface {
     /**
      * Whether the axis domain should be the same across faceted charts (if possible)
      */
-    facetAxisRange?: FacetAxisRange
+    facetDomain?: FacetAxisDomain
 
     /**
      * Minimum pixels to take up.

--- a/grapher/axis/AxisConfigInterface.ts
+++ b/grapher/axis/AxisConfigInterface.ts
@@ -1,4 +1,4 @@
-import { ScaleType } from "../core/GrapherConstants"
+import { FacetAxisRange, ScaleType } from "../core/GrapherConstants"
 
 // Represents the actual entered configuration state in the editor
 export interface AxisConfigInterface {
@@ -9,6 +9,11 @@ export interface AxisConfigInterface {
     canChangeScaleType?: boolean
     removePointsOutsideDomain?: boolean
     hideAxis?: boolean
+
+    /**
+     * Whether the axis domain should be the same across faceted charts (if possible)
+     */
+    facetAxisRange?: FacetAxisRange
 
     /**
      * Minimum pixels to take up.

--- a/grapher/axis/AxisConfigInterface.ts
+++ b/grapher/axis/AxisConfigInterface.ts
@@ -28,4 +28,10 @@ export interface AxisConfigInterface {
      * See: https://github.com/d3/d3-scale#continuous_nice
      */
     nice?: boolean
+
+    /**
+     * The (rough) maximum number of ticks to show. Not a strict limit, more ticks may be shown.
+     * See: https://github.com/d3/d3-scale#continuous_ticks
+     */
+    maxTicks?: number
 }

--- a/grapher/axis/AxisViews.tsx
+++ b/grapher/axis/AxisViews.tsx
@@ -29,6 +29,10 @@ const dominantBaselineFromAlign = (
     return "auto"
 }
 
+const TICK_COLOR = "#ddd"
+const FAINT_TICK_COLOR = "#eee"
+const DOMAIN_TICK_COLOR = "#999"
+
 @observer
 export class VerticalAxisGridLines extends React.Component<{
     verticalAxis: VerticalAxis
@@ -43,10 +47,10 @@ export class VerticalAxisGridLines extends React.Component<{
             <g className={classNames("AxisGridLines", "horizontalLines")}>
                 {axis.getTickValues().map((t, i) => {
                     const color = t.faint
-                        ? "#eee"
+                        ? FAINT_TICK_COLOR
                         : t.value === 0
-                        ? "#ccc"
-                        : "#d3d3d3"
+                        ? DOMAIN_TICK_COLOR
+                        : TICK_COLOR
 
                     return (
                         <line
@@ -90,10 +94,10 @@ export class HorizontalAxisGridLines extends React.Component<{
             <g className={classNames("AxisGridLines", "verticalLines")}>
                 {axis.getTickValues().map((t, i) => {
                     const color = t.faint
-                        ? "#eee"
+                        ? FAINT_TICK_COLOR
                         : t.value === 0
-                        ? "#ccc"
-                        : "#d3d3d3"
+                        ? DOMAIN_TICK_COLOR
+                        : TICK_COLOR
 
                     return (
                         <line
@@ -249,7 +253,7 @@ export class HorizontalAxisComponent extends React.Component<{
                 tickMarkXPositions={tickLabels.map((label): number =>
                     axis.place(label.value)
                 )}
-                color="#ccc"
+                color={DOMAIN_TICK_COLOR}
             />
         ) : undefined
 

--- a/grapher/axis/AxisViews.tsx
+++ b/grapher/axis/AxisViews.tsx
@@ -6,25 +6,12 @@ import { VerticalAxis, HorizontalAxis, DualAxis } from "./Axis"
 import classNames from "classnames"
 import { ScaleType } from "../core/GrapherConstants"
 import { HorizontalAlign, VerticalAlign } from "../../clientUtils/owidTypes"
+import { dyFromAlign, textAnchorFromAlign } from "../../clientUtils/Util"
 
 const dasharrayFromFontSize = (fontSize: number): string => {
     const dashLength = Math.round((fontSize / 16) * 3)
     const spaceLength = Math.round((dashLength * 2) / 3)
     return `${dashLength},${spaceLength}`
-}
-
-const textAnchorFromAlign = (
-    align: HorizontalAlign
-): "start" | "middle" | "end" => {
-    if (align === HorizontalAlign.center) return "middle"
-    if (align === HorizontalAlign.right) return "end"
-    return "start"
-}
-
-const dyFromAlign = (align: VerticalAlign): string => {
-    if (align === VerticalAlign.middle) return ".32em"
-    if (align === VerticalAlign.bottom) return ".71em"
-    return "0"
 }
 
 const TICK_COLOR = "#ddd"

--- a/grapher/axis/AxisViews.tsx
+++ b/grapher/axis/AxisViews.tsx
@@ -253,10 +253,6 @@ export class HorizontalAxisComponent extends React.Component<{
                     return (
                         <text
                             key={i}
-                            // We use placeTickLabel() instead of using tick.x directly because the
-                            // range may have shifted e.g. to create space for the Y axis.
-                            // We use placeTickLabel() instead of place() because it sets an X
-                            // coordinate that may be different from the X coordinate of the tick mark.
                             x={x}
                             y={bounds.bottom - labelOffset}
                             fill={textColor}

--- a/grapher/axis/AxisViews.tsx
+++ b/grapher/axis/AxisViews.tsx
@@ -21,12 +21,10 @@ const textAnchorFromAlign = (
     return "start"
 }
 
-const dominantBaselineFromAlign = (
-    align: VerticalAlign
-): "auto" | "middle" | "hanging" => {
-    if (align === VerticalAlign.middle) return "middle"
-    if (align === VerticalAlign.bottom) return "hanging"
-    return "auto"
+const dyFromAlign = (align: VerticalAlign): string => {
+    if (align === VerticalAlign.middle) return ".32em"
+    if (align === VerticalAlign.bottom) return ".71em"
+    return "0"
 }
 
 const TICK_COLOR = "#ddd"
@@ -204,13 +202,11 @@ export class VerticalAxisComponent extends React.Component<{
                                 verticalAxis.labelPadding
                             ).toFixed(2)}
                             y={y}
-                            fill={textColor}
-                            dominantBaseline={dominantBaselineFromAlign(
-                                yAlign ?? VerticalAlign.middle
-                            )}
+                            dy={dyFromAlign(yAlign ?? VerticalAlign.middle)}
                             textAnchor={textAnchorFromAlign(
                                 xAlign ?? HorizontalAlign.right
                             )}
+                            fill={textColor}
                             fontSize={verticalAxis.tickFontSize}
                         >
                             {formattedValue}

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -23,7 +23,7 @@ import {
     HorizontalAxisGridLines,
 } from "../axis/AxisViews"
 import { NoDataModal } from "../noDataModal/NoDataModal"
-import { AxisConfig } from "../axis/AxisConfig"
+import { AxisConfig, FontSizeManager } from "../axis/AxisConfig"
 import { ColorSchemes } from "../color/ColorSchemes"
 import { ChartInterface } from "../chart/ChartInterface"
 import {
@@ -60,7 +60,7 @@ export class DiscreteBarChart
         bounds?: Bounds
         manager: DiscreteBarChartManager
     }>
-    implements ChartInterface {
+    implements ChartInterface, FontSizeManager {
     base: React.RefObject<SVGGElement> = React.createRef()
 
     transformTable(table: OwidTable): OwidTable {
@@ -112,7 +112,7 @@ export class DiscreteBarChart
         return (this.props.bounds ?? DEFAULT_BOUNDS).padRight(10)
     }
 
-    @computed private get baseFontSize(): number {
+    @computed get fontSize(): number {
         return this.manager.baseFontSize ?? BASE_FONT_SIZE
     }
 
@@ -121,7 +121,7 @@ export class DiscreteBarChart
         fontWeight: number
     } {
         return {
-            fontSize: 0.75 * this.baseFontSize,
+            fontSize: 0.75 * this.fontSize,
             fontWeight: 700,
         }
     }
@@ -131,7 +131,7 @@ export class DiscreteBarChart
         fontWeight: number
     } {
         return {
-            fontSize: 0.75 * this.baseFontSize,
+            fontSize: 0.75 * this.fontSize,
             fontWeight: 400,
         }
     }
@@ -202,7 +202,7 @@ export class DiscreteBarChart
     }
 
     @computed private get yAxisConfig(): AxisConfig {
-        return this.manager.yAxis || new AxisConfig()
+        return new AxisConfig(this.manager.yAxisConfig, this)
     }
 
     @computed get yAxis(): HorizontalAxis {

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -42,6 +42,7 @@ import { HeaderManager } from "../header/HeaderManager"
 import { exposeInstanceOnWindow } from "../../clientUtils/Util"
 import { SelectionArray } from "../selection/SelectionArray"
 import { EntityName } from "../../coreTable/OwidTableConstants"
+import { AxisConfig } from "../axis/AxisConfig"
 
 export interface CaptionedChartManager
     extends ChartManager,
@@ -58,6 +59,8 @@ export interface CaptionedChartManager
     fontSize?: number
     tab?: GrapherTabOption
     type?: ChartTypeName
+    yAxis?: AxisConfig
+    xAxis?: AxisConfig
     typeExceptWhenLineChartAndSingleTimeThenWillBeBarChart?: ChartTypeName
     isReady?: boolean
     whatAreWeWaitingFor?: string

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -29,8 +29,8 @@ import {
     SmallCountriesFilterManager,
     AbsRelToggleManager,
     HighlightToggleManager,
-    FacetYRangeToggle,
-    FacetYRangeToggleManager,
+    FacetYDomainToggle,
+    FacetYDomainToggleManager,
     FacetStrategyDropdown,
     FacetStrategyDropdownManager,
 } from "../controls/Controls"
@@ -52,7 +52,7 @@ export interface CaptionedChartManager
         AbsRelToggleManager,
         FooterManager,
         HeaderManager,
-        FacetYRangeToggleManager,
+        FacetYDomainToggleManager,
         FacetStrategyDropdownManager {
     containerElement?: HTMLDivElement
     tabBounds?: Bounds
@@ -71,7 +71,7 @@ export interface CaptionedChartManager
     showXScaleToggle?: boolean
     showZoomToggle?: boolean
     showAbsRelToggle?: boolean
-    showFacetYRangeToggle?: boolean
+    showFacetYDomainToggle?: boolean
     showHighlightToggle?: boolean
     showChangeEntityButton?: boolean
     showAddEntityButton?: boolean
@@ -267,9 +267,12 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         if (manager.showAbsRelToggle)
             controls.push(<AbsRelToggle key="AbsRelToggle" manager={manager} />)
 
-        if (manager.showFacetYRangeToggle)
+        if (manager.showFacetYDomainToggle)
             controls.push(
-                <FacetYRangeToggle key="FacetYRangeToggle" manager={manager} />
+                <FacetYDomainToggle
+                    key="FacetYDomainToggle"
+                    manager={manager}
+                />
             )
 
         if (manager.showHighlightToggle)

--- a/grapher/chart/ChartManager.ts
+++ b/grapher/chart/ChartManager.ts
@@ -1,4 +1,3 @@
-import { AxisConfig } from "../axis/AxisConfig"
 import { ColorScaleConfigInterface } from "../color/ColorScaleConfig"
 import {
     EntitySelectionMode,
@@ -37,12 +36,10 @@ export interface ChartManager {
     zoomToSelection?: boolean
     matchingEntitiesOnly?: boolean
 
-    colorScale?: ColorScaleConfigInterface
+    colorScale?: Readonly<ColorScaleConfigInterface>
 
-    yAxis?: AxisConfig // Remove? Just pass interfaces?
-    xAxis?: AxisConfig
-    yAxisConfig?: AxisConfigInterface
-    xAxisConfig?: AxisConfigInterface
+    yAxisConfig?: Readonly<AxisConfigInterface>
+    xAxisConfig?: Readonly<AxisConfigInterface>
 
     addCountryMode?: EntitySelectionMode
 

--- a/grapher/chart/ChartManager.ts
+++ b/grapher/chart/ChartManager.ts
@@ -62,9 +62,6 @@ export interface ChartManager {
     hidePoints?: boolean // for line options
     lineStrokeWidth?: number
 
-    hideXAxis?: boolean
-    hideYAxis?: boolean
-
     facetStrategy?: FacetStrategy // todo: make a strategy? a column prop? etc
 
     sortConfig?: SortConfig

--- a/grapher/chart/ChartManager.ts
+++ b/grapher/chart/ChartManager.ts
@@ -57,7 +57,6 @@ export interface ChartManager {
     seriesColorMap?: SeriesColorMap
 
     hidePoints?: boolean // for line options
-    lineStrokeWidth?: number
 
     facetStrategy?: FacetStrategy // todo: make a strategy? a column prop? etc
 

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -15,7 +15,7 @@ import { faShareAlt } from "@fortawesome/free-solid-svg-icons/faShareAlt"
 import { faExpand } from "@fortawesome/free-solid-svg-icons/faExpand"
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons/faExternalLinkAlt"
 import {
-    FacetAxisRange,
+    FacetAxisDomain,
     FacetStrategy,
     GrapherTabOption,
     HighlightToggleConfig,
@@ -131,24 +131,22 @@ export class AbsRelToggle extends React.Component<{
     }
 }
 
-export interface FacetYRangeToggleManager {
+export interface FacetYDomainToggleManager {
     yAxis?: AxisConfig
 }
 
 @observer
-export class FacetYRangeToggle extends React.Component<{
-    manager: FacetYRangeToggleManager
+export class FacetYDomainToggle extends React.Component<{
+    manager: FacetYDomainToggleManager
 }> {
     @action.bound onToggle(): void {
-        this.props.manager.yAxis!.facetAxisRange = this.isYRangeShared
-            ? FacetAxisRange.independent
-            : FacetAxisRange.shared
+        this.props.manager.yAxis!.facetDomain = this.isYDomainShared
+            ? FacetAxisDomain.independent
+            : FacetAxisDomain.shared
     }
 
-    @computed get isYRangeShared(): boolean {
-        return (
-            this.props.manager.yAxis!.facetAxisRange === FacetAxisRange.shared
-        )
+    @computed get isYDomainShared(): boolean {
+        return this.props.manager.yAxis!.facetDomain === FacetAxisDomain.shared
     }
 
     render(): JSX.Element {
@@ -156,9 +154,9 @@ export class FacetYRangeToggle extends React.Component<{
             <label className="clickable">
                 <input
                     type="checkbox"
-                    checked={this.isYRangeShared}
+                    checked={this.isYDomainShared}
                     onChange={this.onToggle}
-                    data-track-note="chart-facet-yrange-toggle"
+                    data-track-note="chart-facet-ydomain-toggle"
                 />{" "}
                 &nbsp;Uniform y-axis
             </label>

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1903,7 +1903,8 @@ export class Grapher
         // that could offer both, faceting by entity is strictly worse than the original together view.
         if (this.hasMultipleYColumns) {
             strategies.push(FacetStrategy.column)
-        } else if (this.selection.numSelectedEntities > 1) {
+        }
+        if (this.selection.numSelectedEntities > 1) {
             strategies.push(FacetStrategy.entity)
         }
 

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1836,7 +1836,7 @@ export class Grapher
         this.showFacets = !this.showFacets
     }
 
-    @computed get showFacetYRangeToggle(): boolean {
+    @computed get showFacetYDomainToggle(): boolean {
         // don't offer to make the y range relative if the range is discrete
         return this.facet !== FacetStrategy.none && !this.isStackedDiscreteBar
     }

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -165,6 +165,7 @@ import {
 import { ColumnTypeMap, CoreColumn } from "../../coreTable/CoreTableColumns"
 import { ChartInterface } from "../chart/ChartInterface"
 import { LegacyChartDimensionInterface } from "../../clientUtils/LegacyVariableDisplayConfigInterface"
+import { AxisConfigInterface } from "../axis/AxisConfigInterface"
 import Bugsnag from "@bugsnag/js"
 
 declare const window: any
@@ -500,6 +501,14 @@ export class Grapher
 
     @computed private get isOnMapTab(): boolean {
         return this.tab === GrapherTabOption.map
+    }
+
+    @computed get yAxisConfig(): Readonly<AxisConfigInterface> {
+        return this.yAxis.toObject()
+    }
+
+    @computed get xAxisConfig(): Readonly<AxisConfigInterface> {
+        return this.xAxis.toObject()
     }
 
     @computed get tableForSelection(): OwidTable {

--- a/grapher/core/GrapherConstants.ts
+++ b/grapher/core/GrapherConstants.ts
@@ -43,9 +43,9 @@ export enum FacetStrategy {
     column = "column", // One chart for each Y column
 }
 
-export enum FacetAxisRange {
-    independent = "independent", // all facets have their own y range
-    shared = "shared", // all facets share the same y range
+export enum FacetAxisDomain {
+    independent = "independent", // all facets have their own y domain
+    shared = "shared", // all facets share the same y domain
 }
 
 export enum SeriesStrategy {

--- a/grapher/core/schema.json
+++ b/grapher/core/schema.json
@@ -194,7 +194,7 @@
                 "canChangeScaleType": {
                     "type": "boolean"
                 },
-                "facetAxisRange": {
+                "facetDomain": {
                     "type": "string"
                 },
                 "numDecimalPlaces": {

--- a/grapher/facetChart/FacetChart.stories.tsx
+++ b/grapher/facetChart/FacetChart.stories.tsx
@@ -8,7 +8,7 @@ import {
 import { Bounds } from "../../clientUtils/Bounds"
 import { ChartTypeName, FacetStrategy } from "../core/GrapherConstants"
 import { Meta } from "@storybook/react"
-import { AxisConfig } from "../axis/AxisConfig"
+import { ChartManager } from "../chart/ChartManager"
 
 // See https://storybook.js.org/docs/react/essentials/controls for Control Types
 const CSF: Meta = {
@@ -24,12 +24,11 @@ export const OneMetricOneCountryPerChart = (): JSX.Element => {
     const table = SynthesizeGDPTable({
         entityCount: 4,
     })
-    const manager = {
+    const manager: ChartManager = {
         table,
         selection: table.availableEntityNames,
         yColumnSlug: SampleColumnSlugs.GDP,
         xColumnSlug: SampleColumnSlugs.Population,
-        yAxis: new AxisConfig(),
     }
 
     return (
@@ -55,7 +54,6 @@ export const MultipleMetricsOneCountryPerChart = (): JSX.Element => {
                 manager={{
                     selection: table.availableEntityNames,
                     table,
-                    yAxis: new AxisConfig(),
                 }}
             />
         </svg>

--- a/grapher/facetChart/FacetChart.test.ts
+++ b/grapher/facetChart/FacetChart.test.ts
@@ -115,7 +115,7 @@ describe("uniform axes", () => {
         )
     })
 
-    it("x axis is shared by default", () => {
+    it("x axis domains are identical", () => {
         expect(xAxisConfigs[0]?.min).toBeDefined()
         expect(xAxisConfigs[0]?.max).toBeDefined()
         expect(
@@ -126,15 +126,19 @@ describe("uniform axes", () => {
         ).toBeTruthy()
     })
 
-    it("shared bottom axis is shown in first row of facets", () => {
-        const first = chart.placedSeries[0]
-        const last = chart.placedSeries[xAxisConfigs.length - 1]
-        expect(first.bounds.height).toBeGreaterThan(last.bounds.height)
-        expect(first.bounds.height).toBeCloseTo(
-            last.bounds.height + (xAxisConfigs[0]?.minSize ?? 0),
-            0
-        )
+    it("x axis is shown on all facets", () => {
+        expect(xAxisConfigs.every((config) => !config?.hideAxis)).toBeTruthy()
     })
+
+    // it("shared bottom axis is shown in first row of facets", () => {
+    //     const first = chart.placedSeries[0]
+    //     const last = chart.placedSeries[xAxisConfigs.length - 1]
+    //     expect(first.bounds.height).toBeGreaterThan(last.bounds.height)
+    //     expect(first.bounds.height).toBeCloseTo(
+    //         last.bounds.height + (xAxisConfigs[0]?.minSize ?? 0),
+    //         0
+    //     )
+    // })
 })
 
 describe("config overrides", () => {

--- a/grapher/facetChart/FacetChart.test.ts
+++ b/grapher/facetChart/FacetChart.test.ts
@@ -5,7 +5,7 @@ import { SynthesizeGDPTable } from "../../coreTable/OwidTableSynthesizers"
 import { ChartManager } from "../chart/ChartManager"
 import {
     ChartTypeName,
-    FacetAxisRange,
+    FacetAxisDomain,
     FacetStrategy,
 } from "../core/GrapherConstants"
 import { uniq } from "../../clientUtils/Util"
@@ -58,7 +58,7 @@ describe("uniform axes", () => {
         selection: table.availableEntityNames,
         facetStrategy: FacetStrategy.entity,
         yAxisConfig: {
-            facetAxisRange: FacetAxisRange.shared,
+            facetDomain: FacetAxisDomain.shared,
         },
     }
     const chart = new FacetChart({
@@ -148,7 +148,7 @@ describe("config overrides", () => {
         facetStrategy: FacetStrategy.entity,
         yAxisConfig: {
             compactLabels: false,
-            facetAxisRange: FacetAxisRange.shared,
+            facetDomain: FacetAxisDomain.shared,
             min: -1e15,
             max: 1e15,
         },
@@ -169,7 +169,7 @@ describe("config overrides", () => {
         const newManager: ChartManager = {
             ...manager,
             yAxisConfig: {
-                facetAxisRange: FacetAxisRange.independent,
+                facetDomain: FacetAxisDomain.independent,
                 nice: true,
             },
         }

--- a/grapher/facetChart/FacetChart.test.ts
+++ b/grapher/facetChart/FacetChart.test.ts
@@ -4,14 +4,12 @@ import { FacetChart } from "./FacetChart"
 import { SynthesizeGDPTable } from "../../coreTable/OwidTableSynthesizers"
 import { ChartManager } from "../chart/ChartManager"
 import { FacetStrategy } from "../core/GrapherConstants"
-import { AxisConfig } from "../axis/AxisConfig"
 
 it("can create a new FacetChart", () => {
     const table = SynthesizeGDPTable({ timeRange: [2000, 2010] })
     const manager: ChartManager = {
         table,
         selection: table.availableEntityNames,
-        yAxis: new AxisConfig(),
     }
     const chart = new FacetChart({ manager })
 
@@ -31,7 +29,6 @@ it("uses the transformed data for display in country mode", () => {
         // simulate the transformation that is done by Grapher on the data
         transformedTable: table.filterByTimeRange(2002, 2008),
         facetStrategy: FacetStrategy.entity,
-        yAxis: new AxisConfig(),
     }
     const chart = new FacetChart({ manager })
 

--- a/grapher/facetChart/FacetChart.test.ts
+++ b/grapher/facetChart/FacetChart.test.ts
@@ -3,7 +3,16 @@
 import { FacetChart } from "./FacetChart"
 import { SynthesizeGDPTable } from "../../coreTable/OwidTableSynthesizers"
 import { ChartManager } from "../chart/ChartManager"
-import { FacetStrategy } from "../core/GrapherConstants"
+import {
+    ChartTypeName,
+    FacetAxisRange,
+    FacetStrategy,
+} from "../core/GrapherConstants"
+import { uniq } from "../../clientUtils/Util"
+
+const allElementsAreEqual = (array: any[]): boolean => {
+    return uniq(array).length === 1
+}
 
 it("can create a new FacetChart", () => {
     const table = SynthesizeGDPTable({ timeRange: [2000, 2010] })
@@ -36,5 +45,142 @@ it("uses the transformed data for display in country mode", () => {
     chart.series.forEach((s) => {
         expect(s.manager.table!.minTime).toEqual(2002)
         expect(s.manager.table!.maxTime).toEqual(2008)
+    })
+})
+
+describe("uniform axes", () => {
+    const table = SynthesizeGDPTable({
+        timeRange: [2000, 2010],
+        entityCount: 6,
+    })
+    const manager: ChartManager = {
+        table,
+        selection: table.availableEntityNames,
+        facetStrategy: FacetStrategy.entity,
+        yAxisConfig: {
+            facetAxisRange: FacetAxisRange.shared,
+        },
+    }
+    const chart = new FacetChart({
+        manager,
+        chartTypeName: ChartTypeName.LineChart,
+    })
+    const yAxisConfigs = chart.placedSeries.map(
+        (series) => series.manager.yAxisConfig
+    )
+    const xAxisConfigs = chart.placedSeries.map(
+        (series) => series.manager.xAxisConfig
+    )
+
+    it("creates correct number of facets", () => {
+        expect(chart.series.length).toEqual(6)
+    })
+
+    it("some y axes are collapsed", () => {
+        expect(
+            yAxisConfigs.some((config) => config?.hideAxis === true)
+        ).toBeTruthy()
+    })
+
+    it("y axes have compact labels", () => {
+        expect(
+            yAxisConfigs.every((config) => config?.compactLabels === true)
+        ).toBeTruthy()
+    })
+
+    it("y axis domains are identical", () => {
+        expect(yAxisConfigs[0]?.min).toBeDefined()
+        expect(yAxisConfigs[0]?.max).toBeDefined()
+        expect(
+            allElementsAreEqual(yAxisConfigs.map((config) => config?.min))
+        ).toBeTruthy()
+        expect(
+            allElementsAreEqual(yAxisConfigs.map((config) => config?.max))
+        ).toBeTruthy()
+    })
+
+    it("allocates space for shared y axis", () => {
+        const minSizes = yAxisConfigs.map((config) => config?.minSize)
+        expect(allElementsAreEqual(minSizes)).toBeTruthy()
+
+        const minSize = minSizes[0] ?? 0
+        expect(minSize).toBeGreaterThan(0)
+
+        expect(chart.placedSeries[0].bounds.width).toBeGreaterThan(
+            chart.placedSeries[1].bounds.width
+        )
+        expect(chart.placedSeries[0].bounds.width).toBeCloseTo(
+            chart.placedSeries[1].bounds.width + minSize,
+            0
+        )
+    })
+
+    it("x axis is shared by default", () => {
+        expect(xAxisConfigs[0]?.min).toBeDefined()
+        expect(xAxisConfigs[0]?.max).toBeDefined()
+        expect(
+            allElementsAreEqual(xAxisConfigs.map((config) => config?.min))
+        ).toBeTruthy()
+        expect(
+            allElementsAreEqual(xAxisConfigs.map((config) => config?.max))
+        ).toBeTruthy()
+    })
+
+    it("shared bottom axis is shown in first row of facets", () => {
+        const first = chart.placedSeries[0]
+        const last = chart.placedSeries[xAxisConfigs.length - 1]
+        expect(first.bounds.height).toBeGreaterThan(last.bounds.height)
+        expect(first.bounds.height).toBeCloseTo(
+            last.bounds.height + (xAxisConfigs[0]?.minSize ?? 0),
+            0
+        )
+    })
+})
+
+describe("config overrides", () => {
+    const table = SynthesizeGDPTable({
+        timeRange: [2000, 2010],
+        entityCount: 6,
+    })
+    const manager: ChartManager = {
+        table,
+        selection: table.availableEntityNames,
+        facetStrategy: FacetStrategy.entity,
+        yAxisConfig: {
+            compactLabels: false,
+            facetAxisRange: FacetAxisRange.shared,
+            min: -1e15,
+            max: 1e15,
+        },
+    }
+    const chart = new FacetChart({
+        manager,
+        chartTypeName: ChartTypeName.LineChart,
+    })
+
+    it("preserves config passed from manager", () => {
+        const yAxisConfig = chart.placedSeries[0].manager.yAxisConfig
+        expect(yAxisConfig?.compactLabels).toEqual(false)
+        expect(yAxisConfig?.min).toEqual(-1e15)
+        expect(yAxisConfig?.max).toEqual(1e15)
+    })
+
+    it("preserves axis nice parameter for independent axes", () => {
+        const newManager: ChartManager = {
+            ...manager,
+            yAxisConfig: {
+                facetAxisRange: FacetAxisRange.independent,
+                nice: true,
+            },
+        }
+        const chart = new FacetChart({
+            manager: newManager,
+            chartTypeName: ChartTypeName.LineChart,
+        })
+        expect(chart.placedSeries[0].manager.yAxisConfig?.nice).toEqual(true)
+    })
+
+    it("entity legend is hidden for single-metric facets by entity", () => {
+        expect(chart.placedSeries[0].manager.hideLegend).toEqual(true)
     })
 })

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -32,7 +32,11 @@ import {
     values,
 } from "../../clientUtils/Util"
 import { AxisConfigInterface } from "../axis/AxisConfigInterface"
-import { Position, PositionMap } from "../../clientUtils/owidTypes"
+import {
+    IDEAL_CHART_ASPECT_RATIO,
+    Position,
+    PositionMap,
+} from "../../clientUtils/owidTypes"
 import { AxisConfig, FontSizeManager } from "../axis/AxisConfig"
 import { HorizontalAxis, VerticalAxis } from "../axis/Axis"
 
@@ -154,6 +158,7 @@ export class FacetChart
         const baseFontSize = this.fontSize
         const gridBoundsArr = this.bounds.grid(
             count,
+            IDEAL_CHART_ASPECT_RATIO,
             getChartPadding(count, baseFontSize)
         )
         const {
@@ -300,6 +305,7 @@ export class FacetChart
         const count = this.intermediatePlacedSeries.length
         const gridBoundsArr = fullBounds.grid(
             count,
+            IDEAL_CHART_ASPECT_RATIO,
             getChartPadding(count, this.fontSize)
         )
         return this.intermediatePlacedSeries.map((series, i) => {

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -4,7 +4,7 @@ import { Bounds, DEFAULT_BOUNDS } from "../../clientUtils/Bounds"
 import { computed } from "mobx"
 import {
     ChartTypeName,
-    FacetAxisRange,
+    FacetAxisDomain,
     FacetStrategy,
     SeriesStrategy,
 } from "../core/GrapherConstants"
@@ -132,7 +132,7 @@ export class FacetChart
     }
 
     @computed private get uniformYAxis(): boolean {
-        return this.yAxisConfig.facetAxisRange === FacetAxisRange.shared
+        return this.yAxisConfig.facetDomain === FacetAxisDomain.shared
     }
 
     @computed private get uniformXAxis(): boolean {

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -110,15 +110,11 @@ export class FacetChart
                 series.chartTypeName ??
                 this.props.chartTypeName ??
                 ChartTypeName.LineChart
-            const hideXAxis = false // row < rows - 1 // todo: figure out design issues here
-            const hideYAxis = false // column > 0 // todo: figure out design issues here
             const hideLegend = false // !(column !== columns - 1) // todo: only show 1?
             const hidePoints = true
 
             const manager: ChartManager = {
                 table,
-                hideXAxis,
-                hideYAxis,
                 baseFontSize,
                 lineStrokeWidth,
                 hideLegend,

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -26,6 +26,8 @@ import { SelectionArray } from "../selection/SelectionArray"
 import { CoreColumn } from "../../coreTable/CoreTableColumns"
 import {
     excludeUndefined,
+    getIdealGridParams,
+    GridParameters,
     max,
     maxBy,
     min,
@@ -138,6 +140,16 @@ export class FacetChart
         return true
     }
 
+    @computed private get gridParams(): GridParameters {
+        const count = this.series.length
+        const containerAspectRatio = this.bounds.width / this.bounds.height
+        return getIdealGridParams({
+            count,
+            containerAspectRatio,
+            idealAspectRatio: IDEAL_CHART_ASPECT_RATIO,
+        })
+    }
+
     /**
      * Holds the intermediate render properties for chart views, before axes are synchronized,
      * collapsed, aligned, etc.
@@ -157,10 +169,10 @@ export class FacetChart
         // Copy properties from manager to facets
         const baseFontSize = this.fontSize
         const gridBoundsArr = this.bounds.grid(
-            count,
-            IDEAL_CHART_ASPECT_RATIO,
+            this.gridParams,
             getChartPadding(count, baseFontSize)
         )
+
         const {
             yColumnSlug,
             xColumnSlug,
@@ -304,8 +316,7 @@ export class FacetChart
         const fullBounds = this.bounds.pad(sharedAxesPadding)
         const count = this.intermediatePlacedSeries.length
         const gridBoundsArr = fullBounds.grid(
-            count,
-            IDEAL_CHART_ASPECT_RATIO,
+            this.gridParams,
             getChartPadding(count, this.fontSize)
         )
         return this.intermediatePlacedSeries.map((series, i) => {

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -153,8 +153,8 @@ export class FacetChart
             }
         )
         const sharedAxisPadding: PositionMap<number> = {}
-        const xAxisConfig: AxisConfigInterface = {}
-        const yAxisConfig: AxisConfigInterface = {}
+        const globalXAxisConfig: AxisConfigInterface = {}
+        const globalYAxisConfig: AxisConfigInterface = {}
         // set the axis minSize
         const chartInstanceWithLargestXAxis = maxBy(
             chartInstances,
@@ -162,7 +162,7 @@ export class FacetChart
         )
         if (chartInstanceWithLargestXAxis) {
             const { size } = chartInstanceWithLargestXAxis.xAxis!
-            xAxisConfig.minSize = size
+            globalXAxisConfig.minSize = size
         }
         const chartInstanceWithLargestYAxis = maxBy(
             chartInstances,
@@ -170,7 +170,7 @@ export class FacetChart
         )
         if (chartInstanceWithLargestYAxis) {
             const { size } = chartInstanceWithLargestYAxis.yAxis!
-            yAxisConfig.minSize = size
+            globalYAxisConfig.minSize = size
         }
         // Uniform X axis
         const uniformXAxis = true
@@ -185,8 +185,8 @@ export class FacetChart
                     )
                 )
             )
-            xAxisConfig.min = min
-            xAxisConfig.max = max
+            globalXAxisConfig.min = min
+            globalXAxisConfig.max = max
             // xAxisConfig.labelPadding = 8
             if (chartInstanceWithLargestXAxis) {
                 const axis = chartInstanceWithLargestXAxis.xAxis!.clone()
@@ -208,9 +208,9 @@ export class FacetChart
                     )
                 )
             )
-            yAxisConfig.min = min
-            yAxisConfig.max = max
-            yAxisConfig.labelPadding = 8
+            globalYAxisConfig.min = min
+            globalYAxisConfig.max = max
+            globalYAxisConfig.labelPadding = 8
             if (chartInstanceWithLargestYAxis) {
                 const axis = chartInstanceWithLargestYAxis.yAxis!.clone()
                 axis.updateDomainPreservingUserSettings([min, max]).size
@@ -247,7 +247,7 @@ export class FacetChart
                     ...series.manager,
                     xAxisConfig: {
                         ...series.manager.xAxisConfig,
-                        ...xAxisConfig,
+                        ...globalXAxisConfig,
                         hideAxis:
                             xAxis &&
                             xAxis.position in sharedAxisPadding &&
@@ -259,7 +259,7 @@ export class FacetChart
                     },
                     yAxisConfig: {
                         ...series.manager.yAxisConfig,
-                        ...yAxisConfig,
+                        ...globalYAxisConfig,
                         hideAxis:
                             yAxis &&
                             yAxis.position in sharedAxisPadding &&

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -34,7 +34,7 @@ import {
 } from "../../clientUtils/Util"
 import { AxisConfigInterface } from "../axis/AxisConfigInterface"
 import {
-    IDEAL_CHART_ASPECT_RATIO,
+    IDEAL_PLOT_ASPECT_RATIO,
     GridParameters,
     Position,
     PositionMap,
@@ -131,7 +131,7 @@ export class FacetChart
         return getIdealGridParams({
             count,
             containerAspectRatio,
-            idealAspectRatio: IDEAL_CHART_ASPECT_RATIO,
+            idealAspectRatio: IDEAL_PLOT_ASPECT_RATIO,
         })
     }
 

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -153,12 +153,14 @@ export class FacetChart
         const table = this.transformedTable
 
         return series.map((series, index) => {
-            const { bounds } = gridBoundsArr[index]
+            const { bounds, edges } = gridBoundsArr[index]
             const chartTypeName =
                 series.chartTypeName ??
                 this.props.chartTypeName ??
                 ChartTypeName.LineChart
-            const hideLegend = false // !(column !== columns - 1) // todo: only show 1?
+
+            // TODO figure out how to do legends better
+            const hideLegend = !edges.has(Position.right)
             const hidePoints = true
 
             const manager: ChartManager = {

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -27,7 +27,6 @@ import { CoreColumn } from "../../coreTable/CoreTableColumns"
 import {
     excludeUndefined,
     getIdealGridParams,
-    GridParameters,
     max,
     maxBy,
     min,
@@ -36,6 +35,7 @@ import {
 import { AxisConfigInterface } from "../axis/AxisConfigInterface"
 import {
     IDEAL_CHART_ASPECT_RATIO,
+    GridParameters,
     Position,
     PositionMap,
 } from "../../clientUtils/owidTypes"

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -191,11 +191,11 @@ export class FacetChart
     @computed private get placedSeries(): PlacedFacetSeries[] {
         // Create intermediate chart views to determine some of the properties
         const chartInstances = this.intermediatePlacedSeries.map(
-            ({ manager, chartTypeName }) => {
+            ({ bounds, manager, chartTypeName }) => {
                 const ChartClass =
                     ChartComponentClassMap.get(chartTypeName) ??
                     DefaultChartClass
-                return new ChartClass({ manager })
+                return new ChartClass({ bounds, manager })
             }
         )
         const sharedAxesSizes: PositionMap<number> = {}

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -6,7 +6,6 @@ import {
     ChartTypeName,
     FacetAxisRange,
     FacetStrategy,
-    ScaleType,
     SeriesStrategy,
 } from "../core/GrapherConstants"
 import {
@@ -131,6 +130,7 @@ export class FacetChart
     }
 
     @computed private get uniformXAxis(): boolean {
+        // TODO: maybe should not be the default for ScatterPlot?
         return true
     }
 
@@ -233,7 +233,8 @@ export class FacetChart
         })
     }
 
-    @computed private get placedSeries(): PlacedFacetSeries[] {
+    // Only made public for testing
+    @computed get placedSeries(): PlacedFacetSeries[] {
         // Create intermediate chart views to determine some of the properties
         const chartInstances = this.intermediatePlacedSeries.map(
             ({ bounds, manager, chartTypeName }) => {

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -183,10 +183,6 @@ export class FacetChart
             // Force disable nice axes if we care about the trend,
             // because nice axes misrepresent trends.
             globalYAxisConfig.nice = false
-
-            const isLogScale =
-                this.manager.yAxisConfig?.scaleType === ScaleType.log
-            if (!isLogScale) globalYAxisConfig.maxTicks = 3
         }
 
         const table = this.transformedTable

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -353,7 +353,7 @@ export class FacetChart
         return makeSelectionArray(this.manager)
     }
 
-    @computed private get countryFacets(): FacetSeries[] {
+    @computed private get entityFacets(): FacetSeries[] {
         const table = this.transformedTable.filterByEntityNames(
             this.selectionArray.selectedEntityNames
         )
@@ -409,7 +409,7 @@ export class FacetChart
     @computed get series(): FacetSeries[] {
         return this.facetStrategy === FacetStrategy.column
             ? this.columnFacets
-            : this.countryFacets
+            : this.entityFacets
     }
 
     @computed protected get bounds(): Bounds {

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -100,14 +100,14 @@ export class FacetChart
     }
 
     /**
-     * Holds the intermediate render properties for chart views, as well as the intermediate chart
-     * views themselves.
+     * Holds the intermediate render properties for chart views, before axes are synchronized,
+     * collapsed, aligned, etc.
      *
      * An example: a StackedArea has a Y axis domain that is the largest sum of all columns.
      * In order to avoid replicating that logic here (stacking values), we initialize StackedArea
      * instances, without rendering them. In a later method, we use those intermediate chart views to
      * determine the final axes for facets, e.g. for a uniform axis, we would iterate through all
-     * instances to find the domain.
+     * instances to find the full extent of the domain.
      *
      * @danielgavrilov, 2021-07-13
      */

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -152,7 +152,6 @@ export class FacetChart
 
         // Copy properties from manager to facets
         const baseFontSize = this.fontSize
-        const lineStrokeWidth = count > 16 ? 1.5 : undefined
         const gridBoundsArr = this.bounds.grid(
             count,
             getChartPadding(count, baseFontSize)
@@ -203,7 +202,6 @@ export class FacetChart
             const manager: ChartManager = {
                 table,
                 baseFontSize,
-                lineStrokeWidth,
                 hideLegend,
                 hidePoints,
                 yColumnSlug,

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -334,7 +334,9 @@ export class FacetChart
     }
 
     @computed protected get bounds(): Bounds {
-        return (this.props.bounds ?? DEFAULT_BOUNDS).padTop(this.facetFontSize)
+        return (this.props.bounds ?? DEFAULT_BOUNDS).padTop(
+            this.facetFontSize + 10
+        )
     }
 
     @computed protected get manager(): ChartManager {

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -84,7 +84,7 @@ export class FacetChart
 
         // Copy properties from manager to facets
         const baseFontSize = this.facetFontSize
-        const lineStrokeWidth = count > 16 ? 1 : undefined
+        const lineStrokeWidth = count > 16 ? 1.5 : undefined
         const gridBoundsArr = this.bounds.grid(
             count,
             getChartPadding(count, baseFontSize)

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -193,6 +193,15 @@ export class FacetChart
                 axis.updateDomainPreservingUserSettings([min, max]).size
                 sharedAxisPadding[axis.position] = axis.size
             }
+        } else {
+            if (this.facetStrategy === FacetStrategy.entity) {
+                // Force disable nice axes because we care about the trend,
+                // which gets skewed with "nice" axes.
+                globalXAxisConfig.nice = false
+                // Only show up to 3 ticks since we care about the trend
+                // (this is a rough input to D3, not a strict limit)
+                globalXAxisConfig.maxTicks = 3
+            }
         }
 
         // Uniform Y axis
@@ -215,6 +224,15 @@ export class FacetChart
                 const axis = chartInstanceWithLargestYAxis.yAxis!.clone()
                 axis.updateDomainPreservingUserSettings([min, max]).size
                 sharedAxisPadding[axis.position] = axis.size
+            }
+        } else {
+            if (this.facetStrategy === FacetStrategy.entity) {
+                // Force disable nice axes because we care about the trend,
+                // which gets skewed with "nice" axes.
+                globalYAxisConfig.nice = false
+                // Only show up to 3 ticks since we care about the trend
+                // (this is a rough input to D3, not a strict limit)
+                globalYAxisConfig.maxTicks = 3
             }
         }
         // Allocate space for axes

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -121,8 +121,15 @@ export class FacetChart
             sizeColumnSlug,
             isRelativeMode,
         } = manager
-        const xAxisConfig = this.manager.xAxisConfig
-        const yAxisConfig = this.manager.yAxisConfig
+        const compactLabels = count > 2
+        const xAxisConfig = {
+            compactLabels,
+            ...this.manager.xAxisConfig,
+        }
+        const yAxisConfig = {
+            compactLabels,
+            ...this.manager.yAxisConfig,
+        }
 
         const table = this.transformedTable
 

--- a/grapher/facetChart/FacetChartConstants.ts
+++ b/grapher/facetChart/FacetChartConstants.ts
@@ -18,4 +18,5 @@ export interface PlacedFacetSeries extends FacetSeries {
     manager: ChartManager
     chartTypeName: ChartTypeName
     bounds: Bounds
+    contentBounds: Bounds
 }

--- a/grapher/facetChart/FacetChartUtils.tsx
+++ b/grapher/facetChart/FacetChartUtils.tsx
@@ -7,27 +7,20 @@ export const getFontSize = (
     minSize = 8
 ): number => {
     if (count <= 2) return Math.max(minSize, baseFontSize * (16 / 16))
-    if (count <= 4) return Math.max(minSize, baseFontSize * (14 / 16))
-    if (count <= 9) return Math.max(minSize, baseFontSize * (12 / 16))
-    if (count <= 16) return Math.max(minSize, baseFontSize * (10 / 16))
-    if (count <= 25) return Math.max(minSize, baseFontSize * (8 / 16))
+    if (count <= 4) return Math.max(minSize, baseFontSize * (14.5 / 16))
+    if (count <= 9) return Math.max(minSize, baseFontSize * (13 / 16))
+    if (count <= 16) return Math.max(minSize, baseFontSize * (12 / 16))
+    if (count <= 25) return Math.max(minSize, baseFontSize * (11 / 16))
     return minSize
 }
 
 export const getChartPadding = (
-    count: number
+    count: number,
+    baseFontSize: number
 ): { rowPadding: number; columnPadding: number; outerPadding: number } => {
-    if (count > 9) {
-        return {
-            rowPadding: 30,
-            columnPadding: 10,
-            outerPadding: 0,
-        }
-    }
-
     return {
-        rowPadding: 50,
-        columnPadding: 40,
+        rowPadding: Math.round(baseFontSize * 3.5),
+        columnPadding: Math.round(baseFontSize),
         outerPadding: 0,
     }
 }

--- a/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -9,6 +9,7 @@ import {
     last,
     flatten,
     sum,
+    dyFromAlign,
 } from "../../clientUtils/Util"
 import { Bounds } from "../../clientUtils/Bounds"
 import {
@@ -17,7 +18,11 @@ import {
     CategoricalBin,
 } from "../color/ColorScaleBin"
 import { BASE_FONT_SIZE } from "../core/GrapherConstants"
-import { Color, HorizontalAlign } from "../../clientUtils/owidTypes"
+import {
+    Color,
+    HorizontalAlign,
+    VerticalAlign,
+} from "../../clientUtils/owidTypes"
 
 interface PositionedBin {
     x: number
@@ -420,7 +425,7 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                         // we can't use dominant-baseline to do proper alignment since our svg-to-png library Sharp
                         // doesn't support that (https://github.com/lovell/sharp/issues/1996), so we'll have to make
                         // do with some rough positioning.
-                        dy=".75em"
+                        dy={dyFromAlign(VerticalAlign.bottom)}
                         fontSize={label.fontSize}
                     >
                         {label.text}
@@ -562,7 +567,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
                                     // we can't use dominant-baseline to do proper alignment since our svg-to-png library Sharp
                                     // doesn't support that (https://github.com/lovell/sharp/issues/1996), so we'll have to make
                                     // do with some rough positioning.
-                                    dy=".75em"
+                                    dy={dyFromAlign(VerticalAlign.bottom)}
                                     fontSize={mark.label.fontSize}
                                 >
                                     {mark.label.text}

--- a/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -222,7 +222,7 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
             return {
                 text: text,
                 fontSize: tickFontSize,
-                bounds: labelBounds.extend({ x: x, y: y }),
+                bounds: labelBounds.set({ x: x, y: y }),
                 hidden: false,
             }
         }
@@ -237,7 +237,7 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
             return {
                 text: bin.bin.text,
                 fontSize: tickFontSize,
-                bounds: labelBounds.extend({ x: x, y: y }),
+                bounds: labelBounds.set({ x: x, y: y }),
                 priority: true,
                 hidden: false,
             }
@@ -284,7 +284,7 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
             for (let index = 1; index < labels.length; index++) {
                 const label = labels[index]
                 if (index % 2 !== 0) {
-                    label.bounds = label.bounds.extend({
+                    label.bounds = label.bounds.set({
                         y: label.bounds.y - label.bounds.height - 1,
                     })
                 }
@@ -471,7 +471,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
 
             const label = {
                 text: bin.text,
-                bounds: labelBounds.extend({
+                bounds: labelBounds.set({
                     x: markX + rectSize + rectPadding,
                     y: markY + 1,
                 }),
@@ -514,7 +514,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
                     : 0
             line.marks.forEach((mark) => {
                 mark.x += xShift
-                mark.label.bounds = mark.label.bounds.extend({
+                mark.label.bounds = mark.label.bounds.set({
                     x: mark.label.bounds.x + xShift,
                 })
             })

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -749,13 +749,8 @@ export class LineChart
     }
 
     @computed private get yAxisConfig(): AxisConfig {
-        return new AxisConfig(
-            {
-                nice: true,
-                ...this.manager.yAxisConfig,
-            },
-            this
-        )
+        // TODO: enable nice axis ticks for linear scales
+        return new AxisConfig(this.manager.yAxisConfig, this)
     }
 
     @computed private get verticalAxisPart(): VerticalAxis {

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -507,7 +507,7 @@ export class LineChart
 
     @computed get clipPathBounds(): Bounds {
         const { dualAxis, bounds } = this
-        return bounds.extend({ x: dualAxis.innerBounds.x }).expand(10)
+        return bounds.set({ x: dualAxis.innerBounds.x }).expand(10)
     }
 
     @computed get clipPath(): { id: string; element: JSX.Element } {

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -9,6 +9,7 @@ import {
     flatten,
     last,
     exposeInstanceOnWindow,
+    round,
 } from "../../clientUtils/Util"
 import { computed, action, observable } from "mobx"
 import { observer } from "mobx-react"
@@ -142,6 +143,7 @@ class Lines extends React.Component<LinesProps> {
                     <path
                         stroke={series.color}
                         strokeLinecap="round"
+                        strokeLinejoin="round"
                         d={pointsToPath(
                             series.placedPoints.map((value) => [
                                 value.x,
@@ -177,6 +179,7 @@ class Lines extends React.Component<LinesProps> {
                 <path
                     key={getSeriesKey(series, "line")}
                     strokeLinecap="round"
+                    strokeLinejoin="round"
                     stroke="#ddd"
                     d={pointsToPath(
                         series.placedPoints.map((value) => [
@@ -704,8 +707,8 @@ export class LineChart
                     placedPoints: series.points.map(
                         (point) =>
                             new PointVector(
-                                Math.round(horizontalAxis.place(point.x)),
-                                Math.round(verticalAxis.place(point.y))
+                                round(horizontalAxis.place(point.x), 1),
+                                round(verticalAxis.place(point.y), 1)
                             )
                     ),
                 }

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -736,7 +736,6 @@ export class LineChart
         const { manager } = this
         const axisConfig =
             manager.xAxis ?? new AxisConfig(manager.xAxisConfig, this)
-        if (manager.hideXAxis) axisConfig.hideAxis = true
         const axis = axisConfig.toHorizontalAxis()
         axis.updateDomainPreservingUserSettings(
             this.transformedTable.timeDomainFor(this.yColumnSlugs)
@@ -754,9 +753,7 @@ export class LineChart
     }
 
     @computed private get verticalAxisPart(): VerticalAxis {
-        const { manager } = this
         const axisConfig = this.yAxisConfig
-        if (manager.hideYAxis) axisConfig.hideAxis = true
         const yDomain = this.transformedTable.domainFor(this.yColumnSlugs)
         const domain = axisConfig.domain
         const axis = axisConfig.toVerticalAxis()

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -34,7 +34,7 @@ import {
     SeriesStrategy,
 } from "../core/GrapherConstants"
 import { ColorSchemes } from "../color/ColorSchemes"
-import { AxisConfig } from "../axis/AxisConfig"
+import { AxisConfig, FontSizeManager } from "../axis/AxisConfig"
 import { ChartInterface } from "../chart/ChartInterface"
 import {
     LinesProps,
@@ -242,7 +242,7 @@ export class LineChart
         bounds?: Bounds
         manager: LineChartManager
     }>
-    implements ChartInterface, LineLegendManager {
+    implements ChartInterface, LineLegendManager, FontSizeManager {
     base: React.RefObject<SVGGElement> = React.createRef()
 
     transformTable(table: OwidTable): OwidTable {
@@ -732,11 +732,14 @@ export class LineChart
         })
     }
 
-    @computed private get horizontalAxisPart(): HorizontalAxis {
+    @computed private get xAxisConfig(): AxisConfig {
         const { manager } = this
-        const axisConfig =
-            manager.xAxis ?? new AxisConfig(manager.xAxisConfig, this)
-        const axis = axisConfig.toHorizontalAxis()
+        const config = manager.xAxis?.toObject() ?? manager.xAxisConfig
+        return new AxisConfig(config, this)
+    }
+
+    @computed private get horizontalAxisPart(): HorizontalAxis {
+        const axis = this.xAxisConfig.toHorizontalAxis()
         axis.updateDomainPreservingUserSettings(
             this.transformedTable.timeDomainFor(this.yColumnSlugs)
         )
@@ -749,7 +752,14 @@ export class LineChart
 
     @computed private get yAxisConfig(): AxisConfig {
         const { manager } = this
-        return manager.yAxis ?? new AxisConfig(manager.yAxisConfig, this)
+        const config = manager.yAxis?.toObject() ?? manager.yAxisConfig
+        return new AxisConfig(
+            {
+                ...config,
+                nice: true,
+            },
+            this
+        )
     }
 
     @computed private get verticalAxisPart(): VerticalAxis {

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -733,9 +733,7 @@ export class LineChart
     }
 
     @computed private get xAxisConfig(): AxisConfig {
-        const { manager } = this
-        const config = manager.xAxis?.toObject() ?? manager.xAxisConfig
-        return new AxisConfig(config, this)
+        return new AxisConfig(this.manager.xAxisConfig, this)
     }
 
     @computed private get horizontalAxisPart(): HorizontalAxis {
@@ -751,12 +749,10 @@ export class LineChart
     }
 
     @computed private get yAxisConfig(): AxisConfig {
-        const { manager } = this
-        const config = manager.yAxis?.toObject() ?? manager.yAxisConfig
         return new AxisConfig(
             {
-                ...config,
                 nice: true,
+                ...this.manager.yAxisConfig,
             },
             this
         )

--- a/grapher/lineLegend/LineLegend.tsx
+++ b/grapher/lineLegend/LineLegend.tsx
@@ -62,7 +62,7 @@ function stackGroupVertically(
 ): PlacedSeries[] {
     let currentY = y
     group.forEach((mark) => {
-        mark.bounds = mark.bounds.extend({ y: currentY })
+        mark.bounds = mark.bounds.set({ y: currentY })
         mark.repositions += 1
         currentY += mark.bounds.height + LEGEND_ITEM_MIN_SPACING
     })

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -131,7 +131,7 @@ const geoBoundsFor = (projectionName: MapProjectionName): Bounds[] => {
 
         // HACK (Mispy): The path generator calculates weird bounds for Fiji (probably it wraps around the map)
         if (feature.id === "Fiji")
-            return bounds.extend({
+            return bounds.set({
                 x: bounds.right - bounds.height,
                 width: bounds.height,
             })

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -656,15 +656,11 @@ export class ScatterPlotChart
     }
 
     @computed private get yAxisConfig(): AxisConfig {
-        return (
-            this.manager.yAxis ?? new AxisConfig(this.manager.yAxisConfig, this)
-        )
+        return new AxisConfig(this.manager.yAxisConfig, this)
     }
 
     @computed private get xAxisConfig(): AxisConfig {
-        return (
-            this.manager.xAxis ?? new AxisConfig(this.manager.xAxisConfig, this)
-        )
+        return new AxisConfig(this.manager.xAxisConfig, this)
     }
 
     @computed private get yColumnSlug(): string {

--- a/grapher/scatterCharts/ScatterPointsWithLabels.tsx
+++ b/grapher/scatterCharts/ScatterPointsWithLabels.tsx
@@ -257,18 +257,18 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
     ): void {
         for (const label of labels) {
             if (label.bounds.left < bounds.left - 1)
-                label.bounds = label.bounds.extend({
+                label.bounds = label.bounds.set({
                     x: label.bounds.x + label.bounds.width,
                 })
             else if (label.bounds.right > bounds.right + 1)
-                label.bounds = label.bounds.extend({
+                label.bounds = label.bounds.set({
                     x: label.bounds.x - label.bounds.width,
                 })
 
             if (label.bounds.top < bounds.top - 1)
-                label.bounds = label.bounds.extend({ y: bounds.top })
+                label.bounds = label.bounds.set({ y: bounds.top })
             else if (label.bounds.bottom > bounds.bottom + 1)
-                label.bounds = label.bounds.extend({
+                label.bounds = label.bounds.set({
                     y: bounds.bottom - label.bounds.height,
                 })
         }

--- a/grapher/scatterCharts/ScatterUtils.ts
+++ b/grapher/scatterCharts/ScatterUtils.ts
@@ -194,11 +194,11 @@ export const makeEndLabel = (
     })
 
     if (labelPos.x < lastPos.x)
-        labelBounds = labelBounds.extend({
+        labelBounds = labelBounds.set({
             x: labelBounds.x - labelBounds.width,
         })
     if (labelPos.y > lastPos.y)
-        labelBounds = labelBounds.extend({
+        labelBounds = labelBounds.set({
             y: labelBounds.y + labelBounds.height / 2,
         })
 

--- a/grapher/slopeCharts/SlopeChart.tsx
+++ b/grapher/slopeCharts/SlopeChart.tsx
@@ -49,6 +49,7 @@ import { OwidTable } from "../../coreTable/OwidTable"
 import { Color } from "../../coreTable/CoreTableConstants"
 import { autoDetectYColumnSlugs, makeSelectionArray } from "../chart/ChartUtils"
 import { ColorSchemeName } from "../color/ColorConstants"
+import { AxisConfig, FontSizeManager } from "../axis/AxisConfig"
 
 @observer
 export class SlopeChart
@@ -632,7 +633,9 @@ class Slope extends React.Component<SlopeProps> {
 }
 
 @observer
-class LabelledSlopes extends React.Component<LabelledSlopesProps> {
+class LabelledSlopes
+    extends React.Component<LabelledSlopesProps>
+    implements FontSizeManager {
     base: React.RefObject<SVGGElement> = React.createRef()
 
     @computed private get data() {
@@ -649,6 +652,10 @@ class LabelledSlopes extends React.Component<LabelledSlopesProps> {
 
     @computed private get bounds() {
         return this.props.bounds
+    }
+
+    @computed get fontSize() {
+        return this.manager.baseFontSize ?? BASE_FONT_SIZE
     }
 
     @computed private get focusedSeriesNames() {
@@ -689,8 +696,12 @@ class LabelledSlopes extends React.Component<LabelledSlopesProps> {
         )
     }
 
+    @computed private get yAxisConfig(): AxisConfig {
+        return new AxisConfig(this.manager.yAxisConfig, this)
+    }
+
     @computed private get yScaleType() {
-        return this.manager.yAxis?.scaleType || ScaleType.linear
+        return this.yAxisConfig.scaleType || ScaleType.linear
     }
 
     @computed private get yDomainDefault(): [number, number] {
@@ -705,7 +716,7 @@ class LabelledSlopes extends React.Component<LabelledSlopesProps> {
     }
 
     @computed private get yDomain(): [number, number] {
-        const domain = this.manager.yAxis?.domain || [Infinity, -Infinity]
+        const domain = this.yAxisConfig.domain || [Infinity, -Infinity]
         const domainDefault = this.yDomainDefault
         return [
             Math.min(domain[0], domainDefault[0]),
@@ -781,9 +792,7 @@ class LabelledSlopes extends React.Component<LabelledSlopesProps> {
             const [v1, v2] = series.values
             const [x1, x2] = [xScale(v1.x), xScale(v2.x)]
             const [y1, y2] = [yScale(v1.y), yScale(v2.y)]
-            const fontSize =
-                (isPortrait ? 0.6 : 0.65) *
-                (this.manager.baseFontSize ?? BASE_FONT_SIZE)
+            const fontSize = (isPortrait ? 0.6 : 0.65) * this.fontSize
             const leftValueStr = yColumn.formatValueShort(v1.y)
             const rightValueStr = yColumn.formatValueShort(v2.y)
             const leftValueWidth = Bounds.forText(leftValueStr, {
@@ -1025,9 +1034,9 @@ class LabelledSlopes extends React.Component<LabelledSlopesProps> {
     }
 
     render() {
-        const baseFontSize = this.manager.baseFontSize ?? BASE_FONT_SIZE
-        const yScaleType = this.yScaleType
         const {
+            fontSize,
+            yScaleType,
             bounds,
             slopeData,
             isPortrait,
@@ -1103,7 +1112,7 @@ class LabelledSlopes extends React.Component<LabelledSlopesProps> {
                     y={y1 + 10}
                     textAnchor="middle"
                     fill="#666"
-                    fontSize={baseFontSize}
+                    fontSize={fontSize}
                 >
                     {xDomain[0].toString()}
                 </Text>
@@ -1112,7 +1121,7 @@ class LabelledSlopes extends React.Component<LabelledSlopesProps> {
                     y={y1 + 10}
                     textAnchor="middle"
                     fill="#666"
-                    fontSize={baseFontSize}
+                    fontSize={fontSize}
                 >
                     {xDomain[1].toString()}
                 </Text>

--- a/grapher/stackedCharts/AbstractStackedChart.tsx
+++ b/grapher/stackedCharts/AbstractStackedChart.tsx
@@ -17,7 +17,11 @@ import {
 import { computed } from "mobx"
 import { observer } from "mobx-react"
 import React from "react"
-import { StackedPointPositionType, StackedSeries } from "./StackedConstants"
+import {
+    StackedPoint,
+    StackedPointPositionType,
+    StackedSeries,
+} from "./StackedConstants"
 import { OwidTable } from "../../coreTable/OwidTable"
 import {
     autoDetectSeriesStrategy,
@@ -229,7 +233,7 @@ export class AbstactStackedChart<PositionType extends StackedPointPositionType>
             : this.columnsAsSeries
     }
 
-    @computed protected get allStackedPoints() {
+    @computed protected get allStackedPoints(): StackedPoint<PositionType>[] {
         return flatten(this.series.map((series) => series.points))
     }
 

--- a/grapher/stackedCharts/AbstractStackedChart.tsx
+++ b/grapher/stackedCharts/AbstractStackedChart.tsx
@@ -189,13 +189,8 @@ export class AbstactStackedChart<PositionType extends StackedPointPositionType>
     }
 
     @computed private get yAxisConfig(): AxisConfig {
-        return new AxisConfig(
-            {
-                nice: true,
-                ...this.manager.yAxisConfig,
-            },
-            this
-        )
+        // TODO: enable nice axis ticks for linear scales
+        return new AxisConfig(this.manager.yAxisConfig, this)
     }
 
     @computed private get verticalAxisPart(): VerticalAxis {

--- a/grapher/stackedCharts/AbstractStackedChart.tsx
+++ b/grapher/stackedCharts/AbstractStackedChart.tsx
@@ -172,8 +172,6 @@ export class AbstactStackedChart<PositionType extends StackedPointPositionType>
     @computed private get horizontalAxisPart(): HorizontalAxis {
         const axisConfig =
             this.manager.xAxis || new AxisConfig(this.manager.xAxisConfig, this)
-        if (this.manager.hideXAxis) axisConfig.hideAxis = true
-
         const axis = axisConfig.toHorizontalAxis()
         axis.updateDomainPreservingUserSettings(
             this.transformedTable.timeDomainFor(this.yColumnSlugs)
@@ -192,7 +190,6 @@ export class AbstactStackedChart<PositionType extends StackedPointPositionType>
         )
         const axisConfig =
             this.manager.yAxis || new AxisConfig(this.manager.yAxisConfig, this)
-        if (this.manager.hideYAxis) axisConfig.hideAxis = true
         const axis = axisConfig.toVerticalAxis()
         // Use user settings for axis, unless relative mode
         if (this.manager.isRelativeMode) axis.domain = [0, 100]

--- a/grapher/stackedCharts/AbstractStackedChart.tsx
+++ b/grapher/stackedCharts/AbstractStackedChart.tsx
@@ -173,10 +173,12 @@ export class AbstactStackedChart<PositionType extends StackedPointPositionType>
         return this.dualAxis.horizontalAxis
     }
 
+    @computed private get xAxisConfig(): AxisConfig {
+        return new AxisConfig(this.manager.xAxisConfig, this)
+    }
+
     @computed private get horizontalAxisPart(): HorizontalAxis {
-        const axisConfig =
-            this.manager.xAxis || new AxisConfig(this.manager.xAxisConfig, this)
-        const axis = axisConfig.toHorizontalAxis()
+        const axis = this.xAxisConfig.toHorizontalAxis()
         axis.updateDomainPreservingUserSettings(
             this.transformedTable.timeDomainFor(this.yColumnSlugs)
         )
@@ -186,15 +188,17 @@ export class AbstactStackedChart<PositionType extends StackedPointPositionType>
         return axis
     }
 
+    @computed private get yAxisConfig(): AxisConfig {
+        return new AxisConfig(this.manager.yAxisConfig, this)
+    }
+
     @computed private get verticalAxisPart(): VerticalAxis {
         // const lastSeries = this.series[this.series.length - 1]
         // const yValues = lastSeries.points.map((d) => d.yOffset + d.y)
         const yValues = this.allStackedPoints.map(
             (point) => point.value + point.valueOffset
         )
-        const axisConfig =
-            this.manager.yAxis || new AxisConfig(this.manager.yAxisConfig, this)
-        const axis = axisConfig.toVerticalAxis()
+        const axis = this.yAxisConfig.toVerticalAxis()
         // Use user settings for axis, unless relative mode
         if (this.manager.isRelativeMode) axis.domain = [0, 100]
         else axis.updateDomainPreservingUserSettings([0, max(yValues) ?? 100]) // Stacked area chart must have its own y domain)

--- a/grapher/stackedCharts/AbstractStackedChart.tsx
+++ b/grapher/stackedCharts/AbstractStackedChart.tsx
@@ -189,7 +189,13 @@ export class AbstactStackedChart<PositionType extends StackedPointPositionType>
     }
 
     @computed private get yAxisConfig(): AxisConfig {
-        return new AxisConfig(this.manager.yAxisConfig, this)
+        return new AxisConfig(
+            {
+                nice: true,
+                ...this.manager.yAxisConfig,
+            },
+            this
+        )
     }
 
     @computed private get verticalAxisPart(): VerticalAxis {

--- a/grapher/stackedCharts/StackedAreaChart.test.ts
+++ b/grapher/stackedCharts/StackedAreaChart.test.ts
@@ -20,7 +20,7 @@ class MockManager implements ChartManager {
         timeRange: [1950, 2010],
     })
     yColumnSlugs = [SampleColumnSlugs.GDP]
-    yAxis = new AxisConfig({ min: 0, max: 200 })
+    yAxisConfig = new AxisConfig({ min: 0, max: 200 })
     @observable isRelativeMode = false
     selection = new SelectionArray()
 }

--- a/grapher/stackedCharts/StackedBarChart.tsx
+++ b/grapher/stackedCharts/StackedBarChart.tsx
@@ -287,7 +287,7 @@ export class StackedBarChart
             const bounds = Bounds.forText(text, { fontSize: this.tickFontSize })
             return {
                 text,
-                bounds: bounds.extend({
+                bounds: bounds.set({
                     x: xPos + barWidth / 2 - bounds.width / 2,
                     y: dualAxis.innerBounds.bottom + 5,
                 }),

--- a/grapher/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.tsx
@@ -196,7 +196,7 @@ export class StackedDiscreteBarChart
     }
 
     @computed private get yAxisConfig(): AxisConfig {
-        return this.manager.yAxis || new AxisConfig()
+        return new AxisConfig(this.manager.yAxisConfig, this)
     }
 
     @computed get yAxis(): HorizontalAxis {


### PR DESCRIPTION
Notion: [Gridlines, axis labels, titles](https://www.notion.so/Gridlines-axis-labels-titles-066fcc51c1dc4a36b9593159b178cfc6)

[Live on playfair](https://playfair-owid.netlify.app/explorers/coronavirus-data-explorer?zoomToSelection=true&time=2020-03-01..latest&pickerSort=asc&pickerMetric=location&Metric=Confirmed+cases&Interval=7-day+rolling+average&Relative+to+Population=true&Align+outbreaks=false&country=GBR~CAN~DEU~ITA~ESP~PRT~FRA~NLD~SWE~NOR~MKD~HRV).

Ready for review, but it's based on https://github.com/owid/owid-grapher/pull/960 which needs to be merged before this one.

### Before / After

<img width="1934" alt="Screenshot 2021-07-28 at 18 09 52" src="https://user-images.githubusercontent.com/1308115/127366514-0b3f03c2-ecc4-4cd0-b50d-ea9597700aa0.png">

**Changes**

- Axes collapse when uniform (only first row shows X axis, only left-most facets show Y axis)
- Chart plot areas are identical, space is separately allocated for axes, and all axis sizes are identical (so all chart plots are aligned)
- The captions (United Kingdom, Canada...) are aligned with the start of the plot
- X axis labels no longer overlap
- Compact tick labels (`5k` instead of `5,000`)
- Empty space at the bottom removed, padding improved
- Improved facet grid algorithm, gets closer to the ideal aspect ratio for charts

---

**Looking for both design and code feedback**. 

A potential thing to trip over when making changes is the order of overrides. There is config:
- `manager`: at the top-level Grapher config, specified by authors (e.g. `yAxisMin`)
- `countryFacets`, `columnFacets`: config generated depending on whether it's entity or column
- `intermediatePlacedSeries`: the config initially passed to facets, in order to find out the rendered axis dimensions & domain
- `placedSeries`: the final config for facets

At each stage we are modifying the config, and the order we assign it in matter, and it needs care. There is often a distinction between setting `undefined` and not setting a value.

---

**Things to improve after merge**:

- Use `nice` axes for some charts. They are implemented in this PR but disabled everywhere to make it easier to review & merge this PR. 