### PR TITLE
migration(variables): add catalogPath and dimensions columns to variables

### DIFF
--- a/db/migration/1662646791543-VariableViews.ts
+++ b/db/migration/1662646791543-VariableViews.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class VariableViews1662646791543 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE variables
+              ADD COLUMN catalogPath TEXT,
+              ADD dimensions JSON;
+            `
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE variables
+              DROP COLUMN catalogPath,
+              DROP COLUMN dimensions;
+            `
+        )
+    }
+}

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -36,6 +36,8 @@ export interface VariableRow {
     coverage?: string
     timespan?: string
     columnOrder?: number
+    catalogPath?: string
+    dimensions?: string
 }
 
 export type UnparsedVariableRow = VariableRow & { display: string }


### PR DESCRIPTION
Add columns `catalogPath` that points to the table in the catalog (aka variable view) and `dimensions` which contain information about dimensions in JSON format that we need to locate that variable in the table.

@danyx23 I hope there wouldn't be any side effects. There weren't any the last time we added column to `variables`.