### PR TITLE
Fix typos in 'Devcontainer setup guide' page

### DIFF
--- a/docs/devcontainer-setup.md
+++ b/docs/devcontainer-setup.md
@@ -85,7 +85,7 @@ Storybook allows you to interact with our Grapher and Explorer components visual
 
 This section explains how to check the logs for the database loading script that runs the first time you use this setup.
 
-An important note first: when using the VS Code Devcontainers extension, there is difference between the terminal in VS Code and a normal terminal that you open on your computer (i.e. your normal Windows or Mac terminal). The VS Code terminal gives you a shell running **inside** the development container. It has access to all the tools like node, yarn etc that you need to compile and run the codebase. It does not have access to the docker runtime though which the container is running. A normal terminal is the opposite, it operates **outside** the container - it has access to the docker command line tools but not all the tools running inside the development container.
+An important note first: when using the VS Code Devcontainers extension, there is difference between the terminal in VS Code and a normal terminal that you open on your computer (i.e. your normal Windows or Mac terminal). The VS Code terminal gives you a shell running **inside** the development container. It has access to all the tools like node, yarn etc that you need to compile and run the codebase. It does not have access to the docker runtime though which is running the container. A normal terminal is the opposite, it operates **outside** the container - it has access to the docker command line tools but not all the tools running inside the development container.
 
 To check the status, make sure you run the following commands in a terminal **outside** your devcontainer, in the working directory root of this repository:
 

--- a/docs/devcontainer-setup.md
+++ b/docs/devcontainer-setup.md
@@ -1,8 +1,8 @@
 # Visual Studio Code Devcontainer setup
 
-This page describes how to run our develpment environment entirely within a VS Code devcontainer setup - i.e. without instally NodeJS, Mysql etc locally. All that is required is to have needs [VS Code](https://code.visualstudio.com/) with the [remote containers extension](https://code.visualstudio.com/docs/remote/containers) and the [docker runtime](https://www.docker.com/) installed.
+This page describes how to run our develpment environment entirely within a VS Code devcontainer setup - i.e. without installing NodeJS, Mysql etc locally. All that is required is to have [VS Code](https://code.visualstudio.com/) with the [remote containers extension](https://code.visualstudio.com/docs/remote/containers) and the [docker runtime](https://www.docker.com/) installed.
 
-⚠ If you are on Windows, make sure that you configure git to use linux line ending (LF) instead of windows line endings (CRLR) before checking out this repository on your local machine. Follow the [Set up git on windows](./before-you-start-on-windows.md) instructions.
+⚠ If you are on Windows, make sure that you configure git to use linux line endings (LF) instead of windows line endings (CRLF) before checking out this repository on your local machine. Follow the [Set up git on windows](./before-you-start-on-windows.md) instructions.
 
 Once you have the tools mentioned above installed, just open this repository in VS Code. You should see a notice in the lower left that asks if you want to open this again inside a devcontainer. Answer yes and it will spin that up. Note that the first time you run this it needs to download and ingest the database which takes 5-20 minutes. To see if the database loading has finished refer to the [Checking the docker compose logs](#checking-the-docker-compose-logs) section.
 
@@ -85,7 +85,7 @@ Storybook allows you to interact with our Grapher and Explorer components visual
 
 This section explains how to check the logs for the database loading script that runs the first time you use this setup.
 
-An important note first: when using the VS Code Devcontainers extension, there is difference between the terminal in VS Code and a normal terminal that you open on your computer (i.e. your normal Windows or Mac terminal). The VS Code terminal gives you a shell running **inside** the development container. It has access to all the tools like node, yarn etc that you need to compile and run the codebase. It does not have access to the docker runtime though wich is running the container. A normal terminal is the opposite, it operates **outside** the container - it has access to the docker command line tools but not all the tools running inside the development container.
+An important note first: when using the VS Code Devcontainers extension, there is difference between the terminal in VS Code and a normal terminal that you open on your computer (i.e. your normal Windows or Mac terminal). The VS Code terminal gives you a shell running **inside** the development container. It has access to all the tools like node, yarn etc that you need to compile and run the codebase. It does not have access to the docker runtime though which the container is running. A normal terminal is the opposite, it operates **outside** the container - it has access to the docker command line tools but not all the tools running inside the development container.
 
 To check the status, make sure you run the following commands in a terminal **outside** your devcontainer, in the working directory root of this repository:
 


### PR DESCRIPTION
Quick fix for a few typos and words.