### PR TITLE
chore: add "make refresh.meta" to only refresh grapher metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ help:
 	@echo '  make up            start dev environment via docker-compose and tmux'
 	@echo '  make down          stop any services still running'
 	@echo '  make refresh       (while up) download a new grapher snapshot and update MySQL'
+	@echo '  make refresh.meta  (while up) refresh grapher metadata only'
 	@echo '  make migrate       (while up) run any outstanding db migrations'
 	@echo '  make test          run full suite of CI checks including unit tests'
 	@echo
@@ -118,6 +119,13 @@ refresh:
 
 	@echo '==> Updating grapher database'
 	@. ./.env && DATA_FOLDER=tmp-downloads ./devTools/docker/refresh-grapher-data.sh
+
+refresh.meta:
+	@echo '==> Downloading chart metadata'
+	./devTools/docker/download-grapher-metadata-mysql.sh
+	
+	@echo '==> Updating grapher database'
+	@. ./.env && DATA_FOLDER=tmp-downloads SKIP_CHARTDATA=1 ./devTools/docker/refresh-grapher-data.sh
 
 refresh.wp:
 	@echo '==> Downloading wordpress data'

--- a/devTools/docker/refresh-grapher-data.sh
+++ b/devTools/docker/refresh-grapher-data.sh
@@ -30,12 +30,14 @@ fillGrapherDb() {
         return 1;
     fi
 
-    if [ -f "${DATA_FOLDER}/owid_chartdata.sql.gz" ]; then
-        echo "Importing live Grapher chartdata database (owid_chartdata)"
-        import_db $DATA_FOLDER/owid_chartdata.sql.gz
-    else
-        echo "Skipping import of owid_chartdata (owid_chartdata.sql.gz missing in ${DATA_FOLDER})"
-        # This is a legitimate use case, so execution should continue.
+    if [ ! "${SKIP_CHARTDATA}" ]; then
+        if [ -f "${DATA_FOLDER}/owid_chartdata.sql.gz" -o "${SKIP_CHARTDATA}" ]; then
+            echo "Importing live Grapher chartdata database (owid_chartdata)"
+            import_db $DATA_FOLDER/owid_chartdata.sql.gz
+        else
+            echo "Skipping import of owid_chartdata (owid_chartdata.sql.gz missing in ${DATA_FOLDER})"
+            # This is a legitimate use case, so execution should continue.
+        fi
     fi
     echo "==> ✅ Grapher DB refresh complete"
 }


### PR DESCRIPTION
For some development workflows, it's not important to have the data values from grapher, only up-to-date metadata.

This PR adds `make refresh.meta` which does this, downloading and fetching only the grapher metadata.
