### PR TITLE
Moves standalone visualizations to left column

### DIFF
--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -262,6 +262,12 @@ export interface FullPost {
     glossary: boolean
 }
 
+export enum WP_ColumnStyle {
+    StickyRight = "sticky-right",
+    StickyLeft = "sticky-left",
+    SideBySide = "side-by-side",
+}
+
 export enum SuggestedChartRevisionStatus {
     pending = "pending",
     approved = "approved",

--- a/site/formatting.test.ts
+++ b/site/formatting.test.ts
@@ -6,9 +6,11 @@ import {
 } from "./formatting.js"
 
 const paragraph = `<p>Some paragraph</p>`
-const chart = `<figure data-grapher-src="http://ourworldindata.org/grapher/pneumococcal-vaccination-averted-deaths" class="${GRAPHER_PREVIEW_CLASS}"></figure>`
+const chart = `<figure data-grapher-src="https://ourworldindata.org/grapher/pneumococcal-vaccination-averted-deaths" class="${GRAPHER_PREVIEW_CLASS}"></figure>`
 const chart2 = `<figure data-grapher-src="https://ourworldindata.org/grapher/pneumonia-and-lower-respiratory-diseases-deaths" class="${GRAPHER_PREVIEW_CLASS}"></figure>`
 const chart3 = `<figure data-grapher-src="https://ourworldindata.org/grapher/pneumonia-mortality-by-age" class="${GRAPHER_PREVIEW_CLASS}"></figure>`
+const figure = `<figure class="wp-block-image size-large"><img src="https://ourworldindata.org/uploads/2022/02/child-mortality-800x245.png" alt="Child mortality" class="wp-image-46764"><figcaption>Child mortality</figcaption></figure>`
+const table = `<div class="tableContainer"><table></table></div>`
 const h2 = `<h2>Some h2 heading</h2>`
 const h3 = `<h3>Some h3 heading</h3>`
 const h4 = `<h4>Some h4 heading</h4>`
@@ -85,12 +87,28 @@ describe("splits text and chart", () => {
     })
 })
 
-it("places standalone charts in sticky-left columns", () => {
-    const content = h3 + chart + h3
-    const $ = cheerio.load(content)
+describe("places standalone visualizations in sticky-left columns", () => {
+    it("chart", () => {
+        const content = h3 + chart + h3
+        const $ = cheerio.load(content)
 
-    splitContentIntoSectionsAndColumns($)
-    testColumnsContent($, chart, "", WP_ColumnStyle.StickyLeft)
+        splitContentIntoSectionsAndColumns($)
+        testColumnsContent($, chart, "", WP_ColumnStyle.StickyLeft)
+    })
+    it("figure", () => {
+        const content = h3 + figure + h3
+        const $ = cheerio.load(content)
+
+        splitContentIntoSectionsAndColumns($)
+        testColumnsContent($, figure, "", WP_ColumnStyle.StickyLeft)
+    })
+    it("table", () => {
+        const content = h3 + table + h3
+        const $ = cheerio.load(content)
+
+        splitContentIntoSectionsAndColumns($)
+        testColumnsContent($, table, "", WP_ColumnStyle.StickyLeft)
+    })
 })
 
 describe("splits consecutive charts in side-by-side columns", () => {

--- a/site/formatting.test.ts
+++ b/site/formatting.test.ts
@@ -84,6 +84,14 @@ describe("splits text and chart", () => {
     })
 })
 
+it("places standalone charts in sticky-left columns", () => {
+    const content = h3 + chart + h3
+    const $ = cheerio.load(content)
+
+    splitContentIntoSectionsAndColumns($)
+    testColumnsContent($, chart, "", "sticky-left")
+})
+
 describe("splits consecutive charts in side-by-side columns", () => {
     it("2 charts after content", () => {
         const content = paragraph + chart + chart2
@@ -98,6 +106,6 @@ describe("splits consecutive charts in side-by-side columns", () => {
 
         splitContentIntoSectionsAndColumns($)
         testColumnsContent($, chart, chart2, "side-by-side")
-        testColumnsContent($, "", chart3, "sticky-right")
+        testColumnsContent($, chart3, "", "sticky-left")
     })
 })

--- a/site/formatting.test.ts
+++ b/site/formatting.test.ts
@@ -1,4 +1,5 @@
 import * as cheerio from "cheerio"
+import { WP_ColumnStyle } from "../clientUtils/owidTypes.js"
 import {
     GRAPHER_PREVIEW_CLASS,
     splitContentIntoSectionsAndColumns,
@@ -16,7 +17,7 @@ const testColumnsContent = (
     $: CheerioStatic,
     firstColumnHTML: string,
     lastColumnHTML: string,
-    style: string = "sticky-right"
+    style: string = WP_ColumnStyle.StickyRight
 ) => {
     expect($(`.is-style-${style}`).children().first().html()).toEqual(
         firstColumnHTML
@@ -89,7 +90,7 @@ it("places standalone charts in sticky-left columns", () => {
     const $ = cheerio.load(content)
 
     splitContentIntoSectionsAndColumns($)
-    testColumnsContent($, chart, "", "sticky-left")
+    testColumnsContent($, chart, "", WP_ColumnStyle.StickyLeft)
 })
 
 describe("splits consecutive charts in side-by-side columns", () => {
@@ -98,14 +99,14 @@ describe("splits consecutive charts in side-by-side columns", () => {
         const $ = cheerio.load(content)
 
         splitContentIntoSectionsAndColumns($)
-        testColumnsContent($, chart, chart2, "side-by-side")
+        testColumnsContent($, chart, chart2, WP_ColumnStyle.SideBySide)
     })
     it("3 charts", () => {
         const content = chart + chart2 + chart3
         const $ = cheerio.load(content)
 
         splitContentIntoSectionsAndColumns($)
-        testColumnsContent($, chart, chart2, "side-by-side")
-        testColumnsContent($, chart3, "", "sticky-left")
+        testColumnsContent($, chart, chart2, WP_ColumnStyle.SideBySide)
+        testColumnsContent($, chart3, "", WP_ColumnStyle.StickyLeft)
     })
 })

--- a/site/formatting.test.ts
+++ b/site/formatting.test.ts
@@ -14,6 +14,7 @@ const table = `<div class="tableContainer"><table></table></div>`
 const h2 = `<h2>Some h2 heading</h2>`
 const h3 = `<h3>Some h3 heading</h3>`
 const h4 = `<h4>Some h4 heading</h4>`
+const h6 = `<h6>Some h6 heading</h6>`
 
 const testColumnsContent = (
     $: CheerioStatic,
@@ -109,6 +110,14 @@ describe("places standalone visualizations in sticky-left columns", () => {
         splitContentIntoSectionsAndColumns($)
         testColumnsContent($, table, "", WP_ColumnStyle.StickyLeft)
     })
+})
+
+it("does not move legacy h6 caption + image to the left column", () => {
+    const content = h3 + h6 + figure + h3
+    const $ = cheerio.load(content)
+
+    splitContentIntoSectionsAndColumns($)
+    testColumnsContent($, "", h6 + figure, WP_ColumnStyle.StickyRight)
 })
 
 describe("splits consecutive charts in side-by-side columns", () => {

--- a/site/formatting.tsx
+++ b/site/formatting.tsx
@@ -191,12 +191,11 @@ export const splitContentIntoSectionsAndColumns = (
         }
     }
 
-    class StandaloneChartHandler extends AbstractHandler {
+    class StandaloneFigureHandler extends AbstractHandler {
         handle(el: CheerioElement, context: ColumnsContext) {
             const $el = cheerioEl(el)
             if (
-                el.name === "figure" &&
-                $el.hasClass(GRAPHER_PREVIEW_CLASS) &&
+                FigureHandler.isFigure(el) &&
                 isElementFlushingColumns(el.nextSibling) &&
                 isColumnsEmpty(context.columns)
             ) {
@@ -210,9 +209,9 @@ export const splitContentIntoSectionsAndColumns = (
     }
 
     class FigureHandler extends AbstractHandler {
-        handle(el: CheerioElement, context: ColumnsContext) {
+        static isFigure(el: CheerioElement) {
             const $el = cheerioEl(el)
-            if (
+            return (
                 el.name === "figure" ||
                 el.name === "iframe" ||
                 // Temporary support for old chart iframes
@@ -229,7 +228,12 @@ export const splitContentIntoSectionsAndColumns = (
                     !$el.find(
                         ".wp-block-owid-additional-information[data-variation='merge-left']"
                     ))
-            ) {
+            )
+        }
+
+        handle(el: CheerioElement, context: ColumnsContext) {
+            const $el = cheerioEl(el)
+            if (FigureHandler.isFigure(el)) {
                 context.columns.last.append($el)
                 return null
             }
@@ -253,7 +257,7 @@ export const splitContentIntoSectionsAndColumns = (
     fullWidthHandler
         .setNext(new H4Handler())
         .setNext(new SideBySideHandler())
-        .setNext(new StandaloneChartHandler())
+        .setNext(new StandaloneFigureHandler())
         .setNext(new FigureHandler())
         .setNext(new DefaultHandler())
 

--- a/site/formatting.tsx
+++ b/site/formatting.tsx
@@ -191,6 +191,23 @@ export const splitContentIntoSectionsAndColumns = (
         }
     }
 
+    class StandaloneChartHandler extends AbstractHandler {
+        handle(el: CheerioElement, context: ColumnsContext) {
+            const $el = cheerioEl(el)
+            if (
+                el.name === "figure" &&
+                $el.hasClass(GRAPHER_PREVIEW_CLASS) &&
+                (!el.nextSibling || isElementFlushingColumns(el.nextSibling)) &&
+                isColumnsEmpty(context.columns)
+            ) {
+                context.columns = getColumns(ColumnStyle.StickyLeft)
+                context.columns.first.append($el)
+                flushAndResetColumns(context) // not strictly necessary since we know the next element flushes but keeps the abstraction clean
+                return null
+            }
+            return super.handle(el, context)
+        }
+    }
 
     class FigureHandler extends AbstractHandler {
         handle(el: CheerioElement, context: ColumnsContext) {
@@ -236,6 +253,7 @@ export const splitContentIntoSectionsAndColumns = (
     fullWidthHandler
         .setNext(new H4Handler())
         .setNext(new SideBySideHandler())
+        .setNext(new StandaloneChartHandler())
         .setNext(new FigureHandler())
         .setNext(new DefaultHandler())
 

--- a/site/formatting.tsx
+++ b/site/formatting.tsx
@@ -254,6 +254,10 @@ export const splitContentIntoSectionsAndColumns = (
 
     // Set up chain of responsibility pattern. Elements are being passed
     // through the chain until a handler can process them.
+    // - For each element in a section, handlers are executed one by one in order.
+    // - It's the responsibility of the handler to figure out whether to 1) apply some transformation, or 2) do nothing, pass responsibility onto the next handler in the chain.
+    // - A handler should never do both 1) and 2) – both apply a transformation and additionally let other handlers apply transformations.
+    // see https://github.com/owid/owid-grapher/pull/1220#discussion_r816126831
     fullWidthHandler
         .setNext(new H4Handler())
         .setNext(new SideBySideHandler())

--- a/site/formatting.tsx
+++ b/site/formatting.tsx
@@ -82,7 +82,9 @@ export const splitContentIntoSectionsAndColumns = (
 
     const isElementFlushingColumns = (el: CheerioElement): boolean => {
         return (
-            FullWidthHandler.isElementFullWidth(el) || H4Handler.isElementH4(el)
+            !el ||
+            FullWidthHandler.isElementFullWidth(el) ||
+            H4Handler.isElementH4(el)
         )
     }
 
@@ -195,7 +197,7 @@ export const splitContentIntoSectionsAndColumns = (
             if (
                 el.name === "figure" &&
                 $el.hasClass(GRAPHER_PREVIEW_CLASS) &&
-                (!el.nextSibling || isElementFlushingColumns(el.nextSibling)) &&
+                isElementFlushingColumns(el.nextSibling) &&
                 isColumnsEmpty(context.columns)
             ) {
                 context.columns = getColumns(WP_ColumnStyle.StickyLeft)

--- a/site/formatting.tsx
+++ b/site/formatting.tsx
@@ -52,7 +52,15 @@ export const splitContentIntoSectionsAndColumns = (
         last: Cheerio
     }
 
-    const getColumns = (style: string = "sticky-right"): Columns => {
+    enum ColumnStyle {
+        StickyRight = "sticky-right",
+        StickyLeft = "sticky-left",
+        SideBySide = "side-by-side",
+    }
+
+    const getColumns = (
+        style: ColumnStyle = ColumnStyle.StickyRight
+    ): Columns => {
         const emptyColumns = `<div class="wp-block-columns is-style-${style}"><div class="wp-block-column"></div><div class="wp-block-column"></div></div>`
         const cheerioEl = cheerio.load(emptyColumns)
         const $columns = cheerioEl("body").children().first()
@@ -63,6 +71,10 @@ export const splitContentIntoSectionsAndColumns = (
         }
     }
 
+    const hasColumnsStyle = (columns: Columns, style: ColumnStyle): boolean => {
+        return columns.wrapper.hasClass(`is-style-${style}`)
+    }
+
     const isColumnsEmpty = (columns: Columns) => {
         return columns.first.children().length === 0 &&
             columns.last.children().length === 0
@@ -70,29 +82,47 @@ export const splitContentIntoSectionsAndColumns = (
             : false
     }
 
-    const flushColumns = (columns: Columns, $section: Cheerio): Columns => {
-        $section.append(columns.wrapper)
-        return getColumns()
+    const isElementFlushingColumns = (el: CheerioElement): boolean => {
+        return (
+            FullWidthHandler.isElementFullWidth(el) || H4Handler.isElementH4(el)
+        )
     }
 
-    // Wrap content demarcated by headings into section blocks
-    // and automatically divide content into columns
-    const sectionStarts = [cheerioEl("body").children().get(0)].concat(
-        cheerioEl("body > h2").toArray()
-    )
-    for (const start of sectionStarts) {
-        const $start = cheerioEl(start)
-        const $section = cheerioEl("<section>")
-        let columns = getColumns()
-        let sideBySideColumns = getColumns("side-by-side")
-        const $tempWrapper = cheerioEl("<div>")
-        const $contents = $tempWrapper
-            .append($start.clone(), $start.nextUntil(cheerioEl("h2")))
-            .contents()
+    const flushAndResetColumns = (context: ColumnsContext): void => {
+        if (isColumnsEmpty(context.columns)) return
 
-        $contents.each((i, el) => {
+        context.$section.append(context.columns.wrapper)
+        context.columns = getColumns()
+    }
+
+    interface ColumnsContext {
+        columns: Columns
+        $section: Cheerio
+    }
+
+    interface Handler {
+        setNext: (handler: Handler) => Handler
+        handle: (el: CheerioElement, context: ColumnsContext) => Columns | null
+    }
+
+    abstract class AbstractHandler implements Handler {
+        #nextHandler: Handler | null = null
+
+        setNext(handler: Handler) {
+            this.#nextHandler = handler
+            return handler
+        }
+
+        handle(el: CheerioElement, context: ColumnsContext) {
+            if (this.#nextHandler) return this.#nextHandler.handle(el, context)
+            return null
+        }
+    }
+
+    class FullWidthHandler extends AbstractHandler {
+        static isElementFullWidth(el: CheerioElement) {
             const $el = cheerioEl(el)
-            if (
+            return (
                 el.name === "h2" ||
                 el.name === "h3" ||
                 $el.hasClass("wp-block-columns") ||
@@ -101,70 +131,135 @@ export const splitContentIntoSectionsAndColumns = (
                 $el.find(
                     '.wp-block-owid-additional-information[data-variation="full-width"]'
                 ).length !== 0
-            ) {
-                if (!isColumnsEmpty(columns)) {
-                    columns = flushColumns(columns, $section)
-                }
-                $section.append($el)
-            } else if (el.name === "h4") {
-                if (!isColumnsEmpty(columns)) {
-                    columns = flushColumns(columns, $section)
-                }
-                columns.first.append($el)
-                columns = flushColumns(columns, $section)
-            } else {
-                if (
-                    el.name === "figure" &&
-                    $el.hasClass(GRAPHER_PREVIEW_CLASS)
-                ) {
-                    if (isColumnsEmpty(sideBySideColumns)) {
-                        // Only fill the side by side buffer if there is an upcoming chart for a potential comparison.
-                        // Otherwise let the standard process (sticky right) take over.
-                        if (
-                            $contents[i].nextSibling?.attribs?.class ===
-                            GRAPHER_PREVIEW_CLASS
-                        ) {
-                            columns = flushColumns(columns, $section)
-                            sideBySideColumns.first.append($el)
-                        } else {
-                            columns.last.append($el)
-                        }
-                    } else {
-                        sideBySideColumns.last.append($el)
-                        $section.append(sideBySideColumns.wrapper)
-                        sideBySideColumns = getColumns("side-by-side")
-                    }
-                }
-
-                // Move images to the right column
-                else if (
-                    el.name === "figure" ||
-                    el.name === "iframe" ||
-                    // Temporary support for old chart iframes
-                    el.name === "address" ||
-                    $el.hasClass("wp-block-image") ||
-                    $el.hasClass("tableContainer") ||
-                    // Temporary support for non-Gutenberg iframes wrapped in wpautop's <p>
-                    // Also catches older iframes (e.g. https://ourworldindata.org/food-per-person#world-map-of-minimum-and-average-dietary-energy-requirement-mder-and-ader)
-                    $el.find("iframe").length !== 0 ||
-                    // TODO: remove temporary support for pre-Gutenberg images and associated captions
-                    el.name === "h6" ||
-                    ($el.find("img").length !== 0 &&
-                        !$el.hasClass(PROMINENT_LINK_CLASSNAME) &&
-                        !$el.find(
-                            ".wp-block-owid-additional-information[data-variation='merge-left']"
-                        ))
-                ) {
-                    columns.last.append($el)
-                } else {
-                    // Move non-heading, non-image content to the left column
-                    columns.first.append($el)
-                }
-            }
-        })
-        if (!isColumnsEmpty(columns)) {
-            $section.append(columns.wrapper)
+            )
         }
+
+        handle(el: CheerioElement, context: ColumnsContext) {
+            const $el = cheerioEl(el)
+            if (FullWidthHandler.isElementFullWidth(el)) {
+                flushAndResetColumns(context)
+                context.$section.append($el)
+                return null
+            }
+            return super.handle(el, context)
+        }
+    }
+
+    class H4Handler extends AbstractHandler {
+        static isElementH4 = (el: CheerioElement): boolean => {
+            return el.name === "h4"
+        }
+
+        handle(el: CheerioElement, context: ColumnsContext) {
+            const $el = cheerioEl(el)
+            if (H4Handler.isElementH4(el)) {
+                flushAndResetColumns(context)
+                context.columns.first.append($el)
+                flushAndResetColumns(context)
+                return null
+            }
+            return super.handle(el, context)
+        }
+    }
+
+    class SideBySideHandler extends AbstractHandler {
+        handle(el: CheerioElement, context: ColumnsContext) {
+            const $el = cheerioEl(el)
+
+            if (
+                el.name === "figure" &&
+                $el.hasClass(GRAPHER_PREVIEW_CLASS) &&
+                hasColumnsStyle(context.columns, ColumnStyle.SideBySide)
+            ) {
+                context.columns.last.append($el)
+                flushAndResetColumns(context)
+                return null
+            }
+
+            if (
+                el.name === "figure" &&
+                $el.hasClass(GRAPHER_PREVIEW_CLASS) &&
+                el.nextSibling?.attribs?.class === GRAPHER_PREVIEW_CLASS
+            ) {
+                flushAndResetColumns(context)
+                context.columns = getColumns(ColumnStyle.SideBySide)
+                context.columns.first.append($el)
+                return null
+            }
+
+            return super.handle(el, context)
+        }
+    }
+
+
+    class FigureHandler extends AbstractHandler {
+        handle(el: CheerioElement, context: ColumnsContext) {
+            const $el = cheerioEl(el)
+            if (
+                el.name === "figure" ||
+                el.name === "iframe" ||
+                // Temporary support for old chart iframes
+                el.name === "address" ||
+                $el.hasClass("wp-block-image") ||
+                $el.hasClass("tableContainer") ||
+                // Temporary support for non-Gutenberg iframes wrapped in wpautop's <p>
+                // Also catches older iframes (e.g. https://ourworldindata.org/food-per-person#world-map-of-minimum-and-average-dietary-energy-requirement-mder-and-ader)
+                $el.find("iframe").length !== 0 ||
+                // TODO: remove temporary support for pre-Gutenberg images and associated captions
+                el.name === "h6" ||
+                ($el.find("img").length !== 0 &&
+                    !$el.hasClass(PROMINENT_LINK_CLASSNAME) &&
+                    !$el.find(
+                        ".wp-block-owid-additional-information[data-variation='merge-left']"
+                    ))
+            ) {
+                context.columns.last.append($el)
+                return null
+            }
+            return super.handle(el, context)
+        }
+    }
+
+    class DefaultHandler extends AbstractHandler {
+        handle(el: CheerioElement, context: ColumnsContext) {
+            const $el = cheerioEl(el)
+            // Move non-heading, non-image content to the left column
+            context.columns.first.append($el)
+            return null
+        }
+    }
+
+    const fullWidthHandler = new FullWidthHandler()
+
+    // Set up chain of responsibility pattern. Elements are being passed
+    // through the chain until a handler can process them.
+    fullWidthHandler
+        .setNext(new H4Handler())
+        .setNext(new SideBySideHandler())
+        .setNext(new FigureHandler())
+        .setNext(new DefaultHandler())
+
+    // Wrap content demarcated by headings into section blocks
+    // and automatically divide content into columns
+    const sectionStarts = [cheerioEl("body").children().get(0)].concat(
+        cheerioEl("body > h2").toArray()
+    )
+
+    for (const start of sectionStarts) {
+        const $start = cheerioEl(start)
+        const $section = cheerioEl("<section>")
+        const context = { columns: getColumns(), $section }
+        const $tempWrapper = cheerioEl("<div>")
+        const $contents = $tempWrapper
+            .append($start.clone(), $start.nextUntil(cheerioEl("h2")))
+            .contents()
+
+        $contents.each((i, el) => {
+            fullWidthHandler.handle(el, context)
+        })
+        // Flushes the last set of columns at the end each section (since
+        // columns are only flushed when a flushing element is encountered).
+        flushAndResetColumns(context)
         $start.replaceWith($section)
     }
 }

--- a/site/formatting.tsx
+++ b/site/formatting.tsx
@@ -4,6 +4,7 @@ import ReactDOMServer from "react-dom/server.js"
 import {
     FormattedPost,
     TocHeading,
+    WP_ColumnStyle,
     WP_PostType,
 } from "../clientUtils/owidTypes.js"
 import { last } from "../clientUtils/Util.js"
@@ -52,14 +53,8 @@ export const splitContentIntoSectionsAndColumns = (
         last: Cheerio
     }
 
-    enum ColumnStyle {
-        StickyRight = "sticky-right",
-        StickyLeft = "sticky-left",
-        SideBySide = "side-by-side",
-    }
-
     const getColumns = (
-        style: ColumnStyle = ColumnStyle.StickyRight
+        style: WP_ColumnStyle = WP_ColumnStyle.StickyRight
     ): Columns => {
         const emptyColumns = `<div class="wp-block-columns is-style-${style}"><div class="wp-block-column"></div><div class="wp-block-column"></div></div>`
         const cheerioEl = cheerio.load(emptyColumns)
@@ -71,7 +66,10 @@ export const splitContentIntoSectionsAndColumns = (
         }
     }
 
-    const hasColumnsStyle = (columns: Columns, style: ColumnStyle): boolean => {
+    const hasColumnsStyle = (
+        columns: Columns,
+        style: WP_ColumnStyle
+    ): boolean => {
         return columns.wrapper.hasClass(`is-style-${style}`)
     }
 
@@ -169,7 +167,7 @@ export const splitContentIntoSectionsAndColumns = (
             if (
                 el.name === "figure" &&
                 $el.hasClass(GRAPHER_PREVIEW_CLASS) &&
-                hasColumnsStyle(context.columns, ColumnStyle.SideBySide)
+                hasColumnsStyle(context.columns, WP_ColumnStyle.SideBySide)
             ) {
                 context.columns.last.append($el)
                 flushAndResetColumns(context)
@@ -182,7 +180,7 @@ export const splitContentIntoSectionsAndColumns = (
                 el.nextSibling?.attribs?.class === GRAPHER_PREVIEW_CLASS
             ) {
                 flushAndResetColumns(context)
-                context.columns = getColumns(ColumnStyle.SideBySide)
+                context.columns = getColumns(WP_ColumnStyle.SideBySide)
                 context.columns.first.append($el)
                 return null
             }
@@ -200,7 +198,7 @@ export const splitContentIntoSectionsAndColumns = (
                 (!el.nextSibling || isElementFlushingColumns(el.nextSibling)) &&
                 isColumnsEmpty(context.columns)
             ) {
-                context.columns = getColumns(ColumnStyle.StickyLeft)
+                context.columns = getColumns(WP_ColumnStyle.StickyLeft)
                 context.columns.first.append($el)
                 flushAndResetColumns(context) // not strictly necessary since we know the next element flushes but keeps the abstraction clean
                 return null


### PR DESCRIPTION
resolves #1112 

![image (2)](https://user-images.githubusercontent.com/13406362/155725303-9cdda0fa-3b70-4a10-b35c-2685b75716f9.jpg)


## Special cases

- legacy h6 caption + image combos are not considered standalone figures and are not moved to the left column

<img width="1438" alt="Screenshot 2022-02-25 at 14 30 38" src="https://user-images.githubusercontent.com/13406362/155724720-eaecadd7-ef00-4d92-a7f5-748e52aec8ff.png">

- 2n+1 charts are positioned as follows: 2n in a `side-by-side` split, and the remaining one in the left column of a `sticky-left` layout. Reason for not using a `side-by-side` layout for the remaining chart: added complexity not warranted given the low occurrence of that setup.
![image](https://user-images.githubusercontent.com/13406362/155723328-3b64e570-f64c-4af3-8f5a-28e14ecc15a3.jpg)

## Developer perspective
- add tests for automatic layout engine (`splitContentIntoSectionsAndColumns()`)
- refactor automatic layout engine using chain of responsibility pattern (baseline tests before refactoring added in #1219)