### PR TITLE
feat(admin): add button to trigger manual deploy

### DIFF
--- a/adminSiteClient/Admin.tsx
+++ b/adminSiteClient/Admin.tsx
@@ -70,7 +70,7 @@ export class Admin {
     // Make a request with no error or response handling
     async rawRequest(
         path: string,
-        data: string | File,
+        data: string | File | undefined,
         method: HTTPMethod
     ): Promise<Response> {
         const headers: HeadersInit = {}

--- a/adminSiteClient/DeployStatusPage.tsx
+++ b/adminSiteClient/DeployStatusPage.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { observer } from "mobx-react"
-import { observable, runInAction } from "mobx"
+import { action, observable, runInAction } from "mobx"
 import { format } from "timeago.js"
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
@@ -21,12 +21,27 @@ export class DeployStatusPage extends React.Component {
     context!: AdminAppContextType
 
     @observable deploys: Deploy[] = []
+    @observable canManuallyDeploy = true
 
     render() {
         return (
             <AdminLayout title="Deploys">
                 <main className="DeploysPage">
-                    <h1>Deploy status</h1>
+                    <div className="topbar">
+                        <h2>Deploy status</h2>
+                        <button
+                            className="btn btn-secondary"
+                            type="button"
+                            disabled={!this.canManuallyDeploy}
+                            onClick={async () => {
+                                this.canManuallyDeploy = false
+                                await this.triggerDeploy()
+                                await this.getData()
+                            }}
+                        >
+                            Manually enqueue a deploy
+                        </button>
+                    </div>
                     {this.deploys.length > 0 ? (
                         <table className="DeploysTable">
                             <thead>
@@ -90,6 +105,11 @@ export class DeployStatusPage extends React.Component {
                 </main>
             </AdminLayout>
         )
+    }
+
+    @action.bound async triggerDeploy() {
+        const { admin } = this.context
+        await admin.rawRequest("/api/deploy", undefined, "PUT")
     }
 
     async getData() {

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -2492,4 +2492,8 @@ apiRouter.get("/deploys.json", async () => ({
     deploys: await new DeployQueueServer().getDeploys(),
 }))
 
+apiRouter.put("/deploy", async (req: Request, res: Response) => {
+    triggerStaticBuild(res.locals.user, "Manually triggered deploy")
+})
+
 export { apiRouter }


### PR DESCRIPTION
Live on _tufte_. [Try it here](https://tufte.owid.cloud/admin/deploys) (yes, feel free to hit that button).

Are you tired of modifying a random chart just to trigger an explorer bake? Or to kick off an awfully long-running rebake after a staging server DB update?

Here comes the solution - it's a button!

(And yes, I realize that this isn't the ideal solution for the explorer baking issue, but it might as well be good enough. And it can be used in other cases, too!)