### PR TITLE
Show custom label for categorical datum in map tooltip

### DIFF
--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -333,9 +333,7 @@ export class MapChart
                 if (label !== undefined && label !== "") return label
             }
             else if (isString(d)) {
-                const bin = colorScale.getBinForValue(d)
-                const label = bin?.label
-                if (label !== undefined && label !== "") return label
+                return d
             }
             return mapColumn?.formatValueLong(d) ?? ""
         }

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -326,8 +326,13 @@ export class MapChart
         const { mapConfig, mapColumn, colorScale } = this
 
         return (d: PrimitiveType): string => {
-                if (isString(d) || mapConfig.tooltipUseCustomLabels) {
+            if (mapConfig.tooltipUseCustomLabels) {
                 // Find the bin (and its label) that this value belongs to
+                const bin = colorScale.getBinForValue(d)
+                const label = bin?.label
+                if (label !== undefined && label !== "") return label
+            }
+            else if (isString(d)) {
                 const bin = colorScale.getBinForValue(d)
                 const label = bin?.label
                 if (label !== undefined && label !== "") return label

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -326,8 +326,7 @@ export class MapChart
         const { mapConfig, mapColumn, colorScale } = this
 
         return (d: PrimitiveType): string => {
-            if (isString(d)) return d
-            else if (mapConfig.tooltipUseCustomLabels) {
+                if (isString(d) || mapConfig.tooltipUseCustomLabels) {
                 // Find the bin (and its label) that this value belongs to
                 const bin = colorScale.getBinForValue(d)
                 const label = bin?.label

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -331,8 +331,7 @@ export class MapChart
                 const bin = colorScale.getBinForValue(d)
                 const label = bin?.label
                 if (label !== undefined && label !== "") return label
-            }
-            else if (isString(d)) {
+            } else if (isString(d)) {
                 return d
             }
             return mapColumn?.formatValueLong(d) ?? ""

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -264,7 +264,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                             >
                                 {datum
                                     ? this.props.formatValue(datum.value)
-                                    : "No data"}
+                                    : this.props.formatValue("No data")}
                             </div>
                             <div className="time">
                                 {preposition}{" "}


### PR DESCRIPTION
Fixes #1342 

Transformation of data into labels was already done for numeric values, so I included the condition for strings as well.

The same formatting is done to empty/undefined data, instead of returning a constant "No data" string.

I have tested this in the dev admin server and the graph mentioned in the issue, please let me know if any changes need to be made.