### PR TITLE
fix(explorer): in a switcher explorer, correctly show available entities

### DIFF
--- a/grapher/controls/entityPicker/EntityPicker.tsx
+++ b/grapher/controls/entityPicker/EntityPicker.tsx
@@ -135,8 +135,9 @@ export class EntityPicker extends React.Component<{
     }
 
     @computed private get availableEntitiesForCurrentView(): Set<string> {
-        if (!this.manager.requiredColumnSlugs?.length || !this.grapherTable)
-            return this.selection.availableEntityNameSet
+        if (!this.grapherTable) return this.selection.availableEntityNameSet
+        if (!this.manager.requiredColumnSlugs?.length)
+            return this.grapherTable.availableEntityNameSet
         return this.grapherTable.entitiesWith(this.manager.requiredColumnSlugs)
     }
 


### PR DESCRIPTION
This fixes an issue that I noticed with the climate change explorer.
Since the explorer is based on `grapherId`s (aka switcher explorer), the unavailable entities weren't properly greyed out. Since entities are often non-overlapping in this specific explorer, this made things extra bad because one didn't even know what could be selected.

## Good / Bad
![image](https://user-images.githubusercontent.com/2641501/133683975-499e6360-ddcc-4fa5-b25f-3a002c3fdbff.png)

---
## Technical stuff
`SelectionArray`'s `availableEntities` array is monotonically non-decreasing over time, i.e. is always growing and never shrinking. Therefore, `this.selection.availableEntityNameSet` always returns every entity that is visible in the entity picker, and should only be used if `grapherTable` isn't available (don't know when that would be the case, actually?).
Otherwise, let's use `grapherTable`, which in the case of a switcher explorer contains only the entities contained in the loaded grapher.

_Maybe we should rework our selection logic at some point 😬_