### PR TITLE
enhance(grapher): ensure width/height are integers

### DIFF
--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -121,12 +121,12 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
 
     @computed protected get chartHeight(): number {
         const controlsRowHeight = this.controls.length ? CONTROLS_ROW_HEIGHT : 0
-        return (
+        return Math.floor(
             this.bounds.height -
-            this.header.height -
-            controlsRowHeight -
-            this.footer.height -
-            PADDING_ABOVE_FOOTER
+                this.header.height -
+                controlsRowHeight -
+                this.footer.height -
+                PADDING_ABOVE_FOOTER
         )
     }
 

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1656,14 +1656,18 @@ export class Grapher
     // These are the final render dimensions
     // Todo: add explanation around why isExporting removes 5 px
     @computed private get renderWidth(): number {
-        return this.useIdealBounds
-            ? this.widthForDeviceOrientation * this.scaleToFitIdeal
-            : this.bounds.width - (this.isExportingtoSvgOrPng ? 0 : 5)
+        return Math.floor(
+            this.useIdealBounds
+                ? this.widthForDeviceOrientation * this.scaleToFitIdeal
+                : this.bounds.width - (this.isExportingtoSvgOrPng ? 0 : 5)
+        )
     }
     @computed private get renderHeight(): number {
-        return this.useIdealBounds
-            ? this.heightForDeviceOrientation * this.scaleToFitIdeal
-            : this.bounds.height - (this.isExportingtoSvgOrPng ? 0 : 5)
+        return Math.floor(
+            this.useIdealBounds
+                ? this.heightForDeviceOrientation * this.scaleToFitIdeal
+                : this.bounds.height - (this.isExportingtoSvgOrPng ? 0 : 5)
+        )
     }
 
     @computed get tabBounds(): Bounds {


### PR DESCRIPTION
If they are not integers, there can be very slight increase in blurring/aliasing (or imbalanced border colors) in anything that has lots of horizontal/vertical lines, e.g. legends.

#### Before

<img width="600" alt="Screenshot 2021-12-15 at 12 13 06" src="https://user-images.githubusercontent.com/1308115/146184721-3a4d2af1-6b90-4159-8306-b44f4a762c94.png">

#### After

<img width="600" alt="Screenshot 2021-12-15 at 12 13 23" src="https://user-images.githubusercontent.com/1308115/146184739-d459e767-c981-4564-94d2-25fe0ef8353a.png">

(the top border on "before" is more prominent than the bottom border, in "after" they are _perceptually_ even)