### PR TITLE
1761-sdg-heading-supertitle

### DIFF
--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -33,6 +33,7 @@ export {
     GitCommit,
     SerializedGridProgram,
     TocHeading,
+    TocHeadingWithTitleSupertitle,
     GdocsContentSource,
     OwidArticleTypeJSON,
     OwidArticleTypePublished,

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -147,6 +147,11 @@ export interface TocHeading {
     isSubheading: boolean
 }
 
+export interface TocHeadingWithTitleSupertitle extends TocHeading {
+    title: string
+    supertitle?: string
+}
+
 // todo; remove
 export interface PostRow {
     id: number
@@ -429,7 +434,7 @@ export interface OwidArticleContent {
     byline?: string | string[]
     dateline?: string
     excerpt?: string
-    toc?: TocHeading[]
+    toc?: TocHeadingWithTitleSupertitle[]
     refs?: OwidArticleBlock[]
     summary?: OwidArticleBlock[]
     citation?: OwidArticleBlock[]

--- a/site/css/variables.scss
+++ b/site/css/variables.scss
@@ -38,6 +38,7 @@ $grapher-height: 575px;
 
 $article-cover-height: 224px;
 $article-page-top-offset: 88px;
+$fixed-section-margin-bottom: 32px;
 /***************************
 
 ****************************************************

--- a/site/css/variables.scss
+++ b/site/css/variables.scss
@@ -38,7 +38,6 @@ $grapher-height: 575px;
 
 $article-cover-height: 224px;
 $article-page-top-offset: 88px;
-$fixed-section-margin-bottom: 32px;
 /***************************
 
 ****************************************************

--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -8,7 +8,10 @@ import FixedGraphic from "./FixedGraphic"
 import Recirc from "./Recirc"
 import List from "./List"
 import Image from "./Image"
-import { OwidArticleBlock, TocHeading } from "@ourworldindata/utils"
+import {
+    OwidArticleBlock,
+    TocHeadingWithTitleSupertitle,
+} from "@ourworldindata/utils"
 import SDGGrid from "./SDGGrid.js"
 import { BlockErrorBoundary } from "./BlockErrorBoundary"
 import SDGTableOfContents from "./SDGTableOfContents.js"
@@ -18,7 +21,7 @@ export default function ArticleBlock({
     toc,
 }: {
     d: OwidArticleBlock
-    toc?: TocHeading[]
+    toc?: TocHeadingWithTitleSupertitle[]
 }) {
     const handleArchie = (d: OwidArticleBlock, key: string) => {
         const _type = d.type.toLowerCase()

--- a/site/gdocs/ArticleBlocks.tsx
+++ b/site/gdocs/ArticleBlocks.tsx
@@ -1,13 +1,16 @@
 import React from "react"
 import ArticleBlock from "./ArticleBlock.js"
-import { OwidArticleBlock, TocHeading } from "@ourworldindata/utils"
+import {
+    OwidArticleBlock,
+    TocHeadingWithTitleSupertitle,
+} from "@ourworldindata/utils"
 
 export const ArticleBlocks = ({
     blocks,
     toc,
 }: {
     blocks: OwidArticleBlock[]
-    toc?: TocHeading[]
+    toc?: TocHeadingWithTitleSupertitle[]
 }) => (
     <>
         {blocks.map((block: OwidArticleBlock, i: number) => {

--- a/site/gdocs/OwidArticle.tsx
+++ b/site/gdocs/OwidArticle.tsx
@@ -26,7 +26,7 @@ export function OwidArticle(props: OwidArticleType) {
             <div className={"articleCover"} style={coverStyle}></div>
             <div className={"articlePage"}></div>
             <h1 className={"title"}>{content.title}</h1>
-            <h2 className={"subtitle"}>{content.subtitle}</h2>
+            <div className={"subtitle"}>{content.subtitle}</div>
             <div className={"bylineContainer"}>
                 <div>
                     By: <div className={"byline"}>{content.byline}</div>

--- a/site/gdocs/SDGTableOfContents.tsx
+++ b/site/gdocs/SDGTableOfContents.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { TocHeading } from "@ourworldindata/utils"
+import { TocHeadingWithTitleSupertitle } from "@ourworldindata/utils"
 import { faArrowDown } from "@fortawesome/free-solid-svg-icons/faArrowDown"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus"
@@ -7,28 +7,19 @@ import { faMinus } from "@fortawesome/free-solid-svg-icons/faMinus"
 import classNames from "classnames"
 import AnimateHeight from "react-animate-height"
 
-const VERTICAL_TAB_CHAR = "\u000b"
-
 // See ARIA roles: https://w3c.github.io/aria-practices/examples/menu-button/menu-button-links.html
 
-export default function SDGTableOfContents({ toc }: { toc: TocHeading[] }) {
+export default function SDGTableOfContents({
+    toc,
+}: {
+    toc: TocHeadingWithTitleSupertitle[]
+}) {
     const [height, setHeight] = useState<"auto" | 0>(0)
     const [isOpen, setIsOpen] = useState(false)
 
     const toggleIsOpen = () => {
         setHeight(height === 0 ? "auto" : 0)
     }
-
-    const tocHeadingsWithSupertitle = toc.map((heading) => {
-        const [beforeSeparator, afterSeparator] =
-            heading.text.split(VERTICAL_TAB_CHAR)
-
-        return {
-            ...heading,
-            supertitle: afterSeparator ? beforeSeparator : undefined,
-            title: afterSeparator || beforeSeparator,
-        }
-    })
 
     return (
         <nav
@@ -68,7 +59,7 @@ export default function SDGTableOfContents({ toc }: { toc: TocHeading[] }) {
                     role="menu"
                     aria-labelledby="sdg-toc-menu-button"
                 >
-                    {tocHeadingsWithSupertitle.map(
+                    {toc.map(
                         (
                             { title, supertitle, isSubheading, slug },
                             i: number

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -30,6 +30,40 @@
     z-index: 1;
 }
 
+.owidArticle h2:not(.subtitle),
+.owidArticle h3 {
+    text-align: center;
+    .supertitle {
+        @include overline-black-caps;
+        display: block;
+        margin-bottom: 8px;
+        color: $blue-50;
+    }
+}
+
+.owidArticle h2:not(.subtitle) {
+    // Probably better to refactor the subtitle to not use an <h2>.
+    @include h1-semibold;
+    margin-top: 48px;
+    margin-bottom: 24px;
+    padding-top: 48px;
+    border-top: 1px solid $blue-20; // this border doesn't go all the way to the edge.
+}
+
+// HACK: reusing the bottom border of preceeding fixedSections, and reducing the
+// top margin of h2 to visually get the desired 48px between the border and the h2.
+.owidArticle > .fixedSection + div > h2 {
+    margin-top: #{48px - $fixed-section-margin-bottom}; // making the hack visible
+    border: none;
+    padding-top: 0;
+}
+
+.owidArticle h3 {
+    @include h2-bold;
+    margin-top: 64px;
+    margin-bottom: 32px;
+}
+
 .owidArticle > figure {
     grid-row: auto;
     grid-column: 4 / span 8;
@@ -163,7 +197,7 @@
     grid-column: 2 / -2;
     border-bottom: solid 1px #dbe5f0;
     padding-bottom: 32px;
-    margin-bottom: 32px;
+    margin-bottom: $fixed-section-margin-bottom;
 }
 
 .owidArticle .fixedSection .fixedSectionContent {

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -30,7 +30,7 @@
     z-index: 1;
 }
 
-.owidArticle h2:not(.subtitle),
+.owidArticle h2,
 .owidArticle h3 {
     text-align: center;
     .supertitle {
@@ -41,8 +41,7 @@
     }
 }
 
-.owidArticle h2:not(.subtitle) {
-    // Probably better to refactor the subtitle to not use an <h2>.
+.owidArticle h2 {
     @include h1-semibold;
     margin-top: 48px;
     margin-bottom: 24px;

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -49,14 +49,6 @@
     border-top: 1px solid $blue-20; // this border doesn't go all the way to the edge.
 }
 
-// HACK: reusing the bottom border of preceeding fixedSections, and reducing the
-// top margin of h2 to visually get the desired 48px between the border and the h2.
-.owidArticle > .fixedSection + div > h2 {
-    margin-top: #{48px - $fixed-section-margin-bottom}; // making the hack visible
-    border: none;
-    padding-top: 0;
-}
-
 .owidArticle h3 {
     @include h2-bold;
     margin-top: 64px;
@@ -194,14 +186,16 @@
     @include grid(12);
     grid-template-rows: auto;
     grid-column: 2 / -2;
-    border-bottom: solid 1px #dbe5f0;
-    padding-bottom: 32px;
-    margin-bottom: $fixed-section-margin-bottom;
+    margin-bottom: 32px;
 }
 
 .owidArticle .fixedSection .fixedSectionContent {
     grid-row: 1 / auto;
     grid-column: 1 / span 6;
+
+    h3 {
+        text-align: left;
+    }
 }
 .owidArticle .fixedSection .fixedSectionGraphic {
     grid-row: 1 / auto;


### PR DESCRIPTION
closes #1761 

Relies on #1733's vertical tab character for separating the heading from its supertitle, without creating ArchieML overhead for authors.
 
Test document: https://docs.google.com/document/d/1iLmMolntBXj1lhsApKI8FuLW7795DGB6t5e_iwdeeyk/edit

Known issues:
- the first heading below the table of contents shouldn't show a separation line. This will be possible when #1729 is merged and removes wrapping `<div>s` and allowing for the use of `:first-of-type` selectors.
- the separation line above headings is only as wide as the content column for now. Will re-evaluate feasibility once #1729 is merged.

<img width="856" alt="Screenshot 2022-11-29 at 15 12 06" src="https://user-images.githubusercontent.com/13406362/204554656-0afb8ad4-bd82-438f-8e48-5b4ee8d8cbc1.png">

