### PR TITLE
Fix explorer crash on iOS

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -951,7 +951,7 @@ export class Grapher
 
     @computed get shouldLinkToOwid(): boolean {
         if (
-            this.isEmbeddedInAnOwidPage ||
+            this.props.isEmbeddedInAnOwidPage ||
             this.isExportingtoSvgOrPng ||
             !this.isInIFrame
         )
@@ -1606,18 +1606,23 @@ export class Grapher
                 Bugsnag.getPlugin("react").createErrorBoundary(React)
         }
 
-        const bounds = Bounds.fromRect(containerNode.getBoundingClientRect())
-
-        const props: GrapherProgrammaticInterface = {
-            ...config,
-            bounds,
+        const setBoundsFromContainerAndRender = (): void => {
+            const props: GrapherProgrammaticInterface = {
+                ...config,
+                bounds: Bounds.fromRect(containerNode.getBoundingClientRect()),
+            }
+            ReactDOM.render(
+                <ErrorBoundary>
+                    <Grapher ref={grapherInstanceRef} {...props} />
+                </ErrorBoundary>,
+                containerNode
+            )
         }
 
-        ReactDOM.render(
-            <ErrorBoundary>
-                <Grapher ref={grapherInstanceRef} {...props} />
-            </ErrorBoundary>,
-            containerNode
+        setBoundsFromContainerAndRender()
+        window.addEventListener(
+            "resize",
+            debounce(setBoundsFromContainerAndRender, 400)
         )
 
         return grapherInstanceRef.current
@@ -1646,10 +1651,6 @@ export class Grapher
 
     @computed get isMobile(): boolean {
         return isMobile()
-    }
-
-    @computed get isEmbeddedInAnOwidPage(): boolean {
-        return this.props.isEmbeddedInAnOwidPage || false
     }
 
     @computed private get bounds(): Bounds {
@@ -1682,7 +1683,11 @@ export class Grapher
         } = this
 
         // For these, defer to the bounds that is set externally
-        if (this.isEmbeddedInAnOwidPage || this.props.manager || isInIFrame)
+        if (
+            this.props.isEmbeddedInAnOwidPage ||
+            this.props.manager ||
+            isInIFrame
+        )
             return false
 
         // If the user is using interactive version and then goes to export chart, use current bounds to maintain WYSIWYG
@@ -2154,23 +2159,6 @@ export class Grapher
 
     componentDidMount(): void {
         window.addEventListener("scroll", this.checkVisibility)
-        window.addEventListener(
-            "resize",
-            debounce(() => {
-                if (
-                    this.containerElement &&
-                    this.containerElement.parentElement
-                ) {
-                    Grapher.renderGrapherIntoContainer(
-                        {
-                            ...this.toObject(),
-                            isEmbeddedInAnOwidPage: this.isEmbeddedInAnOwidPage,
-                        },
-                        this.containerElement.parentElement
-                    )
-                }
-            }, 200)
-        )
         this.setBaseFontSize()
         this.checkVisibility()
         exposeInstanceOnWindow(this, "grapher")


### PR DESCRIPTION
This change in resize logic did not play safely with the way explorers use graphers.

The explorer render path doesn't leverage `renderGrapherIntoContainer` , but `componentDidMount` still calls and something about the config was not persisting correctly causing the view to break when changing tabs.

This reverts the change.