### PR TITLE
fix(map): `tooltipUseCustomLabels` mode respects bins

### DIFF
--- a/grapher/color/ColorScale.test.ts
+++ b/grapher/color/ColorScale.test.ts
@@ -49,6 +49,28 @@ describe(ColorScale, () => {
             )
         })
 
+        it("returns correct bin indices", () => {
+            const colorValuePairs = [
+                { value: -10 },
+                { value: 1.1 },
+                { value: 2.1 },
+                { value: 15 },
+            ]
+            const scale = createColorScaleFromTable(
+                colorValuePairs,
+                colorScaleConfig
+            )
+            expect(scale.getBinIndex(-100)).toEqual(-1) // doesn't belong in any bin
+            expect(scale.getBinIndex(-10)).toEqual(0)
+            expect(scale.getBinIndex(0)).toEqual(0)
+            expect(scale.getBinIndex(0.9)).toEqual(0)
+            expect(scale.getBinIndex(1)).toEqual(0)
+            expect(scale.getBinIndex(1.1)).toEqual(1)
+            expect(scale.getBinIndex(2)).toEqual(1)
+            expect(scale.getBinIndex(3)).toEqual(2)
+            expect(scale.getBinIndex(15)).toEqual(2)
+        })
+
         describe("filtering outliers", () => {
             it("should filter out outliers", () => {
                 const colorValuePairs = [

--- a/grapher/color/ColorScale.test.ts
+++ b/grapher/color/ColorScale.test.ts
@@ -60,15 +60,16 @@ describe(ColorScale, () => {
                 colorValuePairs,
                 colorScaleConfig
             )
-            expect(scale.getBinIndex(-100)).toEqual(-1) // doesn't belong in any bin
-            expect(scale.getBinIndex(-10)).toEqual(0)
-            expect(scale.getBinIndex(0)).toEqual(0)
-            expect(scale.getBinIndex(0.9)).toEqual(0)
-            expect(scale.getBinIndex(1)).toEqual(0)
-            expect(scale.getBinIndex(1.1)).toEqual(1)
-            expect(scale.getBinIndex(2)).toEqual(1)
-            expect(scale.getBinIndex(3)).toEqual(2)
-            expect(scale.getBinIndex(15)).toEqual(2)
+            const bins = scale.legendBins
+            expect(scale.getBinForValue(-100)).toBeUndefined() // doesn't belong in any bin
+            expect(scale.getBinForValue(-10)).toEqual(bins[0])
+            expect(scale.getBinForValue(0)).toEqual(bins[0])
+            expect(scale.getBinForValue(0.9)).toEqual(bins[0])
+            expect(scale.getBinForValue(1)).toEqual(bins[0])
+            expect(scale.getBinForValue(1.1)).toEqual(bins[1])
+            expect(scale.getBinForValue(2)).toEqual(bins[1])
+            expect(scale.getBinForValue(3)).toEqual(bins[2])
+            expect(scale.getBinForValue(15)).toEqual(bins[2])
         })
 
         describe("filtering outliers", () => {

--- a/grapher/color/ColorScale.ts
+++ b/grapher/color/ColorScale.ts
@@ -342,15 +342,16 @@ export class ColorScale {
         })
     }
 
-    getBinIndex(value: number | string | undefined): number {
+    getBinForValue(
+        value: number | string | undefined
+    ): ColorScaleBin | undefined {
         return value === undefined
-            ? -1
-            : this.legendBins.findIndex((bin) => bin.contains(value))
+            ? undefined
+            : this.legendBins.find((bin) => bin.contains(value))
     }
 
     getColor(value: number | string | undefined): string | undefined {
         if (value === undefined) return this.noDataColor
-        const binIndex = this.getBinIndex(value)
-        return this.legendBins[binIndex]?.color
+        return this.getBinForValue(value)?.color
     }
 }

--- a/grapher/color/ColorScale.ts
+++ b/grapher/color/ColorScale.ts
@@ -342,9 +342,15 @@ export class ColorScale {
         })
     }
 
-    getColor(value: number | string | undefined): string | undefined {
+    getBinIndex(value: number | string | undefined): number {
         return value === undefined
-            ? this.noDataColor
-            : this.legendBins.find((bin) => bin.contains(value))?.color
+            ? -1
+            : this.legendBins.findIndex((bin) => bin.contains(value))
+    }
+
+    getColor(value: number | string | undefined): string | undefined {
+        if (value === undefined) return this.noDataColor
+        const binIndex = this.getBinIndex(value)
+        return this.legendBins[binIndex]?.color
     }
 }

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -313,12 +313,16 @@ export class MapChart
     @computed get formatTooltipValue(): (d: number | string) => string {
         const { mapConfig, mapColumn, colorScale } = this
 
-        const customLabels = mapConfig.tooltipUseCustomLabels
-            ? colorScale.customNumericLabels
-            : []
         return (d: number | string): string => {
             if (isString(d)) return d
-            else return customLabels[d] ?? mapColumn?.formatValueLong(d) ?? ""
+            else if (mapConfig.tooltipUseCustomLabels) {
+                // Find the bin (and its label) that this value belongs to
+                const binIndex = colorScale.getBinIndex(d)
+                const customLabels = colorScale.customNumericLabels
+                const customLabel = customLabels[binIndex]
+                if (customLabel !== undefined) return customLabel
+            }
+            return mapColumn?.formatValueLong(d) ?? ""
         }
     }
 

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -317,10 +317,9 @@ export class MapChart
             if (isString(d)) return d
             else if (mapConfig.tooltipUseCustomLabels) {
                 // Find the bin (and its label) that this value belongs to
-                const binIndex = colorScale.getBinIndex(d)
-                const customLabels = colorScale.customNumericLabels
-                const customLabel = customLabels[binIndex]
-                if (customLabel !== undefined) return customLabel
+                const bin = colorScale.getBinForValue(d)
+                const label = bin?.label
+                if (label !== undefined && label !== "") return label
             }
             return mapColumn?.formatValueLong(d) ?? ""
         }

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -466,7 +466,7 @@ export class MapChart
 
         if (focusBracket) return focusBracket
 
-        if (focusValue)
+        if (focusValue !== undefined)
             return numericLegendData.find((bin) => bin.contains(focusValue))
 
         return undefined
@@ -478,7 +478,7 @@ export class MapChart
         if (focusBracket && focusBracket instanceof CategoricalBin)
             return focusBracket
 
-        if (focusValue)
+        if (focusValue !== undefined)
             return categoricalLegendData.find((bin) => bin.contains(focusValue))
 
         return undefined


### PR DESCRIPTION
This fixes an issue that [Charlie reported on Slack](https://owid.slack.com/archives/C46U9LXRR/p1627505440001300):
![image](https://user-images.githubusercontent.com/2641501/127400116-49d9c50f-a4dc-4bfb-9179-568bebcfb8ac.png)

Turns out that `tooltipUseCustomLabels` was assuming that all data values would just be `0, 1, 2, ...`, and it was completely disregarding the configured bins. That was dumb (and [I'm the one to blame](https://github.com/owid/owid-grapher/pull/439)).