### PR TITLE
Prevent WSOD in gdocs preview

### DIFF
--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -222,7 +222,7 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                         errors={errors}
                     />
                 </Drawer>
-                <DebugProvider isPreviewing={true}>
+                <DebugProvider>
                     <OwidArticle {...gdoc} />
                 </DebugProvider>
             </main>

--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -30,6 +30,7 @@ import { GdocsMoreMenu } from "./GdocsMoreMenu.js"
 import { faAngleLeft } from "@fortawesome/free-solid-svg-icons/faAngleLeft"
 import { GdocsEditLink } from "./GdocsEditLink.js"
 import { openSuccessNotification } from "./gdocsNotifications.js"
+import { DebugProvider } from "../site/gdocs/DebugContext.js"
 
 export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
     const { id } = match.params
@@ -221,8 +222,9 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                         errors={errors}
                     />
                 </Drawer>
-
-                <OwidArticle {...gdoc} />
+                <DebugProvider isPreviewing={true}>
+                    <OwidArticle {...gdoc} />
+                </DebugProvider>
             </main>
         </AdminLayout>
     ) : null

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
         "react-codemirror2": "^7.2.1",
         "react-color": "^2.18.1",
         "react-dom": "^16.14.0",
+        "react-error-boundary": "^3.1.4",
         "react-flip-toolkit": "^7.0.9",
         "react-horizontal-scrolling-menu": "^2.7.1",
         "react-intersection-observer": "^9.4.0",

--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -10,45 +10,14 @@ import List from "./List"
 import Image from "./Image"
 import { OwidArticleBlock } from "@ourworldindata/utils"
 import SDGGrid from "./SDGGrid.js"
-import { ErrorBoundary } from "react-error-boundary"
-
-const ErrorFallback = ({
-    error,
-    resetErrorBoundary,
-}: {
-    error: Error
-    resetErrorBoundary: VoidFunction
-}): JSX.Element => {
-    return (
-        <div
-            style={{
-                textAlign: "center",
-                backgroundColor: "rgba(255,0,0,0.1)",
-                padding: "20px",
-            }}
-        >
-            <h3>Error while rendering the block</h3>
-            Please check the source content.
-            <div>
-                <button style={{ margin: "10px" }} onClick={resetErrorBoundary}>
-                    Try again
-                </button>
-            </div>
-            <div>{error.message}</div>
-        </div>
-    )
-}
+import { BlockErrorBoundary } from "./BlockErrorBoundary"
 
 export default function ArticleBlock({ d }: { d: OwidArticleBlock }) {
     const handleArchie = (d: OwidArticleBlock, key: string) => {
         const _type = d.type.toLowerCase()
         let content: any = JSON.stringify(d)
         if (_type === "chart") {
-            content = (
-                <ErrorBoundary FallbackComponent={ErrorFallback}>
-                    <Chart d={d} key={key} />
-                </ErrorBoundary>
-            )
+            content = <Chart d={d} key={key} />
         } else if (_type === "aside") {
             content = (
                 <figure
@@ -106,7 +75,7 @@ export default function ArticleBlock({ d }: { d: OwidArticleBlock }) {
             content = <SDGGrid d={d} key={key} />
         }
 
-        return content
+        return <BlockErrorBoundary>{content}</BlockErrorBoundary>
     }
 
     if (d.type === "text") {

--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -10,13 +10,45 @@ import List from "./List"
 import Image from "./Image"
 import { OwidArticleBlock } from "@ourworldindata/utils"
 import SDGGrid from "./SDGGrid.js"
+import { ErrorBoundary } from "react-error-boundary"
+
+const ErrorFallback = ({
+    error,
+    resetErrorBoundary,
+}: {
+    error: Error
+    resetErrorBoundary: VoidFunction
+}): JSX.Element => {
+    return (
+        <div
+            style={{
+                textAlign: "center",
+                backgroundColor: "rgba(255,0,0,0.1)",
+                padding: "20px",
+            }}
+        >
+            <h3>Error while rendering the block</h3>
+            Please check the source content.
+            <div>
+                <button style={{ margin: "10px" }} onClick={resetErrorBoundary}>
+                    Try again
+                </button>
+            </div>
+            <div>{error.message}</div>
+        </div>
+    )
+}
 
 export default function ArticleBlock({ d }: { d: OwidArticleBlock }) {
     const handleArchie = (d: OwidArticleBlock, key: string) => {
         const _type = d.type.toLowerCase()
         let content: any = JSON.stringify(d)
         if (_type === "chart") {
-            content = <Chart d={d} key={key} />
+            content = (
+                <ErrorBoundary FallbackComponent={ErrorFallback}>
+                    <Chart d={d} key={key} />
+                </ErrorBoundary>
+            )
         } else if (_type === "aside") {
             content = (
                 <figure

--- a/site/gdocs/BlockErrorBoundary.tsx
+++ b/site/gdocs/BlockErrorBoundary.tsx
@@ -1,0 +1,45 @@
+import React from "react"
+import { ErrorBoundary } from "react-error-boundary"
+import { useDebug } from "./DebugContext.js"
+
+export const BlockErrorBoundary = ({
+    children,
+}: {
+    children: React.ReactNode
+}) => {
+    const debug = useDebug()
+    return debug.isPreviewing ? (
+        <ErrorBoundary FallbackComponent={BlockErrorFallback}>
+            {children}
+        </ErrorBoundary>
+    ) : (
+        <>{children}</>
+    )
+}
+
+const BlockErrorFallback = ({
+    error,
+    resetErrorBoundary,
+}: {
+    error: Error
+    resetErrorBoundary: VoidFunction
+}): JSX.Element => {
+    return (
+        <div
+            style={{
+                textAlign: "center",
+                backgroundColor: "rgba(255,0,0,0.1)",
+                padding: "20px",
+            }}
+        >
+            <h3>Error while rendering the block</h3>
+            Please check the source content.
+            <div>
+                <button style={{ margin: "10px" }} onClick={resetErrorBoundary}>
+                    Try again
+                </button>
+            </div>
+            <div>{error.message}</div>
+        </div>
+    )
+}

--- a/site/gdocs/BlockErrorBoundary.tsx
+++ b/site/gdocs/BlockErrorBoundary.tsx
@@ -8,7 +8,7 @@ export const BlockErrorBoundary = ({
     children: React.ReactNode
 }) => {
     const debug = useDebug()
-    return debug.isPreviewing ? (
+    return debug ? (
         <ErrorBoundary FallbackComponent={BlockErrorFallback}>
             {children}
         </ErrorBoundary>

--- a/site/gdocs/BlockErrorBoundary.tsx
+++ b/site/gdocs/BlockErrorBoundary.tsx
@@ -21,7 +21,7 @@ const BlockErrorFallback = ({
     error,
     resetErrorBoundary,
 }: {
-    error: Error
+    error?: Error
     resetErrorBoundary: VoidFunction
 }): JSX.Element => {
     return (
@@ -39,7 +39,7 @@ const BlockErrorFallback = ({
                     Try again
                 </button>
             </div>
-            <div>{error.message}</div>
+            <div>{error?.message}</div>
         </div>
     )
 }

--- a/site/gdocs/DebugContext.tsx
+++ b/site/gdocs/DebugContext.tsx
@@ -1,0 +1,29 @@
+import React, { createContext, useState } from "react"
+
+interface DebugContextType {
+    isPreviewing: boolean
+}
+
+const DebugContext = createContext<DebugContextType | undefined>(undefined)
+
+export const DebugProvider = ({
+    isPreviewing = false,
+    children,
+}: {
+    isPreviewing: boolean
+    children: React.ReactNode
+}) => {
+    const [debug] = useState({ isPreviewing })
+
+    return (
+        <DebugContext.Provider value={debug}>{children}</DebugContext.Provider>
+    )
+}
+
+export const useDebug = () => {
+    const context = React.useContext(DebugContext)
+    if (context === undefined) {
+        throw new Error("useDebug must be used within a DebugProvider")
+    }
+    return context
+}

--- a/site/gdocs/DebugContext.tsx
+++ b/site/gdocs/DebugContext.tsx
@@ -14,11 +14,7 @@ either way, but we might still want to catch client-side errors in the future.
 
 const DebugContext = createContext<true | undefined>(undefined)
 
-export const DebugProvider = ({
-    children,
-}: {
-    children: React.ReactNode
-}) => {
+export const DebugProvider = ({ children }: { children: React.ReactNode }) => {
     return (
         <DebugContext.Provider value={true}>{children}</DebugContext.Provider>
     )
@@ -26,7 +22,7 @@ export const DebugProvider = ({
 
 export const useDebug = () => {
     const context = React.useContext(DebugContext)
-    
+
     // This will come handy when the context is used in more scenarios, with a
     // payload, to simplify existence checks in consumers. Right now, the
     // absence of context is a feature (see above).

--- a/site/gdocs/DebugContext.tsx
+++ b/site/gdocs/DebugContext.tsx
@@ -1,29 +1,38 @@
 import React, { createContext, useState } from "react"
 
-interface DebugContextType {
-    isPreviewing: boolean
-}
+/*
+We rely on the <OwidArticle> being wrapped around a <DebugProvider> to indicate
+whether we want to turn on error boundary debugging. For that, we don't need the
+context to hold any information, hence the type "true" below (could be any other
+value). 
 
-const DebugContext = createContext<DebugContextType | undefined>(undefined)
+<DebugProvider> is only used when the article is previewed (see
+GdocsPreviewPage). When the article is baked or rendered through the mockServer,
+<OwidArticle> is rendered as-is. Error boundaries do not catch errors on SSR
+either way, but we might still want to catch client-side errors in the future.
+*/
+
+const DebugContext = createContext<true | undefined>(undefined)
 
 export const DebugProvider = ({
-    isPreviewing = false,
     children,
 }: {
-    isPreviewing: boolean
     children: React.ReactNode
 }) => {
-    const [debug] = useState({ isPreviewing })
-
     return (
-        <DebugContext.Provider value={debug}>{children}</DebugContext.Provider>
+        <DebugContext.Provider value={true}>{children}</DebugContext.Provider>
     )
 }
 
 export const useDebug = () => {
     const context = React.useContext(DebugContext)
-    if (context === undefined) {
-        throw new Error("useDebug must be used within a DebugProvider")
-    }
+    
+    // This will come handy when the context is used in more scenarios, with a
+    // payload, to simplify existence checks in consumers. Right now, the
+    // absence of context is a feature (see above).
+
+    //if (context === undefined) {
+    // throw new Error("useDebug must be used within a DebugProvider")
+    // }
     return context
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18112,6 +18112,13 @@ react-element-to-jsx-string@^14.3.4:
     is-plain-object "5.0.0"
     react-is "17.0.2"
 
+react-error-boundary@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-flip-toolkit@^7.0.9:
   version "7.0.9"
   resolved "https://registry.npmjs.org/react-flip-toolkit/-/react-flip-toolkit-7.0.9.tgz"


### PR DESCRIPTION
https://user-images.githubusercontent.com/13406362/198077498-8e247297-f146-4264-bee6-8b845d1d0528.mp4



Features:
- captures errors in individual components (only `<Chart>` for this PoC) so finding the misbehaving component is easier
- allows retries when source updated

Not done:
- [x] not tested in baking scenarios
- [x] should consider expected behaviour in production
- [x] errors should prevent publishing - although we might want to implement of softer fail in the future, e.g. DataValue below:

<img width="1293" alt="20220420-missing_data_value" src="https://user-images.githubusercontent.com/13406362/199770725-38bb36df-f236-4897-b12d-a70cecce4f86.png">

Supersedes #1726 (discussed with @danyx23)