### PR TITLE
Disable DoD footnotes on bake

### DIFF
--- a/baker/GrapherImageBaker.tsx
+++ b/baker/GrapherImageBaker.tsx
@@ -20,6 +20,7 @@ export async function bakeGraphersToPngs(
 ) {
     const grapher = new Grapher({ ...jsonConfig, manuallyProvideData: true })
     grapher.isExportingtoSvgOrPng = true
+    grapher.shouldIncludeDetailsInStaticExport = false
     grapher.receiveOwidData(vardata)
     const outPath = path.join(outDir, grapher.slug as string)
 
@@ -124,6 +125,7 @@ export function initGrapherForSvgExport(
         queryStr,
     })
     grapher.isExportingtoSvgOrPng = true
+    grapher.shouldIncludeDetailsInStaticExport = false
     return grapher
 }
 
@@ -214,6 +216,7 @@ export async function grapherToSVG(
 ): Promise<string> {
     const grapher = new Grapher({ ...jsonConfig, manuallyProvideData: true })
     grapher.isExportingtoSvgOrPng = true
+    grapher.shouldIncludeDetailsInStaticExport = false
     grapher.receiveOwidData(vardata)
     return grapher.staticSVG
 }


### PR DESCRIPTION
I ran the local baker with configs that included DoDs before and after these changes: it's fixed!