### PR TITLE
feat: automatic prominent links (bis)

### DIFF
--- a/baker/formatWordpressPost.tsx
+++ b/baker/formatWordpressPost.tsx
@@ -50,6 +50,7 @@ import {
     getLegacyVariableDisplayConfig,
 } from "../db/model/Variable"
 import { AnnotatingDataValue } from "../site/AnnotatingDataValue"
+import { renderAutomaticProminentLinks } from "./siteRenderers"
 
 const initMathJax = () => {
     const adaptor = liteAdaptor()
@@ -293,6 +294,7 @@ export const formatWordpressPost = async (
 
     // SSR rendering of Gutenberg blocks, before hydration on client
     renderBlocks(cheerioEl)
+    await renderAutomaticProminentLinks(cheerioEl, post)
 
     // Extract blog info content
     let info = null

--- a/baker/formatting.tsx
+++ b/baker/formatting.tsx
@@ -183,7 +183,7 @@ export const isStandaloneInternalLink = (
     $: CheerioStatic
 ) => {
     return (
-        el.attribs.href.startsWith(BAKED_BASE_URL) &&
+        el.attribs.href?.startsWith(BAKED_BASE_URL) &&
         el.parent.tagName === "p" &&
         $(el.parent).contents().length === 1
     )

--- a/baker/formatting.tsx
+++ b/baker/formatting.tsx
@@ -2,7 +2,6 @@ import * as cheerio from "cheerio"
 import {
     DataValueConfiguration,
     DataValueQueryArgs,
-    DimensionProperty,
     FormattedPost,
     FormattingOptions,
     KeyValueProps,
@@ -176,4 +175,16 @@ export const formatCountryProfile = (
     })
 
     return { ...post, html: getHtmlContentWithStyles(cheerioEl) }
+}
+
+// Relies on formatLinks URL standardisation
+export const isStandaloneInternalLink = (
+    el: CheerioElement,
+    $: CheerioStatic
+) => {
+    return (
+        el.attribs.href.startsWith(BAKED_BASE_URL) &&
+        el.parent.tagName === "p" &&
+        $(el.parent).contents().length === 1
+    )
 }

--- a/baker/siteRenderers.test.ts
+++ b/baker/siteRenderers.test.ts
@@ -1,0 +1,168 @@
+#! /usr/bin/env jest
+
+import {
+    ProminentLinkStyles,
+    PROMINENT_LINK_CLASSNAME,
+    renderAuthoredProminentLinks,
+    WITH_IMAGE,
+} from "../site/blocks/ProminentLink"
+import * as cheerio from "cheerio"
+import { FullPost, WP_PostType } from "../clientUtils/owidTypes"
+import * as wpdb from "../db/wpdb"
+import { renderAutomaticProminentLinks } from "./siteRenderers"
+import { BAKED_BASE_URL } from "../settings/clientSettings"
+
+// There are many possible dimensions to test:
+// - style: default / thin
+// - title: with / without
+// - content: with / without
+// - image: with / without
+// - authored / automatic
+// - link to: post / grapher page / missing page
+//
+// Only a few significant ones have been selected in order to have a offer good
+// coverage while keeping the maitenance burden in check.
+
+const title = "The prominent link title"
+const content = "<p>Some text</p>"
+const imageSrc = `${BAKED_BASE_URL}/path/to/image.png`
+const imageId = 123
+const postSlug = "child-mortality"
+const grapherSlug = "cancer-deaths-rate-and-age-standardized-rate-index"
+const grapherUrl = `${BAKED_BASE_URL}/grapher/${grapherSlug}?country=~OWID_WRL`
+
+const getMockBlock = (
+    url: string,
+    title: string,
+    imageSrc: string | null,
+    content: string,
+    style?: ProminentLinkStyles
+) => {
+    const image = imageSrc
+        ? `
+    <img width="768" height="382"
+        src=${imageSrc}
+        class="attachment-medium_large size-medium_large" alt="" loading="lazy"
+        srcset="${BAKED_BASE_URL}/app/uploads/2021/10/image-768x382.png 768w, ${BAKED_BASE_URL}/app/uploads/2021/10/image-400x199.png 400w, ${BAKED_BASE_URL}/app/uploads/2021/10/image-800x398.png 800w, ${BAKED_BASE_URL}/app/uploads/2021/10/image-150x75.png 150w, ${BAKED_BASE_URL}/app/uploads/2021/10/image.png 1492w"
+        sizes="(max-width: 768px) 100vw, 768px" />`
+        : ""
+    return `
+<block type="prominent-link" style="${style || ""}">
+    <link-url>${url}</link-url>
+    <title>${title}</title>
+    <content>${content}</content>
+    <figure>${image}</figure>
+</block>
+`
+}
+
+const getMockTitle = (slug: string): string => {
+    return `title of ${slug}`
+}
+
+const getMockPostWithImage = (slug: string): FullPost => {
+    return {
+        id: 123,
+        type: WP_PostType.Post,
+        slug: slug,
+        path: "",
+        title: getMockTitle(slug),
+        date: new Date(0),
+        modifiedDate: new Date(0),
+        authors: [],
+        content: "",
+        glossary: false,
+        imageId,
+    }
+}
+
+const getMockThumbnailUrl = (id: number) => {
+    return `${BAKED_BASE_URL}/path/to/image-${id}.svg`
+}
+
+const getMockGrapherThumbnailUrl = (slug: string) => {
+    return `${BAKED_BASE_URL}/grapher/exports/${slug}.svg`
+}
+
+const getPostBySlug = jest.spyOn(wpdb, "getPostBySlug")
+getPostBySlug.mockImplementation(
+    (slug) => Promise.resolve(getMockPostWithImage(slug)) // only for more descriptive error message
+)
+
+const getMediaThumbnailUrl = jest.spyOn(wpdb, "getMediaThumbnailUrl")
+getMediaThumbnailUrl.mockImplementation((id) =>
+    Promise.resolve(getMockThumbnailUrl(id))
+)
+
+it("renders authored prominent link (grapher, image override, default style)", () => {
+    const block = getMockBlock(grapherUrl, title, imageSrc, content)
+    const cheerioEl = cheerio.load(block)
+    renderAuthoredProminentLinks(cheerioEl)
+    const prominentLinkEl = cheerioEl(`.${PROMINENT_LINK_CLASSNAME}`)
+
+    expect(prominentLinkEl.hasClass(WITH_IMAGE)).toBe(true)
+    expect(prominentLinkEl.attr("data-style")).toEqual(
+        ProminentLinkStyles.default
+    )
+    expect(cheerioEl("h3").text()).toEqual(title)
+    expect(cheerioEl("figure > img").attr("src")).toEqual(imageSrc)
+    expect(cheerioEl(".content").html()).toEqual(content)
+})
+
+it("renders authored prominent link (grapher, thin, no image override)", () => {
+    const block = getMockBlock(
+        grapherUrl,
+        title,
+        null,
+        content,
+        ProminentLinkStyles.thin
+    )
+    const cheerioEl = cheerio.load(block)
+    renderAuthoredProminentLinks(cheerioEl)
+    const prominentLinkEl = cheerioEl(`.${PROMINENT_LINK_CLASSNAME}`)
+
+    expect(prominentLinkEl.hasClass(WITH_IMAGE)).toBe(true)
+    expect(prominentLinkEl.attr("data-style")).toEqual(ProminentLinkStyles.thin)
+    expect(cheerioEl(".title").text()).toEqual(title)
+    expect(cheerioEl("figure > img").attr("src")).toEqual(
+        getMockGrapherThumbnailUrl(grapherSlug)
+    )
+    expect(cheerioEl(".content").html()).toEqual(content)
+})
+
+it("renders automatic prominent link (link to post, thin)", async () => {
+    const htmlLink = `<p><a href="${BAKED_BASE_URL}/${postSlug}"></a></p>`
+
+    const cheerioEl = cheerio.load(htmlLink)
+
+    await renderAutomaticProminentLinks(
+        cheerioEl,
+        getMockPostWithImage("current-post") // only for more descriptive error message
+    )
+
+    const prominentLinkEl = cheerioEl(`.${PROMINENT_LINK_CLASSNAME}`)
+
+    expect(prominentLinkEl.hasClass(WITH_IMAGE)).toBe(true)
+    expect(prominentLinkEl.attr("data-style")).toEqual(ProminentLinkStyles.thin)
+
+    expect(cheerioEl(".title").text()).toEqual(getMockTitle(postSlug))
+    expect(cheerioEl("figure > img").attr("src")).toEqual(
+        getMockThumbnailUrl(imageId)
+    )
+    expect(cheerioEl(".content").html()).toBeNull()
+})
+
+it("does not convert links with surrounding text", async () => {
+    const htmlLink = `<p>this should not be converted <a href="${BAKED_BASE_URL}/${postSlug}"></a></p>`
+
+    const cheerioEl = cheerio.load(htmlLink)
+
+    await renderAutomaticProminentLinks(
+        cheerioEl,
+        getMockPostWithImage("current-post") // only for more descriptive error message
+    )
+
+    const prominentLinkEl = cheerioEl(`.${PROMINENT_LINK_CLASSNAME}`)
+
+    expect(prominentLinkEl.length).toEqual(0)
+})

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -419,6 +419,11 @@ export const renderAutomaticProminentLinks = async (
             const url = Url.fromURL(anchor.attribs.href)
             if (!url.slug) return
 
+            // todo: remove early return when "/uploads" standalone links removed from content
+            // conversion failing silently on purpose
+            // see https://www.notion.so/owid/Automatic-prominent-links-1eafcce85953483d912b6e5f20b928ec#55ca3ed4f72e41b8bd477f2eba2455b6
+            if (url.isUpload) return
+
             if (url.isGrapher) {
                 logErrorAndMaybeSendToSlack(
                     new Error(
@@ -441,7 +446,7 @@ export const renderAutomaticProminentLinks = async (
                 // netlify-redirected upon click if applicable).
                 logErrorAndMaybeSendToSlack(
                     new Error(
-                        `Automatic prominent link convertion failed: no post found at ${
+                        `Automatic prominent link conversion failed: no post found at ${
                             anchor.attribs.href
                         } in ${formatWordpressEditLink(
                             currentPost.id

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -419,6 +419,19 @@ export const renderAutomaticProminentLinks = async (
             const url = Url.fromURL(anchor.attribs.href)
             if (!url.slug) return
 
+            if (url.isGrapher) {
+                logErrorAndMaybeSendToSlack(
+                    new Error(
+                        `Automatic prominent link conversion failed for ${
+                            anchor.attribs.href
+                        } in ${formatWordpressEditLink(
+                            currentPost.id
+                        )}. Grapher link are not yet supported.`
+                    )
+                )
+                return
+            }
+
             let targetPost
             try {
                 targetPost = await getPostBySlug(url.slug)
@@ -428,11 +441,11 @@ export const renderAutomaticProminentLinks = async (
                 // netlify-redirected upon click if applicable).
                 logErrorAndMaybeSendToSlack(
                     new Error(
-                        `${currentPost.title} (${formatWordpressEditLink(
-                            currentPost.id
-                        )}) wants to convert ${
+                        `Automatic prominent link convertion failed: no post found at ${
                             anchor.attribs.href
-                        } into a prominent link but this URL doesn't match any post. This might be because the URL of the target has been recently changed.`
+                        } in ${formatWordpressEditLink(
+                            currentPost.id
+                        )}. This might be because the URL of the target has been recently changed.`
                     )
                 )
             }

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -1,4 +1,8 @@
-import { LongFormPage, PageOverrides } from "../site/LongFormPage"
+import {
+    formatWordpressEditLink,
+    LongFormPage,
+    PageOverrides,
+} from "../site/LongFormPage"
 import { BlogIndexPage } from "../site/BlogIndexPage"
 import { FrontPage } from "../site/FrontPage"
 import { ChartsIndexPage, ChartIndexItem } from "../site/ChartsIndexPage"
@@ -9,7 +13,12 @@ import { DonatePage } from "../site/DonatePage"
 import * as React from "react"
 import * as ReactDOMServer from "react-dom/server"
 import * as lodash from "lodash"
-import { extractFormattingOptions, formatCountryProfile } from "./formatting"
+import {
+    extractFormattingOptions,
+    formatCountryProfile,
+    formatLinks,
+    isStandaloneInternalLink,
+} from "./formatting"
 import {
     bakeGrapherUrls,
     getGrapherExportsByUrl,
@@ -42,6 +51,7 @@ import {
     getEntriesByCategory,
     getFullPost,
     getLatestPostRevision,
+    getMediaThumbnailUrl,
     getPostBySlug,
     getPosts,
     selectHomepagePosts,
@@ -49,6 +59,12 @@ import {
 } from "../db/wpdb"
 import { mysqlFirst, queryMysql, knexTable } from "../db/db"
 import { getPageOverrides, isPageOverridesCitable } from "./pageOverrides"
+import { Url } from "../clientUtils/urls/Url"
+import { logErrorAndMaybeSendToSlack } from "./slackLog"
+import {
+    ProminentLink,
+    ProminentLinkStyles,
+} from "../site/blocks/ProminentLink"
 export const renderToHtmlPage = (element: any) =>
     `<!doctype html>${ReactDOMServer.renderToStaticMarkup(element)}`
 
@@ -391,3 +407,63 @@ export const countryProfileCountryPage = async (
 }
 
 export const flushCache = () => getCountryProfilePost.cache.clear?.()
+
+export const renderAutomaticProminentLinks = async (
+    cheerioEl: CheerioStatic,
+    currentPost: FullPost
+) => {
+    const anchorElements = cheerioEl("a").toArray()
+    await Promise.all(
+        anchorElements.map(async (anchor) => {
+            if (!isStandaloneInternalLink(anchor, cheerioEl)) return
+            const url = Url.fromURL(anchor.attribs.href)
+            if (!url.slug) return
+
+            let targetPost
+            try {
+                targetPost = await getPostBySlug(url.slug)
+            } catch (err) {
+                // not throwing here as this is not considered a critical error.
+                // Standalone links will just show up as such (and get
+                // netlify-redirected upon click if applicable).
+                logErrorAndMaybeSendToSlack(
+                    new Error(
+                        `${currentPost.title} (${formatWordpressEditLink(
+                            currentPost.id
+                        )}) wants to convert ${
+                            anchor.attribs.href
+                        } into a prominent link but this URL doesn't match any post. This might be because the URL of the target has been recently changed.`
+                    )
+                )
+            }
+            if (!targetPost) return
+
+            let image
+            if (targetPost.imageId) {
+                const mediaThumbnailUrl = await getMediaThumbnailUrl(
+                    targetPost.imageId
+                )
+                if (mediaThumbnailUrl) {
+                    image = ReactDOMServer.renderToStaticMarkup(
+                        <img src={formatLinks(mediaThumbnailUrl)} />
+                    )
+                }
+            }
+
+            const rendered = ReactDOMServer.renderToStaticMarkup(
+                <div className="block-wrapper">
+                    <ProminentLink
+                        href={anchor.attribs.href}
+                        style={ProminentLinkStyles.thin}
+                        title={targetPost.title}
+                        image={image}
+                    />
+                </div>
+            )
+
+            const $anchorParent = cheerioEl(anchor.parent)
+            $anchorParent.after(rendered)
+            $anchorParent.remove()
+        })
+    )
+}

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -875,17 +875,6 @@ export function sortByUndefinedLast<T>(
     return order === SortOrder.asc ? sorted : sorted.reverse()
 }
 
-export function getAttributesOfHTMLElement(el: HTMLElement): {
-    [key: string]: string
-} {
-    const attributes: { [key: string]: string } = {}
-    for (let i = 0; i < el.attributes.length; i++) {
-        const attr = el.attributes.item(i)
-        if (attr) attributes[attr.name] = attr.value
-    }
-    return attributes
-}
-
 export const mapNullToUndefined = <T>(
     array: (T | undefined | null)[]
 ): (T | undefined)[] => array.map((v) => (v === null ? undefined : v))

--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -182,6 +182,10 @@ export enum WP_PostType {
     Page = "page",
 }
 
+export enum WP_MediaSizes {
+    Thumbnail = "thumbnail",
+}
+
 export interface EntryNode {
     slug: string
     title: string
@@ -236,6 +240,7 @@ export interface FullPost {
     content: string
     excerpt?: string
     imageUrl?: string
+    imageId?: number
     postId?: number
     relatedCharts?: RelatedChart[]
     glossary: boolean

--- a/clientUtils/urls/Url.test.ts
+++ b/clientUtils/urls/Url.test.ts
@@ -68,4 +68,23 @@ describe(Url, () => {
             "/grapher/123"
         )
     })
+
+    it("detects grapher pages restrictively", () => {
+        expect(url.isGrapher).toBe(true)
+        expect(
+            Url.fromURL("https://ourworldindata.org/not/a/grapher/page")
+                .isGrapher
+        ).toBe(false)
+    })
+
+    it("detects uploads restrictively", () => {
+        expect(
+            Url.fromURL("https://ourworldindata.org/uploads/file.png").isUpload
+        ).toBe(true)
+        expect(
+            Url.fromURL(
+                "https://ourworldindata.org/not/supported/uploads/file.png"
+            ).isUpload
+        ).toBe(false)
+    })
 })

--- a/clientUtils/urls/Url.ts
+++ b/clientUtils/urls/Url.ts
@@ -79,6 +79,10 @@ export class Url {
         return this.props.pathname
     }
 
+    get slug(): string | undefined {
+        return this.props.pathname?.replace(/^\/+/, "")
+    }
+
     get originAndPath(): string | undefined {
         const strings = excludeUndefined([this.origin, this.pathname])
         if (strings.length === 0) return undefined
@@ -113,6 +117,10 @@ export class Url {
 
     get encodedQueryParams(): QueryParams {
         return strToQueryParams(this.queryStr, true)
+    }
+
+    get isGrapher(): boolean {
+        return this.pathname ? /\/grapher\//.test(this.pathname) : false
     }
 
     update(props: UrlProps) {

--- a/clientUtils/urls/Url.ts
+++ b/clientUtils/urls/Url.ts
@@ -120,7 +120,8 @@ export class Url {
     }
 
     get isGrapher(): boolean {
-        return this.pathname ? /\/grapher\//.test(this.pathname) : false
+        return this.pathname ? /^\/grapher\//.test(this.pathname) : false
+    }
     }
 
     update(props: UrlProps) {

--- a/clientUtils/urls/Url.ts
+++ b/clientUtils/urls/Url.ts
@@ -122,6 +122,9 @@ export class Url {
     get isGrapher(): boolean {
         return this.pathname ? /^\/grapher\//.test(this.pathname) : false
     }
+
+    get isUpload(): boolean {
+        return this.pathname ? /\/uploads\//.test(this.pathname) : false
     }
 
     update(props: UrlProps) {

--- a/clientUtils/urls/Url.ts
+++ b/clientUtils/urls/Url.ts
@@ -124,7 +124,7 @@ export class Url {
     }
 
     get isUpload(): boolean {
-        return this.pathname ? /\/uploads\//.test(this.pathname) : false
+        return this.pathname ? /^\/uploads\//.test(this.pathname) : false
     }
 
     update(props: UrlProps) {

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -29,11 +29,13 @@ import {
     PostReference,
     JsonError,
     CategoryNode,
+    WP_MediaSizes,
     FilterFnPostRestApi,
     PostRestApi,
 } from "../clientUtils/owidTypes"
 import { getContentGraph, GraphType } from "./contentGraph"
 import { memoize } from "../clientUtils/Util"
+import { Url } from "../clientUtils/urls/Url"
 
 let _knexInstance: Knex
 
@@ -111,8 +113,8 @@ export const ENTRIES_CATEGORY_ID = 44
 
 /* Wordpress GraphQL API query
  *
- * Note: in contrast to the REST API query, the GQL query does not throw when a
- * resource is not found, as GQL returns a 200, with a shape that is different between
+ * Note: in contrast to the REST API query, the GraphQL query does not throw when a
+ * resource is not found, as GraphQL returns a 200, with a shape that is different between
  * every query. So it is the caller's responsibility to throw (if necessary) on
  * "faux 404".
  */
@@ -606,6 +608,7 @@ export const getFullPost = async (
     imageUrl: `${BAKED_BASE_URL}${
         postApi.featured_media_path ?? "/default-thumbnail.jpg"
     }`,
+    imageId: postApi.featured_media,
     relatedCharts:
         postApi.type === "page"
             ? await getRelatedCharts(postApi.id)
@@ -618,6 +621,32 @@ export const getBlogIndex = memoize(async (): Promise<FullPost[]> => {
     const posts = await getPosts([WP_PostType.Post], selectHomepagePosts)
     return Promise.all(posts.map((post) => getFullPost(post, true)))
 })
+
+export const getMediaThumbnailUrl = async (
+    id: number
+): Promise<string | undefined> => {
+    const query = `
+    query getMediaSizes($id: ID!) {
+        mediaItem(id: $id, idType: DATABASE_ID) {
+          mediaDetails {
+            sizes {
+              name
+              sourceUrl
+            }
+          }
+        }
+      }
+    `
+
+    const mediaSizes = await graphqlQuery(query, { id })
+
+    const thumbnail = mediaSizes?.data?.mediaItem?.mediaDetails?.sizes?.find(
+        (mediaSize: { name: WP_MediaSizes; sourceUrl: string }) =>
+            mediaSize.name === WP_MediaSizes.Thumbnail
+    )
+
+    return thumbnail?.sourceUrl
+}
 
 interface TablepressTable {
     tableId: string

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -28,7 +28,8 @@ export const BAKED_GRAPHER_URL: string =
 export const ADMIN_BASE_URL: string =
     process.env.ADMIN_BASE_URL ??
     `http://${ADMIN_SERVER_HOST}:${ADMIN_SERVER_PORT}`
-export const WORDPRESS_URL: string = process.env.WORDPRESS_URL ?? ""
+export const WORDPRESS_URL: string =
+    process.env.WORDPRESS_URL ?? "http://owid.lndo.site"
 
 export const ALGOLIA_ID: string = process.env.ALGOLIA_ID ?? ""
 export const ALGOLIA_SEARCH_KEY: string = process.env.ALGOLIA_SEARCH_KEY ?? ""

--- a/site/LongFormPage.tsx
+++ b/site/LongFormPage.tsx
@@ -409,7 +409,7 @@ export const LongFormPage = (props: {
                             <li id="wp-admin-bar-edit">
                                 <a
                                     className="ab-item"
-                                    href={`${WORDPRESS_URL}/wp/wp-admin/post.php?post=${post.id}&action=edit`}
+                                    href={formatWordpressEditLink(post.id)}
                                 >
                                     Edit Page
                                 </a>
@@ -436,4 +436,8 @@ export const LongFormPage = (props: {
             </body>
         </html>
     )
+}
+
+export const formatWordpressEditLink = (postId: number) => {
+    return `${WORDPRESS_URL}/wp/wp-admin/post.php?post=${postId}&action=edit`
 }

--- a/site/blocks/ProminentLink.tsx
+++ b/site/blocks/ProminentLink.tsx
@@ -1,8 +1,9 @@
 import * as React from "react"
 import ReactDOM from "react-dom"
+import * as ReactDOMServer from "react-dom/server"
 import { observer } from "mobx-react"
 import { computed } from "mobx"
-import { union, getAttributesOfHTMLElement } from "../../clientUtils/Util"
+import { union } from "../../clientUtils/Util"
 import {
     getSelectedEntityNamesParam,
     migrateSelectedEntityNamesParam,
@@ -11,19 +12,30 @@ import {
 import { SelectionArray } from "../../grapher/selection/SelectionArray"
 import { Url } from "../../clientUtils/urls/Url"
 import { EntityName } from "../../coreTable/OwidTableConstants"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faArrowRight } from "@fortawesome/free-solid-svg-icons/faArrowRight"
+import { BAKED_BASE_URL } from "../../settings/clientSettings"
 
 export const PROMINENT_LINK_CLASSNAME = "wp-block-owid-prominent-link"
 
+export enum ProminentLinkStyles {
+    thin = "is-style-thin",
+    default = "is-style-default",
+}
+
+export const WITH_IMAGE = "with-image"
+
 @observer
-class ProminentLink extends React.Component<{
-    originalAnchorAttributes: { [key: string]: string }
-    innerHTML: string | null
+export class ProminentLink extends React.Component<{
+    href: string
+    style: string | null
+    title: string | null
+    content?: string | null
+    image?: string | null
     globalEntitySelection?: SelectionArray
 }> {
     @computed get originalUrl(): Url {
-        return migrateSelectedEntityNamesParam(
-            Url.fromURL(this.props.originalAnchorAttributes.href)
-        )
+        return migrateSelectedEntityNamesParam(Url.fromURL(this.props.href))
     }
 
     @computed private get originalSelectedEntities(): EntityName[] {
@@ -42,33 +54,149 @@ class ProminentLink extends React.Component<{
         return setSelectedEntityNamesParam(this.originalUrl, newEntityList)
     }
 
+    @computed private get style(): string {
+        return this.props.style || ProminentLinkStyles.default
+    }
+
     render() {
+        const classes = [
+            PROMINENT_LINK_CLASSNAME,
+            this.props.image ? WITH_IMAGE : null,
+        ]
+
+        const renderImage = () => {
+            return this.props.image ? (
+                <figure
+                    dangerouslySetInnerHTML={{
+                        __html: this.props.image,
+                    }}
+                />
+            ) : null
+        }
+
+        const renderContent = () => {
+            return this.props.content ? (
+                <div
+                    className="content"
+                    dangerouslySetInnerHTML={{
+                        __html: this.props.content,
+                    }}
+                />
+            ) : null
+        }
+
+        const renderThinStyle = () => {
+            return (
+                <>
+                    {renderImage()}
+                    <div className="content-wrapper">
+                        {renderContent()}
+                        {this.props.title ? (
+                            <div className="title">{this.props.title}</div>
+                        ) : null}
+                    </div>
+                </>
+            )
+        }
+
+        const renderDefaultStyle = () => {
+            return (
+                <>
+                    {this.props.title ? (
+                        <h3>
+                            {this.props.title}
+                            <FontAwesomeIcon icon={faArrowRight} />
+                        </h3>
+                    ) : null}
+                    <div className="content-wrapper">
+                        {renderImage()}
+                        {renderContent()}
+                    </div>
+                </>
+            )
+        }
+
+        const target = this.updatedUrl.isGrapher ? { target: "_blank" } : {}
+
         return (
-            <a
-                dangerouslySetInnerHTML={{ __html: this.props.innerHTML ?? "" }}
-                {...this.props.originalAnchorAttributes}
-                href={this.updatedUrl.fullUrl}
-            />
+            <div
+                className={classes.join(" ")}
+                data-no-lightbox
+                data-style={this.style}
+                data-title={this.props.title}
+            >
+                <a href={this.updatedUrl.fullUrl} {...target}>
+                    {this.style === ProminentLinkStyles.thin
+                        ? renderThinStyle()
+                        : renderDefaultStyle()}
+                </a>
+            </div>
         )
     }
 }
 
-export const renderProminentLink = (globalEntitySelection?: SelectionArray) =>
+export const renderAuthoredProminentLinks = ($: CheerioStatic) => {
+    $("block[type='prominent-link']").each((_, el: CheerioElement) => {
+        const $block = $(el)
+        const href = $block.find("link-url").text()
+        const url = Url.fromURL(href)
+
+        const style = $block.attr("style")
+        const title = $block.find("title").text()
+        const content = $block.find("content").html()
+        const image =
+            $block.find("figure").html() ||
+            (url.isGrapher
+                ? `<img src="${BAKED_BASE_URL}/grapher/exports/${url.pathname
+                      ?.split("/")
+                      .pop()}.svg" />`
+                : null)
+
+        const rendered = ReactDOMServer.renderToStaticMarkup(
+            <div className="block-wrapper">
+                <ProminentLink
+                    href={href}
+                    style={style}
+                    title={title}
+                    content={content}
+                    image={image}
+                />
+            </div>
+        )
+
+        $block.after(rendered)
+        $block.remove()
+    })
+}
+
+export const hydrateProminentLink = (
+    globalEntitySelection?: SelectionArray
+) => {
     document
         .querySelectorAll<HTMLElement>(`.${PROMINENT_LINK_CLASSNAME}`)
-        .forEach((el) => {
-            const anchorTag = el.querySelector("a")
-            if (!anchorTag) return
+        .forEach((block) => {
+            const href = block.querySelector("a")?.href
+            if (!href) return
+
+            const style = block.getAttribute("data-style")
+            const title = block.getAttribute("data-title")
+            const content = block.querySelector(".content")?.innerHTML || null
+            const image = block.querySelector("figure")?.innerHTML || null
 
             const rendered = (
                 <ProminentLink
-                    originalAnchorAttributes={getAttributesOfHTMLElement(
-                        anchorTag
-                    )}
-                    innerHTML={anchorTag.innerHTML}
+                    href={href}
+                    style={style}
+                    title={title}
+                    content={content}
+                    image={image}
                     globalEntitySelection={globalEntitySelection}
                 />
             )
 
-            ReactDOM.render(rendered, el)
+            // this should be a hydrate() call, but it does not work on page
+            // load for some reason (works fine when interacting with the global
+            // entity selector afterwards). Maybe a race condition with Mobx?
+            ReactDOM.render(rendered, block.parentElement)
         })
+}

--- a/site/blocks/index.ts
+++ b/site/blocks/index.ts
@@ -3,7 +3,7 @@ import {
     render as renderAdditionalInformation,
 } from "./AdditionalInformation"
 import { renderHelp } from "./Help"
-import { renderProminentLink } from "./ProminentLink"
+import { renderAuthoredProminentLinks } from "./ProminentLink"
 import { runSearchCountry } from "../../site/SearchCountry"
 import { runExpandableInlineBlock } from "../../site/ExpandableInlineBlock"
 import { runDataTokens } from "../../site/runDataTokens"
@@ -12,7 +12,9 @@ import { shouldProgressiveEmbed } from "../../site/multiembedder/MultiEmbedder"
 export const renderBlocks = (cheerioEl: CheerioStatic) => {
     renderAdditionalInformation(cheerioEl)
     renderHelp(cheerioEl)
+    renderAuthoredProminentLinks(cheerioEl)
 }
+
 export const runBlocks = () => {
     if (!shouldProgressiveEmbed()) {
         // Used by Help blocks. Pierces encapsulation but considered not worth going through hydration / client side rendering for this.

--- a/site/blocks/prominent-link.scss
+++ b/site/blocks/prominent-link.scss
@@ -24,7 +24,7 @@
         @include cancel-link-styles;
     }
 
-    &.is-style-default {
+    &[data-style="is-style-default"] {
         @include left-media-columns;
         margin-bottom: 2rem;
         a {
@@ -41,7 +41,7 @@
         }
     }
 
-    &.is-style-thin {
+    &[data-style="is-style-thin"] {
         background-color: transparent;
         margin-bottom: $vertical-spacing;
         .content-wrapper {

--- a/site/owid.entry.ts
+++ b/site/owid.entry.ts
@@ -36,7 +36,7 @@ import { Grapher } from "../grapher/core/Grapher"
 import { MultiEmbedderSingleton } from "../site/multiembedder/MultiEmbedder"
 import { CoreTable } from "../coreTable/CoreTable"
 import { SiteAnalytics } from "./SiteAnalytics"
-import { renderProminentLink } from "./blocks/ProminentLink"
+import { hydrateProminentLink } from "./blocks/ProminentLink"
 import Bugsnag from "@bugsnag/js"
 import BugsnagPluginReact from "@bugsnag/plugin-react"
 import { runMonkeyPatchForGoogleTranslate } from "./hacks"
@@ -68,9 +68,9 @@ window.runSiteFooterScripts = () => {
     if (!document.querySelector(`.${GRAPHER_PAGE_BODY_CLASS}`)) {
         MultiEmbedderSingleton.setUpGlobalEntitySelectorForEmbeds()
         MultiEmbedderSingleton.embedAll()
-        renderProminentLink(MultiEmbedderSingleton.selection)
+        hydrateProminentLink(MultiEmbedderSingleton.selection)
     } else {
-        renderProminentLink()
+        hydrateProminentLink()
     }
 }
 

--- a/wordpress/web/app/plugins/owid/src/ProminentLink/prominent-link.php
+++ b/wordpress/web/app/plugins/owid/src/ProminentLink/prominent-link.php
@@ -2,94 +2,32 @@
 
 namespace OWID\blocks\prominent_link;
 
-const STYLE_DEFAULT = "is-style-default";
-const STYLE_THIN = "is-style-thin";
-
 function render($attributes, $content)
 {
-    $style = !empty($attributes['className'])
-        ? $attributes['className']
-        : STYLE_DEFAULT;
-    $classes = 'wp-block-owid-prominent-link ' . $style;
-
-    $title = null;
-    if (!empty($attributes['title'])) {
-        $title_tag = 'h3';
-        if ($style === STYLE_THIN) {
-            $title_tag = 'div class="title"';
-        }
-        $title =
-            "<{$title_tag}>{$attributes['title']}" .
-            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M190.5 66.9l22.2-22.2c9.4-9.4 24.6-9.4 33.9 0L441 239c9.4 9.4 9.4 24.6 0 33.9L246.6 467.3c-9.4 9.4-24.6 9.4-33.9 0l-22.2-22.2c-9.5-9.5-9.3-25 .4-34.3L311.4 296H24c-13.3 0-24-10.7-24-24v-32c0-13.3 10.7-24 24-24h287.4L190.9 101.2c-9.8-9.3-10-24.8-.4-34.3z"/></svg>' .
-            "</{$title_tag}>";
+    if (empty($attributes["linkUrl"])) {
+        return;
     }
 
-    $linkStart = $linkEnd = null;
-    $isGrapher = null;
-    if (!empty($attributes['linkUrl'])) {
-        $isGrapher =
-            substr(parse_url($attributes['linkUrl'], PHP_URL_PATH), 0, 9) ===
-            '/grapher/';
-        $target_blank = $isGrapher ? ' target="_blank"' : null;
-        $linkStart =
-            '<a href="' .
-            esc_url($attributes['linkUrl']) .
-            '"' .
-            $target_blank .
-            '>';
-        $linkEnd = '</a>';
-    }
+    $linkUrl = esc_url($attributes["linkUrl"]);
+    $style = $attributes["className"] ? "style=\"$attributes[className]\"" : "";
+    $title = $attributes["title"] ?? "";
 
-    $img = null;
+    $image = null;
     if (!empty($attributes['mediaUrl'])) {
-        $img = wp_get_attachment_image($attributes['mediaId'], 'medium_large');
-    } else {
-        if ($isGrapher) {
-            $pathElements = explode(
-                "/",
-                parse_url($attributes['linkUrl'], PHP_URL_PATH)
-            );
-            $chartSlug = end($pathElements);
-            $img = '<img src="/grapher/exports/' . $chartSlug . '.svg" />';
-        }
+        $image = wp_get_attachment_image(
+            $attributes['mediaId'],
+            'medium_large'
+        );
     }
 
-    $figure = null;
-    if ($img) {
-        $figure = "<figure>" . $img . "</figure>";
-        $classes .= ' with-image';
-    }
-
-    $block = null;
-    if ($style === STYLE_THIN) {
-        $block = <<<EOD
-      <div class="$classes" data-no-lightbox>
-        $linkStart
-          $figure
-          <div class="content-wrapper">
-            <div class="content">
-              $content
-            </div>
-            $title
-          </div>
-        $linkEnd
-      </div>
+    $block = <<<EOD
+    <block type="prominent-link" $style>
+        <link-url>$linkUrl</link-url>
+        <title>$title</title>
+        <content>$content</content>
+        <figure>$image</figure>
+    </block>
 EOD;
-    } else {
-        $block = <<<EOD
-      <div class="$classes" data-no-lightbox>
-        $linkStart
-          $title
-          <div class="content-wrapper">
-            $figure
-            <div class="content">
-              $content
-            </div>
-          </div>
-        $linkEnd
-      </div>
-EOD;
-    }
 
     return $block;
 }


### PR DESCRIPTION
sequel to https://github.com/owid/owid-grapher/pull/1030

Loosened error logging on /uploads standalone links, while content is being rewritten. See [notion issue](https://www.notion.so/owid/Automatic-prominent-links-1eafcce85953483d912b6e5f20b928ec#4c7b604dc6894217bf7ad361e49f58b2) for long-term fix.