### PR TITLE
refactor: introduce new column type `NumberOrStringColumn`

### DIFF
--- a/coreTable/CoreColumnDef.ts
+++ b/coreTable/CoreColumnDef.ts
@@ -3,7 +3,7 @@ import { ColumnSlug } from "../clientUtils/owidTypes.js"
 import { CoreValueType, Color } from "./CoreTableConstants.js"
 
 export enum ColumnTypeNames {
-    MixedType = "MixedType",
+    NumberOrString = "NumberOrString",
     Numeric = "Numeric",
     String = "String",
     Region = "Region",

--- a/coreTable/CoreColumnDef.ts
+++ b/coreTable/CoreColumnDef.ts
@@ -3,6 +3,7 @@ import { ColumnSlug } from "../clientUtils/owidTypes.js"
 import { CoreValueType, Color } from "./CoreTableConstants.js"
 
 export enum ColumnTypeNames {
+    MixedType = "MixedType",
     Numeric = "Numeric",
     String = "String",
     Region = "Region",

--- a/coreTable/CoreTableColumns.test.ts
+++ b/coreTable/CoreTableColumns.test.ts
@@ -47,8 +47,10 @@ describe(ColumnTypeNames.Quarter, () => {
     })
 })
 
-describe(ColumnTypeMap.MixedType, () => {
-    const col = new ColumnTypeMap.MixedType(new OwidTable(), { slug: "test" })
+describe(ColumnTypeMap.NumberOrString, () => {
+    const col = new ColumnTypeMap.NumberOrString(new OwidTable(), {
+        slug: "test",
+    })
 
     it("should format values correctly", () => {
         expect(col.formatValue(null)).toEqual("")
@@ -61,6 +63,7 @@ describe(ColumnTypeMap.MixedType, () => {
     it("should parse values correctly", () => {
         expect(col.parse(1.19)).toEqual(1.19)
         expect(col.parse("1.19")).toEqual(1.19)
+        expect(col.parse(-5.62431784101729e-5)).toEqual(-5.62431784101729e-5)
         expect(col.parse("test")).toEqual("test")
     })
 })

--- a/coreTable/CoreTableColumns.test.ts
+++ b/coreTable/CoreTableColumns.test.ts
@@ -46,3 +46,21 @@ describe(ColumnTypeNames.Quarter, () => {
         expect(csvFormatted).toEqual("2020-Q1")
     })
 })
+
+describe(ColumnTypeMap.MixedType, () => {
+    const col = new ColumnTypeMap.MixedType(new OwidTable(), { slug: "test" })
+
+    it("should format values correctly", () => {
+        expect(col.formatValue(null)).toEqual("")
+        expect(col.formatValue("")).toEqual("")
+        expect(col.formatValue("test")).toEqual("test")
+        expect(col.formatValue(1.19)).toEqual("1.19")
+        expect(col.formatValue(1.191919)).toEqual("1.19")
+    })
+
+    it("should parse values correctly", () => {
+        expect(col.parse(1.19)).toEqual(1.19)
+        expect(col.parse("1.19")).toEqual(1.19)
+        expect(col.parse("test")).toEqual("test")
+    })
+})

--- a/coreTable/CoreTableColumns.ts
+++ b/coreTable/CoreTableColumns.ts
@@ -595,12 +595,12 @@ abstract class AbstractNumericColumn<
  * We strive to have clearly typed variables in the future, but for now our
  * grapher variables are still untyped. Most are number-only, but we also have some
  * string-only, and even some mixed ones.
- * Hence, MixedTypeColumn is used to store grapher variables.
+ * Hence, NumberOrStringColumn is used to store grapher variables.
  * It is not ideal that it extends AbstractNumericColumn, but that ensures that we
  * have implementations of formatValueShortWithAbbreviations and the like already.
  * -- @marcelgerber, 2022-07-01
  */
-class MixedTypeColumn extends AbstractNumericColumn<number | string> {
+class NumberOrStringColumn extends AbstractNumericColumn<number | string> {
     formatValue(value: any, options?: TickFormattingOptions): string {
         if (isNumber(value)) {
             return super.formatValue(value, options)
@@ -776,7 +776,7 @@ export const ColumnTypeMap = {
     Categorical: CategoricalColumn,
     Region: RegionColumn,
     Continent: ContinentColumn,
-    MixedType: MixedTypeColumn,
+    NumberOrString: NumberOrStringColumn,
     Numeric: NumericColumn,
     Day: DayColumn,
     Date: DateColumn,

--- a/grapher/core/LegacyToOwidTable.ts
+++ b/grapher/core/LegacyToOwidTable.ts
@@ -256,7 +256,9 @@ const columnDefFromOwidVariable = (
         retrievedDate: source?.retrievedDate,
         additionalInfo: source?.additionalInfo,
         owidVariableId: variable.id,
-        type: isContinent ? ColumnTypeNames.Continent : ColumnTypeNames.Numeric,
+        type: isContinent
+            ? ColumnTypeNames.Continent
+            : ColumnTypeNames.MixedType,
     }
 }
 

--- a/grapher/core/LegacyToOwidTable.ts
+++ b/grapher/core/LegacyToOwidTable.ts
@@ -258,7 +258,7 @@ const columnDefFromOwidVariable = (
         owidVariableId: variable.id,
         type: isContinent
             ? ColumnTypeNames.Continent
-            : ColumnTypeNames.MixedType,
+            : ColumnTypeNames.NumberOrString,
     }
 }
 

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -331,8 +331,6 @@ export class MapChart
                 const bin = colorScale.getBinForValue(d)
                 const label = bin?.label
                 if (label !== undefined && label !== "") return label
-            } else if (isString(d)) {
-                return d
             }
             return mapColumn?.formatValueLong(d) ?? ""
         }


### PR DESCRIPTION
[As discussed on Slack](https://owid.slack.com/archives/CQQUA2C2U/p1654084452507939?thread_ts=1654073915.561489&cid=CQQUA2C2U) | Incidentally fixes #1273 

Our `CoreTableColumns` are all typed, but that is not a good fit for grapher variables. These can be either numeric, or have string values, or can even contain a mix of the two.
While `NumericColumn` can mostly handle string values fine, it cannot format them and will only output an empty string in this case.

So, in this PR I introduce a new column type, `NumberOrStringColumn`, that behaves mostly like `NumericColumn` but can also format string values.