### PR TITLE
fix(admin): allow resetting dimension color using color picker

### DIFF
--- a/adminSiteClient/DimensionCard.tsx
+++ b/adminSiteClient/DimensionCard.tsx
@@ -96,6 +96,7 @@ export class DimensionCard extends React.Component<{
             dimensions: grapher.filledDimensions.map((dim) => dim.toObject()),
         })
 
+        grapher.seriesColorMap?.clear()
         grapher.rebuildInputOwidTable()
     }
 

--- a/adminSiteClient/EditorDataTab.tsx
+++ b/adminSiteClient/EditorDataTab.tsx
@@ -37,8 +37,6 @@ class EntityItem extends React.Component<EntityItemProps> {
     }
 
     @action.bound onColor(color: string | undefined) {
-        if (!color) return
-
         const { grapher } = this.props
         grapher.selectedEntityColors[this.props.entityName] = color
         grapher.legacyConfigAsAuthored.selectedEntityColors = {

--- a/adminSiteClient/EditorDataTab.tsx
+++ b/adminSiteClient/EditorDataTab.tsx
@@ -44,6 +44,7 @@ class EntityItem extends React.Component<EntityItemProps> {
             [this.props.entityName]: color,
         }
 
+        grapher.seriesColorMap?.clear()
         grapher.rebuildInputOwidTable()
     }
 

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -300,7 +300,9 @@ export class Grapher
     @observable backgroundSeriesLimit?: number = undefined
 
     @observable selectedEntityNames: EntityName[] = []
-    @observable selectedEntityColors: { [entityName: string]: string } = {}
+    @observable selectedEntityColors: {
+        [entityName: string]: string | undefined
+    } = {}
     @observable selectedEntityIds: EntityId[] = []
     @observable excludedEntities?: number[] = undefined
     /** IncludedEntities are ususally empty which means use all available entites. When

--- a/grapher/core/GrapherInterface.ts
+++ b/grapher/core/GrapherInterface.ts
@@ -75,7 +75,7 @@ export interface GrapherInterface extends SortConfig {
     excludedEntities?: number[]
     includedEntities?: number[]
     selectedEntityNames?: EntityName[]
-    selectedEntityColors?: { [entityName: string]: string }
+    selectedEntityColors?: { [entityName: string]: string | undefined }
     selectedEntityIds?: EntityId[]
     facet?: FacetStrategy
 


### PR DESCRIPTION
Live on _tufte_.

---

Fixes #1145.

This is mostly using the existing fix from #846, but there was a `grapher.seriesColorMap.clear()` missing to make sure that the update is immediately visible in the preview.

---

There is one problem that still exists, which is `selectedData`. For charts where it is still present, it's not possible to clear the color that's set in `selectedData`.
You can see this in action at http://tufte.owid.cloud/admin/charts/216/edit, for example: Try to clear out the orange color for "Western Pacific", and you'll fail miserably.
However, I feel like this should be addressed separately, and the issue with `selectedData` is already tracked in #1111.