### PR TITLE
Map sparklines #2: Feature work

### DIFF
--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -149,14 +149,29 @@ type OptionalKeysOf<T> = Exclude<
     undefined
 >
 
-type PartialWithoutUndefinedKey<T> = {
+type AllowUndefinedValues<T> = {
     [K in keyof T]: T[K] | undefined
 }
 
+/**
+ * This generic makes every (top-level) optional property in an interface required,
+ * but with `undefined` as an allowed value.
+ *
+ * For example:
+ *     AllKeysRequired<{
+ *         a: number
+ *         b?: number
+ *     }>
+ * becomes:
+ *     {
+ *         a: number
+ *         b: number | undefined
+ *     }
+ */
 // This was tricky to construct.
 // It seems like the initial, elegant approach is:
 //
-// export type NoUndefinedKeys<T> = {
+// export type AllKeysRequired<T> = {
 //     [K in keyof T]-?: T extends Record<K, T[K]> ? T[K] : T[K] | undefined
 // }
 //
@@ -164,7 +179,7 @@ type PartialWithoutUndefinedKey<T> = {
 // make the key required with `-?`. So we have this ugly workaround.
 //
 // -@danielgavrilov, 2022-02-15
-export type NoUndefinedKeys<T> = PartialWithoutUndefinedKey<
+export type AllKeysRequired<T> = AllowUndefinedValues<
     Required<Pick<T, OptionalKeysOf<T>>>
 > &
     Exclude<T, OptionalKeysOf<T>>

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -142,6 +142,33 @@ export type NoUndefinedValues<T> = {
     [P in keyof T]: Required<NonNullable<T[P]>>
 }
 
+type OptionalKeysOf<T> = Exclude<
+    {
+        [K in keyof T]: T extends Record<K, T[K]> ? never : K
+    }[keyof T],
+    undefined
+>
+
+type PartialWithoutUndefinedKey<T> = {
+    [K in keyof T]: T[K] | undefined
+}
+
+// This was tricky to construct.
+// It seems like the initial, elegant approach is:
+//
+// export type NoUndefinedKeys<T> = {
+//     [K in keyof T]-?: T extends Record<K, T[K]> ? T[K] : T[K] | undefined
+// }
+//
+// But TypeScript will omit `undefined` from the value type whenever you
+// make the key required with `-?`. So we have this ugly workaround.
+//
+// -@danielgavrilov, 2022-02-15
+export type NoUndefinedKeys<T> = PartialWithoutUndefinedKey<
+    Required<Pick<T, OptionalKeysOf<T>>>
+> &
+    Exclude<T, OptionalKeysOf<T>>
+
 export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 
 // d3 v6 changed the default minus sign used in d3-format to "−" (Unicode minus sign), which looks

--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -23,7 +23,6 @@ import {
     CoreColumnStore,
     CoreRow,
     CoreTableInputOption,
-    PrimitiveType,
     Time,
     TransformType,
     ValueRange,
@@ -69,7 +68,7 @@ import {
 } from "./ErrorValues.js"
 import { OwidTableSlugs } from "./OwidTableConstants.js"
 import { applyTransforms } from "./Transforms.js"
-import { ColumnSlug } from "../clientUtils/owidTypes.js"
+import { ColumnSlug, PrimitiveType } from "../clientUtils/owidTypes.js"
 
 interface AdvancedOptions {
     tableDescription?: string

--- a/coreTable/CoreTableColumns.ts
+++ b/coreTable/CoreTableColumns.ts
@@ -15,13 +15,7 @@ import {
 } from "../clientUtils/Util.js"
 import { isPresent } from "../clientUtils/isPresent.js"
 import { CoreTable } from "./CoreTable.js"
-import {
-    CoreRow,
-    Time,
-    PrimitiveType,
-    JsTypes,
-    CoreValueType,
-} from "./CoreTableConstants.js"
+import { Time, JsTypes, CoreValueType } from "./CoreTableConstants.js"
 import { ColumnTypeNames, CoreColumnDef } from "./CoreColumnDef.js"
 import { EntityName, OwidVariableRow } from "./OwidTableConstants.js" // todo: remove. Should not be on CoreTable
 import { ErrorValue, ErrorValueTypes, isNotErrorValue } from "./ErrorValues.js"
@@ -34,7 +28,7 @@ import {
     TickFormattingOptions,
 } from "../clientUtils/formatValue.js"
 import { OwidVariableDisplayConfigInterface } from "../clientUtils/OwidVariableDisplayConfigInterface.js"
-import { ColumnSlug } from "../clientUtils/owidTypes.js"
+import { ColumnSlug, PrimitiveType } from "../clientUtils/owidTypes.js"
 
 interface ColumnSummary {
     numErrorValues: number

--- a/coreTable/CoreTableConstants.ts
+++ b/coreTable/CoreTableConstants.ts
@@ -1,3 +1,4 @@
+import { PrimitiveType } from "../clientUtils/owidTypes.js"
 import { ErrorValue } from "./ErrorValues.js"
 
 export type TableSlug = string // a url friendly name for a table
@@ -19,7 +20,6 @@ export type Color = string
 export type Time = Integer
 export type TimeRange = [Time, Time]
 
-export type PrimitiveType = number | string | boolean
 export type ValueRange = [number, number]
 
 export type TimeTolerance = Integer

--- a/coreTable/OwidTableConstants.ts
+++ b/coreTable/OwidTableConstants.ts
@@ -1,13 +1,6 @@
-import {
-    CoreRow,
-    Integer,
-    PrimitiveType,
-    Time,
-    Year,
-} from "./CoreTableConstants.js"
+import { CoreRow, Integer, Time, Year } from "./CoreTableConstants.js"
 import { ColumnTypeNames, CoreColumnDef } from "./CoreColumnDef.js"
-import { OwidSource } from "../clientUtils/OwidSource.js"
-import { ColumnSlug } from "../clientUtils/owidTypes.js"
+import { ColumnSlug, PrimitiveType } from "../clientUtils/owidTypes.js"
 
 export enum OwidTableSlugs {
     entityName = "entityName",

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -60,10 +60,7 @@ import {
 import { ColorScheme } from "../color/ColorScheme.js"
 import { SelectionArray } from "../selection/SelectionArray.js"
 import { CoreColumn } from "../../coreTable/CoreTableColumns.js"
-import {
-    CoreValueType,
-    PrimitiveType,
-} from "../../coreTable/CoreTableConstants.js"
+import { CoreValueType } from "../../coreTable/CoreTableConstants.js"
 import { CategoricalBin, ColorScaleBin } from "../color/ColorScaleBin.js"
 import { ColorScale, ColorScaleManager } from "../color/ColorScale.js"
 import {
@@ -75,7 +72,11 @@ import { ColorSchemeName } from "../color/ColorConstants.js"
 import { MultiColorPolyline } from "../scatterCharts/MultiColorPolyline.js"
 import { CategoricalColorAssigner } from "../color/CategoricalColorAssigner.js"
 import { EntityName } from "../../coreTable/OwidTableConstants.js"
-import { Color, HorizontalAlign } from "../../clientUtils/owidTypes.js"
+import {
+    Color,
+    HorizontalAlign,
+    PrimitiveType,
+} from "../../clientUtils/owidTypes.js"
 import {
     darkenColorForHighContrastText,
     darkenColorForLine,

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -322,7 +322,7 @@ export class MapChart
         this.mapConfig.projection = value
     }
 
-    @computed private get formatTooltipValue(): (d: PrimitiveType) => string {
+    @computed private get formatTooltipValue(): (d: number | string) => string {
         const { mapConfig, mapColumn, colorScale } = this
 
         return (d: PrimitiveType): string => {

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -66,7 +66,11 @@ import { NoDataModal } from "../noDataModal/NoDataModal.js"
 import { ColorScaleConfig } from "../color/ColorScaleConfig.js"
 import { CoreColumn } from "../../coreTable/CoreTableColumns.js"
 import { SelectionArray } from "../selection/SelectionArray.js"
-import { Color, HorizontalAlign } from "../../clientUtils/owidTypes.js"
+import {
+    Color,
+    HorizontalAlign,
+    PrimitiveType,
+} from "../../clientUtils/owidTypes.js"
 
 const PROJECTION_CHOOSER_WIDTH = 110
 const PROJECTION_CHOOSER_HEIGHT = 22
@@ -318,10 +322,10 @@ export class MapChart
         this.mapConfig.projection = value
     }
 
-    @computed get formatTooltipValue(): (d: number | string) => string {
+    @computed private get formatTooltipValue(): (d: PrimitiveType) => string {
         const { mapConfig, mapColumn, colorScale } = this
 
-        return (d: number | string): string => {
+        return (d: PrimitiveType): string => {
             if (isString(d)) return d
             else if (mapConfig.tooltipUseCustomLabels) {
                 // Find the bin (and its label) that this value belongs to
@@ -334,8 +338,7 @@ export class MapChart
     }
 
     @computed get series(): ChoroplethSeries[] {
-        const { mapColumn, selectionArray, targetTime, formatTooltipValue } =
-            this
+        const { mapColumn, selectionArray, targetTime } = this
         if (mapColumn.isMissing) return []
         if (targetTime === undefined) return []
 
@@ -346,7 +349,6 @@ export class MapChart
                 if (!color) return undefined
                 return {
                     seriesName: entityName,
-                    displayValue: formatTooltipValue(value),
                     time,
                     value,
                     isSelected: selectionArray.selectedSet.has(entityName),
@@ -590,10 +592,6 @@ export class MapChart
 
         const { projection } = mapConfig
 
-        const tooltipDatum = tooltipTarget
-            ? seriesMap.get(tooltipTarget.featureId)
-            : undefined
-
         return (
             <g ref={this.base} className="mapTab">
                 <ChoroplethMap
@@ -627,13 +625,15 @@ export class MapChart
                 </foreignObject>
                 {tooltipTarget && (
                     <MapTooltip
-                        tooltipDatum={tooltipDatum}
+                        entityName={tooltipTarget?.featureId}
+                        timeSeriesTable={this.inputTable}
+                        formatValue={this.formatTooltipValue}
                         isEntityClickable={this.isEntityClickable(
                             tooltipTarget?.featureId
                         )}
                         tooltipTarget={tooltipTarget}
                         manager={this.manager}
-                        colorScale={this.colorScale}
+                        colorScaleManager={this}
                         targetTime={this.targetTime}
                     />
                 )}

--- a/grapher/mapCharts/MapChartConstants.ts
+++ b/grapher/mapCharts/MapChartConstants.ts
@@ -23,7 +23,6 @@ export interface MapEntity {
 
 export interface ChoroplethSeries extends ChartSeries {
     value: number | string
-    displayValue: string
     time: number
     isSelected?: boolean
     highlightFillColor: Color

--- a/grapher/mapCharts/MapTooltip.jsdom.test.tsx
+++ b/grapher/mapCharts/MapTooltip.jsdom.test.tsx
@@ -25,8 +25,7 @@ test("map tooltip renders iff mouseenter", () => {
     expect(grapherWrapperWithHover.find(".map-tooltip")).toHaveLength(1)
 
     const tooltipWrapper = grapherWrapperWithHover.find(".map-tooltip")
-    expect(tooltipWrapper.find(".bar")).toHaveLength(20)
-    expect(tooltipWrapper.find(".count").text()).toEqual(
-        "4% of children under 5 "
+    expect(tooltipWrapper.find(".value").text()).toEqual(
+        "4% of children under 5"
     )
 })

--- a/grapher/mapCharts/MapTooltip.scss
+++ b/grapher/mapCharts/MapTooltip.scss
@@ -28,6 +28,5 @@
     .value-wrapper.no-plot {
         text-align: center;
         padding: 0;
-        text-align: center;
     }
 }

--- a/grapher/mapCharts/MapTooltip.scss
+++ b/grapher/mapCharts/MapTooltip.scss
@@ -1,79 +1,33 @@
-.map-tooltip {
-    $bar-color: #555555;
-    $highlight-color: $bar-color;
+.map-value-with-sparkline {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
 
-    .time-series-value {
+    .sparkline {
+        flex: 0;
+    }
+
+    .value-wrapper {
+        flex: 1;
+        text-align: left;
         line-height: 1.3;
         white-space: nowrap;
-
-        .count {
-            font-size: 16px;
-            font-weight: 700;
-            display: block;
-            margin-bottom: 1px;
-        }
-
-        .date {
-            font-size: 13px;
-            font-weight: 400;
-            display: block;
-            opacity: 1;
-        }
-
-        .date.latest {
-            font-size: 12px;
-            font-weight: 400;
-            opacity: 0.65;
-        }
-
-        &.current .count {
-            color: $bar-color;
-        }
-
-        &.highlighted {
-            color: $highlight-color;
-        }
-    }
-
-    .bar {
-        background-color: $bar-color;
-
-        &.normal {
-            opacity: 0.25;
-        }
-
-        &.highlighted {
-            background-color: $highlight-color;
-        }
-    }
-
-    .trend {
-        display: flex;
-        height: 100%;
-
-        .plot {
-            flex: 0;
-            margin-bottom: -1px;
-            align-self: flex-end;
-        }
+        padding: 0 0 0 0.75em;
 
         .value {
-            flex: 1;
-            align-self: center;
-            padding-top: 12px;
-            padding-bottom: 12px;
-            padding-left: 12px;
-            padding-right: 12px;
-            text-align: left;
+            font-size: 1.125em;
+            font-weight: 700;
         }
 
-        .value.no-plot {
-            text-align: center;
-            padding-top: 0.3em;
-
-            .count {
-                text-align: center;
-            }
+        .time {
+            font-size: 0.8125em;
+            font-weight: 400;
         }
+    }
+
+    .value-wrapper.no-plot {
+        text-align: center;
+        padding: 0;
+        text-align: center;
     }
 }

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -27,7 +27,7 @@ interface MapTooltipProps {
     entityName: EntityName
     manager: MapChartManager
     colorScaleManager: ColorScaleManager
-    formatValue: (d: PrimitiveType) => string
+    formatValue: (d: number | string) => string
     timeSeriesTable: OwidTable
     tooltipTarget: { x: number; y: number; featureId: string }
     targetTime?: Time
@@ -73,7 +73,9 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
             )
     }
 
-    @computed private get datum(): OwidVariableRow<PrimitiveType> | undefined {
+    @computed private get datum():
+        | OwidVariableRow<number | string>
+        | undefined {
         return this.mapTable.get(this.mapColumnSlug).owidRows[0]
     }
 

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -143,6 +143,9 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                 hideAxis: false,
                 hideGridlines: false,
                 compactLabels: true,
+                // Copy min/max from top-level Grapher config
+                min: this.props.manager.yAxisConfig?.min,
+                max: this.props.manager.yAxisConfig?.max,
                 ticks: [
                     { value: 0, priority: 1 },
                     // Show minimum and maximum

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -22,7 +22,7 @@ import {
     darkenColorForText,
 } from "../color/ColorUtils.js"
 import { getPreposition } from "../../coreTable/CoreTableUtils.js"
-import { isNumber, NoUndefinedKeys } from "../../clientUtils/Util.js"
+import { isNumber, AllKeysRequired } from "../../clientUtils/Util.js"
 
 interface MapTooltipProps {
     entityName: EntityName
@@ -89,7 +89,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
         // Make sure all ColorScaleManager props are included.
         // We can't ...rest here because I think mobx computeds aren't
         // enumerable or something.
-        const newManager: NoUndefinedKeys<ColorScaleManager> = {
+        const newManager: AllKeysRequired<ColorScaleManager> = {
             colorScaleConfig: oldManager.colorScaleConfig,
             hasNoDataBin: oldManager.hasNoDataBin,
             defaultNoDataColor: oldManager.defaultNoDataColor,
@@ -105,7 +105,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
         // Make sure all ColorScaleManager props are included.
         // We can't ...rest here because I think mobx computeds aren't
         // enumerable or something.
-        const newManager: NoUndefinedKeys<ColorScaleManager> = {
+        const newManager: AllKeysRequired<ColorScaleManager> = {
             colorScaleConfig: oldManager.colorScaleConfig,
             hasNoDataBin: oldManager.hasNoDataBin,
             defaultNoDataColor: oldManager.defaultNoDataColor,

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -216,8 +216,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                         fontSize: "1em",
                     }}
                 >
-                    {tooltipTarget.featureId ||
-                        tooltipTarget.featureId.replace(/_/g, " ")}
+                    {tooltipTarget.featureId}
                 </div>
                 <div
                     className="map-tooltip"

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -44,6 +44,13 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
         return this.props.manager.mapColumnSlug
     }
 
+    @computed private get mapAndYColumnAreTheSame(): boolean {
+        const { yColumnSlug, yColumnSlugs, mapColumnSlug } = this.props.manager
+        return yColumnSlugs && mapColumnSlug !== undefined
+            ? yColumnSlugs.includes(mapColumnSlug)
+            : yColumnSlug === mapColumnSlug
+    }
+
     @computed private get entityName(): EntityName {
         return this.props.entityName
     }
@@ -151,9 +158,13 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                 hideAxis: false,
                 hideGridlines: false,
                 compactLabels: true,
-                // Copy min/max from top-level Grapher config
-                min: this.props.manager.yAxisConfig?.min,
-                max: this.props.manager.yAxisConfig?.max,
+                // Copy min/max from top-level Grapher config if Y column == Map column
+                min: this.mapAndYColumnAreTheSame
+                    ? this.props.manager.yAxisConfig?.min
+                    : undefined,
+                max: this.mapAndYColumnAreTheSame
+                    ? this.props.manager.yAxisConfig?.max
+                    : undefined,
                 ticks: [
                     { value: 0, priority: 1 },
                     // Show minimum and maximum

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -37,6 +37,7 @@ interface MapTooltipProps {
 
 const SPARKLINE_WIDTH = 140
 const SPARKLINE_HEIGHT = 60
+const SPARKLINE_PADDING = 7
 
 @observer
 export class MapTooltip extends React.Component<MapTooltipProps> {
@@ -259,7 +260,11 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                                             0,
                                             SPARKLINE_WIDTH,
                                             SPARKLINE_HEIGHT
-                                        ).pad({ top: 7, left: 7, right: 7 })}
+                                        ).pad({
+                                            top: SPARKLINE_PADDING,
+                                            left: SPARKLINE_PADDING,
+                                            right: SPARKLINE_PADDING,
+                                        })}
                                     />
                                 </svg>
                             </div>

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -2,113 +2,106 @@ import React from "react"
 import { computed } from "mobx"
 import { observer } from "mobx-react"
 import { Tooltip } from "../tooltip/Tooltip.js"
-import { takeWhile, last, first, isMobile } from "../../clientUtils/Util.js"
-import {
-    SparkBars,
-    SparkBarsDatum,
-    SparkBarsProps,
-} from "../sparkBars/SparkBars.js"
-import { SparkBarTimeSeriesValue } from "../sparkBars/SparkBarTimeSeriesValue.js"
-import { MapChartManager, ChoroplethSeries } from "./MapChartConstants.js"
-import { ColorScale } from "../color/ColorScale.js"
+import { MapChartManager } from "./MapChartConstants.js"
+import { ColorScale, ColorScaleManager } from "../color/ColorScale.js"
 import { Time } from "../../coreTable/CoreTableConstants.js"
 import { ChartTypeName } from "../core/GrapherConstants.js"
 import { OwidTable } from "../../coreTable/OwidTable.js"
-import { CoreColumn } from "../../coreTable/CoreTableColumns.js"
+import {
+    EntityName,
+    OwidVariableRow,
+} from "../../coreTable/OwidTableConstants.js"
+import { LineChart } from "../lineCharts/LineChart.js"
+import { PrimitiveType } from "../../clientUtils/owidTypes.js"
+import classNames from "classnames"
+import { Bounds } from "../../clientUtils/Bounds.js"
+import { LineChartManager } from "../lineCharts/LineChartConstants.js"
+import {
+    darkenColorForHighContrastText,
+    darkenColorForLine,
+    darkenColorForText,
+} from "../color/ColorUtils.js"
+import { getPreposition } from "../../coreTable/CoreTableUtils.js"
+import { isNumber } from "../../clientUtils/Util.js"
 
 interface MapTooltipProps {
-    tooltipDatum?: ChoroplethSeries
-    tooltipTarget?: { x: number; y: number; featureId: string }
-    isEntityClickable?: boolean
+    entityName: EntityName
     manager: MapChartManager
-    colorScale?: ColorScale
+    colorScaleManager: ColorScaleManager
+    formatValue: (d: PrimitiveType) => string
+    timeSeriesTable: OwidTable
+    tooltipTarget: { x: number; y: number; featureId: string }
     targetTime?: Time
+    isEntityClickable?: boolean
 }
+
+const SPARKLINE_WIDTH = 140
+const SPARKLINE_HEIGHT = 60
 
 @observer
 export class MapTooltip extends React.Component<MapTooltipProps> {
-    private sparkBarsDatumXAccessor = (d: SparkBarsDatum): number => d.time
-
-    @computed private get sparkBarsToDisplay(): number {
-        return isMobile() ? 13 : 20
-    }
-
-    @computed private get sparkBarsProps(): SparkBarsProps<SparkBarsDatum> {
-        return {
-            data: this.sparkBarsData,
-            x: this.sparkBarsDatumXAccessor,
-            y: (d: SparkBarsDatum): number => d.value,
-            xDomain: this.sparkBarsDomain,
-        }
-    }
-
-    @computed get inputTable(): OwidTable {
-        return this.props.manager.table
-    }
-
     @computed private get mapColumnSlug(): string | undefined {
         return this.props.manager.mapColumnSlug
     }
 
-    // Uses the rootTable because if a target year is set, we filter the years at the grapher level.
-    // Todo: might want to do all filtering a step below the Grapher level?
-    @computed private get sparkBarColumn(): CoreColumn {
-        return this.inputTable.rootTable.get(this.mapColumnSlug)
+    @computed private get entityName(): EntityName {
+        return this.props.entityName
     }
 
-    @computed private get sparkBarsData(): SparkBarsDatum[] {
-        const tooltipDatum = this.props.tooltipDatum
-        if (!tooltipDatum) return []
-
-        const sparkBarValues: SparkBarsDatum[] = []
-        this.sparkBarColumn.valueByEntityNameAndOriginalTime
-            .get(tooltipDatum.seriesName)
-            ?.forEach((value, key) => {
-                sparkBarValues.push({
-                    time: key,
-                    value: value as number,
-                })
-            })
-
-        return takeWhile(
-            sparkBarValues,
-            (d) => d.time <= tooltipDatum.time
-        ).slice(-this.sparkBarsToDisplay)
+    // Table pre-filtered by targetTime, exlcudes time series
+    @computed private get mapTable(): OwidTable {
+        const table =
+            this.props.manager.transformedTable ?? this.props.manager.table
+        return table.filterByEntityNames([this.entityName])
     }
 
-    @computed private get sparkBarsDomain(): [number, number] {
-        const lastVal = last(this.sparkBarsData)
-
-        const end = lastVal ? this.sparkBarsDatumXAccessor(lastVal) : 0
-        const start = end > 0 ? end - this.sparkBarsToDisplay + 1 : 0
-
-        return [start, end]
+    @computed private get timeSeriesTable(): OwidTable | undefined {
+        if (this.mapColumnSlug === undefined) return undefined
+        return this.props.timeSeriesTable
+            .filterByEntityNames([this.entityName])
+            .columnFilter(
+                this.mapColumnSlug,
+                isNumber,
+                "Drop rows with non-number values in Y column"
+            )
     }
 
-    @computed private get currentSparkBar(): number | undefined {
-        const lastVal = last(this.sparkBarsData)
-        return lastVal ? this.sparkBarsDatumXAccessor(lastVal) : undefined
+    @computed private get datum(): OwidVariableRow<PrimitiveType> | undefined {
+        return this.mapTable.get(this.mapColumnSlug).owidRows[0]
     }
 
-    colorScale = this.props.colorScale ?? new ColorScale()
-
-    @computed private get renderSparkBars(): boolean | undefined {
-        return this.props.manager.mapIsClickable
+    @computed private get hasTimeSeriesData(): boolean {
+        return this.timeSeriesTable !== undefined
+            ? this.timeSeriesTable.numRows > 1
+            : false
     }
 
-    @computed private get darkestColorInColorScheme(): string | undefined {
-        const { colorScale } = this
-        return colorScale.isColorSchemeInverted
-            ? first(colorScale.baseColors)
-            : last(colorScale.baseColors)
+    @computed private get lineColorScale(): ColorScale {
+        const manager = this.props.colorScaleManager
+        return new ColorScale({
+            colorScaleConfig: manager.colorScaleConfig,
+            hasNoDataBin: manager.hasNoDataBin,
+            defaultNoDataColor: manager.defaultNoDataColor,
+            defaultBaseColorScheme: manager.defaultBaseColorScheme,
+            colorScaleColumn: manager.colorScaleColumn,
+            transformColor: darkenColorForLine,
+        })
     }
 
-    @computed private get barColor(): string | undefined {
-        const { colorScale } = this
-        return colorScale.singleColorScale &&
-            !colorScale.customNumericColorsActive
-            ? this.darkestColorInColorScheme
-            : undefined
+    @computed private get textColorScale(): ColorScale {
+        const manager = this.props.colorScaleManager
+        return new ColorScale({
+            colorScaleConfig: manager.colorScaleConfig,
+            hasNoDataBin: manager.hasNoDataBin,
+            defaultNoDataColor: manager.defaultNoDataColor,
+            defaultBaseColorScheme: manager.defaultBaseColorScheme,
+            colorScaleColumn: manager.colorScaleColumn,
+            transformColor: darkenColorForText,
+        })
+    }
+
+    @computed private get showSparkline(): boolean {
+        return this.hasTimeSeriesData
     }
 
     @computed private get tooltipTarget(): {
@@ -125,25 +118,74 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
         )
     }
 
-    render(): JSX.Element {
-        const { tooltipDatum, isEntityClickable, targetTime, manager } =
-            this.props
+    // Line chart fields
+    @computed private get sparklineTable(): OwidTable {
+        return this.timeSeriesTable ?? new OwidTable()
+    }
+    @computed private get sparklineManager(): LineChartManager {
+        return {
+            table: this.sparklineTable,
+            transformedTable: this.sparklineTable,
+            yColumnSlug: this.mapColumnSlug,
+            colorColumnSlug: this.mapColumnSlug,
+            selection: [this.entityName],
+            colorScaleOverride: this.lineColorScale,
+            hideLegend: true,
+            hidePoints: true,
+            baseFontSize: 11,
+            disableIntroAnimation: true,
+            lineStrokeWidth: 3.5,
+            annotation: {
+                entityName: this.entityName,
+                year: this.datum?.time,
+            },
+            yAxisConfig: {
+                hideAxis: true,
+                hideGridlines: false,
+                compactLabels: true,
+                ticks: [
+                    { value: 0, priority: 1 },
+                    // { value: -Infinity, priority: 2 },
+                    // { value: Infinity, priority: 2 },
+                ],
+            },
+            xAxisConfig: {
+                hideAxis: false,
+                hideGridlines: true,
+                compactLabels: true,
+                // Always show up to the target time on the X axis
+                min: this.props.targetTime,
+                max: this.props.targetTime,
+                // Horizontal axes by default add the start & end ticks,
+                // and we don't need any further ticks.
+                maxTicks: 0,
+            },
+        }
+    }
 
+    render(): JSX.Element {
+        const { tooltipTarget, mapTable, datum, textColorScale } = this
+        const { isEntityClickable, targetTime, manager } = this.props
+
+        // Only LineChart and ScatterPlot allow `mapIsClickable`
         const clickToSelectMessage =
             manager.type === ChartTypeName.LineChart
                 ? "Click for change over time"
                 : "Click to select"
 
-        const { timeColumn } = this.inputTable
-        const { renderSparkBars, barColor, tooltipTarget } = this
-
+        // TODO simplify?
+        const { timeColumn } = mapTable
+        const preposition = getPreposition(timeColumn)
         const displayTime = !timeColumn.isMissing
             ? timeColumn.formatValue(targetTime)
             : targetTime
         const displayDatumTime =
-            timeColumn && tooltipDatum
-                ? timeColumn.formatValue(tooltipDatum.time)
-                : tooltipDatum?.time.toString() ?? ""
+            timeColumn && datum
+                ? timeColumn.formatValue(datum?.time)
+                : datum?.time.toString() ?? ""
+        const valueColor: string | undefined = darkenColorForHighContrastText(
+            textColorScale?.getColor(datum?.value) ?? "#333"
+        )
 
         return (
             <Tooltip
@@ -168,43 +210,55 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                         tooltipTarget.featureId.replace(/_/g, " ")}
                 </h3>
                 <div
+                    className="map-tooltip"
                     style={{
                         margin: 0,
                         padding: "0.3em 0.3em",
                     }}
                 >
-                    {tooltipDatum ? (
-                        <div className="map-tooltip">
-                            <div className="trend">
-                                {renderSparkBars && (
-                                    <div className="plot">
-                                        <SparkBars<SparkBarsDatum>
-                                            {...this.sparkBarsProps}
-                                            currentX={this.currentSparkBar}
-                                            color={barColor}
-                                        />
-                                    </div>
-                                )}
-                                <div
-                                    className={
-                                        "value" +
-                                        (renderSparkBars ? "" : " no-plot")
-                                    }
+                    <div className="map-value-with-sparkline">
+                        {this.showSparkline && (
+                            <div className="sparkline">
+                                <svg
+                                    className="plot"
+                                    width={SPARKLINE_WIDTH}
+                                    height={SPARKLINE_HEIGHT}
                                 >
-                                    <SparkBarTimeSeriesValue
-                                        className="current"
-                                        value={tooltipDatum.displayValue}
-                                        displayDate={displayDatumTime}
-                                        valueColor={
-                                            renderSparkBars ? barColor : "black"
-                                        }
+                                    <LineChart
+                                        manager={this.sparklineManager}
+                                        // Add padding so that the edges of the plot doesn't get clipped.
+                                        // The plot can go out of boundaries due to line stroke thickness.
+                                        bounds={new Bounds(
+                                            0,
+                                            0,
+                                            SPARKLINE_WIDTH,
+                                            SPARKLINE_HEIGHT
+                                        ).pad({ top: 7, left: 7, right: 7 })}
                                     />
-                                </div>
+                                </svg>
+                            </div>
+                        )}
+
+                        <div
+                            className={classNames({
+                                "value-wrapper": true,
+                                "no-plot": !this.showSparkline,
+                            })}
+                        >
+                            <div
+                                className="value"
+                                style={{ color: valueColor }}
+                            >
+                                {datum
+                                    ? this.props.formatValue(datum.value)
+                                    : "No data"}
+                            </div>
+                            <div className="time">
+                                {preposition}{" "}
+                                {datum ? displayDatumTime : displayTime}
                             </div>
                         </div>
-                    ) : (
-                        `No data for ${displayTime}`
-                    )}
+                    </div>
                 </div>
                 {isEntityClickable && (
                     <div>

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -140,25 +140,29 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                 year: this.datum?.time,
             },
             yAxisConfig: {
-                hideAxis: true,
+                hideAxis: false,
                 hideGridlines: false,
                 compactLabels: true,
                 ticks: [
                     { value: 0, priority: 1 },
-                    // { value: -Infinity, priority: 2 },
-                    // { value: Infinity, priority: 2 },
+                    // Show minimum and maximum
+                    { value: -Infinity, priority: 2 },
+                    { value: Infinity, priority: 2 },
                 ],
             },
             xAxisConfig: {
                 hideAxis: false,
                 hideGridlines: true,
                 compactLabels: true,
-                // Always show up to the target time on the X axis
+                // Always show up to the target time on the X axis,
+                // even if there is no data for it.
                 min: this.props.targetTime,
                 max: this.props.targetTime,
-                // Horizontal axes by default add the start & end ticks,
-                // and we don't need any further ticks.
-                maxTicks: 0,
+                ticks: [
+                    // Show minimum and maximum
+                    { value: -Infinity, priority: 1 },
+                    { value: Infinity, priority: 1 },
+                ],
             },
         }
     }

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -205,9 +205,9 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                 offsetY={10}
                 offsetYDirection={"upward"}
             >
-                <h3
+                <div
                     style={{
-                        padding: "0.3em 0.3em",
+                        padding: "0.3em",
                         margin: 0,
                         fontWeight: "normal",
                         fontSize: "1em",
@@ -215,7 +215,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                 >
                     {tooltipTarget.featureId ||
                         tooltipTarget.featureId.replace(/_/g, " ")}
-                </h3>
+                </div>
                 <div
                     className="map-tooltip"
                     style={{

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -22,7 +22,7 @@ import {
     darkenColorForText,
 } from "../color/ColorUtils.js"
 import { getPreposition } from "../../coreTable/CoreTableUtils.js"
-import { isNumber } from "../../clientUtils/Util.js"
+import { isNumber, NoUndefinedKeys } from "../../clientUtils/Util.js"
 
 interface MapTooltipProps {
     entityName: EntityName
@@ -77,27 +77,35 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
     }
 
     @computed private get lineColorScale(): ColorScale {
-        const manager = this.props.colorScaleManager
-        return new ColorScale({
-            colorScaleConfig: manager.colorScaleConfig,
-            hasNoDataBin: manager.hasNoDataBin,
-            defaultNoDataColor: manager.defaultNoDataColor,
-            defaultBaseColorScheme: manager.defaultBaseColorScheme,
-            colorScaleColumn: manager.colorScaleColumn,
+        const oldManager = this.props.colorScaleManager
+        // Make sure all ColorScaleManager props are included.
+        // We can't ...rest here because I think mobx computeds aren't
+        // enumerable or something.
+        const newManager: NoUndefinedKeys<ColorScaleManager> = {
+            colorScaleConfig: oldManager.colorScaleConfig,
+            hasNoDataBin: oldManager.hasNoDataBin,
+            defaultNoDataColor: oldManager.defaultNoDataColor,
+            defaultBaseColorScheme: oldManager.defaultBaseColorScheme,
+            colorScaleColumn: oldManager.colorScaleColumn,
             transformColor: darkenColorForLine,
-        })
+        }
+        return new ColorScale(newManager)
     }
 
     @computed private get textColorScale(): ColorScale {
-        const manager = this.props.colorScaleManager
-        return new ColorScale({
-            colorScaleConfig: manager.colorScaleConfig,
-            hasNoDataBin: manager.hasNoDataBin,
-            defaultNoDataColor: manager.defaultNoDataColor,
-            defaultBaseColorScheme: manager.defaultBaseColorScheme,
-            colorScaleColumn: manager.colorScaleColumn,
+        const oldManager = this.props.colorScaleManager
+        // Make sure all ColorScaleManager props are included.
+        // We can't ...rest here because I think mobx computeds aren't
+        // enumerable or something.
+        const newManager: NoUndefinedKeys<ColorScaleManager> = {
+            colorScaleConfig: oldManager.colorScaleConfig,
+            hasNoDataBin: oldManager.hasNoDataBin,
+            defaultNoDataColor: oldManager.defaultNoDataColor,
+            defaultBaseColorScheme: oldManager.defaultBaseColorScheme,
+            colorScaleColumn: oldManager.colorScaleColumn,
             transformColor: darkenColorForText,
-        })
+        }
+        return new ColorScale(newManager)
     }
 
     @computed private get showSparkline(): boolean {

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -200,7 +200,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                 key="mapTooltip"
                 x={tooltipTarget.x}
                 y={tooltipTarget.y}
-                style={{ textAlign: "center", padding: "8px" }}
+                style={{ textAlign: "center", padding: "0.3em" }}
                 offsetX={15}
                 offsetY={10}
                 offsetYDirection={"upward"}
@@ -220,7 +220,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                     className="map-tooltip"
                     style={{
                         margin: 0,
-                        padding: "0.3em 0.3em",
+                        padding: "0.3em",
                     }}
                 >
                     <div className="map-value-with-sparkline">
@@ -272,7 +272,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                         <p
                             style={{
                                 margin: 0,
-                                padding: "0.3em 0.9em",
+                                padding: "0.3em",
                                 fontSize: "13px",
                                 opacity: 0.6,
                             }}

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -19,7 +19,6 @@ import { LineChartManager } from "../lineCharts/LineChartConstants.js"
 import {
     darkenColorForHighContrastText,
     darkenColorForLine,
-    darkenColorForText,
 } from "../color/ColorUtils.js"
 import { getPreposition } from "../../coreTable/CoreTableUtils.js"
 import { isNumber, AllKeysRequired } from "../../clientUtils/Util.js"
@@ -100,22 +99,6 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
         return new ColorScale(newManager)
     }
 
-    @computed private get textColorScale(): ColorScale {
-        const oldManager = this.props.colorScaleManager
-        // Make sure all ColorScaleManager props are included.
-        // We can't ...rest here because I think mobx computeds aren't
-        // enumerable or something.
-        const newManager: AllKeysRequired<ColorScaleManager> = {
-            colorScaleConfig: oldManager.colorScaleConfig,
-            hasNoDataBin: oldManager.hasNoDataBin,
-            defaultNoDataColor: oldManager.defaultNoDataColor,
-            defaultBaseColorScheme: oldManager.defaultBaseColorScheme,
-            colorScaleColumn: oldManager.colorScaleColumn,
-            transformColor: darkenColorForText,
-        }
-        return new ColorScale(newManager)
-    }
-
     @computed private get showSparkline(): boolean {
         return this.hasTimeSeriesData
     }
@@ -191,7 +174,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
     }
 
     render(): JSX.Element {
-        const { tooltipTarget, mapTable, datum, textColorScale } = this
+        const { tooltipTarget, mapTable, datum, lineColorScale } = this
         const { isEntityClickable, targetTime, manager } = this.props
 
         // Only LineChart and ScatterPlot allow `mapIsClickable`
@@ -211,7 +194,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                 ? timeColumn.formatValue(datum?.time)
                 : datum?.time.toString() ?? ""
         const valueColor: string | undefined = darkenColorForHighContrastText(
-            textColorScale?.getColor(datum?.value) ?? "#333"
+            lineColorScale?.getColor(datum?.value) ?? "#333"
         )
 
         return (


### PR DESCRIPTION
Fixes #1087, continuation of and based on top of #1159.


https://user-images.githubusercontent.com/1308115/154110274-e1a8fe4f-901a-4984-a399-182d7df1e131.mp4

### Preview on playfair
- [Life expectancy map](https://playfair-owid.netlify.app/grapher/life-expectancy) (interesting because UK data starts at 1543 but others much later)
- [Energy embedded in traded goods map](https://playfair-owid.netlify.app/grapher/traded-energy-share-domestic) (diverging color scale, contains negative values)
- [COVID vaccine age map](https://playfair-owid.netlify.app/grapher/covid-vaccine-age) (numerical values are coded to text values)
- [COVID cases map](https://playfair-owid.netlify.app/explorers/coronavirus-data-explorer?tab=map&zoomToSelection=true&time=2021-08-20&facet=none&pickerSort=asc&pickerMetric=location&Interval=7-day+rolling+average&Relative+to+Population=true&Color+by+test+positivity=false&country=~FRA&Metric=Confirmed+cases) (lots of data points, demonstrates potential performance issues)
- [World bank income groups](https://playfair-owid.netlify.app/grapher/world-banks-income-groups?country=ITA~NLD~LIE) (categorical maps have no sparkline)
- [Yaws endemicity and number of cases](https://playfair-owid.netlify.app/grapher/yaws-status-and-case-numbers) (mixed categorical and numeric values, sparkline only shown for numeric, see Cameroon and Indonesia)
- [Excess mortality map](https://playfair-owid.netlify.app/explorers/coronavirus-data-explorer?tab=map&zoomToSelection=true&time=2022-01-31&facet=none&pickerSort=asc&pickerMetric=location&Metric=Excess+mortality+%28%25%29&Interval=Weekly&Relative+to+Population=true&Align+outbreaks=false&country=~FRA) (contains data gaps, faint color scale)

### Design decisions ([discussed on Slack](https://owid.slack.com/archives/C5BDCB2R3/p1644485174789959))

- **Use a colored line**. Sparklines only show the trend, color helps you compare countries by magnitude too (and quickly, without having to read an axis, although less accurate).

- **Show only the minimum & maximum ticks on both the X and Y axes**. 

- **Use `yAxis.min` and `yAxis.max` from the top-level Grapher config** but not any of the other axis config options. The effect of these is that authors often want to show Y=0 line, and it will be shown on sparklines too if that's set up for the top-level chart.

- **Always extend the X axis domain up to the selected time on the timeline (to the past or future)**. This means if the country has data 1990–2000 but 2010 is selected on the timeline, a domain of 1990–2010 will be used for the sparkline (half of the sparkline being blank basically).
   
   Instead of doing this, another option is to keep the X domain of the sparkline identical across all countries. So for the [life expectancy map](http://localhost:3030/grapher/life-expectancy?time=2019) this would mean all sparklines start from 1543, but only UK data start that early, most countries start from 1900s, so I decided not to do it this way.

### Issues

- Because of the way we are plotting the colored line, the coloring can potentially be misleading when you look at it up close. Basically we color the points correctly, but the color transition always happens halfway between points:
  
   <img width="685" alt="multi-color-polyline" src="https://user-images.githubusercontent.com/1308115/154106532-8dedb1a3-952a-48ac-9547-2fb7b159ab0e.png">

   We decided it's not worth addressing for now.

- Charts where the numerical values have been transformed to categorical (using the legend) are a bit unusual and might be confusing for readers:

   <img width="571" alt="Screenshot 2022-02-10 at 18 47 13" src="https://user-images.githubusercontent.com/1308115/154106829-54ad3a91-649b-4de5-b07c-e89726be58a8.png">

  We kind of decided not to address it, but [Max is still in weak favour of visualising these differently](https://owid.slack.com/archives/C5BDCB2R3/p1644595692629799?thread_ts=1644485460.127289&cid=C5BDCB2R3). For now, it seems good enough as it is, but might need to be fixed in the future.

