### PR TITLE
fix(admin): make dimension color picker work

### DIFF
--- a/adminSiteClient/DimensionCard.tsx
+++ b/adminSiteClient/DimensionCard.tsx
@@ -84,7 +84,7 @@ export class DimensionCard extends React.Component<{
         const { grapher } = this.props.editor
 
         grapher.updateAuthoredVersion({
-            dimensions: grapher.filledDimensions.map((dim) => dim.toObject()),
+            dimensions: grapher.dimensions.map((dim) => dim.toObject()),
         })
 
         grapher.seriesColorMap?.clear()

--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -113,10 +113,15 @@ class DimensionSlotView extends React.Component<{
         this.disposers.push(
             reaction(
                 () => this.props.slot.dimensions,
-                () =>
-                    (this.dimensionsInDisplayOrder = [
-                        ...this.props.slot.dimensions,
-                    ]),
+                () => {
+                    if (
+                        this.props.slot.dimensions.length !==
+                        this.dimensionsInDisplayOrder.length
+                    )
+                        this.dimensionsInDisplayOrder = [
+                            ...this.props.slot.dimensions,
+                        ]
+                },
                 { fireImmediately: true }
             )
         )

--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -169,6 +169,10 @@ class DimensionSlotView extends React.Component<{
         this.updateLegacySelectionAndRebuildTable()
     }
 
+    @action.bound onBlur() {
+        this.updateLegacySelectionAndRebuildTable()
+    }
+
     @action.bound private onStartDrag(targetSlug: ColumnSlug) {
         this.draggingColumnSlug = targetSlug
 
@@ -201,7 +205,7 @@ class DimensionSlotView extends React.Component<{
         const canAddMore = slot.allowMultiple || slot.dimensions.length === 0
 
         return (
-            <div>
+            <div onBlur={this.onBlur}>
                 <h5>{slot.name}</h5>
                 <EditableList>
                     {this.dimensionsInDisplayOrder.map((dim) => {


### PR DESCRIPTION
Changing the color of a dimension no longer works ([reported on Slack](https://owid.slack.com/archives/C46U9LXRR/p1661944664407249)), likely we broke it in https://github.com/owid/owid-grapher/pull/1623.

> I am trying to change the colors in [this chart](https://owid.cloud/admin/charts/5906/edit) but am unable to do so. I neither can change the hex codes nor select a color from the palette.

This fix works, but I don't understand why.