### PR TITLE
fix(grapher): add exception to default source name shortening

### DIFF
--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1302,7 +1302,16 @@ export class Grapher
                 "World Bank",
                 "ILOSTAT",
             ]) {
-                if (sourceName.startsWith(majorSource)) return majorSource
+                if (
+                    sourceName.startsWith(majorSource) &&
+                    !sourceName.match(
+                        new RegExp(
+                            "^" + majorSource + "\\s+(based on|and)",
+                            "gi"
+                        )
+                    )
+                )
+                    return majorSource
             }
             return sourceName
         })


### PR DESCRIPTION
Solves a minor problem where the Grapher is shortening source names on display when this behavior is not desired for a number of source names in the latest World Bank World Development Indicators dataset.

- e.g. the source name "World Bank and OECD" should not be shortened to "World Bank" by default.
- e.g. the source name "World Bank based on UN Population Division" should not be shortened to "World Bank" by default.

This fix alters the default source name shortening behavior to NOT shorten source names on display when the source name starts with a `majorSource` (e.g. "World Bank") followed by either " and" or " based on".