### PR TITLE
Marimekko-tweaks-with-feedback

### DIFF
--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -356,7 +356,7 @@ abstract class AbstractAxis {
         return parseFloat(this.d3_scale(value).toFixed(1))
     }
 
-    /** This function returns the inverse of place - i.e. give a screen space
+    /** This function returns the inverse of place - i.e. given a screen space
      *  coordinate, it returns the corresponding domain value. This is useful
      *  for cases where you want to make sure that something is at least one pixel high.
      */

--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -356,6 +356,14 @@ abstract class AbstractAxis {
         return parseFloat(this.d3_scale(value).toFixed(1))
     }
 
+    /** This function returns the inverse of place - i.e. give a screen space
+     *  coordinate, it returns the corresponding domain value. This is useful
+     *  for cases where you want to make sure that something is at least one pixel high.
+     */
+    invert(value: number): number {
+        return this.d3_scale.invert(value)
+    }
+
     @computed get tickFontSize(): number {
         return 0.9 * this.fontSize
     }

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1492,6 +1492,7 @@ export class Grapher
         )
             return false
 
+        if (this.isMarimekko && this.xColumnSlug === undefined) return false
         return !this.hideRelativeToggle
     }
 
@@ -2437,7 +2438,7 @@ export class Grapher
     }
 
     @computed get showNoDataAreaToggle(): boolean {
-        return this.isMarimekko
+        return this.isMarimekko && this.xColumnSlug !== undefined
     }
 
     @computed get showChangeEntityButton(): boolean {

--- a/grapher/stackedCharts/MarimekkoChart.tsx
+++ b/grapher/stackedCharts/MarimekkoChart.tsx
@@ -558,7 +558,7 @@ export class MarimekkoChart
             // charts, e.g. each continent being assigned to the same color.
             // inputTable is unfiltered, so it contains every value that exists in the variable.
 
-            manager.tableAfterAuthorTimelineAndActiveChartTransformAndPopulationFilter?.get(
+            manager.tableAfterAuthorTimelineAndActiveChartTransform?.get(
                 this.colorColumnSlug
             ) ??
             inputTable.get(this.colorColumnSlug)
@@ -795,7 +795,7 @@ export class MarimekkoChart
         let sortFunc: (a: Item, b: Item) => number
         switch (sortConfig.sortBy) {
             case SortBy.custom:
-                sortFunc = () => 0
+                sortFunc = (): number => 0
                 break
             case SortBy.entityName:
                 sortFunc = (a: Item, b: Item): number =>
@@ -1830,7 +1830,7 @@ export class MarimekkoChart
 
     @computed get failMessage(): string {
         const column = this.yColumns[0]
-        const { yColumns, yColumnSlugs, xColumn } = this
+        const { yColumns, yColumnSlugs } = this
 
         if (!column) return "No Y column to chart"
 

--- a/grapher/stackedCharts/MarimekkoChart.tsx
+++ b/grapher/stackedCharts/MarimekkoChart.tsx
@@ -549,14 +549,19 @@ export class MarimekkoChart
     }
 
     @computed get colorScaleColumn(): CoreColumn {
+        const { manager, inputTable } = this
         return (
             // For faceted charts, we have to get the values of inputTable before it's filtered by
             // the faceting logic.
-            this.manager.colorScaleColumnOverride ??
+            manager.colorScaleColumnOverride ??
             // We need to use filteredTable in order to get consistent coloring for a variable across
             // charts, e.g. each continent being assigned to the same color.
             // inputTable is unfiltered, so it contains every value that exists in the variable.
-            this.inputTable.get(this.colorColumnSlug)
+
+            manager.tableAfterAuthorTimelineAndActiveChartTransformAndPopulationFilter?.get(
+                this.colorColumnSlug
+            ) ??
+            inputTable.get(this.colorColumnSlug)
         )
     }
     @computed private get sortConfig(): SortConfig {

--- a/grapher/stackedCharts/MarimekkoChart.tsx
+++ b/grapher/stackedCharts/MarimekkoChart.tsx
@@ -7,9 +7,9 @@ import {
     last,
     flatten,
     excludeUndefined,
-    sortBy,
     sumBy,
     partition,
+    cloneDeep,
     first,
 } from "../../clientUtils/Util.js"
 import { action, computed, observable } from "mobx"
@@ -18,7 +18,6 @@ import { Bounds, DEFAULT_BOUNDS } from "../../clientUtils/Bounds.js"
 import {
     BASE_FONT_SIZE,
     EntitySelectionMode,
-    SeriesName,
 } from "../core/GrapherConstants.js"
 import { DualAxisComponent } from "../axis/AxisViews.js"
 import { NoDataModal } from "../noDataModal/NoDataModal.js"
@@ -635,8 +634,14 @@ export class MarimekkoChart
     }
 
     @computed private get xAxisConfig(): AxisConfig {
+        const { xColumnSlug } = this
         return new AxisConfig(
-            { ...this.manager.xAxisConfig, orient: Position.top },
+            {
+                ...this.manager.xAxisConfig,
+                orient: Position.top,
+                hideAxis: xColumnSlug === undefined,
+                hideGridlines: xColumnSlug === undefined,
+            },
             this
         )
     }
@@ -667,7 +672,7 @@ export class MarimekkoChart
         const { manager, xAxisLabelBase, xDomainDefault, xColumn } = this
         const config = this.xAxisConfig
         let axis = config.toHorizontalAxis()
-        if (manager.isRelativeMode && this.xColumn) {
+        if (manager.isRelativeMode && xColumn) {
             // MobX and classes  interact in an annoying way here so we have to construct a new object via
             // an object copy of the AxisConfig class instance to be able to set a property without
             // making MobX unhappy about a mutation originating from a computed property
@@ -782,29 +787,46 @@ export class MarimekkoChart
     @computed private get sortedItems(): Item[] {
         const { items, sortConfig } = this
 
-        let sortByFunc: (item: Item) => number | string | undefined
+        let sortFunc: (a: Item, b: Item) => number
         switch (sortConfig.sortBy) {
             case SortBy.custom:
-                sortByFunc = () => undefined
+                sortFunc = () => 0
                 break
             case SortBy.entityName:
-                sortByFunc = (item: Item): string => item.entityName
+                sortFunc = (a: Item, b: Item): number =>
+                    a.entityName.localeCompare(b.entityName)
                 break
             case SortBy.column:
                 const sortColumnSlug = sortConfig.sortColumnSlug
-                sortByFunc = (item: Item): number =>
-                    item.bars.find((b) => b.seriesName === sortColumnSlug)
-                        ?.yPoint.value ?? 0
+                sortFunc = (a: Item, b: Item): number => {
+                    const aValue =
+                        a.bars.find((bar) => bar.seriesName === sortColumnSlug)
+                            ?.yPoint.value ?? 0
+                    const bValue =
+                        b.bars.find((bar) => bar.seriesName === sortColumnSlug)
+                            ?.yPoint.value ?? 0
+                    const diff = aValue - bValue
+                    if (diff !== 0) return diff
+                    return a.entityName.localeCompare(b.entityName)
+                }
                 break
             default:
             case SortBy.total:
-                sortByFunc = (item: Item): number => {
-                    const lastPoint = last(item.bars)?.yPoint
-                    if (!lastPoint) return 0
-                    return lastPoint.valueOffset + lastPoint.value
+                sortFunc = (a: Item, b: Item): number => {
+                    const aLastPoint = last(a.bars)?.yPoint
+                    const bLastPoint = last(b.bars)?.yPoint
+                    const aValue =
+                        (aLastPoint?.valueOffset ?? 0) +
+                        (aLastPoint?.value ?? 0)
+                    const bValue =
+                        (bLastPoint?.valueOffset ?? 0) +
+                        (bLastPoint?.value ?? 0)
+                    const diff = aValue - bValue
+                    if (diff !== 0) return diff
+                    else return a.entityName.localeCompare(b.entityName)
                 }
         }
-        const sortedItems = sortBy(items, sortByFunc)
+        const sortedItems = items.sort(sortFunc)
         const sortOrder = sortConfig.sortOrder ?? SortOrder.desc
         if (sortOrder === SortOrder.desc) sortedItems.reverse()
 
@@ -1073,9 +1095,33 @@ export class MarimekkoChart
                     !focusColorBin.contains(entityColor?.colorDomainValue)) ||
                 (hasSelection && !isSelected)
 
+            // figure out what the minimum height in domain space has to be so
+            // that a bar is at least one pixel high in screen space.
+            const yAxisOnePixelDomainEquivalent =
+                this.dualAxis.verticalAxis.invert(
+                    this.dualAxis.verticalAxis.place(y0) - 1
+                ) -
+                this.dualAxis.verticalAxis.invert(
+                    this.dualAxis.verticalAxis.place(y0)
+                )
+            const adjustedBars = []
+            let currentY = 0
+            for (const bar of bars) {
+                const barCopy = cloneDeep(bar)
+                // we want to draw bars at least one pixel high so that they are guaranteed to have a
+                // visual representation in our chart (as a 1px line in this case)
+                barCopy.yPoint.value = Math.max(
+                    barCopy.yPoint.value,
+                    yAxisOnePixelDomainEquivalent
+                )
+                barCopy.yPoint.valueOffset = currentY
+                currentY += barCopy.yPoint.value
+                adjustedBars.push(barCopy)
+            }
+
             const barsProps = {
                 entityName,
-                bars,
+                bars: adjustedBars,
                 xPoint,
                 entityColor,
                 isFaint,
@@ -1162,6 +1208,7 @@ export class MarimekkoChart
             selectedItems,
             xRange,
             baseFontSize,
+            sortConfig,
             paddingInPixels,
         } = this
 
@@ -1205,9 +1252,11 @@ export class MarimekkoChart
             const yRowsForA = a.item.ySortValue
             const yRowsForB = b.item.ySortValue
 
-            if (yRowsForA !== undefined && yRowsForB !== undefined)
-                return yRowsForB - yRowsForA
-            else if (yRowsForA === undefined && yRowsForB !== undefined)
+            if (yRowsForA !== undefined && yRowsForB !== undefined) {
+                const diff = yRowsForB - yRowsForA
+                if (diff !== 0) return diff
+                else return b.item.entityName.localeCompare(a.item.entityName)
+            } else if (yRowsForA === undefined && yRowsForB !== undefined)
                 return -1
             else if (yRowsForA !== undefined && yRowsForB === undefined)
                 return 1
@@ -1215,32 +1264,31 @@ export class MarimekkoChart
             else return 0
         })
 
-        const averageCharacterCount =
-            sumBy(labelCandidates, (item) => item.item.entityName.length) /
-            labelCandidates.length
+        if (sortConfig.sortOrder === SortOrder.desc) {
+            labelCandidates.reverse()
+        }
 
-        const firstDefined = labelCandidates.find(
-            (item) => item.item.ySortValue !== undefined
+        const [sortedLabelsWithValues, sortedLabelsWithoutValues] = partition(
+            labelCandidates,
+            (item) =>
+                item.item.ySortValue !== 0 && item.item.ySortValue !== undefined
         )
-        //const labelCharacterCountThreshold = 1.4 * averageCharacterCount
-        // Always pick the first and last element and the first one that is not undefined for y
-        // but only if it is less than 1.4 times as long in character count as the average label (avoid
-        // picking "Democratic Republic of Congo" for this reason and thus needing lots of space)
-        if (
-            firstDefined
-            // &&             firstDefined.item.entityName.length < labelCharacterCountThreshold
-        )
-            firstDefined.isPicked = true
-        const labelHeight = labelCandidates[0].bounds.height
-        // if (
-        //     labelCandidates[labelCandidates.length - 1].item.entityName.length <
-        //     labelCharacterCountThreshold
-        // )
-        labelCandidates[labelCandidates.length - 1].isPicked = true
+
+        if (sortedLabelsWithValues.length) {
+            first(sortedLabelsWithValues)!.isPicked = true
+            last(sortedLabelsWithValues)!.isPicked = true
+        }
+        if (sortedLabelsWithoutValues.length) {
+            if (sortConfig.sortOrder === SortOrder.desc)
+                first(sortedLabelsWithoutValues)!.isPicked = true
+            else last(sortedLabelsWithoutValues)!.isPicked = true
+        }
         const availablePixels = xRange[1] - xRange[0]
 
+        const labelHeight = labelCandidates[0].bounds.height
+
         const numLabelsToAdd = Math.floor(
-            Math.min(availablePixels / (labelHeight + paddingInPixels) / 4, 20) // factor 4 is arbitrary to taste
+            Math.min(availablePixels / (labelHeight + paddingInPixels) / 3, 20) // factor 4 is arbitrary to taste
         )
         const chunks = MarimekkoChart.splitIntoEqualDomainSizeChunks(
             labelCandidates,
@@ -1341,9 +1389,11 @@ export class MarimekkoChart
         // labels we don't want to use +infinity :) so we Math.min it with the longest label width
         if (labelsWithPlacements.length === 0) return []
 
-        labelsWithPlacements.sort(
-            (a, b) => a.preferredPlacement - b.preferredPlacement
-        )
+        labelsWithPlacements.sort((a, b) => {
+            const diff = a.preferredPlacement - b.preferredPlacement
+            if (diff !== 0) return diff
+            else return a.labelKey.localeCompare(b.labelKey)
+        })
 
         const labelWidth = unrotatedHighestLabelHeight
         const correctionFactor =
@@ -1366,7 +1416,8 @@ export class MarimekkoChart
         ].correctedPlacement = Math.min(
             labelsWithPlacements[labelsWithPlacements.length - 1]
                 .correctedPlacement,
-            dualAxis.horizontalAxis.rangeSize
+            dualAxis.horizontalAxis.rangeSize +
+                dualAxis.horizontalAxis.place(x0)
         )
         for (let i = labelsWithPlacements.length - 1; i > 0; i--) {
             const current = labelsWithPlacements[i]

--- a/grapher/stackedCharts/MarimekkoChart.tsx
+++ b/grapher/stackedCharts/MarimekkoChart.tsx
@@ -1190,7 +1190,10 @@ export class MarimekkoChart
                 MarimekkoChart.labelCandidateFromItem(
                     {
                         entityName: row.entityName,
-                        xValue: xColumnAtLastTimePoint ? row.value : 1,
+                        xValue:
+                            xColumnAtLastTimePoint !== undefined
+                                ? row.value
+                                : 1,
                         ySortValue: ySizeMap.get(row.entityName),
                     },
                     baseFontSize,
@@ -1219,21 +1222,21 @@ export class MarimekkoChart
         const firstDefined = labelCandidates.find(
             (item) => item.item.ySortValue !== undefined
         )
-        const labelCharacterCountThreshold = 1.4 * averageCharacterCount
+        //const labelCharacterCountThreshold = 1.4 * averageCharacterCount
         // Always pick the first and last element and the first one that is not undefined for y
         // but only if it is less than 1.4 times as long in character count as the average label (avoid
         // picking "Democratic Republic of Congo" for this reason and thus needing lots of space)
         if (
-            firstDefined &&
-            firstDefined.item.entityName.length < labelCharacterCountThreshold
+            firstDefined
+            // &&             firstDefined.item.entityName.length < labelCharacterCountThreshold
         )
             firstDefined.isPicked = true
         const labelHeight = labelCandidates[0].bounds.height
-        if (
-            labelCandidates[labelCandidates.length - 1].item.entityName.length <
-            labelCharacterCountThreshold
-        )
-            labelCandidates[labelCandidates.length - 1].isPicked = true
+        // if (
+        //     labelCandidates[labelCandidates.length - 1].item.entityName.length <
+        //     labelCharacterCountThreshold
+        // )
+        labelCandidates[labelCandidates.length - 1].isPicked = true
         const availablePixels = xRange[1] - xRange[0]
 
         const numLabelsToAdd = Math.floor(


### PR DESCRIPTION
Additional tweaks based on authors feedback. This does the following:
* X axis and grid lines hidden if no x variable mapped
* improved sorting and label picking to make sure first and last items are picked of the range with values and the first (desc) or last (asc) label of the no/0 values range
* Ensured that sort order with same values is consistent (sort by name if value is equal)
* Bars are rendered at least one pixel high always so that they are visible as a thin line
* Hide controls that don't make sense without the x variable being mapped

I attempted to get Antarctica to hide automatically but that didn't work unfortunately.

This PR now has diffs against existing Marimekkos because I changed the labeling strategy somewhat, I think for the better.