### PR TITLE
fix(DataTable): show correct entity type in table header

### DIFF
--- a/coreTable/OwidTable.ts
+++ b/coreTable/OwidTable.ts
@@ -59,8 +59,6 @@ import { ColumnSlug } from "../clientUtils/owidTypes"
 // and value column(s). Whether or not we need in the long run is uncertain and it may just be a stepping stone
 // to go from our Variables paradigm to the Table paradigm.
 export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
-    entityType = "Country"
-
     @imemo get availableEntityNames(): any[] {
         return Array.from(this.availableEntityNameSet)
     }

--- a/grapher/dataTable/DataTable.stories.tsx
+++ b/grapher/dataTable/DataTable.stories.tsx
@@ -14,9 +14,12 @@ const table = SynthesizeGDPTable({
     entityCount: 7,
 })
 
+const entityType = "country"
+
 export const Default = (): JSX.Element => {
     const manager: DataTableManager = {
         table,
+        entityType,
     }
     return <DataTable manager={manager} />
 }
@@ -24,6 +27,7 @@ export const Default = (): JSX.Element => {
 export const WithTimeRange = (): JSX.Element => {
     const manager: DataTableManager = {
         table,
+        entityType,
     }
     manager.startTime = 1950
     manager.endTime = 2000
@@ -51,6 +55,7 @@ export const WithTolerance = (): JSX.Element => {
                     table,
                     startTime: 2010,
                     endTime: 2010,
+                    entityType,
                 }}
             />
             <div>
@@ -62,6 +67,7 @@ export const WithTolerance = (): JSX.Element => {
                     startTime: 2010,
                     endTime: 2010,
                     table: filteredTable,
+                    entityType,
                 }}
             />
         </div>

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -62,6 +62,7 @@ const inverseSortOrder = (order: SortOrder): SortOrder =>
 
 export interface DataTableManager {
     table: OwidTable
+    entityType: string
     endTime?: Time
     startTime?: Time
     minPopulationFilter?: number
@@ -118,11 +119,16 @@ export class DataTable extends React.Component<{
     }
 
     @computed get manager(): DataTableManager {
-        return this.props.manager || { table: BlankOwidTable() }
+        return (
+            this.props.manager ?? {
+                table: BlankOwidTable(),
+                entityType: "country",
+            }
+        )
     }
 
     @computed private get entityType(): string {
-        return this.table.entityType
+        return this.manager.entityType
     }
 
     @computed private get sortValueMapper(): (


### PR DESCRIPTION
Now gets `entityType` from manager, not from the `OwidTable`. 

This is a lapse from Project Next – the entity type isn't ever defined on the table, at least yet. It's messier right now to define it there, even though it _feels_ like it belongs there.

https://www.notion.so/owid/Grapher-table-view-labels-entity-as-Country-always-209c27d7a8aa45b593f0b754153db901