### PR TITLE
chore: improve "make deploy" and "make stage" with nx reset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,7 @@ deploy:
 	yarn buildAndDeploySite live
 
 stage:
+	@echo '==> Preparing to deploy to $(STAGING)'
 	@echo '==> Starting from a clean slate...'
 	rm -rf itsJustJavascript
 	
@@ -246,7 +247,7 @@ stage:
 	yarn nx reset
 	yarn run tsc -b
 	
-	@echo '==> Deploying to staging...'
+	@echo '==> Deploying to $(STAGING)...'
 	yarn buildAndDeploySite $(STAGING)
 
 test: 

--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,8 @@ deploy:
 	@echo '==> Building...'
 	yarn
 	yarn nx reset
+	yarn lerna bootstrap
+	yarn lerna run build
 	yarn run tsc -b
 	
 	@echo '==> Deploying...'
@@ -245,6 +247,8 @@ stage:
 	@echo '==> Building...'
 	yarn
 	yarn nx reset
+	yarn lerna bootstrap
+	yarn lerna run build
 	yarn run tsc -b
 	
 	@echo '==> Deploying to $(STAGING)...'

--- a/Makefile
+++ b/Makefile
@@ -227,11 +227,11 @@ wordpress/web/app/uploads/2022:
 
 deploy:
 	@echo '==> Starting from a clean slate...'
-	yarn nx reset
 	rm -rf itsJustJavascript
 	
 	@echo '==> Building...'
 	yarn
+	yarn nx reset
 	yarn run tsc -b
 	
 	@echo '==> Deploying...'
@@ -239,11 +239,11 @@ deploy:
 
 stage:
 	@echo '==> Starting from a clean slate...'
-	yarn nx reset
 	rm -rf itsJustJavascript
 	
 	@echo '==> Building...'
 	yarn
+	yarn nx reset
 	yarn run tsc -b
 	
 	@echo '==> Deploying to staging...'

--- a/Makefile
+++ b/Makefile
@@ -231,6 +231,8 @@ deploy:
 	
 	@echo '==> Building...'
 	yarn
+	yarn lerna bootstrap
+	yarn lerna run build
 	yarn run tsc -b
 	
 	@echo '==> Deploying...'
@@ -243,6 +245,8 @@ stage:
 	
 	@echo '==> Building...'
 	yarn
+	yarn lerna bootstrap
+	yarn lerna run build
 	yarn run tsc -b
 	
 	@echo '==> Deploying to $(STAGING)...'

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@
 # https://unix.stackexchange.com/questions/352316/finding-out-the-default-shell-of-a-user-within-a-shell-script
 LOGIN_SHELL = $(shell finger $(USER) | grep 'Shell:*' | cut -f3 -d ":")
 
+# what is the staging environment we should use
+STAGING ?= staging
+
 # setting .env variables as Make variables for validate.env targets
 # https://lithic.tech/blog/2020-05/makefile-dot-env/
 ifneq (,$(wildcard ./.env))
@@ -224,6 +227,7 @@ wordpress/web/app/uploads/2022:
 
 deploy:
 	@echo '==> Starting from a clean slate...'
+	yarn nx reset
 	rm -rf itsJustJavascript
 	
 	@echo '==> Building...'
@@ -235,6 +239,7 @@ deploy:
 
 stage:
 	@echo '==> Starting from a clean slate...'
+	yarn nx reset
 	rm -rf itsJustJavascript
 	
 	@echo '==> Building...'
@@ -242,7 +247,7 @@ stage:
 	yarn run tsc -b
 	
 	@echo '==> Deploying to staging...'
-	yarn buildAndDeploySite staging
+	yarn buildAndDeploySite $(STAGING)
 
 test: 
 	@echo '==> Linting'

--- a/Makefile
+++ b/Makefile
@@ -231,9 +231,6 @@ deploy:
 	
 	@echo '==> Building...'
 	yarn
-	yarn nx reset
-	yarn lerna bootstrap
-	yarn lerna run build
 	yarn run tsc -b
 	
 	@echo '==> Deploying...'
@@ -246,9 +243,6 @@ stage:
 	
 	@echo '==> Building...'
 	yarn
-	yarn nx reset
-	yarn lerna bootstrap
-	yarn lerna run build
 	yarn run tsc -b
 	
 	@echo '==> Deploying to $(STAGING)...'

--- a/baker/Deployer.ts
+++ b/baker/Deployer.ts
@@ -221,6 +221,8 @@ yarn testPrettierAll`
             createDatasetSoftlinks: `mkdir -p ${finalDataDir}/datasetsExport && ln -sf ${finalDataDir}/datasetsExport ${rsyncTargetDirTmp}/datasetsExport`,
             createSettingsSoftlinks: `ln -sf ${finalDataDir}/.env ${rsyncTargetDirTmp}/.env`,
             yarn: `cd ${rsyncTargetDirTmp} && yarn install --production --frozen-lockfile`,
+            lernaBootstrap: `cd ${rsyncTargetDirTmp} && yarn lerna bootstrap`,
+            lernaBuild: `cd ${rsyncTargetDirTmp} && yarn lerna run build`,
             webpack: `cd ${rsyncTargetDirTmp} && yarn buildWebpack`,
             migrateDb: `cd ${rsyncTargetDirTmp} && yarn runDbMigrations`,
             algolia: `cd ${rsyncTargetDirTmp} && node --unhandled-rejections=strict itsJustJavascript/baker/algolia/configureAlgolia.js`,


### PR DESCRIPTION
This change aims to avoid accidental carry-over state from Lerna if you switched branch before deploy, by doing `yarn nx reset` before deploy or stage.

It also enhances the `make stage` command. Previously, you could only target the `staging` server, but now you can run `STAGING=myserver make stage` to target a different one.

## Testing

- [ ] Works on a local built environment
- [ ] Works on a fresh clone of the repo
