### PR TITLE
perf(explorer): call heavy explorer getters only once

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -673,9 +673,9 @@ export class Explorer
 
     private tableSlugHasColumnSlug(
         tableSlug: TableSlug | undefined,
-        columnSlug: ColumnSlug
+        columnSlug: ColumnSlug,
+        columnDefsByTableSlug: Map<TableSlug | undefined, CoreColumnDef[]>
     ) {
-        const columnDefsByTableSlug = this.explorerProgram.columnDefsByTableSlug
         return !!columnDefsByTableSlug
             .get(tableSlug)
             ?.find((def) => def.slug === columnSlug)
@@ -684,15 +684,27 @@ export class Explorer
     private getTableSlugOfColumnSlug(
         columnSlug: ColumnSlug
     ): TableSlug | undefined {
+        const columnDefsByTableSlug = this.explorerProgram.columnDefsByTableSlug
+
         // In most cases, column slugs will be duplicated in the tables, e.g. entityName.
         // Prefer the current Grapher table if it contains the column slug.
         const grapherTableSlug = this.explorerProgram.grapherConfig.tableSlug
-        if (this.tableSlugHasColumnSlug(grapherTableSlug, columnSlug)) {
+        if (
+            this.tableSlugHasColumnSlug(
+                grapherTableSlug,
+                columnSlug,
+                columnDefsByTableSlug
+            )
+        ) {
             return grapherTableSlug
         }
         // ...otherwise, search all tables for the column slug
         return this.explorerProgram.tableSlugs.find((tableSlug) =>
-            this.tableSlugHasColumnSlug(tableSlug, columnSlug)
+            this.tableSlugHasColumnSlug(
+                tableSlug,
+                columnSlug,
+                columnDefsByTableSlug
+            )
         )
     }
 

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -232,8 +232,9 @@ export class ExplorerProgram extends GridProgram {
             ExplorerGrammar.columns.keyword
         )
 
+        const matrix = this.asArrays
         for (const row of colDefsRows) {
-            const tableSlugs = this.asArrays[row].slice(1)
+            const tableSlugs = matrix[row].slice(1)
             const columnDefinitions: CoreColumnDef[] =
                 columnDefinitionsFromDelimited(this.getBlock(row)).map((row) =>
                     trimAndParseObject(row, ColumnGrammar)


### PR DESCRIPTION
With the upcoming demography explorer (currently: 140 tables), switching the entity picker sort metric currently stalls the UI thread for >10 seconds.

With these two variables pulled out of the loop and shared between the calls, switching metrics happens in an instant instead.