### PR TITLE
Disallow splitting by product for charts with more than one unit

### DIFF
--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -78,7 +78,7 @@ export interface Label {
 }
 
 interface DiscreteBarItem {
-    yColumnSlug: string
+    yColumn: CoreColumn
     seriesName: string
     value: number
     time: number
@@ -417,15 +417,11 @@ export class DiscreteBarChart
                 {this.hasColorLegend && (
                     <HorizontalNumericColorLegend manager={this} />
                 )}
-                {/* only show the axis if all columns share a unit */}
-                {new Set(this.yColumns.map((column) => column.unit)).size ===
-                    1 && (
-                    <HorizontalAxisComponent
-                        bounds={boundsWithoutColorLegend}
-                        axis={yAxis}
-                        preferredAxisPosition={innerBounds.bottom}
-                    />
-                )}
+                <HorizontalAxisComponent
+                    bounds={boundsWithoutColorLegend}
+                    axis={yAxis}
+                    preferredAxisPosition={innerBounds.bottom}
+                />
                 <HorizontalAxisGridLines
                     horizontalAxis={yAxis}
                     bounds={innerBounds}
@@ -524,23 +520,19 @@ export class DiscreteBarChart
     }
 
     formatValue(series: DiscreteBarSeries): Label {
-        let column = this.yColumns.find(
-            (yCol) => yCol.slug === series.yColumnSlug
-        )
-        if (column == undefined) column = this.yColumns[0]
-
         const { transformedTable } = this
+        const { yColumn } = series
 
         const showYearLabels =
             this.manager.showYearLabels || series.time !== this.targetTime
-        const displayValue = column.formatValueShort(series.value)
+        const displayValue = yColumn.formatValueShort(series.value)
         const { timeColumn } = transformedTable
         const preposition = OwidTable.getPreposition(timeColumn)
 
         return {
             valueString: displayValue,
             timeString: showYearLabels
-                ? ` ${preposition} ${column.formatTime(series.time)}`
+                ? ` ${preposition} ${yColumn.formatTime(series.time)}`
                 : "",
         }
     }
@@ -598,7 +590,7 @@ export class DiscreteBarChart
                       entityNames[index] as string
                   )
             return {
-                yColumnSlug: col.slug,
+                yColumn: col,
                 seriesName,
                 value: values[index] as number,
                 time: originalTimes[index] as number,
@@ -771,10 +763,10 @@ export class DiscreteBarChart
 
     @computed get series(): DiscreteBarSeries[] {
         const series = this.sortedRawSeries.map((rawSeries) => {
-            const { value, time, colorValue, seriesName, color, yColumnSlug } =
+            const { value, time, colorValue, seriesName, color, yColumn } =
                 rawSeries
             const series: DiscreteBarSeries = {
-                yColumnSlug,
+                yColumn,
                 value,
                 time,
                 colorValue,

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -352,9 +352,20 @@ export class DiscreteBarChart
         if (
             this.yColumns.length > 1 &&
             this.selectionArray.numSelectedEntities > 1
-        )
+        ) {
+            // if we have more than one unit, then faceting by entity is not allowed
+            // as comparing multiple units in a single chart isn't meaningful
+            const uniqueUnits = new Set(
+                this.yColumns.map((column) => column.unit)
+            )
+            if (uniqueUnits.size > 1) {
+                return [FacetStrategy.metric]
+            }
+
             return [FacetStrategy.entity, FacetStrategy.metric]
-        else return [FacetStrategy.none]
+        }
+
+        return [FacetStrategy.none]
     }
 
     componentDidMount(): void {

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -356,7 +356,7 @@ export class DiscreteBarChart
             // if we have more than one unit, then faceting by entity is not allowed
             // as comparing multiple units in a single chart isn't meaningful
             const uniqueUnits = new Set(
-                this.yColumns.map((column) => column.unit)
+                this.yColumns.map((column) => column.shortUnit)
             )
             if (uniqueUnits.size > 1) {
                 return [FacetStrategy.metric]

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartConstants.ts
@@ -1,9 +1,9 @@
 import { ChartManager } from "../chart/ChartManager"
-import { CoreValueType, Time } from "@ourworldindata/core-table"
+import { CoreColumn, CoreValueType, Time } from "@ourworldindata/core-table"
 import { ChartSeries } from "../chart/ChartInterface"
 
 export interface DiscreteBarSeries extends ChartSeries {
-    yColumnSlug: string
+    yColumn: CoreColumn
     value: number
     time: Time
     colorValue?: CoreValueType

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartConstants.ts
@@ -3,6 +3,7 @@ import { CoreValueType, Time } from "@ourworldindata/core-table"
 import { ChartSeries } from "../chart/ChartInterface"
 
 export interface DiscreteBarSeries extends ChartSeries {
+    yColumnSlug: string
     value: number
     time: Time
     colorValue?: CoreValueType

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -310,7 +310,9 @@ export class AbstractStackedChart
         const hasMultipleEntities =
             this.selectionArray.selectedEntityNames.length > 1
         const hasMultipleYColumns = this.yColumns.length > 1
-        const uniqueUnits = new Set(this.yColumns.map((column) => column.unit))
+        const uniqueUnits = new Set(
+            this.yColumns.map((column) => column.shortUnit)
+        )
         const hasMultipleUnits = uniqueUnits.size > 1
 
         // Normally StackedArea/StackedBar charts are always single-entity or single-column, but if we are ever in a mode where we

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -310,6 +310,8 @@ export class AbstractStackedChart
         const hasMultipleEntities =
             this.selectionArray.selectedEntityNames.length > 1
         const hasMultipleYColumns = this.yColumns.length > 1
+        const uniqueUnits = new Set(this.yColumns.map((column) => column.unit))
+        const hasMultipleUnits = uniqueUnits.size > 1
 
         // Normally StackedArea/StackedBar charts are always single-entity or single-column, but if we are ever in a mode where we
         // have multiple entities selected (e.g. through GlobalEntitySelector) and multiple columns, it only makes sense when faceted.
@@ -318,7 +320,8 @@ export class AbstractStackedChart
         else if (this.isEntitySeries && !hasMultipleYColumns)
             strategies.push(FacetStrategy.none)
 
-        if (hasMultipleEntities) strategies.push(FacetStrategy.entity)
+        if (hasMultipleEntities && !hasMultipleUnits)
+            strategies.push(FacetStrategy.entity)
 
         if (hasMultipleYColumns) strategies.push(FacetStrategy.metric)
 


### PR DESCRIPTION
fixes #1928

[As suggested by Marcel](https://owid.slack.com/archives/C5BDCB2R3/p1677880789986719?thread_ts=1677861957.213109&cid=C5BDCB2R3), we'll disallow splitting by product if that means we would be comparing different units along the same axis.

This PR does both:
- Fixes the particular issue in #1928 (if splitting by product were allowed)
- Disallows splitting by product when appropriate (such that the fix from above shouldn't be necessary)