### PR TITLE
enhance(axis): do not show solid 0 line for date columns

### DIFF
--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -12,7 +12,7 @@ import {
 import { Bounds, DEFAULT_BOUNDS } from "../../clientUtils/Bounds.js"
 import { TextWrap } from "../text/TextWrap.js"
 import { AxisConfig } from "./AxisConfig.js"
-import { CoreColumn } from "../../coreTable/CoreTableColumns.js"
+import { ColumnTypeMap, CoreColumn } from "../../coreTable/CoreTableColumns.js"
 import { ValueRange } from "../../coreTable/CoreTableConstants.js"
 import {
     AxisAlign,
@@ -292,6 +292,13 @@ abstract class AbstractAxis {
 
         if (this.hideFractionalTicks)
             ticks = ticks.filter((t) => t.value % 1 === 0)
+
+        // mark value=0 ticks as solid for non-time columns
+        if (!(this.formatColumn instanceof ColumnTypeMap.Time)) {
+            ticks = ticks.map((tick) =>
+                tick.value === 0 ? { ...tick, solid: true } : tick
+            )
+        }
 
         return uniq(ticks)
     }

--- a/grapher/axis/AxisConfigInterface.ts
+++ b/grapher/axis/AxisConfigInterface.ts
@@ -7,6 +7,7 @@ export interface Tickmark {
     priority: number
     faint?: boolean
     gridLineOnly?: boolean
+    solid?: boolean // mostly for labelling domain start (e.g. 0)
 }
 
 // Represents the actual entered configuration state in the editor

--- a/grapher/axis/AxisViews.tsx
+++ b/grapher/axis/AxisViews.tsx
@@ -20,7 +20,7 @@ const dasharrayFromFontSize = (fontSize: number): string => {
 
 const TICK_COLOR = "#ddd"
 const FAINT_TICK_COLOR = "#eee"
-const DOMAIN_TICK_COLOR = "#999"
+const SOLID_TICK_COLOR = "#999"
 
 @observer
 export class VerticalAxisGridLines extends React.Component<{
@@ -37,8 +37,8 @@ export class VerticalAxisGridLines extends React.Component<{
                 {axis.getTickValues().map((t, i) => {
                     const color = t.faint
                         ? FAINT_TICK_COLOR
-                        : t.value === 0
-                        ? DOMAIN_TICK_COLOR
+                        : t.solid
+                        ? SOLID_TICK_COLOR
                         : TICK_COLOR
 
                     return (
@@ -50,11 +50,11 @@ export class VerticalAxisGridLines extends React.Component<{
                             y2={axis.place(t.value)}
                             stroke={color}
                             strokeDasharray={
-                                t.value !== 0
-                                    ? dasharrayFromFontSize(
+                                t.solid
+                                    ? undefined
+                                    : dasharrayFromFontSize(
                                           verticalAxis.tickFontSize
                                       )
-                                    : undefined
                             }
                         />
                     )
@@ -84,8 +84,8 @@ export class HorizontalAxisGridLines extends React.Component<{
                 {axis.getTickValues().map((t, i) => {
                     const color = t.faint
                         ? FAINT_TICK_COLOR
-                        : t.value === 0
-                        ? DOMAIN_TICK_COLOR
+                        : t.solid
+                        ? SOLID_TICK_COLOR
                         : TICK_COLOR
 
                     return (
@@ -97,11 +97,11 @@ export class HorizontalAxisGridLines extends React.Component<{
                             y2={bounds.top.toFixed(2)}
                             stroke={color}
                             strokeDasharray={
-                                t.value !== 0
-                                    ? dasharrayFromFontSize(
+                                t.solid
+                                    ? undefined
+                                    : dasharrayFromFontSize(
                                           horizontalAxis.tickFontSize
                                       )
-                                    : undefined
                             }
                         />
                     )
@@ -251,7 +251,7 @@ export class HorizontalAxisComponent extends React.Component<{
                 tickMarkXPositions={tickLabels.map((label): number =>
                     axis.place(label.value)
                 )}
-                color={DOMAIN_TICK_COLOR}
+                color={SOLID_TICK_COLOR}
             />
         ) : undefined
 

--- a/grapher/mapCharts/MapTooltip.tsx
+++ b/grapher/mapCharts/MapTooltip.tsx
@@ -153,7 +153,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                     ? this.props.manager.yAxisConfig?.max
                     : undefined,
                 ticks: [
-                    { value: 0, priority: 1 },
+                    { value: 0, priority: 1, solid: true },
                     // Show minimum and maximum
                     { value: -Infinity, priority: 2 },
                     { value: Infinity, priority: 2 },


### PR DESCRIPTION
Fixes #1172.

No longer shows solid line for value=0 when the axis `formatColumn` is a date column.

<img width="858" alt="Screenshot 2022-07-05 at 11 40 49" src="https://user-images.githubusercontent.com/1308115/177310394-34b7c97d-9616-407e-a468-b3ac3ea280ff.png">

