### PR TITLE
chore(actions): only run schema action when schema changes

### DIFF
--- a/.github/workflows/sync-grapher-schema-to-digital-ocean.yml
+++ b/.github/workflows/sync-grapher-schema-to-digital-ocean.yml
@@ -3,7 +3,8 @@ on:
     push:
         branches:
             - master
-            - schema-do-sync-github-action
+        paths:
+            - "grapher/schema/**"
 jobs:
     upload:
         runs-on: ubuntu-latest


### PR DESCRIPTION
See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-only-when-a-push-affects-specific-files