### PR TITLE
Remote dev

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,13 @@
             "type": "pwa-node"
         },
         {
+            "name": "Remote dev",
+            "program": "${workspaceFolder}/itsJustJavascript/adminSiteServer/app.js",
+            "request": "launch",
+            "preLaunchTask": "start (remote)",
+            "type": "node"
+        },
+        {
             "name": "Build content graph",
             "program": "${workspaceFolder}/itsJustJavascript/db/contentGraph.js",
             "request": "launch",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,9 +10,32 @@
             }
         },
         {
+            "label": "startLernaWatcher",
+            "type": "shell",
+            "command": "yarn startLernaWatcher",
+            "problemMatcher": {
+                "pattern": {
+                    "regexp": "Error: Command failed",
+                    "kind": "file",
+                    "message": 0,
+                    "file": 1
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "watching packages",
+                    "endsPattern": "watching packages"
+                }
+            },
+            "isBackground": true,
+            "presentation": {
+                "group": "watch2",
+                "reveal": "silent"
+            }
+        },
+        {
             "label": "startTscServer",
             "type": "shell",
-            "command": "yarn startTscServer",
+            "command": "source ~/.bashrc;yarn startTscServer",
             "problemMatcher": ["$tsc-watch"],
             "isBackground": true,
             "presentation": {
@@ -22,7 +45,7 @@
         {
             "label": "startSiteFront",
             "type": "shell",
-            "command": "yarn startSiteFront",
+            "command": "yarn startSiteFront --no-web-socket-server", // WS need to be somewhat proxied in nginx. This could be done later.
             "isBackground": true,
             "presentation": {
                 "group": "watch"
@@ -40,6 +63,16 @@
                     "endsPattern": "webpack [\\S]+ compiled"
                 }
             }
+        },
+        {
+            "label": "start (remote)",
+            "dependsOn": [
+                "startTscServer",
+                "startSiteFront",
+                "startLernaWatcher"
+            ],
+            "dependsOrder": "sequence",
+            "problemMatcher": []
         },
         {
             "label": "start (full)",

--- a/devTools/droplet/refresh-staging-db.sh
+++ b/devTools/droplet/refresh-staging-db.sh
@@ -36,7 +36,8 @@ gr_mysql() {
   mysql -u${GRAPHER_DB_USER} -p"${GRAPHER_DB_PASS}" -h $GRAPHER_DB_HOST --default-character-set=utf8mb4 "$@" 2>/dev/null
 }
 
-DL_FOLDER="/tmp"
+DL_FOLDER="/tmp/$(whoami)"
+mkdir -p $DL_FOLDER
 
 # Default options
 WITH_UPLOADS=false


### PR DESCRIPTION
This allows for development to happen remotely on staging, using VSCode remote extensions.

The initial staging server setup is slightly different (different UNIX user, doesn't add a pm2 app for the admin). 

The refresh script has also been slightly altered to cater for this different UNIX user and avoid permission issues on downloaded DB dumps in /tmp.