### PR TITLE
additional-information h3 CSS fix

### DIFF
--- a/site/blocks/AdditionalInformation.tsx
+++ b/site/blocks/AdditionalInformation.tsx
@@ -106,6 +106,7 @@ const AdditionalInformation = ({
             className={classes.join(" ")}
         >
             <h3
+                className="additional-information__heading"
                 onClick={onClickHandler}
                 data-track-note="additional-information-toggle"
             >

--- a/site/blocks/additional-information.scss
+++ b/site/blocks/additional-information.scss
@@ -1,6 +1,6 @@
 .wp-block-owid-additional-information {
     margin-bottom: 2rem;
-    h3 {
+    h3.additional-information__heading {
         @include h3-style;
         display: flex;
         align-items: center;
@@ -18,7 +18,7 @@
         }
     }
     &.open {
-        h3 {
+        h3.additional-information__heading {
             background-color: $blue-10;
             svg {
                 margin-right: 32px;
@@ -30,7 +30,7 @@
     &[data-variation="merge-left"] {
         @include block-shadow;
         @include left-media-columns;
-        h3 {
+        h3.additional-information__heading {
             padding: 1.5rem $padding-x-sm;
             @include md-up {
                 padding: 1.5rem $padding-x-md;
@@ -56,7 +56,7 @@
             margin-right: -#{$padding-x-md};
             padding: 0 $padding-x-md;
         }
-        h3 {
+        h3.additional-information__heading {
             padding: 1.5rem 0;
         }
         .content {

--- a/site/css/content.scss
+++ b/site/css/content.scss
@@ -43,7 +43,6 @@
     margin-bottom: 1rem;
     text-align: center;
     line-height: 0;
-
     width: 100%;
 
     > a {
@@ -61,7 +60,7 @@
         box-shadow: 0px 0px 4px #000;
     }
 
-    img {
+    &.grapherPreview img {
         margin: 0;
         padding: 0;
         width: 100%;


### PR DESCRIPTION
Fixes some minor CSS scoping glitches with the Additional Information block

I tested how this would impact other h3's if they were in the additional information block and found that any child h3 gets lifted up to the "main heading" of the block, so presumably multiple h3's is a case we don't have to worry about.

The `&.grapherPreview img` change addresses the `img` rule which was also affecting all `img`'s within a Grapher inside `article-content`. I suspect it was written to only apply to the preview `img` before the embed is hydrated, so I made the rule only apply when `grapherPreview` is active.

## Before
![image](https://user-images.githubusercontent.com/11844404/198356335-eb36e10b-8ebf-49c7-a6e7-3604bf5daa22.png)

## After
![image](https://user-images.githubusercontent.com/11844404/198355817-d916421b-b67c-4e5d-98af-25571438101d.png)
