### PR TITLE
Backporting should retain html in html blocks

### DIFF
--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -212,7 +212,7 @@ function* rawBlockRecircToArchieMLString(
 function escapeRawText(text: string): string {
     // In ArchieML, single words followed by a colon are interpreted as a key-value pair. Since here
     // we are trying to output raw text, we need to escape colons.
-    return text.replace(/^\s*(\w+)\s*:/, "$1\\:")
+    return text.replace(/^\s*(\w+)\s*:/m, "$1\\:")
 }
 
 function* rawBlockTextToArchieMLString(
@@ -224,7 +224,15 @@ function* rawBlockTextToArchieMLString(
 function* rawBlockHtmlToArchieMLString(
     block: RawBlockHtml
 ): Generator<string, void, undefined> {
-    yield keyValueToArchieMlString("html", block.value)
+    if (block.value !== undefined) {
+        // When creating Gdocs we need a straightforward way to detect if we
+        // are inside an html block so we *don't* parse Html tags in there (as
+        // this would remove the tags). We make this easier by writing html
+        // tags as properties that are always serialized as multiline properites
+        // with an ":end" marker, even if the content is a single line.
+        yield `html: ${escapeRawText(block.value)}`
+        yield `:end`
+    }
 }
 
 function* rawBlockUrlToArchieMLString(


### PR DESCRIPTION
This PR fixes an issue with raw html blocks. They are used in backporting for things like HTML tables and thus quite important. The previous code had no special handling for html blocks. This meant that when we do our usual transformations like so:
```mermaid
flowchart LR
  enriched --> raw
  raw --> archieml[ArchieMl with inline HTML for styling]  
  archieml --> cheerio[Cheerio nodes]
  cheerio --> gdoc[GDoc DOM]
```
... then the problem is that the cheerio parsing step would parse the tables etc and we only want to use it to parse inline styles like `<a>`, `<em>` etc.

So this PR a) ensures that html properties are always written in the archieml multiline style with the `:end` token, and b) uses this information to skip cheerio parsing from the beginning of `html: ` until the :end token.
