### PR TITLE
feat: provide citation guidance in download tab

### DIFF
--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -2301,7 +2301,7 @@ export class Grapher
     }
 
     @computed private get footerControlsLines(): number {
-        return this.hasTimeline ? 2 : 1
+        return this.showTimeline ? 2 : 1
     }
 
     @computed get footerControlsHeight(): number {

--- a/grapher/downloadTab/DownloadTab.scss
+++ b/grapher/downloadTab/DownloadTab.scss
@@ -19,7 +19,7 @@
     }
 
     .grouped-menu-section + .grouped-menu-section {
-        margin-top: 3em;
+        margin-top: 1.5em;
     }
 
     .grouped-menu-item {

--- a/grapher/downloadTab/DownloadTab.scss
+++ b/grapher/downloadTab/DownloadTab.scss
@@ -7,7 +7,7 @@
 
     .grouped-menu {
         width: 100%;
-        max-width: 35em;
+        max-width: 45em;
         margin: auto;
     }
 
@@ -81,14 +81,18 @@
         .faint {
             font-weight: normal;
         }
+
+        li {
+            margin-left: 1.25em;
+        }
     }
 
-    .download-icon {
+    .aside-icon {
         opacity: 0.5;
         padding-left: 0.5em;
         padding-right: 1.5em;
     }
-    .grouped-menu-item:hover .download-icon {
+    .grouped-menu-item:hover .aside-icon {
         opacity: 1;
     }
 

--- a/grapher/downloadTab/DownloadTab.tsx
+++ b/grapher/downloadTab/DownloadTab.tsx
@@ -5,6 +5,7 @@ import { Bounds, DEFAULT_BOUNDS } from "../../clientUtils/Bounds.js"
 import { LoadingIndicator } from "../loadingIndicator/LoadingIndicator.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faDownload } from "@fortawesome/free-solid-svg-icons/faDownload"
+import { faQuoteLeft } from "@fortawesome/free-solid-svg-icons/faQuoteLeft"
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons/faInfoCircle"
 import { BlankOwidTable, OwidTable } from "../../coreTable/OwidTable.js"
 import {
@@ -30,6 +31,7 @@ export interface DownloadTabManager {
     externalCsvLink?: string // Todo: we can ditch this once rootTable === externalCsv (currently not quite the case for Covid Explorer)
     shouldIncludeDetailsInStaticExport?: boolean
     detailRenderers: MarkdownTextWrap[]
+    sourcesLine?: string
 }
 
 interface DownloadTabProps {
@@ -225,6 +227,11 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
         }
     }
 
+    @computed get sourcesLine(): string | undefined {
+        const { sourcesLine } = this.manager
+        return sourcesLine?.replace(/; /g, ", ")
+    }
+
     private renderReady(): JSX.Element {
         const { targetWidth, targetHeight, svgPreviewUrl, bounds } = this
 
@@ -271,7 +278,7 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
                                 </p>
                             </div>
                             <div className="grouped-menu-icon">
-                                <span className="download-icon">
+                                <span className="aside-icon">
                                     <FontAwesomeIcon icon={faDownload} />
                                 </span>
                             </div>
@@ -295,7 +302,7 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
                                 </p>
                             </div>
                             <div className="grouped-menu-icon">
-                                <span className="download-icon">
+                                <span className="aside-icon">
                                     <FontAwesomeIcon icon={faDownload} />
                                 </span>
                             </div>
@@ -378,7 +385,7 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
                                     </p>
                                 </div>
                                 <div className="grouped-menu-icon">
-                                    <span className="download-icon">
+                                    <span className="aside-icon">
                                         <FontAwesomeIcon icon={faDownload} />
                                     </span>
                                 </div>
@@ -386,6 +393,41 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
                         </div>
                     )}
                 </div>
+
+                {this.sourcesLine !== undefined && (
+                    <div className="grouped-menu-section">
+                        <div className="grouped-menu-list">
+                            <div className="grouped-menu-item">
+                                <div className="grouped-menu-content">
+                                    <h3 className="title">How to cite</h3>
+                                    <div className="description">
+                                        When reusing this chart, please give
+                                        attribution to the data publishers.
+                                        <ul>
+                                            <li>
+                                                Cite the <strong>data</strong>{" "}
+                                                as: <i>{this.sourcesLine}</i>
+                                            </li>
+                                            <li>
+                                                Cite the <strong>chart</strong>{" "}
+                                                as:{" "}
+                                                <i>
+                                                    Data from {this.sourcesLine}
+                                                    ; Chart by Our World in Data
+                                                </i>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                                <div className="grouped-menu-icon">
+                                    <span className="aside-icon">
+                                        <FontAwesomeIcon icon={faQuoteLeft} />
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                )}
             </div>
         )
     }

--- a/grapher/downloadTab/DownloadTab.tsx
+++ b/grapher/downloadTab/DownloadTab.tsx
@@ -227,9 +227,21 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
         }
     }
 
-    @computed get sourcesLine(): string | undefined {
+    @computed get dataCitationLine(): string | undefined {
         const { sourcesLine } = this.manager
-        return sourcesLine?.replace(/; /g, ", ")
+        if (sourcesLine)
+            return sourcesLine
+                .replace(/; /g, ", ")
+                .replace(/\bOWID\b/g, "Our World in Data")
+                .replace(/^Data from /g, "")
+        else return undefined
+    }
+
+    @computed get chartCitationLine(): string | undefined {
+        const { dataCitationLine } = this
+        if (dataCitationLine)
+            return `Data from ${dataCitationLine}; Chart by Our World in Data`
+        else return undefined
     }
 
     private renderReady(): JSX.Element {
@@ -394,27 +406,25 @@ export class DownloadTab extends React.Component<DownloadTabProps> {
                     )}
                 </div>
 
-                {this.sourcesLine !== undefined && (
+                {this.dataCitationLine !== undefined && (
                     <div className="grouped-menu-section">
+                        <h2>How to cite this work</h2>
                         <div className="grouped-menu-list">
                             <div className="grouped-menu-item">
                                 <div className="grouped-menu-content">
-                                    <h3 className="title">How to cite</h3>
                                     <div className="description">
                                         When reusing this chart, please give
                                         attribution to the data publishers.
                                         <ul>
                                             <li>
                                                 Cite the <strong>data</strong>{" "}
-                                                as: <i>{this.sourcesLine}</i>
+                                                as:{" "}
+                                                <i>{this.dataCitationLine}</i>
                                             </li>
                                             <li>
                                                 Cite the <strong>chart</strong>{" "}
                                                 as:{" "}
-                                                <i>
-                                                    Data from {this.sourcesLine}
-                                                    ; Chart by Our World in Data
-                                                </i>
+                                                <i>{this.chartCitationLine}</i>
                                             </li>
                                         </ul>
                                     </div>


### PR DESCRIPTION
Fixes #1137 | Live on [tufte](https://tufte-owid.netlify.app)

![image](https://user-images.githubusercontent.com/2641501/185906796-c88d2fa7-a262-49f4-8d20-c17f13353242.png)

---

TODOs:
- [ ] Provide a copy button next to the text
- [ ] Do we need the content of the citation guidance to be customizable per chart?