### PR TITLE
cleanup(explorer): remove `facet` property from grammar

### DIFF
--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -104,12 +104,6 @@ export const GrapherGrammar: Grammar = {
         keyword: "sourceDesc",
         description: "Short comma-separated list of source names",
     },
-    facet: {
-        ...EnumCellDef,
-        description: "Facet by column or entities",
-        keyword: "facet",
-        terminalOptions: toTerminalOptions(Object.values(FacetStrategy)),
-    },
     hideTitleAnnotation: {
         ...BooleanCellDef,
         description: "Hide automatic time/entity",

--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -59,7 +59,8 @@ export const GrapherGrammar: Grammar = {
     },
     tableSlug: {
         ...SlugDeclarationCellDef,
-        description: "Slug of the table to use.",
+        description:
+            "Slug of the explorer table (i.e. csv file) to use for this row. All variables used in this row must be present in the table/file.",
         keyword: "tableSlug",
     },
     hasMapTab: {
@@ -96,7 +97,7 @@ export const GrapherGrammar: Grammar = {
     tableSlugs: {
         ...SlugsDeclarationCellDef,
         description:
-            "ColumnSlug(s) for the Table tab. If not specified all active slugs will be used.",
+            "Columns to show in the Table tab of the chart. If not specified all active slugs will be used.",
         keyword: "tableSlugs",
     },
     sourceDesc: {


### PR DESCRIPTION
Turns out it doesn't do anything...

The harder part of this task however is to remove all uses of the `facet` column in the owid-content repo (and replace them with `selectedFacetStrategy`, if not already present).