### PR TITLE
enhance: add primitive way to see list of migration errors

### DIFF
--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -8,6 +8,7 @@ import {
     OwidArticlePublicationContext,
     OwidArticleType,
     sortBy,
+    OwidArticleBackportingStatistics,
 } from "@ourworldindata/utils"
 import * as Post from "./model/Post.js"
 import fs from "fs"
@@ -106,7 +107,7 @@ const migrate = async (): Promise<void> => {
                 numBlocks: archieMlBodyElements.length,
                 htmlTagCounts: parsingContext.htmlTagCounts,
                 wpTagCounts: parsingContext.wpTagCounts,
-            }
+            } as OwidArticleBackportingStatistics
 
             const insertQuery = `
         UPDATE posts SET archieml = ?, archieml_update_statistics = ? WHERE id = ?

--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -553,7 +553,7 @@ function finishWpComponent(
                     ...content.errors,
                     {
                         name: "unexpected wp component tag",
-                        details: `Found unexpected tag ${details.tagName}`,
+                        details: `Found unhandled wp:comment tag ${details.tagName}`,
                     },
                 ],
                 content: content.content,

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -81,6 +81,7 @@ export {
     OwidArticleTypePublished,
     OwidEnrichedArticleBlock,
     OwidRawArticleBlock,
+    OwidArticleBackportingStatistics,
     OwidVariableId,
     ParseError,
     Position,

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -913,6 +913,14 @@ export interface OwidArticleTypePublished extends OwidArticleType {
     content: OwidArticleContentPublished
 }
 
+export interface OwidArticleBackportingStatistics {
+    errors: { name: string; details: string }[]
+    numErrors: number
+    numBlocks: number
+    htmlTagCounts: Record<string, number>
+    wpTagCounts: Record<string, number>
+}
+
 export interface OwidArticleContent {
     body?: OwidEnrichedArticleBlock[]
     title?: string


### PR DESCRIPTION
This is a very bare-bones way of surfacing the migration errors we collect for every post. This might be useful to alert users to inspect certain elements in more detail or just to show if the system sees anything wrong with the translation.