### PR TITLE
Additional Information CSS and hydration fixes

### DIFF
--- a/baker/formatWordpressPost.tsx
+++ b/baker/formatWordpressPost.tsx
@@ -60,6 +60,7 @@ import {
 import { renderKeyInsights, renderProminentLinks } from "./siteRenderers.js"
 import { logContentErrorAndMaybeSendToSlack } from "../serverUtils/slackLog.js"
 import { KEY_INSIGHTS_CLASS_NAME } from "../site/blocks/KeyInsights.js"
+import { RELATED_CHARTS_CLASS_NAME } from "../site/blocks/RelatedCharts.js"
 
 const initMathJax = () => {
     const adaptor = liteAdaptor()
@@ -491,6 +492,11 @@ export const formatWordpressPost = async (
     ;(["left", "right"] as const).forEach((side) => {
         cheerioEl(`.wp-block-columns.is-style-sticky-${side}`).each(
             (_, columns) => {
+                // don't nest the columns when inside related-charts
+                const parentClassName = columns.parent.attribs.class
+                if (parentClassName === RELATED_CHARTS_CLASS_NAME) {
+                    return
+                }
                 nestStickyContainer(cheerioEl(columns), side)
             }
         )

--- a/site/blocks/additional-information.scss
+++ b/site/blocks/additional-information.scss
@@ -21,6 +21,7 @@
         h3 {
             background-color: $blue-10;
             svg {
+                margin-right: 32px;
                 transform: rotate(90deg);
             }
         }

--- a/site/blocks/additional-information.scss
+++ b/site/blocks/additional-information.scss
@@ -8,13 +8,12 @@
         transition: background-color 0.2s;
         &:hover {
             cursor: pointer;
-            background-color: $blue-100;
             svg {
-                margin-right: $padding-x-md;
+                margin-right: 32px;
             }
         }
         svg {
-            margin-right: $padding-x-sm;
+            margin-right: 24px;
             transition: all 0.2s;
         }
     }


### PR DESCRIPTION
#1657 and #1659 regressed Additional Information blocks.

**Before:**

https://user-images.githubusercontent.com/11844404/191357057-5b17467d-854f-4295-8400-0e8be1432ed2.mov

**After:**

https://user-images.githubusercontent.com/11844404/191357224-21070377-8eed-4312-baba-29e69dc4704d.mov

