### PR TITLE
Details on demand editor implementation

### DIFF
--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -11,6 +11,7 @@ import { EditorFeatures } from "./EditorFeatures.js"
 import { Admin } from "./Admin.js"
 import { BAKED_GRAPHER_URL } from "../settings/clientSettings.js"
 import { Topic } from "../grapher/core/GrapherConstants.js"
+import { GrapherInterface } from "../grapher/core/GrapherInterface.js"
 
 type EditorTab = string
 
@@ -78,6 +79,8 @@ export interface ChartEditorManager {
     references: PostReference[]
     redirects: ChartRedirect[]
     allTopics: Topic[]
+    details: GrapherInterface["details"]
+    invalidDetailReferences: Record<"subtitle" | "note", [string, string][]>
 }
 
 interface VariableIdUsageRecord {
@@ -136,6 +139,10 @@ export class ChartEditor {
 
     @computed get allTopics() {
         return this.manager.allTopics
+    }
+
+    @computed get details() {
+        return this.manager.details
     }
 
     @computed get availableTabs(): EditorTab[] {

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -272,28 +272,32 @@ export class ChartEditorPage
         this.fetchTopics()
     }
 
-    dispose!: IReactionDisposer
-    disposeDetailHandler!: IReactionDisposer
+    disposers: IReactionDisposer[] = []
+
     componentDidMount(): void {
         this.refresh()
 
-        this.dispose = reaction(
-            () => this.editor && this.editor.previewMode,
-            () => {
-                if (this.editor) {
-                    localStorage.setItem(
-                        "editorPreviewMode",
-                        this.editor.previewMode
-                    )
+        this.disposers.push(
+            reaction(
+                () => this.editor && this.editor.previewMode,
+                () => {
+                    if (this.editor) {
+                        localStorage.setItem(
+                            "editorPreviewMode",
+                            this.editor.previewMode
+                        )
+                    }
                 }
-            }
+            )
         )
 
-        this.disposeDetailHandler = reaction(
-            () => this.currentlyReferencedDetails,
-            (currentlyReferencedDetails = {}) => {
-                this.grapher.details = currentlyReferencedDetails
-            }
+        this.disposers.push(
+            reaction(
+                () => this.currentlyReferencedDetails,
+                (currentlyReferencedDetails = {}) => {
+                    this.grapher.details = currentlyReferencedDetails
+                }
+            )
         )
     }
 
@@ -304,8 +308,7 @@ export class ChartEditorPage
     }
 
     componentWillUnmount(): void {
-        this.dispose()
-        this.disposeDetailHandler()
+        this.disposers.forEach((dispose) => dispose())
     }
 
     render(): JSX.Element {

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -11,7 +11,7 @@ import {
 } from "mobx"
 import { Prompt, Redirect } from "react-router-dom"
 import { Bounds } from "../clientUtils/Bounds.js"
-import { capitalize } from "../clientUtils/Util.js"
+import { capitalize, getIndexableKeys } from "../clientUtils/Util.js"
 import { Grapher } from "../grapher/core/Grapher.js"
 import { Admin } from "./Admin.js"
 import {
@@ -44,7 +44,9 @@ import {
     VisionDeficiencyEntity,
 } from "./VisionDeficiencies.js"
 import { EditorMarimekkoTab } from "./EditorMarimekkoTab.js"
-import { Topic } from "../grapher/core/GrapherConstants.js"
+import { Detail, Topic } from "../grapher/core/GrapherConstants.js"
+import { get, has, set } from "lodash"
+import { GrapherInterface } from "../grapher/core/GrapherInterface.js"
 
 @observer
 class TabBinder extends React.Component<{ editor: ChartEditor }> {
@@ -80,6 +82,15 @@ class TabBinder extends React.Component<{ editor: ChartEditor }> {
     }
 }
 
+function extractDetailsFromSyntax(str: string): [string, string][] {
+    const pattern = /\(hover::(\w+)::(\w+)\)/g
+
+    return [...str.matchAll(pattern)].map(([_, category, term]) => [
+        category,
+        term,
+    ])
+}
+
 @observer
 export class ChartEditorPage
     extends React.Component<{
@@ -95,6 +106,7 @@ export class ChartEditorPage
     @observable references: PostReference[] = []
     @observable redirects: ChartRedirect[] = []
     @observable allTopics: Topic[] = []
+    @observable details: GrapherInterface["details"] = {}
 
     @observable.ref grapherElement?: JSX.Element
 
@@ -186,6 +198,60 @@ export class ChartEditorPage
         runInAction(() => (this.allTopics = json.topics))
     }
 
+    async fetchDetails(): Promise<void> {
+        const data = (await this.context.admin.getJSON(`/api/details`)) as {
+            details: Detail[]
+        }
+
+        runInAction(() => {
+            this.details = data.details.reduce(
+                (acc, detail) =>
+                    set(acc, [detail.category, detail.term], detail),
+                {}
+            )
+        })
+    }
+
+    // unvalidated tuples extracted from the subtitle and note fields
+    // these may point to non-existent details e.g. ["not_a_real_category", "not_a_real_term"]
+    @computed get currentDetailReferences() {
+        return {
+            subtitle: extractDetailsFromSyntax(this.grapher.subtitle),
+            note: extractDetailsFromSyntax(this.grapher.note),
+        }
+    }
+
+    // the actual Detail objects, indexed by category.term
+    @computed get currentlyReferencedDetails(): GrapherInterface["details"] {
+        const grapherConfigDetails: GrapherInterface["details"] = {}
+        const allReferences = Object.values(this.currentDetailReferences).flat()
+
+        allReferences.forEach((categoryAndTerm) => {
+            const detail = get(this.details, categoryAndTerm)
+            if (detail) {
+                set(grapherConfigDetails, categoryAndTerm, detail)
+            }
+        })
+
+        return grapherConfigDetails
+    }
+
+    @computed get invalidDetailReferences() {
+        const keys = getIndexableKeys(this.currentDetailReferences)
+
+        const invalidReferences = keys.reduce(
+            (acc, key) => ({
+                ...acc,
+                [key]: this.currentDetailReferences[key].filter(
+                    (path) => !has(this.details, path)
+                ),
+            }),
+            {} as typeof this.currentDetailReferences
+        )
+
+        return invalidReferences
+    }
+
     @computed get admin(): Admin {
         return this.context.admin
     }
@@ -198,6 +264,7 @@ export class ChartEditorPage
 
     @action.bound refresh(): void {
         this.fetchGrapher()
+        this.fetchDetails()
         this.fetchData()
         this.fetchLogs()
         this.fetchRefs()
@@ -206,6 +273,7 @@ export class ChartEditorPage
     }
 
     dispose!: IReactionDisposer
+    disposeDetailHandler!: IReactionDisposer
     componentDidMount(): void {
         this.refresh()
 
@@ -220,6 +288,13 @@ export class ChartEditorPage
                 }
             }
         )
+
+        this.disposeDetailHandler = reaction(
+            () => this.currentlyReferencedDetails,
+            (currentlyReferencedDetails = {}) => {
+                this.grapher.details = currentlyReferencedDetails
+            }
+        )
     }
 
     // This funny construction allows the "new chart" link to work by forcing an update
@@ -230,6 +305,7 @@ export class ChartEditorPage
 
     componentWillUnmount(): void {
         this.dispose()
+        this.disposeDetailHandler()
     }
 
     render(): JSX.Element {

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { action, runInAction } from "mobx"
+import { action, computed, runInAction } from "mobx"
 import { observer } from "mobx-react"
 import { ChartEditor } from "./ChartEditor.js"
 import {
@@ -27,6 +27,7 @@ import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus"
 import { faMinus } from "@fortawesome/free-solid-svg-icons/faMinus"
 import Select from "react-select"
 import { TOPICS_CONTENT_GRAPH } from "../settings/clientSettings.js"
+import { getIndexableKeys } from "../clientUtils/Util.js"
 
 @observer
 export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
@@ -54,6 +55,25 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
     @action.bound onRemoveRelatedQuestion(idx: number) {
         const { grapher } = this.props.editor
         grapher.relatedQuestions.splice(idx, 1)
+    }
+
+    @computed get errorMessages() {
+        const { invalidDetailReferences } = this.props.editor.manager
+        const keys = getIndexableKeys(invalidDetailReferences)
+
+        const errorMessages: Partial<Record<typeof keys[number], string>> = {}
+
+        keys.forEach((key) => {
+            const references = invalidDetailReferences[key]
+            if (references.length) {
+                errorMessages[
+                    key
+                ] = `Invalid detail(s) specified: ${references.map(
+                    (reference) => reference.join("::")
+                )}`
+            }
+        })
+        return errorMessages
     }
 
     render() {
@@ -97,6 +117,7 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                         placeholder="Briefly describe the context of the data. It's best to avoid duplicating any information which can be easily inferred from other visual elements of the chart."
                         textarea
                         softCharacterLimit={280}
+                        errorMessage={this.errorMessages.subtitle}
                     />
                     <RadioGroup
                         label="Logo"
@@ -145,6 +166,7 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                         store={grapher}
                         helpText="Any important clarification needed to avoid miscommunication"
                         softCharacterLimit={140}
+                        errorMessage={this.errorMessages.note}
                     />
                 </Section>
 

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -174,6 +174,9 @@ export class TextAreaField extends React.Component<TextFieldProps> {
                         limit={props.softCharacterLimit}
                     />
                 )}
+                {props.errorMessage && (
+                    <ErrorMessage message={props.errorMessage} />
+                )}
             </div>
         )
     }
@@ -674,9 +677,7 @@ export class BindString extends React.Component<{
     }
 
     render() {
-        const { props } = this
-
-        const { field, store, label, textarea, ...rest } = props
+        const { field, store, label, textarea, ...rest } = this.props
         const value = store[field] as string | undefined
         if (textarea)
             return (

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -1265,3 +1265,7 @@ export function moveArrayItemToIndex<Item>(
     newArray.splice(toIndex, 0, removed)
     return newArray
 }
+
+export const getIndexableKeys = Object.keys as <T extends object>(
+    obj: T
+) => Array<keyof T>

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -48,6 +48,7 @@ import {
     FacetAxisDomain,
     DEFAULT_GRAPHER_WIDTH,
     DEFAULT_GRAPHER_HEIGHT,
+    Detail,
 } from "../core/GrapherConstants.js"
 import { OwidVariablesAndEntityKey } from "../../clientUtils/OwidVariable.js"
 import * as Cookies from "js-cookie"
@@ -310,6 +311,7 @@ export class Grapher
     @observable includedEntities?: number[] = undefined
     @observable comparisonLines: ComparisonLineConfig[] = [] // todo: Persistables?
     @observable relatedQuestions: RelatedQuestionsConfig[] = [] // todo: Persistables?
+    @observable details: Record<string, Record<string, Detail>> = {}
     @observable.ref annotation?: Annotation = undefined
 
     @observable hideFacetControl?: boolean = true
@@ -2239,6 +2241,7 @@ export class Grapher
         this.timelineMinTime = grapher.timelineMinTime
         this.timelineMaxTime = grapher.timelineMaxTime
         this.relatedQuestions = grapher.relatedQuestions
+        this.details = grapher.details
     }
 
     debounceMode = false

--- a/grapher/core/GrapherConstants.ts
+++ b/grapher/core/GrapherConstants.ts
@@ -88,6 +88,14 @@ export interface Topic {
     name: string
 }
 
+export interface Detail {
+    category: string
+    term: string
+    title: string
+    content: string
+    id: number
+}
+
 export const WorldEntityName = "World"
 
 // When a user hovers over a connected series line in a ScatterPlot we show

--- a/grapher/core/GrapherInterface.ts
+++ b/grapher/core/GrapherInterface.ts
@@ -7,6 +7,7 @@ import {
     EntitySelection,
     ChartTypeName,
     FacetStrategy,
+    Detail,
 } from "./GrapherConstants.js"
 import { AxisConfigInterface } from "../axis/AxisConfigInterface.js"
 import { TimeBound } from "../../clientUtils/TimeBounds.js"
@@ -58,6 +59,7 @@ export interface GrapherInterface extends SortConfig {
     tab?: GrapherTabOption
     overlay?: GrapherTabOption
     relatedQuestions?: RelatedQuestionsConfig[]
+    details?: Record<string, Record<string, Detail>>
     internalNotes?: string
     variantName?: string
     originUrl?: string
@@ -176,4 +178,5 @@ export const grapherKeysToSerialize = [
     "comparisonLines",
     "relatedQuestions",
     "topicIds",
+    "details",
 ]


### PR DESCRIPTION
Resolves #1482 

Adds support for the adding Details to our grapher configs.

How it works:
1. fetch all the Details from the DB
2. Watch the `subtitle` and `note` fields for changes, specifically for the inclusion of any text that matches the `hover::category::term` syntax
3. If there's a match, check to see if it corresponds with a Detail defined in the DB
4. Pass all corresponding Details through to Grapher as an object with the shape `Record<string, Record<string, Detail>>`
5. Track the Detail references that _don't_ match, and warn the user

https://user-images.githubusercontent.com/11844404/172952619-a3c59e2e-2fdf-4fc7-9701-2214d72d1b42.mov

