### PR TITLE
enhance(DiscreteBarChart): Improve readability of DiscreteBar value and year labels

### DIFF
--- a/grapher/barCharts/DiscreteBarChart.test.ts
+++ b/grapher/barCharts/DiscreteBarChart.test.ts
@@ -110,8 +110,11 @@ describe("barcharts with columns as the series", () => {
                 endTime: 2020,
             },
         })
-        expect(chart.formatValue(chart.series[0])).toEqual("1,002")
-        expect(chart.formatValue(chart.series[1])).toEqual("1,000 (2019)")
+        expect(chart.formatValue(chart.series[0])).toEqual(["1,002", ""])
+        expect(chart.formatValue(chart.series[1])).toEqual([
+            "1,000",
+            " in 2019",
+        ])
     })
 })
 

--- a/grapher/barCharts/DiscreteBarChart.test.ts
+++ b/grapher/barCharts/DiscreteBarChart.test.ts
@@ -112,11 +112,11 @@ describe("barcharts with columns as the series", () => {
         })
         expect(chart.formatValue(chart.series[0])).toEqual({
             valueString: "1,002",
-            yearString: "",
+            timeString: "",
         })
         expect(chart.formatValue(chart.series[1])).toEqual({
             valueString: "1,000",
-            yearString: " in 2019",
+            timeString: " in 2019",
         })
     })
 })

--- a/grapher/barCharts/DiscreteBarChart.test.ts
+++ b/grapher/barCharts/DiscreteBarChart.test.ts
@@ -110,11 +110,14 @@ describe("barcharts with columns as the series", () => {
                 endTime: 2020,
             },
         })
-        expect(chart.formatValue(chart.series[0])).toEqual(["1,002", ""])
-        expect(chart.formatValue(chart.series[1])).toEqual([
-            "1,000",
-            " in 2019",
-        ])
+        expect(chart.formatValue(chart.series[0])).toEqual({
+            valueString: "1,002",
+            yearString: "",
+        })
+        expect(chart.formatValue(chart.series[1])).toEqual({
+            valueString: "1,000",
+            yearString: " in 2019",
+        })
     })
 })
 

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -197,7 +197,7 @@ export class DiscreteBarChart
 
         const positiveLabels = this.series
             .filter((d) => d.value >= 0)
-            .map((d) => this.formatValue(d))
+            .map((d) => this.formatValue(d)[0] + this.formatValue(d)[1])
         const longestPositiveLabel = maxBy(positiveLabels, (l) => l.length)
         return Bounds.forText(longestPositiveLabel, this.valueLabelStyle).width
     }
@@ -210,7 +210,7 @@ export class DiscreteBarChart
 
         const negativeLabels = this.series
             .filter((d) => d.value < 0)
-            .map((d) => this.formatValue(d))
+            .map((d) => this.formatValue(d)[0] + this.formatValue(d)[1])
         const longestNegativeLabel = maxBy(negativeLabels, (l) => l.length)
         return (
             Bounds.forText(longestNegativeLabel, this.valueLabelStyle).width +
@@ -379,7 +379,8 @@ export class DiscreteBarChart
                         ? yAxis.place(this.x0) - barX
                         : yAxis.place(series.value) - barX
                     const barColor = series.color
-                    const valueLabel = this.formatValue(series)
+                    const valueLabel = this.formatValue(series)[0]
+                    const yearLabel = this.formatValue(series)[1]
                     const labelX = isNegative
                         ? barX -
                           Bounds.forText(valueLabel, this.valueLabelStyle)
@@ -434,6 +435,7 @@ export class DiscreteBarChart
                                 {...this.valueLabelStyle}
                             >
                                 {valueLabel}
+                                <tspan fill="#999">{yearLabel}</tspan>
                             </text>
                         </g>
                     )
@@ -459,19 +461,21 @@ export class DiscreteBarChart
             : ""
     }
 
-    formatValue(series: DiscreteBarSeries): string {
+    formatValue(series: DiscreteBarSeries): [string, string] {
         const column = this.yColumns[0] // todo: do we need to use the right column here?
         const { transformedTable } = this
 
         const showYearLabels =
             this.manager.showYearLabels || series.time !== this.targetTime
         const displayValue = column.formatValueShort(series.value)
-        return (
-            displayValue +
-            (showYearLabels
-                ? ` (${transformedTable.timeColumnFormatFunction(series.time)})`
-                : "")
-        )
+        return [
+            displayValue,
+            showYearLabels
+                ? ` in ${transformedTable.timeColumnFormatFunction(
+                      series.time
+                  )}`
+                : "",
+        ]
     }
 
     @computed private get yColumnSlugs(): string[] {

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -71,6 +71,11 @@ const labelToBarPadding = 5
 
 const LEGEND_PADDING = 25
 
+export interface Label {
+    valueString: string
+    yearString: string
+}
+
 interface DiscreteBarItem {
     seriesName: string
     value: number
@@ -197,7 +202,11 @@ export class DiscreteBarChart
 
         const positiveLabels = this.series
             .filter((d) => d.value >= 0)
-            .map((d) => this.formatValue(d)[0] + this.formatValue(d)[1])
+            .map(
+                (d) =>
+                    this.formatValue(d).valueString +
+                    this.formatValue(d).yearString
+            )
         const longestPositiveLabel = maxBy(positiveLabels, (l) => l.length)
         return Bounds.forText(longestPositiveLabel, this.valueLabelStyle).width
     }
@@ -210,7 +219,11 @@ export class DiscreteBarChart
 
         const negativeLabels = this.series
             .filter((d) => d.value < 0)
-            .map((d) => this.formatValue(d)[0] + this.formatValue(d)[1])
+            .map(
+                (d) =>
+                    this.formatValue(d).valueString +
+                    this.formatValue(d).yearString
+            )
         const longestNegativeLabel = maxBy(negativeLabels, (l) => l.length)
         return (
             Bounds.forText(longestNegativeLabel, this.valueLabelStyle).width +
@@ -379,12 +392,13 @@ export class DiscreteBarChart
                         ? yAxis.place(this.x0) - barX
                         : yAxis.place(series.value) - barX
                     const barColor = series.color
-                    const valueLabel = this.formatValue(series)[0]
-                    const yearLabel = this.formatValue(series)[1]
+                    const label = this.formatValue(series)
                     const labelX = isNegative
                         ? barX -
-                          Bounds.forText(valueLabel, this.valueLabelStyle)
-                              .width -
+                          Bounds.forText(
+                              label.valueString,
+                              this.valueLabelStyle
+                          ).width -
                           labelToTextPadding
                         : barX - labelToBarPadding
 
@@ -434,8 +448,8 @@ export class DiscreteBarChart
                                 textAnchor={isNegative ? "end" : "start"}
                                 {...this.valueLabelStyle}
                             >
-                                {valueLabel}
-                                <tspan fill="#999">{yearLabel}</tspan>
+                                {label.valueString}
+                                <tspan fill="#999">{label.yearString}</tspan>
                             </text>
                         </g>
                     )
@@ -461,21 +475,21 @@ export class DiscreteBarChart
             : ""
     }
 
-    formatValue(series: DiscreteBarSeries): [string, string] {
+    formatValue(series: DiscreteBarSeries): Label {
         const column = this.yColumns[0] // todo: do we need to use the right column here?
         const { transformedTable } = this
 
         const showYearLabels =
             this.manager.showYearLabels || series.time !== this.targetTime
         const displayValue = column.formatValueShort(series.value)
-        return [
-            displayValue,
-            showYearLabels
+        return {
+            valueString: displayValue,
+            yearString: showYearLabels
                 ? ` in ${transformedTable.timeColumnFormatFunction(
                       series.time
                   )}`
                 : "",
-        ]
+        }
     }
 
     @computed private get yColumnSlugs(): string[] {

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -73,7 +73,7 @@ const LEGEND_PADDING = 25
 
 export interface Label {
     valueString: string
-    yearString: string
+    timeString: string
 }
 
 interface DiscreteBarItem {
@@ -205,7 +205,7 @@ export class DiscreteBarChart
             .map(
                 (d) =>
                     this.formatValue(d).valueString +
-                    this.formatValue(d).yearString
+                    this.formatValue(d).timeString
             )
         const longestPositiveLabel = maxBy(positiveLabels, (l) => l.length)
         return Bounds.forText(longestPositiveLabel, this.valueLabelStyle).width
@@ -222,7 +222,7 @@ export class DiscreteBarChart
             .map(
                 (d) =>
                     this.formatValue(d).valueString +
-                    this.formatValue(d).yearString
+                    this.formatValue(d).timeString
             )
         const longestNegativeLabel = maxBy(negativeLabels, (l) => l.length)
         return (
@@ -449,7 +449,7 @@ export class DiscreteBarChart
                                 {...this.valueLabelStyle}
                             >
                                 {label.valueString}
-                                <tspan fill="#999">{label.yearString}</tspan>
+                                <tspan fill="#999">{label.timeString}</tspan>
                             </text>
                         </g>
                     )
@@ -482,10 +482,13 @@ export class DiscreteBarChart
         const showYearLabels =
             this.manager.showYearLabels || series.time !== this.targetTime
         const displayValue = column.formatValueShort(series.value)
+        const { timeColumn } = transformedTable
+        const preposition = OwidTable.getPreposition(timeColumn)
+
         return {
             valueString: displayValue,
-            yearString: showYearLabels
-                ? ` in ${transformedTable.timeColumnFormatFunction(
+            timeString: showYearLabels
+                ? ` ${preposition} ${transformedTable.timeColumnFormatFunction(
                       series.time
                   )}`
                 : "",


### PR DESCRIPTION
This PR closes #1347.
Improved readability and updated DiscreteBarChart.test to take changes into account

It now looks like this:
![average-working-hours-of-children](https://user-images.githubusercontent.com/56021613/162074604-84d602bb-39fb-4925-b71f-07e70b5f1679.png)

