### PR TITLE
Search, part 2: better chart search

### DIFF
--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -57,11 +57,18 @@ export const configureAlgolia = async () => {
     await chartsIndex.setSettings({
         ...baseSettings,
         searchableAttributes: [
+            /**
+             * It may seem unintuitive that we're ranking `keyChartForTags` higher than `title`.
+             * However, many of the search queries we get are for "topics", like `migration` or
+             * `tourism`. If for this topic we have a key chart, we want to show that first,
+             * since that's hand-picked to be super relevant for the topic.
+             */
+            "unordered(keyChartForTags)",
             "unordered(title)",
             "unordered(slug)",
             "unordered(variantName)",
             "unordered(subtitle)",
-            "unordered(_tags)",
+            "unordered(tags)",
             "unordered(availableEntities)",
         ],
         customRanking: [
@@ -71,7 +78,7 @@ export const configureAlgolia = async () => {
         ],
         attributesToSnippet: ["subtitle:24"],
         attributeForDistinct: "id",
-        disableExactOnAttributes: ["_tags"],
+        disableExactOnAttributes: ["tags"],
         optionalWords: ["vs"],
     })
 

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -145,7 +145,7 @@ export const configureAlgolia = async () => {
         ["hdi", "human development index"],
         ["drug", "drugs", "substance use"],
         ["r&d", "r & d", "research"],
-        ["plane", "airplane", "aviation", "airline"],
+        ["plane", "airplane", "aviation", "airline", "flying"],
         ["ev", "electric vehicle", "electric car"],
         ["train", "railway"],
     ]

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -140,6 +140,12 @@ export const configureAlgolia = async () => {
         ["vaccine hesitancy", "vaccine attitude", "vaccine willingness"],
         ["electric power", "power", "electricity"],
         ["artificial intelligence", "ai", "machine learning", "neural network"],
+        ["hdi", "human development index"],
+        ["drug", "drugs", "substance use"],
+        ["r&d", "r & d", "research"],
+        ["plane", "airplane", "aviation", "airline"],
+        ["ev", "electric vehicle", "electric car"],
+        ["train", "railway"],
     ]
 
     // Send all our country variant names to algolia as synonyms

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -148,6 +148,7 @@ export const configureAlgolia = async () => {
         ["plane", "airplane", "aviation", "airline", "flying"],
         ["ev", "electric vehicle", "electric car"],
         ["train", "railway"],
+        ["dying", "death", "mortality"],
     ]
 
     // Send all our country variant names to algolia as synonyms

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -47,6 +47,8 @@ export const configureAlgolia = async () => {
         exactOnSingleWordQuery: "none",
         removeStopWords: ["en"],
         snippetEllipsisText: "…",
+        highlightPreTag: "<strong>",
+        highlightPostTag: "</strong>",
         distinct: true,
         advancedSyntax: true,
         advancedSyntaxFeatures: ["exactPhrase"],

--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -5,6 +5,7 @@ import { getRelatedArticles } from "../../db/wpdb.js"
 import { ALGOLIA_INDEXING } from "../../settings/serverSettings.js"
 import { getAlgoliaClient } from "./configureAlgolia.js"
 import { isPathRedirectedToExplorer } from "../../explorerAdminServer/ExplorerRedirects.js"
+import { ChartRecord } from "../../site/search/searchTypes.js"
 
 const getChartsRecords = async () => {
     const allCharts = await db.queryMysql(`
@@ -35,7 +36,7 @@ const getChartsRecords = async () => {
         }
     }
 
-    const records = []
+    const records: ChartRecord[] = []
     for (const c of chartsToIndex) {
         if (!c.tags) continue
         // Our search currently cannot render explorers, so don't index them because
@@ -51,7 +52,7 @@ const getChartsRecords = async () => {
             title: c.title,
             variantName: c.variantName,
             subtitle: c.subtitle,
-            _tags: c.tags.map((t: any) => t.name),
+            tags: c.tags.map((t: any) => t.name),
             availableEntities: JSON.parse(c.availableEntitiesStr),
             publishedAt: c.publishedAt,
             updatedAt: c.updatedAt,

--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -16,13 +16,14 @@ const getChartsRecords = async () => {
     `)
 
     const chartTags = await db.queryMysql(`
-        SELECT ct.chartId, ct.tagId, t.name as tagName FROM chart_tags ct
+        SELECT ct.chartId, ct.tagId, ct.isKeyChart, t.name as tagName FROM chart_tags ct
         JOIN charts c ON c.id=ct.chartId
         JOIN tags t ON t.id=ct.tagId
     `)
 
     for (const c of allCharts) {
         c.tags = []
+        c.keyChartForTags = []
     }
 
     const chartsById = lodash.keyBy(allCharts, (c) => c.id)
@@ -33,6 +34,11 @@ const getChartsRecords = async () => {
         if (c) {
             c.tags.push({ id: ct.tagId, name: ct.tagName })
             chartsToIndex.push(c)
+
+            if (ct.isKeyChart) {
+                // chart is a key chart for this tag
+                c.keyChartForTags.push({ id: ct.tagId, name: ct.tagName })
+            }
         }
     }
 
@@ -52,6 +58,7 @@ const getChartsRecords = async () => {
             title: c.title,
             variantName: c.variantName,
             subtitle: c.subtitle,
+            keyChartForTags: c.keyChartForTags.map((t: any) => t.name),
             tags: c.tags.map((t: any) => t.name),
             availableEntities: JSON.parse(c.availableEntitiesStr),
             publishedAt: c.publishedAt,

--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -6,6 +6,7 @@ import { ALGOLIA_INDEXING } from "../../settings/serverSettings.js"
 import { getAlgoliaClient } from "./configureAlgolia.js"
 import { isPathRedirectedToExplorer } from "../../explorerAdminServer/ExplorerRedirects.js"
 import { ChartRecord } from "../../site/search/searchTypes.js"
+import { MarkdownTextWrap } from "@ourworldindata/utils"
 
 const getChartsRecords = async () => {
     const allCharts = await db.queryMysql(`
@@ -51,13 +52,18 @@ const getChartsRecords = async () => {
 
         const relatedArticles = (await getRelatedArticles(c.id)) ?? []
 
+        const plaintextSubtitle = new MarkdownTextWrap({
+            text: c.subtitle,
+            fontSize: 10, // doesn't matter, but is a mandatory field
+        }).plaintext
+
         records.push({
             objectID: c.id,
             chartId: c.id,
             slug: c.slug,
             title: c.title,
             variantName: c.variantName,
-            subtitle: c.subtitle,
+            subtitle: plaintextSubtitle,
             keyChartForTags: c.keyChartForTags.map((t: any) => t.name),
             tags: c.tags.map((t: any) => t.name),
             availableEntities: JSON.parse(c.availableEntitiesStr),

--- a/packages/@ourworldindata/utils/src/MarkdownTextWrap/MarkdownTextWrap.tsx
+++ b/packages/@ourworldindata/utils/src/MarkdownTextWrap/MarkdownTextWrap.tsx
@@ -539,6 +539,10 @@ export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
         return []
     }
 
+    @computed get plaintext(): string {
+        return this.htmlLines.map(lineToPlaintext).join("\n")
+    }
+
     @computed get htmlLines(): IRToken[][] {
         const tokens = parsimmonToTextTokens(this.ast, this.fontParams)
         return splitIntoLines(tokens, this.maxWidth)

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -1090,9 +1090,13 @@ html:not(.js) {
             border-bottom: 1px solid #ccc;
         }
 
-        li {
+        > ul li {
             list-style-type: none;
             margin-bottom: 1.75rem;
+
+            a {
+                @include owid-link-90;
+            }
 
             p {
                 margin-top: 0;

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -1102,12 +1102,6 @@ html:not(.js) {
         }
     }
 
-    .postResults em,
-    .ChartResult em {
-        font-style: normal;
-        font-weight: bold;
-    }
-
     .algoliaCredit {
         margin-top: 1rem;
         opacity: 0.9;

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -1089,28 +1089,16 @@ html:not(.js) {
             padding-bottom: 1rem;
             border-bottom: 1px solid #ccc;
         }
-    }
 
-    .postResults li {
-        list-style-type: none;
-
-        a {
-            font-size: 16px;
-        }
-
-        p {
-            font-size: 13px;
-            margin-top: 0;
+        li {
+            list-style-type: none;
             margin-bottom: 1.75rem;
-        }
-    }
 
-    .chartResults > ul > li {
-        list-style-type: none;
-        line-height: 1.8em;
-
-        p {
-            font-size: 13px;
+            p {
+                margin-top: 0;
+                margin-bottom: 0;
+                font-size: 13px;
+            }
         }
     }
 

--- a/site/search/SearchResults.tsx
+++ b/site/search/SearchResults.tsx
@@ -52,13 +52,13 @@ class ChartResult extends React.Component<{
                 {hit.variantName ? (
                     <span className="variantName"> {hit.variantName}</span>
                 ) : undefined}
-                {hit._snippetResult ? (
+                {hit._snippetResult?.subtitle && (
                     <p
                         dangerouslySetInnerHTML={{
                             __html: hit._snippetResult.subtitle.value,
                         }}
                     />
-                ) : undefined}
+                )}
             </li>
         )
     }
@@ -131,9 +131,7 @@ class PageResult extends React.Component<{ hit: PageHit }> {
 
 function pickEntitiesForChart(hit: ChartHit, queryCountries: Country[]) {
     const entities = []
-    const availableEntities = hit._highlightResult
-        ? hit._highlightResult.availableEntities
-        : []
+    const availableEntities = hit._highlightResult?.availableEntities ?? []
     for (const res of availableEntities) {
         const entity = res.value.replace(/<\/?em>/g, "")
         if (

--- a/site/search/SearchResults.tsx
+++ b/site/search/SearchResults.tsx
@@ -34,11 +34,20 @@ class ChartResult extends React.Component<{
             ).fullUrl
     }
 
-    @computed get title() {
+    @computed get title(): JSX.Element {
         const { hit } = this.props
         const { entities } = this
-        if (!entities.length) return hit.title
-        else return hit.title.trim() + `, ${entities.join(", ")}`
+        const highlightedTitle = hit._highlightResult?.title?.value ?? ""
+        const title = (
+            <span dangerouslySetInnerHTML={{ __html: highlightedTitle }} />
+        )
+        if (!entities.length) return title
+        else
+            return (
+                <>
+                    {title}, {entities.join(", ")}
+                </>
+            )
     }
 
     render() {
@@ -47,7 +56,6 @@ class ChartResult extends React.Component<{
 
         return (
             <li className="ChartResult">
-                {/* <a href={`${BAKED_GRAPHER_URL}/${hit.slug}`} dangerouslySetInnerHTML={{__html: hit._highlightResult.title.value}}/> */}
                 <a href={`${BAKED_GRAPHER_URL}/${slug}`}>{title}</a>
                 {hit.variantName ? (
                     <span className="variantName"> {hit.variantName}</span>

--- a/site/search/SearchResults.tsx
+++ b/site/search/SearchResults.tsx
@@ -141,7 +141,7 @@ function pickEntitiesForChart(hit: ChartHit, queryCountries: Country[]) {
     const entities = []
     const availableEntities = hit._highlightResult?.availableEntities ?? []
     for (const res of availableEntities) {
-        const entity = res.value.replace(/<\/?em>/g, "")
+        const entity = res.value.replace(/<\/?strong>/g, "")
         if (
             res.matchLevel !== "none" ||
             queryCountries.some((c) => c.name === entity)

--- a/site/search/searchClient.ts
+++ b/site/search/searchClient.ts
@@ -56,7 +56,7 @@ export const siteSearch = async (query: string): Promise<SiteSearchResults> => {
                     "variantName",
                 ],
                 attributesToSnippet: ["subtitle:24"],
-                attributesToHighlight: ["availableEntities"],
+                attributesToHighlight: ["title", "availableEntities"],
                 hitsPerPage: 10,
                 removeStopWords: true,
                 replaceSynonymsInHighlight: false,

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -50,6 +50,7 @@ export interface ChartRecord {
     title: string
     subtitle: string
     variantName: string
+    keyChartForTags: string[]
     tags: string[]
     availableEntities: string[]
     publishedAt: string

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -67,6 +67,10 @@ export interface ChartHit extends ChartRecord {
         }
     }
     _highlightResult?: {
+        title?: {
+            value: string
+            matchLevel: AlgoliaMatchLevel
+        }
         availableEntities?: {
             value: string
             matchLevel: AlgoliaMatchLevel

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -50,19 +50,25 @@ export interface ChartRecord {
     title: string
     subtitle: string
     variantName: string
+    tags: string[]
+    availableEntities: string[]
+    publishedAt: string
+    updatedAt: string
+    numDimensions: number
+    titleLength: number
+    numRelatedArticles: number
 }
 
 export interface ChartHit extends ChartRecord {
     _snippetResult?: {
-        subtitle: {
+        subtitle?: {
             value: string
         }
     }
     _highlightResult?: {
-        availableEntities: {
+        availableEntities?: {
             value: string
-            matchLevel: "none" | "full"
-            matchedWords: string[]
+            matchLevel: AlgoliaMatchLevel
         }[]
     }
 }


### PR DESCRIPTION
Live on _tufte_, together with #1916.

Improving search, but this time for charts.

Includes:
- _Biggest change_: Ranking charts at the top when they are key charts for a tag, e.g. for "Artificial intelligence", "Chess ability of the best computers" is one of the first results, even if AI is nowhere to be found in its title & subtitle.
- some more style touchups, including ones that align it more with the "pages" results
- highlighting occurrences of the search term
- stripping out Markdown syntax and DoDs before indexing
- add some more synonyms