### PR TITLE
fix: exclude test files from TypeORM's source files

### DIFF
--- a/db/dataSource.ts
+++ b/db/dataSource.ts
@@ -14,7 +14,7 @@ export const dataSource = new DataSource({
     username: GRAPHER_DB_USER || "root",
     password: GRAPHER_DB_PASS || "",
     database: GRAPHER_DB_NAME,
-    entities: ["itsJustJavascript/db/model/**/*.js"],
-    migrations: ["itsJustJavascript/db/migration/**/*.js"],
+    entities: ["itsJustJavascript/db/model/**/!(*.test).js"],
+    migrations: ["itsJustJavascript/db/migration/**/!(*.test).js"],
     charset: "utf8mb4",
 })


### PR DESCRIPTION
This is a pretty large footgun honestly, but with the addition of `db/model/Gdoc/htmlToEnriched.test.ts` in #1853, TypeORM tries to load that file and fails.
You'll see that failure when running `yarn startAdminServer`.

I'll merge this right away to un-break master, but we can discuss more if needed.
cc @danyx23 @mlbrgl 