### PR TITLE
Improve stacked bar tooltip to better handle missing data

### DIFF
--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -113,7 +113,7 @@ export class StackedBarChart
     // currently hovered legend color
     @observable hoverColor?: string
     // currently hovered axis label
-    @observable hoverTick?: TickmarkPlacement
+    @observable hoveredTick?: TickmarkPlacement
     // current hovered individual bar
     @observable hoverBar?: StackedPoint<Time>
     @observable hoverSeries?: StackedSeries<Time>
@@ -234,11 +234,11 @@ export class StackedBarChart
             yColumns,
             hoverSeries,
             series,
-            hoverTick,
+            hoveredTick,
         } = this
-        if (hoverBar === undefined && hoverTick === undefined) return
+        if (hoverBar === undefined && hoveredTick === undefined) return
         const xPos = mapXValueToOffset.get(
-            hoverBar ? hoverBar.position : Number(hoverTick?.text)
+            hoverBar ? hoverBar.position : Number(hoveredTick?.text)
         )
         if (xPos === undefined) {
             return
@@ -247,7 +247,7 @@ export class StackedBarChart
         const yPos = dualAxis.verticalAxis.place(
             hoverBar
                 ? hoverBar.valueOffset + hoverBar.value
-                : hoverTick?.bounds.y
+                : hoveredTick?.bounds.y
         )
 
         const yColumn = yColumns[0] // we can just use the first column for formatting, b/c we assume all columns have same type
@@ -258,7 +258,7 @@ export class StackedBarChart
             point: series.points.find(
                 (bar) =>
                     bar.position ===
-                    (hoverBar ? hoverBar.position : Number(hoverTick?.text))
+                    (hoverBar ? hoverBar.position : Number(hoveredTick?.text))
             ),
         }))
         const totalValue = sum(seriesRows.map((bar) => bar.point?.value ?? 0))
@@ -280,7 +280,7 @@ export class StackedBarChart
                                     {yColumn.formatTime(
                                         hoverBar
                                             ? hoverBar.position
-                                            : hoverTick!.text
+                                            : hoveredTick!.text
                                     )}
                                 </strong>
                             </td>
@@ -418,12 +418,12 @@ export class StackedBarChart
     }
 
     @action.bound onLabelMouseOver(tick: TickmarkPlacement): void {
-        this.hoverTick = tick
+        this.hoveredTick = tick
         console.log("hovered", tick)
     }
 
     @action.bound onLabelMouseLeave(): void {
-        this.hoverTick = undefined
+        this.hoveredTick = undefined
     }
 
     @action.bound onBarMouseOver(

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -414,7 +414,6 @@ export class StackedBarChart
 
     @action.bound onLabelMouseOver(tick: TickmarkPlacement): void {
         this.hoveredTick = tick
-        console.log("hovered", tick)
     }
 
     @action.bound onLabelMouseLeave(): void {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -284,10 +284,11 @@ export class StackedBarChart
                                 <tr
                                     key={seriesName}
                                     style={{
-                                        color:
-                                            isHovered || !point?.fake
-                                                ? "#000"
-                                                : "#888",
+                                        color: point?.fake
+                                            ? "#888"
+                                            : isHovered
+                                            ? "#000"
+                                            : "#333",
                                         fontWeight: isHovered
                                             ? "bold"
                                             : undefined,
@@ -313,7 +314,7 @@ export class StackedBarChart
                                         }}
                                     >
                                         {point?.fake
-                                            ? "NA"
+                                            ? "No data"
                                             : yColumn.formatValueLong(
                                                   point?.value,
                                                   {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -44,6 +44,7 @@ interface StackedBarSegmentProps extends React.SVGAttributes<SVGGElement> {
 }
 
 interface TickmarkPlacement {
+    time: number
     text: string
     bounds: Bounds
     isHidden: boolean
@@ -238,7 +239,7 @@ export class StackedBarChart
         } = this
         if (hoverBar === undefined && hoveredTick === undefined) return
         const xPos = mapXValueToOffset.get(
-            hoverBar ? hoverBar.position : Number(hoveredTick?.text)
+            hoverBar ? hoverBar.position : hoveredTick?.time
         )
         if (xPos === undefined) {
             return
@@ -258,7 +259,7 @@ export class StackedBarChart
             point: series.points.find(
                 (bar) =>
                     bar.position ===
-                    (hoverBar ? hoverBar.position : Number(hoveredTick?.text))
+                    (hoverBar ? hoverBar.position : hoveredTick?.time)
             ),
         }))
         const totalValue = sum(seriesRows.map((bar) => bar.point?.value ?? 0))
@@ -280,7 +281,7 @@ export class StackedBarChart
                                     {yColumn.formatTime(
                                         hoverBar
                                             ? hoverBar.position
-                                            : hoveredTick!.text
+                                            : hoveredTick!.time
                                     )}
                                 </strong>
                             </td>
@@ -378,6 +379,7 @@ export class StackedBarChart
 
             const bounds = Bounds.forText(text, { fontSize: this.tickFontSize })
             return {
+                time: x,
                 text,
                 bounds: bounds.set({
                     x: xPos + barWidth / 2 - bounds.width / 2,

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -251,7 +251,6 @@ export class StackedBarChart
         )
 
         const yColumn = yColumns[0] // we can just use the first column for formatting, b/c we assume all columns have same type
-        let emptySeries = 1
         const seriesRows = [...series].reverse().map((series) => ({
             seriesName: series.seriesName,
             color: series.color,
@@ -262,14 +261,7 @@ export class StackedBarChart
                     (hoverBar ? hoverBar.position : Number(hoverTick?.text))
             ),
         }))
-        const totalValue = sum(
-            seriesRows.map((bar) => {
-                if (!bar.point?.fake) {
-                    emptySeries = 0
-                }
-                return bar.point?.value ?? 0
-            })
-        )
+        const totalValue = sum(seriesRows.map((bar) => bar.point?.value ?? 0))
         const showTotalValue: boolean = seriesRows.length > 1
         return (
             <Tooltip
@@ -349,11 +341,9 @@ export class StackedBarChart
                                         whiteSpace: "nowrap",
                                     }}
                                 >
-                                    {!emptySeries
-                                        ? yColumn.formatValueLong(totalValue, {
-                                              trailingZeroes: true,
-                                          })
-                                        : "NA"}
+                                    {yColumn.formatValueLong(totalValue, {
+                                        trailingZeroes: true,
+                                    })}
                                 </td>
                             </tr>
                         )}


### PR DESCRIPTION
Closes #1866.

This PR fixes the two problems mentioned in the issue.

1) Missing data has a 'fake' property, which comes from the function `withMissingValuesAsZeroes`. If fake, display "NA" instead of zero.

2) 
- I extended the tooltip to show when hovering over year labels as well. 
- Tooltip position maybe needs to be adjusted, but I'm not sure what would be a good way to determine it.
- Adding the label tooltip into the bar tooltip might make it a bit more confusing, maybe it could be moved into a separate component?.

Here are some screenshots:
Hovering over 'low income' bar:
![image](https://user-images.githubusercontent.com/90795679/216851325-533a0450-7a78-46ef-8034-9a2b55f81879.png)

Hovering over the year label:
![image](https://user-images.githubusercontent.com/90795679/216851342-e2375907-d46c-49c0-b585-b10f325ad952.png)
![image](https://user-images.githubusercontent.com/90795679/216851357-6aa7c0ca-480f-480d-8339-a865ba65b933.png)

I don't think I can access explorers from the devcontainer setup, so I tested in the admin page by creating a new chart and using the deaths_drought data variable.

Let me know what you think, thanks!