### PR TITLE
migration(sources): fill missing dataPublishedBy with source name

### DIFF
--- a/db/migration/1667317480367-FillMissingPublishedByBySourceName.ts
+++ b/db/migration/1667317480367-FillMissingPublishedByBySourceName.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class FillMissingPublishedByBySourceName1667317480367
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE sources
+            SET description = JSON_SET(description, '$.dataPublishedBy', name)
+            where
+            (
+                description->'$.dataPublishedBy' = CAST('null' AS JSON) or
+                description->'$.dataPublishedBy' is null or
+                description->'$.dataPublishedBy' = ""
+            )`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // no going back...
+    }
+}

--- a/db/readme.md
+++ b/db/readme.md
@@ -28,7 +28,7 @@ The database dumps we provide has all migrations already applied.
 Run:
 
 ```sh
-yarn typeorm migration:create -n MigrationName
+yarn typeorm migration:create db/migration/MigrationName
 ```
 
 And then populate the file with the SQL statements to alter the tables, using [past migration files](./migration) for reference if needed. Don't forget to rebuild the JavaScript artifacts now from TypeScript view `yarn buildTsc`, then run migrations with `yarn runDbMigrations`.


### PR DESCRIPTION
If source doesn't have `dataPublishedBy` attribute, use its `source.name`. This migration cannot be rolled back, here's at least a list of 164 sources that will be updated.

```
"id","description->'$.dataPublishedBy'","name"
44,"null","Our World In Data"
189,"","Multiple sources compiled by Our World in Data (2019)"
302,"null","OECD: Education at a Glance 2012"
582,"null","Hypothetical global emissions - CDIAC (2014)"
588,"null","Renewable Investment as % of GDP - BNEP and World Bank"
669,"null","Number of people with and without access to improved water sources - World Bank and UN"
2218,"null","Cereal Yield Index - World Bank (2017) & OWID"
2219,"null","Land under cereal production index - World Bank (2017)"
2221,"null","Daily protein supply - FAO (2017)"
2804,"null","Dietary macronutrient compositions - FAO (2017)"
2819,"null","US Corn Yields - USDA (2017) & FAO (2017)"
2826,"null","HALF Index (Land Use) - Alexander et al. (2016)"
2827,"null","Peak Farmland Projection - Ausbuel et al. (2013)"
2831,"null","FAO 2030-50 Projections of Arable Land (FAO (2017))"
2837,"null","Projections of peak agricultural land - FAO (2006), OECD (2012), MEA (2005)"
2839,"null","Long-term wheat yields - FAO (2017) & Bayliss-Smith (1984)"
2855,"null","Meat conversion efficiencies - Alexander et al. (2016)"
2862,"null","Historical UN population projections"
6729,"null","Metal production - Clio Infra & USGS"
6734,"null","Fertilizer use per hectare of land - FAO (2017) & Federico (2008)"
6793,"","Our World In Data based on US Public Health Service; US Center for Disease Control; and WHO"
6808,"null","Lighting efficiency in UK - OWID based on Fouquet & Pearson (2007)"
6821,"null","Land Use Map by Area - OWID based on FAO"
6823,"null","Livestock counts - HYDE & FAO (2017)"
6825,"null","Food waste in the supply chain - WRAP (2015) & Europa (2015)"
6833,"null","Fossil fuel consumption per capita - BP & UN (2017 revision)"
6834,"null","Long-term per capita fossil fuels - OWID based on UN, Gapminder, BP, Etemad & Luciana"
6841,"null","Our World In Data based on GGDC-10 (2015)"
6893,"null","Antibiotic use in livestock - European Commision & Boeckel et al."
14896,"null","Emissions intensity & value added by sector - World Input-Output Tables"
15485,"null","Hypothetical meat consumption - OWID based on FAO & UN"
15527,"null","Homicide rates in Europe over long-term (Eisner & IHME)"
15558,"""""","Our World in Data based on Geyer et al. (2017) and OECD"
15635,"null","Maternal mortality projection to 2030 (based on World Bank, 2018)"
15637,"null","Required rate of maternal mortality decline for SDG - based on World Bank (2018)"
15638,"null","Maternal deaths to 2030 (BAU vs. SDG Target) - based on World Bank & UN (2018)"
15657,"","Correlates of War; Conflict Catalogue, PRIO, UCDP"
15724,"","Country programmable aid (CPA) from 2000-2019 (OECD, 2018)"
15725,"","Developmental Food Aid (OECD, 2018)"
16221,"","World Inequality Database (2018)"
16257,"","Global Consumption and Income Project"
16717,"","Penn World Tables (2017)"
16754,""," "
16772,"","Causes of child death by sex in India (IHME, 2019)"
16982,"","Wellcome Global Monitor (2020)"
16986,"","Alliance for Affordable Internet (2019)"
17005,"","BOND Internet Trends (2019)"
17041,"","World Bank (2020)"
17612,"","Bowles, S. (2009), Gat, A. (2008), Knauft, B. M. et al (1987), Keeley, L. H. (1996), Pinker, S. (2011), and Walker, R. S., & Bailey, D. H. (2013)"
17613,"","GAVI country eligibility - 2019"
17795,"","WHO COVID-2019 Situation Reports"
17800,"","COVID-2019 - Johns Hopkins (2020)"
17818,"","Matthew Shum (2004)"
17819,"","Ryland Thomas and Nicholas Dimsdale. (2017)"
17887,"","Eurostat (2020), OECD (2020) and individual national statistical offices"
17922,"","Calculated by Our World in Data based on WHO/UNICEF or IHME and UN Population Division (2019)"
17924,"","Figure_15.6_United_States_Decades"
17943,"","Swedish COVID-19 deaths comparison"
17970,"","Centers for Disease Control and Prevention – Last updated 1 November 2022 (Eastern Time)"
17972,"","OECD Collective Bargaining Coverage"
17977,"","Swedish Public Health Agency – Last updated 28 October 2022"
17980,"","Government of Israel"
17985,"","Reconstruction of historical global extreme poverty rates, 1820-2017 (Roser and Hasell (2021) and World Bank(2020))"
18005,"","PovCal (2021)"
18025,"","Imperial College London YouGov Covid 19 Behaviour Tracker Data Hub – Last updated 15 March 2022, 09:00 (London time)"
18026,"","Undernourishment (FAO, 2021)"
18029,"","IEA Energy Coverage"
18038,"","global_agricultural_productivity"
18053,"","OWID based on Maddison Project Database 2020, GCIP and van Zanden et al. (2014))"
18058,"","GISAID, via CoVariants.org – Last updated 31 October 2022"
20539,"""""","Robert J. Barro and Jong-Wha Lee"
20540,"""""","Demographic and Health Surveys (DHS)"
20541,"""""","World Bank staff calculations based on Multiple Indicator Cluster Survey (MICS) data"
20542,"""""","Multiple Indicator Cluster Surveys (MICS)"
20543,"""""","International Telecommunication Union, World Telecommunication/ICT Development Report and database"
20544,"""""","Early Grade Reading Assessment (EGRA)"
20545,"""""","Latin American Laboratory for Assessment of the Quality of Education (LLECE)"
20546,"""""","Program for the Analysis of CONFEMEN Education Systems (PASEC)"
20547,"""""","OECD Programme for the International Assessment of Adult Competencies (PIAAC)"
20548,"""""","International Association for the Evaluation of Educational Achievement (IEA) Progress in International Reading Literacy Study (PIRLS)"
20549,"""""","OECD Programme for International Student Assessment (PISA)"
20550,"""""","Southern and Eastern Africa Consortium for Monitoring Educational Quality (SACMEQ) Data Archive"
20551,"""""","International Association for the Evaluation of Educational Achievement (IEA)'s Trends in International Mathematics and Science Study"
20552,"""""","World Bank national accounts data, and OECD National Accounts data files"
20553,"""""","World Bank, International Comparison Program database"
20554,"""""","Organisation for Economic Co-operation and Development (OECD)"
20555,"""""","Wittgenstein Centre for Demography and Global Human Capital"
20556,"""""","Systems Approach for Better Education Results (SABER), World Bank"
20557,"""""","UNESCO Institute for Statistics"
20558,"""""","UNAIDS estimates"
20559,"""""","Estimates Developed by the UN Inter-agency Group for Child Mortality Estimation (UNICEF, WHO, World Bank, UN DESA Population Division)"
20560,"""""","International Labour Organization, ILOSTAT database"
20561,"""""","Derived using data from International Labour Organization, ILOSTAT database and World Bank population estimates"
20562,"""""","International Labour Organization, Key Indicators of the Labour Market database"
20563,"""""","World Bank staff estimates using the World Bank's total population and age/sex distributions of the United Nations Population Division's World Population Prospects"
20564,"""""","World Bank staff estimates based on age/sex distributions of United Nations Population Division's World Population Prospects"
20565,"""""","UNESCO Institute for Statistics (Derived)"
20566,"""""","Derived from total population. Population source: (1) United Nations Population Division. World Population Prospects, (2) Census reports and other statistical publications from national statistical offices, (3) Eurostat: Demographic Statistics, (4) United Nations Statistical Division. Population and Vital Statistics Reprot (various years), (5) U.S. Census Bureau: International Database, and (6) Secretariat of the Pacific Community: Statistics and Demography Programme"
20567,"""""","(1) United Nations Population Division. World Population Prospects, (2) Census reports and other statistical publications from national statistical offices, (3) Eurostat: Demographic Statistics, (4) United Nations Statistical Division. Population and Vital Statistics Report (various years), (5) U.S. Census Bureau: International Database, and (6) Secretariat of the Pacific Community: Statistics and Demography Programme"
20598,"","Climate impacts (multiple sources)"
20622,"","KLEMS (2008)"
20624,"","world-regions-according-to-the-united-nations"
21250,"","Office for National Statistics, National Immunisation Management Service"
21251,"","Solar and wind projections"
21252,"","Disasters Severity"
21265,"","Federal Office of Public Health"
21268,"","GISAID, via CoVariants.org – Last updated 31 October 2022"
21271,"","Wikipedia (wikipedia.org/wiki/Biosafety_level)"
21272,"","NASA Center for Near-Earth Object Studies (2022)"
21277,"","Official data collated by Our World in Data"
21280,"","SO2 by fuel"
21284,"","country_air_pollution"
21304,"","CDC COVID-19 Response, Epidemiology Task Force"
21310,"","Minimum and average caloric requirements (UN FAO)"
21326,"","IPCC Scenarios (IIASA)"
21931,"","Correlates of War Project, Stockholm International Peace Research Institute, MeasuringWorth"
21943,"","United Nations High Commissioner for Refugees"
21945,"","COVID - Hong Kong vaccinations by age group & manufacturer"
21948,"","Ukraine-Russia (Global food based on UN FAO)"
21958,"","TEST JOE: All UCDP geolocated data"
21964,"","World Health Organization"
22593,"","John C. McCallum (2022)"
22597,"","COVID testing time series data (Vietnam exemplar)"
22612,"","COVID-19 - Vaccinations (debug)"
22709,"","data-wpp22-tmp(3)"
22715,"","Air pollution deaths by sector (Chowdhury et al. 2022)"
22722,"","JOE – compare WID and PIP inequality measures"
22723,"","Historical conflict deaths and casualties - OWID"
22730,"null","United Nations"
26701,"","Environmental impacts of food (Clark et al. 2022)"
26704,"","Air pollution emissions by fuel per capita (CEDS, 2022)"
26713,"null","Food and Agriculture Organization of the United Nations"
26714,"null","Food and Agriculture Organization of the United Nations"
26715,"null","Food and Agriculture Organization of the United Nations"
26716,"null","Food and Agriculture Organization of the United Nations"
26717,"null","Food and Agriculture Organization of the United Nations"
26718,"null","Food and Agriculture Organization of the United Nations"
26719,"null","Food and Agriculture Organization of the United Nations"
26720,"null","Food and Agriculture Organization of the United Nations"
26721,"null","Food and Agriculture Organization of the United Nations"
26722,"null","Food and Agriculture Organization of the United Nations"
26723,"null","Food and Agriculture Organization of the United Nations"
26724,"null","Food and Agriculture Organization of the United Nations"
26725,"null","Food and Agriculture Organization of the United Nations"
26726,"null","Food and Agriculture Organization of the United Nations"
26727,"null","Food and Agriculture Organization of the United Nations"
26728,"null","Food and Agriculture Organization of the United Nations"
26729,"null","Food and Agriculture Organization of the United Nations"
26730,"null","Food and Agriculture Organization of the United Nations"
26731,"null","Food and Agriculture Organization of the United Nations"
26732,"null","Food and Agriculture Organization of the United Nations"
26733,"null","Food and Agriculture Organization of the United Nations"
26734,"null","Food and Agriculture Organization of the United Nations"
26735,"null","Food and Agriculture Organization of the United Nations"
26736,"null","Food and Agriculture Organization of the United Nations"
26740,"null","United Nations, Department of Economic and Social Affairs, Population Division (2022)"
26742,"","test_of_show_breaks"
27077,"null","World Health Organisation"
27082,"null","World Health Organization (2020)"
27088,"null","United Nations - Population Division (2022)"
27097,"null","International Renewable Energy Agency (IRENA)"
27098,"","Our World in Data based on certified LCA reports; Poore and Nemecek (2018)"
27102,"","Income inequality (Gini coefficient) in the US - Luxembourg Income Study"
27108,"null","World Bank, Gender Statistics"
```