### PR TITLE
fix(ScatterPlot): Use X/Y min/max from config when only a single bubble is plotted

### DIFF
--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -349,11 +349,12 @@ export const previous = <T>(set: T[], current: T): T => {
 export const domainExtent = (
     numValues: number[],
     scaleType: ScaleType,
-    maxValueMultiplierForPadding = 1
+    maxValueMultiplierForPadding = 1,
+    userDomain?: number[]
 ): [number, number] => {
     const filterValues =
         scaleType === ScaleType.log ? numValues.filter((v) => v > 0) : numValues
-    const [minValue, maxValue] = extent(filterValues)
+    let [minValue, maxValue] = extent(filterValues)
 
     if (
         minValue !== undefined &&
@@ -365,6 +366,14 @@ export const domainExtent = (
             return [minValue, maxValue * maxValueMultiplierForPadding]
         } else {
             // Only one value, make up a reasonable default
+
+            if (userDomain !== undefined) {
+                // if there are user defined domains, use them.
+
+                if (minValue > userDomain[0]) minValue = userDomain[0]
+                if (maxValue < userDomain[1]) maxValue = userDomain[1]
+                return [minValue, maxValue]
+            }
             return scaleType === ScaleType.log
                 ? [minValue / 10, minValue * 10]
                 : [minValue - 1, maxValue + 1]

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -826,7 +826,10 @@ export class ScatterPlotChart
                 scaleType,
                 this.manager.zoomToSelection && this.selectedPoints.length
                     ? 1.1
-                    : 1
+                    : 1,
+                property === "y"
+                    ? this.yAxisConfig.toVerticalAxis().domain
+                    : this.xAxisConfig.toHorizontalAxis().domain
             )
         }
 


### PR DESCRIPTION
Fixes #1332.
The life expectancy vs. Liberal democracy scatterplot now looks like

https://user-images.githubusercontent.com/56021613/164884809-05b4699b-ca7e-4d3b-a1df-7ceffbe60bd5.mp4




