### PR TITLE
Copy Wordpress authors and excerpt to posts, use in backporting

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,6 +57,13 @@
             "type": "node"
         },
         {
+            "name": "Sync WP posts to grapher",
+            "program": "${workspaceFolder}/itsJustJavascript/db/syncPostsToGrapher.js",
+            "request": "launch",
+            "skipFiles": ["<node_internals>/**"],
+            "type": "node"
+        },
+        {
             "name": "Run SVGTester",
             "program": "${workspaceFolder}/itsJustJavascript/devTools/svgTester/verify-graphs.js",
             "request": "launch",

--- a/adminSiteServer/adminRouter.tsx
+++ b/adminSiteServer/adminRouter.tsx
@@ -19,7 +19,8 @@ import {
 import { GitCmsServer } from "../gitCms/GitCmsServer.js"
 import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants.js"
 import {
-    OwidArticleType,
+    getArticleFromJSON,
+    OwidArticleTypeJSON,
     parseIntOrUndefined,
     slugify,
     stringifyUnkownError,
@@ -158,8 +159,10 @@ adminRouter.get("/posts/compare/:postId", async (req, res) => {
     const archieMlText = await Post.select("archieml").from(
         db.knexTable(Post.postsTable).where({ id: postId })
     )
-    const archieMl = JSON.parse(archieMlText[0].archieml) as OwidArticleType
-    console.log("", archieMl.publishedAt)
+    const archieMlJson = JSON.parse(
+        archieMlText[0].archieml
+    ) as OwidArticleTypeJSON
+    const archieMl = getArticleFromJSON(archieMlJson)
     const archieMlPage = renderGdocsArticle(archieMl)
 
     res.send(`<!doctype html>

--- a/baker/postUpdatedHook.ts
+++ b/baker/postUpdatedHook.ts
@@ -24,27 +24,18 @@ const syncPostToGrapher = async (
         -- constructed by finding the revisions related to this post/page and
         -- taking the earliest one post_date.
 
-        -- We use a CTE to find the all revisions for each post/page
-        with revisions as (
-            select
-                post_date,
-                post_parent,
-                row_number() over
-                        ( order by post_date) row_num
-            from
-                wp_posts
-            where
-                post_type = 'revision' and post_parent = ?
-        ),
-        -- and then we use another CTE to find the first revision
-        first_revision as (
+        -- We use a CTE to find the first revisions for the post/page
+        with first_revision as (
             select
                 post_date as created_at,
                 post_parent as post_id
             from
-                revisions
+                wp_posts
             where
-                row_num = 1),
+                post_type = 'revision' and post_parent = ?
+            order by post_date
+            limit 1
+        ),
         -- now we select all the fields from wp_posts and then we also
         -- json array aggregate the authors. The authors come as strings like
         -- Charlie Giattino Charlie Giattino Charlie Giattino 44 charlie@ourworldindata.org

--- a/baker/postUpdatedHook.ts
+++ b/baker/postUpdatedHook.ts
@@ -23,7 +23,12 @@ const syncPostToGrapher = async (
         -- json array aggregate the authors. The authors come as strings like
         -- Charlie Giattino Charlie Giattino Charlie Giattino 44 charlie@ourworldindata.org
         -- so we use regexp_replace to cut out the first two words
-        SELECT p.*, JSON_ARRAYAGG(regexp_replace(t.description, '^([[:alnum:]]+) ([[:alnum:]]+) .+$' , '$1 $2')) as authors
+        SELECT p.*, JSON_ARRAYAGG(
+            JSON_OBJECT('author',
+                regexp_replace(t.description, '^([[:alnum:]]+) ([[:alnum:]]+) .+$' , '$1 $2'),
+                'order',
+                r.term_order
+            )) as authors
          FROM wp_posts p
          left join wp_term_relationships r on p.id = r.object_id
          left join wp_term_taxonomy t on t.term_taxonomy_id = r.term_taxonomy_id
@@ -53,6 +58,7 @@ const syncPostToGrapher = async (
                       ? "1970-01-01 00:00:00"
                       : wpPost.post_modified_gmt,
               authors: wpPost.authors,
+              excerpt: wpPost.post_excerpt,
           } as PostRow)
         : undefined
 

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -18,12 +18,6 @@ import {
     getEnrichedBlockTextFromBlockParseResult,
 } from "./model/Gdoc/htmlToEnriched.js"
 
-function formatAuthors(authors: string[]): string {
-    if (authors.length === 0) return ""
-    if (authors.length === 1) return authors[0]
-    return `${authors.slice(0, -1).join(", ")} and ${authors.slice(-1)}`
-}
-
 const migrate = async (): Promise<void> => {
     const writeToFile = false
     await db.getConnection()
@@ -122,11 +116,10 @@ const migrate = async (): Promise<void> => {
                     body: archieMlBodyElements,
                     title: post.title,
                     subtitle: post.excerpt,
-                    byline: formatAuthors(
-                        sortBy(authors, ["order"]).map(
-                            (author) => author.author
-                        )
-                    ),
+                    excerpt: post.excerpt,
+                    byline: sortBy(authors, ["order"])
+                        .map((author) => author.author)
+                        .join(", "),
                     dateline: dateline,
                     // TODO: this discards block level elements - those might be needed?
                     refs: refParsingResults,

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -103,9 +103,9 @@ const migrate = async (): Promise<void> => {
                     refs: refParsingResults,
                 },
                 published: false, // post.published_at !== null,
-                createdAt: post.updated_at, // TODO: this is wrong but it doesn't seem we have a created date in the posts table
-                publishedAt: null, // post.published_at,
-                updatedAt: null, // post.updated_at,
+                createdAt: post.updated_at, // TODO: this is wrong but it doesn't seem that wordpress tracks the creation date
+                publishedAt: post.published_at,
+                updatedAt: post.updated_at,
                 publicationContext: OwidArticlePublicationContext.listed, // TODO: not all articles are listed, take this from the DB
                 revisionId: null,
             }

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -7,6 +7,7 @@ import {
     EnrichedBlockText,
     OwidArticlePublicationContext,
     OwidArticleType,
+    sortBy,
 } from "@ourworldindata/utils"
 import * as Post from "./model/Post.js"
 import fs from "fs"
@@ -27,7 +28,9 @@ const migrate = async (): Promise<void> => {
         "title",
         "content",
         "published_at",
-        "updated_at"
+        "updated_at",
+        "authors",
+        "excerpt"
     ).from(db.knexTable(Post.postsTable)) //.where("id", "=", "22821"))
 
     for (const post of posts) {
@@ -91,14 +94,31 @@ const migrate = async (): Promise<void> => {
                 }
             )
 
+            // request a weekday along with a long date
+            const options = {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+            } as const
+            const dateline = post.published_at
+                ? post.published_at.toLocaleDateString("en-US", options)
+                : ""
+
+            const authors: { author: string; order: number }[] = JSON.parse(
+                post.authors
+            )
+
             const archieMlFieldContent: OwidArticleType = {
                 id: `wp-${post.id}`,
                 slug: post.slug,
                 content: {
                     body: archieMlBodyElements,
                     title: post.title,
-                    byline: "todo", // TOOD: fetch authors from WP and store them in posts table
-                    dateline: post.published_at?.toISOString() ?? "",
+                    subtitle: post.excerpt,
+                    byline: sortBy(authors, ["order"])
+                        .map((author) => author.author)
+                        .join(", "),
+                    dateline: dateline,
                     // TODO: this discards block level elements - those might be needed?
                     refs: refParsingResults,
                 },

--- a/db/migration/1675447441269-AddAuthorsToPosts.ts
+++ b/db/migration/1675447441269-AddAuthorsToPosts.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddAuthorsToPosts1675447441269 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE posts
+        ADD COLUMN authors JSON comment 'json array of strings in the form "firstname lastname"'
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE posts
+        DROP COLUMN authors
+        `)
+    }
+}

--- a/db/migration/1675774335211-AddExcerptToPosts.ts
+++ b/db/migration/1675774335211-AddExcerptToPosts.ts
@@ -1,15 +1,15 @@
 import { MigrationInterface, QueryRunner } from "typeorm"
 
-export class AddAuthorsToPosts1675447441269 implements MigrationInterface {
+export class AddExcerptToPosts1675774335211 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE posts
-        ADD COLUMN authors JSON comment 'json array of objects with field author in the form "firstname lastname" and field order'
+        ADD COLUMN excerpt text
         `)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE posts
-        DROP COLUMN authors
+        DROP COLUMN excerpt
         `)
     }
 }

--- a/db/migration/1676470290267-AddCreatedAtInWordpressToPosts.ts
+++ b/db/migration/1676470290267-AddCreatedAtInWordpressToPosts.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddCreatedAtToPosts1676470290267 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE posts
+        ADD COLUMN created_at_in_wordpress datetime
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE posts
+        DROP COLUMN created_at_in_wordpress
+        `)
+    }
+}

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -168,7 +168,8 @@ export interface PostRow {
     archieml: string
     archieml_update_statistics: string
     gdocSuccessorId: string
-    authors: string[]
+    authors: string
+    excerpt: string
 }
 
 export interface Tag extends TagReactTagAutocomplete {

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -168,6 +168,7 @@ export interface PostRow {
     archieml: string
     archieml_update_statistics: string
     gdocSuccessorId: string
+    authors: string[]
 }
 
 export interface Tag extends TagReactTagAutocomplete {

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -170,6 +170,7 @@ export interface PostRow {
     gdocSuccessorId: string
     authors: string
     excerpt: string
+    created_at_in_wordpress: Date | null
 }
 
 export interface Tag extends TagReactTagAutocomplete {


### PR DESCRIPTION
This PR collects the authors from wordpress (all of them, with their order) and the excerpt (what is shown as the subtitle in both old and new style articles). The posts table in our mysql database is extended with two columns, the scripts to bulk fetch wordpress posts and the hook to update single posts on wordpress save are updated, and the information is used in backporting to create gdoc articles. This is part of issue #1870 

When rolling this out to prod:
- [ ] Run the /db/syncPostsToGrapher script on prod to fill the new columns
- [ ] Run the /db/migrateWpPostsToArchieMl script on prod to copy this information into the archieml json

