### PR TITLE
fix(facet): do not share Y axis on StackedDiscreteBar

### DIFF
--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -323,7 +323,9 @@ export class FacetChart
                 config: {},
                 axisAccessor: (instance) => instance.yAxis,
                 uniform: this.uniformYAxis,
-                shared: this.uniformYAxis,
+                shared:
+                    this.uniformYAxis &&
+                    this.chartTypeName !== ChartTypeName.StackedDiscreteBar,
             },
         }
         values(axes).forEach(({ config, axisAccessor, uniform, shared }) => {

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -122,6 +122,10 @@ export class FacetChart
         return this.props.manager
     }
 
+    @computed private get chartTypeName(): ChartTypeName {
+        return this.props.chartTypeName ?? ChartTypeName.LineChart
+    }
+
     @computed get failMessage(): string {
         return ""
     }
@@ -248,11 +252,6 @@ export class FacetChart
 
         return series.map((series, index) => {
             const { bounds } = gridBoundsArr[index]
-            const chartTypeName =
-                series.chartTypeName ??
-                this.props.chartTypeName ??
-                ChartTypeName.LineChart
-
             const hideLegend = this.hideFacetLegends
             const hidePoints = true
 
@@ -285,7 +284,6 @@ export class FacetChart
             return {
                 bounds,
                 contentBounds: bounds,
-                chartTypeName,
                 manager,
                 seriesName: series.seriesName,
                 color: series.color,
@@ -294,14 +292,12 @@ export class FacetChart
     }
 
     @computed private get intermediateChartInstances(): ChartInterface[] {
-        return this.intermediatePlacedSeries.map(
-            ({ bounds, manager, chartTypeName }) => {
-                const ChartClass =
-                    ChartComponentClassMap.get(chartTypeName) ??
-                    DefaultChartClass
-                return new ChartClass({ bounds, manager })
-            }
-        )
+        return this.intermediatePlacedSeries.map(({ bounds, manager }) => {
+            const ChartClass =
+                ChartComponentClassMap.get(this.chartTypeName) ??
+                DefaultChartClass
+            return new ChartClass({ bounds, manager })
+        })
     }
 
     // Only made public for testing
@@ -552,7 +548,7 @@ export class FacetChart
                 )}
                 {this.placedSeries.map((facetChart, index: number) => {
                     const ChartClass =
-                        ChartComponentClassMap.get(facetChart.chartTypeName) ??
+                        ChartComponentClassMap.get(this.chartTypeName) ??
                         DefaultChartClass
                     const { bounds, contentBounds, seriesName } = facetChart
                     const shiftTop = facetFontSize * 0.9

--- a/grapher/facetChart/FacetChartConstants.ts
+++ b/grapher/facetChart/FacetChartConstants.ts
@@ -11,12 +11,10 @@ export interface FacetChartProps {
 
 export interface FacetSeries extends ChartSeries {
     manager: Partial<ChartManager>
-    chartTypeName?: ChartTypeName
 }
 
 export interface PlacedFacetSeries extends FacetSeries {
     manager: ChartManager
-    chartTypeName: ChartTypeName
     bounds: Bounds
     contentBounds: Bounds
 }


### PR DESCRIPTION
Notion: [DiscreteBar y axis should not collapse when faceted](https://www.notion.so/DiscreteBar-y-axis-should-not-collapse-when-faceted-85cbc4790e2c4f97a9137195ff92afaa)

Example chart where this goes wrong: https://ourworldindata.org/grapher/per-capita-energy-stacked?facet=metric&country=USA~GBR~OWID_WRL~CHN~IND~FRA~DEU~SWE~ZAF~JPN~BRA

![per-capita-energy-stacked](https://user-images.githubusercontent.com/1308115/135098155-48299757-e12a-4483-a0a7-c8154916d0c3.png)
