### PR TITLE
Add ability manually curate 'featured work' on the front page

### DIFF
--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -216,27 +216,29 @@ export const renderFrontPage = async () => {
     const entries = await getEntriesByCategory()
     const posts = await getBlogIndex()
 
-    const NUM_FEATURED_POSTS = 6;
+    const NUM_FEATURED_POSTS = 6
 
     /**
-     * A frontPageConfig should specify a list of 
+     * A frontPageConfig should specify a list of
      * articles to feature in the featured work block,
      * and which position they should be placed in.
-     * 
+     *
      * Note that this can be underspecified, so some positions
      * may not be filled in.
-     * 
+     *
      */
-    const frontPageConfigGdoc = new Gdoc('1LpZ5LFDTA6buEb_uL-IOWQC1YLAEbpj7odup-zgg1II');
-    await frontPageConfigGdoc.getEnrichedArticle();
-    const frontPageConfig: any = frontPageConfigGdoc.content;
-    const featuredPosts: {slug: String, position: Number}[] = frontPageConfig.featuredPosts;
-
+    const frontPageConfigGdoc = new Gdoc(
+        "1LpZ5LFDTA6buEb_uL-IOWQC1YLAEbpj7odup-zgg1II"
+    )
+    await frontPageConfigGdoc.getEnrichedArticle()
+    const frontPageConfig: any = frontPageConfigGdoc.content
+    const featuredPosts: { slug: String; position: Number }[] =
+        frontPageConfig.featuredPosts
 
     // Generate the candidate posts to fill in any missing slots
-    const slugs = featuredPosts.map(d => d.slug);
-    const filteredPosts = posts.filter(post => {
-        return !slugs.includes(post.slug);
+    const slugs = featuredPosts.map((d) => d.slug)
+    const filteredPosts = posts.filter((post) => {
+        return !slugs.includes(post.slug)
     })
 
     /**
@@ -244,19 +246,24 @@ export const renderFrontPage = async () => {
      * manually curated list of posts and filling in any empty
      * positions with the latest available posts, while avoiding
      * adding any duplicates.
-    */
-    let missingPosts = 0;
-    const featuredWork = [... new Array(NUM_FEATURED_POSTS)].map((_, i) => i).map((idx) => {
-        const manuallySetPost = featuredPosts.find(d => +d.position === (idx+1));
-        if (manuallySetPost) {
-            const post = posts.find((post) => post.slug === manuallySetPost.slug);
-            if (post) {
-                return post;
+     */
+    let missingPosts = 0
+    const featuredWork = [...new Array(NUM_FEATURED_POSTS)]
+        .map((_, i) => i)
+        .map((idx) => {
+            const manuallySetPost = featuredPosts.find(
+                (d) => +d.position === idx + 1
+            )
+            if (manuallySetPost) {
+                const post = posts.find(
+                    (post) => post.slug === manuallySetPost.slug
+                )
+                if (post) {
+                    return post
+                }
             }
-        }
-        return filteredPosts[missingPosts++];
-    });
-
+            return filteredPosts[missingPosts++]
+        })
 
     const totalCharts = (
         await queryMysql(

--- a/site/FrontPage.tsx
+++ b/site/FrontPage.tsx
@@ -35,8 +35,9 @@ export const FrontPage = (props: {
     posts: IndexPost[]
     totalCharts: number
     baseUrl: string
+    featuredWork: IndexPost[]
 }) => {
-    const { entries, posts, totalCharts, baseUrl } = props
+    const { entries, posts, totalCharts, baseUrl, featuredWork } = props
 
     // Structured data for google
     const structuredMarkup = {
@@ -183,10 +184,10 @@ export const FrontPage = (props: {
                             <div className="owid-col flex-row">
                                 <div className="homepage-posts--explainers">
                                     <div className="header">
-                                        <h2>Our latest work</h2>
+                                        <h2>Featured work</h2>
                                     </div>
                                     <ul>
-                                        {posts.slice(0, 6).map((post) => (
+                                        {featuredWork.map((post) => (
                                             <li key={post.slug}>
                                                 <PostCard post={post} />
                                             </li>


### PR DESCRIPTION
This is an attempt to change the "latest work" block on the front page to "featured work". This is based on a strong desire from the editorial side to have ability to choose which posts appear there, and mitigate some pressure to constantly be publishing to posts so that the front page doesn't get stale. 

The new featured work block is powered by a Google Doc (https://docs.google.com/document/d/1LpZ5LFDTA6buEb_uL-IOWQC1YLAEbpj7odup-zgg1II/edit#) which allows an editor to choose up to six custom posts to appear in the featured work section. They must specify a `slug` (the slug of the post) and a `position` (the position within the featured work block, from 1 to 6). If the featured work block is underspecified, then it will fall back to fill in any missing slots with the latest posts available, while avoiding duplicating any post that was manually specified.

I'm opening this as a draft since it isn't really production ready (e.g. the GDoc ID is hardcoded, and its a bit of a hack on ot of the existing ArchieML infrastructure). But wanted to get feedback and hopefully get some version of this merged soon to take some pressure off of the authors. 