### PR TITLE
feat(explorer): one column def can be used for multiple tables

### DIFF
--- a/explorer/ExplorerProgram.test.ts
+++ b/explorer/ExplorerProgram.test.ts
@@ -57,6 +57,33 @@ ${ExplorerGrammar.graphers.keyword}
         )
     })
 
+    it("properly assigns column defs to table slugs", () => {
+        const program = new ExplorerProgram(
+            "test",
+            `columns
+\tslug\tname
+\tgdp\tGDP
+columns\ttable1\ttable2\ttable3
+\tslug\tname
+\tbanana\tBananas`
+        )
+
+        expect([...program.columnDefsByTableSlug.keys()]).toEqual([
+            undefined,
+            "table1",
+            "table2",
+            "table3",
+        ])
+
+        const columnDef1 = [{ slug: "gdp", name: "GDP" }]
+        const columnDef2 = [{ slug: "banana", name: "Bananas" }]
+
+        expect(program.columnDefsByTableSlug.get(undefined)).toEqual(columnDef1)
+        expect(program.columnDefsByTableSlug.get("table1")).toEqual(columnDef2)
+        expect(program.columnDefsByTableSlug.get("table2")).toEqual(columnDef2)
+        expect(program.columnDefsByTableSlug.get("table3")).toEqual(columnDef2)
+    })
+
     it("can detect errors", () => {
         const results = new ExplorerProgram("test", `titleTypo Foo`).getCell({
             row: 0,

--- a/gridLang/GridProgram.test.ts
+++ b/gridLang/GridProgram.test.ts
@@ -35,7 +35,9 @@ describe(GridProgram, () => {
             "test",
             `table
 \tslug
-\tcountry`
+\tcountry
+columns\ta
+columns\tb`
         )
 
         it("can get blocks", () => {
@@ -47,6 +49,10 @@ describe(GridProgram, () => {
             expect(program.getRowMatchingWords(undefined, "nada")).toEqual(-1)
         })
 
+        it("can search for all occurences", () => {
+            expect(program.getAllRowsMatchingWords("columns")).toEqual([3, 4])
+        })
+
         it("can update blocks", () => {
             const newBlock = `slug\tname
 country\tCountry`
@@ -55,7 +61,9 @@ country\tCountry`
         })
 
         it("can delete blocks", () => {
-            expect(program.deleteBlock(0).toString()).toEqual(`table`)
+            expect(program.deleteBlock(0).toString()).toEqual(`table
+columns\ta
+columns\tb`)
 
             const program2 = new GridProgram(
                 "test",

--- a/gridLang/GridProgram.ts
+++ b/gridLang/GridProgram.ts
@@ -285,15 +285,27 @@ export class GridProgram {
             .filter(isPresent)
     }
 
-    getRowMatchingWords(...words: (string | undefined)[]) {
-        const matches = (line: string[]) =>
-            words.every(
-                (word, index) => word === undefined || line[index] === word
-            )
-        return this.asArrays.findIndex(matches)
+    private static lineMatchesWords = (
+        line: string[],
+        words: (string | undefined)[]
+    ): boolean =>
+        words.every((word, index) => word === undefined || line[index] === word)
+
+    getRowMatchingWords(...words: (string | undefined)[]): number {
+        return this.asArrays.findIndex((line) =>
+            GridProgram.lineMatchesWords(line, words)
+        )
     }
 
-    get asArrays() {
+    getAllRowsMatchingWords(...words: (string | undefined)[]): number[] {
+        const rows: number[] = []
+        this.asArrays.forEach((line: string[], rowIndex: number) => {
+            if (GridProgram.lineMatchesWords(line, words)) rows.push(rowIndex)
+        })
+        return rows
+    }
+
+    get asArrays(): string[][] {
         return this.lines.map((line) => line.split(this.cellDelimiter))
     }
 


### PR DESCRIPTION
Notion: [Investigate small-ish explorer improvements to reduce excessive repetition](https://www.notion.so/Investigate-small-ish-explorer-improvements-to-reduce-excessive-repetition-23ac1351285849d4ab964b06c0a82178)

This allows a single column def to be used by multiple tables, like this:
```
table	https://abc	apples
table	https://def	bananas
columns	apples	bananas
	slug	type
	entity_name	EntityName
```

This should make our life way easier with the Global Food Explorer, where we're probably using tens of tables with the same column definitions.