### PR TITLE
refactor(grapher): remove automatic source name shortening

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1398,30 +1398,9 @@ export class Grapher
     }
 
     @computed private get defaultSourcesLine(): string {
-        let sourceNames = this.columnsWithSources.map(
+        const sourceNames = this.columnsWithSources.map(
             (column) => column.source.name ?? ""
         )
-
-        // Shorten automatic source names for certain major sources: todo: this sort of thing we could do in a smarter editor, and not at runtime
-        sourceNames = sourceNames.map((sourceName) => {
-            for (const majorSource of [
-                "World Bank – WDI",
-                "World Bank",
-                "ILOSTAT",
-            ]) {
-                if (
-                    sourceName.startsWith(majorSource) &&
-                    !sourceName.match(
-                        new RegExp(
-                            "^" + majorSource + "\\s+(based on|and)",
-                            "gi"
-                        )
-                    )
-                )
-                    return majorSource
-            }
-            return sourceName
-        })
 
         return uniq(sourceNames).join(", ")
     }


### PR DESCRIPTION
Source name that gets displayed in the footer was automatically shortened from `World Bank*` to `World Bank`. Figuring that this is happening gave us a lot of headache. This shouldn't be implicit, but should be either given as an explicit footer or long source name should be moved to source description.

I've already manually updated footer of all affected charts (~60 charts).