### PR TITLE
enhance: switch existing stacked area default chart

### DIFF
--- a/grapher/color/CustomSchemes.ts
+++ b/grapher/color/CustomSchemes.ts
@@ -263,24 +263,14 @@ NonPriorityCustomColorSchemes.push(OwidCategoricalEScheme)
 
 NonPriorityCustomColorSchemes.push({
     name: ColorSchemeName.stackedAreaDefault,
-    displayName: "OWID 4 Color Gradient",
-    colorSets: [
-        ["#3360a9"],
-        ["#3360a9", "#34983f"],
-        ["#3360a9", "#34983f", "#ffd53e"],
-        ["#3360a9", "#ca2628", "#ffd53e", "#34983f"],
-        ["#3360a9", "#ca2628", "#ffd53e", "#9ecc8a", "#34983f"],
-        ["#3360a9", "#e6332e", "#ca2628", "#ffd53e", "#9ecc8a", "#34983f"],
-        [
-            "#3360a9",
-            "#2a939b",
-            "#e6332e",
-            "#ca2628",
-            "#ffd53e",
-            "#9ecc8a",
-            "#34983f",
-        ],
-    ],
+    displayName: "OWID 4 Color Gradient (=Owid Distinct)",
+    // TODO: this is now a copy of owid-distinct. After a data migration to get
+    // rid of stackedAreaDefault in existing chart configs we should replace it with
+    // owid-distinct
+    // We use the feature of ColorSchemes to use the Palette A permutation
+    // for 12 categories or less and the Palette C to reach up to 24 different
+    // colors
+    colorSets: [CategoricalColorsPaletteA, CategoricalColorsPaletteC],
 })
 
 export const ContinentColors = {

--- a/grapher/stackedCharts/StackedAreaChart.test.ts
+++ b/grapher/stackedCharts/StackedAreaChart.test.ts
@@ -69,7 +69,9 @@ describe("column charts", () => {
         const assignedColors = chart.series.map((series) => series.color)
         expect(assignedColors).toHaveLength(2)
         for (const color of assignedColors)
-            expect(color).toMatch(/^#[0-9a-f]{6}$/i) // valid hex color string
+            expect(color).toMatch(
+                /^#[0-9a-f]{6}$|^rgb\(\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}\s*\)$/i
+            ) // valid hex color string or rgb() string
     })
 })
 


### PR DESCRIPTION
This makes the old stackedAreaDefault color scheme synomymous with owid-distinct as per the new style guide.

Once we do the data migrations we can get rid of the stackedAreaDefault in favour of owid-distinct everywhere