### PR TITLE
feat: MarkdownTextWrap merges adjacent text tokens

### DIFF
--- a/packages/@ourworldindata/grapher/src/text/MarkdownTextWrap.tsx
+++ b/packages/@ourworldindata/grapher/src/text/MarkdownTextWrap.tsx
@@ -45,7 +45,7 @@ export class IRText implements IRToken {
         return undefined
     }
     toHTML(key?: React.Key): JSX.Element {
-        return <React.Fragment key={key}>{this.text}</React.Fragment>
+        return <span key={key}>{this.text}</span>
     }
     toSVG(key?: React.Key): JSX.Element {
         return <React.Fragment key={key}>{this.text}</React.Fragment>
@@ -66,7 +66,7 @@ export class IRWhitespace implements IRToken {
         return { tokenIndex: 0, tokenStartOffset: 0, breakOffset: 0.0001 }
     }
     toHTML(key?: React.Key): JSX.Element {
-        return <React.Fragment key={key}> </React.Fragment>
+        return <span key={key}> </span>
     }
     toSVG(key?: React.Key): JSX.Element {
         return <React.Fragment key={key}> </React.Fragment>

--- a/packages/@ourworldindata/grapher/src/text/MarkdownTextWrap.tsx
+++ b/packages/@ourworldindata/grapher/src/text/MarkdownTextWrap.tsx
@@ -409,6 +409,33 @@ export function lineToPlaintext(tokens: IRToken[]): string {
     return tokens.map((t) => t.toPlaintext()).join("")
 }
 
+export const isTextToken = (token: IRToken): token is IRText | IRWhitespace =>
+    token instanceof IRText || token instanceof IRWhitespace
+
+export const recursiveMergeTextTokens = (tokens: IRToken[]): IRToken[] => {
+    if (tokens.length === 0) return []
+    const [first, ...tail] = tokens
+
+    if (first instanceof IRElement) {
+        // go into children of first
+        return [
+            first.getClone(recursiveMergeTextTokens(first.children)),
+            ...recursiveMergeTextTokens(tail),
+        ]
+    } else if (tail.length > 0) {
+        const [second, ...rest] = tail
+        if (isTextToken(first) && isTextToken(second)) {
+            // merge first and second into single IRText node
+            return recursiveMergeTextTokens([
+                new IRText(first.toPlaintext() + second.toPlaintext()),
+                ...rest,
+            ])
+        } else return [first, ...recursiveMergeTextTokens(tail)]
+    }
+
+    return [first]
+}
+
 export function splitIntoLines(
     tokens: IRToken[],
     maxWidth: number
@@ -547,7 +574,8 @@ export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
 
     @computed get htmlLines(): IRToken[][] {
         const tokens = parsimmonToTextTokens(this.ast, this.fontParams)
-        return splitIntoLines(tokens, this.maxWidth)
+        const lines = splitIntoLines(tokens, this.maxWidth)
+        return lines.map(recursiveMergeTextTokens)
     }
 
     // We render DoDs differently for SVG (superscript reference  numbers) so we need to calculate
@@ -619,16 +647,10 @@ export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
                         .map((token) => token.toPlaintext())
                         .join("")
                     return (
-                        <span
-                            className="markdown-text-wrap__line"
-                            key={`${i}-${plaintextLine}`}
-                        >
-                            {line.length ? (
-                                line.map((token, i) => token.toHTML(i))
-                            ) : (
-                                <br />
-                            )}
-                        </span>
+                        <MarkdownTextWrapLine
+                            key={`${plaintextLine}-${i}`}
+                            line={line}
+                        />
                     )
                 })}
             </span>
@@ -679,4 +701,12 @@ export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
     render(): JSX.Element | null {
         return this.renderHTML()
     }
+}
+
+function MarkdownTextWrapLine({ line }: { line: IRToken[] }): JSX.Element {
+    return (
+        <span className="markdown-text-wrap__line">
+            {line.length ? line.map((token, i) => token.toHTML(i)) : <br />}
+        </span>
+    )
 }


### PR DESCRIPTION
This is a proof of concept at this point. | Currently live on _tufte_, check it out here: https://tufte-owid.netlify.app/migration

#1785 happens in part because in MarkdownTextWrap, we build up a `span` that contains lots and lots of `React.Fragment`s. These are then not handled gracefully by Google Translate, which confuses the hell out of React.
If we instead ensure that all `span`s have "more normal" children, then all is well.

In this PR, I introduce a post-processing step that reduces something like `[IRText("one"), IRWhitespace(), IRText("two")]` down to a single `IRText("one two")` node. It only does this just before rendering a line to HTML, thereby not interfering at all with line-splitting code etc.

I think it will be best to demo this - demoing what exactly it is that makes Google Translate/React choke, and also how this PR helps in this - so please reach out when would be a good time for you. 