### PR TITLE
fix: shut down workerpools

### DIFF
--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -371,9 +371,6 @@ const bakeAllPublishedChartsVariableDataAndMetadata = async (
     const poolOptions = {
         minWorkers: 2,
         maxWorkers: maxWorkers,
-        onTerminateWorker: async () => {
-            await cleanup()
-        },
     }
     const pool = workerpool.pool(__dirname + "/worker.js", poolOptions)
     const jobs: BakeVariableDataArguments[] = variableIds.map((variableId) => ({
@@ -464,9 +461,6 @@ export const bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers =
         const poolOptions = {
             minWorkers: 2,
             maxWorkers: maxWorkers,
-            onTerminateWorker: async () => {
-                await cleanup()
-            },
         }
         const pool = workerpool.pool(__dirname + "/worker.js", poolOptions)
         try {


### PR DESCRIPTION
Our usual logic for using and releasing DB resources is to share a db connection within a process and to release them when the process is about to shut down. This works well for many cases but with the new workerpool implementation in baking we now have several workerthreads that get spawned which create their own connections but then the usual automatic cleanup fails.

The workerpool library complicates this picture and it is unclear what the best way for managing resources is there ATM. They have a onTerminateWorker callback but unhelpfully this is called on the main thread, not inside the worker thread.

This PR now does only the minimal thing which is to explicitly terminate the worker pool. In some preliminary tests this already released connections although TBH this is a bit surprising given that what we listen for for cleanup is SIGINT and SIGTERM - but maybe the node runtime emulates these for threads? Anyhow, this is now a minimal improvement but longer term explicit resource management would be desireable.