### PR TITLE
fix(Variable): fix case with no entities

### DIFF
--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -148,17 +148,7 @@ export async function getVariableMetadataFromMySQL(
         },
     }
 
-    const entities = await db.queryMysql(
-        `
-    SELECT
-        id,
-        name,
-        code
-    FROM entities WHERE id in (?) ORDER BY name ASC
-    `,
-        [_.uniq(variableData.entities)]
-    )
-
+    const entities = await loadEntitiesInfo(variableData.entities)
     const years = _.uniq(variableData.years).map((year) => ({ id: year }))
 
     return {
@@ -168,6 +158,20 @@ export async function getVariableMetadataFromMySQL(
             entities: { values: entities },
         },
     }
+}
+
+async function loadEntitiesInfo(entityIds: number[]): Promise<any> {
+    if (entityIds.length === 0) return []
+    return db.queryMysql(
+        `
+        SELECT
+            id,
+            name,
+            code
+        FROM entities WHERE id in (?) ORDER BY name ASC
+        `,
+        [_.uniq(entityIds)]
+    )
 }
 
 export function detectValuesType(


### PR DESCRIPTION
`db.queryMysql` throws an error when parameter is an empty array