### PR TITLE
Automatically upload schema files to DO spaces

### DIFF
--- a/.github/workflows/sync-grapher-schema-to-digital-ocean.yml
+++ b/.github/workflows/sync-grapher-schema-to-digital-ocean.yml
@@ -14,7 +14,7 @@ jobs:
               with:
                   access_key: ${{ secrets.DO_ACCESS_KEY}}
                   secret_key: ${{ secrets.DO_SECRET_KEY }}
-                  space_name: ${{ secrets.DO_SPACE_NAME }}
-                  space_region: ${{ secrets.DO_SPACE_REGION }}
+                  space_name: owid-public
+                  space_region: nyc3
                   source: grapher/schema
                   out_dir: schemas

--- a/.github/workflows/sync-grapher-schema-to-digital-ocean.yml
+++ b/.github/workflows/sync-grapher-schema-to-digital-ocean.yml
@@ -1,0 +1,20 @@
+name: Upload to DO Spaces
+on:
+    push:
+        branches:
+            - master
+            - schema-do-sync-github-action
+jobs:
+    upload:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout Repository
+              uses: actions/checkout@master
+            - uses: BetaHuhn/do-spaces-action@v2
+              with:
+                  access_key: ${{ secrets.DO_ACCESS_KEY}}
+                  secret_key: ${{ secrets.DO_SECRET_KEY }}
+                  space_name: ${{ secrets.DO_SPACE_NAME }}
+                  space_region: ${{ secrets.DO_SPACE_REGION }}
+                  source: grapher/schema
+                  out_dir: schemas


### PR DESCRIPTION
This adds a github action to copy all files in the /grapher/schema directory into the /schemas directory in our owid-public repo (files.ourworldindata.org). This is useful so that any new and updated schema are always available there. 

The Bulk FASTT editor is the main consumer of the schema at the moment (it uses it to figure out what columns to show and how to access the data in them).

I considered using an admin endpoint to serve the schema as the main way to fetch it. As @marcelgerber said this has the upside of being deployed atomically with the admin. We can still do that in addition to this but I think syncing to s3 is something we should do in any case so that the public can always know what the schemas are we have (or had) for grapher