### PR TITLE
Sticky Nav

### DIFF
--- a/baker/formatWordpressPost.tsx
+++ b/baker/formatWordpressPost.tsx
@@ -58,6 +58,7 @@ import {
 import { renderKeyInsights, renderProminentLinks } from "./siteRenderers.js"
 import { logContentErrorAndMaybeSendToSlack } from "../serverUtils/slackLog.js"
 import { KEY_INSIGHTS_CLASS_NAME } from "../site/blocks/KeyInsights.js"
+import { get } from "lodash"
 
 const initMathJax = () => {
     const adaptor = liteAdaptor()
@@ -540,9 +541,21 @@ export const formatWordpressPost = async (
         $heading.append(`<a class="${DEEP_LINK_CLASS}" href="#${slug}"></a>`)
     })
 
+    // Extracting the useful information from the HTML
+    const stickyNavLinks: { text: string; target: string }[] = []
+    const $stickyNavContents = cheerioEl(".sticky-nav-contents")
+    const $stickyNavLinks = $stickyNavContents.children().children()
+    $stickyNavLinks.each((_, element) => {
+        const text = get(element, ["children", 0, "children", 0, "data"])
+        const target = get(element, ["attribs", "href"])
+        if (text && target) stickyNavLinks.push({ text, target })
+    })
+    $stickyNavContents.remove()
+
     return {
         ...post,
         supertitle,
+        stickyNavLinks,
         lastUpdated,
         byline,
         info,

--- a/baker/formatWordpressPost.tsx
+++ b/baker/formatWordpressPost.tsx
@@ -58,7 +58,6 @@ import {
 import { renderKeyInsights, renderProminentLinks } from "./siteRenderers.js"
 import { logContentErrorAndMaybeSendToSlack } from "../serverUtils/slackLog.js"
 import { KEY_INSIGHTS_CLASS_NAME } from "../site/blocks/KeyInsights.js"
-import { get } from "lodash"
 
 const initMathJax = () => {
     const adaptor = liteAdaptor()
@@ -546,8 +545,9 @@ export const formatWordpressPost = async (
     const $stickyNavContents = cheerioEl(".sticky-nav-contents")
     const $stickyNavLinks = $stickyNavContents.children().children()
     $stickyNavLinks.each((_, element) => {
-        const text = get(element, ["children", 0, "children", 0, "data"])
-        const target = get(element, ["attribs", "href"])
+        const $elem = cheerioEl(element)
+        const text = $elem.text()
+        const target = $elem.attr("href")
         if (text && target) stickyNavLinks.push({ text, target })
     })
     $stickyNavContents.remove()

--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -64,6 +64,7 @@ export const BLOCK_WRAPPER_DATATYPE = "block-wrapper"
 
 export interface FormattedPost extends FullPost {
     supertitle?: string
+    stickyNavLinks?: { text: string; target: string }[]
     lastUpdated?: string
     byline?: string
     info?: string

--- a/devTools/docker/create-wordpress-admin-user.sh
+++ b/devTools/docker/create-wordpress-admin-user.sh
@@ -20,7 +20,7 @@ createWordpressAdminUser() {
     _mysql 'INSERT INTO wp_users (user_login, user_email, user_pass, user_registered, user_nicename) VALUES ("admin", "admin@example.com", "$2y$10$2ilzpLslIA29cZezVXJTDOqLlkGyXK6YcNvr2QPvn95WdmVdnxl2S", NOW(), "Admin");'
 
     echo "Giving the admin user administrator privileges"
-    _mysql `INSERT INTO wp_usermeta (user_id, meta_key, meta_value) VALUES ((SELECT id FROM wp_users WHERE user_email = "admin@example.com"), "wp_capabilities", "a:1:{s:13:"administrator";s:1:"1";}");`
+    _mysql `INSERT INTO wp_usermeta (user_id, meta_key, meta_value) VALUES ((SELECT id FROM wp_users WHERE user_email = "admin@example.com"), "wp_capabilities", "a:1:{s:13:\"administrator\";s:1:\"1\";}");`
     _mysql 'INSERT INTO wp_usermeta (user_id, meta_key, meta_value) VALUES ((SELECT id FROM wp_users WHERE user_email = "admin@example.com"), "rich_editing", "true");'
 
     return 0

--- a/devTools/docker/create-wordpress-admin-user.sh
+++ b/devTools/docker/create-wordpress-admin-user.sh
@@ -20,7 +20,7 @@ createWordpressAdminUser() {
     _mysql 'INSERT INTO wp_users (user_login, user_email, user_pass, user_registered, user_nicename) VALUES ("admin", "admin@example.com", "$2y$10$2ilzpLslIA29cZezVXJTDOqLlkGyXK6YcNvr2QPvn95WdmVdnxl2S", NOW(), "Admin");'
 
     echo "Giving the admin user administrator privileges"
-    _mysql 'INSERT INTO wp_usermeta (user_id, meta_key, meta_value) VALUES ((SELECT id FROM wp_users WHERE user_email = "admin@example.com"), "wp_capabilities", "a:1:{s:13:"administrator";b:1;}");'
+    _mysql `INSERT INTO wp_usermeta (user_id, meta_key, meta_value) VALUES ((SELECT id FROM wp_users WHERE user_email = "admin@example.com"), "wp_capabilities", "a:1:{s:13:"administrator";s:1:"1";}");`
     _mysql 'INSERT INTO wp_usermeta (user_id, meta_key, meta_value) VALUES ((SELECT id FROM wp_users WHERE user_email = "admin@example.com"), "rich_editing", "true");'
 
     return 0

--- a/site/LongFormPage.tsx
+++ b/site/LongFormPage.tsx
@@ -21,6 +21,7 @@ import { Byline } from "./Byline.js"
 import { PageInfo } from "./PageInfo.js"
 import { BackToTopic } from "./BackToTopic.js"
 import { omit } from "../clientUtils/Util.js"
+import StickyNav from "./blocks/StickyNav.js"
 
 export interface PageOverrides {
     pageTitle?: string
@@ -211,6 +212,11 @@ export const LongFormPage = (props: {
                                 )}
                             </header>
                         </div>
+                        {post.stickyNavLinks && (
+                            <nav className="sticky-nav">
+                                <StickyNav links={post.stickyNavLinks} />
+                            </nav>
+                        )}
                         {!isPost && formattingOptions.subnavId && (
                             <SiteSubnavigation
                                 subnavId={formattingOptions.subnavId}

--- a/site/TableOfContents.tsx
+++ b/site/TableOfContents.tsx
@@ -53,7 +53,7 @@ export const TableOfContents = ({
         if ("IntersectionObserver" in window) {
             // Sets up an intersection observer to notify when the element with the class
             // `.sticky-sentinel` becomes visible/invisible at the top of the viewport.
-            // Inspired by https://developers.google.com/web/updates/2017/09/sticky-navs
+            // Inspired by https://developers.google.com/web/updates/2017/09/sticky-headers
             const observer = new IntersectionObserver((records) => {
                 for (const record of records) {
                     const targetInfo = record.boundingClientRect

--- a/site/TableOfContents.tsx
+++ b/site/TableOfContents.tsx
@@ -53,7 +53,7 @@ export const TableOfContents = ({
         if ("IntersectionObserver" in window) {
             // Sets up an intersection observer to notify when the element with the class
             // `.sticky-sentinel` becomes visible/invisible at the top of the viewport.
-            // Inspired by https://developers.google.com/web/updates/2017/09/sticky-headers
+            // Inspired by https://developers.google.com/web/updates/2017/09/sticky-navs
             const observer = new IntersectionObserver((records) => {
                 for (const record of records) {
                     const targetInfo = record.boundingClientRect

--- a/site/blocks/StickyNav.tsx
+++ b/site/blocks/StickyNav.tsx
@@ -148,21 +148,16 @@ class StickyNav extends React.Component<
 
     componentDidMount() {
         this.filterValidLinks()
-        window.addEventListener("scroll", this.handleScroll)
+        window.addEventListener("scroll", this.handleScroll, { passive: true })
         // Web fonts and grapher hydration make the page height change
         // So we recalculate the heading positions whenever the document body changes size
         this.resizeObserver = new ResizeObserver(this.handleResize)
-        if (this.resizeObserver) {
-            this.resizeObserver.observe(document.body)
-        }
+        this.resizeObserver.observe(document.body)
     }
 
     componentWillUnmount() {
         window.removeEventListener("scroll", this.handleScroll)
-
-        if (this.resizeObserver) {
-            this.resizeObserver.disconnect()
-        }
+        this.resizeObserver?.disconnect()
     }
 
     render() {

--- a/site/blocks/StickyNav.tsx
+++ b/site/blocks/StickyNav.tsx
@@ -1,7 +1,7 @@
 import React, { createRef } from "react"
 import ReactDOM from "react-dom"
 import classnames from "classnames"
-import { debounce } from "../../clientUtils/Util.js"
+import { throttle } from "../../clientUtils/Util.js"
 
 function getTotalOffset(element: HTMLElement): {
     x: number
@@ -42,13 +42,13 @@ class StickyNav extends React.Component<
         links: this.props.links,
     }
 
-    handleResize = debounce(() => {
+    handleResize = throttle(() => {
         this.setHeadingPositions()
-    }, 100)
+    }, 50)
 
-    handleScroll = debounce(() => {
+    handleScroll = throttle(() => {
         this.setCurrentHeading()
-    }, 100)
+    }, 50)
 
     // Make sure that each item in the nav actually points to a heading in the page
     filterValidLinks() {

--- a/site/blocks/StickyNav.tsx
+++ b/site/blocks/StickyNav.tsx
@@ -203,7 +203,7 @@ export const hydrateStickyNav = () => {
     if (wrapper) {
         const anchorTags =
             document.querySelectorAll<HTMLAnchorElement>(".sticky-nav a")
-        const links: { target: string; text: string }[] = []
+        const links: StickyNavLink[] = []
 
         for (const anchorTag of anchorTags) {
             const text = anchorTag.innerText

--- a/site/blocks/StickyNav.tsx
+++ b/site/blocks/StickyNav.tsx
@@ -1,7 +1,7 @@
 import React, { createRef } from "react"
 import ReactDOM from "react-dom"
 import classnames from "classnames"
-import { debounce, get } from "../../clientUtils/Util.js"
+import { debounce } from "../../clientUtils/Util.js"
 
 function getTotalOffset(element: HTMLElement): {
     x: number
@@ -188,12 +188,13 @@ export default StickyNav
 
 export const hydrateStickyNav = () => {
     const wrapper = document.querySelector(".sticky-nav")
-    const anchorTags = document.querySelectorAll<HTMLElement>(".sticky-nav a")
+    const anchorTags =
+        document.querySelectorAll<HTMLAnchorElement>(".sticky-nav a")
     const links: { target: string; text: string }[] = []
 
     for (const anchorTag of anchorTags) {
-        const text = get(anchorTag, ["text"])
-        const target = get(anchorTag, ["hash"])
+        const text = anchorTag.innerText
+        const target = anchorTag.hash
         links.push({ text, target })
     }
 

--- a/site/blocks/StickyNav.tsx
+++ b/site/blocks/StickyNav.tsx
@@ -45,6 +45,7 @@ class StickyNav extends React.Component<
     }
 > {
     ulRef = createRef<HTMLUListElement>()
+    resizeObserver: ResizeObserver | null = null
 
     state = {
         currentHeadingIndex: undefined,
@@ -147,19 +148,21 @@ class StickyNav extends React.Component<
 
     componentDidMount() {
         this.filterValidLinks()
-        // Web fonts change the position of elements
-        // so we set the active heading only once we know where everything is.
-        // The alternative is to call setHeadingPositions as soon as the component mounts,
-        // but this can make currentHeadingIndex jump around.
-        window.addEventListener("load", this.handleResize)
         window.addEventListener("scroll", this.handleScroll)
-        window.addEventListener("resize", this.handleResize)
+        // Web fonts and grapher hydration make the page height change
+        // So we recalculate the heading positions whenever the document body changes size
+        this.resizeObserver = new ResizeObserver(this.handleResize)
+        if (this.resizeObserver) {
+            this.resizeObserver.observe(document.body)
+        }
     }
 
     componentWillUnmount() {
         window.removeEventListener("scroll", this.handleScroll)
-        window.removeEventListener("resize", this.handleResize)
-        window.removeEventListener("load", this.handleResize)
+
+        if (this.resizeObserver) {
+            this.resizeObserver.disconnect()
+        }
     }
 
     render() {

--- a/site/blocks/StickyNav.tsx
+++ b/site/blocks/StickyNav.tsx
@@ -23,22 +23,32 @@ function getTotalOffset(element: HTMLElement): {
 const STICKY_NAV_HEIGHT = 54
 const HEADING_SCROLL_MARGIN = 16
 
+interface HeadingPosition {
+    id: string
+    yPosition: number
+}
+
+interface StickyNavLink {
+    text: string
+    target: string
+}
+
 interface StickyNavProps {
-    links: { text: string; target: string }[]
+    links: StickyNavLink[]
 }
 class StickyNav extends React.Component<
     StickyNavProps,
     {
-        headingPositions: { id: string; yPosition: number }[]
+        headingPositions: HeadingPosition[]
         currentHeadingIndex?: number
-        links: { text: string; target: string }[]
+        links: StickyNavLink[]
     }
 > {
     ulRef = createRef<HTMLUListElement>()
 
     state = {
         currentHeadingIndex: undefined,
-        headingPositions: [] as { id: string; yPosition: number }[],
+        headingPositions: [] as HeadingPosition[],
         links: this.props.links,
     }
 
@@ -105,7 +115,7 @@ class StickyNav extends React.Component<
     }
 
     setHeadingPositions() {
-        const headingPositions: { id: string; yPosition: number }[] = []
+        const headingPositions: HeadingPosition[] = []
 
         this.state.links.forEach(({ target }, i) => {
             const element = document.querySelector<HTMLElement>(target)
@@ -116,9 +126,11 @@ class StickyNav extends React.Component<
                 // Because of filterValidLinks, this should never happen
                 // But if it does, pretend the heading exists
                 // 1 pixel after the preceding heading
+                const previousHeadingYPosition =
+                    i === 0 ? 0 : headingPositions[i - 1].yPosition
                 headingPositions.push({
                     id: target,
-                    yPosition: headingPositions[i - 1].yPosition + 1,
+                    yPosition: previousHeadingYPosition + 1,
                 })
             }
         })
@@ -188,15 +200,17 @@ export default StickyNav
 
 export const hydrateStickyNav = () => {
     const wrapper = document.querySelector(".sticky-nav")
-    const anchorTags =
-        document.querySelectorAll<HTMLAnchorElement>(".sticky-nav a")
-    const links: { target: string; text: string }[] = []
+    if (wrapper) {
+        const anchorTags =
+            document.querySelectorAll<HTMLAnchorElement>(".sticky-nav a")
+        const links: { target: string; text: string }[] = []
 
-    for (const anchorTag of anchorTags) {
-        const text = anchorTag.innerText
-        const target = anchorTag.hash
-        links.push({ text, target })
+        for (const anchorTag of anchorTags) {
+            const text = anchorTag.innerText
+            const target = anchorTag.hash
+            links.push({ text, target })
+        }
+
+        ReactDOM.hydrate(<StickyNav links={links} />, wrapper)
     }
-
-    ReactDOM.hydrate(<StickyNav links={links} />, wrapper)
 }

--- a/site/blocks/StickyNav.tsx
+++ b/site/blocks/StickyNav.tsx
@@ -30,13 +30,13 @@ class StickyNav extends React.Component<
     StickyNavProps,
     {
         headingPositions: { id: string; position: number }[]
-        currentHeadingIndex: number
+        currentHeadingIndex?: number
     }
 > {
     ulRef = createRef<HTMLUListElement>()
 
     state = {
-        currentHeadingIndex: 0,
+        currentHeadingIndex: undefined,
         headingPositions: [] as { id: string; position: number }[],
     }
 
@@ -114,7 +114,11 @@ class StickyNav extends React.Component<
     }
 
     componentDidMount() {
-        this.setHeadingPositions()
+        // Web fonts change the position of elements
+        // so we set the active heading only once we know where everything is.
+        // The alternative is to call setHeadingPositions as soon as the component mounts,
+        // but this can make currentHeadingIndex jump around.
+        window.addEventListener("load", this.handleResize)
         window.addEventListener("scroll", this.handleScroll)
         window.addEventListener("resize", this.handleResize)
     }
@@ -122,6 +126,7 @@ class StickyNav extends React.Component<
     componentWillUnmount() {
         window.removeEventListener("scroll", this.handleScroll)
         window.removeEventListener("resize", this.handleResize)
+        window.removeEventListener("load", this.handleResize)
     }
 
     render() {

--- a/site/blocks/StickyNav.tsx
+++ b/site/blocks/StickyNav.tsx
@@ -1,0 +1,140 @@
+import React from "react"
+import ReactDOM from "react-dom"
+import classnames from "classnames"
+import { debounce, get } from "../../clientUtils/Util.js"
+
+function getPositionFromTopOfPage(element: HTMLElement): number {
+    let y = 0
+    while (true) {
+        y += element.offsetTop
+        if (element.offsetParent === null) {
+            break
+        }
+        element = element.offsetParent as HTMLElement
+    }
+    return y
+}
+
+// Actual height is 54px but this gives it some top margin
+const STICKY_NAV_HEIGHT = 80
+
+interface StickyNavProps {
+    links: { text: string; target: string }[]
+}
+class StickyNav extends React.Component<
+    StickyNavProps,
+    {
+        headingPositions: { id: string; position: number }[]
+        currentHeadingIndex: number
+    }
+> {
+    state = {
+        currentHeadingIndex: 0,
+        headingPositions: [] as { id: string; position: number }[],
+    }
+
+    get links() {
+        return this.props.links
+    }
+
+    handleResize = debounce(() => {
+        this.setHeadingPositions()
+    }, 100)
+
+    handleScroll = debounce(() => {
+        this.setCurrentHeading()
+    }, 100)
+
+    setCurrentHeading() {
+        const { scrollY } = window
+        let currentHeadingIndex = 0
+        for (let i = 0; i < this.state.headingPositions.length; i++) {
+            const heading = this.state.headingPositions[i]
+            if (scrollY < heading.position - STICKY_NAV_HEIGHT - 1) {
+                break
+            } else {
+                currentHeadingIndex = i
+            }
+        }
+        this.setState({
+            currentHeadingIndex,
+        })
+    }
+
+    setHeadingPositions() {
+        const headingPositions: any[] = []
+        this.links.forEach((link) => {
+            const element = document.querySelector<HTMLElement>(link.target)
+            if (element) {
+                const y = getPositionFromTopOfPage(element)
+                headingPositions.push({ id: link.target, position: y })
+            }
+        })
+
+        this.setState(
+            {
+                headingPositions,
+            },
+            () => {
+                this.setCurrentHeading()
+            }
+        )
+    }
+
+    componentDidMount() {
+        this.setHeadingPositions()
+        window.addEventListener("scroll", this.handleScroll)
+        window.addEventListener("resize", this.handleResize)
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener("scroll", this.handleScroll)
+        window.removeEventListener("resize", this.handleResize)
+    }
+
+    render() {
+        if (!this.links) return null
+        return (
+            <>
+                <style>
+                    {`
+                    [id] {
+                         scroll-margin-top:${STICKY_NAV_HEIGHT}px;
+                    }`}
+                </style>
+                <ul className="sticky-nav-container">
+                    {this.links.map((link, i) => (
+                        <li key={link.target}>
+                            <a
+                                tabIndex={0}
+                                className={classnames({
+                                    active:
+                                        i === this.state.currentHeadingIndex,
+                                })}
+                                href={link.target}
+                            >
+                                {link.text}
+                            </a>
+                        </li>
+                    ))}
+                </ul>
+            </>
+        )
+    }
+}
+
+export default StickyNav
+
+export const hydrateStickyNav = () => {
+    const wrapper = document.querySelector(".sticky-nav")
+    const anchorTags = document.querySelectorAll(".sticky-nav a")
+    const links: { target: string; text: string }[] = []
+
+    for (const anchorTag of anchorTags) {
+        const text = get(anchorTag, ["text"])
+        const target = get(anchorTag, ["hash"])
+        links.push({ text, target })
+    }
+
+    ReactDOM.hydrate(<StickyNav links={links} />, wrapper)
+}

--- a/site/blocks/index.ts
+++ b/site/blocks/index.ts
@@ -4,6 +4,7 @@ import { runExpandableInlineBlock } from "../../site/ExpandableInlineBlock.js"
 import { runDataTokens } from "../../site/runDataTokens.js"
 import { shouldProgressiveEmbed } from "../../site/multiembedder/MultiEmbedder.js"
 import { hydrateKeyInsights } from "./KeyInsights.js"
+import { hydrateStickyNav } from "./StickyNav.js"
 
 export const runBlocks = () => {
     if (!shouldProgressiveEmbed()) {
@@ -18,4 +19,5 @@ export const runBlocks = () => {
     runSearchCountry()
     hydrateAdditionalInformation()
     hydrateKeyInsights()
+    hydrateStickyNav()
 }

--- a/site/css/colors.scss
+++ b/site/css/colors.scss
@@ -72,7 +72,7 @@ $controls-color: #0073e6;
 $light-shadow: rgba(0, 0, 0, 0.1) 0px 0px 0px 1px,
     rgba(0, 0, 0, 0.08) 0px 2px 2px;
 
-// New color defintions from resdesign
+// New color definitions from redesign
 // Brand colors
 $oxford-blue: #002147;
 $vermillion: #ce261e;

--- a/site/css/colors.scss
+++ b/site/css/colors.scss
@@ -71,3 +71,29 @@ $culture-color: #af488f;
 $controls-color: #0073e6;
 $light-shadow: rgba(0, 0, 0, 0.1) 0px 0px 0px 1px,
     rgba(0, 0, 0, 0.08) 0px 2px 2px;
+
+// New color defintions from resdesign
+// Brand colors
+$oxford-blue: #002147;
+$vermillion: #ce261e;
+$amber: #f7c020;
+
+// Text colors
+$blue-100: #002147;
+$blue-90: #1d3d63;
+$blue-60: #577291;
+$blue-50: #6e87a2;
+$blue-40: #98a9bd;
+$blue-30: #a4b6ca;
+
+// Accent colors
+$accent-electric-blue: #2162e6;
+$accent-pale-blue: #e7f2ff;
+$accent-vermillion: #ce261e;
+
+// Background colors
+$blue-20: #dbe5f0;
+$blue-10: #ebeef2;
+$gray-10: #f7f7f7;
+$beige: #fbf9f3;
+$white: #ffffff;

--- a/site/css/page.scss
+++ b/site/css/page.scss
@@ -215,6 +215,8 @@
     > ul {
         display: flex;
         flex-direction: row;
+        overflow: scroll;
+        scrollbar-width: none;
     }
 
     li {
@@ -224,7 +226,9 @@
         padding: 16px;
 
         a {
+            transition: color 500ms ease-in-out;
             color: $blue-40;
+            white-space: nowrap;
 
             &:visited {
                 color: $blue-40;

--- a/site/css/page.scss
+++ b/site/css/page.scss
@@ -221,7 +221,6 @@
 
     li {
         list-style: none;
-        font-size: 14px;
         margin: 0 8px;
         padding: 16px;
         @media (max-width: 768px) {

--- a/site/css/page.scss
+++ b/site/css/page.scss
@@ -6,7 +6,8 @@
 
     .content-and-footnotes,
     .article-header,
-    .site-subnavigation {
+    .site-subnavigation,
+    .sticky-nav-container {
         @include content-wrapper;
         @include lg-up {
             max-width: $text-max-content-width + $graph-max-content-width + 3 *
@@ -203,5 +204,38 @@
 
     @include sm-only {
         display: block;
+    }
+}
+
+.sticky-nav {
+    position: sticky;
+    top: 0;
+    background-color: #ebeef2;
+    z-index: 10;
+    > ul {
+        display: flex;
+        flex-direction: row;
+    }
+
+    li {
+        list-style: none;
+        font-size: 14px;
+        margin: 0 8px;
+        padding: 16px;
+
+        a {
+            color: $blue-40;
+
+            &:visited {
+                color: $blue-40;
+            }
+
+            &:active,
+            &.active,
+            &:hover {
+                color: $blue-90;
+                text-decoration: none;
+            }
+        }
     }
 }

--- a/site/css/page.scss
+++ b/site/css/page.scss
@@ -224,9 +224,12 @@
         font-size: 14px;
         margin: 0 8px;
         padding: 16px;
+        @media (max-width: 768px) {
+            padding: 12px;
+        }
 
         a {
-            transition: color 500ms ease-in-out;
+            transition: color 0.25s ease-in-out;
             color: $blue-40;
             white-space: nowrap;
 
@@ -240,6 +243,14 @@
                 color: $blue-90;
                 text-decoration: none;
             }
+        }
+    }
+
+    li:first-child {
+        margin-left: 0;
+        @media (max-width: 768px) {
+            // completely flush with text for mobile
+            padding-left: 0;
         }
     }
 }

--- a/site/css/page.scss
+++ b/site/css/page.scss
@@ -216,7 +216,12 @@
         display: flex;
         flex-direction: row;
         overflow: scroll;
+        // firefox
         scrollbar-width: none;
+        &::-webkit-scrollbar {
+            // chrome
+            display: none;
+        }
     }
 
     li {

--- a/wordpress/web/app/plugins/owid/owid.php
+++ b/wordpress/web/app/plugins/owid/owid.php
@@ -28,6 +28,7 @@ include 'src/KeyInsightsSlider/key-insights-slider.php';
 include 'src/KeyInsight/key-insight.php';
 include 'src/TechnicalText/technical-text.php';
 include 'src/AllCharts/all-charts.php';
+include 'src/StickyNav/sticky-nav.php';
 
 const KEY_PERFORMANCE_INDICATORS_META_FIELD = "owid_key_performance_indicators_meta_field";
 const GLOSSARY_META_FIELD = "owid_glossary_meta_field";
@@ -184,6 +185,10 @@ function register()
 
     register_block_type(__DIR__ . '/src/AllCharts', [
         'render_callback' => __NAMESPACE__ . '\blocks\all_charts\render',
+    ]);
+
+    register_block_type(__DIR__ . '/src/StickyNav', [
+        'render_callback' => __NAMESPACE__ . '\blocks\sticky_nav\render',
     ]);
 }
 

--- a/wordpress/web/app/plugins/owid/src/StickyNav/StickyNav.js
+++ b/wordpress/web/app/plugins/owid/src/StickyNav/StickyNav.js
@@ -1,0 +1,47 @@
+import { InnerBlocks, useBlockProps } from "@wordpress/block-editor"
+import { registerBlockType } from "@wordpress/blocks"
+import block from "./block.json"
+
+const blockStyle = {
+    border: "1px dashed lightgrey",
+    padding: "0 1rem",
+    marginBottom: "1rem",
+    color: "darkgrey",
+}
+
+const StickyNav = {
+    edit: () => {
+        const blockProps = useBlockProps({ style: blockStyle })
+        return (
+            <div {...blockProps}>
+                <h4>Sticky nav</h4>
+                <p>
+                    For each menu item you want, add a "Custom Link" to this
+                    block
+                </p>
+                <p>
+                    Set the target to the{" "}
+                    <a
+                        href="https://wordpress.org/support/article/page-jumps/#put-a-html-anchor"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        HTML anchor
+                    </a>{" "}
+                    of the heading you want to link to
+                </p>
+                <p>e.g. #data-explorers</p>
+                <p>
+                    And then edit the link so that the title is "Data Explorers"
+                    and not "#data-explorers"
+                </p>
+                <InnerBlocks allowedBlocks={["core/navigation-link"]} />
+            </div>
+        )
+    },
+    save: () => <InnerBlocks.Content />,
+}
+
+export const registerStickyNav = () => {
+    registerBlockType(block.name, StickyNav)
+}

--- a/wordpress/web/app/plugins/owid/src/StickyNav/block.json
+++ b/wordpress/web/app/plugins/owid/src/StickyNav/block.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 2,
+    "name": "owid/sticky-nav",
+    "title": "Sticky nav",
+    "icon": "schedule",
+    "category": "layout"
+}

--- a/wordpress/web/app/plugins/owid/src/StickyNav/sticky-nav.php
+++ b/wordpress/web/app/plugins/owid/src/StickyNav/sticky-nav.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OWID\blocks\sticky_nav;
+
+function render($attributes, $content)
+{
+    $block = <<<EOD
+	<div class="sticky-nav-contents">$content</div>
+EOD;
+
+    return $block;
+}

--- a/wordpress/web/app/plugins/owid/src/blocks.js
+++ b/wordpress/web/app/plugins/owid/src/blocks.js
@@ -10,6 +10,7 @@ import { registerKeyInsightsSlider } from "./KeyInsightsSlider/KeyInsightsSlider
 import { registerKeyInsight } from "./KeyInsight/KeyInsight.js"
 import { registerTechnicalText } from "./TechnicalText/TechnicalText.js"
 import { registerAllCharts } from "./AllCharts/AllCharts.js"
+import { registerStickyNav } from "./StickyNav/StickyNav.js"
 const { registerBlockType, registerBlockStyle } = wp.blocks
 const { createHigherOrderComponent } = wp.compose
 const { addFilter } = wp.hooks
@@ -26,6 +27,7 @@ registerKeyInsightsSlider()
 registerKeyInsight()
 registerTechnicalText()
 registerAllCharts()
+registerStickyNav()
 
 registerBlockStyle("core/columns", {
     name: "sticky-right",


### PR DESCRIPTION
[Staging demo](https://ptolemy.owid.cloud/admin/posts/preview/50414)

The first component for our new topic page front matter module.

We can't dynamically generate the nav because the names of the headings in the sticky nav are different from the header titles in the actual page. 

e.g. the sticky nav may say "Data Explorers" but the heading is "Explore our data on Poverty"

Ergo we need to manually specify the text content and the HTML IDs, and the custom link interface seemed as good a way to do this as any (per Matthieu's advice to not over-engineer these modules while the designs are still likely to change)

<img width="944" alt="wordpress-example" src="https://user-images.githubusercontent.com/11844404/182184986-ae10e4c7-73e0-40fe-a80b-3715132ed0dd.png">

https://user-images.githubusercontent.com/11844404/182184587-212fad5c-39ab-4e32-916a-c30b84532d62.mov

TODO:
- [ ] Keyboard navigation
- [x] Mobile styling (will check with Matt/Marwa)
