### PR TITLE
fix(facets): do not share Y axis on faceted DiscreteBar

### DIFF
--- a/grapher/controls/Controls.tsx
+++ b/grapher/controls/Controls.tsx
@@ -122,7 +122,7 @@ export class FacetYDomainToggle extends React.Component<{
                     onChange={this.onToggle}
                     data-track-note="chart-facet-ydomain-toggle"
                 />{" "}
-                &nbsp;Uniform y-axis
+                &nbsp;Align axis scales
             </label>
         )
     }

--- a/grapher/core/GrapherConstants.ts
+++ b/grapher/core/GrapherConstants.ts
@@ -47,6 +47,9 @@ export enum FacetStrategy {
 
 export enum FacetAxisDomain {
     independent = "independent", // all facets have their own y domain
+    // TODO: rename to "uniform", since "shared" has a different meaning when
+    // axes are being plotted (it means the axis is omitted).
+    // Need to migrate Grapher & Explorer configs.
     shared = "shared", // all facets share the same y domain
 }
 

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -361,7 +361,10 @@ export class FacetChart
                 uniform: this.uniformYAxis,
                 shared:
                     this.uniformYAxis &&
-                    this.chartTypeName !== ChartTypeName.StackedDiscreteBar,
+                    ![
+                        ChartTypeName.StackedDiscreteBar,
+                        ChartTypeName.DiscreteBar,
+                    ].includes(this.chartTypeName),
             },
         }
         values(axes).forEach(({ config, axisAccessor, uniform, shared }) => {

--- a/grapher/facetChart/FacetChart.tsx
+++ b/grapher/facetChart/FacetChart.tsx
@@ -341,6 +341,18 @@ export class FacetChart
         const { intermediateChartInstances } = this
         // Define the global axis config, shared between all facets
         const sharedAxesSizes: PositionMap<number> = {}
+
+        // When the Y axis is uniform for all facets:
+        // - for most charts, we want to only show the axis on the left-most facet charts, and omit
+        //   it on the others
+        // - for bar charts the Y axis is plotted horizontally, so we don't want to omit it
+        const isSharedYAxis =
+            this.uniformYAxis &&
+            ![
+                ChartTypeName.StackedDiscreteBar,
+                ChartTypeName.DiscreteBar,
+            ].includes(this.chartTypeName)
+
         const axes: AxesInfo = {
             x: {
                 config: {},
@@ -359,12 +371,7 @@ export class FacetChart
                 config: {},
                 axisAccessor: (instance) => instance.yAxis,
                 uniform: this.uniformYAxis,
-                shared:
-                    this.uniformYAxis &&
-                    ![
-                        ChartTypeName.StackedDiscreteBar,
-                        ChartTypeName.DiscreteBar,
-                    ].includes(this.chartTypeName),
+                shared: isSharedYAxis,
             },
         }
         values(axes).forEach(({ config, axisAccessor, uniform, shared }) => {


### PR DESCRIPTION
`DiscreteBar` used to try to collapse the axis when "uniform Y axis" is checked, this fixes that ([chart](https://ourworldindata.org/grapher/share-who-currently-had-depression-by-age-and-gender)):

https://user-images.githubusercontent.com/1308115/168875112-277ddf4a-ac95-450f-bba8-a79c62d20f67.mp4