### PR TITLE
wip: remote dev

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
         {
             "label": "docker start (full)",
             "type": "shell",
-            "command": "docker compose -f docker-compose.full.yml up -d",
+            "command": "docker-compose -f docker-compose.full.yml up -d",
             "presentation": {
                 "reveal": "silent"
             }
@@ -31,7 +31,7 @@
         {
             "label": "startSiteFront",
             "type": "shell",
-            "command": "yarn startSiteFront --no-web-socket-server", // WS need to be somewhat proxied in nginx. This could be done later.
+            "command": "yarn startSiteFront", // WS need to be somewhat proxied in nginx. This could be done later.
             "isBackground": true,
             "presentation": {
                 "group": "watch"
@@ -85,7 +85,7 @@
             // - comment out "download wordpress uploads" below
             "label": "refresh wordpress",
             "type": "shell",
-            "command": "docker compose -f docker-compose.full.yml run --rm db-load-data /app/refresh-wordpress-data.sh",
+            "command": "docker-compose -f docker-compose.full.yml run --rm db-load-data /app/refresh-wordpress-data.sh",
             "dependsOrder": "parallel",
             "dependsOn": [
                 // "download wordpress database"
@@ -115,7 +115,7 @@
             // - comment out "download grapher chartdata" below
             "label": "refresh grapher",
             "type": "shell",
-            "command": "docker compose -f docker-compose.full.yml run --rm db-load-data /app/refresh-grapher-data.sh",
+            "command": "docker-compose -f docker-compose.full.yml run --rm db-load-data /app/refresh-grapher-data.sh",
             "dependsOrder": "parallel",
             "dependsOn": [
                 "download grapher metadata",

--- a/devTools/docker/vhosts.conf
+++ b/devTools/docker/vhosts.conf
@@ -12,7 +12,7 @@ upstream php {
 server {
   listen 80 default_server;
 #   listen 443 ssl;
-  server_name localhost;
+#   server_name localhost;
 #   ssl_certificate           /certs/cert.crt;
 #   ssl_certificate_key       /certs/cert.key;
 #   ssl_verify_client         off;
@@ -36,9 +36,9 @@ server {
     access_log off;
   }
 
-  location = / {
-    return 302 http://localhost:8080/admin$is_args$args;
-  }
+#   location = / {
+#     return 302 wp$is_args$args;
+#   }
 
   location / {
     # This is cool because no php is touched for static content.
@@ -48,22 +48,23 @@ server {
 
 
   ### START CUSTOM CONFIGURATION ###
-  location /admin {
-        try_files $uri @nodeAdmin;
-        add_header X-Robots-Tag noindex;
-  }
+#   location /admin {
+#         try_files $uri @nodeAdmin;
+#         add_header X-Robots-Tag noindex;
+#   }
 
-  location @nodeAdmin {
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      # enable this if and only if you use HTTPS
-      # proxy_set_header X-Forwarded-Proto https;
-      proxy_set_header Host $http_host;
-      # we don't want nginx trying to do something clever with
-      # redirects, we set the Host: header above already.
-      proxy_redirect off;
-      proxy_buffering off;
-      proxy_pass http://host.docker.internal:3030;
-  }
+#   location @nodeAdmin {
+#       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#       # enable this if and only if you use HTTPS
+#       # proxy_set_header X-Forwarded-Proto https;
+#       proxy_set_header Host $http_host;
+#       # we don't want nginx trying to do something clever with
+#       # redirects, we set the Host: header above already.
+#       proxy_redirect off;
+#       proxy_buffering off;
+#       proxy_pass http://matthieu-dev-3:3030;
+#     #   proxy_pass http://host.docker.internal:3030;
+#   }
   ### END CUSTOM CONFIGURATION ###
 
   location ~ \.php$ {

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -74,7 +74,8 @@ services:
     web:
         image: nginx:1.21
         ports:
-            - 8080:80
+            - 80:80
+            # - 8080:80
         volumes:
             - ./devTools/docker/vhosts.conf:/etc/nginx/conf.d/default.conf
             - ./wordpress:/app

--- a/site/webpackUtils.tsx
+++ b/site/webpackUtils.tsx
@@ -3,7 +3,9 @@ import urljoin from "url-join"
 import * as path from "path"
 import { ENV } from "../settings/serverSettings.js"
 
-const WEBPACK_DEV_URL = process.env.WEBPACK_DEV_URL ?? "http://localhost:8090"
+const WEBPACK_DEV_URL =
+    process.env.WEBPACK_DEV_URL ??
+    `http://${process.env.WEBPACK_DEV_HOST}:${process.env.WEBPACK_DEV_PORT}`
 const WEBPACK_OUTPUT_PATH =
     process.env.WEBPACK_OUTPUT_PATH ?? path.join(__dirname + "/../", "webpack")
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,6 +1,9 @@
 import webpack from "webpack"
 import "webpack-dev-server" // just imported for type magic
 import path from "path"
+import * as dotenv from "dotenv"
+
+dotenv.config()
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 const MiniCssExtractPlugin = require("mini-css-extract-plugin")
@@ -119,8 +122,8 @@ const config = (env: any, argv: any): webpack.Configuration => {
             }),
         ],
         devServer: {
-            host: "localhost",
-            port: 8090,
+            host: process.env.WEBPACK_DEV_HOST,
+            port: process.env.WEBPACK_DEV_PORT,
             allowedHosts: "all",
             headers: {
                 "Access-Control-Allow-Origin": "*",


### PR DESCRIPTION
Other half of https://github.com/owid/ops/pull/40 (see "Approach 1")

Brings WP to 80 and the admin to 3030 only (no longer proxied through nginx/8080).

Requires changes to .env files:
```
WORDPRESS_URL=http://matthieu-dev-3
WEBPACK_DEV_HOST=matthieu-dev-3
WEBPACK_DEV_PORT=8090
ADMIN_SERVER_HOST=matthieu-dev-3
```
Also wordpress/.env

```
WP_HOME=http://matthieu-dev-3
WP_SITEURL=http://matthieu-dev-3/wp
```