### PR TITLE
schema(mysql): add columns dataPath and metadataPath to variables table

### DIFF
--- a/db/migration/1676024933829-AddDataPathToVariables.ts
+++ b/db/migration/1676024933829-AddDataPathToVariables.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddDataPathToVariables1676024933829 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE variables
+              ADD COLUMN dataPath TEXT,
+              ADD COLUMN metadataPath TEXT;
+            `
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE variables
+              DROP COLUMN dataPath,
+              DROP COLUMN metadataPath;
+            `
+        )
+    }
+}

--- a/db/readme.md
+++ b/db/readme.md
@@ -39,7 +39,7 @@ You can find examples of older migrations here: https://github.com/owid/owid-gra
 
 ### Reverting a migration
 
-To revert the last migration on **your local development server**, use `yarn typeorm migration:revert`. Running that repeatedly will revert additional migrations. This is useful when working with migrations locally – when you make a change to an existing migration, you need to revert and re-run it.
+To revert the last migration on **your local development server**, use `yarn revertLastDbMigration`. Running that repeatedly will revert additional migrations. This is useful when working with migrations locally – when you make a change to an existing migration, you need to revert and re-run it.
 
 If the migration **has been run in production**, create a new migration that is a duplicate of the one you want to revert, and then swap the `up` and `down` functions.
 


### PR DESCRIPTION
I've separated this from data JSON changes because it believe it deserves its own discussion (and merging this separately would let me fill those columns from ETL before merging the actual data JSON changes in grapher).

This PR adds two columns `dataPath` and `metadataPath` to `variables` table. The typical paths look like this:
* https://catalog.ourworldindata.org/baked-variables/live_grapher/data/37.json.gz
* https://catalog.ourworldindata.org/baked-variables/live_grapher/metadata/37.json.gz (or perhaps ungzipped)

Instead of having concrete paths for every variable, we could create paths on the fly (e.g. with environment variables), but this becomes annoying once you start cloning live server as staging where you need to mix paths from production and staging.

A drawback is that you need really long string for every variable and MySQL dumps grow by about 50mb due to this. This doesn't matter much as we compress dumps, but still... (I thought MySQL would apply some form of prefix compression, but it doesn't look like it)