### PR TITLE
migrate(chart_tags): make isKey column non-null and rename to isKeyChart

### DIFF
--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -1018,7 +1018,7 @@ export class EditableTags extends React.Component<{
     }
 
     @action.bound onToggleKey(index: number) {
-        this.tags[index].isKey = !this.tags[index].isKey
+        this.tags[index].isKeyChart = !this.tags[index].isKeyChart
         this.props.onSave(this.tags.filter(filterUncategorizedTag))
     }
 

--- a/adminSiteClient/TagBadge.tsx
+++ b/adminSiteClient/TagBadge.tsx
@@ -21,16 +21,16 @@ export class TagBadge extends React.Component<{
 
         if (onToggleKey) {
             classes.push("hasKeyChartSupport")
-            if (tag.isKey) classes.push("isKey")
+            if (tag.isKeyChart) classes.push("isKeyChart")
             return (
                 <Tippy
                     content={`${
-                        tag.isKey ? "⬇️ Demote from" : "⬆️ Promote to"
+                        tag.isKeyChart ? "⬇️ Demote from" : "⬆️ Promote to"
                     } key charts on topic "${tag.name}"`}
                 >
                     <span className={classes.join(" ")} onClick={onToggleKey}>
                         {searchHighlight ? searchHighlight(tag.name) : tag.name}
-                        {tag.isKey && <FontAwesomeIcon icon={faStar} />}
+                        {tag.isKeyChart && <FontAwesomeIcon icon={faStar} />}
                     </span>
                 </Tippy>
             )

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -862,7 +862,7 @@ main:not(.ChartEditorPage):not(.GdocsEditPage) {
         background-color: #c0c0c0;
     }
 
-    &.isKey {
+    &.isKeyChart {
         svg {
             margin-left: 5px;
         }

--- a/db/migration/1675374345914-ChartTagIsKeyChartNonNull.ts
+++ b/db/migration/1675374345914-ChartTagIsKeyChartNonNull.ts
@@ -1,6 +1,8 @@
 import { MigrationInterface, QueryRunner } from "typeorm"
 
-export class ChartTagIsKeyNonNull1675374345914 implements MigrationInterface {
+export class ChartTagIsKeyChartNonNull1675374345914
+    implements MigrationInterface
+{
     public async up(queryRunner: QueryRunner): Promise<void> {
         queryRunner.query(`
         UPDATE chart_tags
@@ -10,9 +12,17 @@ export class ChartTagIsKeyNonNull1675374345914 implements MigrationInterface {
         queryRunner.query(`
         ALTER TABLE chart_tags
         MODIFY COLUMN isKey TINYINT UNSIGNED NOT NULL DEFAULT FALSE`)
+
+        queryRunner.query(`
+        ALTER TABLE chart_tags
+        RENAME COLUMN isKey TO isKeyChart`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`
+        ALTER TABLE chart_tags
+        RENAME COLUMN isKeyChart TO isKey`)
+
         queryRunner.query(`
         ALTER TABLE chart_tags
         MODIFY COLUMN isKey TINYINT UNSIGNED`)

--- a/db/migration/1675374345914-ChartTagIsKeyNonNull.ts
+++ b/db/migration/1675374345914-ChartTagIsKeyNonNull.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class ChartTagIsKeyNonNull1675374345914 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`
+        UPDATE chart_tags
+        SET isKey = 0
+        WHERE isKey IS NULL`)
+
+        queryRunner.query(`
+        ALTER TABLE chart_tags
+        MODIFY COLUMN isKey TINYINT UNSIGNED NOT NULL DEFAULT FALSE`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`
+        ALTER TABLE chart_tags
+        MODIFY COLUMN isKey TINYINT UNSIGNED`)
+    }
+}

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -78,11 +78,11 @@ export class Chart extends BaseEntity {
 
     static async setTags(chartId: number, tags: Tag[]): Promise<void> {
         await db.transaction(async (t) => {
-            const tagRows = tags.map((tag) => [tag.id, chartId, tag.isKey])
+            const tagRows = tags.map((tag) => [tag.id, chartId, tag.isKeyChart])
             await t.execute(`DELETE FROM chart_tags WHERE chartId=?`, [chartId])
             if (tagRows.length)
                 await t.execute(
-                    `INSERT INTO chart_tags (tagId, chartId, isKey) VALUES ?`,
+                    `INSERT INTO chart_tags (tagId, chartId, isKeyChart) VALUES ?`,
                     [tagRows]
                 )
 
@@ -106,7 +106,7 @@ export class Chart extends BaseEntity {
         charts: { id: number; tags: any[] }[]
     ): Promise<void> {
         const chartTags = await db.queryMysql(`
-            SELECT ct.chartId, ct.tagId, ct.isKey, t.name as tagName FROM chart_tags ct
+            SELECT ct.chartId, ct.tagId, ct.isKeyChart, t.name as tagName FROM chart_tags ct
             JOIN charts c ON c.id=ct.chartId
             JOIN tags t ON t.id=ct.tagId
         `)
@@ -123,7 +123,7 @@ export class Chart extends BaseEntity {
                 chart.tags.push({
                     id: ct.tagId,
                     name: ct.tagName,
-                    isKey: !!ct.isKey,
+                    isKeyChart: !!ct.isKeyChart,
                 })
         }
     }

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -611,7 +611,7 @@ export const getRelatedCharts = async (
             charts.config->>"$.slug" AS slug,
             charts.config->>"$.title" AS title,
             charts.config->>"$.variantName" AS variantName,
-            chart_tags.isKey
+            chart_tags.isKeyChart
         FROM charts
         INNER JOIN chart_tags ON charts.id=chart_tags.chartId
         INNER JOIN post_tags ON chart_tags.tagId=post_tags.tag_id

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -118,6 +118,7 @@ export {
     RawSDGGridItem,
     RawBlockSDGToc,
     RawBlockMissingData,
+    BasicChartInformation,
     RelatedChart,
     ScaleType,
     SerializedGridProgram,

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -51,11 +51,14 @@ export enum ScaleType {
     log = "log",
 }
 
-export interface RelatedChart {
+export interface BasicChartInformation {
     title: string
     slug: string
     variantName?: string | null
-    isKey?: boolean
+}
+
+export interface RelatedChart extends BasicChartInformation {
+    isKey: boolean
 }
 
 export type OwidVariableId = Integer // remove.

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -58,7 +58,7 @@ export interface BasicChartInformation {
 }
 
 export interface RelatedChart extends BasicChartInformation {
-    isKey: boolean
+    isKeyChart: boolean
 }
 
 export type OwidVariableId = Integer // remove.
@@ -171,7 +171,7 @@ export interface PostRow {
 }
 
 export interface Tag extends TagReactTagAutocomplete {
-    isKey?: boolean
+    isKeyChart?: boolean
 }
 
 export interface EntryMeta {

--- a/site/ChartListItemVariant.tsx
+++ b/site/ChartListItemVariant.tsx
@@ -1,7 +1,11 @@
 import React from "react"
-import { RelatedChart } from "@ourworldindata/utils"
+import { BasicChartInformation } from "@ourworldindata/utils"
 
-export const ChartListItemVariant = ({ chart }: { chart: RelatedChart }) => {
+export const ChartListItemVariant = ({
+    chart,
+}: {
+    chart: BasicChartInformation
+}) => {
     return (
         <li>
             <a href={`/grapher/${chart.slug}`}>{chart.title}</a>

--- a/site/GrapherPage.jsdom.test.tsx
+++ b/site/GrapherPage.jsdom.test.tsx
@@ -48,12 +48,12 @@ beforeAll(() => {
         {
             title: "Chart 1",
             slug: "chart-1",
-            isKey: false,
+            isKeyChart: false,
         },
         {
             title: "Chart 2",
             slug: "chart-2",
-            isKey: true,
+            isKeyChart: true,
         },
     ]
 })

--- a/site/GrapherPage.jsdom.test.tsx
+++ b/site/GrapherPage.jsdom.test.tsx
@@ -48,10 +48,12 @@ beforeAll(() => {
         {
             title: "Chart 1",
             slug: "chart-1",
+            isKey: false,
         },
         {
             title: "Chart 2",
             slug: "chart-2",
+            isKey: true,
         },
     ]
 })

--- a/site/blocks/AllChartsListItem.tsx
+++ b/site/blocks/AllChartsListItem.tsx
@@ -2,7 +2,7 @@ import {
     DEFAULT_GRAPHER_HEIGHT,
     DEFAULT_GRAPHER_WIDTH,
 } from "@ourworldindata/grapher"
-import { RelatedChart } from "@ourworldindata/utils"
+import { BasicChartInformation } from "@ourworldindata/utils"
 import React from "react"
 import {
     BAKED_BASE_URL,
@@ -14,7 +14,7 @@ export const AllChartsListItem = ({
     onClick,
     isActive,
 }: {
-    chart: RelatedChart
+    chart: BasicChartInformation
     onClick: (e: React.MouseEvent) => void
     isActive: boolean
 }) => {

--- a/site/blocks/RelatedCharts.jsdom.test.tsx
+++ b/site/blocks/RelatedCharts.jsdom.test.tsx
@@ -15,10 +15,12 @@ const charts = [
     {
         title: "Chart 1",
         slug: "chart-1",
+        isKey: false,
     },
     {
         title: "Chart 2",
         slug: "chart-2",
+        isKey: true,
     },
 ]
 
@@ -28,26 +30,30 @@ it("renders active chart links and loads respective chart on click", () => {
     expect(wrapper.find("li")).toHaveLength(2)
 
     expect(wrapper.find("li").first().hasClass("active")).toEqual(true)
-    expect(wrapper.find("li").first().text()).toBe("Chart 1")
+    expect(wrapper.find("li").first().text()).toBe("Chart 2")
     expect(
         wrapper
             .find("li")
             .first()
             .find(
-                `img[src="${BAKED_GRAPHER_EXPORTS_BASE_URL}/${charts[0].slug}.svg"]`
+                `img[src="${BAKED_GRAPHER_EXPORTS_BASE_URL}/${charts[1].slug}.svg"]`
             )
     ).toHaveLength(1)
 
     wrapper.find("a").forEach((link, idx) => {
+        // Chart 2 is a key chart, so the charts should be in reverse order: `Chart 2, Chart 1`
+        const expectedChartIdx = 1 - idx
         link.simulate("click")
         expect(wrapper.find("figure")).toHaveLength(1)
         expect(
             wrapper.find(
-                `figure[data-grapher-src="${BAKED_BASE_URL}/grapher/${charts[idx].slug}"]`
+                `figure[data-grapher-src="${BAKED_BASE_URL}/grapher/${charts[expectedChartIdx].slug}"]`
             )
         ).toHaveLength(1)
         // should have forced re-render by changing the `key`
-        expect(wrapper.find("figure").key()).toEqual(charts[idx].slug)
+        expect(wrapper.find("figure").key()).toEqual(
+            charts[expectedChartIdx].slug
+        )
     })
 
     expect(wrapper.find("li").last().hasClass("active")).toEqual(true)

--- a/site/blocks/RelatedCharts.jsdom.test.tsx
+++ b/site/blocks/RelatedCharts.jsdom.test.tsx
@@ -15,12 +15,12 @@ const charts = [
     {
         title: "Chart 1",
         slug: "chart-1",
-        isKey: false,
+        isKeyChart: false,
     },
     {
         title: "Chart 2",
         slug: "chart-2",
-        isKey: true,
+        isKeyChart: true,
     },
 ]
 

--- a/site/blocks/RelatedCharts.tsx
+++ b/site/blocks/RelatedCharts.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef } from "react"
 import ReactDOM from "react-dom"
-import { RelatedChart } from "@ourworldindata/utils"
+import { orderBy, RelatedChart } from "@ourworldindata/utils"
 import { useEmbedChart } from "../hooks.js"
 import { GalleryArrow, GalleryArrowDirection } from "./GalleryArrow.js"
 import { AllChartsListItem } from "./AllChartsListItem.js"
@@ -15,10 +15,7 @@ export const RelatedCharts = ({ charts }: { charts: RelatedChart[] }) => {
     const isFirstSlideActive = activeChartIdx === 0
     const isLastSlideActive = activeChartIdx === charts.length - 1
 
-    const sortedCharts = [...charts].sort(
-        // isKey is returned from MySQL as 0, 1 or NULL
-        (a, b) => Number(!!b.isKey) - Number(!!a.isKey)
-    )
+    const sortedCharts = orderBy(charts, (chart) => chart.isKey, "desc")
     const activeChartSlug = sortedCharts[activeChartIdx].slug
 
     const onClickItem = (event: React.MouseEvent, idx: number) => {

--- a/site/blocks/RelatedCharts.tsx
+++ b/site/blocks/RelatedCharts.tsx
@@ -15,7 +15,7 @@ export const RelatedCharts = ({ charts }: { charts: RelatedChart[] }) => {
     const isFirstSlideActive = activeChartIdx === 0
     const isLastSlideActive = activeChartIdx === charts.length - 1
 
-    const sortedCharts = orderBy(charts, (chart) => chart.isKey, "desc")
+    const sortedCharts = orderBy(charts, (chart) => chart.isKeyChart, "desc")
     const activeChartSlug = sortedCharts[activeChartIdx].slug
 
     const onClickItem = (event: React.MouseEvent, idx: number) => {


### PR DESCRIPTION
[As discussed on Slack](https://owid.slack.com/archives/CQQUA2C2U/p1675366222423609).

I tested that `/artificial-intelligence` displays the charts in the same order as before even after the ordering change, and adapted the `RelatedCharts.jsdom.test.tsx` test in such a way that it now also incorporates `isKey`, and checks for the correct order.