### PR TITLE
fix: use -l in cron so that nvm env variables are there

### DIFF
--- a/devTools/droplet/live.crontab
+++ b/devTools/droplet/live.crontab
@@ -1,7 +1,7 @@
 @daily chronic sh -c 'pm2 restart live-deploy-queue' | /usr/local/bin/slacktee -a danger -c errors -u crontab
-@daily chronic sh -c 'cd /home/owid/live && node itsJustJavascript/db/exportChartData.js && gzip -f /tmp/owid_chartdata.sql && s3cmd put -P /tmp/owid_chartdata.sql.gz s3://owid' | /usr/local/bin/slacktee -a danger -c errors -u crontab
-@daily chronic sh -c 'cd /home/owid/live && node itsJustJavascript/db/exportMetadata.js && gzip -f /tmp/owid_metadata.sql && s3cmd put -P /tmp/owid_metadata.sql.gz s3://owid' | /usr/local/bin/slacktee -a danger -c errors -u crontab
-0 19 * * 5 chronic sh -c 'cd /home/owid/live && node itsJustJavascript/baker/algolia/indexToAlgolia.js' | /usr/local/bin/slacktee -a danger -c errors -u crontab
-0 19 * * 5 chronic sh -c 'cd /home/owid/live && node itsJustJavascript/baker/algolia/indexChartsToAlgolia.js' | /usr/local/bin/slacktee -a danger -c errors -u crontab
+@daily chronic bash -lc 'cd /home/owid/live && node itsJustJavascript/db/exportChartData.js && gzip -f /tmp/owid_chartdata.sql && s3cmd put -P /tmp/owid_chartdata.sql.gz s3://owid' | /usr/local/bin/slacktee -a danger -c errors -u crontab
+@daily chronic bash -lc 'cd /home/owid/live && node itsJustJavascript/db/exportMetadata.js && gzip -f /tmp/owid_metadata.sql && s3cmd put -P /tmp/owid_metadata.sql.gz s3://owid' | /usr/local/bin/slacktee -a danger -c errors -u crontab
+0 19 * * 5 chronic bash -lc 'cd /home/owid/live && node itsJustJavascript/baker/algolia/indexToAlgolia.js' | /usr/local/bin/slacktee -a danger -c errors -u crontab
+0 19 * * 5 chronic bash -lc 'cd /home/owid/live && node itsJustJavascript/baker/algolia/indexChartsToAlgolia.js' | /usr/local/bin/slacktee -a danger -c errors -u crontab
 0 * * * * chronic sh -c 'cd /home/owid/covid-19-data/scripts && ./scripts/autoupdate.sh' 2>&1 | /usr/local/bin/slacktee --attachment danger --channel corona-data-updates
 10,20,30,40,50 * * * * bash /home/owid/covid-19-data/scripts/scripts/grapherupdate.sh


### PR DESCRIPTION
This is to address a problem on `live` where after upgrade to 20.04 calls to `node` no longer worked from `cron`.
