### PR TITLE
Remove underline from Grapher tabs in .article-content

### DIFF
--- a/grapher/core/grapher.scss
+++ b/grapher/core/grapher.scss
@@ -58,8 +58,16 @@ $zindex-Tooltip: 20;
     .flash {
         margin: 10px;
     }
+
     .clickable {
         cursor: pointer;
+
+        a {
+            text-decoration: none;
+            &:visited {
+                color: initial;
+            }
+        }
     }
     input[type="checkbox"] {
         cursor: pointer;


### PR DESCRIPTION
Changes to link styling mistakenly affected the tabs on graphers in articles. This overrides those changes.