### PR TITLE
Backport refs

### DIFF
--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -37,20 +37,8 @@ const migrate = async (): Promise<void> => {
 
     for (const post of posts) {
         try {
-            let text = post.content
-            const refs = (text.match(/{ref}(.*?){\/ref}/gims) || []).map(
-                function (val: string, i: number) {
-                    // mutate original text
-                    text = text.replace(
-                        val,
-                        `<a class="ref" href="#note-${i + 1}"><sup>${
-                            i + 1
-                        }</sup></a>`
-                    )
-                    // return inner text
-                    return val.replace(/\{\/?ref\}/g, "")
-                }
-            )
+            const text = post.content
+
             // We don't get the first and last nodes if they are comments.
             // This can cause issues with the wp:components so here we wrap
             // everything in a div
@@ -70,31 +58,7 @@ const migrate = async (): Promise<void> => {
                 withoutEmptyOrWhitespaceOnlyTextBlocks(parsedResult).content
             )
 
-            let errors = parsedResult.errors
-            const refParsingResults = refs.map(
-                (refString): EnrichedBlockText => {
-                    const $ref = cheerio.load(refString)
-                    const refElements = $ref("body").contents().toArray()
-                    const parseResult = cheerioElementsToArchieML(refElements, {
-                        $,
-                        shouldParseWpComponents: false,
-                        htmlTagCounts: {},
-                        wpTagCounts: {},
-                    })
-                    const textContentResult =
-                        getEnrichedBlockTextFromBlockParseResult(parseResult)
-                    errors = errors.concat(textContentResult.errors)
-                    return {
-                        type: "text",
-                        value: textContentResult.content.flatMap(
-                            (b) => b.value
-                        ),
-                        parseErrors: textContentResult.content.flatMap(
-                            (b) => b.parseErrors
-                        ),
-                    }
-                }
-            )
+            const errors = parsedResult.errors
 
             // request a weekday along with a long date
             const options = {
@@ -123,7 +87,7 @@ const migrate = async (): Promise<void> => {
                         .join(", "),
                     dateline: dateline,
                     // TODO: this discards block level elements - those might be needed?
-                    refs: refParsingResults,
+                    refs: undefined,
                 },
                 published: false,
                 createdAt:


### PR DESCRIPTION
This PR stops doing special handling for {ref}s which ironically makes them work in the full workflow :). To explain: initially I had put in the work to extract {ref} blocks in the html and replace them with superscript indexed numbers. This would have meant reconstructing the refs again when creating the ArchieML in Gdocs. Now we just leave them be.  This means that in the compare view they are visible as text (i.e. they don't show correctly in a tooltip), but once you create the gdoc they contain the {ref} blocks as before and are then rendered and previewed correctly. I think the fact that it looks a bit different now in the compare view is fine but curious to hear what you think.