### PR TITLE
docs(covid): change source for cases and deaths

### DIFF
--- a/site/covid/CovidConstants.ts
+++ b/site/covid/CovidConstants.ts
@@ -2,8 +2,8 @@ import { SortOrder } from "@ourworldindata/core-table"
 import { NounKey, NounGenerator } from "./CovidTypes.js"
 import { createNoun } from "./CovidUtils.js"
 
-export const JHU_DATA_URL =
-    "https://covid.ourworldindata.org/data/jhu/full_data.csv"
+export const CASES_DEATHS_DATA_URL =
+    "https://covid.ourworldindata.org/data/cases_deaths/full_data.csv"
 
 export const TESTS_DATA_URL = "http://localhost:8080/data/tests/latest/data.csv"
 

--- a/site/covid/CovidFetch.ts
+++ b/site/covid/CovidFetch.ts
@@ -8,10 +8,12 @@ import {
 } from "@ourworldindata/utils"
 
 import { CovidSeries } from "./CovidTypes.js"
-import { JHU_DATA_URL, TESTS_DATA_URL } from "./CovidConstants.js"
+import { CASES_DEATHS_DATA_URL, TESTS_DATA_URL } from "./CovidConstants.js"
 
-async function _fetchJHUData(): Promise<CovidSeries> {
-    const responseText = await retryPromise(() => fetchText(JHU_DATA_URL))
+async function _fetchCaseDeathData(): Promise<CovidSeries> {
+    const responseText = await retryPromise(() =>
+        fetchText(CASES_DEATHS_DATA_URL)
+    )
     const rows: CovidSeries = csvParse(responseText).map((row) => {
         return {
             date: new Date(row.date as string),
@@ -27,7 +29,7 @@ async function _fetchJHUData(): Promise<CovidSeries> {
 
 // We want to memoize (cache) the return value of that fetch, so we don't need to load
 // the file multiple times if we request the data more than once
-export const fetchJHUData = memoize(_fetchJHUData)
+export const fetchCaseDeathData = memoize(_fetchCaseDeathData)
 
 //      'Entity string'
 //      'OWID country'

--- a/site/covid/CovidTable.tsx
+++ b/site/covid/CovidTable.tsx
@@ -40,7 +40,7 @@ import {
     columns,
     CovidTableCellSpec,
 } from "./CovidTableColumns.js"
-import { fetchJHUData } from "./CovidFetch.js"
+import { fetchCaseDeathData } from "./CovidFetch.js"
 
 export class CovidTableState {
     @observable.ref sortKey: CovidSortKey = CovidSortKey.totalCases
@@ -71,7 +71,7 @@ export class CovidTable extends React.Component<CovidTableProps> {
         columns: [],
         mobileColumns: [],
         filter: (d) => d,
-        loadData: fetchJHUData,
+        loadData: fetchCaseDeathData,
         defaultState: {},
     }
 

--- a/site/covid/CovidTableColumns.tsx
+++ b/site/covid/CovidTableColumns.tsx
@@ -370,7 +370,7 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                 </strong>{" "}
                 <br />
                 <span className="note">
-                    JHU data.{" "}
+                    WHO data.{" "}
                     {props.lastUpdated !== undefined ? (
                         <>
                             Up to date for 10&nbsp;AM (CET) on{" "}
@@ -395,7 +395,7 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                 </strong>{" "}
                 <br />
                 <span className="note">
-                    JHU data.{" "}
+                    WHO data.{" "}
                     {props.lastUpdated !== undefined ? (
                         <>
                             Up to date for 10&nbsp;AM (CET) on{" "}
@@ -420,7 +420,7 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                 </strong>{" "}
                 <br />
                 <span className="note">
-                    JHU data.{" "}
+                    WHO data.{" "}
                     {props.lastUpdated !== undefined ? (
                         <>
                             Up to date for 10&nbsp;AM (CET) on{" "}
@@ -445,7 +445,7 @@ export const columns: Record<CovidTableColumnKey, CovidTableColumnSpec> = {
                 </strong>{" "}
                 <br />
                 <span className="note">
-                    JHU data.{" "}
+                    WHO data.{" "}
                     {props.lastUpdated !== undefined ? (
                         <>
                             Up to date for 10&nbsp;AM (CET) on{" "}

--- a/site/covid/index.tsx
+++ b/site/covid/index.tsx
@@ -6,7 +6,7 @@ import { oneOf, Tippy } from "@ourworldindata/utils"
 import classnames from "classnames"
 import React from "react"
 import ReactDOM from "react-dom"
-import { fetchJHUData, fetchTestsData } from "./CovidFetch.js"
+import { fetchCaseDeathData, fetchTestsData } from "./CovidFetch.js"
 import { CovidTable, CovidTableProps } from "./CovidTable.js"
 import { CovidTableColumnKey } from "./CovidTableColumns.js"
 import { CovidSortKey } from "./CovidTypes.js"
@@ -19,7 +19,7 @@ const DEATH_THRESHOLD = 5
 
 const propsByMeasure: Record<Measure, Partial<CovidTableProps>> = {
     cases: {
-        loadData: fetchJHUData,
+        loadData: fetchCaseDeathData,
         columns: [
             CovidTableColumnKey.location,
             CovidTableColumnKey.daysToDoubleCases,
@@ -50,8 +50,8 @@ const propsByMeasure: Record<Measure, Partial<CovidTableProps>> = {
                 </p>
                 <p>
                     Data source:{" "}
-                    <a href="https://github.com/CSSEGISandData/COVID-19">
-                        Johns Hopkins University CSSE
+                    <a href="https://covid19.who.int/">
+                        WHO COVID-19 Dashboard
                     </a>
                     . Download the{" "}
                     <a href="https://ourworldindata.org/coronavirus-source-data">
@@ -63,7 +63,7 @@ const propsByMeasure: Record<Measure, Partial<CovidTableProps>> = {
         ),
     },
     deaths: {
-        loadData: fetchJHUData,
+        loadData: fetchCaseDeathData,
         columns: [
             CovidTableColumnKey.location,
             CovidTableColumnKey.daysToDoubleDeaths,
@@ -94,8 +94,8 @@ const propsByMeasure: Record<Measure, Partial<CovidTableProps>> = {
                 </p>
                 <p>
                     Data source:{" "}
-                    <a href="https://github.com/CSSEGISandData/COVID-19">
-                        Johns Hopkins University CSSE
+                    <a href="https://covid19.who.int/">
+                        WHO COVID-19 Dashboard
                     </a>
                     . Download the{" "}
                     <a href="https://ourworldindata.org/coronavirus-source-data">
@@ -171,7 +171,7 @@ const propsByMeasure: Record<Measure, Partial<CovidTableProps>> = {
         },
     },
     deathsAndCases: {
-        loadData: fetchJHUData,
+        loadData: fetchCaseDeathData,
         columns: [
             CovidTableColumnKey.location,
             CovidTableColumnKey.daysToDoubleDeaths,
@@ -206,8 +206,8 @@ const propsByMeasure: Record<Measure, Partial<CovidTableProps>> = {
                 </p>
                 <p>
                     Data source:{" "}
-                    <a href="https://github.com/CSSEGISandData/COVID-19">
-                        Johns Hopkins University CSSE
+                    <a href="https://covid19.who.int/">
+                        WHO COVID-19 Dashboard
                     </a>
                     . Download the{" "}
                     <a href="https://ourworldindata.org/coronavirus-source-data">


### PR DESCRIPTION
This is part of https://github.com/owid/owid-issues/issues/957.

Change references to JHU in our codebase so that the [deaths](https://ourworldindata.org/covid-deaths#global-comparison-where-are-confirmed-deaths-increasing-most-rapidly) and [cases](https://ourworldindata.org/covid-cases#global-comparison-where-are-confirmed-cases-increasing-most-rapidly) table are updated.

This should _only_ be merged once we finalize the transition JHU → WHO (i.e. finish https://github.com/owid/owid-issues/issues/957).