### PR TITLE
fix(explorer): EntityPicker reacts to current table changing

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -207,6 +207,13 @@ export class Explorer
         window.addEventListener("resize", this.onResizeThrottled)
         this.onResize() // call resize for the first time to initialize chart
 
+        // We always prefer the entity picker metric to be sourced from the currently displayed table.
+        // To properly do that, we need to also react to that table changing.
+        reaction(
+            () => this.explorerProgram.grapherConfig.tableSlug,
+            () => this.updateEntityPickerTable()
+        )
+
         if (this.props.isInStandalonePage) this.bindToWindow()
     }
 

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -190,7 +190,6 @@ export class Explorer
     componentDidMount() {
         this.setGrapher(this.grapherRef!.current!)
         this.updateGrapherFromExplorer()
-        this.updateEntityPickerTable()
 
         let url = Url.fromQueryParams(this.initialQueryParams)
 
@@ -205,6 +204,7 @@ export class Explorer
 
         exposeInstanceOnWindow(this, "explorer")
         this.onResize() // call resize for the first time to initialize chart
+        this.updateEntityPickerTable() // call for the first time to initialize EntityPicker
 
         this.attachEventListeners()
     }
@@ -218,10 +218,13 @@ export class Explorer
         })
 
         // We always prefer the entity picker metric to be sourced from the currently displayed table.
-        // To properly do that, we need to also react to that table changing.
+        // To do this properly, we need to also react to the table changing.
         this.disposers.push(
             reaction(
-                () => this.explorerProgram.grapherConfig.tableSlug,
+                () => [
+                    this.entityPickerMetric,
+                    this.explorerProgram.grapherConfig.tableSlug,
+                ],
                 () => this.updateEntityPickerTable()
             )
         )
@@ -649,7 +652,6 @@ export class Explorer
     }: { metric?: string; sort?: SortOrder } = {}) {
         if (metric) this.entityPickerMetric = metric
         if (sort) this.entityPickerSort = sort
-        this.updateEntityPickerTable()
     }
 
     private tableSlugHasColumnSlug(


### PR DESCRIPTION
Basically, since in the global food explorer we're abusing the notion of multiple tables a bit (since we have multiple tables that all have the same column names), we need to ensure that the entity picker reacts to a table change.

There's also a refactoring of how the different event listeners are disposed of.

https://user-images.githubusercontent.com/2641501/146196753-61438344-9327-49be-837a-331db8860cee.mp4

