### PR TITLE
fix: all charts navigation mobile

### DIFF
--- a/site/blocks/GalleryArrow.scss
+++ b/site/blocks/GalleryArrow.scss
@@ -1,6 +1,9 @@
 $gallery-navigation-button-size: 2.5rem;
 
 button.gallery-arrow {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: $gallery-navigation-button-size;
     height: $gallery-navigation-button-size;
     font-size: 1.2rem;

--- a/site/blocks/related-charts.scss
+++ b/site/blocks/related-charts.scss
@@ -76,12 +76,8 @@
 
             .gallery-navigation {
                 display: flex;
-                justify-content: center;
+                justify-content: space-around;
                 align-items: center;
-
-                .gallery-pagination {
-                    margin: 0 $padding-x-md;
-                }
             }
         }
     }


### PR DESCRIPTION
closes #1794 (iOS)

Also fixes issues on Android
![Screenshot_20221207-141903_Chrome](https://user-images.githubusercontent.com/13406362/206193276-662f5c76-fed8-4cd2-ae57-cf77edc6f065.jpg)

