### PR TITLE
feat(admin): allow finding charts by ID or slug

### DIFF
--- a/adminSiteClient/ChartIndexPage.tsx
+++ b/adminSiteClient/ChartIndexPage.tsx
@@ -43,6 +43,8 @@ export class ChartIndexPage extends React.Component {
                     chart.internalNotes,
                     chart.publishedBy,
                     chart.lastEditedBy,
+                    `${chart.id}`,
+                    chart.slug,
                     ...chart.tags.map((tag) => tag.name),
                 ]
             )


### PR DESCRIPTION
I think this can be quite useful, especially when running SQL queries (yielding the ID) or when `/identifyadmin` didn't work (i.e. only having the slug).