### PR TITLE
perf(map): optimize `geoPathsFor` method

### DIFF
--- a/packages/@ourworldindata/grapher/src/mapCharts/GeoPathRoundingContext.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/GeoPathRoundingContext.ts
@@ -1,0 +1,33 @@
+import { GeoContext } from "d3-geo"
+
+// Can be used as a d3 projection context to convert a geojson feature to a SVG path
+// In contrast to what d3-geo does by default, it will round all coordinates to one decimal place
+// Adapted from https://github.com/d3/d3-geo/blob/8d3f3a98c034b087e2c808f752d2381d51c30015/src/path/string.js
+
+export class GeoPathRoundingContext implements GeoContext {
+    _string: string[] = []
+
+    beginPath(): void {
+        this._string = []
+    }
+
+    moveTo(x: number, y: number): void {
+        this._string.push("M" + x.toFixed(1) + "," + y.toFixed(1))
+    }
+
+    lineTo(x: number, y: number): void {
+        this._string.push("L" + x.toFixed(1) + "," + y.toFixed(1))
+    }
+
+    arc(_x: number, _y: number, _radius: number): void {
+        throw new Error("Method not implemented.")
+    }
+
+    closePath(): void {
+        this._string.push("Z")
+    }
+
+    result(): string {
+        return this._string.join("")
+    }
+}

--- a/packages/@ourworldindata/grapher/src/mapCharts/GeoPathRoundingContext.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/GeoPathRoundingContext.ts
@@ -4,19 +4,24 @@ import { GeoContext } from "d3-geo"
 // In contrast to what d3-geo does by default, it will round all coordinates to one decimal place
 // Adapted from https://github.com/d3/d3-geo/blob/8d3f3a98c034b087e2c808f752d2381d51c30015/src/path/string.js
 
+// FUTURE: Once we update to d3-geo@^3.10, d3-geo can do this by default: https://github.com/d3/d3-geo/pull/272
+
+// Rounds to one decimal place
+const round = (x: number): number => Math.round(x * 10) / 10
+
 export class GeoPathRoundingContext implements GeoContext {
-    _string: string[] = []
+    _string: string = ""
 
     beginPath(): void {
-        this._string = []
+        this._string = ""
     }
 
     moveTo(x: number, y: number): void {
-        this._string.push("M" + x.toFixed(1) + "," + y.toFixed(1))
+        this._string += `M${round(x)},${round(y)}`
     }
 
     lineTo(x: number, y: number): void {
-        this._string.push("L" + x.toFixed(1) + "," + y.toFixed(1))
+        this._string += `L${round(x)},${round(y)}`
     }
 
     arc(_x: number, _y: number, _radius: number): void {
@@ -24,10 +29,10 @@ export class GeoPathRoundingContext implements GeoContext {
     }
 
     closePath(): void {
-        this._string.push("Z")
+        this._string += "Z"
     }
 
     result(): string {
-        return this._string.join("")
+        return this._string
     }
 }

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -22,11 +22,8 @@ import {
     HorizontalColorLegendManager,
     HorizontalNumericColorLegend,
 } from "../horizontalColorLegend/HorizontalColorLegends"
-import {
-    MapProjectionName,
-    MapProjectionGeos,
-    PathToStringWithRoundedNumbersContext,
-} from "./MapProjections"
+import { MapProjectionName, MapProjectionGeos } from "./MapProjections"
+import { GeoPathRoundingContext } from "./GeoPathRoundingContext"
 import { select } from "d3-selection"
 import { easeCubic } from "d3-ease"
 import { MapTooltip } from "./MapTooltip"
@@ -100,7 +97,8 @@ const geoPathsFor = (projectionName: MapProjectionName): string[] => {
     if (geoPathCache.has(projectionName))
         return geoPathCache.get(projectionName)!
 
-    const ctx = new PathToStringWithRoundedNumbersContext()
+    // Use this context to round the path coordinates to a set number of decimal places
+    const ctx = new GeoPathRoundingContext()
     const projectionGeo = MapProjectionGeos[projectionName].context(ctx)
     const strs = GeoFeatures.map((feature) => {
         ctx.beginPath() // restart the path

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapProjections.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapProjections.ts
@@ -3,7 +3,6 @@ import {
     geoConicConformal,
     geoAzimuthalEqualArea,
     GeoPath,
-    GeoContext,
 } from "d3-geo"
 
 import { geoRobinson, geoPatterson } from "./d3-geo-projection.js"
@@ -85,34 +84,3 @@ export const MapProjectionGeos: { [key in MapProjectionName]: GeoPath } = {
             .parallels([-10, -30])
     ),
 } as const
-
-// Can be used as a d3 projection context to convert a geojson feature to a SVG path
-// In contrast to what d3-geo does by default, it will round all coordinates to one decimal place
-// Adapted from https://github.com/d3/d3-geo/blob/8d3f3a98c034b087e2c808f752d2381d51c30015/src/path/string.js
-export class PathToStringWithRoundedNumbersContext implements GeoContext {
-    _string: string[] = []
-
-    beginPath(): void {
-        this._string = []
-    }
-
-    moveTo(x: number, y: number): void {
-        this._string.push("M" + x.toFixed(1) + "," + y.toFixed(1))
-    }
-
-    lineTo(x: number, y: number): void {
-        this._string.push("L" + x.toFixed(1) + "," + y.toFixed(1))
-    }
-
-    arc(_x: number, _y: number, _radius: number): void {
-        throw new Error("Method not implemented.")
-    }
-
-    closePath(): void {
-        this._string.push("Z")
-    }
-
-    result(): string {
-        return this._string.join("")
-    }
-}

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapProjections.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapProjections.ts
@@ -3,6 +3,7 @@ import {
     geoConicConformal,
     geoAzimuthalEqualArea,
     GeoPath,
+    GeoContext,
 } from "d3-geo"
 
 import { geoRobinson, geoPatterson } from "./d3-geo-projection.js"
@@ -84,3 +85,34 @@ export const MapProjectionGeos: { [key in MapProjectionName]: GeoPath } = {
             .parallels([-10, -30])
     ),
 } as const
+
+// Can be used as a d3 projection context to convert a geojson feature to a SVG path
+// In contrast to what d3-geo does by default, it will round all coordinates to one decimal place
+// Adapted from https://github.com/d3/d3-geo/blob/8d3f3a98c034b087e2c808f752d2381d51c30015/src/path/string.js
+export class PathToStringWithRoundedNumbersContext implements GeoContext {
+    _string: string[] = []
+
+    beginPath(): void {
+        this._string = []
+    }
+
+    moveTo(x: number, y: number): void {
+        this._string.push("M" + x.toFixed(1) + "," + y.toFixed(1))
+    }
+
+    lineTo(x: number, y: number): void {
+        this._string.push("L" + x.toFixed(1) + "," + y.toFixed(1))
+    }
+
+    arc(_x: number, _y: number, _radius: number): void {
+        throw new Error("Method not implemented.")
+    }
+
+    closePath(): void {
+        this._string.push("Z")
+    }
+
+    result(): string {
+        return this._string.join("")
+    }
+}


### PR DESCRIPTION
Okay, well, I must admit I got sidetracked when working on map annotations ;)

I noticed the way we first generate a SVG path for a country, then tear it apart to round numbers to one decimal place, and then reconstructing the SVG path is not very performant.

It turns out that d3 allows passing a context to the projection functions. The context is normally used to render to, say, a canvas element, but it's also perfectly fine for our use case here.

And indeed, in my very unscientific testing, `geoPathsFor` takes:
* 30-40ms before this optimization
* 12-15ms now

The return value is totally unchanged, which the SVG tester will confirm.