### PR TITLE
Rename "Align outbreaks" checkbox in COVID Explorer

### DIFF
--- a/explorer/urlMigrations/CovidUrlMigration.ts
+++ b/explorer/urlMigrations/CovidUrlMigration.ts
@@ -23,6 +23,9 @@ const transformMap: QueryParamTransformMap = {
             return value
         },
     },
+    "Align outbreaks": {
+        newName: "Color by test positivity",
+    },
 }
 
 export const covidUrlMigration: UrlMigration = (url: Url) => {

--- a/explorer/urlMigrations/ExplorerUrlMigrationUtils.ts
+++ b/explorer/urlMigrations/ExplorerUrlMigrationUtils.ts
@@ -1,7 +1,7 @@
 import { QueryParams } from "../../clientUtils/urls/UrlUtils"
 import { Url } from "../../clientUtils/urls/Url"
 import { EXPLORERS_ROUTE_FOLDER } from "../ExplorerConstants"
-import { omit } from "../../clientUtils/Util"
+import { identity, omit } from "../../clientUtils/Util"
 
 export const decodeURIComponentOrUndefined = (value: string | undefined) =>
     value !== undefined
@@ -12,7 +12,7 @@ export type QueryParamTransformMap = Record<
     string,
     {
         newName?: string
-        transformValue: (value: string | undefined) => string | undefined
+        transformValue?: (value: string | undefined) => string | undefined
     }
 >
 
@@ -27,9 +27,9 @@ export const transformQueryParams = (
     for (const oldParamName in transformMap) {
         if (!(oldParamName in oldQueryParams)) continue
         const { newName, transformValue } = transformMap[oldParamName]
-        newQueryParams[newName ?? oldParamName] = transformValue(
-            oldQueryParams[oldParamName]
-        )
+        const name = newName ?? oldParamName
+        const transform = transformValue ?? identity
+        newQueryParams[name] = transform(oldQueryParams[oldParamName])
     }
     return newQueryParams
 }


### PR DESCRIPTION
As [discussed on Slack](https://owid.slack.com/archives/C5BDCB2R3/p1641307912017200).

We are getting rid of `Align outbreaks` in favour of `Color by test positivity`.