### PR TITLE
fix(grapher): fix issue where some exports didn't include year in title

### DIFF
--- a/grapher/controls/Controls.scss
+++ b/grapher/controls/Controls.scss
@@ -209,6 +209,9 @@ $footerRowHeight: 32px; // keep in sync with Controls.tsx's footerRowHeight
     bottom: 0;
     z-index: $zindex-ControlsFooter;
     color: #777;
+    display: flex;
+    flex-direction: column;
+    justify-content: end; // align rows in the footer to the bottom
 
     .footerRowSingle,
     .footerRowMulti {

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -394,7 +394,7 @@ export interface FooterControlsManager extends ShareMenuManager {
     currentTab?: GrapherTabOption
     isInIFrame?: boolean
     canonicalUrl?: string
-    hasTimeline?: boolean
+    showTimeline?: boolean
     hasRelatedQuestion?: boolean
     relatedQuestions: RelatedQuestionsConfig[]
     footerControlsHeight?: number
@@ -517,13 +517,13 @@ export class FooterControls extends React.Component<{
                 </div>
             )
 
-        const timeline = !manager.hasTimeline ? null : (
+        const timeline = manager.showTimeline ? (
             <div className="footerRowSingle">
                 <TimelineComponent
                     timelineController={this.manager.timelineController!}
                 />
             </div>
-        )
+        ) : null
 
         return (
             <div

--- a/grapher/core/Grapher.jsdom.test.ts
+++ b/grapher/core/Grapher.jsdom.test.ts
@@ -208,15 +208,17 @@ describe("hasTimeline", () => {
         expect(grapher.hasTimeline).toBeTruthy()
     })
 
-    it("source and download tabs do not have a timeline", () => {
+    it("source and download tabs do not show a timeline", () => {
         const grapher = new Grapher(legacyConfig)
         grapher.type = ChartTypeName.LineChart
 
         grapher.currentTab = GrapherTabOption.sources
-        expect(grapher.hasTimeline).toBeFalsy()
+        expect(grapher.hasTimeline).toBeTruthy()
+        expect(grapher.showTimeline).toBeFalsy()
 
         grapher.currentTab = GrapherTabOption.download
-        expect(grapher.hasTimeline).toBeFalsy()
+        expect(grapher.hasTimeline).toBeTruthy()
+        expect(grapher.showTimeline).toBeFalsy()
     })
 })
 

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1153,6 +1153,13 @@ export class Grapher
         return text.trim()
     }
 
+    /**
+     * Uses some explicit and implicit information to decide whether a timeline is shown.
+     * Note the difference between `hasTimeline` and `showTimeline`:
+     * - `hasTimeline` indicates whether the current _normal_ (non-overlay) tab has a timeline.
+     * - `showTimeline` takes into account whether we are on an overlay tab, and thus indicates
+     *    whether we should currently show the timeline.
+     */
     @computed get hasTimeline(): boolean {
         // we don't have more than one distinct time point in our data, so it doesn't make sense to show a timeline
         if (this.times.length <= 1) return false

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1157,7 +1157,7 @@ export class Grapher
         // we don't have more than one distinct time point in our data, so it doesn't make sense to show a timeline
         if (this.times.length <= 1) return false
 
-        switch (this.currentTab) {
+        switch (this.tab) {
             // the map tab has its own `hideTimeline` option
             case GrapherTabOption.map:
                 return !this.map.hideTimeline
@@ -1177,11 +1177,14 @@ export class Grapher
                     )
                 )
 
-            // never show a timeline while we're showing one of these two overlays
-            case GrapherTabOption.download:
-            case GrapherTabOption.sources:
+            default:
                 return false
         }
+    }
+
+    @computed get showTimeline(): boolean {
+        // don't show the timeline when on an overlay tab
+        return this.hasTimeline && this.overlay === undefined
     }
 
     @computed private get areHandlesOnSameTime(): boolean {


### PR DESCRIPTION
Notion: [Title of svg/png export doesn't include date annotation, but interactive chart does](https://www.notion.so/Title-of-svg-png-export-doesn-t-include-date-annotation-but-interactive-chart-does-89bce5655f3a4ae5a66083e9aae88a6f)

Live on _tufte_. Try it here, for example: https://tufte-owid.netlify.app/grapher/co-emissions-per-capita

---

As outlined in the Notion issue, the problem here was that `hasTimeline` was always set to `false` when we are on an overlay tab (SourcesTab or DownloadTab). Since we are on the DownloadTab when downloading a chart (duh), this lead to the logic in `currentTitle` deciding that we should not include the year in the title, at least in the case where `hideTitleAnnotation=true`.

As a solution, I've split it into `hasTimeline` and `showTimeline`, where:
* `hasTimeline` indicates whether the current _normal_ (non-overlay) tab has a timeline
* `showTimeline = hasTimeline && notOnOverlayTab` indicates whether we should currently show that timeline

By splitting the two, we can also get rid of the problem where the chart would jump downward a bit when one goes to the DownloadTab, because the timeline was suddenly hidden.