### PR TITLE
different fix: Axis tick labels shows proper decimal places

### DIFF
--- a/grapher/axis/Axis.test.ts
+++ b/grapher/axis/Axis.test.ts
@@ -2,7 +2,10 @@
 
 import { HorizontalAxis } from "../axis/Axis.js"
 import { ScaleType } from "../core/GrapherConstants.js"
-import { SynthesizeGDPTable } from "../../coreTable/OwidTableSynthesizers.js"
+import {
+    SynthesizeFruitTable,
+    SynthesizeGDPTable,
+} from "../../coreTable/OwidTableSynthesizers.js"
 import { AxisConfig } from "./AxisConfig.js"
 import { AxisConfigInterface } from "./AxisConfigInterface.js"
 
@@ -115,6 +118,32 @@ it("a single-value domain plots to lower or upper end of range", () => {
     expect(axis.place(-1)).toEqual(0)
     expect(axis.place(0)).toEqual(0)
     expect(axis.place(1)).toEqual(500)
+})
+
+describe("tick labels", () => {
+    // see https://github.com/owid/owid-grapher/issues/1267
+    it("includes sufficient decimal places for small values", () => {
+        const config: AxisConfigInterface = {
+            min: 0,
+            max: 0.0004,
+        }
+        const axis = new AxisConfig(config).toHorizontalAxis()
+        axis.range = [0, 500]
+        // we need to set a formatColumn, otherwise the tick labels are not formatted at all
+        axis.formatColumn = SynthesizeFruitTable().get("Fruit")
+
+        const formattedTickLabels = axis.tickLabels.map((l) => l.formattedValue)
+        expect(formattedTickLabels).toEqual([
+            "0",
+            "0.00005",
+            "0.0001",
+            "0.00015",
+            "0.0002",
+            "0.00025",
+            "0.0003",
+            "0.00035",
+        ])
+    })
 })
 
 describe("manual ticks", () => {

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -483,7 +483,7 @@ export class HorizontalAxis extends AbstractAxis {
         // sort by value, then priority.
         // this way, we don't end up with two ticks of the same value but different priorities.
         // instead, we deduplicate by choosing the highest priority (i.e. lowest priority value).
-        const sortedTicks = sortBy(ticks, (tick) => [tick.value, tick.priority])
+        const sortedTicks = sortBy(ticks, [(t) => t.value, (t) => t.priority])
         return sortedUniqBy(sortedTicks, (t) => t.value)
     }
 

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -7,6 +7,7 @@ import {
     sortBy,
     max,
     numberMagnitude,
+    sortedUniqBy,
 } from "../../clientUtils/Util.js"
 import { Bounds, DEFAULT_BOUNDS } from "../../clientUtils/Bounds.js"
 import { TextWrap } from "../text/TextWrap.js"
@@ -478,7 +479,12 @@ export class HorizontalAxis extends AbstractAxis {
                     priority: startEndPrio,
                 },
             ]
-        return uniq(ticks)
+
+        // sort by value, then priority.
+        // this way, we don't end up with two ticks of the same value but different priorities.
+        // instead, we deduplicate by choosing the highest priority (i.e. lowest priority value).
+        const sortedTicks = sortBy(ticks, (tick) => [tick.value, tick.priority])
+        return sortedUniqBy(sortedTicks, (t) => t.value)
     }
 
     placeTickLabel(value: number): TickLabelPlacement {

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -462,11 +462,7 @@ export class HorizontalAxis extends AbstractAxis {
 
         // Make sure the start and end values are present, if they're whole numbers
         const startEndPrio = this.scaleType === ScaleType.log ? 2 : 1
-        if (
-            domain[0] % 1 === 0 &&
-            // Make sure that start value is not already present.
-            !ticks.some((tick) => tick.value === domain[0])
-        )
+        if (domain[0] % 1 === 0)
             ticks = [
                 {
                     value: domain[0],
@@ -474,12 +470,7 @@ export class HorizontalAxis extends AbstractAxis {
                 },
                 ...ticks,
             ]
-        if (
-            domain[1] % 1 === 0 &&
-            this.hideFractionalTicks &&
-            // Make sure that end value is not already present.
-            !ticks.some((tick) => tick.value === domain[1])
-        )
+        if (domain[1] % 1 === 0 && this.hideFractionalTicks)
             ticks = [
                 ...ticks,
                 {


### PR DESCRIPTION
Fixes #1267, but in a different way to #1394.

I feel like this is the more sensible way to go about this problem.
The main difference here is this one here in the output of `HorizontalAxis.baseTicks`:

```diff
  [
-   { value: 0, priority: 2 },
+   { value: 0, priority: 1 },
    { value: 0.00005, priority: 2 },
    { value: 0.0001, priority: 2 },
    { value: 0.00015, priority: 2 },
    { value: 0.0002, priority: 2 },
    { value: 0.00025, priority: 2 },
    { value: 0.0003, priority: 2 },
    { value: 0.00035, priority: 2 },
    { value: 0.0004, priority: 2 }
  ]
```

In addition, I added a test case (which passes for both the old & new fix, and fails without them) which we should get in either way :)