### PR TITLE
Feedback links to faq

### DIFF
--- a/site/Feedback.tsx
+++ b/site/Feedback.tsx
@@ -73,7 +73,7 @@ const topicMatchers = [
 const vaccineNotice = (
     <a
         key="vaccineNotice"
-        href="https://ourworldindata.org/covid-vaccinations#frequently-asked-questions"
+        href={`${BAKED_BASE_URL}/covid-vaccinations#frequently-asked-questions"`}
         target="_blank"
         rel="noreferrer"
     >
@@ -84,7 +84,7 @@ const vaccineNotice = (
 const copyrightNotice = (
     <a
         key="copyrightNotice"
-        href="https://ourworldindata.org/faqs#how-is-your-work-copyrighted"
+        href={`${BAKED_BASE_URL}/faqs#how-is-your-work-copyrighted"`}
         target="_blank"
         rel="noreferrer"
     >
@@ -94,7 +94,7 @@ const copyrightNotice = (
 const citationNotice = (
     <a
         key="citationNotice"
-        href="https://ourworldindata.org/faqs#how-should-i-cite-your-work"
+        href={`${BAKED_BASE_URL}/faqs#how-should-i-cite-your-work"`}
         target="_blank"
         rel="noreferrer"
     >
@@ -104,7 +104,7 @@ const citationNotice = (
 const translateNotice = (
     <a
         key="translateNotice"
-        href="https://ourworldindata.org/faqs#can-i-translate-your-work-into-another-language"
+        href={`${BAKED_BASE_URL}/faqs#can-i-translate-your-work-into-another-language"`}
         target="_blank"
         rel="noreferrer"
     >

--- a/site/Feedback.tsx
+++ b/site/Feedback.tsx
@@ -7,6 +7,7 @@ import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes"
 import { observable, action, toJS, computed } from "mobx"
 import classnames from "classnames"
 import { faPaperPlane } from "@fortawesome/free-solid-svg-icons/faPaperPlane"
+import { BAKED_BASE_URL } from "../settings/clientSettings"
 
 const sendFeedback = (feedback: Feedback) =>
     new Promise((resolve, reject) => {
@@ -206,23 +207,23 @@ export class FeedbackForm extends React.Component<{
                 <div className="header">Leave us feedback</div>
                 <div className="notice">
                     <p>
-                        You may have a question we've already answered in&nbsp;
+                        <strong>Have a question?</strong> You may find an answer
+                        in:
+                        <br />
                         <a
-                            href="https://ourworldindata.org/faqs"
+                            href={`${BAKED_BASE_URL}/faqs`}
                             target="_blank"
                             rel="noreferrer"
                         >
-                            our Frequently Asked Questions.
-                        </a>
-                        <br></br>
-                        Questions about our Covid vaccination data might&nbsp;
-                        be already answered in&nbsp;
+                            <strong>General FAQ</strong>
+                        </a>{" "}
+                        or{" "}
                         <a
-                            href="https://ourworldindata.org/covid-vaccinations#frequently-asked-questions"
+                            href={`${BAKED_BASE_URL}/covid-vaccinations#frequently-asked-questions`}
                             target="_blank"
                             rel="noreferrer"
                         >
-                            our vaccination FAQ.
+                            <strong>Vaccinations FAQ</strong>
                         </a>
                     </p>
                 </div>
@@ -237,6 +238,12 @@ export class FeedbackForm extends React.Component<{
                             required
                             disabled={loading}
                         />
+                        {notices ? (
+                            <div className="topic-notice">
+                                Your question may be answered in{" "}
+                                <strong>{notices}</strong>.
+                            </div>
+                        ) : null}
                     </div>
                     <div className="formSection">
                         <label htmlFor="feedback.name">Your name</label>
@@ -266,12 +273,6 @@ export class FeedbackForm extends React.Component<{
                         </div>
                     ) : undefined}
                 </div>
-                {notices ? (
-                    <div className="topic-notice">
-                        Your question may be related to this FAQ entry on &nbsp;
-                        {notices}
-                    </div>
-                ) : null}
                 <div className="footer">
                     <button type="submit" disabled={loading}>
                         Send message

--- a/site/Feedback.tsx
+++ b/site/Feedback.tsx
@@ -63,7 +63,7 @@ interface SpecialTopicMatcher {
     topic: SpecialFeedbackTopic
 }
 
-const topicMatchers = [
+const topicMatchers: SpecialTopicMatcher[] = [
     { regex: vaccinationRegex, topic: SpecialFeedbackTopic.Vaccination },
     { regex: licensingRegex, topic: SpecialFeedbackTopic.Licensing },
     { regex: citationRegex, topic: SpecialFeedbackTopic.Citation },

--- a/site/Feedback.tsx
+++ b/site/Feedback.tsx
@@ -45,9 +45,78 @@ class Feedback {
     }
 }
 
-const vaccinationRegexe = /vaccination|vaccine|doses|vaccinat/i
+const vaccinationRegex = /vaccination|vaccine|doses|vaccinat/i
 const licensingRegex = /license|licensing|copyright/i
 const citationRegex = /cite|citation|citing|reference/i
+const translateRegex = /translat/i
+
+enum SpecialFeedbackTopic {
+    Vaccination,
+    Licensing,
+    Citation,
+    Translation,
+}
+
+interface SpecialTopicMatcher {
+    regex: RegExp
+    topic: SpecialFeedbackTopic
+}
+
+const topicMatchers = [
+    { regex: vaccinationRegex, topic: SpecialFeedbackTopic.Vaccination },
+    { regex: licensingRegex, topic: SpecialFeedbackTopic.Licensing },
+    { regex: citationRegex, topic: SpecialFeedbackTopic.Citation },
+    { regex: translateRegex, topic: SpecialFeedbackTopic.Translation },
+]
+
+const vaccineNotice = (
+    <a
+        key="vaccineNotice"
+        href="https://ourworldindata.org/covid-vaccinations#frequently-asked-questions"
+        target="_blank"
+        rel="noreferrer"
+    >
+        Covid Vaccines Questions
+    </a>
+)
+
+const copyrightNotice = (
+    <a
+        key="copyrightNotice"
+        href="https://ourworldindata.org/faqs#how-is-your-work-copyrighted"
+        target="_blank"
+        rel="noreferrer"
+    >
+        Copyright Queries
+    </a>
+)
+const citationNotice = (
+    <a
+        key="citationNotice"
+        href="https://ourworldindata.org/faqs#how-should-i-cite-your-work"
+        target="_blank"
+        rel="noreferrer"
+    >
+        How to Cite our Work
+    </a>
+)
+const translateNotice = (
+    <a
+        key="translateNotice"
+        href="https://ourworldindata.org/faqs#can-i-translate-your-work-into-another-language"
+        target="_blank"
+        rel="noreferrer"
+    >
+        Translating our work
+    </a>
+)
+
+const topicNotices = new Map<SpecialFeedbackTopic, JSX.Element>([
+    [SpecialFeedbackTopic.Vaccination, vaccineNotice],
+    [SpecialFeedbackTopic.Citation, citationNotice],
+    [SpecialFeedbackTopic.Licensing, copyrightNotice],
+    [SpecialFeedbackTopic.Translation, translateNotice],
+])
 
 @observer
 export class FeedbackForm extends React.Component<{
@@ -99,32 +168,16 @@ export class FeedbackForm extends React.Component<{
         this.done = false
     }
 
-    @computed private get isTopicVaccines(): boolean {
+    @computed private get specialTopic(): SpecialFeedbackTopic | undefined {
         const { message } = this.feedback
-        return vaccinationRegexe.test(message)
-    }
-
-    @computed private get isTopicCopyright(): boolean {
-        const { message } = this.feedback
-        return licensingRegex.test(message)
-    }
-
-    @computed private get isTopicCitation(): boolean {
-        const { message } = this.feedback
-        return citationRegex.test(message)
+        return topicMatchers.find((matcher) => matcher.regex.test(message))
+            ?.topic
     }
 
     renderBody() {
-        const {
-            loading,
-            done,
-            isTopicCitation,
-            isTopicVaccines,
-            isTopicCopyright,
-        } = this
+        const { loading, done, specialTopic } = this
         const autofocus = this.props.autofocus ?? true
-        const isSpecialTopic =
-            isTopicCitation || isTopicCopyright || isTopicVaccines
+
         if (done) {
             return (
                 <div className="doneMessage">
@@ -144,46 +197,10 @@ export class FeedbackForm extends React.Component<{
                 </div>
             )
         }
-        const vaccineNotice = (
-            <a
-                key="vaccineNotice"
-                href="https://ourworldindata.org/covid-vaccinations#frequently-asked-questions"
-                target="_blank"
-                rel="noreferrer"
-            >
-                Covid Vaccines Questions
-            </a>
-        )
 
-        const copyrightNotice = (
-            <a
-                key="copyrightNotice"
-                href="https://ourworldindata.org/faqs#how-is-your-work-copyrighted"
-                target="_blank"
-                rel="noreferrer"
-            >
-                Copyright Queries
-            </a>
-        )
-        const citationNotice = (
-            <a
-                key="citationNotice"
-                href="https://ourworldindata.org/faqs#how-should-i-cite-your-work"
-                target="_blank"
-                rel="noreferrer"
-            >
-                How to Cite our Work&nbsp;
-            </a>
-        )
-        const notices = isSpecialTopic
-            ? isTopicCitation
-                ? citationNotice
-                : isTopicCopyright
-                ? copyrightNotice
-                : isTopicVaccines
-                ? vaccineNotice
-                : null
-            : null
+        const notices = specialTopic
+            ? topicNotices.get(specialTopic)
+            : undefined
         return (
             <React.Fragment>
                 <div className="header">Leave us feedback</div>

--- a/site/Feedback.tsx
+++ b/site/Feedback.tsx
@@ -4,7 +4,7 @@ import { observer } from "mobx-react"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faCommentAlt } from "@fortawesome/free-solid-svg-icons/faCommentAlt"
 import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes"
-import { observable, action, toJS } from "mobx"
+import { observable, action, toJS, computed } from "mobx"
 import classnames from "classnames"
 import { faPaperPlane } from "@fortawesome/free-solid-svg-icons/faPaperPlane"
 
@@ -44,6 +44,10 @@ class Feedback {
         this.message = ""
     }
 }
+
+const vaccinationRegexe = /vaccination|vaccine|doses/i
+const licensingRegex = /license|licensing|copyright/i
+const citationRegex = /cite|citation/i
 
 @observer
 export class FeedbackForm extends React.Component<{
@@ -95,9 +99,32 @@ export class FeedbackForm extends React.Component<{
         this.done = false
     }
 
+    @computed private get isTopicVaccines(): boolean {
+        const { message } = this.feedback
+        return vaccinationRegexe.test(message)
+    }
+
+    @computed private get isTopicCopyright(): boolean {
+        const { message } = this.feedback
+        return licensingRegex.test(message)
+    }
+
+    @computed private get isTopicCitation(): boolean {
+        const { message } = this.feedback
+        return citationRegex.test(message)
+    }
+
     renderBody() {
-        const { loading, done } = this
+        const {
+            loading,
+            done,
+            isTopicCitation,
+            isTopicVaccines,
+            isTopicCopyright,
+        } = this
         const autofocus = this.props.autofocus ?? true
+        const isSpecialTopic =
+            isTopicCitation || isTopicCopyright || isTopicVaccines
         if (done) {
             return (
                 <div className="doneMessage">
@@ -117,13 +144,67 @@ export class FeedbackForm extends React.Component<{
                 </div>
             )
         }
+        const vaccineNotice = (
+            <a
+                key="vaccineNotice"
+                href="https://ourworldindata.org/covid-vaccinations#frequently-asked-questions"
+                target="_blank"
+                rel="noreferrer"
+            >
+                Covid Vaccines Questions
+            </a>
+        )
+
+        const copyrightNotice = (
+            <a
+                key="copyrightNotice"
+                href="https://ourworldindata.org/faqs#how-is-your-work-copyrighted"
+                target="_blank"
+                rel="noreferrer"
+            >
+                Copyright Queries
+            </a>
+        )
+        const citationNotice = (
+            <a
+                key="citationNotice"
+                href="https://ourworldindata.org/faqs#how-should-i-cite-your-work"
+                target="_blank"
+                rel="noreferrer"
+            >
+                How to Cite our Work&nbsp;
+            </a>
+        )
+        const notices = isSpecialTopic
+            ? isTopicCitation
+                ? citationNotice
+                : isTopicCopyright
+                ? copyrightNotice
+                : isTopicVaccines
+                ? vaccineNotice
+                : undefined
+            : [
+                  vaccineNotice,
+                  <span key="vaccineComma">, </span>,
+                  copyrightNotice,
+                  <span key="copyrightComma">, </span>,
+                  citationNotice,
+              ]
         return (
             <React.Fragment>
                 <div className="header">Leave us feedback</div>
                 <div className="notice">
                     <p>
-                        We read and consider all feedback, but due to a high
-                        volume of messages we are not able to reply to all.
+                        You may have a question we've already answered in&nbsp;
+                        <a
+                            href="https://ourworldindata.org/faqs"
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            our Frequently Asked Questions.&nbsp;
+                        </a>
+                        Find quick answers to&nbsp;
+                        {notices}
                     </p>
                 </div>
                 <div className="formBody">

--- a/site/Feedback.tsx
+++ b/site/Feedback.tsx
@@ -45,9 +45,9 @@ class Feedback {
     }
 }
 
-const vaccinationRegexe = /vaccination|vaccine|doses/i
+const vaccinationRegexe = /vaccination|vaccine|doses|vaccinat/i
 const licensingRegex = /license|licensing|copyright/i
-const citationRegex = /cite|citation/i
+const citationRegex = /cite|citation|citing|reference/i
 
 @observer
 export class FeedbackForm extends React.Component<{
@@ -195,7 +195,17 @@ export class FeedbackForm extends React.Component<{
                             target="_blank"
                             rel="noreferrer"
                         >
-                            our Frequently Asked Questions.&nbsp;
+                            our Frequently Asked Questions.
+                        </a>
+                        <br></br>
+                        Questions about our Covid vaccination data might&nbsp;
+                        be already answered in&nbsp;
+                        <a
+                            href="https://ourworldindata.org/covid-vaccinations#frequently-asked-questions"
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            our vaccination FAQ.
                         </a>
                     </p>
                 </div>

--- a/site/Feedback.tsx
+++ b/site/Feedback.tsx
@@ -182,14 +182,8 @@ export class FeedbackForm extends React.Component<{
                 ? copyrightNotice
                 : isTopicVaccines
                 ? vaccineNotice
-                : undefined
-            : [
-                  vaccineNotice,
-                  <span key="vaccineComma">, </span>,
-                  copyrightNotice,
-                  <span key="copyrightComma">, </span>,
-                  citationNotice,
-              ]
+                : null
+            : null
         return (
             <React.Fragment>
                 <div className="header">Leave us feedback</div>
@@ -203,11 +197,20 @@ export class FeedbackForm extends React.Component<{
                         >
                             our Frequently Asked Questions.&nbsp;
                         </a>
-                        Find quick answers to&nbsp;
-                        {notices}
                     </p>
                 </div>
                 <div className="formBody">
+                    <div className="formSection formSectionExpand">
+                        <label htmlFor="feedback.message">Message</label>
+                        <textarea
+                            id="feedback.message"
+                            onChange={this.onMessage}
+                            rows={5}
+                            minLength={30}
+                            required
+                            disabled={loading}
+                        />
+                    </div>
                     <div className="formSection">
                         <label htmlFor="feedback.name">Your name</label>
                         <input
@@ -227,17 +230,6 @@ export class FeedbackForm extends React.Component<{
                             disabled={loading}
                         />
                     </div>
-                    <div className="formSection formSectionExpand">
-                        <label htmlFor="feedback.message">Message</label>
-                        <textarea
-                            id="feedback.message"
-                            onChange={this.onMessage}
-                            rows={5}
-                            minLength={30}
-                            required
-                            disabled={loading}
-                        />
-                    </div>
                     {this.error ? (
                         <div style={{ color: "red" }}>{this.error}</div>
                     ) : undefined}
@@ -247,6 +239,12 @@ export class FeedbackForm extends React.Component<{
                         </div>
                     ) : undefined}
                 </div>
+                {notices ? (
+                    <div className="topic-notice">
+                        Your question may be related to this FAQ entry on &nbsp;
+                        {notices}
+                    </div>
+                ) : null}
                 <div className="footer">
                     <button type="submit" disabled={loading}>
                         Send message

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -1218,12 +1218,13 @@ html:not(.js) {
         }
     }
 
-    .notice {
+    .notice,
+    .topic-notice {
         @include info;
+        font-size: 1rem;
         margin-top: 0;
         padding: 1rem;
-        background-color: $tertiary-color;
-        color: $primary-color;
+        background-color: #f1f1f1;
         .title {
             font-weight: bold;
             margin: 0 0 0.5rem;
@@ -1238,22 +1239,9 @@ html:not(.js) {
     }
 
     .topic-notice {
-        @include info;
-        margin-top: 0;
-        padding: 1rem;
-        background-color: $tertiary-color-brighter;
-        color: $primary-color;
-        .title {
-            font-weight: bold;
-            margin: 0 0 0.5rem;
-            font-size: inherit;
-        }
-        a {
-            color: #453cbb;
-        }
-        a:hover {
-            color: #7d8aef;
-        }
+        font-size: 0.875rem;
+        border-radius: 0 0 3px 3px;
+        padding: 0.5rem 0.75rem;
     }
 
     > .footer {

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -1229,6 +1229,12 @@ html:not(.js) {
             margin: 0 0 0.5rem;
             font-size: inherit;
         }
+        a {
+            color: #453cbb;
+        }
+        a:hover {
+            color: #7d8aef;
+        }
     }
 
     > .footer {

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -1237,6 +1237,25 @@ html:not(.js) {
         }
     }
 
+    .topic-notice {
+        @include info;
+        margin-top: 0;
+        padding: 1rem;
+        background-color: $tertiary-color-brighter;
+        color: $primary-color;
+        .title {
+            font-weight: bold;
+            margin: 0 0 0.5rem;
+            font-size: inherit;
+        }
+        a {
+            color: #453cbb;
+        }
+        a:hover {
+            color: #7d8aef;
+        }
+    }
+
     > .footer {
         box-shadow: 0 -0.07143rem 0.85714rem rgba(0, 0, 0, 0.08);
         padding: 0.8rem 1rem;

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -1153,7 +1153,7 @@ html:not(.js) {
 
 .FeedbackForm {
     height: calc(100vh - 100px);
-    max-height: 600px;
+    max-height: 700px;
     transition: opacity 0.25s ease-in-out;
 
     &.loading > * {


### PR DESCRIPTION
This PR adds a general link to our FAQ in the feedback form and does a simple match on some of the most common keywords to highlight specific entries. The goal of this is to reduce feedback that is already answered in the FAQ. See the slack thread here for background: https://owid.slack.com/archives/C0149NKLZAM/p1629910262010300