### PR TITLE
Fix bar chart font size

### DIFF
--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -165,8 +165,9 @@ export class DiscreteBarChart
         fontSize: number
         fontWeight: number
     } {
+        const availableHeight = this.boundsWithoutColorLegend.height / this.barCount
         return {
-            fontSize: 0.75 * this.fontSize,
+            fontSize: Math.min(0.75 * this.fontSize, 1.1 * availableHeight),
             fontWeight: 700,
         }
     }
@@ -175,8 +176,9 @@ export class DiscreteBarChart
         fontSize: number
         fontWeight: number
     } {
+        const availableHeight = this.boundsWithoutColorLegend.height / this.barCount
         return {
-            fontSize: 0.75 * this.fontSize,
+            fontSize: Math.min(0.75 * this.fontSize, 1.1 * availableHeight),
             fontWeight: 400,
         }
     }
@@ -418,9 +420,7 @@ export class DiscreteBarChart
                                 fill="#555"
                                 dominantBaseline="middle"
                                 textAnchor="end"
-                                fontSize={this.barHeight < 6 ? 10
-                                : this.barHeight < 8 ? 11 : 0.75 * this.fontSize}
-                                fontWeight={700}
+                                {...this.legendLabelStyle}
                             >
                                 {series.seriesName}
                             </text>

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -418,7 +418,9 @@ export class DiscreteBarChart
                                 fill="#555"
                                 dominantBaseline="middle"
                                 textAnchor="end"
-                                {...this.legendLabelStyle}
+                                fontSize={this.barHeight < 6 ? 10
+                                : this.barHeight < 8 ? 11 : 0.75 * this.fontSize}
+                                fontWeight={700}
                             >
                                 {series.seriesName}
                             </text>

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -161,13 +161,17 @@ export class DiscreteBarChart
         return this.manager.baseFontSize ?? BASE_FONT_SIZE
     }
 
+    @computed private get labelFontSize(): number {
+        const availableHeight = this.boundsWithoutColorLegend.height / this.barCount
+        return Math.min(0.75 * this.fontSize, 1.1 * availableHeight)
+    }
+
     @computed private get legendLabelStyle(): {
         fontSize: number
         fontWeight: number
     } {
-        const availableHeight = this.boundsWithoutColorLegend.height / this.barCount
         return {
-            fontSize: Math.min(0.75 * this.fontSize, 1.1 * availableHeight),
+            fontSize: this.labelFontSize,
             fontWeight: 700,
         }
     }
@@ -176,9 +180,8 @@ export class DiscreteBarChart
         fontSize: number
         fontWeight: number
     } {
-        const availableHeight = this.boundsWithoutColorLegend.height / this.barCount
         return {
-            fontSize: Math.min(0.75 * this.fontSize, 1.1 * availableHeight),
+            fontSize: this.labelFontSize,
             fontWeight: 400,
         }
     }


### PR DESCRIPTION
I'm still trying to fully understand the code but I had an initial idea for this fix. (Issue #1346)

I first thought of editing the `legendLabelStyle` function, but I couldn't figure out how to access `barHeight`, so I moved `fontSize` and `fontWeight` inside the `<text>` tags.

For now, this only takes into consideration `barHeight` with some approximate values for the heights and font sizes.

Please let me know if this approach is alright and I will do the same for `valueLabelStyle` as well.
