### PR TITLE
chore: change TS build target to es2019

### DIFF
--- a/devTools/tsconfigs/tsconfig.base.json
+++ b/devTools/tsconfigs/tsconfig.base.json
@@ -16,7 +16,7 @@
         //   "target": "es2020",
 
         "lib": ["dom", "dom.iterable", "es2020"],
-        "target": "es6",
+        "target": "es2019",
 
         "alwaysStrict": true,
         "noImplicitReturns": true,


### PR DESCRIPTION
Changing the build target means that some newer ES features no longer need to be transpiled.
This includes especially:
* async/await ([es2017](https://flaviocopes.com/es2017/))
* Rest/Spread syntax ([es2018](https://flaviocopes.com/es2018/))
* No new syntax-level features really from [es2019](https://flaviocopes.com/es2019/), but some nice standard library additions at least

Switching to a newer build target reduces the asset size, and can potentially also improve performance by a bit since we're now using the native implementation of these features.

---

I didn't go with es2020 just yet because its syntax features (nullish coalescing and optional chaining) [did "only" get support in iOS Safari 13.4](https://caniuse.com/mdn-javascript_operators_optional_chaining,mdn-javascript_operators_nullish_coalescing), and we have some amount of iOS users using an older version.

For future reference, this table of ES features and their browser support can also come in handy: https://kangax.github.io/compat-table/es2016plus/