### PR TITLE
Add {{FullWidthRawHtml}} data token

### DIFF
--- a/site/DataToken.tsx
+++ b/site/DataToken.tsx
@@ -1,9 +1,10 @@
 import React from "react"
+import { dictionary } from "./runDataTokens.js"
 
 export const DataToken_name = "DataToken"
 
-export const DataToken = ({ token, ...restProps }: { token: string }) => (
-    <span>
+export const DataToken = ({ token, ...restProps }: { token: string }) =>
+    dictionary[token].wrapper(
         <script
             data-type={DataToken_name}
             type="component/props"
@@ -12,5 +13,4 @@ export const DataToken = ({ token, ...restProps }: { token: string }) => (
                 __html: JSON.stringify(restProps),
             }}
         ></script>
-    </span>
-)
+    )

--- a/site/covid/FullWidthRawHtml.tsx
+++ b/site/covid/FullWidthRawHtml.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect, useState } from "react"
+
+export const RawHtml = ({ url }: { url: string }) => {
+    const [html, setHtml] = useState<null | string>(null)
+    useEffect(() => {
+        const fetchHtml = async () => {
+            if (!url) return
+            const response = await fetch(url)
+            if (!response.ok) return
+            setHtml(await response.text())
+        }
+        fetchHtml()
+    }, [])
+
+    return html && <div dangerouslySetInnerHTML={{ __html: html }}></div>
+}
+
+export const FullWidthRawHtml = RawHtml

--- a/site/runDataTokens.tsx
+++ b/site/runDataTokens.tsx
@@ -2,13 +2,30 @@ import React from "react"
 import ReactDOM from "react-dom"
 import { DataToken_name } from "../site/DataToken.js"
 import { LastUpdated } from "./covid/LastUpdated.js"
+import { FullWidthRawHtml } from "./covid/FullWidthRawHtml.js"
 
 interface ComponentDictionary {
-    [key: string]: any
+    [key: string]: {
+        component: any
+        wrapper: DataTokenWrapper
+    }
 }
 
-const dictionary: ComponentDictionary = {
-    LastUpdated,
+type DataTokenWrapper = (children: React.ReactElement) => React.ReactElement
+
+export const dictionary: ComponentDictionary = {
+    LastUpdated: {
+        component: LastUpdated,
+        wrapper: (children) => <span>{children}</span>,
+    },
+
+    FullWidthRawHtml: {
+        component: FullWidthRawHtml,
+        // todo: replace by BlockType.FullContentWidth when merged
+        wrapper: (children) => (
+            <div className="wp-block-full-content-width">{children}</div>
+        ),
+    },
 }
 
 export const runDataTokens = () => {
@@ -21,7 +38,7 @@ export const runDataTokens = () => {
 
         const componentProps = JSON.parse(dataToken.innerHTML)
 
-        const Component = dictionary[token]
+        const Component = dictionary[token]?.component
         if (!Component) return
 
         ReactDOM.render(


### PR DESCRIPTION
Support dynamic **client-side** insertion of covid vaccination table in /covid-vaccinations.

Format: `{{FullWidthRawHtml url:https://[URL_HERE]}}`

## Caveats
- Short version: `{{FullWidthRawHtml}}` tags need to be inside a "Custom HTML" Wordpress block. 
- Longer version: this "need" is a conceptual constraint, to simplify the understanding of {{FullWidthRawHtml}} tags. By default, Gutenberg wraps every paragraph in a `<p>`, which would prevent the [FullWidthHandler](https://github.com/owid/owid-grapher/blob/3d41b1e33227c1312bb8b698bb8840f15fc7d741/site/formatting.tsx#L122) from kicking in (since it only matches top-level elements). Technically, this is not an issue since [empty `<p>` are cleaned up](https://github.com/owid/owid-grapher/blob/3d41b1e33227c1312bb8b698bb8840f15fc7d741/baker/formatWordpressPost.tsx#L447) before being processed by the FullWidthHandler, so this extra `<p>` is never seen. What's not obvious is that this `<p>` is not really empty, since it contains the [<DataToken> script tag](https://github.com/owid/owid-grapher/blob/3d41b1e33227c1312bb8b698bb8840f15fc7d741/site/DataToken.tsx#L8). Given how convoluted this all is, it seems more straightforward conceptually to place `{{FullWidthRawHtml}}` tags inside HTML blocks (which are not wrapped in `<p>` to start with)