### PR TITLE
Fix single-year StackedArea charts and enable timeline for them

### DIFF
--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -344,6 +344,12 @@ export enum VerticalAlign {
     bottom = "bottom",
 }
 
+export enum AxisAlign {
+    start = "start",
+    middle = "middle",
+    end = "end",
+}
+
 export interface GridParameters {
     rows: number
     columns: number

--- a/grapher/axis/Axis.test.ts
+++ b/grapher/axis/Axis.test.ts
@@ -105,7 +105,7 @@ it("creates compact labels", () => {
     ).toBeTruthy()
 })
 
-it("a single-value domain plots to lower or upper end of range", () => {
+it("a single-value vertical domain plots to lower or upper end of range", () => {
     const config: AxisConfigInterface = {
         min: 0,
         max: 0,
@@ -115,6 +115,18 @@ it("a single-value domain plots to lower or upper end of range", () => {
     expect(axis.place(-1)).toEqual(0)
     expect(axis.place(0)).toEqual(0)
     expect(axis.place(1)).toEqual(500)
+})
+
+it("a single-value horizontal domain plots to middle of range", () => {
+    const config: AxisConfigInterface = {
+        min: 0,
+        max: 0,
+    }
+    const axis = new AxisConfig(config).toHorizontalAxis()
+    axis.range = [0, 500]
+    expect(axis.place(-1)).toEqual(250)
+    expect(axis.place(0)).toEqual(250)
+    expect(axis.place(1)).toEqual(250)
 })
 
 describe("manual ticks", () => {

--- a/grapher/axis/Axis.test.ts
+++ b/grapher/axis/Axis.test.ts
@@ -5,6 +5,7 @@ import { ScaleType } from "../core/GrapherConstants.js"
 import { SynthesizeGDPTable } from "../../coreTable/OwidTableSynthesizers.js"
 import { AxisConfig } from "./AxisConfig.js"
 import { AxisConfigInterface } from "./AxisConfigInterface.js"
+import { AxisAlign } from "../../clientUtils/owidTypes.js"
 
 it("can create an axis", () => {
     const axisConfig = new AxisConfig({
@@ -105,28 +106,23 @@ it("creates compact labels", () => {
     ).toBeTruthy()
 })
 
-it("a single-value vertical domain plots to lower or upper end of range", () => {
-    const config: AxisConfigInterface = {
-        min: 0,
-        max: 0,
+describe("singleValueAxisPointAlign", () => {
+    const testAlign = (align: AxisAlign | undefined, expected: number) => {
+        const config: AxisConfigInterface = {
+            min: 0,
+            max: 0,
+            singleValueAxisPointAlign: align,
+        }
+        const axis = new AxisConfig(config).toVerticalAxis()
+        axis.range = [0, 500]
+        expect(axis.place(-1)).toEqual(expected)
+        expect(axis.place(0)).toEqual(expected)
+        expect(axis.place(1)).toEqual(expected)
     }
-    const axis = new AxisConfig(config).toVerticalAxis()
-    axis.range = [0, 500]
-    expect(axis.place(-1)).toEqual(0)
-    expect(axis.place(0)).toEqual(0)
-    expect(axis.place(1)).toEqual(500)
-})
-
-it("a single-value horizontal domain plots to middle of range", () => {
-    const config: AxisConfigInterface = {
-        min: 0,
-        max: 0,
-    }
-    const axis = new AxisConfig(config).toHorizontalAxis()
-    axis.range = [0, 500]
-    expect(axis.place(-1)).toEqual(250)
-    expect(axis.place(0)).toEqual(250)
-    expect(axis.place(1)).toEqual(250)
+    it("aligns to start", () => testAlign(AxisAlign.start, 0))
+    it("aligns to middle", () => testAlign(AxisAlign.middle, 250))
+    it("aligns to end", () => testAlign(AxisAlign.end, 500))
+    it("defaults to middle", () => testAlign(undefined, 250))
 })
 
 describe("manual ticks", () => {

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -342,15 +342,6 @@ abstract class AbstractAxis {
         } else if (this.scaleType === ScaleType.log && value <= 0) {
             console.error(`Can't have ${value} which is <= 0 on a log scale`)
             return value
-        } else if (this.domain[0] === this.domain[1]) {
-            // When the domain is a single value, the D3 scale will by default place
-            // the value at the middle of the range.
-            // We instead want to place it at the end, in order to avoid an axis
-            // domain line being plotted in the middle of a chart (most of the time
-            // this occurs, the domain is [0, 0]).
-            //
-            // -@danielgavrilov, 2021-08-02
-            return value > this.domain[0] ? this.range[1] : this.range[0]
         }
         return parseFloat(this.d3_scale(value).toFixed(1))
     }
@@ -552,6 +543,21 @@ export class VerticalAxis extends AbstractAxis {
 
     @computed get size(): number {
         return this.width
+    }
+
+    place(value: number): number {
+        if (this.domain[0] === this.domain[1]) {
+            // When the domain is a single value, the D3 scale will by default place
+            // the value at the middle of the range.
+            // We instead want to place it at the end, in order to avoid an axis
+            // domain line being plotted in the middle of a chart (most of the time
+            // this occurs, the domain is [0, 0]).
+            // see https://github.com/owid/owid-grapher/pull/975#issuecomment-890798547.
+            //
+            // -@danielgavrilov, 2021-08-02
+            return value > this.domain[0] ? this.range[1] : this.range[0]
+        }
+        return super.place(value)
     }
 
     placeTickLabel(value: number): TickLabelPlacement {

--- a/grapher/axis/AxisConfig.ts
+++ b/grapher/axis/AxisConfig.ts
@@ -12,7 +12,7 @@ import {
 } from "../../clientUtils/persistable/Persistable.js"
 import { AxisConfigInterface, Tickmark } from "./AxisConfigInterface.js"
 import { ScaleSelectorManager } from "../controls/ScaleSelector.js"
-import { Position } from "../../clientUtils/owidTypes.js"
+import { AxisAlign, Position } from "../../clientUtils/owidTypes.js"
 
 export interface FontSizeManager {
     fontSize: number
@@ -34,6 +34,7 @@ class AxisConfigDefaults implements AxisConfigInterface {
     @observable.ref scaleType?: ScaleType = ScaleType.linear
     @observable.ref facetDomain?: FacetAxisDomain = undefined
     @observable.ref ticks?: Tickmark[] = undefined
+    @observable.ref singleValueAxisPointAlign?: AxisAlign = undefined
     @observable.ref label: string = ""
 }
 
@@ -75,6 +76,7 @@ export class AxisConfig
             label: this.label ? this.label : undefined,
             facetDomain: this.facetDomain,
             ticks: this.ticks,
+            singleValueAxisPointAlign: this.singleValueAxisPointAlign,
         })
 
         deleteRuntimeAndUnchangedProps(obj, new AxisConfigDefaults())

--- a/grapher/axis/AxisConfigInterface.ts
+++ b/grapher/axis/AxisConfigInterface.ts
@@ -1,4 +1,4 @@
-import { Position } from "../../clientUtils/owidTypes.js"
+import { AxisAlign, Position } from "../../clientUtils/owidTypes.js"
 import { FacetAxisDomain, ScaleType } from "../core/GrapherConstants.js"
 
 export interface Tickmark {
@@ -68,4 +68,11 @@ export interface AxisConfigInterface {
      * To control the domain, use `min` and `max`.
      */
     ticks?: Tickmark[]
+
+    /**
+     * What to do when .place() is called on an axis that only contains a single
+     * domain value.
+     * Should the point be placed at the start, middle or end of the axis?
+     */
+    singleValueAxisPointAlign?: AxisAlign
 }

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -48,6 +48,7 @@ import {
     SortConfig,
     Color,
     HorizontalAlign,
+    AxisAlign,
 } from "../../clientUtils/owidTypes.js"
 import { CategoricalColorAssigner } from "../color/CategoricalColorAssigner.js"
 import { ColorScale, ColorScaleManager } from "../color/ColorScale.js"
@@ -256,8 +257,17 @@ export class DiscreteBarChart
         ]
     }
 
+    // NB: y-axis settings are used for the horizontal axis in DiscreteBarChart
     @computed private get yAxisConfig(): AxisConfig {
-        return new AxisConfig(this.manager.yAxisConfig, this)
+        return new AxisConfig(
+            {
+                // if we have a single-value x axis, we want to have the vertical axis
+                // on the left of the chart
+                singleValueAxisPointAlign: AxisAlign.start,
+                ...this.manager.yAxisConfig,
+            },
+            this
+        )
     }
 
     @computed get yAxis(): HorizontalAxis {

--- a/grapher/core/Grapher.jsdom.test.ts
+++ b/grapher/core/Grapher.jsdom.test.ts
@@ -177,14 +177,14 @@ describe("hasTimeline", () => {
         expect(grapher.hasTimeline).toBeTruthy()
         grapher.type = ChartTypeName.SlopeChart
         expect(grapher.hasTimeline).toBeTruthy()
+        grapher.type = ChartTypeName.StackedArea
+        expect(grapher.hasTimeline).toBeTruthy()
+        grapher.type = ChartTypeName.StackedBar
+        expect(grapher.hasTimeline).toBeTruthy()
     })
 
     it("charts without timeline", () => {
         const grapher = new Grapher(legacyConfig)
-        grapher.type = ChartTypeName.StackedBar
-        expect(grapher.hasTimeline).toBeFalsy()
-        grapher.type = ChartTypeName.StackedArea
-        expect(grapher.hasTimeline).toBeFalsy()
         grapher.type = ChartTypeName.DiscreteBar
         expect(grapher.hasTimeline).toBeFalsy()
     })
@@ -202,7 +202,7 @@ describe("hasTimeline", () => {
 
     it("table tab has timeline even if chart doesn't", () => {
         const grapher = new Grapher(legacyConfig)
-        grapher.type = ChartTypeName.StackedBar
+        grapher.type = ChartTypeName.DiscreteBar
         expect(grapher.hasTimeline).toBeFalsy()
         grapher.tab = GrapherTabOption.table
         expect(grapher.hasTimeline).toBeTruthy()

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1175,14 +1175,7 @@ export class Grapher
 
             // StackedBar, StackedArea, and DiscreteBar charts never display a timeline
             case GrapherTabOption.chart:
-                return (
-                    !this.hideTimeline &&
-                    !(
-                        this.isStackedBar ||
-                        this.isStackedArea ||
-                        this.isDiscreteBar
-                    )
-                )
+                return !this.hideTimeline && !this.isDiscreteBar
 
             default:
                 return false

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -73,6 +73,7 @@ import { MultiColorPolyline } from "../scatterCharts/MultiColorPolyline.js"
 import { CategoricalColorAssigner } from "../color/CategoricalColorAssigner.js"
 import { EntityName } from "../../coreTable/OwidTableConstants.js"
 import {
+    AxisAlign,
     Color,
     HorizontalAlign,
     PrimitiveType,
@@ -1143,7 +1144,16 @@ export class LineChart
 
     @computed private get yAxisConfig(): AxisConfig {
         // TODO: enable nice axis ticks for linear scales
-        return new AxisConfig(this.manager.yAxisConfig, this)
+        return new AxisConfig(
+            {
+                // if we only have a single y value (probably 0), we want the
+                // horizontal axis to be at the bottom of the chart.
+                // see https://github.com/owid/owid-grapher/pull/975#issuecomment-890798547
+                singleValueAxisPointAlign: AxisAlign.start,
+                ...this.manager.yAxisConfig,
+            },
+            this
+        )
     }
 
     @computed private get verticalAxisPart(): VerticalAxis {

--- a/grapher/stackedCharts/StackedAreaChart.tsx
+++ b/grapher/stackedCharts/StackedAreaChart.tsx
@@ -95,13 +95,24 @@ class Areas extends React.Component<AreasProps> {
         // Stacked area chart stacks each series upon the previous series, so we must keep track of the last point set we used
         let prevPoints = [xBottomLeft, xBottomRight]
         return seriesArr.map((series) => {
-            const mainPoints = series.points.map(
-                (point) =>
-                    [
-                        horizontalAxis.place(point.position),
-                        verticalAxis.place(point.value + point.valueOffset),
-                    ] as [number, number]
-            )
+            let mainPoints: [number, number][] = []
+            if (series.points.length > 1) {
+                mainPoints = series.points.map(
+                    (point) =>
+                        [
+                            horizontalAxis.place(point.position),
+                            verticalAxis.place(point.value + point.valueOffset),
+                        ] as [number, number]
+                )
+            } else if (series.points.length === 1) {
+                // We only have one point, so make it so it stretches out over the whole x axis range
+                const point = series.points[0]
+                const y = verticalAxis.place(point.value + point.valueOffset)
+                mainPoints = [
+                    [horizontalAxis.range[0], y],
+                    [horizontalAxis.range[1], y],
+                ]
+            }
             const points = mainPoints.concat(reverse(clone(prevPoints)) as any)
             prevPoints = mainPoints
 


### PR DESCRIPTION
Fixes #1191 | Fixes #1100 | Live on tufte: [Example](https://tufte-owid.netlify.app/grapher/distribution-of-population-between-different-poverty-thresholds-up-to-30-dollars?stackMode=relative&time=latest&country=~CHN)

Unbreaks StackedArea when a single year is selected (#1191) - it's basically a wide StackedBar chart then - and adds a timeline to StackedArea and StackedBar charts (#1100).

![image](https://user-images.githubusercontent.com/2641501/162060352-7a65b8a5-2569-4102-beee-9110df828edc.png)

## Do we want to enable timelines for all existing StackedArea/StackedBar charts?

All in all, I feel like the timelines are a great benefit and are useful for pretty much all charts.
However, in looking at some of them side-by-side, there are some where `minTime`/`maxTime` is set but `timelineMinTime`/`timelineMaxTime` is not. I will go through and check with the authors if necessary. One example is [this chart on same-sex marriage](https://halley-owid.netlify.app/grapher/same-sex-households-us?time=earliest..latest&country=~USA), which is normally set to 2008-2018 and has weird-looking data for the timespan before 2008. There are also some which currently exclude historical data (seems fine) or projections (probably not fine).

## Tasks
- [x] Solve the single-value `.place()` problem
- [ ] Go through all existing StackedArea and StackedBar charts that have `minTime`/`maxTime` set and check what to do for them
	- Either make changes myself (if easy),
	- or contact authors

<details>
<summary>SQL query for affected charts (and false positives)</summary>

```sql
SELECT id, config
FROM charts
WHERE (config ->> "$.type" = "StackedArea" OR config ->> "$.type" = "StackedBar")
  AND (
        (config ->> "$.minTime" IS NOT NULL AND config ->> "$.minTime" != "earliest")
        OR
        (config ->> "$.maxTime" IS NOT NULL AND config ->> "$.maxTime" != "latest")
    )
;
```

</details>