### PR TITLE
feat: fix the leading whitespace underlined issue in links in gdoc posts

### DIFF
--- a/db/gdocToArchieml.ts
+++ b/db/gdocToArchieml.ts
@@ -54,7 +54,27 @@ export const stringToArchieML = (text: string): OwidArticleContent => {
         return val.replace(/\{\/?ref\}/g, "")
     })
 
-    const parsed = load(text)
+    // A note on the use of Regexps here: doing this is in theory a bit crude
+    // as we are hacking at the plain text representation where we will have a
+    // much richer tree data structure a bit further down. However, manipulating
+    // the tree data structure to correctly collect whitespace and deal with
+    // arbitrary numbers of opening/closing spans correctly adds significant complexity.
+    // Since here we expect to have created the a tag ourselves and always as the
+    // deepest level of nesting (see the readElements function) we can be confident
+    // that this will work as expected in this case and is much simpler than handling
+    // this later.
+
+    // Replace whitespace-only inside links. We need to keep the WS around, they
+    // just should not be displayed as links
+    const noWSOnlyLinks = text.replace(/(<a[^>]*>)(\s+)(<\/a>)/gims, "$2")
+    // Replace leading whitespace inside links. We need to keep the WS around, they
+    // just should not be displayed as links
+    const noLeadingWSLinks = noWSOnlyLinks.replace(
+        /(<a[^>]*>)(\s+)(.*?)(<\/a>)/gims,
+        "$2$1$3$4"
+    )
+
+    const parsed = load(noLeadingWSLinks)
     const toc: TocHeadingWithTitleSupertitle[] = []
     let pointer: Array<string | number> = []
     // archie doesn't have a nested list structure. it treats as a series of text blocks


### PR DESCRIPTION
This solution supersedes the approach in #1824. After a discussion today we decided that simplicity trumps possible correctness at the extreme - i.e. that using regexp to solve the immediate problem in two lines is better than adding a lot of recursive tree walking logic to the same ultimate effect.