### PR TITLE
1784-fix-citation-and-licence-footer-blocks

### DIFF
--- a/site/gdocs/OwidArticle.tsx
+++ b/site/gdocs/OwidArticle.tsx
@@ -80,7 +80,7 @@ export function OwidArticle(props: OwidArticleType) {
                     </div>
                     <div className="span-cols-1 span-sm-cols-2">
                         <a
-                            href="#citation"
+                            href="#article-citation"
                             className="body-1-regular display-block"
                         >
                             <FontAwesomeIcon icon={faBook} />
@@ -88,7 +88,7 @@ export function OwidArticle(props: OwidArticleType) {
                         </a>
 
                         <a
-                            href="#licence"
+                            href="#article-licence"
                             className="body-3-medium display-block"
                         >
                             <FontAwesomeIcon icon={faCreativeCommons} />
@@ -115,7 +115,7 @@ export function OwidArticle(props: OwidArticleType) {
             {/* {content.refs ? <Footnotes d={content.refs} /> : null} */}
 
             <div
-                id="citation"
+                id="article-citation"
                 className="col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12"
             >
                 <h3>Cite this work</h3>
@@ -136,7 +136,7 @@ export function OwidArticle(props: OwidArticleType) {
             </div>
 
             <div
-                id="licence"
+                id="article-licence"
                 className="col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12"
             >
                 <img

--- a/site/gdocs/OwidArticle.tsx
+++ b/site/gdocs/OwidArticle.tsx
@@ -140,7 +140,7 @@ export function OwidArticle(props: OwidArticleType) {
                 className="col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12"
             >
                 <img
-                    src="/owid-logo.svg"
+                    src={`${BAKED_BASE_URL}/owid-logo.svg`}
                     className="img-raw"
                     alt="Our World in Data logo"
                 />

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -90,7 +90,6 @@ h3.article-block__heading.has-supertitle {
 
 #article-citation,
 #article-licence {
-    grid-column: 4 / span 8;
     margin-top: 48px;
     padding-top: 48px;
     @include body-3-medium;

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -25,6 +25,10 @@ h2.article-block__heading.has-supertitle {
     margin-top: 24px;
 }
 
+nav.article-block__sdg-toc + h2.article-block__heading.has-supertitle {
+    border-top: none;
+}
+
 h3.article-block__heading.has-supertitle {
     border-bottom: 1px solid $blue-20;
     padding-bottom: 16px;

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -84,6 +84,42 @@ h3.article-block__heading.has-supertitle {
     }
 }
 
+#article-citation,
+#article-licence {
+    grid-column: 4 / span 8;
+    margin-top: 48px;
+    padding-top: 48px;
+    @include body-3-medium;
+    border-top: 1px solid $blue-10;
+
+    h3 {
+        @include h3-bold;
+        color: $blue-50;
+        margin: 24px 0 16px;
+    }
+
+    a {
+        @include owid-link-60;
+    }
+}
+
+#article-citation {
+    h3 {
+        margin-top: 0;
+    }
+    p {
+        margin-bottom: 16px;
+    }
+    div:last-of-type .wp-code-snippet {
+        margin-bottom: 0;
+    }
+}
+
+#article-licence {
+    text-align: center;
+    margin-bottom: 16px; // Should be 48px, but I don't get why this margin doesn't collapse with the 32px margin of the last paragraph.
+}
+
 .article-block__text,
 .article-block__html {
     @include body-1-regular;


### PR DESCRIPTION
closes #1784 

- fix style regression on citation and licence footer blocks
<img width="1440" alt="Screenshot 2022-12-05 at 11 54 24" src="https://user-images.githubusercontent.com/13406362/205620459-e38eeaf0-e772-4ce1-8e9f-29e17d6a4616.png">

- remove separation on first header when directly following the table of contents
<img width="923" alt="Screenshot 2022-12-05 at 11 54 38" src="https://user-images.githubusercontent.com/13406362/205620491-160d24b0-14f0-4482-ab5c-0ffddfc2b59e.png">
