### PR TITLE
fix(key chart): leaking styles on post list

### DIFF
--- a/adminSiteClient/ChartList.tsx
+++ b/adminSiteClient/ChartList.tsx
@@ -123,6 +123,7 @@ class ChartRow extends React.Component<{
                         tags={chart.tags}
                         suggestions={availableTags}
                         onSave={this.onSaveTags}
+                        hasKeyChartSupport={true}
                     />
                 </td>
                 <td>

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -1001,6 +1001,7 @@ export class EditableTags extends React.Component<{
     suggestions: Tag[]
     onSave: (tags: Tag[]) => void
     disabled?: boolean
+    hasKeyChartSupport?: boolean
 }> {
     @observable isEditing: boolean = false
     base: React.RefObject<HTMLDivElement> = React.createRef()
@@ -1051,7 +1052,7 @@ export class EditableTags extends React.Component<{
     }
 
     render() {
-        const { disabled } = this.props
+        const { disabled, hasKeyChartSupport } = this.props
         const { tags } = this
 
         return (
@@ -1068,7 +1069,11 @@ export class EditableTags extends React.Component<{
                     <div>
                         {tags.map((t, i) => (
                             <TagBadge
-                                onToggleKey={() => this.onToggleKey(i)}
+                                onToggleKey={
+                                    hasKeyChartSupport
+                                        ? () => this.onToggleKey(i)
+                                        : undefined
+                                }
                                 key={t.id}
                                 tag={t}
                             />

--- a/adminSiteClient/TagBadge.tsx
+++ b/adminSiteClient/TagBadge.tsx
@@ -18,9 +18,10 @@ export class TagBadge extends React.Component<{
     render() {
         const { tag, searchHighlight, onToggleKey } = this.props
         const classes = ["TagBadge"]
-        if (tag.isKey) classes.push("isKey")
 
         if (onToggleKey) {
+            classes.push("hasKeyChartSupport")
+            if (tag.isKey) classes.push("isKey")
             return (
                 <Tippy
                     content={`${

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -826,7 +826,7 @@ main:not(.ChartEditorPage) {
     margin-bottom: 5px;
     cursor: pointer;
 
-    &:hover {
+    &.hasKeyChartSupport:hover {
         background-color: #c0c0c0;
     }
 


### PR DESCRIPTION
Key chart tagging should only be available on the charts list. Some of the key chart tagging has leaked onto the posts list. This fixes it.

<img width="1440" alt="Screenshot 2022-07-09 at 08 45 56" src="https://user-images.githubusercontent.com/13406362/178095008-bf306801-00d8-4777-875e-e4a73054884d.png">

_The problem: key chart tagging leaking onto the posts list_