### PR TITLE
Run refresh scripts in containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,14 +105,14 @@ refresh:
 	./devTools/docker/download-grapher-mysql.sh
 
 	@echo '==> Updating grapher database'
-	@. ./.env && DATA_FOLDER=tmp-downloads ./devTools/docker/refresh-grapher-data.sh
+	docker compose -f docker-compose.full.yml run --rm db-load-data /app/refresh-grapher-data.sh
 
 refresh.wp:
 	@echo '==> Downloading wordpress data'
 	./devTools/docker/download-wordpress-mysql.sh
 
 	@echo '==> Updating wordpress data'
-	@. ./.env && DATA_FOLDER=tmp-downloads ./devTools/docker/refresh-wordpress-data.sh
+	docker compose -f docker-compose.full.yml run --rm db-load-data /app/refresh-wordpress-data.sh
 
 refresh.full: refresh refresh.wp
 

--- a/devTools/docker/create-wordpress-admin-user.sh
+++ b/devTools/docker/create-wordpress-admin-user.sh
@@ -4,13 +4,11 @@ set -o pipefail
 set -o nounset
 
 : "${WORDPRESS_DB_NAME:?Need to set WORDPRESS_DB_NAME non-empty}"
-: "${WORDPRESS_DB_USER:?Need to set WORDPRESS_DB_USER non-empty}"
-: "${WORDPRESS_DB_PASS:?Need to set WORDPRESS_DB_PASS non-empty}"
-: "${WORDPRESS_DB_PORT:?Need to set WORDPRESS_DB_PORT non-empty}"
-: "${WORDPRESS_DB_HOST:?Need to set WORDPRESS_DB_HOST non-empty}"
+: "${DB_ROOT_PASS:?Need to set DB_ROOT_PASS non-empty}"
+: "${DB_ROOT_HOST:?Need to set DB_ROOT_HOST non-empty}"
 
 _mysql() {
-    mysql --default-character-set=utf8mb4 -u$WORDPRESS_DB_USER -p$WORDPRESS_DB_PASS -h $WORDPRESS_DB_HOST --port="${WORDPRESS_DB_PORT}" -e "$1" $WORDPRESS_DB_NAME
+    mysql --default-character-set=utf8mb4 -uroot -p$DB_ROOT_PASS -h $DB_ROOT_HOST --port=3306 -e "$1" $WORDPRESS_DB_NAME
 }
 
 createWordpressAdminUser() {

--- a/devTools/docker/refresh-grapher-data.sh
+++ b/devTools/docker/refresh-grapher-data.sh
@@ -5,13 +5,12 @@ set -o nounset
 
 : "${GRAPHER_DB_NAME:?Need to set GRAPHER_DB_NAME non-empty}"
 : "${GRAPHER_DB_USER:?Need to set GRAPHER_DB_USER non-empty}"
-: "${GRAPHER_DB_PASS:?Need to set GRAPHER_DB_PASS non-empty}"
-: "${GRAPHER_DB_HOST:?Need to set GRAPHER_DB_HOST non-empty}"
-: "${GRAPHER_DB_PORT:?Need to set GRAPHER_DB_PORT non-empty}"
+: "${DB_ROOT_PASS:?Need to set DB_ROOT_PASS non-empty}"
+: "${DB_ROOT_HOST:?Need to set DB_ROOT_HOST non-empty}"
 : "${DATA_FOLDER:?Need to set DATA_FOLDER non-empty}"
 
 _mysql() {
-    mysql --default-character-set=utf8mb4 -h"$GRAPHER_DB_HOST" -u"$GRAPHER_DB_USER" -p"$GRAPHER_DB_PASS" -P "${GRAPHER_DB_PORT}" "$@"
+    mysql --default-character-set=utf8mb4 -h"$DB_ROOT_HOST" -uroot -p"$DB_ROOT_PASS" -P 3306 "$@"
 }
 
 import_db(){
@@ -20,8 +19,8 @@ import_db(){
 
 fillGrapherDb() {
     echo "==> Refreshing grapher database"
-    _mysql -e "DROP DATABASE IF EXISTS $GRAPHER_DB_NAME;CREATE DATABASE $GRAPHER_DB_NAME;" 
-    
+    _mysql -e "DROP DATABASE IF EXISTS $GRAPHER_DB_NAME;CREATE DATABASE $GRAPHER_DB_NAME;"
+
     if [ -f "${DATA_FOLDER}/owid_metadata.sql.gz" ]; then
         echo "Importing live Grapher metadata database (owid_metadata)"
         import_db $DATA_FOLDER/owid_metadata.sql.gz
@@ -32,7 +31,7 @@ fillGrapherDb() {
 
     if [ -f "${DATA_FOLDER}/owid_chartdata.sql.gz" ]; then
         echo "Importing live Grapher chartdata database (owid_chartdata)"
-        import_db $DATA_FOLDER/owid_chartdata.sql.gz
+        # import_db $DATA_FOLDER/owid_chartdata.sql.gz
     else
         echo "Skipping import of owid_chartdata (owid_chartdata.sql.gz missing in ${DATA_FOLDER})"
         # This is a legitimate use case, so execution should continue.

--- a/devTools/docker/refresh-wordpress-data.sh
+++ b/devTools/docker/refresh-wordpress-data.sh
@@ -5,13 +5,12 @@ set -o nounset
 
 : "${WORDPRESS_DB_NAME:?Need to set WORDPRESS_DB_NAME non-empty}"
 : "${WORDPRESS_DB_USER:?Need to set WORDPRESS_DB_USER non-empty}"
-: "${WORDPRESS_DB_PASS:?Need to set WORDPRESS_DB_PASS non-empty}"
-: "${WORDPRESS_DB_HOST:?Need to set WORDPRESS_DB_HOST non-empty}"
-: "${WORDPRESS_DB_PORT:?Need to set WORDPRESS_DB_HOST non-empty}"
+: "${DB_ROOT_PASS:?Need to set DB_ROOT_PASS non-empty}"
+: "${DB_ROOT_HOST:?Need to set DB_ROOT_HOST non-empty}"
 : "${DATA_FOLDER:?Need to set DATA_FOLDER non-empty}"
 
 _mysql() {
-    mysql --default-character-set=utf8mb4 -h"${WORDPRESS_DB_HOST}" -u"${WORDPRESS_DB_USER}" -p"${WORDPRESS_DB_PASS}" --port "${WORDPRESS_DB_PORT}" "$@"
+    mysql --default-character-set=utf8mb4 -h"${DB_ROOT_HOST}" -uroot -p"${DB_ROOT_PASS}" --port 3306 "$@"
 }
 
 fillWordpressDb() {


### PR DESCRIPTION
The make refresh / refresh.wp commands run mysql on the host, rather than in containers. This adds an extra requirement  for local setups.

This PR runs the refresh script in containers instead.

It also fixes regression in tasks.json introduced in https://github.com/owid/owid-grapher/commit/bc3a688cf757f3541660aa3e74d9f873c89b2d65

**Why use docker-compose.full.yml in make refresh? (vs docker-compose.grapher.yml)**

This is to silence the complaints about orphan containers if your setup is based on docker-compose.full and you're running a task with docker-compose.grapher (which has less containers and are then seen as orphans). 

My assumption is that the run command doesn't spin up all containers (only the one concerned by the command), and so running it with a docker-compose.full config has no impact on docker-compose.grapher setups. 
No additional containers should be created from the docker-compose.full config.

<img width="668" alt="Screenshot 2022-09-07 at 10 45 30" src="https://user-images.githubusercontent.com/13406362/188845171-755acb33-d6d9-47b7-902f-5cc2e737b1f0.png">

_Running the refresh command on a docker-compose.full config only spins up the necessary containers_
