### PR TITLE
Refresh local env with VSCode tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -50,6 +50,62 @@
             ],
             "dependsOrder": "sequence",
             "problemMatcher": []
+        },
+        {
+            "label": "download wordpress database",
+            "type": "shell",
+            "command": "./devTools/docker/download-wordpress-mysql.sh"
+        },
+        {
+            "label": "download wordpress uploads",
+            "type": "shell",
+            "command": "./devTools/docker/download-wordpress-uploads.sh"
+        },
+        {
+            // This tasks refreshes the wordpress DB as well as wordpress uploads.
+            // Common scenarios:
+            // option 1 (default): download new db dump and refresh local db. Download uploads.
+            // option 2: partial fast refresh (update DB only)
+            // - comment out "download wordpress uploads" below
+            "label": "refresh wordpress",
+            "type": "shell",
+            "command": "docker compose -f docker-compose.full.yml run --rm db-load-data /app/refresh-wordpress-data.sh",
+            "dependsOrder": "parallel",
+            "dependsOn": [
+                "download wordpress database",
+                "download wordpress uploads"
+            ],
+            "problemMatcher": []
+        },
+        {
+            "label": "download grapher metadata",
+            "type": "shell",
+            "command": "./devTools/docker/download-grapher-metadata-mysql.sh"
+        },
+        {
+            "label": "download grapher chartdata",
+            "type": "shell",
+            "command": "./devTools/docker/download-grapher-chartdata-mysql.sh"
+        },
+        {
+            // This task refreshes the grapher DB based on the db dumps found
+            // in /tmp-downloads/.
+            // Common scenarios:
+            // option 1 (default): download new db dumps and refresh local db
+            // option 2: refresh based on previously downloaded db dumps
+            // - comment out the content of the "dependsOn" array below
+            // option 3: partial fast refresh (drop chartdata, update metadata)
+            // - delete /tmp-downloads/owid_chartdata.sql.gz
+            // - comment out "download grapher chartdata" below
+            "label": "refresh grapher",
+            "type": "shell",
+            "command": "docker compose -f docker-compose.full.yml run --rm db-load-data /app/refresh-grapher-data.sh",
+            "dependsOrder": "parallel",
+            "dependsOn": [
+                "download grapher metadata",
+                "download grapher chartdata"
+            ],
+            "problemMatcher": []
         }
     ]
 }

--- a/devTools/docker/create-and-fill-wordpress-db.sh
+++ b/devTools/docker/create-and-fill-wordpress-db.sh
@@ -36,7 +36,5 @@ createAndFillWordpressDb() {
 
     source "$( dirname -- "${BASH_SOURCE[0]}" )/refresh-wordpress-data.sh"
 
-    source "$( dirname -- "${BASH_SOURCE[0]}" )/create-wordpress-admin-user.sh"
-
     return 0
 }

--- a/devTools/docker/create-wordpress-admin-user.sh
+++ b/devTools/docker/create-wordpress-admin-user.sh
@@ -20,7 +20,7 @@ createWordpressAdminUser() {
     _mysql 'INSERT INTO wp_users (user_login, user_email, user_pass, user_registered, user_nicename) VALUES ("admin", "admin@example.com", "$2y$10$2ilzpLslIA29cZezVXJTDOqLlkGyXK6YcNvr2QPvn95WdmVdnxl2S", NOW(), "Admin");'
 
     echo "Giving the admin user administrator privileges"
-    _mysql `INSERT INTO wp_usermeta (user_id, meta_key, meta_value) VALUES ((SELECT id FROM wp_users WHERE user_email = "admin@example.com"), "wp_capabilities", "a:1:{s:13:\"administrator\";s:1:\"1\";}");`
+    _mysql 'INSERT INTO wp_usermeta (user_id, meta_key, meta_value) VALUES ((SELECT id FROM wp_users WHERE user_email = "admin@example.com"), "wp_capabilities", "a:1:{s:13:\"administrator\";s:1:\"1\";}");'
     _mysql 'INSERT INTO wp_usermeta (user_id, meta_key, meta_value) VALUES ((SELECT id FROM wp_users WHERE user_email = "admin@example.com"), "rich_editing", "true");'
 
     return 0

--- a/devTools/docker/download-grapher-chartdata-mysql.sh
+++ b/devTools/docker/download-grapher-chartdata-mysql.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env  bash
+set -o errexit
+set -o pipefail
+set -o nounset
+
+FOLDER="${DATA_FOLDER:-./tmp-downloads}"
+
+mkdir -p $FOLDER
+
+echo "Downloading live Grapher chartdata database (owid_chartdata)"
+curl -Lo $FOLDER/owid_chartdata.sql.gz https://files.ourworldindata.org/owid_chartdata.sql.gz

--- a/devTools/docker/download-grapher-metadata-mysql.sh
+++ b/devTools/docker/download-grapher-metadata-mysql.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env  bash
+set -o errexit
+set -o pipefail
+set -o nounset
+
+FOLDER="${DATA_FOLDER:-./tmp-downloads}"
+
+mkdir -p $FOLDER
+
+echo "Downloading live Grapher metadata database (owid_metadata)"
+curl -Lo $FOLDER/owid_metadata.sql.gz https://files.ourworldindata.org/owid_metadata.sql.gz

--- a/devTools/docker/download-grapher-mysql.sh
+++ b/devTools/docker/download-grapher-mysql.sh
@@ -3,12 +3,6 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-FOLDER="${DATA_FOLDER:-./tmp-downloads}"
+source "$( dirname -- "${BASH_SOURCE[0]}" )/download-grapher-metadata-mysql.sh"
 
-mkdir -p $FOLDER
-
-echo "Downloading live Grapher metadata database (owid_metadata)"
-curl -Lo $FOLDER/owid_metadata.sql.gz https://files.ourworldindata.org/owid_metadata.sql.gz
-
-echo "Downloading live Grapher chartdata database (owid_chartdata)"
-curl -Lo $FOLDER/owid_chartdata.sql.gz https://files.ourworldindata.org/owid_chartdata.sql.gz
+source "$( dirname -- "${BASH_SOURCE[0]}" )/download-grapher-chartdata-mysql.sh"

--- a/devTools/docker/refresh-grapher-data.sh
+++ b/devTools/docker/refresh-grapher-data.sh
@@ -19,11 +19,15 @@ import_db(){
 fillGrapherDb() {
     echo "Refreshing grapher database"
     $MYSQL -h $DB_ROOT_HOST -uroot -p$DB_ROOT_PASS -e "DROP DATABASE IF EXISTS $GRAPHER_DB_NAME;CREATE DATABASE $GRAPHER_DB_NAME; GRANT ALL PRIVILEGES ON $GRAPHER_DB_NAME.* TO '$GRAPHER_DB_USER'"
-    
-    echo "Importing live Grapher metadata database (owid_metadata)"
-    import_db $DATA_FOLDER/owid_metadata.sql.gz    
 
-    echo "Importing live Grapher chartdata database (owid_chartdata)"
-    import_db $DATA_FOLDER/owid_chartdata.sql.gz
+    if [ -f "${DATA_FOLDER}/owid_metadata.sql.gz" ]; then
+        echo "Importing live Grapher metadata database (owid_metadata)"
+        import_db $DATA_FOLDER/owid_metadata.sql.gz
+    fi
+
+    if [ -f "${DATA_FOLDER}/owid_chartdata.sql.gz" ]; then
+        echo "Importing live Grapher chartdata database (owid_chartdata)"
+        import_db $DATA_FOLDER/owid_chartdata.sql.gz
+    fi
 }
 fillGrapherDb

--- a/devTools/docker/refresh-grapher-data.sh
+++ b/devTools/docker/refresh-grapher-data.sh
@@ -23,11 +23,17 @@ fillGrapherDb() {
     if [ -f "${DATA_FOLDER}/owid_metadata.sql.gz" ]; then
         echo "Importing live Grapher metadata database (owid_metadata)"
         import_db $DATA_FOLDER/owid_metadata.sql.gz
+    else
+        echo "owid_metata.sql.gz missing in ${DATA_FOLDER}. Refresh aborted."
+        return 1;
     fi
 
     if [ -f "${DATA_FOLDER}/owid_chartdata.sql.gz" ]; then
         echo "Importing live Grapher chartdata database (owid_chartdata)"
         import_db $DATA_FOLDER/owid_chartdata.sql.gz
+    else
+        echo "Skipping import of owid_chartdata (owid_chartdata.sql.gz missing in ${DATA_FOLDER})"
+        # This is a legitimate use case, so execution should continue.
     fi
 }
 fillGrapherDb

--- a/devTools/docker/refresh-wordpress-data.sh
+++ b/devTools/docker/refresh-wordpress-data.sh
@@ -21,5 +21,7 @@ fillWordpressDb() {
         echo "live_wordpress.sql.gz missing in ${DATA_FOLDER}. Refresh aborted."
         return 1;
     fi
+
+    source "$( dirname -- "${BASH_SOURCE[0]}" )/create-wordpress-admin-user.sh"
 }
 fillWordpressDb

--- a/devTools/docker/refresh-wordpress-data.sh
+++ b/devTools/docker/refresh-wordpress-data.sh
@@ -13,8 +13,13 @@ set -o nounset
 MYSQL="mysql --default-character-set=utf8mb4"
 
 fillWordpressDb() {
-    echo "Importing Wordress database (live_wordpress)"
-    $MYSQL -h$DB_ROOT_HOST -uroot -p$DB_ROOT_PASS --port 3306 -e "DROP DATABASE IF EXISTS $WORDPRESS_DB_NAME;CREATE DATABASE $WORDPRESS_DB_NAME; GRANT ALL PRIVILEGES ON $WORDPRESS_DB_NAME.* TO '$WORDPRESS_DB_USER'"
-    cat $DATA_FOLDER/live_wordpress.sql.gz  | gunzip | $MYSQL -h$DB_ROOT_HOST --port=3306 -u$WORDPRESS_DB_USER -p$WORDPRESS_DB_PASS $WORDPRESS_DB_NAME
+    if [ -f "${DATA_FOLDER}/live_wordpress.sql.gz" ]; then
+        echo "Importing Wordress database (live_wordpress)"
+        $MYSQL -h$DB_ROOT_HOST -uroot -p$DB_ROOT_PASS --port 3306 -e "DROP DATABASE IF EXISTS $WORDPRESS_DB_NAME;CREATE DATABASE $WORDPRESS_DB_NAME; GRANT ALL PRIVILEGES ON $WORDPRESS_DB_NAME.* TO '$WORDPRESS_DB_USER'"
+        cat $DATA_FOLDER/live_wordpress.sql.gz  | gunzip | $MYSQL -h$DB_ROOT_HOST --port=3306 -u$WORDPRESS_DB_USER -p$WORDPRESS_DB_PASS $WORDPRESS_DB_NAME
+    else
+        echo "live_wordpress.sql.gz missing in ${DATA_FOLDER}. Refresh aborted."
+        return 1;
+    fi
 }
 fillWordpressDb


### PR DESCRIPTION
Resolves #1381.
 
This adds local refresh tasks for wordpress (db & uploads) and grapher (db).

The refresh tasks can be run through VSCode: 
- cmd + shift + p  >  "Tasks: Run Task"
- "refresh grapher" or "refresh wordpress".

In their default mode, the tasks download all assets (db dumps and wordpress uploads) and refresh all tables.

Check the comments in .vscode/tasks.json for additional usage scenarios. 