### PR TITLE
fix(facets): relative line charts

### DIFF
--- a/grapher/chart/ChartManager.ts
+++ b/grapher/chart/ChartManager.ts
@@ -15,6 +15,7 @@ import { SelectionArray } from "../selection/SelectionArray"
 import { Annotation, ColumnSlug, SortConfig } from "../../clientUtils/owidTypes"
 import { ColorScaleBin } from "../color/ColorScaleBin"
 import { CoreColumn } from "../../coreTable/CoreTableColumns"
+import { TimeBound } from "../../clientUtils/TimeBounds"
 
 // The possible options common across our chart types. Not all of these apply to every chart type, so there is room to create a better type hierarchy.
 
@@ -61,13 +62,13 @@ export interface ChartManager {
     seriesColorMap?: SeriesColorMap
 
     hidePoints?: boolean // for line options
+    startHandleTimeBound?: TimeBound // for relative-to-first-year line chart
 
     facetStrategy?: FacetStrategy // todo: make a strategy? a column prop? etc
+    seriesStrategy?: SeriesStrategy
 
     sortConfig?: SortConfig
     showNoDataArea?: boolean
-
-    seriesStrategy?: SeriesStrategy
 
     annotation?: Annotation
     resetAnnotation?: () => void

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -21,6 +21,7 @@ import {
     FacetSeries,
     FacetChartProps,
     PlacedFacetSeries,
+    FacetChartManager,
 } from "./FacetChartConstants"
 import { OwidTable } from "../../coreTable/OwidTable"
 import { autoDetectYColumnSlugs, makeSelectionArray } from "../chart/ChartUtils"
@@ -128,7 +129,7 @@ export class FacetChart
         )
     }
 
-    @computed private get manager(): ChartManager {
+    @computed private get manager(): FacetChartManager {
         return this.props.manager
     }
 
@@ -246,6 +247,7 @@ export class FacetChart
             isRelativeMode,
             colorScale,
             sortConfig,
+            startHandleTimeBound,
         } = manager
 
         // Use compact labels, e.g. 50k instead of 50,000.
@@ -295,6 +297,7 @@ export class FacetChart
                 colorScale,
                 colorScaleColumnOverride,
                 sortConfig,
+                startHandleTimeBound,
                 ...series.manager,
                 xAxisConfig: {
                     ...globalXAxisConfig,

--- a/grapher/lineCharts/LineChartConstants.ts
+++ b/grapher/lineCharts/LineChartConstants.ts
@@ -39,8 +39,6 @@ export interface LinesProps {
 }
 
 export interface LineChartManager extends ChartManager {
-    hidePoints?: boolean
     lineStrokeWidth?: number
-    startHandleTimeBound?: TimeBound
     canSelectMultipleEntities?: boolean
 }


### PR DESCRIPTION
Fixes #1098. 

@MarcelGerber was right that only `startHandleTimeBound` needs to be passed on for this to work. I made it a property of `ChartManager` to enable this.

---

Related: Now that we have faceted charts, all the specific chart managers (`LineChartManager`, `ScatterPlotManager`, etc) are basically getting merged into `ChartManager` in order to make it possible to pass props to individual facets. Or at least that's what I'm doing. The alternative is to keep them separate, and make `ChartManager` a union of all specific chart manager – maybe that's better?