### PR TITLE
feat(db): script to export variable metadata CSV

### DIFF
--- a/db/exportVariablesMetadataCSV.ts
+++ b/db/exportVariablesMetadataCSV.ts
@@ -1,0 +1,118 @@
+import * as path from "path"
+import * as fs from "fs-extra"
+import parseArgs from "minimist"
+import lodash from "lodash"
+import { createObjectCsvStringifier } from "csv-writer"
+
+import * as db from "./db"
+
+const argv = parseArgs(process.argv.slice(2))
+const filePath = path.resolve(argv._[0] || "/tmp/owid_variables.csv")
+
+// Use ISO string instead of toString() to stringify dates
+function stringifyDateProperties<Obj extends Record<string, unknown>>(
+    obj: Obj
+): {
+    [key in keyof Obj]: Obj[key] extends Date ? string : Obj[key]
+} {
+    return lodash.mapValues(obj, (value) =>
+        value instanceof Date ? value.toISOString() : value
+    ) as any
+}
+
+const main = async (): Promise<void> => {
+    const conn = await db.getConnection()
+
+    const sqlQuery = `
+        SELECT
+            v.id as variableId, v.name as variableName,
+            v.createdAt as variableCreatedAt, v.updatedAt as variableUpdatedAt,
+            v.description as variableDescription,
+            v.unit as variableUnit, v.shortUnit as variableShortUnit,
+            v.display as variableDisplay,
+
+            v.datasetId, d.name as datasetName, d.namespace as datasetNamespace,
+            d.createdAt as datasetCreatedAt, d.updatedAt as datasetUpdatedAt,
+            d.dataEditedAt as datasetDataEditedAt,
+            uc.fullName as datasetCreatedBy, ue.fullName as datasetdataEditedBy,
+
+            v.sourceId, s.name as sourceName,
+
+            cd.chartIds
+
+        FROM variables as v
+        LEFT JOIN datasets as d
+        ON v.datasetId = d.id
+        LEFT JOIN sources as s
+        ON v.sourceId = s.id
+        LEFT JOIN users as uc
+        ON d.createdByUserId = uc.id
+        LEFT JOIN users as ue
+        ON d.dataEditedByUserId = ue.id
+        LEFT JOIN (
+            SELECT variableId, JSON_ARRAYAGG(chartId) as chartIds
+            FROM chart_dimensions
+            GROUP BY variableId
+        ) as cd
+        ON v.id = cd.variableId
+        ORDER BY datasetDataEditedAt DESC;
+    `
+
+    const columns = [
+        "variableId",
+        "variableName",
+        "variableCreatedAt",
+        "variableUpdatedAt",
+        "variableDescription",
+        "variableUnit",
+        "variableShortUnit",
+        "variableDisplay",
+        "datasetId",
+        "datasetName",
+        "datasetNamespace",
+        "datasetCreatedAt",
+        "datasetUpdatedAt",
+        "datasetDataEditedAt",
+        "datasetCreatedBy",
+        "datasetdataEditedBy",
+        "sourceId",
+        "sourceName",
+        "chartIds",
+    ]
+
+    // Erase file if it already exists
+    if (fs.existsSync(filePath)) {
+        await fs.truncate(filePath)
+    }
+
+    // Create stream so we minimise the RAM necessary to process this big query
+    const queryRunner = conn.createQueryRunner()
+    const resultStream = await queryRunner.stream(sqlQuery)
+
+    const csvStringifier = createObjectCsvStringifier({
+        header: columns.map((col) => ({
+            id: col,
+            title: col,
+        })),
+    })
+
+    const fileStream = fs.createWriteStream(filePath, { flags: "a" })
+    fileStream.write(csvStringifier.getHeaderString())
+
+    resultStream.on("data", (data) =>
+        fileStream.write(
+            csvStringifier.stringifyRecords([
+                stringifyDateProperties(data as any),
+            ])
+        )
+    )
+    resultStream.on("error", (error) => {
+        throw error
+    })
+    resultStream.on("end", async () => {
+        fileStream.close()
+        await db.closeTypeOrmAndKnexConnections()
+    })
+}
+
+main()

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
         "copy-to-clipboard": "^3.3.1",
         "css-loader": "^4.2.2",
         "csv-parse": "^4.4.3",
+        "csv-writer": "^1.6.0",
         "d3": "^6.1.1",
         "d3-geo-projection": "^3.0.0",
         "dayjs": "^1.9.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7205,6 +7205,11 @@ csv-parse@^4.4.3:
   resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.4.3.tgz#a3fc56b6f54de88db76fbd34a55c091861522712"
   integrity sha512-TiLGAy14FPJ7/yB+Gn6RgSxoZLpf6pJTRkGqmCt9t/SGVwubrXjbUWtEw39RlKB6hDHzbdjLyBZaysQ0Ji6p/w==
 
+csv-writer@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/csv-writer/-/csv-writer-1.6.0.tgz#d0cea44b6b4d7d3baa2ecc6f3f7209233514bcf9"
+  integrity sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g==
+
 cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"


### PR DESCRIPTION
Bobbie created [a CSV dump of every variable in the database](https://owid.slack.com/archives/C0146HTMV2R/p1627964599000700) a while ago. 

Joe [finds it very helpful and wants an update](https://owid.slack.com/archives/C0149NKLZAM/p1630939123007300).

This quick script can be run the same way we run the `exportMetadata` and `exportChartData` cron jobs daily – create dump and upload it to a DigitalOcean space: https://github.com/owid/owid-grapher/blob/84fdc519f32a0e9c25496303dd93bbdfbb07fb75/devTools/droplet/live.crontab#L2-L3

