### PR TITLE
Bulk-fastt-enable-latest-earliest

### DIFF
--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -91,6 +91,7 @@ import {
     fetchVariablesParametersFromQueryString,
     filterExpressionNoFilter,
     fetchVariablesParametersToQueryParameters,
+    postProcessJsonLogicTree,
 } from "./GrapherConfigGridEditorTypesAndUtils.js"
 import { Query, Utils as QbUtils, Utils } from "react-awesome-query-builder"
 // types
@@ -1119,10 +1120,16 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
             )
             if (jsonLogic === true) jsonLogic = null // If we have the default query then don't bother any further
 
-            const jsonLogicTree = Utils.loadFromJsonLogic(
+            let jsonLogicTree = Utils.loadFromJsonLogic(
                 jsonLogic as any,
                 this.FilterPanelConfig ?? filterPanelInitialConfig
             )
+
+            if (jsonLogicTree !== undefined) {
+                const mutableTree = Utils.getTree(jsonLogicTree)
+                postProcessJsonLogicTree(mutableTree)
+                jsonLogicTree = QbUtils.loadTree(mutableTree)
+            }
 
             // If we didn't get a working tree then use our default one instead
             const tree =
@@ -1770,8 +1777,16 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
                 cardinality: 0,
                 jsonLogic: "==",
             },
+            is_earliest: {
+                label: "Is earliest",
+                labelForFormat: "Is earliest",
+                sqlOp: "=",
+                cardinality: 0,
+                jsonLogic: "==",
+            },
         } as any
         config.types.number.widgets.number.operators!.push("is_latest")
+        config.types.number.widgets.number.operators!.push("is_earliest")
 
         config.settings.customFieldSelectProps = { showSearch: true }
         return config

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -91,7 +91,7 @@ import {
     fetchVariablesParametersFromQueryString,
     filterExpressionNoFilter,
     fetchVariablesParametersToQueryParameters,
-    postProcessJsonLogicTree,
+    postprocessJsonLogicTree,
 } from "./GrapherConfigGridEditorTypesAndUtils.js"
 import { Query, Utils as QbUtils, Utils } from "react-awesome-query-builder"
 // types
@@ -1128,7 +1128,7 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
 
             if (jsonLogicTree !== undefined) {
                 const mutableTree = Utils.getTree(jsonLogicTree)
-                postProcessJsonLogicTree(mutableTree)
+                postprocessJsonLogicTree(mutableTree)
                 jsonLogicTree = QbUtils.loadTree(mutableTree)
             }
 

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -686,6 +686,7 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
             .with(EditorOption.checkbox, () => "checkbox")
             .with(EditorOption.dropdown, () => "dropdown")
             .with(EditorOption.numeric, () => "numeric")
+            .with(EditorOption.numericWithLatestEarliest, () => "numeric")
             .with(EditorOption.textfield, () => "text")
             .with(EditorOption.textarea, () => "text")
             .with(EditorOption.colorEditor, () => "colorScale")

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -1760,6 +1760,19 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
         //     "multiselect_not_equals",
         // ]
         config.operators = pick(config.operators, operatorsToKeep) as any
+
+        config.operators = {
+            ...config.operators,
+            is_latest: {
+                label: "Is latest",
+                labelForFormat: "Is latest",
+                sqlOp: "=",
+                cardinality: 0,
+                jsonLogic: "==",
+            },
+        } as any
+        config.types.number.widgets.number.operators!.push("is_latest")
+
         config.settings.customFieldSelectProps = { showSearch: true }
         return config
     }

--- a/adminSiteClient/GrapherConfigGridEditorTypesAndUtils.tsx
+++ b/adminSiteClient/GrapherConfigGridEditorTypesAndUtils.tsx
@@ -37,6 +37,8 @@ import {
     Builder,
     BuilderProps,
     JsonTree,
+    Operator,
+    Operators,
     SimpleField,
 } from "react-awesome-query-builder"
 import { Utils as QbUtils } from "react-awesome-query-builder"
@@ -257,6 +259,7 @@ export function isConfigColumn(columnName: string): boolean {
 }
 
 export const filterPanelInitialConfig: BasicConfig = AntdConfig as BasicConfig
+
 export const initialFilterQueryValue: JsonGroup = {
     id: QbUtils.uuid(),
     type: "group",
@@ -452,6 +455,12 @@ export function filterTreeToSExpression(
                         new StringAtom(""),
                     ])
                 })
+                .with("is_latest", (_) => {
+                    return new EqualityComparision(EqualityOperator.equal, [
+                        field,
+                        new StringAtom("latest"),
+                    ])
+                })
 
                 .otherwise(() => undefined)
         )
@@ -497,6 +506,7 @@ export function fieldDescriptionToFilterPanelFieldConfig(
         return [
             description.pointer,
             {
+                // TODO: can we suppress the is_latest operator here on numeric fields that don't allow it?
                 label: description.pointer,
                 type: widget,
                 valueSources: ["value"],

--- a/adminSiteClient/GrapherConfigGridEditorTypesAndUtils.tsx
+++ b/adminSiteClient/GrapherConfigGridEditorTypesAndUtils.tsx
@@ -37,8 +37,6 @@ import {
     Builder,
     BuilderProps,
     JsonTree,
-    Operator,
-    Operators,
     SimpleField,
 } from "react-awesome-query-builder"
 import { Utils as QbUtils } from "react-awesome-query-builder"
@@ -521,6 +519,7 @@ export function simpleColumnToFilterPanelFieldConfig(
             label: column.label,
             type: fieldType,
             valueSources: ["value"],
+            excludeOperators: ["is_latest", "is_earliest"],
             //preferWidgets: widget [widget],
         },
     ]
@@ -535,16 +534,20 @@ export function fieldDescriptionToFilterPanelFieldConfig(
         .with(EditorOption.dropdown, () => "select")
         .with(EditorOption.mappingEditor, () => undefined)
         .with(EditorOption.numeric, () => "number")
+        .with(EditorOption.numericWithLatestEarliest, () => "number")
         .with(EditorOption.primitiveListEditor, () => undefined)
         .with(EditorOption.textarea, () => "text")
         .with(EditorOption.textfield, () => "text")
         .exhaustive()
 
-    if (widget !== undefined)
+    if (widget !== undefined) {
+        const excludedOperators =
+            description.editor === EditorOption.numericWithLatestEarliest
+                ? []
+                : ["is_latest", "is_earliest"]
         return [
             description.pointer,
             {
-                // TODO: can we suppress the is_latest operator here on numeric fields that don't allow it?
                 label: description.pointer,
                 type: widget,
                 valueSources: ["value"],
@@ -552,9 +555,10 @@ export function fieldDescriptionToFilterPanelFieldConfig(
                 fieldSettings: {
                     listValues: description.enumOptions,
                 },
+                excludeOperators: excludedOperators,
             },
         ]
-    else return undefined
+    } else return undefined
 }
 
 export function renderBuilder(props: BuilderProps) {

--- a/adminSiteClient/GrapherConfigGridEditorTypesAndUtils.tsx
+++ b/adminSiteClient/GrapherConfigGridEditorTypesAndUtils.tsx
@@ -347,24 +347,26 @@ export function SExpressionToJsonLogic(
     query operator that we added to RAQL that in our SExpressions are represented as
     field = "latest"
  */
-export function postProcessJsonLogicTree(filterTree: JsonTree | JsonItem) {
+export function postprocessJsonLogicTree(filterTree: JsonTree | JsonItem) {
     if (filterTree.type === "group" && filterTree.children1) {
-        if (isArray(filterTree.children1))
-            for (const child of filterTree.children1)
-                postProcessJsonLogicTree(child)
-        else if (isPlainObject(filterTree.children1))
+        if (
+            isArray(filterTree.children1) ||
+            isPlainObject(filterTree.children1)
+        )
             for (const child of Object.values(filterTree.children1))
-                postProcessJsonLogicTree(child)
+                postprocessJsonLogicTree(child)
     } else if (filterTree.type === "rule") {
-        const isLatest =
-            filterTree.properties.value.length === 1 &&
-            filterTree.properties.value[0] === "latest"
-        const isEarliest =
-            filterTree.properties.value.length === 1 &&
-            filterTree.properties.value[0] === "earliest"
-        const isEqual =
-            filterTree.properties.operator === "equal" ||
-            filterTree.properties.operator === "select_equals"
+        const {
+            properties: { value, operator },
+        } = filterTree
+
+        if (value.length !== 1) return
+
+        const isLatest = value[0] === "latest"
+
+        const isEarliest = value[0] === "earliest"
+
+        const isEqual = operator === "equal" || operator === "select_equals"
         if (isLatest && isEqual) {
             filterTree.properties.operator = "is_latest"
         } else if (isEarliest && isEqual) {

--- a/clientUtils/schemaProcessing.ts
+++ b/clientUtils/schemaProcessing.ts
@@ -17,6 +17,7 @@ export enum EditorOption {
     textarea = "textarea",
     dropdown = "dropdown",
     numeric = "numeric",
+    numericWithLatestEarliest = "numericWithLatestEarliest",
     checkbox = "checkbox",
     colorEditor = "colorEditor",
     mappingEditor = "mappingEditor",
@@ -83,9 +84,8 @@ function getEditorOptionForType(
     else if (isArray(type)) {
         // the following line is aspecial case hack for fields that are usually numeric but can have a
         // special string like "latest"
-        console.log("field type is array", type)
         if (type[0] === "number" && type[1] === "string")
-            return EditorOption.numeric
+            return EditorOption.numericWithLatestEarliest
         else return EditorOption.textfield
     } else if (type === "array") return EditorOption.primitiveListEditor
     else return EditorOption.textfield


### PR DESCRIPTION
This PR is part of #1224 - it adds a new operator so that on time fields like maxTime you can query for entries "latest" or "earliest"