### PR TITLE
Update COVID explorer path in subnavigation

### DIFF
--- a/site/SiteSubnavigation.tsx
+++ b/site/SiteSubnavigation.tsx
@@ -40,7 +40,7 @@ export const subnavs: { [key in SubNavId]: SubnavItem[] } = {
         },
         {
             label: "Data explorer",
-            href: "/coronavirus-data-explorer",
+            href: "/explorers/coronavirus-data-explorer",
             id: "data-explorer",
             highlight: true,
         },


### PR DESCRIPTION
before: https://ourworldindata.org/coronavirus-data-explorer
after: https://ourworldindata.org/explorers/coronavirus-data-explorer

@danielgavrilov there seems to be a client side redirect performed between the two URLs. Any reason not to have it performed server side? (pinging you as I saw you contributed related migration tests, but feel free to pass along)