### PR TITLE
Add edit button to Google Docs index page

### DIFF
--- a/adminSiteClient/GdocsIndexPage.tsx
+++ b/adminSiteClient/GdocsIndexPage.tsx
@@ -11,6 +11,7 @@ import { GdocsAdd } from "./GdocsAdd.js"
 import { Observer } from "mobx-react"
 import { useGdocsStore } from "./GdocsStore.js"
 import { runInAction } from "mobx"
+import { GdocsEditLink } from "./GdocsEditLink.js"
 interface GdocsMatchParams {
     id: string
 }
@@ -85,6 +86,9 @@ export const GdocsIndexPage = ({ match, history }: GdocsMatchProps) => {
                                             >
                                                 Preview
                                             </Link>
+                                            <p style={{ marginTop: 8 }}>
+                                                <GdocsEditLink gdoc={gdoc} />
+                                            </p>
                                         </td>
                                     </tr>
                                 ))}


### PR DESCRIPTION
Small quality of life improvement, I kept wanting to edit articles directly from the index page and assume that other people are the same.

![image](https://user-images.githubusercontent.com/11844404/210600661-e75eb512-5adf-4a2a-b828-80bcbb7a6ada.png)