### PR TITLE
enhance(explorer): explorer dropdowns are never searchable on mobile

### DIFF
--- a/explorer/ExplorerControls.tsx
+++ b/explorer/ExplorerControls.tsx
@@ -139,7 +139,7 @@ export class ExplorerControlPanel extends React.Component<{
                     IndicatorSeparator: null,
                 }}
                 styles={styles}
-                isSearchable={options.length > 20}
+                isSearchable={!this.props.isMobile && options.length > 10}
                 maxMenuHeight={350}
             />
         )


### PR DESCRIPTION
As mentioned [by Charlie on Slack](https://owid.slack.com/archives/C46U9LXRR/p1632928460002300), the keyboard popping up makes this hard to use on a phone.

At the same time I also lowered the threshold to 10 (again, on desktop only), which is roughly where the dropdown starts to have so many options that it scrolls.