### PR TITLE
fix(explorer): preserve tab when switching view

### DIFF
--- a/explorer/Explorer.jsdom.test.tsx
+++ b/explorer/Explorer.jsdom.test.tsx
@@ -24,7 +24,7 @@ describe(Explorer, () => {
         expect(element.text()).toContain("Kingdom")
     })
 
-    it("each grapher has its own set of URL params/options are preserved even when the grapher changes", () => {
+    it("preserves the current tab between explorer views", () => {
         const explorer = element.instance() as Explorer
         expect(explorer.queryParams.tab).toBeUndefined()
 
@@ -35,7 +35,22 @@ describe(Explorer, () => {
         expect(explorer.queryParams.tab).toEqual("table")
 
         explorer.onChangeChoice("Gas")("CO₂")
+        expect(explorer.queryParams.tab).toEqual("table")
+
+        explorer.grapher.tab = GrapherTabOption.chart
+    })
+
+    it("switches to first tab if current tab does not exist in new view", () => {
+        const explorer = element.instance() as Explorer
         expect(explorer.queryParams.tab).toBeUndefined()
+        if (explorer.grapher) explorer.grapher.tab = GrapherTabOption.map
+        else throw Error("where's the grapher?")
+        expect(explorer.queryParams.tab).toEqual("map")
+
+        explorer.onChangeChoice("Gas")("All GHGs (CO₂eq)")
+
+        expect(explorer.grapher.tab).toEqual("chart")
+        expect(explorer.queryParams.tab).toEqual(undefined)
     })
 
     it("recovers country selection from URL params", () => {

--- a/explorer/Explorer.sample.tsx
+++ b/explorer/Explorer.sample.tsx
@@ -14,34 +14,34 @@ Gas Radio	CO₂
 Accounting Radio	Production-based
 subNavCurrentId	co2-data-explorer
 graphers
-	grapherId	Gas Radio	Accounting Radio	Fuel Dropdown	Count Dropdown	Relative to world total Checkbox
-	488	CO₂	Production-based	Total	Per country	false
-	3219	CO₂	Production-based	Total	Per country	Share of global emissions
-	486	CO₂	Production-based	Total	Per capita
-	485	CO₂	Production-based	Total	Cumulative	false
-	3218	CO₂	Production-based	Total	Cumulative	Share of global emissions
-	4267	CO₂	Production-based	Total	Per MWh of energy
-	530	CO₂	Production-based	Total	Per $ of GDP
-	3621	CO₂	Consumption-based		Per country
-	3488	CO₂	Consumption-based		Per capita
-	4331	CO₂	Consumption-based		Per $ of GDP
-	696	CO₂	Consumption-based		Share of emissions embedded in trade
-	4250	CO₂	Production-based	Coal	Per country
-	4251	CO₂	Production-based	Oil	Per country
-	4253	CO₂	Production-based	Gas	Per country
-	4255	CO₂	Production-based	Cement	Per country
-	4332	CO₂	Production-based	Flaring	Per country
-	4249	CO₂	Production-based	Coal	Per capita
-	4252	CO₂	Production-based	Oil	Per capita
-	4254	CO₂	Production-based	Gas	Per capita
-	4256	CO₂	Production-based	Cement	Per capita
-	4333	CO₂	Production-based	Flaring	Per capita
-	4147	All GHGs (CO₂eq)	Production-based		Per country
-	4239	All GHGs (CO₂eq)	Production-based		Per capita
-	4222	Methane	Production-based		Per country
-	4243	Methane	Production-based		Per capita
-	4224	Nitrous oxide	Production-based		Per country
-	4244	Nitrous oxide	Production-based		Per capita`
+	grapherId	Gas Radio	Accounting Radio	Fuel Dropdown	Count Dropdown	Relative to world total Checkbox	hasMapTab
+	488	CO₂	Production-based	Total	Per country	false	true
+	3219	CO₂	Production-based	Total	Per country	Share of global emissions	false
+	486	CO₂	Production-based	Total	Per capita	false
+	485	CO₂	Production-based	Total	Cumulative	false	false
+	3218	CO₂	Production-based	Total	Cumulative	Share of global emissions	false
+	4267	CO₂	Production-based	Total	Per MWh of energy	false
+	530	CO₂	Production-based	Total	Per $ of GDP	false
+	3621	CO₂	Consumption-based		Per country	false
+	3488	CO₂	Consumption-based		Per capita	false
+	4331	CO₂	Consumption-based		Per $ of GDP	false
+	696	CO₂	Consumption-based		Share of emissions embedded in trade	false
+	4250	CO₂	Production-based	Coal	Per country	false
+	4251	CO₂	Production-based	Oil	Per country	false
+	4253	CO₂	Production-based	Gas	Per country	false
+	4255	CO₂	Production-based	Cement	Per country	false
+	4332	CO₂	Production-based	Flaring	Per country	false
+	4249	CO₂	Production-based	Coal	Per capita	false
+	4252	CO₂	Production-based	Oil	Per capita	false
+	4254	CO₂	Production-based	Gas	Per capita	false
+	4256	CO₂	Production-based	Cement	Per capita	false
+	4333	CO₂	Production-based	Flaring	Per capita	false
+	4147	All GHGs (CO₂eq)	Production-based		Per country	false
+	4239	All GHGs (CO₂eq)	Production-based		Per capita	false
+	4222	Methane	Production-based		Per country	false
+	4243	Methane	Production-based		Per capita	false
+	4224	Nitrous oxide	Production-based		Per country	false
+	4244	Nitrous oxide	Production-based		Per capita	false`
 
 export const SampleExplorerOfGraphers = (props?: Partial<ExplorerProps>) => {
     const title = "AlphaBeta"

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -246,10 +246,19 @@ export class Explorer
             ...this.persistedGrapherQueryParamsBySelectedRow.get(
                 this.explorerProgram.currentlySelectedGrapherRow
             ),
+            region: oldGrapherParams.region,
             time: this.grapher.timeParam,
         }
 
+        const previousTab = this.grapher.tab
+
         this.updateGrapherFromExplorer()
+
+        // preserve the previous tab if that's still available in the new view;
+        // and use the first tab otherwise
+        newGrapherParams.tab = this.grapher.availableTabs.includes(previousTab)
+            ? previousTab
+            : this.grapher.availableTabs[0]
 
         this.grapher.populateFromQueryParams(newGrapherParams)
     }


### PR DESCRIPTION
Notion: [Preserve tab when switching between choices on Explorers](https://www.notion.so/Preserve-tab-when-switching-between-choices-on-Explorers-9a06817286b24ba7990a8b105b77881e)

This fixes small issues:
* There were situations when switching the view also inadvertently changed the tab from chart to map tab
* ... and there were cases when the user was on the map tab and switched to a view that didn't have a map tab, but we showed a map anyway