### PR TITLE
Remove link to SDG tracker

### DIFF
--- a/site/FrontPage.tsx
+++ b/site/FrontPage.tsx
@@ -314,7 +314,7 @@ export const FrontPage = (props: {
                 <section className="homepage-projects">
                     <div className="wrapper">
                         <div className="list">
-                            {/* <a
+                            <a
                                 href="https://sdg-tracker.org"
                                 className="list-item"
                                 data-track-note="homepage-projects"
@@ -338,7 +338,7 @@ export const FrontPage = (props: {
                                 <div className="icon-right">
                                     <FontAwesomeIcon icon={faExternalLinkAlt} />
                                 </div>
-                            </a> */}
+                            </a>
                             <a
                                 href="/teaching"
                                 className="list-item"

--- a/site/FrontPage.tsx
+++ b/site/FrontPage.tsx
@@ -314,7 +314,7 @@ export const FrontPage = (props: {
                 <section className="homepage-projects">
                     <div className="wrapper">
                         <div className="list">
-                            <a
+                            {/* <a
                                 href="https://sdg-tracker.org"
                                 className="list-item"
                                 data-track-note="homepage-projects"
@@ -338,7 +338,7 @@ export const FrontPage = (props: {
                                 <div className="icon-right">
                                     <FontAwesomeIcon icon={faExternalLinkAlt} />
                                 </div>
-                            </a>
+                            </a> */}
                             <a
                                 href="/teaching"
                                 className="list-item"

--- a/site/SiteHeader.tsx
+++ b/site/SiteHeader.tsx
@@ -91,14 +91,14 @@ export const SiteHeader = (props: SiteHeaderProps) => (
                                     </a>
                                 </li>
                                 {/* <li><a href="/teaching"  data-track-note="header-navigation">Teaching Hub</a></li> */}
-                                <li>
+                                {/* <li>
                                     <a
                                         href="https://sdg-tracker.org"
                                         data-track-note="header-navigation"
                                     >
                                         Sustainable Development Goals Tracker
                                     </a>
-                                </li>
+                                </li> */}
                             </ul>
                         </div>
                     </div>

--- a/site/SiteHeaderMenus.tsx
+++ b/site/SiteHeaderMenus.tsx
@@ -518,14 +518,14 @@ class MobileTopicsMenu extends React.Component<{
                             Teaching Hub
                         </a>
                     </li>
-                    {/* <li className="end-link">
+                    <li className="end-link">
                         <a
                             href="https://sdg-tracker.org"
                             data-track-note="header-navigation"
                         >
                             Sustainable Development Goals Tracker
                         </a>
-                    </li> */}
+                    </li>
                     <li className="end-link">
                         <a href="/blog" data-track-note="header-navigation">
                             Latest

--- a/site/SiteHeaderMenus.tsx
+++ b/site/SiteHeaderMenus.tsx
@@ -213,7 +213,7 @@ class Header extends React.Component<{
                                         </a>
                                     </li>
                                     {/* <li><a href="/teaching" data-track-note="header-navigation">Teaching Hub</a></li> */}
-                                    <li>
+                                    {/* <li>
                                         <a
                                             href="https://sdg-tracker.org"
                                             data-track-note="header-navigation"
@@ -221,7 +221,7 @@ class Header extends React.Component<{
                                             Sustainable Development Goals
                                             Tracker
                                         </a>
-                                    </li>
+                                    </li> */}
                                 </ul>
                             </div>
                         </div>
@@ -518,14 +518,14 @@ class MobileTopicsMenu extends React.Component<{
                             Teaching Hub
                         </a>
                     </li>
-                    <li className="end-link">
+                    {/* <li className="end-link">
                         <a
                             href="https://sdg-tracker.org"
                             data-track-note="header-navigation"
                         >
                             Sustainable Development Goals Tracker
                         </a>
-                    </li>
+                    </li> */}
                     <li className="end-link">
                         <a href="/blog" data-track-note="header-navigation">
                             Latest


### PR DESCRIPTION
Removing the most prominent link until we've launched the new SDG tracker. I've commented this out rather than remove it since we may add it back with the launch of the new page. 