### PR TITLE
enhance(explorer): improve dynamic page titles exposed to Google

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -201,7 +201,10 @@ export class Explorer
             )
         }
 
-        if (this.props.isInStandalonePage) this.setCanonicalUrl()
+        if (this.props.isInStandalonePage) {
+            // expose a more useful title to the Google crawler
+            this.setCanonicalUrl()
+        }
 
         this.grapher?.populateFromQueryParams(url.queryParams)
 
@@ -210,6 +213,19 @@ export class Explorer
         this.updateEntityPickerTable() // call for the first time to initialize EntityPicker
 
         this.attachEventListeners()
+    }
+
+    private maybeUpdatePageTitle() {
+        // expose the title of the current view to the Google crawler on non-default views
+        // of opted-in standalone explorer pages
+        if (
+            this.props.isInStandalonePage &&
+            this.grapher &&
+            this.explorerProgram.indexViewsSeparately &&
+            document.location.search
+        ) {
+            document.title = `${this.grapher.displayTitle} - Our World in Data`
+        }
     }
 
     private setCanonicalUrl() {
@@ -597,6 +613,9 @@ export class Explorer
 
     render() {
         const { showExplorerControls, showHeaderElement } = this
+
+        this.maybeUpdatePageTitle()
+
         return (
             <div
                 className={classNames({

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -201,10 +201,7 @@ export class Explorer
             )
         }
 
-        if (this.props.isInStandalonePage) {
-            // expose a more useful title to the Google crawler
-            this.setCanonicalUrl()
-        }
+        if (this.props.isInStandalonePage) this.setCanonicalUrl()
 
         this.grapher?.populateFromQueryParams(url.queryParams)
 

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -212,6 +212,10 @@ export class Explorer
         this.attachEventListeners()
     }
 
+    componentDidUpdate() {
+        this.maybeUpdatePageTitle()
+    }
+
     private maybeUpdatePageTitle() {
         // expose the title of the current view to the Google crawler on non-default views
         // of opted-in standalone explorer pages
@@ -610,8 +614,6 @@ export class Explorer
 
     render() {
         const { showExplorerControls, showHeaderElement } = this
-
-        this.maybeUpdatePageTitle()
 
         return (
             <div


### PR DESCRIPTION
Live on halley: [Affected explorer](https://halley-owid.netlify.app/explorers/natural-resources), [Unaffected explorer](https://halley-owid.netlify.app/explorers/global-food)

We have an open experiment where we can opt in explorers to be expanded in our sitemap (#1214). The purpose of this expansion is to allow people to arrive, through Google Search, at specific views of our data represented by specific explorer configurations.

A current problem is that our page titles are all too similar for explorer views, so Google omits them from search as being not helpful to the user.

This change modifies the page title each time the explorer view changes from the default setting, for opted-in explorers. The page title chosen is the grapher display title suffixed with "- Our World In Data".
