### PR TITLE
feat(sdg grid): add responsive

### DIFF
--- a/site/css/grid.scss
+++ b/site/css/grid.scss
@@ -53,7 +53,7 @@ $grid-responsive: (lg, md, sm);
 
 .grid {
     display: grid;
-    gap: 0 24px;
+    gap: 0 $grid-gap;
     grid-template-columns: repeat(12, 1fr);
     grid-auto-rows: min-content;
 }

--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -53,7 +53,7 @@ const layouts: { [key in Container]: Layouts} = {
         ["pull-quote"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["recirc"]: "col-start-11 span-cols-3 span-rows-3 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["scroller"]: "grid span-cols-12 col-start-2",
-        ["sdg-grid"]: "grid col-start-2 span-cols-12 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
+        ["sdg-grid"]: "grid col-start-2 span-cols-12 col-lg-start-3 span-lg-cols-10 span-sm-cols-12 col-sm-start-2",
         ["sdg-toc"]: "grid grid-cols-8 col-start-4 span-cols-8 grid-md-cols-10 col-md-start-3 span-md-cols-10 grid-sm-cols-12 span-sm-cols-12 col-sm-start-2",
         ["side-by-side"]: "grid span-cols-12 col-start-2",
         ["sticky-left-left-column"]: "span-cols-7 span-md-cols-12 grid-md-cols-12",

--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -53,7 +53,7 @@ const layouts: { [key in Container]: Layouts} = {
         ["pull-quote"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["recirc"]: "col-start-11 span-cols-3 span-rows-3 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["scroller"]: "grid span-cols-12 col-start-2",
-        ["sdg-grid"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
+        ["sdg-grid"]: "grid col-start-2 span-cols-12 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["sdg-toc"]: "grid grid-cols-8 col-start-4 span-cols-8 grid-md-cols-10 col-md-start-3 span-md-cols-10 grid-sm-cols-12 span-sm-cols-12 col-sm-start-2",
         ["side-by-side"]: "grid span-cols-12 col-start-2",
         ["sticky-left-left-column"]: "span-cols-7 span-md-cols-12 grid-md-cols-12",

--- a/site/gdocs/SDGGrid.scss
+++ b/site/gdocs/SDGGrid.scss
@@ -1,6 +1,18 @@
 .sdg-grid {
     margin-top: 24px;
     row-gap: $grid-gap;
+    &:before {
+        content: "";
+        @include sm-up {
+            grid-column: 1 / span 2;
+            grid-row: 6;
+        }
+        @include lg-up {
+            grid-column: 1 / span 1;
+            grid-row: 3;
+        }
+    }
+
     li {
         list-style-type: none;
         a {

--- a/site/gdocs/SDGGrid.scss
+++ b/site/gdocs/SDGGrid.scss
@@ -1,5 +1,5 @@
 .sdg-grid {
-    margin-top: 40px;
+    margin-top: 24px;
     row-gap: $grid-gap;
     li {
         list-style-type: none;

--- a/site/gdocs/SDGGrid.scss
+++ b/site/gdocs/SDGGrid.scss
@@ -1,17 +1,7 @@
-.owidArticle .sdg-grid {
-    @include grid(14);
-    grid-column: 1 / -1;
-    padding: 50px 0;
-    background-color: $gray-10;
-
-    h2 {
-        @include h1-semibold;
-        grid-column: 2 / 14;
-        margin: 0 0 40px;
-        text-align: center;
-    }
-
-    .tile {
+.sdg-grid {
+    margin-top: 40px;
+    row-gap: $grid-gap;
+    li {
         list-style-type: none;
         a {
             display: flex;
@@ -43,25 +33,6 @@
 
         .goal {
             margin: auto;
-        }
-    }
-
-    // todo: responsive
-    ul {
-        @include lg-up {
-            @include grid(12);
-            row-gap: $grid-gap;
-            grid-column: 2 / 14;
-
-            // Centering last row
-            &:before {
-                content: "";
-                grid-column: 1 / 2;
-                grid-row: 3;
-            }
-            .tile {
-                grid-column: span 2;
-            }
         }
     }
 }

--- a/site/gdocs/SDGGrid.tsx
+++ b/site/gdocs/SDGGrid.tsx
@@ -10,23 +10,18 @@ export default function SDGGrid({
     className?: string
 }) {
     return (
-        <div className={cx("sdg-grid", className)}>
-            <h2>The 17 goals</h2>
-            <ul>
-                {d.items.map(
-                    (tile: { goal: string; link: string }, i: number) => {
-                        return (
-                            <SDGTile
-                                key={i}
-                                number={i + 1}
-                                goal={tile.goal}
-                                link={tile.link}
-                            />
-                        )
-                    }
-                )}
-            </ul>
-        </div>
+        <ul className={cx("sdg-grid", className)}>
+            {d.items.map((tile: { goal: string; link: string }, i: number) => {
+                return (
+                    <SDGTile
+                        key={i}
+                        number={i + 1}
+                        goal={tile.goal}
+                        link={tile.link}
+                    />
+                )
+            })}
+        </ul>
     )
 }
 
@@ -41,7 +36,7 @@ const SDGTile = ({
 }) => {
     return (
         <li
-            className="tile"
+            className="span-cols-2 span-lg-cols-3 span-md-cols-4 span-sm-cols-8 col-sm-start-3"
             style={
                 {
                     "--sdg-color": `var(--sdg-color-${number})`,

--- a/site/gdocs/SDGGrid.tsx
+++ b/site/gdocs/SDGGrid.tsx
@@ -36,7 +36,7 @@ const SDGTile = ({
 }) => {
     return (
         <li
-            className="span-cols-2 span-lg-cols-3 span-md-cols-4 span-sm-cols-8 col-sm-start-3"
+            className="span-cols-2 span-lg-cols-4 span-sm-cols-8 col-sm-start-3"
             style={
                 {
                     "--sdg-color": `var(--sdg-color-${number})`,

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -231,8 +231,12 @@ h3.article-block__heading.has-supertitle {
 
 .article-block__grey-section {
     background-color: $gray-10;
-    padding: 32px 0;
+    padding: 48px 0;
     margin: 32px 0;
+
+    > *:first-child {
+        margin-top: 0;
+    }
 
     > *:last-child {
         margin-bottom: 0;


### PR DESCRIPTION
Test doc: https://docs.google.com/document/d/1UOhC3dU2Zc1DEt2Yzqblfc3l9K1ZS27fcNHQa7uwnxI/edit#heading=h.o4zdv2a800b3

- Now uses a `grey-section`.
- Moves the "The 17 goals" heading outside of the component, and into the authorable document.

closes #1782 