### PR TITLE
feat(facet): show faceting strategy dropdown when forcing faceting

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -282,7 +282,7 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
             controls.push(<ZoomToggle key="ZoomToggle" manager={manager} />)
 
         if (
-            !manager.hideFacetControl &&
+            manager.showFacetControl &&
             manager.availableFacetStrategies.length > 1
         ) {
             controls.push(

--- a/packages/@ourworldindata/grapher/src/controls/Controls.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/Controls.tsx
@@ -160,7 +160,7 @@ export class ZoomToggle extends React.Component<{
 export interface FacetStrategyDropdownManager {
     availableFacetStrategies: FacetStrategy[]
     facetStrategy?: FacetStrategy
-    hideFacetControl?: boolean
+    showFacetControl?: boolean
     entityType?: string
 }
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1939,6 +1939,15 @@ export class Grapher
         )
     }
 
+    @computed get showFacetControl(): boolean {
+        return (
+            !this.hideFacetControl ||
+            // heuristic: if the chart doesn't make sense unfaceted, then it probably
+            // also makes sense to let the user switch between entity/metric facets
+            !this.availableFacetStrategies.includes(FacetStrategy.none)
+        )
+    }
+
     @action.bound private toggleFacetControlVisibility(): void {
         this.hideFacetControl = !this.hideFacetControl
     }


### PR DESCRIPTION
This is an _optional_ follow-up PR after #1788.

It shows the faceting strategy dropdown in the following _new_ case:
* The current chart is auto-faceted, meaning that it cannot be shown unfaceted, _and_
* both faceting strategies are applicable: by metric and by entity.

E.g. in the below setting:

![image](https://user-images.githubusercontent.com/2641501/206797417-bbf61c4d-6ba6-445d-9cc3-d52978330d20.png)


### Example charts

- [Discrete bar chart, auto-faceted because it uses both multiple dimensions and multiple entities](https://tufte-owid.netlify.app/grapher/daily-new-estimated-infections-of-covid-19?time=2021-01-10&country=DEU~FRA) --- [same chart on live](https://ourworldindata.org/grapher/daily-new-estimated-infections-of-covid-19?time=2021-01-10&country=DEU~FRA)
- [Stacked bar chart, auto-faceted because it shows multiple entities](https://tufte-owid.netlify.app/grapher/deaths-by-age-group-stacked?country=DEU~FRA) --- [same chart on live](https://ourworldindata.org/grapher/deaths-by-age-group-stacked?country=DEU~FRA)
- [Stacked area chart, auto-faceted because it shows multiple entities](https://tufte-owid.netlify.app/grapher/electricity-prod-source-stacked?country=FRA~IND) --- [same chart on live](https://ourworldindata.org/grapher/electricity-prod-source-stacked?country=FRA~IND)
- [Faceted line chart that doesn't show the dropdown, because "no faceting" is available in this case](https://tufte-owid.netlify.app/grapher/life-expectancy?tab=chart&facet=entity) --- [same chart on live](https://ourworldindata.org/grapher/life-expectancy?tab=chart&facet=entity)
- [In the population explorer](https://tufte-owid.netlify.app/explorers/population-and-demography?Metric=Population+by+broad+age+group&Sex=Both+sexes&Age+group=Total&Projection+Scenario=None&country=CHN~IND~USA~IDN~PAK)

---

Caveats:
* While I'm certain that this makes sense in most cases, I haven't checked all cases and there might be some where this is not beneficiary.
* The faceting dropdown will also be shown when the `hideFacetControl` is set, which is the case for almost all charts currently. Hence, there is not a way to forcibly hide the dropdown control at this point. It might make sense to convert the setting into an enum with options `hide,auto,show`.
* We can also just roll it out and then at some point decide whether we like it or not...