### PR TITLE
fix(MarkdownTextWrap): always split text on newline

### DIFF
--- a/grapher/text/MarkdownTextWrap.test.ts
+++ b/grapher/text/MarkdownTextWrap.test.ts
@@ -95,4 +95,14 @@ describe("MarkdownTextWrap", () => {
 
         expect(element.height).toEqual(30)
     })
+
+    it("MarkdownTextWrap should split on newline", () => {
+        const element = new MarkdownTextWrap({
+            text: "_test\n**\nnewline\n**_test",
+            fontSize: 10,
+            lineHeight: 1,
+        })
+
+        expect(element.height).toEqual(40)
+    })
 })

--- a/grapher/text/MarkdownTextWrap.tsx
+++ b/grapher/text/MarkdownTextWrap.tsx
@@ -112,6 +112,11 @@ export abstract class IRElement implements IRToken {
     }
 
     splitOnNextLineBreak(): { before?: IRToken; after?: IRToken } {
+        // const processed: IRToken[] = []
+        // const unprocessed: IRToken[] = [...this.children]
+        // while (unprocessed.length) {
+
+        // }
         const index = this.children.findIndex(
             (token) => token instanceof IRLineBreak
         )

--- a/grapher/text/MarkdownTextWrap.tsx
+++ b/grapher/text/MarkdownTextWrap.tsx
@@ -1,9 +1,9 @@
-import React, { CSSProperties, StyleHTMLAttributes } from "react"
+import React, { CSSProperties } from "react"
 import { computed } from "mobx"
 import { EveryMarkdownNode, MarkdownRoot, mdParser } from "./parser.js"
 import { Bounds, FontFamily } from "../../clientUtils/Bounds.js"
 import { imemo } from "../../coreTable/CoreTableUtils.js"
-import { excludeUndefined, sum } from "../../clientUtils/Util.js"
+import { excludeUndefined, last, sum } from "../../clientUtils/Util.js"
 
 export interface IRFontParams {
     fontSize?: number
@@ -111,27 +111,19 @@ export abstract class IRElement implements IRToken {
         }
     }
 
-    splitOnNextLineBreak(): { before?: IRToken; after?: IRToken } {
-        // const processed: IRToken[] = []
-        // const unprocessed: IRToken[] = [...this.children]
-        // while (unprocessed.length) {
-
-        // }
-        const index = this.children.findIndex(
-            (token) => token instanceof IRLineBreak
-        )
-        if (index >= 0) {
-            return {
-                before:
-                    // do not create an empty element if the first child
-                    // is a newline
-                    index === 0
-                        ? undefined
-                        : this.getClone(this.children.slice(0, index)),
-                after: this.getClone(this.children.slice(index + 1)),
-            }
+    splitOnLineBreaks(): IRToken[][] {
+        const lines = splitAllOnNewline(this.children)
+        if (lines.length > 1) {
+            return lines.map((tokens) =>
+                // Do not create a clone without children.
+                // There aren't any children in a line when the first or last
+                // token is a newline.
+                tokens.length ? [this.getClone(tokens)] : []
+            )
         }
-        return { before: this }
+        // Do not create copies of element
+        // if there are no newlines inside.
+        return [[this]]
     }
 
     abstract getClone(children: IRToken[]): IRElement
@@ -256,13 +248,11 @@ function splitAllOnNewline(tokens: IRToken[]): IRToken[][] {
     while (unproccessed.length > 0) {
         const token = unproccessed.shift()!
         if (token instanceof IRElement) {
-            const { before, after } = token.splitOnNextLineBreak()
-            if (before) currentLine.push(before)
-            if (after) {
-                currentLine = []
-                lines.push(currentLine)
-                // move to unprocessed stack, it might contain futher newlines
-                unproccessed.unshift(after)
+            const [firstLine, ...otherLines] = token.splitOnLineBreaks()
+            if (firstLine) currentLine.push(...firstLine)
+            if (otherLines.length) {
+                lines.push(...otherLines)
+                currentLine = last(lines)!
             }
         } else if (token instanceof IRLineBreak) {
             currentLine = []


### PR DESCRIPTION
Fixes an issue in a PR: https://github.com/owid/owid-grapher/pull/1535#issuecomment-1176034159

> - There is a bug with newline nodes, they don't get lifted up to the top (they are supposed to). I can implement a fix for this, shouldn't take long – we just need to recursively call the splitting method.

#### Before:

<img width="764" alt="Screenshot 2022-07-12 at 01 25 49" src="https://user-images.githubusercontent.com/1308115/178380674-b935fd16-a6be-43ee-9206-7fef0b790dfd.png">

#### After:

<img width="764" alt="Screenshot 2022-07-12 at 01 25 32" src="https://user-images.githubusercontent.com/1308115/178380689-50e95f8c-cfe9-44f5-ab39-f72272a549d4.png">

