### PR TITLE
chore: Add "make up.full" and "make down.full" for wordpress

### DIFF
--- a/.env.example-full
+++ b/.env.example-full
@@ -11,3 +11,5 @@ DB_HOST=127.0.0.1
 # Enable linkage between grapher and wordpress
 WORDPRESS_DB_NAME=wordpress
 WORDPRESS_URL='http://localhost:8080'
+WORDPRESS_API_USER=admin@example.com
+WORDPRESS_API_PASS=admin

--- a/.env.example-full
+++ b/.env.example-full
@@ -4,12 +4,18 @@ TZ=utc
 SECRET_KEY='fejwiaof jewiafo jeioa fjieowajf isa fjidosajfgj'
 
 DB_NAME=grapher
-DB_USER='root'
-DB_PASS='weeniest-stretch-contaminate-gnarl'
+DB_USER='grapher'
+DB_PASS='grapher'
 DB_HOST=127.0.0.1
+DB_PORT=3306
+
+WORDPRESS_DB_NAME='wordpress'
+WORDPRESS_DB_USER='wordpress'
+WORDPRESS_DB_PASS='wordpress'
+WORDPRESS_DB_HOST='127.0.0.1'
+WORDPRESS_DB_PORT=3306
 
 # Enable linkage between grapher and wordpress
-WORDPRESS_DB_NAME=wordpress
 WORDPRESS_URL='http://localhost:8080'
 WORDPRESS_API_USER=admin@example.com
 WORDPRESS_API_PASS=admin

--- a/.env.example-grapher
+++ b/.env.example-grapher
@@ -4,6 +4,7 @@ TZ=utc
 SECRET_KEY='fejwiaof jewiafo jeioa fjieowajf isa fjidosajfgj'
 
 DB_NAME=grapher
-DB_USER='root'
-DB_PASS='weeniest-stretch-contaminate-gnarl'
+DB_USER='grapher'
+DB_PASS='grapher'
 DB_HOST=127.0.0.1
+DB_PORT=3306

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ up: require tmp-downloads/owid_chartdata.sql.gz
 		new-window -n welcome 'devTools/docker/banner.sh; exec $(LOGIN_SHELL)' \; \
 		bind R respawn-pane -k \; \
 		bind X kill-pane \; \
-		bind Q kill-server
+		bind Q kill-server \
+		|| make down
 
 up.full: require tmp-downloads/owid_chartdata.sql.gz tmp-downloads/live_wordpress.sql.gz wordpress/web/app/uploads/2022
 	@echo '==> Setting up .env if need be'
@@ -61,7 +62,8 @@ up.full: require tmp-downloads/owid_chartdata.sql.gz tmp-downloads/live_wordpres
 		new-window -n welcome 'devTools/docker/banner.sh; exec $(LOGIN_SHELL)' \; \
 		bind R respawn-pane -k \; \
 		bind X kill-pane \; \
-		bind Q kill-server
+		bind Q kill-server \
+		|| make down.full
 
 down:
 	@echo '==> Stopping services'


### PR DESCRIPTION
Add a Makefile flow for working with the full wordpress stack, including downloading the data you need.

- All data required will be downloaded, including uploads
- If your `.env` file is missing wordpress configuration, it will warn you and abort
- If you have no `.env` file, it will use `.env.example-full` instead
