### PR TITLE
enhance(scatter): set "Other" as default label for points without color

### DIFF
--- a/grapher/color/ColorScaleConfig.test.ts
+++ b/grapher/color/ColorScaleConfig.test.ts
@@ -2,7 +2,7 @@
 
 import { BinningStrategy } from "./BinningStrategy.js"
 import { ColorSchemeName } from "./ColorConstants.js"
-import { NO_DATA_LABEL } from "./ColorScale.js"
+import { DEFAULT_NO_DATA_LABEL } from "./ColorScale.js"
 import { ColorScaleConfig } from "./ColorScaleConfig.js"
 
 it("can serialize for saving", () => {
@@ -30,7 +30,7 @@ describe("fromDSL", () => {
         expect(colorScale.customCategoryLabels).toEqual({
             one: "uno",
             two: "dos",
-            [NO_DATA_LABEL]: "Datas missing",
+            [DEFAULT_NO_DATA_LABEL]: "Datas missing",
         })
         expect(colorScale.customCategoryColors).toEqual({
             one: "#ddd",

--- a/grapher/color/ColorScaleConfig.ts
+++ b/grapher/color/ColorScaleConfig.ts
@@ -10,7 +10,7 @@ import {
 import { extend, isEmpty, trimObject } from "../../clientUtils/Util.js"
 import { ColorSchemeName } from "./ColorConstants.js"
 import { BinningStrategy } from "./BinningStrategy.js"
-import { NO_DATA_LABEL } from "./ColorScale.js"
+import { DEFAULT_NO_DATA_LABEL } from "./ColorScale.js"
 
 export class ColorScaleConfigDefaults {
     // Color scheme
@@ -148,7 +148,8 @@ export class ColorScaleConfig
                     label.join(INTRA_BIN_DELIMITER).trim() || undefined
             })
         if (scale.colorScaleNoDataLabel) {
-            customCategoryLabels[NO_DATA_LABEL] = scale.colorScaleNoDataLabel
+            customCategoryLabels[DEFAULT_NO_DATA_LABEL] =
+                scale.colorScaleNoDataLabel
         }
 
         // Use user-defined binning strategy, otherwise set to manual if user has
@@ -212,7 +213,7 @@ export class ColorScaleConfig
                     ].join(INTRA_BIN_DELIMITER)
                 )
                 .join(INTER_BIN_DELIMITER),
-            colorScaleNoDataLabel: customCategoryLabels[NO_DATA_LABEL],
+            colorScaleNoDataLabel: customCategoryLabels[DEFAULT_NO_DATA_LABEL],
             colorScaleCategoricalBins: Object.keys(customCategoryColors ?? {})
                 .map((value) =>
                     [

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -92,6 +92,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
             colorScaleConfig: oldManager.colorScaleConfig,
             hasNoDataBin: oldManager.hasNoDataBin,
             defaultNoDataColor: oldManager.defaultNoDataColor,
+            defaultNoDataLabel: oldManager.defaultNoDataLabel,
             defaultBaseColorScheme: oldManager.defaultBaseColorScheme,
             colorScaleColumn: oldManager.colorScaleColumn,
             transformColor: darkenColorForLine,

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -711,6 +711,7 @@ export class ScatterPlotChart
 
     defaultBaseColorScheme = ColorSchemeName.continents
     defaultNoDataColor = "#959595"
+    defaultNoDataLabel = "Other"
 
     @computed get hasNoDataBin(): boolean {
         if (this.colorColumn.isMissing) return false


### PR DESCRIPTION
Fixes #1167. [Slack thread](https://owid.slack.com/archives/C5BDCB2R3/p1647944889676269). We decided that `Other` is better than `No data`. 

### To-do

- [ ] Add tests
- [ ] Check/think how case where data contains `"Other"` should be handled
- [ ] Define no data color outside `customCategoryLabels`? Could be 2 new fields for `ColorScale`: `noDataLabel` and `noDataColor`