### PR TITLE
enhance(Variable): only load data from S3 and deprecate data_values

### DIFF
--- a/db/Variable.test.ts
+++ b/db/Variable.test.ts
@@ -4,6 +4,7 @@ import {
     writeVariableCSV,
     getVariableData,
     VariableQueryRow,
+    detectValuesType,
 } from "./model/Variable.js"
 import * as db from "./db.js"
 import * as Variable from "./model/Variable.js"
@@ -229,5 +230,35 @@ describe("getVariableData", () => {
                 updatedAt: date,
             },
         })
+    })
+})
+
+describe("detectValuesType", () => {
+    test("returns 'int' when all values are integers", () => {
+        expect(detectValuesType([1, 2, 3])).toEqual("int")
+    })
+
+    test("returns 'float' when all values are floats", () => {
+        expect(detectValuesType([1.1, 2.2, 3.3])).toEqual("float")
+    })
+
+    test("returns 'string' when all values are strings", () => {
+        expect(detectValuesType(["a", "b", "c"])).toEqual("string")
+    })
+
+    test("returns 'mixed' when values are a mix of integers and strings", () => {
+        expect(detectValuesType([1, "a", 2, "b"])).toEqual("mixed")
+    })
+
+    test("returns 'float' when values are a mix of integers and floats", () => {
+        expect(detectValuesType([1, 1.1, 2, 2.2])).toEqual("float")
+    })
+
+    test("returns 'mixed' when values are a mix of floats and strings", () => {
+        expect(detectValuesType([1.1, "a", 2.2, "b"])).toEqual("mixed")
+    })
+
+    test("returns 'mixed' when values are empty", () => {
+        expect(detectValuesType([])).toEqual("mixed")
     })
 })

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -7,14 +7,14 @@ import {
     OwidVariableDisplayConfigInterface,
     MultipleOwidVariableDataDimensionsMap,
     OwidVariableDataMetadataDimensions,
-    OwidVariableDimensionValueFull,
-    OwidVariableDimensionValuePartial,
     OwidVariableMixedData,
-    OwidVariableWithSourceAndType,
-    omitNullableValues,
     DataValueQueryArgs,
     DataValueResult,
+    OwidVariableWithSourceAndDimension,
     OwidVariableId,
+    OwidVariableWithSourceAndType,
+    OwidVariableTypeOptions,
+    omitNullableValues,
     OwidSource,
     retryPromise,
 } from "@ourworldindata/utils"
@@ -66,14 +66,6 @@ export type VariableQueryRow = Readonly<
     }
 >
 
-interface S3DataRow {
-    value: string
-    year: number
-    entityId: number
-}
-
-type DataRow = S3DataRow & { entityName: string; entityCode: string }
-
 export type Field = keyof VariableRow
 
 export const variableTable = "variables"
@@ -87,13 +79,30 @@ export function parseVariableRows(
     return plainRows as VariableRow[]
 }
 
-// TODO: we'll want to split this into getVariableData and getVariableMetadata once
-// the data API can provide us with the type and distinct dimension values for a
-// variable. Before that we need to fetch and iterate the data before we can return
-// the metadata so it doesn't make much sense to split this into two functions yet.
 export async function getVariableData(
     variableId: number
 ): Promise<OwidVariableDataMetadataDimensions> {
+    const data = await fetchS3Values(variableId)
+
+    // NOTE: we could be fetching metadata from S3, but there's a latency that could
+    // cause problems with admin. It's safer to fetch it directly from the database.
+    // In the future when we isolate ETL from admin and use variable fallbacks (i.e.
+    // metadataPath would be only editable by ETL), it should be safe to fetch from S3.
+    // The only thing preventing us from doing so is that we allow editing non-ETL variables
+    // (in owid namespace). These are pretty rarely edited anyway.
+    // const metadata = await fetchS3MetadataByPath(metadataPath)
+    const metadata = await getVariableMetadataFromMySQL(variableId, data)
+
+    return {
+        data: data,
+        metadata: metadata,
+    }
+}
+
+export async function getVariableMetadataFromMySQL(
+    variableId: number,
+    variableData: OwidVariableMixedData
+): Promise<OwidVariableWithSourceAndDimension> {
     const variableQuery: Promise<VariableQueryRow | undefined> = db.mysqlFirst(
         `
         SELECT
@@ -113,9 +122,6 @@ export async function getVariableData(
     const row = await variableQuery
     if (row === undefined) throw new Error(`Variable ${variableId} not found`)
 
-    // load data from data_values or S3 if `dataPath` exists
-    const results = await dataAsRecords([variableId])
-
     const {
         sourceId,
         sourceName,
@@ -128,7 +134,7 @@ export async function getVariableData(
     const partialSource: OwidSource = JSON.parse(sourceDescription)
     const variableMetadata: OwidVariableWithSourceAndType = {
         ...omitNullableValues(variable),
-        type: "mixed", // precise type will be updated further down
+        type: detectValuesType(variableData.values),
         nonRedistributable: Boolean(nonRedistributable),
         display,
         source: {
@@ -141,65 +147,56 @@ export async function getVariableData(
             additionalInfo: partialSource.additionalInfo || "",
         },
     }
-    const variableData: OwidVariableMixedData = {
-        years: [],
-        entities: [],
-        values: [],
+
+    const entities = await db.queryMysql(
+        `
+    SELECT
+        id,
+        name,
+        code
+    FROM entities WHERE id in (?)
+    `,
+        [_.uniq(variableData.entities)]
+    )
+
+    const years = _.uniq(variableData.years).map((year) => ({ id: year }))
+
+    return {
+        ...variableMetadata,
+        dimensions: {
+            years: { values: years },
+            entities: { values: entities },
+        },
     }
+}
 
-    const entityMap = new Map<number, OwidVariableDimensionValueFull>()
-    const yearMap = new Map<number, OwidVariableDimensionValuePartial>()
-
+function detectValuesType(
+    values: (string | number)[]
+): OwidVariableTypeOptions {
     let encounteredFloatDataValues = false
     let encounteredIntDataValues = false
     let encounteredStringDataValues = false
 
-    for (const row of results) {
-        variableData.years.push(row.year)
-        variableData.entities.push(row.entityId)
-        const asNumber = parseFloat(row.value)
-        const asInt = parseInt(row.value)
-        if (!isNaN(asNumber)) {
-            if (!isNaN(asInt)) encounteredIntDataValues = true
-            else encounteredFloatDataValues = true
-            variableData.values.push(asNumber)
+    for (const value of values) {
+        if (Number.isInteger(value)) {
+            encounteredIntDataValues = true
+        } else if (typeof value === "number") {
+            encounteredFloatDataValues = true
         } else {
             encounteredStringDataValues = true
-            variableData.values.push(row.value)
-        }
-
-        if (!entityMap.has(row.entityId)) {
-            entityMap.set(row.entityId, {
-                id: row.entityId,
-                name: row.entityName,
-                code: row.entityCode,
-            })
-        }
-
-        if (!yearMap.has(row.year)) {
-            yearMap.set(row.year, { id: row.year })
         }
     }
 
     if (encounteredFloatDataValues && encounteredStringDataValues) {
-        variableMetadata.type = "mixed"
+        return "mixed"
     } else if (encounteredFloatDataValues) {
-        variableMetadata.type = "float"
+        return "float"
     } else if (encounteredIntDataValues) {
-        variableMetadata.type = "int"
+        return "int"
     } else if (encounteredStringDataValues) {
-        variableMetadata.type = "string"
-    }
-
-    return {
-        data: variableData,
-        metadata: {
-            ...variableMetadata,
-            dimensions: {
-                years: { values: Array.from(yearMap.values()) },
-                entities: { values: Array.from(entityMap.values()) },
-            },
-        },
+        return "string"
+    } else {
+        return "mixed"
     }
 }
 
@@ -288,7 +285,7 @@ export const getDataValue = async ({
 
     if (df.shape.height == 0) return
 
-    const row = df.toRecords()[0]
+    const row = df.slice(0, 1).toRecords()[0]
 
     return {
         value: Number(row.value),
@@ -361,6 +358,13 @@ const _castDataDF = (df: pl.DataFrame): pl.DataFrame => {
     )
 }
 
+export const assertFileExistsInS3 = async (dataPath: string): Promise<void> => {
+    const resp = await fetch(dataPath, { method: "HEAD", agent: httpsAgent })
+    if (resp.status !== 200) {
+        throw new Error("URL not found on S3: " + dataPath)
+    }
+}
+
 const emptyDataDF = (): pl.DataFrame => {
     return _castDataDF(
         pl.DataFrame({
@@ -410,41 +414,10 @@ export const _dataAsDFfromS3 = async (
     return _castDataDF(df.join(entityDF, { on: "entityId" }))
 }
 
-const _dataAsDFfromMySQL = async (
-    variableIds: OwidVariableId[]
-): Promise<pl.DataFrame> => {
-    if (variableIds.length == 0) {
-        return emptyDataDF()
-    }
-
-    // this function will be eventually deprecated by _dataAsDFfromS3
-    const df = await readSQLasDF(
-        `
-    SELECT
-        data_values.variableId as variableId,
-        value,
-        year,
-        entities.id AS entityId,
-        entities.name AS entityName,
-        entities.code AS entityCode
-    FROM data_values
-    LEFT JOIN entities ON data_values.entityId = entities.id
-    WHERE data_values.variableId in (?)
-        `,
-        [variableIds]
-    )
-
-    if (df.height == 0) {
-        return emptyDataDF()
-    }
-
-    return _castDataDF(df)
-}
-
 export const dataAsDF = async (
     variableIds: OwidVariableId[]
 ): Promise<pl.DataFrame> => {
-    // return variables values as a DataFrame from either S3 or data_values table
+    // return variables values as a DataFrame from S3
     const rows = await db.queryMysql(
         `
     SELECT
@@ -456,8 +429,7 @@ export const dataAsDF = async (
         [variableIds]
     )
 
-    // variables with dataPath are stored in S3 and variables without it
-    // are stored in data_values table
+    // variables with dataPath are stored in S3
     const variableIdsWithDataPath = rows
         .filter((row: any) => row.dataPath)
         .map((row: any) => row.id)
@@ -466,23 +438,28 @@ export const dataAsDF = async (
         .filter((row: any) => !row.dataPath)
         .map((row: any) => row.id)
 
-    return pl.concat([
-        await _dataAsDFfromMySQL(variableIdsWithoutDataPath),
-        await _dataAsDFfromS3(variableIdsWithDataPath),
-    ])
+    // variables without dataPath shouldn't exist!
+    if (variableIdsWithoutDataPath.length > 0)
+        throw new Error(
+            `Variables ${variableIdsWithoutDataPath} are missing dataPath`
+        )
+
+    return _dataAsDFfromS3(variableIdsWithDataPath)
 }
 
-export const getOwidVariableDataPath = async (
+export const getOwidVariableDataAndMetadataPath = async (
     variableId: OwidVariableId
-): Promise<string | undefined> => {
+): Promise<{ dataPath: string; metadataPath: string }> => {
+    // NOTE: refactor this with Variable object in TypeORM
     const row = await db.mysqlFirst(
-        `SELECT dataPath FROM variables WHERE id = ?`,
+        `SELECT dataPath, metadataPath FROM variables WHERE id = ?`,
         [variableId]
     )
-    return row.dataPath
+    return { dataPath: row.dataPath, metadataPath: row.metadataPath }
 }
 
-// limit number of concurrent requests to 20 when fetching values from S3
+// limit number of concurrent requests to 20 when fetching values from S3, otherwise
+// we might get ECONNRESET errors
 const httpsAgent = new https.Agent({
     keepAlive: true,
     maxSockets: 20,
@@ -491,9 +468,14 @@ const httpsAgent = new https.Agent({
 export const fetchS3Values = async (
     variableId: OwidVariableId
 ): Promise<OwidVariableMixedData> => {
-    const dataPath = await getOwidVariableDataPath(variableId)
+    const { dataPath, metadataPath } = await getOwidVariableDataAndMetadataPath(
+        variableId
+    )
     if (!dataPath) {
         throw new Error(`Missing dataPath for variable ${variableId}`)
+    }
+    if (!metadataPath) {
+        throw new Error(`Missing metadataPath for variable ${variableId}`)
     }
     return fetchS3ValuesByPath(dataPath)
 }
@@ -513,11 +495,19 @@ export const fetchS3ValuesByPath = async (
     return resp.json()
 }
 
-export const dataAsRecords = async (
-    variableIds: OwidVariableId[]
-): Promise<DataRow[]> => {
-    // return data values as a list of DataRows
-    return (await dataAsDF(variableIds)).toRecords() as DataRow[]
+export const fetchS3MetadataByPath = async (
+    metadataPath: string
+): Promise<OwidVariableWithSourceAndDimension> => {
+    // avoid cache as Cloudflare worker caches up to 1 hour
+    const resp = await retryPromise(() =>
+        fetch(`${metadataPath}?nocache`, { agent: httpsAgent })
+    )
+    if (!resp.ok) {
+        throw new Error(
+            `Error fetching data from S3 for ${metadataPath}: ${resp.status} ${resp.statusText}`
+        )
+    }
+    return resp.json()
 }
 
 export const createDataFrame = (data: any): pl.DataFrame => {

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -397,6 +397,7 @@ export {
     type MultipleOwidVariableDataDimensionsMap,
     type OwidVariableDimensionValuePartial,
     type OwidVariableDimensionValueFull,
+    type OwidVariableTypeOptions,
     type OwidEntityKey,
 } from "./OwidVariable.js"
 


### PR DESCRIPTION
Previously we were baking data either from S3 if `dataPath` was defined on variable or from `data_values` table if `dataPath` was missing. In this PR we remove the branch that bakes from `data_values`.

In order to make this work, we have to make sure that `dataPath` always exists. This is currently done by running `datasync` service in ETL that synces data from `data_values` to S3. That means there's some latency (<30s). This is fine for JSON data, but would trickier for JSON metadata - if someone is editing variable metadata in admin, they wouldn't see their changes changed instantly. That is why we still fetch metadata from MySQL. Hopefully, once we separate ETL and admin, we could start fetching JSON metadata too.

This PR also refactors a few things to fix performance issues we're having. It is also an intermediate step towards S3 urls.


### Missing `dataPath`?

We assert that `dataPath` and `metadataPath` exist for all variables. All ETL variables now come with both paths by default, but non-ETL variables need to by synced by the `datasync` service. That can take ~30s for most datasets, more for large datasets (these usually come from ETL though). As far as I know, the only service that could be problematic is "Import CSV" (which we hope to deprecate soon). Still, if we run into this race condition, we can retry until `dataPath` exists and also make `datasync` much faster if needed.

I believe it is safe to assume this and merge it. It this assumption fails, we'd see it failing during baking and not on live.