### PR TITLE
fix(TextWrap): match SVG and HTML rendering

### DIFF
--- a/grapher/axis/Axis.ts
+++ b/grapher/axis/Axis.ts
@@ -438,6 +438,7 @@ abstract class AbstractAxis {
                   maxWidth: this.labelWidth,
                   fontSize: this.labelFontSize,
                   text,
+                  lineHeight: 1,
               })
             : undefined
     }

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -79,7 +79,7 @@ interface CaptionedChartProps {
 }
 
 const OUTSIDE_PADDING = 15
-const PADDING_BELOW_HEADER = 18
+const PADDING_BELOW_HEADER = 16
 const CONTROLS_ROW_HEIGHT = 36
 const PADDING_ABOVE_FOOTER = 25
 

--- a/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/grapher/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -370,6 +370,7 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                   fontSize: this.legendTitleFontSize,
                   fontWeight: 700,
                   maxWidth: this.maxWidth / 3,
+                  lineHeight: 1,
               })
             : undefined
     }

--- a/grapher/lineLegend/LineLegend.tsx
+++ b/grapher/lineLegend/LineLegend.tsx
@@ -191,6 +191,7 @@ export class LineLegend extends React.Component<{
                       text: label.annotation,
                       maxWidth: maxAnnotationWidth,
                       fontSize: fontSize * 0.9,
+                      lineHeight: 1,
                   })
                 : undefined
             const textWrap = new TextWrap({
@@ -198,6 +199,7 @@ export class LineLegend extends React.Component<{
                 maxWidth: maxTextWidth,
                 fontSize,
                 fontWeight,
+                lineHeight: 1,
             })
             return {
                 ...label,

--- a/grapher/scatterCharts/ConnectedScatterLegend.tsx
+++ b/grapher/scatterCharts/ConnectedScatterLegend.tsx
@@ -34,6 +34,7 @@ export class ConnectedScatterLegend {
             text: manager.displayStartTime,
             fontSize,
             maxWidth: maxLabelWidth,
+            lineHeight: 1,
         })
     }
 
@@ -43,6 +44,7 @@ export class ConnectedScatterLegend {
             text: manager.displayEndTime,
             fontSize,
             maxWidth: maxLabelWidth,
+            lineHeight: 1,
         })
     }
 

--- a/grapher/scatterCharts/ScatterSizeLegend.tsx
+++ b/grapher/scatterCharts/ScatterSizeLegend.tsx
@@ -100,6 +100,7 @@ export class ScatterSizeLegend {
             // actually visibly overflow.
             maxWidth: this.maxWidth + 12,
             fontSize,
+            lineHeight: 1,
         })
     }
 
@@ -113,6 +114,7 @@ export class ScatterSizeLegend {
             maxWidth: this.maxWidth + 10,
             fontSize,
             fontWeight: 700,
+            lineHeight: 1,
         })
     }
 

--- a/grapher/scatterCharts/ScatterTooltip.tsx
+++ b/grapher/scatterCharts/ScatterTooltip.tsx
@@ -37,6 +37,7 @@ export class ScatterTooltip extends React.Component<ScatterTooltipProps> {
             wrap: new TextWrap({
                 maxWidth: maxWidth,
                 fontSize: 0.75 * fontSize,
+                lineHeight: 1,
                 text: series.label,
             }),
         }
@@ -52,6 +53,7 @@ export class ScatterTooltip extends React.Component<ScatterTooltipProps> {
                 wrap: new TextWrap({
                     maxWidth: maxWidth,
                     fontSize: 0.65 * fontSize,
+                    lineHeight: 1,
                     text: v.time.span
                         ? `${yColumn.formatTime(
                               v.time.span[0]
@@ -66,6 +68,7 @@ export class ScatterTooltip extends React.Component<ScatterTooltipProps> {
                 wrap: new TextWrap({
                     maxWidth: maxWidth,
                     fontSize: 0.55 * fontSize,
+                    lineHeight: 1,
                     text: this.formatValueY(v),
                 }),
             }
@@ -76,6 +79,7 @@ export class ScatterTooltip extends React.Component<ScatterTooltipProps> {
                 wrap: new TextWrap({
                     maxWidth: maxWidth,
                     fontSize: 0.55 * fontSize,
+                    lineHeight: 1,
                     text: this.formatValueX(v),
                 }),
             }

--- a/grapher/slopeCharts/SlopeChart.tsx
+++ b/grapher/slopeCharts/SlopeChart.tsx
@@ -814,11 +814,13 @@ class LabelledSlopes
             const leftLabel = new TextWrap({
                 maxWidth,
                 fontSize,
+                lineHeight: 1,
                 text,
             })
             const rightLabel = new TextWrap({
                 maxWidth,
                 fontSize,
+                lineHeight: 1,
                 text,
             })
 

--- a/grapher/text/TextWrap.stories.tsx
+++ b/grapher/text/TextWrap.stories.tsx
@@ -1,0 +1,71 @@
+import React from "react"
+
+import { TextWrap } from "./TextWrap.js"
+
+export default {
+    title: "TextWrap",
+}
+
+const RED = "#f97272"
+const GREEN = "#008400"
+
+const HTMLAndSVG = ({
+    text = "The quick brown fox jumped over the lazy dog.",
+    fontSize = 16,
+    maxWidth = 400,
+    lineHeight = 1.1,
+}: {
+    text?: string
+    fontSize?: number
+    maxWidth?: number
+    lineHeight?: number
+}): JSX.Element => {
+    const textwrap = new TextWrap({
+        maxWidth,
+        fontSize,
+        lineHeight,
+        text,
+    })
+    const width = maxWidth
+    const height = textwrap.height
+    return (
+        <div>
+            <div
+                style={{
+                    position: "absolute",
+                    width: `${width}px`,
+                    height: `${height}px`,
+                    border: "1px dashed #ccc",
+                }}
+            ></div>
+            <svg width={width} height={height} style={{ position: "absolute" }}>
+                <g style={{ fill: RED, opacity: 0.75 }}>
+                    {textwrap.render(0, 0)}
+                </g>
+            </svg>
+            <div
+                style={{
+                    color: GREEN,
+                    opacity: 0.75,
+                    ...textwrap.htmlStyle,
+                }}
+            >
+                {textwrap.renderHTML()}
+            </div>
+        </div>
+    )
+}
+
+export const HTMLAndSVGComparison = (): JSX.Element => (
+    <div>
+        <HTMLAndSVG fontSize={12.4} maxWidth={120} lineHeight={1} />
+        <br />
+        <HTMLAndSVG fontSize={16} maxWidth={140} lineHeight={1} />
+        <br />
+        <HTMLAndSVG fontSize={20} maxWidth={200} lineHeight={1.2} />
+        <br />
+        <HTMLAndSVG fontSize={20} maxWidth={200} lineHeight={2} />
+        <br />
+        <HTMLAndSVG fontSize={40} maxWidth={400} lineHeight={1.5} />
+    </div>
+)

--- a/grapher/text/TextWrap.test.ts
+++ b/grapher/text/TextWrap.test.ts
@@ -69,6 +69,18 @@ describe("height()", () => {
             renderedHeight("test\ntest") + lineHeight
         )
     })
+
+    it("calculates correct height with custom lineHeight", () => {
+        const textwrap = new TextWrap({
+            maxWidth: Infinity,
+            fontSize: 10,
+            lineHeight: 1.5,
+            text: "line\nline\nline",
+        })
+        // line (10) + space (5) + line (10) + space (5) + line (10)
+        // NOTE: no specing after the bottom line
+        expect(textwrap.height).toEqual(40)
+    })
 })
 
 describe(shortenForTargetWidth, () => {

--- a/grapher/text/TextWrap.test.ts
+++ b/grapher/text/TextWrap.test.ts
@@ -77,9 +77,7 @@ describe("height()", () => {
             lineHeight: 1.5,
             text: "line\nline\nline",
         })
-        // line (10) + space (5) + line (10) + space (5) + line (10)
-        // NOTE: no specing after the bottom line
-        expect(textwrap.height).toEqual(40)
+        expect(textwrap.height).toEqual(45)
     })
 })
 

--- a/grapher/text/TextWrap.tsx
+++ b/grapher/text/TextWrap.tsx
@@ -130,12 +130,9 @@ export class TextWrap {
     }
 
     @computed get height(): number {
-        if (this.lines.length === 0) return 0
-
-        return (
-            this.lines.reduce((total, line) => total + line.height, 0) +
-            this.lineHeight * (this.lines.length - 1)
-        )
+        const { lines, lineHeight, fontSize } = this
+        if (lines.length === 0) return 0
+        return fontSize + lineHeight * fontSize * (lines.length - 1)
     }
 
     @computed get width(): number {

--- a/grapher/text/TextWrap.tsx
+++ b/grapher/text/TextWrap.tsx
@@ -132,7 +132,7 @@ export class TextWrap {
     @computed get height(): number {
         const { lines, lineHeight, fontSize } = this
         if (lines.length === 0) return 0
-        return fontSize + lineHeight * fontSize * (lines.length - 1)
+        return lines.length * lineHeight * fontSize
     }
 
     @computed get width(): number {
@@ -198,7 +198,16 @@ export class TextWrap {
 
         if (lines.length === 0) return null
 
-        const yOffset = y + lines[0].height - lines[0].height * 0.2
+        // Magic number set through experimentation.
+        // The HTML and SVG renderers need to position lines identically.
+        // This number was tweaked until the overlaid HTML and SVG outputs
+        // overlap (see storybook of this component).
+        const HEIGHT_CORRECTION_FACTOR = 0.74
+
+        const textHeight = lines[0].height * HEIGHT_CORRECTION_FACTOR
+        const containerHeight = lineHeight * fontSize
+        const yOffset =
+            y + (containerHeight - (containerHeight - textHeight) / 2)
         return (
             <text
                 fontSize={fontSize.toFixed(2)}
@@ -213,10 +222,7 @@ export class TextWrap {
                             <tspan
                                 key={i}
                                 x={x}
-                                y={
-                                    yOffset +
-                                    (i === 0 ? 0 : lineHeight * fontSize * i)
-                                }
+                                y={yOffset + lineHeight * fontSize * i}
                                 dangerouslySetInnerHTML={{ __html: line.text }}
                             />
                         )

--- a/grapher/verticalColorLegend/VerticalColorLegend.tsx
+++ b/grapher/verticalColorLegend/VerticalColorLegend.tsx
@@ -62,6 +62,7 @@ export class VerticalColorLegend extends React.Component<{
             maxWidth: this.maxLegendWidth,
             fontSize: this.fontSize,
             fontWeight: 700,
+            lineHeight: 1,
             text: this.manager.legendTitle,
         })
     }
@@ -84,6 +85,7 @@ export class VerticalColorLegend extends React.Component<{
                 const textWrap = new TextWrap({
                     maxWidth: this.maxLegendWidth,
                     fontSize,
+                    lineHeight: 1,
                     text: label ?? "",
                 })
                 return {


### PR DESCRIPTION
In Details on Demand (#1552) we noticed that the height `TextWrap` returns is not correct – `lineHeight` is not multiplied by the `fontSize`.