### PR TITLE
fix(Variable): don't use cache when fetching data from S3

### DIFF
--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -500,8 +500,9 @@ export const fetchS3Values = async (
 export const fetchS3ValuesByPath = async (
     dataPath: string
 ): Promise<OwidVariableMixedData> => {
+    // avoid cache as Cloudflare worker caches up to 1 hour
     return (
-        await fetch(dataPath, { agent: httpsAgent })
+        await fetch(`${dataPath}?nocache`, { agent: httpsAgent })
     ).json() as Promise<OwidVariableMixedData>
 }
 


### PR DESCRIPTION
We're now fetching data from S3 that goes through a worker with 1 hour Cloudflare cache. It can happen that when you import dataset that already exists, you'd still see an old version (it happened for [excess mortality](https://owid.slack.com/archives/C46U9LXRR/p1677579233857919)).

This PR skips the cache when fetching data from S3 (which applies to both admin and baking). There are alternative ways how to fix this:

1. Purge cache when data is uploaded to S3 - I couldn't find a way how to purge only a certain cache key for all workers. We could call `cache.delete` in worker, but that only applies to local cache of a single worker.
2. Lower cache from 1 hour to something much smaller - not sure about the implications, but something like 5 mins could perhaps work
3. Switch to R2 and turn off caching