### PR TITLE
enhance(facets): decrease columns in grid if all charts can fit in fewer columns

### DIFF
--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -587,11 +587,14 @@ export const getIdealGridParams = ({
     // See Observable notebook: https://observablehq.com/@danielgavrilov/pack-rectangles-of-a-preferred-aspect-ratio
     // Also Desmos graph: https://www.desmos.com/calculator/tmajzuq5tm
     const ratio = containerAspectRatio / idealAspectRatio
-    // prefer vertical grid for count=2
+    // Prefer vertical grid for count=2.
     if (count === 2 && ratio < 2) return { rows: 2, columns: 1 }
-    // otherwise, optimize for closest to the ideal aspect ratio
-    const columns = Math.min(Math.round(Math.sqrt(count * ratio)), count)
-    const rows = Math.ceil(count / columns)
+    // Otherwise, optimize for closest to the ideal aspect ratio.
+    const initialColumns = Math.min(Math.round(Math.sqrt(count * ratio)), count)
+    const rows = Math.ceil(count / initialColumns)
+    // Remove extra columns if we can fit everything in fewer.
+    // This will result in wider aspect ratios than ideal, which is ok.
+    const columns = Math.ceil(count / rows)
     return {
         rows,
         columns,

--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -2,7 +2,7 @@
 export const EPOCH_DATE = "2020-01-21"
 
 /** The "plot" is a chart without any header, footer or controls */
-export const IDEAL_PLOT_ASPECT_RATIO: number = 2.2
+export const IDEAL_PLOT_ASPECT_RATIO: number = 1.8
 
 export interface Box {
     x: number


### PR DESCRIPTION
Notion: [Tweak facet layout algorithm](https://www.notion.so/Tweak-facet-layout-algorithm-2b1a1959a0c14c4d9923ae1ac18b442f)

The [very quick fix](https://github.com/owid/owid-grapher/commit/7f288b0ca9b6d8c28be28245c83b1caa7f06bc1f) I deployed temporarily increased `IDEAL_PLOT_ASPECT_RATIO`, this changes it back.

I'd like to spend some time testing different cases before deploying (will be doing this next week).

I've added this tweak to the [Observable notebook](https://observablehq.com/@danielgavrilov/pack-rectangles-of-a-preferred-aspect-ratio) under "Round col, then derive row, remove extra columns".