### PR TITLE
feat(explorer): gitCms automatically pulls before committing changes

### DIFF
--- a/explorerAdminClient/ExplorerCreatePage.tsx
+++ b/explorerAdminClient/ExplorerCreatePage.tsx
@@ -127,11 +127,16 @@ export class ExplorerCreatePage extends React.Component<{
     @action.bound private async _save(slug: string, commitMessage: string) {
         this.loadingModalOn()
         this.program.slug = slug
-        await this.gitCmsClient.writeRemoteFile({
+        const res = await this.gitCmsClient.writeRemoteFile({
             filepath: this.program.fullPath,
             content: this.program.toString(),
             commitMessage,
         })
+        if (!res.success) {
+            alert(`Saving the explorer failed!\n\n${res.error}`)
+            return
+        }
+
         this.loadingModalOff()
         this.programOnDisk = new ExplorerProgram("", this.program.toString())
         this.setProgram(this.programOnDisk.toString())

--- a/explorerAdminClient/ExplorersListPage.tsx
+++ b/explorerAdminClient/ExplorersListPage.tsx
@@ -240,15 +240,6 @@ export class ExplorersIndexPage extends React.Component<{
             } else return text
         }
 
-        const needsPull = true // todo: implement needsPull on server side and then use this.needsPull
-        const pullButton = needsPull && (
-            <span>
-                <a href="#" onClick={this.pullFromGithub}>
-                    Check for new commits from GitHub
-                </a>{" "}
-            </span>
-        )
-
         return (
             <main className="DatasetsIndexPage">
                 <div className="ExplorersListPageHeader">
@@ -257,6 +248,13 @@ export class ExplorersIndexPage extends React.Component<{
                         explorers
                     </div>
                     <div style={{ textAlign: "right" }}>
+                        <a
+                            className="btn btn-secondary"
+                            href="#"
+                            onClick={this.pullFromGithub}
+                        >
+                            Pull updates from GitHub
+                        </a>{" "}
                         <a
                             className="btn btn-primary"
                             href={`/admin/${EXPLORERS_ROUTE_FOLDER}/${DefaultNewExplorerSlug}`}
@@ -271,7 +269,6 @@ export class ExplorersIndexPage extends React.Component<{
                     indexPage={this}
                     gitCmsBranchName={this.gitCmsBranchName}
                 />
-                {pullButton} |{" "}
                 <a
                     href={`${GIT_CMS_REPO_URL}/commits/${this.gitCmsBranchName}`}
                 >

--- a/gitCms/GitCmsServer.ts
+++ b/gitCms/GitCmsServer.ts
@@ -63,6 +63,12 @@ export class GitCmsServer {
                 baseDir: this.baseDir,
                 binary: "git",
                 maxConcurrentProcesses: 1,
+                // Needed since git won't let you commit if there's no user name config present (i.e. CI), even if you always
+                // specify `author=` in every command. See https://stackoverflow.com/q/29685337/10670163 for example.
+                config: [
+                    `user.name='${GIT_DEFAULT_USERNAME}'`,
+                    `user.email='${GIT_DEFAULT_EMAIL}'`,
+                ],
             })
         return this._git
     }
@@ -72,10 +78,6 @@ export class GitCmsServer {
         if (!existsSync(baseDir)) mkdirSync(baseDir)
         await this.git.init()
 
-        // Needed since git won't let you commit if there's no user name config present (i.e. CI), even if you always
-        // specify `author=` in every command. See https://stackoverflow.com/q/29685337/10670163 for example.
-        await this.git.addConfig("user.name", GIT_DEFAULT_USERNAME)
-        await this.git.addConfig("user.email", GIT_DEFAULT_EMAIL)
         return this
     }
 

--- a/gitCms/GitCmsServer.ts
+++ b/gitCms/GitCmsServer.ts
@@ -28,6 +28,7 @@ import {
     GIT_CMS_PULL_ROUTE,
 } from "./GitCmsConstants"
 import { sync } from "glob"
+import { logErrorAndMaybeSendToSlack } from "../serverUtils/slackLog"
 
 // todo: cleanup typings
 interface ResponseWithUserInfo extends Response {
@@ -195,7 +196,7 @@ export class GitCmsServer {
             await this.autopush()
             return { success: true }
         } catch (error) {
-            if (this.verbose) console.log(error)
+            logErrorAndMaybeSendToSlack(error)
             return { success: false, error }
         }
     }
@@ -229,7 +230,7 @@ export class GitCmsServer {
             await this.autopush()
             return { success: true }
         } catch (error) {
-            if (this.verbose) console.log(error)
+            logErrorAndMaybeSendToSlack(error)
             return { success: false, error }
         }
     }

--- a/gitCms/GitCmsServer.ts
+++ b/gitCms/GitCmsServer.ts
@@ -106,8 +106,9 @@ export class GitCmsServer {
                 stdout: JSON.stringify(res.summary, null, 2),
             } as GitPullResponse
         } catch (error) {
-            if (verbose ?? this.verbose) console.log(error)
-            return { success: false, error }
+            const err = error as Error
+            if (verbose ?? this.verbose) console.log(err)
+            return { success: false, error: err.toString() }
         }
     }
 
@@ -116,12 +117,12 @@ export class GitCmsServer {
         const res = await this.pullCommand(false)
 
         if (!res.success) {
-            const err = res.error as Error | undefined
+            const err = res.error as string | undefined
             if (
-                err?.message.includes(
+                err?.includes(
                     "There is no tracking information for the current branch." // local-only branch
                 ) ||
-                err?.message.includes("You are not currently on a branch.") // detached HEAD
+                err?.includes("You are not currently on a branch.") // detached HEAD
             )
                 return { success: true }
         }
@@ -140,10 +141,11 @@ export class GitCmsServer {
             const content = await readFile(absolutePath, "utf8")
             return { success: true, content }
         } catch (error) {
-            if (this.verbose) console.log(error)
+            const err = error as Error
+            if (this.verbose) console.log(err)
             return {
                 success: false,
-                error,
+                error: err.toString(),
                 content: "",
             }
         }
@@ -196,8 +198,9 @@ export class GitCmsServer {
             await this.autopush()
             return { success: true }
         } catch (error) {
-            logErrorAndMaybeSendToSlack(error)
-            return { success: false, error }
+            const err = error as Error
+            logErrorAndMaybeSendToSlack(err)
+            return { success: false, error: err.toString() }
         }
     }
 
@@ -230,8 +233,9 @@ export class GitCmsServer {
             await this.autopush()
             return { success: true }
         } catch (error) {
-            logErrorAndMaybeSendToSlack(error)
-            return { success: false, error }
+            const err = error as Error
+            logErrorAndMaybeSendToSlack(err)
+            return { success: false, error: err.toString() }
         }
     }
 

--- a/gitCms/tsconfig.json
+++ b/gitCms/tsconfig.json
@@ -4,5 +4,5 @@
         "outDir": "../itsJustJavascript/gitCms",
         "rootDir": "."
     },
-    "references": [{ "path": "../settings" }]
+    "references": [{ "path": "../settings" }, { "path": "../serverUtils" }]
 }


### PR DESCRIPTION
Notion: [Explorer GitCMS should do a pull before pushing](https://www.notion.so/Explorer-GitCMS-should-do-a-pull-before-pushing-5ecb7cffd4cb47a1a2be29141bcd2d25)

turns out, there's a lot of smaller fixes that have come together in here now:
* most importantly, gitCms runs an automatic pull before every write and delete operation
  * ... but only if the branch has an upstream branch set up
* if the pull fails, the whole operation fails and is communicated back to the user (through an `alert()`, _but still_)
* the failure is then also logged to slack
* the pull button on the ExplorerListPage is moved all the way to the top, since it might become a little more important now
* there was also an issue where gitCms would always set the git username and email in the `owid-content` repo - which bugged me - and which is now also fixed