### PR TITLE
fix(baker): halt deploy on non-zero exit code

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -27,7 +27,7 @@ import { ChartRevision } from "../db/model/ChartRevision"
 import { SuggestedChartRevision } from "../db/model/SuggestedChartRevision"
 import { Post } from "../db/model/Post"
 import { camelCaseProperties } from "../clientUtils/string"
-import { log } from "../baker/slackLog"
+import { logErrorAndMaybeSendToSlack } from "../baker/slackLog"
 import { denormalizeLatestCountryData } from "../baker/countryProfiles"
 import { BAKED_BASE_URL } from "../settings/serverSettings"
 import { PostReference, ChartRedirect } from "../adminSiteClient/ChartEditor"
@@ -1229,7 +1229,7 @@ apiRouter.put("/datasets/:datasetId", async (req: Request, res: Response) => {
             commitEmail: res.locals.user.email,
         })
     } catch (err) {
-        log.logErrorAndMaybeSendToSlack(err)
+        logErrorAndMaybeSendToSlack(err)
         // Continue
     }
 
@@ -1302,7 +1302,7 @@ apiRouter.delete(
                 commitEmail: res.locals.user.email,
             })
         } catch (err) {
-            log.logErrorAndMaybeSendToSlack(err)
+            logErrorAndMaybeSendToSlack(err)
             // Continue
         }
 

--- a/adminSiteServer/app.tsx
+++ b/adminSiteServer/app.tsx
@@ -14,7 +14,6 @@ import {
 } from "../settings/serverSettings"
 import * as db from "../db/db"
 import * as wpdb from "../db/wpdb"
-import { log } from "../baker/slackLog"
 import { IndexPage } from "./IndexPage"
 import { authCloudflareSSOMiddleware, authMiddleware } from "./authentication"
 import { apiRouter } from "./apiRouter"

--- a/baker/DeployUtils.ts
+++ b/baker/DeployUtils.ts
@@ -1,6 +1,6 @@
 import fs from "fs-extra"
 import { SiteBaker } from "../baker/SiteBaker"
-import { log } from "./slackLog"
+import { warn, logErrorAndMaybeSendToSlack } from "./slackLog"
 import { DeployQueueServer } from "./DeployQueueServer"
 import { BAKED_SITE_DIR, BAKED_BASE_URL } from "../settings/serverSettings"
 import { DeployChange } from "../clientUtils/owidTypes"
@@ -16,7 +16,7 @@ const defaultCommitMessage = async (): Promise<string> => {
         const sha = await fs.readFile("public/head.txt", "utf8")
         message += `\nowid/owid-grapher@${sha}`
     } catch (err) {
-        log.warn(err)
+        warn(err)
     }
 
     return message
@@ -38,7 +38,7 @@ const bakeAndDeploy = async (
         await baker.bakeAll()
         await baker.deployToNetlifyAndPushToGitPush(message, email, name)
     } catch (err) {
-        log.logErrorAndMaybeSendToSlack(err)
+        logErrorAndMaybeSendToSlack(err)
         throw err
     }
 }
@@ -48,7 +48,7 @@ export const tryBake = async () => {
     try {
         await baker.bakeAll()
     } catch (err) {
-        log.logErrorAndMaybeSendToSlack(err)
+        logErrorAndMaybeSendToSlack(err)
     } finally {
         baker.endDbConnections()
     }
@@ -69,7 +69,7 @@ export const tryDeploy = async (
     try {
         await baker.deployToNetlifyAndPushToGitPush(message, email, name)
     } catch (err) {
-        log.logErrorAndMaybeSendToSlack(err)
+        logErrorAndMaybeSendToSlack(err)
     } finally {
         baker.endDbConnections()
     }

--- a/baker/Deployer.ts
+++ b/baker/Deployer.ts
@@ -223,13 +223,13 @@ yarn testPrettierAll`
             yarn: `cd ${rsyncTargetDirTmp} && yarn install --production --frozen-lockfile`,
             webpack: `cd ${rsyncTargetDirTmp} && yarn buildWebpack`,
             migrateDb: `cd ${rsyncTargetDirTmp} && yarn runDbMigrations`,
-            algolia: `cd ${rsyncTargetDirTmp} && node itsJustJavascript/baker/algolia/configureAlgolia.js`,
+            algolia: `cd ${rsyncTargetDirTmp} && node --unhandled-rejections=strict itsJustJavascript/baker/algolia/configureAlgolia.js`,
             createQueueFile: `cd ${rsyncTargetDirTmp} && touch .queue && chmod 0666 .queue`,
             swapFolders: `rm -rf ${oldRepoBackupDir} && mv ${finalTargetDir} ${oldRepoBackupDir} || true && mv ${rsyncTargetDirTmp} ${finalTargetDir}`,
             restartAdminServer: `pm2 restart ${target}`,
             stopDeployQueueServer: `pm2 stop ${target}-deploy-queue`,
-            bakeSiteOnStagingServer: `cd ${finalTargetDir} && node itsJustJavascript/baker/bakeSiteOnStagingServer.js`,
-            deployToNetlify: `cd ${finalTargetDir} && node itsJustJavascript/baker/deploySiteFromStagingServer.js "${gitEmail}" "${gitName}"`,
+            bakeSiteOnStagingServer: `cd ${finalTargetDir} && node --unhandled-rejections=strict itsJustJavascript/baker/bakeSiteOnStagingServer.js`,
+            deployToNetlify: `cd ${finalTargetDir} && node --unhandled-rejections=strict itsJustJavascript/baker/deploySiteFromStagingServer.js "${gitEmail}" "${gitName}"`,
             restartQueue: `pm2 start ${target}-deploy-queue`,
         }
 

--- a/baker/GrapherBakingUtils.ts
+++ b/baker/GrapherBakingUtils.ts
@@ -9,7 +9,7 @@ import {
 
 import * as db from "../db/db"
 import { bakeGraphersToSvgs } from "../baker/GrapherImageBaker"
-import { log } from "./slackLog"
+import { warn } from "./slackLog"
 import { Chart } from "../db/model/Chart"
 import md5 from "md5"
 import { Url } from "../clientUtils/urls/Url"
@@ -58,13 +58,13 @@ export const bakeGrapherUrls = async (urls: string[]) => {
 
         const slug = lodash.last(Url.fromURL(url).pathname?.split("/"))
         if (!slug) {
-            log.warn(`Invalid chart url ${url}`)
+            warn(`Invalid chart url ${url}`)
             continue
         }
 
         const chartId = slugToId[slug]
         if (chartId === undefined) {
-            log.warn(`Couldn't find chart with slug ${slug}`)
+            warn(`Couldn't find chart with slug ${slug}`)
             continue
         }
 
@@ -73,7 +73,7 @@ export const bakeGrapherUrls = async (urls: string[]) => {
             [chartId]
         )
         if (!rows.length) {
-            log.warn(`Mysteriously missing chart by id ${chartId}`)
+            warn(`Mysteriously missing chart by id ${chartId}`)
             continue
         }
 

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -38,7 +38,7 @@ import { Post } from "../db/model/Post"
 import { bakeCountries } from "../baker/countryProfiles"
 import { countries } from "../clientUtils/countries"
 import { execWrapper } from "../db/execWrapper"
-import { log } from "./slackLog"
+import { logErrorAndMaybeSendToSlack } from "./slackLog"
 import { countryProfileSpecs } from "../site/countryProfileProjects"
 import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer"
 import { getRedirects } from "./redirects"
@@ -384,7 +384,7 @@ export class SiteBaker {
             return await execWrapper(cmd)
         } catch (error) {
             // Log error to Slack, but do not throw error
-            return log.logErrorAndMaybeSendToSlack(error)
+            return logErrorAndMaybeSendToSlack(error)
         }
     }
 

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -100,4 +100,4 @@ export const configureAlgolia = async () => {
     })
 }
 
-if (require.main === module) configureAlgolia()
+configureAlgolia()

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -1,14 +1,33 @@
-import algoliasearch from "algoliasearch"
+import algoliasearch, { SearchClient } from "algoliasearch"
 import { Synonym } from "@algolia/client-search"
 import { ALGOLIA_ID } from "../../settings/clientSettings"
-import { ALGOLIA_SECRET_KEY } from "../../settings/serverSettings"
+import {
+    ALGOLIA_INDEXING,
+    ALGOLIA_SECRET_KEY,
+} from "../../settings/serverSettings"
 import { countries } from "../../clientUtils/countries"
 
+export const getAlgoliaClient = (): SearchClient | undefined => {
+    if (!ALGOLIA_ID || !ALGOLIA_SECRET_KEY) {
+        console.error(`Missing ALGOLIA_ID or ALGOLIA_SECRET_KEY`)
+        return
+    }
+
+    const client = algoliasearch(ALGOLIA_ID, ALGOLIA_SECRET_KEY)
+    return client
+}
+
 // This function initializes and applies settings to the Algolia search indices
-// Algolia settings should be configured here rather than   in the Algolia dashboard UI, as then
+// Algolia settings should be configured here rather than in the Algolia dashboard UI, as then
 // they are recorded and transferrable across dev/prod instances
 export const configureAlgolia = async () => {
-    const client = algoliasearch(ALGOLIA_ID, ALGOLIA_SECRET_KEY)
+    if (!ALGOLIA_INDEXING) return
+
+    const client = getAlgoliaClient()
+    if (!client)
+        // throwing here to halt deploy process
+        throw new Error("Algolia configuration failed (client not initialized)")
+
     const chartsIndex = client.initIndex("charts")
 
     await chartsIndex.setSettings({
@@ -100,4 +119,4 @@ export const configureAlgolia = async () => {
     })
 }
 
-configureAlgolia()
+if (require.main === module) configureAlgolia()

--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -53,8 +53,6 @@ const getChartsRecords = async () => {
         })
     }
 
-    await db.closeTypeOrmAndKnexConnections()
-
     return records
 }
 
@@ -71,6 +69,8 @@ const indexChartsToAlgolia = async () => {
 
     const records = await getChartsRecords()
     await index.replaceAllObjects(records)
+
+    await db.closeTypeOrmAndKnexConnections()
 }
 
 indexChartsToAlgolia()

--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -1,9 +1,8 @@
-import algoliasearch from "algoliasearch"
 import * as lodash from "lodash"
 
 import * as db from "../../db/db"
-import { ALGOLIA_ID } from "../../settings/clientSettings"
-import { ALGOLIA_SECRET_KEY } from "../../settings/serverSettings"
+import { ALGOLIA_INDEXING } from "../../settings/serverSettings"
+import { getAlgoliaClient } from "./configureAlgolia"
 
 const getChartsRecords = async () => {
     const allCharts = await db.queryMysql(`
@@ -60,7 +59,14 @@ const getChartsRecords = async () => {
 }
 
 const indexChartsToAlgolia = async () => {
-    const client = algoliasearch(ALGOLIA_ID, ALGOLIA_SECRET_KEY)
+    if (!ALGOLIA_INDEXING) return
+
+    const client = getAlgoliaClient()
+    if (!client) {
+        console.error(`Failed indexing charts (Algolia client not initialized)`)
+        return
+    }
+
     const index = client.initIndex("charts")
 
     const records = await getChartsRecords()

--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -4,11 +4,8 @@ import * as lodash from "lodash"
 import * as db from "../../db/db"
 import { ALGOLIA_ID } from "../../settings/clientSettings"
 import { ALGOLIA_SECRET_KEY } from "../../settings/serverSettings"
-import { configureAlgolia } from "./configureAlgolia"
 
 const indexChartsToAlgolia = async () => {
-    await configureAlgolia()
-
     const allCharts = await db.queryMysql(`
         SELECT id, publishedAt, updatedAt, JSON_LENGTH(config->"$.dimensions") AS numDimensions, config->>"$.type" AS type, config->>"$.slug" AS slug, config->>"$.title" AS title, config->>"$.subtitle" AS subtitle, config->>"$.variantName" AS variantName, config->>"$.data.availableEntities" as availableEntitiesStr
         FROM charts

--- a/baker/algolia/indexToAlgolia.ts
+++ b/baker/algolia/indexToAlgolia.ts
@@ -36,10 +36,7 @@ const getPostType = (post: FormattedPost, tags: Tag[]) => {
     return "page"
 }
 
-const indexToAlgolia = async () => {
-    const client = algoliasearch(ALGOLIA_ID, ALGOLIA_SECRET_KEY)
-    const index = client.initIndex("pages")
-
+const getPagesRecords = async () => {
     const postsApi = await wpdb.getPosts()
 
     const records = []
@@ -88,10 +85,18 @@ const indexToAlgolia = async () => {
         }
     }
 
-    index.replaceAllObjects(records)
-
     await wpdb.singleton.end()
     await db.closeTypeOrmAndKnexConnections()
+
+    return records
+}
+
+const indexToAlgolia = async () => {
+    const client = algoliasearch(ALGOLIA_ID, ALGOLIA_SECRET_KEY)
+    const index = client.initIndex("pages")
+
+    const records = await getPagesRecords()
+    index.replaceAllObjects(records)
 }
 
 indexToAlgolia()

--- a/baker/algolia/indexToAlgolia.ts
+++ b/baker/algolia/indexToAlgolia.ts
@@ -83,9 +83,6 @@ const getPagesRecords = async () => {
         }
     }
 
-    await wpdb.singleton.end()
-    await db.closeTypeOrmAndKnexConnections()
-
     return records
 }
 
@@ -101,6 +98,9 @@ const indexToAlgolia = async () => {
 
     const records = await getPagesRecords()
     index.replaceAllObjects(records)
+
+    await wpdb.singleton.end()
+    await db.closeTypeOrmAndKnexConnections()
 }
 
 indexToAlgolia()

--- a/baker/algolia/indexToAlgolia.ts
+++ b/baker/algolia/indexToAlgolia.ts
@@ -1,13 +1,11 @@
-import algoliasearch from "algoliasearch"
-
 import * as db from "../../db/db"
 import * as wpdb from "../../db/wpdb"
-import { ALGOLIA_ID } from "../../settings/clientSettings"
-import { ALGOLIA_SECRET_KEY } from "../../settings/serverSettings"
+import { ALGOLIA_INDEXING } from "../../settings/serverSettings"
 import { chunkParagraphs, htmlToPlaintext } from "../../clientUtils/search"
 import { countries } from "../../clientUtils/countries"
 import { FormattedPost } from "../../clientUtils/owidTypes"
 import { formatPost } from "../../baker/formatWordpressPost"
+import { getAlgoliaClient } from "./configureAlgolia"
 
 interface Tag {
     id: number
@@ -92,7 +90,13 @@ const getPagesRecords = async () => {
 }
 
 const indexToAlgolia = async () => {
-    const client = algoliasearch(ALGOLIA_ID, ALGOLIA_SECRET_KEY)
+    if (!ALGOLIA_INDEXING) return
+
+    const client = getAlgoliaClient()
+    if (!client) {
+        console.error(`Failed indexing pages (Algolia client not initialized)`)
+        return
+    }
     const index = client.initIndex("pages")
 
     const records = await getPagesRecords()

--- a/baker/buildAndDeploySite.ts
+++ b/baker/buildAndDeploySite.ts
@@ -14,4 +14,5 @@ const deployer = new Deployer({
     skipChecks: parsedArgs["skip-checks"] === true,
     runChecksRemotely: parsedArgs["r"] === true,
 })
-deployer.deploy()
+
+deployer.buildAndDeploy()

--- a/baker/pageOverrides.tsx
+++ b/baker/pageOverrides.tsx
@@ -4,14 +4,14 @@ import { stringifyUnkownError, urlToSlug } from "../clientUtils/Util"
 import { FormattingOptions, FullPost } from "../clientUtils/owidTypes"
 import { getPostBySlug, isPostCitable } from "../db/wpdb"
 import { getTopSubnavigationParentItem } from "../site/SiteSubnavigation"
-import { log } from "./slackLog"
+import { logErrorAndMaybeSendToSlack } from "./slackLog"
 
 export const getPostBySlugLogToSlackNoThrow = async (slug: string) => {
     let post
     try {
         post = await getPostBySlug(slug)
     } catch (err) {
-        log.logErrorAndMaybeSendToSlack(stringifyUnkownError(err))
+        logErrorAndMaybeSendToSlack(stringifyUnkownError(err))
     } finally {
         return post
     }
@@ -38,7 +38,7 @@ export const getLandingOnlyIfParent = async (
     // citation overrides are absent, but the rest keeps updating.
     const landing = await getPostBySlugLogToSlackNoThrow(landingSlug)
     if (!landing) {
-        log.logErrorAndMaybeSendToSlack(
+        logErrorAndMaybeSendToSlack(
             `Warning: The href of the first item of the "subnavs[${formattingOptions.subnavId}]" array (the landing page) is likely out-of-date and is being redirected. Please update to avoid unnecessary and SEO damaging internal redirects.`
         )
     }

--- a/baker/pageOverrides.tsx
+++ b/baker/pageOverrides.tsx
@@ -32,14 +32,15 @@ export const getLandingOnlyIfParent = async (
     if (landingSlug === post.slug) return
 
     // Using no-throw version to prevent throwing and stopping baking mid-way.
-    // Since deploying steps are independent, throwing would result in baking
-    // the site up to that point, and running a deploy of that half-baked
-    // version. It is more desirable to deploy a more consistent version, where
-    // citation overrides are absent, but the rest keeps updating.
+    // It is more desirable to temporarily deploy with citation overrides
+    // absent, while fixing the issue.
     const landing = await getPostBySlugLogToSlackNoThrow(landingSlug)
     if (!landing) {
+        // todo: the concept of "citation overrides" does not belong to that
+        // generic function. Logging this message should be the responsibility
+        // of the caller function.
         logErrorAndMaybeSendToSlack(
-            `Warning: The href of the first item of the "subnavs[${formattingOptions.subnavId}]" array (the landing page) is likely out-of-date and is being redirected. Please update to avoid unnecessary and SEO damaging internal redirects.`
+            `Error: citation overrides not applied for ${post.slug}. Please check the href of the "subnavs[${formattingOptions.subnavId}]" landing page (the first item in the array): it is likely out-of-date and is being redirected.`
         )
     }
 

--- a/baker/pageOverrides.tsx
+++ b/baker/pageOverrides.tsx
@@ -40,7 +40,9 @@ export const getLandingOnlyIfParent = async (
         // generic function. Logging this message should be the responsibility
         // of the caller function.
         logErrorAndMaybeSendToSlack(
-            `Error: citation overrides not applied for ${post.slug}. Please check the href of the "subnavs[${formattingOptions.subnavId}]" landing page (the first item in the array): it is likely out-of-date and is being redirected.`
+            new Error(
+                `Citation overrides not applied for ${post.slug}. Please check the href of the "subnavs[${formattingOptions.subnavId}]" landing page (the first item in the array): it is likely out-of-date and is being redirected.`
+            )
         )
     }
 

--- a/baker/slackLog.ts
+++ b/baker/slackLog.ts
@@ -50,11 +50,9 @@ const sendErrorToSlack = async (err: any) => {
     })
 }
 
-export namespace log {
-    export const logErrorAndMaybeSendToSlack = async (err: any) => {
-        console.error(err)
-        if (SLACK_ERRORS_WEBHOOK_URL) sendErrorToSlack(err)
-    }
-
-    export const warn = (err: any) => console.warn(err)
+export const logErrorAndMaybeSendToSlack = async (err: any) => {
+    console.error(err)
+    if (SLACK_ERRORS_WEBHOOK_URL) sendErrorToSlack(err)
 }
+
+export const warn = (err: any) => console.warn(err)

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -71,6 +71,8 @@ export const SESSION_COOKIE_AGE: number =
     parseIntOrUndefined(serverSettings.SESSION_COOKIE_AGE) ?? 1209600
 export const ALGOLIA_SECRET_KEY: string =
     serverSettings.ALGOLIA_SECRET_KEY ?? ""
+export const ALGOLIA_INDEXING: boolean =
+    serverSettings.ALGOLIA_INDEXING === "true" ?? false
 export const STRIPE_SECRET_KEY: string = serverSettings.STRIPE_SECRET_KEY ?? ""
 
 // Settings for automated email sending, e.g. for admin invite


### PR DESCRIPTION
Notion issue: [Exceptions in baking should prevent deploy](https://www.notion.so/Exceptions-in-baking-should-prevent-deploy-161e34b212734dee944441bee742063a)

I haven't tested this at all, just sharing this because I spotted it yesterday during the call – seems like the exit code was being captured but no action taken. Now the deploy process should halt on a non-zero exit code.

Some things that could lead to this not working:

- A script exits with a non-zero code that we don't care about (e.g. failure to remove a file that isn't there)
- The errors thrown from the baker don't trigger a non-zero exit code

I won't be working on this, I just hope it's useful when/if @mlbrgl gets to look into it. 