### PR TITLE
fix(facet): pass `endTime` to faceted chart

### DIFF
--- a/grapher/chart/ChartManager.ts
+++ b/grapher/chart/ChartManager.ts
@@ -71,6 +71,11 @@ export interface ChartManager {
     hidePoints?: boolean // for line options
     startHandleTimeBound?: TimeBound // for relative-to-first-year line chart
 
+    // we need endTime so DiscreteBarCharts and StackedDiscreteBarCharts can
+    // know what date the timeline is set to. and let's pass startTime in, too.
+    startTime?: number
+    endTime?: number
+
     facetStrategy?: FacetStrategy // todo: make a strategy? a column prop? etc
     seriesStrategy?: SeriesStrategy
 

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -251,6 +251,8 @@ export class FacetChart
             colorScale,
             sortConfig,
             startHandleTimeBound,
+            startTime,
+            endTime,
         } = manager
 
         // Use compact labels, e.g. 50k instead of 50,000.
@@ -301,6 +303,8 @@ export class FacetChart
                 colorScaleColumnOverride,
                 sortConfig,
                 startHandleTimeBound,
+                startTime,
+                endTime,
                 ...series.manager,
                 xAxisConfig: {
                     ...globalXAxisConfig,


### PR DESCRIPTION
[Slack context](https://owid.slack.com/archives/C46U9LXRR/p1652300758047539)

otherwise, DiscreteBarChart and StackedBarChart don't know whether a
value was tolerance-induced or not, and will always display the date of
the data point

![image](https://user-images.githubusercontent.com/2641501/168077678-3b3cc0bd-bfa4-49d3-b2d3-caa231260e62.png)

In the above view, the `on Dec 30, 2021` shouldn't be there because every data point is from that date, _and_ the timeline is set to that date, too.