### PR TITLE
Fix: fix image paths being dropped in backport

### DIFF
--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -728,8 +728,8 @@ function cheerioToArchieML(
                             {
                                 type: "image",
                                 // TODO ike
-                                filename: "",
-                                alt: "",
+                                filename: image?.attribs["src"] ?? "",
+                                alt: image?.attribs["alt"] ?? "",
                                 parseErrors: [],
                                 dataErrors: [],
                                 originalWidth: undefined,


### PR DESCRIPTION
Image backporting will have to switch to the new drive based image hosting in the future but for now this is better than not showing images at all