### PR TITLE
DoD export style touchups

### DIFF
--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -12,6 +12,7 @@ import extend from "lodash/extend.js"
 import findIndex from "lodash/findIndex.js"
 import findLastIndex from "lodash/findLastIndex.js"
 import flatten from "lodash/flatten.js"
+import get from "lodash/get.js"
 import groupBy from "lodash/groupBy.js"
 import identity from "lodash/identity.js"
 import invert from "lodash/invert.js"
@@ -19,8 +20,8 @@ import isArray from "lodash/isArray.js"
 import isBoolean from "lodash/isBoolean.js"
 import isEmpty from "lodash/isEmpty.js"
 import isEqual from "lodash/isEqual.js"
-import isNumber from "lodash/isNumber.js"
 import isNull from "lodash/isNull.js"
+import isNumber from "lodash/isNumber.js"
 import isObject from "lodash/isObject.js"
 import isPlainObject from "lodash/isPlainObject.js"
 import isString from "lodash/isString.js"
@@ -44,6 +45,7 @@ import reverse from "lodash/reverse.js"
 import round from "lodash/round.js"
 import sample from "lodash/sample.js"
 import sampleSize from "lodash/sampleSize.js"
+import set from "lodash/set.js"
 import sortBy from "lodash/sortBy.js"
 import sortedUniqBy from "lodash/sortedUniqBy.js"
 import startCase from "lodash/startCase.js"
@@ -72,6 +74,7 @@ export {
     findIndex,
     findLastIndex,
     flatten,
+    get,
     groupBy,
     identity,
     invert,
@@ -102,6 +105,7 @@ export {
     round,
     sample,
     sampleSize,
+    set,
     sortBy,
     sortedUniqBy,
     startCase,

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -314,7 +314,12 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
     }
 
     renderSVGDetails(): JSX.Element | null {
-        if (isEmpty(this.manager.details)) return null
+        if (
+            isEmpty(this.manager.details) ||
+            !this.manager.shouldIncludeDetailsInStaticExport
+        ) {
+            return null
+        }
 
         let yOffset = 0
         let previousOffset = 0
@@ -323,7 +328,7 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
                 <line
                     x1={OUTSIDE_PADDING}
                     y1={this.bounds.height}
-                    x2={this.boundsForChart.width - OUTSIDE_PADDING}
+                    x2={this.boundsForChart.width + OUTSIDE_PADDING}
                     y2={this.bounds.height}
                     stroke="#777"
                 ></line>

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -321,16 +321,17 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         return (
             <>
                 <line
-                    x1={15}
+                    x1={OUTSIDE_PADDING}
                     y1={this.bounds.height}
-                    x2={this.boundsForChart.width - 15}
+                    x2={this.boundsForChart.width - OUTSIDE_PADDING}
                     y2={this.bounds.height}
                     stroke="#777"
                 ></line>
                 <g
                     style={{
                         transform: `translate(15px, ${
-                            this.bounds.height + 15
+                            // + padding below the grey line
+                            this.bounds.height + OUTSIDE_PADDING
                         }px)`,
                     }}
                 >

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -319,17 +319,28 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         let yOffset = 0
         let previousOffset = 0
         return (
-            <g
-                style={{
-                    transform: `translate(15px, ${this.bounds.height}px)`,
-                }}
-            >
-                {this.manager.detailRenderers.map((detail, i) => {
-                    previousOffset = yOffset
-                    yOffset += detail.height + STATIC_EXPORT_DETAIL_SPACING
-                    return detail.renderSVG(0, previousOffset, { key: i })
-                })}
-            </g>
+            <>
+                <line
+                    x1={15}
+                    y1={this.bounds.height}
+                    x2={this.bounds.width - 15}
+                    y2={this.bounds.height}
+                    stroke="#777"
+                ></line>
+                <g
+                    style={{
+                        transform: `translate(15px, ${
+                            this.bounds.height + 15
+                        }px)`,
+                    }}
+                >
+                    {this.manager.detailRenderers.map((detail, i) => {
+                        previousOffset = yOffset
+                        yOffset += detail.height + STATIC_EXPORT_DETAIL_SPACING
+                        return detail.renderSVG(0, previousOffset, { key: i })
+                    })}
+                </g>
+            </>
         )
     }
 

--- a/grapher/captionedChart/CaptionedChart.tsx
+++ b/grapher/captionedChart/CaptionedChart.tsx
@@ -323,7 +323,7 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
                 <line
                     x1={15}
                     y1={this.bounds.height}
-                    x2={this.bounds.width - 15}
+                    x2={this.boundsForChart.width - 15}
                     y2={this.bounds.height}
                     stroke="#777"
                 ></line>

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1184,7 +1184,10 @@ export class Grapher
                 let text = `**${i + 1}.** `
                 const detail = this.details[category][term]
                 if (detail) {
-                    text += `**${detail.title}**\n\n${detail.content}`
+                    text += `**${detail.title}**: ${detail.content.replaceAll(
+                        /\n\n/g,
+                        " "
+                    )}`
                 }
                 return new MarkdownTextWrap({
                     text,
@@ -1193,7 +1196,7 @@ export class Grapher
                     maxWidth: this.idealBounds.width - 30,
                     lineHeight: 1.2,
                     style: {
-                        fill: "#555",
+                        fill: "#777",
                     },
                 })
             }

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -1180,8 +1180,9 @@ export class Grapher
                 return new MarkdownTextWrap({
                     text,
                     fontSize: 12,
-                    maxWidth: this.bounds.width,
-                    lineHeight: 0.75,
+                    // 30 is 15 margin on both sides
+                    maxWidth: this.idealBounds.width - 30,
+                    lineHeight: 1.2,
                     style: {
                         fill: "#555",
                     },

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -31,6 +31,8 @@ import {
     isInIFrame,
     differenceObj,
     isEmpty,
+    get,
+    set,
 } from "../../clientUtils/Util.js"
 import { QueryParams } from "../../clientUtils/urls/UrlUtils.js"
 import {
@@ -178,7 +180,6 @@ import { FacetChartManager } from "../facetChart/FacetChartConstants.js"
 import { globalDetailsOnDemand } from "../detailsOnDemand/detailsOnDemand.js"
 import { MarkdownTextWrap } from "../text/MarkdownTextWrap.js"
 import { detailOnDemandRegex } from "../text/parser.js"
-import { get, set } from "lodash"
 
 declare const window: any
 

--- a/grapher/detailsOnDemand/detailsOnDemand.scss
+++ b/grapher/detailsOnDemand/detailsOnDemand.scss
@@ -1,10 +1,12 @@
 span.dod-term {
-    border-bottom: 1px dotted $controls-color;
-    color: $controls-color;
+    border-bottom: 1px dotted #666;
+    color: #666;
+}
 
-    &:hover {
-        color: darken($controls-color, 10%);
-    }
+.dod-tippy-container {
+    overflow-y: auto;
+    // should only result in scrollbars when viewport height is very small
+    max-height: 80vh;
 }
 
 .dod-tooltip {

--- a/grapher/detailsOnDemand/detailsOnDemand.scss
+++ b/grapher/detailsOnDemand/detailsOnDemand.scss
@@ -1,3 +1,7 @@
+.interactive-tippy-wrapper {
+    display: inline-block;
+}
+
 span.dod-term {
     border-bottom: 1px dotted #666;
     color: #666;

--- a/grapher/detailsOnDemand/detailsOnDemand.tsx
+++ b/grapher/detailsOnDemand/detailsOnDemand.tsx
@@ -4,7 +4,6 @@ import { MarkdownTextWrap } from "../text/MarkdownTextWrap.js"
 import { computed, observable, ObservableMap } from "mobx"
 import { observer } from "mobx-react"
 import { Detail } from "../core/GrapherConstants.js"
-import { throttle } from "lodash"
 
 class DetailsOnDemand {
     @observable details = new ObservableMap<
@@ -42,15 +41,9 @@ interface DoDWrapperProps {
 }
 
 @observer
-export class DoDWrapper extends React.Component<
-    DoDWrapperProps,
-    { innerHeight: number }
-> {
+export class DoDWrapper extends React.Component<DoDWrapperProps> {
     constructor(props: DoDWrapperProps) {
         super(props)
-        this.state = {
-            innerHeight: window.innerHeight,
-        }
     }
     @computed get category() {
         return this.props.category
@@ -68,20 +61,6 @@ export class DoDWrapper extends React.Component<
         return ""
     }
 
-    handleResize = throttle(() => {
-        this.setState({
-            innerHeight: window.innerHeight,
-        })
-    }, 200)
-
-    componentDidMount() {
-        window.addEventListener("resize", this.handleResize)
-    }
-
-    componentWillUnmount() {
-        window.removeEventListener("resize", this.handleResize)
-    }
-
     @computed get title() {
         if (this.detail) {
             return this.detail.title
@@ -91,12 +70,9 @@ export class DoDWrapper extends React.Component<
     render() {
         if (!this.content) return this.props.children
         return (
-            <span>
+            <span className="interactive-tippy-wrapper">
                 <Tippy
-                    // Tippy gets it wrong when viewport height is very low
-                    // because it doesn't realize that the .GrapherComponent
-                    // container is overflow: hidden
-                    placement={this.state.innerHeight < 300 ? "right" : "auto"}
+                    placement="auto"
                     className="dod-tippy-container"
                     content={
                         <div className="dod-tooltip">

--- a/grapher/downloadTab/DownloadTab.tsx
+++ b/grapher/downloadTab/DownloadTab.tsx
@@ -82,8 +82,7 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
                 sumTextWrapHeights(
                     this.manager.detailRenderers,
                     STATIC_EXPORT_DETAIL_SPACING
-                ) +
-                15 // padding for grey bar
+                )
             )
         }
         return this.idealBounds.height

--- a/grapher/downloadTab/DownloadTab.tsx
+++ b/grapher/downloadTab/DownloadTab.tsx
@@ -82,7 +82,8 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
                 sumTextWrapHeights(
                     this.manager.detailRenderers,
                     STATIC_EXPORT_DETAIL_SPACING
-                )
+                ) +
+                15 // padding for grey bar
             )
         }
         return this.idealBounds.height

--- a/grapher/footer/Footer.tsx
+++ b/grapher/footer/Footer.tsx
@@ -108,6 +108,8 @@ export class Footer extends React.Component<{
             maxWidth,
             fontSize,
             text: noteText,
+            detailOnDemandReferenceOrder:
+                this.manager.detailsOrderedByReference,
         })
     }
 

--- a/grapher/footer/Footer.tsx
+++ b/grapher/footer/Footer.tsx
@@ -108,8 +108,7 @@ export class Footer extends React.Component<{
             maxWidth,
             fontSize,
             text: noteText,
-            detailOnDemandReferenceOrder:
-                this.manager.detailsOrderedByReference,
+            detailsOrderedByReference: this.manager.detailsOrderedByReference,
         })
     }
 

--- a/grapher/footer/FooterManager.ts
+++ b/grapher/footer/FooterManager.ts
@@ -14,4 +14,5 @@ export interface FooterManager {
     tooltips?: TooltipManager["tooltips"]
     tabBounds?: Bounds
     details?: GrapherInterface["details"]
+    detailsOrderedByReference?: { category: string; term: string }[]
 }

--- a/grapher/header/Header.tsx
+++ b/grapher/header/Header.tsx
@@ -92,6 +92,8 @@ export class Header extends React.Component<{
             fontSize: 0.8 * this.fontSize,
             text: this.subtitleText,
             lineHeight: 1.2,
+            detailOnDemandReferenceOrder:
+                this.manager.detailsOrderedByReference,
         })
     }
 

--- a/grapher/header/Header.tsx
+++ b/grapher/header/Header.tsx
@@ -92,8 +92,7 @@ export class Header extends React.Component<{
             fontSize: 0.8 * this.fontSize,
             text: this.subtitleText,
             lineHeight: 1.2,
-            detailOnDemandReferenceOrder:
-                this.manager.detailsOrderedByReference,
+            detailsOrderedByReference: this.manager.detailsOrderedByReference,
         })
     }
 

--- a/grapher/header/HeaderManager.ts
+++ b/grapher/header/HeaderManager.ts
@@ -10,4 +10,5 @@ export interface HeaderManager {
     logo?: string
     canonicalUrl?: string
     tabBounds?: Bounds
+    detailsOrderedByReference?: { category: string; term: string }[]
 }

--- a/grapher/text/MarkdownTextWrap.scss
+++ b/grapher/text/MarkdownTextWrap.scss
@@ -3,9 +3,18 @@
     white-space: pre-wrap;
 }
 
-.markdown-text-wrap {
+.GrapherComponent .markdown-text-wrap {
     a,
     a:visited {
-        color: $link-color;
+        color: #666;
+        text-decoration: underline;
+    }
+    a:hover {
+        color: darken(#666, 10%);
+    }
+
+    // needed so DoD border-bottom doesn't clip
+    .markdown-text-wrap__line:last-child {
+        margin-bottom: 2px;
     }
 }

--- a/grapher/text/MarkdownTextWrap.scss
+++ b/grapher/text/MarkdownTextWrap.scss
@@ -8,10 +8,4 @@
     a:visited {
         color: $link-color;
     }
-
-    svg {
-        a {
-            fill: $link-color;
-        }
-    }
 }

--- a/grapher/text/MarkdownTextWrap.stories.tsx
+++ b/grapher/text/MarkdownTextWrap.stories.tsx
@@ -22,6 +22,10 @@ Testing this somewhat long line. **I am bold-_and-italic_. And the formatting ex
 
 newlines!**
 
+These DoDs won't render on hover because there's no data for them, but they'll demonstrate the superscript on SVG:
+
+[A dod](hover::general::term1) [another dod.](hover::general::term2) [The other dod](hover::general::term1)
+
 [links can contain _formatting_ too](http://ourworldindata.org). Averylongtokenthatcantbesplitbutshouldbeincludedanyway.**Canhavebold**withoutlinebreak.
 
 _THE END_
@@ -101,7 +105,7 @@ _THE END_
                     </div>
                     <pre>isSVG Example</pre>
                     <svg
-                        viewBox={`0,0,${svgContainerWidth},200`}
+                        viewBox={`0,0,${svgContainerWidth},400`}
                         style={{ outline: "1px solid black" }}
                     >
                         {new MarkdownTextWrap({

--- a/grapher/text/MarkdownTextWrap.test.ts
+++ b/grapher/text/MarkdownTextWrap.test.ts
@@ -28,8 +28,8 @@ describe("MarkdownTextWrap", () => {
             maxWidth: 200,
         })
 
-        const plainWidth = getLineWidth(plainMarkdownTextWrap.lines[0])
-        const boldWidth = getLineWidth(boldMarkdownTextWrap.lines[0])
+        const plainWidth = getLineWidth(plainMarkdownTextWrap.htmlLines[0])
+        const boldWidth = getLineWidth(boldMarkdownTextWrap.htmlLines[0])
         expect(plainWidth).toBeLessThan(boldWidth)
     })
 

--- a/grapher/text/MarkdownTextWrap.tsx
+++ b/grapher/text/MarkdownTextWrap.tsx
@@ -515,7 +515,7 @@ type MarkdownTextWrapProps = {
     lineHeight?: number
     maxWidth?: number
     style?: CSSProperties
-    detailOnDemandReferenceOrder?: { category: string; term: string }[]
+    detailsOrderedByReference?: { category: string; term: string }[]
 }
 
 export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
@@ -538,11 +538,11 @@ export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
     @computed get text(): string {
         return this.props.text
     }
-    @computed get detailOnDemandReferenceOrder(): {
+    @computed get detailsOrderedByReference(): {
         category: string
         term: string
     }[] {
-        return this.props.detailOnDemandReferenceOrder || []
+        return this.props.detailsOrderedByReference || []
     }
     @computed get ast(): MarkdownRoot["children"] {
         if (!this.text) return []
@@ -562,7 +562,7 @@ export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
     // their width differently. Height should remain the same.
     @computed get svgLines(): IRToken[][] {
         const references: { category: string; term: string }[] =
-            this.detailOnDemandReferenceOrder
+            this.detailsOrderedByReference
         function appendReferenceNumbers(tokens: IRToken[]): IRToken[] {
             function traverse(
                 token: IRToken,

--- a/grapher/text/MarkdownTextWrap.tsx
+++ b/grapher/text/MarkdownTextWrap.tsx
@@ -267,6 +267,7 @@ export class IRLink extends IRElement {
                 key={key}
                 href={this.href}
                 target="_blank"
+                style={{ textDecoration: "underline" }}
                 rel="noopener noreferrer"
             >
                 {this.children.map((child, i) => child.toSVG(i))}

--- a/grapher/text/parser.ts
+++ b/grapher/text/parser.ts
@@ -326,6 +326,8 @@ const detailOnDemandContentParser: (
         r.nonBracketWord
     )
 
+export const detailOnDemandRegex = /\(hover::(\w+)::(\w+)\)/
+
 const detailOnDemandParser: (r: MdParser) => P.Parser<DetailOnDemand> = (
     r: MdParser
 ) =>


### PR DESCRIPTION
Implements Marwa's design feedback for static exports.

Business logic outline:
1. Scan through the subtitle and note text, find all DoD references and create a unique ordered list (because in the case where the same DoD is referenced twice, we don't want to increment the citation number)
2. Traverse the Markdown AST and whenever we find a DoD, append a IRSuperscript token into its children that uses the corresponding index from the unique ordered list

Rendering superscript in SVG has some quirks but it seems to work fairly well.

TODO:
- [x] link restyling
- [x] fix right-side text clipping

![renewable-share-energy(2)](https://user-images.githubusercontent.com/11844404/180835843-48af58c7-1a99-416a-b13c-ce2a3c4b7ee3.png)


