### PR TITLE
feat(explorer): ability to index explorers in Google Search

### DIFF
--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -1,3 +1,4 @@
+import { encodeXML } from "entities"
 import { Chart } from "../db/model/Chart.js"
 import {
     BAKED_BASE_URL,
@@ -20,14 +21,16 @@ interface SitemapUrl {
 }
 
 const xmlify = (url: SitemapUrl) => {
+    const escapedUrl = encodeXML(url.loc)
+
     if (url.lastmod)
         return `    <url>
-        <loc>${url.loc}</loc>
+        <loc>${escapedUrl}</loc>
         <lastmod>${url.lastmod}</lastmod>
     </url>`
 
     return `    <url>
-        <loc>${url.loc}</loc>
+        <loc>${escapedUrl}</loc>
     </url>`
 }
 

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -201,6 +201,8 @@ export class Explorer
             )
         }
 
+        if (this.props.isInStandalonePage) this.setCanonicalUrl()
+
         this.grapher?.populateFromQueryParams(url.queryParams)
 
         exposeInstanceOnWindow(this, "explorer")
@@ -208,6 +210,14 @@ export class Explorer
         this.updateEntityPickerTable() // call for the first time to initialize EntityPicker
 
         this.attachEventListeners()
+    }
+
+    private setCanonicalUrl() {
+        // see https://developers.google.com/search/docs/advanced/javascript/javascript-seo-basics#properly-inject-canonical-links
+        const canonicalElement = document.createElement("link")
+        canonicalElement.setAttribute("rel", "canonical")
+        canonicalElement.href = this.canonicalUrlForGoogle
+        document.head.appendChild(canonicalElement)
     }
 
     private attachEventListeners() {
@@ -414,6 +424,15 @@ export class Explorer
     @computed get currentUrl(): Url {
         if (this.props.isPreview) return Url.fromQueryParams(this.queryParams)
         return Url.fromURL(this.baseUrl).setQueryParams(this.queryParams)
+    }
+
+    @computed get canonicalUrlForGoogle(): string {
+        // we want the canonical URL to match what's in the sitemap, so it's different depending on indexViewsSeparately
+        if (this.explorerProgram.indexViewsSeparately)
+            return Url.fromURL(this.baseUrl).setQueryParams(
+                this.currentChoiceParams
+            ).fullUrl
+        else return this.baseUrl
     }
 
     private bindToWindow() {

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -214,6 +214,7 @@ export class Explorer
 
     private setCanonicalUrl() {
         // see https://developers.google.com/search/docs/advanced/javascript/javascript-seo-basics#properly-inject-canonical-links
+        // Note that the URL is not updated when the user interacts with the explorer - this should be enough for Googlebot I hope.
         const canonicalElement = document.createElement("link")
         canonicalElement.setAttribute("rel", "canonical")
         canonicalElement.href = this.canonicalUrlForGoogle

--- a/explorer/ExplorerGrammar.ts
+++ b/explorer/ExplorerGrammar.ts
@@ -99,6 +99,12 @@ export const ExplorerGrammar: Grammar = {
         keyword: "isPublished",
         description: "Set to true to make this Explorer public.",
     },
+    indexViewsSeparately: {
+        ...BooleanCellDef,
+        keyword: "indexViewsSeparately",
+        description:
+            "Set to true to make Google index every view of this explorer, rather than only indexing the default view.",
+    },
     wpBlockId: {
         ...IntegerCellDef,
         keyword: "wpBlockId",

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -185,6 +185,13 @@ export class ExplorerProgram extends GridProgram {
         )
     }
 
+    get indexViewsSeparately() {
+        return (
+            this.getLineValue(ExplorerGrammar.indexViewsSeparately.keyword) ===
+            GridBoolean.true
+        )
+    }
+
     get wpBlockId() {
         const blockIdString = this.getLineValue(
             ExplorerGrammar.wpBlockId.keyword

--- a/site/ExplorerPage.tsx
+++ b/site/ExplorerPage.tsx
@@ -81,6 +81,7 @@ window.Explorer.renderSingleExplorerOnExplorerPage(explorerProgram, grapherConfi
         <html>
             <Head
                 canonicalUrl={`${baseUrl}/${EXPLORERS_ROUTE_FOLDER}/${slug}`}
+                hideCanonicalUrl // explorers set their canonical url dynamically
                 pageTitle={explorerTitle}
                 imageUrl={thumbnail}
                 baseUrl={baseUrl}

--- a/site/Head.tsx
+++ b/site/Head.tsx
@@ -3,13 +3,14 @@ import { webpackUrl } from "../site/webpackUtils.js"
 
 export const Head = (props: {
     canonicalUrl: string
+    hideCanonicalUrl?: boolean
     pageTitle?: string
     pageDesc?: string
     imageUrl?: string
     children?: any
     baseUrl: string
 }) => {
-    const { canonicalUrl, baseUrl } = props
+    const { canonicalUrl, hideCanonicalUrl, baseUrl } = props
     const pageTitle = props.pageTitle || `Our World in Data`
     const fullPageTitle = props.pageTitle
         ? `${props.pageTitle} - Our World in Data`
@@ -27,7 +28,7 @@ export const Head = (props: {
             />
             <title>{fullPageTitle}</title>
             <meta name="description" content={pageDesc} />
-            <link rel="canonical" href={canonicalUrl} />
+            {!hideCanonicalUrl && <link rel="canonical" href={canonicalUrl} />}
             <link
                 rel="alternate"
                 type="application/atom+xml"


### PR DESCRIPTION
Resolves #1214 | Live on tufte: [Affected explorer](https://tufte-owid.netlify.app/explorers/natural-resources), [Unaffected explorer](https://tufte-owid.netlify.app/explorers/global-food), [Sitemap](https://tufte-owid.netlify.app/sitemap.xml)

Implements the `indexViewsSeparately` explorer keyword, as outlined in https://github.com/owid/owid-grapher/issues/1214#issuecomment-1242311179.
When enabled, it includes the URLs of all views in the sitemap, and uses the fully-specified view URL as a canonical URL.

As outlined in #1214, the plan is to enable this option on the `natural-resources` and `water-and-sanitation` explorers for now.