### PR TITLE
Google doc formatting fixes

### DIFF
--- a/db/gdocToArchieml.ts
+++ b/db/gdocToArchieml.ts
@@ -41,7 +41,14 @@ export const gdocToArchieML = async ({
         val: string,
         i: number
     ) {
-        text = text.replace(val, `<ref id="${i}" />`)
+        text = text.replace(
+            val,
+            `<a class="ref" id="ref-${i + 1}" href="#note-${i + 1}">
+                <sup>
+                ${i + 1}
+                </sup>
+            </a>`
+        )
         return val.replace(/\{\/?ref\}/g, "")
     })
 

--- a/db/gdocToArchieml.ts
+++ b/db/gdocToArchieml.ts
@@ -41,14 +41,7 @@ export const gdocToArchieML = async ({
         val: string,
         i: number
     ) {
-        text = text.replace(
-            val,
-            `<a class="ref" id="ref-${i + 1}" href="#note-${i + 1}">
-                <sup>
-                ${i + 1}
-                </sup>
-            </a>`
-        )
+        text = text.replace(val, `<ref id="note-${i + 1}" />`)
         return val.replace(/\{\/?ref\}/g, "")
     })
 

--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -81,6 +81,10 @@ export default function ArticleBlock({ d }: { d: OwidArticleBlock }) {
         if (d.value.trim() === "") {
             return null
         }
+        const makeRef = (index: string) => `
+            <a class="ref" id="ref-${index}" href="#note-${index}">
+                <sup>${index}</sup>
+            </a>`
         return (
             <div
                 dangerouslySetInnerHTML={{
@@ -88,7 +92,13 @@ export default function ArticleBlock({ d }: { d: OwidArticleBlock }) {
                         d.value.startsWith("<div") ||
                         d.value.trim() === "<hr />"
                             ? d.value.replace(/\\:/g, ":")
-                            : `<p>${d.value.replace(/\\:/g, ":")}</p>`,
+                            : `<p>${d.value
+                                  .replace(/\\:/g, ":")
+                                  .replace(
+                                      /<ref id="note-(\d+) \/>"/g,
+                                      (_: string, index: string) =>
+                                          makeRef(index)
+                                  )}</p>`,
                 }}
             />
         )

--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -93,7 +93,7 @@ export default function ArticleBlock({ d }: { d: OwidArticleBlock }) {
                             : `<p>${d.value
                                   .replace(/\\:/g, ":")
                                   .replace(
-                                      /<ref id="note-(\d+) \/>"/g,
+                                      /<ref id="note-(\d+)" \/>/g,
                                       (_: string, index: string) =>
                                           makeRef(index)
                                   )}</p>`,

--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -81,10 +81,8 @@ export default function ArticleBlock({ d }: { d: OwidArticleBlock }) {
         if (d.value.trim() === "") {
             return null
         }
-        const makeRef = (index: string) => `
-            <a class="ref" id="ref-${index}" href="#note-${index}">
-                <sup>${index}</sup>
-            </a>`
+        const makeRef = (index: string) =>
+            `<a class="ref" id="ref-${index}" href="#note-${index}"><sup>${index}</sup></a>`
         return (
             <div
                 dangerouslySetInnerHTML={{

--- a/site/gdocs/Footnotes.tsx
+++ b/site/gdocs/Footnotes.tsx
@@ -12,6 +12,7 @@ export default function Footnotes({ d }: any) {
                     return (
                         <li
                             key={i}
+                            id={`note-${i + 1}`}
                             className={"footnote"}
                             dangerouslySetInnerHTML={{
                                 __html: footnote.replace(/\n+/g, "<br/><br/>"),

--- a/site/gdocs/List.tsx
+++ b/site/gdocs/List.tsx
@@ -5,7 +5,9 @@ export default function List({ d }: { d: OwidArticleBlock }) {
     return (
         <ul className={"list"}>
             {d.value.map((_d: string, i: number) => {
-                return <li key={i}>{_d}</li>
+                return (
+                    <li key={i} dangerouslySetInnerHTML={{ __html: _d }}></li>
+                )
             })}
         </ul>
     )

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -88,6 +88,10 @@
     font-weight: 700;
 }
 
+.owidArticle > ul {
+    margin-bottom: 32px;
+}
+
 .owidArticle .articlePage {
     position: relative;
     top: -150px;

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -180,7 +180,6 @@
     position: sticky;
     top: 0;
     align-self: start;
-    height: 100vh;
     display: flex;
     flex-direction: column;
     justify-content: center;


### PR DESCRIPTION
Fixes:
- Inline footnotes
- Bold in lists
- `.fixedSectionGraphic` height

[Staging preview](https://ptolemy.owid.cloud/admin/gdocs/1clAEly4t6MihroNdKxPFbYO5xhbO_UZFJhGmOf0xjsw/preview)