### PR TITLE
fix: Display data values in DataTable for columns with xOverrideYear

### DIFF
--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -710,7 +710,7 @@ export const es6mapValues = <K, V, M>(
         })
     )
 
-interface DataValue {
+export interface DataValue {
     time: Time | undefined
     value: number | string | undefined
 }

--- a/coreTable/CoreColumnDef.ts
+++ b/coreTable/CoreColumnDef.ts
@@ -70,6 +70,9 @@ export interface CoreColumnDef extends ColumnColorScale {
     retrievedDate?: string
     additionalInfo?: string
 
+    // Informational only
+    targetTime?: number
+
     // For developer internal use only.
     values?: CoreValueType[]
     generator?: () => number // A function for generating synthetic data for testing

--- a/grapher/core/LegacyToOwidTable.test.ts
+++ b/grapher/core/LegacyToOwidTable.test.ts
@@ -307,6 +307,7 @@ describe(legacyToOwidTableAndDimensions, () => {
                 const column = table.get("3-2022")
                 expect(column.valuesIncludingErrorValues).toEqual([21, 21, 21])
                 expect(column.originalTimes).toEqual([2021, 2021, 2021])
+                expect(column.def.targetTime).toEqual(2022)
             })
         })
     })

--- a/grapher/core/LegacyToOwidTable.ts
+++ b/grapher/core/LegacyToOwidTable.ts
@@ -110,6 +110,8 @@ export const legacyToOwidTableAndDimensions = (
                 ...trimObject(dimension.display),
             }
         }
+        if (dimension.targetYear !== undefined)
+            valueColumnDef.targetTime = dimension.targetYear
         columnDefs.set(valueColumnDef.slug, valueColumnDef)
 
         // Annotations column

--- a/grapher/dataTable/DataTable.jsdom.test.tsx
+++ b/grapher/dataTable/DataTable.jsdom.test.tsx
@@ -3,14 +3,13 @@
 import React from "react"
 
 import { DataTable } from "./DataTable.js"
-import { Grapher } from "../core/Grapher.js"
 import { ChartTypeName, GrapherTabOption } from "../core/GrapherConstants.js"
 import {
     childMortalityGrapher,
     IncompleteDataTable,
 } from "./DataTable.sample.js"
 
-import { shallow, ShallowWrapper, mount, ReactWrapper, configure } from "enzyme"
+import { shallow, mount, ReactWrapper, configure } from "enzyme"
 import Adapter from "enzyme-adapter-react-16"
 configure({ adapter: new Adapter() })
 
@@ -109,13 +108,29 @@ describe("when you select a range of years", () => {
 describe("when the table doesn't have data for all rows", () => {
     const grapher = IncompleteDataTable()
     grapher.timelineHandleTimeBounds = [2000, 2000]
-    const view = shallow(<DataTable manager={grapher} />)
+    const view = mount(<DataTable manager={grapher} />)
 
     it("renders no value when data is not available for years within the tolerance", () => {
         expect(view.find("tbody .dimension").at(0).first().text()).toBe("")
     })
 
     it("renders a tolerance notice when data is not from targetYear", () => {
-        expect(view.find(".closest-time-notice-icon").text()).toContain("2001")
+        const toleranceNotices = view.find(".closest-time-notice-icon")
+        expect(toleranceNotices.length).toBe(2)
+        expect(toleranceNotices.at(0).text()).toContain("2001") // first column
+        expect(toleranceNotices.at(1).text()).toContain("2009") // second column
+    })
+
+    it("renders a data value for the column with targetTime 2010", () => {
+        expect(view.find("tbody .dimension").at(1).first().text()).toBe(
+            "20.00%"
+        )
+    })
+
+    it("displays correct targetTime for columns", () => {
+        const timeHeaders = view.find("thead .dimension .time")
+        expect(timeHeaders.length).toBe(2)
+        expect(timeHeaders.at(0).text()).toBe("2000")
+        expect(timeHeaders.at(1).text()).toBe("2010")
     })
 })

--- a/grapher/dataTable/DataTable.sample.ts
+++ b/grapher/dataTable/DataTable.sample.ts
@@ -54,12 +54,23 @@ export const IncompleteDataTable = (
                     isProjection: false,
                 },
             },
+            {
+                variableId: 3512,
+                property: DimensionProperty.x,
+                targetYear: 2010,
+                display: {
+                    name: "Children in 2010",
+                    unit: "% of children under 5",
+                    tolerance: 1,
+                    isProjection: false,
+                },
+            },
         ],
         ...props,
         owidDataset: {
             variables: {
                 "3512": {
-                    years: [2000, 2001, 2010, 2010],
+                    years: [2000, 2001, 2010, 2009],
                     entities: [207, 33, 15, 207],
                     values: [4, 22, 20, 34],
                     id: 3512,

--- a/grapher/dataTable/DataTable.scss
+++ b/grapher/dataTable/DataTable.scss
@@ -172,12 +172,12 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
     .dimension {
         text-align: right;
 
-        .name,
-        .unit {
-            display: block;
+        .divider {
+            opacity: 0.25;
         }
 
-        .unit {
+        .unit,
+        .time {
             font-weight: 700;
             opacity: 0.5;
             padding-bottom: 3px;

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -213,6 +213,8 @@ export class DataTable extends React.Component<{
             const actualColumn = dim.coreTableColumn
             const unit =
                 actualColumn.unit === "%" ? "percent" : dim.coreTableColumn.unit
+            const targetTime =
+                dim.columns.length == 1 ? dim.columns[0].targetTime : undefined
             const columnName =
                 actualColumn.displayName !== ""
                     ? actualColumn.displayName
@@ -220,8 +222,17 @@ export class DataTable extends React.Component<{
 
             const dimensionHeaderText = (
                 <React.Fragment>
-                    <span className="name">{upperFirst(columnName)}</span>
-                    <span className="unit">{unit}</span>
+                    <div className="name">{upperFirst(columnName)}</div>
+                    <div>
+                        <span className="unit">{unit}</span>{" "}
+                        <span className="divider">
+                            {unit && targetTime !== undefined && "•"}
+                        </span>{" "}
+                        <span className="time">
+                            {targetTime !== undefined &&
+                                actualColumn.table.formatTime(targetTime)}
+                        </span>
+                    </div>
                 </React.Fragment>
             )
 

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -457,6 +457,7 @@ export class DataTable extends React.Component<{
         return this.table.columnsAsArray.filter(
             (column) =>
                 !skips.has(column.slug) &&
+                !column.slug.endsWith("-originalTime") &&
                 //  dim.property !== "color" &&
                 (column.display?.includeInTable ?? true)
         )

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -503,7 +503,12 @@ export class DataTable extends React.Component<{
 
     @computed get columnsWithValues(): Dimension[] {
         return this.columnsToShow.map((sourceColumn) => {
-            const targetTimes = this.targetTimes ?? [sourceColumn.maxTime]
+            let targetTimes: number[]
+            if (sourceColumn.def.targetTime !== undefined)
+                targetTimes = [sourceColumn.def.targetTime]
+            else if (this.targetTimes !== undefined)
+                targetTimes = this.targetTimes
+            else targetTimes = [sourceColumn.maxTime]
 
             const targetTimeMode =
                 targetTimes.length < 2

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -230,7 +230,9 @@ export class DataTable extends React.Component<{
                         </span>{" "}
                         <span className="time">
                             {targetTime !== undefined &&
-                                actualColumn.table.formatTime(targetTime)}
+                                actualColumn.originalTimeColumn.formatValue(
+                                    targetTime
+                                )}
                         </span>
                     </div>
                 </React.Fragment>
@@ -262,7 +264,9 @@ export class DataTable extends React.Component<{
             dim.columns.map((column, i) => {
                 const headerText = isDeltaColumn(column.key)
                     ? columnNameByType[column.key]
-                    : dim.coreTableColumn.table.formatTime(column.targetTime!)
+                    : dim.coreTableColumn.originalTimeColumn.formatValue(
+                          column.targetTime!
+                      )
                 return (
                     <ColumnHeader
                         key={column.key}
@@ -335,8 +339,10 @@ export class DataTable extends React.Component<{
             >
                 {shouldShowClosestTimeNotice &&
                     makeClosestTimeNotice(
-                        actualColumn.table.formatTime(column.targetTime!),
-                        actualColumn.table.formatTime(value.time!) // todo: add back format: "MMM D",
+                        actualColumn.originalTimeColumn.formatValue(
+                            column.targetTime!
+                        ),
+                        actualColumn.originalTimeColumn.formatValue(value.time!) // todo: add back format: "MMM D",
                     )}
                 <span>{value.displayValue}</span>
             </td>

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -22,6 +22,7 @@ import {
     countBy,
     union,
     exposeInstanceOnWindow,
+    DataValue,
 } from "../../clientUtils/Util.js"
 import { SortIcon } from "../controls/SortIcon.js"
 import { Tippy } from "../chart/Tippy.js"
@@ -500,7 +501,6 @@ export class DataTable extends React.Component<{
         return [endTime]
     }
 
-    // todo: this function should be refactored. It's about 5x-10x too long. I'm currently getting an undefined value but it's very hard to figure out where.
     @computed get columnsWithValues(): Dimension[] {
         return this.columnsToShow.map((sourceColumn) => {
             const targetTimes = this.targetTimes ?? [sourceColumn.maxTime]
@@ -510,136 +510,165 @@ export class DataTable extends React.Component<{
                     ? TargetTimeMode.point
                     : TargetTimeMode.range
 
-            const prelimValuesByEntity =
-                targetTimeMode === TargetTimeMode.range
-                    ? // In the "range" mode, we receive all data values within the range. But we
-                      // only want to plot the start & end values in the table.
-                      // getStartEndValues() extracts these two values.
-                      es6mapValues(
-                          valuesByEntityWithinTimes(
-                              sourceColumn.valueByEntityNameAndOriginalTime,
-                              targetTimes
-                          ),
-                          getStartEndValues
-                      )
-                    : valuesByEntityAtTimes(
-                          sourceColumn.valueByEntityNameAndOriginalTime,
-                          targetTimes,
-                          sourceColumn.tolerance
-                      )
+            const prelimValuesByEntity = this.preliminaryDimensionValues(
+                targetTimeMode,
+                sourceColumn,
+                targetTimes
+            )
 
-            const isRange = targetTimes.length === 2
+            const valueByEntity = this.dataValuesFromPreliminaryValues(
+                prelimValuesByEntity,
+                targetTimeMode,
+                sourceColumn
+            )
 
-            // Inject delta columns if we have start & end values to compare in the table.
-            // One column for absolute difference, another for % difference.
-            const deltaColumns: DimensionColumn[] = []
-            if (isRange) {
-                const tableDisplay = {} as any
-                if (!tableDisplay?.hideAbsoluteChange)
-                    deltaColumns.push({ key: RangeValueKey.delta })
-                if (!tableDisplay?.hideRelativeChange)
-                    deltaColumns.push({ key: RangeValueKey.deltaRatio })
-            }
-
-            const columns: DimensionColumn[] = [
-                ...targetTimes.map((targetTime, index) => ({
-                    key: isRange
-                        ? index === 0
-                            ? RangeValueKey.start
-                            : RangeValueKey.end
-                        : SingleValueKey.single,
-                    targetTime,
-                    targetTimeMode,
-                })),
-                ...deltaColumns,
-            ]
-
-            const valueByEntity = es6mapValues(prelimValuesByEntity, (dvs) => {
-                // There is always a column, but not always a data value (in the delta column the
-                // value needs to be calculated)
-                if (isRange) {
-                    const [start, end]: (Value | undefined)[] = dvs
-                    const result: RangeValue = {
-                        start: {
-                            ...start,
-                            displayValue: this.formatValue(
-                                sourceColumn,
-                                start?.value
-                            ),
-                        },
-                        end: {
-                            ...end,
-                            displayValue: this.formatValue(
-                                sourceColumn,
-                                end?.value
-                            ),
-                        },
-                        delta: undefined,
-                        deltaRatio: undefined,
-                    }
-
-                    if (
-                        start !== undefined &&
-                        end !== undefined &&
-                        typeof start.value === "number" &&
-                        typeof end.value === "number"
-                    ) {
-                        const deltaValue = end.value - start.value
-                        const deltaRatioValue =
-                            deltaValue / Math.abs(start.value)
-
-                        result.delta = {
-                            value: deltaValue,
-                            displayValue: this.formatValue(
-                                sourceColumn,
-                                deltaValue,
-                                {
-                                    showPlus: true,
-                                    unit:
-                                        sourceColumn.shortUnit === "%"
-                                            ? "pp"
-                                            : sourceColumn.shortUnit,
-                                }
-                            ),
-                        }
-
-                        result.deltaRatio = {
-                            value: deltaRatioValue,
-                            displayValue:
-                                isFinite(deltaRatioValue) &&
-                                !isNaN(deltaRatioValue)
-                                    ? this.formatValue(
-                                          sourceColumn,
-                                          deltaRatioValue * 100,
-                                          {
-                                              unit: "%",
-                                              numDecimalPlaces: 0,
-                                              showPlus: true,
-                                          }
-                                      )
-                                    : undefined,
-                        }
-                    }
-                    return result
-                } else {
-                    // if single time
-                    const dv = dvs[0]
-                    const result: SingleValue = {
-                        single: { ...dv },
-                    }
-                    if (dv !== undefined)
-                        result.single!.displayValue = this.formatValue(
-                            sourceColumn,
-                            dv.value
-                        )
-                    return result
-                }
-            })
+            const columns: DimensionColumn[] = this.dimensionColumns(
+                targetTimes,
+                targetTimeMode
+            )
 
             return {
                 columns,
                 valueByEntity,
                 sourceColumn,
+            }
+        })
+    }
+
+    private dimensionColumns(
+        targetTimes: number[],
+        targetTimeMode: TargetTimeMode
+    ): DimensionColumn[] {
+        // Inject delta columns if we have start & end values to compare in the table.
+        // One column for absolute difference, another for % difference.
+        const deltaColumns: DimensionColumn[] = []
+        if (targetTimeMode === TargetTimeMode.range) {
+            const tableDisplay = {} as any
+            if (!tableDisplay?.hideAbsoluteChange)
+                deltaColumns.push({ key: RangeValueKey.delta })
+            if (!tableDisplay?.hideRelativeChange)
+                deltaColumns.push({ key: RangeValueKey.deltaRatio })
+        }
+
+        const valueColumns = targetTimes.map((targetTime, index) => ({
+            key:
+                targetTimeMode === TargetTimeMode.range
+                    ? index === 0
+                        ? RangeValueKey.start
+                        : RangeValueKey.end
+                    : SingleValueKey.single,
+            targetTime,
+            targetTimeMode,
+        }))
+        return [...valueColumns, ...deltaColumns]
+    }
+
+    private preliminaryDimensionValues(
+        targetTimeMode: TargetTimeMode,
+        sourceColumn: CoreColumn,
+        targetTimes: number[]
+    ): Map<string, (DataValue | undefined)[]> {
+        return targetTimeMode === TargetTimeMode.range
+            ? // In the "range" mode, we receive all data values within the range. But we
+
+              // only want to plot the start & end values in the table.
+              // getStartEndValues() extracts these two values.
+              es6mapValues(
+                  valuesByEntityWithinTimes(
+                      sourceColumn.valueByEntityNameAndOriginalTime,
+                      targetTimes
+                  ),
+                  getStartEndValues
+              )
+            : valuesByEntityAtTimes(
+                  sourceColumn.valueByEntityNameAndOriginalTime,
+                  targetTimes,
+                  sourceColumn.tolerance
+              )
+    }
+
+    private dataValuesFromPreliminaryValues(
+        prelimValuesByEntity: Map<string, (DataValue | undefined)[]>,
+        targetTimeMode: TargetTimeMode,
+        sourceColumn: CoreColumn
+    ): Map<string, DimensionValue> {
+        return es6mapValues(prelimValuesByEntity, (dvs) => {
+            // There is always a column, but not always a data value (in the delta column the
+            // value needs to be calculated)
+            if (targetTimeMode === TargetTimeMode.range) {
+                const [start, end]: (Value | undefined)[] = dvs
+                const result: RangeValue = {
+                    start: {
+                        ...start,
+                        displayValue: this.formatValue(
+                            sourceColumn,
+                            start?.value
+                        ),
+                    },
+                    end: {
+                        ...end,
+                        displayValue: this.formatValue(
+                            sourceColumn,
+                            end?.value
+                        ),
+                    },
+                    delta: undefined,
+                    deltaRatio: undefined,
+                }
+
+                if (
+                    start !== undefined &&
+                    end !== undefined &&
+                    typeof start.value === "number" &&
+                    typeof end.value === "number"
+                ) {
+                    const deltaValue = end.value - start.value
+                    const deltaRatioValue = deltaValue / Math.abs(start.value)
+
+                    result.delta = {
+                        value: deltaValue,
+                        displayValue: this.formatValue(
+                            sourceColumn,
+                            deltaValue,
+                            {
+                                showPlus: true,
+                                unit:
+                                    sourceColumn.shortUnit === "%"
+                                        ? "pp"
+                                        : sourceColumn.shortUnit,
+                            }
+                        ),
+                    }
+
+                    result.deltaRatio = {
+                        value: deltaRatioValue,
+                        displayValue:
+                            isFinite(deltaRatioValue) && !isNaN(deltaRatioValue)
+                                ? this.formatValue(
+                                      sourceColumn,
+                                      deltaRatioValue * 100,
+                                      {
+                                          unit: "%",
+                                          numDecimalPlaces: 0,
+                                          showPlus: true,
+                                      }
+                                  )
+                                : undefined,
+                    }
+                }
+                return result
+            } else {
+                // if single time
+                const dv = dvs[0]
+                const result: SingleValue = {
+                    single: { ...dv },
+                }
+                if (dv !== undefined)
+                    result.single!.displayValue = this.formatValue(
+                        sourceColumn,
+                        dv.value
+                    )
+                return result
             }
         })
     }


### PR DESCRIPTION
Fixes #1274 | Live on tufte: [One](https://tufte-owid.netlify.app/grapher/smoking-death-rate-1990-2017?tab=table), [Two](https://tufte-owid.netlify.app/grapher/tests-of-covid-19-per-thousand-people-vs-gdp-per-capita?tab=table)

Data tables didn't show these values because they were assuming the `targetTimes` to be the same for every column, and didn't take into account that the `targetTime` can be overriden for some columns.

There's also a slight visual change in the table tab, which is that the `targetTime` is now displayed as part of the column header.
In some cases it is redundant, but it is crucial in many cases. It's always displayed when the timeline is set to a single year.

![image](https://user-images.githubusercontent.com/2641501/173881514-cfa9a734-14bd-4cf0-a2d4-1a15fb4e59ef.png)

---

### Review notes

9b4ca4a0c9c1f5dfe5a66559c00dd537905d90ae is a refactoring of the `columnsWithValues` method, which was massive.
I did nothing else but to split it up into a few methods. Logically everything is exactly the same.

You can review more easily using 9b4ca4a...e4451ac1ad96e008462e94971ebb49656f7626a5