### PR TITLE
chore(db): add migration to remove bogus targetYear fields

### DIFF
--- a/db/migration/1657627850269-TargetYear.ts
+++ b/db/migration/1657627850269-TargetYear.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class TargetYear1657627850269 implements MigrationInterface {
+    name = "TargetYear1657627850269"
+
+    async runAll(queryRunner: QueryRunner, query: string): Promise<void> {
+        // There is no way for a query to target all indices of a JSON array, so we just run it multiple times.
+        for (let i = 0; i < 50; i++) {
+            const currentQuery = query.replace(/§§/g, i.toString())
+            await queryRunner.query(currentQuery)
+        }
+    }
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Get rid of all `dimension.targetYear: null` values, across all chart types.
+        await this.runAll(
+            queryRunner,
+            `UPDATE charts
+            SET config = JSON_REMOVE(config, "$.dimensions[§§].targetYear")
+            WHERE config ->> "$.dimensions[§§].targetYear" = 'null'`
+        )
+
+        // Setting targetYear only makes sense for ScatterPlots and Marimekko charts.
+        // Get rid of all `dimension.targetYear` values that are set on charts that are not of type `ScatterPlot` or `Marimekko`.
+        await this.runAll(
+            queryRunner,
+            `UPDATE charts
+            SET config = JSON_REMOVE(config, "$.dimensions[§§].targetYear")
+            WHERE config ->> "$.dimensions[§§].targetYear" IS NOT NULL
+            AND COALESCE(config ->> '$.type', 'LineChart') NOT IN ('ScatterPlot', 'Marimekko')`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/grapher/schema/grapher-schema.001.json
+++ b/grapher/schema/grapher-schema.001.json
@@ -448,7 +448,7 @@
                 "required": ["property", "variableId"],
                 "properties": {
                     "targetYear": {
-                        "type": ["integer", "null"],
+                        "type": "integer",
                         "description": "Charts that can display more than one primary dimensions (i.e. scatter and marimekko)\nsometimes need to \"hardcode\" one dimension to a specific year. This happens e.g. when\nmixing a daily X variable in a scatter plot with a yearly one, e.g. population.\n"
                     },
                     "property": {

--- a/grapher/schema/grapher-schema.001.yaml
+++ b/grapher/schema/grapher-schema.001.yaml
@@ -397,9 +397,7 @@ properties:
                 - variableId
             properties:
                 targetYear:
-                    type:
-                        - integer
-                        - "null"
+                    type: integer
                     description: |
                         Charts that can display more than one primary dimensions (i.e. scatter and marimekko)
                         sometimes need to "hardcode" one dimension to a specific year. This happens e.g. when


### PR DESCRIPTION
As discussed [on Slack](https://owid.slack.com/archives/CQQUA2C2U/p1657621825175579).

There appear to be some charts that have `dimension.targetYear` set to 2000 (chart id <= 409) or to `null` (chart id <= 1686).

`targetYear` only makes sense for scatter plots and Marimekko charts, and it being present when it shouldn't be can throw up some DataTable code. Same goes for when it's `null` when it shouldn't be.