### PR TITLE
fix: use `fetch` instead of `fetchWithRetries` in SiteHeaderMenus

### DIFF
--- a/site/SiteHeaderMenus.tsx
+++ b/site/SiteHeaderMenus.tsx
@@ -559,7 +559,7 @@ class SiteHeaderMenus extends React.Component<{ baseUrl: string }> {
 
     private async getEntries() {
         const json = await (
-            await fetchWithRetries("/headerMenu.json", {
+            await fetch("/headerMenu.json", {
                 method: "GET",
                 credentials: "same-origin",
                 headers: {


### PR DESCRIPTION
There is some Safari bug on both macOS and iOS that leads to a `(0,m.fetchWithRetries) is not a function.` error. 

We could potentially see if #1060 fixes it, but until then we can just fetch the header menu without retries.

Slack discussion: https://owid.slack.com/archives/CQQUA2C2U/p1643017308010200

Error on Bugsnag: https://app.bugsnag.com/our-world-in-data/our-world-in-data-website/errors/61e8217018e327000758b9e3

