### PR TITLE
Perf: adds a new implementation for full joining multiple tables

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,15 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "args": [],
+            "internalConsoleOptions": "openOnSessionStart",
+            "name": "Jest Tests",
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
+            "request": "launch",
+            "skipFiles": ["<node_internals>/**"],
+            "type": "node"
+        },
+        {
             "name": "Launch site dev",
             "program": "${workspaceFolder}/itsJustJavascript/adminSiteServer/app.js",
             "request": "launch",

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -780,6 +780,14 @@ export function dateDiffInDays(a: Date, b: Date): number {
 export const diffDateISOStringInDays = (a: string, b: string): number =>
     dayjs.utc(a).diff(dayjs.utc(b), "day")
 
+export const getYearFromISOStringAndDayOffset = (
+    epoch: string,
+    daysOffset: number
+): number => {
+    const date = dayjs.utc(epoch).add(daysOffset, "day")
+    return date.year()
+}
+
 export const addDays = (date: Date, days: number): Date => {
     const newDate = new Date(date.getTime())
     newDate.setDate(newDate.getDate() + days)

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -913,6 +913,12 @@ export const intersectionOfSets = <T>(sets: Set<T>[]): Set<T> => {
     return intersection
 }
 
+export const unionOfSets = <T>(sets: Set<T>[]): Set<T> => {
+    if (!sets.length) return new Set<T>()
+    const unionSet = new Set<T>(...sets)
+    return unionSet
+}
+
 export const differenceOfSets = <T>(sets: Set<T>[]): Set<T> => {
     if (!sets.length) return new Set<T>()
     const diff = new Set<T>(sets[0])

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -60,6 +60,7 @@ import uniqBy from "lodash/uniqBy.js"
 import uniqWith from "lodash/uniqWith.js"
 import upperFirst from "lodash/upperFirst.js"
 import without from "lodash/without.js"
+import zip from "lodash/zip.js"
 export {
     capitalize,
     chunk,
@@ -120,6 +121,7 @@ export {
     uniqWith,
     upperFirst,
     without,
+    zip,
 }
 import { extent, pairs } from "d3-array"
 export { pairs }

--- a/grapher/core/LegacyToOwidTable.test.ts
+++ b/grapher/core/LegacyToOwidTable.test.ts
@@ -461,7 +461,7 @@ describe(legacyToOwidTableAndDimensions, () => {
 
         describe("scatter-specific behavior", () => {
             it("only joins targetTime on Scatters", () => {
-                expect(table.rows.length).toEqual(3)
+                expect(table.rows.length).toEqual(3) // used to be 4 but IMHO that was wrong legacy behaviour (from combining left and right join and then dropping duplicates)
             })
 
             it("joins targetTime", () => {

--- a/grapher/core/LegacyToOwidTable.test.ts
+++ b/grapher/core/LegacyToOwidTable.test.ts
@@ -184,6 +184,8 @@ describe(legacyToOwidTableAndDimensions, () => {
             const worldRows = table.rows.filter(
                 (row) => row.entityName === "World"
             )
+            expect(table.rows.length).toEqual(5)
+            expect(worldRows.length).toEqual(4)
             expect(worldRows[0]["3"]).toEqual(
                 ErrorValueTypes.NoMatchingValueAfterJoin
             )

--- a/grapher/core/LegacyToOwidTable.test.ts
+++ b/grapher/core/LegacyToOwidTable.test.ts
@@ -461,7 +461,7 @@ describe(legacyToOwidTableAndDimensions, () => {
 
         describe("scatter-specific behavior", () => {
             it("only joins targetTime on Scatters", () => {
-                expect(table.rows.length).toEqual(4)
+                expect(table.rows.length).toEqual(3)
             })
 
             it("joins targetTime", () => {

--- a/grapher/core/LegacyToOwidTable.ts
+++ b/grapher/core/LegacyToOwidTable.ts
@@ -219,10 +219,6 @@ export const legacyToOwidTableAndDimensions = (
         else variableTablesToJoinByYear.push(variableTable)
     })
 
-    const variablesJoinedByYear = fullJoinTables(variableTablesToJoinByYear, [
-        OwidTableSlugs.year,
-        OwidTableSlugs.entityId,
-    ])
     const variablesJoinedByDay = fullJoinTables(variableTablesToJoinByDay, [
         OwidTableSlugs.day,
         OwidTableSlugs.entityId,
@@ -258,14 +254,17 @@ export const legacyToOwidTableAndDimensions = (
             variablesJoinedByDay.appendColumns([newYearColumn])
 
         joinedVariablesTable = fullJoinTables(
-            [variablesJoinedByDayWithYearFilled, variablesJoinedByYear],
+            [variablesJoinedByDayWithYearFilled, ...variableTablesToJoinByYear],
             [OwidTableSlugs.day, OwidTableSlugs.entityId],
             // [OwidTableSlugs.year, OwidTableSlugs.entityId]
             [OwidTableSlugs.entityId] // Id' rather join with year here but the legacy behaviour
             // is to join with entityId only and filter year based variables to single years beforehand
         )
     } else if (variableTablesToJoinByYear.length > 0)
-        joinedVariablesTable = variablesJoinedByYear
+        joinedVariablesTable = fullJoinTables(variableTablesToJoinByYear, [
+            OwidTableSlugs.year,
+            OwidTableSlugs.entityId,
+        ])
     else if (variableTablesToJoinByDay.length > 0) {
         mainIndexColumns = [OwidTableSlugs.day, OwidTableSlugs.entityId]
         joinedVariablesTable = variablesJoinedByDay

--- a/grapher/core/LegacyToOwidTable.ts
+++ b/grapher/core/LegacyToOwidTable.ts
@@ -236,7 +236,7 @@ export const legacyToOwidTableAndDimensions = (
     // has values for all countries but only for the year 2015. If we join that with covid era days
     // we still want to retain the continents so we have the fallback to entity only (this was also
     // the only behaviour prior to July 2022). Remember that tolerance will only be applied much later -
-    // here we are only concerned with merging mutliple variables into an inputTable that retains information.
+    // here we are only concerned with merging multiple variables into an inputTable that retains information.
     // Another approach would be to convert years into days when we have days - then we could simplify the fallback
     // join key logic described above.
     // Another caveat is that by switching to day+entity as the primary index that we use to join we can drop some entities.
@@ -281,7 +281,7 @@ export const legacyToOwidTableAndDimensions = (
         const variablesJoinedByDayWithYearFilled =
             variablesJoinedByDay.appendColumns([newYearColumn])
 
-        // Now join the already merged days table with all the years. It is imporant
+        // Now join the already merged days table with all the years. It is important
         // to not join the years together into one table already before so that each
         // table lookup for fallback values is looked at individually.
         // See the longer comment above for the idea behind the fallback cascade here of
@@ -294,7 +294,7 @@ export const legacyToOwidTableAndDimensions = (
                 [OwidTableSlugs.entityId],
             ]
         )
-        // If we have scatter/marimekko varables that had a targetTime set
+        // If we have scatter/marimekko variables that had a targetTime set
         // then these are now joined in by matching entity only
         if (variableTablesWithYearToJoinByEntityOnly.length > 0)
             joinedVariablesTable = fullJoinTables(
@@ -313,7 +313,7 @@ export const legacyToOwidTableAndDimensions = (
             OwidTableSlugs.entityId,
         ])
 
-        // If we have scatter/marimekko varables that had a targetTime set
+        // If we have scatter/marimekko variables that had a targetTime set
         // then these are now joined in by matching entity only
         if (variableTablesWithYearToJoinByEntityOnly.length > 0)
             joinedVariablesTable = fullJoinTables(
@@ -328,7 +328,7 @@ export const legacyToOwidTableAndDimensions = (
         // If we only have day variables life is also easy but this case is rare
         joinedVariablesTable = variablesJoinedByDay
 
-        // If we have scatter/marimekko varables that had a targetTime set
+        // If we have scatter/marimekko variables that had a targetTime set
         // then these are now joined in by matching entity only
         if (variableTablesWithYearToJoinByEntityOnly.length > 0)
             joinedVariablesTable = fullJoinTables(
@@ -376,7 +376,7 @@ const fullJoinTables = (
     // is that we also have a list of fallback merge columns. This is required so we can handle
     // not just the easy case where we have year+entity for every table to be merged (which in our
     // data model is by far the most common default), but also handle cases where we merge year and
-    // day based variables together. For this latter case we need to still contstruct the set of index
+    // day based variables together. For this latter case we need to still construct the set of index
     // values for the final table, but then when we try to look up values in the various tables to
     // merge together we will not find values by day+entity for the year based tables. So for this
     // case we get a series of fallback column tuples that we try in turn if the main index lookup
@@ -497,7 +497,7 @@ const fullJoinTables = (
                 // This case should be rare but it can come up. The old algorithm ran into this often because it
                 // joined a lot more stuff on entity only and then when you look up by entity into a table that has
                 // several years you end up with multiple matches. The old algorithm used to just pick one value.
-                // We still do this utlimately but because we try to match even day and year variables by year+entity
+                // We still do this ultimately but because we try to match even day and year variables by year+entity
                 // first we should usually be able to find a unique match. The error output is here so that when
                 // something is weird in an edge case then this shows up as a debugging hint in the console.
                 console.error(

--- a/grapher/core/LegacyToOwidTable.ts
+++ b/grapher/core/LegacyToOwidTable.ts
@@ -395,8 +395,8 @@ const fullJoinTables = (
         // lookups by main index to fail and we'll try the fallback index
         mergeFallbackLookupColumns &&
         difference(indexColumnNames, table.columnSlugs).length > 0
-            ? table.rowIndex(indexColumnNames)
-            : new Map()
+            ? new Map()
+            : table.rowIndex(indexColumnNames)
     )
 
     // Construct all the fallback index lookup values for all tables. mergeFallbackLookupColumns is an

--- a/grapher/core/LegacyToOwidTable.ts
+++ b/grapher/core/LegacyToOwidTable.ts
@@ -277,7 +277,7 @@ export const legacyToOwidTableAndDimensions = (
             slug: OwidTableSlugs.year,
             name: OwidTableSlugs.year,
             values: yearsForDaysValues,
-        } as unknown as OwidColumnDef
+        } as OwidColumnDef
         const variablesJoinedByDayWithYearFilled =
             variablesJoinedByDay.appendColumns([newYearColumn])
 
@@ -393,8 +393,8 @@ const fullJoinTables = (
         // When we get a mergeFallbackLookupColumn then it can happen that a table does not have all the
         // columns of the main index. In this case, just return an empty map because that will lead all
         // lookups by main index to fail and we'll try the fallback index
-        !mergeFallbackLookupColumns ||
-        difference(indexColumnNames, table.columnSlugs).length === 0
+        mergeFallbackLookupColumns &&
+        difference(indexColumnNames, table.columnSlugs).length > 0
             ? table.rowIndex(indexColumnNames)
             : new Map()
     )

--- a/grapher/core/LegacyToOwidTable.ts
+++ b/grapher/core/LegacyToOwidTable.ts
@@ -17,6 +17,7 @@ import {
     makeAnnotationsSlug,
     trimObject,
     uniqBy,
+    zip,
 } from "../../clientUtils/Util.js"
 import {
     OwidEntityKey,
@@ -34,7 +35,6 @@ import {
 import { OwidTable } from "../../coreTable/OwidTable.js"
 import { ColumnSlug, EPOCH_DATE } from "../../clientUtils/owidTypes.js"
 import { OwidChartDimensionInterface } from "../../clientUtils/OwidVariableDisplayConfigInterface.js"
-import { sortBy, zip } from "lodash"
 import { ErrorValueTypes } from "../../coreTable/ErrorValues.js"
 import { makeKeyFn } from "../../coreTable/CoreTableUtils.js"
 

--- a/grapher/core/LegacyToOwidTable.ts
+++ b/grapher/core/LegacyToOwidTable.ts
@@ -298,7 +298,7 @@ const fullJoinTables = (
         // When we get a mergeFallbackLookupColumn then it can happen that a table does not have all the
         // columns of the main index. In this case, just return an empty map because that will lead all
         // lookups by main index to fail and we'll try the fallback index
-        mergeFallbackLookupColumns &&
+        !mergeFallbackLookupColumns ||
         difference(indexColumnNames, table.columnSlugs).length === 0
             ? table.rowIndex(indexColumnNames)
             : new Map()


### PR DESCRIPTION
This should allevieate performance issues with many variables as recently reported. In one test the time to do the full join went down from 4 seconds to 600 ms and the memory use from 250MB to 85MB

Slack discussion: https://owid.slack.com/archives/CQQUA2C2U/p1659005364871929

> The original motivation was performance improvements. Those were quite straightforward but then I kept running into breaking charts with the svg tester that led me to add several iterations of fixes (felt so close every time ). The end result is several improvements over the status quo and one open question:
> 
> **Benefits**
> 
> -   Performance - the chart initialization time for some heavy multi-variable charts improved from ~4000 ms join cpu time to ~600ms and a memory footprint reduction by about half. (e.g. this chart <https://ourworldindata.org/grapher/share-of-deaths-by-cause> that Pablo mentioned recently and Fiona complained about perf for similar charts)
> -   Day and Year variables are now joined properly. This means that you can now do scatter and marimekko charts that use day variables (e.g. covid vaccinations) and year variables (e.g. GDP/Population) and days are matched to year values of the corresponding year. One caveat: the year variable has to have values for the years the days are in (i.e. you need values for population or gdp for 2022 for this to show up correctly). For population we have a shared historical + predicted population variable that has values for 2022 but for GDP we might need such a unified variable for day based joins to work correctly. The problem when the year variable does not have values for the correct year is that the join picks an arbitrary year (usually the first in the time series). Properly fixing this would require some bigger refactorings. For now this means that the charts that use population with day variables should switch to the population version that has projections.
> -   Multi-variable joins are now more correct in some edge cases. E.g. population used to be joined after some other joins and for scatter plots could then often implicitly use the year for population that was picked in the join before. Now all years are lined up at once and special scatter logic only applies for variables that have a target year set. This also recovers a few countries that were previously dropped as they fell out of the tolerance ranges because of the old join logic - e.g. In <https://owid.cloud/admin/charts/867/edit> Yemen and Afghanistan have high values but are missing in the old join code; or Nigeria is missing currently in <https://owid.cloud/admin/charts/3041/edit> )
> 
> **Unwanted changes**
> 
> -   Continent colors are shifted in scatter plots that join day and year variables (i.e. covid scatter plots). This has to do with how Antarctica is treated that doesn't appear in the daily data series and is discarded in the new algorithm but was still present in the inputTable in the old algorithm. I am inclined to ignore this for now, especially as Marwa and Matt are working on improving color anyhow and then we'll probably want to implement stable mappings for continents anyhow. Thoughts?
> 
> You can see all differences in charts in the svg tester images for the branch: <https://github.com/owid/owid-grapher-svgs/commit/292fa892f0791bc8335b395adb8b717ca05d6512> (use swipe to easily see a larger version of each chart in the before/after view). For a few charts I will do some minor fixes after this is merged so that e.g. population will be used correctly for day variables.