### PR TITLE
feat: add an unlink button - this keeps the gdoc but severs the link to posts/gdocs

### DIFF
--- a/adminSiteClient/PostsIndexPage.tsx
+++ b/adminSiteClient/PostsIndexPage.tsx
@@ -140,7 +140,7 @@ class PostRow extends React.Component<PostRowProps> {
                         </>
                     </Link>
                     <button
-                        onClick={async () => await this.onRecreateGdoc()}
+                        onClick={this.onRecreateGdoc}
                         className="btn btn-primary alert-danger"
                     >
                         <FontAwesomeIcon
@@ -151,7 +151,7 @@ class PostRow extends React.Component<PostRowProps> {
                         />
                     </button>
                     <button
-                        onClick={async () => await this.onUnlinkGdoc()}
+                        onClick={this.onUnlinkGdoc}
                         className="btn btn-primary alert-danger"
                     >
                         <FontAwesomeIcon

--- a/adminSiteClient/PostsIndexPage.tsx
+++ b/adminSiteClient/PostsIndexPage.tsx
@@ -13,6 +13,11 @@ import { Tag } from "./TagBadge.js"
 import { match } from "ts-pattern"
 import { Link } from "./Link.js"
 
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
+import { faEye } from "@fortawesome/free-solid-svg-icons/faEye"
+import { faChainBroken } from "@fortawesome/free-solid-svg-icons/faChainBroken"
+import { faRecycle } from "@fortawesome/free-solid-svg-icons/faRecycle"
+
 interface PostIndexMeta {
     id: number
     title: string
@@ -93,6 +98,24 @@ class PostRow extends React.Component<PostRowProps> {
         }
     }
 
+    @action.bound async onUnlinkGdoc() {
+        if (
+            window.confirm(
+                "This will unlink the GDoc that was created. The GDoc will NOT be deleted but it will no longer show up here. Are you sure?"
+            )
+        ) {
+            this.postGdocStatus = GdocStatus.CONVERTING
+            const { admin } = this.context
+            const json = await admin.requestJSON(
+                `/api/posts/${this.props.post.id}/unlinkGdoc`,
+                {},
+                "POST"
+            )
+            this.postGdocStatus = GdocStatus.MISSING
+            this.props.post.gdocSuccessorId = undefined
+        }
+    }
+
     render() {
         const { post, highlight, availableTags } = this.props
         const { postGdocStatus } = this
@@ -112,13 +135,29 @@ class PostRow extends React.Component<PostRowProps> {
                         to={`gdocs/${post.gdocSuccessorId}/preview`}
                         className="btn btn-primary"
                     >
-                        Preview
+                        <>
+                            <FontAwesomeIcon icon={faEye} /> Preview
+                        </>
                     </Link>
                     <button
                         onClick={async () => await this.onRecreateGdoc()}
                         className="btn btn-primary alert-danger"
                     >
-                        Recreate
+                        <FontAwesomeIcon
+                            icon={faRecycle}
+                            title={
+                                "Recreate the Gdoc, replacing existing content"
+                            }
+                        />
+                    </button>
+                    <button
+                        onClick={async () => await this.onUnlinkGdoc()}
+                        className="btn btn-primary alert-danger"
+                    >
+                        <FontAwesomeIcon
+                            icon={faChainBroken}
+                            title={"Unlink the GDoc"}
+                        />
                     </button>
                 </>
             ))

--- a/db/model/Gdoc/archieToGdoc.ts
+++ b/db/model/Gdoc/archieToGdoc.ts
@@ -265,7 +265,7 @@ async function createGdoc(
 
 export async function createGdocAndInsertOwidArticleContent(
     content: OwidArticleContent,
-    existingGdocId: string | undefined
+    existingGdocId: string | null
 ): Promise<string> {
     const batchUpdates = articleToBatchUpdates(content)
 
@@ -292,7 +292,7 @@ export async function createGdocAndInsertOwidArticleContent(
     // Now that we have either created a new document or deleted the content of an existing one,
     // we can insert the new content.
     await client.documents.batchUpdate({
-        documentId,
+        documentId: documentId ?? undefined,
         requestBody: {
             requests: batchUpdates,
         },

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -159,6 +159,7 @@ export {
     WP_ColumnStyle,
     WP_PostType,
     type Year,
+    type PostRowWithGdocPublishStatus,
 } from "./owidTypes.js"
 
 export {

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -168,10 +168,14 @@ export interface PostRow {
     updated_at_in_wordpress: Date | null
     archieml: string
     archieml_update_statistics: string
-    gdocSuccessorId: string
+    gdocSuccessorId: string | null
     authors: string
     excerpt: string
     created_at_in_wordpress: Date | null
+}
+
+export interface PostRowWithGdocPublishStatus extends PostRow {
+    isGdocPublished: boolean
 }
 
 export interface Tag extends TagReactTagAutocomplete {


### PR DESCRIPTION
This was requested by Joe.  It happens that authors are working on converting an entry that is not supposed to be converted as one entity. In those cases it is useful if, after creating a gdoc and copying some fragments, the link to the doc can be cut again so as not to confuse
yourself or others in the future. 