### PR TITLE
Refactor explorerAdminServer

### DIFF
--- a/adminSiteServer/adminRouter.tsx
+++ b/adminSiteServer/adminRouter.tsx
@@ -255,7 +255,7 @@ adminRouter.get("/errorTest.csv", async (req, res) => {
     return `Simulating code ${code}`
 })
 
-const explorerAdminServer = new ExplorerAdminServer(GIT_CMS_DIR, BAKED_BASE_URL)
+const explorerAdminServer = new ExplorerAdminServer(GIT_CMS_DIR)
 
 adminRouter.get(`/${GetAllExplorersRoute}`, async (req, res) => {
     res.send(await explorerAdminServer.getAllExplorersCommand())

--- a/adminSiteServer/adminRouter.tsx
+++ b/adminSiteServer/adminRouter.tsx
@@ -15,7 +15,7 @@ import { User } from "../db/model/User"
 import { UserInvitation } from "../db/model/UserInvitation"
 import { BAKED_BASE_URL, ENV } from "../settings/serverSettings"
 import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer"
-import { renderPreview } from "../baker/siteRenderers"
+import { renderExplorerPage, renderPreview } from "../baker/siteRenderers"
 import { JsonError } from "../clientUtils/owidTypes"
 import { GitCmsServer } from "../gitCms/GitCmsServer"
 import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants"
@@ -255,8 +255,10 @@ adminRouter.get("/errorTest.csv", async (req, res) => {
     return `Simulating code ${code}`
 })
 
+const explorerAdminServer = new ExplorerAdminServer(GIT_CMS_DIR, BAKED_BASE_URL)
+
 adminRouter.get(`/${GetAllExplorersRoute}`, async (req, res) => {
-    res.send(await this.getAllExplorersCommand())
+    res.send(await explorerAdminServer.getAllExplorersCommand())
 })
 
 adminRouter.get(`/${EXPLORERS_PREVIEW_ROUTE}/:slug`, async (req, res) => {
@@ -264,18 +266,15 @@ adminRouter.get(`/${EXPLORERS_PREVIEW_ROUTE}/:slug`, async (req, res) => {
     const filename = slug + EXPLORER_FILE_SUFFIX
     if (slug === DefaultNewExplorerSlug)
         return res.send(
-            await this.renderExplorerPage(
+            await renderExplorerPage(
                 new ExplorerProgram(DefaultNewExplorerSlug, "")
             )
         )
-    if (!slug || !existsSync(this.absoluteFolderPath + filename))
+    if (!slug || !existsSync(explorerAdminServer.absoluteFolderPath + filename))
         return res.send(`File not found`)
-    const explorer = await this.getExplorerFromFile(filename)
-    return res.send(await this.renderExplorerPage(explorer))
+    const explorer = await explorerAdminServer.getExplorerFromFile(filename)
+    return res.send(await renderExplorerPage(explorer))
 })
-
-// const explorerAdminServer = new ExplorerAdminServer(GIT_CMS_DIR, BAKED_BASE_URL)
-// explorerAdminServer.addAdminRoutes(adminRouter)
 
 const gitCmsServer = new GitCmsServer({
     baseDir: GIT_CMS_DIR,

--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -15,6 +15,7 @@ import {
     renderBlogByPageNum,
     renderCovidPage,
     countryProfileCountryPage,
+    renderExplorerPage,
 } from "../baker/siteRenderers"
 import { grapherSlugToHtmlPage } from "../baker/GrapherBaker"
 import {
@@ -97,14 +98,15 @@ mockSiteRouter.get("/grapher/latest", async (req, res) => {
     else throw new JsonError("No latest chart", 404)
 })
 
+const explorerAdminServer = new ExplorerAdminServer(GIT_CMS_DIR, BAKED_BASE_URL)
+
 mockSiteRouter.get(`/${EXPLORERS_ROUTE_FOLDER}/:slug`, async (req, res) => {
     res.set("Access-Control-Allow-Origin", "*")
-    const explorers = await this.getAllPublishedExplorers()
+    const explorers = await explorerAdminServer.getAllPublishedExplorers()
     const explorerProgram = explorers.find(
         (program) => program.slug === req.params.slug
     )
-    if (explorerProgram)
-        res.send(await this.renderExplorerPage(explorerProgram))
+    if (explorerProgram) res.send(await renderExplorerPage(explorerProgram))
     else
         throw new JsonError(
             "A published explorer with that slug was not found",
@@ -118,17 +120,14 @@ mockSiteRouter.get("/*", async (req, res, next) => {
 
     const { migrationId, baseQueryStr } = explorerRedirect
     const { explorerSlug } = explorerUrlMigrationsById[migrationId]
-    const program = await this.getExplorerFromSlug(explorerSlug)
+    const program = await explorerAdminServer.getExplorerFromSlug(explorerSlug)
     res.send(
-        await this.renderExplorerPage(program, {
+        await renderExplorerPage(program, {
             explorerUrlMigrationId: migrationId,
             baseQueryStr,
         })
     )
 })
-
-// const explorerAdminServer = new ExplorerAdminServer(GIT_CMS_DIR, BAKED_BASE_URL)
-// explorerAdminServer.addMockBakedSiteRoutes(mockSiteRouter)
 
 mockSiteRouter.get("/grapher/:slug", async (req, res) => {
     // XXX add dev-prod parity for this

--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -42,6 +42,9 @@ import { bakeEmbedSnippet } from "../site/webpackUtils"
 import { JsonError } from "../clientUtils/owidTypes"
 import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants"
 import { isWordpressAPIEnabled } from "../db/wpdb"
+import { EXPLORERS_ROUTE_FOLDER } from "../explorer/ExplorerConstants"
+import { getExplorerRedirectForPath } from "../explorerAdminServer/ExplorerRedirects"
+import { explorerUrlMigrationsById } from "../explorer/urlMigrations/ExplorerUrlMigrations"
 
 require("express-async-errors")
 
@@ -94,8 +97,38 @@ mockSiteRouter.get("/grapher/latest", async (req, res) => {
     else throw new JsonError("No latest chart", 404)
 })
 
-const explorerAdminServer = new ExplorerAdminServer(GIT_CMS_DIR, BAKED_BASE_URL)
-explorerAdminServer.addMockBakedSiteRoutes(mockSiteRouter)
+mockSiteRouter.get(`/${EXPLORERS_ROUTE_FOLDER}/:slug`, async (req, res) => {
+    res.set("Access-Control-Allow-Origin", "*")
+    const explorers = await this.getAllPublishedExplorers()
+    const explorerProgram = explorers.find(
+        (program) => program.slug === req.params.slug
+    )
+    if (explorerProgram)
+        res.send(await this.renderExplorerPage(explorerProgram))
+    else
+        throw new JsonError(
+            "A published explorer with that slug was not found",
+            404
+        )
+})
+mockSiteRouter.get("/*", async (req, res, next) => {
+    const explorerRedirect = getExplorerRedirectForPath(req.path)
+    // If no explorer redirect exists, continue to next express handler
+    if (!explorerRedirect) return next()
+
+    const { migrationId, baseQueryStr } = explorerRedirect
+    const { explorerSlug } = explorerUrlMigrationsById[migrationId]
+    const program = await this.getExplorerFromSlug(explorerSlug)
+    res.send(
+        await this.renderExplorerPage(program, {
+            explorerUrlMigrationId: migrationId,
+            baseQueryStr,
+        })
+    )
+})
+
+// const explorerAdminServer = new ExplorerAdminServer(GIT_CMS_DIR, BAKED_BASE_URL)
+// explorerAdminServer.addMockBakedSiteRoutes(mockSiteRouter)
 
 mockSiteRouter.get("/grapher/:slug", async (req, res) => {
     // XXX add dev-prod parity for this

--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -98,7 +98,7 @@ mockSiteRouter.get("/grapher/latest", async (req, res) => {
     else throw new JsonError("No latest chart", 404)
 })
 
-const explorerAdminServer = new ExplorerAdminServer(GIT_CMS_DIR, BAKED_BASE_URL)
+const explorerAdminServer = new ExplorerAdminServer(GIT_CMS_DIR)
 
 mockSiteRouter.get(`/${EXPLORERS_ROUTE_FOLDER}/:slug`, async (req, res) => {
     res.set("Access-Control-Allow-Origin", "*")

--- a/baker/ExplorerBaker.tsx
+++ b/baker/ExplorerBaker.tsx
@@ -3,10 +3,11 @@ import path from "path"
 import { ExplorerProgram } from "../explorer/ExplorerProgram"
 import { explorerUrlMigrationsById } from "../explorer/urlMigrations/ExplorerUrlMigrations"
 import { explorerRedirectTable } from "../explorerAdminServer/ExplorerRedirects"
+import { renderExplorerPage } from "./siteRenderers"
 
 const bakeAllPublishedExplorers = async (outputFolder: string) => {
-    const published = await this.getAllPublishedExplorers()
-    await this.bakeExplorersToDir(outputFolder, published)
+    const published = await getAllPublishedExplorers()
+    await bakeExplorersToDir(outputFolder, published)
 }
 
 const bakeExplorersToDir = async (
@@ -14,15 +15,15 @@ const bakeExplorersToDir = async (
     explorers: ExplorerProgram[] = []
 ) => {
     for (const explorer of explorers) {
-        await this.write(
+        await write(
             `${directory}/${explorer.slug}.html`,
-            await this.renderExplorerPage(explorer)
+            await renderExplorerPage(explorer)
         )
     }
 }
 
 const bakeAllExplorerRedirects = async (outputFolder: string) => {
-    const explorers = await this.getAllExplorers()
+    const explorers = await getAllExplorers()
     const redirects = explorerRedirectTable.rows
     for (const redirect of redirects) {
         const { migrationId, path: redirectPath, baseQueryStr } = redirect
@@ -41,14 +42,15 @@ const bakeAllExplorerRedirects = async (outputFolder: string) => {
                 `No explorer with slug '${explorerSlug}'. Fix the list of explorer redirects and retry.`
             )
         }
-        const html = await this.renderExplorerPage(program, {
+        const html = await renderExplorerPage(program, {
             explorerUrlMigrationId: migrationId,
             baseQueryStr,
         })
-        await this.write(path.join(outputFolder, `${redirectPath}.html`), html)
+        await write(path.join(outputFolder, `${redirectPath}.html`), html)
     }
 }
 
+// todo: merge with SiteBaker's?
 const write = async (outPath: string, content: string) => {
     await mkdirp(path.dirname(outPath))
     await writeFile(outPath, content)

--- a/baker/ExplorerBaker.tsx
+++ b/baker/ExplorerBaker.tsx
@@ -2,11 +2,15 @@ import { mkdirp, writeFile } from "fs-extra"
 import path from "path"
 import { ExplorerProgram } from "../explorer/ExplorerProgram"
 import { explorerUrlMigrationsById } from "../explorer/urlMigrations/ExplorerUrlMigrations"
+import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer"
 import { explorerRedirectTable } from "../explorerAdminServer/ExplorerRedirects"
 import { renderExplorerPage } from "./siteRenderers"
 
-const bakeAllPublishedExplorers = async (outputFolder: string) => {
-    const published = await getAllPublishedExplorers()
+export const bakeAllPublishedExplorers = async (
+    outputFolder: string,
+    explorerAdminServer: ExplorerAdminServer
+) => {
+    const published = await explorerAdminServer.getAllPublishedExplorers()
     await bakeExplorersToDir(outputFolder, published)
 }
 
@@ -22,8 +26,11 @@ const bakeExplorersToDir = async (
     }
 }
 
-const bakeAllExplorerRedirects = async (outputFolder: string) => {
-    const explorers = await getAllExplorers()
+export const bakeAllExplorerRedirects = async (
+    outputFolder: string,
+    explorerAdminServer: ExplorerAdminServer
+) => {
+    const explorers = await explorerAdminServer.getAllExplorers()
     const redirects = explorerRedirectTable.rows
     for (const redirect of redirects) {
         const { migrationId, path: redirectPath, baseQueryStr } = redirect

--- a/baker/ExplorerBaker.tsx
+++ b/baker/ExplorerBaker.tsx
@@ -1,0 +1,56 @@
+import { mkdirp, writeFile } from "fs-extra"
+import path from "path"
+import { ExplorerProgram } from "../explorer/ExplorerProgram"
+import { explorerUrlMigrationsById } from "../explorer/urlMigrations/ExplorerUrlMigrations"
+import { explorerRedirectTable } from "../explorerAdminServer/ExplorerRedirects"
+
+const bakeAllPublishedExplorers = async (outputFolder: string) => {
+    const published = await this.getAllPublishedExplorers()
+    await this.bakeExplorersToDir(outputFolder, published)
+}
+
+const bakeExplorersToDir = async (
+    directory: string,
+    explorers: ExplorerProgram[] = []
+) => {
+    for (const explorer of explorers) {
+        await this.write(
+            `${directory}/${explorer.slug}.html`,
+            await this.renderExplorerPage(explorer)
+        )
+    }
+}
+
+const bakeAllExplorerRedirects = async (outputFolder: string) => {
+    const explorers = await this.getAllExplorers()
+    const redirects = explorerRedirectTable.rows
+    for (const redirect of redirects) {
+        const { migrationId, path: redirectPath, baseQueryStr } = redirect
+        const transform = explorerUrlMigrationsById[migrationId]
+        if (!transform) {
+            throw new Error(
+                `No explorer URL migration with id '${migrationId}'. Fix the list of explorer redirects and retry.`
+            )
+        }
+        const { explorerSlug } = transform
+        const program = explorers.find(
+            (program) => program.slug === explorerSlug
+        )
+        if (!program) {
+            throw new Error(
+                `No explorer with slug '${explorerSlug}'. Fix the list of explorer redirects and retry.`
+            )
+        }
+        const html = await this.renderExplorerPage(program, {
+            explorerUrlMigrationId: migrationId,
+            baseQueryStr,
+        })
+        await this.write(path.join(outputFolder, `${redirectPath}.html`), html)
+    }
+}
+
+const write = async (outPath: string, content: string) => {
+    await mkdirp(path.dirname(outPath))
+    await writeFile(outPath, content)
+    console.log(outPath)
+}

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -227,10 +227,7 @@ export class SiteBaker {
             await makeSitemap()
         )
 
-        const explorerAdminServer = new ExplorerAdminServer(
-            GIT_CMS_DIR,
-            this.baseUrl
-        )
+        const explorerAdminServer = new ExplorerAdminServer(GIT_CMS_DIR)
 
         await bakeAllExplorerRedirects(this.bakedSiteDir, explorerAdminServer)
 

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -40,13 +40,17 @@ import { countries } from "../clientUtils/countries"
 import { execWrapper } from "../db/execWrapper"
 import { logErrorAndMaybeSendToSlack } from "../serverUtils/slackLog"
 import { countryProfileSpecs } from "../site/countryProfileProjects"
-import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer"
 import { getRedirects } from "./redirects"
 import { bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers } from "./GrapherBaker"
 import { EXPLORERS_ROUTE_FOLDER } from "../explorer/ExplorerConstants"
 import { bakeEmbedSnippet } from "../site/webpackUtils"
 import { FullPost } from "../clientUtils/owidTypes"
 import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants"
+import {
+    bakeAllExplorerRedirects,
+    bakeAllPublishedExplorers,
+} from "./ExplorerBaker"
+import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer"
 
 export class SiteBaker {
     private grapherExports!: GrapherExports
@@ -228,10 +232,11 @@ export class SiteBaker {
             this.baseUrl
         )
 
-        await explorerAdminServer.bakeAllExplorerRedirects(this.bakedSiteDir)
+        await bakeAllExplorerRedirects(this.bakedSiteDir, explorerAdminServer)
 
-        await explorerAdminServer.bakeAllPublishedExplorers(
-            `${this.bakedSiteDir}/${EXPLORERS_ROUTE_FOLDER}/`
+        await bakeAllPublishedExplorers(
+            `${this.bakedSiteDir}/${EXPLORERS_ROUTE_FOLDER}/`,
+            explorerAdminServer
         )
         this.progressBar.tick({ name: "✅ baked special pages" })
     }

--- a/baker/siteRenderers.test.ts
+++ b/baker/siteRenderers.test.ts
@@ -9,8 +9,12 @@ import {
 import * as cheerio from "cheerio"
 import { FullPost, WP_PostType } from "../clientUtils/owidTypes"
 import * as wpdb from "../db/wpdb"
-import { renderAutomaticProminentLinks } from "./siteRenderers"
+import {
+    renderAutomaticProminentLinks,
+    renderExplorerPage,
+} from "./siteRenderers"
 import { BAKED_BASE_URL } from "../settings/clientSettings"
+import { ExplorerProgram } from "../explorer/ExplorerProgram"
 
 // There are many possible dimensions to test:
 // - style: default / thin
@@ -229,4 +233,12 @@ describe("does not render automatic prominent link", () => {
         expect(cheerioEl(`.${PROMINENT_LINK_CLASSNAME}`).length).toEqual(0)
         expect(console.error).toHaveBeenCalledTimes(0)
     })
+})
+
+it("renders an explorer page with title", async () => {
+    expect(
+        await renderExplorerPage(
+            new ExplorerProgram("foo", "explorerTitle helloWorld")
+        )
+    ).toContain("helloWorld")
 })

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -492,7 +492,7 @@ export const renderAutomaticProminentLinks = async (
     )
 }
 
-const renderExplorerPage = async (
+export const renderExplorerPage = async (
     program: ExplorerProgram,
     urlMigrationSpec?: ExplorerPageUrlMigrationSpec
 ) => {

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -522,7 +522,7 @@ const renderExplorerPage = async (
                 grapherConfigs={grapherConfigs}
                 program={program}
                 wpContent={wpContent}
-                baseUrl={this.baseUrl}
+                baseUrl={BAKED_BASE_URL}
                 urlMigrationSpec={urlMigrationSpec}
             />
         )

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -56,6 +56,7 @@ import {
     getPosts,
     selectHomepagePosts,
     isPostCitable,
+    getBlockContent,
 } from "../db/wpdb"
 import { mysqlFirst, queryMysql, knexTable } from "../db/db"
 import { getPageOverrides, isPageOverridesCitable } from "./pageOverrides"
@@ -65,6 +66,11 @@ import {
     ProminentLink,
     ProminentLinkStyles,
 } from "../site/blocks/ProminentLink"
+import { GrapherInterface } from "../grapher/core/GrapherInterface"
+import { Grapher, GrapherProgrammaticInterface } from "../grapher/core/Grapher"
+import { ExplorerProgram } from "../explorer/ExplorerProgram"
+import { ExplorerPageUrlMigrationSpec } from "../explorer/urlMigrations/ExplorerPageUrlMigrationSpec"
+import { ExplorerPage } from "../site/ExplorerPage"
 export const renderToHtmlPage = (element: any) =>
     `<!doctype html>${ReactDOMServer.renderToStaticMarkup(element)}`
 
@@ -483,5 +489,42 @@ export const renderAutomaticProminentLinks = async (
             $anchorParent.after(rendered)
             $anchorParent.remove()
         })
+    )
+}
+
+const renderExplorerPage = async (
+    program: ExplorerProgram,
+    urlMigrationSpec?: ExplorerPageUrlMigrationSpec
+) => {
+    const { requiredGrapherIds } = program.decisionMatrix
+    let grapherConfigRows: any[] = []
+    if (requiredGrapherIds.length)
+        grapherConfigRows = await queryMysql(
+            `SELECT id, config FROM charts WHERE id IN (?)`,
+            [requiredGrapherIds]
+        )
+
+    const wpContent = program.wpBlockId
+        ? await getBlockContent(program.wpBlockId)
+        : undefined
+
+    const grapherConfigs: GrapherInterface[] = grapherConfigRows.map((row) => {
+        const config: GrapherProgrammaticInterface = JSON.parse(row.config)
+        config.id = row.id // Ensure each grapher has an id
+        config.manuallyProvideData = true
+        return new Grapher(config).toObject()
+    })
+
+    return (
+        `<!doctype html>` +
+        ReactDOMServer.renderToStaticMarkup(
+            <ExplorerPage
+                grapherConfigs={grapherConfigs}
+                program={program}
+                wpContent={wpContent}
+                baseUrl={this.baseUrl}
+                urlMigrationSpec={urlMigrationSpec}
+            />
+        )
     )
 }

--- a/explorerAdminServer/ExplorerAdminServer.test.ts
+++ b/explorerAdminServer/ExplorerAdminServer.test.ts
@@ -2,18 +2,11 @@
 
 jest.setTimeout(10000) // wait up to 10s
 
-import { ExplorerProgram } from "../explorer/ExplorerProgram"
 import { ExplorerAdminServer } from "./ExplorerAdminServer"
 
 it("can init", async () => {
-    const server = new ExplorerAdminServer(__dirname, "https://example.com")
+    const server = new ExplorerAdminServer(__dirname)
     expect(server).toBeTruthy()
-
-    expect(
-        await server.renderExplorerPage(
-            new ExplorerProgram("foo", "explorerTitle helloWorld")
-        )
-    ).toContain("helloWorld")
 
     const allExplorersResult = await server.getAllExplorersCommand()
     expect(allExplorersResult.success).toBeTruthy()

--- a/explorerAdminServer/ExplorerAdminServer.tsx
+++ b/explorerAdminServer/ExplorerAdminServer.tsx
@@ -74,7 +74,7 @@ export class ExplorerAdminServer {
         return this.getExplorerFromFile(`${slug}${EXPLORER_FILE_SUFFIX}`)
     }
 
-    private async getAllPublishedExplorers() {
+    async getAllPublishedExplorers() {
         const explorers = await this.getAllExplorers()
         return explorers.filter((exp) => exp.isPublished)
     }

--- a/explorerAdminServer/ExplorerAdminServer.tsx
+++ b/explorerAdminServer/ExplorerAdminServer.tsx
@@ -1,5 +1,4 @@
-import { existsSync, readdir, writeFile, mkdirp, readFile } from "fs-extra"
-import path from "path"
+import { existsSync, readdir, readFile } from "fs-extra"
 import {
     EXPLORER_FILE_SUFFIX,
     ExplorerProgram,
@@ -7,14 +6,10 @@ import {
 import { Router } from "express"
 import {
     EXPLORERS_GIT_CMS_FOLDER,
-    EXPLORERS_PREVIEW_ROUTE,
-    GetAllExplorersRoute,
     ExplorersRouteResponse,
-    DefaultNewExplorerSlug,
     EXPLORERS_ROUTE_FOLDER,
 } from "../explorer/ExplorerConstants"
 import simpleGit, { SimpleGit } from "simple-git"
-import { slugify } from "../clientUtils/Util"
 import { GitCommit, JsonError } from "../clientUtils/owidTypes"
 import { getExplorerRedirectForPath } from "./ExplorerRedirects"
 import { explorerUrlMigrationsById } from "../explorer/urlMigrations/ExplorerUrlMigrations"
@@ -96,39 +91,6 @@ export class ExplorerAdminServer {
                     baseQueryStr,
                 })
             )
-        })
-    }
-
-    addAdminRoutes(app: Router) {
-        app.get("/errorTest.csv", async (req, res) => {
-            // Add `table /admin/errorTest.csv?code=404` to test fetch download failures
-            const code =
-                req.query.code && !isNaN(parseInt(req.query.code))
-                    ? req.query.code
-                    : 400
-
-            res.status(code)
-
-            return `Simulating code ${code}`
-        })
-
-        app.get(`/${GetAllExplorersRoute}`, async (req, res) => {
-            res.send(await this.getAllExplorersCommand())
-        })
-
-        app.get(`/${EXPLORERS_PREVIEW_ROUTE}/:slug`, async (req, res) => {
-            const slug = slugify(req.params.slug)
-            const filename = slug + EXPLORER_FILE_SUFFIX
-            if (slug === DefaultNewExplorerSlug)
-                return res.send(
-                    await this.renderExplorerPage(
-                        new ExplorerProgram(DefaultNewExplorerSlug, "")
-                    )
-                )
-            if (!slug || !existsSync(this.absoluteFolderPath + filename))
-                return res.send(`File not found`)
-            const explorer = await this.getExplorerFromFile(filename)
-            return res.send(await this.renderExplorerPage(explorer))
         })
     }
 

--- a/explorerAdminServer/ExplorerAdminServer.tsx
+++ b/explorerAdminServer/ExplorerAdminServer.tsx
@@ -11,12 +11,10 @@ import simpleGit, { SimpleGit } from "simple-git"
 import { GitCommit } from "../clientUtils/owidTypes"
 
 export class ExplorerAdminServer {
-    constructor(gitDir: string, baseUrl: string) {
+    constructor(gitDir: string) {
         this.gitDir = gitDir
-        this.baseUrl = baseUrl
     }
 
-    private baseUrl: string
     private gitDir: string
 
     private _simpleGit?: SimpleGit

--- a/explorerAdminServer/ExplorerAdminServer.tsx
+++ b/explorerAdminServer/ExplorerAdminServer.tsx
@@ -3,16 +3,12 @@ import {
     EXPLORER_FILE_SUFFIX,
     ExplorerProgram,
 } from "../explorer/ExplorerProgram"
-import { Router } from "express"
 import {
     EXPLORERS_GIT_CMS_FOLDER,
     ExplorersRouteResponse,
-    EXPLORERS_ROUTE_FOLDER,
 } from "../explorer/ExplorerConstants"
 import simpleGit, { SimpleGit } from "simple-git"
-import { GitCommit, JsonError } from "../clientUtils/owidTypes"
-import { getExplorerRedirectForPath } from "./ExplorerRedirects"
-import { explorerUrlMigrationsById } from "../explorer/urlMigrations/ExplorerUrlMigrations"
+import { GitCommit } from "../clientUtils/owidTypes"
 
 export class ExplorerAdminServer {
     constructor(gitDir: string, baseUrl: string) {
@@ -60,38 +56,6 @@ export class ExplorerAdminServer {
                 errorMessage: err,
             } as ExplorersRouteResponse
         }
-    }
-
-    addMockBakedSiteRoutes(app: Router) {
-        app.get(`/${EXPLORERS_ROUTE_FOLDER}/:slug`, async (req, res) => {
-            res.set("Access-Control-Allow-Origin", "*")
-            const explorers = await this.getAllPublishedExplorers()
-            const explorerProgram = explorers.find(
-                (program) => program.slug === req.params.slug
-            )
-            if (explorerProgram)
-                res.send(await this.renderExplorerPage(explorerProgram))
-            else
-                throw new JsonError(
-                    "A published explorer with that slug was not found",
-                    404
-                )
-        })
-        app.get("/*", async (req, res, next) => {
-            const explorerRedirect = getExplorerRedirectForPath(req.path)
-            // If no explorer redirect exists, continue to next express handler
-            if (!explorerRedirect) return next()
-
-            const { migrationId, baseQueryStr } = explorerRedirect
-            const { explorerSlug } = explorerUrlMigrationsById[migrationId]
-            const program = await this.getExplorerFromSlug(explorerSlug)
-            res.send(
-                await this.renderExplorerPage(program, {
-                    explorerUrlMigrationId: migrationId,
-                    baseQueryStr,
-                })
-            )
-        })
     }
 
     // todo: make private? once we remove covid legacy stuff?

--- a/explorerAdminServer/ExplorerAdminServer.tsx
+++ b/explorerAdminServer/ExplorerAdminServer.tsx
@@ -79,7 +79,7 @@ export class ExplorerAdminServer {
         return explorers.filter((exp) => exp.isPublished)
     }
 
-    private async getAllExplorers() {
+    async getAllExplorers() {
         if (!existsSync(this.absoluteFolderPath)) return []
         const files = await readdir(this.absoluteFolderPath)
         const explorerFiles = files.filter((filename) =>

--- a/explorerAdminServer/ExplorerAdminServer.tsx
+++ b/explorerAdminServer/ExplorerAdminServer.tsx
@@ -19,11 +19,6 @@ export class ExplorerAdminServer {
     private baseUrl: string
     private gitDir: string
 
-    // we store explorers in a subdir of the gitcms for now. idea is we may store other things in there later.
-    private get absoluteFolderPath() {
-        return this.gitDir + "/" + EXPLORERS_GIT_CMS_FOLDER + "/"
-    }
-
     private _simpleGit?: SimpleGit
     private get simpleGit() {
         if (!this._simpleGit)
@@ -33,6 +28,11 @@ export class ExplorerAdminServer {
                 maxConcurrentProcesses: 1,
             })
         return this._simpleGit
+    }
+
+    // we store explorers in a subdir of the gitcms for now. idea is we may store other things in there later.
+    get absoluteFolderPath() {
+        return this.gitDir + "/" + EXPLORERS_GIT_CMS_FOLDER + "/"
     }
 
     async getAllExplorersCommand() {


### PR DESCRIPTION
This comes as a side-effect of [Shift prominent link transformation to editor on copy / paste](https://www.notion.so/Shift-prominent-link-transformation-to-editor-on-copy-paste-6dc963e803f34363b48d6f2147e74428), which merges authored (aka manual) prominent links with automatic prominent links (whereby https://ourworldindata.org/xyz is transformed into a fully-fledged prominent links at bake time).

Authored prominent links will then inherit the capabilities of their automatic counterpart, which rely on requesting missing information (title and image) from the DB.

Previously, explorer pages were only rendering authored prominent links. With this merge, they now need to be able to render the full prominent links (with optional DB fallback). Pulling that content in can't (and shouldn't anyway) happen at the level of `ExplorerPage`, which lives in `site` and has no knowledge of the DB.

One level up is `renderExplorerPage()`, in the `explorerAdminServer` TS project. However `explorerAdminServer` is already a TS project reference to `baker`, where the coveted `renderProminentLinks()` would live. `explorerAdminServer` thus can't reference `baker` without creating a circular dependency.

The solution outlined in this PR fits in with the current architecture and moves:
- explorer routes to the existing routers (`adminSiteServer/[admin/mockSite]Router.tsx`)
- explorer renderers to the existing renderers (`baker/siteRenderers.tsx`)
- explorer baking functions to the baker (`baker/ExplorerBaker.tsx`)

With this change, `renderExplorerPage()` now lives in the baker, and has access to the necessary rendering and formatting functions.

_The commits in this PR are used as steps to outline the transformation, but do not build individually. Only the last few ones  do._