### PR TITLE
enhance(Variable): retry variable fetching and start logging errors

### DIFF
--- a/adminSiteServer/FunctionalRouter.ts
+++ b/adminSiteServer/FunctionalRouter.ts
@@ -15,7 +15,13 @@ export class FunctionalRouter {
 
     wrap(callback: (req: Request, res: Response) => Promise<any>) {
         return async (req: Request, res: Response) => {
-            res.send(await callback(req, res))
+            try {
+                res.send(await callback(req, res))
+            } catch (e) {
+                // log errors to stderr and rethrow
+                console.error(e)
+                throw e
+            }
         }
     }
 

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -16,6 +16,7 @@ import {
     DataValueResult,
     OwidVariableId,
     OwidSource,
+    retryPromise,
 } from "@ourworldindata/utils"
 import fetch from "node-fetch"
 import pl from "nodejs-polars"
@@ -481,10 +482,10 @@ export const getOwidVariableDataPath = async (
     return row.dataPath
 }
 
-// limit number of concurrent requests to 50 when fetching values from S3
+// limit number of concurrent requests to 20 when fetching values from S3
 const httpsAgent = new https.Agent({
     keepAlive: true,
-    maxSockets: 50,
+    maxSockets: 20,
 })
 
 export const fetchS3Values = async (
@@ -501,9 +502,15 @@ export const fetchS3ValuesByPath = async (
     dataPath: string
 ): Promise<OwidVariableMixedData> => {
     // avoid cache as Cloudflare worker caches up to 1 hour
-    return (
-        await fetch(`${dataPath}?nocache`, { agent: httpsAgent })
-    ).json() as Promise<OwidVariableMixedData>
+    const resp = await retryPromise(() =>
+        fetch(`${dataPath}?nocache`, { agent: httpsAgent })
+    )
+    if (!resp.ok) {
+        throw new Error(
+            `Error fetching data from S3 for ${dataPath}: ${resp.status} ${resp.statusText}`
+        )
+    }
+    return resp.json()
 }
 
 export const dataAsRecords = async (


### PR DESCRIPTION
We're getting errors all over admin that are hard to replicate (e.g. [this one](https://github.com/owid/owid-grapher/issues/1978)). They have probably something to do with fetching data from S3, but we're unable to pinpoint the root cause. We also ran into this error once [on this chart](https://owid.cloud/admin/charts/1471/edit).

They sometimes happen when we hit Cloudflare worker on https://catalog.ourworldindata.org/baked-variables/live_grapher/data/576162.json?nocache. I've done some load testing and we start running into problems for ~1000 parallel requests (we shouldn't be doing such number of requests anywhere from admin though). There might be rate limiting on Cloudflare when doing requests from single IP. Load testing S3 directly was ok.

We also ran into this error
```
FetchError: request to https://catalog.ourworldindata.org/baked-variables/live_grapher/data/576162.json?nocache failed, reason: socket hang up
    at ClientRequest.<anonymous> (/home/owid/live/node_modules/node-fetch/lib/index.js:1491:11)
    at ClientRequest.emit (node:events:390:28)
    at ClientRequest.emit (node:domain:475:12)
    at TLSSocket.socketCloseListener (node:_http_client:420:11)
```

This PR adds some basic retry logic around fetching from S3 and logs errors from api endpoints.