### PR TITLE
fix: properly reset dimensions on explorer change

### DIFF
--- a/grapher/core/Grapher.tsx
+++ b/grapher/core/Grapher.tsx
@@ -2355,6 +2355,7 @@ export class Grapher
         this.sortOrder = grapher.sortOrder
         this.sortColumnSlug = grapher.sortColumnSlug
         this.hideRelativeToggle = grapher.hideRelativeToggle
+        this.dimensions = grapher.dimensions
         this.stackMode = grapher.stackMode
         this.hideTotalValueLabel = grapher.hideTotalValueLabel
         this.hideTitleAnnotation = grapher.hideTitleAnnotation


### PR DESCRIPTION
Fixes an issue I spotted in the `food-footprints` explorer:

We have two different ways of specifying dimensions, one for `grapherId`-based explorer views and one for proper spreadsheet-powered explorer views.
For explorers using both of these, we fail to reset the `grapher.dimensions` when switching away from the `grapherId` chart, which can lead to edge-case behaviour.

In particular, when [navigating to this view](https://ourworldindata.org/explorers/food-footprints?uniformYAxis=0&country=Beef+%28beef+herd%29~Lamb+%26+Mutton~Beef+%28dairy+herd%29~Prawns+%28farmed%29~Cheese~Pig+Meat~Poultry+Meat~Eggs~Rice~Tofu+%28soybeans%29~Milk~Tomatoes~Maize~Wheat+%26+Rye~Peas~Bananas~Potatoes~Nuts~Almonds~Avocados~Beefburger~Cow%27s+milk~Dairy-free+ice+cream~Lentils~Vegan+pizza~Almond+milk~Bread~Meat+pizza~Vegetable+lasagne~Macaroni+cheese~Coconut+milk&Commodity+or+Specific+Food+Product=Specific+food+products&Environmental+Impact=Carbon+footprint&Kilogram+%2F+Protein+%2F+Calories=Compare+nutritional+units&By+stage+of+supply+chain=false), the chart is faceted as expected. However, when we then change over to `Commodity` and back to the previous view, the chart is no longer faceted since `grapher.dimensions` wasn't reset properly.