### PR TITLE
enhance(admin): exclude archived datasets

### DIFF
--- a/db/migration/1654553380446-AddSourceChecksum.ts
+++ b/db/migration/1654553380446-AddSourceChecksum.ts
@@ -3,15 +3,15 @@ import { MigrationInterface, QueryRunner } from "typeorm"
 export class AddSourceChecksum1654553380446 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            ALTER TABLE datasets 
-            ADD COLUMN sourceChecksum VARCHAR(64) 
+            ALTER TABLE datasets
+            ADD COLUMN sourceChecksum VARCHAR(64)
             DEFAULT NULL;
         `)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            ALTER TABLE datasets 
+            ALTER TABLE datasets
             DROP COLUMN sourceChecksum;
         `)
     }

--- a/db/migration/1656580147849-CreateActiveDatasetsView.ts
+++ b/db/migration/1656580147849-CreateActiveDatasetsView.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CreateActiveDatasetsView1656580147849
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+        CREATE VIEW active_datasets AS SELECT * FROM datasets WHERE not isArchived;
+      `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+        DROP VIEW active_datasets;
+      `)
+    }
+}


### PR DESCRIPTION
Exclude archived datasets from `admin/datasets` and other lists (sources, variables, etc.). Instead of manually adding WHERE conditions we could have a `active_datasets` or `unarchived_datasets` view with the `not isArchived` filter.