### PR TITLE
fix(svg): use `text-rendering: geometricPrecision` to fix text rendering issue on Android Chrome

### DIFF
--- a/grapher/captionedChart/CaptionedChart.scss
+++ b/grapher/captionedChart/CaptionedChart.scss
@@ -2,7 +2,6 @@
 .SourcesFooterHTML {
     font-family: $sans-serif-font-stack;
     font-size: 16px;
-    text-rendering: optimizelegibility;
     -webkit-font-smoothing: antialiased;
 }
 

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -344,7 +344,7 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         )
     }
 
-    @computed protected get svgProps() {
+    @computed protected get svgProps(): React.SVGProps<SVGSVGElement> {
         return {
             xmlns: "http://www.w3.org/2000/svg",
             version: "1.1",
@@ -353,7 +353,7 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
                     "Lato, 'Helvetica Neue', Helvetica, Arial, sans-serif",
                 fontSize: this.manager.fontSize ?? BASE_FONT_SIZE,
                 backgroundColor: "white",
-                textRendering: "optimizeLegibility" as any,
+                textRendering: "geometricPrecision",
                 WebkitFontSmoothing: "antialiased",
             },
         }


### PR DESCRIPTION
Fixes #360.

This is live on _tufte_, complete with newly rebaked exports.

---

The process of deploying this and regenerating all existing SVGs should looks something like this:
```sh
pm2 stop live-deploy-queue
cd live/bakedSite
git rm -r grapher/exports
git rm -r exports
mkdir grapher/exports
mkdir exports

# ...
yarn buildAndDeploySite live
```
Note: The deploy will take about two hours to rebake all exports.