### PR TITLE
enhance(map): use levelled sparkline for some charts

### DIFF
--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -212,6 +212,7 @@ class Lines extends React.Component<LinesProps> {
                         )}
                     />
                     <MultiColorPolyline
+                        interpolation={this.props.lineInterpolation}
                         points={series.placedPoints}
                         strokeLinejoin="round"
                         strokeWidth={this.strokeWidth}
@@ -736,6 +737,7 @@ export class LineChart
                         hidePoints={manager.hidePoints}
                         onHover={this.onHover}
                         focusedSeriesNames={this.focusedSeriesNames}
+                        lineInterpolation={this.manager.lineInterpolation}
                         lineStrokeWidth={this.lineStrokeWidth}
                         lineOutlineWidth={this.lineOutlineWidth}
                         markerRadius={this.markerRadius}

--- a/grapher/lineCharts/LineChartConstants.ts
+++ b/grapher/lineCharts/LineChartConstants.ts
@@ -5,6 +5,7 @@ import { TimeBound } from "../../clientUtils/TimeBounds.js"
 import { ChartSeries } from "../chart/ChartInterface.js"
 import { CoreValueType } from "../../coreTable/CoreTableConstants.js"
 import { Color } from "../../clientUtils/owidTypes.js"
+import { MultiColorPolylineInterpolation } from "../scatterCharts/MultiColorPolyline.js"
 
 export interface LinePoint {
     x: number
@@ -33,6 +34,7 @@ export interface LinesProps {
     focusedSeriesNames: SeriesName[]
     onHover: (hoverX: number | undefined) => void
     hidePoints?: boolean
+    lineInterpolation?: MultiColorPolylineInterpolation
     lineStrokeWidth?: number
     lineOutlineWidth?: number
     markerRadius?: number
@@ -40,5 +42,6 @@ export interface LinesProps {
 
 export interface LineChartManager extends ChartManager {
     lineStrokeWidth?: number
+    lineInterpolation?: MultiColorPolylineInterpolation
     canSelectMultipleEntities?: boolean
 }

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -22,6 +22,7 @@ import {
 } from "../color/ColorUtils.js"
 import { getPreposition } from "../../coreTable/CoreTableUtils.js"
 import { isNumber, AllKeysRequired } from "../../clientUtils/Util.js"
+import { MultiColorPolylineInterpolation } from "../scatterCharts/MultiColorPolyline.js"
 
 interface MapTooltipProps {
     entityName: EntityName
@@ -105,6 +106,10 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
         return this.hasTimeSeriesData
     }
 
+    @computed private get isLevelledSparkline(): boolean {
+        return !!this.props.manager.mapConfig?.tooltipUseCustomLabels
+    }
+
     @computed private get tooltipTarget(): {
         x: number
         y: number
@@ -135,13 +140,16 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
             hidePoints: true,
             baseFontSize: 11,
             disableIntroAnimation: true,
+            lineInterpolation: this.isLevelledSparkline
+                ? MultiColorPolylineInterpolation.levels
+                : undefined,
             lineStrokeWidth: 3.5,
             annotation: {
                 entityName: this.entityName,
                 year: this.datum?.time,
             },
             yAxisConfig: {
-                hideAxis: false,
+                hideAxis: this.isLevelledSparkline,
                 hideGridlines: false,
                 compactLabels: true,
                 // Copy min/max from top-level Grapher config if Y column == Map column

--- a/grapher/scatterCharts/MultiColorPolyline.test.ts
+++ b/grapher/scatterCharts/MultiColorPolyline.test.ts
@@ -1,13 +1,13 @@
 #! /usr/bin/env jest
 
-import { getSegmentsFromPoints } from "../scatterCharts/MultiColorPolyline.js"
+import { getLinearlyInterpolatedSegments } from "../scatterCharts/MultiColorPolyline.js"
 
 it("splits different-colored segments", () => {
     const points = [
         { x: 0, y: 0, color: "#000" },
         { x: 1, y: 0, color: "#111" },
     ]
-    const segments = getSegmentsFromPoints(points)
+    const segments = getLinearlyInterpolatedSegments(points)
 
     expect(segments.length).toEqual(2)
 
@@ -25,7 +25,7 @@ it("preserves same-colored segments", () => {
         { x: 0, y: 0, color: "#000" },
         { x: 1, y: 0, color: "#000" },
     ]
-    const segments = getSegmentsFromPoints(points)
+    const segments = getLinearlyInterpolatedSegments(points)
 
     expect(segments.length).toEqual(1)
     expect(segments[0].color).toEqual("#000")
@@ -41,7 +41,7 @@ it("merges segments of same color", () => {
         { x: 5, y: 4, color: "#111" },
         { x: 6, y: 4, color: "#000" },
     ]
-    const segments = getSegmentsFromPoints(points)
+    const segments = getLinearlyInterpolatedSegments(points)
 
     expect(segments.length).toEqual(3)
 


### PR DESCRIPTION
The Slack thread to [change the way we handle ordinal variables in sparklines](https://owid.slack.com/archives/C5BDCB2R3/p1645098840053389?thread_ts=1644485460.127289&cid=C5BDCB2R3) is managing to stay alive. I'm not sure if we're gonna change them. Might be a cooldown task.

I'm just dumping some code I had to created **"levelled" line charts (sparklines)**:

<img width="407" alt="Screenshot 2022-02-18 at 10 12 05" src="https://user-images.githubusercontent.com/1308115/154668009-e37e7f86-3dc5-4402-a6af-b5e9aeb44199.png">

As opposed to how they are visualised now:

<img width="407" alt="Screenshot 2022-02-18 at 10 12 49" src="https://user-images.githubusercontent.com/1308115/154668054-d2dcc806-efde-46a5-b4cd-ebe1c2374dc5.png">

This PR contains a very crude way to decide when sparklines should be levelled – basically whenever `tooltipUseCustomLabels` is `true`. We likely need something better before we can ship to production.

### Todo

- [ ] Figure out a better way to detect ordinal/categorical variables (or just add `type` as explicit configuration on the variable level?)
- [ ] Add tests for levelled line chart – especially around the color/y changes. It works a bit differently.

### Potential issues

- **Is the midpoint between two points the right place to split up the line?** Or should it be at the start/end?