### PR TITLE
feat(gdocs): add support for page supertitle

### DIFF
--- a/adminSiteClient/gdocsDeploy.ts
+++ b/adminSiteClient/gdocsDeploy.ts
@@ -30,6 +30,7 @@ export const checkIsLightningUpdate = (
     const lightningContentProps: Array<keyof OwidArticleContent> = [
         "body",
         "subtitle",
+        "supertitle",
         "refs",
         "summary",
         "citation",

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -429,6 +429,7 @@ export interface OwidArticleTypePublished extends OwidArticleType {
 export interface OwidArticleContent {
     body?: OwidArticleBlock[]
     title?: string
+    supertitle?: string
     subtitle?: string
     template?: string
     byline?: string | string[]

--- a/site/gdocs/OwidArticle.tsx
+++ b/site/gdocs/OwidArticle.tsx
@@ -25,8 +25,11 @@ export function OwidArticle(props: OwidArticleType) {
         <article className={"owidArticle"}>
             <div className={"articleCover"} style={coverStyle}></div>
             <div className={"articlePage"}></div>
-            <h1 className={"title"}>{content.title}</h1>
-            <div className={"subtitle"}>{content.subtitle}</div>
+            <div className={"titling"}>
+                <div className={"supertitle"}>{content.supertitle}</div>
+                <h1 className={"title"}>{content.title}</h1>
+                <div className={"subtitle"}>{content.subtitle}</div>
+            </div>
             <div className={"bylineContainer"}>
                 <div>
                     By: <div className={"byline"}>{content.byline}</div>

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -138,29 +138,39 @@
     z-index: 0;
 }
 
-.owidArticle > .title {
-    margin: 0;
-    line-height: 48px;
-    font-size: 40px;
-    max-width: 100%;
-    font-weight: 600;
-    letter-spacing: -1%;
-    margin-top: 56px + $article-page-top-offset;
-    text-align: center;
-}
+.owidArticle .titling {
+    margin-top: 52px + $article-page-top-offset;
 
-.owidArticle > .subtitle {
-    margin: 0;
-    margin-bottom: 0.5em;
-    line-height: 32px;
-    letter-spacing: 0;
-    font-size: 24px;
-    font-weight: 500;
-    font-family: "Lato", sans-serif;
-    color: #6e87a2;
-    text-align: center;
-    margin-top: 32px;
-    margin-bottom: 32px;
+    .supertitle {
+        @include overline-black-caps;
+        text-align: center;
+        display: block;
+        margin-bottom: 8px;
+        color: $blue-50;
+    }
+    .title {
+        margin: 0;
+        line-height: 48px;
+        font-size: 40px;
+        max-width: 100%;
+        font-weight: 600;
+        letter-spacing: -1%;
+        text-align: center;
+    }
+
+    .subtitle {
+        margin: 0;
+        margin-bottom: 0.5em;
+        line-height: 32px;
+        letter-spacing: 0;
+        font-size: 24px;
+        font-weight: 500;
+        font-family: "Lato", sans-serif;
+        color: #6e87a2;
+        text-align: center;
+        margin-top: 32px;
+        margin-bottom: 32px;
+    }
 }
 
 .owidArticle .bylineContainer .dateline {


### PR DESCRIPTION
closes #1760 

Similar to #1758's `cover-color`, the `supertitle` frontmatter property is not surfaced in the preview settings pane until it is elevated to the rank of a more generic feature used beyond SDG pages.