### PR TITLE
fix: Axis tick labels shows proper decimal places.

### DIFF
--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -463,21 +463,26 @@ export class HorizontalAxis extends AbstractAxis {
         // Make sure the start and end values are present, if they're whole numbers
         const startEndPrio = this.scaleType === ScaleType.log ? 2 : 1
         if (domain[0] % 1 === 0)
-            ticks = [
-                {
-                    value: domain[0],
-                    priority: startEndPrio,
-                },
-                ...ticks,
-            ]
+            if (!ticks.some((tick) => tick.value === domain[0]))
+                // Make sure that start value is not already present.
+                ticks = [
+                    {
+                        value: domain[0],
+                        priority: startEndPrio,
+                    },
+                    ...ticks,
+                ]
         if (domain[1] % 1 === 0 && this.hideFractionalTicks)
-            ticks = [
-                ...ticks,
-                {
-                    value: domain[1],
-                    priority: startEndPrio,
-                },
-            ]
+            if (!ticks.some((tick) => tick.value === domain[1]))
+                // Make sure that end value is not already present.
+
+                ticks = [
+                    ...ticks,
+                    {
+                        value: domain[1],
+                        priority: startEndPrio,
+                    },
+                ]
         return uniq(ticks)
     }
 


### PR DESCRIPTION
This PR fixes #1267 
Now Axis tick labels include sufficient decimal places.

The chart now looks like this,
![share-of-cumulative-co2](https://user-images.githubusercontent.com/56021613/163672880-6860873d-0714-403a-bf6a-6ee65e7affca.png)

Often baseTicks added ticks with duplicate start and end values with different priorities. Since they had different priorities, they were not filtered by `uniq`.

https://github.com/owid/owid-grapher/blob/58fb266f3c105f8fef13741b86332f655df7452b/grapher/axis/Axis.ts#L463-L482

Due to this, `numDecimalPlaces` is always 1
https://github.com/owid/owid-grapher/blob/58fb266f3c105f8fef13741b86332f655df7452b/grapher/axis/Axis.ts#L323-L332
