### PR TITLE
feat(gdocs): add support for rich text in summary

### DIFF
--- a/site/gdocs/article-block.tsx
+++ b/site/gdocs/article-block.tsx
@@ -11,7 +11,7 @@ import Recirc from "./recirc"
 import List from "./list"
 import Image from "./image"
 
-export default function ArticleElement({ d }: { d: OwidArticleBlock }) {
+export default function ArticleBlock({ d }: { d: OwidArticleBlock }) {
     const handleArchie = (d: OwidArticleBlock, key: string) => {
         const _type = d.type.toLowerCase()
         let content: any = JSON.stringify(d)

--- a/site/gdocs/article-blocks.tsx
+++ b/site/gdocs/article-blocks.tsx
@@ -1,0 +1,11 @@
+import React from "react"
+import ArticleElement from "./article-element.js"
+import { OwidArticleBlock } from "./gdoc-types.js"
+
+export const ArticleBlocks = ({ blocks }: { blocks: OwidArticleBlock[] }) => (
+    <>
+        {blocks.map((block: OwidArticleBlock, i: number) => {
+            return <ArticleElement key={i} d={block} />
+        })}
+    </>
+)

--- a/site/gdocs/article-blocks.tsx
+++ b/site/gdocs/article-blocks.tsx
@@ -1,11 +1,11 @@
 import React from "react"
-import ArticleElement from "./article-element.js"
+import ArticleBlock from "./article-block.js"
 import { OwidArticleBlock } from "./gdoc-types.js"
 
 export const ArticleBlocks = ({ blocks }: { blocks: OwidArticleBlock[] }) => (
     <>
         {blocks.map((block: OwidArticleBlock, i: number) => {
-            return <ArticleElement key={i} d={block} />
+            return <ArticleBlock key={i} d={block} />
         })}
     </>
 )

--- a/site/gdocs/fixed-graphic.tsx
+++ b/site/gdocs/fixed-graphic.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 
-import ArticleElement from "./article-element"
+import ArticleBlock from "./article-block"
 import { OwidArticleBlock } from "./gdoc-types.js"
 
 export default function FixedSection({ d }: { d: OwidArticleBlock }) {
@@ -17,7 +17,7 @@ export default function FixedSection({ d }: { d: OwidArticleBlock }) {
                             _d.value.startsWith("<img src=")
                     )
                     .map((_d: OwidArticleBlock, j: number) => {
-                        return <ArticleElement key={j} d={_d} />
+                        return <ArticleBlock key={j} d={_d} />
                     })}
             </div>
             <div className={"fixedSectionContent"}>
@@ -28,7 +28,7 @@ export default function FixedSection({ d }: { d: OwidArticleBlock }) {
                             !_d.value.startsWith("<img src=")
                     )
                     .map((_d: OwidArticleBlock, j: number) => {
-                        return <ArticleElement key={j} d={_d} />
+                        return <ArticleBlock key={j} d={_d} />
                     })}
             </div>
         </section>

--- a/site/gdocs/owid-article.tsx
+++ b/site/gdocs/owid-article.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import ReactDOM from "react-dom"
+import { ArticleBlocks } from "./article-blocks.js"
 
-import ArticleElement from "./article-element.js"
 import Footnotes from "./footnotes.js"
 
 import { OwidArticleType, OwidArticleBlock } from "./gdoc-types.js"
@@ -33,18 +33,12 @@ export function OwidArticle(props: OwidArticleType) {
                 <div>
                     <details className={"summary"} open={true}>
                         <summary>Summary</summary>
-                        {content.summary.map(
-                            (d: OwidArticleBlock, i: number) => {
-                                return <ArticleElement key={i} d={d} />
-                            }
-                        )}
+                        <ArticleBlocks blocks={content.summary} />
                     </details>
                 </div>
             ) : null}
 
-            {content.body.map((d: OwidArticleBlock, i: number) => {
-                return <ArticleElement key={i} d={d} />
-            })}
+            <ArticleBlocks blocks={content.body} />
 
             {content.refs ? <Footnotes d={content.refs} /> : null}
 

--- a/site/gdocs/owid-article.tsx
+++ b/site/gdocs/owid-article.tsx
@@ -33,12 +33,10 @@ export function OwidArticle(props: OwidArticleType) {
                 <div>
                     <details className={"summary"} open={true}>
                         <summary>Summary</summary>
-                        {content.summary.reduce(
-                            (memo: string, d: OwidArticleBlock) => {
-                                const text: string = d.value
-                                return memo + " " + text
-                            },
-                            ""
+                        {content.summary.map(
+                            (d: OwidArticleBlock, i: number) => {
+                                return <ArticleElement key={i} d={d} />
+                            }
                         )}
                     </details>
                 </div>


### PR DESCRIPTION
<img width="646" alt="Screenshot 2022-08-18 at 15 12 11" src="https://user-images.githubusercontent.com/13406362/185403573-cee692a2-ad5c-45cc-97a6-37e829e582ff.png">

This brings support for rich text (bold, italics, etc...) as well as the full range of custom `ArticleElement`s to the summary block.