### PR TITLE
refactor(intersect.observer): remove warning

### DIFF
--- a/site/multiembedder/MultiEmbedder.tsx
+++ b/site/multiembedder/MultiEmbedder.tsx
@@ -57,18 +57,14 @@ class MultiEmbedder {
     graphersAndExplorersToUpdate: Set<SelectionArray> = new Set()
 
     constructor() {
-        if (typeof window !== "undefined" && "IntersectionObserver" in window) {
-            this.figuresObserver = new IntersectionObserver(
-                this.onIntersecting.bind(this),
-                {
-                    rootMargin: "200%",
-                }
-            )
-        } else {
-            console.warn(
-                "IntersectionObserver not available; interactive embeds won't load on this page"
-            )
-        }
+        if (typeof window === "undefined") return
+
+        this.figuresObserver = new IntersectionObserver(
+            this.onIntersecting.bind(this),
+            {
+                rootMargin: "200%",
+            }
+        )
     }
 
     /**


### PR DESCRIPTION
Warning was unnecessarily showing in the node console when running adminSiteServer/app.

It is also unnecessary in the browser since IntersectionObserver is polyfilled (no IntersectionObserver warning ever made it to bugsnag).

- [ ] Mock `IntersectionObserver` in tests?