### PR TITLE
enhance(grapher): redesign download tab

### DIFF
--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -1141,3 +1141,23 @@ export function toRectangularMatrix<T, F>(arr: T[][], fill: F): (T | F)[][] {
         else return row
     })
 }
+
+// Wrapped because JSDOM does not support this method yet:
+// https://stackoverflow.com/questions/52968969/jest-url-createobjecturl-is-not-a-function/56643520#56643520
+export const createObjectURL = (obj: any): string =>
+    URL.createObjectURL ? URL.createObjectURL(obj) : ""
+export const revokeObjectURL = (obj: any): void =>
+    URL.revokeObjectURL ? URL.revokeObjectURL(obj) : undefined
+
+export const triggerDownloadFromBlob = (filename: string, blob: Blob): void => {
+    const objectUrl = createObjectURL(blob)
+    triggerDownloadFromUrl(filename, objectUrl)
+    revokeObjectURL(objectUrl)
+}
+
+export const triggerDownloadFromUrl = (filename: string, url: string): void => {
+    const downloadLink = document.createElement("a")
+    downloadLink.setAttribute("href", url)
+    downloadLink.setAttribute("download", filename)
+    downloadLink.click()
+}

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -1142,17 +1142,10 @@ export function toRectangularMatrix<T, F>(arr: T[][], fill: F): (T | F)[][] {
     })
 }
 
-// Wrapped because JSDOM does not support this method yet:
-// https://stackoverflow.com/questions/52968969/jest-url-createobjecturl-is-not-a-function/56643520#56643520
-export const createObjectURL = (obj: any): string =>
-    URL.createObjectURL ? URL.createObjectURL(obj) : ""
-export const revokeObjectURL = (obj: any): void =>
-    URL.revokeObjectURL ? URL.revokeObjectURL(obj) : undefined
-
 export const triggerDownloadFromBlob = (filename: string, blob: Blob): void => {
-    const objectUrl = createObjectURL(blob)
+    const objectUrl = URL.createObjectURL(blob)
     triggerDownloadFromUrl(filename, objectUrl)
-    revokeObjectURL(objectUrl)
+    URL.revokeObjectURL(objectUrl)
 }
 
 export const triggerDownloadFromUrl = (filename: string, url: string): void => {

--- a/grapher/downloadTab/DownloadTab.scss
+++ b/grapher/downloadTab/DownloadTab.scss
@@ -1,106 +1,98 @@
-.DownloadTab .download-csv {
-    align-items: center;
-    text-align: center;
+.DownloadTab {
+    padding: 2em;
+    color: #444;
+    line-height: 1.4;
+    display: flex; // allows vertical centering when using margin:auto
+    overflow: auto; // we want to be able to scroll if contents overflow
 
-    .btn {
-        color: #fff;
-        background-color: #0275d8;
-        border-color: #0275d8;
-        display: inline-block;
-        font-weight: 400;
-        text-align: center;
-        vertical-align: middle;
-        cursor: pointer;
-        -webkit-user-select: none;
-        -moz-user-select: none;
-        -ms-user-select: none;
-        user-select: none;
-        border: 1px solid transparent;
-        padding: 0.375rem 1rem;
-        font-size: 1em;
-        line-height: 1.5;
-        border-radius: 0.25rem;
-        text-decoration: none;
+    .grouped-menu {
+        width: 100%;
+        max-width: 35em;
+        margin: auto;
+    }
 
-        :hover {
-            color: #fff;
-            background-color: #025aa5;
-            border-color: #01549b;
+    .grouped-menu-section {
+        h2 {
+            font-size: 1.125em;
+            font-weight: 700;
         }
     }
-}
 
-.DownloadTab {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-
-    padding: 2em;
-
-    p {
-        font-size: 0.9rem;
+    .grouped-menu-section + .grouped-menu-section {
+        margin-top: 3em;
     }
 
-    > a > div {
-        display: flex;
-    }
-
-    .img-downloads {
+    .grouped-menu-item {
         display: flex;
         flex-direction: row;
-        justify-content: center;
+        align-items: center;
+        color: #444;
+        background-color: #fafafa;
+        border: 1px solid rgba(0, 0, 0, 0.15);
+        position: relative;
+        width: 100%;
+        margin-top: -1px;
+        padding: 0;
+        overflow: hidden;
+        text-align: left;
 
-        a {
-            color: #333;
-            text-decoration: none;
-            margin: 0 1rem 1rem;
-            margin-bottom: 1rem;
-
-            div {
-                display: flex;
-                flex-flow: column;
-                align-items: center;
-            }
-
-            img {
-                margin: 1rem 1rem 0.5rem 1rem;
-            }
-
-            aside {
-                margin: 0 2rem 0;
-
-                h2 {
-                    margin-bottom: 0;
-                    text-align: center;
-                    font-size: 1.5rem;
-                }
-            }
+        &:first-child {
+            margin-top: 0;
+            border-top-left-radius: 3px;
+            border-top-right-radius: 3px;
         }
 
-        > a:hover > div {
-            text-decoration: underline;
+        &:last-child {
+            border-bottom-left-radius: 3px;
+            border-bottom-right-radius: 3px;
+        }
+
+        &:hover {
+            z-index: 1;
+            background-color: #f3f3f3;
+            border-color: rgba(0, 0, 0, 0.25);
+            color: #222;
         }
     }
 
-    &.mobile {
-        .img-downloads {
-            margin-bottom: 2rem;
+    .grouped-menu-icon {
+        flex: 0;
+
+        img {
+            display: block;
+            margin: 10px;
+            margin-right: 3px;
+            box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15),
+                0 2px 4px 1px rgba(0, 0, 0, 0.09);
+        }
+    }
+
+    .grouped-menu-content {
+        flex: 1;
+        padding: 0.85em 1em;
+
+        .title {
+            font-size: 1em;
+            margin: 0 0 0.35em;
         }
 
-        a {
+        .description {
+            font-size: 0.9375em;
             margin: 0;
-
-            aside {
-                margin: 0;
-
-                h2 {
-                    font-size: 1.2rem;
-                }
-            }
+            opacity: 0.9;
         }
 
-        p {
-            font-size: 0.7rem;
+        .faint {
+            font-weight: normal;
         }
+    }
+
+    .download-icon {
+        opacity: 0.5;
+        padding-left: 0.5em;
+        padding-right: 1.5em;
+    }
+    .grouped-menu-item:hover .download-icon {
+        opacity: 1;
     }
 }


### PR DESCRIPTION
Notion issue: [Reorganise download tab options to make space for "not allowed to download" notice](https://www.notion.so/Reorganise-download-tab-options-to-make-space-for-not-allowed-to-download-notice-dfe622ff9ed342618dee2c4ed52786f4)

Deployed on `playfair`: [Explorer](https://playfair-owid.netlify.app/explorers/coronavirus-data-explorer?zoomToSelection=true&time=2020-03-01..latest&facet=none&pickerSort=asc&pickerMetric=location&Metric=Confirmed+cases&Interval=7-day+rolling+average&Relative+to+Population=true&Align+outbreaks=false&country=USA~GBR~CAN~DEU~ITA~IND) | [Grapher](https://playfair-owid.netlify.app/grapher/excess-mortality-raw-death-count)

### Before

<img width="799" alt="Screenshot 2021-11-10 at 14 06 17" src="https://user-images.githubusercontent.com/1308115/141127662-756d5ef7-8d52-444d-8021-c55a5cafe682.png">

### After

<img width="799" alt="Screenshot 2021-11-10 at 14 05 49" src="https://user-images.githubusercontent.com/1308115/141127698-b2008e57-edab-4574-b94d-0af8240ba149.png">