### PR TITLE
1733-sdg-table-of-contents-index

### DIFF
--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -423,6 +423,7 @@ export interface OwidArticleContent {
     byline?: string | string[]
     dateline?: string
     excerpt?: string
+    toc?: TocHeading[]
     refs?: OwidArticleBlock[]
     summary?: OwidArticleBlock[]
     citation?: OwidArticleBlock[]

--- a/site/css/content.scss
+++ b/site/css/content.scss
@@ -184,9 +184,7 @@ figure[data-explorer-src] {
  * Columns
  */
 .page .wp-block-columns {
-    display: grid;
-    grid-template-columns: repeat(12, 1fr);
-    column-gap: 24px;
+    @include grid(12);
 
     // default is first column is full-width, second column should be empty
     .wp-block-column {

--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -8,11 +8,18 @@ import FixedGraphic from "./FixedGraphic"
 import Recirc from "./Recirc"
 import List from "./List"
 import Image from "./Image"
-import { OwidArticleBlock } from "@ourworldindata/utils"
+import { OwidArticleBlock, TocHeading } from "@ourworldindata/utils"
 import SDGGrid from "./SDGGrid.js"
 import { BlockErrorBoundary } from "./BlockErrorBoundary"
+import SDGTableOfContents from "./SDGTableOfContents.js"
 
-export default function ArticleBlock({ d }: { d: OwidArticleBlock }) {
+export default function ArticleBlock({
+    d,
+    toc,
+}: {
+    d: OwidArticleBlock
+    toc?: TocHeading[]
+}) {
     const handleArchie = (d: OwidArticleBlock, key: string) => {
         const _type = d.type.toLowerCase()
         let content: any = JSON.stringify(d)
@@ -73,6 +80,8 @@ export default function ArticleBlock({ d }: { d: OwidArticleBlock }) {
             content = <Image d={d} key={key} />
         } else if (_type === "sdg-grid") {
             content = <SDGGrid d={d} key={key} />
+        } else if (_type === "sdg-toc" && toc) {
+            content = <SDGTableOfContents toc={toc} />
         }
 
         return <BlockErrorBoundary>{content}</BlockErrorBoundary>

--- a/site/gdocs/ArticleBlocks.tsx
+++ b/site/gdocs/ArticleBlocks.tsx
@@ -1,11 +1,17 @@
 import React from "react"
 import ArticleBlock from "./ArticleBlock.js"
-import { OwidArticleBlock } from "@ourworldindata/utils"
+import { OwidArticleBlock, TocHeading } from "@ourworldindata/utils"
 
-export const ArticleBlocks = ({ blocks }: { blocks: OwidArticleBlock[] }) => (
+export const ArticleBlocks = ({
+    blocks,
+    toc,
+}: {
+    blocks: OwidArticleBlock[]
+    toc?: TocHeading[]
+}) => (
     <>
         {blocks.map((block: OwidArticleBlock, i: number) => {
-            return <ArticleBlock key={i} d={block} />
+            return <ArticleBlock key={i} d={block} toc={toc} />
         })}
     </>
 )

--- a/site/gdocs/OwidArticle.tsx
+++ b/site/gdocs/OwidArticle.tsx
@@ -44,7 +44,9 @@ export function OwidArticle(props: OwidArticleType) {
                 </div>
             ) : null}
 
-            {content.body ? <ArticleBlocks blocks={content.body} /> : null}
+            {content.body ? (
+                <ArticleBlocks toc={content.toc} blocks={content.body} />
+            ) : null}
 
             {content.refs ? <Footnotes d={content.refs} /> : null}
 

--- a/site/gdocs/SDGTableOfContents.scss
+++ b/site/gdocs/SDGTableOfContents.scss
@@ -35,8 +35,7 @@
             color: $blue-60;
         }
         a {
-            @include owid-link-90; // todo: probably not needed after the style reconcialiation
-            text-decoration: none;
+            color: $blue-90;
 
             &:hover {
                 text-decoration: underline;

--- a/site/gdocs/SDGTableOfContents.scss
+++ b/site/gdocs/SDGTableOfContents.scss
@@ -2,6 +2,13 @@
     grid-column: 4 / span 8;
     background-color: $beige;
 
+    .sdg-toc-toggle {
+        @include h2-bold;
+        display: flex;
+        justify-content: space-between;
+        cursor: pointer;
+    }
+
     ul {
         list-style-type: none;
     }

--- a/site/gdocs/SDGTableOfContents.scss
+++ b/site/gdocs/SDGTableOfContents.scss
@@ -1,0 +1,28 @@
+.sdg-toc {
+    grid-column: 4 / span 8;
+    background-color: $beige;
+
+    ul {
+        list-style-type: none;
+    }
+
+    li.section {
+        .supertitle {
+            display: block;
+            color: $blue-60;
+        }
+        a {
+            @include owid-link-90; // todo: probably not needed after the style reconcialiation
+            text-decoration: none;
+
+            &:hover {
+                text-decoration: underline;
+            }
+        }
+        svg {
+            font-size: 0.75em;
+            vertical-align: middle;
+            margin-left: 10px;
+        }
+    }
+}

--- a/site/gdocs/SDGTableOfContents.scss
+++ b/site/gdocs/SDGTableOfContents.scss
@@ -31,12 +31,14 @@
             margin-left: 10px;
         }
         &.section {
+            @include body-2-semibold;
             .supertitle {
                 display: block;
             }
         }
 
         &.subsection {
+            @include body-3-medium;
             margin-left: 24px;
             .supertitle {
                 &::after {

--- a/site/gdocs/SDGTableOfContents.scss
+++ b/site/gdocs/SDGTableOfContents.scss
@@ -1,15 +1,21 @@
 .sdg-toc {
     grid-column: 4 / span 8;
+    @include grid(8);
+    padding: 40px 0;
     background-color: $beige;
 
     .sdg-toc-toggle {
+        grid-column: 2 / span 6;
         @include h2-bold;
+        margin: 0;
         display: flex;
         justify-content: space-between;
         cursor: pointer;
     }
 
     ul {
+        grid-column: 2 / span 6;
+        margin-top: 24px;
         list-style-type: none;
     }
 
@@ -34,6 +40,7 @@
             @include body-2-semibold;
             .supertitle {
                 display: block;
+                margin-bottom: 8px;
             }
         }
 
@@ -45,6 +52,15 @@
                     content: " ";
                 }
             }
+        }
+        &.section + .subsection {
+            margin-top: 8px;
+        }
+
+        &.subsection + .section {
+            margin-top: 24px;
+            border-top: 1px solid $blue-20;
+            padding-top: 24px;
         }
     }
 }

--- a/site/gdocs/SDGTableOfContents.scss
+++ b/site/gdocs/SDGTableOfContents.scss
@@ -6,9 +6,8 @@
         list-style-type: none;
     }
 
-    li.section {
+    li {
         .supertitle {
-            display: block;
             color: $blue-60;
         }
         a {
@@ -23,6 +22,20 @@
             font-size: 0.75em;
             vertical-align: middle;
             margin-left: 10px;
+        }
+        &.section {
+            .supertitle {
+                display: block;
+            }
+        }
+
+        &.subsection {
+            margin-left: 24px;
+            .supertitle {
+                &::after {
+                    content: " ";
+                }
+            }
         }
     }
 }

--- a/site/gdocs/SDGTableOfContents.scss
+++ b/site/gdocs/SDGTableOfContents.scss
@@ -4,6 +4,14 @@
     padding: 40px 0;
     background-color: $beige;
 
+    &.open::before {
+        grid-column: span 1;
+        grid-row: span 2;
+        content: "";
+        border-right: 1px solid #ffd3d3;
+        margin-right: $grid-gap;
+    }
+
     .sdg-toc-toggle {
         grid-column: 2 / span 6;
         @include h2-bold;

--- a/site/gdocs/SDGTableOfContents.scss
+++ b/site/gdocs/SDGTableOfContents.scss
@@ -3,6 +3,7 @@
     @include grid(8);
     padding: 40px 0;
     background-color: $beige;
+    cursor: pointer;
 
     &.open::before {
         grid-column: span 1;
@@ -19,6 +20,9 @@
         display: flex;
         justify-content: space-between;
         cursor: pointer;
+        border: none;
+        color: $blue-90;
+        background-color: transparent;
     }
 
     .sdg-toc-content {

--- a/site/gdocs/SDGTableOfContents.scss
+++ b/site/gdocs/SDGTableOfContents.scss
@@ -21,8 +21,11 @@
         cursor: pointer;
     }
 
-    ul {
+    .sdg-toc-content {
         grid-column: 2 / span 6;
+    }
+
+    ul {
         margin-top: 24px;
         list-style-type: none;
     }

--- a/site/gdocs/SDGTableOfContents.tsx
+++ b/site/gdocs/SDGTableOfContents.tsx
@@ -5,14 +5,16 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus"
 import { faMinus } from "@fortawesome/free-solid-svg-icons/faMinus"
 import classNames from "classnames"
+import AnimateHeight from "react-animate-height"
 
 const VERTICAL_TAB_CHAR = "\u000b"
 
 export default function SDGTableOfContents({ toc }: { toc: TocHeading[] }) {
-    const [isOpen, setIsOpen] = useState(true)
+    const [height, setHeight] = useState<"auto" | 0>(0)
+    const [isOpen, setIsOpen] = useState(false)
 
     const toggleIsOpen = () => {
-        setIsOpen(!isOpen)
+        setHeight(height === 0 ? "auto" : 0)
     }
 
     const tocHeadingsWithSupertitle = toc.map((heading) => {
@@ -38,7 +40,17 @@ export default function SDGTableOfContents({ toc }: { toc: TocHeading[] }) {
                     <FontAwesomeIcon icon={isOpen ? faMinus : faPlus} />
                 </div>
             </div>
-            {isOpen && (
+            <AnimateHeight
+                className="sdg-toc-content"
+                height={height}
+                onHeightAnimationStart={(newHeight) => {
+                    if (newHeight != 0) setIsOpen(true)
+                }}
+                onHeightAnimationEnd={(newHeight) => {
+                    if (newHeight === 0) setIsOpen(false)
+                }}
+                animateOpacity
+            >
                 <ul>
                     {tocHeadingsWithSupertitle.map(
                         (
@@ -69,7 +81,7 @@ export default function SDGTableOfContents({ toc }: { toc: TocHeading[] }) {
                         )
                     )}
                 </ul>
-            )}
+            </AnimateHeight>
         </nav>
     )
 }

--- a/site/gdocs/SDGTableOfContents.tsx
+++ b/site/gdocs/SDGTableOfContents.tsx
@@ -2,6 +2,8 @@ import React, { useState } from "react"
 import { TocHeading } from "../../clientUtils/owidTypes.js"
 import { faArrowDown } from "@fortawesome/free-solid-svg-icons/faArrowDown"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
+import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus"
+import { faMinus } from "@fortawesome/free-solid-svg-icons/faMinus"
 
 const VERTICAL_TAB_CHAR = "\u000b"
 
@@ -25,9 +27,16 @@ export default function SDGTableOfContents({ toc }: { toc: TocHeading[] }) {
 
     return (
         <nav className="sdg-toc">
-            <span onClick={toggleIsOpen} data-track-note="sdg-toc-toggle">
-                Index
-            </span>
+            <div
+                onClick={toggleIsOpen}
+                className="sdg-toc-toggle"
+                data-track-note="sdg-toc-toggle"
+            >
+                <div>Index</div>
+                <div>
+                    <FontAwesomeIcon icon={isOpen ? faMinus : faPlus} />
+                </div>
+            </div>
             {isOpen && (
                 <ul>
                     {tocHeadingsWithSupertitle.map(

--- a/site/gdocs/SDGTableOfContents.tsx
+++ b/site/gdocs/SDGTableOfContents.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from "react"
+import { TocHeading } from "../../clientUtils/owidTypes.js"
+
+export default function SDGTableOfContents({ toc }: { toc: TocHeading[] }) {
+    const [isOpen, setIsOpen] = useState(false)
+
+    const toggleIsOpen = () => {
+        setIsOpen(!isOpen)
+    }
+
+    return (
+        <nav className="entry-toc">
+            <span onClick={toggleIsOpen} data-track-note="sdg-toc-toggle">
+                Index
+            </span>
+            {isOpen && (
+                <ul>
+                    {toc.map((heading, i: number) => (
+                        <li
+                            key={i}
+                            className={
+                                heading.isSubheading ? "subsection" : "section"
+                            }
+                        >
+                            <a
+                                href={`#${heading.slug}`}
+                                data-track-note="sdg-toc-link"
+                            >
+                                {heading.text}
+                            </a>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </nav>
+    )
+}

--- a/site/gdocs/SDGTableOfContents.tsx
+++ b/site/gdocs/SDGTableOfContents.tsx
@@ -41,15 +41,15 @@ export default function SDGTableOfContents({ toc }: { toc: TocHeading[] }) {
                                     isSubheading ? "subsection" : "section"
                                 }
                             >
-                                {supertitle ? (
-                                    <span className="supertitle">
-                                        {supertitle}
-                                    </span>
-                                ) : null}
                                 <a
                                     href={`#${slug}`}
                                     data-track-note="sdg-toc-link"
                                 >
+                                    {supertitle ? (
+                                        <span className="supertitle">
+                                            {supertitle}
+                                        </span>
+                                    ) : null}
                                     {title}
                                 </a>
                                 {!isSubheading && (

--- a/site/gdocs/SDGTableOfContents.tsx
+++ b/site/gdocs/SDGTableOfContents.tsx
@@ -4,6 +4,7 @@ import { faArrowDown } from "@fortawesome/free-solid-svg-icons/faArrowDown"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus"
 import { faMinus } from "@fortawesome/free-solid-svg-icons/faMinus"
+import classNames from "classnames"
 
 const VERTICAL_TAB_CHAR = "\u000b"
 
@@ -26,7 +27,7 @@ export default function SDGTableOfContents({ toc }: { toc: TocHeading[] }) {
     })
 
     return (
-        <nav className="sdg-toc">
+        <nav className={classNames("sdg-toc", { open: isOpen })}>
             <div
                 onClick={toggleIsOpen}
                 className="sdg-toc-toggle"

--- a/site/gdocs/SDGTableOfContents.tsx
+++ b/site/gdocs/SDGTableOfContents.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { TocHeading } from "../../clientUtils/owidTypes.js"
+import { TocHeading } from "@ourworldindata/utils"
 import { faArrowDown } from "@fortawesome/free-solid-svg-icons/faArrowDown"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus"

--- a/site/gdocs/SDGTableOfContents.tsx
+++ b/site/gdocs/SDGTableOfContents.tsx
@@ -1,35 +1,63 @@
 import React, { useState } from "react"
 import { TocHeading } from "../../clientUtils/owidTypes.js"
+import { faArrowDown } from "@fortawesome/free-solid-svg-icons/faArrowDown"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
+
+const VERTICAL_TAB_CHAR = "\u000b"
 
 export default function SDGTableOfContents({ toc }: { toc: TocHeading[] }) {
-    const [isOpen, setIsOpen] = useState(false)
+    const [isOpen, setIsOpen] = useState(true)
 
     const toggleIsOpen = () => {
         setIsOpen(!isOpen)
     }
 
+    const tocHeadingsWithSupertitle = toc.map((heading) => {
+        const [beforeSeparator, afterSeparator] =
+            heading.text.split(VERTICAL_TAB_CHAR)
+
+        return {
+            ...heading,
+            supertitle: afterSeparator ? beforeSeparator : undefined,
+            title: afterSeparator || beforeSeparator,
+        }
+    })
+
     return (
-        <nav className="entry-toc">
+        <nav className="sdg-toc">
             <span onClick={toggleIsOpen} data-track-note="sdg-toc-toggle">
                 Index
             </span>
             {isOpen && (
                 <ul>
-                    {toc.map((heading, i: number) => (
-                        <li
-                            key={i}
-                            className={
-                                heading.isSubheading ? "subsection" : "section"
-                            }
-                        >
-                            <a
-                                href={`#${heading.slug}`}
-                                data-track-note="sdg-toc-link"
+                    {tocHeadingsWithSupertitle.map(
+                        (
+                            { title, supertitle, isSubheading, slug },
+                            i: number
+                        ) => (
+                            <li
+                                key={i}
+                                className={
+                                    isSubheading ? "subsection" : "section"
+                                }
                             >
-                                {heading.text}
-                            </a>
-                        </li>
-                    ))}
+                                {supertitle ? (
+                                    <span className="supertitle">
+                                        {supertitle}
+                                    </span>
+                                ) : null}
+                                <a
+                                    href={`#${slug}`}
+                                    data-track-note="sdg-toc-link"
+                                >
+                                    {title}
+                                </a>
+                                {!isSubheading && (
+                                    <FontAwesomeIcon icon={faArrowDown} />
+                                )}
+                            </li>
+                        )
+                    )}
                 </ul>
             )}
         </nav>

--- a/site/gdocs/SDGTableOfContents.tsx
+++ b/site/gdocs/SDGTableOfContents.tsx
@@ -9,6 +9,8 @@ import AnimateHeight from "react-animate-height"
 
 const VERTICAL_TAB_CHAR = "\u000b"
 
+// See ARIA roles: https://w3c.github.io/aria-practices/examples/menu-button/menu-button-links.html
+
 export default function SDGTableOfContents({ toc }: { toc: TocHeading[] }) {
     const [height, setHeight] = useState<"auto" | 0>(0)
     const [isOpen, setIsOpen] = useState(false)
@@ -29,17 +31,27 @@ export default function SDGTableOfContents({ toc }: { toc: TocHeading[] }) {
     })
 
     return (
-        <nav className={classNames("sdg-toc", { open: isOpen })}>
-            <div
-                onClick={toggleIsOpen}
+        <nav
+            className={classNames("sdg-toc", { open: isOpen })}
+            role="button"
+            onClick={toggleIsOpen}
+            aria-haspopup="true"
+            aria-controls="sdg-toc-menu"
+            data-track-note="sdg-toc-toggle"
+        >
+            <button
+                id="sdg-toc-menu-button"
                 className="sdg-toc-toggle"
+                onClick={toggleIsOpen}
+                aria-haspopup="true"
+                aria-controls="sdg-toc-menu"
                 data-track-note="sdg-toc-toggle"
             >
-                <div>Index</div>
-                <div>
+                <span>Index</span>
+                <span>
                     <FontAwesomeIcon icon={isOpen ? faMinus : faPlus} />
-                </div>
-            </div>
+                </span>
+            </button>
             <AnimateHeight
                 className="sdg-toc-content"
                 height={height}
@@ -51,7 +63,11 @@ export default function SDGTableOfContents({ toc }: { toc: TocHeading[] }) {
                 }}
                 animateOpacity
             >
-                <ul>
+                <ul
+                    id="sdg-toc-menu"
+                    role="menu"
+                    aria-labelledby="sdg-toc-menu-button"
+                >
                     {tocHeadingsWithSupertitle.map(
                         (
                             { title, supertitle, isSubheading, slug },
@@ -62,10 +78,13 @@ export default function SDGTableOfContents({ toc }: { toc: TocHeading[] }) {
                                 className={
                                     isSubheading ? "subsection" : "section"
                                 }
+                                role="none"
                             >
                                 <a
                                     href={`#${slug}`}
                                     data-track-note="sdg-toc-link"
+                                    role="menuitem"
+                                    onClick={(e) => e.stopPropagation()}
                                 >
                                     {supertitle ? (
                                         <span className="supertitle">

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -156,6 +156,10 @@
     padding: 32px 0;
 }
 
+.owidArticle details.summary {
+    margin-bottom: 32px;
+}
+
 .owidArticle .fixedSection {
     display: contents;
     position: relative;

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -4,12 +4,11 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    display: grid;
+    @include grid(12);
     grid-template-columns: calc((100vw - 1280px) / 2) repeat(12, 1fr) calc(
             (100vw - 1280px) / 2
         );
     grid-template-rows: auto;
-    column-gap: 24px;
     /* max-width: 1440px; */
     margin: 0 auto;
     background-color: #fff;
@@ -164,10 +163,8 @@
     display: contents;
     position: relative;
 
-    display: grid;
-    grid-template-columns: repeat(12, 1fr);
+    @include grid(12);
     grid-template-rows: auto;
-    column-gap: 24px;
     grid-column: 2 / -2;
     border-bottom: solid 1px #dbe5f0;
     padding-bottom: 32px;
@@ -395,14 +392,11 @@
 }
 
 .owidArticle .stickySection {
-    display: grid;
+    @include grid(12);
     grid-column: 2 / -2;
-    display: grid;
-    grid-template-columns: repeat(12, 1fr);
     grid-template-rows: auto;
     /* height: 100vh; */
     position: relative;
-    column-gap: 24px;
 }
 
 .owidArticle .stickyFigure {

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -73,6 +73,7 @@
 @import "site/AnnotatingDataValue.scss";
 @import "site/gdocs/centered-article.scss";
 @import "site/gdocs/SDGGrid.scss";
+@import "site/gdocs/SDGTableOfContents.scss";
 
 /* HACK (Mispy): Fix search autozooming on iPhone Safari.
    http://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone */


### PR DESCRIPTION
https://user-images.githubusercontent.com/13406362/198972317-3cd5589a-93c1-43d4-af88-f9559bb71f37.mp4

- dynamic generation based on document headings
- support supertitles by adding a line return (shift + enter) in the heading
- open / close animation
- ⚠️ responsive work pending grid refactor

- [demo gdoc](https://docs.google.com/document/d/1iLmMolntBXj1lhsApKI8FuLW7795DGB6t5e_iwdeeyk/edit)

closes #1733 