### PR TITLE
fix(explorer): `metric` facet strategy not available with multiple columns

### DIFF
--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1940,7 +1940,7 @@ export class Grapher
     @computed get availableFacetStrategies(): FacetStrategy[] {
         const strategies: FacetStrategy[] = [FacetStrategy.none]
 
-        const numNonProjectedColumns = this.yColumns.filter(
+        const numNonProjectedColumns = this.yColumnsFromDimensionsOrSlugsOrAuto.filter(
             (c) => !c.display?.isProjection
         ).length
         if (


### PR DESCRIPTION
Fixes the issue Ernst reported on Slack: https://owid.slack.com/archives/CQQUA2C2U/p1631129614055600