### PR TITLE
refactor(entitySelector): remove hacky event listener

### DIFF
--- a/grapher/controls/EntitySelectorModal.scss
+++ b/grapher/controls/EntitySelectorModal.scss
@@ -48,9 +48,7 @@ $zindex-EntitySelector: 30;
         line-height: 1.15;
         font-size: 1em;
     }
-}
 
-.EntitySelectorSingle {
     ul {
         margin: 0;
         padding: 0;
@@ -58,14 +56,7 @@ $zindex-EntitySelector: 30;
 
     li {
         list-style-type: none;
-        padding: 0.5em;
-        color: #666;
-        cursor: pointer;
         margin-bottom: 0.3em;
-    }
-
-    li:hover {
-        background-color: #eee;
     }
 
     input[type="search"] {
@@ -74,6 +65,18 @@ $zindex-EntitySelector: 30;
         padding: 0.4em;
         margin-bottom: 0.4em;
         border: 1px solid #ccc;
+    }
+}
+
+.EntitySelectorSingle {
+    li {
+        padding: 0.5em;
+        color: #666;
+        cursor: pointer;
+    }
+
+    li:hover {
+        background-color: #eee;
     }
 }
 
@@ -99,26 +102,8 @@ $zindex-EntitySelector: 30;
         }
     }
 
-    ul {
-        margin: 0;
-        padding: 0;
-    }
-
-    li {
-        list-style-type: none;
-        margin-bottom: 0.3em;
-    }
-
     li > label {
         width: 100%;
-    }
-
-    input[type="search"] {
-        width: 100%;
-        font-size: 0.9em;
-        padding: 0.4em;
-        margin-bottom: 0.4em;
-        border: 1px solid #ccc;
     }
 
     input[type="checkbox"],

--- a/grapher/controls/EntitySelectorModal.tsx
+++ b/grapher/controls/EntitySelectorModal.tsx
@@ -54,7 +54,7 @@ export class EntitySelectorModal extends React.Component<{
     isMulti: boolean
     onDismiss: () => void
 }> {
-    @observable searchInput?: string
+    @observable searchInput: string = ""
     searchField!: HTMLInputElement
     base: React.RefObject<HTMLDivElement> = React.createRef()
 
@@ -96,6 +96,7 @@ export class EntitySelectorModal extends React.Component<{
         if (
             this.base?.current &&
             !this.base.current.contains(e.target as Node) &&
+            // check that the target is still mounted to the document; we also get click events on nodes that have since been removed by React
             document.contains(e.target as Node)
         )
             this.props.onDismiss()
@@ -194,7 +195,7 @@ export class EntitySelectorModal extends React.Component<{
                                 type="search"
                                 placeholder="Search..."
                                 value={searchInput}
-                                onInput={(e): void => {
+                                onChange={(e): void => {
                                     this.searchInput = e.currentTarget.value
                                 }}
                                 onKeyDown={this.onSearchKeyDown}

--- a/grapher/controls/EntitySelectorModal.tsx
+++ b/grapher/controls/EntitySelectorModal.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { observer } from "mobx-react"
 import { computed, action, observable } from "mobx"
-import { uniqBy, isTouchDevice, sortBy } from "../../clientUtils/Util.js"
+import { isTouchDevice, sortBy } from "../../clientUtils/Util.js"
 import { FuzzySearch } from "./FuzzySearch.js"
 import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
@@ -9,6 +9,43 @@ import { SelectionArray } from "../selection/SelectionArray.js"
 
 interface SearchableEntity {
     name: string
+}
+
+interface SearchResultProps {
+    result: SearchableEntity
+    isMulti: boolean
+    isChecked: boolean
+    onSelect: (entityName: string) => void
+}
+
+class EntitySearchResult extends React.PureComponent<SearchResultProps> {
+    render(): JSX.Element {
+        const { result, isMulti, isChecked, onSelect } = this.props
+
+        if (isMulti) {
+            return (
+                <li>
+                    <label className="clickable">
+                        <input
+                            type="checkbox"
+                            checked={isChecked}
+                            onChange={(): void => onSelect(result.name)}
+                        />{" "}
+                        {result.name}
+                    </label>
+                </li>
+            )
+        } else {
+            return (
+                <li
+                    className="clickable"
+                    onClick={(): void => onSelect(result.name)}
+                >
+                    {result.name}
+                </li>
+            )
+        }
+    }
 }
 
 @observer
@@ -87,52 +124,11 @@ class EntitySelectorBase extends React.Component<{
         this.props.selectionArray.clearSelection()
     }
 
-    renderSearchResults(): JSX.Element {
-        if (this.isMulti) {
-            return (
-                <ul>
-                    {this.searchResults.map((result): JSX.Element => {
-                        return (
-                            <li key={result.name}>
-                                <label className="clickable">
-                                    <input
-                                        type="checkbox"
-                                        checked={this.props.selectionArray.selectedSet.has(
-                                            result.name
-                                        )}
-                                        onChange={(): void =>
-                                            this.onSelect(result.name)
-                                        }
-                                    />{" "}
-                                    {result.name}
-                                </label>
-                            </li>
-                        )
-                    })}
-                </ul>
-            )
-        } else {
-            return (
-                <ul>
-                    {this.searchResults.map((d): JSX.Element => {
-                        return (
-                            <li
-                                key={d.name}
-                                className="clickable"
-                                onClick={(): void => this.onSelect(d.name)}
-                            >
-                                {d.name}
-                            </li>
-                        )
-                    })}
-                </ul>
-            )
-        }
-    }
-
     renderSelectedData() {
         const selectedEntityNames =
             this.props.selectionArray.selectedEntityNames
+
+        // only render something in isMulti mode
         if (this.isMulti) {
             return (
                 <div className="selectedData">
@@ -174,8 +170,6 @@ class EntitySelectorBase extends React.Component<{
         const { selectionArray } = this.props
         const { searchResults, searchInput } = this
 
-        const selectedEntityNames = selectionArray.selectedEntityNames
-
         return (
             <div className="entitySelectorOverlay">
                 <div
@@ -208,7 +202,19 @@ class EntitySelectorBase extends React.Component<{
                                     (this.searchField = e as HTMLInputElement)
                                 }
                             />
-                            {this.renderSearchResults()}
+                            <ul>
+                                {searchResults.map((result) => (
+                                    <EntitySearchResult
+                                        key={result.name}
+                                        result={result}
+                                        isMulti={this.isMulti}
+                                        isChecked={selectionArray.selectedSet.has(
+                                            result.name
+                                        )}
+                                        onSelect={this.onSelect}
+                                    />
+                                ))}
+                            </ul>
                         </div>
                         {this.renderSelectedData()}
                     </div>

--- a/grapher/controls/EntitySelectorModal.tsx
+++ b/grapher/controls/EntitySelectorModal.tsx
@@ -12,8 +12,9 @@ interface SearchableEntity {
 }
 
 @observer
-class EntitySelectorMulti extends React.Component<{
+class EntitySelectorBase extends React.Component<{
     selectionArray: SelectionArray
+    isMulti: boolean
     onDismiss: () => void
 }> {
     @observable searchInput?: string
@@ -22,6 +23,10 @@ class EntitySelectorMulti extends React.Component<{
 
     @computed get availableEntities(): string[] {
         return this.props.selectionArray.availableEntityNames
+    }
+
+    @computed get isMulti(): boolean {
+        return this.props.isMulti
     }
 
     @computed get fuzzy(): FuzzySearch<SearchableEntity> {
@@ -41,7 +46,7 @@ class EntitySelectorMulti extends React.Component<{
     }
 
     @action.bound onSelect(entityName: string): void {
-        if (this.multi) {
+        if (this.isMulti) {
             this.props.selectionArray.toggleSelection(entityName)
         } else {
             this.props.selectionArray.setSelectedEntities([entityName])
@@ -73,13 +78,96 @@ class EntitySelectorMulti extends React.Component<{
         e: React.KeyboardEvent<HTMLInputElement>
     ): void {
         if (e.key === "Enter" && this.searchResults.length > 0) {
-            this.props.selectionArray.selectEntity(this.searchResults[0].name)
+            this.onSelect(this.searchResults[0].name)
             this.searchInput = ""
         } else if (e.key === "Escape") this.props.onDismiss()
     }
 
     @action.bound onClear(): void {
         this.props.selectionArray.clearSelection()
+    }
+
+    renderSearchResults(): JSX.Element {
+        if (this.isMulti) {
+            return (
+                <ul>
+                    {this.searchResults.map((result): JSX.Element => {
+                        return (
+                            <li key={result.name}>
+                                <label className="clickable">
+                                    <input
+                                        type="checkbox"
+                                        checked={this.props.selectionArray.selectedSet.has(
+                                            result.name
+                                        )}
+                                        onChange={(): void =>
+                                            this.onSelect(result.name)
+                                        }
+                                    />{" "}
+                                    {result.name}
+                                </label>
+                            </li>
+                        )
+                    })}
+                </ul>
+            )
+        } else {
+            return (
+                <ul>
+                    {this.searchResults.map((d): JSX.Element => {
+                        return (
+                            <li
+                                key={d.name}
+                                className="clickable"
+                                onClick={(): void => this.onSelect(d.name)}
+                            >
+                                {d.name}
+                            </li>
+                        )
+                    })}
+                </ul>
+            )
+        }
+    }
+
+    renderSelectedData() {
+        const selectedEntityNames =
+            this.props.selectionArray.selectedEntityNames
+        if (this.isMulti) {
+            return (
+                <div className="selectedData">
+                    <ul>
+                        {selectedEntityNames.map((name) => {
+                            return (
+                                <li key={name}>
+                                    <label className="clickable">
+                                        <input
+                                            type="checkbox"
+                                            checked={true}
+                                            onChange={(): void => {
+                                                this.onSelect(name)
+                                            }}
+                                        />{" "}
+                                        {name}
+                                    </label>
+                                </li>
+                            )
+                        })}
+                    </ul>
+                    {selectedEntityNames.length > 1 ? (
+                        <button
+                            className="clearSelection"
+                            onClick={this.onClear}
+                        >
+                            <span className="icon">
+                                <FontAwesomeIcon icon={faTimes} />
+                            </span>{" "}
+                            Unselect all
+                        </button>
+                    ) : undefined}
+                </div>
+            )
+        } else return undefined
     }
 
     render(): JSX.Element {
@@ -90,7 +178,14 @@ class EntitySelectorMulti extends React.Component<{
 
         return (
             <div className="entitySelectorOverlay">
-                <div ref={this.base} className="EntitySelectorMulti">
+                <div
+                    ref={this.base}
+                    className={
+                        this.isMulti
+                            ? "EntitySelectorMulti"
+                            : "EntitySelectorSingle"
+                    }
+                >
                     <header className="wrapper">
                         <h2>
                             Choose data to show{" "}
@@ -113,172 +208,9 @@ class EntitySelectorMulti extends React.Component<{
                                     (this.searchField = e as HTMLInputElement)
                                 }
                             />
-                            <ul>
-                                {searchResults.map((result): JSX.Element => {
-                                    return (
-                                        <li key={result.name}>
-                                            <label className="clickable">
-                                                <input
-                                                    type="checkbox"
-                                                    checked={selectionArray.selectedSet.has(
-                                                        result.name
-                                                    )}
-                                                    onChange={(): SelectionArray =>
-                                                        selectionArray.toggleSelection(
-                                                            result.name
-                                                        )
-                                                    }
-                                                />{" "}
-                                                {result.name}
-                                            </label>
-                                        </li>
-                                    )
-                                })}
-                            </ul>
+                            {this.renderSearchResults()}
                         </div>
-                        <div className="selectedData">
-                            <ul>
-                                {selectedEntityNames.map((name) => {
-                                    return (
-                                        <li key={name}>
-                                            <label className="clickable">
-                                                <input
-                                                    type="checkbox"
-                                                    checked={true}
-                                                    onChange={(): void => {
-                                                        selectionArray.deselectEntity(
-                                                            name
-                                                        )
-                                                    }}
-                                                />{" "}
-                                                {name}
-                                            </label>
-                                        </li>
-                                    )
-                                })}
-                            </ul>
-                            {selectedEntityNames.length > 1 ? (
-                                <button
-                                    className="clearSelection"
-                                    onClick={this.onClear}
-                                >
-                                    <span className="icon">
-                                        <FontAwesomeIcon icon={faTimes} />
-                                    </span>{" "}
-                                    Unselect all
-                                </button>
-                            ) : undefined}
-                        </div>
-                    </div>
-                </div>
-            </div>
-        )
-    }
-}
-
-@observer
-class EntitySelectorSingle extends React.Component<{
-    selectionArray: SelectionArray
-    isMobile: boolean
-    onDismiss: () => void
-}> {
-    @observable searchInput?: string
-    searchField!: HTMLInputElement
-    base: React.RefObject<HTMLDivElement> = React.createRef()
-
-    @computed private get availableEntities(): { id: string; label: string }[] {
-        const availableItems: { id: string; label: string }[] = []
-        this.props.selectionArray.availableEntityNames.forEach((name) => {
-            availableItems.push({
-                id: name,
-                label: name,
-            })
-        })
-        return uniqBy(availableItems, (d) => d.label)
-    }
-
-    @computed get fuzzy(): FuzzySearch<{ id: string; label: string }> {
-        return new FuzzySearch(this.availableEntities, "label")
-    }
-
-    @computed get searchResults(): { id: string; label: string }[] {
-        return this.searchInput
-            ? this.fuzzy.search(this.searchInput)
-            : sortBy(this.availableEntities, (result): any => result.label)
-    }
-
-    @action.bound onDocumentClick(e: MouseEvent): void {
-        // check if the click was outside of the modal
-        if (this.base?.current && !this.base.current.contains(e.target as Node))
-            this.props.onDismiss()
-    }
-
-    componentDidMount(): void {
-        document.addEventListener("click", this.onDocumentClick)
-
-        if (!this.props.isMobile) this.searchField.focus()
-    }
-
-    componentWillUnmount(): void {
-        document.removeEventListener("click", this.onDocumentClick)
-    }
-
-    @action.bound onSearchKeyDown(
-        e: React.KeyboardEvent<HTMLInputElement>
-    ): void {
-        if (e.key === "Enter" && this.searchResults.length > 0) {
-            this.onSelect(this.searchResults[0].label)
-            this.searchInput = ""
-        } else if (e.key === "Escape") this.props.onDismiss()
-    }
-
-    @action.bound onSelect(entityName: string): void {
-        this.props.selectionArray.setSelectedEntities([entityName])
-        this.props.onDismiss()
-    }
-
-    render(): JSX.Element {
-        const { searchResults, searchInput } = this
-
-        return (
-            <div className="entitySelectorOverlay">
-                <div ref={this.base} className="EntitySelectorSingle">
-                    <header className="wrapper">
-                        <h2>
-                            Choose data to show{" "}
-                            <button onClick={this.props.onDismiss}>
-                                <FontAwesomeIcon icon={faTimes} />
-                            </button>
-                        </h2>
-                    </header>
-                    <div className="wrapper">
-                        <input
-                            type="search"
-                            placeholder="Search..."
-                            value={searchInput}
-                            onInput={(e): void => {
-                                this.searchInput = e.currentTarget.value
-                            }}
-                            onKeyDown={this.onSearchKeyDown}
-                            ref={(e): HTMLInputElement =>
-                                (this.searchField = e as HTMLInputElement)
-                            }
-                        />
-                        <ul>
-                            {searchResults.map((d): JSX.Element => {
-                                return (
-                                    <li
-                                        key={d.id}
-                                        className="clickable"
-                                        onClick={(): void =>
-                                            this.onSelect(d.id)
-                                        }
-                                    >
-                                        {d.label}
-                                    </li>
-                                )
-                            })}
-                        </ul>
+                        {this.renderSelectedData()}
                     </div>
                 </div>
             </div>
@@ -294,10 +226,11 @@ export class EntitySelectorModal extends React.Component<{
     onDismiss: () => void
 }> {
     render(): JSX.Element {
-        return this.props.canChangeEntity ? (
-            <EntitySelectorSingle {...this.props} />
-        ) : (
-            <EntitySelectorMulti {...this.props} />
+        return (
+            <EntitySelectorBase
+                isMulti={!this.props.canChangeEntity}
+                {...this.props}
+            />
         )
     }
 }

--- a/grapher/controls/EntitySelectorModal.tsx
+++ b/grapher/controls/EntitySelectorModal.tsx
@@ -49,7 +49,7 @@ class EntitySearchResult extends React.PureComponent<SearchResultProps> {
 }
 
 @observer
-class EntitySelectorBase extends React.Component<{
+export class EntitySelectorModal extends React.Component<{
     selectionArray: SelectionArray
     isMulti: boolean
     onDismiss: () => void
@@ -220,23 +220,6 @@ class EntitySelectorBase extends React.Component<{
                     </div>
                 </div>
             </div>
-        )
-    }
-}
-
-@observer
-export class EntitySelectorModal extends React.Component<{
-    selectionArray: SelectionArray
-    canChangeEntity?: boolean
-    isMobile: boolean
-    onDismiss: () => void
-}> {
-    render(): JSX.Element {
-        return (
-            <EntitySelectorBase
-                isMulti={!this.props.canChangeEntity}
-                {...this.props}
-            />
         )
     }
 }

--- a/grapher/controls/EntitySelectorModal.tsx
+++ b/grapher/controls/EntitySelectorModal.tsx
@@ -58,8 +58,8 @@ export class EntitySelectorModal extends React.Component<{
     searchField!: HTMLInputElement
     base: React.RefObject<HTMLDivElement> = React.createRef()
 
-    @computed get availableEntities(): string[] {
-        return this.props.selectionArray.availableEntityNames
+    @computed get sortedAvailableEntities(): string[] {
+        return sortBy(this.props.selectionArray.availableEntityNames)
     }
 
     @computed get isMulti(): boolean {
@@ -71,7 +71,7 @@ export class EntitySelectorModal extends React.Component<{
     }
 
     @computed private get searchableEntities(): SearchableEntity[] {
-        return this.availableEntities.map((name) => {
+        return this.sortedAvailableEntities.map((name) => {
             return { name } as SearchableEntity
         })
     }
@@ -79,7 +79,7 @@ export class EntitySelectorModal extends React.Component<{
     @computed get searchResults(): SearchableEntity[] {
         return this.searchInput
             ? this.fuzzy.search(this.searchInput)
-            : sortBy(this.searchableEntities, (result) => result.name)
+            : this.searchableEntities
     }
 
     @action.bound onSelect(entityName: string): void {

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -2134,10 +2134,8 @@ export class Grapher
                 />
                 {this.isSelectingData && (
                     <EntitySelectorModal
-                        canChangeEntity={this.canChangeEntity}
+                        isMulti={!this.canChangeEntity}
                         selectionArray={this.selection}
-                        key="entitySelector"
-                        isMobile={this.isMobile}
                         onDismiss={action(() => (this.isSelectingData = false))}
                     />
                 )}


### PR DESCRIPTION
Live on _tufte_.

---

`EntitySelectorMulti` and `EntitySelectorSingle` had lots of overlap and were even drifting apart in some parts.
It's also the source of [a common bug on Bugsnag](https://app.bugsnag.com/our-world-in-data/our-world-in-data-website/errors/6138db61982a0900079c7883).

So, I got rid of that duplication, but (for now) without changing anything about the looks, styling, functionality of the modal.

