### PR TITLE
Tests-wp-archieml-backporting

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,16 @@
             "type": "node"
         },
         {
+            //somewhat unstable, WIP
+            "type": "node",
+            "request": "launch",
+            "name": "Jest Test current file",
+            "program": "${workspaceFolder}/node_modules/.bin/jest",
+            "args": ["${fileBasenameNoExtension}.js", "--watch"],
+            "console": "integratedTerminal"
+            // "internalConsoleOptions": "neverOpen"
+        },
+        {
             "name": "Launch site dev",
             "program": "${workspaceFolder}/itsJustJavascript/adminSiteServer/app.js",
             "request": "launch",

--- a/db/model/Gdoc/htmlToEnriched.test.ts
+++ b/db/model/Gdoc/htmlToEnriched.test.ts
@@ -1,0 +1,79 @@
+import { cheerioElementsToArchieML } from "./htmlToEnriched.js"
+import cheerio from "cheerio"
+
+it("parses a Wordpress paragraph within the content", () => {
+    // The wrapping <div> is there to help simulate paragraphs within the
+    // content (as opposed to paragraphs appearing as the first element). This
+    // allows us to get all nodes, including the first wp:paragraph comment
+    // node, which would be skipped by cheerio.load() otherwise (cheerio.load
+    // ignores comments if they are the first node in the document).
+    const html = `
+    <div>
+        <!-- wp:paragraph -->
+        <p>or sit amet, consectetur adipiscing elit</p>
+        <!-- /wp:paragraph -->
+    </div>
+    `
+    const $: CheerioStatic = cheerio.load(html)
+    // The first element of the <div> contents is a new line, so we skip it
+    const bodyContents = $("body > div").contents().toArray().slice(1)
+
+    const parsedResult = cheerioElementsToArchieML(bodyContents, {
+        $,
+        shouldParseWpComponents: true,
+    })
+
+    expect(parsedResult.content).toEqual([
+        // The first element will be removed by the subsequent call to
+        // convertAllWpComponentsToArchieMLBlocks(withoutEmptyOrWhitespaceOnlyTextBlocks())
+        {
+            tagName: "paragraph",
+            attributes: undefined,
+            isVoidElement: false,
+            childrenResults: [],
+        },
+        {
+            type: "text",
+            value: [
+                {
+                    spanType: "span-simple-text",
+                    text: "or sit amet, consectetur adipiscing elit",
+                },
+            ],
+            parseErrors: [],
+        },
+    ])
+})
+
+it("parses a Wordpress paragraph as the first element", () => {
+    // In this case, the first element is a wp:paragraph comment node, which
+    // gets skipped by cheerio.load(). Given that we would clean up that opening
+    // wp:paragraph either way (cf. above), we are effectively getting for both
+    // first child paragraphs or in-content paragraphs the same output.
+    const html = `
+        <!-- wp:paragraph -->
+        <p>or sit amet, consectetur adipiscing elit</p>
+        <!-- /wp:paragraph -->
+    `
+    const $: CheerioStatic = cheerio.load(html)
+
+    const bodyContents = $("body").contents().toArray()
+
+    const parsedResult = cheerioElementsToArchieML(bodyContents, {
+        $,
+        shouldParseWpComponents: true,
+    })
+
+    expect(parsedResult.content).toEqual([
+        {
+            type: "text",
+            value: [
+                {
+                    spanType: "span-simple-text",
+                    text: "or sit amet, consectetur adipiscing elit",
+                },
+            ],
+            parseErrors: [],
+        },
+    ])
+})

--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -351,7 +351,7 @@ export function convertAllWpComponentsToArchieMLBlocks(
     temporary structure of a WpCompnent around (e.g. the latter is the case for wp:column
     contained inside wp:columns)
      */
-function parseWpComponent(
+export function parseWpComponent(
     elements: CheerioElement[],
     context: ParseContext
 ): WpComponentIntermediateParseResult {


### PR DESCRIPTION
Add a couple a tests to shine a light on the backporting of wp:paragraph tags, 
- either ignored by cheerio.load() if they happen to be the first element in the document
- or ignored by the parsing code

Add a WIP launch.json debug task to run and debug individual tests in VSCode