### PR TITLE
copyedits on homepage

### DIFF
--- a/site/FrontPage.tsx
+++ b/site/FrontPage.tsx
@@ -112,7 +112,7 @@ export const FrontPage = (props: {
                             data-smooth-scroll
                             data-track-note="homepage-scroll"
                         >
-                            Scroll to all our articles
+                            Scroll to all of our topics
                             <span className="icon">
                                 <FontAwesomeIcon icon={faAngleDoubleDown} />
                             </span>
@@ -198,7 +198,7 @@ export const FrontPage = (props: {
                                             data-track-note="homepage-see-all-explainers"
                                         >
                                             <div className="label">
-                                                See all posts
+                                                See all of our latest work
                                             </div>
                                             <div className="icon">
                                                 <FontAwesomeIcon
@@ -370,7 +370,7 @@ export const FrontPage = (props: {
                 <section id="entries" className="homepage-entries">
                     <div className="wrapper">
                         <h2>
-                            All our articles on global problems and global
+                            All of our pages on global problems and global
                             changes
                         </h2>
                         {entries.map((category) => (


### PR DESCRIPTION
Based on a discussion with Max, these updates align with our policy to use the terminology of "articles" and "topic pages" instead of "posts" and "entries". 

Note that I don't use "topic pages" explicitly here, but favor using clear language that is still in line with those terms. 

I've also changed the phrasing of "all our X" to "all of our X" because the "of" is needed for the phrase to be grammatical (because ['our' is a pronoun](https://proofed.com/writing-tips/word-choice-all-of/#:~:text=When%20deciding%20whether%20to%20write,that%20begins%20with%20a%20determiner.), weird rule.)