### PR TITLE
fix: edit some charts to make Y=0 line always visible

### DIFF
--- a/db/migration/1647866984314-LineChartYMaxZero.ts
+++ b/db/migration/1647866984314-LineChartYMaxZero.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class LineChartYMaxZero1647866984314 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`
+            UPDATE charts
+            SET config = JSON_SET(config, "$.yAxis.max", 0)
+            WHERE (
+                config->"$.type" = "LineChart" OR
+                config->"$.type" IS NULL
+            )
+            AND config->"$.yAxis.min" = 0
+            AND config->"$.yAxis.max" IS NULL
+        `)
+    }
+
+    public async down(): Promise<void> {
+        // no going back
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/owid/owid-issues/issues/140.

This is a **database migration only**, no implementation changes on the Grapher. It's a mass-fix for an authoring issue.

The `version` is not bumped intentionally, to avoid re-baking the data and exports for 2000+ charts. The chart config is updated on every bake anyway (unlike exports), so all interactive charts will be fixed without a version bump.

