### PR TITLE
Search, part 3: add click-through analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,6 +201,7 @@
         "safe-stable-stringify": "^2.4.1",
         "sass": "^1.52.1",
         "sass-loader": "^13.0.2",
+        "search-insights": "^2.2.3",
         "sharp": "^0.31.0",
         "shell-quote": "^1.7.3",
         "shelljs": "^0.8.5",

--- a/site/CookiePreferencesManager.tsx
+++ b/site/CookiePreferencesManager.tsx
@@ -168,8 +168,9 @@ export const parseDate = (date?: string): number | undefined => {
 
 export const getPreferenceValue = (
     type: PreferenceType,
-    preferences: Preference[]
+    preferences?: Preference[]
 ) => {
+    preferences ??= getInitialState().preferences
     return (
         preferences.find((preference) => {
             return preference.type === type

--- a/site/CookiePreferencesManager.tsx
+++ b/site/CookiePreferencesManager.tsx
@@ -168,9 +168,8 @@ export const parseDate = (date?: string): number | undefined => {
 
 export const getPreferenceValue = (
     type: PreferenceType,
-    preferences?: Preference[]
+    preferences: Preference[] = getInitialState().preferences
 ) => {
-    preferences ??= getInitialState().preferences
     return (
         preferences.find((preference) => {
             return preference.type === type

--- a/site/search/searchClient.ts
+++ b/site/search/searchClient.ts
@@ -5,11 +5,26 @@ import {
     ALGOLIA_SEARCH_KEY,
 } from "../../settings/clientSettings.js"
 import { PageHit, SiteSearchResults, ChartHit } from "./searchTypes.js"
+import insightsClient, { InsightsClient } from "search-insights"
+import type { InsightsSearchClickEvent } from "search-insights/dist/click.js"
 
 let algolia: SearchClient | undefined
 const getClient = () => {
     if (!algolia) algolia = algoliasearch(ALGOLIA_ID, ALGOLIA_SEARCH_KEY)
     return algolia
+}
+
+let insightsInitialized = false
+const getInsightsClient = (): InsightsClient => {
+    if (!insightsInitialized) {
+        insightsClient("init", {
+            appId: ALGOLIA_ID,
+            apiKey: ALGOLIA_SEARCH_KEY,
+            useCookie: true,
+        })
+        insightsInitialized = true
+    }
+    return insightsClient
 }
 
 export const siteSearch = async (query: string): Promise<SiteSearchResults> => {
@@ -39,10 +54,11 @@ export const siteSearch = async (query: string): Promise<SiteSearchResults> => {
             indexName: "pages",
             query,
             params: {
-                attributesToRetrieve: ["slug", "title", "type"],
+                attributesToRetrieve: ["objectID", "slug", "title", "type"],
                 attributesToSnippet: ["excerpt:20", "content:20"],
                 attributesToHighlight: ["title"],
                 hitsPerPage: 10,
+                clickAnalytics: true,
             },
         },
         {
@@ -50,6 +66,7 @@ export const siteSearch = async (query: string): Promise<SiteSearchResults> => {
             query: chartQuery,
             params: {
                 attributesToRetrieve: [
+                    "objectID",
                     "chartId",
                     "slug",
                     "title",
@@ -60,6 +77,7 @@ export const siteSearch = async (query: string): Promise<SiteSearchResults> => {
                 hitsPerPage: 10,
                 removeStopWords: true,
                 replaceSynonymsInHighlight: false,
+                clickAnalytics: true,
             },
         },
     ])
@@ -69,4 +87,11 @@ export const siteSearch = async (query: string): Promise<SiteSearchResults> => {
         charts: json.results[1].hits as ChartHit[],
         countries: matchCountries,
     }
+}
+
+export const logSiteSearchClick = (
+    event: Omit<InsightsSearchClickEvent, "eventName">
+) => {
+    const client = getInsightsClient()
+    client("clickedObjectIDsAfterSearch", { ...event, eventName: "click" })
 }

--- a/site/search/searchClient.ts
+++ b/site/search/searchClient.ts
@@ -5,6 +5,7 @@ import {
     ALGOLIA_SEARCH_KEY,
 } from "../../settings/clientSettings.js"
 import { PageHit, SiteSearchResults, ChartHit } from "./searchTypes.js"
+import type { SearchResponse } from "@algolia/client-search"
 import insightsClient, { InsightsClient } from "search-insights"
 import type { InsightsSearchClickEvent } from "search-insights/dist/click.js"
 import {
@@ -88,8 +89,8 @@ export const siteSearch = async (query: string): Promise<SiteSearchResults> => {
     ])
 
     return {
-        pages: json.results[0].hits as PageHit[],
-        charts: json.results[1].hits as ChartHit[],
+        pages: json.results[0] as SearchResponse<PageHit>,
+        charts: json.results[1] as SearchResponse<ChartHit>,
         countries: matchCountries,
     }
 }

--- a/site/search/searchClient.ts
+++ b/site/search/searchClient.ts
@@ -7,6 +7,10 @@ import {
 import { PageHit, SiteSearchResults, ChartHit } from "./searchTypes.js"
 import insightsClient, { InsightsClient } from "search-insights"
 import type { InsightsSearchClickEvent } from "search-insights/dist/click.js"
+import {
+    getPreferenceValue,
+    PreferenceType,
+} from "../CookiePreferencesManager.js"
 
 let algolia: SearchClient | undefined
 const getClient = () => {
@@ -20,7 +24,8 @@ const getInsightsClient = (): InsightsClient => {
         insightsClient("init", {
             appId: ALGOLIA_ID,
             apiKey: ALGOLIA_SEARCH_KEY,
-            useCookie: true,
+            userHasOptedOut: !getPreferenceValue(PreferenceType.Analytics),
+            useCookie: true, // insightsClient doesn't set the cookie when userHasOptedOut is true
         })
         insightsInitialized = true
     }

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -1,4 +1,5 @@
 import { Country } from "@ourworldindata/utils"
+import type { SearchResponse } from "@algolia/client-search"
 
 export type PageType =
     | "about"
@@ -79,7 +80,7 @@ export interface ChartHit extends ChartRecord {
 }
 
 export interface SiteSearchResults {
-    pages: PageHit[]
-    charts: ChartHit[]
+    pages: SearchResponse<PageHit>
+    charts: SearchResponse<ChartHit>
     countries: Country[]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16405,6 +16405,7 @@ __metadata:
     safe-stable-stringify: ^2.4.1
     sass: ^1.52.1
     sass-loader: ^13.0.2
+    search-insights: ^2.2.3
     sharp: ^0.31.0
     shell-quote: ^1.7.3
     shelljs: ^0.8.5
@@ -26804,6 +26805,13 @@ __metadata:
   dependencies:
     compute-scroll-into-view: ^1.0.17
   checksum: 6b888404ccf68fe2f2f1da8977e1a8a0a64a7139352e02e98621a0e8be3b3db393519ee3dcfb7c32aff3c4790a36829f1be1cccc0cfb2b90a60a61caa669eee2
+  languageName: node
+  linkType: hard
+
+"search-insights@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "search-insights@npm:2.2.3"
+  checksum: cf828b5677ff2108963965cc55a23ea2e751a55eabdcb0a1ef575a9b3b148510c0a6f29805e649eb99638d016dcdf3ff4274e62f0b993d05a13fe243e1c8fea8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #1877 | Live on _tufte_, together with #1915.

By communicating back click-through analytics to Algolia, they can provide us with insights like this one here:
![image](https://user-images.githubusercontent.com/2641501/217644936-390a41e5-2e13-40b1-8a87-007c0fd876a8.png)

As you can see, this is working fine already :)

One pretty big caveat right now is that for charts, we track click-throughs for all chart links, but don't track clicking on the interactive chart result, or interacting with it.