### PR TITLE
Dereference blocks in posts table

### DIFF
--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -9,7 +9,17 @@ import { postsTable, select } from "./model/Post.js"
 
 const zeroDateString = "0000-00-00 00:00:00"
 
+export const blockRefRegex = /<!-- wp:block \{"ref":(?<id>\d+)\} \/-->/g
+
 const syncPostsToGrapher = async (): Promise<void> => {
+    const blocks: { ID: number; post_content: string }[] =
+        await wpdb.singleton.query(
+            "select ID, post_content from wp_posts where post_type='wp_block' AND post_status = 'publish'"
+        )
+
+    const allBlocks = keyBy(blocks, "ID")
+    console.log(typeof blocks[0].ID)
+
     const rows = await wpdb.singleton.query(
         "select * from wp_posts where (post_type='page' or post_type='post') AND post_status != 'trash'"
     )
@@ -23,14 +33,47 @@ const syncPostsToGrapher = async (): Promise<void> => {
     const toDelete = existsInGrapher
         .filter((p) => !doesExistInWordpress[p.id])
         .map((p) => p.id)
+    const replacer = (
+        _match: string,
+        _firstPattern: string,
+        _offset: number,
+        fullString: string,
+        matches: Record<string, string>
+    ): string => {
+        const block = allBlocks[matches["id"].toString()]
+        if (block) return block.post_content
+        else return fullString
+    }
     const toInsert = rows.map((post: any) => {
+        // Now resolve references by using replace with a regex and a function.
+        // There are two special cases - one is that not all refs resolve (🤨)
+        // in which case we leave the original ref comment as is; the second is
+        // that some blocks reference other blocks (🎉 recursion!) and so we
+        // check in a loop if the regexp still matches and run replace again.
+        // Because not all refs we have to limit the number of attempts, for now
+        // we try it 3 times which should be plenty for all reasonably sane
+        // scenarios
+        const content = post.post_content as string
+        let contentWithBlocksInlined = content.replace(blockRefRegex, replacer)
+        for (
+            let recursionLevelsRemaining = 3;
+            recursionLevelsRemaining > 0 &&
+            contentWithBlocksInlined.match(blockRefRegex);
+            recursionLevelsRemaining--
+        ) {
+            contentWithBlocksInlined = contentWithBlocksInlined.replace(
+                blockRefRegex,
+                replacer
+            )
+        }
+
         return {
             id: post.ID,
             title: post.post_title,
             slug: post.post_name.replace(/__/g, "/"),
             type: post.post_type,
             status: post.post_status,
-            content: post.post_content,
+            content: contentWithBlocksInlined,
             published_at:
                 post.post_date_gmt === zeroDateString
                     ? null

--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -18,7 +18,6 @@ const syncPostsToGrapher = async (): Promise<void> => {
         )
 
     const allBlocks = keyBy(blocks, "ID")
-    console.log(typeof blocks[0].ID)
 
     const rows = await wpdb.singleton.query(
         "select * from wp_posts where (post_type='page' or post_type='post') AND post_status != 'trash'"
@@ -50,9 +49,8 @@ const syncPostsToGrapher = async (): Promise<void> => {
         // in which case we leave the original ref comment as is; the second is
         // that some blocks reference other blocks (🎉 recursion!) and so we
         // check in a loop if the regexp still matches and run replace again.
-        // Because not all refs we have to limit the number of attempts, for now
-        // we try it 3 times which should be plenty for all reasonably sane
-        // scenarios
+        // Because not all refs resolve we have to limit the number of attempts - for now
+        // we try it 3 times which should be plenty for all reasonably sane scenarios
         const content = post.post_content as string
         let contentWithBlocksInlined = content.replace(blockRefRegex, replacer)
         for (


### PR DESCRIPTION
Wordpress has the concept of "reusable blocks" and we have about 350 of them in wordpress. When a page/post embeds a reusable block this is marked with an html comment that uses a syntax like this: `<!-- wp:block {"ref":44179} /-->`.

We sync pages and posts (and also to some degree blocks) into the grapher database in the posts table. In BigQuery and Datasette we then use regex queries to figure out which posts reference/embed which charts etc. For these kinds of queries, the reusable blocks are pretty annoying.

What this PR does is change the syncPostsToGrapher and postUpdateHook scripts to dereference refs that point to reusable blocks - i.e. it inlines them before writing to the posts table in the grapher database. This is a nicer mode of operation for things like figuring out what links to charts etc.