### PR TITLE
Collect html and wp:component tag statistics during backporting

### DIFF
--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -51,10 +51,16 @@ const migrate = async (): Promise<void> => {
             //`<div>${post.content}</div>`)
             const $: CheerioStatic = cheerio.load(text)
             const bodyContents = $("body").contents().toArray()
-            const parsedResult = cheerioElementsToArchieML(bodyContents, {
+            const parsingContext = {
                 $,
                 shouldParseWpComponents: true,
-            })
+                htmlTagCounts: {},
+                wpTagCounts: {},
+            }
+            const parsedResult = cheerioElementsToArchieML(
+                bodyContents,
+                parsingContext
+            )
             const archieMlBodyElements = convertAllWpComponentsToArchieMLBlocks(
                 withoutEmptyOrWhitespaceOnlyTextBlocks(parsedResult).content
             )
@@ -67,6 +73,8 @@ const migrate = async (): Promise<void> => {
                     const parseResult = cheerioElementsToArchieML(refElements, {
                         $,
                         shouldParseWpComponents: false,
+                        htmlTagCounts: {},
+                        wpTagCounts: {},
                     })
                     const textContentResult =
                         getEnrichedBlockTextFromBlockParseResult(parseResult)
@@ -105,6 +113,8 @@ const migrate = async (): Promise<void> => {
                 errors,
                 numErrors: errors.length,
                 numBlocks: archieMlBodyElements.length,
+                htmlTagCounts: parsingContext.htmlTagCounts,
+                wpTagCounts: parsingContext.wpTagCounts,
             }
 
             const insertQuery = `

--- a/db/model/Gdoc/htmlToEnriched.test.ts
+++ b/db/model/Gdoc/htmlToEnriched.test.ts
@@ -18,10 +18,14 @@ it("parses a Wordpress paragraph within the content", () => {
     // The first element of the <div> contents is a new line, so we skip it
     const bodyContents = $("body > div").contents().toArray().slice(1)
 
-    const parsedResult = cheerioElementsToArchieML(bodyContents, {
+    const context = {
         $,
         shouldParseWpComponents: true,
-    })
+        htmlTagCounts: {},
+        wpTagCounts: {},
+    }
+
+    const parsedResult = cheerioElementsToArchieML(bodyContents, context)
 
     expect(parsedResult.content).toEqual([
         // The first element will be removed by the subsequent call to
@@ -62,6 +66,8 @@ it("parses a Wordpress paragraph as the first element", () => {
     const parsedResult = cheerioElementsToArchieML(bodyContents, {
         $,
         shouldParseWpComponents: true,
+        wpTagCounts: {},
+        htmlTagCounts: {},
     })
 
     expect(parsedResult.content).toEqual([

--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -241,6 +241,8 @@ interface WpComponentIntermediateParseResult {
 interface ParseContext {
     $: CheerioStatic
     shouldParseWpComponents: boolean
+    htmlTagCounts: Record<string, number>
+    wpTagCounts: Record<string, number>
 }
 
 /** Regular expression to identify wordpress components in html components. These
@@ -371,6 +373,8 @@ export function parseWpComponent(
             "Tried to start parsing a WP component on a non-comment block!"
         )
     const componentDetails = getWpComponentDetails(startElement)
+    context.wpTagCounts[componentDetails.tagName] =
+        (context.wpTagCounts[componentDetails.tagName] ?? 0) + 1
 
     let remainingElements = elements.slice(1)
     const collectedContent: BlockParseResult<ArchieBlockOrWpComponent>[] = []
@@ -536,6 +540,8 @@ function cheerioToArchieML(
             content: [{ type: "text", value: [span], parseErrors: [] }],
         }
     else if (element.type === "tag") {
+        context.htmlTagCounts[element.tagName] =
+            (context.htmlTagCounts[element.tagName] ?? 0) + 1
         const result: BlockParseResult<ArchieBlockOrWpComponent> = match(
             element
         )

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -27,7 +27,7 @@ import {
 import { match } from "ts-pattern"
 
 function appendDotEndIfMultiline(line: string): string {
-    if (line.includes("\n")) return line + "\n.end"
+    if (line.includes("\n")) return line + "\n:end"
     return line
 }
 


### PR DESCRIPTION
This PR collects the counts of tag types, both HTML and wp: comment component ones, of each post and stores these stats in the archieml_update_statistics column of the posts table. This information will be useful during the iterative process of backporting so that you can e.g. easily see the posts that have a <video> tag.