### PR TITLE
Perf: adds a new implementation for full joining multiple tables.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,15 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "args": [],
+            "internalConsoleOptions": "openOnSessionStart",
+            "name": "Jest Tests",
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
+            "request": "launch",
+            "skipFiles": ["<node_internals>/**"],
+            "type": "node"
+        },
+        {
             "name": "Launch site dev",
             "program": "${workspaceFolder}/itsJustJavascript/adminSiteServer/app.js",
             "request": "launch",

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -911,6 +911,12 @@ export const intersectionOfSets = <T>(sets: Set<T>[]): Set<T> => {
     return intersection
 }
 
+export const unionOfSets = <T>(sets: Set<T>[]): Set<T> => {
+    if (!sets.length) return new Set<T>()
+    const unionSet = new Set<T>(...sets)
+    return unionSet
+}
+
 export const differenceOfSets = <T>(sets: Set<T>[]): Set<T> => {
     if (!sets.length) return new Set<T>()
     const diff = new Set<T>(sets[0])

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -780,6 +780,14 @@ export function dateDiffInDays(a: Date, b: Date): number {
 export const diffDateISOStringInDays = (a: string, b: string): number =>
     dayjs.utc(a).diff(dayjs.utc(b), "day")
 
+export const getYearFromISOStringAndDayOffset = (
+    epoch: string,
+    daysOffset: number
+): number => {
+    const date = dayjs.utc(epoch).add(daysOffset, "day")
+    return date.year()
+}
+
 export const addDays = (date: Date, days: number): Date => {
     const newDate = new Date(date.getTime())
     newDate.setDate(newDate.getDate() + days)

--- a/grapher/core/LegacyToOwidTable.test.ts
+++ b/grapher/core/LegacyToOwidTable.test.ts
@@ -461,7 +461,7 @@ describe(legacyToOwidTableAndDimensions, () => {
 
         describe("scatter-specific behavior", () => {
             it("only joins targetTime on Scatters", () => {
-                expect(table.rows.length).toEqual(3)
+                expect(table.rows.length).toEqual(3) // used to be 4 but IMHO that was wrong legacy behaviour (from combining left and right join and then dropping duplicates)
             })
 
             it("joins targetTime", () => {

--- a/grapher/core/LegacyToOwidTable.test.ts
+++ b/grapher/core/LegacyToOwidTable.test.ts
@@ -184,6 +184,8 @@ describe(legacyToOwidTableAndDimensions, () => {
             const worldRows = table.rows.filter(
                 (row) => row.entityName === "World"
             )
+            expect(table.rows.length).toEqual(5)
+            expect(worldRows.length).toEqual(4)
             expect(worldRows[0]["3"]).toEqual(
                 ErrorValueTypes.NoMatchingValueAfterJoin
             )

--- a/grapher/core/LegacyToOwidTable.test.ts
+++ b/grapher/core/LegacyToOwidTable.test.ts
@@ -461,7 +461,7 @@ describe(legacyToOwidTableAndDimensions, () => {
 
         describe("scatter-specific behavior", () => {
             it("only joins targetTime on Scatters", () => {
-                expect(table.rows.length).toEqual(4)
+                expect(table.rows.length).toEqual(3)
             })
 
             it("joins targetTime", () => {

--- a/grapher/core/LegacyToOwidTable.ts
+++ b/grapher/core/LegacyToOwidTable.ts
@@ -298,7 +298,7 @@ const fullJoinTables = (
         // When we get a mergeFallbackLookupColumn then it can happen that a table does not have all the
         // columns of the main index. In this case, just return an empty map because that will lead all
         // lookups by main index to fail and we'll try the fallback index
-        mergeFallbackLookupColumns &&
+        !mergeFallbackLookupColumns ||
         difference(indexColumnNames, table.columnSlugs).length === 0
             ? table.rowIndex(indexColumnNames)
             : new Map()


### PR DESCRIPTION
This should allevieate performance issues with many variables as recently reported. In one test the time to do the full join went down from 4 seconds to 600 ms and the memory use from 250MB to 85MB