### PR TITLE
fix(Variable): fix loading from datasets with mixed types

### DIFF
--- a/db/Variable.test.ts
+++ b/db/Variable.test.ts
@@ -4,6 +4,7 @@ import {
     writeVariableCSV,
     getVariableData,
     VariableQueryRow,
+    _dataAsDFfromS3,
 } from "./model/Variable.js"
 import * as db from "./db.js"
 import * as Variable from "./model/Variable.js"
@@ -226,6 +227,28 @@ describe("getVariableData", () => {
                 unit: "",
                 updatedAt: date,
             },
+        })
+    })
+})
+
+describe("_dataAsDFfromS3", () => {
+    it("works correctly for mixed data", async () => {
+        const s3data = {
+            1: {
+                values: [1, "NA"],
+                years: [2000, 2001],
+                entities: [1, 1],
+            },
+        }
+        mockS3data(s3data)
+        const df = await _dataAsDFfromS3([1])
+        expect(df.toObject()).toEqual({
+            entityCode: ["code", "code"],
+            entityId: [1, 1],
+            entityName: ["UK", "UK"],
+            value: ["1", "NA"],
+            variableId: [1, 1],
+            year: [2000, 2001],
         })
     })
 })

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -384,6 +384,10 @@ export const _dataAsDFfromS3 = async (
     const dfs = await Promise.all(
         variableIds.map(async (variableId) => {
             const s3values = await fetchS3Values(variableId)
+            // convert values to strings before creating dataframe
+            s3values.values = s3values.values.map((value) => {
+                return value.toString()
+            })
             return createDataFrame(s3values)
                 .rename({
                     values: "value",


### PR DESCRIPTION
Previously our data files had (wrongly) only string values. The current grapher baking doesn't work with mixed types, so we have to convert them to strings beforehand.