### PR TITLE
chore(webpack): factor out node_modules from comons.js into vendors.js

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -2,7 +2,11 @@
     "files": [
         {
             "path": "./itsJustJavascript/webpack/commons.js",
-            "maxSize": "1.85 MB"
+            "maxSize": "850 KB"
+        },
+        {
+            "path": "./itsJustJavascript/webpack/vendors.js",
+            "maxSize": "1 MB"
         },
         {
             "path": "./itsJustJavascript/webpack/owid.js",

--- a/adminSiteServer/IndexPage.tsx
+++ b/adminSiteServer/IndexPage.tsx
@@ -40,6 +40,7 @@ export const IndexPage = (props: {
             <body>
                 <div id="app"></div>
                 <script src={webpackUrl("commons.js", "/admin")}></script>
+                <script src={webpackUrl("vendors.js", "/admin")}></script>
                 <script src={webpackUrl("admin.js", "/admin")}></script>
                 <script
                     type="text/javascript"

--- a/site/SiteFooter.tsx
+++ b/site/SiteFooter.tsx
@@ -240,6 +240,7 @@ export const SiteFooter = (props: SiteFooterProps) => (
             <div className="site-tools" />
             <script src="https://polyfill.io/v3/polyfill.min.js?features=es6,fetch,URL,IntersectionObserver,IntersectionObserverEntry" />
             <script src={webpackUrl("commons.js", props.baseUrl)} />
+            <script src={webpackUrl("vendors.js", props.baseUrl)} />
             <script src={webpackUrl("owid.js", props.baseUrl)} />
             <script
                 dangerouslySetInnerHTML={{

--- a/site/webpackUtils.tsx
+++ b/site/webpackUtils.tsx
@@ -42,13 +42,14 @@ document.head.appendChild(link)
 let loadedScripts = 0;
 const checkReady = () => {
     loadedScripts++
-    if (loadedScripts === 3)
+    if (loadedScripts === 4)
         window.MultiEmbedderSingleton.embedAll()
 }
 
 const coreScripts = [
     'https://polyfill.io/v3/polyfill.min.js?features=es6,fetch,URL,IntersectionObserver,IntersectionObserverEntry',
     '${webpackUrl("commons.js", baseUrl)}',
+    '${webpackUrl("vendors.js", baseUrl)}',
     '${webpackUrl("owid.js", baseUrl)}'
 ]
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -29,10 +29,18 @@ const config: webpack.ConfigurationFactory = async (env, argv) => {
         optimization: {
             splitChunks: {
                 cacheGroups: {
+                    vendors: {
+                        test: /[\\/]node_modules[\\/]/,
+                        name: "vendors",
+                        chunks: "all",
+                        minChunks: 2,
+                        priority: 1, // needs to be higher than for "commons"
+                    },
                     commons: {
                         name: "commons",
                         chunks: "all",
                         minChunks: 2,
+                        priority: 0,
                     },
                 },
             },

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -30,7 +30,9 @@ const config: webpack.ConfigurationFactory = async (env, argv) => {
             splitChunks: {
                 cacheGroups: {
                     vendors: {
-                        test: /[\\/]node_modules[\\/]/,
+                        test: (module) =>
+                            !module.type?.startsWith("css") &&
+                            /[\\/]node_modules[\\/]/.test(module.resource),
                         name: "vendors",
                         chunks: "all",
                         minChunks: 2,

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -29,15 +29,19 @@ const config: webpack.ConfigurationFactory = async (env, argv) => {
         optimization: {
             splitChunks: {
                 cacheGroups: {
+                    // The bundle created through this cache group contains all the dependencies
+                    // that are _both_ used by owid.entry.js and admin.entry.js.
                     vendors: {
                         test: (module) =>
-                            !module.type?.startsWith("css") &&
+                            !module.type?.startsWith("css") && // no need to split CSS, since there's very little vendor css anyway
                             /[\\/]node_modules[\\/]/.test(module.resource),
                         name: "vendors",
                         chunks: "all",
                         minChunks: 2,
                         priority: 1, // needs to be higher than for "commons"
                     },
+                    // The bundle created through this cache group contains all the code
+                    // that is _both_ used by owid.entry.js and admin.entry.js.
                     commons: {
                         name: "commons",
                         chunks: "all",


### PR DESCRIPTION
Supersedes #994.

This solves the "`commons.js` is too big" problem another way, namely by splitting `commons.js` into two parts, one containing the dependencies included in there (`vendors.js`) and the other containing the rest of the shared code (`commons.js`).

This approach has several advantages:
* The assets are always named the same, so finding which assets we need to include stays super easy
* We don't need to re-generate and re-upload >5000 files whenever our JS changes, which leads to long deploy times
* No need to worry about edge cases where assets might be deleted (through a deploy) at the exact time when they are requested