### PR TITLE
fix: further Google Translate fixes

### DIFF
--- a/grapher/controls/globalEntitySelector/GlobalEntitySelector.tsx
+++ b/grapher/controls/globalEntitySelector/GlobalEntitySelector.tsx
@@ -310,7 +310,7 @@ export class GlobalEntitySelector extends React.Component<{
                             autoFocus={true}
                         />
                     ) : (
-                        <>
+                        <div>
                             {!this.selection.hasSelection
                                 ? "None selected"
                                 : this.selection.selectedEntityNames
@@ -329,7 +329,7 @@ export class GlobalEntitySelector extends React.Component<{
                                                   : [...acc, ", ", item],
                                           [] as (JSX.Element | string)[]
                                       )}
-                        </>
+                        </div>
                     )}
                 </div>
                 <div className="narrow-actions">

--- a/grapher/text/TextWrap.tsx
+++ b/grapher/text/TextWrap.tsx
@@ -135,7 +135,7 @@ export class TextWrap {
         //     return <p style={{ fontSize: fontSize.toFixed(2) + "px", lineHeight: lineHeight, width: this.width }} {...options}>{strip(text)}</p>
 
         return (
-            <React.Fragment>
+            <span>
                 {lines.map((line, index) => {
                     const content = props.rawHtml ? (
                         <span
@@ -150,7 +150,7 @@ export class TextWrap {
                             }}
                         />
                     ) : (
-                        line.text
+                        <span>{line.text}</span>
                     )
                     return (
                         <React.Fragment key={index}>
@@ -159,7 +159,7 @@ export class TextWrap {
                         </React.Fragment>
                     )
                 })}
-            </React.Fragment>
+            </span>
         )
     }
 


### PR DESCRIPTION
Live on _tufte_.

Followup for #1005.

I noticed a major issue with Google Translate where the chart title wouldn't update in an explorer:

https://user-images.githubusercontent.com/2641501/133777716-f285bb40-65d4-4121-be79-0e2591d03cec.mp4

This is not new behaviour, but has been the case before #1005 already.

Also note that `TextWrap.renderHtml` is only used for the chart header and footer (i.e. title, subtitle, source line, note).

---

We could also think about `renderHtml` just returning the text as is and it leaving the wrapping to the browser? This works quite nicely for chart title and subtitle, although it would of course introduce disparities between the interactive chart and the static version. It also results in way nicer translated versions.