### PR TITLE
feat: include published explorers in sitemap

### DIFF
--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -53,7 +53,7 @@ mockSiteRouter.use(express.urlencoded({ extended: true }))
 mockSiteRouter.use(express.json())
 
 mockSiteRouter.get("/sitemap.xml", async (req, res) =>
-    res.send(await makeSitemap())
+    res.send(await makeSitemap(explorerAdminServer))
 )
 
 mockSiteRouter.get("/atom.xml", async (req, res) =>

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -218,12 +218,13 @@ export class SiteBaker {
             `${this.bakedSiteDir}/headerMenu.json`,
             await renderMenuJson()
         )
-        await this.stageWrite(
-            `${this.bakedSiteDir}/sitemap.xml`,
-            await makeSitemap()
-        )
 
         const explorerAdminServer = new ExplorerAdminServer(GIT_CMS_DIR)
+
+        await this.stageWrite(
+            `${this.bakedSiteDir}/sitemap.xml`,
+            await makeSitemap(explorerAdminServer)
+        )
 
         await bakeAllExplorerRedirects(this.bakedSiteDir, explorerAdminServer)
 


### PR DESCRIPTION
Part of #1214.

A very first part of that effort should be to include all our published explorers in the sitemap (the default view only).