### PR TITLE
chore: Pin the id of the dev user to 1

### DIFF
--- a/db/exportMetadata.ts
+++ b/db/exportMetadata.ts
@@ -58,7 +58,7 @@ async function dataExport(): Promise<void> {
         // Add default admin user
         await fs.appendFile(
             filePath,
-            "INSERT INTO users (`password`, `isSuperuser`, `email`, `fullName`, `createdAt`, `updatedAt`, `isActive`) VALUES ('bcrypt$$2b$12$EXfM7cWsjlNchpinv.j6KuOwK92hihg5r3fNssty8tLCUpOubST9u', 1, 'admin@example.com', 'Admin User', '2016-01-01 00:00:00', '2016-01-01 00:00:00', 1);\n"
+            "INSERT INTO users (`id`, `password`, `isSuperuser`, `email`, `fullName`, `createdAt`, `updatedAt`, `isActive`) VALUES (1, 'bcrypt$$2b$12$EXfM7cWsjlNchpinv.j6KuOwK92hihg5r3fNssty8tLCUpOubST9u', 1, 'admin@example.com', 'Admin User', '2016-01-01 00:00:00', '2016-01-01 00:00:00', 1);\n"
         )
     }
 


### PR DESCRIPTION
The dev user currently gets inserted and auto-assigned an integer `id`. But other tools like the `etl` and `importers` that need to use the grapher DB need to specify a user id, and we would like them to use this dev user for their example config.

Currently id 1 is unused in production (id 2 is Max).
