### PR TITLE
fix(admin): properly check for duplicate slugs

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -196,7 +196,9 @@ const saveGrapher = async (
     async function isSlugUsedInRedirect() {
         const rows = await transactionContext.query(
             `SELECT * FROM chart_slug_redirects WHERE chart_id != ? AND slug = ?`,
-            [existingConfig ? existingConfig.id : undefined, newConfig.slug]
+            // -1 is a placeholder ID that will never exist; but we cannot use NULL because
+            // in that case we would always get back an empty resultset
+            [existingConfig ? existingConfig.id : -1, newConfig.slug]
         )
         return rows.length > 0
     }
@@ -204,7 +206,9 @@ const saveGrapher = async (
     async function isSlugUsedInOtherGrapher() {
         const rows = await transactionContext.query(
             `SELECT * FROM charts WHERE id != ? AND JSON_EXTRACT(config, "$.isPublished") IS TRUE AND JSON_EXTRACT(config, "$.slug") = ?`,
-            [existingConfig ? existingConfig.id : undefined, newConfig.slug]
+            // -1 is a placeholder ID that will never exist; but we cannot use NULL because
+            // in that case we would always get back an empty resultset
+            [existingConfig ? existingConfig.id : -1, newConfig.slug]
         )
         return rows.length > 0
     }


### PR DESCRIPTION
Fixes #1209.

In the case where a new chart would immediately be published (without first creating a draft), the duplicate slug detection didn't quite work.
Since we didn't yet have an ID for that chart, the corresponding query would look like this:
```sql
SELECT *
FROM charts
WHERE id != NULL
  AND JSON_EXTRACT(config, "$.isPublished") IS TRUE
  AND JSON_EXTRACT(config, "$.slug") = '...'
```

However, since SQL is oh-so-awesome, `id != NULL` would never evaluate to true.