### PR TITLE
enhance: use mysql-server:latest image for better arm64 support

### DIFF
--- a/devTools/docker/mysql-init-docker/Dockerfile
+++ b/devTools/docker/mysql-init-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql/mysql-server:8.0
+FROM mysql/mysql-server:latest
 
 RUN microdnf -y update \
  && microdnf install -y \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ version: "3.7"
 services:
     # Stock mysql database. Used for both grapher and wordpress databases. Root password is hardcoded for now
     db:
-        image: mysql/mysql-server:8.0
+        image: mysql/mysql-server:latest
         command: --default-authentication-plugin=mysql_native_password
         restart: always
         volumes:
@@ -52,7 +52,7 @@ services:
     db-load-data:
         build:
             context: ./devTools/docker/mysql-init-docker
-        # image: mysql/mysql-server:8.0
+        # image: mysql/mysql-server:latest
         command: "/app/full-mysql-init.sh"
         volumes:
             - ./devTools/docker:/app


### PR DESCRIPTION
The mysql-server:8.0 image only has amd64 as a flavour, meaning that the first init takes ~1h on M1 Macs. After the switch it takes more like ~10min.
