### PR TITLE
1944 mutually exclusive breakpoint ranges

### DIFF
--- a/site/blocks/front-matter.scss
+++ b/site/blocks/front-matter.scss
@@ -64,7 +64,7 @@
     padding-left: 24px;
     display: none;
 
-    @media (min-width: 960px) {
+    @include md-up {
         display: block;
     }
 

--- a/site/css/header.scss
+++ b/site/css/header.scss
@@ -143,7 +143,7 @@
 
     a {
         display: none;
-        @media (min-width: $lg) {
+        @include lg-up {
             display: initial;
             margin: 1px;
         }

--- a/site/css/variables.scss
+++ b/site/css/variables.scss
@@ -86,7 +86,7 @@ $xxlg: 1536px;
     }
 }
 
-@mixin lg-only {
+@mixin xlg-only {
     @media (min-width: #{$lg + 1}) and (max-width: $xlg) {
         @content;
     }

--- a/site/css/variables.scss
+++ b/site/css/variables.scss
@@ -57,7 +57,7 @@ $xxlg: 1536px;
 }
 
 @mixin sm-up {
-    @media (min-width: $sm) {
+    @media (min-width: #{$sm + 1}) {
         @content;
     }
 }
@@ -69,7 +69,7 @@ $xxlg: 1536px;
 }
 
 @mixin md-up {
-    @media (min-width: $md) {
+    @media (min-width: #{$md + 1}) {
         @content;
     }
 }
@@ -81,13 +81,13 @@ $xxlg: 1536px;
 }
 
 @mixin lg-up {
-    @media (min-width: $lg) {
+    @media (min-width: #{$lg + 1}) {
         @content;
     }
 }
 
 @mixin lg-only {
-    @media (min-width: $lg) and (max-width: $xlg) {
+    @media (min-width: #{$lg + 1}) and (max-width: $xlg) {
         @content;
     }
 }
@@ -95,11 +95,12 @@ $xxlg: 1536px;
 // Blocks are shown side-by-side from that breakpoint up (when applicable)
 
 @mixin xlg-up {
-    @media only screen and (min-width: $xlg) {
+    @media only screen and (min-width: #{$xlg + 1}) {
         @content;
     }
 }
 
+// mixin duplicated in packages/@ourworldindata/grapher/src/core/grapher.scss
 @mixin xxlg-down {
     @media only screen and (max-width: $xxlg) {
         @content;
@@ -107,9 +108,8 @@ $xxlg: 1536px;
 }
 
 // The sidebar is shown from that breakpoint up
-// mixin duplicated in packages/@ourworldindata/grapher/src/core/grapher.scss
 @mixin xxlg-up {
-    @media only screen and (min-width: $xxlg) {
+    @media only screen and (min-width: #{$xxlg + 1}) {
         @content;
     }
 }


### PR DESCRIPTION
closes #1944 

I went through all the `max-width` media-queries and updated the relevant ones but I didn't quite figure out whether [this one should be updated](https://github.com/owid/owid-grapher/blob/8539eb8ea6e5ab0eda6b82894a04c373f9c3a406/site/css/grid.scss#L46).