### PR TITLE
fix: avoid redundant recomputation in choroplethMap on hover

### DIFF
--- a/clientUtils/ComponentWithReactiveProps.ts
+++ b/clientUtils/ComponentWithReactiveProps.ts
@@ -1,0 +1,42 @@
+import { autorun, IReactionDisposer, observable } from "mobx"
+
+import React from "react"
+/** This is a helper class for React components that don't use the Manager pattern
+    we often use but just want to use normal props in an efficient way.
+
+    The problem with MobX and React props is that creating props at the usage site
+    creates a new prop object and thus all properties in a class using computed
+    properties to derive values from props will be regenerated.
+
+    This class solves this by adding a new observable called reactiveProps that
+    should be used instead of this.props when computing derived values in a React
+    component. The reactiveProps are updated from props automatically but because
+    this is copied to a separate observable object the usual mobx magic works again
+    and only properties that change trigger updates in derived classes.
+
+    When using the manager pattern this is not necessary because we usually pass
+    a reference to the parent object anyhow that does not change. It is also unnecessary
+    if all props are themselves observable objects (since then mobx tracking works again).
+*/
+export class ComponentWithReactiveProps<T> extends React.Component<T> {
+    constructor(props: T) {
+        super(props)
+        const reactiveProps = {}
+        Object.assign(reactiveProps, this.props)
+        this.reactiveProps = reactiveProps as T
+        this.reactivePropsCleanup = autorun(() =>
+            Object.assign(this.reactiveProps, this.props)
+        )
+    }
+
+    override componentWillUnmount(): void {
+        if (super.componentWillUnmount) super.componentWillUnmount()
+        this.reactivePropsCleanup()
+    }
+
+    reactivePropsCleanup: IReactionDisposer
+
+    /** A copy of the React props that tracks updates more effeciently to minimize
+    unnecessary recomputations. Use this instead of props. */
+    @observable.struct reactiveProps: T
+}

--- a/grapher/mapCharts/MapChart.tsx
+++ b/grapher/mapCharts/MapChart.tsx
@@ -656,13 +656,6 @@ class ChoroplethMap extends React.Component<ChoroplethMapProps> {
         return this.props.bounds
     }
 
-    @computed.struct private get choroplethData(): Map<
-        string,
-        ChoroplethSeries
-    > {
-        return this.props.choroplethData
-    }
-
     @computed.struct private get defaultFill(): string {
         return this.props.defaultFill
     }
@@ -682,7 +675,8 @@ class ChoroplethMap extends React.Component<ChoroplethMapProps> {
 
     // Check if a geo entity is currently focused, either directly or via the bracket
     private hasFocus(id: string): boolean {
-        const { choroplethData, focusBracket, focusEntity } = this
+        const { focusBracket, focusEntity } = this
+        const { choroplethData } = this.props
         if (focusEntity && focusEntity.id === id) return true
         else if (!focusBracket) return false
 
@@ -692,7 +686,8 @@ class ChoroplethMap extends React.Component<ChoroplethMapProps> {
     }
 
     private isSelected(id: string): boolean | undefined {
-        return this.choroplethData.get(id)!.isSelected
+        const { choroplethData } = this.props
+        return choroplethData.get(id)!.isSelected
     }
 
     // Viewport for each projection, defined by center and width+height in fractional coordinates
@@ -777,8 +772,9 @@ class ChoroplethMap extends React.Component<ChoroplethMapProps> {
     }
 
     @computed private get featuresWithData(): RenderFeature[] {
+        const { choroplethData } = this.props
         return this.featuresInProjection.filter((feature) =>
-            this.choroplethData.has(feature.id)
+            choroplethData.has(feature.id)
         )
     }
 
@@ -850,7 +846,6 @@ class ChoroplethMap extends React.Component<ChoroplethMapProps> {
         const {
             uid,
             bounds,
-            choroplethData,
             defaultFill,
             matrixTransform,
             viewportScale,
@@ -863,6 +858,7 @@ class ChoroplethMap extends React.Component<ChoroplethMapProps> {
         const selectedStrokeWidth = 1
         const blurFillOpacity = 0.2
         const blurStrokeOpacity = 0.5
+        const { choroplethData } = this.props
 
         const clipPath = makeClipPath(uid, bounds)
 


### PR DESCRIPTION
@coder-whale discovered that choropleth maps recompute too much when hovering over countries. This PR fixes it by getting rid of the indirection for the choroplethData property that is passed down through props. When caching this with a computed property it was causing frequent re-evaluations.