### PR TITLE
fix: fix debug destructuring bug

### DIFF
--- a/site/runSiteFooterScripts.ts
+++ b/site/runSiteFooterScripts.ts
@@ -11,15 +11,20 @@ import { MultiEmbedderSingleton } from "./multiembedder/MultiEmbedder.js"
 import { runHeaderMenus } from "./SiteHeaderMenus.js"
 import { runSiteTools } from "./SiteTools.js"
 
-export const runSiteFooterScripts = ({
-    debug,
-    context,
-    container,
-}: {
-    debug?: boolean
-    context?: SiteFooterContext
-    container?: HTMLElement
-}) => {
+export const runSiteFooterScripts = (
+    args:
+        | {
+              debug?: boolean
+              context?: SiteFooterContext
+              container?: HTMLElement
+          }
+        | undefined
+) => {
+    // We used to destructure this in the function signature, but that caused
+    // a weird issue reported by bugsnag: https://app.bugsnag.com/our-world-in-data/our-world-in-data-website/errors/63ca39b631e8660009464eb4?event_id=63d384c500acc25fc0810000&i=sk&m=ef
+    // So now we define the object as potentially undefined and then destructure it here.
+    const { debug, context, container } = args || {}
+
     switch (context) {
         case SiteFooterContext.gdocsPreview:
             runBlocks()


### PR DESCRIPTION
The de-structuring of debug causes recurring issues to a small but significant number of users. We don't really know how this comes to be but assume that some html pages must be still using a cached version that could lead to the value passed into runSiteFooterScripts to be undefined. Anyhow, this change guards against this and should fix this issue.