### PR TITLE
fix: get the admin pane working on first load

### DIFF
--- a/devTools/docker/wait-for-mysql.sh
+++ b/devTools/docker/wait-for-mysql.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env  bash
+
 set -o errexit
 set -o pipefail
 set -o nounset
+
+if [ -e .env ]; then
+    source .env
+fi
 
 : "${GRAPHER_DB_NAME:?Need to set GRAPHER_DB_NAME non-empty}"
 : "${GRAPHER_DB_USER:?Need to set GRAPHER_DB_USER non-empty}"


### PR DESCRIPTION
Fixes #1591

The `wait-for-mysql.sh` script appears to be missing grapher variables from `.env`, so we source `.env` first.
