### PR TITLE
fix(admin): set grapher id of newly saved grapher

### DIFF
--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -189,10 +189,7 @@ export class ChartEditor {
             if (isNewGrapher) {
                 this.newChartId = json.chartId
                 this.grapher.id = json.chartId
-                this.savedGrapherJson = JSON.stringify({
-                    ...currentGrapherObject,
-                    id: json.chartId,
-                })
+                this.savedGrapherJson = JSON.stringify(this.grapher.object)
             } else {
                 runInAction(() => {
                     grapher.version += 1

--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -188,6 +188,11 @@ export class ChartEditor {
         if (json.success) {
             if (isNewGrapher) {
                 this.newChartId = json.chartId
+                this.grapher.id = json.chartId
+                this.savedGrapherJson = JSON.stringify({
+                    ...currentGrapherObject,
+                    id: json.chartId,
+                })
             } else {
                 runInAction(() => {
                     grapher.version += 1
@@ -195,9 +200,7 @@ export class ChartEditor {
                     this.savedGrapherJson = JSON.stringify(currentGrapherObject)
                 })
             }
-        } else {
-            if (onError) onError()
-        }
+        } else onError?.()
     }
 
     async saveAsNewGrapher(): Promise<void> {


### PR DESCRIPTION
Notion: [Updating a newly created chart creates a duplicate of it](https://www.notion.so/Updating-a-newly-created-chart-creates-a-duplicate-of-it-87e732bd8fe54e41be19fc4e3f48bf9a)

This fixes the most prominent issue, and most importantly prevents duplicate slugs from appearing for now.