### PR TITLE
fix: do not show non-numeric warning for scientific notation

### DIFF
--- a/adminSiteClient/ImportPage.tsx
+++ b/adminSiteClient/ImportPage.tsx
@@ -85,6 +85,9 @@ class EditableDataset {
     }
 }
 
+// https://stackoverflow.com/questions/638565/parsing-scientific-notation-sensibly
+const reValidNumber = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+\-]?\d+)?$/
+
 @observer
 class DataPreview extends React.Component<{ csv: CSV }> {
     @observable rowOffset: number = 0
@@ -347,7 +350,7 @@ class CSV {
             for (let j = 2; j < row.length; j++) {
                 if (
                     row[j] !== "" &&
-                    (isNaN(parseFloat(row[j])) || !row[j].match(/^[0-9.-]+$/))
+                    (isNaN(parseFloat(row[j])) || !row[j].match(reValidNumber))
                 )
                     nonNumeric.push(`${i + 1} '${row[j]}'`)
             }


### PR DESCRIPTION
When importing data, there are client-side warnings that check if a value is a number. We have plenty of scientific notation numbers in our database and they are handled fine, so I'm allowing scientific notation in the regex that checks for numbers.

Problem reported by [Pablo on Slack](https://owid.slack.com/archives/C01GAN73R5W/p1645453849936399).