### PR TITLE
fix(admin): don't auto-select multiple entities in multi-variable charts

### DIFF
--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -110,7 +110,7 @@ class DimensionSlotView extends React.Component<{
                     const entity = availableEntityNameSet.has(WorldEntityName)
                         ? WorldEntityName
                         : sample(availableEntityNames)
-                    selection.selectEntity(entity!)
+                    if (entity) selection.setSelectedEntities([entity])
                     grapher.addCountryMode = EntitySelectionMode.SingleEntity
                 } else {
                     selection.setSelectedEntities(


### PR DESCRIPTION
Fixes #1354.

I stumbled upon this when working on related code, and it turns out the fix for #1354 is super super easy.
We might still want to get rid of auto-selection altogether, or at least rework how it works, but for now it at least won't screw up every StackedArea ever again.
I think this bug also lead to a considerable amount of buggy charts that we published and then noticed that something's wrong, so here's hoping that's no more.