### PR TITLE
improve(FacetChart.tsx): tooltips

### DIFF
--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -137,6 +137,7 @@ import {
 } from "./owidTypes.js"
 import { PointVector } from "./PointVector.js"
 import { isNegativeInfinity, isPositiveInfinity } from "./TimeBounds.js"
+import React from "react"
 
 export type NoUndefinedValues<T> = {
     [P in keyof T]: Required<NonNullable<T[P]>>
@@ -209,12 +210,9 @@ const getRootSVG = (
 
 export const getRelativeMouse = (
     node: Element | SVGGraphicsElement | SVGSVGElement,
-    event: TouchEvent | { clientX: number; clientY: number }
+    event: React.TouchEvent | TouchEvent | { clientX: number; clientY: number }
 ): PointVector => {
-    const isTouchEvent = !!(event as TouchEvent).targetTouches
-    const eventOwner = isTouchEvent
-        ? (event as TouchEvent).targetTouches[0]
-        : (event as MouseEvent)
+    const eventOwner = checkIsTouchEvent(event) ? event.targetTouches[0] : event
 
     const { clientX, clientY } = eventOwner
 
@@ -1226,6 +1224,15 @@ export function isPlainObjectWithGuard(
     x: unknown
 ): x is Record<string, unknown> {
     return isPlainObject(x)
+}
+
+function checkIsTouchEvent(
+    event: unknown
+): event is React.TouchEvent | TouchEvent {
+    if (isPlainObjectWithGuard(event)) {
+        return event.hasOwnProperty("targetTouches")
+    }
+    return false
 }
 
 export const triggerDownloadFromBlob = (filename: string, blob: Blob): void => {

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -1220,7 +1220,7 @@ export function toRectangularMatrix<T, F>(arr: T[][], fill: F): (T | F)[][] {
     })
 }
 
-export function isPlainObjectWithGuard(
+export function checkIsPlainObjectWithGuard(
     x: unknown
 ): x is Record<string, unknown> {
     return isPlainObject(x)
@@ -1229,7 +1229,7 @@ export function isPlainObjectWithGuard(
 function checkIsTouchEvent(
     event: unknown
 ): event is React.TouchEvent | TouchEvent {
-    if (isPlainObjectWithGuard(event)) {
+    if (checkIsPlainObjectWithGuard(event)) {
         return event.hasOwnProperty("targetTouches")
     }
     return false

--- a/clientUtils/patchHelper.ts
+++ b/clientUtils/patchHelper.ts
@@ -1,7 +1,7 @@
 import jsonpointer from "json8-pointer"
 import { isNil } from "lodash"
 import { GrapherConfigPatch } from "./AdminSessionTypes.js"
-import { isArray, isEqual, isPlainObjectWithGuard } from "./Util.js"
+import { isArray, isEqual, checkIsPlainObjectWithGuard } from "./Util.js"
 
 export function setValueRecursiveInplace(
     json: any,
@@ -130,7 +130,7 @@ export function applyPatch(patchSet: GrapherConfigPatch, config: unknown): any {
     if (
         config !== undefined &&
         config !== null &&
-        !(isArray(config) || isPlainObjectWithGuard(config))
+        !(isArray(config) || checkIsPlainObjectWithGuard(config))
     ) {
         throw Error(
             "When given an non-empty pointer, config must be either an object or array but it is " +

--- a/clientUtils/schemaProcessing.ts
+++ b/clientUtils/schemaProcessing.ts
@@ -1,5 +1,5 @@
 import {
-    isPlainObjectWithGuard,
+    checkIsPlainObjectWithGuard,
     omit,
     keys,
     isArray,
@@ -124,7 +124,7 @@ function extractSchemaRecursive(
     ) {
         console.error("shouldn't come here?", pointer)
         return
-    } else if (isPlainObjectWithGuard(schema)) {
+    } else if (checkIsPlainObjectWithGuard(schema)) {
         // If the current schema fragment describes a normal object
         // then do not emit anything directly and recurse over the
         // described properties
@@ -132,7 +132,7 @@ function extractSchemaRecursive(
             schema.hasOwnProperty("type") &&
             schema.type === "object" &&
             schema.hasOwnProperty("properties") &&
-            isPlainObjectWithGuard(schema.properties)
+            checkIsPlainObjectWithGuard(schema.properties)
         ) {
             // Color scales are complex objects that are treated as opaque objects with a special
             // rich editor. We identify them by the property they are stored as. If we have a color
@@ -174,7 +174,7 @@ function extractSchemaRecursive(
                 schema.patternProperties as Record<string, any>
             ).every(
                 (item: any) =>
-                    isPlainObjectWithGuard(item) &&
+                    checkIsPlainObjectWithGuard(item) &&
                     item.hasOwnProperty("type") &&
                     isPlainTypeString((item as any).type)
             )
@@ -263,7 +263,7 @@ function recursiveDereference(
     if (
         schema !== null &&
         schema !== undefined &&
-        isPlainObjectWithGuard(schema)
+        checkIsPlainObjectWithGuard(schema)
     ) {
         if (schema.hasOwnProperty("$ref")) {
             const ref = schema["$ref"] as string
@@ -293,7 +293,7 @@ function dereference(schema: Record<string, unknown>): any {
 export function extractFieldDescriptionsFromSchema(
     schema: unknown
 ): FieldDescription[] {
-    if (isPlainObjectWithGuard(schema)) {
+    if (checkIsPlainObjectWithGuard(schema)) {
         const dereferenced = dereference(schema)
         const fieldDescriptions: FieldDescription[] = []
         extractSchemaRecursive(dereferenced, "", fieldDescriptions)

--- a/grapher/chart/ChartManager.ts
+++ b/grapher/chart/ChartManager.ts
@@ -6,7 +6,7 @@ import {
     SeriesStrategy,
 } from "../core/GrapherConstants.js"
 import { ComparisonLineConfig } from "../scatterCharts/ComparisonLine.js"
-import { TooltipProps } from "../tooltip/TooltipProps.js"
+import { TooltipManager } from "../tooltip/TooltipProps.js"
 import { OwidTable } from "../../coreTable/OwidTable.js"
 import { AxisConfigInterface } from "../axis/AxisConfigInterface.js"
 import { ColorSchemeName } from "../color/ColorConstants.js"
@@ -36,7 +36,7 @@ export interface ChartManager {
     isRelativeMode?: boolean
     comparisonLines?: ComparisonLineConfig[]
     hideLegend?: boolean
-    tooltip?: TooltipProps
+    tooltips?: TooltipManager["tooltips"]
     useTimelineDomains?: boolean
     baseColorScheme?: ColorSchemeName
     invertColorScheme?: boolean

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -54,7 +54,7 @@ import {
     LegacyDimensionsManager,
 } from "../chart/ChartDimension.js"
 import { Bounds, DEFAULT_BOUNDS } from "../../clientUtils/Bounds.js"
-import { TooltipProps, TooltipManager } from "../tooltip/TooltipProps.js"
+import { TooltipManager } from "../tooltip/TooltipProps.js"
 import {
     minTimeBoundFromJSONOrNegativeInfinity,
     maxTimeBoundFromJSONOrPositiveInfinity,

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -103,7 +103,7 @@ import {
     FooterControls,
     FooterControlsManager,
 } from "../controls/Controls.js"
-import { TooltipView } from "../tooltip/Tooltip.js"
+import { TooltipContainer } from "../tooltip/Tooltip.js"
 import { EntitySelectorModal } from "../controls/EntitySelectorModal.js"
 import { DownloadTab, DownloadTabManager } from "../downloadTab/DownloadTab.js"
 import ReactDOM from "react-dom"
@@ -631,7 +631,7 @@ export class Grapher
 
     @observable.ref isMediaCard = false
     @observable.ref isExportingtoSvgOrPng = false
-    @observable.ref tooltip?: TooltipProps
+    tooltips?: TooltipManager["tooltips"] = observable.map({}, { deep: false })
     @observable isPlaying = false
     @observable.ref isSelectingData = false
 
@@ -2076,9 +2076,9 @@ export class Grapher
                 <FooterControls manager={this} />
                 {this.renderOverlayTab()}
                 {this.popups}
-                <TooltipView
-                    width={this.renderWidth}
-                    height={this.renderHeight}
+                <TooltipContainer
+                    containerWidth={this.renderWidth}
+                    containerHeight={this.renderHeight}
                     tooltipProvider={this}
                 />
                 {this.isSelectingData && (

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -441,6 +441,7 @@ export class FacetChart
                     ...series.manager.yAxisConfig,
                     ...axes.y.config,
                 },
+                tooltips: this.manager.tooltips,
             }
             const contentBounds = getContentBounds(
                 bounds,

--- a/grapher/footer/Footer.tsx
+++ b/grapher/footer/Footer.tsx
@@ -246,6 +246,7 @@ export class Footer extends React.Component<{
                 {!this.isCompact && license}
                 {tooltipTarget && (
                     <Tooltip
+                        id="footer"
                         tooltipManager={this.manager}
                         x={tooltipTarget.x}
                         y={tooltipTarget.y}

--- a/grapher/footer/FooterManager.ts
+++ b/grapher/footer/FooterManager.ts
@@ -1,4 +1,4 @@
-import { TooltipProps } from "../tooltip/TooltipProps.js"
+import { TooltipManager } from "../tooltip/TooltipProps.js"
 import { Bounds } from "../../clientUtils/Bounds.js"
 
 export interface FooterManager {
@@ -10,6 +10,6 @@ export interface FooterManager {
     originUrlWithProtocol?: string
     isMediaCard?: boolean
     currentTab?: string
-    tooltip?: TooltipProps
+    tooltips?: TooltipManager["tooltips"]
     tabBounds?: Bounds
 }

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -259,7 +259,7 @@ class Lines extends React.Component<LinesProps> {
     private container?: SVGElement
     componentDidMount(): void {
         const base = this.base.current as SVGGElement
-        const container = base.closest("svg") as SVGElement
+        const container = base.closest("g.LineChart") as SVGElement
         container.addEventListener("mousemove", this.onCursorMove)
         container.addEventListener("mouseleave", this.onCursorLeave)
         container.addEventListener("touchstart", this.onCursorMove)
@@ -364,14 +364,10 @@ export class LineChart
         return table
     }
 
-    // todo: rename mouseHoverX -> hoverX and hoverX -> activeX
-    @observable mouseHoverX?: number = undefined
-    @action.bound onHover(hoverX: number | undefined): void {
-        this.mouseHoverX = hoverX
-    }
+    @observable hoverX?: number = undefined
 
-    @computed get hoverX(): number | undefined {
-        return this.mouseHoverX ?? this.props.manager.annotation?.year
+    @action.bound onHover(hoverX: number | undefined): void {
+        this.hoverX = hoverX ?? this.props.manager.annotation?.year
     }
 
     @computed private get manager(): LineChartManager {
@@ -707,7 +703,7 @@ export class LineChart
                 />
             )
 
-        const { manager, tooltip, dualAxis, hoverX, clipPath } = this
+        const { hoverX, manager, tooltip, dualAxis, clipPath } = this
         const { horizontalAxis, verticalAxis } = dualAxis
 
         const comparisonLines = manager.comparisonLines || []

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -439,6 +439,7 @@ export class LineChart
 
         return (
             <Tooltip
+                id={this.renderUid}
                 tooltipManager={this.manager}
                 x={dualAxis.horizontalAxis.place(hoverX)}
                 y={

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -364,10 +364,10 @@ export class LineChart
         return table
     }
 
-    @observable hoverX?: number = undefined
+    @observable hoverX?: number = this.props.manager.annotation?.year
 
     @action.bound onHover(hoverX: number | undefined): void {
-        this.hoverX = hoverX ?? this.props.manager.annotation?.year
+        this.hoverX = hoverX
     }
 
     @computed private get manager(): LineChartManager {

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -338,10 +338,14 @@ export class LineChart
         this.onHover(hoverX)
     }
 
-    @observable hoverX?: number = this.props.manager.annotation?.year
+    @observable hoverX?: number = undefined
 
     @action.bound onHover(hoverX: number | undefined): void {
         this.hoverX = hoverX
+    }
+
+    @computed get activeX(): number | undefined {
+        return this.hoverX ?? this.props.manager.annotation?.year
     }
 
     @computed private get manager(): LineChartManager {
@@ -395,23 +399,23 @@ export class LineChart
     }
 
     @computed private get tooltip(): JSX.Element | undefined {
-        const { hoverX, dualAxis, inputTable, formatColumn, hasColorScale } =
+        const { activeX, dualAxis, inputTable, formatColumn, hasColorScale } =
             this
 
-        if (hoverX === undefined) return undefined
+        if (activeX === undefined) return undefined
 
         const sortedData = sortBy(this.series, (series) => {
-            const value = series.points.find((point) => point.x === hoverX)
+            const value = series.points.find((point) => point.x === activeX)
             return value !== undefined ? -value.y : Infinity
         })
 
-        const formatted = inputTable.timeColumnFormatFunction(hoverX)
+        const formatted = inputTable.timeColumnFormatFunction(activeX)
 
         return (
             <Tooltip
                 id={this.renderUid}
                 tooltipManager={this.manager}
-                x={dualAxis.horizontalAxis.place(hoverX)}
+                x={dualAxis.horizontalAxis.place(activeX)}
                 y={
                     dualAxis.verticalAxis.rangeMin +
                     dualAxis.verticalAxis.rangeSize / 2
@@ -451,7 +455,7 @@ export class LineChart
                     <tbody>
                         {sortedData.map((series) => {
                             const value = series.points.find(
-                                (point) => point.x === hoverX
+                                (point) => point.x === activeX
                             )
 
                             const annotation = this.getAnnotationsForSeries(
@@ -471,8 +475,8 @@ export class LineChart
                                 if (
                                     startX === undefined ||
                                     endX === undefined ||
-                                    startX > hoverX ||
-                                    endX < hoverX
+                                    startX > activeX ||
+                                    endX < activeX
                                 )
                                     return undefined
                             }
@@ -677,7 +681,7 @@ export class LineChart
                 />
             )
 
-        const { hoverX, manager, tooltip, dualAxis, clipPath } = this
+        const { activeX, manager, tooltip, dualAxis, clipPath } = this
         const { horizontalAxis, verticalAxis } = dualAxis
 
         const comparisonLines = manager.comparisonLines || []
@@ -721,18 +725,18 @@ export class LineChart
                         markerRadius={this.markerRadius}
                     />
                 </g>
-                {hoverX !== undefined && (
+                {activeX !== undefined && (
                     <g className="hoverIndicator">
                         <line
-                            x1={horizontalAxis.place(hoverX)}
+                            x1={horizontalAxis.place(activeX)}
                             y1={verticalAxis.range[0]}
-                            x2={horizontalAxis.place(hoverX)}
+                            x2={horizontalAxis.place(activeX)}
                             y2={verticalAxis.range[1]}
                             stroke="rgba(180,180,180,.4)"
                         />
                         {this.series.map((series) => {
                             const value = series.points.find(
-                                (point) => point.x === hoverX
+                                (point) => point.x === activeX
                             )
                             if (!value || this.seriesIsBlurred(series))
                                 return null

--- a/grapher/lineCharts/LineChartConstants.ts
+++ b/grapher/lineCharts/LineChartConstants.ts
@@ -1,7 +1,6 @@
 import { DualAxis } from "../axis/Axis.js"
 import { ChartManager } from "../chart/ChartManager.js"
 import { SeriesName } from "../core/GrapherConstants.js"
-import { TimeBound } from "../../clientUtils/TimeBounds.js"
 import { ChartSeries } from "../chart/ChartInterface.js"
 import { CoreValueType } from "../../coreTable/CoreTableConstants.js"
 import { Color } from "../../clientUtils/owidTypes.js"

--- a/grapher/mapCharts/MapTooltip.stories.tsx
+++ b/grapher/mapCharts/MapTooltip.stories.tsx
@@ -8,7 +8,7 @@ export default {
     component: MapTooltip,
 }
 
-// todo: refactor TooltipView stuff so we can decouple from Grapher
+// todo: refactor TooltipContainer stuff so we can decouple from Grapher
 export const WithSparkChart = (): JSX.Element => (
     <Grapher {...legacyMapGrapher} />
 )

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -199,6 +199,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
 
         return (
             <Tooltip
+                id={this.tooltipTarget.featureId}
                 tooltipManager={this.props.manager}
                 key="mapTooltip"
                 x={tooltipTarget.x}

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -199,7 +199,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
 
         return (
             <Tooltip
-                id={this.tooltipTarget.featureId}
+                id="mapTooltip"
                 tooltipManager={this.props.manager}
                 key="mapTooltip"
                 x={tooltipTarget.x}

--- a/grapher/stackedCharts/StackedAreaChart.tsx
+++ b/grapher/stackedCharts/StackedAreaChart.tsx
@@ -335,6 +335,7 @@ export class StackedAreaChart
 
         return (
             <Tooltip
+                id={this.renderUid}
                 tooltipManager={this.props.manager}
                 x={dualAxis.horizontalAxis.place(bottomSeriesPoint.position)}
                 y={

--- a/grapher/stackedCharts/StackedBarChart.tsx
+++ b/grapher/stackedCharts/StackedBarChart.tsx
@@ -228,6 +228,7 @@ export class StackedBarChart
         const yColumn = yColumns[0] // we can just use the first column for formatting, b/c we assume all columns have same type
         return (
             <Tooltip
+                id={this.renderUid}
                 tooltipManager={this.props.manager}
                 x={xPos + barWidth}
                 y={yPos}

--- a/grapher/tooltip/Tooltip.tsx
+++ b/grapher/tooltip/Tooltip.tsx
@@ -83,7 +83,7 @@ export class TooltipContainer extends React.Component<{
         if (!tooltipsMap) return null
         const tooltips = Object.entries(tooltipsMap.toJSON())
         return (
-            <>
+            <div className="tooltip-container">
                 {tooltips.map(([id, tooltip]) => (
                     <TooltipCard
                         {...tooltip}
@@ -92,7 +92,7 @@ export class TooltipContainer extends React.Component<{
                         containerHeight={this.props.containerHeight}
                     />
                 ))}
-            </>
+            </div>
         )
     }
 

--- a/grapher/tooltip/Tooltip.tsx
+++ b/grapher/tooltip/Tooltip.tsx
@@ -28,7 +28,7 @@ class TooltipCard extends React.Component<
         this.updateBounds()
     }
 
-    @computed private get rendered(): JSX.Element {
+    render(): JSX.Element {
         const offsetX = this.props.offsetX ?? 0
         let offsetY = this.props.offsetY ?? 0
         if (this.props.offsetYDirection === "upward") {
@@ -66,9 +66,6 @@ class TooltipCard extends React.Component<
                 {this.props.children}
             </div>
         )
-    }
-    render(): JSX.Element {
-        return this.rendered
     }
 }
 

--- a/grapher/tooltip/TooltipProps.ts
+++ b/grapher/tooltip/TooltipProps.ts
@@ -1,9 +1,12 @@
+import { ObservableMap } from "mobx"
+
 // We can't pass the property directly because we need it to be observable.
 export interface TooltipManager {
-    tooltip?: TooltipProps
+    tooltips?: ObservableMap<TooltipProps["id"], TooltipProps>
 }
 
 export interface TooltipProps {
+    id: number | string
     x: number
     y: number
     offsetX?: number


### PR DESCRIPTION
Partially resolves https://github.com/owid/owid-grapher/issues/1084

## Changes

**The Tooltip module now stores tooltips in an `ObservableMap` instead of referencing a single instance.**
_This will allow for simultaneous synchronised tooltips on facet charts in the future_

**Connects  `FacetChart`'s managers to the parent `Grapher` `tooltips` instance**
_This allows the tooltip to be added to the tooltips map correctly and be rendered by Grapher._


## Example

![facets](https://user-images.githubusercontent.com/11844404/166511167-be8e5551-fbd1-4bbb-b854-5b19c57e0fc7.gif)
