### PR TITLE
feat(faceting): force faceting in some situations

### DIFF
--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -24,6 +24,7 @@ import {
     ScaleType,
     BASE_FONT_SIZE,
     SeriesStrategy,
+    FacetStrategy,
 } from "../core/GrapherConstants"
 import {
     HorizontalAxisComponent,
@@ -342,6 +343,17 @@ export class DiscreteBarChart
         this.d3Bars()
             .transition()
             .attr("width", (_, i) => this.barWidths[i])
+    }
+
+    @computed get facetAvailableStrategies(): FacetStrategy[] {
+        // if we have multi-dimension, multi-entity data (which is necessarily single-year),
+        // then *only* faceting makes sense. otherwise, faceting is not useful.
+        if (
+            this.yColumns.length > 1 &&
+            this.selectionArray.numSelectedEntities > 1
+        )
+            return [FacetStrategy.metric, FacetStrategy.entity]
+        else return [FacetStrategy.none]
     }
 
     componentDidMount(): void {

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -352,7 +352,7 @@ export class DiscreteBarChart
             this.yColumns.length > 1 &&
             this.selectionArray.numSelectedEntities > 1
         )
-            return [FacetStrategy.metric, FacetStrategy.entity]
+            return [FacetStrategy.entity, FacetStrategy.metric]
         else return [FacetStrategy.none]
     }
 

--- a/packages/@ourworldindata/grapher/src/chart/ChartInterface.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartInterface.ts
@@ -1,5 +1,5 @@
 import { Color, OwidTable } from "@ourworldindata/core-table"
-import { SeriesName } from "../core/GrapherConstants"
+import { FacetStrategy, SeriesName } from "../core/GrapherConstants"
 import { ColorScale } from "../color/ColorScale"
 import { HorizontalAxis, VerticalAxis } from "../axis/Axis"
 import { HorizontalColorLegendManager } from "../horizontalColorLegend/HorizontalColorLegends"
@@ -35,4 +35,6 @@ export interface ChartInterface {
      * Used to create a global legend for faceted charts.
      */
     externalLegend?: HorizontalColorLegendManager
+
+    facetAvailableStrategies?: FacetStrategy[]
 }

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1998,8 +1998,11 @@ export class Grapher
         if (
             // multiple entities
             this.selection.numSelectedEntities > 1 &&
-            // more than one data point per entity
-            this.transformedTable.numRows > this.selection.numSelectedEntities
+            // more than one data point per entity (e.g. multiple years in a LineChart)
+            (this.transformedTable.numRows >
+                this.selection.numSelectedEntities ||
+                // or: multiple dimensions
+                numNonProjectedColumns > 1)
         ) {
             strategies.push(FacetStrategy.entity)
         }

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -64,6 +64,7 @@ import {
     SortOrder,
     TopicId,
     OwidChartDimensionInterface,
+    firstOfNonEmptyArray,
 } from "@ourworldindata/utils"
 import {
     ChartTypeName,
@@ -1980,13 +1981,10 @@ export class Grapher
     }
 
     @computed get availableFacetStrategies(): FacetStrategy[] {
-        console.log(this.chartInstance.facetAvailableStrategies)
-        return (
-            this.chartInstance.facetAvailableStrategies ?? [FacetStrategy.none]
-        )
+        return this.chartInstance.facetAvailableStrategies?.length
+            ? this.chartInstance.facetAvailableStrategies
+            : [FacetStrategy.none]
     }
-
-    private disableAutoFaceting = true // turned off for now
 
     // the actual facet setting used by a chart, potentially overriding selectedFacetStrategy
     @computed get facetStrategy(): FacetStrategy {
@@ -1996,24 +1994,7 @@ export class Grapher
         )
             return this.selectedFacetStrategy
 
-        if (this.disableAutoFaceting) return FacetStrategy.none
-
-        // Auto facet on SingleEntity charts with multiple selected entities
-        if (
-            this.addCountryMode === EntitySelectionMode.SingleEntity &&
-            this.selection.numSelectedEntities > 1
-        )
-            return FacetStrategy.entity
-
-        // Auto facet when multiple slugs and multiple entities selected. todo: not sure if this is correct.
-        if (
-            this.addCountryMode === EntitySelectionMode.MultipleEntities &&
-            this.hasMultipleYColumns &&
-            this.selection.numSelectedEntities > 1
-        )
-            return FacetStrategy.metric
-
-        return FacetStrategy.none
+        return firstOfNonEmptyArray(this.availableFacetStrategies)
     }
 
     set facetStrategy(facet: FacetStrategy) {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1980,34 +1980,10 @@ export class Grapher
     }
 
     @computed get availableFacetStrategies(): FacetStrategy[] {
-        const strategies: FacetStrategy[] = [FacetStrategy.none]
-
-        const numNonProjectedColumns =
-            this.yColumnsFromDimensionsOrSlugsOrAuto.filter(
-                (c) => !c.display?.isProjection
-            ).length
-        if (
-            // multiple metrics (excluding projections)
-            numNonProjectedColumns > 1 &&
-            // more than one data point per metric
-            this.transformedTable.numRows > 1
-        ) {
-            strategies.push(FacetStrategy.metric)
-        }
-
-        if (
-            // multiple entities
-            this.selection.numSelectedEntities > 1 &&
-            // more than one data point per entity (e.g. multiple years in a LineChart)
-            (this.transformedTable.numRows >
-                this.selection.numSelectedEntities ||
-                // or: multiple dimensions
-                numNonProjectedColumns > 1)
-        ) {
-            strategies.push(FacetStrategy.entity)
-        }
-
-        return strategies
+        console.log(this.chartInstance.facetAvailableStrategies)
+        return (
+            this.chartInstance.facetAvailableStrategies ?? [FacetStrategy.none]
+        )
     }
 
     private disableAutoFaceting = true // turned off for now

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -729,13 +729,13 @@ export class LineChart
     @computed get facetAvailableStrategies(): FacetStrategy[] {
         const strategies: FacetStrategy[] = [FacetStrategy.none]
 
+        if (this.selectionArray.numSelectedEntities > 1)
+            strategies.push(FacetStrategy.entity)
+
         const numNonProjectionColumns = this.yColumns.filter(
             (c) => !c.display?.isProjection
         ).length
         if (numNonProjectionColumns > 1) strategies.push(FacetStrategy.metric)
-
-        if (this.selectionArray.numSelectedEntities > 1)
-            strategies.push(FacetStrategy.entity)
 
         return strategies
     }

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -42,6 +42,7 @@ import {
     SeriesName,
     ScaleType,
     SeriesStrategy,
+    FacetStrategy,
 } from "../core/GrapherConstants"
 import { ColorSchemes } from "../color/ColorSchemes"
 import { AxisConfig, FontSizeManager } from "../axis/AxisConfig"
@@ -723,6 +724,20 @@ export class LineChart
         return this.manager.hideLegend
             ? undefined
             : new LineLegend({ manager: this })
+    }
+
+    @computed get facetAvailableStrategies(): FacetStrategy[] {
+        const strategies: FacetStrategy[] = [FacetStrategy.none]
+
+        const numNonProjectionColumns = this.yColumns.filter(
+            (c) => !c.display?.isProjection
+        ).length
+        if (numNonProjectionColumns > 1) strategies.push(FacetStrategy.metric)
+
+        if (this.selectionArray.numSelectedEntities > 1)
+            strategies.push(FacetStrategy.entity)
+
+        return strategies
     }
 
     render(): JSX.Element {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -301,9 +301,14 @@ export class AbstractStackedChart
 
     @computed get facetAvailableStrategies(): FacetStrategy[] {
         const strategies: FacetStrategy[] = []
+
         if (this.selectionArray.selectedEntityNames.length <= 1)
             strategies.push(FacetStrategy.none)
-        else strategies.push(FacetStrategy.entity)
+        else {
+            // Normally StackedArea/StackedBar charts are always single-entity, but if we are ever in a mode where we
+            // have multiple entities selected (e.g. through GlobalEntitySelector), it only makes sense when faceted.
+            strategies.push(FacetStrategy.entity)
+        }
 
         if (this.yColumns.length > 1) strategies.push(FacetStrategy.metric)
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -302,15 +302,20 @@ export class AbstractStackedChart
     @computed get facetAvailableStrategies(): FacetStrategy[] {
         const strategies: FacetStrategy[] = []
 
-        if (this.selectionArray.selectedEntityNames.length <= 1)
-            strategies.push(FacetStrategy.none)
-        else {
-            // Normally StackedArea/StackedBar charts are always single-entity, but if we are ever in a mode where we
-            // have multiple entities selected (e.g. through GlobalEntitySelector), it only makes sense when faceted.
-            strategies.push(FacetStrategy.entity)
-        }
+        const hasMultipleEntities =
+            this.selectionArray.selectedEntityNames.length > 1
+        const hasMultipleYColumns = this.yColumns.length > 1
 
-        if (this.yColumns.length > 1) strategies.push(FacetStrategy.metric)
+        // Normally StackedArea/StackedBar charts are always single-entity or single-column, but if we are ever in a mode where we
+        // have multiple entities selected (e.g. through GlobalEntitySelector) and multiple columns, it only makes sense when faceted.
+        if (!this.isEntitySeries && !hasMultipleEntities)
+            strategies.push(FacetStrategy.none)
+        else if (this.isEntitySeries && !hasMultipleYColumns)
+            strategies.push(FacetStrategy.none)
+
+        if (hasMultipleEntities) strategies.push(FacetStrategy.entity)
+
+        if (hasMultipleYColumns) strategies.push(FacetStrategy.metric)
 
         return strategies
     }

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -4,6 +4,7 @@ import { ChartInterface } from "../chart/ChartInterface"
 import { ChartManager } from "../chart/ChartManager"
 import {
     BASE_FONT_SIZE,
+    FacetStrategy,
     SeriesName,
     SeriesStrategy,
 } from "../core/GrapherConstants"
@@ -296,6 +297,17 @@ export class AbstractStackedChart
     /** Whether we want to display series with only zeroes. Defaults to true but e.g. StackedArea charts want to set this to false */
     get showAllZeroSeries(): boolean {
         return true
+    }
+
+    @computed get facetAvailableStrategies(): FacetStrategy[] {
+        const strategies: FacetStrategy[] = []
+        if (this.selectionArray.selectedEntityNames.length <= 1)
+            strategies.push(FacetStrategy.none)
+        else strategies.push(FacetStrategy.entity)
+
+        if (this.yColumns.length > 1) strategies.push(FacetStrategy.metric)
+
+        return strategies
     }
 
     @computed get unstackedSeries(): readonly StackedSeries<number>[] {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -417,6 +417,14 @@ export class StackedDiscreteBarChart
         return this.yColumns[0]
     }
 
+    @computed get facetAvailableStrategies(): FacetStrategy[] {
+        const strategies = [FacetStrategy.none]
+
+        if (this.yColumns.length > 1) strategies.push(FacetStrategy.metric)
+
+        return strategies
+    }
+
     @bind private formatValueForLabel(value: number): string {
         // Compute how many decimal places we should show.
         // Basically, this makes us show 2 significant digits, or no decimal places if the number

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -20,7 +20,11 @@ import {
 } from "@ourworldindata/utils"
 import { action, computed, observable } from "mobx"
 import { observer } from "mobx-react"
-import { BASE_FONT_SIZE, SeriesName } from "../core/GrapherConstants"
+import {
+    BASE_FONT_SIZE,
+    FacetStrategy,
+    SeriesName,
+} from "../core/GrapherConstants"
 import {
     HorizontalAxisComponent,
     HorizontalAxisGridLines,


### PR DESCRIPTION
Fixes #1124 #1695 | Live on _tufte_.

---

There are certain situations where a chart is misleading when it is not faceted, e.g. stacked area charts with multiple entities and multiple dimensions, or bar charts with multi-entity, multi-metric.

We now do auto-faceting in these cases, to make the chart more correct.
In addition, every chart instance can have its own logic to decide which faceting strategies (none, entity, metric) are available at any given point.

---

### Example charts
- [Discrete bar chart, auto-faceted because it uses both multiple dimensions and multiple entities](https://tufte-owid.netlify.app/grapher/daily-new-estimated-infections-of-covid-19?time=2021-01-10&country=DEU~FRA) --- [same chart on live](https://ourworldindata.org/grapher/daily-new-estimated-infections-of-covid-19?time=2021-01-10&country=DEU~FRA)
- [Stacked bar chart, auto-faceted because it shows multiple entities](https://tufte-owid.netlify.app/grapher/deaths-by-age-group-stacked?country=DEU~FRA) --- [same chart on live](https://ourworldindata.org/grapher/deaths-by-age-group-stacked?country=DEU~FRA)
- [Stacked area chart, auto-faceted because it shows multiple entities](https://tufte-owid.netlify.app/grapher/electricity-prod-source-stacked?country=FRA~IND) --- [same chart on live](https://ourworldindata.org/grapher/electricity-prod-source-stacked?country=FRA~IND)
- [Faceted line chart that is largely unaffected, and still collapses to an unfaceted bar chart](https://tufte-owid.netlify.app/grapher/life-expectancy?tab=chart&facet=entity) --- [same chart on live](https://ourworldindata.org/grapher/life-expectancy?tab=chart&facet=entity)

### Outstanding questions:
- [ ] We had some code for auto faceting, which was a disabled feature until now.
      In some of the cases that it had we essentially auto-facet now (the cases where _only_ a faceted chart makes sense), but the feature also covers cases where faceting would be nice-to-have.
      I removed it, should we keep it instead?
- [ ] Marimekko charts cannot be faceted right now; I checked and there's currently no Marimekko chart that is stacked, which is the only case where faceting makes sense at all. @danyx23 do you think it makes sense to introduce faceting to Marimekko charts?
- [ ] In cases where we auto-facet now, it is not possible for the user to choose between faceting by metric or by entity (I think all chart types default to entity-faceting when auto-faceting now) because the dropdown is not shown. Should we display the dropdown when auto-faceting so the user has the choice?
- [ ] Or, alternatively, do we think that the time has come now to always show the dropdown, now that most faceting worries have been ironed out?