### PR TITLE
feat: expand mouse target for LineChart/StackedArea tooltip

### DIFF
--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -329,7 +329,10 @@ export class LineChart
         const boxPadding = isMobile() ? 44 : 25
 
         // expand the box width, so it's easier to see the tooltip for the first & last timepoints
-        const boundedBox = this.dualAxis.innerBounds.padWidth(-boxPadding)
+        const boundedBox = this.dualAxis.innerBounds.expand({
+            left: boxPadding,
+            right: boxPadding,
+        })
 
         let hoverX
         if (boundedBox.contains(mouse)) {

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -404,6 +404,47 @@ export class LineChart
         )
     }
 
+    @computed get activeXVerticalLine(): JSX.Element | undefined {
+        const { activeX, dualAxis } = this
+        const { horizontalAxis, verticalAxis } = dualAxis
+
+        if (activeX === undefined) return undefined
+
+        return (
+            <g className="hoverIndicator">
+                <line
+                    x1={horizontalAxis.place(activeX)}
+                    y1={verticalAxis.range[0]}
+                    x2={horizontalAxis.place(activeX)}
+                    y2={verticalAxis.range[1]}
+                    stroke="rgba(180,180,180,.4)"
+                />
+                {this.series.map((series) => {
+                    const value = series.points.find(
+                        (point) => point.x === activeX
+                    )
+                    if (!value || this.seriesIsBlurred(series)) return null
+
+                    return (
+                        <circle
+                            key={getSeriesKey(series)}
+                            cx={horizontalAxis.place(value.x)}
+                            cy={verticalAxis.place(value.y)}
+                            r={this.lineStrokeWidth / 2 + 3.5}
+                            fill={
+                                this.hasColorScale
+                                    ? this.getColorScaleColor(value.colorValue)
+                                    : series.color
+                            }
+                            stroke="#fff"
+                            strokeWidth={0.5}
+                        />
+                    )
+                })}
+            </g>
+        )
+    }
+
     @computed private get tooltip(): JSX.Element | undefined {
         const { activeX, dualAxis, inputTable, formatColumn, hasColorScale } =
             this
@@ -686,8 +727,8 @@ export class LineChart
                 />
             )
 
-        const { activeX, manager, tooltip, dualAxis, clipPath } = this
-        const { horizontalAxis, verticalAxis } = dualAxis
+        const { manager, tooltip, dualAxis, clipPath, activeXVerticalLine } =
+            this
 
         const comparisonLines = manager.comparisonLines || []
 
@@ -734,42 +775,7 @@ export class LineChart
                         markerRadius={this.markerRadius}
                     />
                 </g>
-                {activeX !== undefined && (
-                    <g className="hoverIndicator">
-                        <line
-                            x1={horizontalAxis.place(activeX)}
-                            y1={verticalAxis.range[0]}
-                            x2={horizontalAxis.place(activeX)}
-                            y2={verticalAxis.range[1]}
-                            stroke="rgba(180,180,180,.4)"
-                        />
-                        {this.series.map((series) => {
-                            const value = series.points.find(
-                                (point) => point.x === activeX
-                            )
-                            if (!value || this.seriesIsBlurred(series))
-                                return null
-
-                            return (
-                                <circle
-                                    key={getSeriesKey(series)}
-                                    cx={horizontalAxis.place(value.x)}
-                                    cy={verticalAxis.place(value.y)}
-                                    r={this.lineStrokeWidth / 2 + 3.5}
-                                    fill={
-                                        this.hasColorScale
-                                            ? this.getColorScaleColor(
-                                                  value.colorValue
-                                              )
-                                            : series.color
-                                    }
-                                    stroke="#fff"
-                                    strokeWidth={0.5}
-                                />
-                            )
-                        })}
-                    </g>
-                )}
+                {activeXVerticalLine}
 
                 {tooltip}
             </g>

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -106,8 +106,6 @@ const LEGEND_PADDING = 25
 
 @observer
 class Lines extends React.Component<LinesProps> {
-    base: React.RefObject<SVGGElement> = React.createRef()
-
     @computed get bounds(): Bounds {
         const { horizontalAxis, verticalAxis } = this.props.dualAxis
         return Bounds.fromCorners(
@@ -234,7 +232,7 @@ class Lines extends React.Component<LinesProps> {
         const { bounds } = this
 
         return (
-            <g ref={this.base} className="Lines">
+            <g className="Lines">
                 <rect
                     x={Math.round(bounds.x)}
                     y={Math.round(bounds.y)}

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -728,7 +728,6 @@ export class LineChart
                         dualAxis={dualAxis}
                         placedSeries={this.placedSeries}
                         hidePoints={manager.hidePoints}
-                        onHover={this.onHover}
                         focusedSeriesNames={this.focusedSeriesNames}
                         lineStrokeWidth={this.lineStrokeWidth}
                         lineOutlineWidth={this.lineOutlineWidth}

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -13,6 +13,7 @@ import {
     excludeUndefined,
     isNumber,
     sortedUniqBy,
+    isMobile,
 } from "../../clientUtils/Util.js"
 import { computed, action, observable } from "mobx"
 import { observer } from "mobx-react"
@@ -327,8 +328,13 @@ export class LineChart
 
         const mouse = getRelativeMouse(this.base.current, ev)
 
+        const boxPadding = isMobile() ? 44 : 25
+
+        // expand the box width, so it's easier to see the tooltip for the first & last timepoints
+        const boundedBox = this.dualAxis.innerBounds.padWidth(-boxPadding)
+
         let hoverX
-        if (this.dualAxis.innerBounds.contains(mouse)) {
+        if (boundedBox.contains(mouse)) {
             const closestValue = minBy(this.allValues, (point) =>
                 Math.abs(this.dualAxis.horizontalAxis.place(point.x) - mouse.x)
             )
@@ -700,6 +706,11 @@ export class LineChart
                 onTouchMove={this.onCursorMove}
             >
                 {clipPath.element}
+                <rect {...this.bounds.toProps()} fill="transparent">
+                    {/* This <rect> ensures that the parent <g> is big enough such that we get mouse hover events for the
+                    whole charting area, including the axis, the entity labels, and the whitespace next to them.
+                    We need these to be able to show the tooltip for the first/last year even if the mouse is outside the charting area. */}
+                </rect>
                 {this.hasColorLegend && (
                     <HorizontalNumericColorLegend manager={this} />
                 )}

--- a/grapher/lineCharts/LineChartConstants.ts
+++ b/grapher/lineCharts/LineChartConstants.ts
@@ -30,7 +30,6 @@ export interface LinesProps {
     dualAxis: DualAxis
     placedSeries: PlacedLineChartSeries[]
     focusedSeriesNames: SeriesName[]
-    onHover: (hoverX: number | undefined) => void
     hidePoints?: boolean
     lineStrokeWidth?: number
     lineOutlineWidth?: number

--- a/grapher/stackedCharts/StackedAreaChart.tsx
+++ b/grapher/stackedCharts/StackedAreaChart.tsx
@@ -239,7 +239,10 @@ export class StackedAreaChart
         const boxPadding = isMobile() ? 44 : 25
 
         // expand the box width, so it's easier to see the tooltip for the first & last timepoints
-        const boundedBox = this.dualAxis.innerBounds.padWidth(-boxPadding)
+        const boundedBox = this.dualAxis.innerBounds.expand({
+            left: boxPadding,
+            right: boxPadding,
+        })
 
         if (boundedBox.contains(mouse)) {
             const closestPoint = minBy(series[0].points, (d) =>

--- a/grapher/stackedCharts/StackedAreaChart.tsx
+++ b/grapher/stackedCharts/StackedAreaChart.tsx
@@ -41,8 +41,6 @@ const BLUR_COLOR = "#ddd"
 
 @observer
 class Areas extends React.Component<AreasProps> {
-    base: React.RefObject<SVGGElement> = React.createRef()
-
     private seriesIsBlur(series: StackedSeries<Time>): boolean {
         return (
             this.props.focusedSeriesNames.length > 0 &&
@@ -122,7 +120,7 @@ class Areas extends React.Component<AreasProps> {
         const { horizontalAxis, verticalAxis } = dualAxis
 
         return (
-            <g ref={this.base} className="Areas">
+            <g className="Areas">
                 <rect
                     x={horizontalAxis.range[0]}
                     y={verticalAxis.range[1]}


### PR DESCRIPTION
Fixes #1331.

Expands the mouse target zone around the first and last point in the chart by ~5% of the axis width each~ 44px (mobile) or 25px (otherwise). These numbers are of course arbitrary, but seem to work quite well on my phone and laptop.

https://user-images.githubusercontent.com/2641501/165938794-32033030-9e28-416f-9e31-66602099ad4e.mp4


