### PR TITLE
Add option to show only one tab in grapher and hide the tab bar

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/Controls.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/Controls.tsx
@@ -387,9 +387,13 @@ export class FooterControls extends React.Component<{
             isRelatedQuestionTargetDifferentFromCurrentPage,
             relatedQuestions,
         } = manager
-        const tabsElement = (
-            <div className="footerRowSingle">{this._getTabsElement()}</div>
-        )
+        const tabsElement =
+            this.manager.availableTabs === undefined ||
+            this.manager.availableTabs.length > 1 ? (
+                <div className="footerRowSingle">{this._getTabsElement()}</div>
+            ) : (
+                <></>
+            )
 
         const shareMenuElement = isShareMenuActive && (
             <ShareMenu manager={manager} onDismiss={this.onShareMenu} />

--- a/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
@@ -60,6 +60,24 @@ const TestGrapherConfig = (): {
     }
 }
 
+it("Can hide the tab bar by setting only one tab in shownTabs", () => {
+    const grapher = new Grapher({ shownTabs: [GrapherTabOption.map] })
+
+    expect(grapher.availableTabs.length).toBe(1)
+    expect(grapher.hasOnlySingleTab).toBe(true)
+    expect(grapher.footerControlsHeight).toBe(0) // If we have neither a timeline nor tabs in the footer the height should be 0
+})
+
+it("The tab bar is visible if there are more than one tabs shown", () => {
+    const grapher = new Grapher({
+        shownTabs: [GrapherTabOption.map, GrapherTabOption.table],
+    })
+
+    expect(grapher.availableTabs.length).toBe(2)
+    expect(grapher.hasOnlySingleTab).toBe(false)
+    expect(grapher.footerControlsHeight).toBe(32) // If we have no timeline but tabs in the footer the height should be 32
+})
+
 it("regression fix: container options are not serialized", () => {
     const grapher = new Grapher({ xAxis: { min: 1 } })
     const obj = grapher.toObject().xAxis!

--- a/packages/@ourworldindata/grapher/src/core/Grapher.stories.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.stories.tsx
@@ -47,6 +47,11 @@ const basics: GrapherProgrammaticInterface = {
 
 export const Line = (): JSX.Element => <Grapher {...basics} />
 
+export const LineWithoutTabs = (): JSX.Element => {
+    const model = { ...basics, shownTabs: [GrapherTabOption.chart] }
+    return <Grapher {...model} />
+}
+
 export const SlopeChart = (): JSX.Element => {
     const model = {
         type: ChartTypeName.SlopeChart,

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -319,6 +319,7 @@ export class Grapher
     @observable.ref showYearLabels?: boolean = undefined // Always show year in labels for bar charts
     @observable.ref hasChartTab: boolean = true
     @observable.ref hasMapTab: boolean = false
+    @observable.ref shownTabs: GrapherTabOption[] = []
     @observable.ref tab = GrapherTabOption.chart
     @observable.ref overlay?: GrapherTabOption = undefined
     @observable.ref internalNotes = ""
@@ -1198,6 +1199,9 @@ export class Grapher
     }
 
     @computed get availableTabs(): GrapherTabOption[] {
+        const { shownTabs } = this
+        if (shownTabs && shownTabs.length > 0) return shownTabs
+
         return [
             this.hasChartTab && GrapherTabOption.chart,
             this.hasMapTab && GrapherTabOption.map,
@@ -1268,6 +1272,10 @@ export class Grapher
             default:
                 return false
         }
+    }
+
+    @computed get hasOnlySingleTab(): boolean {
+        return this.availableTabs.length === 1
     }
 
     @computed get showTimeline(): boolean {
@@ -2261,7 +2269,9 @@ export class Grapher
     }
 
     @computed private get footerControlsLines(): number {
-        return this.hasTimeline ? 2 : 1
+        const numTimelineRows = this.hasTimeline ? 1 : 0
+        const numTabRows = this.hasOnlySingleTab ? 0 : 1
+        return numTimelineRows + numTabRows
     }
 
     @computed get footerControlsHeight(): number {

--- a/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
@@ -98,6 +98,7 @@ export interface GrapherInterface extends SortConfig {
     xSlug?: ColumnSlug
     sizeSlug?: ColumnSlug
     colorSlug?: ColumnSlug
+    shownTabs?: GrapherTabOption[]
 }
 
 export interface LegacyGrapherInterface extends GrapherInterface {
@@ -189,4 +190,5 @@ export const grapherKeysToSerialize = [
     "details",
     "adminBaseUrl",
     "bakedGrapherURL",
+    "shownTabs",
 ]

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.json
@@ -21,10 +21,7 @@
                     "type": "string",
                     "description": "Toggle linear/logarithmic",
                     "default": "linear",
-                    "enum": [
-                        "linear",
-                        "log"
-                    ]
+                    "enum": ["linear", "log"]
                 },
                 "max": {
                     "type": "number",
@@ -38,10 +35,7 @@
                 "facetDomain": {
                     "type": "string",
                     "description": "Whether the axis domain should be the same across faceted charts (if possible)",
-                    "enum": [
-                        "independent",
-                        "shared"
-                    ]
+                    "enum": ["independent", "shared"]
                 }
             },
             "additionalProperties": false
@@ -54,10 +48,7 @@
                     "type": "array",
                     "description": "Custom labels for each numeric bin. Only applied when strategy is `manual`.\n`null` falls back to default label.\n",
                     "items": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
+                        "type": ["string", "null"]
                     }
                 },
                 "customCategoryColors": {
@@ -139,12 +130,7 @@
                     "type": "string",
                     "description": "The strategy for generating the bin boundaries",
                     "default": "ckmeans",
-                    "enum": [
-                        "equalInterval",
-                        "quantiles",
-                        "ckmeans",
-                        "manual"
-                    ]
+                    "enum": ["equalInterval", "quantiles", "ckmeans", "manual"]
                 },
                 "legendDescription": {
                     "type": "string",
@@ -154,10 +140,7 @@
                     "type": "array",
                     "description": "Override some or all colors for the numerical color legend.\nColors are CSS colors, usually in the form `#aa9944`\n`null` falls back the color scheme color.\n",
                     "items": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
+                        "type": ["string", "null"]
                     }
                 },
                 "customNumericValues": {
@@ -200,11 +183,7 @@
             "additionalProperties": false
         }
     },
-    "required": [
-        "title",
-        "version",
-        "dimensions"
-    ],
+    "required": ["title", "version", "dimensions"],
     "type": "object",
     "description": "Our World In Data grapher configuration. Most of the fields can be left empty and will be\nfilled with reasonable default values.\n",
     "properties": {
@@ -265,9 +244,7 @@
                         },
                         {
                             "type": "string",
-                            "enum": [
-                                "latest"
-                            ]
+                            "enum": ["latest"]
                         }
                     ]
                 },
@@ -289,10 +266,7 @@
                 },
                 {
                     "type": "string",
-                    "enum": [
-                        "latest",
-                        "earliest"
-                    ]
+                    "enum": ["latest", "earliest"]
                 }
             ]
         },
@@ -304,10 +278,7 @@
             "type": "array",
             "description": "The initial selection of entities",
             "items": {
-                "type": [
-                    "string",
-                    "null"
-                ]
+                "type": ["string", "null"]
             }
         },
         "baseColorScheme": {
@@ -322,13 +293,7 @@
             "type": "string",
             "description": "The tab that is shown initially",
             "default": "chart",
-            "enum": [
-                "chart",
-                "map",
-                "sources",
-                "download",
-                "table"
-            ]
+            "enum": ["chart", "map", "sources", "download", "table"]
         },
         "matchingEntitiesOnly": {
             "type": "boolean",
@@ -386,21 +351,13 @@
             "type": "string",
             "default": "year",
             "description": "When a user hovers over a connected series line in a ScatterPlot we show\na label for each point. By default that value will be from the \"year\" column\nbut by changing this option the column used for the x or y axis could be used instead.\n",
-            "enum": [
-                "x",
-                "y",
-                "year"
-            ]
+            "enum": ["x", "y", "year"]
         },
         "selectedFacetStrategy": {
             "type": "string",
             "default": "none",
             "description": "The desired facetting strategy (none for no facetting)",
-            "enum": [
-                "none",
-                "entity",
-                "metric"
-            ]
+            "enum": ["none", "entity", "metric"]
         },
         "sourceDesc": {
             "type": "string",
@@ -452,11 +409,7 @@
             "type": "string",
             "description": "Which logo to show on the upper right side",
             "default": "owid",
-            "enum": [
-                "owid",
-                "core+owid",
-                "gv+owid"
-            ]
+            "enum": ["owid", "core+owid", "gv+owid"]
         },
         "entityType": {
             "type": "string",
@@ -472,10 +425,7 @@
             "description": "List of dimensions and their mapping to variables",
             "items": {
                 "type": "object",
-                "required": [
-                    "property",
-                    "variableId"
-                ],
+                "required": ["property", "variableId"],
                 "properties": {
                     "targetYear": {
                         "type": "integer",
@@ -484,13 +434,7 @@
                     "property": {
                         "type": "string",
                         "description": "Which dimension this property maps to",
-                        "enum": [
-                            "y",
-                            "x",
-                            "size",
-                            "color",
-                            "table"
-                        ]
+                        "enum": ["y", "x", "size", "color", "table"]
                     },
                     "display": {
                         "type": "object",
@@ -593,11 +537,7 @@
             "type": "string",
             "description": "Whether the user can change countries, add additional ones or neither",
             "default": "add-country",
-            "enum": [
-                "add-country",
-                "change-country",
-                "disabled"
-            ]
+            "enum": ["add-country", "change-country", "disabled"]
         },
         "compareEndPointsOnly": {
             "type": "boolean",
@@ -660,28 +600,13 @@
             "description": "Enumeration of the tabs that should be visible. If only one is visible, the tab bar is hidden.\nThis enumeration takes precedence over the hasMapTab and hasChartTab options.\n",
             "items": {
                 "type": "string",
-                "enum": [
-                    "chart",
-                    "map",
-                    "sources",
-                    "download",
-                    "table"
-                ]
+                "enum": ["chart", "map", "sources", "download", "table"]
             }
         },
         "stackMode": {
-            "type": [
-                "string",
-                "null"
-            ],
+            "type": ["string", "null"],
             "description": "Stack mode. Only absolute and relative are actively used.",
-            "enum": [
-                "absolute",
-                "relative",
-                "grouped",
-                "stacked",
-                null
-            ]
+            "enum": ["absolute", "relative", "grouped", "stacked", null]
         },
         "minTime": {
             "oneOf": [
@@ -690,10 +615,7 @@
                 },
                 {
                     "type": "string",
-                    "enum": [
-                        "latest",
-                        "earliest"
-                    ]
+                    "enum": ["latest", "earliest"]
                 }
             ],
             "description": "Start point of the initially selected time span."
@@ -757,20 +679,13 @@
             "type": "string",
             "description": "Sort criterium (used by stacked bar charts and marimekko)",
             "default": "total",
-            "enum": [
-                "column",
-                "total",
-                "entityName"
-            ]
+            "enum": ["column", "total", "entityName"]
         },
         "sortOrder": {
             "type": "string",
             "description": "Sort order (used by stacked bar charts and marimekko)",
             "default": "desc",
-            "enum": [
-                "desc",
-                "asc"
-            ]
+            "enum": ["desc", "asc"]
         },
         "sortColumnSlug": {
             "description": "Sort column if sortBy is column (used by stacked bar charts and marimekko)",

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.json
@@ -21,7 +21,10 @@
                     "type": "string",
                     "description": "Toggle linear/logarithmic",
                     "default": "linear",
-                    "enum": ["linear", "log"]
+                    "enum": [
+                        "linear",
+                        "log"
+                    ]
                 },
                 "max": {
                     "type": "number",
@@ -35,7 +38,10 @@
                 "facetDomain": {
                     "type": "string",
                     "description": "Whether the axis domain should be the same across faceted charts (if possible)",
-                    "enum": ["independent", "shared"]
+                    "enum": [
+                        "independent",
+                        "shared"
+                    ]
                 }
             },
             "additionalProperties": false
@@ -48,7 +54,10 @@
                     "type": "array",
                     "description": "Custom labels for each numeric bin. Only applied when strategy is `manual`.\n`null` falls back to default label.\n",
                     "items": {
-                        "type": ["string", "null"]
+                        "type": [
+                            "string",
+                            "null"
+                        ]
                     }
                 },
                 "customCategoryColors": {
@@ -130,7 +139,12 @@
                     "type": "string",
                     "description": "The strategy for generating the bin boundaries",
                     "default": "ckmeans",
-                    "enum": ["equalInterval", "quantiles", "ckmeans", "manual"]
+                    "enum": [
+                        "equalInterval",
+                        "quantiles",
+                        "ckmeans",
+                        "manual"
+                    ]
                 },
                 "legendDescription": {
                     "type": "string",
@@ -140,7 +154,10 @@
                     "type": "array",
                     "description": "Override some or all colors for the numerical color legend.\nColors are CSS colors, usually in the form `#aa9944`\n`null` falls back the color scheme color.\n",
                     "items": {
-                        "type": ["string", "null"]
+                        "type": [
+                            "string",
+                            "null"
+                        ]
                     }
                 },
                 "customNumericValues": {
@@ -183,7 +200,11 @@
             "additionalProperties": false
         }
     },
-    "required": ["title", "version", "dimensions"],
+    "required": [
+        "title",
+        "version",
+        "dimensions"
+    ],
     "type": "object",
     "description": "Our World In Data grapher configuration. Most of the fields can be left empty and will be\nfilled with reasonable default values.\n",
     "properties": {
@@ -244,7 +265,9 @@
                         },
                         {
                             "type": "string",
-                            "enum": ["latest"]
+                            "enum": [
+                                "latest"
+                            ]
                         }
                     ]
                 },
@@ -266,7 +289,10 @@
                 },
                 {
                     "type": "string",
-                    "enum": ["latest", "earliest"]
+                    "enum": [
+                        "latest",
+                        "earliest"
+                    ]
                 }
             ]
         },
@@ -278,7 +304,10 @@
             "type": "array",
             "description": "The initial selection of entities",
             "items": {
-                "type": ["string", "null"]
+                "type": [
+                    "string",
+                    "null"
+                ]
             }
         },
         "baseColorScheme": {
@@ -293,7 +322,13 @@
             "type": "string",
             "description": "The tab that is shown initially",
             "default": "chart",
-            "enum": ["chart", "map", "sources", "download", "table"]
+            "enum": [
+                "chart",
+                "map",
+                "sources",
+                "download",
+                "table"
+            ]
         },
         "matchingEntitiesOnly": {
             "type": "boolean",
@@ -351,13 +386,21 @@
             "type": "string",
             "default": "year",
             "description": "When a user hovers over a connected series line in a ScatterPlot we show\na label for each point. By default that value will be from the \"year\" column\nbut by changing this option the column used for the x or y axis could be used instead.\n",
-            "enum": ["x", "y", "year"]
+            "enum": [
+                "x",
+                "y",
+                "year"
+            ]
         },
         "selectedFacetStrategy": {
             "type": "string",
             "default": "none",
             "description": "The desired facetting strategy (none for no facetting)",
-            "enum": ["none", "entity", "metric"]
+            "enum": [
+                "none",
+                "entity",
+                "metric"
+            ]
         },
         "sourceDesc": {
             "type": "string",
@@ -409,7 +452,11 @@
             "type": "string",
             "description": "Which logo to show on the upper right side",
             "default": "owid",
-            "enum": ["owid", "core+owid", "gv+owid"]
+            "enum": [
+                "owid",
+                "core+owid",
+                "gv+owid"
+            ]
         },
         "entityType": {
             "type": "string",
@@ -425,7 +472,10 @@
             "description": "List of dimensions and their mapping to variables",
             "items": {
                 "type": "object",
-                "required": ["property", "variableId"],
+                "required": [
+                    "property",
+                    "variableId"
+                ],
                 "properties": {
                     "targetYear": {
                         "type": "integer",
@@ -434,7 +484,13 @@
                     "property": {
                         "type": "string",
                         "description": "Which dimension this property maps to",
-                        "enum": ["y", "x", "size", "color", "table"]
+                        "enum": [
+                            "y",
+                            "x",
+                            "size",
+                            "color",
+                            "table"
+                        ]
                     },
                     "display": {
                         "type": "object",
@@ -537,7 +593,11 @@
             "type": "string",
             "description": "Whether the user can change countries, add additional ones or neither",
             "default": "add-country",
-            "enum": ["add-country", "change-country", "disabled"]
+            "enum": [
+                "add-country",
+                "change-country",
+                "disabled"
+            ]
         },
         "compareEndPointsOnly": {
             "type": "boolean",
@@ -595,10 +655,33 @@
             "default": false,
             "description": "Indicates if the map tab should be shown"
         },
+        "shownTabs": {
+            "type": "array",
+            "description": "Enumeration of the tabs that should be visible. If only one is visible, the tab bar is hidden.\nThis enumeration takes precedence over the hasMapTab and hasChartTab options.\n",
+            "items": {
+                "type": "string",
+                "enum": [
+                    "chart",
+                    "map",
+                    "sources",
+                    "download",
+                    "table"
+                ]
+            }
+        },
         "stackMode": {
-            "type": ["string", "null"],
+            "type": [
+                "string",
+                "null"
+            ],
             "description": "Stack mode. Only absolute and relative are actively used.",
-            "enum": ["absolute", "relative", "grouped", "stacked", null]
+            "enum": [
+                "absolute",
+                "relative",
+                "grouped",
+                "stacked",
+                null
+            ]
         },
         "minTime": {
             "oneOf": [
@@ -607,7 +690,10 @@
                 },
                 {
                     "type": "string",
-                    "enum": ["latest", "earliest"]
+                    "enum": [
+                        "latest",
+                        "earliest"
+                    ]
                 }
             ],
             "description": "Start point of the initially selected time span."
@@ -671,13 +757,20 @@
             "type": "string",
             "description": "Sort criterium (used by stacked bar charts and marimekko)",
             "default": "total",
-            "enum": ["column", "total", "entityName"]
+            "enum": [
+                "column",
+                "total",
+                "entityName"
+            ]
         },
         "sortOrder": {
             "type": "string",
             "description": "Sort order (used by stacked bar charts and marimekko)",
             "default": "desc",
-            "enum": ["desc", "asc"]
+            "enum": [
+                "desc",
+                "asc"
+            ]
         },
         "sortColumnSlug": {
             "description": "Sort column if sortBy is column (used by stacked bar charts and marimekko)",
@@ -712,11 +805,11 @@
             "patternProperties": {
                 "^\\w+$": {
                     "type": "object",
-                    "description": "Details on Demand category",
+                    "description": "Detail on Demand category",
                     "patternProperties": {
                         "^\\w+$": {
                             "type": "object",
-                            "description": "Details on Demand data",
+                            "description": "Detail on Demand data",
                             "properties": {
                                 "id": {
                                     "type": "number",

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.yaml
@@ -524,6 +524,19 @@ properties:
         type: boolean
         default: false
         description: Indicates if the map tab should be shown
+    shownTabs:
+        type: array
+        description: |
+            Enumeration of the tabs that should be visible. If only one is visible, the tab bar is hidden.
+            This enumeration takes precedence over the hasMapTab and hasChartTab options.
+        items:
+            type: string
+            enum:
+                - chart
+                - map
+                - sources
+                - download
+                - table
     stackMode:
         type:
             - string


### PR DESCRIPTION
This is part of the data pages project, see #1948

What this does is add a new config option `shownTabs` that is an array of tabs to show. If only one tab is shown then the tab bar is hidden.

This is not exposed in the admin at the moment. We could do that in the future but for now this is a config only option so the data pages can utilize this functionality