### PR TITLE
Disable linear interpolation on StackedBar charts

### DIFF
--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -41,7 +41,7 @@ import { HorizontalColorLegendManager } from "../horizontalColorLegend/Horizonta
 export interface AbstractStackedChartProps {
     bounds?: Bounds
     manager: ChartManager
-    disableLinearInterpolation?: boolean // just for testing
+    enableLinearInterpolation?: boolean // defaults to true
 }
 
 @observer
@@ -59,7 +59,7 @@ export class AbstractStackedChart
             .replaceNonNumericCellsWithErrorValues(this.yColumnSlugs)
             .dropRowsWithErrorValuesForAllColumns(this.yColumnSlugs)
 
-        if (!this.props.disableLinearInterpolation) {
+        if (this.shouldRunLinearInterpolation) {
             this.yColumnSlugs.forEach((slug) => {
                 table = table.interpolateColumnLinearly(slug)
             })
@@ -80,6 +80,11 @@ export class AbstractStackedChart
                   )
         }
         return table
+    }
+
+    @computed get shouldRunLinearInterpolation(): boolean {
+        // enabled by default
+        return this.props.enableLinearInterpolation ?? true
     }
 
     @computed get inputTable(): OwidTable {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.stories.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.stories.tsx
@@ -58,7 +58,7 @@ export const EntitiesAsSeriesWithMissingRowsNoInterpolation =
     (): JSX.Element => (
         <svg width={600} height={600}>
             <StackedAreaChart
-                disableLinearInterpolation={true}
+                enableLinearInterpolation={false}
                 manager={{
                     ...entitiesChart,
                     table: table.dropRandomRows(30, seed),
@@ -84,7 +84,7 @@ export const EntitiesAsSeriesWithMissingRowsNoInterpolationRelative =
     (): JSX.Element => (
         <svg width={600} height={600}>
             <StackedAreaChart
-                disableLinearInterpolation={true}
+                enableLinearInterpolation={false}
                 manager={{
                     ...entitiesChart,
                     table: table.dropRandomRows(30, seed),

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -145,6 +145,11 @@ export class StackedBarChart
         return this.sidebarWidth + 20
     }
 
+    @computed get shouldRunLinearInterpolation(): boolean {
+        // disabled by default
+        return this.props.enableLinearInterpolation ?? false
+    }
+
     // All currently hovered group keys, combining the legend and the main UI
     @computed get hoverKeys(): string[] {
         const { hoverColor, manager } = this


### PR DESCRIPTION
[As discussed on Slack](https://owid.slack.com/archives/C03NV9Z3YSV/p1674057135213079)

This kind of interpolation doesn't make sense for Stacked Bar charts, and as it turns out there's not a change for the worse in the SVG tester either.