### PR TITLE
refactor: move SuggestedChartRevisionStatus enum to clientUtils

### DIFF
--- a/adminSiteClient/SuggestedChartRevision.ts
+++ b/adminSiteClient/SuggestedChartRevision.ts
@@ -1,11 +1,5 @@
 import { GrapherInterface } from "../grapher/core/GrapherInterface"
-
-export enum SuggestedChartRevisionStatus {
-    pending = "pending",
-    approved = "approved",
-    rejected = "rejected",
-    flagged = "flagged",
-}
+import { SuggestedChartRevisionStatus } from "../clientUtils/owidTypes"
 
 export interface SuggestedChartRevisionSerialized {
     id: number

--- a/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
+++ b/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
@@ -8,7 +8,10 @@ import Select from "react-select"
 import classNames from "classnames"
 import { Bounds } from "../clientUtils/Bounds"
 import { getStylesForTargetHeight } from "../clientUtils/react-select"
-import { SortOrder } from "../clientUtils/owidTypes"
+import {
+    SortOrder,
+    SuggestedChartRevisionStatus,
+} from "../clientUtils/owidTypes"
 import { Grapher } from "../grapher/core/Grapher"
 import { TextAreaField, NumberField, RadioGroup, Toggle } from "./Forms"
 import { PostReference } from "./ChartEditor"
@@ -32,10 +35,7 @@ import {
     VisionDeficiencyDropdown,
     VisionDeficiencyEntity,
 } from "./VisionDeficiencies"
-import {
-    SuggestedChartRevisionSerialized,
-    SuggestedChartRevisionStatus,
-} from "./SuggestedChartRevision"
+import { SuggestedChartRevisionSerialized } from "./SuggestedChartRevision"
 
 @observer
 export class SuggestedChartRevisionApproverPage extends React.Component<{

--- a/adminSiteClient/SuggestedChartRevisionList.tsx
+++ b/adminSiteClient/SuggestedChartRevisionList.tsx
@@ -12,7 +12,7 @@ import { AdminAppContext, AdminAppContextType } from "./AdminAppContext"
 import { BAKED_GRAPHER_URL } from "../settings/clientSettings"
 import { ChartListItem } from "./ChartList"
 import { Link } from "./Link"
-import { SuggestedChartRevisionStatus } from "./SuggestedChartRevision"
+import { SuggestedChartRevisionStatus } from "../clientUtils/owidTypes"
 
 export interface SuggestedChartRevisionListItem {
     id: number

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -22,7 +22,7 @@ import {
     GrapherInterface,
     grapherKeysToSerialize,
 } from "../grapher/core/GrapherInterface"
-import { SuggestedChartRevisionStatus } from "../adminSiteClient/SuggestedChartRevision"
+import { SuggestedChartRevisionStatus } from "../clientUtils/owidTypes"
 import {
     VariableAnnotationsResponse,
     VariableAnnotationPatch,

--- a/baker/tsconfig.json
+++ b/baker/tsconfig.json
@@ -10,6 +10,7 @@
         { "path": "../db" },
         { "path": "../settings" },
         { "path": "../clientUtils" },
-        { "path": "../serverUtils" }
+        { "path": "../serverUtils" },
+        { "path": "../gitCms" }
     ]
 }

--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -265,6 +265,13 @@ export interface FullPost {
     glossary: boolean
 }
 
+export enum SuggestedChartRevisionStatus {
+    pending = "pending",
+    approved = "approved",
+    rejected = "rejected",
+    flagged = "flagged",
+}
+
 // Exception format that can be easily given as an API error
 export class JsonError extends Error {
     status: number

--- a/db/model/SuggestedChartRevision.ts
+++ b/db/model/SuggestedChartRevision.ts
@@ -1,6 +1,6 @@
 import { Entity, PrimaryGeneratedColumn, Column, BaseEntity } from "typeorm"
 
-import { SuggestedChartRevisionStatus } from "../../adminSiteClient/SuggestedChartRevision"
+import { SuggestedChartRevisionStatus } from "../../clientUtils/owidTypes"
 
 @Entity("suggested_chart_revisions")
 export class SuggestedChartRevision extends BaseEntity {

--- a/db/tsconfig.json
+++ b/db/tsconfig.json
@@ -7,7 +7,7 @@
     },
     "references": [
         { "path": "../clientUtils" },
-        { "path": "../adminSiteClient" },
-        { "path": "../settings" }
+        { "path": "../settings" },
+        { "path": "../grapher" }
     ]
 }

--- a/devTools/project-dependencies.md
+++ b/devTools/project-dependencies.md
@@ -39,14 +39,15 @@ graph TD;
     baker --> clientUtils;
     baker --> db;
     baker --> explorerAdminServer;
+    baker --> gitCms;
     baker --> serverUtils;
     baker --> settings;
     baker --> site;
 
     coreTable --> clientUtils;
 
-    db --> adminSiteClient;
     db --> clientUtils;
+    db --> grapher;
     db --> settings;
 
     explorer --> clientUtils;


### PR DESCRIPTION
This is part 1 of ♾️ of the #1082 work.

I noticed that `db` had a dependency on `adminSiteClient`, which is a red flag really. Thankfully, the dependency only existed because of an enum import, and could be resolved by using this type to `owidTypes` in the bottom `clientUtils` module.

I also realized that TS project references are transitive (i.e. if A -> B and B -> C, then A can also import modules from C without explicitly listing C), so the `project-dependencies.md` graph doesn't even reflect all the various interdependencies that we have.