### PR TITLE
fix(facet): always show entities in legend if user can edit selection

### DIFF
--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -169,6 +169,7 @@ import { LegacyChartDimensionInterface } from "../../clientUtils/LegacyVariableD
 import { MarimekkoChartManager } from "../stackedCharts/MarimekkoChartConstants"
 import { AxisConfigInterface } from "../axis/AxisConfigInterface"
 import Bugsnag from "@bugsnag/js"
+import { FacetChartManager } from "../facetChart/FacetChartConstants"
 
 declare const window: any
 
@@ -239,6 +240,7 @@ export class Grapher
         ScatterPlotManager,
         MarimekkoChartManager,
         FacetStrategyDropdownManager,
+        FacetChartManager,
         MapChartManager {
     @observable.ref type = ChartTypeName.LineChart
     @observable.ref id?: number = undefined

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -5,6 +5,7 @@ import { action, computed, observable } from "mobx"
 import {
     BASE_FONT_SIZE,
     ChartTypeName,
+    EntitySelectionMode,
     FacetAxisDomain,
     FacetStrategy,
     SeriesColorMap,
@@ -523,7 +524,18 @@ export class FacetChart
                         index,
                     })
             )
-            if (bins.length > 1) return bins
+            if (
+                bins.length > 1 ||
+                // If the facetStrategy is metric, then the legend (probably?) shows entity items.
+                // If the user happens to select only a single entity, we don't want to collapse the
+                // legend, because it's (probably?) the only information about what is selected.
+                // This is fragile and ideally we shouldn't be making assumptions about what type of
+                // items are shown on the legend, but it works for now...
+                // -@danielgavrilov, 2021-09-28
+                (this.facetStrategy === FacetStrategy.metric &&
+                    this.props.manager.canSelectMultipleEntities)
+            )
+                return bins
         }
         return []
     }

--- a/grapher/facetChart/FacetChartConstants.ts
+++ b/grapher/facetChart/FacetChartConstants.ts
@@ -3,10 +3,14 @@ import { ChartManager } from "../chart/ChartManager"
 import { ChartTypeName } from "../core/GrapherConstants"
 import { Bounds } from "../../clientUtils/Bounds"
 
+export interface FacetChartManager extends ChartManager {
+    canSelectMultipleEntities?: boolean
+}
+
 export interface FacetChartProps {
     bounds?: Bounds
     chartTypeName?: ChartTypeName
-    manager: ChartManager
+    manager: FacetChartManager
 }
 
 export interface FacetSeries extends ChartSeries {


### PR DESCRIPTION
Notion issue: [Figure out better logic for when to hide/show legend](https://www.notion.so/Figure-out-better-logic-for-when-to-hide-show-legend-d1ec076ec8894dc79c62280106ca5dc5)

When a chart faceted by metric can have countries added/removed, and the user selects only one country, the legend used to collapse itself, example: https://ourworldindata.org/grapher/excess-mortality-p-scores-average-baseline-by-age?country=~GBR

![excess-mortality-p-scores-average-baseline-by-age](https://user-images.githubusercontent.com/1308115/135114140-4d7f54e4-dcf6-4fe9-b8ee-875644d5f331.png)

The chart doesn't mention anywhere that the selected entity is United Kingdom. One workaround is to untick "Hide automatic time/entity" in order to show the entity name in the title, but this is not ideal, it leaves it to the author to anticipate that the chart can end up in a state without a legend. 

This PR makes it so that the facet legend is not collapsed if there is only a single bin, and the legend shows entity items, and the user can add/remove entities.

It's a bit fragile and ideally we shouldn't be making assumptions about what type of items are shown on the legend, but it works for now...