### PR TITLE
fix: get rid of race condition on "make dbtests"

### DIFF
--- a/db/tests/run-db-tests.sh
+++ b/db/tests/run-db-tests.sh
@@ -17,8 +17,6 @@ docker-compose -f docker-compose.dbtests.yml up -d
 
 ./devTools/docker/wait-for-tests-mysql.sh
 
-sleep 3s # This is to give the db init script time to create the user, database and tables
-
 echo '==> Running migrations'
 
 yarn typeorm migration:run -d itsJustJavascript/db/tests/dataSource.dbtests.js
@@ -27,10 +25,12 @@ echo '==> Running tests'
 if ! yarn run jest --config=jest.db.config.js --runInBand # runInBand runs multiple test files serially - useful to avoid weird race conditions
 then
     echo '💀 Tests failed'
+    ./devTools/docker/mark-test-mysql-dirty.sh
     docker-compose -f docker-compose.dbtests.yml stop
     exit 23
 else
     echo '✅ DB tests succeeded'
+    ./devTools/docker/mark-test-mysql-dirty.sh
     docker-compose -f docker-compose.dbtests.yml stop
     exit 0
 fi

--- a/devTools/docker/create-test-db.sh
+++ b/devTools/docker/create-test-db.sh
@@ -31,9 +31,11 @@ createTestDb() {
     echo "creating user if it doesn't exist"
     _mysql -e "CREATE USER IF NOT EXISTS '$GRAPHER_TEST_DB_USER' IDENTIFIED BY '$GRAPHER_TEST_DB_PASS'; GRANT ALL PRIVILEGES ON * . * TO '$GRAPHER_TEST_DB_USER'; FLUSH PRIVILEGES;"
 
-
     echo "Ingesting sql creation script"
     cat /migration/pre-migrations-schema.sql | _mysql $GRAPHER_TEST_DB_NAME
+
+    echo "Indicating we are done"
+    _mysql -e "CREATE TABLE _test_db_ready (id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id));" $GRAPHER_TEST_DB_NAME
 
     echo "done"
     return 0

--- a/devTools/docker/mark-test-mysql-dirty.sh
+++ b/devTools/docker/mark-test-mysql-dirty.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env  bash
+#
+#  mark-test-mysql-dirty.sh
+#
+#  Remove the _test_db_ready table from the test database, so that next time
+#  we run the tests, our runner will wait until the database has been
+#  recreated.
+#
 
 set -o errexit
 set -o pipefail
@@ -14,9 +21,10 @@ fi
 : "${GRAPHER_TEST_DB_HOST:?Need to set GRAPHER_TEST_DB_HOST non-empty}"
 : "${GRAPHER_TEST_DB_PORT:?Need to set GRAPHER_TEST_DB_PORT non-empty}"
 
-printf 'Waiting for MySQL to come up...'
-while ! mysql -u$GRAPHER_TEST_DB_USER -p$GRAPHER_TEST_DB_PASS -h $GRAPHER_TEST_DB_HOST --port=$GRAPHER_TEST_DB_PORT -e 'select 1 from _test_db_ready' $GRAPHER_TEST_DB_NAME &>/dev/null; do
-    printf '.'
-    sleep 1
-done
-printf 'ok\n'
+mysql \
+    -u$GRAPHER_TEST_DB_USER \
+    -p$GRAPHER_TEST_DB_PASS \
+    -h $GRAPHER_TEST_DB_HOST \
+    --port=$GRAPHER_TEST_DB_PORT \
+    -e 'drop table _test_db_ready' \
+    $GRAPHER_TEST_DB_NAME


### PR DESCRIPTION
When running "make dbtest", a new MySQL testing database is intialised with a base schema and users. It must be ready before tests can be run.

Currently, the command we use to wait may return before the database is in fact ready, which we workaround with "sleep 3", although on some machines 3s is not enough.

This change replaces this strategy with by adding a "tombstone" table called `_test_db_ready` which is added at the end of db init. The wait script waits for this table to be created, meaning there is no longer a race condition on first run.

To avoid a race condition on second run, we delete the tombstone after every test run, meaning that on subsequent runs we will wait until the db is re-initialised again.
