### PR TITLE
feat(docker): enable php opcache

### DIFF
--- a/devTools/docker/wordpress-php-docker/Dockerfile
+++ b/devTools/docker/wordpress-php-docker/Dockerfile
@@ -5,10 +5,10 @@ RUN apt-get update && apt-get install -y \
     unzip \
     mariadb-client \
     libmariadb-dev \
- && docker-php-ext-install mysqli  \
+ && docker-php-ext-install mysqli opcache \
  && rm -rf /var/lib/apt/lists/*
 
- RUN pecl install xdebug \
+RUN pecl install xdebug \
     && docker-php-ext-enable xdebug
 
 RUN curl https://getcomposer.org/download/latest-2.2.x/composer.phar --output /usr/local/bin/composer \


### PR DESCRIPTION
My Docker Wordpress was very slow.
[After a quick look around](https://serverfault.com/a/956661), I found out that opcache is not enabled by default, and enabling that speeds up PHP considerably.

And sure enough, after enabling opcache (and running `docker-compose -f docker-compose.full.yml --build`) Wordpress is now okay fast (not blazing fast sadly).

For review for @mlbrgl because he will know best what the repercussions are :)