### PR TITLE
fix(algolia): correctly compute number of related articles again

### DIFF
--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -42,7 +42,7 @@ const getChartsRecords = async () => {
         // otherwise they will fail when rendered in the search results
         if (isPathRedirectedToExplorer(`/grapher/${c.slug}`)) continue
 
-        const relatedArticles = (await getRelatedArticles(c.slug)) ?? []
+        const relatedArticles = (await getRelatedArticles(c.id)) ?? []
 
         records.push({
             objectID: c.id,


### PR DESCRIPTION
I almost can't believe it, but the calculation of `numRelatedArticles` in our Algolia `charts` index has been broken for almost one year, ever since #1070.
`numRelatedArticles` is our main means of ranking for the charts index.

#1070 changed `getRelatedArticles` from accepting a slug to an id, but since in this case `c` is untyped that did go unnoticed all this time.