### PR TITLE
Backport prominent links

### DIFF
--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -51,11 +51,11 @@ const migrate = async (): Promise<void> => {
                     return val.replace(/\{\/?ref\}/g, "")
                 }
             )
-            //TODO: we don't seem to get the first node if it is a comment.
-            // Maybe this is benign but if not this works as a workaround:
-            //`<div>${post.content}</div>`)
-            const $: CheerioStatic = cheerio.load(text)
-            const bodyContents = $("body").contents().toArray()
+            // We don't get the first and last nodes if they are comments.
+            // This can cause issues with the wp:components so here we wrap
+            // everything in a div
+            const $: CheerioStatic = cheerio.load(`<div>${text}</div>`)
+            const bodyContents = $("body>div").contents().toArray()
             const parsingContext = {
                 $,
                 shouldParseWpComponents: true,

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -30,10 +30,18 @@ const migrate = async (): Promise<void> => {
         "published_at",
         "updated_at_in_wordpress",
         "authors",
+<<<<<<< HEAD
         "excerpt",
         "created_at_in_wordpress",
         "updated_at"
     ).from(db.knexTable(Post.postsTable)) //.where("id", "=", "22821"))
+||||||| parent of 727c5acc6 (feat: add backporting of prominent links)
+        "excerpt"
+    ).from(db.knexTable(Post.postsTable)) //.where("id", "=", "22821"))
+=======
+        "excerpt"
+    ).from(db.knexTable(Post.postsTable)) //.where("id", "=", "1441"))
+>>>>>>> 727c5acc6 (feat: add backporting of prominent links)
 
     for (const post of posts) {
         try {
@@ -125,12 +133,20 @@ const migrate = async (): Promise<void> => {
                     // TODO: this discards block level elements - those might be needed?
                     refs: refParsingResults,
                 },
+<<<<<<< HEAD
                 published: false,
                 createdAt:
                     post.created_at_in_wordpress ??
                     post.updated_at_in_wordpress ??
                     post.updated_at ??
                     new Date(),
+||||||| parent of 727c5acc6 (feat: add backporting of prominent links)
+                published: false, // post.published_at !== null,
+                createdAt: post.updated_at_in_wordpress, // TODO: this is wrong but it doesn't seem that wordpress tracks the creation date
+=======
+                published: false, // post.published_at !== null,
+                createdAt: post.updated_at_in_wordpress ?? new Date(), // TODO: this is wrong but it doesn't seem that wordpress tracks the creation date
+>>>>>>> 727c5acc6 (feat: add backporting of prominent links)
                 publishedAt: post.published_at,
                 updatedAt: post.updated_at_in_wordpress,
                 publicationContext: OwidArticlePublicationContext.listed, // TODO: not all articles are listed, take this from the DB

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -30,18 +30,10 @@ const migrate = async (): Promise<void> => {
         "published_at",
         "updated_at_in_wordpress",
         "authors",
-<<<<<<< HEAD
         "excerpt",
         "created_at_in_wordpress",
         "updated_at"
     ).from(db.knexTable(Post.postsTable)) //.where("id", "=", "22821"))
-||||||| parent of 727c5acc6 (feat: add backporting of prominent links)
-        "excerpt"
-    ).from(db.knexTable(Post.postsTable)) //.where("id", "=", "22821"))
-=======
-        "excerpt"
-    ).from(db.knexTable(Post.postsTable)) //.where("id", "=", "1441"))
->>>>>>> 727c5acc6 (feat: add backporting of prominent links)
 
     for (const post of posts) {
         try {
@@ -133,20 +125,12 @@ const migrate = async (): Promise<void> => {
                     // TODO: this discards block level elements - those might be needed?
                     refs: refParsingResults,
                 },
-<<<<<<< HEAD
                 published: false,
                 createdAt:
                     post.created_at_in_wordpress ??
                     post.updated_at_in_wordpress ??
                     post.updated_at ??
                     new Date(),
-||||||| parent of 727c5acc6 (feat: add backporting of prominent links)
-                published: false, // post.published_at !== null,
-                createdAt: post.updated_at_in_wordpress, // TODO: this is wrong but it doesn't seem that wordpress tracks the creation date
-=======
-                published: false, // post.published_at !== null,
-                createdAt: post.updated_at_in_wordpress ?? new Date(), // TODO: this is wrong but it doesn't seem that wordpress tracks the creation date
->>>>>>> 727c5acc6 (feat: add backporting of prominent links)
                 publishedAt: post.published_at,
                 updatedAt: post.updated_at_in_wordpress,
                 publicationContext: OwidArticlePublicationContext.listed, // TODO: not all articles are listed, take this from the DB

--- a/db/model/Gdoc/gdocUtils.ts
+++ b/db/model/Gdoc/gdocUtils.ts
@@ -1,6 +1,29 @@
 import { Span } from "@ourworldindata/utils"
-import { match } from "ts-pattern"
+import { match, P } from "ts-pattern"
 import * as cheerio from "cheerio"
+
+export function spanToSimpleString(s: Span): string {
+    return match(s)
+        .with({ spanType: "span-simple-text" }, (span) => span.text)
+        .with({ spanType: "span-newline" }, () => "</br>")
+        .with(
+            {
+                spanType: P.union(
+                    "span-link",
+                    "span-ref",
+                    "span-italic",
+                    "span-bold",
+                    "span-underline",
+                    "span-subscript",
+                    "span-superscript",
+                    "span-quote",
+                    "span-fallback"
+                ),
+            },
+            (other) => other.children.map(spanToSimpleString).join("")
+        )
+        .exhaustive()
+}
 
 export function spanToHtmlString(s: Span): string {
     return match(s)
@@ -53,6 +76,14 @@ export function spansToHtmlString(spans: Span[]): string {
     if (spans.length === 0) return ""
     else {
         const result = spans.map(spanToHtmlString).join("")
+        return result
+    }
+}
+
+export function spansToSimpleString(spans: Span[]): string {
+    if (spans.length === 0) return ""
+    else {
+        const result = spans.map(spanToSimpleString).join("")
         return result
     }
 }

--- a/db/model/Gdoc/gdocUtils.ts
+++ b/db/model/Gdoc/gdocUtils.ts
@@ -5,7 +5,7 @@ import * as cheerio from "cheerio"
 export function spanToSimpleString(s: Span): string {
     return match(s)
         .with({ spanType: "span-simple-text" }, (span) => span.text)
-        .with({ spanType: "span-newline" }, () => "</br>")
+        .with({ spanType: "span-newline" }, () => "\n")
         .with(
             {
                 spanType: P.union(

--- a/db/model/Gdoc/htmlToEnriched.test.ts
+++ b/db/model/Gdoc/htmlToEnriched.test.ts
@@ -28,14 +28,6 @@ it("parses a Wordpress paragraph within the content", () => {
     const parsedResult = cheerioElementsToArchieML(bodyContents, context)
 
     expect(parsedResult.content).toEqual([
-        // The first element will be removed by the subsequent call to
-        // convertAllWpComponentsToArchieMLBlocks(withoutEmptyOrWhitespaceOnlyTextBlocks())
-        {
-            tagName: "paragraph",
-            attributes: undefined,
-            isVoidElement: false,
-            childrenResults: [],
-        },
         {
             type: "text",
             value: [

--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -386,11 +386,11 @@ export function parseWpComponent(
     // tag that we want to ignore then don't try to find a closing tag
     if (componentDetails.isVoidElement)
         return {
-            remainingElements,
-            result: {
+            result: finishWpComponent(componentDetails, {
                 errors: [],
-                content: [componentDetails],
-            },
+                content: [],
+            }),
+            remainingElements: remainingElements,
         }
     if (wpComponentTagsToIgnore.includes(componentDetails.tagName))
         return {

--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -21,10 +21,12 @@ import {
     EnrichedBlockList,
     EnrichedBlockStickyRightContainer,
     EnrichedBlockNumberedList,
+    EnrichedBlockProminentLink,
 } from "@ourworldindata/utils"
 import { match, P } from "ts-pattern"
 import { compact, flatten, isPlainObject, partition } from "lodash"
 import * as cheerio from "cheerio"
+import { spansToSimpleString } from "./gdocUtils.js"
 
 //#region Spans
 function spanFallback(element: CheerioElement): SpanFallback {
@@ -211,6 +213,8 @@ type ErrorNames =
     | "columns block expects children to be column components"
     | "ol without children"
     | "unhandled html tag found"
+    | "prominent link missing title"
+    | "prominent link missing url"
 
 interface BlockParseError {
     name: ErrorNames
@@ -380,15 +384,20 @@ export function parseWpComponent(
     const collectedContent: BlockParseResult<ArchieBlockOrWpComponent>[] = []
     // If the wp component tag was closing (ended with /--> ) or if this is a component
     // tag that we want to ignore then don't try to find a closing tag
-    if (
-        componentDetails.isVoidElement ||
-        wpComponentTagsToIgnore.includes(componentDetails.tagName)
-    )
+    if (componentDetails.isVoidElement)
         return {
             remainingElements,
             result: {
                 errors: [],
                 content: [componentDetails],
+            },
+        }
+    if (wpComponentTagsToIgnore.includes(componentDetails.tagName))
+        return {
+            remainingElements,
+            result: {
+                errors: [],
+                content: [],
             },
         }
     // Now iterate until we find the matching closing tag. If we find an opening wp:component
@@ -500,6 +509,43 @@ function finishWpComponent(
                     } as EnrichedBlockStickyRightContainer,
                 ],
             }
+        })
+        .with("owid/prominent-link", () => {
+            const errors = content.errors
+            const title = details.attributes?.title as string | undefined
+            const url = details.attributes?.linkUrl as string | undefined
+            if (title === undefined) {
+                errors.push({
+                    name: "prominent link missing title",
+                    details: `Prominent link is missing a title attribute`,
+                })
+            }
+            if (url === undefined) {
+                errors.push({
+                    name: "prominent link missing url",
+                    details: `Prominent link is missing a linkUrl attribute`,
+                })
+            }
+            if (title !== undefined && url !== undefined) {
+                const descriptionBlock =
+                    content.content.length > 0 ? content.content[0] : undefined
+                let description = ""
+                if (descriptionBlock && isEnrichedTextBlock(descriptionBlock)) {
+                    description = spansToSimpleString(descriptionBlock.value)
+                }
+                return {
+                    errors,
+                    content: [
+                        {
+                            type: "prominent-link",
+                            title,
+                            url,
+                            description,
+                            parseErrors: [],
+                        } as EnrichedBlockProminentLink,
+                    ],
+                }
+            } else return { ...content, errors }
         })
         .otherwise(() => {
             return {


### PR DESCRIPTION
This PR backports prominent links. Prominent links will need to fetch fallback titles (the title of the content they are pointing to) and thumbnails (of the content they are pointing to) - but this has to happen at bake time, not at backport time. This concern is thus tracked in #1921 