### PR TITLE
Remove /charts searchbar autofocus and prevent URL hash from disappearing

### DIFF
--- a/site/ChartsIndexPage.tsx
+++ b/site/ChartsIndexPage.tsx
@@ -104,7 +104,6 @@ export const ChartsIndexPage = (props: {
                                             type="search"
                                             className="chartsSearchInput"
                                             placeholder="Filter interactive charts by title"
-                                            autoFocus
                                         />
                                     </header>
                                     <section id="explorers-section">

--- a/site/runChartsIndexPage.ts
+++ b/site/runChartsIndexPage.ts
@@ -86,7 +86,8 @@ class ChartFilter {
             null,
             document.title,
             window.location.pathname +
-                (this.query ? `?search=${encodeHashSafe(this.query)}` : "")
+                (this.query ? `?search=${encodeHashSafe(this.query)}` : "") +
+                window.location.hash
         )
 
         if (!this.query) {


### PR DESCRIPTION
Fixes #1680 

I noticed another bug where the sidebar isn't highlighting the correct heading that corresponds with the user's position on the page, but that's another issue.