### PR TITLE
CSS fixes for topic pages and details on demand

### DIFF
--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -51,7 +51,6 @@ import {
     KeyInsight,
     OwidArticleType,
     PostRow,
-    WP_PostType,
     Url,
 } from "@ourworldindata/utils"
 import { CountryProfileSpec } from "../site/countryProfileProjects.js"
@@ -59,11 +58,8 @@ import { formatPost } from "./formatWordpressPost.js"
 import {
     getBlogIndex,
     getEntriesByCategory,
-    getFullPost,
     getLatestPostRevision,
     getPostBySlug,
-    getPosts,
-    selectHomepagePosts,
     isPostCitable,
     getBlockContent,
 } from "../db/wpdb.js"

--- a/packages/@ourworldindata/grapher/src/controls/VerticalScrollContainer.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/VerticalScrollContainer.tsx
@@ -140,7 +140,7 @@ const ScrollingShadow = (props: {
                 background: background,
                 opacity: props.opacity,
                 pointerEvents: "none",
-                zIndex: 10,
+                zIndex: 2,
             }}
         />
     )

--- a/packages/@ourworldindata/grapher/src/controls/globalEntitySelector/GlobalEntitySelector.scss
+++ b/packages/@ourworldindata/grapher/src/controls/globalEntitySelector/GlobalEntitySelector.scss
@@ -3,9 +3,9 @@
     top: 5px;
     z-index: $zindex-global-entity-select;
 
-    // @include xxlg-down {
-    //     margin-left: 128px; // space for ToC "Contents" button
-    // }
+    @include xxlg-down {
+        margin-left: 128px; // space for ToC "Contents" button
+    }
 }
 
 .global-entity-control {

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -16,6 +16,7 @@ $light-shadow: rgba(0, 0, 0, 0.1) 0px 0px 0px 1px,
 $oxford-blue: #002147;
 $text-color: #1d3d63;
 $white: #fff;
+$xxlg: 1536px;
 
 // These should be between 0–100 in order to avoid conflicting with
 // site dropdowns, search overlays, etc.
@@ -23,6 +24,13 @@ $zindex-chart: 1;
 $zindex-tab: 1;
 $zindex-global-entity-select: 11;
 $zindex-Tooltip: 20;
+
+// needed for .global-entity-control-container
+@mixin xxlg-down {
+    @media only screen and (max-width: $xxlg) {
+        @content;
+    }
+}
 
 // All styles are scoped to GrapherComponent only, to prevent rule leaking
 // and low-specificity rules from the site CSS trumping these ones.

--- a/packages/@ourworldindata/grapher/src/detailsOnDemand/detailsOnDemand.scss
+++ b/packages/@ourworldindata/grapher/src/detailsOnDemand/detailsOnDemand.scss
@@ -1,5 +1,9 @@
 .interactive-tippy-wrapper {
     display: inline-block;
+
+    > div {
+        height: 50%;
+    }
 }
 
 span.dod-term {
@@ -9,8 +13,7 @@ span.dod-term {
 
 .dod-tippy-container {
     overflow-y: auto;
-    // should only result in scrollbars when viewport height is very small
-    max-height: 80vh;
+    height: 100%;
 }
 
 .dod-tooltip {

--- a/site/blocks/KeyInsights.scss
+++ b/site/blocks/KeyInsights.scss
@@ -84,6 +84,7 @@ $slide-content-height: $grapher-height;
     .thumb {
         width: 250px;
         min-height: 104px;
+        height: 100%;
         margin-right: 8px;
         padding: 16px 24px;
         border: 1px solid $blue-10;

--- a/site/blocks/research-and-writing.scss
+++ b/site/blocks/research-and-writing.scss
@@ -102,6 +102,10 @@
         grid-column: 1 / 13;
     }
 
+    img {
+        border-color: #fff;
+    }
+
     .research-and-writing__top-right {
         grid-column: 1 / 13;
         @include grid(2);
@@ -171,6 +175,9 @@
 
     .title {
         @include h3-bold;
+    }
+    img {
+        border-color: #fff;
     }
 }
 

--- a/site/css/sidebar.scss
+++ b/site/css/sidebar.scss
@@ -91,6 +91,10 @@
             padding: $vertical-spacing 0;
             pointer-events: none;
 
+            @include md-down {
+                transform: translateX(calc(100% + $padding-x-sm));
+            }
+
             @include md-up {
                 margin-left: $padding-x-md;
             }

--- a/site/css/variables.scss
+++ b/site/css/variables.scss
@@ -101,6 +101,7 @@ $xxlg: 1536px;
 }
 
 // The sidebar is shown from that breakpoint up
+// mixin duplicated in packages/@ourworldindata/grapher/src/core/grapher.scss
 @mixin xxlg-up {
     @media only screen and (min-width: $xxlg) {
         @content;


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/1765

And a couple of small fixes caught by Marwa and Daniel today.

### z-index conflict between the `VerticalScrollContainer` and sticky nav:
![image](https://user-images.githubusercontent.com/11844404/204660750-54f0b7ce-5822-4fdc-9dcc-d264ad90531b.png)

### Underline in research and writing cards:
![image](https://user-images.githubusercontent.com/11844404/204660815-c4f860dc-56b2-4699-bbe5-31541c66c6a5.png)

### Detail on demand text overflow: 
https://user-images.githubusercontent.com/11844404/204660872-19604104-9b92-4ab7-bc90-ca8c829e800d.mov

### ToC button covered
https://user-images.githubusercontent.com/11844404/204864858-087d91de-4d6d-4c2c-a8fc-acd24dd8d20c.mov



