### PR TITLE
feature(admin): add tab with redirect to fast-track app

### DIFF
--- a/adminSiteClient/AdminSidebar.tsx
+++ b/adminSiteClient/AdminSidebar.tsx
@@ -6,6 +6,7 @@ import { faFile } from "@fortawesome/free-solid-svg-icons/faFile"
 import { faArrowPointer } from "@fortawesome/free-solid-svg-icons/faArrowPointer"
 import { faUpload } from "@fortawesome/free-solid-svg-icons/faUpload"
 import { faTable } from "@fortawesome/free-solid-svg-icons/faTable"
+import { faTruckFast } from "@fortawesome/free-solid-svg-icons/faTruckFast"
 import { faSkullCrossbones } from "@fortawesome/free-solid-svg-icons/faSkullCrossbones"
 import { faPen } from "@fortawesome/free-solid-svg-icons/faPen"
 import { faDatabase } from "@fortawesome/free-solid-svg-icons/faDatabase"
@@ -20,6 +21,8 @@ import { faBook } from "@fortawesome/free-solid-svg-icons/faBook"
 import { faSatelliteDish } from "@fortawesome/free-solid-svg-icons/faSatelliteDish"
 import { faCodeBranch } from "@fortawesome/free-solid-svg-icons/faCodeBranch"
 import { faDownload } from "@fortawesome/free-solid-svg-icons/faDownload"
+
+import { FASTTRACK_URL } from "../settings/clientSettings.js"
 
 export const AdminSidebar = (): JSX.Element => (
     <aside className="AdminSidebar">
@@ -48,6 +51,16 @@ export const AdminSidebar = (): JSX.Element => (
                 <Link to="/import">
                     <FontAwesomeIcon icon={faUpload} /> Import CSV
                 </Link>
+            </li>
+            <li>
+                <a
+                    href={FASTTRACK_URL}
+                    target="_blank"
+                    rel="noopener"
+                    title="Tailscale required"
+                >
+                    <FontAwesomeIcon icon={faTruckFast} /> Fast-track
+                </a>
             </li>
             <li>
                 <Link to="/datasets">

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -49,3 +49,7 @@ export const TOPICS_CONTENT_GRAPH: boolean =
 export const GDOCS_CLIENT_EMAIL: string = process.env.GDOCS_CLIENT_EMAIL ?? ""
 export const GDOCS_BASIC_ARTICLE_TEMPLATE_URL: string =
     process.env.GDOCS_BASIC_ARTICLE_TEMPLATE_URL ?? ""
+
+// Fast-track settings, by default points to staging version. You need Tailscale to access it.
+export const FASTTRACK_URL: string =
+    process.env.FASTTRACK_URL ?? "http://owid-analytics:8083/"


### PR DESCRIPTION
Add a tab that redirects to fast-track running on our analytics server. To access it, users will need to **install Tailscale and login with Github**.  Lars said it's [reasonable ask](https://github.com/owid/engineering/issues/34#issuecomment-1323363904) to want this from authors (I guess we'll want to use it for other things in the future too). We could also set up nginx proxy from owid-analytics, but that sounds painful and I don't want to overcomplicate it (given that future of fast-track is unclear). On the other hand, isn't asking for Tailscale too much?

If we go with Tailscale, it's gonna be confusing for authors without Tailscale to land on a page that doesn't work... Not sure how to communicate that in the admin though.

(Fast-track is currently running only for staging at http://owid-analytics:8083/)