### PR TITLE
Scope Grapher CSS

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/EntitySelectorModal.scss
+++ b/packages/@ourworldindata/grapher/src/controls/EntitySelectorModal.scss
@@ -1,5 +1,11 @@
 $zindex-EntitySelector: 30;
 
+&.GrapherPortraitClass .EntitySelectorMulti {
+    .selectedData {
+        min-width: 50%;
+    }
+}
+
 .entitySelectorOverlay {
     position: absolute;
     top: 0;
@@ -121,11 +127,5 @@ $zindex-EntitySelector: 30;
         &:hover {
             color: $controls-color;
         }
-    }
-}
-
-.GrapherComponent.GrapherPortraitClass .EntitySelectorMulti {
-    .selectedData {
-        min-width: 50%;
     }
 }

--- a/packages/@ourworldindata/grapher/src/controls/ShareMenu.scss
+++ b/packages/@ourworldindata/grapher/src/controls/ShareMenu.scss
@@ -2,6 +2,10 @@ $zindex-ControlsFooterMenu: 3;
 $zindex-ControlsFooter: 2;
 $zindex-embedMenu: 12;
 
+&.mobile .ShareMenu .btn-embed {
+    display: none;
+}
+
 .ShareMenu {
     position: absolute;
     right: 1em;
@@ -80,8 +84,4 @@ $zindex-embedMenu: 12;
 .embedMenu textarea {
     width: 100%;
     height: 80%;
-}
-
-.GrapherComponent.mobile .ShareMenu .btn-embed {
-    display: none;
 }

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -30,7 +30,6 @@ $zindex-Tooltip: 20;
 // if you want to write a rule that requires .GrapherComponent to have a second class.
 // e.g. &.narrow is equivalent to .GrapherComponent.narrow
 .GrapherComponent {
-    @import "../controls/entityPicker/EntityPicker.scss";
     @import "../controls/globalEntitySelector/GlobalEntitySelector.scss";
     @import "../controls/CommandPalette.scss";
     @import "../controls/ScaleSelector.scss";
@@ -47,11 +46,15 @@ $zindex-Tooltip: 20;
     @import "../dataTable/DataTable.scss";
     @import "../sourcesTab/SourcesTab.scss";
     @import "../mapCharts/MapTooltip.scss";
-    @import "../sparkBars/SparkBars.scss";
     @import "../loadingIndicator/LoadingIndicator.scss";
     @import "../text/MarkdownTextWrap.scss";
     @import "../detailsOnDemand/detailsOnDemand.scss";
 }
+
+// These rules are currently used elsewhere in the site. e.g. Explorers
+// so we can't scope them to be grapher-only
+@import "../controls/entityPicker/EntityPicker.scss";
+@import "../sparkBars/SparkBars.scss";
 
 .GrapherComponent,
 .GrapherComponent p,

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -24,27 +24,34 @@ $zindex-tab: 1;
 $zindex-global-entity-select: 11;
 $zindex-Tooltip: 20;
 
-@import "../controls/entityPicker/EntityPicker.scss";
-@import "../controls/globalEntitySelector/GlobalEntitySelector.scss";
-@import "../controls/CommandPalette.scss";
-@import "../controls/ScaleSelector.scss";
-@import "../controls/Controls.scss";
-@import "../timeline/TimelineComponent.scss";
-@import "../controls/ShareMenu.scss";
-@import "../noDataModal/NoDataModal.scss";
-@import "../controls/CollapsibleList/CollapsibleList.scss";
-@import "../controls/ControlsRow.scss";
-@import "../captionedChart/CaptionedChart.scss";
-@import "../controls/EntitySelectorModal.scss";
-@import "../controls/AddEntityButton.scss";
-@import "../downloadTab/DownloadTab.scss";
-@import "../dataTable/DataTable.scss";
-@import "../sourcesTab/SourcesTab.scss";
-@import "../mapCharts/MapTooltip.scss";
-@import "../sparkBars/SparkBars.scss";
-@import "../loadingIndicator/LoadingIndicator.scss";
-@import "../text/MarkdownTextWrap.scss";
-@import "../detailsOnDemand/detailsOnDemand.scss";
+// All styles are scoped to GrapherComponent only, to prevent rule leaking
+// and low-specificity rules from the site CSS trumping these ones.
+// You can use sass's "&" syntax at the top level of one of these files
+// if you want to write a rule that requires .GrapherComponent to have a second class.
+// e.g. &.narrow is equivalent to .GrapherComponent.narrow
+.GrapherComponent {
+    @import "../controls/entityPicker/EntityPicker.scss";
+    @import "../controls/globalEntitySelector/GlobalEntitySelector.scss";
+    @import "../controls/CommandPalette.scss";
+    @import "../controls/ScaleSelector.scss";
+    @import "../controls/Controls.scss";
+    @import "../timeline/TimelineComponent.scss";
+    @import "../controls/ShareMenu.scss";
+    @import "../noDataModal/NoDataModal.scss";
+    @import "../controls/CollapsibleList/CollapsibleList.scss";
+    @import "../controls/ControlsRow.scss";
+    @import "../captionedChart/CaptionedChart.scss";
+    @import "../controls/EntitySelectorModal.scss";
+    @import "../controls/AddEntityButton.scss";
+    @import "../downloadTab/DownloadTab.scss";
+    @import "../dataTable/DataTable.scss";
+    @import "../sourcesTab/SourcesTab.scss";
+    @import "../mapCharts/MapTooltip.scss";
+    @import "../sparkBars/SparkBars.scss";
+    @import "../loadingIndicator/LoadingIndicator.scss";
+    @import "../text/MarkdownTextWrap.scss";
+    @import "../detailsOnDemand/detailsOnDemand.scss";
+}
 
 .GrapherComponent,
 .GrapherComponent p,

--- a/packages/@ourworldindata/grapher/src/sourcesTab/SourcesTab.scss
+++ b/packages/@ourworldindata/grapher/src/sourcesTab/SourcesTab.scss
@@ -1,3 +1,7 @@
+&.narrow .datasource-wrapper {
+    padding: 0;
+}
+
 .sourcesTab,
 .DownloadTab {
     padding: 1rem;
@@ -59,8 +63,4 @@
 }
 .datasource-additional p {
     margin-top: 0.3em;
-}
-
-.GrapherComponent.narrow .datasource-wrapper {
-    padding: 0;
 }

--- a/packages/@ourworldindata/grapher/src/text/MarkdownTextWrap.scss
+++ b/packages/@ourworldindata/grapher/src/text/MarkdownTextWrap.scss
@@ -2,7 +2,7 @@
     display: block;
 }
 
-.GrapherComponent .markdown-text-wrap {
+.markdown-text-wrap {
     a,
     a:visited {
         color: #666;

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -119,7 +119,7 @@
     background-color: #fff;
 }
 
-.owidArticle .title {
+.owidArticle > .title {
     margin: 0;
     line-height: 48px;
     font-size: 40px;
@@ -130,7 +130,7 @@
     text-align: center;
 }
 
-.owidArticle .subtitle {
+.owidArticle > .subtitle {
     margin: 0;
     margin-bottom: 0.5em;
     line-height: 32px;


### PR DESCRIPTION
The Lerna branch changed the order in which some SCSS files had to be imported. 

This meant that in a few places, low-specificity Grapher rules were being trumped by the low-specificity site-wide rules because they were declared later.

e.g.
```css
// before
.article h2 {
  margin-bottom: 32px
}

.grapher-header h2 {
  margin-bottom:  0;
}
```

```css
// after
.grapher-header h2 {
  margin-bottom:  0;
}

.article h2 {
  margin-bottom: 32px
}
```

This PR nests all Grapher CSS in a top-level `.GrapherComponent` selector, which increases all rules' specificity to at least `0-2-1`, which seems to be sufficient to trump generic site rules. 

It also prevents any Grapher CSS rules from leaking out to the rest of the site.

[Staging preview](https://ptolemy-owid.netlify.app/grapher/global-pasture?country=~OWID_WRL)

Things to check
- [x] Standalone Grapher pages, each tab and modal
- [x] Explorers
- [x] Articles with embedded Graphers
- [x] Pages with embedded Graphers