### PR TITLE
Decouple grapher and explorer page styles

### DIFF
--- a/explorer/Explorer.scss
+++ b/explorer/Explorer.scss
@@ -5,6 +5,11 @@ $explorer-min-width-first-col: 200px;
 $explorer-padding: 0.5rem;
 
 #ExplorerContainer {
+    @include content-wrapper;
+    @include lg-up {
+        max-width: $text-max-content-width + $graph-max-content-width + 3 *
+            $padding-x-md;
+    }
     min-height: $placeholder-height;
     width: 100%;
     position: relative;
@@ -82,7 +87,6 @@ html.IsInIframe .ExplorerFigure,
     margin: 0 auto;
     padding-top: $explorer-grid-gap;
     width: 100%;
-    max-width: $max-width-covid-data-explorer;
     height: 90vh;
     max-height: 900px;
     min-height: 480px;

--- a/explorer/Explorer.scss
+++ b/explorer/Explorer.scss
@@ -67,6 +67,15 @@ html.IsInIframe #ExplorerContainer {
     }
 }
 
+html.IsInIframe .StandaloneExplorerPage {
+    background-color: inherit;
+
+    @include hide-site-chrome;
+    .explorerContentContainer {
+        display: none;
+    }
+}
+
 html.IsInIframe .Explorer,
 .Explorer.is-embed {
     height: 100%;

--- a/explorer/ExplorerConstants.ts
+++ b/explorer/ExplorerConstants.ts
@@ -60,6 +60,8 @@ export const EMBEDDED_EXPLORER_GRAPHER_CONFIGS =
 
 export const EXPLORER_EMBEDDED_FIGURE_SELECTOR = "data-explorer-src"
 
+export const EXPLORER_PAGE_BODY_CLASS = "StandaloneExplorerPage"
+
 export const ExplorerContainerId = "ExplorerContainer"
 
 export const GetAllExplorersRoute = "allExplorers.json"

--- a/grapher/controls/ShareMenu.scss
+++ b/grapher/controls/ShareMenu.scss
@@ -64,6 +64,8 @@ $zindex-embedMenu: 12;
     top: 5%;
     width: 90%;
     height: 90%;
+    display: flex;
+    flex-direction: column;
     border: 1px solid #e0e0e0;
     box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.12), 0 2px 2px 0 rgba(0, 0, 0, 0.24);
     background: rgba(255, 255, 255, 0.95);
@@ -73,13 +75,12 @@ $zindex-embedMenu: 12;
 }
 
 .embedMenu p {
-    margin-bottom: 0;
     margin-bottom: 0.5em;
 }
 
 .embedMenu textarea {
     width: 100%;
-    height: 80%;
+    flex: 1;
 }
 
 .GrapherComponent.mobile .ShareMenu .btn-embed {

--- a/grapher/core/GrapherConstants.ts
+++ b/grapher/core/GrapherConstants.ts
@@ -16,7 +16,7 @@ export enum ChartTypeName {
 
 export const GRAPHER_EMBEDDED_FIGURE_ATTR = "data-grapher-src"
 
-export const GRAPHER_PAGE_BODY_CLASS = "StandaloneGrapherOrExplorerPage"
+export const GRAPHER_PAGE_BODY_CLASS = "StandaloneGrapherPage"
 
 export const GRAPHER_IS_IN_IFRAME_CLASS = "IsInIframe"
 

--- a/site/ExplorerPage.tsx
+++ b/site/ExplorerPage.tsx
@@ -96,7 +96,7 @@ window.Explorer.renderSingleExplorerOnExplorerPage(explorerProgram, grapherConfi
                     <LoadingIndicator />
                 </main>
                 {wpContent && <ExplorerContent content={wpContent} />}
-                <SiteFooter baseUrl={baseUrl} />
+                <SiteFooter shouldEmbedCharts={false} baseUrl={baseUrl} />
                 <script dangerouslySetInnerHTML={{ __html: inlineJs }} />
             </body>
         </html>

--- a/site/ExplorerPage.tsx
+++ b/site/ExplorerPage.tsx
@@ -9,11 +9,11 @@ import {
     EMBEDDED_EXPLORER_GRAPHER_CONFIGS,
     EMBEDDED_EXPLORER_DELIMITER,
     ExplorerContainerId,
+    EXPLORER_PAGE_BODY_CLASS,
 } from "../explorer/ExplorerConstants.js"
 import { ExplorerProgram } from "../explorer/ExplorerProgram.js"
 import { GrapherInterface } from "../grapher/core/GrapherInterface.js"
 import { serializeJSONForHTML } from "../clientUtils/serializers.js"
-import { GRAPHER_PAGE_BODY_CLASS } from "../grapher/core/GrapherConstants.js"
 import { ExplorerPageUrlMigrationSpec } from "../explorer/urlMigrations/ExplorerPageUrlMigrationSpec.js"
 
 interface ExplorerPageSettings {
@@ -86,7 +86,7 @@ window.Explorer.renderSingleExplorerOnExplorerPage(explorerProgram, grapherConfi
             >
                 <IFrameDetector />
             </Head>
-            <body className={GRAPHER_PAGE_BODY_CLASS}>
+            <body className={EXPLORER_PAGE_BODY_CLASS}>
                 <SiteHeader
                     baseUrl={baseUrl}
                     hideAlertBanner={hideAlertBanner || false}

--- a/site/GrapherPage.tsx
+++ b/site/GrapherPage.tsx
@@ -119,7 +119,7 @@ window.Grapher.renderSingleGrapherOnGrapherPage(jsonConfig)`
                         </div>
                     )}
                 </main>
-                <SiteFooter baseUrl={baseUrl} />
+                <SiteFooter shouldEmbedCharts={false} baseUrl={baseUrl} />
                 <script dangerouslySetInnerHTML={{ __html: script }} />
             </body>
         </html>

--- a/site/SiteFooter.tsx
+++ b/site/SiteFooter.tsx
@@ -3,14 +3,19 @@ import { webpackUrl } from "../site/webpackUtils.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faAngleRight } from "@fortawesome/free-solid-svg-icons/faAngleRight"
 
-interface SiteFooterProps {
-    hideDonate?: boolean
+export interface SiteFooterProps {
     baseUrl: string
+    hideDonate?: boolean
+    shouldEmbedCharts?: boolean
 }
 
-export const SiteFooter = (props: SiteFooterProps) => (
+export const SiteFooter = ({
+    baseUrl,
+    hideDonate = false,
+    shouldEmbedCharts = true,
+}: SiteFooterProps) => (
     <>
-        {!props.hideDonate && (
+        {!hideDonate && (
             <section className="donate-footer">
                 <div className="wrapper">
                     <div className="owid-row flex-align-center">
@@ -178,7 +183,7 @@ export const SiteFooter = (props: SiteFooterProps) => (
                                 data-track-note="footer-navigation"
                             >
                                 <img
-                                    src={`${props.baseUrl}/oms-logo.svg`}
+                                    src={`${baseUrl}/oms-logo.svg`}
                                     alt="Oxford Martin School logo"
                                     loading="lazy"
                                 />
@@ -189,7 +194,7 @@ export const SiteFooter = (props: SiteFooterProps) => (
                                 data-track-note="footer-navigation"
                             >
                                 <img
-                                    src={`${props.baseUrl}/yc-logo.png`}
+                                    src={`${baseUrl}/yc-logo.png`}
                                     alt="Y Combinator logo"
                                     loading="lazy"
                                 />
@@ -238,7 +243,7 @@ export const SiteFooter = (props: SiteFooterProps) => (
                                     data-track-note="footer-navigation"
                                 >
                                     <img
-                                        src={`${props.baseUrl}/gcdl-logo.svg`}
+                                        src={`${baseUrl}/gcdl-logo.svg`}
                                         alt="Global Change Data Lab logo"
                                         loading="lazy"
                                     />
@@ -257,12 +262,15 @@ export const SiteFooter = (props: SiteFooterProps) => (
             </div>
             <div className="site-tools" />
             <script src="https://polyfill.io/v3/polyfill.min.js?features=es6,fetch,URL,IntersectionObserver,IntersectionObserverEntry" />
-            <script src={webpackUrl("commons.js", props.baseUrl)} />
-            <script src={webpackUrl("vendors.js", props.baseUrl)} />
-            <script src={webpackUrl("owid.js", props.baseUrl)} />
+            <script src={webpackUrl("commons.js", baseUrl)} />
+            <script src={webpackUrl("vendors.js", baseUrl)} />
+            <script src={webpackUrl("owid.js", baseUrl)} />
             <script
                 dangerouslySetInnerHTML={{
-                    __html: `window.runSiteFooterScripts()`, // todo: gotta be a better way.
+                    __html: `window.runSiteFooterScripts(${JSON.stringify({
+                        baseUrl,
+                        shouldEmbedCharts,
+                    })})`, // todo: gotta be a better way.
                 }}
             />
         </footer>

--- a/site/css/chart.scss
+++ b/site/css/chart.scss
@@ -1,6 +1,6 @@
 @use "sass:math";
 
-.StandaloneGrapherOrExplorerPage main figure[data-grapher-src],
+.StandaloneGrapherPage main figure[data-grapher-src],
 #fallback {
     display: flex;
     align-items: center;
@@ -63,7 +63,7 @@
     border: 1px solid #ccc;
 }
 
-.StandaloneGrapherOrExplorerPage main {
+.StandaloneGrapherPage main {
     .related-research-data {
         @include block-spacing;
         margin-top: $vertical-spacing;
@@ -90,7 +90,7 @@
     }
 }
 
-html.IsInIframe .StandaloneGrapherOrExplorerPage {
+html.IsInIframe .StandaloneGrapherPage {
     background-color: inherit;
 
     > main {
@@ -105,14 +105,8 @@ html.IsInIframe .StandaloneGrapherOrExplorerPage {
         max-width: none;
     }
 
-    .site-header,
-    .alert-banner,
-    .offset-subnavigation,
-    .donate-footer,
-    .cookie-notice,
-    .site-footer,
-    .related-research-data,
-    .explorerContentContainer {
+    @include hide-site-chrome;
+    .related-research-data {
         display: none;
     }
 }

--- a/site/css/chart.scss
+++ b/site/css/chart.scss
@@ -63,12 +63,6 @@
     border: 1px solid #ccc;
 }
 
-.StandaloneGrapherOrExplorerPage .site-subnavigation {
-    padding-left: 1rem;
-    margin: 0 auto;
-    max-width: $max-width-covid-data-explorer;
-}
-
 .StandaloneGrapherOrExplorerPage main {
     .related-research-data {
         @include block-spacing;

--- a/site/css/header.scss
+++ b/site/css/header.scss
@@ -170,10 +170,16 @@
 }
 
 .site-subnavigation {
+    @include content-wrapper;
+    @include lg-up {
+        max-width: $text-max-content-width + $graph-max-content-width + 3 *
+            $padding-x-md;
+    }
     color: $primary-color;
     position: relative;
 
     @include sm-only {
+        padding-right: 0;
         &::before {
             content: "";
             position: absolute;

--- a/site/css/mixins.scss
+++ b/site/css/mixins.scss
@@ -254,3 +254,14 @@
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
     opacity: 0.9;
 }
+
+@mixin hide-site-chrome {
+    .site-header,
+    .alert-banner,
+    .offset-subnavigation,
+    .donate-footer,
+    .cookie-notice,
+    .site-footer {
+        display: none;
+    }
+}

--- a/site/css/page.scss
+++ b/site/css/page.scss
@@ -5,17 +5,11 @@
     }
 
     .content-and-footnotes,
-    .article-header,
-    .site-subnavigation {
+    .article-header {
         @include content-wrapper;
         @include lg-up {
             max-width: $text-max-content-width + $graph-max-content-width + 3 *
                 $padding-x-md;
-        }
-    }
-    @include sm-only {
-        .site-subnavigation {
-            padding-right: 0;
         }
     }
 

--- a/site/owid.entry.ts
+++ b/site/owid.entry.ts
@@ -23,15 +23,8 @@ import { runSiteTools } from "./SiteTools.js"
 import { runCovid } from "./covid/index.js"
 import { runFootnotes } from "./Footnote.js"
 import { Explorer } from "../explorer/Explorer.js"
-import {
-    BAKED_BASE_URL,
-    ENV,
-    BUGSNAG_API_KEY,
-} from "../settings/clientSettings.js"
-import {
-    CookieKey,
-    GRAPHER_PAGE_BODY_CLASS,
-} from "../grapher/core/GrapherConstants.js"
+import { ENV, BUGSNAG_API_KEY } from "../settings/clientSettings.js"
+import { CookieKey } from "../grapher/core/GrapherConstants.js"
 import { Grapher } from "../grapher/core/Grapher.js"
 import { MultiEmbedderSingleton } from "../site/multiembedder/MultiEmbedder.js"
 import { CoreTable } from "../coreTable/CoreTable.js"
@@ -40,6 +33,7 @@ import { hydrateProminentLink } from "./blocks/ProminentLink.js"
 import Bugsnag from "@bugsnag/js"
 import BugsnagPluginReact from "@bugsnag/plugin-react"
 import { runMonkeyPatchForGoogleTranslate } from "./hacks.js"
+import { SiteFooterProps } from "./SiteFooter.js"
 
 declare let window: any
 window.Grapher = Grapher
@@ -57,15 +51,18 @@ window.runRelatedCharts = runRelatedCharts
 window.MultiEmbedderSingleton = MultiEmbedderSingleton
 
 // Note: do a text search of the project for "runSiteFooterScripts" to find the usage. todo: clean that up.
-window.runSiteFooterScripts = () => {
-    runHeaderMenus(BAKED_BASE_URL)
+window.runSiteFooterScripts = ({
+    baseUrl,
+    shouldEmbedCharts,
+}: SiteFooterProps) => {
+    runHeaderMenus(baseUrl)
     runBlocks()
     runLightbox()
     runSiteTools()
     runCookiePreferencesManager()
     runCovid()
     runFootnotes()
-    if (!document.querySelector(`.${GRAPHER_PAGE_BODY_CLASS}`)) {
+    if (shouldEmbedCharts) {
         MultiEmbedderSingleton.setUpGlobalEntitySelectorForEmbeds()
         MultiEmbedderSingleton.embedAll()
         hydrateProminentLink(MultiEmbedderSingleton.selection)


### PR DESCRIPTION
This consists of preparatory work for #1447.

Given this touches external embeds styles, it made sense to review separately.

The most visible change is explorers going full content width on explorer pages (previously constrained to an arbitrary number). This brings consistency and allows subnavigation styles to be used in their generic form across all pages: wordpress, grapher and explorers.

https://user-images.githubusercontent.com/13406362/175066803-46af7fa2-5f35-46d1-b0d8-5799fad1463f.mp4




