### PR TITLE
refactor: drop momentjs in favor of dayjs

### DIFF
--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -4,7 +4,7 @@ import {
     BAKED_BASE_URL,
     BAKED_GRAPHER_URL,
 } from "../settings/serverSettings.js"
-import moment from "moment"
+import dayjs from "../clientUtils/dayjs.js"
 import * as db from "../db/db.js"
 import { countries } from "../clientUtils/countries.js"
 import urljoin from "url-join"
@@ -55,13 +55,13 @@ export const makeSitemap = async () => {
         .concat(
             posts.map((p) => ({
                 loc: urljoin(BAKED_BASE_URL, p.slug),
-                lastmod: moment(p.updated_at).format("YYYY-MM-DD"),
+                lastmod: dayjs(p.updated_at).format("YYYY-MM-DD"),
             }))
         )
         .concat(
             charts.map((c) => ({
                 loc: urljoin(BAKED_GRAPHER_URL, c.slug),
-                lastmod: moment(c.updatedAt).format("YYYY-MM-DD"),
+                lastmod: dayjs(c.updatedAt).format("YYYY-MM-DD"),
             }))
         ) as SitemapUrl[]
 

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -119,7 +119,7 @@ export {
 }
 import { extent, pairs } from "d3-array"
 export { pairs }
-import moment from "moment"
+import dayjs from "./dayjs.js"
 import { formatLocale } from "d3-format"
 import striptags from "striptags"
 import parseUrl from "url-parse"
@@ -268,10 +268,10 @@ export function formatDay(
     options?: { format?: string }
 ): string {
     const format = options?.format ?? "MMM D, YYYY"
-    // Use moments' UTC mode https://momentjs.com/docs/#/parsing/utc/
-    // This will force moment to format in UTC time instead of local time,
+    // Use dayjs' UTC mode
+    // This will force dayjs to format in UTC time instead of local time,
     // making dates consistent no matter what timezone the user is in.
-    return moment.utc(EPOCH_DATE).add(dayAsYear, "days").format(format)
+    return dayjs.utc(EPOCH_DATE).add(dayAsYear, "days").format(format)
 }
 
 export const formatYear = (year: number): string => {
@@ -773,7 +773,7 @@ export function dateDiffInDays(a: Date, b: Date): number {
 }
 
 export const diffDateISOStringInDays = (a: string, b: string): number =>
-    moment.utc(a).diff(moment.utc(b), "days")
+    dayjs.utc(a).diff(dayjs.utc(b), "day")
 
 export const addDays = (date: Date, days: number): Date => {
     const newDate = new Date(date.getTime())

--- a/clientUtils/dayjs.ts
+++ b/clientUtils/dayjs.ts
@@ -1,16 +1,19 @@
 // Imports dayjs and loads the plugins we need. Then exports it with the correct types.
 
 import dayjs, { Dayjs } from "dayjs"
-import utc from "dayjs/plugin/utc"
+import customParseFormat from "dayjs/plugin/customParseFormat"
 import relativeTime from "dayjs/plugin/relativeTime"
+import utc from "dayjs/plugin/utc"
 
-dayjs.extend(utc)
+dayjs.extend(customParseFormat)
 dayjs.extend(relativeTime)
+dayjs.extend(utc)
 
 export default dayjs
 
 // We need these explicit plugin type imports _and exports_ to get the right Dayjs type down the line
-import type utcType from "dayjs/plugin/utc"
+import type customParseFormatType from "dayjs/plugin/customParseFormat"
 import type relativeTimeType from "dayjs/plugin/relativeTime"
+import type utcType from "dayjs/plugin/utc"
 
-export type { Dayjs, utcType, relativeTimeType }
+export type { Dayjs, customParseFormatType, relativeTimeType, utcType }

--- a/clientUtils/dayjs.ts
+++ b/clientUtils/dayjs.ts
@@ -1,0 +1,16 @@
+// Imports dayjs and loads the plugins we need. Then exports it with the correct types.
+
+import dayjs, { Dayjs } from "dayjs"
+import utc from "dayjs/plugin/utc"
+import relativeTime from "dayjs/plugin/relativeTime"
+
+dayjs.extend(utc)
+dayjs.extend(relativeTime)
+
+export default dayjs
+
+// We need these explicit plugin type imports _and exports_ to get the right Dayjs type down the line
+import type utcType from "dayjs/plugin/utc"
+import type relativeTimeType from "dayjs/plugin/relativeTime"
+
+export type { Dayjs, utcType, relativeTimeType }

--- a/coreTable/CoreTableColumns.ts
+++ b/coreTable/CoreTableColumns.ts
@@ -21,7 +21,7 @@ import { EntityName, OwidVariableRow } from "./OwidTableConstants.js" // todo: r
 import { ErrorValue, ErrorValueTypes, isNotErrorValue } from "./ErrorValues.js"
 import { getOriginalTimeColumnSlug } from "./OwidTableUtil.js"
 import { imemo } from "./CoreTableUtils.js"
-import moment from "moment"
+import dayjs from "../clientUtils/dayjs.js"
 import { OwidSource } from "../clientUtils/OwidSource.js"
 import {
     formatValue,
@@ -680,8 +680,8 @@ class DateColumn extends DayColumn {
             dateToTimeCache.set(
                 val,
                 dateDiffInDays(
-                    moment.utc(val).toDate(),
-                    moment.utc("2020-01-21").toDate()
+                    dayjs.utc(val).toDate(),
+                    dayjs.utc("2020-01-21").toDate()
                 )
             )
         return dateToTimeCache.get(val)!

--- a/devTools/cypress/integration/cookiePreferences.js
+++ b/devTools/cypress/integration/cookiePreferences.js
@@ -1,10 +1,10 @@
-import moment from "moment"
+import dayjs from "dayjs"
 
 describe("Cookie preferences", function () {
     const DATE_FORMAT = "YYYYMMDD"
     const COOKIE_NAME = "cookie_preferences"
     const COOKIE_NOTICE = "@cookieNotice"
-    const today = moment().format(DATE_FORMAT)
+    const today = dayjs().format(DATE_FORMAT)
 
     beforeEach(() => {
         cy.visit("/privacy-policy")
@@ -73,10 +73,10 @@ describe("Cookie preferences", function () {
     it("Shows / hides the cookie banner in relation to a policy update", () => {
         cy.get("[data-test-policy-date]").then((el) => {
             const policyDate = el.attr("data-test-policy-date")
-            const dayBeforePolicyUpdate = moment(policyDate)
+            const dayBeforePolicyUpdate = dayjs(policyDate)
                 .subtract(1, "days")
                 .format(DATE_FORMAT)
-            const dayAfterPolicyUpdate = moment(policyDate)
+            const dayAfterPolicyUpdate = dayjs(policyDate)
                 .add(1, "days")
                 .format(DATE_FORMAT)
 

--- a/explorerAdminClient/ExplorersListPage.tsx
+++ b/explorerAdminClient/ExplorersListPage.tsx
@@ -17,7 +17,7 @@ import {
     GIT_CMS_DEFAULT_BRANCH,
     GIT_CMS_REPO_URL,
 } from "../gitCms/GitCmsConstants.js"
-import moment from "moment"
+import dayjs from "../clientUtils/dayjs.js"
 import {
     EXPLORERS_GIT_CMS_FOLDER,
     GetAllExplorersRoute,
@@ -110,9 +110,7 @@ class ExplorerRow extends React.Component<{
                     <div>{lastCommit?.message}</div>
                     <div style={{ fontSize: "80%", opacity: 0.8 }}>
                         <a href={lastCommitLink}>
-                            {lastCommit
-                                ? moment(lastCommit.date).fromNow()
-                                : ""}
+                            {lastCommit ? dayjs(lastCommit.date).fromNow() : ""}
                         </a>{" "}
                         by {lastCommit?.author_name} | {fileHistoryButton}
                         {googleSheetButton}
@@ -203,7 +201,7 @@ export class ExplorersIndexPage extends React.Component<{
     @computed get explorersToShow(): ExplorerProgram[] {
         return orderBy(
             this.explorers,
-            (program) => moment(program.lastCommit?.date).unix(),
+            (program) => dayjs(program.lastCommit?.date).unix(),
             ["desc"]
         )
     }

--- a/package.json
+++ b/package.json
@@ -156,8 +156,6 @@
         "mobx-formatters": "^1.0.2",
         "mobx-react": "5",
         "mobx-utils": "5",
-        "moment": "^2.29.1",
-        "moment-locales-webpack-plugin": "^1.2.0",
         "mousetrap": "^1.6.5",
         "multiprocessing": "^1.2.0",
         "mysql": "^2.18.1",

--- a/site/CitationMeta.tsx
+++ b/site/CitationMeta.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import moment from "moment"
+import dayjs from "../clientUtils/dayjs.js"
 
 export const CitationMeta = (props: {
     // id: number
@@ -22,10 +22,10 @@ export const CitationMeta = (props: {
             {/* <meta name="citation_volume" content="1"/>
         <meta name="citation_issue" content="1"/>
         <meta name="citation_firstpage" content={`e${id}`}/>
-        <meta name="citation_online_date" content={moment(date).format("YYYY/MM/DD")}/> */}
+        <meta name="citation_online_date" content={dayjs(date).format("YYYY/MM/DD")}/> */}
             <meta
                 name="citation_publication_date"
-                content={moment(date).format("YYYY/MM/DD")}
+                content={dayjs(date).format("YYYY/MM/DD")}
             />
             <meta name="citation_journal_title" content="Our World in Data" />
             <meta name="citation_journal_abbrev" content="Our World in Data" />

--- a/site/CookiePreferencesManager.tsx
+++ b/site/CookiePreferencesManager.tsx
@@ -76,7 +76,7 @@ export const CookiePreferencesManager = ({
             />
             <CookiePreferences
                 preferences={state.preferences}
-                date={state.date}
+                date={`${state.date}`}
                 dispatch={dispatch}
             />
         </div>

--- a/site/CookiePreferencesManager.tsx
+++ b/site/CookiePreferencesManager.tsx
@@ -4,7 +4,7 @@ import { useEffect, useReducer } from "react"
 import * as Cookies from "js-cookie"
 import { CookiePreferences } from "../site/blocks/CookiePreferences.js"
 import { CookieNotice } from "../site/CookieNotice.js"
-import moment from "moment"
+import dayjs from "../clientUtils/dayjs.js"
 
 export enum PreferenceType {
     Analytics = "a",
@@ -162,7 +162,7 @@ export const isValidPreference = ({ type, value }: Preference) => {
 export const parseDate = (date?: string): number | undefined => {
     if (!date) return
 
-    return moment(date, DATE_FORMAT, true).isValid()
+    return dayjs(date, DATE_FORMAT, true).isValid()
         ? parseInt(date, 10)
         : undefined
 }
@@ -213,7 +213,7 @@ export const serializeState = (state: State) => {
     return `${serializedPreferences}${DATE_SEPARATOR}${state.date}`
 }
 
-export const getTodayDate = () => moment().format(DATE_FORMAT)
+export const getTodayDate = () => dayjs().format(DATE_FORMAT)
 
 export const runCookiePreferencesManager = () => {
     const div = document.createElement("div")

--- a/site/EntriesByYearPage.tsx
+++ b/site/EntriesByYearPage.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import moment from "moment"
+import dayjs from "../clientUtils/dayjs.js"
 import { Head } from "./Head.js"
 import { SiteHeader } from "./SiteHeader.js"
 import { SiteFooter } from "./SiteFooter.js"
@@ -15,7 +15,7 @@ export const EntriesByYearPage = (props: {
 }) => {
     const { baseUrl } = props
     const entriesByYear = groupBy(props.entries, (entry) =>
-        moment(entry.published_at as Date).year()
+        dayjs(entry.published_at as Date).year()
     )
 
     const years = Object.keys(entriesByYear).sort().reverse()
@@ -105,7 +105,7 @@ export const EntriesForYearPage = (props: {
 }) => {
     const { baseUrl, year } = props
     const entriesByYear = groupBy(props.entries, (entry) =>
-        moment(entry.published_at as Date).year()
+        dayjs(entry.published_at as Date).year()
     )
 
     const years = Object.keys(entriesByYear)

--- a/site/blocks/CookiePreferences.tsx
+++ b/site/blocks/CookiePreferences.tsx
@@ -1,4 +1,4 @@
-import moment from "moment"
+import dayjs from "../../clientUtils/dayjs.js"
 import React from "react"
 import ReactDOM from "react-dom"
 import {
@@ -113,7 +113,7 @@ export const CookiePreferences = ({
             {date ? (
                 <div className="last-updated">
                     Preferences last updated:{" "}
-                    {moment(date, DATE_FORMAT).format("LL")}
+                    {dayjs(date, DATE_FORMAT).format("MMMM D, YYYY")}
                 </div>
             ) : (
                 <button

--- a/site/blocks/CookiePreferences.tsx
+++ b/site/blocks/CookiePreferences.tsx
@@ -71,7 +71,7 @@ export const CookiePreferences = ({
     dispatch,
 }: {
     preferences: Preference[]
-    date?: number
+    date?: string
     dispatch: any
 }) => {
     const cookiePreferencesDomSlot = document.querySelector(

--- a/site/covid/CovidFetch.ts
+++ b/site/covid/CovidFetch.ts
@@ -1,5 +1,5 @@
 import { csvParse } from "d3-dsv"
-import moment from "moment"
+import dayjs from "../../clientUtils/dayjs.js"
 
 import {
     fetchText,
@@ -60,7 +60,7 @@ export async function fetchTestsData(): Promise<CovidSeries> {
     const responseText = await retryPromise(() => fetchText(TESTS_DATA_URL))
     const rows: CovidSeries = csvParse(responseText).map((row) => {
         return {
-            date: moment(
+            date: dayjs(
                 row["Date to which estimate refers (dd mmm yyyy)"] as string,
                 "DD MMMM YYYY"
             ).toDate(),
@@ -74,7 +74,7 @@ export async function fetchTestsData(): Promise<CovidSeries> {
                 ),
                 sourceURL: row["Source URL"],
                 sourceLabel: row["Source label"],
-                publicationDate: moment(
+                publicationDate: dayjs(
                     `${row["Date of source publication (dd mmm yyyy)"]} ${row["Time of source publication (hh:mm)"]}`,
                     "DD MMMM YYYY HH:mm"
                 ).toDate(),

--- a/site/covid/LastUpdated.tsx
+++ b/site/covid/LastUpdated.tsx
@@ -1,7 +1,5 @@
 import React, { useEffect, useState } from "react"
-import dayjs, { Dayjs } from "dayjs"
-import relativeTime from "dayjs/plugin/relativeTime"
-dayjs.extend(relativeTime)
+import dayjs, { Dayjs } from "../../clientUtils/dayjs.js"
 
 export interface LastUpdatedTokenProps {
     timestampUrl?: string

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -3,7 +3,6 @@ import path from "path"
 
 const MiniCssExtractPlugin = require("mini-css-extract-plugin")
 const ManifestPlugin = require("webpack-manifest-plugin")
-const MomentLocalesPlugin = require("moment-locales-webpack-plugin")
 
 const TerserJSPlugin = require("terser-webpack-plugin")
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin")
@@ -108,10 +107,6 @@ const config: webpack.ConfigurationFactory = async (env, argv) => {
             new webpack.IgnorePlugin(
                 /settings\/(serverSettings|clientSettingsReader)/
             ),
-
-            // Remove all moment locales except for "en"
-            // This way of doing so is recommended by Moment itself: https://momentjs.com/docs/#/use-it/webpack/
-            new MomentLocalesPlugin(),
         ],
         devServer: {
             host: "localhost",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13730,13 +13730,6 @@ moize@^6.0.0:
     fast-equals "2.0.0"
     micro-memoize "4.0.9"
 
-moment-locales-webpack-plugin@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.2.0.tgz#9af83876a44053706b868ceece5119584d10d7aa"
-  integrity sha512-QAi5v0OlPUP7GXviKMtxnpBAo8WmTHrUNN7iciAhNOEAd9evCOvuN0g1N7ThIg3q11GLCkjY1zQ2saRcf/43nQ==
-  dependencies:
-    lodash.difference "^4.5.0"
-
 moment@2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"


### PR DESCRIPTION
Live on _tufte_.

MomentJS is old and creaky and bloated, dayjs is new and beautiful and, crucially, mostly a drop-in replacement for MomentJS.
So let's get rid of moment for good.