### PR TITLE
fix(import): import fontawesome /index

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -6,11 +6,11 @@
         },
         {
             "path": "./itsJustJavascript/webpack/vendors.js",
-            "maxSize": "900 KB"
+            "maxSize": "850 KB"
         },
         {
             "path": "./itsJustJavascript/webpack/owid.js",
-            "maxSize": "450 KB"
+            "maxSize": "500 KB"
         }
     ],
     "defaultCompression": "none"

--- a/adminSiteClient/GrapherConfigGridEditorTypesAndUtils.tsx
+++ b/adminSiteClient/GrapherConfigGridEditorTypesAndUtils.tsx
@@ -24,7 +24,7 @@ import {
 } from "../clientUtils/SqlFilterSExpression.js"
 import * as React from "react"
 import { IconDefinition } from "@fortawesome/fontawesome-common-types"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 
 import { GrapherInterface } from "../grapher/core/GrapherInterface.js"
 import {

--- a/site/SiteTools.tsx
+++ b/site/SiteTools.tsx
@@ -7,7 +7,7 @@ import {
     NewsletterSubscriptionForm,
     NewsletterSubscriptionContext,
 } from "./NewsletterSubscription.js"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faHandshake } from "@fortawesome/free-solid-svg-icons/faHandshake"
 
 const SITE_TOOLS_CLASS = "site-tools"


### PR DESCRIPTION
This shifts weight from the owid bundle to the vendors bundle (no overall size change).

Not entirely sure whether 
`import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index"`

is preferable to 
`import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"`

but this makes it consistent across imports.

see [#61f84b7](https://github.com/owid/owid-grapher/pull/1492/commits/61f84b757332cdbef46bb21cad41fa3569d953b8)