### PR TITLE
fix(admin): allow entering decimal points and negative signs in number fields

### DIFF
--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -40,7 +40,7 @@ interface TextFieldProps extends React.HTMLAttributes<HTMLInputElement> {
     rows?: number
     softCharacterLimit?: number
     errorMessage?: string
-    buttonText?: string
+    buttonText?: string | JSX.Element
 }
 
 export class TextField extends React.Component<TextFieldProps> {
@@ -99,15 +99,17 @@ export class TextField extends React.Component<TextFieldProps> {
                         {...passthroughProps}
                     />
                     {props.buttonText && (
-                        <button
-                            className="btn btn-outline-secondary"
-                            type="button"
-                            onClick={() =>
-                                props.onButtonClick && props.onButtonClick()
-                            }
-                        >
-                            {props.buttonText}
-                        </button>
+                        <div className="input-group-append">
+                            <button
+                                className="btn btn-outline-secondary"
+                                type="button"
+                                onClick={() =>
+                                    props.onButtonClick && props.onButtonClick()
+                                }
+                            >
+                                {props.buttonText}
+                            </button>
+                        </div>
                     )}
                 </div>
                 {props.helpText && (
@@ -195,6 +197,8 @@ interface NumberFieldProps {
     title?: string
     disabled?: boolean
     helpText?: string
+    buttonText?: string | JSX.Element
+    onButtonClick?: () => void
 }
 
 interface NumberFieldState {
@@ -605,20 +609,12 @@ export class AutoTextField extends React.Component<AutoTextFieldProps> {
         const { props } = this
 
         return (
-            <div className="form-group AutoTextField">
-                {props.label && <label>{props.label}</label>}
-                <div className="input-group mb-2 mb-sm-0">
-                    <input
-                        type="text"
-                        className="form-control"
-                        value={props.value}
-                        placeholder={props.placeholder}
-                        onChange={(e) => props.onValue(e.currentTarget.value)}
-                        onBlur={props.onBlur}
-                    />
+            <TextField
+                {...props}
+                value={props.isAuto ? undefined : props.value}
+                placeholder={props.isAuto ? props.value : undefined}
+                buttonText={
                     <div
-                        className="input-group-addon"
-                        onClick={() => props.onToggleAuto(!props.isAuto)}
                         title={
                             props.isAuto ? "Automatic default" : "Manual input"
                         }
@@ -629,19 +625,9 @@ export class AutoTextField extends React.Component<AutoTextFieldProps> {
                             <FontAwesomeIcon icon={faUnlink} />
                         )}
                     </div>
-                </div>
-                {props.helpText && (
-                    <small className="form-text text-muted">
-                        {props.helpText}
-                    </small>
-                )}
-                {props.softCharacterLimit && props.value && (
-                    <SoftCharacterLimit
-                        text={props.value}
-                        limit={props.softCharacterLimit}
-                    />
-                )}
-            </div>
+                }
+                onButtonClick={() => props.onToggleAuto(!props.isAuto)}
+            />
         )
     }
 }
@@ -757,17 +743,29 @@ class AutoFloatField extends React.Component<AutoFloatFieldProps> {
     render() {
         const { props } = this
 
-        const textFieldProps = {
-            ...props,
-            value: props.isAuto ? undefined : props.value.toString(),
-            onValue: (value: string) => {
-                const asNumber = parseFloat(value)
-                props.onValue(isNaN(asNumber) ? undefined : asNumber)
-            },
-            placeholder: props.isAuto ? props.value.toString() : undefined,
-        }
-
-        return <AutoTextField {...textFieldProps} />
+        return (
+            <NumberField
+                allowDecimal
+                allowNegative
+                {...props}
+                value={props.isAuto ? undefined : props.value}
+                placeholder={props.isAuto ? props.value.toString() : undefined}
+                buttonText={
+                    <div
+                        title={
+                            props.isAuto ? "Automatic default" : "Manual input"
+                        }
+                    >
+                        {props.isAuto ? (
+                            <FontAwesomeIcon icon={faLink} />
+                        ) : (
+                            <FontAwesomeIcon icon={faUnlink} />
+                        )}
+                    </div>
+                }
+                onButtonClick={() => props.onToggleAuto(!props.isAuto)}
+            />
+        )
     }
 }
 
@@ -782,17 +780,7 @@ class FloatField extends React.Component<FloatFieldProps> {
     render() {
         const { props } = this
 
-        const textFieldProps = {
-            ...props,
-            value:
-                props.value === undefined ? undefined : props.value.toString(),
-            onValue: (value: string) => {
-                const asNumber = parseFloat(value)
-                props.onValue(isNaN(asNumber) ? undefined : asNumber)
-            },
-        }
-
-        return <TextField {...textFieldProps} />
+        return <NumberField {...props} allowDecimal allowNegative />
     }
 }
 

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -40,7 +40,7 @@ interface TextFieldProps extends React.HTMLAttributes<HTMLInputElement> {
     rows?: number
     softCharacterLimit?: number
     errorMessage?: string
-    buttonText?: string | JSX.Element
+    buttonContent?: React.ReactNode
 }
 
 export class TextField extends React.Component<TextFieldProps> {
@@ -98,7 +98,7 @@ export class TextField extends React.Component<TextFieldProps> {
                         onKeyDown={this.onKeyDown}
                         {...passthroughProps}
                     />
-                    {props.buttonText && (
+                    {props.buttonContent && (
                         <div className="input-group-append">
                             <button
                                 className="btn btn-outline-secondary"
@@ -107,7 +107,7 @@ export class TextField extends React.Component<TextFieldProps> {
                                     props.onButtonClick && props.onButtonClick()
                                 }
                             >
-                                {props.buttonText}
+                                {props.buttonContent}
                             </button>
                         </div>
                     )}
@@ -197,7 +197,7 @@ interface NumberFieldProps {
     title?: string
     disabled?: boolean
     helpText?: string
-    buttonText?: string | JSX.Element
+    buttonContent?: React.ReactNode
     onButtonClick?: () => void
 }
 
@@ -613,7 +613,7 @@ export class AutoTextField extends React.Component<AutoTextFieldProps> {
                 {...props}
                 value={props.isAuto ? undefined : props.value}
                 placeholder={props.isAuto ? props.value : undefined}
-                buttonText={
+                buttonContent={
                     <div
                         title={
                             props.isAuto ? "Automatic default" : "Manual input"
@@ -644,7 +644,7 @@ export class BindString extends React.Component<{
     disabled?: boolean
     rows?: number
     errorMessage?: string
-    buttonText?: string
+    buttonContent?: React.ReactChild
     onButtonClick?: () => void
 }> {
     @action.bound onValue(value: string = "") {
@@ -750,7 +750,7 @@ class AutoFloatField extends React.Component<AutoFloatFieldProps> {
                 {...props}
                 value={props.isAuto ? undefined : props.value}
                 placeholder={props.isAuto ? props.value.toString() : undefined}
-                buttonText={
+                buttonContent={
                     <div
                         title={
                             props.isAuto ? "Automatic default" : "Manual input"

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -1550,7 +1550,7 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
                         field="columnFilter"
                         store={this}
                         label="Filter columns"
-                        buttonText="Clear"
+                        buttonContent="Clear"
                         onButtonClick={this.clearColumnFilter}
                     />
 


### PR DESCRIPTION
Fixes #1427

We have a pretty sophisticated `<NumberField>` component already which works well, so we can also use it for `<AutoFloatField>`.
In general, there was lots of overlap between the `AutoTextField` and `TextField` components, so I decided to base them on each other, too.
This also brings about a change in design:
![image](https://user-images.githubusercontent.com/2641501/188747122-70a77b0a-d160-4f9c-991b-713aaba7a266.png)
