### PR TITLE
fix(explorer): properly size the grapher component when explorer switches between wide and narrow mode

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -483,21 +483,26 @@ export class Explorer
     }
 
     @action.bound private onResize() {
+        const oldIsNarrow = this.isNarrow
         this.isNarrow = isNarrow()
-        this.grapherBounds = this.getGrapherBounds() || this.grapherBounds
+        this.updateGrapherBounds()
+
+        // If we changed between narrow and wide mode, we need to wait for CSS changes to kick in
+        // to properly calculate the new grapher bounds
+        if (this.isNarrow !== oldIsNarrow)
+            window.setTimeout(() => this.updateGrapherBounds(), 0)
     }
 
     // Todo: add better logic to maximize the size of the Grapher
-    private getGrapherBounds() {
+    private updateGrapherBounds() {
         const grapherContainer = this.grapherContainerRef.current
-        return grapherContainer
-            ? new Bounds(
-                  0,
-                  0,
-                  grapherContainer.clientWidth,
-                  grapherContainer.clientHeight
-              )
-            : undefined
+        if (grapherContainer)
+            this.grapherBounds = new Bounds(
+                0,
+                0,
+                grapherContainer.clientWidth,
+                grapherContainer.clientHeight
+            )
     }
 
     @observable private showMobileControlsPopup = false


### PR DESCRIPTION
This has been a long-standing issue, but noone really came around to fixing it.
Basically, what's happening here is that `this.isNarrow` specifies whether the `mobile-explorer` class is applied or not, and that class changes up the layout by a layout.
So if we ever change `isNarrow`, we have to wait for the browser to apply the new layout before we fetch the size of the grapher div.

https://user-images.githubusercontent.com/2641501/146197462-81ca4b86-b723-47d7-8090-6655e1c33517.mp4
