### PR TITLE
feat(map): open-ended brackets redesign

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -2,7 +2,7 @@
     "files": [
         {
             "path": "./itsJustJavascript/webpack/commons.js",
-            "maxSize": "850 KB"
+            "maxSize": "900 KB"
         },
         {
             "path": "./itsJustJavascript/webpack/vendors.js",

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -1167,3 +1167,7 @@ export const triggerDownloadFromUrl = (filename: string, url: string): void => {
     downloadLink.setAttribute("download", filename)
     downloadLink.click()
 }
+
+export const removeAllWhitespace = (text: string): string => {
+    return text.replace(/\s+|\n/g, "")
+}

--- a/grapher/color/ColorScale.ts
+++ b/grapher/color/ColorScale.ts
@@ -273,13 +273,13 @@ export class ColorScale {
                 this.colorScaleColumn?.formatValueShort(max) ?? max.toString()
 
             const currentMin = min
+            const isFirst = index === 0
+            const isLast = index === bucketMaximums.length - 1
             min = max
             return new NumericBin({
-                isFirst: index === 0,
-                isOpenLeft: index === 0 && currentMin > minPossibleValue,
-                isOpenRight:
-                    index === bucketMaximums.length - 1 &&
-                    max < maxPossibleValue,
+                isFirst,
+                isOpenLeft: isFirst && currentMin > minPossibleValue,
+                isOpenRight: isLast && max < maxPossibleValue,
                 min: currentMin,
                 max,
                 color,

--- a/grapher/color/ColorScaleBin.ts
+++ b/grapher/color/ColorScaleBin.ts
@@ -43,10 +43,12 @@ export class NumericBin extends AbstractColorScaleBin<NumericBinProps> {
         return this.props.max
     }
     get minText(): string {
-        return (this.props.isOpenLeft ? `<` : "") + this.props.displayMin
+        if (this.props.isOpenLeft) return ""
+        return this.props.displayMin
     }
     get maxText(): string {
-        return (this.props.isOpenRight ? `>` : "") + this.props.displayMax
+        if (this.props.isOpenRight) return ""
+        return this.props.displayMax
     }
     get text(): string {
         return this.props.label || ""

--- a/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -247,8 +247,9 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
         for (const bin of positionedBins) {
             if (bin.bin.text) labels.push(makeRangeLabel(bin))
             else if (bin.bin instanceof NumericBin) {
-                labels.push(makeBoundaryLabel(bin, "min", bin.bin.minText))
-                if (bin === last(positionedBins))
+                if (bin.bin.minText)
+                    labels.push(makeBoundaryLabel(bin, "min", bin.bin.minText))
+                if (bin === last(positionedBins) && bin.bin.maxText)
                     labels.push(makeBoundaryLabel(bin, "max", bin.bin.maxText))
             }
         }
@@ -396,7 +397,7 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                             numericFocusBracket &&
                             positionedBin.bin.equals(numericFocusBracket)
                         return (
-                            <rect
+                            <NumericBinRect
                                 key={index}
                                 x={this.legendX + positionedBin.x}
                                 y={bottomY - rectHeight}
@@ -430,6 +431,16 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
             </g>
         )
     }
+}
+
+interface NumericBinRectProps extends React.SVGProps<SVGRectElement> {
+    isOpenLeft?: boolean
+    isOpenRight?: boolean
+}
+
+const NumericBinRect = (props: NumericBinRectProps) => {
+    const { isOpenLeft, isOpenRight, ...rectProps } = props
+    return <rect {...rectProps} />
 }
 
 @observer

--- a/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -10,6 +10,7 @@ import {
     flatten,
     sum,
     dyFromAlign,
+    removeAllWhitespace,
 } from "../../clientUtils/Util"
 import { Bounds } from "../../clientUtils/Bounds"
 import {
@@ -461,26 +462,26 @@ const NumericBinRect = (props: NumericBinRectProps) => {
     if (isOpenRight) {
         const a = ARROW_SIZE
         const w = width - a
-        const d = `
+        const d = removeAllWhitespace(`
             M ${x}, ${y}
             l ${w}, 0
             l ${a}, ${height / 2}
             l ${-a}, ${height / 2}
             l ${-w}, 0
             z
-        `
+        `)
         return <path d={d} {...restProps} />
     } else if (isOpenLeft) {
         const a = ARROW_SIZE
         const w = width - a
-        const d = `
+        const d = removeAllWhitespace(`
             M ${x + a}, ${y}
             l ${w}, 0
             l 0, ${height}
             l ${-w}, 0
             l ${-a}, ${-height / 2}
             z
-        `
+        `)
         return <path d={d} {...restProps} />
     } else {
         return <rect x={x} y={y} width={width} height={height} {...restProps} />

--- a/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -393,9 +393,10 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                 ))}
                 {sortBy(
                     positionedBins.map((positionedBin, index) => {
+                        const bin = positionedBin.bin
                         const isFocus =
                             numericFocusBracket &&
-                            positionedBin.bin.equals(numericFocusBracket)
+                            bin.equals(numericFocusBracket)
                         return (
                             <NumericBinRect
                                 key={index}
@@ -403,12 +404,22 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                                 y={bottomY - rectHeight}
                                 width={positionedBin.width}
                                 height={rectHeight}
-                                fill={positionedBin.bin.color}
+                                fill={bin.color}
                                 opacity={manager.legendOpacity} // defaults to undefined which removes the prop
                                 stroke={
                                     isFocus ? FOCUS_BORDER_COLOR : borderColor
                                 }
                                 strokeWidth={isFocus ? 2 : 0.3}
+                                isOpenLeft={
+                                    bin instanceof NumericBin
+                                        ? bin.props.isOpenLeft
+                                        : false
+                                }
+                                isOpenRight={
+                                    bin instanceof NumericBin
+                                        ? bin.props.isOpenRight
+                                        : false
+                                }
                             />
                         )
                     }),
@@ -434,13 +445,46 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
 }
 
 interface NumericBinRectProps extends React.SVGProps<SVGRectElement> {
+    x: number
+    y: number
+    width: number
+    height: number
     isOpenLeft?: boolean
     isOpenRight?: boolean
 }
 
+/** The width of the arrowhead for open-ended bins (left or right) */
+const ARROW_SIZE = 5
+
 const NumericBinRect = (props: NumericBinRectProps) => {
-    const { isOpenLeft, isOpenRight, ...rectProps } = props
-    return <rect {...rectProps} />
+    const { isOpenLeft, isOpenRight, x, y, width, height, ...restProps } = props
+    if (isOpenRight) {
+        const a = ARROW_SIZE
+        const w = width - a
+        const d = `
+            M ${x}, ${y}
+            l ${w}, 0
+            l ${a}, ${height / 2}
+            l ${-a}, ${height / 2}
+            l ${-w}, 0
+            z
+        `
+        return <path d={d} {...restProps} />
+    } else if (isOpenLeft) {
+        const a = ARROW_SIZE
+        const w = width - a
+        const d = `
+            M ${x + a}, ${y}
+            l ${w}, 0
+            l 0, ${height}
+            l ${-w}, 0
+            l ${-a}, ${-height / 2}
+            z
+        `
+        return <path d={d} {...restProps} />
+    } else {
+        return <rect x={x} y={y} width={width} height={height} {...restProps} />
+    }
 }
 
 @observer

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -72,6 +72,7 @@ const PROJECTION_CHOOSER_WIDTH = 110
 const PROJECTION_CHOOSER_HEIGHT = 22
 
 const DEFAULT_STROKE_COLOR = "#333"
+const CHOROPLETH_MAP_CLASSNAME = "ChoroplethMap"
 
 // TODO refactor to use transform pattern, bit too much info for a pure component
 
@@ -379,7 +380,7 @@ export class MapChart
 
     componentDidMount(): void {
         select(this.base.current)
-            .selectAll("path")
+            .selectAll(`.${CHOROPLETH_MAP_CLASSNAME} path`)
             .attr("data-fill", function () {
                 return (this as SVGPathElement).getAttribute("fill")
             })
@@ -865,7 +866,7 @@ class ChoroplethMap extends React.Component<ChoroplethMapProps> {
         return (
             <g
                 ref={this.base}
-                className="ChoroplethMap"
+                className={CHOROPLETH_MAP_CLASSNAME}
                 clipPath={clipPath.id}
                 onMouseDown={
                     (ev: SVGMouseEvent): void =>


### PR DESCRIPTION
Notion issue: [Open-ended map brackets](https://www.notion.so/Open-ended-map-brackets-1b46c058954042909716d0d71e2cbe74)

Deployed on playfair, see [**all affected charts**](https://playfair.owid.cloud/admin/test/embeds?ids=26,46,66,75,128,134,194,225,254,259,268,319,351,360,365,366,373,390,438,485,486,488,500,530,533,534,540,586,632,637,639,677,696,699,701,712,737,745,762,768,769,772,775,779,780,797,802,807,812,873,878,879,880,886,888,891,893,909,918,919,1017,1019,1022,1024,1025,1031,1032,1038,1039,1040,1042,1073,1090,1111,1125,1154,1165,1214,1229,1245,1249,1252,1264,1270,1312,1329,1331,1332,1341,1342,1377,1385,1403,1410,1419,1431,1433,1469,1470,1484,1523,1536,1572,1584,1590,1595,1598,1615,1619,1623,1624,1644,1645,1646,1669,1672,1703,1704,1706,1749,1773,1793,1797,1798,1800,1821,1822,1828,1831,1833,1835,1836,1838,1860,1861,1862,1879,1881,1899,1900,1901,1902,1908,1909,1910,1915,1916,1917,1918,1919,1921,1932,1940,1941,1943,1948,1949,1951,1952,1956,1957,1958,1959,1960,1964,1966,1984,1985,1986,1987,1994,2005,2013,2015,2016,2018,2019,2020,2021,2031,2032,2035,2036,2037,2041,2042,2044,2045,2046,2049,2052,2053,2054,2056,2057,2058,2064,2071,2072,2074,2080,2084,2090,2091,2093,2100,2101,2104,2105,2109,2110,2111,2123,2127,2129,2140,2141,2143,2154,2155,2156,2157,2159,2163,2164,2176,2177,2178,2179,2186,2193,2198,2201,2202,2203,2204,2210,2236,2242,2253,2255,2264,2266,2269,2286,2290,2301,2322,2323,2328,2329,2330,2333,2334,2385,2387,2392,2395,2396,2416,2431,2450,2459,2472,2474,2478,2482,2484,2488,2490,2491,2494,2495,2509,2510,2511,2536,2546,2562,2564,2566,2599,2600,2609,2610,2611,2615,2624,2625,2627,2628,2629,2630,2635,2636,2637,2651,2656,2657,2658,2659,2660,2668,2672,2673,2680,2681,2695,2700,2711,2713,2718,2723,2724,2725,2727,2732,2733,2737,2740,2741,2752,2755,2760,2774,2777,2779,2781,2784,2787,2789,2790,2791,2793,2795,2796,2797,2803,2804,2805,2838,2847,2849,2859,2876,2881,2882,2902,2926,2938,2939,2947,2968,2984,2985,2994,3003,3030,3049,3074,3116,3117,3118,3119,3128,3143,3147,3154,3167,3168,3169,3170,3171,3172,3175,3176,3188,3189,3199,3217,3218,3219,3227,3267,3293,3308,3309,3314,3329,3334,3336,3337,3353,3410,3411,3415,3475,3487,3488,3491,3494,3495,3496,3498,3499,3500,3503,3504,3505,3521,3558,3589,3590,3621,3623,3624,3633,3634,3637,3680,3742,3756,3757,3760,3786,3790,3798,3799,3811,3812,3832,3834,3848,3849,3850,3852,3854,3856,3868,3884,3885,3892,3893,3894,3895,3912,3914,3916,3917,3956,3962,3966,3970,3971,3975,3976,3977,3978,3979,3980,3981,3982,3996,3998,3999,4000,4002,4003,4004,4005,4006,4008,4010,4011,4012,4013,4014,4015,4016,4017,4018,4019,4027,4028,4030,4051,4081,4119,4120,4147,4148,4191,4193,4194,4195,4196,4197,4198,4203,4204,4209,4210,4211,4212,4214,4215,4218,4219,4221,4222,4239,4243,4244,4249,4250,4251,4252,4253,4254,4256,4267,4268,4273,4277,4278,4279,4288,4290,4292,4293,4294,4296,4298,4303,4309,4315,4320,4322,4324,4325,4326,4331,4332,4333,4378,4379,4380,4381,4382,4383,4385,4386,4387,4389,4391,4392,4393,4394,4395,4396,4397,4399,4400,4401,4403,4435,4436,4437,4438,4439,4440,4441,4443,4444,4445,4446,4447,4451,4452,4453,4454,4455,4456,4458,4489,4491,4494,4495,4503,4504,4505,4508,4509,4511,4514,4515,4516,4517,4518,4527,4529,4531,4537,4550,4551,4563,4564,4565,4566,4567,4568,4569,4571,4572,4574,4577,4578,4579,4580,4581,4583,4587,4595,4601,4602,4603,4604,4605,4606,4607,4608,4610,4668,4672,4674,4748,4749,4750,4751,4752,4754,4755,4758,4759,4760,4761,4762,4765,4772,4774,4814,5046,5052,5068,5069) (well, almost all – map tabs that aren't selected by default are not in the list).

**Before**, open-ended brackets used to have a `>` or `<` prefix added to their label. **This PR** removes the label completely for open-ended brackets, and it shows an "arrowhead" at the edge of the bin, to suggest it extends further.

Example ([link](https://playfair.owid.cloud/admin/test/embeds?ids=194&comparisonUrl=https%3A%2F%2Fourworldindata.org)):

<img width="1440" alt="Screenshot 2021-12-14 at 23 15 51" src="https://user-images.githubusercontent.com/1308115/146187230-10779864-057d-4a69-8dd8-e9795f22213c.png">

Based on the [Slack discussion](https://owid.slack.com/archives/C5BDCB2R3/p1639524202003600?thread_ts=1639407507.000600&cid=C5BDCB2R3), authors prefer to have this applied to all existing charts, without adding any additional config.