### PR TITLE
fix: several small issues with MarkdownTextWrap and Sticky Nav

### DIFF
--- a/grapher/text/MarkdownTextWrap.scss
+++ b/grapher/text/MarkdownTextWrap.scss
@@ -1,6 +1,5 @@
 .markdown-text-wrap__line {
     display: block;
-    white-space: pre-wrap;
 }
 
 .GrapherComponent .markdown-text-wrap {

--- a/grapher/text/MarkdownTextWrap.tsx
+++ b/grapher/text/MarkdownTextWrap.tsx
@@ -570,7 +570,7 @@ export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
                                     category === token.category &&
                                     term === token.term
                             ) + 1
-                        if (referenceIndex === 0) return
+                        if (referenceIndex === 0) return token
                         token.children.push(
                             new IRSuperscript(
                                 String(referenceIndex),

--- a/grapher/text/MarkdownTextWrap.tsx
+++ b/grapher/text/MarkdownTextWrap.tsx
@@ -609,15 +609,23 @@ export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
         if (htmlLines.length === 0) return null
         return (
             <span style={this.style} className="markdown-text-wrap">
-                {htmlLines.map((line, i) => (
-                    <span className="markdown-text-wrap__line" key={i}>
-                        {line.length ? (
-                            line.map((token, i) => token.toHTML(i))
-                        ) : (
-                            <br />
-                        )}
-                    </span>
-                ))}
+                {htmlLines.map((line, i) => {
+                    const plaintextLine = line
+                        .map((token) => token.toPlaintext())
+                        .join("")
+                    return (
+                        <span
+                            className="markdown-text-wrap__line"
+                            key={`${i}-${plaintextLine}`}
+                        >
+                            {line.length ? (
+                                line.map((token, i) => token.toHTML(i))
+                            ) : (
+                                <br />
+                            )}
+                        </span>
+                    )
+                })}
             </span>
         )
     }

--- a/site/LongFormPage.tsx
+++ b/site/LongFormPage.tsx
@@ -216,7 +216,7 @@ export const LongFormPage = (props: {
                                 )}
                             </header>
                         </div>
-                        {post.stickyNavLinks && (
+                        {post.stickyNavLinks?.length && (
                             <nav className="sticky-nav">
                                 <StickyNav links={post.stickyNavLinks} />
                             </nav>

--- a/site/SiteFooter.tsx
+++ b/site/SiteFooter.tsx
@@ -256,7 +256,7 @@ export const SiteFooter = (props: SiteFooterProps) => (
                 </div>
             </div>
             <div className="site-tools" />
-            <script src="https://polyfill.io/v3/polyfill.min.js?features=es6,fetch,URL,IntersectionObserver,IntersectionObserverEntry" />
+            <script src="https://polyfill.io/v3/polyfill.min.js?features=es6,fetch,URL,IntersectionObserver,IntersectionObserverEntry,ResizeObserver" />
             <script src={webpackUrl("commons.js", props.baseUrl)} />
             <script src={webpackUrl("vendors.js", props.baseUrl)} />
             <script src={webpackUrl("owid.js", props.baseUrl)} />

--- a/site/webpackUtils.tsx
+++ b/site/webpackUtils.tsx
@@ -47,7 +47,7 @@ const checkReady = () => {
 }
 
 const coreScripts = [
-    'https://polyfill.io/v3/polyfill.min.js?features=es6,fetch,URL,IntersectionObserver,IntersectionObserverEntry',
+    'https://polyfill.io/v3/polyfill.min.js?features=es6,fetch,URL,IntersectionObserver,IntersectionObserverEntry,ResizeObserver',
     '${webpackUrl("commons.js", baseUrl)}',
     '${webpackUrl("vendors.js", baseUrl)}',
     '${webpackUrl("owid.js", baseUrl)}'


### PR DESCRIPTION
I'll go through these one by one:
* `ResizeObserver` is [well-supported](https://caniuse.com/resizeobserver), but we're still getting [some Bugsnag errors](https://app.bugsnag.com/our-world-in-data/our-world-in-data-website/errors/62f156e75adfd5000841ad32) from browsers not supporting it, especially iOS 12.
  Our rough policy for supporting old browsers is "only fix it if it's very very easy to do", and in this case it thankfully is by adding `ResizeObserver` to what we request from polyfill.io.
* [Google Translate is doing some very weird shit that is not always React-compatible](https://github.com/facebook/react/issues/11538). We had issues with that before already. I noticed some of that is going on with MarkdownTextWrap, too, which [surfaced via Bugsnag](https://app.bugsnag.com/our-world-in-data/our-world-in-data-website/errors/6144b0de60893000071c0d30).
  Changing the `key` we use here seems like the simplest way out, because it makes React unmount the TextWrap nodes rather than trying to reuse them after prop updates.
* The `white-space: pre-wrap` _seems_ unnecessary, because we probably don't want to actually render multiple whitespace characters in a sequence as such? The only reason I'm removing it now is because it's also looking a bit weird with Google Translate, where there are dual spaces between characters (again, they are doing weird things). But if there's a good reason to have them then let's keep them.