### PR TITLE
Migration to add sourceChecksum column for datasets

### DIFF
--- a/db/migration/1654553380446-AddSourceChecksum.ts
+++ b/db/migration/1654553380446-AddSourceChecksum.ts
@@ -3,16 +3,16 @@ import { MigrationInterface, QueryRunner } from "typeorm"
 export class AddSourceChecksum1654553380446 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-			ALTER TABLE datasets 
-			ADD COLUMN sourceChecksum VARCHAR(64) 
-			DEFAULT NULL;
-    	`)
+            ALTER TABLE datasets 
+            ADD COLUMN sourceChecksum VARCHAR(64) 
+            DEFAULT NULL;
+        `)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-			ALTER TABLE datasets 
-			DROP COLUMN sourceChecksum;
-    	`)
+            ALTER TABLE datasets 
+            DROP COLUMN sourceChecksum;
+        `)
     }
 }

--- a/db/migration/1654553380446-AddSourceChecksum.ts
+++ b/db/migration/1654553380446-AddSourceChecksum.ts
@@ -1,0 +1,20 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class AddSourceChecksum1654553380446 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+    	await queryRunner.query(`
+			ALTER TABLE datasets 
+			ADD COLUMN sourceChecksum VARCHAR(64) 
+			DEFAULT NULL;
+    	`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+    	await queryRunner.query(`
+			ALTER TABLE datasets 
+			DROP COLUMN sourceChecksum;
+    	`)
+    }
+
+}

--- a/db/migration/1654553380446-AddSourceChecksum.ts
+++ b/db/migration/1654553380446-AddSourceChecksum.ts
@@ -1,9 +1,8 @@
-import {MigrationInterface, QueryRunner} from "typeorm";
+import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class AddSourceChecksum1654553380446 implements MigrationInterface {
-
     public async up(queryRunner: QueryRunner): Promise<void> {
-    	await queryRunner.query(`
+        await queryRunner.query(`
 			ALTER TABLE datasets 
 			ADD COLUMN sourceChecksum VARCHAR(64) 
 			DEFAULT NULL;
@@ -11,10 +10,9 @@ export class AddSourceChecksum1654553380446 implements MigrationInterface {
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-    	await queryRunner.query(`
+        await queryRunner.query(`
 			ALTER TABLE datasets 
 			DROP COLUMN sourceChecksum;
     	`)
     }
-
 }


### PR DESCRIPTION
Adds a yet-unused `sourceChecksum` column to `datasets` table. See https://github.com/owid/etl/pull/208 for the logic to actually write this column.