### PR TITLE
enhance: Add "Liberation" fonts as a fallback font, for Wikipedia

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -412,6 +412,7 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
                 textRendering: "geometricPrecision",
                 WebkitFontSmoothing: "antialiased",
             },
+            fill: "white",
         }
     }
 }

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -406,7 +406,7 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
             version: "1.1",
             style: {
                 fontFamily:
-                    "Lato, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+                    "Lato, 'Helvetica Neue', Helvetica, Arial, 'Liberation Sans', sans-serif",
                 fontSize: this.manager.fontSize ?? BASE_FONT_SIZE,
                 backgroundColor: "white",
                 textRendering: "geometricPrecision",

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -1,5 +1,7 @@
-$sans-serif-font-stack: Lato, "Helvetica Neue", Arial, sans-serif;
-$serif-font-stack: "Playfair Display", Georgia, "Times New Roman", serif;
+$sans-serif-font-stack: Lato, "Helvetica Neue", Helvetica, Arial,
+    "Liberation Sans", sans-serif;
+$serif-font-stack: "Playfair Display", Georgia, "Times New Roman",
+    "Liberation Serif", serif;
 
 // Variables duplicated from site CSS
 $blue-10: #ebeef2;

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -119,7 +119,7 @@ export class Header extends React.Component<{
                     href={manager.canonicalUrl}
                     style={{
                         fontFamily:
-                            '"Playfair Display", Georgia, "Times New Roman", serif',
+                            "'Playfair Display', Georgia, 'Times New Roman', 'Liberation Serif', serif",
                     }}
                     target="_blank"
                     rel="noopener"

--- a/site/css/variables.scss
+++ b/site/css/variables.scss
@@ -119,8 +119,10 @@ $xxlg: 1536px;
  * Fonts
  */
 
-$sans-serif-font-stack: Lato, "Helvetica Neue", Arial, sans-serif;
-$serif-font-stack: "Playfair Display", Georgia, "Times New Roman", serif;
+$sans-serif-font-stack: Lato, "Helvetica Neue", Helvetica, Arial,
+    "Liberation Sans", sans-serif;
+$serif-font-stack: "Playfair Display", Georgia, "Times New Roman",
+    "Liberation Serif", serif;
 
 /*******************************************************************************
  * Z-index


### PR DESCRIPTION
Fixes #1993.

This will be quite the SVG diff, but that's to be expected.
