### PR TITLE
enhance: Remove specific numbers from country profiles

### DIFF
--- a/baker/countryProfiles.tsx
+++ b/baker/countryProfiles.tsx
@@ -180,7 +180,6 @@ export const countryProfilePage = async (
 
             indicators.push({
                 year: latestValue.year,
-                value: column.formatValueShort(value),
                 name: grapher.title as string,
                 slug: `/grapher/${grapher.slug}?tab=chart&country=${country.code}`,
                 variantName: grapher.variantName,

--- a/site/CountryProfilePage.tsx
+++ b/site/CountryProfilePage.tsx
@@ -7,7 +7,6 @@ import urljoin from "url-join"
 export interface CountryProfileIndicator {
     name: string
     slug: string
-    value: string
     year: number
     variantName?: string
 }
@@ -88,7 +87,7 @@ export const CountryProfilePage = (props: CountryProfilePageProps) => {
                                         </a>
                                     </div>
                                     <div className="indicatorValue">
-                                        {indicator.value} ({indicator.year})
+                                        ({indicator.year})
                                     </div>
                                 </li>
                             ))}

--- a/site/CountryProfilePage.tsx
+++ b/site/CountryProfilePage.tsx
@@ -60,6 +60,10 @@ export const CountryProfilePage = (props: CountryProfilePageProps) => {
                         <span>Population, persons:</span> {keyStats.population.value} ({keyStats.population.year})
                     </li>
                 </ul> */}
+                    <p>
+                        Below are all indicators in our database for which this
+                        country has a value.
+                    </p>
                     <div>
                         <input
                             type="search"


### PR DESCRIPTION
The country profile numbers are poorly formatted, have too many decimal places, and no units. We would prefer not to show them at all. So this PR prunes them from the output.
