### PR TITLE
chore: remove unused `useTimelineDomains`

### DIFF
--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -417,33 +417,6 @@ export const cagr = (
 export const makeAnnotationsSlug = (columnSlug: string): string =>
     `${columnSlug}-annotations`
 
-// Todo: add unit tests
-export const relativeMinAndMax = (
-    points: Point[],
-    property: "x" | "y"
-): [number, number] => {
-    let minChange = 0
-    let maxChange = 0
-
-    const filteredPoints = points.filter(
-        (point) => point.x !== 0 && point.y !== 0
-    )
-
-    for (let i = 0; i < filteredPoints.length; i++) {
-        const indexValue = filteredPoints[i]
-        for (let j = i + 1; j < filteredPoints.length; j++) {
-            const targetValue = filteredPoints[j]
-
-            if (targetValue.entityName !== indexValue.entityName) continue
-
-            const change = cagrFromPoints(indexValue, targetValue, property)
-            if (change < minChange) minChange = change
-            if (change > maxChange) maxChange = change
-        }
-    }
-    return [minChange, maxChange]
-}
-
 export const isVisible = (elm: HTMLElement | null): boolean => {
     if (!elm || !elm.getBoundingClientRect) return false
     const rect = elm.getBoundingClientRect()

--- a/clientUtils/Util.ts
+++ b/clientUtils/Util.ts
@@ -384,23 +384,6 @@ export const domainExtent = (
 // Compound annual growth rate
 // cagr = ((new_value - old_value) ** (1 / Δt)) - 1
 // see https://en.wikipedia.org/wiki/Compound_annual_growth_rate
-interface Point {
-    timeValue: Time
-    entityName?: string
-    x?: number
-    y?: number
-}
-// Todo: add unit tests
-const cagrFromPoints = (
-    startPoint: Point,
-    endPoint: Point,
-    property: "x" | "y"
-): number => {
-    const elapsed = endPoint.timeValue - startPoint.timeValue
-    if (!elapsed) return 0
-    return cagr(startPoint[property]!, endPoint[property]!, elapsed)
-}
-
 export const cagr = (
     startValue: number,
     endValue: number,

--- a/grapher/chart/ChartManager.ts
+++ b/grapher/chart/ChartManager.ts
@@ -37,7 +37,6 @@ export interface ChartManager {
     comparisonLines?: ComparisonLineConfig[]
     hideLegend?: boolean
     tooltips?: TooltipManager["tooltips"]
-    useTimelineDomains?: boolean
     baseColorScheme?: ColorSchemeName
     invertColorScheme?: boolean
     compareEndPointsOnly?: boolean

--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -730,9 +730,6 @@ export class Grapher
         }`
     }
 
-    // at startDrag, we want to show the full axis
-    @observable.ref useTimelineDomains = false
-
     /**
      * Whether the chart is rendered in an Admin context (e.g. on owid.cloud).
      */
@@ -2506,12 +2503,10 @@ export class Grapher
     // todo: restore this behavior??
     onStartPlayOrDrag(): void {
         this.debounceMode = true
-        this.useTimelineDomains = true
     }
 
     onStopPlayOrDrag(): void {
         this.debounceMode = false
-        this.useTimelineDomains = false
     }
 
     @computed get disablePlay(): boolean {

--- a/grapher/scatterCharts/ScatterPlotChart.tsx
+++ b/grapher/scatterCharts/ScatterPlotChart.tsx
@@ -13,7 +13,6 @@ import {
     isNumber,
     domainExtent,
     lowerCaseFirstLetterUnlessAbbreviation,
-    relativeMinAndMax,
     exposeInstanceOnWindow,
     groupBy,
     sampleFrom,
@@ -820,22 +819,10 @@ export class ScatterPlotChart
     // domains across the entire timeline
     private domainDefault(property: "x" | "y"): [number, number] {
         const scaleType = property === "x" ? this.xScaleType : this.yScaleType
-        if (!this.manager.useTimelineDomains) {
-            return domainExtent(
-                this.pointsForAxisDomains.map((point) => point[property]),
-                scaleType,
-                this.manager.zoomToSelection && this.selectedPoints.length
-                    ? 1.1
-                    : 1
-            )
-        }
-
-        if (this.manager.isRelativeMode)
-            return relativeMinAndMax(this.allPoints, property)
-
         return domainExtent(
-            this.allPoints.map((v) => v[property]),
-            scaleType
+            this.pointsForAxisDomains.map((point) => point[property]),
+            scaleType,
+            this.manager.zoomToSelection && this.selectedPoints.length ? 1.1 : 1
         )
     }
 


### PR DESCRIPTION
Old pre-next behaviour. Since we haven't restored it, I think we should get rid of it.