### PR TITLE
Marimekko tweaks

### DIFF
--- a/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -675,6 +675,10 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
         return this.manager.categoricalLegendData ?? []
     }
 
+    @computed private get visibleCategoricalBins(): CategoricalBin[] {
+        return this.categoricalLegendData.filter((bin) => !bin.isHidden)
+    }
+
     @computed private get markLines(): MarkLine[] {
         const fontSize = this.fontSize * 0.8
         const rectSize = this.fontSize * 0.75
@@ -685,7 +689,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
         let marks: CategoricalMark[] = []
         let xOffset = 0
         let yOffset = 0
-        this.categoricalLegendData.forEach((bin) => {
+        this.visibleCategoricalBins.forEach((bin) => {
             const labelBounds = Bounds.forText(bin.text, { fontSize })
             const markWidth =
                 rectSize + rectPadding + labelBounds.width + markPadding

--- a/grapher/stackedCharts/MarimekkoChart.jsdom.test.tsx
+++ b/grapher/stackedCharts/MarimekkoChart.jsdom.test.tsx
@@ -69,7 +69,7 @@ it("can filter years correctly", () => {
         { value: 1000, entity: "small", time: 2001 },
     ]
     expect(chart.series[0].points).toEqual(expectedYPoints)
-    expect(chart.xSeries.points).toEqual(expectedXPoints)
+    expect(chart.xSeries!.points).toEqual(expectedXPoints)
     // placedItems should be in default sort order
     expect(chart.placedItems.map(roundXPosition)).toEqual([
         {
@@ -172,7 +172,7 @@ it("shows no data points at the end", () => {
         { value: 1000, entity: "small", time: 2001 },
     ]
     expect(chart.series[0].points).toEqual(expectedYPoints)
-    expect(chart.xSeries.points).toEqual(expectedXPoints)
+    expect(chart.xSeries!.points).toEqual(expectedXPoints)
     // placedItems should be in default sort order
     expect(chart.placedItems.map(roundXPosition)).toEqual([
         {
@@ -279,7 +279,7 @@ test("interpolation works as expected", () => {
         { value: 1000, entity: "small", time: 2001 },
     ]
     expect(chart.series[0].points).toEqual(expectedYPoints)
-    expect(chart.xSeries.points).toEqual(expectedXPoints)
+    expect(chart.xSeries!.points).toEqual(expectedXPoints)
     // placedItems should be in default sort order
     expect(chart.placedItems.map(roundXPosition)).toEqual([
         {
@@ -407,7 +407,7 @@ it("can deal with y columns with missing values", () => {
     ]
     expect(chart.series[0].points).toEqual(expectedYPoints1)
     expect(chart.series[1].points).toEqual(expectedYPoints2)
-    expect(chart.xSeries.points).toEqual(expectedXPoints)
+    expect(chart.xSeries!.points).toEqual(expectedXPoints)
     // placedItems should be in default sort order
     expect(chart.placedItems.map(roundXPosition)).toEqual([
         {

--- a/grapher/stackedCharts/MarimekkoChart.test.tsx
+++ b/grapher/stackedCharts/MarimekkoChart.test.tsx
@@ -35,7 +35,7 @@ it("can create a chart", () => {
     expect(chart.failMessage).toEqual("")
     expect(chart.series.length).toEqual(1)
     expect(chart.series[0].points.length).toEqual(5)
-    expect(chart.xSeries.points.length).toEqual(5)
+    expect(chart.xSeries!.points.length).toEqual(5)
     expect(chart.placedItems.length).toEqual(5)
     //expect(chart.placedItems)
 })
@@ -96,7 +96,7 @@ it("can display a Marimekko chart correctly", () => {
         { value: 1000, entity: "small", time: 2001 },
     ]
     expect(chart.series[0].points).toEqual(expectedYPoints)
-    expect(chart.xSeries.points).toEqual(expectedXPoints)
+    expect(chart.xSeries!.points).toEqual(expectedXPoints)
     // placedItems should be in default sort order
     expect(chart.placedItems.map(roundXPosition)).toEqual([
         {
@@ -230,7 +230,7 @@ it("can display two time series stacked correctly", () => {
     ]
     expect(chart.series[0].points).toEqual(expectedYPointsFirstSeries)
     expect(chart.series[1].points).toEqual(expectedYPointsSecondSeries)
-    expect(chart.xSeries.points).toEqual(expectedXPoints)
+    expect(chart.xSeries!.points).toEqual(expectedXPoints)
     // placedItems should be in default sort order
     expect(chart.placedItems.map(roundXPosition)).toEqual([
         {
@@ -358,7 +358,7 @@ it("can do sorting", () => {
         { value: 1000, entity: "CC", time: 2001 },
     ]
     expect(chart.series[0].points).toEqual(expectedYPoints)
-    expect(chart.xSeries.points).toEqual(expectedXPoints)
+    expect(chart.xSeries!.points).toEqual(expectedXPoints)
     // placedItems should be in default sort order
     const items = new Map<string, Item>([
         [

--- a/grapher/stackedCharts/MarimekkoChart.tsx
+++ b/grapher/stackedCharts/MarimekkoChart.tsx
@@ -676,7 +676,7 @@ export class MarimekkoChart
         const { manager, xAxisLabelBase, xDomainDefault, xColumn } = this
         const config = this.xAxisConfig
         let axis = config.toHorizontalAxis()
-        if (manager.isRelativeMode) {
+        if (manager.isRelativeMode && this.xColumn) {
             // MobX and classes  interact in an annoying way here so we have to construct a new object via
             // an object copy of the AxisConfig class instance to be able to set a property without
             // making MobX unhappy about a mutation originating from a computed property

--- a/grapher/stackedCharts/MarimekkoChart.tsx
+++ b/grapher/stackedCharts/MarimekkoChart.tsx
@@ -953,6 +953,7 @@ export class MarimekkoChart
         const selectionSet = this.selectionArray.selectedSet
         const targetTime = this.manager.endTime
         const timeColumn = this.inputTable.timeColumn
+        const xOverrideTime = this.manager.xOverrideTime
         const yAxisColumn = this.formatColumn
         const xAxisColumn = this.xColumn
         const labelYOffset = 0
@@ -1046,6 +1047,7 @@ export class MarimekkoChart
                 timeColumn,
                 yAxisColumn,
                 xAxisColumn,
+                xOverrideTime,
             }
 
             const barWidth =
@@ -1549,11 +1551,13 @@ export class MarimekkoChart
 
     static Tooltip(props: TooltipProps): JSX.Element {
         const isSingleVariable = props.item.bars.length === 1
-        // shouldShowXTimeNoitice is a bit of a lie since at the moment we don't include
-        // entities that don't have x values for the current year. This might change though
-        // and then the mechanism is already in place
+        // TODO: when we have proper time support to work across date/year variables then
+        // this should be set properly and the x axis time be passed in on it's own.
+        // For now we disable x axis notices when the xOverrideTime is set which is
+        // usually the case when matching day and year variables
         const shouldShowXTimeNotice =
-            props.item.xPoint.time !== props.targetTime
+            props.item.xPoint.time !== props.targetTime &&
+            props.xOverrideTime === undefined
         let hasTimeNotice = shouldShowXTimeNotice
         const header = isSingleVariable ? (
             <tr>

--- a/grapher/stackedCharts/MarimekkoChart.tsx
+++ b/grapher/stackedCharts/MarimekkoChart.tsx
@@ -328,7 +328,7 @@ export class MarimekkoChart
     defaultNoDataColor = "#959595"
     labelAngleInDegrees = -45 // 0 is horizontal, -90 is vertical from bottom to top, ...
 
-    @computed get filteredTable(): OwidTable {
+    transformTable(table: OwidTable): OwidTable {
         const { excludedEntities, includedEntities } = this.manager
         const { inputTable } = this
         if (!this.yColumnSlugs.length) return inputTable
@@ -352,16 +352,12 @@ export class MarimekkoChart
             const includedList = includedEntities
                 ? includedEntities.join(", ")
                 : ""
-            return inputTable.columnFilter(
+            table = inputTable.columnFilter(
                 OwidTableSlugs.entityId,
                 filterFn,
                 `Excluded entity ids specified by author: ${excludedList} - Included entity ids specified by author: ${includedList}`
             )
-        } else return inputTable
-    }
-
-    transformTable(table: OwidTable): OwidTable {
-        if (!this.yColumnSlugs.length) return table
+        } else table = inputTable
         // if (!this.xColumnSlug) return table
         const { yColumnSlugs, manager, colorColumnSlug, xColumnSlug } = this
 
@@ -412,10 +408,8 @@ export class MarimekkoChart
     }
 
     @computed get transformedTable(): OwidTable {
-        return (
-            this.manager.transformedTable ??
-            this.transformTable(this.filteredTable)
-        )
+        const { inputTable } = this
+        return this.manager.transformedTable ?? this.transformTable(inputTable)
     }
 
     @computed private get unstackedSeries(): StackedSeries<EntityName>[] {
@@ -566,7 +560,7 @@ export class MarimekkoChart
             // We need to use filteredTable in order to get consistent coloring for a variable across
             // charts, e.g. each continent being assigned to the same color.
             // inputTable is unfiltered, so it contains every value that exists in the variable.
-            this.filteredTable.get(this.colorColumnSlug)
+            this.inputTable.get(this.colorColumnSlug)
         )
     }
     @computed private get sortConfig(): SortConfig {

--- a/grapher/stackedCharts/MarimekkoChart.tsx
+++ b/grapher/stackedCharts/MarimekkoChart.tsx
@@ -706,7 +706,7 @@ export class MarimekkoChart
         return sortedItems.filter((item) => selectedSet.has(item.entityName))
     }
 
-    @computed private get uniqueEntitiyNames(): EntityName[] | undefined {
+    @computed private get uniqueEntityNames(): EntityName[] | undefined {
         return this.xColumn?.uniqEntityNames ?? this.yColumns[0].uniqEntityNames
     }
 
@@ -714,14 +714,14 @@ export class MarimekkoChart
         string,
         EntityColorData
     > {
-        const { colorColumn, colorScale, uniqueEntitiyNames } = this
+        const { colorColumn, colorScale, uniqueEntityNames } = this
         const hasColorColumn = !colorColumn.isMissing
         const colorRowsByEntity = hasColorColumn
             ? colorColumn.owidRowsByEntityName
             : undefined
         const domainColorMap = new Map<string, EntityColorData>()
-        if (uniqueEntitiyNames !== undefined) {
-            for (const name of uniqueEntitiyNames) {
+        if (uniqueEntityNames !== undefined) {
+            for (const name of uniqueEntityNames) {
                 const colorDomainValue = colorRowsByEntity?.get(name)?.[0]
 
                 if (colorDomainValue) {
@@ -738,12 +738,12 @@ export class MarimekkoChart
     }
 
     @computed private get items(): Item[] {
-        const { xSeries, series, domainColorForEntityMap, uniqueEntitiyNames } =
+        const { xSeries, series, domainColorForEntityMap, uniqueEntityNames } =
             this
 
-        if (uniqueEntitiyNames === undefined) return []
+        if (uniqueEntityNames === undefined) return []
 
-        const items: Item[] = uniqueEntitiyNames
+        const items: Item[] = uniqueEntityNames
             .map((entityName) => {
                 const xPoint = xSeries
                     ? xSeries.points.find(

--- a/grapher/stackedCharts/MarimekkoChart.tsx
+++ b/grapher/stackedCharts/MarimekkoChart.tsx
@@ -873,6 +873,8 @@ export class MarimekkoChart
 
     @computed get categoricalLegendData(): CategoricalBin[] {
         const { colorColumnSlug, colorScale, series } = this
+        const customHiddenCategories =
+            this.colorScaleConfig?.customHiddenCategories
         if (colorColumnSlug) return colorScale.categoricalLegendBins
         else
             return series.map((series, index) => {
@@ -881,6 +883,9 @@ export class MarimekkoChart
                     value: series.seriesName,
                     label: series.seriesName,
                     color: series.color,
+                    isHidden:
+                        customHiddenCategories &&
+                        !!customHiddenCategories[series.seriesName],
                 })
             })
     }
@@ -1193,7 +1198,7 @@ export class MarimekkoChart
                 MarimekkoChart.labelCandidateFromItem(
                     {
                         entityName: row.entityName,
-                        xValue: row.value,
+                        xValue: xColumnAtLastTimePoint ? row.value : 1,
                         ySortValue: ySizeMap.get(row.entityName),
                     },
                     baseFontSize,

--- a/grapher/stackedCharts/MarimekkoChartConstants.ts
+++ b/grapher/stackedCharts/MarimekkoChartConstants.ts
@@ -58,7 +58,7 @@ export interface Item {
     entityName: string
     entityColor: EntityColorData | undefined
     bars: Bar[] // contains the y values for every y variable
-    xPoint: SimplePoint // contains the single x value
+    xPoint: SimplePoint | undefined // contains the single x value
 }
 
 export interface PlacedItem extends Item {
@@ -71,7 +71,7 @@ export interface TooltipProps {
     targetTime?: Time
     timeColumn: CoreColumn
     yAxisColumn: CoreColumn
-    xAxisColumn: CoreColumn
+    xAxisColumn: CoreColumn | undefined
     xOverrideTime?: Time
 }
 

--- a/grapher/stackedCharts/MarimekkoChartConstants.ts
+++ b/grapher/stackedCharts/MarimekkoChartConstants.ts
@@ -72,6 +72,7 @@ export interface TooltipProps {
     timeColumn: CoreColumn
     yAxisColumn: CoreColumn
     xAxisColumn: CoreColumn
+    xOverrideTime?: Time
 }
 
 export interface EntityWithSize {


### PR DESCRIPTION
This fixes a few issues that Charlie found and adds a few things I wanted to do for a while:

1. It is now possible to hide categories from the legend (Antarctica was a common request to hide)
2. The (wrong) interpolation hint in the on-hover panel for the x axis is now gone when the "x axis time override" is set. A proper solution will need proper join support between years and days. For now, all Marimekko charts that want to merge days and years (e.g. vaccincation data and population) use the x axis time override anyhow and so we can use this to hide the wrong time notice in the tooltip
3. I made it possible to use a marimekko chart without specifying an x axis. This turns it into a tightly stacked bar chart which can be useful for 