### PR TITLE
Scatter size legend #1: Prep work

### DIFF
--- a/adminSiteClient/DimensionCard.tsx
+++ b/adminSiteClient/DimensionCard.tsx
@@ -18,7 +18,6 @@ import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { OwidTable } from "../coreTable/OwidTable.js"
 import { faArrowsAltV } from "@fortawesome/free-solid-svg-icons/faArrowsAltV.js"
-import { DimensionProperty } from "../clientUtils/owidTypes.js"
 
 @observer
 export class DimensionCard extends React.Component<{
@@ -33,14 +32,6 @@ export class DimensionCard extends React.Component<{
 
     @computed get table(): OwidTable {
         return this.props.editor.grapher.table
-    }
-
-    @computed get hasExpandedOptions(): boolean {
-        return (
-            this.props.dimension.property === DimensionProperty.y ||
-            this.props.dimension.property === DimensionProperty.x ||
-            this.props.dimension.property === DimensionProperty.color
-        )
     }
 
     @action.bound onToggleExpand() {
@@ -113,20 +104,18 @@ export class DimensionCard extends React.Component<{
             >
                 <header>
                     <div>
-                        {this.hasExpandedOptions && (
-                            <span
-                                className="clickable"
-                                onClick={this.onToggleExpand}
-                            >
-                                <FontAwesomeIcon
-                                    icon={
-                                        this.isExpanded
-                                            ? faChevronUp
-                                            : faChevronDown
-                                    }
-                                />
-                            </span>
-                        )}
+                        <span
+                            className="clickable"
+                            onClick={this.onToggleExpand}
+                        >
+                            <FontAwesomeIcon
+                                icon={
+                                    this.isExpanded
+                                        ? faChevronUp
+                                        : faChevronDown
+                                }
+                            />
+                        </span>
                     </div>
                     <div>
                         <FontAwesomeIcon icon={faArrowsAltV} />

--- a/clientUtils/formatValue.ts
+++ b/clientUtils/formatValue.ts
@@ -10,6 +10,13 @@ export interface TickFormattingOptions {
     showPlus?: boolean
 }
 
+// Used outside this module to figure out if the unit will be joined with the number.
+export function isVeryShortUnit(unit: string): boolean {
+    return ["%", "$", "£"].some((collapsedUnit) =>
+        unit.startsWith(collapsedUnit)
+    )
+}
+
 // todo: Should this be numberSuffixes instead of Prefixes?
 // todo: we should have unit tests for this one. lot's of great features but hard to see how to use all of them.
 export function formatValue(

--- a/clientUtils/formatValue.ts
+++ b/clientUtils/formatValue.ts
@@ -12,9 +12,7 @@ export interface TickFormattingOptions {
 
 // Used outside this module to figure out if the unit will be joined with the number.
 export function isVeryShortUnit(unit: string): boolean {
-    return ["%", "$", "£"].some((collapsedUnit) =>
-        unit.startsWith(collapsedUnit)
-    )
+    return ["%", "$", "£"].includes(unit)
 }
 
 // todo: Should this be numberSuffixes instead of Prefixes?

--- a/coreTable/CoreTableColumns.ts
+++ b/coreTable/CoreTableColumns.ts
@@ -25,6 +25,7 @@ import dayjs from "../clientUtils/dayjs.js"
 import { OwidSource } from "../clientUtils/OwidSource.js"
 import {
     formatValue,
+    isVeryShortUnit,
     TickFormattingOptions,
 } from "../clientUtils/formatValue.js"
 import { OwidVariableDisplayConfigInterface } from "../clientUtils/OwidVariableDisplayConfigInterface.js"
@@ -533,6 +534,13 @@ abstract class AbstractNumericColumn extends AbstractCoreColumn<number> {
         return super.formatValueShortWithAbbreviations(value, {
             shortNumberPrefixes: true,
             // do not set a unit
+            ...omitUndefinedValues({
+                unit:
+                    this.shortUnit !== undefined &&
+                    isVeryShortUnit(this.shortUnit)
+                        ? this.shortUnit
+                        : undefined,
+            }),
             ...options,
         })
     }

--- a/coreTable/CoreTableColumns.ts
+++ b/coreTable/CoreTableColumns.ts
@@ -533,7 +533,7 @@ abstract class AbstractNumericColumn extends AbstractCoreColumn<number> {
     ): string {
         return super.formatValueShortWithAbbreviations(value, {
             shortNumberPrefixes: true,
-            // do not set a unit
+            // only include a unit if it's very short (e.g. %, $ or £)
             ...omitUndefinedValues({
                 unit:
                     this.shortUnit !== undefined &&

--- a/db/migration/1646223315110-DropDisplayForSizeDimension.ts
+++ b/db/migration/1646223315110-DropDisplayForSizeDimension.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class ScatterSizeDimensionLegend1646223315110
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE charts
+            JOIN chart_dimensions ON chart_dimensions.chartId = charts.id
+            SET charts.config = JSON_REMOVE(
+                charts.config,
+                CONCAT("$.dimensions[", chart_dimensions.order, "].display")
+            )
+            WHERE charts.config->"$.type" = "ScatterPlot"
+            AND chart_dimensions.property = "size"
+        `)
+    }
+
+    public async down(): Promise<void> {
+        // no way back :(
+    }
+}

--- a/grapher/scatterCharts/Halos.tsx
+++ b/grapher/scatterCharts/Halos.tsx
@@ -9,7 +9,7 @@ const DefaultHaloStyle: React.CSSProperties = {
 }
 
 export const getElementWithHalo = (
-    key: string,
+    key: React.Key,
     element: React.ReactElement,
     styles: React.CSSProperties = {}
 ): JSX.Element => {

--- a/grapher/scatterCharts/ScatterPlotChart.test.ts
+++ b/grapher/scatterCharts/ScatterPlotChart.test.ts
@@ -131,7 +131,6 @@ describe("interpolation defaults", () => {
             {
                 slug: "size",
                 type: ColumnTypeNames.Numeric,
-                display: { tolerance: 1 },
             },
         ]
     )
@@ -150,7 +149,7 @@ describe("interpolation defaults", () => {
         ).toEqual(["Europe", "Europe", "Europe"])
     })
 
-    it("size defaults to infinity tolerance regardless if one specified", () => {
+    it("size defaults to infinity tolerance if none specified", () => {
         expect(
             chart.transformedTable.get("size").valuesIncludingErrorValues
         ).toEqual([100, 100, 100])

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -543,7 +543,7 @@ export class ScatterPlotChart
         )
     }
 
-    @computed get title(): string | undefined {
+    @computed get legendTitle(): string | undefined {
         return this.colorScale.legendDescription
     }
 

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -146,11 +146,11 @@ export class ScatterPlotChart
             table = table.replaceNonPositiveCellsForLogScale([this.yColumnSlug])
 
         if (this.sizeColumnSlug) {
-            // The tolerance on the size column is ignored. If we want to change this in the future
-            // we need to check all charts for regressions.
+            const tolerance =
+                table.get(this.sizeColumnSlug)?.display?.tolerance ?? Infinity
             table = table.interpolateColumnWithTolerance(
                 this.sizeColumnSlug,
-                Infinity
+                tolerance
             )
         }
 

--- a/grapher/scatterCharts/ScatterPlotChartConstants.ts
+++ b/grapher/scatterCharts/ScatterPlotChartConstants.ts
@@ -74,8 +74,6 @@ export interface ScatterRenderPoint {
     }
 }
 
-export const ScatterLabelFontFamily = "Arial, sans-serif"
-
 export interface ScatterRenderSeries extends ChartSeries {
     displayKey: string
     size: number

--- a/grapher/scatterCharts/ScatterPointsWithLabels.tsx
+++ b/grapher/scatterCharts/ScatterPointsWithLabels.tsx
@@ -27,7 +27,6 @@ import {
     ScatterRenderSeries,
     ScatterLabel,
     ScatterRenderPoint,
-    ScatterLabelFontFamily,
     ScatterSeries,
 } from "./ScatterPlotChartConstants.js"
 import { ScatterLine, ScatterPoint } from "./ScatterPoints.js"
@@ -485,7 +484,6 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
                                 2
                             )}
                             fontSize={label.fontSize}
-                            fontFamily={ScatterLabelFontFamily}
                             fontWeight={label.fontWeight}
                             fill={label.color}
                         >
@@ -549,7 +547,6 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
                 onMouseMove={this.onMouseMove}
                 onMouseLeave={this.onMouseLeave}
                 onClick={this.onClick}
-                fontFamily={ScatterLabelFontFamily}
             >
                 <rect
                     key="background"

--- a/grapher/scatterCharts/ScatterUtils.ts
+++ b/grapher/scatterCharts/ScatterUtils.ts
@@ -5,7 +5,6 @@ import {
     ScatterLabel,
     ScatterRenderPoint,
     ScatterRenderSeries,
-    ScatterLabelFontFamily as fontFamily,
 } from "./ScatterPlotChartConstants.js"
 
 export const labelPriority = (label: ScatterLabel): number => {
@@ -45,7 +44,6 @@ export const makeStartLabel = (
         x: pos.x,
         y: pos.y,
         fontSize: fontSize,
-        fontFamily,
     })
     if (pos.x < firstValue.position.x)
         bounds = new Bounds(
@@ -125,7 +123,6 @@ export const makeMidLabels = (
             y: pos.y,
             fontSize: fontSize,
             fontWeight: fontWeight,
-            fontFamily,
         })
         if (pos.x < v.position.x)
             bounds = new Bounds(
@@ -190,7 +187,6 @@ export const makeEndLabel = (
         x: labelPos.x,
         y: labelPos.y,
         fontSize: fontSize,
-        fontFamily,
     })
 
     if (labelPos.x < lastPos.x)

--- a/grapher/verticalColorLegend/VerticalColorLegend.stories.tsx
+++ b/grapher/verticalColorLegend/VerticalColorLegend.stories.tsx
@@ -11,7 +11,7 @@ export default {
 
 const manager: VerticalColorLegendManager = {
     maxLegendWidth: 500,
-    title: "Legend Title",
+    legendTitle: "Legend Title",
     legendItems: [
         {
             label: "Canada",

--- a/grapher/verticalColorLegend/VerticalColorLegend.tsx
+++ b/grapher/verticalColorLegend/VerticalColorLegend.tsx
@@ -10,7 +10,7 @@ export interface VerticalColorLegendManager {
     maxLegendWidth?: number
     fontSize?: number
     legendItems: LegendItem[]
-    title?: string
+    legendTitle?: string
     onLegendMouseOver?: (color: string) => void
     onLegendClick?: (color: string) => void
     onLegendMouseLeave?: () => void
@@ -57,12 +57,12 @@ export class VerticalColorLegend extends React.Component<{
     private lineHeight = 5
 
     @computed private get title(): TextWrap | undefined {
-        if (!this.manager.title) return undefined
+        if (!this.manager.legendTitle) return undefined
         return new TextWrap({
             maxWidth: this.maxLegendWidth,
             fontSize: this.fontSize,
             fontWeight: 700,
-            text: this.manager.title,
+            text: this.manager.legendTitle,
         })
     }
 


### PR DESCRIPTION
Working on https://github.com/owid/owid-grapher/issues/1089.

In this PR:

- The Admin now allows specifying `dimension.display` for the size dimension on a Grapher (the dropdown used to be disabled)

    <img width="1035" alt="Screenshot_2022-03-07_at_16_47_55" src="https://user-images.githubusercontent.com/1308115/157079403-10669fd3-373b-49ef-b464-2f9efe0e69fc.png">

- Consequently, **the `tolerance` for the `size` dimension is now considered**. It used to be ignored and always `Infinity`.

- Some older charts had `dimension.display` populated for the `size` dimension, even though it was ignored. **A migration now wipes `dimension.display` for the size dimension for all ScatterPlots.** I have gone through all affected charts, and they all seem good (there are 3 categories: [charts that use the default size variable](https://playfair.owid.cloud/admin/test/embeds?ids=51,53,84,85,150,161,172,177,178,185,212,213,214,245,250,251,275,290,294,306,335,340,354,355,356,370,371,374,386,387,388,407,417,418,419,437,446,450,463,468,483,502,509,515,517,549,557,558,567,571,572,575,579,587,590,623,624,629,635,646,659,663,664,666,667,674,675,684,686,705,708,711,720,721,723,736,753,765,771,774,782,784,791,811,814,821,825,826,827,836,838,841,842,845,846,847,851,853,855,856,866,867,868,870,906,908,910,914,920,923,924,925,926,927,930,931,932,936,937,939,940,945,948,953,960,971,972,973,976,977,979,980,1003,1005,1033,1035,1044,1045,1047,1080,1100,1131,1142,1144,1148,1162,1169,1178,1185,1206,1212,1215,1221,1231,1232,1234,1235,1237,1249,1250,1254,1255,1265,1266,1269,1271,1274,1277,1289,1292,1293,1298,1302,1305,1306,1317,1321,1326,1334,1344,1348,1354,1355,1364,1367,1374,1436,1441,1442,1449,1450,1461,1462,1463,1477,1490,1496,1498,1499,1503,1504,1505,1506,1516,1521,1559,1563,1576,1583,1592,1642,1658,1691,1699,1700,1716,1721,1722,1746,1776,1778,1787,1794,1796,1799,1805,1820,1825,1844,1864,1872,1873,1875,1885,1886,1887,1888,1890,1891,1898,1924,1929,1930,1933,1962,1976,1983,1993,1995,2002,2014,2038,2040,2051,2081,2083,2102,2103,2120,2124,2130,2135,2136,2137,2150,2160,2167,2170,2190,2206,2207,2217,2218,2219,2221,2233,2235,2256,2257,2258,2282,2283,2284,2288,2297,2302,2307,2308,2309,2321,2336,2338,2344,2345,2347,2357,2364,2368,2373,2376,2381,2384,2388,2393,2397,2399,2410,2413,2414,2415,2420,2437,2447,2463,2476,2477,2497,2507,2521,2524,2529,2538,2539,2540,2541,2542,2577,2597,2602,2603,2606,2620,2640,2643,2644,2664,2667,2669,2689,2691,2692,2698,2705,2706,2707,2722,2736,2806,2815,2846,2890,2891,2899,2900,2901,2946,2948,2949,2950,2951,2969,2970,2971,2972,2973,2974,2992,2996,2999,3000,3041,3112,3114,3149,3150,3162,3163,3174,3230,3231,3233,3234,3313,3320,3322,3323,3324,3325,3368,3369,3465,3480,3510,3513,3538,3544,3572,3593,3636,3740,3796,3947,3948,3957,4423,4424,4431,4450,4539,4552,4553,4554,4556,4614,4645,4654,4669,4695,4696,4697,4698,4699,4704,4705,4799,4865,4903,4909,4910,4912,4913,4914,4915,4917,5057,5134,5165,5168,5170,5173,5252,5276,5277,5319,5414,5464,5474,5500,5516,5532), [charts that don't use the default but should](https://docs.google.com/spreadsheets/d/1OmzUXBNFjBQg2WycAhxD0ZdNp07Pv94UcEDqQK0xIyU/edit#gid=1597261388), [charts that use another variable](https://playfair.owid.cloud/admin/test/embeds?ids=179,231,273,308,451,3144,3161,3185,3186,3187,3210,3326,3342,3349,3442,3514,3515,3516,3517,3518,3519,3540,3550,3582,3587,3635,4009,4349,4366,4462,4478,4559,4639,4976,5058))

- `formatValueShortWithAbbreviations` now includes the unit if it's one of `%`, `$` or `£`. Apart from the ScatterPlot size legend, this function is also used in the Explorer country select sidebar.

Minor design tweaks:

- Now using `Lato` font for bubble labels inside plot (somehow we missed this when changing fonts)
