### PR TITLE
Rename more env variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ up: require create-if-missing.env tmp-downloads/owid_chartdata.sql.gz
 		bind Q kill-server \
 		|| make down
 
-up.full: require create-if-missing.env.full tmp-downloads/owid_chartdata.sql.gz tmp-downloads/live_wordpress.sql.gz wordpress/web/app/uploads/2022
+up.full: require create-if-missing.env.full wordpress/.env tmp-downloads/owid_chartdata.sql.gz tmp-downloads/live_wordpress.sql.gz wordpress/web/app/uploads/2022
 	@make validate.env.full
 	@make check-port-3306
 
@@ -131,6 +131,10 @@ tmp-downloads/owid_chartdata.sql.gz:
 tmp-downloads/live_wordpress.sql.gz:
 	@echo '==> Downloading wordpress data'
 	./devtools/docker/download-wordpress-mysql.sh
+
+wordpress/.env:
+	@echo 'Copying wordpress/.env.example --> wordpress/.env'
+	@cp -f wordpress/.env.example wordpress/.env
 
 wordpress/web/app/uploads/2022:
 	@echo '==> Downloading wordpress uploads'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@
 
 ---
 
-**This repo is currently not well-designed for reuse as a visualization library, nor for reproducing the full production environment we have at Our World in Data, as our tools are tightly coupled with our database structure.**
+This repo is currently not well-designed for reuse as a visualization library, nor for reproducing the full production environment we have at Our World in Data, as our tools are tightly coupled with our database structure.
+
+⚠️
+
+**Note: As of April 5th 2022, we have [changed](https://github.com/owid/owid-grapher/pull/1359) the environment variable naming and MySQL port used by the database. If you've been running this project since before then, please update your `.env` and MySQL client accordingly.**
+
+⚠️
 
 We're gradually making steps towards making our work more reusable, however we still prioritize [needs specific to our project](#why-did-we-start-this-project) that can be at odds with making our tools reusable.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repo is currently not well-designed for reuse as a visualization library, n
 
 ⚠️
 
-**Note: As of April 5th 2022, we have [changed](https://github.com/owid/owid-grapher/pull/1359) the environment variable naming and MySQL port used by the database. If you've been running this project since before then, please update your `.env` and MySQL client accordingly.**
+**Note: As of April 5th 2022, we have [changed](https://github.com/owid/owid-grapher/pull/1359) the environment variable naming and MySQL port used by the database. If you've been running this project since before then, please update your `.env` and MySQL client accordingly (see the [example file](./.env.example) as a reference for the required changes).**
 
 ⚠️
 

--- a/docs/docker-compose-mysql.md
+++ b/docs/docker-compose-mysql.md
@@ -57,7 +57,7 @@ The first time you run this it will take a while to download and set up the data
 
 Now you can open [http://localhost:3030/admin/charts](http://localhost:3030/admin/charts) and start creating charts. Any changes to the TypeScript code you make will be automatically compiled, but you will have to refresh your page to see the changes.
 
-### Inspecting the databases
+## Inspecting the databases
 
 For all operating systems, we recommend using [DBeaver](https://dbeaver.io/).
 
@@ -76,3 +76,31 @@ Use this connection configuration:
 We also have [a schema diagram for reference.](screenshots/er_diagram.png)
 
 Note that in the MySQL database that was set up, the `data_values` table is incomplete – it only contains data used in charts. In production, this table is >30GB (uncompressed) and contains unreviewed and undocumented data, so we currently don't offer a full export of it.
+
+## Resetting your environment
+
+If you've modified or broken your database and want to start over from scratch, you'll need to clear the docker volumes that the database persists on.
+
+To do so, get their names
+
+```bash
+docker volume ls
+```
+
+and remove them with
+
+```bash
+docker volume rm volume_name
+```
+
+The names of the volumes should usually be something like `owid-grapher_mysql_data` and `owid-grapher_mysql_data_public`.
+
+You can also remove your local copies of the database exports if you want to download the latest version. Skip this step if you want your database to be exactly the same as it was on your last setup.
+
+```bash
+rm tmp-downloads/*
+```
+
+With that done, the next time you run `make up`, the database files will be re-downloaded.
+
+A new database will then be created (expect another 10-20 minutes.)

--- a/docs/full-wordpress-setup.md
+++ b/docs/full-wordpress-setup.md
@@ -6,8 +6,6 @@ This setup is very similar to the [Local setup with MySQL and grapher admin](doc
 
 ## Running the full setup
 
-One quick thing to check is if you are already running MySQL on your computer at port 3306 and if so to stop this service while running the Docker setup. Our Docker based setup tries to expose the MySQL Docker container at port 3306 of your computer for easy interaction with other tools (e.g. a SQL editor). If this port is already taken then starting this container will fail.
-
 All you need to do now is to open a terminal and run
 
 ```bash
@@ -17,7 +15,11 @@ make up.full
 The full setup includes an nginx server exposed at http://localhost:8080 that does some basic routing (/admin goes to the grapher admin running on your host, /wp/ goes to the php container running wordpress).
 
 The most important URLs:
+
 http://localhost:8080/admin - the grapher admin
+
 http://localhost:8080/wp/wp-admin - the wordpress admin
 
 Note that in the MySQL database that was set up, the `data_values` table will be incomplete – it will only contain data used in charts. In production, this table is >30GB (uncompressed) and contains unreviewed and undocumented data, so we currently don't offer a full export of it.
+
+If you'd like to interact with the databases, see the [inspecting and refreshing the databases](docker-compose-mysql.md#inspecting-the-databases) section of the prerequisite tutorial.

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -49,7 +49,7 @@ export const GRAPHER_DB_HOST: string =
     serverSettings.GRAPHER_DB_HOST ?? "localhost"
 // The OWID stack uses 3307, but incase it's unset, assume user is running a local setup
 export const GRAPHER_DB_PORT: number =
-    parseIntOrUndefined(serverSettings.DB_PORT) ?? 3306
+    parseIntOrUndefined(serverSettings.GRAPHER_DB_PORT) ?? 3306
 
 export const BAKED_SITE_DIR: string =
     serverSettings.BAKED_SITE_DIR ?? path.resolve(BASE_DIR, "bakedSite") // Where the static build output goes

--- a/wordpress/.env.example
+++ b/wordpress/.env.example
@@ -1,18 +1,18 @@
-DB_NAME=wordpress
-DB_USER=wordpress
-DB_PASSWORD=wordpress
-DB_HOST=db
+WORDPRESS_DB_NAME=wordpress
+WORDPRESS_DB_USER=wordpress
+WORDPRESS_DB_PASSWORD=wordpress
+WORDPRESS_DB_HOST=db
 
 # Must be set on staging in order to be able to refresh the database
 GRAPHER_DB_HOST=
 GRAPHER_DB_NAME=
 
 # Optionally, you can use a data source name (DSN)
-# When using a DSN, you can remove the DB_NAME, DB_USER, DB_PASSWORD, and DB_HOST variables
-# DATABASE_URL=mysql://database_user:database_password@database_host:database_port/database_name
+# When using a DSN, you can remove the WORDPRESS_DB_NAME, WORDPRESS_DB_USER, WORDPRESS_DB_PASSWORD, and WORDPRESS_DB_HOST variables
+# WORDPRESS_DATABASE_URL=mysql://database_user:database_password@database_host:database_port/database_name
 
 # Optional variables
-# DB_PREFIX=wp_
+# WORDPRESS_DB_PREFIX=wp_
 
 WP_ENV=development
 WP_HOME=http://localhost:8080

--- a/wordpress/config/application.php
+++ b/wordpress/config/application.php
@@ -37,8 +37,12 @@ $dotenv = Dotenv\Dotenv::createUnsafeImmutable($root_dir, $env_files, false);
 if (file_exists($root_dir . '/.env')) {
     $dotenv->load();
     $dotenv->required(['WP_HOME', 'WP_SITEURL']);
-    if (!env('DATABASE_URL')) {
-        $dotenv->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD']);
+    if (!env('WORDPRESS_DATABASE_URL')) {
+        $dotenv->required([
+            'WORDPRESS_DB_NAME',
+            'WORDPRESS_DB_USER',
+            'WORDPRESS_DB_PASSWORD',
+        ]);
     }
 }
 
@@ -67,16 +71,16 @@ Config::define(
 /**
  * DB settings
  */
-Config::define('DB_NAME', env('DB_NAME'));
-Config::define('DB_USER', env('DB_USER'));
-Config::define('DB_PASSWORD', env('DB_PASSWORD'));
-Config::define('DB_HOST', env('DB_HOST') ?: 'localhost');
+Config::define('DB_NAME', env('WORDPRESS_DB_NAME'));
+Config::define('DB_USER', env('WORDPRESS_DB_USER'));
+Config::define('DB_PASSWORD', env('WORDPRESS_DB_PASSWORD'));
+Config::define('DB_HOST', env('WORDPRESS_DB_HOST') ?: 'localhost');
 Config::define('DB_CHARSET', 'utf8mb4');
 Config::define('DB_COLLATE', '');
-$table_prefix = env('DB_PREFIX') ?: 'wp_';
+$table_prefix = env('WORDPRESS_DB_PREFIX') ?: 'wp_';
 
-if (env('DATABASE_URL')) {
-    $dsn = (object) parse_url(env('DATABASE_URL'));
+if (env('WORDPRESS_DATABASE_URL')) {
+    $dsn = (object) parse_url(env('WORDPRESS_DATABASE_URL'));
 
     Config::define('DB_NAME', substr($dsn->path, 1));
     Config::define('DB_USER', $dsn->user);


### PR DESCRIPTION
Follow up to #1359.

I think we have to rename these ones too in order to be consistent, or is there a specific reason you left them out @ikesau?

basically, this means that in `wordpress/.env` too, everyone will have to rename `DB_NAME` -> `WORDPRESS_DB_NAME` etc.