### PR TITLE
fix: getBySlug method properly returns null

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -1336,7 +1336,8 @@ apiRouter.put("/users/:userId", async (req: Request, res: Response) => {
         throw new JsonError("Permission denied", 403)
 
     const userId = parseIntOrUndefined(req.params.userId)
-    const user = await User.findOneBy({ id: userId })
+    const user =
+        userId !== undefined ? await User.findOneBy({ id: userId }) : null
     if (!user) throw new JsonError("No such user", 404)
 
     user.fullName = req.body.fullName

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -69,8 +69,10 @@ export class Chart extends BaseEntity {
     }
 
     static async getBySlug(slug: string): Promise<Chart | null> {
-        const slugsById = await this.mapSlugsToIds()
-        return await Chart.findOneBy({ id: slugsById[slug] })
+        const slugToIdMap = await this.mapSlugsToIds()
+        const chartId = slugToIdMap[slug]
+        if (chartId === undefined) return null
+        return await Chart.findOneBy({ id: chartId })
     }
 
     static async getById(id: number): Promise<Chart | null> {


### PR DESCRIPTION
Fixes #1990 

In #1665, I changed two instances of `Table.findOne(id)` to `Table.findOneBy({ id })`, thinking they were entirely equivalent.
This is not the case, however, in the case where `id` is nullish - in that case we would be running `Table.findOneBy({})`, which is effectively returning the first row in the table.