### PR TITLE
refactor: clean up country profile code

### DIFF
--- a/baker/countryProfiles.tsx
+++ b/baker/countryProfiles.tsx
@@ -40,8 +40,8 @@ const countryIndicatorGraphers = async (): Promise<GrapherInterface[]> =>
         ).map((c: any) => JSON.parse(c.config)) as GrapherInterface[]
         return graphers.filter(
             (grapher) =>
-                grapher.hasChartTab &&
-                grapher.type === "LineChart" &&
+                (grapher.hasChartTab ?? true) &&
+                (grapher.type ?? "LineChart") === "LineChart" &&
                 grapher.dimensions?.length === 1
         )
     })

--- a/baker/countryProfiles.tsx
+++ b/baker/countryProfiles.tsx
@@ -72,13 +72,15 @@ export const denormalizeLatestCountryData = async (variableIds?: number[]) => {
     if (!variableIds)
         variableIds = (await countryIndicatorVariables()).map((v) => v.id)
 
+    const currentYear = new Date().getUTCFullYear()
+
     const dataValuesQuery = db
         .knexTable("data_values")
         .select("variableId", "entityId", "value", "year")
         .whereIn("variableId", variableIds)
         .whereRaw(`entityId in (?)`, [entityIds])
-        .andWhere("year", ">", 2010)
-        .andWhere("year", "<", 2020)
+        .andWhere("year", ">", currentYear - 10) // latest data point should be at most 10 years old
+        .andWhere("year", "<=", currentYear)
         .orderBy("year", "DESC")
 
     let dataValues = (await dataValuesQuery) as {

--- a/baker/countryProfiles.tsx
+++ b/baker/countryProfiles.tsx
@@ -143,8 +143,6 @@ export const countryProfilePage = async (
     if (!country) throw new JsonError(`No such country ${countrySlug}`, 404)
 
     const graphers = await countryIndicatorGraphers()
-    const variables = await countryIndicatorVariables()
-    const variablesById = lodash.keyBy(variables, (v) => v.id)
     const dataValues = await countryIndicatorLatestData(country.code)
 
     const valuesByVariableId = lodash.groupBy(dataValues, (v) => v.variableId)
@@ -157,26 +155,6 @@ export const countryProfilePage = async (
 
         if (values && values.length) {
             const latestValue = values[0]
-            const variable = variablesById[vid]
-
-            // todo: this is a lot of setup to get formatValueShort. Maybe cleanup?
-            const table = new OwidTable(
-                [],
-                [
-                    {
-                        slug: vid.toString(),
-                        unit: variable.unit,
-                        display: variable.display,
-                    },
-                ]
-            )
-            const column = table.get(vid.toString())
-
-            let value: string | number
-            value = parseFloat(latestValue.value)
-            if (isNaN(value)) value = latestValue.value
-            else if (variable.display.conversionFactor)
-                value *= variable.display.conversionFactor
 
             indicators.push({
                 year: latestValue.year,

--- a/site/CountryProfilePage.tsx
+++ b/site/CountryProfilePage.tsx
@@ -83,12 +83,12 @@ export const CountryProfilePage = (props: CountryProfilePageProps) => {
                                             )}
                                         >
                                             {indicator.name}
-                                            {indicator.variantName
-                                                ? " (" +
-                                                  indicator.variantName +
-                                                  ")"
-                                                : ""}
                                         </a>
+                                        {indicator.variantName && (
+                                            <span className="variantName">
+                                                {indicator.variantName}
+                                            </span>
+                                        )}
                                     </div>
                                     <div className="indicatorValue">
                                         ({indicator.year})

--- a/site/runCountryProfilePage.ts
+++ b/site/runCountryProfilePage.ts
@@ -54,10 +54,10 @@ class ChartFilter {
             document.querySelectorAll(".CountryProfilePage main li")
         ) as HTMLLIElement[]
         this.chartItems = lis.map((li) => ({
-            title: ((li.firstChild as any).textContent as string).replace(
-                /₂/g,
-                "2"
-            ),
+            title:
+                li
+                    .querySelector(".indicatorName > a")
+                    ?.textContent?.replace(/₂/g, "2") ?? "",
             li: li,
             ul: li.closest("ul") as HTMLUListElement,
         }))


### PR DESCRIPTION
Spun off from #1320, this is an attempt to use the cleanup work from there at least:
* remove unused code that was used to format the latest data value
* properly handle undefined config fields like `config.type` and `config.hasChartType`, and use the defaults there (LineChart, true)
* always use the current year as the latest year, and a 10-year backwards time window around it
* display the variant name in grey and not as part of the link