### PR TITLE
enhance(grapher): Add URL parameters for faceting

### DIFF
--- a/grapher/axis/AxisConfig.ts
+++ b/grapher/axis/AxisConfig.ts
@@ -29,7 +29,7 @@ class AxisConfigDefaults implements AxisConfigInterface {
     @observable.ref maxTicks?: number = undefined
     @observable.ref compactLabels?: boolean = undefined
     @observable.ref scaleType?: ScaleType = ScaleType.linear
-    @observable.ref facetDomain?: FacetAxisDomain = FacetAxisDomain.shared
+    @observable.ref facetDomain?: FacetAxisDomain = undefined
     @observable.ref label: string = ""
 }
 

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -280,7 +280,7 @@ export class FacetStrategyDropdown extends React.Component<{
         return {
             [FacetStrategy.none]: "All together",
             [FacetStrategy.entity]: `Split by ${entityLabel}`,
-            [FacetStrategy.column]: "Split by metric",
+            [FacetStrategy.metric]: "Split by metric",
         }
     }
 
@@ -289,7 +289,7 @@ export class FacetStrategyDropdown extends React.Component<{
             this.props.manager.availableFacetStrategies || [
                 FacetStrategy.none,
                 FacetStrategy.entity,
-                FacetStrategy.column,
+                FacetStrategy.metric,
             ]
         )
     }

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -145,7 +145,9 @@ export class FacetYDomainToggle extends React.Component<{
     }
 
     @computed get isYDomainShared(): boolean {
-        return this.props.manager.yAxis!.facetDomain === FacetAxisDomain.shared
+        const facetDomain =
+            this.props.manager.yAxis!.facetDomain || FacetAxisDomain.shared
+        return facetDomain === FacetAxisDomain.shared
     }
 
     render(): JSX.Element {

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1474,7 +1474,7 @@ export class Grapher
                 this.yScaleType !== ScaleType.log
             )
 
-        if (this.facetStrategy === FacetStrategy.column) return false
+        if (this.facetStrategy === FacetStrategy.metric) return false
 
         return !this.hideRelativeToggle
     }
@@ -1898,7 +1898,7 @@ export class Grapher
         const strategies: FacetStrategy[] = [FacetStrategy.none]
 
         if (this.hasMultipleYColumns) {
-            strategies.push(FacetStrategy.column)
+            strategies.push(FacetStrategy.metric)
         }
 
         if (this.selection.numSelectedEntities > 1) {
@@ -1933,7 +1933,7 @@ export class Grapher
             this.hasMultipleYColumns &&
             this.selection.numSelectedEntities > 1
         )
-            return FacetStrategy.column
+            return FacetStrategy.metric
 
         return FacetStrategy.none
     }

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -47,6 +47,7 @@ import {
     FacetStrategy,
     ThereWasAProblemLoadingThisChart,
     SeriesColorMap,
+    FacetAxisDomain,
 } from "../core/GrapherConstants"
 import { LegacyVariablesAndEntityKey } from "./LegacyVariableCode"
 import * as Cookies from "js-cookie"
@@ -489,6 +490,14 @@ export class Grapher
 
         if (this.addCountryMode !== EntitySelectionMode.Disabled && selection)
             this.selection.setSelectedEntities(selection)
+
+        // faceting
+        if (params.facet && params.facet in FacetStrategy) {
+            this.selectedFacetStrategy = params.facet as FacetStrategy
+        }
+        if (params.uniformYAxis === "0") {
+            this.yAxis.facetDomain = FacetAxisDomain.independent
+        }
     }
 
     @action.bound private setTimeFromTimeQueryParam(time: string): void {
@@ -2213,6 +2222,9 @@ export class Grapher
         params.endpointsOnly = this.compareEndPointsOnly ? "1" : "0"
         params.time = this.timeParam
         params.region = this.map.projection
+        params.facet = this.selectedFacetStrategy
+        params.uniformYAxis =
+            this.yAxis.facetDomain === FacetAxisDomain.independent ? "0" : "1"
         return setSelectedEntityNamesParam(
             Url.fromQueryParams(params),
             this.selectedEntitiesIfDifferentThanAuthors

--- a/grapher/core/GrapherConstants.ts
+++ b/grapher/core/GrapherConstants.ts
@@ -40,7 +40,7 @@ export const BASE_FONT_SIZE = 16
 export enum FacetStrategy {
     none = "none", // No facets
     entity = "entity", // One chart for each country/entity
-    column = "column", // One chart for each Y column
+    metric = "metric", // One chart for each Y column
 }
 
 export enum FacetAxisDomain {

--- a/grapher/core/GrapherInterface.ts
+++ b/grapher/core/GrapherInterface.ts
@@ -106,6 +106,8 @@ export interface GrapherQueryParams extends QueryParams {
     shown?: string
     endpointsOnly?: string
     selection?: string
+    facet?: string
+    uniformYAxis?: string
 }
 
 export interface LegacyGrapherQueryParams extends GrapherQueryParams {

--- a/grapher/core/schema.json
+++ b/grapher/core/schema.json
@@ -337,7 +337,7 @@
         },
         "selectedFacetStrategy": {
             "type": "string",
-            "enum": ["none", "entity", "column"]
+            "enum": ["none", "entity", "metric"]
         },
         "sourceDesc": {
             "type": "string"

--- a/grapher/facetChart/FacetChart.stories.tsx
+++ b/grapher/facetChart/FacetChart.stories.tsx
@@ -70,7 +70,7 @@ export const OneChartPerMetric = (): JSX.Element => {
                 bounds={bounds}
                 chartTypeName={ChartTypeName.LineChart}
                 manager={{
-                    facetStrategy: FacetStrategy.column,
+                    facetStrategy: FacetStrategy.metric,
                     yColumnSlugs: table.numericColumnSlugs,
                     selection: table.availableEntityNames,
                     table,

--- a/grapher/facetChart/FacetChart.test.ts
+++ b/grapher/facetChart/FacetChart.test.ts
@@ -25,8 +25,8 @@ it("can create a new FacetChart", () => {
     // default to country facets
     expect(chart.series.length).toEqual(2)
 
-    // switch to column facets
-    manager.facetStrategy = FacetStrategy.column
+    // switch to metric facets
+    manager.facetStrategy = FacetStrategy.metric
     expect(chart.series.length).toEqual(3)
 })
 

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -418,7 +418,7 @@ export class FacetChart
     }
 
     @computed get series(): FacetSeries[] {
-        return this.facetStrategy === FacetStrategy.column
+        return this.facetStrategy === FacetStrategy.metric
             ? this.columnFacets
             : this.entityFacets
     }

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -117,7 +117,10 @@ export class FacetChart
     }
 
     @computed private get uniformYAxis(): boolean {
-        return this.yAxisConfig.facetDomain === FacetAxisDomain.shared
+        // default to shared
+        const facetDomain =
+            this.yAxisConfig.facetDomain || FacetAxisDomain.shared
+        return facetDomain === FacetAxisDomain.shared
     }
 
     @computed private get uniformXAxis(): boolean {


### PR DESCRIPTION
Add two new URL parameters to preserve faceting settings. They are:

- `facet`: can be (`none`, `entity`, `metric`)
- `uniformYAxis`: can be (`1`, `0`)

Refactoring

- Renamed `FacetStrategy.column` to `FacetStrategy.metric`
- Make `yAxis.facetDomain` to `undefined` by default (but default it to `FacetAxisDomain.shared`)

Expected behaviour

- The URL parameters can override the default settings
- They get auto-added if you vary from the default settings, and auto-removed if you go back to any default setting

https://www.notion.so/owid/URL-parameter-support-for-facets-c7fb9b2a1e864f5e85137de71a736fca