### PR TITLE
fix: ensure connection is ready before `getListedGdocs()`

### DIFF
--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -719,6 +719,8 @@ export const getBlogIndex = memoize(async (): Promise<IndexPost[]> => {
     const wordpressPostsCards = await Promise.all(
         wordpressPosts.map((post) => getFullPost(post, true))
     )
+
+    await db.getConnection() // side effect: ensure connection is established
     const listedGdocs = await Gdoc.getListedGdocs()
 
     return orderBy(


### PR DESCRIPTION
Fixes #1811

Avoid a `DataSource is not set for this entity` error when querying the typeorm model for Google Docs by connecting before calling the method.
