### PR TITLE
fix: consistent grapher schema URLs

### DIFF
--- a/adminSiteClient/VariablesAnnotationPage.tsx
+++ b/adminSiteClient/VariablesAnnotationPage.tsx
@@ -744,7 +744,7 @@ class VariablesAnnotationComponent extends React.Component {
         // TODO: this should switch to files.ourwordindata.org but if I do this I get a CORS error -
         // areh HEAD requests not forwarded?
         const json = await fetch(
-            "https://owid.nyc3.digitaloceanspaces.com/schemas/grapher-schema.001.json"
+            "https://files.ourworldindata.org/schemas/grapher-schema.001.json"
         ).then((response) => response.json())
         const fieldDescriptions = extractFieldDescriptionsFromSchema(json)
         runInAction(() => {

--- a/devTools/schemaProcessor/columns.json
+++ b/devTools/schemaProcessor/columns.json
@@ -2,7 +2,7 @@
     {
         "type": "string",
         "pointer": "/$schema",
-        "default": "https://owid.nyc3.digitaloceanspaces.com/schemas/grapher-schema.v001.json",
+        "default": "https://files.ourworldindata.org/schemas/grapher-schema.001.json",
         "editor": "textfield"
     },
     {

--- a/devTools/schemaProcessor/schema.json
+++ b/devTools/schemaProcessor/schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://owid.nyc3.digitaloceanspaces.com/schemas/grapher-schema.v001.json",
+    "$id": "https://files.ourworldindata.org/schemas/grapher-schema.001.json",
     "$defs": {
         "axis": {
             "type": "object",
@@ -191,7 +191,7 @@
             "type": "string",
             "description": "Url of the concrete schema version to use to validate this document",
             "format": "uri",
-            "default": "https://owid.nyc3.digitaloceanspaces.com/schemas/grapher-schema.v001.json"
+            "default": "https://files.ourworldindata.org/schemas/grapher-schema.001.json"
         },
         "id": {
             "type": "integer",

--- a/grapher/schema/grapher-schema.001.json
+++ b/grapher/schema/grapher-schema.001.json
@@ -191,7 +191,7 @@
             "type": "string",
             "description": "Url of the concrete schema version to use to validate this document",
             "format": "uri",
-            "default": "https://owid.nyc3.digitaloceanspaces.com/schemas/grapher-schema.v001.json"
+            "default": "https://files.ourworldindata.org/schemas/grapher-schema.001.json"
         },
         "id": {
             "type": "integer",

--- a/grapher/schema/grapher-schema.001.yaml
+++ b/grapher/schema/grapher-schema.001.yaml
@@ -176,7 +176,7 @@ properties:
         type: string
         description: Url of the concrete schema version to use to validate this document
         format: uri
-        default: "https://owid.nyc3.digitaloceanspaces.com/schemas/grapher-schema.v001.json"
+        default: "https://files.ourworldindata.org/schemas/grapher-schema.001.json"
     id:
         type: integer
         description: Internal DB id. Useful internally for OWID but not required if just using grapher directly.


### PR DESCRIPTION
We are currently linking to files in `nyc3.digitaloceanspaces.com` which is harder to redirect from if we moved the files in the future. Instead I think it's better to link to `files.ourworldindata.org` which we have complete control over. (We could also use a different domain for these things, but this one is already set up.)

Also there were some dead links linking to `grapher-schema.v001.json` instead of `grapher-schema.001.json`.

### Todo

- [ ] Make sure files.ourworldindata.org supports CORS