### PR TITLE
fix: strip out newlines in TextWrap

### DIFF
--- a/clientUtils/Bounds.ts
+++ b/clientUtils/Bounds.ts
@@ -88,7 +88,8 @@ export class Bounds {
 
         const isBold = fontWeight >= 600
 
-        let bounds = Bounds.empty()
+        const height = fontSize
+        let bounds = new Bounds(x, y - height, 0, height)
         if (str) {
             // pixelWidth uses a precomputed character width table to quickly give a
             // rough estimate of string width based on characters in a string - it is probably not
@@ -98,8 +99,7 @@ export class Bounds {
                 size: fontSize,
                 bold: isBold,
             })
-            const height = fontSize
-            bounds = new Bounds(x, y - height, width, height)
+            bounds = bounds.set({ width })
         }
 
         return bounds

--- a/grapher/text/TextWrap.test.ts
+++ b/grapher/text/TextWrap.test.ts
@@ -75,3 +75,21 @@ describe(shortenForTargetWidth, () => {
         expect(shortenForTargetWidth(text, 1)).toEqual("")
     })
 })
+
+describe("lines()", () => {
+    it("should not contain any newline characters", () => {
+        const text = "a very very very very long line\n\nshort one"
+        const wrap = new TextWrap({
+            text,
+            maxWidth: 100,
+            fontSize: FONT_SIZE,
+        })
+        expect(wrap.lines.map((l) => l.text)).toEqual([
+            "a very very",
+            "very very long",
+            "line",
+            "",
+            "short one",
+        ])
+    })
+})

--- a/grapher/text/TextWrap.test.ts
+++ b/grapher/text/TextWrap.test.ts
@@ -62,6 +62,13 @@ describe("height()", () => {
         const text = ""
         expect(renderedHeight(text)).toEqual(0)
     })
+
+    it("calculates correct height for multiple newlines", () => {
+        const lineHeight = renderedHeight("test")
+        expect(renderedHeight("test\n\ntest")).toBeGreaterThanOrEqual(
+            renderedHeight("test\ntest") + lineHeight
+        )
+    })
 })
 
 describe(shortenForTargetWidth, () => {

--- a/grapher/text/TextWrap.test.ts
+++ b/grapher/text/TextWrap.test.ts
@@ -92,4 +92,20 @@ describe("lines()", () => {
             "short one",
         ])
     })
+
+    it("should work in rawHtml mode", () => {
+        // the HTML version of this string won't fit into a width of 150, but it will once the HTML tags are stripped
+        // - that's what the rawHtml mode is for.
+        const text =
+            "an <strong>important</strong> <a href='https://youtu.be/dQw4w9WgXcQ'>line</a>"
+        const wrap = new TextWrap({
+            text,
+            maxWidth: 150,
+            fontSize: FONT_SIZE,
+            rawHtml: true,
+        })
+        expect(wrap.lines.map((l) => l.text)).toEqual([
+            "an <strong>important</strong> <a href='https://youtu.be/dQw4w9WgXcQ'>line</a>",
+        ])
+    })
 })

--- a/grapher/text/TextWrap.tsx
+++ b/grapher/text/TextWrap.tsx
@@ -103,13 +103,17 @@ export class TextWrap {
                 startsWithNewline(word) ||
                 (nextBounds.width + 10 > maxWidth && line.length >= 1)
             ) {
+                const wordWithoutNewline = word.replace(/^\n/, "")
                 lines.push({
                     text: line.join(" "),
                     width: lineBounds.width,
                     height: lineBounds.height,
                 })
-                line = [word]
-                lineBounds = Bounds.forText(word, { fontSize, fontWeight })
+                line = [wordWithoutNewline]
+                lineBounds = Bounds.forText(wordWithoutNewline, {
+                    fontSize,
+                    fontWeight,
+                })
             } else {
                 line = nextLine
                 lineBounds = nextBounds


### PR DESCRIPTION
Issue: [Lucas reported this issue here on Slack](https://owid.slack.com/archives/C46U9LXRR/p1653160820675989)

In our svg and png exports, the first line after a newline had an unintentional indent:
![](https://ourworldindata.org/grapher/exports/dietary-choices-uk.svg)

This happened because `TextWrap.lines()` was not stripping out leading newlines, and they would be rendered as a space in the svg version of a chart (but not in the HTML version).
E.g. for the above chart, it would be `["- Flexitarian [...]", "\n- Pescetarian [...]"]`.

I also used the opportunity to add test cases for `.lines()`, which didn't have any test coverage beforehand.