### PR TITLE
fix: Add updatedAtInWordpress field to posts table

### DIFF
--- a/adminSiteClient/NewsletterPage.tsx
+++ b/adminSiteClient/NewsletterPage.tsx
@@ -17,7 +17,7 @@ interface PostIndexMeta {
     type: string
     status: string
     publishedAt: string
-    updatedAt: string
+    updatedAtInWordpress: string
     excerpt: string
     slug: string
     url: string
@@ -55,7 +55,7 @@ class PostRow extends React.Component<{
                 <td>{post.type}</td>
                 <td>{post.status}</td>
                 <td>
-                    <Timeago time={post.updatedAt} />
+                    <Timeago time={post.updatedAtInWordpress} />
                 </td>
                 <td>
                     <a

--- a/adminSiteClient/PostsIndexPage.tsx
+++ b/adminSiteClient/PostsIndexPage.tsx
@@ -20,7 +20,7 @@ interface PostIndexMeta {
     type: string
     status: string
     authors: string[]
-    updatedAt: string
+    updatedAtInWordpress: string
     tags: Tag[]
     gdocSuccessorId: string | undefined
 }
@@ -139,7 +139,7 @@ class PostRow extends React.Component<PostRowProps> {
                     />
                 </td>
                 <td>
-                    <Timeago time={post.updatedAt} />
+                    <Timeago time={post.updatedAtInWordpress} />
                 </td>
                 <td>
                     <a

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -2209,9 +2209,14 @@ apiRouter.get("/posts.json", async (req) => {
         "title",
         "type",
         "status",
-        "updated_at",
+        "updated_at_in_wordpress",
         "gdocSuccessorId"
-    ).from(db.knexInstance().from(postsTable).orderBy("updated_at", "desc"))
+    ).from(
+        db
+            .knexInstance()
+            .from(postsTable)
+            .orderBy("updated_at_in_wordpress", "desc")
+    )
 
     const tagsByPostId = await getTagsByPostId()
 
@@ -2249,7 +2254,7 @@ apiRouter.get("/newsletterPosts.json", async (req) => {
         return {
             id: row.id,
             title: row.title,
-            updatedAt: row.updatedAt,
+            updatedAtInWordpress: row.updatedAt,
             publishedAt: row.publishedAt,
             type: row.type,
             status: row.status,

--- a/baker/postUpdatedHook.ts
+++ b/baker/postUpdatedHook.ts
@@ -81,7 +81,7 @@ const syncPostToGrapher = async (
                   wpPost.post_date_gmt === zeroDateString
                       ? null
                       : wpPost.post_date_gmt,
-              updated_at:
+              updated_at_in_wordpress:
                   wpPost.post_modified_gmt === zeroDateString
                       ? "1970-01-01 00:00:00"
                       : wpPost.post_modified_gmt,

--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -60,7 +60,10 @@ export const makeSitemap = async (explorerAdminServer: ExplorerAdminServer) => {
     const posts = (await db
         .knexTable(postsTable)
         .where({ status: "publish" })
-        .select("slug", "updated_at")) as { slug: string; updated_at: Date }[]
+        .select("slug", "updated_at_in_wordpress")) as {
+        slug: string
+        updated_at_in_wordpress: Date
+    }[]
     const charts = (await db
         .knexTable(Chart.table)
         .select(db.knexRaw(`updatedAt, config->>"$.slug" AS slug`))
@@ -86,7 +89,7 @@ export const makeSitemap = async (explorerAdminServer: ExplorerAdminServer) => {
         .concat(
             posts.map((p) => ({
                 loc: urljoin(BAKED_BASE_URL, p.slug),
-                lastmod: dayjs(p.updated_at).format("YYYY-MM-DD"),
+                lastmod: dayjs(p.updated_at_in_wordpress).format("YYYY-MM-DD"),
             }))
         )
         .concat(

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -31,7 +31,8 @@ const migrate = async (): Promise<void> => {
         "updated_at_in_wordpress",
         "authors",
         "excerpt",
-        "created_at_in_wordpress"
+        "created_at_in_wordpress",
+        "updated_at"
     ).from(db.knexTable(Post.postsTable)) //.where("id", "=", "22821"))
 
     for (const post of posts) {
@@ -128,7 +129,8 @@ const migrate = async (): Promise<void> => {
                 createdAt:
                     post.created_at_in_wordpress ??
                     post.updated_at_in_wordpress ??
-                    post.updated_at,
+                    post.updated_at ??
+                    new Date(),
                 publishedAt: post.published_at,
                 updatedAt: post.updated_at_in_wordpress,
                 publicationContext: OwidArticlePublicationContext.listed, // TODO: not all articles are listed, take this from the DB

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -28,7 +28,7 @@ const migrate = async (): Promise<void> => {
         "title",
         "content",
         "published_at",
-        "updated_at",
+        "updated_at_in_wordpress",
         "authors",
         "excerpt",
         "created_at_in_wordpress"
@@ -125,9 +125,12 @@ const migrate = async (): Promise<void> => {
                     refs: refParsingResults,
                 },
                 published: false,
-                createdAt: post.created_at_in_wordpress ?? post.updated_at,
+                createdAt:
+                    post.created_at_in_wordpress ??
+                    post.updated_at_in_wordpress ??
+                    post.updated_at,
                 publishedAt: post.published_at,
-                updatedAt: post.updated_at,
+                updatedAt: post.updated_at_in_wordpress,
                 publicationContext: OwidArticlePublicationContext.listed, // TODO: not all articles are listed, take this from the DB
                 revisionId: null,
             }

--- a/db/migration/1676042584151-AddUpdatedAtInWordpressToPosts.ts
+++ b/db/migration/1676042584151-AddUpdatedAtInWordpressToPosts.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddUpdatedAtInWordpressToPosts1676042584151
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE posts
+        ADD COLUMN updated_at_in_wordpress datetime
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE posts
+        DROP COLUMN updated_at_in_wordpress
+        `)
+    }
+}

--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -192,7 +192,7 @@ const syncPostsToGrapher = async (): Promise<void> => {
                 post.post_date_gmt === zeroDateString
                     ? null
                     : post.post_date_gmt,
-            updated_at:
+            updated_at_in_wordpress:
                 post.post_modified_gmt === zeroDateString
                     ? "1970-01-01 00:00:00"
                     : post.post_modified_gmt,

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -164,7 +164,8 @@ export interface PostRow {
     status: string
     content: string
     published_at: Date | null
-    updated_at: Date
+    updated_at: Date | null
+    updated_at_in_wordpress: Date | null
     archieml: string
     archieml_update_statistics: string
     gdocSuccessorId: string


### PR DESCRIPTION
Because the posts table mirrors wordpress posts into our database, we use it to understand when the wordpress post was last modified. The [recent unification of automatic timestamps](https://github.com/owid/owid-grapher/pull/1888) interferes with this now - when running the archieml update for example that touches every post, the updated_at field is now automatically changed. This commit adds a new field so that we can separate the "wordpress changed" meaning from "the table was touched"