### PR TITLE
Fix StackedBar mouse-hover highlighting multiple dimensions

### DIFF
--- a/grapher/stackedCharts/StackedBarChart.tsx
+++ b/grapher/stackedCharts/StackedBarChart.tsx
@@ -106,6 +106,8 @@ export class StackedBarChart
         super(props)
     }
 
+    // currently hovered legend series name
+    @observable hoverSeriesName?: string
     // currently hovered legend color
     @observable hoverColor?: string
     // current hovered individual bar
@@ -143,14 +145,14 @@ export class StackedBarChart
 
     // All currently hovered group keys, combining the legend and the main UI
     @computed get hoverKeys(): string[] {
-        const { hoverColor } = this
+        const { hoverSeriesName } = this
 
         const hoverKeys =
-            hoverColor === undefined
+            hoverSeriesName === undefined
                 ? []
                 : uniq(
                       this.series
-                          .filter((g) => g.color === hoverColor)
+                          .filter((g) => g.seriesName === hoverSeriesName)
                           .map((g) => g.seriesName)
                   )
 
@@ -163,12 +165,12 @@ export class StackedBarChart
 
         if (!activeKeys.length)
             // No hover means they're all active by default
-            return uniq(this.series.map((g) => g.color))
+            return uniq(this.series.map((g) => g.seriesName))
 
         return uniq(
             this.series
                 .filter((g) => activeKeys.indexOf(g.seriesName) !== -1)
-                .map((g) => g.color)
+                .map((g) => g.seriesName)
         )
     }
 
@@ -370,12 +372,12 @@ export class StackedBarChart
         return tickPlacements.filter((t) => !t.isHidden)
     }
 
-    @action.bound onLegendMouseOver(color: string): void {
-        this.hoverColor = color
+    @action.bound onLegendMouseOver(seriesName: string): void {
+        this.hoverSeriesName = seriesName
     }
 
     @action.bound onLegendMouseLeave(): void {
-        this.hoverColor = undefined
+        this.hoverSeriesName = undefined
     }
 
     @action.bound onLegendClick(): void {}

--- a/grapher/verticalColorLegend/VerticalColorLegend.tsx
+++ b/grapher/verticalColorLegend/VerticalColorLegend.tsx
@@ -11,7 +11,7 @@ export interface VerticalColorLegendManager {
     fontSize?: number
     legendItems: LegendItem[]
     legendTitle?: string
-    onLegendMouseOver?: (color: string) => void
+    onLegendMouseOver?: (seriesName: string) => void
     onLegendClick?: (color: string) => void
     onLegendMouseLeave?: () => void
     legendX?: number
@@ -141,11 +141,14 @@ export class VerticalColorLegend extends React.Component<{
                     style={{ cursor: "pointer" }}
                 >
                     {series.map((series, index) => {
-                        const isActive = activeColors.includes(series.color)
+                        const isActive = activeColors.includes(
+                            series.textWrap.text
+                        )
                         const isFocus =
                             focusColors?.includes(series.color) ?? false
                         const mouseOver = onLegendMouseOver
-                            ? (): void => onLegendMouseOver(series.color)
+                            ? (): void =>
+                                  onLegendMouseOver(series.textWrap.text)
                             : undefined
                         const mouseLeave = onLegendMouseLeave || undefined
                         const click = onLegendClick


### PR DESCRIPTION
Closes #1366 

Changed the logic to compare the name of the data point instead of the color, however I left the `activeColors` name unchanged as that would require editing other charts that use it. Currently the StackedBar chart works correctly.

I would love to hear some feedback on this PR, if the approach is correct I will try and implement it in the other charts/tests, thank you!