### PR TITLE
When previewing a gdoc with an error, show json instead of blank screen

### DIFF
--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -222,7 +222,7 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                     />
                 </Drawer>
 
-                <OwidArticle {...gdoc} />
+                <OwidArticle article={gdoc} isPreviewing={true} />
             </main>
         </AdminLayout>
     ) : null

--- a/clientUtils/owidTypes.ts
+++ b/clientUtils/owidTypes.ts
@@ -397,6 +397,11 @@ export interface OwidArticleType {
     updatedAt: Date | null
 }
 
+export interface OwidArticleProps {
+    article: OwidArticleType
+    isPreviewing: boolean
+}
+
 // see also: getArticleFromJSON()
 export interface OwidArticleTypeJSON
     extends Omit<OwidArticleType, "createdAt" | "publishedAt" | "updatedAt"> {

--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -74,28 +74,22 @@ export default function ArticleBlock({ d }: { d: OwidArticleBlock }) {
         return content
     }
 
-    try {
-        if (d.type === "text") {
-            if (d.value.trim() === "") {
-                return null
-            }
-            return (
-                <div
-                    dangerouslySetInnerHTML={{
-                        __html:
-                            d.value.startsWith("<div") ||
-                            d.value.trim() === "<hr />"
-                                ? d.value.replace(/\\:/g, ":")
-                                : `<p>${d.value.replace(/\\:/g, ":")}</p>`,
-                    }}
-                />
-            )
-        } else {
-            return handleArchie(d, "")
+    if (d.type === "text") {
+        if (d.value.trim() === "") {
+            return null
         }
-    } catch (e) {
-        console.error("got an error")
-        console.log(e)
-        return null
+        return (
+            <div
+                dangerouslySetInnerHTML={{
+                    __html:
+                        d.value.startsWith("<div") ||
+                        d.value.trim() === "<hr />"
+                            ? d.value.replace(/\\:/g, ":")
+                            : `<p>${d.value.replace(/\\:/g, ":")}</p>`,
+                }}
+            />
+        )
+    } else {
+        return handleArchie(d, "")
     }
 }

--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -74,22 +74,28 @@ export default function ArticleBlock({ d }: { d: OwidArticleBlock }) {
         return content
     }
 
-    if (d.type === "text") {
-        if (d.value.trim() === "") {
-            return null
+    try {
+        if (d.type === "text") {
+            if (d.value.trim() === "") {
+                return null
+            }
+            return (
+                <div
+                    dangerouslySetInnerHTML={{
+                        __html:
+                            d.value.startsWith("<div") ||
+                            d.value.trim() === "<hr />"
+                                ? d.value.replace(/\\:/g, ":")
+                                : `<p>${d.value.replace(/\\:/g, ":")}</p>`,
+                    }}
+                />
+            )
+        } else {
+            return handleArchie(d, "")
         }
-        return (
-            <div
-                dangerouslySetInnerHTML={{
-                    __html:
-                        d.value.startsWith("<div") ||
-                        d.value.trim() === "<hr />"
-                            ? d.value.replace(/\\:/g, ":")
-                            : `<p>${d.value.replace(/\\:/g, ":")}</p>`,
-                }}
-            />
-        )
-    } else {
-        return handleArchie(d, "")
+    } catch (e) {
+        console.error("got an error")
+        console.log(e)
+        return null
     }
 }

--- a/site/gdocs/OwidArticle.tsx
+++ b/site/gdocs/OwidArticle.tsx
@@ -5,22 +5,73 @@ import Footnotes from "./Footnotes"
 import {
     OwidArticleBlock,
     OwidArticleProps,
+    OwidArticleType,
 } from "../../clientUtils/owidTypes.js"
 import { formatDate, getArticleFromJSON } from "../../clientUtils/Util.js"
 
+interface OwidArticleErrorBoundaryProps {
+    article: OwidArticleType
+    isPreviewing: boolean
+    children?: React.ReactNode
+}
+
+class OwidArticleErrorBoundary extends React.Component<
+    OwidArticleErrorBoundaryProps,
+    { hasError: boolean; error: Error | undefined },
+    Record<string, never>
+> {
+    constructor(props: OwidArticleErrorBoundaryProps) {
+        super(props)
+        this.state = { hasError: false, error: undefined }
+    }
+
+    static getDerivedStateFromError(error: Error) {
+        // Update state so the next render will show the fallback UI.
+
+        return { hasError: true, error: error }
+    }
+    componentDidCatch(error: any, errorInfo: any) {
+        // You can also log the error to an error reporting service
+        // console.error(error, errorInfo)
+    }
+    render() {
+        if (this.state.hasError && this.props.isPreviewing) {
+            // You can render any custom fallback UI
+
+            return (
+                <div>
+                    <h3>There is an error in the ArchieML JSON structure</h3>
+                    <p>The error message was:</p>
+                    <pre>
+                        {this.state.error?.message ??
+                            "error message not provided - please look in the dev console (F12)"}
+                    </pre>
+                    <p>
+                        Check below that the JSON structure looks correct.
+                        Verify that e.g. chart elements have a url value etc.
+                    </p>
+                    <pre>{JSON.stringify(this.props.article, null, 2)}</pre>
+                </div>
+            )
+        }
+        return this.props.children
+    }
+}
 export function OwidArticle(props: OwidArticleProps) {
     const { content, publishedAt } = props.article
-    let element: JSX.Element
 
-    try {
-        const coverStyle = content["cover-image"]
-            ? {
-                  background: `url(${content["cover-image"][0].value.src})`,
-                  backgroundSize: "cover",
-              }
-            : {}
+    const coverStyle = content["cover-image"]
+        ? {
+              background: `url(${content["cover-image"][0].value.src})`,
+              backgroundSize: "cover",
+          }
+        : {}
 
-        element = (
+    const element: JSX.Element = (
+        <OwidArticleErrorBoundary
+            article={props.article}
+            isPreviewing={props.isPreviewing}
+        >
             <article className={"owidArticle"}>
                 <div className={"articleCover"} style={coverStyle}></div>
                 <div className={"articlePage"}></div>
@@ -69,17 +120,9 @@ export function OwidArticle(props: OwidArticleProps) {
                     </div>
                 ) : null}
             </article>
-        )
-    } catch (e) {
-        if (props.isPreviewing)
-            element = (
-                <div>
-                    There was an error rendering this article. Please check the
-                    console for more details.
-                </div>
-            )
-        else throw e
-    }
+        </OwidArticleErrorBoundary>
+    )
+
     return element
 }
 

--- a/site/gdocs/OwidArticle.tsx
+++ b/site/gdocs/OwidArticle.tsx
@@ -4,74 +4,91 @@ import { ArticleBlocks } from "./ArticleBlocks"
 import Footnotes from "./Footnotes"
 import {
     OwidArticleBlock,
-    OwidArticleType,
+    OwidArticleProps,
 } from "../../clientUtils/owidTypes.js"
 import { formatDate, getArticleFromJSON } from "../../clientUtils/Util.js"
 
-export function OwidArticle(props: OwidArticleType) {
-    const { content, publishedAt } = props
+export function OwidArticle(props: OwidArticleProps) {
+    const { content, publishedAt } = props.article
+    let element: JSX.Element
 
-    const coverStyle = content["cover-image"]
-        ? {
-              background: `url(${content["cover-image"][0].value.src})`,
-              backgroundSize: "cover",
-          }
-        : {}
+    try {
+        const coverStyle = content["cover-image"]
+            ? {
+                  background: `url(${content["cover-image"][0].value.src})`,
+                  backgroundSize: "cover",
+              }
+            : {}
 
-    return (
-        <article className={"owidArticle"}>
-            <div className={"articleCover"} style={coverStyle}></div>
-            <div className={"articlePage"}></div>
-            <h1 className={"title"}>{content.title}</h1>
-            <h2 className={"subtitle"}>{content.subtitle}</h2>
-            <div className={"bylineContainer"}>
+        element = (
+            <article className={"owidArticle"}>
+                <div className={"articleCover"} style={coverStyle}></div>
+                <div className={"articlePage"}></div>
+                <h1 className={"title"}>{content.title}</h1>
+                <h2 className={"subtitle"}>{content.subtitle}</h2>
+                <div className={"bylineContainer"}>
+                    <div>
+                        By: <div className={"byline"}>{content.byline}</div>
+                    </div>
+                    <div className={"dateline"}>
+                        {content.dateline ||
+                            (publishedAt && formatDate(publishedAt))}
+                    </div>
+                </div>
+
+                {content.summary ? (
+                    <div>
+                        <details className={"summary"} open={true}>
+                            <summary>Summary</summary>
+                            <ArticleBlocks blocks={content.summary} />
+                        </details>
+                    </div>
+                ) : null}
+
+                {content.body ? <ArticleBlocks blocks={content.body} /> : null}
+
+                {content.refs ? <Footnotes d={content.refs} /> : null}
+
+                {content.citation &&
+                content.citation.some(
+                    (d: OwidArticleBlock) => d.type === "text"
+                ) ? (
+                    <div>
+                        <h3>Please cite this article as:</h3>
+                        <pre>
+                            <code>
+                                {content.citation.map((d: OwidArticleBlock) => {
+                                    if (d.type === "text") {
+                                        return d.value
+                                    } else {
+                                        return ""
+                                    }
+                                })}
+                            </code>
+                        </pre>
+                    </div>
+                ) : null}
+            </article>
+        )
+    } catch (e) {
+        if (props.isPreviewing)
+            element = (
                 <div>
-                    By: <div className={"byline"}>{content.byline}</div>
+                    There was an error rendering this article. Please check the
+                    console for more details.
                 </div>
-                <div className={"dateline"}>
-                    {content.dateline ||
-                        (publishedAt && formatDate(publishedAt))}
-                </div>
-            </div>
-
-            {content.summary ? (
-                <div>
-                    <details className={"summary"} open={true}>
-                        <summary>Summary</summary>
-                        <ArticleBlocks blocks={content.summary} />
-                    </details>
-                </div>
-            ) : null}
-
-            {content.body ? <ArticleBlocks blocks={content.body} /> : null}
-
-            {content.refs ? <Footnotes d={content.refs} /> : null}
-
-            {content.citation &&
-            content.citation.some(
-                (d: OwidArticleBlock) => d.type === "text"
-            ) ? (
-                <div>
-                    <h3>Please cite this article as:</h3>
-                    <pre>
-                        <code>
-                            {content.citation.map((d: OwidArticleBlock) => {
-                                if (d.type === "text") {
-                                    return d.value
-                                } else {
-                                    return ""
-                                }
-                            })}
-                        </code>
-                    </pre>
-                </div>
-            ) : null}
-        </article>
-    )
+            )
+        else throw e
+    }
+    return element
 }
 
 export const hydrateOwidArticle = () => {
     const wrapper = document.querySelector("#owid-article-root")
     const props = getArticleFromJSON(window._OWID_ARTICLE_PROPS)
-    ReactDOM.hydrate(<OwidArticle {...props} />, wrapper)
+    // TODO: how should isPreviewing supposed to be set in the hydration case?
+    ReactDOM.hydrate(
+        <OwidArticle article={props} isPreviewing={false} />,
+        wrapper
+    )
 }

--- a/site/gdocs/OwidArticlePage.tsx
+++ b/site/gdocs/OwidArticlePage.tsx
@@ -70,7 +70,7 @@ export default function OwidArticlePage({
             <body>
                 <SiteHeader baseUrl={baseUrl} />
                 <div id="owid-article-root">
-                    <OwidArticle {...article} />
+                    <OwidArticle article={article} isPreviewing={false} />
                 </div>
                 <SiteFooter
                     baseUrl={baseUrl}


### PR DESCRIPTION
This is a first step towards better error feedback. As a first step if there is a serious problem with the archiesyntax this PR makes it so that the parsed json structure is shown instead of a white screen.