### PR TITLE
Consume api in admin and baking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ localBake/
 /differentGrapherSvgs
 /owid-content
 tmp-downloads
+/data_files_checksums

--- a/adminSiteClient/Admin.tsx
+++ b/adminSiteClient/Admin.tsx
@@ -13,6 +13,7 @@ type HTTPMethod = "GET" | "PUT" | "POST" | "DELETE" | "PATCH"
 interface ClientSettings {
     ENV: "development" | "production"
     GITHUB_USERNAME: string
+    DATA_API_FOR_ADMIN_UI?: string
 }
 
 interface ErrorMessage {
@@ -80,7 +81,9 @@ export class Admin {
         }
         headers["Accept"] = "application/json"
 
-        return fetch(this.url(path), {
+        const fetchUrl = path.startsWith("http") ? path : this.url(path)
+
+        return fetch(fetchUrl, {
             method: method,
             credentials: "same-origin",
             headers: headers,

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -143,6 +143,8 @@ export class ChartEditorPage
                     getGrapherInstance: (grapher) => {
                         this.grapher = grapher
                     },
+                    dataApiUrlForAdmin:
+                        this.context.admin.settings.DATA_API_FOR_ADMIN_UI, // passed this way because clientSettings are baked and need a recompile to be updated
                 }}
             />
         )

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -313,6 +313,8 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
             getGrapherInstance: (grapher: Grapher) => {
                 this.grapher = grapher
             },
+            dataApiUrlForAdmin:
+                this.context.admin.settings.DATA_API_FOR_ADMIN_UI, // passed this way because clientSettings are baked and need a recompile to be updated
         }
         if (this.grapherElement) {
             this.grapher.setAuthoredVersion(newConfig)

--- a/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
+++ b/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
@@ -1239,6 +1239,9 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                             {...{
                                 ...grapherConfig,
                                 bounds: this.grapherBounds,
+                                dataApiUrlForAdmin:
+                                    this.context.admin.settings
+                                        .DATA_API_FOR_ADMIN_UI, // passed this way because clientSettings are baked and need a recompile to be updated
                             }}
                         />
                     </figure>

--- a/adminSiteServer/IndexPage.tsx
+++ b/adminSiteServer/IndexPage.tsx
@@ -1,5 +1,9 @@
 import React from "react"
-import { ENV, GITHUB_USERNAME } from "../settings/serverSettings.js"
+import {
+    ENV,
+    GITHUB_USERNAME,
+    DATA_API_FOR_ADMIN_UI,
+} from "../settings/serverSettings.js"
 import { webpackUrl } from "../site/webpackUtils.js"
 
 export const IndexPage = (props: {
@@ -12,7 +16,7 @@ export const IndexPage = (props: {
         window.admin = new Admin({ username: "${
             props.username
         }", isSuperuser: ${props.isSuperuser.toString()}, settings: ${JSON.stringify(
-        { ENV, GITHUB_USERNAME }
+        { ENV, GITHUB_USERNAME, DATA_API_FOR_ADMIN_UI }
     )}})
         admin.start(document.querySelector("#app"), '${props.gitCmsBranchName}')
 `

--- a/clientUtils/OwidVariable.ts
+++ b/clientUtils/OwidVariable.ts
@@ -70,6 +70,11 @@ export type OwidVariableWithSourceAndDimension = OwidVariableWithSource & {
     dimensions: OwidVariableDimensions
 }
 
+export type OwidVariableWithSourceAndDimensionWithoutId = Omit<
+    OwidVariableWithSourceAndDimension,
+    "id"
+>
+
 export interface OwidVariableMixedData {
     years: number[]
     entities: number[]

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -20,6 +20,10 @@ export const ENV: "development" | "production" = clientSettings.ENV
 
 export const ADMIN_SERVER_PORT: number = clientSettings.ADMIN_SERVER_PORT
 export const ADMIN_SERVER_HOST: string = clientSettings.ADMIN_SERVER_HOST
+export const DATA_API_FOR_ADMIN_UI: string | undefined =
+    serverSettings.DATA_API_FOR_ADMIN_UI
+export const DATA_API_FOR_BAKING: string | undefined =
+    serverSettings.DATA_API_FOR_BAKING
 export const BAKED_BASE_URL: string = clientSettings.BAKED_BASE_URL
 
 export const ADMIN_BASE_URL: string = clientSettings.ADMIN_BASE_URL
@@ -101,3 +105,7 @@ export const DEPLOY_QUEUE_FILE_PATH: string =
 export const DEPLOY_PENDING_FILE_PATH: string =
     serverSettings.DEPLOY_PENDING_FILE_PATH ?? `${BASE_DIR}/.pending`
 export const CLOUDFLARE_AUD: string = serverSettings.CLOUDFLARE_AUD ?? ""
+
+export const DATA_FILES_CHECKSUMS_DIRECTORY: string =
+    serverSettings.DATA_FILES_CHECKSUMS_DIRECTORY ??
+    `${BASE_DIR}/data_files_checksums`

--- a/site/GrapherFigureView.tsx
+++ b/site/GrapherFigureView.tsx
@@ -30,6 +30,8 @@ export class GrapherFigureView extends React.Component<{ grapher: Grapher }> {
         const props = {
             ...this.props.grapher.toObject(),
             bounds: this.bounds,
+            dataApiUrlForAdmin:
+                this.context?.admin?.settings?.DATA_API_FOR_ADMIN_UI, // passed this way because clientSettings are baked and need a recompile to be updated
         }
         return (
             // They key= in here makes it so that the chart is re-loaded when the slug changes.


### PR DESCRIPTION
This implements #1568 - allows to fetch data for both baking and the grapher admin from the data api instead of from the mysql database directly.

To test it, set either of/both of  DATA_API_FOR_BAKING and DATA_API_FOR_ADMIN_UI to a running instance of the data api. One convenient instance to use is the one running on our analytics server. Create the tunnel with:

```bash
ssh -f owid-analytics -L 7000:localhost:8000 -N
```

Then set the keys above in your .env file to "http://localhost:7000". You should now be able to use the admin UI with variable metadata and data requests going to the data-api; or run baking where the variable metadata and data is fetched from the data api. Note that in both cases you still need the mysql database (and the admin server running) for the other parts of the infrastructure (like grapher charts etc).

Smaller tasks
- [x] move checksums ~into one big file outside of the baking directory and pass checksums to parallel runners in arguments~ into a separate directory so they do not get published. (this avoids having to deal with bi-directional communication of data to parallel workers and back again and just keeps everything as files which is much more straightforward)

I wanted to have a setting for controlling if/which url to use for fetching data from the data-api that can be changed by just changing an .env variable on the admin server and restarting it. This part is now a bit hacky but I created this follow-up ticket to make a more principled solution for it: #1602