### PR TITLE
enhance(StackedArea): do not trim trailing zeroes in tooltip

### DIFF
--- a/grapher/stackedCharts/StackedAreaChart.tsx
+++ b/grapher/stackedCharts/StackedAreaChart.tsx
@@ -393,7 +393,8 @@ export class StackedAreaChart
                                             {point.fake
                                                 ? "No data"
                                                 : yColumn.formatValueLong(
-                                                      point.value
+                                                      point.value,
+                                                      { trailingZeroes: true }
                                                   )}
                                         </td>
                                     </tr>
@@ -415,7 +416,8 @@ export class StackedAreaChart
                                     <span>
                                         <strong>
                                             {yColumn.formatValueLong(
-                                                totalValue
+                                                totalValue,
+                                                { trailingZeroes: true }
                                             )}
                                         </strong>
                                     </span>


### PR DESCRIPTION
Just a tiny fix. Didn't check if other chart tooltips might be missing this...

#### Before

<img width="407" alt="Screenshot 2022-06-02 at 11 22 35" src="https://user-images.githubusercontent.com/1308115/171609701-ee897d9d-f635-46b5-b642-0a3c6d58457e.png">

#### After

<img width="407" alt="Screenshot 2022-06-02 at 11 22 12" src="https://user-images.githubusercontent.com/1308115/171609690-94ac3f58-cc3c-41d8-8253-92782e81aa43.png">