### PR TITLE
refactor: move `formatTime` method from table-level to column-level

### DIFF
--- a/coreTable/CoreTable.ts
+++ b/coreTable/CoreTable.ts
@@ -463,18 +463,6 @@ export class CoreTable<
         return this.entityNameColumn.slug
     }
 
-    // Todo: remove this. Generally this should not be called until the data is loaded. Even then, all calls should probably be made
-    // on the column itself, and not tied tightly to the idea of a time column.
-    @imemo get timeColumnFormatFunction(): (year: number) => string {
-        return !this.timeColumn.isMissing
-            ? this.timeColumn.formatValue
-            : formatYear
-    }
-
-    formatTime(value: any): string {
-        return this.timeColumnFormatFunction(value)
-    }
-
     @imemo private get columnsWithParseErrors(): CoreColumn[] {
         return this.columnsAsArray.filter((col) => col.numErrorValues)
     }

--- a/coreTable/CoreTableColumns.ts
+++ b/coreTable/CoreTableColumns.ts
@@ -194,6 +194,10 @@ export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
         return csvEscape(anyToString(value))
     }
 
+    formatTime(time: number): string {
+        return this.originalTimeColumn.formatValue(time)
+    }
+
     @imemo get numDecimalPlaces(): number {
         return this.display?.numDecimalPlaces ?? 2
     }
@@ -683,6 +687,10 @@ export abstract class TimeColumn extends AbstractCoreColumn<number> {
     jsType = JsTypes.number
 
     abstract preposition: string
+
+    formatTime(time: number): string {
+        return this.formatValue(time)
+    }
 
     parse(val: any): number | ErrorValue {
         return parseInt(val)

--- a/grapher/barCharts/DiscreteBarChart.tsx
+++ b/grapher/barCharts/DiscreteBarChart.tsx
@@ -504,9 +504,7 @@ export class DiscreteBarChart
         return {
             valueString: displayValue,
             timeString: showYearLabels
-                ? ` ${preposition} ${transformedTable.timeColumnFormatFunction(
-                      series.time
-                  )}`
+                ? ` ${preposition} ${column.formatTime(series.time)}`
                 : "",
         }
     }

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1710,7 +1710,7 @@ export class Grapher
     }
 
     formatTimeFn(time: Time): string {
-        return this.inputTable.timeColumnFormatFunction(time)
+        return this.inputTable.timeColumn.formatTime(time)
     }
 
     @action.bound private toggleTabCommand(): void {
@@ -2395,8 +2395,6 @@ export class Grapher
 
     formatTime(value: Time): string {
         const timeColumn = this.table.timeColumn
-        if (timeColumn.isMissing)
-            return this.table.timeColumnFormatFunction(value)
         return isMobile()
             ? timeColumn.formatValueForMobile(value)
             : timeColumn.formatValue(value)

--- a/grapher/dataTable/DataTable.tsx
+++ b/grapher/dataTable/DataTable.tsx
@@ -230,9 +230,7 @@ export class DataTable extends React.Component<{
                         </span>{" "}
                         <span className="time">
                             {targetTime !== undefined &&
-                                actualColumn.originalTimeColumn.formatValue(
-                                    targetTime
-                                )}
+                                actualColumn.formatTime(targetTime)}
                         </span>
                     </div>
                 </React.Fragment>
@@ -264,9 +262,7 @@ export class DataTable extends React.Component<{
             dim.columns.map((column, i) => {
                 const headerText = isDeltaColumn(column.key)
                     ? columnNameByType[column.key]
-                    : dim.coreTableColumn.originalTimeColumn.formatValue(
-                          column.targetTime!
-                      )
+                    : dim.coreTableColumn.formatTime(column.targetTime!)
                 return (
                     <ColumnHeader
                         key={column.key}
@@ -339,10 +335,8 @@ export class DataTable extends React.Component<{
             >
                 {shouldShowClosestTimeNotice &&
                     makeClosestTimeNotice(
-                        actualColumn.originalTimeColumn.formatValue(
-                            column.targetTime!
-                        ),
-                        actualColumn.originalTimeColumn.formatValue(value.time!) // todo: add back format: "MMM D",
+                        actualColumn.formatTime(column.targetTime!),
+                        actualColumn.formatTime(value.time!) // todo: add back format: "MMM D",
                     )}
                 <span>{value.displayValue}</span>
             </td>

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -458,7 +458,7 @@ export class LineChart
             return value !== undefined ? -value.y : Infinity
         })
 
-        const formatted = inputTable.timeColumnFormatFunction(activeX)
+        const formatted = formatColumn.formatTime(activeX)
 
         return (
             <Tooltip

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -392,13 +392,13 @@ export class ScatterPlotChart
     }
 
     @computed get displayStartTime(): string {
-        return this.transformedTable.timeColumnFormatFunction(
+        return this.transformedTable.timeColumn.formatTime(
             this.transformedTable.minTime ?? 1900
         )
     }
 
     @computed get displayEndTime(): string {
-        return this.transformedTable.timeColumnFormatFunction(
+        return this.transformedTable.timeColumn.formatTime(
             this.transformedTable.maxTime ?? 2000
         )
     }
@@ -945,7 +945,7 @@ export class ScatterPlotChart
         } else if (strat === ScatterPointLabelStrategy.x) {
             label = this.xColumn?.formatValue(row[this.xColumnSlug])
         } else {
-            label = this.transformedTable.timeColumnFormatFunction(
+            label = this.transformedTable.timeColumn.formatTime(
                 row[this.transformedTable.timeColumn.slug]
             )
         }

--- a/grapher/scatterCharts/ScatterTooltip.tsx
+++ b/grapher/scatterCharts/ScatterTooltip.tsx
@@ -16,9 +16,7 @@ export class ScatterTooltip extends React.Component<ScatterTooltipProps> {
     formatValueX(value: SeriesPoint): string {
         let s = `X Axis: ${this.props.xColumn.formatValueLong(value.x)}`
         if (!value.time.span && value.time.y !== value.time.x)
-            s += ` (data from ${this.props.xColumn.originalTimeColumn.formatValue(
-                value.time.x
-            )})`
+            s += ` (data from ${this.props.xColumn.formatTime(value.time.x)})`
         return s
     }
 
@@ -55,12 +53,10 @@ export class ScatterTooltip extends React.Component<ScatterTooltipProps> {
                     maxWidth: maxWidth,
                     fontSize: 0.65 * fontSize,
                     text: v.time.span
-                        ? `${yColumn.table.formatTime(
+                        ? `${yColumn.formatTime(
                               v.time.span[0]
-                          )} to ${yColumn.originalTimeColumn.formatValue(
-                              v.time.span[1]
-                          )}`
-                        : yColumn.originalTimeColumn.formatValue(v.time.y),
+                          )} to ${yColumn.formatTime(v.time.span[1])}`
+                        : yColumn.formatTime(v.time.y),
                 }),
             }
             offset += year.wrap.height

--- a/grapher/sourcesTab/SourcesTab.tsx
+++ b/grapher/sourcesTab/SourcesTab.tsx
@@ -31,7 +31,7 @@ export class SourcesTab extends React.Component<{
     }
 
     private renderSource(column: CoreColumn): JSX.Element {
-        const { table, slug, source, def } = column
+        const { slug, source, def } = column
         const { datasetId, coverage } = def as OwidColumnDef
 
         const editUrl = this.manager.showAdminControls
@@ -41,9 +41,9 @@ export class SourcesTab extends React.Component<{
         const { minTime, maxTime } = column
         let timespan = ""
         if (minTime !== undefined && maxTime !== undefined)
-            timespan = `${table.timeColumn?.formatValue(
-                minTime
-            )} – ${table.timeColumn?.formatValue(maxTime)}`
+            timespan = `${column.formatTime(minTime)} – ${column.formatTime(
+                maxTime
+            )}`
 
         return (
             <div key={slug} className="datasource-wrapper">

--- a/grapher/stackedCharts/StackedAreaChart.tsx
+++ b/grapher/stackedCharts/StackedAreaChart.tsx
@@ -353,7 +353,7 @@ export class StackedAreaChart
                         <tr>
                             <td>
                                 <strong>
-                                    {this.inputTable.timeColumnFormatFunction(
+                                    {yColumn.formatTime(
                                         bottomSeriesPoint.position
                                     )}
                                 </strong>

--- a/grapher/stackedCharts/StackedBarChart.tsx
+++ b/grapher/stackedCharts/StackedBarChart.tsx
@@ -251,9 +251,7 @@ export class StackedBarChart
                         <tr>
                             <td colSpan={3}>
                                 <strong>
-                                    {inputTable.timeColumnFormatFunction(
-                                        hoverBar.position
-                                    )}
+                                    {yColumn.formatTime(hoverBar.position)}
                                 </strong>
                             </td>
                         </tr>


### PR DESCRIPTION
[As discussed on Slack](https://owid.slack.com/archives/CQQUA2C2U/p1655316054237859)


Different columns can have different time units, and so it makes sense to move the handling of time all the way to the column level.
There is still a `table.timeColumn`, which can be used to format axis labels, for example.