### PR TITLE
fix: install `tmex`

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,9 @@ yarn startAdminServer
 yarn startWebpackServer
 ```
 
-Or alternatively, you can also start all 3 processes in one terminal window with tmux if you have it set up:
+Or alternatively, you can also start all 3 processes in one terminal window with tmux:
 
 ```sh
-# for the command below to work you need to install tmex globally:
-# yarn global add tmex
 yarn startTmuxServer
 ```
 

--- a/package.json
+++ b/package.json
@@ -226,6 +226,7 @@
         "pretty-quick": "^3.0.0",
         "source-map-support": "^0.5.12",
         "storybook": "^6.3.8",
+        "tmex": "^1.0.8",
         "tsc-watch": "^4.2.9",
         "xhr-mock": "^2.5.1"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -18212,6 +18212,11 @@ tippy.js@^6.2.0:
   dependencies:
     "@popperjs/core" "^2.3.2"
 
+tmex@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/tmex/-/tmex-1.0.8.tgz#a6fc022c5765dec4a99591b3a75d075c85748ca7"
+  integrity sha512-PBaw29ZrGkKIGEtlSFXshDEFQsbU+zTCwhyKJti3B4PrJVtV87ezu2UwWgW97tZZrNw8KHXvliDnk4GHUMVuYg==
+
 tmp-promise@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.2.tgz#6e933782abff8b00c3119d63589ca1fb9caaa62a"


### PR DESCRIPTION
Not sure if anyone uses this (we could remove it instead) but for now adding it in dev dependencies prevents the `/bin/sh: tmex: command not found` error that Pablo ran into while following the README instructions.

(`tmux` also needs to be installed btw, maybe should mention that in the README too?)