### PR TITLE
fix: use another method to achieve a solid white background in svgs

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -412,7 +412,6 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
                 textRendering: "geometricPrecision",
                 WebkitFontSmoothing: "antialiased",
             },
-            fill: "white",
         }
     }
 }
@@ -454,6 +453,12 @@ export class StaticCaptionedChart extends CaptionedChart {
                 viewBox={`0 0 ${width} ${height}`}
             >
                 {this.patterns}
+                <rect
+                    className="background-fill"
+                    fill="white"
+                    width={width}
+                    height={height}
+                />
                 {this.header.renderStatic(paddedBounds.x, paddedBounds.y)}
                 {this.renderChart()}
                 {this.footer.renderStatic(


### PR DESCRIPTION
Fixes [the svg issue I mentioned on Slack](https://owid.slack.com/archives/C46U9LXRR/p1678729334780529).

Also makes it so the white background is only present on exports, which should be okay I think