### PR TITLE
Table of Contents improvements

### DIFF
--- a/grapher/controls/globalEntitySelector/GlobalEntitySelector.scss
+++ b/grapher/controls/globalEntitySelector/GlobalEntitySelector.scss
@@ -1,8 +1,11 @@
 .global-entity-control-container {
     position: sticky;
     top: 5px;
-    margin-left: 7rem; // HACK, making horizontal space for "Contents" button
     z-index: $zindex-global-entity-select;
+
+    @include xxlg-down {
+        margin-left: 128px; // space for ToC "Contents" button
+    }
 }
 
 .global-entity-control {

--- a/site/TableOfContents.tsx
+++ b/site/TableOfContents.tsx
@@ -7,6 +7,7 @@ import { useTriggerWhenClickOutside } from "./hooks.js"
 import { wrapInDiv } from "../clientUtils/Util.js"
 import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes"
 import { TocHeading } from "../clientUtils/owidTypes.js"
+import classNames from "classnames"
 
 const TOC_WRAPPER_CLASSNAME = "toc-wrapper"
 
@@ -37,15 +38,15 @@ export const TableOfContents = ({
     pageTitle,
     hideSubheadings,
 }: TableOfContentsData) => {
-    const [isToggled, setIsToggled] = useState(false)
+    const [isOpen, setIsOpen] = useState(false)
     const [activeHeading, setActiveHeading] = useState("")
     const tocRef = useRef<HTMLElement>(null)
 
-    const toggle = () => {
-        setIsToggled(!isToggled)
+    const toggleIsOpen = () => {
+        setIsOpen(!isOpen)
     }
 
-    useTriggerWhenClickOutside(tocRef, isToggled, setIsToggled)
+    useTriggerWhenClickOutside(tocRef, isOpen, setIsOpen)
 
     useEffect(() => {
         if ("IntersectionObserver" in window) {
@@ -123,7 +124,9 @@ export const TableOfContents = ({
     return (
         <div className={TOC_WRAPPER_CLASSNAME}>
             <aside
-                className={`entry-sidebar${isToggled ? " toggled" : ""}`}
+                className={classNames("entry-sidebar", {
+                    "entry-sidebar--is-open": isOpen,
+                })}
                 ref={tocRef}
             >
                 <nav className="entry-toc">
@@ -131,7 +134,7 @@ export const TableOfContents = ({
                         <li>
                             <a
                                 onClick={() => {
-                                    toggle()
+                                    toggleIsOpen()
                                     setActiveHeading("")
                                 }}
                                 href="#"
@@ -159,7 +162,7 @@ export const TableOfContents = ({
                                     }
                                 >
                                     <a
-                                        onClick={toggle}
+                                        onClick={toggleIsOpen}
                                         href={`#${heading.slug}`}
                                         data-track-note="toc-link"
                                     >
@@ -173,13 +176,13 @@ export const TableOfContents = ({
                     <button
                         data-track-note="page-toggle-toc"
                         aria-label={`${
-                            isToggled ? "Close" : "Open"
+                            isOpen ? "Close" : "Open"
                         } table of contents`}
-                        onClick={toggle}
+                        onClick={toggleIsOpen}
                     >
-                        <FontAwesomeIcon icon={isToggled ? faTimes : faBars} />
+                        <FontAwesomeIcon icon={isOpen ? faTimes : faBars} />
                         <span className="label">
-                            {isToggled ? "Close" : "Contents"}
+                            {isOpen ? "Close" : "Contents"}
                         </span>
                     </button>
                 </div>

--- a/site/TableOfContents.tsx
+++ b/site/TableOfContents.tsx
@@ -38,40 +38,14 @@ export const TableOfContents = ({
     hideSubheadings,
 }: TableOfContentsData) => {
     const [isToggled, setIsToggled] = useState(false)
-    const [isSticky, setIsSticky] = useState(false)
     const [activeHeading, setActiveHeading] = useState("")
     const tocRef = useRef<HTMLElement>(null)
-    const stickySentinelRef = useRef<HTMLDivElement>(null)
 
     const toggle = () => {
         setIsToggled(!isToggled)
     }
 
     useTriggerWhenClickOutside(tocRef, isToggled, setIsToggled)
-
-    useEffect(() => {
-        if ("IntersectionObserver" in window) {
-            // Sets up an intersection observer to notify when the element with the class
-            // `.sticky-sentinel` becomes visible/invisible at the top of the viewport.
-            // Inspired by https://developers.google.com/web/updates/2017/09/sticky-headers
-            const observer = new IntersectionObserver((records) => {
-                for (const record of records) {
-                    const targetInfo = record.boundingClientRect
-                    // Started sticking
-                    if (targetInfo.top < 0) {
-                        setIsSticky(true)
-                    }
-                    // Stopped sticking
-                    if (targetInfo.bottom > 0) {
-                        setIsSticky(false)
-                    }
-                }
-            })
-            if (stickySentinelRef.current) {
-                observer.observe(stickySentinelRef.current)
-            }
-        }
-    }, [])
 
     useEffect(() => {
         if ("IntersectionObserver" in window) {
@@ -149,12 +123,9 @@ export const TableOfContents = ({
     return (
         <div className={TOC_WRAPPER_CLASSNAME}>
             <aside
-                className={`entry-sidebar${isToggled ? " toggled" : ""}${
-                    isSticky ? " sticky" : ""
-                }`}
+                className={`entry-sidebar${isToggled ? " toggled" : ""}`}
                 ref={tocRef}
             >
-                <div className="sticky-sentinel" ref={stickySentinelRef} />
                 <nav className="entry-toc">
                     <ul>
                         <li>

--- a/site/css/footer.scss
+++ b/site/css/footer.scss
@@ -102,7 +102,6 @@
     background-color: $amber;
     padding: 1.25rem 0;
     text-align: center;
-    margin-top: 2rem;
 
     @include md-up {
         text-align: left;

--- a/site/css/page.scss
+++ b/site/css/page.scss
@@ -13,6 +13,17 @@
             max-width: $xlg;
         }
     }
+
+    .content-and-footnotes {
+        margin-top: 32px;
+    }
+
+    &.with-sidebar .content-and-footnotes {
+        @include xxlg-up {
+            max-width: min(calc(100vw - 384px), $xlg);
+        }
+    }
+
     @include sm-only {
         .site-subnavigation {
             padding-right: 0;

--- a/site/css/sidebar.scss
+++ b/site/css/sidebar.scss
@@ -1,5 +1,9 @@
 /* Page Navigation Sidebar
 --------------------------------------------- */
+.sidebar-root {
+    margin-top: -16px;
+}
+
 .toc-wrapper {
     @include xxlg-down {
         height: 2rem; // HACK, prevent "Contents" button to run over content when page hasn't been scrolled yet.
@@ -14,11 +18,7 @@
     width: $sidebar-content-width + 2 * $padding-x-md;
     z-index: $zindex-sidebar;
     border-right: 1px solid rgba(0, 0, 0, 0.1);
-    background-color: $white;
-
-    &.sticky {
-        background: $blue-10;
-    }
+    background: $blue-10;
 
     .entry-toc {
         top: 0;
@@ -132,7 +132,6 @@
     @include xxlg-up {
         position: relative;
         height: 100%;
-        background-color: initial;
 
         .sticky-sentinel {
             position: absolute;

--- a/site/css/sidebar.scss
+++ b/site/css/sidebar.scss
@@ -18,7 +18,7 @@
     width: $sidebar-content-width + 2 * $padding-x-md;
     z-index: $zindex-sidebar;
     border-right: 1px solid rgba(0, 0, 0, 0.1);
-    background: $blue-10;
+    background: $white;
 
     .entry-toc {
         top: 0;
@@ -49,13 +49,13 @@
             padding: $vertical-spacing * 0.25 $padding-x-md;
 
             &:hover {
-                background-color: $blue-20;
+                background-color: $blue-10;
             }
         }
 
         &.active a {
             color: $blue-100;
-            background-color: $blue-20;
+            background-color: $blue-10;
             border-left-color: $oxford-blue;
         }
 
@@ -85,10 +85,12 @@
             position: absolute;
             top: 0;
             bottom: 0;
+            right: 0;
+            transform: translateX(calc(100% + $padding-x-md));
+            transition: transform 300ms ease;
             padding: $vertical-spacing 0;
-            left: $sidebar-content-width + 2 * $padding-x-md;
-            margin-left: $padding-x-sm;
             pointer-events: none;
+
             @include md-up {
                 margin-left: $padding-x-md;
             }
@@ -107,12 +109,13 @@
             display: none;
         }
 
-        &.toggled {
+        &.entry-sidebar--is-open {
             margin-left: 0;
             @include block-shadow;
 
             .toggle-toc {
-                margin-left: -1rem;
+                transform: translateX(-16px);
+
                 @include sm-only {
                     svg {
                         margin: 0 0.25rem;
@@ -132,12 +135,6 @@
     @include xxlg-up {
         position: relative;
         height: 100%;
-
-        .sticky-sentinel {
-            position: absolute;
-            height: 1px;
-            width: inherit;
-        }
 
         .toggle-toc {
             display: none;

--- a/site/css/variables.scss
+++ b/site/css/variables.scss
@@ -17,6 +17,7 @@ $mobile-header-height: $mobile-header-wrapper-height +
 
 $content-max-width: 800px;
 $sidebar-content-width: 224px;
+$sidebar-width: #{$sidebar-content-width + 2 * $padding-x-md};
 $sidebar-padding-top: 32px;
 $sidebar-toggle-width: 32px;
 $sidebar-closed-drawer-width: 0;

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -631,11 +631,12 @@ div.owid-presentations li:nth-of-type(1) a:hover {
 .with-sidebar .section-heading {
     @include xxlg-up {
         position: relative;
-        width: calc(100vw - #{$sidebar-content-width + 2 * $padding-x-md});
-        margin-left: calc(
-            50% - 50vw - #{($sidebar-content-width + 2 * $padding-x-md) * 0.5}
+        width: calc(100vw - $sidebar-width);
+        margin-left: 0;
+        left: min(
+            calc((100vw - 100% - $sidebar-width) / -2),
+            calc(-1 * $padding-x-md)
         );
-        left: $sidebar-content-width + 2 * $padding-x-md;
     }
 }
 


### PR DESCRIPTION
A couple of ToC glitches that I wanted to fix.

[Staging demo](https://ptolemy.owid.cloud/admin/posts/preview/32527)

I have tested the changes on several COVID pages and articles (with and without y-overflow in the sidebar), and the All Charts page.

### Changes:
- Background is now `blue-10` all the time
- Remove the sticky tracking logic
- Fix `.section-heading` positioning on widescreens
- Fix top and bottom margin between the header and footer

### Before:

https://user-images.githubusercontent.com/11844404/191842712-4cc13db3-3ae3-482d-8bc1-da17ac33bbc5.mov

### After:

https://user-images.githubusercontent.com/11844404/191842931-936ab76e-c19b-4d06-9880-e2cef549d525.mov