### PR TITLE
fix(grapher): fix domain extent for scatter plots with few data points

### DIFF
--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -822,6 +822,14 @@ export class ScatterPlotChart
         )
     }
 
+    private validValuesForAxisDomain(property: "x" | "y"): number[] {
+        const scaleType = property === "x" ? this.xScaleType : this.yScaleType
+        const values = this.pointsForAxisDomains.map((point) => point[property])
+        return scaleType === ScaleType.log
+            ? values.filter((v) => v > 0)
+            : values
+    }
+
     @computed private get xDomainDefault(): [number, number] {
         return this.domainDefault("x")
     }
@@ -878,7 +886,10 @@ export class ScatterPlotChart
                 )}`
             }
         } else {
-            axis.updateDomainPreservingUserSettings(yDomainDefault)
+            // only overwrite user's min/max if there is more than one unique value along the y-axis
+            if (new Set(this.validValuesForAxisDomain("y")).size > 1) {
+                axis.updateDomainPreservingUserSettings(yDomainDefault)
+            }
             axis.label = label
         }
 
@@ -913,7 +924,10 @@ export class ScatterPlotChart
                 )}`
             }
         } else {
-            axis.updateDomainPreservingUserSettings(xDomainDefault)
+            // only overwrite user's min/max if there is more than one unique value along the x-axis
+            if (new Set(this.validValuesForAxisDomain("x")).size > 1) {
+                axis.updateDomainPreservingUserSettings(xDomainDefault)
+            }
             const label = xAxisConfig.label || xAxisLabelBase
             if (label) axis.label = label
         }

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -886,10 +886,17 @@ export class ScatterPlotChart
                 )}`
             }
         } else {
+            const validValues = this.validValuesForAxisDomain("y")
+            const isAnyValueOutsideUserDomain = validValues.some(
+                (value) => value < axis.domain[0] || value > axis.domain[1]
+            )
+
             // only overwrite user's min/max if there is more than one unique value along the y-axis
-            if (new Set(this.validValuesForAxisDomain("y")).size > 1) {
+            // or if respecting the user's setting would hide data points
+            if (new Set(validValues).size > 1 || isAnyValueOutsideUserDomain) {
                 axis.updateDomainPreservingUserSettings(yDomainDefault)
             }
+
             axis.label = label
         }
 
@@ -924,10 +931,17 @@ export class ScatterPlotChart
                 )}`
             }
         } else {
+            const validValues = this.validValuesForAxisDomain("x")
+            const isAnyValueOutsideUserDomain = validValues.some(
+                (value) => value < axis.domain[0] || value > axis.domain[1]
+            )
+
             // only overwrite user's min/max if there is more than one unique value along the x-axis
-            if (new Set(this.validValuesForAxisDomain("x")).size > 1) {
+            // or if respecting the user's setting would hide data points
+            if (new Set(validValues).size > 1 || isAnyValueOutsideUserDomain) {
                 axis.updateDomainPreservingUserSettings(xDomainDefault)
             }
+
             const label = xAxisConfig.label || xAxisLabelBase
             if (label) axis.label = label
         }


### PR DESCRIPTION
Fixes the issue described in #1332 by respecting the author's domain extent setting for data sets with a single unique value along an axis.

What happens is that basically if there is only one (unique) value along an axis, the extent of the domain is set to a reasonable default that is (in case of linear scales) `[unique_value - 1, unique_value + 1]`.  The author's setting is then taken into account by _expanding_ (but never _shrinking_) the computed extent. In most cases, that's fine. But when the computed extent was set to `[unique_value - 1, unique_value + 1]`, and thus "overshoots" the actual data range to both sides, then this is not corrected for when taking into account the author's domain setting. Check out [this chart](https://ourworldindata.org/grapher/life-expectancy-vs-liberal-democracy?time=1791). It is important to note that this is usually only perceived as an issue if a certain range of values along an axis are non-sensical (e.g. a scale from 0-1 where negative values don't have any meaning).

I fixed this by making sure the author's domain setting is respected when the dataset consists of a single unique value along an axis. This comes with two caveats though:
- this might lead to erratic jumps when animating through the years (some years might only have a single data value, others more)
- data points might be unintentionally hidden by enforcing the author's setting

Both of these caveats actually happen for [this chart](https://ourworldindata.org/grapher/life-expectancy-vs-liberal-democracy?time=1791) where the author set the x-axis to `[0, 1]` and the y-axis to `[50,85]`. So... we might want to do something more intelligent? ... Or add another option to allow the user to choose whether they want their domain setting to be enforced in all cases? ... Or something else?

closes #1332 