### PR TITLE
Content graph, one taxonomy, entries as topics

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,10 +6,15 @@
     "configurations": [
         {
             "name": "Build content graph",
+            "program": "${workspaceFolder}/itsJustJavascript/db/contentGraph.js",
             "request": "launch",
-            "command": "yarn buildContentGraph",
-            "skipFiles": ["<node_internals>/**"],
-            "type": "node-terminal"
+            "type": "pwa-node"
+        },
+        {
+            "name": "Index content graph",
+            "program": "${workspaceFolder}/itsJustJavascript/baker/algolia/indexContentGraphToAlgolia.js",
+            "request": "launch",
+            "type": "pwa-node"
         },
         {
             "name": "Run SVGTester",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,13 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Build content graph",
+            "request": "launch",
+            "command": "yarn buildContentGraph",
+            "skipFiles": ["<node_internals>/**"],
+            "type": "node-terminal"
+        },
+        {
             "name": "Run SVGTester",
             "program": "${workspaceFolder}/itsJustJavascript/devTools/svgTester/verify-graphs.js",
             "request": "launch",

--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -10,7 +10,6 @@ import { Grapher } from "../grapher/core/Grapher"
 import { EditorFeatures } from "./EditorFeatures"
 import { Admin } from "./Admin"
 import { BAKED_GRAPHER_URL } from "../settings/clientSettings"
-import _ from "lodash"
 import { Topic } from "../grapher/core/GrapherConstants"
 
 type EditorTab = string

--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -11,6 +11,7 @@ import { EditorFeatures } from "./EditorFeatures"
 import { Admin } from "./Admin"
 import { BAKED_GRAPHER_URL } from "../settings/clientSettings"
 import _ from "lodash"
+import { Topic } from "../grapher/core/GrapherConstants"
 
 type EditorTab = string
 
@@ -77,6 +78,7 @@ export interface ChartEditorManager {
     logs: Log[]
     references: PostReference[]
     redirects: ChartRedirect[]
+    allTopics: Topic[]
 }
 
 interface VariableIdUsageRecord {
@@ -131,6 +133,10 @@ export class ChartEditor {
 
     @computed get redirects() {
         return this.manager.redirects
+    }
+
+    @computed get allTopics() {
+        return this.manager.allTopics
     }
 
     @computed get availableTabs(): EditorTab[] {

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -44,6 +44,7 @@ import {
     VisionDeficiencyEntity,
 } from "./VisionDeficiencies"
 import { EditorMarimekkoTab } from "./EditorMarimekkoTab"
+import { Topic } from "../grapher/core/GrapherConstants"
 
 @observer
 class TabBinder extends React.Component<{ editor: ChartEditor }> {
@@ -93,6 +94,7 @@ export class ChartEditorPage
     @observable logs: Log[] = []
     @observable references: PostReference[] = []
     @observable redirects: ChartRedirect[] = []
+    @observable allTopics: Topic[] = []
 
     @observable.ref grapherElement?: JSX.Element
 
@@ -178,6 +180,12 @@ export class ChartEditorPage
         runInAction(() => (this.redirects = json.redirects))
     }
 
+    async fetchTopics(): Promise<void> {
+        const { admin } = this.context
+        const json = await admin.getJSON(`/api/topics.json`)
+        runInAction(() => (this.allTopics = json.topics))
+    }
+
     @computed get admin(): Admin {
         return this.context.admin
     }
@@ -194,6 +202,7 @@ export class ChartEditorPage
         this.fetchLogs()
         this.fetchRefs()
         this.fetchRedirects()
+        this.fetchTopics()
     }
 
     dispose!: IReactionDisposer

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -225,13 +225,18 @@ class TopicsSection extends React.Component<{
                 <h5>Topics</h5>
                 <Select
                     options={this.props.allTopics}
-                    isMulti={true}
-                    value={grapher.topics}
                     getOptionValue={(topic) => topic.id.toString()}
                     getOptionLabel={(topic) => topic.name}
+                    isMulti={true}
+                    value={grapher.topicIds.map((topicId) => ({
+                        id: topicId,
+                        name:
+                            this.props.allTopics.find((t) => t.id === topicId)
+                                ?.name || "TOPIC NOT FOUND",
+                    }))}
                     onChange={(topics) =>
                         runInAction(() => {
-                            grapher.topics = [...topics]
+                            grapher.topicIds = topics.map((topic) => topic.id)
                         })
                     }
                     menuPlacement="auto"

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -127,7 +127,10 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                         placeholder={grapher.originUrlWithProtocol}
                         helpText="The page containing this chart where more context can be found"
                     />
-                    <TopicsSection grapher={grapher} />
+                    <TopicsSection
+                        allTopics={this.props.editor.allTopics}
+                        grapher={grapher}
+                    />
                     {references && references.length > 0 && (
                         <div className="originSuggestions">
                             <p>Origin url suggestions</p>
@@ -212,11 +215,12 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
         )
     }
 }
-
-type TopicName = string
 @observer
-class TopicsSection extends React.Component<{ grapher: Grapher }> {
-    @observable.ref draggedTopic?: TopicName
+class TopicsSection extends React.Component<{
+    allTopics: Topic[]
+    grapher: Grapher
+}> {
+    @observable.ref draggedTopic?: Topic
 
     @action.bound onAddTopic(topic: Topic) {
         this.props.grapher.topics.push(topic)
@@ -227,7 +231,7 @@ class TopicsSection extends React.Component<{ grapher: Grapher }> {
         this.props.grapher.topics.splice(topicIdx, 1)
     }
 
-    @action.bound onStartDrag(topic: TopicName) {
+    @action.bound onStartDrag(topic: Topic) {
         this.draggedTopic = topic
 
         const onDrag = action(() => {
@@ -238,7 +242,7 @@ class TopicsSection extends React.Component<{ grapher: Grapher }> {
         window.addEventListener("mouseup", onDrag)
     }
 
-    @action.bound onMouseEnter(topic: TopicName) {
+    @action.bound onMouseEnter(topic: Topic) {
         if (!this.draggedTopic || topic === this.draggedTopic) return
 
         const { topics } = this.props.grapher
@@ -252,7 +256,9 @@ class TopicsSection extends React.Component<{ grapher: Grapher }> {
     render() {
         const { grapher } = this.props
 
-        const allTopics = ["1", "2", "3"]
+        const availableTopics = this.props.allTopics.filter(
+            (topic) => !this.props.grapher.topics.includes(topic)
+        )
 
         return (
             <>
@@ -260,21 +266,21 @@ class TopicsSection extends React.Component<{ grapher: Grapher }> {
                 <SelectField
                     onValue={this.onAddTopic}
                     value="Select data"
-                    options={["Select data"].concat(allTopics)}
-                    optionLabels={["Select data"].concat(allTopics)}
+                    options={["Select data"].concat(availableTopics)}
+                    optionLabels={["Select data"].concat(availableTopics)}
                 />
                 <EditableList>
-                    {grapher.topics.map((topicName) => (
+                    {grapher.topics.map((topic) => (
                         <EditableListItem
-                            key={topicName}
-                            onMouseDown={() => this.onStartDrag(topicName)}
-                            onMouseEnter={() => this.onMouseEnter(topicName)}
+                            key={topic}
+                            onMouseDown={() => this.onStartDrag(topic)}
+                            onMouseEnter={() => this.onMouseEnter(topic)}
                             className="EditableListItem"
                         >
-                            <div>{topicName}</div>
+                            <div>{topic}</div>
                             <div
                                 className="clickable"
-                                onClick={() => this.onRemoveTopic(topicName)}
+                                onClick={() => this.onRemoveTopic(topic)}
                             >
                                 <FontAwesomeIcon icon={faTimes} />
                             </div>

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -23,6 +23,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus"
 import { faMinus } from "@fortawesome/free-solid-svg-icons/faMinus"
 import Select from "react-select"
+import { TOPICS_CONTENT_GRAPH } from "../settings/clientSettings"
 
 @observer
 export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
@@ -226,7 +227,7 @@ class TopicsSection extends React.Component<{
         return (
             <Section name="Topics">
                 <Select
-                    isDisabled={true}
+                    isDisabled={!TOPICS_CONTENT_GRAPH}
                     options={this.props.allTopics}
                     getOptionValue={(topic) => topic.id.toString()}
                     getOptionLabel={(topic) => topic.name}

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -134,10 +134,7 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                             </ul>
                         </div>
                     )}
-                    <TopicsSection
-                        allTopics={this.props.editor.allTopics}
-                        grapher={grapher}
-                    />
+
                     <BindString
                         label="Footer note"
                         field="note"
@@ -146,6 +143,12 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                         softCharacterLimit={140}
                     />
                 </Section>
+
+                <TopicsSection
+                    allTopics={this.props.editor.allTopics}
+                    grapher={grapher}
+                />
+
                 <Section name="Related">
                     {relatedQuestions.map(
                         (question: RelatedQuestionsConfig, idx: number) => (
@@ -221,8 +224,7 @@ class TopicsSection extends React.Component<{
         const { grapher } = this.props
 
         return (
-            <>
-                <h5>Topics</h5>
+            <Section name="Topics">
                 <Select
                     options={this.props.allTopics}
                     getOptionValue={(topic) => topic.id.toString()}
@@ -241,7 +243,7 @@ class TopicsSection extends React.Component<{
                     }
                     menuPlacement="auto"
                 />
-            </>
+            </Section>
         )
     }
 }

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -226,6 +226,7 @@ class TopicsSection extends React.Component<{
         return (
             <Section name="Topics">
                 <Select
+                    isDisabled={true}
                     options={this.props.allTopics}
                     getOptionValue={(topic) => topic.id.toString()}
                     getOptionLabel={(topic) => topic.name}

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -124,10 +124,6 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                         placeholder={grapher.originUrlWithProtocol}
                         helpText="The page containing this chart where more context can be found"
                     />
-                    <TopicsSection
-                        allTopics={this.props.editor.allTopics}
-                        grapher={grapher}
-                    />
                     {references && references.length > 0 && (
                         <div className="originSuggestions">
                             <p>Origin url suggestions</p>
@@ -138,6 +134,10 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                             </ul>
                         </div>
                     )}
+                    <TopicsSection
+                        allTopics={this.props.editor.allTopics}
+                        grapher={grapher}
+                    />
                     <BindString
                         label="Footer note"
                         field="note"

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -403,8 +403,7 @@ body {
     }
 }
 
-.EditorDataTab .EditableListItem,
-.EditorTextTab .EditableListItem {
+.EditorDataTab .EditableListItem {
     @extend .draggable;
     display: flex;
     justify-content: space-between;

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -403,26 +403,25 @@ body {
     }
 }
 
-.EditorDataTab {
-    .EditableListItem {
-        @extend .draggable;
+.EditorDataTab .EditableListItem,
+.EditorTextTab .EditableListItem {
+    @extend .draggable;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    > div {
         display: flex;
-        justify-content: space-between;
         align-items: center;
+    }
 
-        > div {
-            display: flex;
-            align-items: center;
-        }
+    i {
+        font-size: 1.2rem;
+        color: #666;
+    }
 
-        i {
-            font-size: 1.2rem;
-            color: #666;
-        }
-
-        > div:first-child > * {
-            margin-right: 12px;
-        }
+    > div:first-child > * {
+        margin-right: 12px;
     }
 }
 

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -439,6 +439,10 @@ apiRouter.get(
     })
 )
 
+apiRouter.get("/topics.json", async (req: Request, res: Response) => ({
+    topics: await wpdb.getTopics(),
+}))
+
 apiRouter.get("/countries.json", async (req: Request, res: Response) => {
     let rows = []
 

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -36,8 +36,8 @@ const grapherConfigToHtmlPage = async (grapher: GrapherInterface) => {
             ? await getRelatedCharts(post.id)
             : undefined
     const relatedArticles =
-        grapher.slug && isWordpressAPIEnabled
-            ? await getRelatedArticles(grapher.slug)
+        grapher.id && isWordpressAPIEnabled
+            ? await getRelatedArticles(grapher.id)
             : undefined
 
     return renderToHtmlPage(

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -7,6 +7,8 @@ import {
 } from "../../settings/serverSettings"
 import { countries } from "../../clientUtils/countries"
 
+export const CONTENT_GRAPH_ALGOLIA_INDEX = "graph"
+
 export const getAlgoliaClient = (): SearchClient | undefined => {
     if (!ALGOLIA_ID || !ALGOLIA_SECRET_KEY) {
         console.error(`Missing ALGOLIA_ID or ALGOLIA_SECRET_KEY`)
@@ -134,6 +136,14 @@ export const configureAlgolia = async () => {
     })
     await chartsIndex.saveSynonyms(algoliaSynonyms, {
         replaceExistingSynonyms: true,
+    })
+
+    const graphIndex = client.initIndex(CONTENT_GRAPH_ALGOLIA_INDEX)
+
+    await graphIndex.setSettings({
+        attributesForFaceting: [
+            ...[...Array(5)].map((_, i) => `searchable(topics.lvl${i})`),
+        ],
     })
 }
 

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -1,6 +1,7 @@
 import algoliasearch, { SearchClient } from "algoliasearch"
 import { Synonym, Settings } from "@algolia/client-search"
-import { ALGOLIA_ID } from "../../settings/clientSettings"
+import { ALGOLIA_ID, TOPICS_CONTENT_GRAPH } from "../../settings/clientSettings"
+
 import {
     ALGOLIA_INDEXING,
     ALGOLIA_SECRET_KEY,
@@ -138,14 +139,16 @@ export const configureAlgolia = async () => {
         replaceExistingSynonyms: true,
     })
 
-    const graphIndex = client.initIndex(CONTENT_GRAPH_ALGOLIA_INDEX)
+    if (TOPICS_CONTENT_GRAPH) {
+        const graphIndex = client.initIndex(CONTENT_GRAPH_ALGOLIA_INDEX)
 
-    await graphIndex.setSettings({
-        attributesForFaceting: [
-            ...[...Array(5)].map((_, i) => `searchable(topics.lvl${i})`),
-            "searchable(type)",
-        ],
-    })
+        await graphIndex.setSettings({
+            attributesForFaceting: [
+                ...[...Array(5)].map((_, i) => `searchable(topics.lvl${i})`),
+                "searchable(type)",
+            ],
+        })
+    }
 }
 
 if (require.main === module) configureAlgolia()

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -143,6 +143,7 @@ export const configureAlgolia = async () => {
     await graphIndex.setSettings({
         attributesForFaceting: [
             ...[...Array(5)].map((_, i) => `searchable(topics.lvl${i})`),
+            "searchable(type)",
         ],
     })
 }

--- a/baker/algolia/indexContentGraphToAlgolia.test.ts
+++ b/baker/algolia/indexContentGraphToAlgolia.test.ts
@@ -1,6 +1,7 @@
 #! /usr/bin/env yarn jest
 
 import { formatParentTopicsTrails } from "./indexContentGraphToAlgolia"
+import { excludeNullParentTopics } from "../../db/contentGraph"
 
 it("formats parent topics trails", () => {
     const parentTopicsTitle = [
@@ -17,4 +18,22 @@ it("formats parent topics trails", () => {
             "Coronavirus Pandemic (COVID-19) > Farm Size > Climate Change",
         ],
     })
+})
+
+// Very narrow test, mostly for documentation purposes
+it("excludes null parent topics", () => {
+    const parentTopicsTitleWithNull = [null, "Climate Change"]
+    const parentTopicsTitleWithoutNull = [
+        "Coronavirus Pandemic (COVID-19)",
+        "Farm Size",
+        "Climate Change",
+    ]
+    const allParentTopicsTitle = [
+        parentTopicsTitleWithNull,
+        parentTopicsTitleWithoutNull,
+    ]
+
+    expect(allParentTopicsTitle.filter(excludeNullParentTopics)).toEqual([
+        parentTopicsTitleWithoutNull,
+    ])
 })

--- a/baker/algolia/indexContentGraphToAlgolia.test.ts
+++ b/baker/algolia/indexContentGraphToAlgolia.test.ts
@@ -1,7 +1,6 @@
 #! /usr/bin/env yarn jest
 
 import { formatParentTopicsTrails } from "./indexContentGraphToAlgolia"
-import { excludeNullParentTopics } from "../../db/contentGraph"
 
 it("formats parent topics trails", () => {
     const parentTopicsTitle = [
@@ -18,22 +17,4 @@ it("formats parent topics trails", () => {
             "Coronavirus Pandemic (COVID-19) > Farm Size > Climate Change",
         ],
     })
-})
-
-// Very narrow test, mostly for documentation purposes
-it("excludes null parent topics", () => {
-    const parentTopicsTitleWithNull = [null, "Climate Change"]
-    const parentTopicsTitleWithoutNull = [
-        "Coronavirus Pandemic (COVID-19)",
-        "Farm Size",
-        "Climate Change",
-    ]
-    const allParentTopicsTitle = [
-        parentTopicsTitleWithNull,
-        parentTopicsTitleWithoutNull,
-    ]
-
-    expect(allParentTopicsTitle.filter(excludeNullParentTopics)).toEqual([
-        parentTopicsTitleWithoutNull,
-    ])
 })

--- a/baker/algolia/indexContentGraphToAlgolia.test.ts
+++ b/baker/algolia/indexContentGraphToAlgolia.test.ts
@@ -1,0 +1,20 @@
+#! /usr/bin/env yarn jest
+
+import { formatParentTopicsTrails } from "./indexContentGraphToAlgolia"
+
+it("formats parent topics trails", () => {
+    const parentTopicsTitle = [
+        ["Transport", "Climate Change"],
+        ["Coronavirus Pandemic (COVID-19)", "Farm Size", "Climate Change"],
+    ]
+    expect(formatParentTopicsTrails(parentTopicsTitle)).toEqual({
+        "topics.lvl0": ["Transport", "Coronavirus Pandemic (COVID-19)"],
+        "topics.lvl1": [
+            "Transport > Climate Change",
+            "Coronavirus Pandemic (COVID-19) > Farm Size",
+        ],
+        "topics.lvl2": [
+            "Coronavirus Pandemic (COVID-19) > Farm Size > Climate Change",
+        ],
+    })
+})

--- a/baker/algolia/indexContentGraphToAlgolia.ts
+++ b/baker/algolia/indexContentGraphToAlgolia.ts
@@ -46,10 +46,7 @@ const getContentGraphRecords = async () => {
     for (const documentNode of allDocumentNodes) {
         if (!documentNode.title) continue
 
-        const allParentTopicsTitle = await getParentTopicsTitle(
-            documentNode,
-            allDocumentNodes
-        )
+        const allParentTopicsTitle = await getParentTopicsTitle(documentNode)
 
         let parentTopicsTrails = {}
         if (allParentTopicsTitle && allParentTopicsTitle.length !== 0) {

--- a/baker/algolia/indexContentGraphToAlgolia.ts
+++ b/baker/algolia/indexContentGraphToAlgolia.ts
@@ -1,0 +1,87 @@
+import { DocumentNode } from "../../clientUtils/owidTypes"
+import {
+    getContentGraph,
+    getParentTopicsTitle,
+    GraphType,
+} from "../../db/contentGraph"
+import * as wpdb from "../../db/wpdb"
+import { ALGOLIA_INDEXING } from "../../settings/serverSettings"
+import {
+    CONTENT_GRAPH_ALGOLIA_INDEX,
+    getAlgoliaClient,
+} from "./configureAlgolia"
+
+export const formatParentTopicsTrails = (
+    parentTopicsTitle: string[][]
+): { [facetLevelKey: string]: string[] } => {
+    const facetPrefix = "topics.lvl"
+    const topicsFacets: any = {}
+    parentTopicsTitle.forEach((topicsTitle) => {
+        const allTopicsTitleFromRoot = topicsTitle.map((_, i) => {
+            return topicsTitle.slice(0, i + 1)
+        })
+
+        allTopicsTitleFromRoot.forEach((topicsTitleFromRoot) => {
+            const key = `${facetPrefix}${topicsTitleFromRoot.length - 1}`
+            const topicsTitleTrail = topicsTitleFromRoot.join(" > ")
+            if (topicsFacets.hasOwnProperty(key)) {
+                topicsFacets[key] = [...topicsFacets[key], topicsTitleTrail]
+            } else {
+                topicsFacets[key] = [topicsTitleTrail]
+            }
+        })
+    })
+    return topicsFacets
+}
+
+const getContentGraphRecords = async () => {
+    const store = await getContentGraph()
+
+    const allDocumentNodes: DocumentNode[] = (
+        await store.find(GraphType.Document)
+    ).payload.records
+
+    const records = []
+
+    for (const documentNode of allDocumentNodes) {
+        const parentTopicsTitle = await getParentTopicsTitle(
+            documentNode,
+            allDocumentNodes
+        )
+
+        if (!parentTopicsTitle || parentTopicsTitle.length === 0) continue
+        if (!documentNode.title) continue
+
+        const parentTopicsTrails = formatParentTopicsTrails(parentTopicsTitle)
+        records.push({
+            objectID: documentNode.id,
+            title: documentNode.title,
+            ...parentTopicsTrails,
+        })
+    }
+    return records
+}
+
+const indexContentGraphToAlgolia = async () => {
+    const dryRun = false
+    if (!ALGOLIA_INDEXING) return
+
+    const records = await getContentGraphRecords()
+
+    if (!dryRun) {
+        const client = getAlgoliaClient()
+        if (!client) {
+            console.error(
+                `Failed indexing graph (Algolia client not initialized)`
+            )
+            return
+        }
+
+        const index = client.initIndex(CONTENT_GRAPH_ALGOLIA_INDEX)
+        index.replaceAllObjects(records)
+    }
+
+    await wpdb.singleton.end()
+}
+
+if (require.main === module) indexContentGraphToAlgolia()

--- a/baker/algolia/indexContentGraphToAlgolia.ts
+++ b/baker/algolia/indexContentGraphToAlgolia.ts
@@ -1,4 +1,5 @@
 import {
+    AlgoliaRecord,
     ChartRecord,
     DocumentNode,
     GraphDocumentType,
@@ -67,7 +68,7 @@ export const getParentTopicsTitle = async (
     return parentTopicsTitle.flat()
 }
 
-const getContentGraphRecords = async () => {
+const getContentGraphRecords = async (): Promise<AlgoliaRecord[]> => {
     const records = []
 
     const graph = await getContentGraph()

--- a/baker/algolia/indexContentGraphToAlgolia.ts
+++ b/baker/algolia/indexContentGraphToAlgolia.ts
@@ -84,7 +84,9 @@ const indexContentGraphToAlgolia = async () => {
         }
 
         const index = client.initIndex(CONTENT_GRAPH_ALGOLIA_INDEX)
-        index.replaceAllObjects(records)
+        index.replaceAllObjects(records, {
+            autoGenerateObjectIDIfNotExist: true,
+        })
     }
 
     await wpdb.singleton.end()

--- a/baker/algolia/indexContentGraphToAlgolia.ts
+++ b/baker/algolia/indexContentGraphToAlgolia.ts
@@ -44,15 +44,18 @@ const getContentGraphRecords = async () => {
     const records = []
 
     for (const documentNode of allDocumentNodes) {
-        const parentTopicsTitle = await getParentTopicsTitle(
+        if (!documentNode.title) continue
+
+        const allParentTopicsTitle = await getParentTopicsTitle(
             documentNode,
             allDocumentNodes
         )
 
-        if (!parentTopicsTitle || parentTopicsTitle.length === 0) continue
-        if (!documentNode.title) continue
+        let parentTopicsTrails = {}
+        if (allParentTopicsTitle && allParentTopicsTitle.length !== 0) {
+            parentTopicsTrails = formatParentTopicsTrails(allParentTopicsTitle)
+        }
 
-        const parentTopicsTrails = formatParentTopicsTrails(parentTopicsTitle)
         records.push({
             objectID: documentNode.id,
             title: documentNode.title,

--- a/baker/algolia/indexContentGraphToAlgolia.ts
+++ b/baker/algolia/indexContentGraphToAlgolia.ts
@@ -59,6 +59,7 @@ const getContentGraphRecords = async () => {
         records.push({
             objectID: documentNode.id,
             title: documentNode.title,
+            type: documentNode.type,
             ...parentTopicsTrails,
         })
     }

--- a/baker/formatWordpressPost.tsx
+++ b/baker/formatWordpressPost.tsx
@@ -28,7 +28,6 @@ import {
     DEEP_LINK_CLASS,
     extractDataValuesConfiguration,
     formatDataValue,
-    formatLinks,
     parseKeyValueArgs,
 } from "./formatting"
 import { mathjax } from "mathjax-full/js/mathjax"
@@ -47,6 +46,7 @@ import {
 import { AnnotatingDataValue } from "../site/AnnotatingDataValue"
 import { renderAutomaticProminentLinks } from "./siteRenderers"
 import {
+    formatUrls,
     getBodyHtml,
     GRAPHER_PREVIEW_CLASS,
     SUMMARY_CLASSNAME,
@@ -119,10 +119,14 @@ const formatLatex = async (
 
 export const formatWordpressPost = async (
     post: FullPost,
-    html: string,
     formattingOptions: FormattingOptions,
     grapherExports?: GrapherExports
 ): Promise<FormattedPost> => {
+    let html = post.content
+
+    // Standardize urls
+    html = formatUrls(html)
+
     // Strip comments
     html = html.replace(/<!--[^>]+-->/g, "")
 
@@ -244,9 +248,6 @@ export const formatWordpressPost = async (
             )
         return "UNKNOWN TABLE"
     })
-
-    // No need for wordpress urls
-    html = html.replace(new RegExp("/app/uploads", "g"), "/uploads")
 
     // Give "Add country" text (and variations) the appearance of "+ Add Country" chart control
     html = html.replace(
@@ -585,13 +586,11 @@ export const formatPost = async (
     formattingOptions: FormattingOptions,
     grapherExports?: GrapherExports
 ): Promise<FormattedPost> => {
-    const html = formatLinks(post.content)
-
     // No formatting applied, plain source HTML returned
     if (formattingOptions.raw)
         return {
             ...post,
-            html,
+            html: formatUrls(post.content),
             footnotes: [],
             references: [],
             tocHeadings: [],
@@ -605,5 +604,5 @@ export const formatPost = async (
         ...formattingOptions,
     }
 
-    return formatWordpressPost(post, html, options, grapherExports)
+    return formatWordpressPost(post, options, grapherExports)
 }

--- a/baker/formatting.tsx
+++ b/baker/formatting.tsx
@@ -9,7 +9,7 @@ import {
 } from "../clientUtils/owidTypes"
 import { Country } from "../clientUtils/countries"
 import { countryProfileDefaultCountryPlaceholder } from "../site/countryProfileProjects"
-import { BAKED_BASE_URL, WORDPRESS_URL } from "../settings/serverSettings"
+import { BAKED_BASE_URL } from "../settings/serverSettings"
 import { DATA_VALUE } from "../site/DataValue"
 import { OwidVariablesAndEntityKey } from "../clientUtils/OwidVariable"
 import {
@@ -20,13 +20,6 @@ import { legacyToOwidTableAndDimensions } from "../grapher/core/LegacyToOwidTabl
 import { getBodyHtml } from "../site/formatting"
 
 export const DEEP_LINK_CLASS = "deep-link"
-
-// Standardize urls
-export const formatLinks = (html: string) =>
-    html
-        .replace(new RegExp(WORDPRESS_URL, "g"), BAKED_BASE_URL)
-        .replace(new RegExp("https?://owid.cloud", "g"), BAKED_BASE_URL)
-        .replace(new RegExp("https?://ourworldindata.org", "g"), BAKED_BASE_URL)
 
 export const extractFormattingOptions = (html: string): FormattingOptions => {
     const formattingOptionsMatch = html.match(

--- a/baker/siteRenderers.test.ts
+++ b/baker/siteRenderers.test.ts
@@ -13,7 +13,10 @@ import {
     renderAutomaticProminentLinks,
     renderExplorerPage,
 } from "./siteRenderers"
-import { BAKED_BASE_URL } from "../settings/clientSettings"
+import {
+    BAKED_BASE_URL,
+    BAKED_GRAPHER_EXPORTS_BASE_URL,
+} from "../settings/clientSettings"
 import { ExplorerProgram } from "../explorer/ExplorerProgram"
 
 // There are many possible dimensions to test:
@@ -40,6 +43,7 @@ const uploadPath = `/uploads/2021/10/Fish-thumbnail-768x404.png`
 jest.mock("../settings/clientSettings.js", () => ({
     WORDPRESS_URL: "http://owid.lndo.site",
     BAKED_BASE_URL: "http://localhost:3030",
+    BAKED_GRAPHER_EXPORTS_BASE_URL: "http://localhost:3030/grapher/exports",
 }))
 
 const getMockBlock = (
@@ -92,7 +96,7 @@ const getMockThumbnailUrl = (id: number) => {
 }
 
 const getMockGrapherThumbnailUrl = (slug: string) => {
-    return `${BAKED_BASE_URL}/grapher/exports/${slug}.svg`
+    return `${BAKED_GRAPHER_EXPORTS_BASE_URL}/${slug}.svg`
 }
 
 const getPostBySlug = jest.spyOn(wpdb, "getPostBySlug")

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -16,7 +16,6 @@ import * as lodash from "lodash"
 import {
     extractFormattingOptions,
     formatCountryProfile,
-    formatLinks,
     isStandaloneInternalLink,
 } from "./formatting"
 import {
@@ -66,6 +65,7 @@ import {
     ProminentLink,
     ProminentLinkStyles,
 } from "../site/blocks/ProminentLink"
+import { formatUrls } from "../site/formatting"
 import { GrapherInterface } from "../grapher/core/GrapherInterface"
 import { Grapher, GrapherProgrammaticInterface } from "../grapher/core/Grapher"
 import { ExplorerProgram } from "../explorer/ExplorerProgram"
@@ -469,7 +469,7 @@ export const renderAutomaticProminentLinks = async (
                 )
                 if (mediaThumbnailUrl) {
                     image = ReactDOMServer.renderToStaticMarkup(
-                        <img src={formatLinks(mediaThumbnailUrl)} />
+                        <img src={formatUrls(mediaThumbnailUrl)} />
                     )
                 }
             }

--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -184,11 +184,14 @@ export interface EntryNode {
     kpi: string
 }
 
+export type TopicId = number
+
 export interface DocumentNode {
     id: number
     title: string
     slug: string
     content: string | null // if content is empty
+    parentTopics: Array<TopicId>
 }
 
 export interface CategoryNode {
@@ -196,6 +199,12 @@ export interface CategoryNode {
     slug: string
     pages: any
     children: any
+}
+
+export interface ChartRecord {
+    slug: string
+    title: string
+    topics: Array<TopicId>
 }
 
 export interface PostReference {

--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -190,9 +190,14 @@ export enum GraphDocumentType {
     Topic = "topic",
     Article = "article",
 }
-export interface DocumentNode {
+
+export interface AlgoliaRecord {
     id: number
     title: string
+    type: GraphType | GraphDocumentType
+}
+
+export interface DocumentNode extends AlgoliaRecord {
     slug: string
     content: string | null // if content is empty
     type: GraphDocumentType
@@ -211,10 +216,8 @@ export enum GraphType {
     Chart = "chart",
 }
 
-export interface ChartRecord {
-    id: number
+export interface ChartRecord extends AlgoliaRecord {
     slug: string
-    title: string
     type: GraphType // probably a better way to do this, should only be GraphType.chart
     parentTopics: Array<TopicId>
 }

--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -186,11 +186,16 @@ export interface EntryNode {
 
 export type TopicId = number
 
+export enum GraphDocumentType {
+    Topic = "topic",
+    Article = "article",
+}
 export interface DocumentNode {
     id: number
     title: string
     slug: string
     content: string | null // if content is empty
+    type: GraphDocumentType
     parentTopics: Array<TopicId>
 }
 

--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -195,12 +195,16 @@ export interface AlgoliaRecord {
     id: number
     title: string
     type: GraphType | GraphDocumentType
+    image?: string
 }
 
-export interface DocumentNode extends AlgoliaRecord {
+export interface DocumentNode {
+    id: number
+    title: string
     slug: string
     content: string | null // if content is empty
     type: GraphDocumentType
+    image: string | null
     parentTopics: Array<TopicId>
 }
 
@@ -216,7 +220,9 @@ export enum GraphType {
     Chart = "chart",
 }
 
-export interface ChartRecord extends AlgoliaRecord {
+export interface ChartRecord {
+    id: number
+    title: string
     slug: string
     type: GraphType // probably a better way to do this, should only be GraphType.chart
     parentTopics: Array<TopicId>

--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -209,7 +209,7 @@ export interface CategoryNode {
 export interface ChartRecord {
     slug: string
     title: string
-    topics: Array<TopicId>
+    parentTopics: Array<TopicId>
 }
 
 export interface PostReference {

--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -206,9 +206,16 @@ export interface CategoryNode {
     children: any
 }
 
+export enum GraphType {
+    Document = "document",
+    Chart = "chart",
+}
+
 export interface ChartRecord {
+    id: number
     slug: string
     title: string
+    type: GraphType // probably a better way to do this, should only be GraphType.chart
     parentTopics: Array<TopicId>
 }
 

--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -224,7 +224,7 @@ export interface ChartRecord {
     id: number
     title: string
     slug: string
-    type: GraphType // probably a better way to do this, should only be GraphType.chart
+    type: GraphType.Chart
     parentTopics: Array<TopicId>
 }
 

--- a/db/contentGraph.ts
+++ b/db/contentGraph.ts
@@ -1,5 +1,10 @@
-import { WP_PostType } from "../clientUtils/owidTypes"
+import {
+    ChartRecord,
+    DocumentNode,
+    WP_PostType,
+} from "../clientUtils/owidTypes"
 import { once } from "../clientUtils/Util"
+import { queryMysql } from "./db"
 import { ENTRIES_CATEGORY_ID, getDocumentsInfo } from "./wpdb"
 
 const fortune = require("fortune") // Works in web browsers, too.
@@ -18,10 +23,17 @@ const store = fortune(
         [GraphType.Document]: {
             title: String,
             slug: String,
-            data: [Array("chart"), "research"],
+            content: String,
+            parentTopics: [Array(GraphType.Document), "childrenTopics"],
+            childrenTopics: [Array(GraphType.Document), "parentTopics"],
+            embeddedCharts: [Array(GraphType.Chart), "embeddedIn"],
+            charts: [Array(GraphType.Chart), "topics"],
+            ancestorsPaths: Array(String),
         },
         [GraphType.Chart]: {
-            research: [Array("document"), "data"],
+            title: String,
+            embeddedIn: [Array(GraphType.Document), "embeddedCharts"],
+            topics: [Array(GraphType.Document), "charts"],
         },
     },
     {
@@ -46,6 +58,12 @@ export const getGrapherSlugs = (content: string | null): Set<string> => {
     return slugs
 }
 
+const throwAllButConflictError = (err: unknown): void => {
+    if (!(err instanceof ConflictError)) {
+        throw err
+    }
+}
+
 export const getContentGraph = once(async () => {
     const orderBy = "orderby:{field:MODIFIED, order:DESC}"
     const entries = await getDocumentsInfo(
@@ -55,49 +73,163 @@ export const getContentGraph = once(async () => {
     )
     const posts = await getDocumentsInfo(WP_PostType.Post, "", orderBy)
     const documents = [...entries, ...posts]
+
     for (const document of documents) {
-        // Add posts and entries to the content graph
-        try {
-            await store.create(GraphType.Document, {
-                id: document.id,
-                title: document.title,
-                slug: document.slug,
-            })
-        } catch (err) {
-            // There shouldn't be any ConflictErrors here as the posts are
-            // unique in the list we're iterating on, and the call to generate
-            // the graph is memoized.
-            throw err
+        // Create the parent topics first (add records with the only available
+        // referential information - id - then update the records when going
+        // through the parent topic as a document)
+        for (const parentTopic of document.parentTopics) {
+            try {
+                await store.create(GraphType.Document, {
+                    id: parentTopic,
+                })
+            } catch (err) {
+                // If the document has already being added as a parent topic of
+                // another document, a ConflictError will be raised. Any other
+                // error will be thrown.
+                throwAllButConflictError(err)
+            }
         }
 
-        // Add charts within that post to the content graph
+        // Add posts and entries to the content graph
+        try {
+            await store.create(GraphType.Document, document)
+        } catch (err) {
+            // If the document has already been added as a parent, a
+            // ConflictError will be raised.
+            throwAllButConflictError(err)
+
+            const { id, ...rest } = document
+            await store.update(GraphType.Document, {
+                id,
+                replace: {
+                    ...rest,
+                },
+            })
+        }
+
+        // Add embedded charts within that post to the content graph
         const grapherSlugs = getGrapherSlugs(document.content)
+
         for (const slug of grapherSlugs) {
             try {
                 await store.create(GraphType.Chart, {
                     id: slug,
-                    research: [document.id],
+                    embeddedIn: [document.id],
                 })
             } catch (err) {
                 // ConflictErrors occur when attempting to create a chart that
                 // already exists
-                if (!(err instanceof ConflictError)) {
-                    throw err
-                }
+                throwAllButConflictError(err)
+
                 try {
                     await store.update(GraphType.Chart, {
                         id: slug,
-                        push: { research: document.id },
+                        push: { embeddedIn: document.id },
                     })
                 } catch (err) {
                     // ConflictErrors occur here when a chart <-> post
                     // relationship already exists
-                    if (!(err instanceof ConflictError)) {
-                        throw err
-                    }
+                    throwAllButConflictError(err)
                 }
             }
         }
     }
+
+    // Add all charts
+    const allCharts = await getChartsRecords()
+
+    for (const chart of allCharts) {
+        const { slug, title, topics } = chart
+        try {
+            await store.create(GraphType.Chart, {
+                id: slug,
+                title,
+                topics: topics ?? [],
+            })
+        } catch (err) {
+            // ConflictErrors occur when a chart has already been added from an
+            // embedding document
+            throwAllButConflictError(err)
+            await store.update(GraphType.Chart, {
+                id: slug,
+                replace: { title, topics: topics ?? [] },
+            })
+        }
+    }
+
+    const allDocumentNodes: DocumentNode[] = (
+        await store.find(GraphType.Document)
+    ).payload.records
+
+    const getAncestorsPaths = async (
+        node: DocumentNode,
+        allDocumentNodes: DocumentNode[],
+        previousPath = ""
+    ): Promise<string[]> => {
+        const currentPath = `${previousPath ? previousPath + " > " : ""}${
+            node.title
+        }`
+        // if (!node.parentTopics || node.parentTopics.length === 0)
+        //     return [currentPath]
+
+        const parentTopicsPaths = await Promise.all(
+            node.parentTopics.map(async (parentTopic: number) => {
+                const parentNode = (
+                    await store.find(GraphType.Document, parentTopic)
+                ).payload.records[0]
+
+                const ancestorsPaths = await getAncestorsPaths(
+                    parentNode,
+                    allDocumentNodes,
+                    currentPath
+                )
+                return ancestorsPaths
+            })
+        )
+
+        return [currentPath, ...parentTopicsPaths.flat()]
+    }
+
+    for (const documentNode of allDocumentNodes) {
+        const ancestorsPaths = await getAncestorsPaths(
+            documentNode,
+            allDocumentNodes
+        )
+
+        await store.update(GraphType.Document, {
+            id: documentNode.id,
+            replace: {
+                ancestorsPaths,
+            },
+        })
+    }
+
     return store
 })
+
+export const getChartsRecords = async (): Promise<ChartRecord[]> => {
+    const allCharts = await queryMysql(`
+        SELECT config->>"$.slug" AS slug, config->>"$.title" AS title, config->>"$.topicIds" as topics
+        FROM charts
+        WHERE publishedAt IS NOT NULL
+        AND is_indexable IS TRUE
+    `)
+
+    const records = []
+    for (const c of allCharts) {
+        records.push({
+            slug: c.slug,
+            title: c.title,
+            topics: JSON.parse(c.topics),
+        })
+    }
+
+    return records
+}
+
+const main = async (): Promise<void> => {
+    await getContentGraph()
+}
+
+if (require.main === module) main()

--- a/db/contentGraph.ts
+++ b/db/contentGraph.ts
@@ -47,7 +47,7 @@ const store = fortune(
     }
 )
 
-const getParentTopicsTitle = async (
+export const getParentTopicsTitle = async (
     node: DocumentNode,
     allDocumentNodes: DocumentNode[],
     childrenTopicsTitle: string[] = []
@@ -208,48 +208,12 @@ export const getContentGraph = once(async () => {
     return store
 })
 
-const formatParentTopicsTrails = (
-    parentTopicsTitle: string[][]
-): { [facetLevelKey: string]: string[] } => {
-    const facetPrefix = "topics.lvl"
-    const topicsFacets: any = {}
-    parentTopicsTitle.forEach((topicsTitle) => {
-        const key = `${facetPrefix}${topicsTitle.length - 1}`
-        const topicsTitleTrail = topicsTitle.join(" > ")
-        if (topicsFacets.hasOwnProperty(key)) {
-            topicsFacets[key] = [...topicsFacets[key], topicsTitleTrail]
-        } else {
-            topicsFacets[key] = [topicsTitleTrail]
-        }
-    })
-    return topicsFacets
-}
-
 const main = async (): Promise<void> => {
     const store = await getContentGraph()
 
-    const allDocumentNodes: DocumentNode[] = (
-        await store.find(GraphType.Document)
-    ).payload.records
-
-    const recordsToIndex = []
-
-    for (const documentNode of allDocumentNodes) {
-        const parentTopicsTitle = await getParentTopicsTitle(
-            documentNode,
-            allDocumentNodes
-        )
-
-        if (!parentTopicsTitle || parentTopicsTitle.length === 0) continue
-
-        const parentTopicsTrails = formatParentTopicsTrails(parentTopicsTitle)
-
-        recordsToIndex.push({
-            id: documentNode.id,
-            title: documentNode.title,
-            ...parentTopicsTrails,
-        })
-    }
+    // const allDocumentNodes: DocumentNode[] = (
+    //     await store.find(GraphType.Document)
+    // ).payload.records
 }
 
 if (require.main === module) main()

--- a/db/contentGraph.ts
+++ b/db/contentGraph.ts
@@ -216,8 +216,12 @@ export const getContentGraph = once(async () => {
     return graph
 })
 
-const main = async (): Promise<void> => {
-    const graph = await getContentGraph()
-}
+// Uncomment the following lines to use the "Build content graph" debug task
+// (see launch.json). This will let you inspect the graph without running the
+// risk of mistakenly sending thousands of records to Algolia.
 
-if (require.main === module) main()
+// const main = async (): Promise<void> => {
+//     const graph = await getContentGraph()
+// }
+
+// if (require.main === module) main()

--- a/db/contentGraph.ts
+++ b/db/contentGraph.ts
@@ -59,7 +59,7 @@ const throwAllButConflictError = (err: unknown): void => {
     }
 }
 
-const addDocumentsToGraph = async (
+export const addDocumentsToGraph = async (
     documents: DocumentNode[],
     graph: any
 ): Promise<void> => {
@@ -159,7 +159,7 @@ export const removeUnpublishedDocuments = async (graph: any): Promise<void> => {
     await graph.delete(GraphType.Document, ids)
 }
 
-const fortuneRecordTypes = {
+export const fortuneRecordTypes = {
     [GraphType.Document]: {
         title: String,
         slug: String,

--- a/db/contentGraph.ts
+++ b/db/contentGraph.ts
@@ -24,7 +24,6 @@ const store = fortune(
         [GraphType.Document]: {
             title: String,
             slug: String,
-            content: String,
             parentTopics: [Array(GraphType.Document), "childrenTopics"],
             childrenTopics: [Array(GraphType.Document), "parentTopics"],
             embeddedCharts: [Array(GraphType.Chart), "embeddedIn"],

--- a/db/contentGraph.ts
+++ b/db/contentGraph.ts
@@ -2,6 +2,7 @@ import {
     ChartRecord,
     DocumentNode,
     GraphDocumentType,
+    GraphType,
     TopicId,
     WP_PostType,
 } from "../clientUtils/owidTypes"
@@ -15,49 +16,16 @@ const {
     errors: { ConflictError },
 } = fortune
 
-export enum GraphType {
-    Document = "document",
-    Chart = "chart",
-}
-
 export const WPPostTypeToGraphDocumentType = {
     [WP_PostType.Page]: GraphDocumentType.Topic,
     [WP_PostType.Post]: GraphDocumentType.Article,
 }
 
-const store = fortune(
-    {
-        [GraphType.Document]: {
-            title: String,
-            slug: String,
-            type: String,
-            content: String,
-            parentTopics: [Array(GraphType.Document), "childrenTopics"],
-            childrenTopics: [Array(GraphType.Document), "parentTopics"],
-            embeddedCharts: [Array(GraphType.Chart), "embeddedIn"],
-            charts: [Array(GraphType.Chart), "parentTopics"],
-        },
-        [GraphType.Chart]: {
-            title: String,
-            embeddedIn: [Array(GraphType.Document), "embeddedCharts"],
-            parentTopics: [Array(GraphType.Document), "charts"],
-        },
-    },
-    {
-        adapter: [
-            MemoryAdapter,
-            {
-                // see https://github.com/fortunejs/fortune/commit/70593721efae304ff2db40d1b8f9b43295fed79b#diff-ebb028a2d1528eac83ee833036ef6e50bed6fb7b2b7137f59ac1fb567a5e6ec2R25
-                recordsPerType: Infinity,
-            },
-        ],
-    }
-)
-
-const getParentTopicsTitleWithNull = async (
-    node: DocumentNode,
-    childrenTopicsTitle: (string | null)[] = []
-): Promise<(string | null)[][]> => {
+export const getParentTopicsTitle = async (
+    node: DocumentNode | ChartRecord,
+    graph: any,
+    childrenTopicsTitle: string[] = []
+): Promise<string[][]> => {
     const currentTopicsTitle = [...childrenTopicsTitle]
 
     if (node.type === GraphDocumentType.Topic)
@@ -69,11 +37,12 @@ const getParentTopicsTitleWithNull = async (
     const parentTopicsTitle = await Promise.all(
         node.parentTopics.map(async (parentTopicId: TopicId) => {
             const parentNode = (
-                await store.find(GraphType.Document, parentTopicId)
+                await graph.find(GraphType.Document, parentTopicId)
             ).payload.records[0]
 
-            const grandParentTopicsTitle = await getParentTopicsTitleWithNull(
+            const grandParentTopicsTitle = await getParentTopicsTitle(
                 parentNode,
+                graph,
                 currentTopicsTitle
             )
             return grandParentTopicsTitle
@@ -83,22 +52,9 @@ const getParentTopicsTitleWithNull = async (
     return parentTopicsTitle.flat()
 }
 
-export const excludeNullParentTopics = (
-    parentTopicsTitle: Array<string | null>
-): boolean => !parentTopicsTitle.includes(null)
-
-export const getParentTopicsTitle = async (
-    node: DocumentNode,
-    childrenTopicsTitle: string[] = []
-): Promise<string[][]> => {
-    return (
-        await getParentTopicsTitleWithNull(node, childrenTopicsTitle)
-    )?.filter(excludeNullParentTopics) as string[][]
-}
-
 export const getChartsRecords = async (): Promise<ChartRecord[]> => {
     const allCharts = await queryMysql(`
-        SELECT config->>"$.slug" AS slug, config->>"$.title" AS title, config->>"$.topicIds" as parentTopics
+        SELECT id, config->>"$.slug" AS slug, config->>"$.title" AS title, config->>"$.topicIds" as parentTopics
         FROM charts
         WHERE publishedAt IS NOT NULL
         AND is_indexable IS TRUE
@@ -107,9 +63,11 @@ export const getChartsRecords = async (): Promise<ChartRecord[]> => {
     const records = []
     for (const c of allCharts) {
         records.push({
+            id: c.id,
             slug: c.slug,
             title: c.title,
-            parentTopics: JSON.parse(c.parentTopics),
+            type: GraphType.Chart,
+            parentTopics: JSON.parse(c.parentTopics) ?? [],
         })
     }
 
@@ -133,23 +91,17 @@ const throwAllButConflictError = (err: unknown): void => {
     }
 }
 
-export const getContentGraph = once(async () => {
-    const orderBy = "orderby:{field:MODIFIED, order:DESC}"
-    const entries = await getDocumentsInfo(
-        WP_PostType.Page,
-        "",
-        `categoryId: ${ENTRIES_CATEGORY_ID}, ${orderBy}`
-    )
-    const posts = await getDocumentsInfo(WP_PostType.Post, "", orderBy)
-    const documents = [...entries, ...posts]
-
+const addDocumentsToGraph = async (
+    documents: DocumentNode[],
+    graph: any
+): Promise<void> => {
     for (const document of documents) {
         // Create the parent topics first (add records with the only available
         // referential information - id - then update the records when going
         // through the parent topic as a document)
         for (const parentTopic of document.parentTopics) {
             try {
-                await store.create(GraphType.Document, {
+                await graph.create(GraphType.Document, {
                     id: parentTopic,
                 })
             } catch (err) {
@@ -163,80 +115,159 @@ export const getContentGraph = once(async () => {
         // Add posts and entries to the content graph
         try {
             // Warning: this mutates document (removes keys that are not listed
-            // in the graph / store schema)
-            await store.create(GraphType.Document, document)
+            // in the graph / graph schema)
+            await graph.create(GraphType.Document, document)
         } catch (err) {
             // If the document has already been added as a parent, a
             // ConflictError will be raised.
             throwAllButConflictError(err)
 
             const { id, ...rest } = document
-            await store.update(GraphType.Document, {
+            await graph.update(GraphType.Document, {
                 id,
                 replace: {
                     ...rest,
                 },
             })
         }
+    }
+}
 
+const addChartsToGraph = async (
+    allCharts: ChartRecord[],
+    graph: any
+): Promise<void> => {
+    for (const chart of allCharts) {
+        try {
+            await graph.create(GraphType.Chart, chart)
+        } catch (err) {
+            throw err
+        }
+    }
+    // for (const chart of allCharts) {
+    //     const { parentTopics } = chart
+    //     try {
+    //         await graph.create(GraphType.Chart, {
+    //             id: slug,
+    //             title,
+    //             parentTopics: parentTopics ?? [],
+    //         })
+    //     } catch (err) {
+    //         // NOT NECESSARY ANYMORE
+    //         // ConflictErrors occur when a chart has already been added from an
+    //         // embedding document
+    //         throwAllButConflictError(err)
+    //         await graph.update(GraphType.Chart, {
+    //             id: slug,
+    //             replace: { title, parentTopics: parentTopics ?? [] },
+    //         })
+    //     }
+    // }
+}
+
+const addEmbeddedChartsToGraph = async (
+    documents: DocumentNode[],
+    graph: any
+): Promise<void> => {
+    for (const document of documents) {
         // Add embedded charts within that post to the content graph
         const grapherSlugs = getGrapherSlugs(document.content)
 
         for (const slug of grapherSlugs) {
+            const id = (
+                await graph.find(GraphType.Chart, null, {
+                    fields: { id: true },
+                    match: { slug },
+                })
+            ).payload.records?.[0]?.id
+
+            if (!id) continue // chart only embedded, not queried. Should only happen during dev, when building partial graph.
             try {
-                await store.create(GraphType.Chart, {
-                    id: slug,
-                    embeddedIn: [document.id],
+                await graph.update(GraphType.Chart, {
+                    id,
+                    push: { embeddedIn: document.id },
                 })
             } catch (err) {
-                // ConflictErrors occur when attempting to create a chart that
-                // already exists
+                // ConflictErrors occur here when a chart <-> post
+                // relationship already exists
                 throwAllButConflictError(err)
-
-                try {
-                    await store.update(GraphType.Chart, {
-                        id: slug,
-                        push: { embeddedIn: document.id },
-                    })
-                } catch (err) {
-                    // ConflictErrors occur here when a chart <-> post
-                    // relationship already exists
-                    throwAllButConflictError(err)
-                }
             }
         }
     }
+}
 
-    // Add all charts
+export const removeUnpublishedDocuments = async (graph: any): Promise<void> => {
+    const ids = (
+        await graph.find(GraphType.Document, null, {
+            fields: { id: true },
+            match: { title: null },
+        })
+    ).payload.records?.map((record: { id: number }) => record.id)
+
+    await graph.delete(GraphType.Document, ids)
+}
+
+const fortuneRecordTypes = {
+    [GraphType.Document]: {
+        title: String,
+        slug: String,
+        type: String,
+        content: String,
+        parentTopics: [Array(GraphType.Document), "childrenTopics"],
+        childrenTopics: [Array(GraphType.Document), "parentTopics"],
+        embeddedCharts: [Array(GraphType.Chart), "embeddedIn"],
+        charts: [Array(GraphType.Chart), "parentTopics"],
+    },
+    [GraphType.Chart]: {
+        title: String,
+        slug: String,
+        type: String,
+        embeddedIn: [Array(GraphType.Document), "embeddedCharts"],
+        parentTopics: [Array(GraphType.Document), "charts"],
+    },
+}
+
+export const getContentGraph = once(async () => {
+    const graph = fortune(fortuneRecordTypes, {
+        adapter: [
+            MemoryAdapter,
+            {
+                // see https://github.com/fortunejs/fortune/commit/70593721efae304ff2db40d1b8f9b43295fed79b#diff-ebb028a2d1528eac83ee833036ef6e50bed6fb7b2b7137f59ac1fb567a5e6ec2R25
+                recordsPerType: Infinity,
+            },
+        ],
+    })
+
+    // Add documents (topics, articles)
+    const orderBy = "orderby:{field:MODIFIED, order:DESC}"
+    const entries = await getDocumentsInfo(
+        WP_PostType.Page,
+        "",
+        `categoryId: ${ENTRIES_CATEGORY_ID}, ${orderBy}`
+    )
+    const posts = await getDocumentsInfo(WP_PostType.Post, "", orderBy)
+    const documents = [...entries, ...posts]
+    await addDocumentsToGraph(documents, graph)
+
+    // Add all public charts
     const allCharts = await getChartsRecords()
+    await addChartsToGraph(allCharts, graph)
 
-    for (const chart of allCharts) {
-        const { slug, title, parentTopics } = chart
-        try {
-            await store.create(GraphType.Chart, {
-                id: slug,
-                title,
-                parentTopics: parentTopics ?? [],
-            })
-        } catch (err) {
-            // ConflictErrors occur when a chart has already been added from an
-            // embedding document
-            throwAllButConflictError(err)
-            await store.update(GraphType.Chart, {
-                id: slug,
-                replace: { title, parentTopics: parentTopics ?? [] },
-            })
-        }
-    }
+    // Add all embedded charts
+    await addEmbeddedChartsToGraph(documents, graph)
 
-    return store
+    // Unpublished topics might be referenced as a parent. As a result, only the
+    // referential information (id) is present.
+    await removeUnpublishedDocuments(graph)
+
+    return graph
 })
 
-const main = async (): Promise<void> => {
-    const store = await getContentGraph()
 
+const main = async (): Promise<void> => {
+    const graph = await getContentGraph()
     // const allDocumentNodes: DocumentNode[] = (
-    //     await store.find(GraphType.Document)
+    //     await graph.find(GraphType.Document)
     // ).payload.records
 }
 

--- a/db/contentGraph.ts
+++ b/db/contentGraph.ts
@@ -53,8 +53,8 @@ const getParentTopicsTitle = async (
     childrenTopicsTitle: string[] = []
 ): Promise<string[][]> => {
     const currentTopicsTitle = [node.title, ...childrenTopicsTitle]
-    // if (!node.parentTopics || node.parentTopics.length === 0)
-    //     return [currentPath]
+    if (!node.parentTopics || node.parentTopics.length === 0)
+        return [currentTopicsTitle]
 
     const parentTopicsTitle = await Promise.all(
         node.parentTopics.map(async (parentTopicId: TopicId) => {
@@ -71,7 +71,7 @@ const getParentTopicsTitle = async (
         })
     )
 
-    return [...parentTopicsTitle.flat(), currentTopicsTitle]
+    return parentTopicsTitle.flat()
 }
 
 export const getChartsRecords = async (): Promise<ChartRecord[]> => {

--- a/db/contentGraph.ts
+++ b/db/contentGraph.ts
@@ -1,6 +1,7 @@
 import {
     ChartRecord,
     DocumentNode,
+    GraphDocumentType,
     TopicId,
     WP_PostType,
 } from "../clientUtils/owidTypes"
@@ -19,11 +20,17 @@ export enum GraphType {
     Chart = "chart",
 }
 
+export const WPPostTypeToGraphDocumentType = {
+    [WP_PostType.Page]: GraphDocumentType.Topic,
+    [WP_PostType.Post]: GraphDocumentType.Article,
+}
+
 const store = fortune(
     {
         [GraphType.Document]: {
             title: String,
             slug: String,
+            type: String,
             parentTopics: [Array(GraphType.Document), "childrenTopics"],
             childrenTopics: [Array(GraphType.Document), "parentTopics"],
             embeddedCharts: [Array(GraphType.Chart), "embeddedIn"],

--- a/db/contentGraph.ts
+++ b/db/contentGraph.ts
@@ -74,7 +74,6 @@ const getParentTopicsTitleWithNull = async (
 
             const grandParentTopicsTitle = await getParentTopicsTitleWithNull(
                 parentNode,
-                allDocumentNodes,
                 currentTopicsTitle
             )
             return grandParentTopicsTitle

--- a/db/contentGraph.ts
+++ b/db/contentGraph.ts
@@ -31,6 +31,7 @@ const store = fortune(
             title: String,
             slug: String,
             type: String,
+            content: String,
             parentTopics: [Array(GraphType.Document), "childrenTopics"],
             childrenTopics: [Array(GraphType.Document), "parentTopics"],
             embeddedCharts: [Array(GraphType.Chart), "embeddedIn"],
@@ -168,6 +169,8 @@ export const getContentGraph = once(async () => {
 
         // Add posts and entries to the content graph
         try {
+            // Warning: this mutates document (removes keys that are not listed
+            // in the graph / store schema)
             await store.create(GraphType.Document, document)
         } catch (err) {
             // If the document has already been added as a parent, a

--- a/db/contentGraph.ts
+++ b/db/contentGraph.ts
@@ -67,6 +67,21 @@ export const addDocumentsToGraph = async (
         // Create the parent topics first (add records with the only available
         // referential information - id - then update the records when going
         // through the parent topic as a document)
+        //
+        // e.g. Document "One" (id: 1) has "ParentTwo" (id: 2) and "ParentThree"
+        // (id: 3) as parent topics. When document "One" is processed,
+        // "ParentTwo" and "ParentThree" need to be added first to the graph, so
+        // they can then be referenced by document "One" as parents and satisfy
+        // the referential integrity constraint. At this stage, the only
+        // information available for these parent nodes is their "id", hence the
+        // presence of that single field ("id") during their initial creation.
+        // It is possible for these nodes to already exist however: maybe
+        // "ParentTwo" and "ParentThree" were referenced as parents of other
+        // nodes, or maybe they were already processed and added in full by the
+        // main loop. In that sense, the "ConflictErrors" raised when trying to
+        // add existing nodes (or at least sharing the same "id") are a natural
+        // and expected part of the building process of the graph, which is why
+        // they are discarded.
         if (document.parentTopics) {
             for (const parentTopic of document.parentTopics) {
                 try {

--- a/db/contentGraph.ts
+++ b/db/contentGraph.ts
@@ -3,7 +3,6 @@ import {
     DocumentNode,
     GraphDocumentType,
     GraphType,
-    TopicId,
     WP_PostType,
 } from "../clientUtils/owidTypes"
 import { once } from "../clientUtils/Util"
@@ -19,37 +18,6 @@ const {
 export const WPPostTypeToGraphDocumentType = {
     [WP_PostType.Page]: GraphDocumentType.Topic,
     [WP_PostType.Post]: GraphDocumentType.Article,
-}
-
-export const getParentTopicsTitle = async (
-    node: DocumentNode | ChartRecord,
-    graph: any,
-    childrenTopicsTitle: string[] = []
-): Promise<string[][]> => {
-    const currentTopicsTitle = [...childrenTopicsTitle]
-
-    if (node.type === GraphDocumentType.Topic)
-        currentTopicsTitle.unshift(node.title)
-
-    if (!node.parentTopics || node.parentTopics.length === 0)
-        return [currentTopicsTitle]
-
-    const parentTopicsTitle = await Promise.all(
-        node.parentTopics.map(async (parentTopicId: TopicId) => {
-            const parentNode = (
-                await graph.find(GraphType.Document, parentTopicId)
-            ).payload.records[0]
-
-            const grandParentTopicsTitle = await getParentTopicsTitle(
-                parentNode,
-                graph,
-                currentTopicsTitle
-            )
-            return grandParentTopicsTitle
-        })
-    )
-
-    return parentTopicsTitle.flat()
 }
 
 export const getChartsRecords = async (): Promise<ChartRecord[]> => {

--- a/db/contentGraph.ts
+++ b/db/contentGraph.ts
@@ -162,6 +162,7 @@ const fortuneRecordTypes = {
         slug: String,
         type: String,
         content: String,
+        image: String,
         parentTopics: [Array(GraphType.Document), "childrenTopics"],
         childrenTopics: [Array(GraphType.Document), "parentTopics"],
         embeddedCharts: [Array(GraphType.Chart), "embeddedIn"],
@@ -211,7 +212,6 @@ export const getContentGraph = once(async () => {
 
     return graph
 })
-
 
 const main = async (): Promise<void> => {
     const graph = await getContentGraph()

--- a/db/contentGraph.ts
+++ b/db/contentGraph.ts
@@ -112,25 +112,6 @@ const addChartsToGraph = async (
             throw err
         }
     }
-    // for (const chart of allCharts) {
-    //     const { parentTopics } = chart
-    //     try {
-    //         await graph.create(GraphType.Chart, {
-    //             id: slug,
-    //             title,
-    //             parentTopics: parentTopics ?? [],
-    //         })
-    //     } catch (err) {
-    //         // NOT NECESSARY ANYMORE
-    //         // ConflictErrors occur when a chart has already been added from an
-    //         // embedding document
-    //         throwAllButConflictError(err)
-    //         await graph.update(GraphType.Chart, {
-    //             id: slug,
-    //             replace: { title, parentTopics: parentTopics ?? [] },
-    //         })
-    //     }
-    // }
 }
 
 const addEmbeddedChartsToGraph = async (
@@ -234,9 +215,6 @@ export const getContentGraph = once(async () => {
 
 const main = async (): Promise<void> => {
     const graph = await getContentGraph()
-    // const allDocumentNodes: DocumentNode[] = (
-    //     await graph.find(GraphType.Document)
-    // ).payload.records
 }
 
 if (require.main === module) main()

--- a/db/contentGraph.ts
+++ b/db/contentGraph.ts
@@ -56,7 +56,6 @@ const store = fortune(
 
 const getParentTopicsTitleWithNull = async (
     node: DocumentNode,
-    allDocumentNodes: DocumentNode[],
     childrenTopicsTitle: (string | null)[] = []
 ): Promise<(string | null)[][]> => {
     const currentTopicsTitle = [...childrenTopicsTitle]
@@ -91,15 +90,10 @@ export const excludeNullParentTopics = (
 
 export const getParentTopicsTitle = async (
     node: DocumentNode,
-    allDocumentNodes: DocumentNode[],
     childrenTopicsTitle: string[] = []
 ): Promise<string[][]> => {
     return (
-        await getParentTopicsTitleWithNull(
-            node,
-            allDocumentNodes,
-            childrenTopicsTitle
-        )
+        await getParentTopicsTitleWithNull(node, childrenTopicsTitle)
     )?.filter(excludeNullParentTopics) as string[][]
 }
 

--- a/db/contentGraph.ts
+++ b/db/contentGraph.ts
@@ -28,7 +28,7 @@ export const getChartsRecords = async (): Promise<ChartRecord[]> => {
         AND is_indexable IS TRUE
     `)
 
-    const records = []
+    const records: ChartRecord[] = []
     for (const c of allCharts) {
         records.push({
             id: c.id,

--- a/db/contentGraph.ts
+++ b/db/contentGraph.ts
@@ -58,7 +58,11 @@ const getParentTopicsTitleWithNull = async (
     allDocumentNodes: DocumentNode[],
     childrenTopicsTitle: (string | null)[] = []
 ): Promise<(string | null)[][]> => {
-    const currentTopicsTitle = [node.title, ...childrenTopicsTitle]
+    const currentTopicsTitle = [...childrenTopicsTitle]
+
+    if (node.type === GraphDocumentType.Topic)
+        currentTopicsTitle.unshift(node.title)
+
     if (!node.parentTopics || node.parentTopics.length === 0)
         return [currentTopicsTitle]
 

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -34,7 +34,11 @@ import {
     PostRestApi,
     TopicId,
 } from "../clientUtils/owidTypes"
-import { getContentGraph, GraphType } from "./contentGraph"
+import {
+    getContentGraph,
+    GraphType,
+    WPPostTypeToGraphDocumentType,
+} from "./contentGraph"
 import { memoize } from "../clientUtils/Util"
 import { Topic } from "../grapher/core/GrapherConstants"
 
@@ -264,6 +268,9 @@ export const getDocumentsInfo = async (
             node: DocumentNode & { parentTopics: { nodes: { id: TopicId }[] } }
         ) => ({
             ...node,
+            type: WPPostTypeToGraphDocumentType[
+                type.toLowerCase() as WP_PostType
+            ],
             parentTopics: node.parentTopics.nodes.map((topic) => topic.id),
         })
     )

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -35,9 +35,9 @@ import {
     TopicId,
     GraphType,
 } from "../clientUtils/owidTypes"
-import { getContentGraph, WPPostTypeToGraphDocumentType } from "./contentGraph"
 import { memoize } from "../clientUtils/Util"
 import { Topic } from "../grapher/core/GrapherConstants"
+import { getContentGraph, WPPostTypeToGraphDocumentType } from "./contentGraph"
 
 let _knexInstance: Knex
 
@@ -249,6 +249,11 @@ export const getDocumentsInfo = async (
                 slug
                 type: __typename
                 content
+                image: featuredImage {
+                    node {
+                        sourceUrl
+                    }
+                }
                 parentTopics {
                     nodes {
                         id: databaseId
@@ -262,12 +267,16 @@ export const getDocumentsInfo = async (
     const pageInfo = documents?.data[typePlural].pageInfo
     const nodes = documents?.data[typePlural].nodes.map(
         (
-            node: DocumentNode & { parentTopics: { nodes: { id: TopicId }[] } }
+            node: DocumentNode & {
+                image: { node: { sourceUrl: string } }
+                parentTopics: { nodes: { id: TopicId }[] }
+            }
         ) => ({
             ...node,
             type: WPPostTypeToGraphDocumentType[
                 type.toLowerCase() as WP_PostType
             ],
+            image: node.image?.node.sourceUrl ?? null,
             parentTopics: node.parentTopics.nodes.map((topic) => topic.id),
         })
     )

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -657,17 +657,16 @@ export const getTopics = async (cursor: string = ""): Promise<Topic[]> => {
                 endCursor
             }
             nodes {
-                title
+                id: databaseId
+                name: title
             }
         }
       }`
 
     const documents = await graphqlQuery(query, { cursor })
     const pageInfo = documents.data.pages.pageInfo
-    const nodes = documents.data.pages.nodes
-    if (nodes.length === 0) return []
-
-    const topics = nodes.map((n: { title: string }) => n.title)
+    const topics: Topic[] = documents.data.pages.nodes
+    if (topics.length === 0) return []
 
     if (pageInfo.hasNextPage) {
         return topics.concat(await getTopics(pageInfo.endCursor))

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -577,17 +577,17 @@ export const getRelatedCharts = async (
     `)
 
 export const getRelatedArticles = async (
-    chartSlug: string
+    chartId: number
 ): Promise<PostReference[] | undefined> => {
     const graph = await getContentGraph()
 
-    const chartRecord = await graph.find(GraphType.Chart, chartSlug)
+    const chartRecord = await graph.find(GraphType.Chart, chartId)
 
     if (!chartRecord.payload.count) return
 
     const chart = chartRecord.payload.records[0]
     const relatedArticles: PostReference[] = await Promise.all(
-        chart.research.map(async (postId: any) => {
+        chart.embeddedIn.map(async (postId: any) => {
             const postRecord = await graph.find(GraphType.Document, postId)
             const post = postRecord.payload.records[0]
             return {

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -33,12 +33,9 @@ import {
     FilterFnPostRestApi,
     PostRestApi,
     TopicId,
-} from "../clientUtils/owidTypes"
-import {
-    getContentGraph,
     GraphType,
-    WPPostTypeToGraphDocumentType,
-} from "./contentGraph"
+} from "../clientUtils/owidTypes"
+import { getContentGraph, WPPostTypeToGraphDocumentType } from "./contentGraph"
 import { memoize } from "../clientUtils/Util"
 import { Topic } from "../grapher/core/GrapherConstants"
 

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -246,6 +246,7 @@ export const getDocumentsInfo = async (
                 id: databaseId
                 title
                 slug
+                type: __typename
                 content
                 parentTopics {
                     nodes {

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -274,7 +274,7 @@ export class Grapher
     @observable.ref internalNotes = ""
     @observable.ref variantName?: string = undefined
     @observable.ref originUrl = ""
-    @observable topics: Topic[] = []
+    @observable.ref topics: Topic[] = []
     @observable.ref isPublished?: boolean = undefined
     @observable.ref baseColorScheme?: ColorSchemeName = undefined
     @observable.ref invertColorScheme?: boolean = undefined

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -47,7 +47,6 @@ import {
     ThereWasAProblemLoadingThisChart,
     SeriesColorMap,
     FacetAxisDomain,
-    TopicId,
 } from "../core/GrapherConstants"
 import { OwidVariablesAndEntityKey } from "../../clientUtils/OwidVariable"
 import * as Cookies from "js-cookie"
@@ -161,6 +160,7 @@ import {
     SortBy,
     SortConfig,
     SortOrder,
+    TopicId,
 } from "../../clientUtils/owidTypes"
 import { ColumnTypeMap, CoreColumn } from "../../coreTable/CoreTableColumns"
 import { ChartInterface } from "../chart/ChartInterface"

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -47,6 +47,7 @@ import {
     ThereWasAProblemLoadingThisChart,
     SeriesColorMap,
     FacetAxisDomain,
+    Topic,
 } from "../core/GrapherConstants"
 import { OwidVariablesAndEntityKey } from "../../clientUtils/OwidVariable"
 import * as Cookies from "js-cookie"
@@ -273,6 +274,7 @@ export class Grapher
     @observable.ref internalNotes = ""
     @observable.ref variantName?: string = undefined
     @observable.ref originUrl = ""
+    @observable topics: Topic[] = []
     @observable.ref isPublished?: boolean = undefined
     @observable.ref baseColorScheme?: ColorSchemeName = undefined
     @observable.ref invertColorScheme?: boolean = undefined

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -47,7 +47,7 @@ import {
     ThereWasAProblemLoadingThisChart,
     SeriesColorMap,
     FacetAxisDomain,
-    Topic,
+    TopicId,
 } from "../core/GrapherConstants"
 import { OwidVariablesAndEntityKey } from "../../clientUtils/OwidVariable"
 import * as Cookies from "js-cookie"
@@ -274,7 +274,7 @@ export class Grapher
     @observable.ref internalNotes = ""
     @observable.ref variantName?: string = undefined
     @observable.ref originUrl = ""
-    @observable.ref topics: Topic[] = []
+    @observable.ref topicIds: TopicId[] = []
     @observable.ref isPublished?: boolean = undefined
     @observable.ref baseColorScheme?: ColorSchemeName = undefined
     @observable.ref invertColorScheme?: boolean = undefined

--- a/grapher/core/GrapherConstants.ts
+++ b/grapher/core/GrapherConstants.ts
@@ -76,8 +76,10 @@ export interface RelatedQuestionsConfig {
     url: string
 }
 
+export type TopicId = number
+
 export interface Topic {
-    id: number
+    id: TopicId
     name: string
 }
 

--- a/grapher/core/GrapherConstants.ts
+++ b/grapher/core/GrapherConstants.ts
@@ -75,6 +75,7 @@ export interface RelatedQuestionsConfig {
     text: string
     url: string
 }
+export type Topic = string
 
 export const WorldEntityName = "World"
 

--- a/grapher/core/GrapherConstants.ts
+++ b/grapher/core/GrapherConstants.ts
@@ -75,7 +75,11 @@ export interface RelatedQuestionsConfig {
     text: string
     url: string
 }
-export type Topic = string
+
+export interface Topic {
+    id: number
+    name: string
+}
 
 export const WorldEntityName = "World"
 

--- a/grapher/core/GrapherConstants.ts
+++ b/grapher/core/GrapherConstants.ts
@@ -1,3 +1,4 @@
+import { TopicId } from "../../clientUtils/owidTypes"
 import { Color } from "../../coreTable/CoreTableConstants"
 
 export enum ChartTypeName {
@@ -75,8 +76,6 @@ export interface RelatedQuestionsConfig {
     text: string
     url: string
 }
-
-export type TopicId = number
 
 export interface Topic {
     id: TopicId

--- a/grapher/core/GrapherInterface.ts
+++ b/grapher/core/GrapherInterface.ts
@@ -7,6 +7,7 @@ import {
     EntitySelection,
     ChartTypeName,
     FacetStrategy,
+    Topic,
 } from "./GrapherConstants"
 import { AxisConfigInterface } from "../axis/AxisConfigInterface"
 import { TimeBound } from "../../clientUtils/TimeBounds"
@@ -62,6 +63,7 @@ export interface GrapherInterface extends SortConfig {
     internalNotes?: string
     variantName?: string
     originUrl?: string
+    topics?: Topic[]
     isPublished?: boolean
     baseColorScheme?: ColorSchemeName
     invertColorScheme?: boolean
@@ -177,4 +179,5 @@ export const grapherKeysToSerialize = [
     "hideFacetControl",
     "comparisonLines",
     "relatedQuestions",
+    "topics",
 ]

--- a/grapher/core/GrapherInterface.ts
+++ b/grapher/core/GrapherInterface.ts
@@ -179,5 +179,5 @@ export const grapherKeysToSerialize = [
     "hideFacetControl",
     "comparisonLines",
     "relatedQuestions",
-    "topics",
+    "topicIds",
 ]

--- a/grapher/core/GrapherInterface.ts
+++ b/grapher/core/GrapherInterface.ts
@@ -7,7 +7,6 @@ import {
     EntitySelection,
     ChartTypeName,
     FacetStrategy,
-    Topic,
 } from "./GrapherConstants"
 import { AxisConfigInterface } from "../axis/AxisConfigInterface"
 import { TimeBound } from "../../clientUtils/TimeBounds"
@@ -20,7 +19,7 @@ import { EntityId, EntityName } from "../../coreTable/OwidTableConstants"
 import { ColorSchemeName } from "../color/ColorConstants"
 import { QueryParams } from "../../clientUtils/urls/UrlUtils"
 import { OwidChartDimensionInterface } from "../../clientUtils/OwidVariableDisplayConfigInterface"
-import { ColumnSlug, SortConfig } from "../../clientUtils/owidTypes"
+import { ColumnSlug, SortConfig, TopicId } from "../../clientUtils/owidTypes"
 
 // This configuration represents the entire persistent state of a grapher
 // Ideally, this is also all of the interaction state: when a grapher is saved and loaded again
@@ -63,7 +62,7 @@ export interface GrapherInterface extends SortConfig {
     internalNotes?: string
     variantName?: string
     originUrl?: string
-    topics?: Topic[]
+    topicIds?: TopicId[]
     isPublished?: boolean
     baseColorScheme?: ColorSchemeName
     invertColorScheme?: boolean

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
         "buildAndDeploySite": "node ./itsJustJavascript/baker/buildAndDeploySite.js",
         "buildCoverage": "jest --coverage=true --coverageProvider=v8",
         "buildLocalBake": "node ./itsJustJavascript/baker/buildLocalBake.js",
-        "buildContentGraph": "node ./itsJustJavascript/db/contentGraph.js",
         "buildStorybook": "build-storybook -c ./itsJustJavascript/.storybook -o .storybook/build",
         "buildTsc": "tsc -b -verbose",
         "buildWebpack": "rm -rf itsJustJavascript/webpack && ENV=production webpack --config ./itsJustJavascript/webpack.config.js -p --progress",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "buildAndDeploySite": "node ./itsJustJavascript/baker/buildAndDeploySite.js",
         "buildCoverage": "jest --coverage=true --coverageProvider=v8",
         "buildLocalBake": "node ./itsJustJavascript/baker/buildLocalBake.js",
+        "buildContentGraph": "node ./itsJustJavascript/db/contentGraph.js",
         "buildStorybook": "build-storybook -c ./itsJustJavascript/.storybook -o .storybook/build",
         "buildTsc": "tsc -b -verbose",
         "buildWebpack": "rm -rf itsJustJavascript/webpack && ENV=production webpack --config ./itsJustJavascript/webpack.config.js -p --progress",

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -42,3 +42,6 @@ export const DONATE_API_URL: string =
 
 export const RECAPTCHA_SITE_KEY: string =
     process.env.RECAPTCHA_SITE_KEY ?? "6LcJl5YUAAAAAATQ6F4vl9dAWRZeKPBm15MAZj4Q"
+
+export const TOPICS_CONTENT_GRAPH: boolean =
+    process.env.TOPICS_CONTENT_GRAPH === "true" ?? false

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -25,6 +25,8 @@ export const BAKED_BASE_URL: string =
 
 export const BAKED_GRAPHER_URL: string =
     process.env.BAKED_GRAPHER_URL ?? `${BAKED_BASE_URL}/grapher`
+export const BAKED_GRAPHER_EXPORTS_BASE_URL: string =
+    process.env.BAKED_GRAPHER_EXPORTS_BASE_URL ?? `${BAKED_GRAPHER_URL}/exports`
 export const ADMIN_BASE_URL: string =
     process.env.ADMIN_BASE_URL ??
     `http://${ADMIN_SERVER_HOST}:${ADMIN_SERVER_PORT}`

--- a/site/blocks/ProminentLink.tsx
+++ b/site/blocks/ProminentLink.tsx
@@ -14,7 +14,7 @@ import { Url } from "../../clientUtils/urls/Url"
 import { EntityName } from "../../coreTable/OwidTableConstants"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faArrowRight } from "@fortawesome/free-solid-svg-icons/faArrowRight"
-import { BAKED_BASE_URL } from "../../settings/clientSettings"
+import { BAKED_GRAPHER_EXPORTS_BASE_URL } from "../../settings/clientSettings"
 
 export const PROMINENT_LINK_CLASSNAME = "wp-block-owid-prominent-link"
 
@@ -158,7 +158,7 @@ export const renderAuthoredProminentLinks = ($: CheerioStatic) => {
         const image =
             $block.find("figure").html() ||
             (url.isGrapher
-                ? `<img src="${BAKED_BASE_URL}/grapher/exports/${url.pathname
+                ? `<img src="${BAKED_GRAPHER_EXPORTS_BASE_URL}/${url.pathname
                       ?.split("/")
                       .pop()}.svg" />`
                 : null)

--- a/site/formatting.tsx
+++ b/site/formatting.tsx
@@ -21,12 +21,12 @@ import { SectionHeading } from "./SectionHeading"
 export const GRAPHER_PREVIEW_CLASS = "grapherPreview"
 export const SUMMARY_CLASSNAME = "wp-block-owid-summary"
 
-// Standardize urls
-const formatLinks = (html: string) =>
+export const formatUrls = (html: string) =>
     html
         .replace(new RegExp(WORDPRESS_URL, "g"), BAKED_BASE_URL)
         .replace(new RegExp("https?://owid.cloud", "g"), BAKED_BASE_URL)
         .replace(new RegExp("https?://ourworldindata.org", "g"), BAKED_BASE_URL)
+        .replace(new RegExp("/app/uploads", "g"), "/uploads")
 
 export const formatReusableBlock = (html: string): string => {
     const cheerioEl = cheerio.load(html)
@@ -34,7 +34,7 @@ export const formatReusableBlock = (html: string): string => {
     const rendered = cheerioEl("body").html()
     if (!rendered) return ""
 
-    const formatted = formatLinks(rendered)
+    const formatted = formatUrls(rendered)
     return formatted
 }
 

--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -69,7 +69,10 @@
         "wpackagist-plugin/simple-history": "2.42.0",
         "wpackagist-plugin/tablepress": "1.14",
         "wpackagist-plugin/enable-media-replace": "3.5.0",
-        "lcobucci/jwt": "4.1.4"
+        "lcobucci/jwt": "4.1.4",
+        "wpackagist-plugin/meta-box": "^5.4",
+        "wpackagist-plugin/mb-relationships": "^1.10",
+        "hsimah-services/wp-graphql-mb-relationships": "^0.4.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "3.6.0",

--- a/wordpress/composer.lock
+++ b/wordpress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c19dada37e35b297be71e06d53c2cec6",
+    "content-hash": "855f529a78d3da45d3c3505e95d5d48b",
     "packages": [
         {
             "name": "composer/installers",
@@ -216,6 +216,41 @@
                 }
             ],
             "time": "2021-08-28T21:34:50+00:00"
+        },
+        {
+            "name": "hsimah-services/wp-graphql-mb-relationships",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hsimah-services/wp-graphql-mb-relationships.git",
+                "reference": "137a890716e7d813b6239cce7dc1804c462a6c00"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hsimah-services/wp-graphql-mb-relationships/zipball/137a890716e7d813b6239cce7dc1804c462a6c00",
+                "reference": "137a890716e7d813b6239cce7dc1804c462a6c00",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1||^8.0"
+            },
+            "type": "wordpress-plugin",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Hamish Blake",
+                    "email": "hsimah.services@gmail.com"
+                }
+            ],
+            "description": "WPGraphQL integration for MB Relationships",
+            "support": {
+                "issues": "https://github.com/hsimah-services/wp-graphql-mb-relationships/issues",
+                "source": "https://github.com/hsimah-services/wp-graphql-mb-relationships"
+            },
+            "time": "2020-07-25T23:12:54+00:00"
         },
         {
             "name": "ivome/graphql-relay-php",
@@ -1484,6 +1519,42 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/mailgun/"
+        },
+        {
+            "name": "wpackagist-plugin/mb-relationships",
+            "version": "1.10.9",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/mb-relationships/",
+                "reference": "tags/1.10.9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/mb-relationships.1.10.9.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/mb-relationships/"
+        },
+        {
+            "name": "wpackagist-plugin/meta-box",
+            "version": "5.5.1",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/meta-box/",
+                "reference": "tags/5.5.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/meta-box.5.5.1.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/meta-box/"
         },
         {
             "name": "wpackagist-plugin/my-default-post-content",

--- a/wordpress/web/app/plugins/owid/owid.php
+++ b/wordpress/web/app/plugins/owid/owid.php
@@ -422,3 +422,39 @@ add_filter(
     10,
     2
 );
+
+add_action('mb_relationships_init', function () {
+    $sharedConfig = [
+        'object_type' => 'post',
+        'meta_box' => [
+            'title' => "Parent topics",
+        ],
+        'admin_column' => [
+            'position' => 'after title',
+            'link' => 'edit',
+        ],
+        'show_in_graphql' => true,
+        'graphql_name' => "parentTopics",
+    ];
+
+    \MB_Relationships_API::register([
+        'id' => 'posts_to_pages',
+        'from' => array_merge($sharedConfig, [
+            'post_type' => 'post',
+        ]),
+        'to' => 'page',
+    ]);
+    \MB_Relationships_API::register([
+        'id' => 'pages_to_pages',
+        'from' => array_merge($sharedConfig, [
+            'post_type' => 'page',
+        ]),
+        'to' => [
+            'object_type' => 'post',
+            'post_type' => 'page',
+            'meta_box' => [
+                'title' => 'Children topics',
+            ],
+        ],
+    ]);
+});

--- a/wordpress/web/app/plugins/owid/owid.php
+++ b/wordpress/web/app/plugins/owid/owid.php
@@ -423,38 +423,40 @@ add_filter(
     2
 );
 
-add_action('mb_relationships_init', function () {
-    $sharedConfig = [
-        'object_type' => 'post',
-        'meta_box' => [
-            'title' => "Parent topics",
-        ],
-        'admin_column' => [
-            'position' => 'after title',
-            'link' => 'edit',
-        ],
-        'show_in_graphql' => true,
-        'graphql_name' => "parentTopics",
-    ];
-
-    \MB_Relationships_API::register([
-        'id' => 'posts_to_pages',
-        'from' => array_merge($sharedConfig, [
-            'post_type' => 'post',
-        ]),
-        'to' => 'page',
-    ]);
-    \MB_Relationships_API::register([
-        'id' => 'pages_to_pages',
-        'from' => array_merge($sharedConfig, [
-            'post_type' => 'page',
-        ]),
-        'to' => [
+if (getenv("TOPICS_CONTENT_GRAPH") === "true") {
+    add_action('mb_relationships_init', function () {
+        $sharedConfig = [
             'object_type' => 'post',
-            'post_type' => 'page',
             'meta_box' => [
-                'title' => 'Children topics',
+                'title' => "Parent topics",
             ],
-        ],
-    ]);
-});
+            'admin_column' => [
+                'position' => 'after title',
+                'link' => 'edit',
+            ],
+            'show_in_graphql' => true,
+            'graphql_name' => "parentTopics",
+        ];
+
+        \MB_Relationships_API::register([
+            'id' => 'posts_to_pages',
+            'from' => array_merge($sharedConfig, [
+                'post_type' => 'post',
+            ]),
+            'to' => 'page',
+        ]);
+        \MB_Relationships_API::register([
+            'id' => 'pages_to_pages',
+            'from' => array_merge($sharedConfig, [
+                'post_type' => 'page',
+            ]),
+            'to' => [
+                'object_type' => 'post',
+                'post_type' => 'page',
+                'meta_box' => [
+                    'title' => 'Children topics',
+                ],
+            ],
+        ]);
+    });
+}


### PR DESCRIPTION
This is a PoC to merge Wordpress and the admin tagging systems.

Categories and tags are dropped in favour of parent / child relationships: in Wordpress entries become topics that reference each other, while in the admin, charts reference those topics.

Background info, rationale and video demos: [One single taxonomy between grapher and wordpress](https://www.notion.so/One-single-taxonomy-between-grapher-and-wordpress-4992c4f2671248c8872e19073debb172)

Those relationships are baked into a bi-directional data structure (aka "content graph") powered by [Fortune.js](http://fortune.js.org/) (currently used for "All our related research and data" block on grapher pages, e.g. https://ourworldindata.org/grapher/population-density). This data structure is only available at bake and preview time, it is not persisted on disk.

## Added
- Wordpress modules (see composer.json). Installed but deactivated by default
- `indexContentGraphToAlgolia.ts` script that exports the content graph into a new Algolia index ("graph") and can be used to demo the enhancing of search UI with topics organized in hierarchical facets. Runs manually only, **but do not use as is at this will burn through Algolia's quota**.
- "Topics" dropdown in grapher admin, "Text" tab in chart edit screen

Adds two env variables:
- `TOPICS_CONTENT_GRAPH`: activate topics content graph features (Algolia index configuration as well as the new "Topics" dropdown). Require relevant Wordpress modules to be turned on, see composer.json.
- `BAKED_GRAPHER_EXPORTS_BASE_URL`: base URL to grapher exports, e.g. `http://localhost:3030/grapher/exports` on dev

## Transparent
- disabled by default. Meant to run in parallel to current production system without interfering.
- no migration has been performed yet.

## Refactored
- `formatLinks` becomes `formatUrls` and now also rewrites image paths.

## Try
- add `TOPICS_CONTENT_GRAPH=true` to `.env`
- turn on relevant Wordpress modules (see composer.json)
- add parent topics to a few topics (aka "entries" or "pages")
- use `launch.json`'s debug task to build the graph
- **do not run `indexContentGraphToAlgolia.ts` as-is: it will burn through Algolia's quota**

## Next
- simplify `grapher.originUrl` by deriving it from the main (first) topic in the list.
- devise migration path
