### PR TITLE
refactor: remove support for starred charts

### DIFF
--- a/adminSiteClient/BulkDownloadPage.tsx
+++ b/adminSiteClient/BulkDownloadPage.tsx
@@ -39,8 +39,7 @@ export class DownloadChartsSection extends React.Component {
                         Downloads a csv containing all OWID charts. Each row
                         represents a single chart. Each column represents a
                         grapher config field (e.g. title, subtitle, minTime,
-                        ...) or a chart meta field (e.g. isStarred,
-                        lastEditedAt, ...).
+                        ...) or a chart meta field (e.g. lastEditedAt, ...).
                     </p>
                     <p>
                         The csv file does NOT contain all grapher config fields

--- a/adminSiteClient/ChartList.tsx
+++ b/adminSiteClient/ChartList.tsx
@@ -28,7 +28,6 @@ export interface ChartListItem {
     hasChartTab: GrapherInterface["hasChartTab"]
     hasMapTab: GrapherInterface["hasMapTab"]
 
-    isStarred: boolean
     lastEditedAt: string
     lastEditedBy: string
     publishedAt: string
@@ -59,7 +58,6 @@ class ChartRow extends React.Component<{
     searchHighlight?: (text: string) => string | JSX.Element
     availableTags: Tag[]
     onDelete: (chart: ChartListItem) => void
-    onStar: (chart: ChartListItem) => void
 }> {
     static contextType = AdminAppContext
     context!: AdminAppContextType
@@ -196,27 +194,6 @@ export class ChartList extends React.Component<{
         }
     }
 
-    @bind async onStar(chart: ChartListItem) {
-        if (chart.isStarred) return
-
-        const json = await this.context.admin.requestJSON(
-            `/api/charts/${chart.id}/star`,
-            {},
-            "POST"
-        )
-        if (json.success) {
-            runInAction(() => {
-                for (const otherChart of this.props.charts) {
-                    if (otherChart === chart) {
-                        otherChart.isStarred = true
-                    } else if (otherChart.isStarred) {
-                        otherChart.isStarred = false
-                    }
-                }
-            })
-        }
-    }
-
     @bind async getTags() {
         const json = await this.context.admin.getJSON("/api/tags.json")
         runInAction(() => (this.availableTags = json.tags))
@@ -252,7 +229,6 @@ export class ChartList extends React.Component<{
                             availableTags={availableTags}
                             searchHighlight={searchHighlight}
                             onDelete={this.onDeleteChart}
-                            onStar={this.onStar}
                         />
                     ))}
                 </tbody>

--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -89,15 +89,6 @@ mockSiteRouter.get("/grapher/embedCharts.js", async (req, res) =>
     res.send(bakeEmbedSnippet(BAKED_BASE_URL))
 )
 
-mockSiteRouter.get("/grapher/latest", async (req, res) => {
-    const latestRows = await db.queryMysql(
-        `SELECT config->>"$.slug" AS slug FROM charts where starred=1`
-    )
-    if (latestRows.length)
-        res.redirect(`${BAKED_GRAPHER_URL}/${latestRows[0].slug}`)
-    else throw new JsonError("No latest chart", 404)
-})
-
 const explorerAdminServer = new ExplorerAdminServer(GIT_CMS_DIR)
 
 mockSiteRouter.get(`/${EXPLORERS_ROUTE_FOLDER}/:slug`, async (req, res) => {

--- a/baker/redirects.ts
+++ b/baker/redirects.ts
@@ -65,14 +65,6 @@ export const getRedirects = async () => {
         )
     )
 
-    // Redirect /grapher/latest
-    const latestRows = await db.queryMysql(
-        `SELECT JSON_EXTRACT(config, "$.slug") as slug FROM charts where starred=1`
-    )
-    for (const row of latestRows) {
-        redirects.push(`/grapher/latest /grapher/${JSON.parse(row.slug)} 302`)
-    }
-
     // Redirect old slugs to new slugs
     const chartRedirectRows = await db.queryMysql(`
     SELECT chart_slug_redirects.slug, chart_id, JSON_EXTRACT(charts.config, "$.slug") as trueSlug

--- a/db/migration/1646815966637-RemoveStarredCharts.ts
+++ b/db/migration/1646815966637-RemoveStarredCharts.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class RemoveStarredCharts1646815966637 implements MigrationInterface {
+    name = "RemoveStarredCharts1646815966637"
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE charts DROP COLUMN starred;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE charts ADD starred TINYINT NOT NULL;`
+        )
+    }
+}

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -29,7 +29,6 @@ export class Chart extends BaseEntity {
     @Column({ nullable: true }) publishedByUserId!: number
     @Column() createdAt!: Date
     @Column() updatedAt!: Date
-    @Column() starred!: boolean
     @Column() isExplorable!: boolean
 
     @ManyToOne(() => User, (user) => user.lastEditedCharts)
@@ -149,7 +148,6 @@ export class OldChart {
         charts.config->>"$.tab" AS tab,
         JSON_EXTRACT(charts.config, "$.hasChartTab") = true AS hasChartTab,
         JSON_EXTRACT(charts.config, "$.hasMapTab") = true AS hasMapTab,
-        charts.starred AS isStarred,
         charts.lastEditedAt,
         charts.lastEditedByUserId,
         lastEditedByUser.fullName AS lastEditedBy,


### PR DESCRIPTION
Starred charts were a way to feature one big chart on the homepage.
They were [last used in February 2019](https://web.archive.org/web/20190218172333/https://ourworldindata.org/).
So let's get rid of all the code related to them.