### PR TITLE
svgTester: prettier SVGs & file names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ serverSettings.json
 localBake/
 /grapherData
 /grapherSvgs
+/differentGrapherSvgs

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -16,6 +16,7 @@ import * as util from "util"
 import { GrapherInterface } from "../../grapher/core/GrapherInterface"
 import { TESTING_ONLY_reset_guid } from "../../clientUtils/Util"
 import _ from "lodash"
+import prettier from "prettier"
 
 const CONFIG_FILENAME: string = "config.json"
 const RESULTS_FILENAME = "results.csv"
@@ -261,7 +262,8 @@ export async function renderSvg(dir: string): Promise<[string, SvgRecord]> {
     )
 
     grapher.receiveOwidData(data as OwidVariablesAndEntityKey)
-    const svg = grapher.staticSVG
+    const minifiedSvg = grapher.staticSVG
+    const svg = prettier.format(minifiedSvg, { parser: "html" })
     const svgRecord = {
         chartId: config.id!,
         slug: config.slug!,

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -1,10 +1,7 @@
 import * as stream from "stream"
 import * as path from "path"
 import { getVariableData } from "../../db/model/Variable"
-import {
-    initGrapherForSvgExport,
-    buildSvgOutFilename,
-} from "../../baker/GrapherImageBaker"
+import { initGrapherForSvgExport } from "../../baker/GrapherImageBaker"
 import { createGunzip, createGzip } from "zlib"
 import * as fs from "fs-extra"
 import getStream from "get-stream"
@@ -253,13 +250,7 @@ export async function renderSvg(dir: string): Promise<[string, SvgRecord]> {
     // between consecutive runs we reset this id here before every export
     TESTING_ONLY_reset_guid()
     const grapher = initGrapherForSvgExport(config)
-    const { width, height } = grapher.idealBounds
-    const outFilename = buildSvgOutFilename(
-        config.slug!,
-        config.version,
-        width,
-        height
-    )
+    const outFilename = `${config.slug!}.svg`
 
     grapher.receiveOwidData(data as OwidVariablesAndEntityKey)
     const minifiedSvg = grapher.staticSVG


### PR DESCRIPTION
This makes two changes:
- All SVGs are prettified. This makes the diffs more easily understandable, and the GitHub text diff view becomes a bit more useful.
- The SVG file names now contain only the slug. Before, they contained chart version and dimensions, but this naming scheme is only used for grapher embeds inside OWID articles (it's more of a CMS feature than a Grapher feature). The standalone Grapher SVGs only use the slug (e.g. https://ourworldindata.org/grapher/exports/excess-deaths-cumulative-economist.svg)

Not sure if there are some undesired side effects from both of these changes.