### PR TITLE
fix(facet): ensure entity colors are consistent between facet charts and the global legend

### DIFF
--- a/grapher/facetChart/FacetChart.test.ts
+++ b/grapher/facetChart/FacetChart.test.ts
@@ -9,6 +9,9 @@ import {
     FacetStrategy,
 } from "../core/GrapherConstants"
 import { uniq } from "../../clientUtils/Util"
+import { OwidTable } from "../../coreTable/OwidTable"
+import { ColumnTypeNames } from "../../coreTable/CoreColumnDef"
+import { LineChart } from "../lineCharts/LineChart"
 
 const allElementsAreEqual = (array: any[]): boolean => {
     return uniq(array).length === 1
@@ -186,5 +189,58 @@ describe("config overrides", () => {
 
     it("entity legend is hidden for single-metric facets by entity", () => {
         expect(chart.placedSeries[0].manager.hideLegend).toEqual(true)
+    })
+})
+
+describe("global legend", () => {
+    /**
+     * There was an issue where the global legend showed some color for an entity,
+     * but one of the facet charts was actually displaying the same entity in a different color.
+     * This occurred when the order of the first non-empty value for an entity in the table is
+     * different for different columns:
+     * I.e. in the below table, the first entity for the "gdp" column is germany, but for the co2
+     * column it is france.
+     */
+
+    const getColorMap = (chart: LineChart): Map<string, string> =>
+        new Map(chart.series.map((s) => [s.seriesName, s.color]))
+
+    it("consistently assigns entity colors", () => {
+        // The order of lines is important here! see the explanation above.
+        const csv = `gdp,co2,year,entityName
+1,,2000,germany
+2,1,2000,france
+3,2,2001,france
+4,3,2001,germany`
+        const table = new OwidTable(csv, [
+            { slug: "gdp", type: ColumnTypeNames.Numeric },
+            { slug: "co2", type: ColumnTypeNames.Numeric },
+            { slug: "year", type: ColumnTypeNames.Year },
+            { slug: "entityName", type: ColumnTypeNames.EntityName },
+        ])
+
+        const manager: ChartManager = {
+            table,
+            selection: table.availableEntityNames,
+            facetStrategy: FacetStrategy.metric,
+            seriesColorMap: new Map(),
+            // ^- important! this map enables globally consistent colors, if it is passed down correctly in FacetChart.
+        }
+        const chart = new FacetChart({
+            manager,
+            chartTypeName: ChartTypeName.LineChart,
+        })
+
+        const legend = chart.categoricalLegendData
+        const colors = new Map(legend.map((bin) => [bin.value, bin.color]))
+
+        expect(colors.size).toEqual(2)
+
+        expect(
+            getColorMap(chart.placedSeries[0].chartInstance as LineChart)
+        ).toEqual(colors)
+        expect(
+            getColorMap(chart.placedSeries[1].chartInstance as LineChart)
+        ).toEqual(colors)
     })
 })

--- a/grapher/facetChart/FacetChart.test.ts
+++ b/grapher/facetChart/FacetChart.test.ts
@@ -223,8 +223,6 @@ describe("global legend", () => {
             table,
             selection: table.availableEntityNames,
             facetStrategy: FacetStrategy.metric,
-            seriesColorMap: new Map(),
-            // ^- important! this map enables globally consistent colors, if it is passed down correctly in FacetChart.
         }
         const chart = new FacetChart({
             manager,

--- a/grapher/facetChart/FacetChart.test.ts
+++ b/grapher/facetChart/FacetChart.test.ts
@@ -235,10 +235,10 @@ describe("global legend", () => {
         expect(colors.size).toEqual(2)
 
         expect(
-            getColorMap(chart.placedSeries[0].chartInstance as LineChart)
+            getColorMap(chart.intermediateChartInstances[0] as LineChart)
         ).toEqual(colors)
         expect(
-            getColorMap(chart.placedSeries[1].chartInstance as LineChart)
+            getColorMap(chart.intermediateChartInstances[1] as LineChart)
         ).toEqual(colors)
     })
 })

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -20,6 +20,7 @@ import {
     FacetSeries,
     FacetChartProps,
     PlacedFacetSeries,
+    IntermediatePlacedFacetSeries,
 } from "./FacetChartConstants"
 import { OwidTable } from "../../coreTable/OwidTable"
 import { autoDetectYColumnSlugs, makeSelectionArray } from "../chart/ChartUtils"
@@ -200,7 +201,8 @@ export class FacetChart
      *
      * @danielgavrilov, 2021-07-13
      */
-    @computed private get intermediatePlacedSeries(): PlacedFacetSeries[] {
+    @computed
+    private get intermediatePlacedSeries(): IntermediatePlacedFacetSeries[] {
         const { manager, series, facetCount } = this
 
         // Copy properties from manager to facets
@@ -413,6 +415,7 @@ export class FacetChart
                 bounds,
                 contentBounds,
                 manager,
+                chartInstance,
             }
         })
     }

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -221,6 +221,7 @@ export class FacetChart
             colorColumnSlug,
             sizeColumnSlug,
             isRelativeMode,
+            seriesColorMap,
         } = manager
 
         // Use compact labels, e.g. 50k instead of 50,000.
@@ -267,6 +268,7 @@ export class FacetChart
                 colorColumnSlug,
                 sizeColumnSlug,
                 isRelativeMode,
+                seriesColorMap,
                 ...series.manager,
                 xAxisConfig: {
                     ...globalXAxisConfig,

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -7,6 +7,7 @@ import {
     ChartTypeName,
     FacetAxisDomain,
     FacetStrategy,
+    SeriesColorMap,
     SeriesStrategy,
 } from "../core/GrapherConstants"
 import {
@@ -189,6 +190,9 @@ export class FacetChart
         return true
     }
 
+    // Passing this color map is important to ensure that all facets use the same entity colors
+    seriesColorMap: SeriesColorMap = new Map()
+
     /**
      * Holds the intermediate render properties for chart views, before axes are synchronized,
      * collapsed, aligned, etc.
@@ -203,7 +207,7 @@ export class FacetChart
      */
     @computed
     private get intermediatePlacedSeries(): IntermediatePlacedFacetSeries[] {
-        const { manager, series, facetCount } = this
+        const { manager, series, facetCount, seriesColorMap } = this
 
         // Copy properties from manager to facets
         const baseFontSize = this.facetFontSize
@@ -221,7 +225,6 @@ export class FacetChart
             colorColumnSlug,
             sizeColumnSlug,
             isRelativeMode,
-            seriesColorMap,
         } = manager
 
         // Use compact labels, e.g. 50k instead of 50,000.

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -21,7 +21,6 @@ import {
     FacetSeries,
     FacetChartProps,
     PlacedFacetSeries,
-    IntermediatePlacedFacetSeries,
 } from "./FacetChartConstants"
 import { OwidTable } from "../../coreTable/OwidTable"
 import { autoDetectYColumnSlugs, makeSelectionArray } from "../chart/ChartUtils"
@@ -205,8 +204,7 @@ export class FacetChart
      *
      * @danielgavrilov, 2021-07-13
      */
-    @computed
-    private get intermediatePlacedSeries(): IntermediatePlacedFacetSeries[] {
+    @computed private get intermediatePlacedSeries(): PlacedFacetSeries[] {
         const { manager, series, facetCount, seriesColorMap } = this
 
         // Copy properties from manager to facets
@@ -295,7 +293,8 @@ export class FacetChart
         })
     }
 
-    @computed private get intermediateChartInstances(): ChartInterface[] {
+    // Only made public for testing
+    @computed get intermediateChartInstances(): ChartInterface[] {
         return this.intermediatePlacedSeries.map(
             ({ bounds, manager, chartTypeName }) => {
                 const ChartClass =
@@ -420,7 +419,6 @@ export class FacetChart
                 bounds,
                 contentBounds,
                 manager,
-                chartInstance,
             }
         })
     }

--- a/grapher/facetChart/FacetChartConstants.ts
+++ b/grapher/facetChart/FacetChartConstants.ts
@@ -1,4 +1,4 @@
-import { ChartInterface, ChartSeries } from "../chart/ChartInterface"
+import { ChartSeries } from "../chart/ChartInterface"
 import { ChartManager } from "../chart/ChartManager"
 import { ChartTypeName } from "../core/GrapherConstants"
 import { Bounds } from "../../clientUtils/Bounds"
@@ -14,13 +14,9 @@ export interface FacetSeries extends ChartSeries {
     chartTypeName?: ChartTypeName
 }
 
-export interface IntermediatePlacedFacetSeries extends FacetSeries {
+export interface PlacedFacetSeries extends FacetSeries {
     manager: ChartManager
     chartTypeName: ChartTypeName
     bounds: Bounds
     contentBounds: Bounds
-}
-
-export interface PlacedFacetSeries extends IntermediatePlacedFacetSeries {
-    chartInstance: ChartInterface
 }

--- a/grapher/facetChart/FacetChartConstants.ts
+++ b/grapher/facetChart/FacetChartConstants.ts
@@ -1,4 +1,4 @@
-import { ChartSeries } from "../chart/ChartInterface"
+import { ChartInterface, ChartSeries } from "../chart/ChartInterface"
 import { ChartManager } from "../chart/ChartManager"
 import { ChartTypeName } from "../core/GrapherConstants"
 import { Bounds } from "../../clientUtils/Bounds"
@@ -14,9 +14,13 @@ export interface FacetSeries extends ChartSeries {
     chartTypeName?: ChartTypeName
 }
 
-export interface PlacedFacetSeries extends FacetSeries {
+export interface IntermediatePlacedFacetSeries extends FacetSeries {
     manager: ChartManager
     chartTypeName: ChartTypeName
     bounds: Bounds
     contentBounds: Bounds
+}
+
+export interface PlacedFacetSeries extends IntermediatePlacedFacetSeries {
+    chartInstance: ChartInterface
 }


### PR DESCRIPTION
Notion: [Ensure entity color in global legend is consistent with all facets](https://www.notion.so/Ensure-entity-color-in-global-legend-is-consistent-with-all-facets-68588d0d74264c92a01aba601d31ed66)

This is achieved by passing down a `seriesColorMap` to all child charts, which makes sure that entity colors are synchronized between the charts.
I intentionally didn't pass down the Grapher's map (`manager.seriesColorMap`) but rather a map local to FacetChart. That's because otherwise, the facet charts don't use the default blue line color _if_ a user is coming from a non-faceted view at first. I didn't like that behaviour, and so there's now essentially two distinct `seriesColorMap`s being used depending on whether the chart is faceted or not.

I checked this with LineCharts, StackedDiscreteBarCharts and StackedAreaCharts and all seems good :)