### PR TITLE
Update link colours

### DIFF
--- a/site/Breadcrumb/Breadcrumb.scss
+++ b/site/Breadcrumb/Breadcrumb.scss
@@ -8,7 +8,7 @@
         text-decoration: underline;
 
         &:hover {
-            color: #c0023e;
+            color: $accent-vermillion;
         }
     }
 

--- a/site/blocks/expandable-paragraph.scss
+++ b/site/blocks/expandable-paragraph.scss
@@ -37,10 +37,9 @@
 }
 
 .expandable-paragraph__expand-button {
+    @include owid-link-90;
     margin: 16px 0;
     background: none;
     border: none;
     cursor: pointer;
-    color: $blue-90;
-    text-decoration: underline;
 }

--- a/site/blocks/front-matter.scss
+++ b/site/blocks/front-matter.scss
@@ -34,11 +34,11 @@
     cursor: pointer;
 
     &:hover {
-        border-color: darken($accent-vermillion, 10);
+        border-color: $accent-vermillion;
 
         a,
         a:visited {
-            color: darken($accent-vermillion, 10);
+            color: $accent-vermillion;
             text-decoration: none;
         }
     }
@@ -83,11 +83,7 @@
         text-underline-offset: 6px;
 
         a {
-            color: $blue-90;
-        }
-
-        a:visited {
-            color: $blue-60;
+            @include owid-link-90;
         }
 
         a:after {

--- a/site/css/colors.scss
+++ b/site/css/colors.scss
@@ -89,7 +89,11 @@ $blue-30: #a4b6ca;
 // Accent colors
 $accent-electric-blue: #2162e6;
 $accent-pale-blue: #e7f2ff;
-$accent-vermillion: #ce261e;
+$accent-vermillion: #b40000;
+
+// Visited
+$purple-90: #631d49;
+$purple-60: #91577c;
 
 // Background colors
 $blue-20: #dbe5f0;

--- a/site/css/content.scss
+++ b/site/css/content.scss
@@ -5,7 +5,7 @@
  * Links
  */
 .article-content a {
-    @include owid-link;
+    @include owid-link-90;
 }
 
 /*******************************************************************************

--- a/site/css/header.scss
+++ b/site/css/header.scss
@@ -555,7 +555,7 @@
         margin-top: -1px;
 
         a {
-            color: $primary-color;
+            color: $blue-90;
             padding-left: 1.5rem;
             &:hover {
                 background-color: $primary-color-200;

--- a/site/css/mixins.scss
+++ b/site/css/mixins.scss
@@ -1,11 +1,24 @@
-@mixin owid-link {
-    color: $link-color;
+@mixin owid-link-90 {
+    color: $blue-90;
+    text-decoration: underline;
+
     &:visited {
-        color: $link-visited-color;
+        color: $purple-90;
     }
     &:hover {
-        color: $link-hover-color;
-        text-decoration: underline;
+        text-decoration: none;
+    }
+}
+
+@mixin owid-link-60 {
+    color: $blue-60;
+    text-decoration: underline;
+
+    &:visited {
+        color: $purple-60;
+    }
+    &:hover {
+        text-decoration: none;
     }
 }
 

--- a/site/css/page.scss
+++ b/site/css/page.scss
@@ -70,7 +70,7 @@
             color: inherit;
 
             &:hover {
-                color: #c0023e;
+                color: $accent-vermillion;
             }
         }
     }

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -230,7 +230,7 @@ h6:hover .deep-link {
 }
 
 .article-footer a {
-    @include owid-link;
+    @include owid-link-90;
 }
 
 /* Homepage
@@ -988,7 +988,7 @@ html:not(.js) {
         }
 
         a {
-            @include owid-link;
+            @include owid-link-90;
         }
     }
 }
@@ -1230,10 +1230,7 @@ html:not(.js) {
             font-size: inherit;
         }
         a {
-            color: #453cbb;
-        }
-        a:hover {
-            color: #7d8aef;
+            @include owid-link-90;
         }
     }
 


### PR DESCRIPTION
[Staging demo](https://ptolemy-owid.netlify.app/world-population-growth)

Based on the [new link designs in figma](https://www.figma.com/file/cZrEfEgWkpAQTeLLQyukDw/%5BDesktop%5D-Library-1.0?node-id=162%3A357).

I updated the mixin and then manually searched for all `a` tag CSS that used that mixin or a blue similar to blue-90.


