### PR TITLE
feat(algolia): rank chart by number of references to a chart

### DIFF
--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -47,13 +47,18 @@ export const configureAlgolia = async () => {
     await chartsIndex.setSettings({
         ...baseSettings,
         searchableAttributes: [
-            "title",
+            "unordered(title)",
+            "unordered(slug)",
             "unordered(variantName)",
             "unordered(subtitle)",
             "unordered(_tags)",
             "unordered(availableEntities)",
         ],
-        customRanking: ["asc(numDimensions)", "asc(titleLength)"],
+        customRanking: [
+            "desc(numRelatedArticles)",
+            "asc(numDimensions)",
+            "asc(titleLength)",
+        ],
         attributesToSnippet: ["subtitle:24"],
         attributeForDistinct: "id",
         disableExactOnAttributes: ["_tags"],

--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -4,6 +4,7 @@ import * as db from "../../db/db"
 import { getRelatedArticles } from "../../db/wpdb"
 import { ALGOLIA_INDEXING } from "../../settings/serverSettings"
 import { getAlgoliaClient } from "./configureAlgolia"
+import { isPathRedirectedToExplorer } from "../../explorerAdminServer/ExplorerRedirects"
 
 const getChartsRecords = async () => {
     const allCharts = await db.queryMysql(`
@@ -37,6 +38,9 @@ const getChartsRecords = async () => {
     const records = []
     for (const c of chartsToIndex) {
         if (!c.tags) continue
+        // Our search currently cannot render explorers, so don't index them because
+        // otherwise they will fail when rendered in the search results
+        if (isPathRedirectedToExplorer(`/grapher/${c.slug}`)) continue
 
         const relatedArticles = (await getRelatedArticles(c.slug)) ?? []
 

--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -1,6 +1,7 @@
 import * as lodash from "lodash"
 
 import * as db from "../../db/db"
+import { getRelatedArticles } from "../../db/wpdb"
 import { ALGOLIA_INDEXING } from "../../settings/serverSettings"
 import { getAlgoliaClient } from "./configureAlgolia"
 
@@ -37,6 +38,8 @@ const getChartsRecords = async () => {
     for (const c of chartsToIndex) {
         if (!c.tags) continue
 
+        const relatedArticles = (await getRelatedArticles(c.slug)) ?? []
+
         records.push({
             objectID: c.id,
             chartId: c.id,
@@ -50,6 +53,8 @@ const getChartsRecords = async () => {
             updatedAt: c.updatedAt,
             numDimensions: parseInt(c.numDimensions),
             titleLength: c.title.length,
+            // Number of references to this chart in all our posts and pages
+            numRelatedArticles: relatedArticles.length,
         })
     }
 


### PR DESCRIPTION
[As discussed here](https://owid.slack.com/archives/C014N17DHEC/p1643195645008300), this is one of the easiest ways for us to improve the charts that show up in chart results.

At first I was unsure how long "calculating" this information would take for all the charts that we have, but that's not an issue at all thankfully - on tufte index creation took just 6 seconds! (the graph DB is created once, and then only queried subsequently)

~Note, however, that this doesn't consider the new `numRelatedArticles` metric for search ranking yet - that we have to enable once we have played around with it a bit.~