### PR TITLE
enhance(facets): Add global legend for Line, StackedArea & StackedDiscreteBar

### DIFF
--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -55,7 +55,11 @@ export class EditorFeatures {
     }
 
     @computed get hideLegend() {
-        return this.grapher.isLineChart || this.grapher.isStackedArea
+        return (
+            this.grapher.isLineChart ||
+            this.grapher.isStackedArea ||
+            this.grapher.isStackedDiscreteBar
+        )
     }
 
     @computed get stackedArea() {

--- a/grapher/chart/ChartInterface.ts
+++ b/grapher/chart/ChartInterface.ts
@@ -31,5 +31,9 @@ export interface ChartInterface {
     yAxis?: HorizontalAxis | VerticalAxis
     xAxis?: HorizontalAxis | VerticalAxis
 
+    /**
+     * The legend bins that have been hidden from the chart plot and should be shown externally.
+     * Used to create a global legend for faceted charts.
+     */
     externalLegendBins?: CategoricalBin[] // TODO allow NumericBin in the future
 }

--- a/grapher/chart/ChartInterface.ts
+++ b/grapher/chart/ChartInterface.ts
@@ -3,6 +3,7 @@ import { OwidTable } from "../../coreTable/OwidTable"
 import { SeriesName } from "../core/GrapherConstants"
 import { ColorScale } from "../color/ColorScale"
 import { HorizontalAxis, VerticalAxis } from "../axis/Axis"
+import { CategoricalBin } from "../color/ColorScaleBin"
 // The idea of this interface is to try and start reusing more code across our Chart classes and make it easier
 // for a dev to work on a chart type they haven't touched before if they've worked with another that implements
 // this interface.
@@ -29,4 +30,6 @@ export interface ChartInterface {
 
     yAxis?: HorizontalAxis | VerticalAxis
     xAxis?: HorizontalAxis | VerticalAxis
+
+    externalLegendBins?: CategoricalBin[] // TODO allow NumericBin in the future
 }

--- a/grapher/chart/ChartManager.ts
+++ b/grapher/chart/ChartManager.ts
@@ -13,6 +13,7 @@ import { ColorSchemeName } from "../color/ColorConstants"
 import { EntityName } from "../../coreTable/OwidTableConstants"
 import { SelectionArray } from "../selection/SelectionArray"
 import { Annotation, ColumnSlug, SortConfig } from "../../clientUtils/owidTypes"
+import { CategoricalBin } from "../color/ColorScaleBin"
 
 // The possible options common across our chart types. Not all of these apply to every chart type, so there is room to create a better type hierarchy.
 
@@ -66,4 +67,6 @@ export interface ChartManager {
 
     annotation?: Annotation
     resetAnnotation?: () => void
+
+    externalLegendFocusBin?: CategoricalBin | undefined // TODO allow NumericBin in the future
 }

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -185,7 +185,6 @@ export class FacetChart
     }
 
     @computed private get hideFacetLegends(): boolean {
-        if (this.facetCount <= 2) return false
         return true
     }
 

--- a/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -68,7 +68,6 @@ export interface HorizontalColorLegendManager {
     numericLegendY?: number
     legendWidth?: number
     legendHeight?: number
-    scale?: number
     categoricalLegendData?: CategoricalBin[]
     categoricalFocusBracket?: CategoricalBin
     categoricalBinStroke?: Color
@@ -443,12 +442,10 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
     }
 
     @computed private get markLines(): MarkLine[] {
-        const manager = this.manager
-        const scale = manager.scale ?? 1
-        const rectSize = 12 * scale
+        const fontSize = this.fontSize * 0.8
+        const rectSize = fontSize
         const rectPadding = 5
         const markPadding = 5
-        const fontSize = 0.8 * scale * this.fontSize
 
         const lines: MarkLine[] = []
         let marks: CategoricalMark[] = []

--- a/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -499,10 +499,14 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
         return max(this.markLines.map((l) => l.totalWidth)) as number
     }
 
+    @computed private get containerWidth(): number {
+        return this.manager.legendWidth ?? this.contentWidth
+    }
+
     @computed get marks(): CategoricalMark[] {
         const lines = this.markLines
         const align = this.legendAlign
-        const width = this.contentWidth
+        const width = this.containerWidth
 
         // Center each line
         lines.forEach((line) => {
@@ -525,7 +529,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
     }
 
     @computed get height(): number {
-        return max(this.marks.map((mark) => mark.y + mark.rectSize)) as number
+        return max(this.marks.map((mark) => mark.y + mark.rectSize)) ?? 0
     }
 
     render(): JSX.Element {

--- a/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -83,36 +83,36 @@ export interface HorizontalColorLegendManager {
 class HorizontalColorLegend extends React.Component<{
     manager: HorizontalColorLegendManager
 }> {
-    @computed get manager(): HorizontalColorLegendManager {
+    @computed protected get manager(): HorizontalColorLegendManager {
         return this.props.manager
     }
 
-    @computed get legendX(): number {
+    @computed protected get legendX(): number {
         return this.manager.legendX ?? 0
     }
 
-    @computed get categoryLegendY(): number {
+    @computed protected get categoryLegendY(): number {
         return this.manager.categoryLegendY ?? 0
     }
 
-    @computed get numericLegendY(): number {
+    @computed protected get numericLegendY(): number {
         return this.manager.numericLegendY ?? 0
     }
 
-    @computed get legendWidth(): number {
+    @computed protected get legendWidth(): number {
         return this.manager.legendWidth ?? 200
     }
 
-    @computed get legendHeight(): number {
+    @computed protected get legendHeight(): number {
         return this.manager.legendHeight ?? 200
     }
 
-    @computed get legendAlign() {
+    @computed protected get legendAlign(): HorizontalAlign {
         // Assume center alignment if none specified, for backwards-compatibility
         return this.manager.legendAlign ?? HorizontalAlign.center
     }
 
-    @computed get fontSize(): number {
+    @computed protected get fontSize(): number {
         return this.manager.fontSize ?? BASE_FONT_SIZE
     }
 }

--- a/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -473,7 +473,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
                 text: bin.text,
                 bounds: labelBounds.set({
                     x: markX + rectSize + rectPadding,
-                    y: markY + 1,
+                    y: markY + rectSize / 2,
                 }),
                 fontSize,
             }
@@ -572,7 +572,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
                                     // we can't use dominant-baseline to do proper alignment since our svg-to-png library Sharp
                                     // doesn't support that (https://github.com/lovell/sharp/issues/1996), so we'll have to make
                                     // do with some rough positioning.
-                                    dy={dyFromAlign(VerticalAlign.bottom)}
+                                    dy={dyFromAlign(VerticalAlign.middle)}
                                     fontSize={mark.label.fontSize}
                                 >
                                     {mark.label.text}

--- a/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -495,22 +495,23 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
         return lines
     }
 
-    @computed get width(): number {
+    @computed get contentWidth(): number {
         return max(this.markLines.map((l) => l.totalWidth)) as number
     }
 
     @computed get marks(): CategoricalMark[] {
         const lines = this.markLines
         const align = this.legendAlign
+        const width = this.contentWidth
 
         // Center each line
         lines.forEach((line) => {
             // TODO abstract this
             const xShift =
                 align === HorizontalAlign.center
-                    ? (this.width - line.totalWidth) / 2
+                    ? (width - line.totalWidth) / 2
                     : align === HorizontalAlign.right
-                    ? this.width - line.totalWidth
+                    ? width - line.totalWidth
                     : 0
             line.marks.forEach((mark) => {
                 mark.x += xShift

--- a/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -443,7 +443,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
 
     @computed private get markLines(): MarkLine[] {
         const fontSize = this.fontSize * 0.8
-        const rectSize = fontSize
+        const rectSize = this.fontSize * 0.75
         const rectPadding = 5
         const markPadding = 5
 

--- a/grapher/lineCharts/LineChart.test.ts
+++ b/grapher/lineCharts/LineChart.test.ts
@@ -3,6 +3,7 @@
 import { LineChart } from "./LineChart"
 import {
     SampleColumnSlugs,
+    SynthesizeFruitTable,
     SynthesizeFruitTableWithNonPositives,
     SynthesizeFruitTableWithStringValues,
     SynthesizeGDPTable,
@@ -181,4 +182,30 @@ it("reverses order of plotted series to plot the first one over the others", () 
 
     expect(chart.placedSeries).toHaveLength(2)
     expect(chart.placedSeries[0].seriesName).toEqual("pop")
+})
+
+describe("externalLegendBins", () => {
+    const table = SynthesizeFruitTable({
+        timeRange: [2000, 2010],
+        entityCount: 1,
+    })
+    const baseManager: ChartManager = {
+        table,
+        selection: table.sampleEntityName(1),
+        yColumnSlugs: [SampleColumnSlugs.Fruit, SampleColumnSlugs.Vegetables],
+    }
+
+    it("doesn't expose externalLegendBins when legend is shown", () => {
+        const chart = new LineChart({
+            manager: { ...baseManager },
+        })
+        expect(chart["externalLegendBins"].length).toEqual(0)
+    })
+
+    it("exposes externalLegendBins when legend is hidden", () => {
+        const chart = new LineChart({
+            manager: { ...baseManager, hideLegend: true },
+        })
+        expect(chart["externalLegendBins"].length).toEqual(2)
+    })
 })

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -10,6 +10,7 @@ import {
     last,
     exposeInstanceOnWindow,
     round,
+    excludeUndefined,
 } from "../../clientUtils/Util"
 import { computed, action, observable } from "mobx"
 import { observer } from "mobx-react"
@@ -58,6 +59,7 @@ import { ColorScheme } from "../color/ColorScheme"
 import { SelectionArray } from "../selection/SelectionArray"
 import { CoreColumn } from "../../coreTable/CoreTableColumns"
 import { PrimitiveType } from "../../coreTable/CoreTableConstants"
+import { CategoricalBin } from "../color/ColorScaleBin"
 
 const BLUR_COLOR = "#eee"
 
@@ -470,11 +472,11 @@ export class LineChart
     }
 
     @computed get focusedSeriesNames(): string[] {
-        const entityName =
-            this.props.manager.annotation?.entityName ??
-            this.hoveredSeriesName ??
-            undefined
-        return entityName ? [entityName] : []
+        return excludeUndefined([
+            this.manager.externalLegendFocusBin?.value,
+            this.props.manager.annotation?.entityName,
+            this.hoveredSeriesName,
+        ])
     }
 
     @computed get isFocusMode(): boolean {
@@ -796,5 +798,20 @@ export class LineChart
 
     @computed get xAxis(): HorizontalAxis {
         return this.dualAxis.horizontalAxis
+    }
+
+    @computed get externalLegendBins(): CategoricalBin[] {
+        if (this.manager.hideLegend) {
+            return this.series.map(
+                (series, index) =>
+                    new CategoricalBin({
+                        index,
+                        value: series.seriesName,
+                        label: series.seriesName,
+                        color: series.color,
+                    })
+            )
+        }
+        return []
     }
 }

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -550,6 +550,8 @@ export class LineChart
 
         const comparisonLines = manager.comparisonLines || []
 
+        const showLegend = !manager.hideLegend
+
         // The tiny bit of extra space in the clippath is to ensure circles centered on the very edge are still fully visible
         return (
             <g ref={this.base} className="LineChart">
@@ -563,7 +565,7 @@ export class LineChart
                             comparisonLine={line}
                         />
                     ))}
-                    <LineLegend manager={this} />
+                    {showLegend && <LineLegend manager={this} />}
                     <Lines
                         dualAxis={dualAxis}
                         placedSeries={this.placedSeries}

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -66,7 +66,7 @@ import { NoDataModal } from "../noDataModal/NoDataModal"
 import { ColorScaleConfig } from "../color/ColorScaleConfig"
 import { CoreColumn } from "../../coreTable/CoreTableColumns"
 import { SelectionArray } from "../selection/SelectionArray"
-import { Color } from "../../clientUtils/owidTypes"
+import { Color, HorizontalAlign } from "../../clientUtils/owidTypes"
 
 const PROJECTION_CHOOSER_WIDTH = 110
 const PROJECTION_CHOOSER_HEIGHT = 22
@@ -523,9 +523,10 @@ export class MapChart
 
     @computed get legendX(): number {
         const { bounds, numericLegend, categoryLegend } = this
+        // TODO move alignment logic to legend internals
         if (numericLegend) return bounds.centerX - this.legendWidth / 2
-
-        if (categoryLegend) return bounds.centerX - categoryLegend!.width / 2
+        if (categoryLegend)
+            return bounds.centerX - categoryLegend!.contentWidth / 2
         return 0
     }
 
@@ -534,6 +535,11 @@ export class MapChart
 
         if (categoryLegend) return bounds.bottom - categoryLegendHeight
         return 0
+    }
+
+    @computed get legendAlign(): HorizontalAlign {
+        // TODO pass `center` here and move alignment responsibility to legend
+        return HorizontalAlign.left
     }
 
     @computed get numericLegendY(): number {

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -522,12 +522,7 @@ export class MapChart
     }
 
     @computed get legendX(): number {
-        const { bounds, numericLegend, categoryLegend } = this
-        // TODO move alignment logic to legend internals
-        if (numericLegend) return bounds.centerX - this.legendWidth / 2
-        if (categoryLegend)
-            return bounds.centerX - categoryLegend!.contentWidth / 2
-        return 0
+        return this.bounds.centerX - this.legendWidth / 2
     }
 
     @computed get categoryLegendY(): number {
@@ -538,8 +533,7 @@ export class MapChart
     }
 
     @computed get legendAlign(): HorizontalAlign {
-        // TODO pass `center` here and move alignment responsibility to legend
-        return HorizontalAlign.left
+        return HorizontalAlign.center
     }
 
     @computed get numericLegendY(): number {

--- a/grapher/stackedCharts/AbstractStackedChart.tsx
+++ b/grapher/stackedCharts/AbstractStackedChart.tsx
@@ -34,6 +34,7 @@ import { select } from "d3-selection"
 import { ColorSchemes } from "../color/ColorSchemes"
 import { CoreColumn } from "../../coreTable/CoreTableColumns"
 import { SelectionArray } from "../selection/SelectionArray"
+import { CategoricalBin } from "../color/ColorScaleBin"
 
 export interface AbstactStackedChartProps {
     bounds?: Bounds
@@ -315,5 +316,22 @@ export class AbstactStackedChart<PositionType extends StackedPointPositionType>
 
     @computed get series(): readonly StackedSeries<PositionType>[] {
         return this.unstackedSeries
+    }
+
+    @computed get externalLegendBins(): CategoricalBin[] {
+        if (this.manager.hideLegend) {
+            return this.series
+                .map(
+                    (series, index) =>
+                        new CategoricalBin({
+                            index,
+                            value: series.seriesName,
+                            label: series.seriesName,
+                            color: series.color,
+                        })
+                )
+                .reverse()
+        }
+        return []
     }
 }

--- a/grapher/stackedCharts/StackedAreaChart.test.ts
+++ b/grapher/stackedCharts/StackedAreaChart.test.ts
@@ -156,3 +156,29 @@ it("should drop missing values at start or end", () => {
     expect(chart.series[0].points.length).toEqual(3)
     expect(chart.series[1].points.length).toEqual(3)
 })
+
+describe("externalLegendBins", () => {
+    const table = SynthesizeFruitTable({
+        timeRange: [2000, 2010],
+        entityCount: 1,
+    })
+    const baseManager: ChartManager = {
+        table,
+        selection: table.sampleEntityName(1),
+        yColumnSlugs: [SampleColumnSlugs.Fruit, SampleColumnSlugs.Vegetables],
+    }
+
+    it("doesn't expose externalLegendBins when legend is shown", () => {
+        const chart = new StackedAreaChart({
+            manager: { ...baseManager },
+        })
+        expect(chart["externalLegendBins"].length).toEqual(0)
+    })
+
+    it("exposes externalLegendBins when legend is hidden", () => {
+        const chart = new StackedAreaChart({
+            manager: { ...baseManager, hideLegend: true },
+        })
+        expect(chart["externalLegendBins"].length).toEqual(2)
+    })
+})

--- a/grapher/stackedCharts/StackedAreaChart.tsx
+++ b/grapher/stackedCharts/StackedAreaChart.tsx
@@ -7,12 +7,13 @@ import {
     getRelativeMouse,
     makeSafeForCSS,
     minBy,
+    excludeUndefined,
 } from "../../clientUtils/Util"
 import { computed, action, observable } from "mobx"
 import { SeriesName } from "../core/GrapherConstants"
 import { observer } from "mobx-react"
 import { DualAxisComponent } from "../axis/AxisViews"
-import { DualAxis, VerticalAxis } from "../axis/Axis"
+import { DualAxis } from "../axis/Axis"
 import {
     LineLabelSeries,
     LineLegend,
@@ -280,7 +281,10 @@ export class StackedAreaChart
     }
 
     @computed get focusedSeriesNames(): string[] {
-        return this.hoverSeriesName ? [this.hoverSeriesName] : []
+        return excludeUndefined([
+            this.manager.externalLegendFocusBin?.value,
+            this.hoverSeriesName,
+        ])
     }
 
     @computed get isFocusMode(): boolean {

--- a/grapher/stackedCharts/StackedBarChart.tsx
+++ b/grapher/stackedCharts/StackedBarChart.tsx
@@ -13,6 +13,7 @@ import { Text } from "../text/Text"
 import {
     VerticalColorLegend,
     VerticalColorLegendManager,
+    LegendItem,
 } from "../verticalColorLegend/VerticalColorLegend"
 import { Tooltip } from "../tooltip/Tooltip"
 import { BASE_FONT_SIZE } from "../core/GrapherConstants"
@@ -170,7 +171,7 @@ export class StackedBarChart
         )
     }
 
-    @computed get legendItems() {
+    @computed get legendItems(): LegendItem[] {
         return this.series
             .map((series) => {
                 return {

--- a/grapher/stackedCharts/StackedBarChart.tsx
+++ b/grapher/stackedCharts/StackedBarChart.tsx
@@ -192,6 +192,7 @@ export class StackedBarChart
         return 100
     }
     @computed get sidebarWidth(): number {
+        if (this.manager.hideLegend) return 0
         const { sidebarMinWidth, sidebarMaxWidth, legendDimensions } = this
         return Math.max(
             Math.min(legendDimensions.width, sidebarMaxWidth),
@@ -461,7 +462,9 @@ export class StackedBarChart
                     })}
                 </g>
 
-                <VerticalColorLegend manager={this} />
+                {!this.manager.hideLegend && (
+                    <VerticalColorLegend manager={this} />
+                )}
                 {tooltip}
             </g>
         )

--- a/grapher/stackedCharts/StackedDiscreteBarChart.test.ts
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.test.ts
@@ -282,3 +282,33 @@ describe("sorting", () => {
         ])
     })
 })
+
+describe("hideLegend", () => {
+    const table = SynthesizeFruitTable({
+        timeRange: [2000, 2001],
+        entityCount: 5,
+    })
+    const baseManager: ChartManager = {
+        table,
+        selection: table.sampleEntityName(5),
+        yColumnSlugs: [SampleColumnSlugs.Fruit, SampleColumnSlugs.Vegetables],
+    }
+
+    it("renders internal legend when hideLegend is true", () => {
+        const chart = new StackedDiscreteBarChart({
+            manager: { ...baseManager },
+        })
+        expect(chart["legend"].height).toBeGreaterThan(0)
+        expect(chart["categoricalLegendData"].length).toBeGreaterThan(0)
+        expect(chart["externalLegendBins"].length).toEqual(0)
+    })
+
+    it("exposes externalLegendBins when hideLegend is false", () => {
+        const chart = new StackedDiscreteBarChart({
+            manager: { ...baseManager, hideLegend: true },
+        })
+        expect(chart["legend"].height).toEqual(0)
+        expect(chart["categoricalLegendData"].length).toEqual(0)
+        expect(chart["externalLegendBins"].length).toEqual(2)
+    })
+})

--- a/grapher/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.tsx
@@ -160,6 +160,10 @@ export class StackedDiscreteBarChart
         return this.manager.baseFontSize ?? BASE_FONT_SIZE
     }
 
+    @computed private get showLegend(): boolean {
+        return !this.manager.hideLegend
+    }
+
     @computed private get labelStyle() {
         return {
             fontSize: 0.75 * this.baseFontSize,
@@ -241,8 +245,11 @@ export class StackedDiscreteBarChart
         return this.bounds
             .padLeft(this.labelWidth)
             .padBottom(this.yAxis.height)
-            .padTop(this.legendPaddingTop)
-            .padTop(this.legend.height)
+            .padTop(
+                this.showLegend && this.legend.height > 0
+                    ? this.legend.height + this.legendPaddingTop
+                    : 0
+            )
             .padRight(this.totalValueLabelWidth)
     }
 
@@ -440,7 +447,9 @@ export class StackedDiscreteBarChart
                     horizontalAxis={yAxis}
                     bounds={innerBounds}
                 />
-                <HorizontalCategoricalColorLegend manager={this} />
+                {this.showLegend && (
+                    <HorizontalCategoricalColorLegend manager={this} />
+                )}
                 <NodeGroup
                     data={this.placedItems}
                     keyAccessor={(d: PlacedItem) => d.label}

--- a/grapher/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.tsx
@@ -361,7 +361,7 @@ export class StackedDiscreteBarChart
         return this.baseFontSize
     }
 
-    @computed get categoricalLegendData(): CategoricalBin[] {
+    @computed private get legendBins(): CategoricalBin[] {
         return this.series.map((series, index) => {
             return new CategoricalBin({
                 index,
@@ -370,6 +370,14 @@ export class StackedDiscreteBarChart
                 color: series.color,
             })
         })
+    }
+
+    @computed get categoricalLegendData(): CategoricalBin[] {
+        return this.showLegend ? this.legendBins : []
+    }
+
+    @computed get externalLegendBins(): CategoricalBin[] {
+        return this.showLegend ? [] : this.legendBins
     }
 
     @action.bound onLegendMouseOver(bin: CategoricalBin): void {

--- a/grapher/verticalColorLegend/VerticalColorLegend.tsx
+++ b/grapher/verticalColorLegend/VerticalColorLegend.tsx
@@ -20,7 +20,7 @@ export interface VerticalColorLegendManager {
     focusColors?: Color[]
 }
 
-interface LegendItem {
+export interface LegendItem {
     label?: string
     minText?: string
     maxText?: string


### PR DESCRIPTION
Notion: [Global legend for all facets](https://www.notion.so/Global-legend-for-all-facets-c579c294009b4e72a6f21b801a366c8f)

Ready to review. Not quite sure whether this is the right approach for combining legends across charts, but it could be good enough for v1. Wrote some thoughts below:

Not deployed on a staging server because my staging server is used for another PR. But here are screenshots:

<img width="765" alt="Screenshot 2021-08-18 at 18 41 34" src="https://user-images.githubusercontent.com/1308115/129947244-c140c711-a770-4137-bf07-19b072ac6e41.png">
<img width="765" alt="Screenshot 2021-08-18 at 18 42 15" src="https://user-images.githubusercontent.com/1308115/129947254-cdca867c-350c-4ac6-bb90-a2230a22285c.png">

### Questions

**Is it reasonable to assume that a legend with 1 item should be automatically hidden?** 

This applies to the global facet legend, but also the stacked bar legend. There may be cases where it's a multi-metric chart, so the titles don't contain the full information and we need to rely on the legends, but maybe all except one metric happen to be missing for the selected countries. This behaviour would mean that the 1 legend item that is hidden is actually necessary to interpret the chart. 

What we actually want to check for is whether the author, in the original chart config, has selected multiple metrics. Right now we're getting the legend bins from the charts without information whether they are entities or metrics, so we don't have the necessary information on the facet level. 

Do charts maybe need to expose an axis/strategy along which to create a legend? Instead of the way I've done it currently, which is that the legend items are generated by the individual charts and then combined and shown at the facet level, maybe a chart only needs to specify the `legendStrategy`? Does this generalize across charts? 