### PR TITLE
feat(explorers): allow configuring a related question

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -305,8 +305,15 @@ export class Explorer
         const grapher = this.grapher
         if (!grapher) return
         const grapherConfigFromExplorer = this.explorerProgram.grapherConfig
-        const { grapherId, tableSlug, yScaleToggle, yAxisMin, facetYDomain } =
-            grapherConfigFromExplorer
+        const {
+            grapherId,
+            tableSlug,
+            yScaleToggle,
+            yAxisMin,
+            facetYDomain,
+            relatedQuestionText,
+            relatedQuestionUrl,
+        } = grapherConfigFromExplorer
 
         const hasGrapherId = grapherId && isNotErrorValue(grapherId)
 
@@ -327,6 +334,11 @@ export class Explorer
         grapher.yAxis.min = yAxisMin
         if (facetYDomain) {
             grapher.yAxis.facetDomain = facetYDomain
+        }
+        if (relatedQuestionText && relatedQuestionUrl) {
+            grapher.relatedQuestions = [
+                { text: relatedQuestionText, url: relatedQuestionUrl },
+            ]
         }
         grapher.updateFromObject(config)
 

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -48,6 +48,8 @@ interface ExplorerGrapherInterface extends GrapherInterface {
     yScaleToggle?: boolean
     yAxisMin?: number
     facetYDomain?: FacetAxisDomain
+    relatedQuestionText?: string
+    relatedQuestionUrl?: string
 }
 
 const ExplorerRootDef: CellDef = {

--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -8,6 +8,7 @@ import {
     EnumCellDef,
     NumericCellDef,
     CellDef,
+    UrlCellDef,
 } from "../gridLang/GridLangConstants"
 import {
     ChartTypeName,
@@ -202,5 +203,16 @@ export const GrapherGrammar: Grammar = {
         ...BooleanCellDef,
         keyword: "defaultView",
         description: "Whether this view is used as the default view.",
+    },
+    relatedQuestionText: {
+        ...StringCellDef,
+        keyword: "relatedQuestionText",
+        description:
+            "The text used for the related question (at the very bottom of the chart)",
+    },
+    relatedQuestionUrl: {
+        ...UrlCellDef,
+        keyword: "relatedQuestionUrl",
+        description: "The link of the related question text",
     },
 } as const

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -2286,6 +2286,7 @@ export class Grapher
         this.hideTitleAnnotation = grapher.hideTitleAnnotation
         this.timelineMinTime = grapher.timelineMinTime
         this.timelineMaxTime = grapher.timelineMaxTime
+        this.relatedQuestions = grapher.relatedQuestions
     }
 
     debounceMode = false


### PR DESCRIPTION
Notion issue: [Add related link at the bottom of data explorer](https://www.notion.so/Add-related-link-at-the-bottom-of-data-explorer-a06d10a7389e4541b255475a096bc784)

This came up recently, [Max wanted a related question on an explorer](https://owid.slack.com/archives/CLDM2AWCD/p1641496014000100?thread_ts=1641294116.014600&cid=CLDM2AWCD).

In the Grapher config it's possible to add multiple questions, but in the Explorer only a single one. But there are no Graphers that have defined more than one, so I think this is fine.

<details>
<summary>SQL to check for <code>relatedQuestions</code> config:</summary>
<pre>
SELECT id, config->"$.relatedQuestions", JSON_LENGTH(config->"$.relatedQuestions")
FROM charts
WHERE config->"$.relatedQuestions" IS NOT NULL
</pre>
</details>