### PR TITLE
refactor(prom links): simplify renderGrapherImageByChartSlug

### DIFF
--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -504,7 +504,9 @@ export const renderProminentLinks = async (
                     : resolvedUrl.isExplorer
                     ? renderExplorerDefaultThumbnail()
                     : resolvedUrl.isGrapher && resolvedUrl.slug
-                    ? await renderGrapherImageByChartSlug(resolvedUrl.slug)
+                    ? renderGrapherThumbnailByResolvedChartSlug(
+                          resolvedUrl.slug
+                      )
                     : await renderPostThumbnailBySlug(resolvedUrl.slug))
 
             const rendered = ReactDOMServer.renderToStaticMarkup(
@@ -605,9 +607,17 @@ const getExplorerTitleByUrl = async (url: Url): Promise<string | undefined> => {
     return explorer.explorerTitle
 }
 
-const renderGrapherImageByChartSlug = async (
+/**
+ * Renders a chart thumbnail given a slug. The slug is considered "resolved",
+ * meaning it has gone through the internal URL resolver and is final from a
+ * redirects perspective.
+ *
+ * @param chartSlug
+ * @returns
+ */
+const renderGrapherThumbnailByResolvedChartSlug = (
     chartSlug: string
-): Promise<string | null> => {
+): string | null => {
     return `<img src="${BAKED_GRAPHER_EXPORTS_BASE_URL}/${chartSlug}.svg" />`
 }
 

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -611,9 +611,6 @@ const getExplorerTitleByUrl = async (url: Url): Promise<string | undefined> => {
  * Renders a chart thumbnail given a slug. The slug is considered "resolved",
  * meaning it has gone through the internal URL resolver and is final from a
  * redirects perspective.
- *
- * @param chartSlug
- * @returns
  */
 const renderGrapherThumbnailByResolvedChartSlug = (
     chartSlug: string

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -29,7 +29,10 @@ import {
     BAKED_BASE_URL,
     BLOG_POSTS_PER_PAGE,
 } from "../settings/serverSettings.js"
-import { RECAPTCHA_SITE_KEY } from "../settings/clientSettings.js"
+import {
+    BAKED_GRAPHER_EXPORTS_BASE_URL,
+    RECAPTCHA_SITE_KEY,
+} from "../settings/clientSettings.js"
 import {
     EntriesByYearPage,
     EntriesForYearPage,
@@ -605,13 +608,7 @@ const getExplorerTitleByUrl = async (url: Url): Promise<string | undefined> => {
 const renderGrapherImageByChartSlug = async (
     chartSlug: string
 ): Promise<string | null> => {
-    const chart = await Chart.getBySlug(chartSlug)
-    if (!chart) return null
-
-    const canonicalSlug = chart?.config?.slug
-    if (!canonicalSlug) return null
-
-    return `<img src="${BAKED_BASE_URL}/grapher/exports/${canonicalSlug}.svg" />`
+    return `<img src="${BAKED_GRAPHER_EXPORTS_BASE_URL}/${chartSlug}.svg" />`
 }
 
 const renderExplorerDefaultThumbnail = (): string => {


### PR DESCRIPTION
This should be ok given the single usage of this function so far, which always happens after URLs have been resolved.