### PR TITLE
Fix source text footer and improve source styling

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,6 +15,7 @@ ports:
 
 tasks:
     # set everything up
+    # this is run in the prebuild state and should be ready when launching a new workspace
     - init: |
           gp await-port 3306 && ./db/downloadAndCreateDatabase.sh
           mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '';"
@@ -43,3 +44,8 @@ github:
         branches: true
         pullRequests: true
         addCheck: false
+
+vscode:
+  extensions:
+    - dbaeumer.vscode-eslint
+    - esbenp.prettier-vscode

--- a/grapher/core/grapher.scss
+++ b/grapher/core/grapher.scss
@@ -58,21 +58,8 @@ $zindex-Tooltip: 20;
     .flash {
         margin: 10px;
     }
-    .clickable,
-    button {
+    .clickable {
         cursor: pointer;
-        -webkit-user-select: none;
-        -ms-user-select: none;
-        -moz-user-select: none;
-        -webkit-user-select: none;
-        user-select: none;
-    }
-    .noselect {
-        -webkit-user-select: none;
-        -ms-user-select: none;
-        -moz-user-select: none;
-        -webkit-user-select: none;
-        user-select: none;
     }
     input[type="checkbox"] {
         cursor: pointer;

--- a/grapher/footer/Footer.tsx
+++ b/grapher/footer/Footer.tsx
@@ -6,7 +6,7 @@ import { TextWrap } from "../text/TextWrap.js"
 import { Bounds, DEFAULT_BOUNDS } from "../../clientUtils/Bounds.js"
 import { getRelativeMouse } from "../../clientUtils/Util.js"
 import { Tooltip } from "../tooltip/Tooltip.js"
-import { BASE_FONT_SIZE, GrapherTabOption } from "../core/GrapherConstants.js"
+import { BASE_FONT_SIZE } from "../core/GrapherConstants.js"
 import { FooterManager } from "./FooterManager.js"
 
 @observer
@@ -141,10 +141,6 @@ export class Footer extends React.Component<{
         )
     }
 
-    @action.bound private onSourcesClick(): void {
-        this.manager.currentTab = GrapherTabOption.sources
-    }
-
     renderStatic(targetX: number, targetY: number): JSX.Element | null {
         if (this.manager.isMediaCard) return null
 
@@ -241,11 +237,7 @@ export class Footer extends React.Component<{
                 style={{ color: "#777" }}
             >
                 {this.isCompact && license}
-                <p
-                    style={this.sources.htmlStyle}
-                    className="clickable"
-                    onClick={this.onSourcesClick}
-                >
+                <p style={this.sources.htmlStyle}>
                     {this.sources.renderHTML()}
                 </p>
                 {this.note && (

--- a/grapher/sourcesTab/SourcesTab.scss
+++ b/grapher/sourcesTab/SourcesTab.scss
@@ -38,11 +38,19 @@
     font-weight: bold;
 }
 
+.datasource-wrapper table {
+    border-spacing: 0;
+}
+
 .datasource-wrapper td {
     padding: 8px;
     line-height: 1.42857143;
     vertical-align: top;
     border-top: 1px solid #ddd;
+}
+
+.datasource-wrapper tr:first-child td {
+    border: 0;
 }
 
 .datasource-property {

--- a/grapher/sourcesTab/SourcesTab.tsx
+++ b/grapher/sourcesTab/SourcesTab.tsx
@@ -2,13 +2,15 @@ import { linkify } from "../../clientUtils/Util.js"
 import React from "react"
 import { computed } from "mobx"
 import { observer } from "mobx-react"
+import { decodeHTML } from "entities"
 import { Bounds, DEFAULT_BOUNDS } from "../../clientUtils/Bounds.js"
 import { faPencilAlt } from "@fortawesome/free-solid-svg-icons/faPencilAlt.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { CoreColumn } from "../../coreTable/CoreTableColumns.js"
 import { OwidColumnDef } from "../../coreTable/OwidTableConstants.js"
 
-const formatText = (s: string) => linkify(s).replace(/(?:\r\n|\r|\n)/g, "<br/>")
+const formatText = (s: string): string =>
+    linkify(s).replace(/(?:\r\n|\r|\n)/g, "<br/>")
 
 export interface SourcesTabManager {
     adminBaseUrl?: string
@@ -47,7 +49,7 @@ export class SourcesTab extends React.Component<{
         return (
             <div key={slug} className="datasource-wrapper">
                 <h2>
-                    {column.name}{" "}
+                    {decodeHTML(column.name)}{" "}
                     {editUrl && (
                         <a href={editUrl} target="_blank" rel="noopener">
                             <FontAwesomeIcon icon={faPencilAlt} />

--- a/grapher/sourcesTab/SourcesTab.tsx
+++ b/grapher/sourcesTab/SourcesTab.tsx
@@ -2,7 +2,6 @@ import { linkify } from "../../clientUtils/Util.js"
 import React from "react"
 import { computed } from "mobx"
 import { observer } from "mobx-react"
-import { decodeHTML } from "entities"
 import { Bounds, DEFAULT_BOUNDS } from "../../clientUtils/Bounds.js"
 import { faPencilAlt } from "@fortawesome/free-solid-svg-icons/faPencilAlt.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
@@ -49,7 +48,7 @@ export class SourcesTab extends React.Component<{
         return (
             <div key={slug} className="datasource-wrapper">
                 <h2>
-                    {decodeHTML(column.name)}{" "}
+                    {column.name}{" "}
                     {editUrl && (
                         <a href={editUrl} target="_blank" rel="noopener">
                             <FontAwesomeIcon icon={faPencilAlt} />


### PR DESCRIPTION
This PR closes #1151 and contains the following:

**Fix grapher footer source text selection**

Users couldn't select the source text, but this is useful to quickly copy and paste the source. I made the text selectable and removed the `onClick` action that would open the Source tab when clicking the source. I think it's a better user experience because a) selecting the source text in order to copy it would open the Source tab (annoying), b) clicking a non-link, non-button text is not expected to do something, and c) the Source tab is just below and well visible anyways.

I also did the following:
- Removed the class `noselect` as it was not being used (or at least I didn't find where)
- Removed `user-select` from `button`and `clickable` - I don't see what this really adds here?


**Improve source tab styling**

While this was not part of issue #1151 it was somewhat related and I made a proposition to improve the styling of the source table and fix a decoding issue with the source name. In this example `&GreaterEqual;` and HTML entities in general were not decoded probably. Furthermore, the table's first row's top border and the source description's bottom border conflicted visually, I added styling to remove the top border from the first row. Finally, I've removed the border spacing between the `td` elements to get rid of the little gap on the rows' top borders.

It now looks like this:
<img width="819" alt="Screenshot 2022-02-19 at 13 23 30" src="https://user-images.githubusercontent.com/1881676/154801025-8edf44ff-e206-4eeb-b32d-87670192a493.png">


And looked like this before:
<img width="826" alt="Screenshot 2022-02-19 at 13 24 36" src="https://user-images.githubusercontent.com/1881676/154801029-bfbef040-0bd5-4cda-b334-1c4e97f8c021.png">

Let me know if some of the changes I made don't make sense. Happy to update and implement feedback. I'm new to this project so don't have too much context yet.
