### PR TITLE
Split grapher data #1: Remove TypeScript namespaces

### DIFF
--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -3,7 +3,6 @@ import { Chart } from "../db/model/Chart.js"
 import { GrapherInterface } from "../grapher/core/GrapherInterface.js"
 import { GrapherPage } from "../site/GrapherPage.js"
 import { renderToHtmlPage } from "../baker/siteRenderers.js"
-import { Post } from "../db/model/Post.js"
 import { excludeUndefined, urlToSlug, without } from "../clientUtils/Util.js"
 import {
     getRelatedArticles,
@@ -26,10 +25,11 @@ import * as db from "../db/db.js"
 import * as glob from "glob"
 import { JsonError } from "../clientUtils/owidTypes.js"
 import { isPathRedirectedToExplorer } from "../explorerAdminServer/ExplorerRedirects.js"
+import { getPostBySlug } from "../db/model/Post.js"
 
 const grapherConfigToHtmlPage = async (grapher: GrapherInterface) => {
     const postSlug = urlToSlug(grapher.originUrl || "")
-    const post = postSlug ? await Post.bySlug(postSlug) : undefined
+    const post = postSlug ? await getPostBySlug(postSlug) : undefined
     const relatedCharts =
         post && isWordpressDBEnabled
             ? await getRelatedCharts(post.id)

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -34,7 +34,6 @@ import {
     GrapherExports,
 } from "../baker/GrapherBakingUtils.js"
 import { makeSitemap } from "../baker/sitemap.js"
-import { Post } from "../db/model/Post.js"
 import { bakeCountries } from "../baker/countryProfiles.js"
 import { countries } from "../clientUtils/countries.js"
 import { execWrapper } from "../db/execWrapper.js"
@@ -51,6 +50,7 @@ import {
     bakeAllPublishedExplorers,
 } from "./ExplorerBaker.js"
 import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer.js"
+import { postsTable } from "../db/model/Post.js"
 
 export class SiteBaker {
     private grapherExports!: GrapherExports
@@ -247,7 +247,7 @@ export class SiteBaker {
         )
 
         const rows = (await db
-            .knexTable(Post.table)
+            .knexTable(postsTable)
             .where({ status: "publish" })
             .join("post_tags", { "post_tags.post_id": "posts.id" })
             .join("tags", { "tags.id": "post_tags.tag_id" })

--- a/baker/countryProfiles.tsx
+++ b/baker/countryProfiles.tsx
@@ -7,11 +7,15 @@ import {
     CountryProfileIndicator,
     CountryProfilePage,
 } from "../site/CountryProfilePage.js"
-import { Variable } from "../db/model/Variable.js"
 import { SiteBaker } from "./SiteBaker.js"
 import { countries, getCountry } from "../clientUtils/countries.js"
 import { JsonError } from "../clientUtils/owidTypes.js"
 import { renderToHtmlPage } from "./siteRenderers.js"
+import {
+    parseVariableRows,
+    VariableRow,
+    variableTable,
+} from "../db/model/Variable.js"
 
 export const countriesIndexPage = (baseUrl: string) =>
     renderToHtmlPage(
@@ -46,13 +50,13 @@ const countryIndicatorGraphers = async (): Promise<GrapherInterface[]> =>
         return graphers.filter(checkShouldShowIndicator)
     })
 
-const countryIndicatorVariables = async (): Promise<Variable.Row[]> =>
+const countryIndicatorVariables = async (): Promise<VariableRow[]> =>
     bakeCache(countryIndicatorVariables, async () => {
         const variableIds = (await countryIndicatorGraphers()).map(
             (c) => c.dimensions![0]!.variableId
         )
-        return Variable.rows(
-            await db.knexTable(Variable.table).whereIn("id", variableIds)
+        return parseVariableRows(
+            await db.knexTable(variableTable).whereIn("id", variableIds)
         )
     })
 

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -24,7 +24,6 @@ import {
     GrapherExports,
 } from "../baker/GrapherBakingUtils.js"
 import * as cheerio from "cheerio"
-import { Post } from "../db/model/Post.js"
 import {
     BAKED_BASE_URL,
     BLOG_POSTS_PER_PAGE,
@@ -88,6 +87,7 @@ import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer.
 import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants.js"
 import { ExplorerFullQueryParams } from "../explorer/ExplorerConstants.js"
 import { resolveInternalRedirect } from "./redirects.js"
+import { postsTable } from "../db/model/Post.js"
 export const renderToHtmlPage = (element: any) =>
     `<!doctype html>${ReactDOMServer.renderToStaticMarkup(element)}`
 
@@ -294,7 +294,7 @@ ${posts
 
 // These pages exist largely just for Google Scholar
 export const entriesByYearPage = async (year?: number) => {
-    const entries = (await knexTable(Post.table)
+    const entries = (await knexTable(postsTable)
         .where({ status: "publish" })
         .join("post_tags", { "post_tags.post_id": "posts.id" })
         .join("tags", { "tags.id": "post_tags.tag_id" })

--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -1,4 +1,3 @@
-import { Post } from "../db/model/Post.js"
 import { Chart } from "../db/model/Chart.js"
 import {
     BAKED_BASE_URL,
@@ -9,6 +8,7 @@ import * as db from "../db/db.js"
 import { countries } from "../clientUtils/countries.js"
 import urljoin from "url-join"
 import { countryProfileSpecs } from "../site/countryProfileProjects.js"
+import { postsTable } from "../db/model/Post.js"
 
 interface SitemapUrl {
     loc: string
@@ -29,7 +29,7 @@ const xmlify = (url: SitemapUrl) => {
 
 export const makeSitemap = async () => {
     const posts = (await db
-        .knexTable(Post.table)
+        .knexTable(postsTable)
         .where({ status: "publish" })
         .select("slug", "updated_at")) as { slug: string; updated_at: Date }[]
     const charts = (await db

--- a/db/model/Dataset.ts
+++ b/db/model/Dataset.ts
@@ -11,10 +11,11 @@ import { Writable } from "stream"
 
 import { User } from "./User.js"
 import { Source } from "./Source.js"
-import { Variable } from "./Variable.js"
+
 import * as db from "../db.js"
 import { arrToCsvRow, slugify } from "../../clientUtils/Util.js"
 import filenamify from "filenamify"
+import { VariableRow, variableTable } from "./Variable.js"
 
 @Entity("datasets")
 @Unique(["name", "namespace"])
@@ -124,8 +125,8 @@ export class Dataset extends BaseEntity {
         // XXX
         const sources = await Source.find({ datasetId: this.id })
         const variables = (await db
-            .knexTable(Variable.table)
-            .where({ datasetId: this.id })) as Variable.Row[]
+            .knexTable(variableTable)
+            .where({ datasetId: this.id })) as VariableRow[]
         const tags = await db.queryMysql(
             `SELECT t.id, t.name FROM dataset_tags dt JOIN tags t ON t.id=dt.tagId WHERE dt.datasetId=?`,
             [this.id]

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -2,47 +2,46 @@ import * as db from "../db.js"
 import { Knex } from "knex"
 import { PostRow } from "../../clientUtils/owidTypes.js"
 
-export namespace Post {
-    export const table = "posts"
+export const postsTable = "posts"
 
-    export const select = <K extends keyof PostRow>(
-        ...args: K[]
-    ): { from: (query: Knex.QueryBuilder) => Promise<Pick<PostRow, K>[]> } => ({
-        from: (query) => query.select(...args) as any,
-    })
+export const selectPosts = <K extends keyof PostRow>(
+    ...args: K[]
+): { from: (query: Knex.QueryBuilder) => Promise<Pick<PostRow, K>[]> } => ({
+    from: (query) => query.select(...args) as any,
+})
 
-    export const tagsByPostId = async (): Promise<
-        Map<number, { id: number; name: string }[]>
-    > => {
-        const postTags = await db.queryMysql(`
+export const getTagsByPostId = async (): Promise<
+    Map<number, { id: number; name: string }[]>
+> => {
+    const postTags = await db.queryMysql(`
             SELECT pt.post_id AS postId, pt.tag_id AS tagId, t.name as tagName FROM post_tags pt
             JOIN posts p ON p.id=pt.post_id
             JOIN tags t ON t.id=pt.tag_id
         `)
 
-        const tagsByPostId: Map<number, { id: number; name: string }[]> =
-            new Map()
+    const tagsByPostId: Map<number, { id: number; name: string }[]> = new Map()
 
-        for (const pt of postTags) {
-            const tags = tagsByPostId.get(pt.postId) || []
-            tags.push({ id: pt.tagId, name: pt.tagName })
-            tagsByPostId.set(pt.postId, tags)
-        }
-
-        return tagsByPostId
+    for (const pt of postTags) {
+        const tags = tagsByPostId.get(pt.postId) || []
+        tags.push({ id: pt.tagId, name: pt.tagName })
+        tagsByPostId.set(pt.postId, tags)
     }
 
-    export const setTags = async (postId: number, tagIds: number[]) =>
-        await db.transaction(async (t) => {
-            const tagRows = tagIds.map((tagId) => [tagId, postId])
-            await t.execute(`DELETE FROM post_tags WHERE post_id=?`, [postId])
-            if (tagRows.length)
-                await t.execute(
-                    `INSERT INTO post_tags (tag_id, post_id) VALUES ?`,
-                    [tagRows]
-                )
-        })
-
-    export const bySlug = async (slug: string): Promise<PostRow | undefined> =>
-        (await db.knexTable("posts").where({ slug: slug }))[0]
+    return tagsByPostId
 }
+
+export const setTagsForPost = async (postId: number, tagIds: number[]) =>
+    await db.transaction(async (t) => {
+        const tagRows = tagIds.map((tagId) => [tagId, postId])
+        await t.execute(`DELETE FROM post_tags WHERE post_id=?`, [postId])
+        if (tagRows.length)
+            await t.execute(
+                `INSERT INTO post_tags (tag_id, post_id) VALUES ?`,
+                [tagRows]
+            )
+    })
+
+export const getPostBySlug = async (
+    slug: string
+): Promise<PostRow | undefined> =>
+    (await db.knexTable("posts").where({ slug: slug }))[0]

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -14,36 +14,36 @@ import {
 } from "../../clientUtils/owidTypes.js"
 import { OwidSource } from "../../clientUtils/OwidSource.js"
 
-export namespace Variable {
-    export interface Row {
-        id: number
-        name: string
-        code: string | null
-        unit: string
-        shortUnit: string | null
-        description: string | null
-        createdAt: Date
-        updatedAt: Date
-        datasetId: number
-        sourceId: number
-        display: OwidVariableDisplayConfigInterface
-        coverage?: string
-        timespan?: string
-        columnOrder?: number
+export interface VariableRow {
+    id: number
+    name: string
+    code: string | null
+    unit: string
+    shortUnit: string | null
+    description: string | null
+    createdAt: Date
+    updatedAt: Date
+    datasetId: number
+    sourceId: number
+    display: OwidVariableDisplayConfigInterface
+    coverage?: string
+    timespan?: string
+    columnOrder?: number
+}
+
+export type UnparsedVariableRow = VariableRow & { display: string }
+
+export type Field = keyof VariableRow
+
+export const variableTable = "variables"
+
+export function parseVariableRows(
+    plainRows: UnparsedVariableRow[]
+): VariableRow[] {
+    for (const row of plainRows) {
+        row.display = row.display ? JSON.parse(row.display) : undefined
     }
-
-    export type UnparsedRow = Row & { display: string }
-
-    export type Field = keyof Row
-
-    export const table = "variables"
-
-    export function rows(plainRows: UnparsedRow[]): Row[] {
-        for (const row of plainRows) {
-            row.display = row.display ? JSON.parse(row.display) : undefined
-        }
-        return plainRows
-    }
+    return plainRows
 }
 
 export async function getVariableData(variableIds: number[]): Promise<any> {
@@ -51,7 +51,7 @@ export async function getVariableData(variableIds: number[]): Promise<any> {
     const data: OwidVariablesAndEntityKey = { variables: {}, entityKey: {} }
 
     type VariableQueryRow = Readonly<
-        Variable.UnparsedRow & {
+        UnparsedVariableRow & {
             display: string
             datasetName: string
             nonRedistributable: number

--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -3,9 +3,9 @@
 
 import * as wpdb from "./wpdb.js"
 import * as db from "./db.js"
-import { Post } from "./model/Post.js"
 import { keyBy } from "../clientUtils/Util.js"
 import { PostRow } from "../clientUtils/owidTypes.js"
+import { selectPosts, postsTable } from "./model/Post.js"
 
 const zeroDateString = "0000-00-00 00:00:00"
 
@@ -15,8 +15,8 @@ const syncPostsToGrapher = async (): Promise<void> => {
     )
 
     const doesExistInWordpress = keyBy(rows, "ID")
-    const existsInGrapher = await Post.select("id").from(
-        db.knexInstance().from(Post.table)
+    const existsInGrapher = await selectPosts("id").from(
+        db.knexInstance().from(postsTable)
     )
     const doesExistInGrapher = keyBy(existsInGrapher, "id")
 
@@ -44,12 +44,12 @@ const syncPostsToGrapher = async (): Promise<void> => {
 
     await db.knexInstance().transaction(async (t) => {
         if (toDelete.length)
-            await t.whereIn("id", toDelete).delete().from(Post.table)
+            await t.whereIn("id", toDelete).delete().from(postsTable)
 
         for (const row of toInsert) {
             if (doesExistInGrapher[row.id])
-                await t.update(row).where("id", "=", row.id).into(Post.table)
-            else await t.insert(row).into(Post.table)
+                await t.update(row).where("id", "=", row.id).into(postsTable)
+            else await t.insert(row).into(postsTable)
         }
     })
 }


### PR DESCRIPTION
Removes the last bit of TypeScript namespaces that were remaining in the codebase. In preparation for #1522.