### PR TITLE
enhance: line chart in relative mode with toggle always shows "Change in"

### DIFF
--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1132,7 +1132,11 @@ export class Grapher
             if (entityStr?.length) text = `${text}, ${entityStr}`
         }
 
-        if (showTitleAnnotation && this.isLineChart && this.isRelativeMode)
+        if (
+            this.isLineChart &&
+            this.isRelativeMode &&
+            (showTitleAnnotation || this.canToggleRelativeMode)
+        )
             text = "Change in " + lowerCaseFirstLetterUnlessAbbreviation(text)
 
         if (


### PR DESCRIPTION
[Slack context](https://owid.slack.com/archives/C46U9LXRR/p1637071765029300?thread_ts=1637064083.024900&cid=C46U9LXRR)
---

I believe this is better than what we have now but not quite sure?
It's just a quick-and-dirty fix anyway, and we really should [Split "Hide automatic time/entity" toggle into multiple ones](https://www.notion.so/Split-Hide-automatic-time-entity-toggle-into-multiple-ones-a3056259ca2248ad865a01a55af12807).

Also, let's wait and see what differences the svg checker comes up with :)