### PR TITLE
refactor(baking): replace `data_values` table by fetching data JSON files

### DIFF
--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -42,11 +42,7 @@ import {
 } from "@ourworldindata/grapher"
 import workerpool from "workerpool"
 import ProgressBar from "progress"
-import {
-    getVariableData,
-    getOwidVariableDataPath,
-    fetchS3ValuesByPath,
-} from "../db/model/Variable.js"
+import { getVariableData } from "../db/model/Variable.js"
 
 const grapherConfigToHtmlPage = async (grapher: GrapherInterface) => {
     const postSlug = urlToSlug(grapher.originUrl || "")

--- a/db/Variable.test.ts
+++ b/db/Variable.test.ts
@@ -10,15 +10,41 @@ import * as Variable from "./model/Variable.js"
 import pl from "nodejs-polars"
 import { Writable } from "stream"
 
+afterEach(() => {
+    jest.restoreAllMocks()
+})
+
 describe("writeVariableCSV", () => {
     const getCSVOutput = async (
         variablesDf: pl.DataFrame | undefined,
         dataDf: pl.DataFrame | undefined,
-        variableIds: number[] = [1, 2]
+        s3data: any,
+        variableIds: number[]
     ): Promise<string> => {
         const spy = jest.spyOn(Variable, "readSQLasDF")
         if (variablesDf) spy.mockResolvedValueOnce(variablesDf)
         if (dataDf) spy.mockResolvedValueOnce(dataDf)
+
+        jest.spyOn(db, "queryMysql").mockResolvedValueOnce(
+            [
+                { id: 1, dataPath: undefined },
+                { id: 2, dataPath: undefined },
+                { id: 3, dataPath: "testpath" },
+            ].filter((row) => variableIds.includes(row.id))
+        )
+
+        if (s3data) {
+            jest.spyOn(Variable, "fetchS3Values").mockResolvedValueOnce(s3data)
+
+            const entities = pl
+                .DataFrame({
+                    entityId: [1],
+                    entityName: ["UK"],
+                    entityCode: ["code"],
+                })
+                .withColumn(pl.col("entityId").cast(pl.Int32))
+            jest.spyOn(Variable, "entitiesAsDF").mockResolvedValueOnce(entities)
+        }
 
         let out = ""
         const writeStream = new Writable({
@@ -33,9 +59,9 @@ describe("writeVariableCSV", () => {
 
     it("writes to a stream", async () => {
         const variablesDf = pl.DataFrame({
-            variableId: [1, 2],
-            variableName: ["a", "b"],
-            columnOrder: [0, 1],
+            variableId: [1, 2, 3],
+            variableName: ["a", "b", "c"],
+            columnOrder: [0, 1, 2],
         })
 
         const dataDf = pl.DataFrame({
@@ -47,18 +73,24 @@ describe("writeVariableCSV", () => {
             entityCode: ["code", "code", "code", "code"],
         })
 
-        const out = await getCSVOutput(variablesDf, dataDf)
-        expect(out).toEqual(`Entity,Year,a,b
-UK,2000,1.0,3.0
-UK,2001,2.0,4.0
+        const s3data = {
+            values: [5, 6],
+            years: [2000, 2001],
+            entities: [1, 1],
+        }
+
+        const out = await getCSVOutput(variablesDf, dataDf, s3data, [1, 2, 3])
+        expect(out).toEqual(`Entity,Year,a,b,c
+UK,2000,1.0,3.0,5.0
+UK,2001,2.0,4.0,6.0
 `)
     })
 
     it("handles null and NaN values", async () => {
         const variablesDf = pl.DataFrame({
-            variableId: [1, 2],
-            variableName: ["a", "b"],
-            columnOrder: [0, 1],
+            variableId: [1, 2, 3],
+            variableName: ["a", "b", "c"],
+            columnOrder: [0, 1, 2],
         })
 
         const dataDf = pl.DataFrame({
@@ -70,10 +102,16 @@ UK,2001,2.0,4.0
             entityCode: ["code", "code", "code", "code"],
         })
 
-        const out = await getCSVOutput(variablesDf, dataDf)
-        expect(out).toEqual(`Entity,Year,a,b
-UK,2000,,1.0
-UK,2001,2.0,NaN
+        const s3data = {
+            values: [3, null],
+            years: [2000, 2001],
+            entities: [1, 1],
+        }
+
+        const out = await getCSVOutput(variablesDf, dataDf, s3data, [1, 2, 3])
+        expect(out).toEqual(`Entity,Year,a,b,c
+UK,2000,,1.0,3.0
+UK,2001,2.0,NaN,
 `)
     })
 
@@ -86,7 +124,7 @@ UK,2001,2.0,NaN
 
         const dataDf = pl.DataFrame()
 
-        const out = await getCSVOutput(variablesDf, dataDf)
+        const out = await getCSVOutput(variablesDf, dataDf, undefined, [1, 2])
         expect(out).toEqual(`Entity,Year
 `)
     })
@@ -100,7 +138,7 @@ UK,2001,2.0,NaN
 
         expect.assertions(1)
         try {
-            await getCSVOutput(variablesDf, undefined, [1, 2, 3])
+            await getCSVOutput(variablesDf, undefined, undefined, [1, 2, 3])
         } catch (e: any) {
             expect(e.message).toEqual("Variable IDs do not exist: 3")
         }
@@ -138,6 +176,9 @@ describe("getVariableData", () => {
             entityCode: ["code", "code"],
         })
 
+        jest.spyOn(db, "queryMysql").mockResolvedValueOnce([
+            { id: 1, dataPath: undefined },
+        ])
         jest.spyOn(db, "mysqlFirst").mockResolvedValueOnce(variableResult)
         jest.spyOn(Variable, "readSQLasDF").mockResolvedValueOnce(dataDf)
 

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -500,9 +500,9 @@ export const fetchS3Values = async (
 export const fetchS3ValuesByPath = async (
     dataPath: string
 ): Promise<OwidVariableMixedData> => {
-    return (await (
+    return (
         await fetch(dataPath, { agent: httpsAgent })
-    ).json()) as OwidVariableMixedData
+    ).json() as Promise<OwidVariableMixedData>
 }
 
 export const dataAsRecords = async (

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -112,6 +112,7 @@ export async function getVariableData(
     const row = await variableQuery
     if (row === undefined) throw new Error(`Variable ${variableId} not found`)
 
+    // load data from data_values or S3 if `dataPath` exists
     const results = await dataAsRecords([variableId])
 
     const {


### PR DESCRIPTION
Rip out `data_values` table and fetch data from data JSON files instead. To make this work I had to refactor a few things:

1. Start using [nodejs-polars](https://github.com/pola-rs/nodejs-polars) to manipulate with dataframes
2. Only bake new variables for `country_latest_data` (country profiles) - this should be fine given that variables data never changes (we only do revisions), also we'll be replacing it by new country profiles soon
3. Simplify Makefile by removing SQL dump with data values
4. Raise an error when someone tries to use "Import CSV" tool (got replaced by Fast-track)
5. Remove DuckDB and option for reading Parquet
6. Remove option for fetching data from Data API

## Polars

[nodejs-polars](https://github.com/pola-rs/nodejs-polars) is a cool Rust alternative to Pandas. It has a lot of momentum in python world, unfortunately its Node version is not as mature (it is being actively developed, but has only 74 stars and one dev). Even though I had to debug a few cryptic Rust errors and its Node documentation is practically non-existent, I found it more natural to work with than manipulating objects (e.g. joins, writes to csv, etc.). In the long-term we're probably going to move all data stuff to Data API, but until then Polars could be a nice addition to grapher.

## Questions
* Should I split it into multiple PRs?
  * refactoring with polars
  * removing DuckDB and Data API
  * remove `data_values`
* I removed an option for fetching data from Data API... I'm not sure how far are we from using it. Should I keep it in code or bury it in git history?
* Should I add some unit tests (there are basically none at the moment)

## TODO
* [ ] compare all baked JSON files from S3 to those baked from data_values