### PR TITLE
fix: exclude population variable from sources footer

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1384,21 +1384,26 @@ export class Grapher
         // "Countries Continent"
         const continentsVariableId = "123"
 
-        // "Population (historical estimates), Gapminder, HYDE & UN"
-        const populationVariableId = "525711"
+        const populationVariableIds = [
+            "525709", // "Population (historical + projections), Gapminder, HYDE & UN"
+            "525711", // "Population (historical estimates), Gapminder, HYDE & UN"
+        ]
 
         const columnSlugs = [...yColumnSlugs]
 
         if (xColumnSlug !== undefined) {
             // exclude population variable if its used as the x dimension in a marimekko
-            if (xColumnSlug != populationVariableId || !this.isMarimekko)
+            if (
+                !populationVariableIds.includes(xColumnSlug) ||
+                !this.isMarimekko
+            )
                 columnSlugs.push(xColumnSlug)
         }
 
         // exclude population variable if its used as the size dimension in a scatter plot
         if (
             sizeColumnSlug !== undefined &&
-            sizeColumnSlug != populationVariableId
+            !populationVariableIds.includes(sizeColumnSlug)
         )
             columnSlugs.push(sizeColumnSlug)
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1392,7 +1392,7 @@ export class Grapher
         const columnSlugs = [...yColumnSlugs]
 
         if (xColumnSlug !== undefined) {
-            // exclude population variable if its used as the x dimension in a marimekko
+            // exclude population variable if it's used as the x dimension in a marimekko
             if (
                 !populationVariableIds.includes(xColumnSlug) ||
                 !this.isMarimekko
@@ -1400,14 +1400,14 @@ export class Grapher
                 columnSlugs.push(xColumnSlug)
         }
 
-        // exclude population variable if its used as the size dimension in a scatter plot
+        // exclude population variable if it's used as the size dimension in a scatter plot
         if (
             sizeColumnSlug !== undefined &&
             !populationVariableIds.includes(sizeColumnSlug)
         )
             columnSlugs.push(sizeColumnSlug)
 
-        // exclude "Countries Continent" if its used as the color dimension in a scatter plot, slope chart etc.
+        // exclude "Countries Continent" if it's used as the color dimension in a scatter plot, slope chart etc.
         if (
             colorColumnSlug !== undefined &&
             colorColumnSlug != continentsVariableId

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1382,35 +1382,31 @@ export class Grapher
             this
 
         // "Countries Continent"
-        const continentsVariableId = "123"
+        const isContinentsVariableId = (id: string): boolean => id === "123"
 
-        const populationVariableIds = [
-            "525709", // "Population (historical + projections), Gapminder, HYDE & UN"
-            "525711", // "Population (historical estimates), Gapminder, HYDE & UN"
-        ]
+        const isPopulationVariableId = (id: string): boolean =>
+            id === "525709" || // "Population (historical + projections), Gapminder, HYDE & UN"
+            id === "525711" // "Population (historical estimates), Gapminder, HYDE & UN"
 
         const columnSlugs = [...yColumnSlugs]
 
         if (xColumnSlug !== undefined) {
             // exclude population variable if it's used as the x dimension in a marimekko
-            if (
-                !populationVariableIds.includes(xColumnSlug) ||
-                !this.isMarimekko
-            )
+            if (!isPopulationVariableId(xColumnSlug) || !this.isMarimekko)
                 columnSlugs.push(xColumnSlug)
         }
 
         // exclude population variable if it's used as the size dimension in a scatter plot
         if (
             sizeColumnSlug !== undefined &&
-            !populationVariableIds.includes(sizeColumnSlug)
+            !isPopulationVariableId(sizeColumnSlug)
         )
             columnSlugs.push(sizeColumnSlug)
 
         // exclude "Countries Continent" if it's used as the color dimension in a scatter plot, slope chart etc.
         if (
             colorColumnSlug !== undefined &&
-            colorColumnSlug != continentsVariableId
+            isContinentsVariableId(colorColumnSlug)
         )
             columnSlugs.push(colorColumnSlug)
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1381,16 +1381,32 @@ export class Grapher
         const { yColumnSlugs, xColumnSlug, sizeColumnSlug, colorColumnSlug } =
             this
 
+        // "Countries Continent"
+        const continentsVariableId = "123"
+
+        // "Population (historical estimates), Gapminder, HYDE & UN"
+        const populationVariableId = "525711"
+
         const columnSlugs = [...yColumnSlugs]
 
-        if (xColumnSlug !== undefined) columnSlugs.push(xColumnSlug)
+        if (xColumnSlug !== undefined) {
+            // exclude population variable if its used as the x dimension in a marimekko
+            if (xColumnSlug != populationVariableId || !this.isMarimekko)
+                columnSlugs.push(xColumnSlug)
+        }
 
-        // exclude "Total population (Gapminder, HYDE & UN)" if its used as the size dimension in a scatter plot
-        if (sizeColumnSlug !== undefined && sizeColumnSlug != "72")
+        // exclude population variable if its used as the size dimension in a scatter plot
+        if (
+            sizeColumnSlug !== undefined &&
+            sizeColumnSlug != populationVariableId
+        )
             columnSlugs.push(sizeColumnSlug)
 
         // exclude "Countries Continent" if its used as the color dimension in a scatter plot, slope chart etc.
-        if (colorColumnSlug !== undefined && colorColumnSlug != "123")
+        if (
+            colorColumnSlug !== undefined &&
+            colorColumnSlug != continentsVariableId
+        )
             columnSlugs.push(colorColumnSlug)
 
         return this.inputTable


### PR DESCRIPTION
Resolves #1806

... if it's used as a size or marimekko x variable.
had to update the variable id to use.

 [Slack context](https://owid.slack.com/archives/C46U9LXRR/p1670855145129159).