### PR TITLE
fix(duckdb): move require(duckdb) from top to inline to prevent segfaults

### DIFF
--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -23,7 +23,6 @@ import {
 import { OwidSource } from "../../clientUtils/OwidSource.js"
 import { CATALOG_PATH } from "../../settings/serverSettings.js"
 import * as util from "util"
-const duckdb = require("duckdb")
 
 export interface VariableRow {
     id: number
@@ -86,6 +85,8 @@ export type Field = keyof VariableRow
 export const variableTable = "variables"
 
 const initDuckDB = (): any => {
+    // require on top level could cause segfaults in combination with workerpool
+    const duckdb = require("duckdb")
     const ddb = new duckdb.Database(":memory:")
     ddb.exec("INSTALL httpfs;")
     ddb.exec("LOAD httpfs;")


### PR DESCRIPTION
We're still getting segfaults in production even though we're not using duckdb at all. It doesn't play nicely with `workerpool` from deploys and can result in non-deterministic segfaults.

I've been testing moving `require` inline (which never gets called) and it has been working on staging. It's non-deterministic though, so one can never be sure :(. If we still get errors after this we should just remove duckdb altogether.