### PR TITLE
fix: halt deploy on baking error

### DIFF
--- a/baker/DeployUtils.ts
+++ b/baker/DeployUtils.ts
@@ -43,12 +43,14 @@ const bakeAndDeploy = async (
     }
 }
 
-export const tryBake = async () => {
+export const bake = async () => {
     const baker = new SiteBaker(BAKED_SITE_DIR, BAKED_BASE_URL)
     try {
         await baker.bakeAll()
     } catch (err) {
+        baker.endDbConnections()
         logErrorAndMaybeSendToSlack(err)
+        throw err
     } finally {
         baker.endDbConnections()
     }

--- a/baker/bakeSiteOnStagingServer.ts
+++ b/baker/bakeSiteOnStagingServer.ts
@@ -1,4 +1,4 @@
 // todo: remove this file
 
-import { tryBake } from "./DeployUtils"
-tryBake()
+import { bake } from "./DeployUtils"
+bake()


### PR DESCRIPTION
Notion issue: [Exceptions in build&bake should prevent deploy](https://www.notion.so/Exceptions-in-build-bake-should-prevent-deploy-161e34b212734dee944441bee742063a). 

I was getting this error again while deploying `playfair`, so I tried to fix it.

Now it's getting caught:

```
/home/owid/playfair/bakedSite/atmospheric-concentrations.html
/home/owid/playfair/bakedSite/greenhouse-gas-emissions.html
/home/owid/playfair/bakedSite/emissions-by-sector.html
JsonError: Missing data for query variableId:176101 entityId:355 year:1950 | %year the world emitted 6 billion tonnes of CO<sub>2</sub>. Please check the tag for any missing or wrong argument.
    at /home/owid/playfair/itsJustJavascript/baker/formatWordpressPost.js:151:19
    at Generator.next (<anonymous>)
    at fulfilled (/home/owid/playfair/itsJustJavascript/baker/formatWordpressPost.js:24:58)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5) {
  status: 400
}
internal/process/promises.js:194
        triggerUncaughtException(err, true /* fromPromise */);
        ^

JsonError: Missing data for query variableId:176101 entityId:355 year:1950 | %year the world emitted 6 billion tonnes of CO<sub>2</sub>. Please check the tag for any missing or wrong argument.
    at /home/owid/playfair/itsJustJavascript/baker/formatWordpressPost.js:151:19
    at Generator.next (<anonymous>)
    at fulfilled (/home/owid/playfair/itsJustJavascript/baker/formatWordpressPost.js:24:58)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5) {
  status: 400
}
Connection to 165.22.127.239 closed.
Baking and deploying to playfair [=====================---] 21/24 193.2s 📡⛔️ failed running /home/owid/tmp/playfair-danielg/tempDeployScript.bakeSiteOnStagingServer.sh [exit code: 1]
{ exitCode: 1, step: 0 }
✨  Done in 193.35s.
```

It's logged twice because one is the logger (both logging to console and maybe to Slack) and then it's being rethrown to be caught by any parent script that's executing it. 