### PR TITLE
feat(facet): shrink and shorten facet labels if necessary

### DIFF
--- a/grapher/text/TextWrap.test.ts
+++ b/grapher/text/TextWrap.test.ts
@@ -1,6 +1,6 @@
 #! /usr/bin/env jest
 
-import { TextWrap } from "./TextWrap"
+import { TextWrap, shortenForTargetWidth } from "./TextWrap"
 import { Bounds } from "../../clientUtils/Bounds"
 
 const FONT_SIZE = 14
@@ -61,5 +61,17 @@ describe("height()", () => {
     it("calculates a height of zero for an empty string", () => {
         const text = ""
         expect(renderedHeight(text)).toEqual(0)
+    })
+})
+
+describe(shortenForTargetWidth, () => {
+    it("should not shorten if text fits", () => {
+        const text = "a short string"
+        expect(shortenForTargetWidth(text, 10000)).toEqual(text)
+    })
+
+    it("should return empty string if there's no space at all", () => {
+        const text = "a short string"
+        expect(shortenForTargetWidth(text, 1)).toEqual("")
     })
 })

--- a/grapher/text/TextWrap.tsx
+++ b/grapher/text/TextWrap.tsx
@@ -26,6 +26,30 @@ function startsWithNewline(text: string): boolean {
     return /^\n/.test(text)
 }
 
+export const shortenForTargetWidth = (
+    text: string,
+    targetWidth: number,
+    fontSettings: {
+        fontSize?: number
+        fontWeight?: number
+        fontFamily?: string
+    } = {}
+): string => {
+    // use binary search to find the largest substring that fits within the target width
+    let low = 0
+    let high = text.length
+    while (low <= high) {
+        const mid = (high + low) >> 1
+        const bounds = Bounds.forText(text.slice(0, mid), fontSettings)
+        if (bounds.width < targetWidth) {
+            low = mid + 1
+        } else {
+            high = mid - 1
+        }
+    }
+    return text.slice(0, low - 1)
+}
+
 export class TextWrap {
     props: TextWrapProps
     constructor(props: TextWrapProps) {


### PR DESCRIPTION
Notion: [Prevent chart titles from overlapping on FacetCharts](https://www.notion.so/Prevent-chart-titles-from-overlapping-on-FacetCharts-5c643f4fc67740afa555f8a875269a71)

Live on _tufte_. Try [this chart](https://tufte-owid.netlify.app/grapher/technology-and-infrastructure-diffusion-in-the-us?facet=metric&uniformYAxis=0&country=~USA) and make the window small.

---

This work has been living on my laptop for quite a while now, and I finally came around to polish & PR it 🙌 

What it does to shrink down labels is described pretty well in this comment:
```
/**
 * In order to display a potentially long facet label in the potentially tight space, we
 * shrink and shorten the label as follows to prevent overlap between neighbouring labels:
 * - If the label already fits, we're happy :)
 * - Otherwise, we calculate the ideal font size where it would fit perfectly.
 *   However, in order ot not make the label tiny, we cap the font size at 0.7 * baseFontSize
 * - If the label still doesn't fit, we shorten it to the number of characters that fit and append an ellispsis (…)
 * -@MarcelGerber, 2021-10-28
 */
```

## Before / After
![image](https://user-images.githubusercontent.com/2641501/139311610-5ca7cd28-c1aa-4c0b-9e60-fcf581cf0ee0.png)
![image](https://user-images.githubusercontent.com/2641501/139311656-796f7006-0ba8-43cb-ba71-d9a122297ef5.png)

Chart link: https://tufte-owid.netlify.app/grapher/technology-and-infrastructure-diffusion-in-the-us?facet=metric&uniformYAxis=0&country=~USA
