### PR TITLE
enhance(map): automatic legend width

### DIFF
--- a/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -236,7 +236,8 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
 
     private getNumericLabelMinWidth(bin: NumericBin): number {
         if (bin.text) {
-            return this.getTickLabelWidth(bin.text)
+            const tickLabelWidth = this.getTickLabelWidth(bin.text)
+            return tickLabelWidth + MINIMUM_LABEL_DISTANCE
         } else {
             const combinedLabelWidths = sum(
                 [bin.minText, bin.maxText].map(
@@ -436,9 +437,9 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
             for (let j = index + 1; j < labels.length; j++) {
                 const l2 = labels[j]
                 if (
-                    l1.bounds.right + MINIMUM_LABEL_DISTANCE >=
+                    l1.bounds.right + MINIMUM_LABEL_DISTANCE >
                         l2.bounds.centerX ||
-                    (l2.bounds.left - MINIMUM_LABEL_DISTANCE <=
+                    (l2.bounds.left - MINIMUM_LABEL_DISTANCE <
                         l1.bounds.centerX &&
                         !l2.priority)
                 )
@@ -453,7 +454,7 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
         for (let index = 1; index < labels.length; index++) {
             const l1 = labels[index - 1],
                 l2 = labels[index]
-            if (l1.bounds.right + MINIMUM_LABEL_DISTANCE >= l2.bounds.left) {
+            if (l1.bounds.right + MINIMUM_LABEL_DISTANCE > l2.bounds.left) {
                 raisedMode = true
                 break
             }

--- a/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -259,7 +259,9 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
         }))
         // Make sure the legend is big enough to avoid overlapping labels (including `raisedMode`)
         if (this.manager.equalSizeBins) {
-            const minBinWidth = this.fontSize * 3.5
+            // Try to keep the minimum close to the size of the "No data" bin,
+            // so they look visually balanced somewhat.
+            const minBinWidth = this.fontSize * 3.25
             const maxBinWidth =
                 max(
                     spaceRequirements.map(({ labelSpace }) =>

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -494,8 +494,14 @@ export class MapChart
         return DEFAULT_STROKE_COLOR
     }
 
-    @computed get legendWidth(): number {
-        return this.bounds.width * 0.8
+    @computed get legendMaxWidth(): number {
+        // it seems nice to have just a little bit of
+        // extra padding left and right
+        return this.bounds.width * 0.95
+    }
+
+    @computed get legendX(): number {
+        return this.bounds.x + (this.bounds.width - this.legendMaxWidth) / 2
     }
 
     @computed get legendHeight(): number {
@@ -522,10 +528,6 @@ export class MapChart
         return this.numericLegendData.length > 1
             ? new HorizontalNumericColorLegend({ manager: this })
             : undefined
-    }
-
-    @computed get legendX(): number {
-        return this.bounds.centerX - this.legendWidth / 2
     }
 
     @computed get categoryLegendY(): number {


### PR DESCRIPTION
I implemented [automatic legend sizing](https://github.com/owid/owid-grapher/commit/6129ac3c26d8a0c6d716f1acbd0ed678daf1d747) several months ago, but didn't enable it on maps to avoid a large svgTester diff.

By enabling it, denser legends are now wider, and sparse legends narrower. Relatedly, [Max recently suggested legends on maps should be bigger](https://owid.slack.com/archives/C46U9LXRR/p1656510679657209), so this seems like a good time to make the change.

#### Before / after:

<img width="1440" alt="Screenshot 2022-07-01 at 00 51 42" src="https://user-images.githubusercontent.com/1308115/176796816-dc3ef948-2a7a-4963-985c-7d4558444485.png">


<img width="1440" alt="Screenshot 2022-07-01 at 00 39 48" src="https://user-images.githubusercontent.com/1308115/176796808-4fa4c046-4341-4513-8ee1-dca770470929.png">

<img width="1440" alt="Screenshot 2022-07-01 at 00 42 28" src="https://user-images.githubusercontent.com/1308115/176796859-6c915025-39a0-49a6-b511-a5dea28aa7a6.png">

