### PR TITLE
feat: enable `equalSizeBins` by default

### DIFF
--- a/adminSiteClient/EditorColorScaleSection.tsx
+++ b/adminSiteClient/EditorColorScaleSection.tsx
@@ -68,7 +68,7 @@ class ColorLegendSection extends React.Component<{
     onChange?: () => void
 }> {
     @action.bound onEqualSizeBins(isEqual: boolean) {
-        this.props.scale.config.equalSizeBins = isEqual ? true : undefined
+        this.props.scale.config.equalSizeBins = isEqual
         this.props.onChange?.()
     }
 

--- a/devTools/schemaProcessor/columns.json
+++ b/devTools/schemaProcessor/columns.json
@@ -378,7 +378,7 @@
     {
         "type": "boolean",
         "pointer": "/colorScale/equalSizeBins",
-        "default": false,
+        "default": true,
         "editor": "checkbox"
     },
     {

--- a/grapher/color/ColorScale.test.ts
+++ b/grapher/color/ColorScale.test.ts
@@ -33,6 +33,7 @@ describe(ColorScale, () => {
             customCategoryColors: {},
             customCategoryLabels: {},
             customHiddenCategories: {},
+            equalSizeBins: true,
         }
         it("returns correct color", () => {
             const colorValuePairs = [
@@ -138,6 +139,7 @@ describe(ColorScale, () => {
             customCategoryColors: { test: "#eee" },
             customCategoryLabels: {},
             customHiddenCategories: {},
+            equalSizeBins: true,
         }
         const table = new CoreTable(
             {

--- a/grapher/color/ColorScaleConfig.ts
+++ b/grapher/color/ColorScaleConfig.ts
@@ -53,7 +53,7 @@ export class ColorScaleConfigDefaults {
     @observable customNumericColors: (Color | undefined | null)[] = []
 
     /** Whether the visual scaling for the color legend is disabled. */
-    @observable equalSizeBins?: boolean = undefined
+    @observable equalSizeBins?: boolean = true
 
     // Categorical bins
     // ================

--- a/grapher/lineCharts/LineChart.test.ts
+++ b/grapher/lineCharts/LineChart.test.ts
@@ -354,6 +354,7 @@ describe("color scale", () => {
                 customNumericColorsActive: true,
                 customNumericLabels: [],
                 customNumericValues: [1.5, 2.5],
+                equalSizeBins: true,
             },
         }
         const chart = new LineChart({ manager })

--- a/grapher/schema/grapher-schema.001.json
+++ b/grapher/schema/grapher-schema.001.json
@@ -114,7 +114,7 @@
                 },
                 "equalSizeBins": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "Whether the visual scaling for the color legend is disabled."
                 },
                 "customHiddenCategories": {

--- a/grapher/schema/grapher-schema.001.yaml
+++ b/grapher/schema/grapher-schema.001.yaml
@@ -105,7 +105,7 @@ $defs:
                     - default
             equalSizeBins:
                 type: boolean
-                default: false
+                default: true
                 description: Whether the visual scaling for the color legend is disabled.
             customHiddenCategories:
                 type: object


### PR DESCRIPTION
Fixes #1113. No migration applied to past charts. Since in the past only `true` and `undefined` values were possible for `equalSizeBins`, now `undefined` becomes `true`, so we don't _need_ to do any migrations. 

It might be nice for cleanliness, let me know if you think so!