### PR TITLE
fix: consistent grapher schema URLs

### DIFF
--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -1086,8 +1086,6 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
     }
 
     async getFieldDefinitions() {
-        // TODO: this should switch to files.ourwordindata.org but if I do this I get a CORS error -
-        // areh HEAD requests not forwarded?
         const json = await fetch(
             "https://files.ourworldindata.org/schemas/grapher-schema.001.json"
         ).then((response) => response.json())

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -1089,7 +1089,7 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
         // TODO: this should switch to files.ourwordindata.org but if I do this I get a CORS error -
         // areh HEAD requests not forwarded?
         const json = await fetch(
-            "https://owid.nyc3.digitaloceanspaces.com/schemas/grapher-schema.001.json"
+            "https://files.ourworldindata.org/schemas/grapher-schema.001.json"
         ).then((response) => response.json())
         const fieldDescriptions = extractFieldDescriptionsFromSchema(json)
         runInAction(() => {

--- a/devTools/schemaProcessor/columns.json
+++ b/devTools/schemaProcessor/columns.json
@@ -2,7 +2,7 @@
     {
         "type": "string",
         "pointer": "/$schema",
-        "default": "https://owid.nyc3.digitaloceanspaces.com/schemas/grapher-schema.v001.json",
+        "default": "https://files.ourworldindata.org/schemas/grapher-schema.001.json",
         "editor": "textfield"
     },
     {

--- a/grapher/schema/grapher-schema.001.json
+++ b/grapher/schema/grapher-schema.001.json
@@ -191,7 +191,7 @@
             "type": "string",
             "description": "Url of the concrete schema version to use to validate this document",
             "format": "uri",
-            "default": "https://owid.nyc3.digitaloceanspaces.com/schemas/grapher-schema.v001.json"
+            "default": "https://files.ourworldindata.org/schemas/grapher-schema.001.json"
         },
         "id": {
             "type": "integer",

--- a/grapher/schema/grapher-schema.001.yaml
+++ b/grapher/schema/grapher-schema.001.yaml
@@ -176,7 +176,7 @@ properties:
         type: string
         description: Url of the concrete schema version to use to validate this document
         format: uri
-        default: "https://owid.nyc3.digitaloceanspaces.com/schemas/grapher-schema.v001.json"
+        default: "https://files.ourworldindata.org/schemas/grapher-schema.001.json"
     id:
         type: integer
         description: Internal DB id. Useful internally for OWID but not required if just using grapher directly.


### PR DESCRIPTION
Fixes #1439, supersedes #1152.

Now we have a Cloudflare Worker in place for `files.ourworldindata.org`, so we can change all references.