### PR TITLE
feat(grapher): add option to hide scatter labels

### DIFF
--- a/adminSiteClient/EditorScatterTab.tsx
+++ b/adminSiteClient/EditorScatterTab.tsx
@@ -114,13 +114,6 @@ export class EditorScatterTab extends React.Component<{ grapher: Grapher }> {
                         allowNegative
                     />
                 </Section>
-                <Section name="Entity labels">
-                    <Toggle
-                        label="Hide entity labels"
-                        value={!!grapher.hideScatterLabels}
-                        onValue={this.onToggleHideScatterLabels}
-                    />
-                </Section>
                 <Section name="Point Labels">
                     <SelectField
                         value={grapher.scatterPointLabelStrategy}
@@ -128,6 +121,11 @@ export class EditorScatterTab extends React.Component<{ grapher: Grapher }> {
                         options={Object.keys(ScatterPointLabelStrategy).map(
                             (entry) => ({ value: entry })
                         )}
+                    />
+                    <Toggle
+                        label="Hide point labels (except when hovering)"
+                        value={!!grapher.hideScatterLabels}
+                        onValue={this.onToggleHideScatterLabels}
                     />
                 </Section>
                 <Section name="Filtering">

--- a/adminSiteClient/EditorScatterTab.tsx
+++ b/adminSiteClient/EditorScatterTab.tsx
@@ -28,6 +28,10 @@ export class EditorScatterTab extends React.Component<{ grapher: Grapher }> {
         this.props.grapher.hideLinesOutsideTolerance = value || undefined
     }
 
+    @action.bound onToggleHideScatterLabels(value: boolean) {
+        this.props.grapher.hideScatterLabels = value || undefined
+    }
+
     @action.bound onXOverrideYear(value: number | undefined) {
         this.props.grapher.xOverrideTime = value
     }
@@ -108,6 +112,13 @@ export class EditorScatterTab extends React.Component<{ grapher: Grapher }> {
                         value={grapher.xOverrideTime}
                         onValue={debounce(this.onXOverrideYear, 300)}
                         allowNegative
+                    />
+                </Section>
+                <Section name="Entity labels">
+                    <Toggle
+                        label="Hide entity labels"
+                        value={!!grapher.hideScatterLabels}
+                        onValue={this.onToggleHideScatterLabels}
                     />
                 </Section>
                 <Section name="Point Labels">

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -314,6 +314,7 @@ export class Grapher
     @observable.ref entityType = "country"
     @observable.ref entityTypePlural = "countries"
     @observable.ref hideTimeline?: boolean = undefined
+    @observable.ref hideScatterLabels?: boolean = undefined
     @observable.ref zoomToSelection?: boolean = undefined
     @observable.ref showYearLabels?: boolean = undefined // Always show year in labels for bar charts
     @observable.ref hasChartTab: boolean = true

--- a/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
@@ -76,6 +76,7 @@ export interface GrapherInterface extends SortConfig {
     invertColorScheme?: boolean
     hideLinesOutsideTolerance?: boolean
     hideConnectedScatterLines?: boolean // Hides lines between points when timeline spans multiple years. Requested by core-econ for certain charts
+    hideScatterLabels?: boolean
     scatterPointLabelStrategy?: ScatterPointLabelStrategy
     compareEndPointsOnly?: boolean
     matchingEntitiesOnly?: boolean
@@ -162,6 +163,7 @@ export const grapherKeysToSerialize = [
     "invertColorScheme",
     "hideLinesOutsideTolerance",
     "hideConnectedScatterLines",
+    "hideScatterLabels",
     "scatterPointLabelStrategy",
     "compareEndPointsOnly",
     "matchingEntitiesOnly",

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -507,6 +507,10 @@ export class ScatterPlotChart
         return !!this.manager.hideConnectedScatterLines
     }
 
+    @computed private get hideScatterLabels(): boolean {
+        return !!this.manager.hideScatterLabels
+    }
+
     @computed private get points(): JSX.Element {
         return (
             <ScatterPointsWithLabels
@@ -523,6 +527,7 @@ export class ScatterPlotChart
                 focusedSeriesNames={this.focusedEntityNames}
                 hoveredSeriesNames={this.hoveredSeriesNames}
                 disableIntroAnimation={this.manager.disableIntroAnimation}
+                hideScatterLabels={this.hideScatterLabels}
                 onMouseOver={this.onScatterMouseOver}
                 onMouseLeave={this.onScatterMouseLeave}
                 onClick={this.onScatterClick}

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartConstants.ts
@@ -32,6 +32,7 @@ export interface ScatterPlotManager extends ChartManager {
     startTime?: Time
     endTime?: Time
     hasTimeline?: boolean
+    hideScatterLabels?: boolean
 }
 
 export interface ScatterTooltipProps {
@@ -133,4 +134,5 @@ export interface ScatterPointsWithLabelsProps {
     hideConnectedScatterLines: boolean
     noDataModalManager: NoDataModalManager
     disableIntroAnimation?: boolean
+    hideScatterLabels?: boolean
 }

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPointsWithLabels.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPointsWithLabels.tsx
@@ -94,6 +94,10 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
         return this.props.fontScale
     }
 
+    @computed private get hideScatterLabels(): boolean {
+        return !!this.props.hideScatterLabels
+    }
+
     private getPointRadius(value: number | undefined): number {
         const radius =
             value !== undefined
@@ -214,10 +218,19 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
         )
         if (this.focusedSeriesNames.length > 0)
             this.hideUnselectedLabels(labelsByPriority)
+        if (this.hideScatterLabels) {
+            this.hideLabels(labelsByPriority)
+        }
 
         this.hideCollidingLabelsByPriority(labelsByPriority)
 
         return renderData
+    }
+
+    private hideLabels(labels: ScatterLabel[]): void {
+        labels
+            .filter((label) => !label.series.isHover)
+            .forEach((label) => (label.isHidden = true))
     }
 
     private hideUnselectedLabels(labelsByPriority: ScatterLabel[]): void {

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPointsWithLabels.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPointsWithLabels.tsx
@@ -219,7 +219,7 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
         if (this.focusedSeriesNames.length > 0)
             this.hideUnselectedLabels(labelsByPriority)
         if (this.hideScatterLabels) {
-            this.hideLabels(labelsByPriority)
+            this.hideLabels(labelsByPriority, this.hoveredSeriesNames.length)
         }
 
         this.hideCollidingLabelsByPriority(labelsByPriority)
@@ -227,9 +227,12 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
         return renderData
     }
 
-    private hideLabels(labels: ScatterLabel[]): void {
-        labels
-            .filter((label) => !label.series.isHover)
+    private hideLabels(
+        labelsByPriority: ScatterLabel[],
+        nHoveredLabels: number
+    ): void {
+        labelsByPriority
+            .filter((label) => !(label.series.isHover && nHoveredLabels === 1))
             .forEach((label) => (label.isHidden = true))
     }
 

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.json
@@ -662,6 +662,11 @@
             "default": false,
             "description": "Whether to hide the total value label (used on stacked discrete bar charts)"
         },
+        "hideScatterLabels": {
+            "type": "boolean",
+            "default": false,
+            "description": "Hide entity names in Scatter plots"
+        },
         "sortBy": {
             "type": "string",
             "description": "Sort criterium (used by stacked bar charts and marimekko)",

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.yaml
@@ -584,6 +584,10 @@ properties:
         type: boolean
         default: false
         description: Whether to hide the total value label (used on stacked discrete bar charts)
+    hideScatterLabels:
+        type: boolean
+        default: false
+        description: Hide entity names in Scatter plots
     sortBy:
         type: string
         description: Sort criterium (used by stacked bar charts and marimekko)


### PR DESCRIPTION
Adds an option to hide entity names in scatter plots, as requested in #1550.

Issue #1550 states that this option should also work in explorers - that piece is missing atm. Daniel suggested to come back to this in a few days when I'm a bit more familiar with the codebase and focus on Grapher for now.