### PR TITLE
chore: fix mobx-utils peer-dep (mobx)

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
         "md5": "^2.3.0",
         "mini-css-extract-plugin": "^2.4.5",
         "minimist": "^1.2.3",
-        "mobx": "^5.13.0",
+        "mobx": "^5.15.7",
         "mobx-formatters": "^1.0.2",
         "mobx-react": "5",
         "mobx-utils": "5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13068,7 +13068,7 @@ mobx-utils@5:
   resolved "https://registry.yarnpkg.com/mobx-utils/-/mobx-utils-5.6.2.tgz#4858acbdb03f0470e260854f87e8c2ba916ebaec"
   integrity sha512-a/WlXyGkp6F12b01sTarENpxbmlRgPHFyR1Xv2bsSjQBm5dcOtd16ONb40/vOqck8L99NHpI+C9MXQ+SZ8f+yw==
 
-mobx@^5.13.0:
+mobx@^5.15.7:
   version "5.15.7"
   resolved "https://registry.yarnpkg.com/mobx/-/mobx-5.15.7.tgz#b9a5f2b6251f5d96980d13c78e9b5d8d4ce22665"
   integrity sha512-wyM3FghTkhmC+hQjyPGGFdpehrcX1KOXsDuERhfK2YbJemkUhEB+6wzEN639T21onxlfYBmriA1PFnvxTUhcKw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -13069,9 +13069,9 @@ mobx-utils@5:
   integrity sha512-a/WlXyGkp6F12b01sTarENpxbmlRgPHFyR1Xv2bsSjQBm5dcOtd16ONb40/vOqck8L99NHpI+C9MXQ+SZ8f+yw==
 
 mobx@^5.13.0:
-  version "5.13.0"
-  resolved "https://registry.yarnpkg.com/mobx/-/mobx-5.13.0.tgz#0fd68f10aa5ff2d146a4ed9e145b53337cfbca59"
-  integrity sha512-eSAntMSMNj0PFL705rgv+aB/z1RjNqDnFEpBe18yQVreXTWiVgIrmBUXzjnJfuba+eo4eAk6zi+/gXQkSUea8A==
+  version "5.15.7"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-5.15.7.tgz#b9a5f2b6251f5d96980d13c78e9b5d8d4ce22665"
+  integrity sha512-wyM3FghTkhmC+hQjyPGGFdpehrcX1KOXsDuERhfK2YbJemkUhEB+6wzEN639T21onxlfYBmriA1PFnvxTUhcKw==
 
 module-definition@^3.3.1:
   version "3.3.1"


### PR DESCRIPTION
When running `yarn`:
`warning " > mobx-utils@5.6.2" has incorrect peer dependency "mobx@^4.13.1 || ^5.13.1".`
(currently, we are on mobx@5.13.0)

When previewing the site, this manifests as:
<img width="1438" alt="Screenshot 2022-02-02 at 09 14 37" src="https://user-images.githubusercontent.com/13406362/152117859-02f6d90b-d138-469f-b390-8550ed84e2fa.png">

This PR upgrades mobx to the latest 5.x.x