### PR TITLE
feat: can specify custom sort order for StackedDiscreteBar

### DIFF
--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -128,6 +128,10 @@ class SortOrderSection extends React.Component<{ editor: ChartEditor }> {
         return [
             { label: "Entity name", value: { sortBy: SortBy.entityName } },
             { label: "Total value", value: { sortBy: SortBy.total } },
+            {
+                label: "Custom order (use specified entity order)",
+                value: { sortBy: SortBy.custom },
+            },
             ...dimensionSortOptions,
         ]
     }

--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -19,6 +19,7 @@ export enum SortOrder {
 }
 
 export enum SortBy {
+    custom = "custom",
     entityName = "entityName",
     column = "column",
     total = "total",

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -559,8 +559,11 @@ export class DiscreteBarChart
                 ? this.entitiesAsSeries
                 : this.columnsAsSeries
 
-        let sortByFunc: (item: DiscreteBarItem) => number | string
+        let sortByFunc: (item: DiscreteBarItem) => number | string | undefined
         switch (this.sortConfig.sortBy) {
+            case SortBy.custom:
+                sortByFunc = () => undefined
+                break
             case SortBy.entityName:
                 sortByFunc = (item: DiscreteBarItem) => item.seriesName
                 break

--- a/grapher/stackedCharts/MarimekkoChart.tsx
+++ b/grapher/stackedCharts/MarimekkoChart.tsx
@@ -769,8 +769,11 @@ export class MarimekkoChart
     @computed private get sortedItems(): Item[] {
         const { items, sortConfig } = this
 
-        let sortByFunc: (item: Item) => number | string
+        let sortByFunc: (item: Item) => number | string | undefined
         switch (sortConfig.sortBy) {
+            case SortBy.custom:
+                sortByFunc = () => undefined
+                break
             case SortBy.entityName:
                 sortByFunc = (item: Item): string => item.entityName
                 break

--- a/grapher/stackedCharts/StackedDiscreteBarChart.test.ts
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.test.ts
@@ -233,6 +233,22 @@ describe("sorting", () => {
         ])
     })
 
+    it("can use custom sort order", () => {
+        const selection = ["France", "Spain", "Germany"]
+        const chart = new StackedDiscreteBarChart({
+            manager: {
+                ...baseManager,
+                sortConfig: {
+                    sortBy: SortBy.custom,
+                    sortOrder: SortOrder.asc,
+                },
+                selection,
+            },
+        })
+
+        expect(chart.sortedItems.map((item) => item.label)).toEqual(selection)
+    })
+
     it("can sort by single dimension", () => {
         const chart = new StackedDiscreteBarChart({
             manager: {

--- a/grapher/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/grapher/stackedCharts/StackedDiscreteBarChart.tsx
@@ -295,8 +295,11 @@ export class StackedDiscreteBarChart
     }
 
     @computed get sortedItems(): readonly Item[] {
-        let sortByFunc: (item: Item) => number | string
+        let sortByFunc: (item: Item) => number | string | undefined
         switch (this.sortConfig.sortBy) {
+            case SortBy.custom:
+                sortByFunc = (): undefined => undefined
+                break
             case SortBy.entityName:
                 sortByFunc = (item: Item): string => item.label
                 break


### PR DESCRIPTION
Fixes #1344.

We have some charts, like [Global crop production by farm size](https://ourworldindata.org/grapher/global-crop-production-by-farm-size) and [Death rates from smoking by age](https://ourworldindata.org/grapher/death-rates-smoking-age), where none of the existing sort orders make sense. We really want to display the entities in the same order as they are specified in the Admin.

Hence, I added a new option for "custom" order, which then does exactly that. See video below.

https://user-images.githubusercontent.com/2641501/159874897-d200c26b-5121-48e1-8a13-fa4bdd711f4e.mp4
