### PR TITLE
Search, part 4: add pageviews as a ranking criterion

### DIFF
--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -52,6 +52,7 @@ export const configureAlgolia = async () => {
         distinct: true,
         advancedSyntax: true,
         advancedSyntaxFeatures: ["exactPhrase"],
+        unretrievableAttributes: ["views_7d"],
     }
 
     const chartsIndex = client.initIndex("charts")
@@ -75,6 +76,7 @@ export const configureAlgolia = async () => {
         ],
         customRanking: [
             "desc(numRelatedArticles)",
+            "desc(views_7d)",
             "asc(numDimensions)",
             "asc(titleLength)",
         ],
@@ -95,7 +97,7 @@ export const configureAlgolia = async () => {
             "unordered(content)",
             "unordered(authors)",
         ],
-        customRanking: ["desc(importance)"],
+        customRanking: ["desc(importance)", "desc(views_7d)"],
         attributesToSnippet: ["excerpt:20", "content:20"],
         attributeForDistinct: "slug",
         attributesForFaceting: [

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -77,7 +77,6 @@ export const configureAlgolia = async () => {
         customRanking: [
             "desc(score)",
             "desc(numRelatedArticles)",
-            "desc(views_7d)",
             "asc(numDimensions)",
             "asc(titleLength)",
         ],
@@ -98,7 +97,7 @@ export const configureAlgolia = async () => {
             "unordered(content)",
             "unordered(authors)",
         ],
-        customRanking: ["desc(score)", "desc(importance)", "desc(views_7d)"],
+        customRanking: ["desc(score)", "desc(importance)"],
         attributesToSnippet: ["excerpt:20", "content:20"],
         attributeForDistinct: "slug",
         attributesForFaceting: [

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -52,7 +52,7 @@ export const configureAlgolia = async () => {
         distinct: true,
         advancedSyntax: true,
         advancedSyntaxFeatures: ["exactPhrase"],
-        unretrievableAttributes: ["views_7d"],
+        unretrievableAttributes: ["views_7d", "score"],
     }
 
     const chartsIndex = client.initIndex("charts")
@@ -75,6 +75,7 @@ export const configureAlgolia = async () => {
             "unordered(availableEntities)",
         ],
         customRanking: [
+            "desc(score)",
             "desc(numRelatedArticles)",
             "desc(views_7d)",
             "asc(numDimensions)",
@@ -97,7 +98,7 @@ export const configureAlgolia = async () => {
             "unordered(content)",
             "unordered(authors)",
         ],
-        customRanking: ["desc(importance)", "desc(views_7d)"],
+        customRanking: ["desc(score)", "desc(importance)", "desc(views_7d)"],
         attributesToSnippet: ["excerpt:20", "content:20"],
         attributeForDistinct: "slug",
         attributesForFaceting: [

--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -42,7 +42,7 @@ const getChartsRecords = async (): Promise<ChartRecord[]> => {
         )
     }
 
-    const pageviews = await Pageview.viewsByUrlObj()
+    const pageviews = await Pageview.getViewsByUrlObj()
 
     const records: ChartRecord[] = []
     for (const c of chartsToIndex) {

--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -5,6 +5,7 @@ import { getAlgoliaClient } from "./configureAlgolia.js"
 import { isPathRedirectedToExplorer } from "../../explorerAdminServer/ExplorerRedirects.js"
 import { ChartRecord } from "../../site/search/searchTypes.js"
 import { MarkdownTextWrap } from "@ourworldindata/utils"
+import { Pageview } from "../../db/model/Pageview.js"
 
 const getChartsRecords = async (): Promise<ChartRecord[]> => {
     const chartsToIndex = await db.queryMysql(`
@@ -36,6 +37,8 @@ const getChartsRecords = async (): Promise<ChartRecord[]> => {
         )
     }
 
+    const pageviews = await Pageview.viewsByUrlObj()
+
     const records: ChartRecord[] = []
     for (const c of chartsToIndex) {
         // Our search currently cannot render explorers, so don't index them because
@@ -65,6 +68,7 @@ const getChartsRecords = async (): Promise<ChartRecord[]> => {
             titleLength: c.title.length,
             // Number of references to this chart in all our posts and pages
             numRelatedArticles: relatedArticles.length,
+            views_7d: pageviews[`/grapher/${c.slug}`]?.views_7d ?? 0,
         })
     }
 

--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -86,6 +86,7 @@ const indexChartsToAlgolia = async () => {
 
     const index = client.initIndex("charts")
 
+    await db.getConnection()
     const records = await getChartsRecords()
     await index.replaceAllObjects(records)
 

--- a/baker/algolia/indexToAlgolia.ts
+++ b/baker/algolia/indexToAlgolia.ts
@@ -48,7 +48,7 @@ const computeScore = (record: Omit<PageRecord, "score">): number => {
 
 const getPagesRecords = async () => {
     const postsApi = await wpdb.getPosts()
-    const pageviews = await Pageview.viewsByUrlObj()
+    const pageviews = await Pageview.getViewsByUrlObj()
 
     const records: PageRecord[] = []
     for (const country of countries) {

--- a/baker/algolia/indexToAlgolia.ts
+++ b/baker/algolia/indexToAlgolia.ts
@@ -7,6 +7,7 @@ import { formatPost } from "../../baker/formatWordpressPost.js"
 import { getAlgoliaClient } from "./configureAlgolia.js"
 import { htmlToText } from "html-to-text"
 import { PageRecord, PageType } from "../../site/search/searchTypes.js"
+import { Pageview } from "../../db/model/Pageview.js"
 
 interface Tag {
     id: number
@@ -42,6 +43,7 @@ const getPostTypeAndImportance = (
 
 const getPagesRecords = async () => {
     const postsApi = await wpdb.getPosts()
+    const pageviews = await Pageview.viewsByUrlObj()
 
     const records: PageRecord[] = []
     for (const country of countries) {
@@ -55,6 +57,7 @@ const getPagesRecords = async () => {
             slug: `country/${country.slug}`,
             title: country.name,
             content: `All available indicators for ${country.name}.`,
+            views_7d: pageviews[`/country/${country.slug}`]?.views_7d ?? 0,
         })
     }
 
@@ -95,6 +98,7 @@ const getPagesRecords = async () => {
                 modifiedDate: post.modifiedDate.toISOString(),
                 content: c,
                 tags: tags.map((t) => t.name),
+                views_7d: pageviews[`/${post.path}`]?.views_7d ?? 0,
             })
             i += 1
         }

--- a/baker/algolia/indexToAlgolia.ts
+++ b/baker/algolia/indexToAlgolia.ts
@@ -117,6 +117,7 @@ const indexToAlgolia = async () => {
     }
     const index = client.initIndex("pages")
 
+    await db.getConnection()
     const records = await getPagesRecords()
     index.replaceAllObjects(records)
 

--- a/db/model/Pageview.ts
+++ b/db/model/Pageview.ts
@@ -1,0 +1,47 @@
+import { keyBy } from "lodash"
+import { Entity, Column, BaseEntity } from "typeorm"
+
+interface RawPageview {
+    day: Date
+    url: string
+    views_7d: number
+    views_14d: number
+}
+
+@Entity("pageviews")
+export class Pageview extends BaseEntity implements RawPageview {
+    /** The last day with pageview data that is included in the sum */
+    @Column({ primary: true }) day!: Date
+    /**
+     * The _absolute_ URL of the page, e.g. `https://ourworldindata.org/grapher/life-expectancy`.
+     * Does not include any query parameters.
+     * Usually does not include a trailing slash, except for the homepage (`/`) and 404s.
+     */
+    @Column({ primary: true }) url!: string
+    /** Sum of pageviews over the last 7 days. */
+    @Column() views_7d!: number
+    /** Sum of pageviews over the last 14 days. */
+    @Column() views_14d!: number
+
+    static async viewsByUrlObj(): Promise<{ [url: string]: RawPageview }> {
+        const pageviews = await Pageview.find()
+
+        // Normalize URLs to be relative to the root of the site.
+        // This also filters out any URLs that don't start with ourworldindata.org.
+        const pageviewsNormalized: RawPageview[] = pageviews.flatMap((p) => {
+            if (p.url.startsWith("https://ourworldindata.org/"))
+                return [
+                    {
+                        ...p,
+                        url: p.url.replace(
+                            new RegExp("^https://ourworldindata.org"),
+                            ""
+                        ),
+                    },
+                ]
+            else return []
+        })
+
+        return keyBy(pageviewsNormalized, (p) => p.url)
+    }
+}

--- a/db/model/Pageview.ts
+++ b/db/model/Pageview.ts
@@ -23,7 +23,7 @@ export class Pageview extends BaseEntity implements RawPageview {
     /** Sum of pageviews over the last 14 days. */
     @Column() views_14d!: number
 
-    static async viewsByUrlObj(): Promise<{ [url: string]: RawPageview }> {
+    static async getViewsByUrlObj(): Promise<{ [url: string]: RawPageview }> {
         const pageviews = await Pageview.find()
 
         // Normalize URLs to be relative to the root of the site.

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -12,10 +12,12 @@ export type PageType =
 export interface PageRecord {
     objectID: string
     type: PageType
+    importance: number
     slug: string
     title: string
     content: string
     views_7d: number
+    score: number
     postId?: number
     excerpt?: string
     authors?: string[]
@@ -61,6 +63,7 @@ export interface ChartRecord {
     titleLength: number
     numRelatedArticles: number
     views_7d: number
+    score: number
 }
 
 export interface ChartHit extends ChartRecord {

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -15,6 +15,7 @@ export interface PageRecord {
     slug: string
     title: string
     content: string
+    views_7d: number
     postId?: number
     excerpt?: string
     authors?: string[]
@@ -59,6 +60,7 @@ export interface ChartRecord {
     numDimensions: number
     titleLength: number
     numRelatedArticles: number
+    views_7d: number
 }
 
 export interface ChartHit extends ChartRecord {


### PR DESCRIPTION
Resolves #1878 | Live on [tufte](https://tufte-owid.netlify.app/)

This work matches up the data from the `pageviews` table with the actual posts and pages we have, and then adds that as an attribute to the Algolia records.

One important notion is that of a "score" - we don't rank by a single attribute any more, but combine them when we're creating the record already (since Algolia doesn't support computed/generated attributes, sadly).
In particular, the scores are calculated as follows:
- For charts, it's `score = numRelatedArticles * 500 + views_7d`
	- (currently, `numRelatedArticles` is ranging between 0 and 19, for `life-expectancy`)
- For posts, it's `score = importance * 1000 + views_7d`
	- (note that `importance` is one of 3, 1, 0, or -1)

These weighting factors are, of course, simply magic numbers. They seem to produce a pretty nice ranking, but of course there are also other options how to choose these: We could make them dependent on `sum(views_7d)` or `max(views_7d)` in some way, for example.
Curious on your input on this.

To get a sense of how high these scores can be:
- The highest-ranking chart has a score of 46253, the second-highest-ranking has 19611
- The highest-ranking post has a score of 91908, the second-highest ranking has 25418

You can also see the scores of records by looking at the `owid-staging` Algolia application.

Another nice benefit of this is actually also that when you just type a space into the search bar, you get back all the currently-most-viewed charts and posts :)
![image](https://user-images.githubusercontent.com/2641501/219485196-ae1c0695-0b5d-41e3-97b0-21669cd2a3aa.png)
