### PR TITLE
Add Gitpod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ serverSettings.json
 localBake/
 /grapherData
 /grapherSvgs
+/owid-content

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,45 @@
+image: gitpod/workspace-mysql
+
+ports:
+    # express server
+    - port: 3030
+      onOpen: open-browser
+    # mysql server
+    - port: 3306
+      onOpen: ignore
+    - port: 33060
+      onOpen: ignore
+    # webpack server
+    - port: 8090
+      onOpen: ignore
+
+tasks:
+    # set everything up
+    - init: |
+          gp await-port 3306 && ./db/downloadAndCreateDatabase.sh
+          mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '';"
+          nvm install
+          npm install -g yarn
+          git clone https://github.com/owid/owid-content
+          yarn install
+          cp .env.example .env && echo $'\n' >> .env
+          tsc -b
+          gp sync-done initial-setup
+      # setting env variables required for Gitpod, because it doesn't run on localhost
+      command: |
+          echo WEBPACK_DEV_URL=$(gp url 8090) >> .env
+          echo BAKED_BASE_URL=$(gp url 3030) >> .env
+          echo ADMIN_BASE_URL=$(gp url 3030) >> .env
+          yarn startTscServer
+    # wait for initial-setup (above) to finish and then start webpack server
+    - init: gp sync-await initial-setup
+      command: yarn startWebpackServer
+    # wait for initial-setup (above) to finish and then start admin server
+    - init: gp sync-await initial-setup
+      command: yarn startAdminServer
+
+github:
+    prebuilds:
+        branches: true
+        pullRequests: true
+        addCheck: false


### PR DESCRIPTION
This PR adds a Gitpod configuration (`.gitpod.yml`), which allows opening up this code base in Gitpod with one click. It greatly simplifies contributing to projects by spinning up a dev environment with everything set up in the cloud.

<img width="1440" alt="Screenshot 2022-01-28 at 16 00 01" src="https://user-images.githubusercontent.com/1881676/151675458-5dc31135-44a8-4af6-b724-3164a774bd07.png">


You can start the Gitpod environment by simply prefixing a GitHub URL by `gitpod.io/#`. For example, [this link](https://gitpod.io/#https://github.com/owid/owid-grapher/pull/1117) opens this branch/PR in Gitpod. If you're not familiar with Gitpod, check out their [website](https://gitpod.io). It's similar to GitHub codespaces, but open-source and more user-friendly (in my mind).

One caveat with this setup is that I chose MySQL 8.0 (default for Ubuntu 20.04), not 5.7 as recommended in the readme. I can switch to 5.7, but this will complicate the setup a bit and seeing as MySQL reaches EOL end of next year, I thought this should be fine. Seems to work fine. Let me know if this is not good.

I've also added `/owid-content` to `.gitignore`, since that's the folder where `https://github.com/owid/owid-content` is cloned into. I'm happy to remove it again if I'm missing something.

If you want, I can add a short section to the readme that explains this development setup.