### PR TITLE
chore: avoid the need for special ssh settings

### DIFF
--- a/devTools/docker/download-wordpress-mysql.sh
+++ b/devTools/docker/download-wordpress-mysql.sh
@@ -11,5 +11,5 @@ FOLDER="${DATA_FOLDER:-./tmp-downloads}"
 
 mkdir -p $FOLDER
 
-ssh owid-live "sudo mysqldump --default-character-set=utf8mb4 live_wordpress -r /tmp/live_wordpress.sql && sudo gzip -f /tmp/live_wordpress.sql"
-rsync -hav --progress owid-live:/tmp/live_wordpress.sql.gz $FOLDER
+ssh owid@live.owid.io "sudo mysqldump --default-character-set=utf8mb4 live_wordpress -r /tmp/live_wordpress.sql && sudo gzip -f /tmp/live_wordpress.sql"
+rsync -hav --progress owid@live.owid.io:/tmp/live_wordpress.sql.gz $FOLDER

--- a/devTools/docker/download-wordpress-uploads.sh
+++ b/devTools/docker/download-wordpress-uploads.sh
@@ -8,4 +8,4 @@ set -o nounset
 
 # Wordpress uploads
 echo "Downloading Wordress uploads"
-rsync -havz --delete --exclude=/.gitkeep --progress owid-live:live-data/wordpress/uploads/ ./wordpress/web/app/uploads
+rsync -havz --delete --exclude=/.gitkeep --progress owid@live.owid.io:live-data/wordpress/uploads/ ./wordpress/web/app/uploads

--- a/wordpress/scripts/deploy.sh
+++ b/wordpress/scripts/deploy.sh
@@ -11,9 +11,9 @@ PATH_OWID_PLUGIN="web/app/plugins/owid"
 ROOT="/home/owid"
 
 if [[ "$1" =~ ^(staging|hans|playfair|jefferson|nightingale|explorer|exemplars|tufte|roser|snow|halley|neurath)$ ]]; then
-  HOST="owid-staging"
+  HOST="owid@staging.owid.io"
 elif [ "$1" == "live" ]; then
-  HOST="owid-live"
+  HOST="owid@live.owid.io"
 
   if [ "$BRANCH" != "master" ]; then
     echo "Please run from the master branch."

--- a/wordpress/scripts/refresh-staging.sh
+++ b/wordpress/scripts/refresh-staging.sh
@@ -20,6 +20,7 @@ GRAPHER_DB_NAME=$GRAPHER_DB_NAME
 STAGING_SERVER_NAME=$(basename $DIR | cut -d '-' -f1)
 MYSQL="sudo mysql --default-character-set=utf8mb4"
 DL_FOLDER="/tmp"
+HOST=owid@live.owid.io
 
 # Default options
 WITH_UPLOADS=false
@@ -77,8 +78,8 @@ import_db(){
 # Wordpress DB
 if [ "${SKIP_DB_DL}" = false ]; then
   echo "Downloading Wordress database (live_wordpress)"
-  ssh owid-live "sudo mysqldump --default-character-set=utf8mb4 live_wordpress -r /tmp/live_wordpress.sql"
-  rsync -hav --progress owid-live:/tmp/live_wordpress.sql $DL_FOLDER
+  ssh ${HOST} "sudo mysqldump --default-character-set=utf8mb4 live_wordpress -r /tmp/live_wordpress.sql"
+  rsync -hav --progress ${HOST}:/tmp/live_wordpress.sql $DL_FOLDER
 fi
 echo "Importing Wordress database (live_wordpress)"
 purge_db $WORDPRESS_DB_HOST $WORDPRESS_DB_NAME
@@ -87,14 +88,14 @@ import_db $DL_FOLDER/live_wordpress.sql $WORDPRESS_DB_HOST $WORDPRESS_DB_NAME
 # Wordpress uploads
 if [ "${WITH_UPLOADS}" = true ]; then
   echo "Downloading Wordress uploads"
-  rsync -hav --delete --progress owid-live:live-data/wordpress/uploads/ ~/$STAGING_SERVER_NAME-data/wordpress/uploads
+  rsync -hav --delete --progress ${HOST}:live-data/wordpress/uploads/ ~/$STAGING_SERVER_NAME-data/wordpress/uploads
 fi
 
 # Grapher database (owid_metadata)
 if [ "${SKIP_DB_DL}" = false ]; then
   echo "Downloading live Grapher metadata database (owid_metadata)"
-  ssh owid-live "cd live/itsJustJavascript && node db/exportMetadata.js --with-passwords /tmp/owid_metadata_with_passwords.sql"
-  rsync -hav --progress owid-live:/tmp/owid_metadata_with_passwords.sql $DL_FOLDER
+  ssh ${HOST} "cd live/itsJustJavascript && node db/exportMetadata.js --with-passwords /tmp/owid_metadata_with_passwords.sql"
+  rsync -hav --progress ${HOST}:/tmp/owid_metadata_with_passwords.sql $DL_FOLDER
 fi
 echo "Importing live Grapher metadata database (owid_metadata)"
 purge_db $GRAPHER_DB_HOST $GRAPHER_DB_NAME


### PR DESCRIPTION
We currently assume that everyone has the same `.ssh/config` settings for our work, but that's mainly to hard-code IP addresses for our servers.

Instead, this change simply uses the friendly DNS for each step, avoiding the need for common settings.
