### PR TITLE
Fix leading/trailing whitespace links

### DIFF
--- a/db/gdocTests.test.ts
+++ b/db/gdocTests.test.ts
@@ -1,6 +1,10 @@
 #! /usr/bin/env yarn jest
 
-import { EnrichedBlockHeading, RawBlockHeading } from "@ourworldindata/utils"
+import {
+    EnrichedBlockHeading,
+    RawBlockHeading,
+    Span,
+} from "@ourworldindata/utils"
 import { stringToArchieML } from "./gdocToArchieml.js"
 import {
     owidRawArticleBlockToArchieMLString,

--- a/db/gdocTests.test.ts
+++ b/db/gdocTests.test.ts
@@ -4,9 +4,9 @@ import { EnrichedBlockHeading, RawBlockHeading } from "@ourworldindata/utils"
 import { stringToArchieML } from "./gdocToArchieml.js"
 import {
     owidRawArticleBlockToArchieMLString,
+    removeStylesOfLeadingTrackingNonwordSpans,
     spansToHtmlString,
 } from "./gdocUtils.js"
-
 function getArchieMLDocWithContent(content: string): string {
     return `title: Writing OWID Articles With Google Docs
 subtitle: This article documents how to use and configure the various built in features of our template system
@@ -20,6 +20,447 @@ ${content}
 []
 `
 }
+
+const examples: { name: string; input: Span[]; expected: Span[] }[] = [
+    {
+        name: "2 ws spans no nesting",
+        input: [
+            {
+                spanType: "span-simple-text",
+                text: " ",
+            },
+            {
+                spanType: "span-simple-text",
+                text: " ",
+            },
+            {
+                spanType: "span-simple-text",
+                text: "hello",
+            },
+        ],
+        expected: [
+            {
+                spanType: "span-simple-text",
+                text: "  ",
+            },
+            {
+                spanType: "span-simple-text",
+                text: "hello",
+            },
+        ],
+    },
+    {
+        name: "2 ws spans no nesting 2 ws",
+        input: [
+            {
+                spanType: "span-simple-text",
+                text: " ",
+            },
+            {
+                spanType: "span-simple-text",
+                text: " ",
+            },
+            {
+                spanType: "span-simple-text",
+                text: "hello",
+            },
+            {
+                spanType: "span-simple-text",
+                text: " ",
+            },
+            {
+                spanType: "span-simple-text",
+                text: " ",
+            },
+        ],
+        expected: [
+            {
+                spanType: "span-simple-text",
+                text: "  ",
+            },
+            {
+                spanType: "span-simple-text",
+                text: "hello",
+            },
+            {
+                spanType: "span-simple-text",
+                text: "  ",
+            },
+        ],
+    },
+    {
+        name: "2 ws spans with 1 level nesting",
+        input: [
+            {
+                spanType: "span-bold",
+                children: [
+                    {
+                        spanType: "span-simple-text",
+                        text: " ",
+                    },
+                ],
+            },
+            {
+                spanType: "span-simple-text",
+                text: " ",
+            },
+            {
+                spanType: "span-simple-text",
+                text: "hello",
+            },
+        ],
+        expected: [
+            {
+                spanType: "span-simple-text",
+                text: "  ",
+            },
+            {
+                spanType: "span-simple-text",
+                text: "hello",
+            },
+        ],
+    },
+    {
+        name: "2 ws spans with 1 level nesting, nested item is second",
+        input: [
+            {
+                spanType: "span-simple-text",
+                text: " ",
+            },
+            {
+                spanType: "span-bold",
+                children: [
+                    {
+                        spanType: "span-simple-text",
+                        text: " ",
+                    },
+                ],
+            },
+            {
+                spanType: "span-simple-text",
+                text: "hello",
+            },
+        ],
+        expected: [
+            {
+                spanType: "span-simple-text",
+                text: "  ",
+            },
+            {
+                spanType: "span-simple-text",
+                text: "hello",
+            },
+        ],
+    },
+    {
+        name: "2 ws spans with 2 level nesting",
+        input: [
+            {
+                spanType: "span-bold",
+                children: [
+                    {
+                        spanType: "span-simple-text",
+                        text: " ",
+                    },
+                ],
+            },
+            {
+                spanType: "span-bold",
+                children: [
+                    {
+                        spanType: "span-italic",
+                        children: [
+                            {
+                                spanType: "span-simple-text",
+                                text: " ",
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                spanType: "span-simple-text",
+                text: "hello",
+            },
+        ],
+        expected: [
+            {
+                spanType: "span-simple-text",
+                text: "  ",
+            },
+            {
+                spanType: "span-simple-text",
+                text: "hello",
+            },
+        ],
+    },
+    {
+        name: "No ws in the beginning, 2 nested levels",
+        input: [
+            {
+                spanType: "span-bold",
+                children: [
+                    {
+                        spanType: "span-simple-text",
+                        text: "non-ws ",
+                    },
+                ],
+            },
+            {
+                spanType: "span-bold",
+                children: [
+                    {
+                        spanType: "span-italic",
+                        children: [
+                            {
+                                spanType: "span-simple-text",
+                                text: " ",
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                spanType: "span-simple-text",
+                text: "hello",
+            },
+        ],
+        expected: [
+            {
+                spanType: "span-bold",
+                children: [
+                    {
+                        spanType: "span-simple-text",
+                        text: "non-ws ",
+                    },
+                ],
+            },
+            {
+                spanType: "span-bold",
+                children: [
+                    {
+                        spanType: "span-italic",
+                        children: [
+                            {
+                                spanType: "span-simple-text",
+                                text: " ",
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                spanType: "span-simple-text",
+                text: "hello",
+            },
+        ],
+    },
+    {
+        name: "WS in the first word, 2 nested levels",
+        input: [
+            {
+                spanType: "span-bold",
+                children: [
+                    {
+                        spanType: "span-simple-text",
+                        text: "   non-ws ",
+                    },
+                ],
+            },
+            {
+                spanType: "span-bold",
+                children: [
+                    {
+                        spanType: "span-italic",
+                        children: [
+                            {
+                                spanType: "span-simple-text",
+                                text: " ",
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                spanType: "span-simple-text",
+                text: "hello",
+            },
+        ],
+        expected: [
+            {
+                spanType: "span-simple-text",
+                text: "   ",
+            },
+            {
+                spanType: "span-bold",
+                children: [
+                    {
+                        spanType: "span-simple-text",
+                        text: "non-ws ",
+                    },
+                ],
+            },
+            {
+                spanType: "span-bold",
+                children: [
+                    {
+                        spanType: "span-italic",
+                        children: [
+                            {
+                                spanType: "span-simple-text",
+                                text: " ",
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                spanType: "span-simple-text",
+                text: "hello",
+            },
+        ],
+    },
+    {
+        name: "WS in the first span, WS in the second span at nesting level 2, WS at the beginning of the third span at nesting level 3",
+        input: [
+            {
+                spanType: "span-bold",
+                children: [
+                    {
+                        spanType: "span-simple-text",
+                        text: "   ",
+                    },
+                ],
+            },
+            {
+                spanType: "span-bold",
+                children: [
+                    {
+                        spanType: "span-italic",
+                        children: [
+                            {
+                                spanType: "span-simple-text",
+                                text: " ",
+                            },
+                            {
+                                spanType: "span-superscript",
+                                children: [
+                                    {
+                                        spanType: "span-simple-text",
+                                        text: "   non-ws ",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                spanType: "span-simple-text",
+                text: "hello",
+            },
+        ],
+        expected: [
+            {
+                spanType: "span-simple-text",
+                text: "       ",
+            },
+            {
+                spanType: "span-bold",
+                children: [
+                    {
+                        spanType: "span-italic",
+                        children: [
+                            {
+                                spanType: "span-superscript",
+                                children: [
+                                    {
+                                        spanType: "span-simple-text",
+                                        text: "non-ws ",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                spanType: "span-simple-text",
+                text: "hello",
+            },
+        ],
+    },
+    {
+        name: "WS in the first span, WS in the second span at nesting level 2, WS at the beginning of the third span at nesting level 3, WS after the word, then 1 WS only span",
+        input: [
+            {
+                spanType: "span-bold",
+                children: [
+                    {
+                        spanType: "span-simple-text",
+                        text: "   ",
+                    },
+                ],
+            },
+            {
+                spanType: "span-bold",
+                children: [
+                    {
+                        spanType: "span-italic",
+                        children: [
+                            {
+                                spanType: "span-simple-text",
+                                text: " ",
+                            },
+                            {
+                                spanType: "span-superscript",
+                                children: [
+                                    {
+                                        spanType: "span-simple-text",
+                                        text: "   non-ws  ",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                spanType: "span-simple-text",
+                text: "  ",
+            },
+        ],
+        expected: [
+            {
+                spanType: "span-simple-text",
+                text: "       ",
+            },
+            {
+                spanType: "span-bold",
+                children: [
+                    {
+                        spanType: "span-italic",
+                        children: [
+                            {
+                                spanType: "span-superscript",
+                                children: [
+                                    {
+                                        spanType: "span-simple-text",
+                                        text: "non-ws",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                spanType: "span-simple-text",
+                text: "    ",
+            },
+        ],
+    },
+]
 
 describe("gdoc parsing works", () => {
     it("can parse an aside block", () => {
@@ -79,4 +520,13 @@ level: 2
             owidRawArticleBlockToArchieMLString(expectedRawBlock)
         expect(serializedRawBlock).toEqual(archieMLString)
     })
+
+    it.each(examples)(
+        "removes styling of leading/tracking whitespace only spans correctly - #$#",
+        (example) => {
+            expect(
+                removeStylesOfLeadingTrackingNonwordSpans(example.input)
+            ).toEqual(example.expected)
+        }
+    )
 })

--- a/db/gdocUtils.ts
+++ b/db/gdocUtils.ts
@@ -696,7 +696,13 @@ export function htmlToSpans(html: string): Span[] {
     const $ = cheerio.load(html)
     const nodes = $("body").contents().toArray()
     const spans = compact(nodes.map(cheerioToSpan)) ?? []
-    return removeStylesOfLeadingTrackingNonwordSpans(spans)
+    // here we go through each top level span that we created and pull out the leading and trailing whitespace
+    // (either standalone simple-text spans or spans that contain leading whitespace if at the beginning or
+    // trailing whitespace if at the end). "Pull out" means that we convert these whitespace characters to a
+    // standalone simple-text span and remove the whitespace from the span that contained it.
+    return spans.flatMap((span) =>
+        removeStylesOfLeadingTrackingNonwordSpans([span])
+    )
 }
 
 // Sometimes Google automatically linkifies a URL.

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -431,6 +431,16 @@ export type SpanQuote = {
     children: Span[]
 }
 export type UnformattedSpan = SpanSimpleText | SpanNewline
+export const SpanTypesWithChildren = [
+    "span-link",
+    "span-italic",
+    "span-bold",
+    "span-underline",
+    "span-subscript",
+    "span-superscript",
+    "span-quote",
+    "span-fallback",
+] as const
 
 export type Span =
     | SpanSimpleText


### PR DESCRIPTION
In google docs it often happens that links or other styling spans include whitespaces (especially at the beginning of a word in the SDG pages). We want to avoid that. 

To do so, this code goes through the tree of spans recursively and scans while the content is only whitespace. All initial whitespace only span-simple-text spans and the whitespace start of the first non-whitespace containing span are then collected, deleted from the original nested spans and the collected whitespace inserted as one single span-simple-text span at the beginning (and the whole procedure vice versa for the trailing WS)