### PR TITLE
Map sparklines #1: Prep work

### DIFF
--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -11,14 +11,14 @@ import {
     uniqBy,
     intersectionOfSets,
     isNumber,
-} from "../clientUtils/Util"
+} from "../clientUtils/Util.js"
 import { isPresent } from "../clientUtils/isPresent.js"
 import {
     CoreColumn,
     ColumnTypeMap,
     MissingColumn,
     TimeColumn,
-} from "./CoreTableColumns"
+} from "./CoreTableColumns.js"
 import {
     CoreColumnStore,
     CoreRow,

--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -11,9 +11,14 @@ import {
     uniqBy,
     intersectionOfSets,
     isNumber,
-} from "../clientUtils/Util.js"
+} from "../clientUtils/Util"
 import { isPresent } from "../clientUtils/isPresent.js"
-import { CoreColumn, ColumnTypeMap, MissingColumn } from "./CoreTableColumns.js"
+import {
+    CoreColumn,
+    ColumnTypeMap,
+    MissingColumn,
+    TimeColumn,
+} from "./CoreTableColumns"
 import {
     CoreColumnStore,
     CoreRow,
@@ -422,7 +427,7 @@ export class CoreTable<
     // TODO: remove this. Currently we use this to get the right day/year time formatting. For now a chart is either a "day chart" or a "year chart".
     // But we can have charts with multiple time columns. Ideally each place that needs access to the timeColumn, would get the specific column
     // and not the first time column from the table.
-    @imemo get timeColumn(): CoreColumn {
+    @imemo get timeColumn(): TimeColumn | MissingColumn {
         // "time" is the canonical time column slug.
         // See LegacyToOwidTable where this column is injected for all Graphers.
         const maybeTimeColumn = this.get(OwidTableSlugs.time)
@@ -431,10 +436,9 @@ export class CoreTable<
         // If a valid "time" column doesn't exist, find _some_ time column to use.
         // This is somewhat unreliable and currently only used to infer the time
         // column on explorers.
-        return (
-            this.columnsAsArray.find(
-                (col) => col instanceof ColumnTypeMap.Day
-            ) ??
+        return (this.columnsAsArray.find(
+            (col) => col instanceof ColumnTypeMap.Day
+        ) ??
             this.columnsAsArray.find(
                 (col) => col instanceof ColumnTypeMap.Date
             ) ??
@@ -444,8 +448,7 @@ export class CoreTable<
             this.columnsAsArray.find(
                 (col) => col instanceof ColumnTypeMap.Quarter
             ) ??
-            maybeTimeColumn
-        )
+            maybeTimeColumn) as TimeColumn | MissingColumn
     }
 
     // todo: should be on owidtable

--- a/coreTable/CoreTableColumns.ts
+++ b/coreTable/CoreTableColumns.ts
@@ -642,8 +642,10 @@ class EntityCodeColumn extends CategoricalColumn {}
 class EntityNameColumn extends CategoricalColumn {}
 
 // todo: cleanup time columns. current schema is a little incorrect.
-abstract class TimeColumn extends AbstractCoreColumn<number> {
+export abstract class TimeColumn extends AbstractCoreColumn<number> {
     jsType = JsTypes.number
+
+    abstract preposition: string
 
     parse(val: any): number | ErrorValue {
         return parseInt(val)
@@ -651,6 +653,8 @@ abstract class TimeColumn extends AbstractCoreColumn<number> {
 }
 
 class YearColumn extends TimeColumn {
+    preposition = "in"
+
     formatValue(value: number): string {
         // Include BCE
         return formatYear(value)
@@ -658,6 +662,8 @@ class YearColumn extends TimeColumn {
 }
 
 class DayColumn extends TimeColumn {
+    preposition = "on"
+
     formatValue(value: number): string {
         return formatDay(value)
     }
@@ -689,6 +695,8 @@ class DateColumn extends DayColumn {
 }
 
 class QuarterColumn extends TimeColumn {
+    preposition = "in"
+
     private static regEx = /^([+-]?\d+)-Q([1-4])$/
 
     parse(val: any): number | ErrorValue {

--- a/coreTable/CoreTableUtils.ts
+++ b/coreTable/CoreTableUtils.ts
@@ -29,7 +29,7 @@ import {
     OwidEntityIdColumnDef,
     OwidEntityNameColumnDef,
     OwidTableSlugs,
-} from "./OwidTableConstants"
+} from "./OwidTableConstants.js"
 import { ColumnSlug } from "../clientUtils/owidTypes.js"
 import { CoreColumn, TimeColumn } from "./CoreTableColumns.js"
 

--- a/coreTable/CoreTableUtils.ts
+++ b/coreTable/CoreTableUtils.ts
@@ -29,8 +29,9 @@ import {
     OwidEntityIdColumnDef,
     OwidEntityNameColumnDef,
     OwidTableSlugs,
-} from "./OwidTableConstants.js"
+} from "./OwidTableConstants"
 import { ColumnSlug } from "../clientUtils/owidTypes.js"
+import { CoreColumn, TimeColumn } from "./CoreTableColumns.js"
 
 export const columnStoreToRows = (
     columnStore: CoreColumnStore
@@ -690,3 +691,6 @@ export const emptyColumnsInFirstRowInDelimited = (str: string): string[] => {
     })
     return emptySlugs
 }
+
+export const getPreposition = (col: TimeColumn | CoreColumn): string =>
+    col instanceof TimeColumn ? col.preposition : "in"

--- a/coreTable/CoreTableUtils.ts
+++ b/coreTable/CoreTableUtils.ts
@@ -520,18 +520,6 @@ export const renameColumnStore = (
     return newStore
 }
 
-export const replaceCells = (
-    columnStore: CoreColumnStore,
-    columnSlugs: ColumnSlug[],
-    replaceFn: (val: CoreValueType) => CoreValueType
-): CoreColumnStore => {
-    const newStore: CoreColumnStore = { ...columnStore }
-    columnSlugs.forEach((slug) => {
-        newStore[slug] = newStore[slug].map(replaceFn)
-    })
-    return newStore
-}
-
 // Returns a Set of random indexes to drop in an array, preserving the order of the array
 export const getDropIndexes = (
     arrayLength: number,

--- a/grapher/axis/Axis.test.ts
+++ b/grapher/axis/Axis.test.ts
@@ -116,3 +116,51 @@ it("a single-value domain plots to lower or upper end of range", () => {
     expect(axis.place(0)).toEqual(0)
     expect(axis.place(1)).toEqual(500)
 })
+
+describe("manual ticks", () => {
+    const defaultConfig: AxisConfigInterface = {
+        ticks: [
+            { value: -1, priority: 1 },
+            { value: -Infinity, priority: 1 },
+            { value: 49.5, priority: 1 },
+            { value: 99, priority: 2 },
+            { value: Infinity, priority: 1 },
+        ],
+    }
+    const defaultAxis = new AxisConfig(defaultConfig, {
+        fontSize: 16,
+    }).toHorizontalAxis()
+    defaultAxis.domain = [0, 100]
+    defaultAxis.range = [0, 300]
+    defaultAxis.hideFractionalTicks = true // should have no effect
+
+    it("hides manual ticks outside the axis domain", () => {
+        expect(
+            defaultAxis.getTickValues().map((tick) => tick.value)
+        ).not.toContain(-1)
+    })
+
+    it("includes manually specified ticks", () => {
+        expect(defaultAxis.getTickValues().map((tick) => tick.value)).toEqual(
+            expect.arrayContaining([49.5, 99])
+        )
+    })
+
+    it("replaces ±infinity with min/max of the data", () => {
+        expect(defaultAxis.getTickValues().map((tick) => tick.value)).toEqual(
+            expect.arrayContaining([0, 100])
+        )
+    })
+
+    it("doesn't generate any automatic ticks", () => {
+        expect(
+            defaultAxis.getTickValues().map((tick) => tick.value)
+        ).toHaveLength(4)
+    })
+
+    it("hides tick labels that overlap", () => {
+        expect(
+            defaultAxis.tickLabels.map((label) => label.value)
+        ).not.toContain(99)
+    })
+})

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -18,7 +18,7 @@ import {
     Position,
     ScaleType,
     VerticalAlign,
-} from "../../clientUtils/owidTypes"
+} from "../../clientUtils/owidTypes.js"
 import { TickFormattingOptions } from "../../clientUtils/formatValue.js"
 import { Tickmark } from "./AxisConfigInterface.js"
 

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -67,7 +67,6 @@ abstract class AbstractAxis {
     @observable.ref domain: ValueRange
     @observable formatColumn?: CoreColumn // Pass the column purely for formatting reasons. Might be a better way to do this.
     @observable hideFractionalTicks = false
-    @observable hideGridlines = false
     @observable.struct range: ValueRange = [0, 0]
     @observable private _scaleType?: ScaleType
     @observable private _label?: string
@@ -90,6 +89,10 @@ abstract class AbstractAxis {
 
     @computed get hideAxis(): boolean {
         return this.config.hideAxis ?? false
+    }
+
+    @computed get hideGridlines(): boolean {
+        return this.config.hideGridlines ?? false
     }
 
     @computed get labelPadding(): number {
@@ -151,7 +154,6 @@ abstract class AbstractAxis {
         this.formatColumn = parentAxis.formatColumn
         this.domain = parentAxis.domain.slice() as ValueRange
         this.hideFractionalTicks = parentAxis.hideFractionalTicks
-        this.hideGridlines = parentAxis.hideGridlines
         this.range = parentAxis.range.slice() as ValueRange
         this._scaleType = parentAxis._scaleType
         this._label = parentAxis._label

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -18,15 +18,9 @@ import {
     Position,
     ScaleType,
     VerticalAlign,
-} from "../../clientUtils/owidTypes.js"
+} from "../../clientUtils/owidTypes"
 import { TickFormattingOptions } from "../../clientUtils/formatValue.js"
-
-interface Tickmark {
-    value: number
-    priority: number
-    faint?: boolean
-    gridLineOnly?: boolean
-}
+import { Tickmark } from "./AxisConfigInterface.js"
 
 interface TickLabelPlacement {
     value: number
@@ -196,7 +190,19 @@ abstract class AbstractAxis {
         const { scaleType, d3_scale } = this
 
         let ticks: Tickmark[]
-        if (scaleType === ScaleType.log) {
+
+        if (this.config.ticks) {
+            // If custom ticks are supplied, use them without any transformations or additions.
+            const [minValue, maxValue] = d3_scale.domain()
+            return (
+                this.config.ticks
+                    // filter out custom ticks outside the plottable area
+                    .filter(
+                        (tick) =>
+                            tick.value >= minValue && tick.value <= maxValue
+                    )
+            )
+        } else if (scaleType === ScaleType.log) {
             // Show a bit more ticks for log axes
             const maxLabelledTicks = Math.round(this.totalTicksTarget * 1.25)
             const maxTicks = Math.round(this.totalTicksTarget * 3)

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -196,6 +196,14 @@ abstract class AbstractAxis {
             const [minValue, maxValue] = d3_scale.domain()
             return (
                 this.config.ticks
+                    // replace ±Infinity with minimum/maximum
+                    .map((tick) => {
+                        if (tick.value === -Infinity)
+                            return { ...tick, value: minValue }
+                        if (tick.value === Infinity)
+                            return { ...tick, value: maxValue }
+                        return tick
+                    })
                     // filter out custom ticks outside the plottable area
                     .filter(
                         (tick) =>

--- a/grapher/axis/AxisConfig.ts
+++ b/grapher/axis/AxisConfig.ts
@@ -9,7 +9,7 @@ import { HorizontalAxis, VerticalAxis } from "./Axis.js"
 import {
     deleteRuntimeAndUnchangedProps,
     Persistable,
-} from "../../clientUtils/persistable/Persistable"
+} from "../../clientUtils/persistable/Persistable.js"
 import { AxisConfigInterface, Tickmark } from "./AxisConfigInterface.js"
 import { ScaleSelectorManager } from "../controls/ScaleSelector.js"
 import { Position } from "../../clientUtils/owidTypes.js"

--- a/grapher/axis/AxisConfig.ts
+++ b/grapher/axis/AxisConfig.ts
@@ -9,8 +9,8 @@ import { HorizontalAxis, VerticalAxis } from "./Axis.js"
 import {
     deleteRuntimeAndUnchangedProps,
     Persistable,
-} from "../../clientUtils/persistable/Persistable.js"
-import { AxisConfigInterface } from "./AxisConfigInterface.js"
+} from "../../clientUtils/persistable/Persistable"
+import { AxisConfigInterface, Tickmark } from "./AxisConfigInterface.js"
 import { ScaleSelectorManager } from "../controls/ScaleSelector.js"
 import { Position } from "../../clientUtils/owidTypes.js"
 
@@ -33,6 +33,7 @@ class AxisConfigDefaults implements AxisConfigInterface {
     @observable.ref compactLabels?: boolean = undefined
     @observable.ref scaleType?: ScaleType = ScaleType.linear
     @observable.ref facetDomain?: FacetAxisDomain = undefined
+    @observable.ref ticks?: Tickmark[] = undefined
     @observable.ref label: string = ""
 }
 
@@ -73,6 +74,7 @@ export class AxisConfig
             scaleType: this.scaleType,
             label: this.label ? this.label : undefined,
             facetDomain: this.facetDomain,
+            ticks: this.ticks,
         })
 
         deleteRuntimeAndUnchangedProps(obj, new AxisConfigDefaults())

--- a/grapher/axis/AxisConfig.ts
+++ b/grapher/axis/AxisConfig.ts
@@ -26,6 +26,7 @@ class AxisConfigDefaults implements AxisConfigInterface {
     @observable.ref removePointsOutsideDomain?: boolean = undefined
     @observable.ref minSize?: number = undefined
     @observable.ref hideAxis?: boolean = undefined
+    @observable.ref hideGridlines?: boolean = undefined
     @observable.ref labelPadding?: number = undefined
     @observable.ref nice?: boolean = undefined
     @observable.ref maxTicks?: number = undefined
@@ -64,6 +65,7 @@ export class AxisConfig
             removePointsOutsideDomain: this.removePointsOutsideDomain,
             minSize: this.minSize,
             hideAxis: this.hideAxis,
+            hideGridlines: this.hideGridlines,
             labelPadding: this.labelPadding,
             nice: this.nice,
             maxTicks: this.maxTicks,

--- a/grapher/axis/AxisConfigInterface.ts
+++ b/grapher/axis/AxisConfigInterface.ts
@@ -11,6 +11,9 @@ export interface AxisConfigInterface {
     removePointsOutsideDomain?: boolean
     hideAxis?: boolean
 
+    /** Hide the faint lines that are shown inside the plot (axis ticks may still be visible). */
+    hideGridlines?: boolean
+
     /**
      * The *preferred* orientation of the axis.
      * If the orientation is not supported by the axis, this parameter will be ignored.

--- a/grapher/axis/AxisConfigInterface.ts
+++ b/grapher/axis/AxisConfigInterface.ts
@@ -64,6 +64,8 @@ export interface AxisConfigInterface {
 
     /**
      * Custom ticks to use. Any automatic ticks are omitted.
+     * Note that the ticks will be omitted if they are outside the axis domain.
+     * To control the domain, use `min` and `max`.
      */
     ticks?: Tickmark[]
 }

--- a/grapher/axis/AxisConfigInterface.ts
+++ b/grapher/axis/AxisConfigInterface.ts
@@ -1,6 +1,13 @@
 import { Position } from "../../clientUtils/owidTypes.js"
 import { FacetAxisDomain, ScaleType } from "../core/GrapherConstants.js"
 
+export interface Tickmark {
+    value: number
+    priority: number
+    faint?: boolean
+    gridLineOnly?: boolean
+}
+
 // Represents the actual entered configuration state in the editor
 export interface AxisConfigInterface {
     scaleType?: ScaleType
@@ -54,4 +61,9 @@ export interface AxisConfigInterface {
      * Whether to use short labels, e.g. "5k" instead of "5,000".
      */
     compactLabels?: boolean
+
+    /**
+     * Custom ticks to use. Any automatic ticks are omitted.
+     */
+    ticks?: Tickmark[]
 }

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -650,7 +650,7 @@ export class DiscreteBarChart
     defaultBaseColorScheme = ColorSchemeName.YlGnBu
     defaultNoDataColor = "#959595"
     transformColor = darkenColorForLine
-    colorScale = new ColorScale(this)
+    colorScale = this.props.manager.colorScaleOverride ?? new ColorScale(this)
 
     // End of color scale props
 

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -312,8 +312,10 @@ export class DiscreteBarChart
     }
 
     componentDidMount(): void {
-        this.d3Bars().attr("width", 0)
-        this.animateBarWidth()
+        if (!this.manager.disableIntroAnimation) {
+            this.d3Bars().attr("width", 0)
+            this.animateBarWidth()
+        }
         exposeInstanceOnWindow(this)
     }
 
@@ -321,7 +323,7 @@ export class DiscreteBarChart
         // Animating the bar width after a render ensures there's no race condition, where the
         // initial animation (in componentDidMount) did override the now-changed bar width in
         // some cases. Updating the animation with the updated bar widths fixes that.
-        this.animateBarWidth()
+        if (!this.manager.disableIntroAnimation) this.animateBarWidth()
     }
 
     render(): JSX.Element {

--- a/grapher/chart/ChartManager.ts
+++ b/grapher/chart/ChartManager.ts
@@ -78,4 +78,5 @@ export interface ChartManager {
     resetAnnotation?: () => void
 
     externalLegendFocusBin?: ColorScaleBin | undefined
+    disableIntroAnimation?: boolean
 }

--- a/grapher/chart/ChartManager.ts
+++ b/grapher/chart/ChartManager.ts
@@ -20,6 +20,7 @@ import {
 import { ColorScaleBin } from "../color/ColorScaleBin.js"
 import { CoreColumn } from "../../coreTable/CoreTableColumns.js"
 import { TimeBound } from "../../clientUtils/TimeBounds.js"
+import { ColorScale } from "../color/ColorScale.js"
 
 // The possible options common across our chart types. Not all of these apply to every chart type, so there is room to create a better type hierarchy.
 
@@ -46,6 +47,8 @@ export interface ChartManager {
     colorScale?: Readonly<ColorScaleConfigInterface>
     // for consistent automatic color scales across facets
     colorScaleColumnOverride?: CoreColumn
+    // for passing colorScale to sparkline in map charts
+    colorScaleOverride?: ColorScale
 
     yAxisConfig?: Readonly<AxisConfigInterface>
     xAxisConfig?: Readonly<AxisConfigInterface>

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1481,6 +1481,10 @@ export class Grapher
         return staticSvg
     }
 
+    @computed get disableIntroAnimation(): boolean {
+        return this.isExportingtoSvgOrPng
+    }
+
     @computed get mapConfig(): MapConfig {
         return this.map
     }

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -392,9 +392,12 @@ export class LineChart
     }
 
     @computed private get lineStrokeWidth(): number {
-        return this.manager.lineStrokeWidth ?? this.hasColorScale
-            ? VARIABLE_COLOR_STROKE_WIDTH
-            : DEFAULT_STROKE_WIDTH
+        return (
+            this.manager.lineStrokeWidth ??
+            (this.hasColorScale
+                ? VARIABLE_COLOR_STROKE_WIDTH
+                : DEFAULT_STROKE_WIDTH)
+        )
     }
 
     @computed private get lineOutlineWidth(): number {

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -640,11 +640,9 @@ export class LineChart
         unknown
     >
     componentDidMount(): void {
-        if (
-            !this.manager.isExportingtoSvgOrPng &&
-            !this.manager.disableIntroAnimation
-        )
+        if (!this.manager.disableIntroAnimation) {
             this.runFancyIntroAnimation()
+        }
         exposeInstanceOnWindow(this)
     }
 

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -844,7 +844,7 @@ export class LineChart
     defaultBaseColorScheme = ColorSchemeName.YlGnBu
     defaultNoDataColor = "#959595"
     transformColor = darkenColorForLine
-    colorScale = new ColorScale(this)
+    colorScale = this.props.manager.colorScaleOverride ?? new ColorScale(this)
 
     private getColorScaleColor(value: CoreValueType | undefined): Color {
         return this.colorScale.getColor(value) ?? DEFAULT_LINE_COLOR

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -759,7 +759,7 @@ export class LineChart
                                     key={getSeriesKey(series)}
                                     cx={horizontalAxis.place(value.x)}
                                     cy={verticalAxis.place(value.y)}
-                                    r={4}
+                                    r={this.lineStrokeWidth / 2 + 3.5}
                                     fill={
                                         this.hasColorScale
                                             ? this.getColorScaleColor(
@@ -767,6 +767,8 @@ export class LineChart
                                               )
                                             : series.color
                                     }
+                                    stroke="#fff"
+                                    strokeWidth={0.5}
                                 />
                             )
                         })}

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -1113,7 +1113,13 @@ export class LineChart
     }
 
     @computed private get xAxisConfig(): AxisConfig {
-        return new AxisConfig(this.manager.xAxisConfig, this)
+        return new AxisConfig(
+            {
+                hideGridlines: true,
+                ...this.manager.xAxisConfig,
+            },
+            this
+        )
     }
 
     @computed private get horizontalAxisPart(): HorizontalAxis {
@@ -1124,7 +1130,6 @@ export class LineChart
         axis.scaleType = ScaleType.linear
         axis.formatColumn = this.inputTable.timeColumn
         axis.hideFractionalTicks = true
-        axis.hideGridlines = true
         return axis
     }
 

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -740,6 +740,13 @@ export class LineChart
                 </g>
                 {hoverX !== undefined && (
                     <g className="hoverIndicator">
+                        <line
+                            x1={horizontalAxis.place(hoverX)}
+                            y1={verticalAxis.range[0]}
+                            x2={horizontalAxis.place(hoverX)}
+                            y2={verticalAxis.range[1]}
+                            stroke="rgba(180,180,180,.4)"
+                        />
                         {this.series.map((series) => {
                             const value = series.points.find(
                                 (point) => point.x === hoverX
@@ -763,13 +770,6 @@ export class LineChart
                                 />
                             )
                         })}
-                        <line
-                            x1={horizontalAxis.place(hoverX)}
-                            y1={verticalAxis.range[0]}
-                            x2={horizontalAxis.place(hoverX)}
-                            y2={verticalAxis.range[1]}
-                            stroke="rgba(180,180,180,.4)"
-                        />
                     </g>
                 )}
 

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -640,7 +640,11 @@ export class LineChart
         unknown
     >
     componentDidMount(): void {
-        if (!this.manager.isExportingtoSvgOrPng) this.runFancyIntroAnimation()
+        if (
+            !this.manager.isExportingtoSvgOrPng &&
+            !this.manager.disableIntroAnimation
+        )
+            this.runFancyIntroAnimation()
         exposeInstanceOnWindow(this)
     }
 

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -384,21 +384,23 @@ export class MapChart
     hasNoDataBin = true
 
     componentDidMount(): void {
-        select(this.base.current)
-            .selectAll(`.${CHOROPLETH_MAP_CLASSNAME} path`)
-            .attr("data-fill", function () {
-                return (this as SVGPathElement).getAttribute("fill")
-            })
-            .attr("fill", this.colorScale.noDataColor)
-            .transition()
-            .duration(500)
-            .ease(easeCubic)
-            .attr("fill", function () {
-                return (this as SVGPathElement).getAttribute("data-fill")
-            })
-            .attr("data-fill", function () {
-                return (this as SVGPathElement).getAttribute("fill")
-            })
+        if (!this.manager.disableIntroAnimation) {
+            select(this.base.current)
+                .selectAll(`.${CHOROPLETH_MAP_CLASSNAME} path`)
+                .attr("data-fill", function () {
+                    return (this as SVGPathElement).getAttribute("fill")
+                })
+                .attr("fill", this.colorScale.noDataColor)
+                .transition()
+                .duration(500)
+                .ease(easeCubic)
+                .attr("fill", function () {
+                    return (this as SVGPathElement).getAttribute("data-fill")
+                })
+                .attr("data-fill", function () {
+                    return (this as SVGPathElement).getAttribute("fill")
+                })
+        }
         exposeInstanceOnWindow(this)
     }
 

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -209,15 +209,20 @@ export class MapChart
         return ""
     }
 
-    @computed get mapColumn(): CoreColumn {
-        return this.transformedTable.get(this.mapColumnSlug)
-    }
-
     @computed get mapColumnSlug(): string {
         return (
             this.manager.mapColumnSlug ??
             autoDetectYColumnSlugs(this.manager)[0]!
         )
+    }
+
+    @computed private get mapColumn(): CoreColumn {
+        return this.transformedTable.get(this.mapColumnSlug)
+    }
+
+    // The map column without tolerance and timeline filtering applied
+    @computed private get mapColumnUntransformed(): CoreColumn {
+        return this.dropNonMapEntities(this.inputTable).get(this.mapColumnSlug)
     }
 
     @computed private get targetTime(): number | undefined {
@@ -361,9 +366,9 @@ export class MapChart
     }
 
     @computed get colorScaleColumn(): CoreColumn {
-        // Use the table before transform to build the legend.
-        // Otherwise the legend jumps around as you slide the timeline handle.
-        return this.dropNonMapEntities(this.inputTable).get(this.mapColumnSlug)
+        // Use the table before any transforms to collect all possible values over time.
+        // Otherwise the legend changes as you slide the timeline handle.
+        return this.mapColumnUntransformed
     }
 
     colorScale = new ColorScale(this)

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -632,10 +632,15 @@ export class ScatterPlotChart
     colorScale = new ColorScale(this)
 
     @computed get colorScaleColumn(): CoreColumn {
-        // We need to use inputTable in order to get consistent coloring for a variable across
-        // charts, e.g. each continent being assigned to the same color.
-        // inputTable is unfiltered, so it contains every value that exists in the variable.
-        return this.inputTable.get(this.colorColumnSlug)
+        return (
+            // For faceted charts, we have to get the values of inputTable before it's filtered by
+            // the faceting logic.
+            this.manager.colorScaleColumnOverride ??
+            // We need to use inputTable in order to get consistent coloring for a variable across
+            // charts, e.g. each continent being assigned to the same color.
+            // inputTable is unfiltered, so it contains every value that exists in the variable.
+            this.inputTable.get(this.colorColumnSlug)
+        )
     }
 
     @computed get colorScaleConfig(): ColorScaleConfigDefaults | undefined {

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -521,6 +521,7 @@ export class ScatterPlotChart
                 sizeDomain={sizeDomain}
                 focusedSeriesNames={focusedEntityNames}
                 hoveredSeriesNames={hoveredSeriesNames}
+                disableIntroAnimation={this.manager.disableIntroAnimation}
                 onMouseOver={this.onScatterMouseOver}
                 onMouseLeave={this.onScatterMouseLeave}
                 onClick={this.onScatterClick}

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -629,7 +629,7 @@ export class ScatterPlotChart
         return this.bounds.right - this.sidebarWidth
     }
 
-    colorScale = new ColorScale(this)
+    colorScale = this.props.manager.colorScaleOverride ?? new ColorScale(this)
 
     @computed get colorScaleColumn(): CoreColumn {
         return (

--- a/grapher/scatterCharts/ScatterPlotChartConstants.ts
+++ b/grapher/scatterCharts/ScatterPlotChartConstants.ts
@@ -116,4 +116,5 @@ export interface ScatterPointsWithLabelsProps {
     onClick: () => void
     hideConnectedScatterLines: boolean
     noDataModalManager: NoDataModalManager
+    disableIntroAnimation?: boolean
 }

--- a/grapher/scatterCharts/ScatterPointsWithLabels.tsx
+++ b/grapher/scatterCharts/ScatterPointsWithLabels.tsx
@@ -520,7 +520,9 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
     }
 
     componentDidMount(): void {
-        this.runAnimation()
+        if (!this.props.disableIntroAnimation) {
+            this.runAnimation()
+        }
     }
 
     componentWillUnmount(): void {

--- a/grapher/slopeCharts/SlopeChart.tsx
+++ b/grapher/slopeCharts/SlopeChart.tsx
@@ -317,7 +317,11 @@ export class SlopeChart
     }
 
     @computed get colorScaleColumn() {
-        return this.colorColumn
+        return (
+            // For faceted charts, we have to get the values of inputTable before it's filtered by
+            // the faceting logic.
+            this.manager.colorScaleColumnOverride ?? this.colorColumn
+        )
     }
 
     defaultBaseColorScheme = ColorSchemeName.continents

--- a/grapher/slopeCharts/SlopeChart.tsx
+++ b/grapher/slopeCharts/SlopeChart.tsx
@@ -310,7 +310,7 @@ export class SlopeChart
         return ""
     }
 
-    colorScale = new ColorScale(this)
+    colorScale = this.props.manager.colorScaleOverride ?? new ColorScale(this)
 
     @computed get colorScaleConfig() {
         return this.manager.colorScale

--- a/grapher/slopeCharts/SlopeChart.tsx
+++ b/grapher/slopeCharts/SlopeChart.tsx
@@ -1014,7 +1014,9 @@ class LabelledSlopes
     }
 
     componentDidMount() {
-        this.playIntroAnimation()
+        if (!this.manager.disableIntroAnimation) {
+            this.playIntroAnimation()
+        }
     }
 
     private playIntroAnimation() {

--- a/grapher/stackedCharts/AbstractStackedChart.tsx
+++ b/grapher/stackedCharts/AbstractStackedChart.tsx
@@ -131,18 +131,19 @@ export class AbstactStackedChart
 
     base: React.RefObject<SVGGElement> = React.createRef()
     componentDidMount(): void {
-        // Fancy intro animation
-        this.animSelection = select(this.base.current)
-            .selectAll("clipPath > rect")
-            .attr("width", 0)
+        if (!this.manager.disableIntroAnimation) {
+            // Fancy intro animation
+            this.animSelection = select(this.base.current)
+                .selectAll("clipPath > rect")
+                .attr("width", 0)
 
-        this.animSelection
-            .transition()
-            .duration(800)
-            .ease(easeLinear)
-            .attr("width", this.bounds.width)
-            .on("end", () => this.forceUpdate()) // Important in case bounds changes during transition
-
+            this.animSelection
+                .transition()
+                .duration(800)
+                .ease(easeLinear)
+                .attr("width", this.bounds.width)
+                .on("end", () => this.forceUpdate()) // Important in case bounds changes during transition
+        }
         exposeInstanceOnWindow(this)
     }
 

--- a/grapher/stackedCharts/AbstractStackedChart.tsx
+++ b/grapher/stackedCharts/AbstractStackedChart.tsx
@@ -177,7 +177,13 @@ export class AbstactStackedChart
     }
 
     @computed private get xAxisConfig(): AxisConfig {
-        return new AxisConfig(this.manager.xAxisConfig, this)
+        return new AxisConfig(
+            {
+                hideGridlines: true,
+                ...this.manager.xAxisConfig,
+            },
+            this
+        )
     }
 
     @computed private get horizontalAxisPart(): HorizontalAxis {
@@ -187,7 +193,6 @@ export class AbstactStackedChart
         )
         axis.formatColumn = this.inputTable.timeColumn
         axis.hideFractionalTicks = true
-        axis.hideGridlines = true
         return axis
     }
 

--- a/grapher/stackedCharts/MarimekkoChart.tsx
+++ b/grapher/stackedCharts/MarimekkoChart.tsx
@@ -547,10 +547,15 @@ export class MarimekkoChart
     }
 
     @computed get colorScaleColumn(): CoreColumn {
-        // We need to use inputTable in order to get consistent coloring for a variable across
-        // charts, e.g. each continent being assigned to the same color.
-        // inputTable is unfiltered, so it contains every value that exists in the variable.
-        return this.inputTable.get(this.colorColumnSlug)
+        return (
+            // For faceted charts, we have to get the values of inputTable before it's filtered by
+            // the faceting logic.
+            this.manager.colorScaleColumnOverride ??
+            // We need to use inputTable in order to get consistent coloring for a variable across
+            // charts, e.g. each continent being assigned to the same color.
+            // inputTable is unfiltered, so it contains every value that exists in the variable.
+            this.inputTable.get(this.colorColumnSlug)
+        )
     }
     @computed private get sortConfig(): SortConfig {
         return this.manager.sortConfig ?? {}

--- a/grapher/stackedCharts/MarimekkoChart.tsx
+++ b/grapher/stackedCharts/MarimekkoChart.tsx
@@ -538,7 +538,8 @@ export class MarimekkoChart
         return this.transformedTable.get(this.colorColumnSlug)
     }
 
-    colorScale = new ColorScale(this)
+    colorScale = this.props.manager.colorScaleOverride ?? new ColorScale(this)
+
     @computed get colorScaleConfig(): ColorScaleConfigDefaults | undefined {
         return (
             ColorScaleConfig.fromDSL(this.colorColumn.def) ??

--- a/grapher/tooltip/Tooltip.tsx
+++ b/grapher/tooltip/Tooltip.tsx
@@ -43,7 +43,7 @@ export class TooltipView extends React.Component<{
             left: `${x}px`,
             top: `${y}px`,
             whiteSpace: "nowrap",
-            backgroundColor: "rgba(255,255,255,0.92)",
+            backgroundColor: "rgba(255,255,255,0.95)",
             boxShadow: "0 2px 2px rgba(0,0,0,.12), 0 0 1px rgba(0,0,0,.35)",
             borderRadius: "2px",
             textAlign: "left",


### PR DESCRIPTION
This is prep work for implementing https://github.com/owid/owid-grapher/issues/1087.

### Axis

- ⭐ **`ticks` is a config property allowing you to override the automatic tick generation and use manual ticks (it allows showing just the start & end ticks in sparklines). If a tick value is `-Infinity` or `Infinity`, it gets replaced with the minimum or maximum value in the data.**
- `hideGridlines` is now a config property instead of a mutable property of `Axis` (it made things cleaner)

### CoreTable

- ⭐ **Time columns now have prepositions: `in` used for years & quarters, `on` for dates.** (the only place they will be used are sparklines, but we can add them in other places after this is merged)
- `replaceCells` used to be a utility function private to CoreTable, now it's a public method on CoreTable. I had used it for one aspect but ended up not using it in the final version.

### All chart types

- ⭐ **`disableIntroAnimation` GrapherInterface property that disables the animation shown on load**
- Tooltips are more opaque, from 92% to 95%. This is to reduce noise in the background of sparklines, which are harder to interpret because it's a multi-colored line.
- `colorScaleOverride` and `colorScaleColumnOverride` are supported on all chart types. They are currently only used in faceted charts (we want the color scale to be consistent across all facets) and in sparklines (we want the sparkline to use the same color scale as the map chart)

### LineChart

- Fix `lineStrokeWidth` config property being ignored
- Various design details to make it work better as a sparkline, without noticeable differences with full-sized line charts.
