### PR TITLE
feat(scatter): plot time on X axis by default if no columns specified

### DIFF
--- a/grapher/scatterCharts/ScatterPlotChart.test.ts
+++ b/grapher/scatterCharts/ScatterPlotChart.test.ts
@@ -58,6 +58,8 @@ it("doesn't show 'No data' bin when there is no color column", () => {
 it("can remove points outside domain", () => {
     const manager: ScatterPlotManager = {
         table: SynthesizeFruitTable(undefined, 2),
+        yColumnSlug: SampleColumnSlugs.Fruit,
+        xColumnSlug: SampleColumnSlugs.Vegetables,
     }
     const chart = new ScatterPlotChart({ manager })
     const initialCount = chart.allPoints.length

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -669,7 +669,7 @@ export class ScatterPlotChart
 
     @computed private get xColumnSlug(): string {
         const { xColumnSlug } = this.manager
-        return xColumnSlug ?? this.manager.table.numericColumnSlugs[1]
+        return xColumnSlug ?? this.manager.table.timeColumn.slug
     }
 
     @computed private get xColumn(): CoreColumn {


### PR DESCRIPTION
[Charlie needs a ScatterPlot with Time on the X axis](https://owid.slack.com/archives/C5BDCB2R3/p1641411409032800?thread_ts=1641405010.031600&cid=C5BDCB2R3).

Surprisingly, setting the default column (if none is specified) to be `time` _just works_:
<img width="777" alt="Screenshot 2022-01-05 at 19 47 35" src="https://user-images.githubusercontent.com/1308115/148279507-fe3bbbc1-968f-44ad-8413-10bed8f4110d.png">

And svgTester reports no differences.

What do you think about the approach?