### PR TITLE
Ability to enter newlines in explorer config

### DIFF
--- a/explorer/ExplorerProgram.test.ts
+++ b/explorer/ExplorerProgram.test.ts
@@ -121,6 +121,18 @@ columns\ttable1\ttable2\ttable3
             expect(program.grapherConfig.yScaleToggle).toEqual(true)
         })
 
+        it("can convert \\n to a newline", () => {
+            const program = new ExplorerProgram(
+                "test",
+                `graphers
+\tsubtitle\tLine Checkbox
+\tThis is a\\ntwo-line subtitle\tLine`
+            )
+            expect(program.grapherConfig.subtitle).toEqual(
+                "This is a\ntwo-line subtitle"
+            )
+        })
+
         it("can cascade default grapher config props", () => {
             const program = new ExplorerProgram(
                 "test",

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -102,6 +102,9 @@ export class ExplorerProgram extends GridProgram {
 
     static fromMatrix(slug: string, matrix: CoreMatrix) {
         const str = matrix
+            .map((row) =>
+                row.map((cell) => cell && `${cell}`.replace(/\n/g, "\\n"))
+            )
             .map((row) => row.join(GRID_CELL_DELIMITER))
             .join(GRID_NODE_DELIMITER)
         return new ExplorerProgram(slug, str)

--- a/explorerAdminClient/ExplorerCreatePage.tsx
+++ b/explorerAdminClient/ExplorerCreatePage.tsx
@@ -318,7 +318,11 @@ class HotEditor extends React.Component<{
 
     private get hotSettings() {
         const { program, programOnDisk } = this
-        const data = program.asArrays
+
+        // replace literal `\n` with newlines
+        const data = program.asArrays.map((row) =>
+            row.map((cell) => cell.replace(/\\n/g, "\n"))
+        )
 
         const { currentlySelectedGrapherRow } = program
 

--- a/gridLang/GridLangConstants.ts
+++ b/gridLang/GridLangConstants.ts
@@ -65,6 +65,7 @@ export const StringCellDef: CellDef = {
     keyword: "",
     cssClass: "StringCellDef",
     description: "",
+    parse: (value: any) => `${value}`.replace(/\\n/g, "\n"),
 }
 
 export const StringDeclarationDef: CellDef = {


### PR DESCRIPTION
Fixes #1329.

There is now a valid way to enter subtitles with newlines, which doesn't screw up `TextWrap`.
They can be entered either by hand, or by pressing `Ctrl + Enter` in the Handsontable editor.

---

Potential caveat: For the sources tab, we already extensively use HTML formatting and `<br>`s. It might be confusing that the sources tab can use `<br>` just fine, but that authors need to use `\n` for subtitles and footnotes.

---

TODOs after merging:
- [ ] Alter any existing explorers that use `<br>` in the wrong place
	- [ ] 	_At least_ some of the `fish-stocks` views: https://github.com/owid/owid-content/blob/master/explorers/fish-stocks.explorer.tsv