### PR TITLE
API / UI support for selecting key charts in admin

### DIFF
--- a/adminSiteClient/ChartList.tsx
+++ b/adminSiteClient/ChartList.tsx
@@ -65,7 +65,7 @@ class ChartRow extends React.Component<{
         const { chart } = this.props
         const json = await this.context.admin.requestJSON(
             `/api/charts/${chart.id}/setTags`,
-            { tagIds: tags.map((t) => t.id) },
+            { tags },
             "POST"
         )
         if (json.success) {

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -993,6 +993,8 @@ class EditTags extends React.Component<{
     }
 }
 
+const filterUncategorizedTag = (t: Tag) => t.name !== "Uncategorized"
+
 @observer
 export class EditableTags extends React.Component<{
     tags: Tag[]
@@ -1009,7 +1011,7 @@ export class EditableTags extends React.Component<{
         this.tags.push(tag)
         this.tags = lodash
             .uniqBy(this.tags, (t) => t.id)
-            .filter((t) => t.name !== "Uncategorized")
+            .filter(filterUncategorizedTag)
 
         this.ensureUncategorized()
     }
@@ -1030,9 +1032,7 @@ export class EditableTags extends React.Component<{
 
     @action.bound onToggleEdit() {
         if (this.isEditing) {
-            this.props.onSave(
-                this.tags.filter((t) => t.name !== "Uncategorized")
-            )
+            this.props.onSave(this.tags.filter(filterUncategorizedTag))
         }
         this.isEditing = !this.isEditing
     }

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -1021,6 +1021,11 @@ export class EditableTags extends React.Component<{
         this.ensureUncategorized()
     }
 
+    @action.bound onToggleKey(index: number) {
+        this.tags[index].isKey = !this.tags[index].isKey
+        this.props.onSave(this.tags.filter(filterUncategorizedTag))
+    }
+
     @action.bound ensureUncategorized() {
         if (this.tags.length === 0) {
             const uncategorized = this.props.suggestions.find(
@@ -1061,8 +1066,12 @@ export class EditableTags extends React.Component<{
                     />
                 ) : (
                     <div>
-                        {tags.map((t) => (
-                            <TagBadge key={t.id} tag={t} />
+                        {tags.map((t, i) => (
+                            <TagBadge
+                                onToggleKey={() => this.onToggleKey(i)}
+                                key={t.id}
+                                tag={t}
+                            />
                         ))}
                         {!disabled && (
                             <button

--- a/adminSiteClient/TagBadge.tsx
+++ b/adminSiteClient/TagBadge.tsx
@@ -9,16 +9,18 @@ export { Tag }
 @observer
 export class TagBadge extends React.Component<{
     tag: Tag
-    onRemove?: () => void
+    onToggleKey?: () => void
     searchHighlight?: (text: string) => string | JSX.Element
 }> {
     render() {
-        const { tag, searchHighlight, onRemove } = this.props
+        const { tag, searchHighlight, onToggleKey } = this.props
+        const classes = ["TagBadge"]
+        if (tag.isKey) classes.push("isKey")
 
-        if (onRemove) {
+        if (onToggleKey) {
             return (
-                <span className="TagBadge" onClick={onRemove}>
-                    {tag.name}
+                <span className={classes.join(" ")} onClick={onToggleKey}>
+                    {searchHighlight ? searchHighlight(tag.name) : tag.name}
                 </span>
             )
         } else {

--- a/adminSiteClient/TagBadge.tsx
+++ b/adminSiteClient/TagBadge.tsx
@@ -5,6 +5,7 @@ import { Tag } from "../clientUtils/owidTypes.js"
 import { Link } from "./Link.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faStar } from "@fortawesome/free-solid-svg-icons/faStar"
+import Tippy from "@tippyjs/react"
 
 export { Tag }
 
@@ -21,10 +22,16 @@ export class TagBadge extends React.Component<{
 
         if (onToggleKey) {
             return (
-                <span className={classes.join(" ")} onClick={onToggleKey}>
-                    {searchHighlight ? searchHighlight(tag.name) : tag.name}
-                    {tag.isKey && <FontAwesomeIcon icon={faStar} />}
-                </span>
+                <Tippy
+                    content={`${
+                        tag.isKey ? "⬇️ Demote from" : "⬆️ Promote to"
+                    } key charts on topic "${tag.name}"`}
+                >
+                    <span className={classes.join(" ")} onClick={onToggleKey}>
+                        {searchHighlight ? searchHighlight(tag.name) : tag.name}
+                        {tag.isKey && <FontAwesomeIcon icon={faStar} />}
+                    </span>
+                </Tippy>
             )
         } else {
             return (

--- a/adminSiteClient/TagBadge.tsx
+++ b/adminSiteClient/TagBadge.tsx
@@ -3,6 +3,8 @@ import { observer } from "mobx-react"
 import { Tag } from "../clientUtils/owidTypes.js"
 
 import { Link } from "./Link.js"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
+import { faStar } from "@fortawesome/free-solid-svg-icons/faStar"
 
 export { Tag }
 
@@ -21,6 +23,7 @@ export class TagBadge extends React.Component<{
             return (
                 <span className={classes.join(" ")} onClick={onToggleKey}>
                     {searchHighlight ? searchHighlight(tag.name) : tag.name}
+                    {tag.isKey && <FontAwesomeIcon icon={faStar} />}
                 </span>
             )
         } else {

--- a/adminSiteClient/TagBadge.tsx
+++ b/adminSiteClient/TagBadge.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { observer } from "mobx-react"
-import { Tag } from "react-tag-autocomplete"
+import { Tag } from "../clientUtils/owidTypes.js"
 
 import { Link } from "./Link.js"
 

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -827,12 +827,13 @@ main:not(.ChartEditorPage) {
     cursor: pointer;
 
     &:hover {
-        color: #333;
+        background-color: #c0c0c0;
     }
 
     &.isKey {
-        background-color: #333;
-        color: #eee;
+        svg {
+            margin-left: 5px;
+        }
     }
 }
 

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -829,6 +829,11 @@ main:not(.ChartEditorPage) {
     &:hover {
         color: #333;
     }
+
+    &.isKey {
+        background-color: #333;
+        color: #eee;
+    }
 }
 
 .EditableTags {

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -604,7 +604,7 @@ apiRouter.post(
     async (req: Request, res: Response) => {
         const chartId = expectInt(req.params.chartId)
 
-        await Chart.setTags(chartId, req.body.tagIds)
+        await Chart.setTags(chartId, req.body.tags)
 
         return { success: true }
     }

--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -1,3 +1,5 @@
+import { Tag as TagReactTagAutocomplete } from "react-tag-autocomplete"
+
 // todo: remove when we ditch Year and YearIsDay
 export const EPOCH_DATE = "2020-01-21"
 
@@ -153,6 +155,10 @@ export interface PostRow {
     content: string
     published_at: Date | null
     updated_at: Date
+}
+
+export interface Tag extends TagReactTagAutocomplete {
+    isKey?: boolean
 }
 
 export interface EntryMeta {

--- a/db/migration/1656406573545-KeyCharts.ts
+++ b/db/migration/1656406573545-KeyCharts.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class KeyCharts1656406573545 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+        ALTER TABLE chart_tags
+        ADD isKey TINYINT UNSIGNED;
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+        ALTER TABLE chart_tags
+        DROP isKey;
+        `)
+    }
+}

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -103,7 +103,7 @@ export class Chart extends BaseEntity {
         charts: { id: number; tags: any[] }[]
     ): Promise<void> {
         const chartTags = await db.queryMysql(`
-            SELECT ct.chartId, ct.tagId, t.name as tagName FROM chart_tags ct
+            SELECT ct.chartId, ct.tagId, ct.isKey, t.name as tagName FROM chart_tags ct
             JOIN charts c ON c.id=ct.chartId
             JOIN tags t ON t.id=ct.tagId
         `)
@@ -116,7 +116,12 @@ export class Chart extends BaseEntity {
 
         for (const ct of chartTags) {
             const chart = chartsById[ct.chartId]
-            if (chart) chart.tags.push({ id: ct.tagId, name: ct.tagName })
+            if (chart)
+                chart.tags.push({
+                    id: ct.tagId,
+                    name: ct.tagName,
+                    isKey: ct.isKey,
+                })
         }
     }
 

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -12,6 +12,7 @@ import * as db from "../db.js"
 import { getVariableData } from "./Variable.js"
 import { User } from "./User.js"
 import { ChartRevision } from "./ChartRevision.js"
+import { Tag } from "../../clientUtils/owidTypes.js"
 
 // XXX hardcoded filtering to public parent tags
 const PUBLIC_TAG_PARENT_IDS = [
@@ -72,22 +73,22 @@ export class Chart extends BaseEntity {
         return await Chart.findOne({ id })
     }
 
-    static async setTags(chartId: number, tagIds: number[]): Promise<void> {
+    static async setTags(chartId: number, tags: Tag[]): Promise<void> {
         await db.transaction(async (t) => {
-            const tagRows = tagIds.map((tagId) => [tagId, chartId])
+            const tagRows = tags.map((tag) => [tag.id, chartId, tag.isKey])
             await t.execute(`DELETE FROM chart_tags WHERE chartId=?`, [chartId])
             if (tagRows.length)
                 await t.execute(
-                    `INSERT INTO chart_tags (tagId, chartId) VALUES ?`,
+                    `INSERT INTO chart_tags (tagId, chartId, isKey) VALUES ?`,
                     [tagRows]
                 )
 
-            const tags = tagIds.length
+            const parentIds = tags.length
                 ? ((await t.query("select parentId from tags where id in (?)", [
-                      tagIds,
+                      tags.map((t) => t.id),
                   ])) as { parentId: number }[])
                 : []
-            const isIndexable = tags.some((t) =>
+            const isIndexable = parentIds.some((t) =>
                 PUBLIC_TAG_PARENT_IDS.includes(t.parentId)
             )
 

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -120,7 +120,7 @@ export class Chart extends BaseEntity {
                 chart.tags.push({
                     id: ct.tagId,
                     name: ct.tagName,
-                    isKey: ct.isKey,
+                    isKey: !!ct.isKey,
                 })
         }
     }


### PR DESCRIPTION
This handles marking topics as "key topics" on a per-chart basis:
- toggle key status and save on click on a tag
- status persisted as long as the tag is present in the list (per chart): deleting a tag will delete the key status
- new `isKey` column added to `chart_tags` table

_Note: tags (in non-edit mode) were previously links to the corresponding tag pages. This could be added back if it turns out to be a regularly used feature._

https://user-images.githubusercontent.com/13406362/176219672-001049a2-feeb-4fe6-bd2d-cd1f3df36c49.mp4




It comes in support of #1447, which requires charts to be marked as "key charts" on any given topic.