### PR TITLE
Fix TextWrap: do not render unescaped HTML when linkifyText is true

### DIFF
--- a/grapher/text/TextWrap.tsx
+++ b/grapher/text/TextWrap.tsx
@@ -75,11 +75,24 @@ export class TextWrap {
     @computed get lines(): WrapLine[] {
         const { text, maxWidth, fontSize, fontWeight } = this
 
+        const escapeSymbolMap = {
+            "<": "&lt;",
+            ">": "&gt;",
+            "\n": " \n",
+        }
+
         const words = isEmpty(text)
             ? []
-            : // We prepend spaces to newlines in order to be able to do a "starts with"
+            : // We escape html tag and other symbols.
+              // We also prepend spaces to newlines in order to be able to do a "starts with"
               // check to trigger a new line.
-              text.replace(/\n/g, " \n").split(" ")
+              text
+                  .replace(/[<>\n]/g, (char) => {
+                      return escapeSymbolMap[
+                          char as keyof typeof escapeSymbolMap
+                      ]
+                  })
+                  .split(" ")
 
         const lines: WrapLine[] = []
 

--- a/grapher/text/TextWrap.tsx
+++ b/grapher/text/TextWrap.tsx
@@ -26,6 +26,19 @@ function startsWithNewline(text: string): boolean {
     return /^\n/.test(text)
 }
 
+function escapeSymbolHtml(text: string): string {
+    if (isEmpty(text)) return text
+
+    const escapeSymbolMap = {
+        "<": "&lt;",
+        ">": "&gt;",
+    }
+
+    return text.replace(/[<>]/g, (char) => {
+        return escapeSymbolMap[char as keyof typeof escapeSymbolMap]
+    })
+}
+
 export const shortenForTargetWidth = (
     text: string,
     targetWidth: number,
@@ -75,24 +88,11 @@ export class TextWrap {
     @computed get lines(): WrapLine[] {
         const { text, maxWidth, fontSize, fontWeight } = this
 
-        const escapeSymbolMap = {
-            "<": "&lt;",
-            ">": "&gt;",
-            "\n": " \n",
-        }
-
         const words = isEmpty(text)
             ? []
-            : // We escape html tag and other symbols.
-              // We also prepend spaces to newlines in order to be able to do a "starts with"
+            : // We prepend spaces to newlines in order to be able to do a "starts with"
               // check to trigger a new line.
-              text
-                  .replace(/[<>\n]/g, (char) => {
-                      return escapeSymbolMap[
-                          char as keyof typeof escapeSymbolMap
-                      ]
-                  })
-                  .split(" ")
+              text.replace(/\n/g, " \n").split(" ")
 
         const lines: WrapLine[] = []
 
@@ -183,7 +183,7 @@ export class TextWrap {
                     ) : props.linkifyText ? (
                         <span
                             dangerouslySetInnerHTML={{
-                                __html: linkify(line.text),
+                                __html: linkify(escapeSymbolHtml(line.text)),
                             }}
                         />
                     ) : (


### PR DESCRIPTION
Fix #1299 by adding escape for symbol `<` and `>` in function renderHtml of TextWrap when `{ linkifyText: true, rawHtml: false }`
This issue only happens in function renderHtml.

Test:

HeaderHtml - uses fn renderHtml for subtitle -- fixed
![image](https://user-images.githubusercontent.com/31311349/159751553-40ff9782-6f04-43c6-9306-4a828b5abdde.png)

HeaderView - uses fn render for subtitle - work as expected
![image](https://user-images.githubusercontent.com/31311349/159758494-aaefa2b2-8a26-489d-a321-e07693fecb46.png)

