### PR TITLE
chore(make): replace docker-compose with docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ up.full: require create-if-missing.env.full wordpress/.env tmp-downloads/owid_ch
 
 	@echo '==> Starting dev environment'
 	tmux new-session -s grapher \
-		-n docker 'docker-compose -f docker-compose.full.yml up' \; \
+		-n docker 'docker compose -f docker-compose.full.yml up' \; \
 			set remain-on-exit on \; \
 		new-window -n admin \
 			'devTools/docker/wait-for-mysql.sh && yarn run tsc-watch -b --onSuccess "yarn startAdminServer"' \; \
@@ -159,7 +159,7 @@ down.full:
 
 require:
 	@echo '==> Checking your local environment has the necessary commands...'
-	@which docker-compose >/dev/null 2>&1 || (echo "ERROR: docker-compose is required."; exit 1)
+	@which docker >/dev/null 2>&1 || (echo "ERROR: docker is required."; exit 1)
 	@which yarn >/dev/null 2>&1 || (echo "ERROR: yarn is required."; exit 1)
 	@which tmux >/dev/null 2>&1 || (echo "ERROR: tmux is required."; exit 1)
 	@which finger >/dev/null 2>&1 || (echo "ERROR: finger is required."; exit 1)


### PR DESCRIPTION
> The compose command in the Docker CLI supports most of the docker-compose commands and flags. It is expected to be a drop-in replacement for docker-compose.

Source: https://docs.docker.com/compose/cli-command-compatibility/

Used by remote dev setup https://github.com/owid/ops/pull/40