### PR TITLE
fix: get rid of mobx "out of bounds" warning

### DIFF
--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
@@ -181,9 +181,9 @@ export const makeRowFromColumnStore = (
     columnStore: CoreColumnStore
 ): CoreRow => {
     const row: CoreRow = {}
-    const columns = Object.values(columnStore)
-    Object.keys(columnStore).forEach((slug, colIndex) => {
-        row[slug] = columns[colIndex][rowIndex]
+    Object.entries(columnStore).forEach(([slug, col]) => {
+        if (col.length <= rowIndex) row[slug] = undefined
+        else row[slug] = col[rowIndex]
     })
     return row
 }

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2223,9 +2223,11 @@ export class Grapher
         // "ourworldindata.org" and yet should still yield a match.
         // - Note that this won't work on production previews (where the
         //   path is /admin/posts/preview/ID)
+        const { hasRelatedQuestion } = this
         return (
+            hasRelatedQuestion &&
             getWindowUrl().pathname !==
-            Url.fromURL(this.relatedQuestions[0]?.url).pathname
+                Url.fromURL(this.relatedQuestions[0]?.url).pathname
         )
     }
 

--- a/site/multiembedder/MultiEmbedder.tsx
+++ b/site/multiembedder/MultiEmbedder.tsx
@@ -69,7 +69,8 @@ class MultiEmbedder {
                     rootMargin: "200%",
                 }
             )
-        } else {
+        } else if (typeof window === "object" && typeof document === "object") {
+            // only show the warning when we're in something that roughly resembles a browser
             console.warn(
                 "IntersectionObserver not available; interactive embeds won't load on this page"
             )


### PR DESCRIPTION
> [mobx.array] Attempt to read an array index (0) that is out of bounds (0). Please check length first. Out of bound indices will not be tracked by MobX

This might not fix every case we see this warning, but it definitely makes it less common for now.
The `relatedQuestion` one we saw on every chart that didn't feature a related question, for example.