### PR TITLE
fix: introduce monkeypatch for Google Translate to work with React

### DIFF
--- a/grapher/controls/entityPicker/EntityPicker.tsx
+++ b/grapher/controls/entityPicker/EntityPicker.tsx
@@ -341,15 +341,15 @@ export class EntityPicker extends React.Component<{
             } else currentToken.text += char
         }
         return (
-            <React.Fragment>
+            <span>
                 {tokens.map((token, i) =>
                     token.match ? (
                         <mark key={i}>{token.text}</mark>
                     ) : (
-                        <React.Fragment key={i}>{token.text}</React.Fragment>
+                        <span key={i}>{token.text}</span>
                     )
                 )}
-            </React.Fragment>
+            </span>
         )
     }
 

--- a/grapher/controls/entityPicker/EntityPicker.tsx
+++ b/grapher/controls/entityPicker/EntityPicker.tsx
@@ -341,7 +341,7 @@ export class EntityPicker extends React.Component<{
             } else currentToken.text += char
         }
         return (
-            <span>
+            <span translate="no">
                 {tokens.map((token, i) =>
                     token.match ? (
                         <mark key={i}>{token.text}</mark>

--- a/grapher/timeline/TimelineComponent.tsx
+++ b/grapher/timeline/TimelineComponent.tsx
@@ -355,7 +355,7 @@ const TimelineHandle = ({
             }}
         >
             <Tippy
-                content={tooltipContent}
+                content={<span>{tooltipContent}</span>}
                 visible={tooltipVisible}
                 zIndex={tooltipZIndex}
             >

--- a/site/hacks.ts
+++ b/site/hacks.ts
@@ -1,0 +1,47 @@
+/**
+ * React and the browser-integrated Google Translate don't love each other:
+ * In a translated page, some interactions entirely break the page.
+ * Since Google Translate actually works quite well for OWID and we would like to support that use
+ * case, we're monkey-patching the global Node.removeChild and Node.insertBefore instead.
+ * It's a hack that has been suggested by Dan Abramov himself: https://github.com/facebook/react/issues/11538#issuecomment-417504600
+ * -@MarcelGerber, 2021-09-06
+ */
+export const runMonkeyPatchForGoogleTranslate = (): void => {
+    if (typeof Node === "function" && Node.prototype) {
+        const originalRemoveChild = Node.prototype.removeChild
+        Node.prototype.removeChild = function <T extends Node>(child: T): T {
+            if (child.parentNode !== this) {
+                if (console) {
+                    console.error(
+                        "Cannot remove a child from a different parent",
+                        child,
+                        this
+                    )
+                }
+                return child
+            }
+            return originalRemoveChild.apply(this, [child]) as T
+        }
+
+        const originalInsertBefore = Node.prototype.insertBefore
+        Node.prototype.insertBefore = function <T extends Node>(
+            newNode: T,
+            referenceNode: Node | null
+        ) {
+            if (referenceNode && referenceNode.parentNode !== this) {
+                if (console) {
+                    console.error(
+                        "Cannot insert before a reference node from a different parent",
+                        referenceNode,
+                        this
+                    )
+                }
+                return newNode
+            }
+            return originalInsertBefore.apply(this, [
+                newNode,
+                referenceNode,
+            ]) as T
+        }
+    }
+}

--- a/site/owid.entry.ts
+++ b/site/owid.entry.ts
@@ -39,6 +39,7 @@ import { SiteAnalytics } from "./SiteAnalytics"
 import { renderProminentLink } from "./blocks/ProminentLink"
 import Bugsnag from "@bugsnag/js"
 import BugsnagPluginReact from "@bugsnag/plugin-react"
+import { runMonkeyPatchForGoogleTranslate } from "./hacks"
 
 declare let window: any
 window.Grapher = Grapher
@@ -72,6 +73,8 @@ window.runSiteFooterScripts = () => {
         renderProminentLink()
     }
 }
+
+runMonkeyPatchForGoogleTranslate()
 
 if (BUGSNAG_API_KEY) {
     try {


### PR DESCRIPTION
Notion: [Charts often break when translated with Google Translate](https://www.notion.so/Charts-often-break-when-translated-with-Google-Translate-c46a844640714cc698ee14c13b5b504b)

This is live on _tufte_.

---

This problem with Google Translate (there's a video in Notion) is actually one of the most common issues we see in Bugsnag, indicating that this is indeed a problem for many of our users.

The patch is admittedly hacky since it modifies `Node.insertBefore` and `Node.removeChild` in such a way that they only fail silently (`console.error`) instead of throwing.
But the fix was proposed by Dan Abramov himself, which makes me trust it way more :)

---
Tracking issues:
* React issue, including the patch: https://github.com/facebook/react/issues/11538#issuecomment-417504600
* Another explainer as to how to fix the bug _without_ a hack, at usage time: https://github.com/facebook/react/issues/11538#issuecomment-390386520
* Chromium issue: https://bugs.chromium.org/p/chromium/issues/detail?id=872770