### PR TITLE
refactor: remove highlightToggle

### DIFF
--- a/adminSiteClient/EditorScatterTab.tsx
+++ b/adminSiteClient/EditorScatterTab.tsx
@@ -1,36 +1,21 @@
 import * as React from "react"
 import { debounce, excludeUndefined } from "../clientUtils/Util"
-import { observable, computed, action, toJS } from "mobx"
+import { observable, computed, action } from "mobx"
 import { observer } from "mobx-react"
 import { Grapher } from "../grapher/core/Grapher"
 import { ComparisonLineConfig } from "../grapher/scatterCharts/ComparisonLine"
-import { Toggle, NumberField, SelectField, TextField, Section } from "./Forms"
+import { Toggle, NumberField, SelectField, Section } from "./Forms"
 import { faMinus } from "@fortawesome/free-solid-svg-icons/faMinus"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import {
-    ScatterPointLabelStrategy,
-    HighlightToggleConfig,
-} from "../grapher/core/GrapherConstants"
+import { ScatterPointLabelStrategy } from "../grapher/core/GrapherConstants"
 import { EntityName } from "../coreTable/OwidTableConstants"
 
 @observer
 export class EditorScatterTab extends React.Component<{ grapher: Grapher }> {
     @observable comparisonLine: ComparisonLineConfig = { yEquals: undefined }
-    @observable highlightToggle: HighlightToggleConfig = {
-        description: "",
-        paramStr: "",
-    }
-
-    @computed get hasHighlightToggle() {
-        return !!this.props.grapher.highlightToggle
-    }
 
     constructor(props: { grapher: Grapher }) {
         super(props)
-        this.highlightToggle = {
-            ...this.highlightToggle,
-            ...props.grapher.highlightToggle,
-        }
     }
 
     @action.bound onToggleHideTimeline(value: boolean) {
@@ -43,16 +28,6 @@ export class EditorScatterTab extends React.Component<{ grapher: Grapher }> {
 
     @action.bound onXOverrideYear(value: number | undefined) {
         this.props.grapher.xOverrideTime = value
-    }
-
-    @action.bound onToggleHighlightToggle(value: boolean) {
-        if (value) this.props.grapher.highlightToggle = this.highlightToggle
-        else this.props.grapher.highlightToggle = undefined
-    }
-
-    save() {
-        if (this.hasHighlightToggle)
-            this.props.grapher.highlightToggle = toJS(this.highlightToggle)
     }
 
     @computed private get excludedEntityNames(): EntityName[] {
@@ -105,8 +80,7 @@ export class EditorScatterTab extends React.Component<{ grapher: Grapher }> {
     }
 
     render() {
-        const { hasHighlightToggle, highlightToggle, excludedEntityChoices } =
-            this
+        const { excludedEntityChoices } = this
         const { grapher } = this.props
 
         return (
@@ -181,32 +155,6 @@ export class EditorScatterTab extends React.Component<{ grapher: Grapher }> {
                         Allow users to toggle a particular chart selection state
                         to highlight certain entities.
                     </p>
-                    <Toggle
-                        label="Enable highlight toggle"
-                        value={!!hasHighlightToggle}
-                        onValue={this.onToggleHighlightToggle}
-                    />
-                    {hasHighlightToggle && (
-                        <div>
-                            <TextField
-                                label="Description"
-                                value={highlightToggle.description}
-                                onValue={action((value: string) => {
-                                    this.highlightToggle.description = value
-                                    this.save()
-                                })}
-                            />
-                            <TextField
-                                label="URL Params"
-                                placeholder="e.g. ?country=AFG"
-                                value={highlightToggle.paramStr}
-                                onValue={action((value: string) => {
-                                    this.highlightToggle.paramStr = value
-                                    this.save()
-                                })}
-                            />
-                        </div>
-                    )}
                 </Section>
             </div>
         )

--- a/grapher/captionedChart/CaptionedChart.stories.tsx
+++ b/grapher/captionedChart/CaptionedChart.stories.tsx
@@ -27,7 +27,6 @@ const manager: CaptionedChartManager = {
     currentTitle: "This is the Title",
     subtitle: "A Subtitle",
     note: "Here are some footer notes",
-    populateFromQueryParams: (): void => {},
     isReady: true,
     availableFacetStrategies: [FacetStrategy.none],
 }

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -24,11 +24,9 @@ import { CollapsibleList } from "../controls/CollapsibleList/CollapsibleList"
 import {
     ZoomToggle,
     AbsRelToggle,
-    HighlightToggle,
     FilterSmallCountriesToggle,
     SmallCountriesFilterManager,
     AbsRelToggleManager,
-    HighlightToggleManager,
     FacetYDomainToggle,
     FacetYDomainToggleManager,
     FacetStrategyDropdown,
@@ -49,7 +47,6 @@ export interface CaptionedChartManager
     extends ChartManager,
         MapChartManager,
         SmallCountriesFilterManager,
-        HighlightToggleManager,
         AbsRelToggleManager,
         FooterManager,
         HeaderManager,
@@ -74,7 +71,6 @@ export interface CaptionedChartManager
     showAbsRelToggle?: boolean
     showNoDataAreaToggle?: boolean
     showFacetYDomainToggle?: boolean
-    showHighlightToggle?: boolean
     showChangeEntityButton?: boolean
     showAddEntityButton?: boolean
     showSelectEntitiesButton?: boolean
@@ -289,11 +285,6 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
                     key="FacetYDomainToggle"
                     manager={manager}
                 />
-            )
-
-        if (manager.showHighlightToggle)
-            controls.push(
-                <HighlightToggle key="highlight-toggle" manager={manager} />
             )
 
         if (manager.showSmallCountriesFilterToggle)

--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -1,11 +1,6 @@
 import * as React from "react"
 import { computed, action } from "mobx"
 import { observer } from "mobx-react"
-import {
-    getQueryParams,
-    getWindowQueryParams,
-    QueryParams,
-} from "../../clientUtils/urls/UrlUtils"
 import { TimelineComponent } from "../timeline/TimelineComponent"
 import { formatValue } from "../../clientUtils/formatValue"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
@@ -18,78 +13,15 @@ import {
     FacetAxisDomain,
     FacetStrategy,
     GrapherTabOption,
-    HighlightToggleConfig,
     RelatedQuestionsConfig,
     StackMode,
 } from "../core/GrapherConstants"
 import { ShareMenu, ShareMenuManager } from "./ShareMenu"
 import { TimelineController } from "../timeline/TimelineController"
-import { SelectionArray } from "../selection/SelectionArray"
 import { AxisConfig } from "../axis/AxisConfig"
 import { Tippy } from "../chart/Tippy"
 import { Bounds } from "../../clientUtils/Bounds"
 import classnames from "classnames"
-
-export interface HighlightToggleManager {
-    highlightToggle?: HighlightToggleConfig
-    selectionArray?: SelectionArray
-    populateFromQueryParams: (obj: QueryParams) => void
-}
-
-// Todo: Add tests and stories
-@observer
-export class HighlightToggle extends React.Component<{
-    manager: HighlightToggleManager
-}> {
-    @computed private get manager(): HighlightToggleManager {
-        return this.props.manager
-    }
-    @computed private get highlight(): HighlightToggleConfig | undefined {
-        return this.props.manager.highlightToggle
-    }
-
-    @computed private get highlightParams(): QueryParams {
-        return getQueryParams((this.highlight?.paramStr || "").substring(1))
-    }
-
-    @action.bound private onHighlightToggle(
-        event: React.FormEvent<HTMLInputElement>
-    ): void {
-        if (!event.currentTarget.checked) {
-            this.manager.selectionArray?.clearSelection()
-            return
-        }
-
-        const params = {
-            ...getWindowQueryParams(),
-            ...this.highlightParams,
-        }
-        this.manager.populateFromQueryParams(params)
-    }
-
-    private get isHighlightActive(): boolean {
-        const params = getWindowQueryParams()
-        let isActive = true
-        Object.keys(this.highlightParams).forEach((key): void => {
-            if (params[key] !== this.highlightParams[key]) isActive = false
-        })
-        return isActive
-    }
-
-    render(): JSX.Element {
-        const { highlight, isHighlightActive } = this
-        return (
-            <label className="clickable HighlightToggle">
-                <input
-                    type="checkbox"
-                    checked={isHighlightActive}
-                    onChange={this.onHighlightToggle}
-                />{" "}
-                &nbsp;{highlight?.description}
-            </label>
-        )
-    }
-}
 
 export interface NoDataAreaToggleManager {
     showNoDataArea?: boolean

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -10,7 +10,6 @@ import {
     IReactionDisposer,
 } from "mobx"
 import { bind } from "decko"
-import { ColorScale } from "../color/ColorScale"
 import {
     uniqWith,
     isEqual,
@@ -40,7 +39,6 @@ import {
     ScaleType,
     StackMode,
     EntitySelectionMode,
-    HighlightToggleConfig,
     ScatterPointLabelStrategy,
     RelatedQuestionsConfig,
     BASE_FONT_SIZE,
@@ -106,7 +104,6 @@ import {
     FacetStrategyDropdownManager,
     FooterControls,
     FooterControlsManager,
-    HighlightToggleManager,
     SmallCountriesFilterManager,
 } from "../controls/Controls"
 import { TooltipView } from "../tooltip/Tooltip"
@@ -233,7 +230,6 @@ export class Grapher
         LegacyDimensionsManager,
         ShareMenuManager,
         SmallCountriesFilterManager,
-        HighlightToggleManager,
         AbsRelToggleManager,
         TooltipManager,
         FooterControlsManager,
@@ -258,7 +254,6 @@ export class Grapher
     @observable.ref timelineMinTime?: Time = undefined
     @observable.ref timelineMaxTime?: Time = undefined
     @observable.ref addCountryMode = EntitySelectionMode.MultipleEntities
-    @observable.ref highlightToggle?: HighlightToggleConfig = undefined
     @observable.ref stackMode = StackMode.absolute
     @observable.ref showNoDataArea: boolean = true
     @observable.ref hideLegend?: boolean = false
@@ -2485,10 +2480,6 @@ export class Grapher
 
     @computed get showNoDataAreaToggle(): boolean {
         return this.isMarimekko
-    }
-
-    @computed get showHighlightToggle(): boolean {
-        return this.isScatter && !!this.highlightToggle
     }
 
     @computed get showChangeEntityButton(): boolean {

--- a/grapher/core/GrapherConstants.ts
+++ b/grapher/core/GrapherConstants.ts
@@ -71,11 +71,6 @@ export enum ScaleType {
     log = "log",
 }
 
-export interface HighlightToggleConfig {
-    description: string
-    paramStr: string
-}
-
 export interface RelatedQuestionsConfig {
     text: string
     url: string

--- a/grapher/core/GrapherInterface.ts
+++ b/grapher/core/GrapherInterface.ts
@@ -2,7 +2,6 @@ import {
     StackMode,
     GrapherTabOption,
     ScatterPointLabelStrategy,
-    HighlightToggleConfig,
     RelatedQuestionsConfig,
     EntitySelectionMode,
     EntitySelection,
@@ -42,7 +41,6 @@ export interface GrapherInterface extends SortConfig {
     dimensions?: OwidChartDimensionInterface[]
     addCountryMode?: EntitySelectionMode
     comparisonLines?: ComparisonLineConfig[]
-    highlightToggle?: HighlightToggleConfig
     stackMode?: StackMode
 
     showNoDataArea?: boolean
@@ -135,7 +133,6 @@ export const grapherKeysToSerialize = [
     "timelineMinTime",
     "timelineMaxTime",
     "addCountryMode",
-    "highlightToggle",
     "stackMode",
     "showNoDataArea",
     "hideLegend",


### PR DESCRIPTION
[As discussed here](https://owid.slack.com/archives/CQQUA2C2U/p1643054986036100)

we haven't used it in any chart since 2020, so let's get rid of the code behind it now