### PR TITLE
fix: switch to new hardcoded population variable

### DIFF
--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -328,7 +328,7 @@ export class EditorBasicTab extends React.Component<{ editor: ChartEditor }> {
 
         if (!hasSize)
             grapher.addDimension({
-                variableId: 72,
+                variableId: 525709,
                 property: DimensionProperty.size,
             })
     }


### PR DESCRIPTION
The variable id for the population variable to be used by default when creating scatter plots is hardcoded. It used to be variable id 72 for a long time but recently we created a new updated population variable via the ETL and deleted variable 72. This commit updates to the new id.