### PR TITLE
fix: check for clipboard permission before showing copy option

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/ShareMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ShareMenu.tsx
@@ -8,6 +8,7 @@ import { faCode } from "@fortawesome/free-solid-svg-icons/faCode"
 import { faShareAlt } from "@fortawesome/free-solid-svg-icons/faShareAlt"
 import { faCopy } from "@fortawesome/free-solid-svg-icons/faCopy"
 import { faEdit } from "@fortawesome/free-solid-svg-icons/faEdit"
+import { canWriteToClipboard } from "@ourworldindata/utils/dist/Util.js"
 
 export interface ShareMenuManager {
     slug?: string
@@ -26,6 +27,7 @@ interface ShareMenuProps {
 }
 
 interface ShareMenuState {
+    canWriteToClipboard: boolean
     copied: boolean
 }
 
@@ -37,6 +39,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
         super(props)
 
         this.state = {
+            canWriteToClipboard: false,
             copied: false,
         }
     }
@@ -68,6 +71,9 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
 
     componentDidMount(): void {
         document.addEventListener("click", this.onClickSomewhere)
+        canWriteToClipboard().then((canWriteToClipboard) =>
+            this.setState({ canWriteToClipboard })
+        )
     }
 
     componentWillUnmount(): void {
@@ -98,11 +104,11 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
         }
     }
 
-    @action.bound onCopyUrl(): void {
+    @action.bound async onCopyUrl(): Promise<void> {
         if (!this.canonicalUrl) return
 
         try {
-            navigator.clipboard.writeText(this.canonicalUrl)
+            await navigator.clipboard.writeText(this.canonicalUrl)
             this.setState({ copied: true })
         } catch (err) {
             console.error(
@@ -177,7 +183,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
                         <FontAwesomeIcon icon={faShareAlt} /> Share via&hellip;
                     </a>
                 )}
-                {"clipboard" in navigator && (
+                {this.state.canWriteToClipboard && (
                     <a
                         className="btn"
                         title="Copy link to clipboard"

--- a/site/blocks/CodeSnippet.tsx
+++ b/site/blocks/CodeSnippet.tsx
@@ -1,12 +1,18 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import classnames from "classnames"
 import ReactDOM from "react-dom"
 import ReactDOMServer from "react-dom/server.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faCopy } from "@fortawesome/free-solid-svg-icons/faCopy"
+import { canWriteToClipboard } from "@ourworldindata/utils/dist/Util.js"
 
 export const CodeSnippet = (props: { code: string }) => {
+    const [canCopy, setCanCopy] = useState(false)
     const [hasCopied, setHasCopied] = useState(false)
+
+    useEffect(() => {
+        canWriteToClipboard().then(setCanCopy)
+    }, [])
 
     const copy = async () => {
         try {
@@ -27,15 +33,17 @@ export const CodeSnippet = (props: { code: string }) => {
             <pre className="wp-block-code">
                 <code>{props.code}</code>
             </pre>
-            <button
-                className={classnames("code-copy-button", {
-                    "code-copy-button--has-copied": hasCopied,
-                })}
-                onClick={copy}
-                aria-label="Copy to clipboard"
-            >
-                <FontAwesomeIcon icon={faCopy} />
-            </button>
+            {canCopy && (
+                <button
+                    className={classnames("code-copy-button", {
+                        "code-copy-button--has-copied": hasCopied,
+                    })}
+                    onClick={copy}
+                    aria-label="Copy to clipboard"
+                >
+                    <FontAwesomeIcon icon={faCopy} />
+                </button>
+            )}
         </div>
     )
 }

--- a/site/blocks/CodeSnippet.tsx
+++ b/site/blocks/CodeSnippet.tsx
@@ -8,9 +8,9 @@ import { faCopy } from "@fortawesome/free-solid-svg-icons/faCopy"
 export const CodeSnippet = (props: { code: string }) => {
     const [hasCopied, setHasCopied] = useState(false)
 
-    const copy = () => {
+    const copy = async () => {
         try {
-            navigator.clipboard.writeText(props.code)
+            await navigator.clipboard.writeText(props.code)
             setHasCopied(true)
             // reset CSS animation
             setTimeout(() => setHasCopied(false), 500)


### PR DESCRIPTION
Demo available at https://zo6kbr.csb.app/, and currently live on _tufte_.

On live, in pretty much every iframe we were offering the option to `Copy link`, and were suggesting that copying worked fine, when in reality it was just failing. Now we check beforehand whether copying works.

![image](https://user-images.githubusercontent.com/2641501/207142001-9910b51b-25df-4d24-94e5-a8628b449917.png)


---

Context: [a message from Jason a while back](https://owid.slack.com/archives/C46U9LXRR/p1662167698237319?thread_ts=1662072770.585419&cid=C46U9LXRR)