### PR TITLE
add support for explorers

### DIFF
--- a/site/gdocs/Chart.tsx
+++ b/site/gdocs/Chart.tsx
@@ -3,6 +3,7 @@ import { useRef } from "react"
 import { useEmbedChart } from "../hooks.js"
 import { EnrichedBlockChart } from "@ourworldindata/utils"
 import { renderSpans } from "./utils"
+import { EXPLORERS_ROUTE_FOLDER } from '../../explorer/ExplorerConstants.js';
 import cx from "classnames"
 
 export default function Chart({
@@ -31,7 +32,8 @@ export default function Chart({
             <figure
                 // Use unique `key` to force React to re-render tree
                 key={d.url}
-                data-grapher-src={d.url}
+                data-grapher-src={d.url.includes(`/${EXPLORERS_ROUTE_FOLDER}/`) ? undefined : d.url}
+                data-explorer-src={d.url.includes(`/${EXPLORERS_ROUTE_FOLDER}/`) ? d.url : undefined}
                 style={{
                     width: "100%",
                     border: "0px none",


### PR DESCRIPTION
This adds support to the `{chart}` component in GDocs so that it can render explorers as well as Graphers. It does this by examining the provided URL, checking to see if it looks like an explorer, and adding the correct data attribute based on that.