### PR TITLE
feature(baking): get variable data from S3 instead of data_values

### DIFF
--- a/db/Variable.test.ts
+++ b/db/Variable.test.ts
@@ -92,7 +92,7 @@ describe("readValuesFromParquet", () => {
         jest.spyOn(Variable, "executeSQL").mockResolvedValueOnce([
             { value: 286800000, year: 1, entityName: "Belgium" },
         ])
-        jest.spyOn(Variable, "fetchEntities").mockResolvedValueOnce([
+        jest.spyOn(Variable, "fetchEntitiesByNames").mockResolvedValueOnce([
             { entityId: 2, entityCode: "BE", entityName: "Belgium" },
         ])
 

--- a/db/migration/1674055678210-AddDataPathToVariables.ts
+++ b/db/migration/1674055678210-AddDataPathToVariables.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddDataPathToVariables1674055678210 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE variables
+              ADD COLUMN dataPath TEXT;
+            `
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE variables
+              DROP COLUMN dataPath;
+            `
+        )
+    }
+}


### PR DESCRIPTION
Add new column `variables.dataPath` with link to variable data in JSON format saved in S3 (e.g. https://catalog.ourworldindata.org/baked-variables/live_grapher/8872.json.gz). With that we can skip `data_values` table and load data from there and also avoid baking data for those variables and serve them from S3 instead. This is fairly similar to `variables.catalogPath` which is an address to parquet file in the catalog.

There's a script running in ETL that scans new datasets and creates JSON files on the fly. It's almost real-time (it takes less than a minute to detect a change and update S3) and it updates `variables.dataPath` column.

The purpose of this change is twofold:

1. Make our DB smaller by removing (part of) `data_values`
2. Serve data JSON files from S3 instead of Netlify to save bandwidth

### Handling staging/dev environment

Copying live DB still keeps `dataPath`s pointing to datasets from live. If we add any new data (e.g. running ETL locally that upserts data to `data_values`), they would have null `dataPath` and so grapher would use `data_values` instead.

### The future of `data_values`

`data_values` is now used more as a temporary storage for data until we sync it to S3 (or for dev/staging). We could easily replace it with "local catalog" of JSON data and use it as `dataPath` (i.e. making `dataPath` non-null). For that we'd need to make sure nothing is inserting to `data_values` any more (ETL, CSV importer).

Removing `data_values` would probably simplify codebase, though I'd rather do it as a next step after making sure storing data as JSON files works for us. Pruning `data_values` should unblock dynamic staging environments for us.

A lot of our tools uses `data_values`. If we wanted to avoid rewriting them all, we could just prune the largest datasets from `data_values` and keep the rest.

### Questions

1. Should I save it as `[variable_id].json.gz` or `[variable_id].json` (both same gzipped files, is adding `.gz` suffix a good idea?)
3. Not sure what are the implications for `Grapher`?
4. This would replace fetching data from parquet and from API. Perhaps it's a good time to remove them both from our codebase?

### TODO

* [ ] find all uses of `data_values`