### PR TITLE
enhance: retry fetch requests

### DIFF
--- a/clientUtils/Util.test.ts
+++ b/clientUtils/Util.test.ts
@@ -204,17 +204,23 @@ describe(retryPromise, () => {
 
     it("resolves when promise succeeds first-time", async () => {
         const promiseGetter = resolveAfterNthRetry(0, "success")
-        expect(retryPromise(promiseGetter, 1)).resolves.toEqual("success")
+        expect(retryPromise(promiseGetter, { maxRetries: 0 })).resolves.toEqual(
+            "success"
+        )
     })
 
     it("resolves when promise succeeds before retry limit", async () => {
         const promiseGetter = resolveAfterNthRetry(2, "success")
-        expect(retryPromise(promiseGetter, 3)).resolves.toEqual("success")
+        expect(retryPromise(promiseGetter, { maxRetries: 2 })).resolves.toEqual(
+            "success"
+        )
     })
 
     it("rejects when promise doesn't succeed within retry limit", async () => {
         const promiseGetter = resolveAfterNthRetry(3, "success")
-        expect(retryPromise(promiseGetter, 3)).rejects.toBeUndefined()
+        expect(
+            retryPromise(promiseGetter, { maxRetries: 2 })
+        ).rejects.toBeUndefined()
     })
 })
 

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -511,24 +511,18 @@ export const trimObject = <Obj>(
     return clone
 }
 
-// TODO use fetchText() in fetchJSON()
-// decided not to do this while implementing our COVID-19 page in order to prevent breaking something.
 export const fetchText = async (url: string): Promise<string> => {
-    return new Promise((resolve, reject) => {
-        const req = new XMLHttpRequest()
-        req.addEventListener("load", function () {
-            resolve(this.responseText)
-        })
-        req.addEventListener("readystatechange", () => {
-            if (req.readyState === 4) {
-                if (req.status !== 200) {
-                    reject(new Error(`${req.status} ${req.statusText}`))
-                }
-            }
-        })
-        req.open("GET", url)
-        req.send()
-    })
+    const response = await fetchWithRetries(url)
+    if (!response.ok) {
+        throw new Error(`${response.status} ${response.statusText}`)
+    }
+    return await response.text()
+}
+
+export const fetchWithRetries = async (
+    ...params: Parameters<typeof fetch>
+): ReturnType<typeof fetch> => {
+    return await retryPromise(() => fetch(...params))
 }
 
 // todo: can we ditch this in favor of a simple fetch?

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -1,4 +1,4 @@
-import { trimObject } from "../clientUtils/Util"
+import { fetchWithRetries, trimObject } from "../clientUtils/Util"
 import { GitCommit, SubNavId } from "../clientUtils/owidTypes"
 import {
     DefaultNewExplorerSlug,
@@ -363,7 +363,7 @@ export class ExplorerProgram extends GridProgram {
      */
     private static tableDataLoader = new PromiseCache(
         async (url: string): Promise<CoreTableInputOption> => {
-            const response = await fetch(url)
+            const response = await fetchWithRetries(url)
             if (!response.ok) throw new Error(response.statusText)
             const tableInput: CoreTableInputOption = url.endsWith(".json")
                 ? await response.json()

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -31,6 +31,7 @@ import {
     debounce,
     isInIFrame,
     differenceObj,
+    fetchWithRetries,
 } from "../../clientUtils/Util"
 import { QueryParams } from "../../clientUtils/urls/UrlUtils"
 import {
@@ -723,7 +724,7 @@ export class Grapher
                 )
                 this._receiveOwidDataAndApplySelection(json)
             } else {
-                const response = await fetch(this.dataUrl)
+                const response = await fetchWithRetries(this.dataUrl)
                 if (!response.ok) throw new Error(response.statusText)
                 const json = await response.json()
                 this._receiveOwidDataAndApplySelection(json)

--- a/site/EmbedChart.tsx
+++ b/site/EmbedChart.tsx
@@ -11,7 +11,7 @@ import { Grapher } from "../grapher/core/Grapher"
 import { GrapherFigureView } from "./GrapherFigureView"
 import { deserializeJSONFromHTML } from "../clientUtils/serializers"
 import { Url } from "../clientUtils/urls/Url"
-import { excludeUndefined } from "../clientUtils/Util"
+import { fetchWithRetries } from "../clientUtils/Util"
 
 @observer
 export class EmbedChart extends React.Component<{ src: string }> {
@@ -29,7 +29,7 @@ export class EmbedChart extends React.Component<{ src: string }> {
     private async loadConfig() {
         const { configUrl } = this
         if (configUrl === undefined) return
-        const resp = await fetch(configUrl)
+        const resp = await fetchWithRetries(configUrl)
         if (this.configUrl !== configUrl) {
             // Changed while we were fetching
             return

--- a/site/SiteHeaderMenus.tsx
+++ b/site/SiteHeaderMenus.tsx
@@ -10,7 +10,7 @@ import {
 import { observer } from "mobx-react"
 import { HeaderSearch } from "./HeaderSearch"
 import classnames from "classnames"
-import { flatten } from "../clientUtils/Util"
+import { fetchWithRetries, flatten } from "../clientUtils/Util"
 import { bind } from "decko"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faSearch } from "@fortawesome/free-solid-svg-icons/faSearch"
@@ -559,7 +559,7 @@ class SiteHeaderMenus extends React.Component<{ baseUrl: string }> {
 
     private async getEntries() {
         const json = await (
-            await fetch("/headerMenu.json", {
+            await fetchWithRetries("/headerMenu.json", {
                 method: "GET",
                 credentials: "same-origin",
                 headers: {

--- a/site/covid/LastUpdated.tsx
+++ b/site/covid/LastUpdated.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react"
 import dayjs, { Dayjs } from "dayjs"
 import relativeTime from "dayjs/plugin/relativeTime"
+import { fetchWithRetries } from "../../clientUtils/Util"
 dayjs.extend(relativeTime)
 
 export interface LastUpdatedTokenProps {
@@ -12,7 +13,7 @@ export const LastUpdated = ({ timestampUrl }: LastUpdatedTokenProps) => {
     useEffect(() => {
         const fetchTimeStamp = async () => {
             if (!timestampUrl) return
-            const response = await fetch(timestampUrl)
+            const response = await fetchWithRetries(timestampUrl)
             if (!response.ok) return
             const timestampRaw = await response.text()
             const timestamp = timestampRaw.trim()

--- a/site/stripe/DonateForm.tsx
+++ b/site/stripe/DonateForm.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../settings/clientSettings"
 
 import stripe from "./stripe"
-import { stringifyUnkownError } from "../../clientUtils/Util"
+import { fetchWithRetries, stringifyUnkownError } from "../../clientUtils/Util"
 
 type Interval = "once" | "monthly"
 
@@ -131,7 +131,7 @@ export class DonateForm extends React.Component {
         }
 
         const captchaToken = await this.getCaptchaToken()
-        const response = await fetch(DONATE_API_URL, {
+        const response = await fetchWithRetries(DONATE_API_URL, {
             method: "POST",
             credentials: "same-origin",
             headers: {


### PR DESCRIPTION
We have a _lot_ of fetch errors on Bugsnag. I am guessing some good fraction of them are transient network errors (but haven't investigated much), so implementing retries (up to 3 times) would decrease the fetch error rate.

Deployed on [playfair](https://playfair-owid.netlify.app).

Note that `fetch()` doesn't throw when the server responds with an error code, (`404` or `500`):

> -   The Promise returned from `fetch()` **won't reject on HTTP error status** even if the response is an HTTP 404 or 500. Instead, as soon as the server responds with headers, the Promise will resolve normally (with the [`ok`](https://developer.mozilla.org/en-US/docs/Web/API/Response/ok "ok") property of the response set to false if the response isn't in the range 200--299), and it will only reject on network failure or if anything prevented the request from completing.

— [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch)