### PR TITLE
feat(explorer): can specify the row to use as the default view

### DIFF
--- a/explorer/ExplorerProgram.test.ts
+++ b/explorer/ExplorerProgram.test.ts
@@ -363,7 +363,7 @@ france,Life expectancy`
         })
     })
 
-    it("marks a radio as checked if its the only option", () => {
+    it("marks a radio as checked if it's the only option", () => {
         const decisionMatrix = new DecisionMatrix(
             `${grapherIdKeyword},Gas Radio,Accounting Radio
 488,CO₂,Production-based
@@ -460,6 +460,49 @@ france,Life expectancy`
                 `columns\tBag slug`
             ).getCell({ row: 0, column: 1 })
             expect(cell.errorMessage).not.toEqual(``)
+        })
+    })
+
+    describe("defaultView", () => {
+        const matrix = `${grapherIdKeyword},Metric Dropdown,Interval Dropdown,Relative to population Checkbox,defaultView
+1,Cases,Daily,true
+2,Cases,Weekly,true
+3,Cases,Cumulative,true
+4,Cases,Cumulative,false
+5,Tests,Cumulative,true,true
+6,Tests,Cumulative,false`
+
+        it("can set a default view", () => {
+            const decisionMatrix = new DecisionMatrix(matrix)
+
+            expect(decisionMatrix.selectedRow.grapherId).toEqual(5)
+        })
+
+        it("can override defaults", () => {
+            const decisionMatrix1 = new DecisionMatrix(matrix)
+
+            decisionMatrix1.setValuesFromChoiceParams({ Metric: "Cases" })
+            expect(decisionMatrix1.selectedRow.grapherId).toEqual(3)
+
+            const decisionMatrix2 = new DecisionMatrix(matrix)
+
+            decisionMatrix2.setValuesFromChoiceParams({
+                "Relative to population": "false",
+            })
+            expect(decisionMatrix2.selectedRow.grapherId).toEqual(6)
+        })
+
+        it("falls back to the defaultView", () => {
+            const decisionMatrix = new DecisionMatrix(matrix)
+
+            decisionMatrix.setValuesFromChoiceParams({ Metric: "Nonexistent" })
+            expect(decisionMatrix.selectedRow.grapherId).toEqual(5)
+
+            decisionMatrix.setValuesFromChoiceParams({
+                Metric: "Nonexistent",
+                "Relative to population": "false",
+            })
+            expect(decisionMatrix.selectedRow.grapherId).toEqual(6)
         })
     })
 })

--- a/explorer/ExplorerProgram.test.ts
+++ b/explorer/ExplorerProgram.test.ts
@@ -465,12 +465,13 @@ france,Life expectancy`
 
     describe("defaultView", () => {
         const matrix = `${grapherIdKeyword},Metric Dropdown,Interval Dropdown,Relative to population Checkbox,defaultView
-1,Cases,Daily,true
-2,Cases,Weekly,true
-3,Cases,Cumulative,true
-4,Cases,Cumulative,false
+1,Cases,Daily,true,
+2,Cases,Weekly,true,
+3,Cases,Cumulative,true,
+4,Cases,Cumulative,false,
 5,Tests,Cumulative,true,true
-6,Tests,Cumulative,false`
+6,Tests,Cumulative,false,
+7,Deaths,Biweekly,false,`
 
         it("can set a default view", () => {
             const decisionMatrix = new DecisionMatrix(matrix)
@@ -478,18 +479,35 @@ france,Life expectancy`
             expect(decisionMatrix.selectedRow.grapherId).toEqual(5)
         })
 
-        it("can override defaults", () => {
-            const decisionMatrix1 = new DecisionMatrix(matrix)
+        describe("can override defaults", () => {
+            it("case 1: Change the first param: Metric", () => {
+                const decisionMatrix = new DecisionMatrix(matrix)
 
-            decisionMatrix1.setValuesFromChoiceParams({ Metric: "Cases" })
-            expect(decisionMatrix1.selectedRow.grapherId).toEqual(3)
-
-            const decisionMatrix2 = new DecisionMatrix(matrix)
-
-            decisionMatrix2.setValuesFromChoiceParams({
-                "Relative to population": "false",
+                decisionMatrix.setValuesFromChoiceParams({ Metric: "Cases" })
+                expect(decisionMatrix.selectedRow.grapherId).toEqual(3)
             })
-            expect(decisionMatrix2.selectedRow.grapherId).toEqual(6)
+
+            it("case 2: Change the last param: Relative to population", () => {
+                const decisionMatrix = new DecisionMatrix(matrix)
+
+                decisionMatrix.setValuesFromChoiceParams({
+                    "Relative to population": "false",
+                })
+                expect(decisionMatrix.selectedRow.grapherId).toEqual(6)
+            })
+
+            it("case 3: Change Metric in such a way that Interval and Relative also need to be implicitly changed", () => {
+                const decisionMatrix = new DecisionMatrix(matrix)
+
+                decisionMatrix.setValuesFromChoiceParams({ Metric: "Deaths" })
+                expect(decisionMatrix.selectedRow.grapherId).toEqual(7)
+
+                expect(decisionMatrix.toConstrainedOptions()).toEqual({
+                    Metric: "Deaths",
+                    Interval: "Biweekly",
+                    "Relative to population": "false",
+                })
+            })
         })
 
         it("falls back to the defaultView", () => {

--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -198,4 +198,9 @@ export const GrapherGrammar: Grammar = {
         description:
             "Set the maximum time for the timeline. Must be an integer. For days, use days since 21 Jan 2020, e.g. 24 Jan 2020 is '3'.",
     },
+    defaultView: {
+        ...BooleanCellDef,
+        keyword: "defaultView",
+        description: "Whether this view is used as the default view.",
+    },
 } as const


### PR DESCRIPTION
Notion: [Ability to specify the default view of an explorer](https://www.notion.so/Ability-to-specify-the-default-view-of-an-explorer-459b8da60a5043038e84376d959b6383) - we're gonna need this for the food explorer.

This is deployed to _tufte_. Try it here: https://tufte.owid.cloud/admin/explorers/tunnels

It allows the default view of a explorer to be a different one than the first row of the spreadsheet.
The syntax to use is as follows:
```tsv
graphers							
	Type Radio	type		defaultView
	In Ground	DiscreteBar
	Underwater	DiscreteBar
	All types	LineChart	true
```

As you can see in the tests, we also fall back to the default config in the case where a non-existent choice is given, e.g. `?Type=Bridges` would fall back to `All types`.