### PR TITLE
feat(countryProfiles): only include charts that are embedded in at least one page

### DIFF
--- a/baker/countryProfiles.tsx
+++ b/baker/countryProfiles.tsx
@@ -40,8 +40,8 @@ const countryIndicatorGraphers = async (): Promise<GrapherInterface[]> =>
         ).map((c: any) => JSON.parse(c.config)) as GrapherInterface[]
         return graphers.filter(
             (grapher) =>
-                grapher.hasChartTab &&
-                grapher.type === "LineChart" &&
+                (grapher.hasChartTab ?? true) &&
+                (grapher.type ?? "LineChart") === "LineChart" &&
                 grapher.dimensions?.length === 1
         )
     })

--- a/baker/countryProfiles.tsx
+++ b/baker/countryProfiles.tsx
@@ -72,13 +72,15 @@ export const denormalizeLatestCountryData = async (variableIds?: number[]) => {
     if (!variableIds)
         variableIds = (await countryIndicatorVariables()).map((v) => v.id)
 
+    const currentYear = new Date().getUTCFullYear()
+
     const dataValuesQuery = db
         .knexTable("data_values")
         .select("variableId", "entityId", "value", "year")
         .whereIn("variableId", variableIds)
         .whereRaw(`entityId in (?)`, [entityIds])
-        .andWhere("year", ">", 2010)
-        .andWhere("year", "<", 2020)
+        .andWhere("year", ">", currentYear - 10) // latest data point should be at most 10 years old
+        .andWhere("year", "<=", currentYear)
         .orderBy("year", "DESC")
 
     let dataValues = (await dataValuesQuery) as {

--- a/baker/countryProfiles.tsx
+++ b/baker/countryProfiles.tsx
@@ -37,17 +37,24 @@ const countryIndicatorGraphers = async (): Promise<GrapherInterface[]> =>
         const graphers = (
             await db
                 .knexTable("charts")
+                .join(
+                    "chart_dimensions",
+                    "charts.id",
+                    "chart_dimensions.chartId"
+                )
+                .join(
+                    "variables",
+                    "chart_dimensions.variableId",
+                    "variables.id"
+                )
                 .whereRaw("publishedAt is not null and is_indexable is true")
+                .where("variables.datasetId", "=", 5357) // 5357 is the World Development Indicators dataset
+                .where("chart_dimensions.order", "=", 0)
         ).map((c: any) => JSON.parse(c.config)) as GrapherInterface[]
 
         const eligibleGraphers = await Promise.all(
             graphers
-                .filter(
-                    (grapher) =>
-                        (grapher.hasChartTab ?? true) &&
-                        (grapher.type ?? "LineChart") === "LineChart" &&
-                        grapher.dimensions?.length === 1
-                )
+                .filter((grapher) => grapher.dimensions?.length === 1)
 
                 // Exclude graphers which are not embedded in any of our posts
                 .map(async (grapher) => {

--- a/baker/countryProfiles.tsx
+++ b/baker/countryProfiles.tsx
@@ -143,8 +143,6 @@ export const countryProfilePage = async (
     if (!country) throw new JsonError(`No such country ${countrySlug}`, 404)
 
     const graphers = await countryIndicatorGraphers()
-    const variables = await countryIndicatorVariables()
-    const variablesById = lodash.keyBy(variables, (v) => v.id)
     const dataValues = await countryIndicatorLatestData(country.code)
 
     const valuesByVariableId = lodash.groupBy(dataValues, (v) => v.variableId)
@@ -157,26 +155,6 @@ export const countryProfilePage = async (
 
         if (values && values.length) {
             const latestValue = values[0]
-            const variable = variablesById[vid]
-
-            // todo: this is a lot of setup to get formatValueShort. Maybe cleanup?
-            const table = new OwidTable(
-                [],
-                [
-                    {
-                        slug: vid.toString(),
-                        unit: variable.unit,
-                        display: variable.display,
-                    },
-                ]
-            )
-            const column = table.get(vid.toString())
-
-            let value: string | number
-            value = parseFloat(latestValue.value)
-            if (isNaN(value)) value = latestValue.value
-            else if (variable.display.conversionFactor)
-                value *= variable.display.conversionFactor
 
             indicators.push({
                 year: latestValue.year,

--- a/site/CountryProfilePage.tsx
+++ b/site/CountryProfilePage.tsx
@@ -83,12 +83,12 @@ export const CountryProfilePage = (props: CountryProfilePageProps) => {
                                             )}
                                         >
                                             {indicator.name}
-                                            {indicator.variantName
-                                                ? " (" +
-                                                  indicator.variantName +
-                                                  ")"
-                                                : ""}
                                         </a>
+                                        {indicator.variantName && (
+                                            <span className="variantName">
+                                                {indicator.variantName}
+                                            </span>
+                                        )}
                                     </div>
                                     <div className="indicatorValue">
                                         ({indicator.year})

--- a/site/CountryProfilePage.tsx
+++ b/site/CountryProfilePage.tsx
@@ -61,8 +61,13 @@ export const CountryProfilePage = (props: CountryProfilePageProps) => {
                     </li>
                 </ul> */}
                     <p>
-                        Below are all indicators in our database for which this
-                        country has a value.
+                        Below are all charts in our database for which we source
+                        data from the{" "}
+                        <a href="https://datatopics.worldbank.org/world-development-indicators/">
+                            World Development Indicators
+                        </a>{" "}
+                        and where a recent data value for this country is
+                        available.
                     </p>
                     <div>
                         <input

--- a/site/runCountryProfilePage.ts
+++ b/site/runCountryProfilePage.ts
@@ -54,10 +54,10 @@ class ChartFilter {
             document.querySelectorAll(".CountryProfilePage main li")
         ) as HTMLLIElement[]
         this.chartItems = lis.map((li) => ({
-            title: ((li.firstChild as any).textContent as string).replace(
-                /₂/g,
-                "2"
-            ),
+            title:
+                li
+                    .querySelector(".indicatorName > a")
+                    ?.textContent?.replace(/₂/g, "2") ?? "",
             li: li,
             ul: li.closest("ul") as HTMLUListElement,
         }))


### PR DESCRIPTION
Work in progress | Fixes #1236 | [Live on tufte](https://tufte-owid.netlify.app/country/ukraine)

Tasks:
- [x] Fix existing issues with country profile generation & completeness
- [x] Limit displayed graphers to those that are referenced at least once
- [ ] Experiment with adapting the `<RelatedCharts>` block and using it for an instant preview on the country profile
- [ ] Convert the search function on the page to React, instead of manipulating the DOM manually
- [ ] Use https://github.com/owid/owid-grapher/blob/master/clientUtils/search.tsx for search and search highlighting
- [ ] Make style changes so the page looks a bit better
- [ ] _After deploy_: Run `node ./itsJustJavascript/baker/recalcLatestCountryData.js` to regenerate the `country_latest_data` table for charts that were wrongly excluded before.