### PR TITLE
Scatter size legend #2: Feature work

### DIFF
--- a/grapher/scatterCharts/ScatterPlotChart.test.ts
+++ b/grapher/scatterCharts/ScatterPlotChart.test.ts
@@ -249,7 +249,6 @@ describe("basic scatterplot", () => {
                     },
                 ],
                 seriesName: "UK",
-                size: 100,
             },
             {
                 color: chart.defaultNoDataColor,
@@ -260,7 +259,7 @@ describe("basic scatterplot", () => {
                         color: undefined,
                         entityName: "USA",
                         label: "2000",
-                        size: 0,
+                        size: undefined,
                         time: {
                             x: 2000,
                             y: 2000,
@@ -271,7 +270,6 @@ describe("basic scatterplot", () => {
                     },
                 ],
                 seriesName: "USA",
-                size: 0,
             },
         ])
     })

--- a/grapher/scatterCharts/ScatterPlotChart.test.ts
+++ b/grapher/scatterCharts/ScatterPlotChart.test.ts
@@ -7,7 +7,15 @@ import {
     SynthesizeFruitTableWithNonPositives,
     SynthesizeGDPTable,
 } from "../../coreTable/OwidTableSynthesizers.js"
-import { ScatterPlotManager } from "./ScatterPlotChartConstants.js"
+import {
+    ScatterPlotManager,
+    SCATTER_LABEL_DEFAULT_FONT_SIZE,
+    SCATTER_LABEL_MAX_FONT_SIZE,
+    SCATTER_LABEL_MIN_FONT_SIZE,
+    SCATTER_POINT_DEFAULT_RADIUS,
+    SCATTER_POINT_MAX_RADIUS,
+    SCATTER_POINT_MIN_RADIUS,
+} from "./ScatterPlotChartConstants.js"
 import {
     EntitySelectionMode,
     ScaleType,
@@ -20,7 +28,8 @@ import { ContinentColors } from "../color/ColorConstants.js"
 import { OwidTableSlugs } from "../../coreTable/OwidTableConstants.js"
 import { Color } from "../../coreTable/CoreTableConstants.js"
 import { makeOriginalTimeSlugFromColumnSlug } from "../../coreTable/OwidTableUtil.js"
-import { uniq, uniqBy } from "../../clientUtils/Util.js"
+import { sortBy, uniq, uniqBy } from "../../clientUtils/Util.js"
+import { ScatterPointsWithLabels } from "./ScatterPointsWithLabels.js"
 
 it("can create a new chart", () => {
     const manager: ScatterPlotManager = {
@@ -957,5 +966,156 @@ describe("addCountryMode", () => {
             },
         })
         expect(chart.transformedTable.numRows).toEqual(1)
+    })
+})
+
+describe("correct bubble sizes", () => {
+    it("with column", () => {
+        const table = new OwidTable(
+            [
+                [
+                    "entityId",
+                    "entityName",
+                    "entityCode",
+                    "year",
+                    "x",
+                    "y",
+                    "size",
+                ],
+                // sorted alphabetically
+                [1, "SWE", "", 2000, 2, 2, undefined],
+                [2, "UK", "", 2000, 1, 1, 0],
+                [3, "USA", "", 2000, 2, 2, 2],
+                [3, "ZZZ", "", 2000, 2, 2, -20],
+            ],
+            [
+                {
+                    slug: "x",
+                    type: ColumnTypeNames.Numeric,
+                },
+                {
+                    slug: "y",
+                    type: ColumnTypeNames.Numeric,
+                },
+                {
+                    slug: "size",
+                    type: ColumnTypeNames.Numeric,
+                },
+            ]
+        )
+
+        const manager: ScatterPlotManager = {
+            xColumnSlug: "x",
+            yColumnSlug: "y",
+            sizeColumnSlug: "size",
+            table,
+        }
+
+        const chart = new ScatterPlotChart({
+            manager,
+        })
+
+        const scatterPoints = new ScatterPointsWithLabels({
+            noDataModalManager: manager,
+            isConnected: chart["isConnected"],
+            hideConnectedScatterLines: chart["hideConnectedScatterLines"],
+            seriesArray: chart["series"],
+            dualAxis: chart["dualAxis"],
+            sizeScale: chart["sizeScale"],
+            fontScale: chart["fontScale"],
+            focusedSeriesNames: chart["focusedEntityNames"],
+            hoveredSeriesNames: chart["hoveredSeriesNames"],
+            onMouseOver: chart["onScatterMouseOver"],
+            onMouseLeave: chart["onScatterMouseLeave"],
+            onClick: chart["onScatterClick"],
+        })
+
+        const sortedRenderSeries = sortBy(
+            scatterPoints["initialRenderSeries"],
+            (s) => s.seriesName
+        )
+
+        expect(sortedRenderSeries[0].seriesName).toEqual("SWE")
+        expect(sortedRenderSeries[0].size).toEqual(SCATTER_POINT_MIN_RADIUS)
+        expect(sortedRenderSeries[0].fontSize).toEqual(
+            SCATTER_LABEL_MIN_FONT_SIZE
+        )
+        expect(sortedRenderSeries[1].seriesName).toEqual("UK")
+        expect(sortedRenderSeries[1].size).toEqual(SCATTER_POINT_MIN_RADIUS)
+        expect(sortedRenderSeries[1].fontSize).toEqual(
+            SCATTER_LABEL_MIN_FONT_SIZE
+        )
+        expect(sortedRenderSeries[2].seriesName).toEqual("USA")
+        expect(sortedRenderSeries[2].size).toEqual(SCATTER_POINT_MAX_RADIUS)
+        expect(sortedRenderSeries[2].fontSize).toEqual(
+            SCATTER_LABEL_MAX_FONT_SIZE
+        )
+        expect(sortedRenderSeries[3].seriesName).toEqual("ZZZ")
+        expect(sortedRenderSeries[3].size).toEqual(SCATTER_POINT_MIN_RADIUS)
+        expect(sortedRenderSeries[3].fontSize).toEqual(
+            SCATTER_LABEL_MIN_FONT_SIZE
+        )
+    })
+
+    it("without column", () => {
+        const table = new OwidTable(
+            [
+                ["entityId", "entityName", "entityCode", "year", "x", "y"],
+                // sorted alphabetically
+                [1, "SWE", "", 2000, 2, 2],
+                [2, "UK", "", 2000, 1, 1],
+            ],
+            [
+                {
+                    slug: "x",
+                    type: ColumnTypeNames.Numeric,
+                },
+                {
+                    slug: "y",
+                    type: ColumnTypeNames.Numeric,
+                },
+            ]
+        )
+
+        const manager: ScatterPlotManager = {
+            xColumnSlug: "x",
+            yColumnSlug: "y",
+            table,
+        }
+
+        const chart = new ScatterPlotChart({
+            manager,
+        })
+
+        const scatterPoints = new ScatterPointsWithLabels({
+            noDataModalManager: manager,
+            isConnected: chart["isConnected"],
+            hideConnectedScatterLines: chart["hideConnectedScatterLines"],
+            seriesArray: chart["series"],
+            dualAxis: chart["dualAxis"],
+            sizeScale: chart["sizeScale"],
+            fontScale: chart["fontScale"],
+            focusedSeriesNames: chart["focusedEntityNames"],
+            hoveredSeriesNames: chart["hoveredSeriesNames"],
+            onMouseOver: chart["onScatterMouseOver"],
+            onMouseLeave: chart["onScatterMouseLeave"],
+            onClick: chart["onScatterClick"],
+        })
+
+        const sortedRenderSeries = sortBy(
+            scatterPoints["initialRenderSeries"],
+            (s) => s.seriesName
+        )
+
+        expect(sortedRenderSeries[0].seriesName).toEqual("SWE")
+        expect(sortedRenderSeries[0].size).toEqual(SCATTER_POINT_DEFAULT_RADIUS)
+        expect(sortedRenderSeries[0].fontSize).toEqual(
+            SCATTER_LABEL_DEFAULT_FONT_SIZE
+        )
+        expect(sortedRenderSeries[1].seriesName).toEqual("UK")
+        expect(sortedRenderSeries[1].size).toEqual(SCATTER_POINT_DEFAULT_RADIUS)
+        expect(sortedRenderSeries[1].fontSize).toEqual(
+            SCATTER_LABEL_DEFAULT_FONT_SIZE
+        )
     })
 })

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -419,7 +419,7 @@ export class ScatterPlotChart
         if (this.hoveredSeries) this.onSelectEntity(this.hoveredSeries)
     }
 
-    @computed private get tooltipSeries(): ScatterSeries | undefined {
+    @computed get tooltipSeries(): ScatterSeries | undefined {
         const { hoveredSeries, focusedEntityNames } = this
         if (hoveredSeries !== undefined)
             return this.series.find((g) => g.seriesName === hoveredSeries)

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -566,7 +566,8 @@ export class ScatterPlotChart
     }
 
     @computed private get sizeLegend(): ScatterSizeLegend | undefined {
-        if (!this.allSeriesArePoints) return undefined
+        if (!this.allSeriesArePoints || this.sizeColumn.isMissing)
+            return undefined
         return new ScatterSizeLegend(this)
     }
 

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -50,9 +50,7 @@ import {
     ScatterPlotManager,
     ScatterSeries,
     SCATTER_LINE_MAX_WIDTH,
-    SCATTER_LINE_MIN_WIDTH,
     SCATTER_POINT_MAX_RADIUS,
-    SCATTER_POINT_MIN_RADIUS,
     SeriesPoint,
 } from "./ScatterPlotChartConstants.js"
 import { ScatterTooltip } from "./ScatterTooltip.js"
@@ -954,7 +952,10 @@ export class ScatterPlotChart
                 return {
                     x: row[this.xColumnSlug],
                     y: row[this.yColumnSlug],
-                    size: defaultIfErrorValue(row[this.sizeColumn.slug], 0),
+                    size: defaultIfErrorValue(
+                        row[this.sizeColumn.slug],
+                        undefined
+                    ),
                     color: defaultIfErrorValue(
                         row[this.colorColumn.slug],
                         undefined

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -980,7 +980,6 @@ export class ScatterPlotChart
                 seriesName: entityName,
                 label: entityName,
                 color: "#932834", // Default color, used when no color dimension is present
-                size: this.getSizeFromPoints(points),
                 points,
             }
             this.assignColorToSeries(entityName, series)
@@ -1007,10 +1006,5 @@ export class ScatterPlotChart
                 }
             }
         }
-    }
-
-    private getSizeFromPoints(points: SeriesPoint[]): number {
-        const size = last(points.map((v) => v.size).filter(isNumber))
-        return size ?? 0
     }
 }

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -513,29 +513,20 @@ export class ScatterPlotChart
     }
 
     @computed private get points(): JSX.Element {
-        const {
-            dualAxis,
-            focusedEntityNames,
-            hoveredSeriesNames,
-            hideConnectedScatterLines,
-            manager,
-            series,
-            colorScale,
-            colorColumn,
-        } = this
-
         return (
             <ScatterPointsWithLabels
-                noDataModalManager={manager}
+                noDataModalManager={this.manager}
                 isConnected={this.isConnected}
-                hideConnectedScatterLines={hideConnectedScatterLines}
-                seriesArray={series}
-                dualAxis={dualAxis}
-                colorScale={!colorColumn.isMissing ? colorScale : undefined}
+                hideConnectedScatterLines={this.hideConnectedScatterLines}
+                seriesArray={this.series}
+                dualAxis={this.dualAxis}
+                colorScale={
+                    !this.colorColumn.isMissing ? this.colorScale : undefined
+                }
                 sizeScale={this.sizeScale}
                 fontScale={this.fontScale}
-                focusedSeriesNames={focusedEntityNames}
-                hoveredSeriesNames={hoveredSeriesNames}
+                focusedSeriesNames={this.focusedEntityNames}
+                hoveredSeriesNames={this.hoveredSeriesNames}
                 disableIntroAnimation={this.manager.disableIntroAnimation}
                 onMouseOver={this.onScatterMouseOver}
                 onMouseLeave={this.onScatterMouseLeave}

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -49,7 +49,12 @@ import { ChartInterface } from "../chart/ChartInterface.js"
 import {
     ScatterPlotManager,
     ScatterSeries,
+    SCATTER_LABEL_DEFAULT_FONT_SIZE,
+    SCATTER_LABEL_MAX_FONT_SIZE,
+    SCATTER_LABEL_MIN_FONT_SIZE,
+    SCATTER_LINE_DEFAULT_WIDTH,
     SCATTER_LINE_MAX_WIDTH,
+    SCATTER_POINT_DEFAULT_RADIUS,
     SCATTER_POINT_MAX_RADIUS,
     SeriesPoint,
 } from "./ScatterPlotChartConstants.js"
@@ -528,6 +533,7 @@ export class ScatterPlotChart
                 dualAxis={dualAxis}
                 colorScale={!colorColumn.isMissing ? colorScale : undefined}
                 sizeScale={this.sizeScale}
+                fontScale={this.fontScale}
                 focusedSeriesNames={focusedEntityNames}
                 hoveredSeriesNames={hoveredSeriesNames}
                 disableIntroAnimation={this.manager.disableIntroAnimation}
@@ -560,9 +566,37 @@ export class ScatterPlotChart
         return scaleSqrt()
             .domain(this.sizeDomain)
             .range(
-                this.isConnected
-                    ? [0, SCATTER_LINE_MAX_WIDTH]
+                this.sizeColumn.isMissing
+                    ? // if the size column is missing, we want all points/lines to have the same width
+                      this.isConnected
+                        ? [
+                              SCATTER_LINE_DEFAULT_WIDTH,
+                              SCATTER_LINE_DEFAULT_WIDTH,
+                          ]
+                        : [
+                              SCATTER_POINT_DEFAULT_RADIUS,
+                              SCATTER_POINT_DEFAULT_RADIUS,
+                          ]
+                    : this.isConnected
+                    ? // Note that the scale starts at 0.
+                      // When using the scale to plot marks, we need to make sure the minimums
+                      // (e.g. `SCATTER_POINT_MIN_RADIUS`) are respected.
+                      [0, SCATTER_LINE_MAX_WIDTH]
                     : [0, SCATTER_POINT_MAX_RADIUS]
+            )
+    }
+
+    @computed get fontScale(): ScaleLinear<number, number> {
+        return scaleSqrt()
+            .domain(this.sizeDomain)
+            .range(
+                this.sizeColumn.isMissing
+                    ? // if the size column is missing, we want all labels to have the same font size
+                      [
+                          SCATTER_LABEL_DEFAULT_FONT_SIZE,
+                          SCATTER_LABEL_DEFAULT_FONT_SIZE,
+                      ]
+                    : [SCATTER_LABEL_MIN_FONT_SIZE, SCATTER_LABEL_MAX_FONT_SIZE]
             )
     }
 

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -49,7 +49,10 @@ import { ChartInterface } from "../chart/ChartInterface.js"
 import {
     ScatterPlotManager,
     ScatterSeries,
+    SCATTER_LINE_MAX_WIDTH,
+    SCATTER_LINE_MIN_WIDTH,
     SCATTER_POINT_MAX_RADIUS,
+    SCATTER_POINT_MIN_RADIUS,
     SeriesPoint,
 } from "./ScatterPlotChartConstants.js"
 import { ScatterTooltip } from "./ScatterTooltip.js"
@@ -521,6 +524,7 @@ export class ScatterPlotChart
         return (
             <ScatterPointsWithLabels
                 noDataModalManager={manager}
+                isConnected={this.isConnected}
                 hideConnectedScatterLines={hideConnectedScatterLines}
                 seriesArray={series}
                 dualAxis={dualAxis}
@@ -556,18 +560,21 @@ export class ScatterPlotChart
 
     @computed get sizeScale(): ScaleLinear<number, number> {
         return scaleSqrt()
-            .range([0, SCATTER_POINT_MAX_RADIUS])
             .domain(this.sizeDomain)
+            .range(
+                this.isConnected
+                    ? [0, SCATTER_LINE_MAX_WIDTH]
+                    : [0, SCATTER_POINT_MAX_RADIUS]
+            )
     }
 
-    /** Whether all series are shown as points */
-    @computed private get allSeriesArePoints(): boolean {
-        return this.series.every((s) => s.points.length <= 1)
+    /** Whether series are shown as lines (instead of single points) */
+    @computed private get isConnected(): boolean {
+        return this.series.some((s) => s.points.length > 1)
     }
 
     @computed private get sizeLegend(): ScatterSizeLegend | undefined {
-        if (!this.allSeriesArePoints || this.sizeColumn.isMissing)
-            return undefined
+        if (this.isConnected || this.sizeColumn.isMissing) return undefined
         return new ScatterSizeLegend(this)
     }
 

--- a/grapher/scatterCharts/ScatterPlotChartConstants.ts
+++ b/grapher/scatterCharts/ScatterPlotChartConstants.ts
@@ -66,7 +66,6 @@ export interface ScatterRenderPoint {
     position: PointVector
     color: Color
     size: number
-    fontSize: number
     label: string
     time: {
         x: number
@@ -85,10 +84,12 @@ export const SCATTER_LINE_DEFAULT_WIDTH: number = 1
 export const SCATTER_LABEL_MIN_FONT_SIZE: number = 10
 export const SCATTER_LABEL_MAX_FONT_SIZE: number = 13
 export const SCATTER_LABEL_DEFAULT_FONT_SIZE: number = 10.5
+export const SCATTER_LABEL_FONT_SIZE_WHEN_HIDDEN_LINES: number = 12
 
 export interface ScatterRenderSeries extends ChartSeries {
     displayKey: string
     size: number
+    fontSize: number
     points: ScatterRenderPoint[]
     text: string
     isHover?: boolean

--- a/grapher/scatterCharts/ScatterPlotChartConstants.ts
+++ b/grapher/scatterCharts/ScatterPlotChartConstants.ts
@@ -79,8 +79,10 @@ export const SCATTER_POINT_MIN_RADIUS: number = 2
 export const SCATTER_POINT_MAX_RADIUS: number = 18
 export const SCATTER_POINT_OPACITY: number = 0.8
 export const SCATTER_POINT_STROKE_WIDTH: number = 0.5
+export const SCATTER_POINT_DEFAULT_RADIUS: number = 3
 export const SCATTER_LINE_MIN_WIDTH: number = 0.5
 export const SCATTER_LINE_MAX_WIDTH: number = 2
+export const SCATTER_LINE_DEFAULT_WIDTH: number = 1
 
 export interface ScatterRenderSeries extends ChartSeries {
     displayKey: string

--- a/grapher/scatterCharts/ScatterPlotChartConstants.ts
+++ b/grapher/scatterCharts/ScatterPlotChartConstants.ts
@@ -50,7 +50,7 @@ export interface ScatterSeries extends ChartSeries {
 export interface SeriesPoint {
     x: number
     y: number
-    size: number
+    size?: number
     entityName?: EntityName
     label: string
     color?: number | Color
@@ -74,14 +74,17 @@ export interface ScatterRenderPoint {
     }
 }
 
-export const SCATTER_POINT_MIN_RADIUS: number = 2
+export const SCATTER_POINT_MIN_RADIUS: number = 2 // only enforced in rendered points, not in scale
 export const SCATTER_POINT_MAX_RADIUS: number = 18
 export const SCATTER_POINT_OPACITY: number = 0.8
 export const SCATTER_POINT_STROKE_WIDTH: number = 0.5
 export const SCATTER_POINT_DEFAULT_RADIUS: number = 3
-export const SCATTER_LINE_MIN_WIDTH: number = 0.5
+export const SCATTER_LINE_MIN_WIDTH: number = 0.5 // only enforced in rendered lines, not in scale
 export const SCATTER_LINE_MAX_WIDTH: number = 2
 export const SCATTER_LINE_DEFAULT_WIDTH: number = 1
+export const SCATTER_LABEL_MIN_FONT_SIZE: number = 10
+export const SCATTER_LABEL_MAX_FONT_SIZE: number = 13
+export const SCATTER_LABEL_DEFAULT_FONT_SIZE: number = 10.5
 
 export interface ScatterRenderSeries extends ChartSeries {
     displayKey: string
@@ -118,6 +121,7 @@ export interface ScatterPointsWithLabelsProps {
     dualAxis: DualAxis
     colorScale?: ColorScale
     sizeScale: ScaleLinear<number, number>
+    fontScale: ScaleLinear<number, number>
     onMouseOver: (series: ScatterSeries) => void
     onMouseLeave: () => void
     onClick: () => void

--- a/grapher/scatterCharts/ScatterPlotChartConstants.ts
+++ b/grapher/scatterCharts/ScatterPlotChartConstants.ts
@@ -77,6 +77,8 @@ export interface ScatterRenderPoint {
 
 export const SCATTER_POINT_MIN_RADIUS: number = 2
 export const SCATTER_POINT_MAX_RADIUS: number = 18
+export const SCATTER_POINT_OPACITY: number = 0.8
+export const SCATTER_POINT_STROKE_WIDTH: number = 0.5
 
 export interface ScatterRenderSeries extends ChartSeries {
     displayKey: string

--- a/grapher/scatterCharts/ScatterPlotChartConstants.ts
+++ b/grapher/scatterCharts/ScatterPlotChartConstants.ts
@@ -79,6 +79,8 @@ export const SCATTER_POINT_MIN_RADIUS: number = 2
 export const SCATTER_POINT_MAX_RADIUS: number = 18
 export const SCATTER_POINT_OPACITY: number = 0.8
 export const SCATTER_POINT_STROKE_WIDTH: number = 0.5
+export const SCATTER_LINE_MIN_WIDTH: number = 0.5
+export const SCATTER_LINE_MAX_WIDTH: number = 2
 
 export interface ScatterRenderSeries extends ChartSeries {
     displayKey: string
@@ -118,6 +120,7 @@ export interface ScatterPointsWithLabelsProps {
     onMouseOver: (series: ScatterSeries) => void
     onMouseLeave: () => void
     onClick: () => void
+    isConnected: boolean
     hideConnectedScatterLines: boolean
     noDataModalManager: NoDataModalManager
     disableIntroAnimation?: boolean

--- a/grapher/scatterCharts/ScatterPlotChartConstants.ts
+++ b/grapher/scatterCharts/ScatterPlotChartConstants.ts
@@ -1,3 +1,4 @@
+import { ScaleLinear } from "d3-scale"
 import { CoreColumn } from "../../coreTable/CoreTableColumns.js"
 import { Color, Time } from "../../coreTable/CoreTableConstants.js"
 import { DualAxis } from "../axis/Axis.js"
@@ -74,6 +75,9 @@ export interface ScatterRenderPoint {
     }
 }
 
+export const SCATTER_POINT_MIN_RADIUS: number = 2
+export const SCATTER_POINT_MAX_RADIUS: number = 18
+
 export interface ScatterRenderSeries extends ChartSeries {
     displayKey: string
     size: number
@@ -108,7 +112,7 @@ export interface ScatterPointsWithLabelsProps {
     focusedSeriesNames: SeriesName[]
     dualAxis: DualAxis
     colorScale?: ColorScale
-    sizeDomain: [number, number]
+    sizeScale: ScaleLinear<number, number>
     onMouseOver: (series: ScatterSeries) => void
     onMouseLeave: () => void
     onClick: () => void

--- a/grapher/scatterCharts/ScatterPlotChartConstants.ts
+++ b/grapher/scatterCharts/ScatterPlotChartConstants.ts
@@ -43,7 +43,6 @@ export interface ScatterTooltipProps {
 
 export interface ScatterSeries extends ChartSeries {
     label: string
-    size: number
     points: SeriesPoint[]
     isScaleColor?: boolean
 }

--- a/grapher/scatterCharts/ScatterPoints.tsx
+++ b/grapher/scatterCharts/ScatterPoints.tsx
@@ -5,7 +5,6 @@ import React from "react"
 import { MultiColorPolyline } from "./MultiColorPolyline.js"
 import {
     ScatterRenderSeries,
-    SCATTER_POINT_MIN_RADIUS,
     SCATTER_POINT_OPACITY,
     SCATTER_POINT_STROKE_WIDTH,
 } from "./ScatterPlotChartConstants.js"
@@ -25,7 +24,7 @@ export class ScatterPoint extends React.Component<{
         const color = series.isFocus || !isLayerMode ? value.color : "#e2e2e2"
 
         const isLabelled = series.allLabels.some((label) => !label.isHidden)
-        const size = Math.max(SCATTER_POINT_MIN_RADIUS, value.size)
+        const size = value.size
         const cx = value.position.x.toFixed(2)
         const cy = value.position.y.toFixed(2)
         const stroke = isLayerMode ? "#bbb" : isLabelled ? "#333" : "#666"

--- a/grapher/scatterCharts/ScatterPoints.tsx
+++ b/grapher/scatterCharts/ScatterPoints.tsx
@@ -3,7 +3,11 @@ import { first, last } from "../../clientUtils/Util.js"
 import { observer } from "mobx-react"
 import React from "react"
 import { MultiColorPolyline } from "./MultiColorPolyline.js"
-import { ScatterRenderSeries } from "./ScatterPlotChartConstants.js"
+import {
+    ScatterRenderSeries,
+    SCATTER_POINT_OPACITY,
+    SCATTER_POINT_STROKE_WIDTH,
+} from "./ScatterPlotChartConstants.js"
 import { Triangle } from "./Triangle.js"
 
 // When there's only a single point in a series (e.g. single year mode)
@@ -43,9 +47,9 @@ export class ScatterPoint extends React.Component<{
                     cy={cy}
                     r={size.toFixed(2)}
                     fill={color}
-                    opacity={0.8}
+                    opacity={SCATTER_POINT_OPACITY}
                     stroke={stroke}
-                    strokeWidth={0.5}
+                    strokeWidth={SCATTER_POINT_STROKE_WIDTH}
                 />
             </g>
         )

--- a/grapher/scatterCharts/ScatterPoints.tsx
+++ b/grapher/scatterCharts/ScatterPoints.tsx
@@ -16,19 +16,16 @@ import { Triangle } from "./Triangle.js"
 export class ScatterPoint extends React.Component<{
     series: ScatterRenderSeries
     isLayerMode?: boolean
-    isConnected?: boolean
 }> {
     render(): JSX.Element | null {
-        const { series, isLayerMode, isConnected } = this.props
+        const { series, isLayerMode } = this.props
         const value = first(series.points)
         if (value === undefined) return null
 
         const color = series.isFocus || !isLayerMode ? value.color : "#e2e2e2"
 
         const isLabelled = series.allLabels.some((label) => !label.isHidden)
-        const size = isConnected
-            ? SCATTER_POINT_MIN_RADIUS + value.size / 16
-            : value.size
+        const size = Math.max(SCATTER_POINT_MIN_RADIUS, value.size)
         const cx = value.position.x.toFixed(2)
         const cy = value.position.y.toFixed(2)
         const stroke = isLayerMode ? "#bbb" : isLabelled ? "#333" : "#666"
@@ -62,19 +59,12 @@ export class ScatterPoint extends React.Component<{
 export class ScatterLine extends React.Component<{
     series: ScatterRenderSeries
     isLayerMode: boolean
-    isConnected: boolean
 }> {
     render(): JSX.Element | null {
-        const { series, isLayerMode, isConnected } = this.props
+        const { series, isLayerMode } = this.props
 
         if (series.points.length === 1)
-            return (
-                <ScatterPoint
-                    series={series}
-                    isLayerMode={isLayerMode}
-                    isConnected={isConnected}
-                />
-            )
+            return <ScatterPoint series={series} isLayerMode={isLayerMode} />
 
         const firstValue = first(series.points)
         const lastValue = last(series.points)
@@ -90,7 +80,7 @@ export class ScatterLine extends React.Component<{
                 <circle
                     cx={firstValue.position.x.toFixed(2)}
                     cy={firstValue.position.y.toFixed(2)}
-                    r={(1 + firstValue.size / 25).toFixed(1)}
+                    r={(1 + firstValue.size / 2).toFixed(1)}
                     fill={isLayerMode ? "#e2e2e2" : firstValue.color}
                     stroke="none"
                     opacity={opacity}
@@ -101,7 +91,7 @@ export class ScatterLine extends React.Component<{
                         y: v.position.y,
                         color: isLayerMode ? "#ccc" : v.color,
                     }))}
-                    strokeWidth={(0.3 + series.size / 16).toFixed(2)}
+                    strokeWidth={series.size.toFixed(2)}
                     opacity={opacity}
                 />
                 <Triangle
@@ -110,7 +100,7 @@ export class ScatterLine extends React.Component<{
                     )}, ${lastValue.position.y.toFixed(2)})`}
                     cx={lastValue.position.x}
                     cy={lastValue.position.y}
-                    r={1.5 + lastValue.size / 16}
+                    r={1.5 + lastValue.size}
                     fill={isLayerMode ? "#e2e2e2" : lastValue.color}
                     opacity={opacity}
                 />

--- a/grapher/scatterCharts/ScatterPoints.tsx
+++ b/grapher/scatterCharts/ScatterPoints.tsx
@@ -5,6 +5,7 @@ import React from "react"
 import { MultiColorPolyline } from "./MultiColorPolyline.js"
 import {
     ScatterRenderSeries,
+    SCATTER_POINT_MIN_RADIUS,
     SCATTER_POINT_OPACITY,
     SCATTER_POINT_STROKE_WIDTH,
 } from "./ScatterPlotChartConstants.js"
@@ -25,8 +26,9 @@ export class ScatterPoint extends React.Component<{
         const color = series.isFocus || !isLayerMode ? value.color : "#e2e2e2"
 
         const isLabelled = series.allLabels.some((label) => !label.isHidden)
-        const size =
-            !series.isFocus && isConnected ? 1 + value.size / 16 : value.size
+        const size = isConnected
+            ? SCATTER_POINT_MIN_RADIUS + value.size / 16
+            : value.size
         const cx = value.position.x.toFixed(2)
         const cy = value.position.y.toFixed(2)
         const stroke = isLayerMode ? "#bbb" : isLabelled ? "#333" : "#666"

--- a/grapher/scatterCharts/ScatterPointsWithLabels.tsx
+++ b/grapher/scatterCharts/ScatterPointsWithLabels.tsx
@@ -26,7 +26,6 @@ import {
     ScatterPointsWithLabelsProps,
     ScatterRenderSeries,
     ScatterLabel,
-    ScatterRenderPoint,
     ScatterSeries,
     SCATTER_POINT_MIN_RADIUS,
     SCATTER_LINE_MIN_WIDTH,

--- a/grapher/scatterCharts/ScatterPointsWithLabels.tsx
+++ b/grapher/scatterCharts/ScatterPointsWithLabels.tsx
@@ -30,6 +30,8 @@ import {
     ScatterSeries,
     SCATTER_POINT_MIN_RADIUS,
     SCATTER_LINE_MIN_WIDTH,
+    SCATTER_POINT_DEFAULT_RADIUS,
+    SCATTER_LINE_DEFAULT_WIDTH,
 } from "./ScatterPlotChartConstants.js"
 import { ScatterLine, ScatterPoint } from "./ScatterPoints.js"
 import {
@@ -113,18 +115,23 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
                         colorScale !== undefined
                             ? colorScale.getColor(point.color)
                             : undefined
+                    const size = Math.max(
+                        sizeScale(point.size),
+                        this.props.isConnected
+                            ? SCATTER_LINE_MIN_WIDTH
+                            : SCATTER_POINT_MIN_RADIUS
+                    )
                     return {
                         position: new PointVector(
                             Math.floor(xAxis.place(point.x)),
                             Math.floor(yAxis.place(point.y))
                         ),
                         color: scaleColor ?? series.color,
-                        size: Math.max(
-                            sizeScale(point.size),
-                            this.props.isConnected
-                                ? SCATTER_LINE_MIN_WIDTH
-                                : SCATTER_POINT_MIN_RADIUS
-                        ),
+                        size: !isNaN(size)
+                            ? size
+                            : this.props.isConnected
+                            ? SCATTER_LINE_DEFAULT_WIDTH
+                            : SCATTER_POINT_DEFAULT_RADIUS,
                         fontSize: fontScale(series.size || 1),
                         time: point.time,
                         label: point.label,

--- a/grapher/scatterCharts/ScatterPointsWithLabels.tsx
+++ b/grapher/scatterCharts/ScatterPointsWithLabels.tsx
@@ -29,6 +29,7 @@ import {
     SCATTER_LINE_MIN_WIDTH,
     SCATTER_POINT_MIN_RADIUS,
     ScatterRenderPoint,
+    SCATTER_LABEL_MIN_FONT_SIZE,
 } from "./ScatterPlotChartConstants.js"
 import { ScatterLine, ScatterPoint } from "./ScatterPoints.js"
 import {
@@ -109,9 +110,11 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
     }
 
     private getLabelFontSize(value: number | undefined): number {
-        return value !== undefined
-            ? this.fontScale(value)
-            : this.fontScale.range()[0]
+        const fontSize =
+            value !== undefined
+                ? this.fontScale(value)
+                : this.fontScale.range()[0]
+        return Math.max(fontSize, SCATTER_LABEL_MIN_FONT_SIZE)
     }
 
     @computed private get hideConnectedScatterLines(): boolean {

--- a/grapher/scatterCharts/ScatterPointsWithLabels.tsx
+++ b/grapher/scatterCharts/ScatterPointsWithLabels.tsx
@@ -131,7 +131,7 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
                             : this.props.isConnected
                             ? SCATTER_LINE_DEFAULT_WIDTH
                             : SCATTER_POINT_DEFAULT_RADIUS,
-                        fontSize: fontScale(series.size || 1),
+                        fontSize: fontScale(size),
                         time: point.time,
                         label: point.label,
                     }

--- a/grapher/scatterCharts/ScatterPointsWithLabels.tsx
+++ b/grapher/scatterCharts/ScatterPointsWithLabels.tsx
@@ -28,6 +28,7 @@ import {
     ScatterLabel,
     ScatterRenderPoint,
     ScatterSeries,
+    SCATTER_POINT_MIN_RADIUS,
 } from "./ScatterPlotChartConstants.js"
 import { ScatterLine, ScatterPoint } from "./ScatterPoints.js"
 import {
@@ -89,10 +90,7 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
     }
 
     @computed private get sizeScale(): ScaleLinear<number, number> {
-        const sizeScale = scaleLinear()
-            .range([10, 1000])
-            .domain(this.props.sizeDomain)
-        return sizeScale
+        return this.props.sizeScale
     }
 
     @computed private get fontScale(): (d: number) => number {
@@ -114,7 +112,6 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
         return sortNumeric(
             seriesArray.map((series) => {
                 const points = series.points.map((point) => {
-                    const area = sizeScale(point.size || 4)
                     const scaleColor =
                         colorScale !== undefined
                             ? colorScale.getColor(point.color)
@@ -125,7 +122,10 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
                             Math.floor(yAxis.place(point.y))
                         ),
                         color: scaleColor ?? series.color,
-                        size: Math.sqrt(area / Math.PI),
+                        size: Math.max(
+                            SCATTER_POINT_MIN_RADIUS,
+                            sizeScale(point.size)
+                        ),
                         fontSize: fontScale(series.size || 1),
                         time: point.time,
                         label: point.label,

--- a/grapher/scatterCharts/ScatterPointsWithLabels.tsx
+++ b/grapher/scatterCharts/ScatterPointsWithLabels.tsx
@@ -28,6 +28,7 @@ import {
     ScatterSeries,
     SCATTER_LINE_MIN_WIDTH,
     SCATTER_POINT_MIN_RADIUS,
+    ScatterRenderPoint,
 } from "./ScatterPlotChartConstants.js"
 import { ScatterLine, ScatterPoint } from "./ScatterPoints.js"
 import {
@@ -126,30 +127,32 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
         yAxis.range = this.bounds.yRange()
 
         return sortNumeric(
-            seriesArray.map((series) => {
-                const points = series.points.map((point) => {
-                    const scaleColor =
-                        colorScale !== undefined
-                            ? colorScale.getColor(point.color)
-                            : undefined
-                    return {
-                        position: new PointVector(
-                            Math.floor(xAxis.place(point.x)),
-                            Math.floor(yAxis.place(point.y))
-                        ),
-                        color: scaleColor ?? series.color,
-                        size: this.getPointRadius(point.size),
-                        fontSize: this.getLabelFontSize(point.size),
-                        time: point.time,
-                        label: point.label,
+            seriesArray.map((series): ScatterRenderSeries => {
+                const points = series.points.map(
+                    (point): ScatterRenderPoint => {
+                        const scaleColor =
+                            colorScale !== undefined
+                                ? colorScale.getColor(point.color)
+                                : undefined
+                        return {
+                            position: new PointVector(
+                                Math.floor(xAxis.place(point.x)),
+                                Math.floor(yAxis.place(point.y))
+                            ),
+                            color: scaleColor ?? series.color,
+                            size: this.getPointRadius(point.size),
+                            time: point.time,
+                            label: point.label,
+                        }
                     }
-                })
+                )
 
                 return {
                     seriesName: series.seriesName,
                     displayKey: "key-" + makeSafeForCSS(series.seriesName),
                     color: series.color,
                     size: last(points)!.size,
+                    fontSize: this.getLabelFontSize(last(series.points)!.size),
                     points,
                     text: series.label,
                     midLabels: [],

--- a/grapher/scatterCharts/ScatterSizeLegend.tsx
+++ b/grapher/scatterCharts/ScatterSizeLegend.tsx
@@ -141,7 +141,7 @@ export class ScatterSizeLegend {
                 {highlight && (
                     <LegendItem
                         key={highlight.value}
-                        label={this.manager.sizeColumn.formatValueShortWithAbbreviations(
+                        label={this.manager.sizeColumn.formatValueShort(
                             highlight.value
                         )}
                         cx={cx}

--- a/grapher/scatterCharts/ScatterSizeLegend.tsx
+++ b/grapher/scatterCharts/ScatterSizeLegend.tsx
@@ -73,11 +73,10 @@ export class ScatterSizeLegend {
 
     // Since it's circular, this is both the width and the height of the legend.
     @computed private get legendSize(): number {
-        const largestTick = first(this.ticks)
-        if (largestTick === undefined) return 0
-        const radius = this.manager.sizeScale(largestTick)
-        // adding some padding to account for label sticking out of the top
-        return 2 * radius + 3
+        if (this.ticks.length === 0) return 0
+        const maxRadius = this.manager.sizeScale.range()[1]
+        // adding some padding to account for label sticking out at the top
+        return 2 * maxRadius + 2
     }
 
     @computed private get title(): TextWrap {

--- a/grapher/scatterCharts/ScatterSizeLegend.tsx
+++ b/grapher/scatterCharts/ScatterSizeLegend.tsx
@@ -72,11 +72,15 @@ export class ScatterSizeLegend {
     }
 
     // input radius, output font size
-    @computed private get fontSizeScale(): ScaleLinear<number, number> {
-        return scaleLinear()
-            .domain([6, SCATTER_POINT_MAX_RADIUS])
-            .range([8, 11])
-            .clamp(true)
+    @computed private get fontSizeFromRadius(): ScaleLinear<number, number> {
+        return (
+            scaleLinear()
+                // choosing the domain & range somewhat arbitrarily here,
+                // by experimenting visually with font sizes
+                .domain([6, SCATTER_POINT_MAX_RADIUS])
+                .range([8, 11])
+                .clamp(true)
+        )
     }
 
     // Since it's circular, this is both the width and the height of the legend.
@@ -161,7 +165,7 @@ export class ScatterSizeLegend {
                             circleStroke={
                                 highlight ? "#ddd" : LEGEND_CIRCLE_COLOR
                             }
-                            labelFontSize={this.fontSizeScale(radius)}
+                            labelFontSize={this.fontSizeFromRadius(radius)}
                             labelFill={highlight ? "#bbb" : LEGEND_VALUE_COLOR}
                         />
                     )

--- a/grapher/scatterCharts/ScatterSizeLegend.tsx
+++ b/grapher/scatterCharts/ScatterSizeLegend.tsx
@@ -23,9 +23,11 @@ export interface ScatterSizeLegendManager {
     tooltipSeries?: ScatterSeries
 }
 
-const LEGEND_PADDING = 4
+const LEGEND_PADDING = 3
 const LEGEND_CIRCLE_COLOR = "#bbb"
 const LEGEND_VALUE_COLOR = "#444"
+const LABEL_PADDING = 2
+const LABEL_COLOR = "#777"
 const TITLE_COLOR = "#222"
 
 const MIN_FONT_SIZE = 10
@@ -85,6 +87,15 @@ export class ScatterSizeLegend {
         return 2 * maxRadius + 2
     }
 
+    @computed private get label(): TextWrap {
+        const fontSize = Math.max(MIN_FONT_SIZE, 0.625 * this.baseFontSize)
+        return new TextWrap({
+            text: "Points sized by",
+            maxWidth: this.maxWidth + 6,
+            fontSize,
+        })
+    }
+
     @computed private get title(): TextWrap {
         const fontSize = Math.max(MIN_FONT_SIZE, 0.6875 * this.baseFontSize)
         return new TextWrap({
@@ -94,6 +105,7 @@ export class ScatterSizeLegend {
             // actually visibly overflow.
             maxWidth: this.maxWidth + 6,
             fontSize,
+            fontWeight: 700,
         })
     }
 
@@ -102,7 +114,13 @@ export class ScatterSizeLegend {
     }
 
     @computed get height(): number {
-        return this.legendSize + LEGEND_PADDING + this.title.height
+        return (
+            this.legendSize +
+            LEGEND_PADDING +
+            this.label.height +
+            LABEL_PADDING +
+            this.title.height
+        )
     }
 
     @computed private get highlight():
@@ -177,12 +195,25 @@ export class ScatterSizeLegend {
         targetY: number,
         renderOptions: React.SVGAttributes<SVGGElement> = {}
     ): JSX.Element {
+        const centerX = targetX + this.maxWidth / 2
         return (
             <g {...renderOptions}>
                 {this.renderLegend(targetX, targetY)}
+                {this.label.render(
+                    centerX,
+                    targetY + this.legendSize + LEGEND_PADDING,
+                    {
+                        fill: LABEL_COLOR,
+                        textAnchor: "middle",
+                    }
+                )}
                 {this.title.render(
-                    targetX + this.maxWidth / 2,
-                    targetY + this.legendSize + 4,
+                    centerX,
+                    targetY +
+                        this.legendSize +
+                        LEGEND_PADDING +
+                        this.label.height +
+                        LABEL_PADDING,
                     {
                         fill: TITLE_COLOR,
                         textAnchor: "middle",

--- a/grapher/scatterCharts/ScatterSizeLegend.tsx
+++ b/grapher/scatterCharts/ScatterSizeLegend.tsx
@@ -240,7 +240,7 @@ const LegendItem = ({
                 >
                     {label}
                 </text>,
-                { ...style, strokeWidth: 3 }
+                { ...style, strokeWidth: 3.5 }
             )}
         </g>
     )

--- a/grapher/scatterCharts/ScatterSizeLegend.tsx
+++ b/grapher/scatterCharts/ScatterSizeLegend.tsx
@@ -30,7 +30,7 @@ const LABEL_PADDING = 2
 const LABEL_COLOR = "#777"
 const TITLE_COLOR = "#222"
 
-const MIN_FONT_SIZE = 10
+const MIN_FONT_SIZE = 9
 
 export class ScatterSizeLegend {
     manager: ScatterSizeLegendManager
@@ -90,8 +90,11 @@ export class ScatterSizeLegend {
     @computed private get label(): TextWrap {
         const fontSize = Math.max(MIN_FONT_SIZE, 0.625 * this.baseFontSize)
         return new TextWrap({
-            text: "Points sized by",
-            maxWidth: this.maxWidth + 6,
+            text: "Dots sized by",
+            // Allow text to _slightly_ go outside boundaries.
+            // Since we have padding left and right, this doesn't
+            // actually visibly overflow.
+            maxWidth: this.maxWidth + 12,
             fontSize,
         })
     }
@@ -103,7 +106,7 @@ export class ScatterSizeLegend {
             // Allow text to _slightly_ go outside boundaries.
             // Since we have padding left and right, this doesn't
             // actually visibly overflow.
-            maxWidth: this.maxWidth + 6,
+            maxWidth: this.maxWidth + 10,
             fontSize,
             fontWeight: 700,
         })

--- a/grapher/scatterCharts/ScatterUtils.ts
+++ b/grapher/scatterCharts/ScatterUtils.ts
@@ -2,6 +2,7 @@ import { Bounds } from "../../clientUtils/Bounds.js"
 import { PointVector } from "../../clientUtils/PointVector.js"
 import { last, maxBy } from "../../clientUtils/Util.js"
 import {
+    SCATTER_LABEL_FONT_SIZE_WHEN_HIDDEN_LINES,
     ScatterLabel,
     ScatterRenderPoint,
     ScatterRenderSeries,
@@ -17,8 +18,6 @@ export const labelPriority = (label: ScatterLabel): number => {
     return priority
 }
 
-const FONT_SIZE_WHEN_HIDDEN_LINES = 12
-
 // Create the start year label for a series
 export const makeStartLabel = (
     series: ScatterRenderSeries,
@@ -29,7 +28,7 @@ export const makeStartLabel = (
     if (!series.isForeground || series.points.length <= 1) return undefined
 
     const fontSize = hideConnectedScatterLines
-        ? FONT_SIZE_WHEN_HIDDEN_LINES
+        ? SCATTER_LABEL_FONT_SIZE_WHEN_HIDDEN_LINES
         : series.isForeground
         ? isSubtleForeground
             ? 8
@@ -86,7 +85,7 @@ export const makeMidLabels = (
         return []
 
     const fontSize = hideConnectedScatterLines
-        ? FONT_SIZE_WHEN_HIDDEN_LINES
+        ? SCATTER_LABEL_FONT_SIZE_WHEN_HIDDEN_LINES
         : series.isForeground
         ? isSubtleForeground
             ? 8
@@ -163,8 +162,8 @@ export const makeEndLabel = (
     const lastValue = last(series.points) as ScatterRenderPoint
     const lastPos = lastValue.position
     const fontSize = hideConnectedScatterLines
-        ? FONT_SIZE_WHEN_HIDDEN_LINES
-        : lastValue.fontSize *
+        ? SCATTER_LABEL_FONT_SIZE_WHEN_HIDDEN_LINES
+        : series.fontSize *
           (series.isForeground ? (isSubtleForeground ? 1.2 : 1.3) : 1.1)
     const fontWeight =
         series.isForeground && !hideConnectedScatterLines ? 700 : 400


### PR DESCRIPTION
Fixes #1089 | [Deployed on playfair](https://playfair.owid.cloud/admin/test/embeds?type=ScatterPlot) | [Slack #design discussion](https://owid.slack.com/archives/C5BDCB2R3/p1645630994255989)

This PR adds a ScatterPlot size legend:

https://user-images.githubusercontent.com/1308115/157084760-c7fb71ac-7b03-4707-9620-d1c9ad26bfd7.mp4

## Scale changes

- The point radius scale has been changed to be more perceptually accurate – the area did not always correspond to magnitude in the past, [for example](https://playfair.owid.cloud/admin/test/embeds?ids=308&comparisonUrl=https%3A%2F%2Fourworldindata.org) (before/after):

   <img width="1409" alt="Screenshot 2022-03-09 at 17 14 16" src="https://user-images.githubusercontent.com/1308115/157494912-5d6a8ca0-3d9d-4008-bbb5-9af61e897bcd.png">

   (Luxembourg **~$106**, Poland **~$26**. Perceptually the scale was wrong in some cases in the past.)

- It was possible [to have zero-radius, invisible points](https://playfair.owid.cloud/admin/test/embeds?ids=5277&comparisonUrl=https%3A%2F%2Fourworldindata.org) before:

   <img width="1450" alt="Screenshot 2022-03-09 at 17 42 58" src="https://user-images.githubusercontent.com/1308115/157500029-5f9eb6f9-1c26-4c3c-904e-5722f535b5aa.png">


