### PR TITLE
1796-sdg-can-we-remove-the-line-in-the-text-blocks

### DIFF
--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -291,7 +291,7 @@ export default function ArticleBlock({
                             id={id}
                         >
                             {supertitleText ? (
-                                <div className="article-block__heading-supertitle overline-black-caps">
+                                <div className="article-block__heading-supertitle">
                                     {block.supertitle?.text}
                                 </div>
                             ) : null}

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -30,9 +30,11 @@ nav.article-block__sdg-toc + h2.article-block__heading.has-supertitle {
 }
 
 h3.article-block__heading.has-supertitle {
-    border-bottom: 1px solid $blue-20;
-    padding-bottom: 16px;
-    margin-bottom: 24px;
+    margin-bottom: 32px;
+
+    + * {
+        margin-top: 0;
+    }
 }
 
 .article-header__title-container {

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -32,6 +32,12 @@ nav.article-block__sdg-toc + h2.article-block__heading.has-supertitle {
 h3.article-block__heading.has-supertitle {
     margin-bottom: 32px;
 
+    .article-block__heading-supertitle {
+        @include overline-black-caps;
+        color: $blue-50;
+        margin-bottom: 8px;
+    }
+
     + * {
         margin-top: 0;
     }


### PR DESCRIPTION
closes #1796 

Also addresses some style regressions on the h3

Before (with regression)
<img width="1440" alt="Screenshot 2022-12-07 at 15 50 33" src="https://user-images.githubusercontent.com/13406362/206211523-cc65282c-820d-45c2-bcdf-ac1333715dda.png">


After
<img width="1440" alt="Screenshot 2022-12-07 at 15 50 41" src="https://user-images.githubusercontent.com/13406362/206211611-40aad4e8-b0bf-46bd-95ec-d7faab92240b.png">

