### PR TITLE
feat(help): bring help boxes back on mobile

### DIFF
--- a/site/blocks/help.scss
+++ b/site/blocks/help.scss
@@ -1,11 +1,3 @@
-body.is-not-chart-interactive
-    .article-content
-    > section
-    .wp-block-columns
-    .wp-block-help {
-    display: none;
-}
-
 .article-content > section .wp-block-columns .wp-block-help {
     display: flex;
     margin-bottom: 2rem;

--- a/site/blocks/index.ts
+++ b/site/blocks/index.ts
@@ -2,20 +2,12 @@ import { hydrate as hydrateAdditionalInformation } from "./AdditionalInformation
 import { runSearchCountry } from "../../site/SearchCountry.js"
 import { runExpandableInlineBlock } from "../../site/ExpandableInlineBlock.js"
 import { runDataTokens } from "../../site/runDataTokens.js"
-import { shouldProgressiveEmbed } from "../../site/multiembedder/MultiEmbedder.js"
 import { hydrateKeyInsights } from "./KeyInsights.js"
 import { hydrateStickyNav } from "./StickyNav.js"
 import { hydrateExpandableParagraphs } from "./ExpandableParagraph.js"
 import { hydrateCodeSnippets } from "./CodeSnippet.js"
 
 export const runBlocks = () => {
-    if (!shouldProgressiveEmbed()) {
-        // Used by Help blocks. Pierces encapsulation but considered not worth going through hydration / client side rendering for this.
-        // If hydration required for other purposes, then reassess.
-        document
-            .getElementsByTagName("body")[0]
-            .classList.add("is-not-chart-interactive")
-    }
     runDataTokens()
     runExpandableInlineBlock()
     runSearchCountry()


### PR DESCRIPTION
Nowadays not only used next to non-interactive charts but also next to interactive charts (explorers) and in other article contexts, making it overall more desirable to show them.

<img width="413" alt="Screenshot 2023-02-27 at 21 05 46" src="https://user-images.githubusercontent.com/13406362/221646762-6f920937-2821-48e1-8eaa-e2eaaf17e965.png">
