### PR TITLE
fix: use `selectedEntityIds` for original entity ids

### DIFF
--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -2436,7 +2436,9 @@ export class Grapher
         const authoredConfig = this.legacyConfigAsAuthored
 
         const originalSelectedEntityIds =
-            authoredConfig.selectedData?.map((row) => row.entityId) || []
+            uniq(authoredConfig.selectedData?.map((row) => row.entityId)) ??
+            authoredConfig.selectedEntityIds ??
+            []
         const currentSelectedEntityIds = this.selection.allSelectedEntityIds
 
         const entityIdsThatTheUserDeselected = difference(


### PR DESCRIPTION
In order to check whether entities changed between the original view and the current view, we were only using `legacyConfig.selectedData`, and we didn't dedupe it.

This lead to most charts appending a `?country=...` on load automatically.

An example chart is this one here: https://ourworldindata.org/grapher/age-standardized-death-rate-by-cause

---

It's not like the current behaviour was super bad, but it caused a lot of unnecessary `?country=` in https://github.com/owid/owid-grapher-svgs, which are being stripped out by an upcoming fix for #1388.
To get more clean SVG diffs, I'm merging this very easy fix beforehand.

This also means that this PR will lead to SVG diffs, but they are all of the quality:
```diff
- <a href="http://localhost:3030/grapher/sub-energy-fossil-renewables-nuclear?country=~OWID_WRL" style="font-family:
+ <a href="http://localhost:3030/grapher/sub-energy-fossil-renewables-nuclear" style="font-family:
```
