### PR TITLE
feat(details on demand): add details table to grapher DB

### DIFF
--- a/db/migration/1653584089031-DetailsOnDemand.ts
+++ b/db/migration/1653584089031-DetailsOnDemand.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class DetailsOnDemand1653584089031 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE \`details\` (
+            \`id\` int NOT NULL AUTO_INCREMENT,
+            \`category\` varchar(255) NOT NULL,
+            \`term\` varchar(255) NOT NULL,
+            \`title\` varchar(255) NOT NULL,
+            \`content\` varchar(1023) NOT NULL,
+            PRIMARY KEY (\`id\`),
+            UNIQUE(\`category\`, \`term\`)
+        )`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE details`)
+    }
+}


### PR DESCRIPTION
Resolves #1467

~Realized there was no point in having an `AUTO_INCREMENT` id if we can always just use the category and term to index.~

Update: added an `AUTO_INCREMENT` id 😊 