### PR TITLE
enhance: unify "No matching data" message between chart types

### DIFF
--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -503,7 +503,7 @@ export class DiscreteBarChart
 
         // TODO is it better to use .series for this check?
         return this.yColumns.every((col) => col.isEmpty)
-            ? `No matching data in columns ${this.yColumnSlugs.join(", ")}`
+            ? "No matching data"
             : ""
     }
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -1803,12 +1803,10 @@ export class MarimekkoChart
 
     @computed get failMessage(): string {
         const column = this.yColumns[0]
-        const { yColumns, yColumnSlugs } = this
+        const { yColumns } = this
 
         if (!column) return "No Y column to chart"
 
-        return yColumns.every((col) => col.isEmpty)
-            ? `No matching data in columns ${yColumnSlugs.join(", ")}`
-            : ""
+        return yColumns.every((col) => col.isEmpty) ? "No matching data" : ""
     }
 }

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -840,7 +840,7 @@ export class StackedDiscreteBarChart
 
         // TODO is it better to use .series for this check?
         return this.yColumns.every((col) => col.isEmpty)
-            ? `No matching data in columns ${this.yColumnSlugs.join(", ")}`
+            ? "No matching data"
             : ""
     }
 


### PR DESCRIPTION
Since the information _which_ columns lack data is rarely of use to the end user.

[As requested](https://owid.slack.com/archives/C46U9LXRR/p1670861719945009?thread_ts=1670861612.951139&cid=C46U9LXRR) by @JoeHasell 