### PR TITLE
fix: rewrite thumbnail URL from `/app/uploads` to `/uploads`

### DIFF
--- a/site/LongFormPage.tsx
+++ b/site/LongFormPage.tsx
@@ -4,7 +4,11 @@ import { Head } from "./Head.js"
 import { CitationMeta } from "./CitationMeta.js"
 import { SiteHeader } from "./SiteHeader.js"
 import { SiteFooter } from "./SiteFooter.js"
-import { addContentFeatures, formatAuthors } from "../site/formatting.js"
+import {
+    addContentFeatures,
+    formatAuthors,
+    formatUrls,
+} from "../site/formatting.js"
 import { SiteSubnavigation } from "./SiteSubnavigation.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faBook } from "@fortawesome/free-solid-svg-icons/faBook"
@@ -113,7 +117,7 @@ export const LongFormPage = (props: {
                 pageTitle={pageTitleSEO}
                 pageDesc={pageDesc}
                 canonicalUrl={canonicalUrl}
-                imageUrl={post.imageUrl}
+                imageUrl={post.imageUrl ? formatUrls(post.imageUrl) : undefined}
                 baseUrl={baseUrl}
             >
                 {withCitation && (

--- a/site/PostCard/PostCard.tsx
+++ b/site/PostCard/PostCard.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { FullPost } from "../../clientUtils/owidTypes.js"
-import { formatAuthors, formatDate } from "../formatting.js"
+import { formatAuthors, formatDate, formatUrls } from "../formatting.js"
 
 const PostCard = ({ post }: { post: FullPost }) => {
     return (
@@ -10,7 +10,9 @@ const PostCard = ({ post }: { post: FullPost }) => {
                     <div
                         className="cover-image"
                         style={{
-                            backgroundImage: `url(${post.imageUrl})`,
+                            backgroundImage: `url(${formatUrls(
+                                post.imageUrl
+                            )})`,
                         }}
                     />
                 )}


### PR DESCRIPTION
Fixes #1561 | [Live on tufte](https://tufte-owid.netlify.app/) | See [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Ftufte-owid.netlify.app%2Fworld-population-update-2022)

Before this fix, we had thumbnail URLs like `https://ourworldindata.org/app/uploads/2022/07/Population-2022-768x402.png` under the `og:image` meta tag. Notice the `/app` in there.

In addition, there is a 301 redirect going from `/app/uploads/` to `/uploads/`:
https://github.com/owid/owid-grapher/blob/d9b38d588566ab0bdfc93feeba42dc3e2db13df2/baker/redirects.ts#L23-L26

It seems that Facebook didn't like this redirect, and threw up for that reason. With this fix in place, we're rewriting these URLs in the baking step already, and are thus not hitting the redirect any longer.

The nicer solution is probably to change what Wordpress returns in its `/posts` api response to not include the `/app` prefix for thumbnails any longer, but I don't know how we can change this. That's something for @mlbrgl to take a look at once he's back.

<details>
<summary>Example `/posts` response excerpt</summary>

```
GET localhost:8080/wp-json/wp/v2/posts

...
		"featured_media_paths": {
			"thumbnail": "\/app\/uploads\/2022\/03\/Fossil-Fuels-Data-Explorer-150x79.png",
			"medium_large": "\/app\/uploads\/2022\/03\/Fossil-Fuels-Data-Explorer-768x403.png"
		},
...
```

</details>
