### PR TITLE
Multi-table-join: prefer matching the last row on ambiguous matches

### DIFF
--- a/grapher/core/LegacyToOwidTable.test.ts
+++ b/grapher/core/LegacyToOwidTable.test.ts
@@ -645,8 +645,8 @@ describe("variables with mixed days & years with missing overlap and multiple po
         ])
     })
 
-    describe("join behaviour without target times is super weird", () => {
-        it("creates a weird table join", () => {
+    describe("join behaviour without target times is sane", () => {
+        it("creates a sane table join", () => {
             const { table } = legacyToOwidTableAndDimensions(
                 legacyVariableConfig,
                 legacyGrapherConfig
@@ -654,9 +654,13 @@ describe("variables with mixed days & years with missing overlap and multiple po
 
             // A sane join between years and days would create 5 days for the given input
             // data and join them with the other variables by year based on the year of the day
-            // Alas, this is not what the current join does. Instead we get this:
+            // This is what we see below.
+            // Note that variable 4 that does not have any values for years matching the days
+            // it is merged on the last year even though no tolerance is given. This mirrors
+            // the old behaviour and is unfortunately necessary until we pull tolerance into
+            // the this join that constructs the table
 
-            expect(table.rows.length).toEqual(10)
+            expect(table.rows.length).toEqual(5)
             expect(table.columnSlugs.includes("2")).toBeTruthy()
             expect(table.columnSlugs.includes("3")).toBeTruthy()
             expect(table.columnSlugs.includes("4")).toBeTruthy()
@@ -664,59 +668,25 @@ describe("variables with mixed days & years with missing overlap and multiple po
             expect(table.columnSlugs.includes("time")).toBeTruthy()
             let column = table.get("2")
             expect(column.valuesIncludingErrorValues).toEqual([
-                10,
-                11,
-                12,
-                410,
-                810,
-                10,
-                10,
-                ErrorValueTypes.NoMatchingValueAfterJoin,
-                ErrorValueTypes.NoMatchingValueAfterJoin,
-                ErrorValueTypes.NoMatchingValueAfterJoin,
+                10, 11, 12, 410, 810,
             ])
             column = table.get("3")
             expect(column.valuesIncludingErrorValues).toEqual([
-                20,
-                20,
-                20,
-                20,
-                20,
-                21,
-                22,
-                ErrorValueTypes.NoMatchingValueAfterJoin,
-                ErrorValueTypes.NoMatchingValueAfterJoin,
-                ErrorValueTypes.NoMatchingValueAfterJoin,
+                20, 20, 20, 21, 22,
             ])
+            // Note that this here shows that even though variable 4 has no tolerance
+            // we pick the last matching row as a workaround
             column = table.get("4")
             expect(column.valuesIncludingErrorValues).toEqual([
-                ErrorValueTypes.NoMatchingValueAfterJoin,
-                ErrorValueTypes.NoMatchingValueAfterJoin,
-                ErrorValueTypes.NoMatchingValueAfterJoin,
-                ErrorValueTypes.NoMatchingValueAfterJoin,
-                ErrorValueTypes.NoMatchingValueAfterJoin,
-                ErrorValueTypes.NoMatchingValueAfterJoin,
-                ErrorValueTypes.NoMatchingValueAfterJoin,
-                1000,
-                2000,
-                3000,
+                3000, 3000, 3000, 3000, 3000,
             ])
             column = table.get("year")
             expect(column.valuesIncludingErrorValues).toEqual([
-                2020, 2020, 2020, 2020, 2020, 2021, 2022, 1800, 1900, 2000,
+                2020, 2020, 2020, 2021, 2022,
             ])
             column = table.get("time")
             expect(column.valuesIncludingErrorValues).toEqual([
-                1,
-                2,
-                3,
-                400,
-                800,
-                1,
-                1,
-                ErrorValueTypes.NoMatchingValueAfterJoin,
-                ErrorValueTypes.NoMatchingValueAfterJoin,
-                ErrorValueTypes.NoMatchingValueAfterJoin,
+                1, 2, 3, 400, 800,
             ])
         })
     })

--- a/grapher/core/LegacyToOwidTable.ts
+++ b/grapher/core/LegacyToOwidTable.ts
@@ -465,9 +465,7 @@ const fullJoinTables = (
                 indexHits = indexValuesPerTable[tableIndex].get(index)
             }
             def.values?.push(
-                tables[tableIndex].columnStore[def.slug][
-                    indexHits[indexHits.length - 1]
-                ]
+                tables[tableIndex].columnStore[def.slug][indexHits[0]]
             )
         }
         // Now figure out the fallback merge lookup index value from the first table.
@@ -480,10 +478,7 @@ const fullJoinTables = (
         const fallbackMergeIndices =
             mergeFallbackLookupColumns && indexHits
                 ? mergeFallbackLookupColumns.map((columnSet) =>
-                      makeKeyFn(
-                          tables[0].columnStore,
-                          columnSet
-                      )(indexHits![indexHits.length - 1])
+                      makeKeyFn(tables[0].columnStore, columnSet)(indexHits![0])
                   )
                 : undefined
         // now add all the nonindex value columns. We now loop over all tables and for each non-shared column
@@ -535,7 +530,7 @@ const fullJoinTables = (
                         // If any of the fallbacks led to a hit then we use this hit
                         def.values?.push(
                             tables[i].columnStore[def.slug][
-                                indexHits.length - 1
+                                indexHits[indexHits.length - 1]
                             ]
                         )
                     // If none of the fallback values worked either we write ErrorValueTypes.NoMatchingValueAfterJoin into the cell

--- a/grapher/core/LegacyToOwidTable.ts
+++ b/grapher/core/LegacyToOwidTable.ts
@@ -389,7 +389,7 @@ const fullJoinTables = (
     else if (tables.length === 1) return tables[0]
 
     // Get all the index values per table and then figure out the full set of all stringified index values
-    const indexValuesPerTable = tables.map((table) =>
+    const indexValuesPerTable: Map<string, number[]>[] = tables.map((table) =>
         // When we get a mergeFallbackLookupColumn then it can happen that a table does not have all the
         // columns of the main index. In this case, just return an empty map because that will lead all
         // lookups by main index to fail and we'll try the fallback index
@@ -465,7 +465,9 @@ const fullJoinTables = (
                 indexHits = indexValuesPerTable[tableIndex].get(index)
             }
             def.values?.push(
-                tables[tableIndex].columnStore[def.slug][indexHits[0]]
+                tables[tableIndex].columnStore[def.slug][
+                    indexHits[indexHits.length - 1]
+                ]
             )
         }
         // Now figure out the fallback merge lookup index value from the first table.
@@ -478,7 +480,10 @@ const fullJoinTables = (
         const fallbackMergeIndices =
             mergeFallbackLookupColumns && indexHits
                 ? mergeFallbackLookupColumns.map((columnSet) =>
-                      makeKeyFn(tables[0].columnStore, columnSet)(indexHits![0])
+                      makeKeyFn(
+                          tables[0].columnStore,
+                          columnSet
+                      )(indexHits![indexHits.length - 1])
                   )
                 : undefined
         // now add all the nonindex value columns. We now loop over all tables and for each non-shared column
@@ -507,7 +512,9 @@ const fullJoinTables = (
                 // If the main index led to a hit then we just copy the value into the new row from the source table
                 if (indexHits !== undefined)
                     def.values?.push(
-                        tables[i].columnStore[def.slug][indexHits[0]]
+                        tables[i].columnStore[def.slug][
+                            indexHits[indexHits.length - 1]
+                        ]
                     )
                 else {
                     // If the main index did not lead to a hit then we try the fallback indices in turn
@@ -527,7 +534,9 @@ const fullJoinTables = (
                     if (indexHits !== undefined)
                         // If any of the fallbacks led to a hit then we use this hit
                         def.values?.push(
-                            tables[i].columnStore[def.slug][indexHits[0]]
+                            tables[i].columnStore[def.slug][
+                                indexHits.length - 1
+                            ]
                         )
                     // If none of the fallback values worked either we write ErrorValueTypes.NoMatchingValueAfterJoin into the cell
                     else

--- a/grapher/core/LegacyToOwidTable.ts
+++ b/grapher/core/LegacyToOwidTable.ts
@@ -507,9 +507,7 @@ const fullJoinTables = (
                 // If the main index led to a hit then we just copy the value into the new row from the source table
                 if (indexHits !== undefined)
                     def.values?.push(
-                        tables[i].columnStore[def.slug][
-                            indexHits[indexHits.length - 1]
-                        ]
+                        tables[i].columnStore[def.slug][indexHits[0]]
                     )
                 else {
                     // If the main index did not lead to a hit then we try the fallback indices in turn
@@ -528,6 +526,20 @@ const fullJoinTables = (
                     }
                     if (indexHits !== undefined)
                         // If any of the fallbacks led to a hit then we use this hit
+                        // Note that we choose the last of the indexHits entries to look up the row in the columnstore here.
+                        // In the usual case the fallback index should still have enough information to match just one row (e.g.
+                        // year+entity). But for cases when we join day and year variables we have as the ultimate fallback a match
+                        // by entity only and this can then of course result in many indexHits when looking up an entity like Germany
+                        // in e.g. the population variable. If this join here were properly time and tolerance aware then we could
+                        // avoid matching on entity alone as the ultimate fallback but for  now this function is not that clever.
+                        // For the cases when we do get multiple hits for an index we could thus choose any data point. Pre July 2022
+                        // the old code always chose the first datapoint, which is often the first year that the variable has data for
+                        // for the given entity. This is not great, e.g. when using a covid date based variable and joining it to
+                        // population or similar. What we do here now is to use indexHits.length - 1 as the index, i.e. the last
+                        // row that this variable has data for for this entity. This could in theory be pretty wrong as well but in
+                        // practice it often means a very close match.
+                        // The proper solution as mentioned above would be to never fall back to entity matches only and move
+                        // the tolerance matching into this function as well instead.
                         def.values?.push(
                             tables[i].columnStore[def.slug][
                                 indexHits[indexHits.length - 1]


### PR DESCRIPTION
The new multi-table join algorithm has an ultimate fallback for day/year joins where it just tries to match by entity. This is what our old algorithm did always in these cases (unless specifically overridden but that only works in some cases). The issue in those cases is that trying to find any match for a given entity in a variable like Population is of course highly ambiguous - there are many years for any given entity. Our old and also the new version then defaulted to choosing the first row that matches. This has the downside of often being the first year that we have data for for a given entity which is often pretty weird (think of covid daily data for example where we try to merge in population for the size and we have daily data until yesterday but population only exists until two years ago - you don't want all countries to be drawn with bubbles sizes that represent the population in the year 10.000 BC). 

What this PR does is just to default to matching the last row in these cases. This is still wrong but it tends to be a lot closer to what you would expect. Properly fixing this would require to move tolerance into fullJoinTables