### PR TITLE
Fix missing URLs in Explorer grapher configs

### DIFF
--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -30,6 +30,8 @@ import {
     BLOG_POSTS_PER_PAGE,
 } from "../settings/serverSettings.js"
 import {
+    ADMIN_BASE_URL,
+    BAKED_GRAPHER_URL,
     BAKED_GRAPHER_EXPORTS_BASE_URL,
     RECAPTCHA_SITE_KEY,
 } from "../settings/clientSettings.js"
@@ -546,6 +548,8 @@ export const renderExplorerPage = async (
         const config: GrapherProgrammaticInterface = JSON.parse(row.config)
         config.id = row.id // Ensure each grapher has an id
         config.manuallyProvideData = true
+        config.adminBaseUrl = ADMIN_BASE_URL
+        config.bakedGrapherURL = BAKED_GRAPHER_URL
         return new Grapher(config).toObject()
     })
 

--- a/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
@@ -185,4 +185,6 @@ export const grapherKeysToSerialize = [
     "relatedQuestions",
     "topicIds",
     "details",
+    "adminBaseUrl",
+    "bakedGrapherURL",
 ]

--- a/site/multiembedder/MultiEmbedder.tsx
+++ b/site/multiembedder/MultiEmbedder.tsx
@@ -14,6 +14,7 @@ import {
     deserializeJSONFromHTML,
     fetchText,
     getWindowUrl,
+    isArray,
     isMobile,
     isPresent,
     Url,
@@ -148,13 +149,21 @@ class MultiEmbedder {
         const html = await fetchText(fullUrl)
 
         if (isExplorer) {
+            let grapherConfigs = deserializeJSONFromHTML(
+                html,
+                EMBEDDED_EXPLORER_GRAPHER_CONFIGS
+            )
+            if (grapherConfigs && isArray(grapherConfigs)) {
+                grapherConfigs = grapherConfigs.map((grapherConfig) => ({
+                    ...grapherConfig,
+                    adminBaseUrl: ADMIN_BASE_URL,
+                    bakedGrapherURL: BAKED_GRAPHER_URL,
+                }))
+            }
             const props: ExplorerProps = {
                 ...common,
                 ...deserializeJSONFromHTML(html, EMBEDDED_EXPLORER_DELIMITER),
-                grapherConfigs: deserializeJSONFromHTML(
-                    html,
-                    EMBEDDED_EXPLORER_GRAPHER_CONFIGS
-                ),
+                grapherConfigs,
                 queryStr,
                 selection: new SelectionArray(
                     this.selection.selectedEntityNames

--- a/site/multiembedder/MultiEmbedder.tsx
+++ b/site/multiembedder/MultiEmbedder.tsx
@@ -153,7 +153,7 @@ class MultiEmbedder {
                 html,
                 EMBEDDED_EXPLORER_GRAPHER_CONFIGS
             )
-            if (grapherConfigs && isArray(grapherConfigs)) {
+            if (isArray(grapherConfigs)) {
                 grapherConfigs = grapherConfigs.map((grapherConfig) => ({
                     ...grapherConfig,
                     adminBaseUrl: ADMIN_BASE_URL,


### PR DESCRIPTION
Two things broke when we stopped baking the site URLs into Grapher's code directly:
- Explorers weren't injecting the URLs correctly into their Graphers
- These values weren't being exported by Graphers' `toObject` method

This fixes that.

[Staging preview](https://ptolemy-owid.netlify.app/explorers/co2)