### PR TITLE
Remove unit in map sparkline tooltip axis

### DIFF
--- a/grapher/axis/AxisViews.tsx
+++ b/grapher/axis/AxisViews.tsx
@@ -115,12 +115,13 @@ interface DualAxisViewProps {
     dualAxis: DualAxis
     highlightValue?: { x: number; y: number }
     showTickMarks?: boolean
+    miniTooltip?: boolean
 }
 
 @observer
 export class DualAxisComponent extends React.Component<DualAxisViewProps> {
     render(): JSX.Element {
-        const { dualAxis, showTickMarks } = this.props
+        const { dualAxis, showTickMarks, miniTooltip } = this.props
         const { bounds, horizontalAxis, verticalAxis, innerBounds } = dualAxis
 
         const verticalGridlines = verticalAxis.hideGridlines ? null : (
@@ -141,6 +142,7 @@ export class DualAxisComponent extends React.Component<DualAxisViewProps> {
             <VerticalAxisComponent
                 bounds={bounds}
                 verticalAxis={verticalAxis}
+                miniTooltip={miniTooltip}
             />
         )
 
@@ -168,9 +170,10 @@ export class DualAxisComponent extends React.Component<DualAxisViewProps> {
 export class VerticalAxisComponent extends React.Component<{
     bounds: Bounds
     verticalAxis: VerticalAxis
+    miniTooltip?: boolean
 }> {
     render(): JSX.Element {
-        const { bounds, verticalAxis } = this.props
+        const { bounds, verticalAxis, miniTooltip } = this.props
         const { tickLabels, labelTextWrap } = verticalAxis
         const textColor = "#666"
 
@@ -200,7 +203,7 @@ export class VerticalAxisComponent extends React.Component<{
                             fill={textColor}
                             fontSize={verticalAxis.tickFontSize}
                         >
-                            {formattedValue}
+                            {miniTooltip ? label.value : formattedValue}
                         </text>
                     )
                 })}

--- a/grapher/lineCharts/LineChart.tsx
+++ b/grapher/lineCharts/LineChart.tsx
@@ -254,6 +254,7 @@ export class LineChart
     extends React.Component<{
         bounds?: Bounds
         manager: LineChartManager
+        miniTooltip?: boolean
     }>
     implements
         ChartInterface,
@@ -359,7 +360,9 @@ export class LineChart
     @computed private get manager(): LineChartManager {
         return this.props.manager
     }
-
+    @computed get miniTooltip(): boolean | undefined {
+        return this.props.miniTooltip
+    }
     @computed get bounds(): Bounds {
         return this.props.bounds ?? DEFAULT_BOUNDS
     }
@@ -729,8 +732,14 @@ export class LineChart
                 />
             )
 
-        const { manager, tooltip, dualAxis, clipPath, activeXVerticalLine } =
-            this
+        const {
+            manager,
+            tooltip,
+            dualAxis,
+            clipPath,
+            activeXVerticalLine,
+            miniTooltip,
+        } = this
 
         const comparisonLines = manager.comparisonLines || []
 
@@ -757,7 +766,11 @@ export class LineChart
                 {this.hasColorLegend && (
                     <HorizontalNumericColorLegend manager={this} />
                 )}
-                <DualAxisComponent dualAxis={dualAxis} showTickMarks={true} />
+                <DualAxisComponent
+                    dualAxis={dualAxis}
+                    showTickMarks={true}
+                    miniTooltip={miniTooltip}
+                />
                 <g clipPath={clipPath.id}>
                     {comparisonLines.map((line, index) => (
                         <ComparisonLine

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -248,6 +248,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                                             left: SPARKLINE_PADDING,
                                             right: SPARKLINE_PADDING,
                                         })}
+                                        miniTooltip={true}
                                     />
                                 </svg>
                             </div>


### PR DESCRIPTION
Closes #1516 

Quick fix for this issue, `miniTooltip` (placeholder name for now) is used to indicate if the `LineChart` is being called inside the tooltip, there's probably a better method but this is my initial solution.

I also had trouble formatting the `label.value`, it currently displays the raw value.

I would love any guidance on how to continue with this issue, thanks!