### PR TITLE
Complete backport publishing workflow

### DIFF
--- a/adminSiteClient/NewsletterPage.tsx
+++ b/adminSiteClient/NewsletterPage.tsx
@@ -96,7 +96,7 @@ export class NewsletterPage extends React.Component {
     }
 
     @computed get postsToShow(): PostIndexMeta[] {
-        const { searchInput, searchIndex, maxVisibleRows } = this
+        const { searchInput, searchIndex, maxVisibleRows, posts } = this
         if (searchInput) {
             const results = fuzzysort.go(searchInput, searchIndex, {
                 limit: 50,
@@ -104,7 +104,7 @@ export class NewsletterPage extends React.Component {
             })
             return lodash.uniq(results.map((result) => result.obj.post))
         } else {
-            return this.posts.slice(0, maxVisibleRows)
+            return posts.slice(0, maxVisibleRows)
         }
     }
 

--- a/adminSiteClient/PostsIndexPage.tsx
+++ b/adminSiteClient/PostsIndexPage.tsx
@@ -12,6 +12,7 @@ import { WORDPRESS_URL } from "../settings/clientSettings.js"
 import { Tag } from "./TagBadge.js"
 import { match } from "ts-pattern"
 import { GdocsEditLink } from "./GdocsEditLink.js"
+import { Link } from "./Link.js"
 
 interface PostIndexMeta {
     id: number
@@ -92,7 +93,12 @@ class PostRow extends React.Component<PostRowProps> {
             ))
             .with(GdocStatus.CONVERTING, () => <span>Converting...</span>)
             .with(GdocStatus.CONVERTED, () => (
-                <GdocsEditLink gdocId={post.gdocSuccessorId!} />
+                <Link
+                    to={`gdocs/${post.gdocSuccessorId}/preview`}
+                    className="btn btn-primary"
+                >
+                    Preview
+                </Link>
             ))
             .exhaustive()
 

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -2302,6 +2302,9 @@ apiRouter.post("/posts/:postId/createGdoc", async (req: Request) => {
         archieMl.content,
         post.gdocSuccessorId
     )
+    // If we did not yet have a gdoc associated with this post, we need to register
+    // the gdocSuccessorId and create an entry in the posts_gdocs table. Otherwise
+    // we don't need to make changes to the DB (only the gdoc regeneration was required)
     if (!existingGdocId) {
         post.gdocSuccessorId = gdocId
         // This is not ideal - we are using knex for on thing and typeorm for another

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -209,7 +209,22 @@ export class SiteBaker {
     }
 
     private async bakePosts() {
-        const postsApi = await wpdb.getPosts()
+        // In the backporting workflow, the users create gdoc posts for posts. As long as these are not yet published,
+        // we still want to bake them from the WP posts. Once the users presses publish there though, we want to stop
+        // baking them from the wordpress post. Here we fetch all the slugs of posts that have been published via gdocs
+        // and exclude them from the baking process.
+        const alreadyPublishedViaGdocsSlugs = await db.knexRaw(`--sql
+            select p.slug as slug from posts p
+            inner join posts_gdocs pg on p.gdocSuccessorId = pg.id
+            where pg.published = TRUE`)
+        const alreadyPublishedViaGdocsSlugsSet = new Set(
+            alreadyPublishedViaGdocsSlugs.map((row: any) => row.slug)
+        )
+
+        const postsApi = await wpdb.getPosts(
+            undefined,
+            (postrow) => !alreadyPublishedViaGdocsSlugsSet.has(postrow.slug)
+        )
 
         const postSlugs = []
         for (const postApi of postsApi) {

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -213,10 +213,9 @@ export class SiteBaker {
         // we still want to bake them from the WP posts. Once the users presses publish there though, we want to stop
         // baking them from the wordpress post. Here we fetch all the slugs of posts that have been published via gdocs
         // and exclude them from the baking process.
-        const alreadyPublishedViaGdocsSlugs = await db.knexRaw(`--sql
-            select p.slug as slug from posts p
-            inner join posts_gdocs pg on p.gdocSuccessorId = pg.id
-            where pg.published = TRUE`)
+        const alreadyPublishedViaGdocsSlugs = await db.knexRaw(`-- sql
+            select slug from posts_with_gdoc_publish_status
+            where isGdocPublished = TRUE`)
         const alreadyPublishedViaGdocsSlugsSet = new Set(
             alreadyPublishedViaGdocsSlugs.map((row: any) => row.slug)
         )

--- a/db/migration/1676022628012-AddPostsWithGdocPublishStatusView.ts
+++ b/db/migration/1676022628012-AddPostsWithGdocPublishStatusView.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddPostsWithGdocPublishStatusView1676022628012
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+        create view posts_with_gdoc_publish_status as
+            select p.*, pg.published as isGdocPublished from posts p
+            left join posts_gdocs pg on p.gdocSuccessorId = pg.id COLLATE utf8mb4_0900_ai_ci
+            order by pg.published desc;
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+        drop view posts_with_gdoc_publish_status;
+        `)
+    }
+}

--- a/db/model/Gdoc/archieToGdoc.ts
+++ b/db/model/Gdoc/archieToGdoc.ts
@@ -10,7 +10,7 @@ import {
 } from "./rawToArchie.js"
 import { GDOCS_BACKPORTING_TARGET_FOLDER } from "../../../settings/serverSettings.js"
 import { enrichedBlockToRawBlock } from "./enrichtedToRaw.js"
-import { google, docs_v1 } from "googleapis"
+import { google, docs_v1, drive_v3 } from "googleapis"
 import { Gdoc } from "./Gdoc.js"
 import * as cheerio from "cheerio"
 
@@ -194,13 +194,67 @@ function articleToBatchUpdates(
     return batchUpdates
 }
 
+async function deleteGdocContent(
+    client: docs_v1.Docs,
+    existingGdocId: string
+): Promise<void> {
+    // Retrieve raw data from Google
+    const { data } = await client.documents.get({
+        documentId: existingGdocId,
+        suggestionsViewMode: "PREVIEW_WITHOUT_SUGGESTIONS",
+    })
+    const content = data.body?.content
+    if (content) {
+        const endIndex = content[content.length - 1].endIndex!
+        const deleteUpdate = [
+            {
+                deleteContentRange: {
+                    range: {
+                        startIndex: 1,
+                        endIndex: endIndex - 1,
+                    },
+                },
+            },
+        ]
+        await client.documents.batchUpdate({
+            // The ID of the document to update.
+            documentId: existingGdocId,
+
+            // Request body metadata
+            requestBody: {
+                requests: deleteUpdate,
+            },
+        })
+    }
+}
+
+async function createGdoc(
+    driveClient: drive_v3.Drive,
+    title: string | undefined,
+    targetFolder: string
+): Promise<string> {
+    const docsMimeType = "application/vnd.google-apps.document"
+    const createResp = await driveClient.files.create({
+        supportsAllDrives: true,
+        requestBody: {
+            parents: [targetFolder],
+            mimeType: docsMimeType,
+            name: title,
+        },
+        media: {
+            mimeType: docsMimeType,
+            body: "",
+        },
+    })
+    return createResp.data.id!
+}
+
 export async function createGdocAndInsertOwidArticleContent(
     content: OwidArticleContent,
-    existingGdoc: string | undefined
+    existingGdocId: string | undefined
 ): Promise<string> {
     const batchUpdates = articleToBatchUpdates(content)
 
-    const docsMimeType = "application/vnd.google-apps.document"
     const targetFolder = GDOCS_BACKPORTING_TARGET_FOLDER
     if (targetFolder === undefined || targetFolder === "")
         throw new Error("GDOCS_BACKPORTING_TARGET_FOLDER is not set")
@@ -213,57 +267,18 @@ export async function createGdocAndInsertOwidArticleContent(
         version: "v3",
         auth,
     })
-    let documentId = existingGdoc
-    if (existingGdoc) {
-        // Retrieve raw data from Google
-        const { data } = await client.documents.get({
-            documentId: existingGdoc,
-            suggestionsViewMode: "PREVIEW_WITHOUT_SUGGESTIONS",
-        })
-        const content = data.body?.content
-        if (content) {
-            const endIndex = content[content.length - 1].endIndex!
-            const deleteUpdate = [
-                {
-                    deleteContentRange: {
-                        range: {
-                            startIndex: 1,
-                            endIndex: endIndex - 1,
-                        },
-                    },
-                },
-            ]
-            await client.documents.batchUpdate({
-                // The ID of the document to update.
-                documentId,
+    let documentId = existingGdocId
 
-                // Request body metadata
-                requestBody: {
-                    requests: deleteUpdate,
-                },
-            })
-        }
+    if (existingGdocId) {
+        await deleteGdocContent(client, existingGdocId)
     } else {
-        const createResp = await driveClient.files.create({
-            supportsAllDrives: true,
-            requestBody: {
-                parents: [targetFolder],
-                mimeType: docsMimeType,
-                name: content.title,
-            },
-            media: {
-                mimeType: docsMimeType,
-                body: "",
-            },
-        })
-        documentId = createResp.data.id!
+        documentId = await createGdoc(driveClient, content.title, targetFolder)
     }
 
+    // Now that we have either created a new document or deleted the content of an existing one,
+    // we can insert the new content.
     await client.documents.batchUpdate({
-        // The ID of the document to update.
         documentId,
-
-        // Request body metadata
         requestBody: {
             requests: batchUpdates,
         },

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -26,9 +26,11 @@ import {
 } from "@ourworldindata/utils"
 import { match } from "ts-pattern"
 
-export function appendDotEndIfMultiline(line: string): string {
-    if (line.includes("\n")) return line + "\n:end"
-    return line
+export function appendDotEndIfMultiline(
+    line: string | null | undefined
+): string {
+    if (line && line.includes("\n")) return line + "\n:end"
+    return line ?? ""
 }
 
 export function* encloseLinesAsPropertyPossiblyMultiline(
@@ -51,7 +53,7 @@ export function* encloseLinesAsPropertyPossiblyMultiline(
 
 export function keyValueToArchieMlString(
     key: string,
-    val: string | undefined
+    val: string | undefined | null
 ): string {
     if (val !== undefined) return `${key}: ${appendDotEndIfMultiline(val)}`
     return ""

--- a/devTools/docker/vhosts.conf
+++ b/devTools/docker/vhosts.conf
@@ -53,6 +53,11 @@ server {
         add_header X-Robots-Tag noindex;
   }
 
+  location /gdocs {
+        try_files $uri @nodeAdmin;
+        add_header X-Robots-Tag noindex;
+  }
+
   location @nodeAdmin {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       # enable this if and only if you use HTTPS


### PR DESCRIPTION
This PR completes the workflow of converting selected wordpress posts into gdocs and then allowing publishing those. Before we did create gdocs documents but they were not registered in the posts_gdocs table and there was no way to publish them from there. This PR now adds that capability.

To test it, go to the posts table. You can view compare for all posts and then also hit "Create GDoc" (this needs the .env setting entry GDOCS_BACKPORTING_TARGET_FOLDER to be set). Once the GDoc is created, a link brings you to the preview page from where you can also go the the gdoc and edit it.