### PR TITLE
enhance: Improve faceting boundary cases

### DIFF
--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1912,7 +1912,12 @@ export class Grapher
             strategies.push(FacetStrategy.metric)
         }
 
-        if (this.selection.numSelectedEntities > 1) {
+        if (
+            // multiple entities
+            this.selection.numSelectedEntities > 1 &&
+            // more than one data point per entity
+            this.transformedTable.numRows > this.selection.numSelectedEntities
+        ) {
             strategies.push(FacetStrategy.entity)
         }
 

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1908,7 +1908,12 @@ export class Grapher
     @computed get availableFacetStrategies(): FacetStrategy[] {
         const strategies: FacetStrategy[] = [FacetStrategy.none]
 
-        if (this.hasMultipleYColumns) {
+        if (
+            // multiple metrics
+            this.hasMultipleYColumns &&
+            // more than one data point per metric
+            this.transformedTable.numRows > 1
+        ) {
             strategies.push(FacetStrategy.metric)
         }
 

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1908,9 +1908,12 @@ export class Grapher
     @computed get availableFacetStrategies(): FacetStrategy[] {
         const strategies: FacetStrategy[] = [FacetStrategy.none]
 
+        const numNonProjectedColumns = this.yColumns.filter(
+            (c) => !c.display || !c.display.isProjection
+        ).length
         if (
-            // multiple metrics
-            this.hasMultipleYColumns &&
+            // multiple metrics (excluding projections)
+            numNonProjectedColumns > 1 &&
             // more than one data point per metric
             this.transformedTable.numRows > 1
         ) {

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1485,7 +1485,12 @@ export class Grapher
                 this.yScaleType !== ScaleType.log
             )
 
-        if (this.facetStrategy !== FacetStrategy.none) return false
+        // actually trying to exclude relative mode with just one metric
+        if (
+            this.isStackedDiscreteBar &&
+            this.facetStrategy !== FacetStrategy.none
+        )
+            return false
 
         return !this.hideRelativeToggle
     }
@@ -1963,8 +1968,11 @@ export class Grapher
     }
 
     set facetStrategy(facet: FacetStrategy) {
-        this.selectedFacetStrategy = facet
-        if (facet !== FacetStrategy.none) {
+        if (
+            this.isStackedDiscreteBar &&
+            this.selectedFacetStrategy !== FacetStrategy.none
+        ) {
+            // actually trying to exclude relative mode with just one metric
             this.stackMode = StackMode.absolute
         }
     }

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1485,7 +1485,7 @@ export class Grapher
                 this.yScaleType !== ScaleType.log
             )
 
-        if (this.facetStrategy === FacetStrategy.metric) return false
+        if (this.facetStrategy !== FacetStrategy.none) return false
 
         return !this.hideRelativeToggle
     }
@@ -1964,6 +1964,9 @@ export class Grapher
 
     set facetStrategy(facet: FacetStrategy) {
         this.selectedFacetStrategy = facet
+        if (facet !== FacetStrategy.none) {
+            this.stackMode = StackMode.absolute
+        }
     }
 
     @action.bound randomSelection(num: number): void {

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1909,7 +1909,7 @@ export class Grapher
         const strategies: FacetStrategy[] = [FacetStrategy.none]
 
         const numNonProjectedColumns = this.yColumns.filter(
-            (c) => !c.display || !c.display.isProjection
+            (c) => !c.display?.isProjection
         ).length
         if (
             // multiple metrics (excluding projections)


### PR DESCRIPTION
Constrain the faceting experience so that we offer faceting only when it makes sense, and so that faceting interacts better with relative mode in the StackedDiscreteBar case.

Note that we change the relative mode state when switching to faceting. The ideal solution would not do this, just override it, but that would take a big refactor. So this is the compromise approach.

- [X] Disable facet-by-entity if there is only one data point
- [X] Disable facet-by-metric if there is only one data point
- [x] Disable facet-by-metric when one metric is a projection of the other
- [x] Disable relative mode when turning on faceting
- [x] Disable relative mode control during faceting

https://www.notion.so/owid/Ensure-all-possible-faceting-combinations-make-sense-for-v1-launch-5006ee5a119844c9bca5007b1e42e598