### PR TITLE
fix(tests): fix failing parquet sets when env is set

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,3 +16,8 @@ module.exports = {
         },
     ],
 }
+
+// special envs for tests
+process.env = Object.assign(process.env, {
+    CATALOG_PATH: "https://owid-catalog.nyc3.digitaloceanspaces.com",
+})


### PR DESCRIPTION
This can currently break deploys if env variable CATALOG_PATH is set to something else (like in production).