### PR TITLE
chore(ci): svgTester better communicates errors

### DIFF
--- a/.github/workflows/svg-compare.yml
+++ b/.github/workflows/svg-compare.yml
@@ -44,7 +44,7 @@ jobs:
               run: git branch ${{ env.PUSH_BRANCH_NAME }} && git checkout ${{ env.PUSH_BRANCH_NAME }}
 
             # Run the verify tool overwriting any svgs. Stdout is piped to compare-result which will be a 0 byte file if everything works or contain failed grapher ids otherwise
-            - name: Run tests & checks
+            - name: Generate SVGs and compare to reference
               id: run-verify-graphs
               continue-on-error: true
               env:
@@ -61,11 +61,20 @@ jobs:
                   push_options: "--force"
                   commit_message: Automated commit with svg differences triggered by commit https://github.com/owid/owid-grapher/commit/${{github.sha}}
 
+            # The action fails if there were any errors.
+            - name: Fail with error message if we had errors
+              if: ${{ steps.run-verify-graphs.outputs.num_errors > 0 }}
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      core.setFailed('Errors were thrown during checking! Please check diffs at https://github.com/owid/owid-grapher-svgs/commits/${{ env.PUSH_BRANCH_NAME }}')
+
             # We make the action fail if there were any differences and if we are on a branch other than master. On master
             # we do not want to fail because the differences on master are intended to be authorative and thus there is no
             # reason to mark this action as failed.
             - name: Fail with error message if we had differences
-              if: ${{ steps.run-verify-graphs.outcome == 'failure' && env.PUSH_BRANCH_NAME != 'master' }}
+              if: ${{ steps.run-verify-graphs.outputs.num_differences > 0 }}
+              continue-on-error: ${{ env.PUSH_BRANCH_NAME == 'master' }}
               uses: actions/github-script@v6
               with:
                   script: |

--- a/.github/workflows/svg-compare.yml
+++ b/.github/workflows/svg-compare.yml
@@ -47,7 +47,10 @@ jobs:
             - name: Run tests & checks
               id: run-verify-graphs
               continue-on-error: true
-              run: node itsJustJavascript/devTools/svgTester/verify-graphs.js -i owid-grapher-svgs/configs -o owid-grapher-svgs/svg -r owid-grapher-svgs/svg > compare-result
+              env:
+                  # using "ternary operator" from https://github.com/actions/runner/issues/409#issuecomment-752775072
+                  RM_ON_ERROR: ${{ env.PUSH_BRANCH_NAME == 'master' && '' || '--rmOnError' }}
+              run: node itsJustJavascript/devTools/svgTester/verify-graphs.js -i owid-grapher-svgs/configs -o owid-grapher-svgs/svg -r owid-grapher-svgs/svg $RM_ON_ERROR > compare-result
 
             # If the last step failed we want to commit all changed svgs and push them to the new branch on the owid-grapher-svgs repo
             - uses: stefanzweifel/git-auto-commit-action@v4

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -516,6 +516,15 @@ export async function prepareVerifyRun(
     return directoriesToProcess
 }
 
+// no-op when not running inside GH Actions
+const setGhActionsOutput = (key: string, value: string | number) => {
+    const outPath = process.env.GITHUB_OUTPUT
+    if (outPath && fs.existsSync(outPath)) {
+        // this is not bulletproof and expects both to not contain special characters
+        fs.appendFileSync(outPath, `${key}=${value}`)
+    }
+}
+
 export function displayVerifyResultsAndGetExitCode(
     validationResults: VerifyResult[],
     verbose: boolean,
@@ -547,6 +556,7 @@ export function displayVerifyResultsAndGetExitCode(
             for (const result of errorResults) {
                 console.log(result.graphId?.toString(), result.error) // write to stdout one grapher id per file for easy piping to other processes
             }
+            setGhActionsOutput("num_errors", errorResults.length)
         }
         if (differenceResults.length) {
             console.warn(
@@ -559,6 +569,7 @@ export function displayVerifyResultsAndGetExitCode(
             for (const result of differenceResults) {
                 console.log("", result.difference.chartId) // write to stdout one grapher id per file for easy piping to other processes
             }
+            setGhActionsOutput("num_differences", differenceResults.length)
         }
         returnCode = errorResults.length + differenceResults.length
     }

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -16,6 +16,7 @@ async function main(parsedArgs: parseArgs.ParsedArgs) {
         const suffix = parsedArgs["s"] ?? ""
         // minimist turns a single number into a JS number so we do toString to normalize (TS types are misleading)
         const rawGrapherIds: string = (parsedArgs["g"] ?? "").toString()
+        const rmOnError = parsedArgs["rmOnError"] ?? false
 
         if (!fs.existsSync(inDir))
             throw `Input directory does not exist ${inDir}`
@@ -39,6 +40,7 @@ async function main(parsedArgs: parseArgs.ParsedArgs) {
             outDir,
             verbose,
             suffix,
+            rmOnError,
         }))
 
         const pool = workerpool.pool(__dirname + "/worker.js", {
@@ -90,6 +92,7 @@ Options:
     -g IDS         Manually specify ids to verify (use comma separated ids and ranges, all without spaces. E.g.: 2,4-8,10)
     -v             Verbose mode
     -s SUFFIX      Suffix for different svg files to create <NAME><SUFFIX>.svg files - useful if you want to set output to the same as reference
+    --rmOnError    Remove output files where we encounter errors, so errors are apparent in diffs
     `)
     process.exit(0)
 } else {


### PR DESCRIPTION
Up until now, the svgTester was not failing (on master, at least) when there were errors occurring!

When not on master, it was also hard to notice these errors because they were only part of the log, not of the diff.

This now makes it such that:
- Errors are very apparent as the exit reason (even on master)
- When not on master, erroneous svg files will be deleted, such that they are visible in the GH diff