### PR TITLE
feat(admin): split "Hide automatic time/entity" toggle into multiple controls

### DIFF
--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -57,20 +57,20 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
 
     @action.bound onToggleTitleAnnotationEntity(value: boolean) {
         const { grapher } = this.props.editor
-        grapher.hideTitleAnnotations = grapher.hideTitleAnnotations || {}
-        grapher.hideTitleAnnotations.entity = value || undefined
+        grapher.hideTitleAnnotation = grapher.hideTitleAnnotation || {}
+        grapher.hideTitleAnnotation.entity = value || undefined
     }
 
     @action.bound onToggleTitleAnnotationTime(value: boolean) {
         const { grapher } = this.props.editor
-        grapher.hideTitleAnnotations = grapher.hideTitleAnnotations || {}
-        grapher.hideTitleAnnotations.time = value || undefined
+        grapher.hideTitleAnnotation = grapher.hideTitleAnnotation || {}
+        grapher.hideTitleAnnotation.time = value || undefined
     }
 
     @action.bound onToggleTitleAnnotationChange(value: boolean) {
         const { grapher } = this.props.editor
-        grapher.hideTitleAnnotations = grapher.hideTitleAnnotations || {}
-        grapher.hideTitleAnnotations.change = value || undefined
+        grapher.hideTitleAnnotation = grapher.hideTitleAnnotation || {}
+        grapher.hideTitleAnnotation.change = value || undefined
     }
 
     @computed get errorMessages() {
@@ -107,17 +107,17 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                     />
                     <Toggle
                         label="Hide automatic entity (where possible)"
-                        value={!!grapher.hideTitleAnnotations?.entity}
+                        value={!!grapher.hideTitleAnnotation?.entity}
                         onValue={this.onToggleTitleAnnotationEntity}
                     />
                     <Toggle
                         label="Hide automatic time (where possible)"
-                        value={!!grapher.hideTitleAnnotations?.time}
+                        value={!!grapher.hideTitleAnnotation?.time}
                         onValue={this.onToggleTitleAnnotationTime}
                     />
                     <Toggle
                         label="Don't prepend 'Change in' automatically (where possible)"
-                        value={!!grapher.hideTitleAnnotations?.change}
+                        value={!!grapher.hideTitleAnnotation?.change}
                         onValue={this.onToggleTitleAnnotationChange}
                     />
                     <AutoTextField

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -55,6 +55,24 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
         grapher.relatedQuestions.splice(idx, 1)
     }
 
+    @action.bound onToggleTitleAnnotationEntity(value: boolean) {
+        const { grapher } = this.props.editor
+        grapher.hideTitleAnnotations = grapher.hideTitleAnnotations || {}
+        grapher.hideTitleAnnotations.entity = value || undefined
+    }
+
+    @action.bound onToggleTitleAnnotationTime(value: boolean) {
+        const { grapher } = this.props.editor
+        grapher.hideTitleAnnotations = grapher.hideTitleAnnotations || {}
+        grapher.hideTitleAnnotations.time = value || undefined
+    }
+
+    @action.bound onToggleTitleAnnotationChange(value: boolean) {
+        const { grapher } = this.props.editor
+        grapher.hideTitleAnnotations = grapher.hideTitleAnnotations || {}
+        grapher.hideTitleAnnotations.change = value || undefined
+    }
+
     @computed get errorMessages() {
         const { invalidDetailReferences } = this.props.editor.manager
         const keys = getIndexableKeys(invalidDetailReferences)
@@ -88,13 +106,19 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                         softCharacterLimit={100}
                     />
                     <Toggle
-                        label="Hide automatic time/entity"
-                        value={!!grapher.hideTitleAnnotation}
-                        onValue={action(
-                            (value: boolean) =>
-                                (grapher.hideTitleAnnotation =
-                                    value || undefined)
-                        )}
+                        label="Hide automatic entity (where possible)"
+                        value={!!grapher.hideTitleAnnotations?.entity}
+                        onValue={this.onToggleTitleAnnotationEntity}
+                    />
+                    <Toggle
+                        label="Hide automatic time (where possible)"
+                        value={!!grapher.hideTitleAnnotations?.time}
+                        onValue={this.onToggleTitleAnnotationTime}
+                    />
+                    <Toggle
+                        label="Don't prepend 'Change in' automatically (where possible)"
+                        value={!!grapher.hideTitleAnnotations?.change}
+                        onValue={this.onToggleTitleAnnotationChange}
                     />
                     <AutoTextField
                         label="/grapher"

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -57,20 +57,20 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
 
     @action.bound onToggleTitleAnnotationEntity(value: boolean) {
         const { grapher } = this.props.editor
-        grapher.hideTitleAnnotation = grapher.hideTitleAnnotation || {}
-        grapher.hideTitleAnnotation.entity = value || undefined
+        grapher.hideAnnotationFieldsInTitle ??= {}
+        grapher.hideAnnotationFieldsInTitle.entity = value || undefined
     }
 
     @action.bound onToggleTitleAnnotationTime(value: boolean) {
         const { grapher } = this.props.editor
-        grapher.hideTitleAnnotation = grapher.hideTitleAnnotation || {}
-        grapher.hideTitleAnnotation.time = value || undefined
+        grapher.hideAnnotationFieldsInTitle ??= {}
+        grapher.hideAnnotationFieldsInTitle.time = value || undefined
     }
 
-    @action.bound onToggleTitleAnnotationChange(value: boolean) {
+    @action.bound onToggleTitleAnnotationChangeInPrefix(value: boolean) {
         const { grapher } = this.props.editor
-        grapher.hideTitleAnnotation = grapher.hideTitleAnnotation || {}
-        grapher.hideTitleAnnotation.change = value || undefined
+        grapher.hideAnnotationFieldsInTitle ??= {}
+        grapher.hideAnnotationFieldsInTitle.changeInPrefix = value || undefined
     }
 
     @computed get errorMessages() {
@@ -92,6 +92,14 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
         return errorMessages
     }
 
+    @computed get showChangeInPrefixToggle() {
+        const { grapher } = this.props.editor
+        return (
+            grapher.isLineChart &&
+            (grapher.isRelativeMode || grapher.canToggleRelativeMode)
+        )
+    }
+
     render() {
         const { grapher, references } = this.props.editor
         const { relatedQuestions } = grapher
@@ -107,19 +115,25 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                     />
                     <Toggle
                         label="Hide automatic entity (where possible)"
-                        value={!!grapher.hideTitleAnnotation?.entity}
+                        value={!!grapher.hideAnnotationFieldsInTitle?.entity}
                         onValue={this.onToggleTitleAnnotationEntity}
                     />
                     <Toggle
                         label="Hide automatic time (where possible)"
-                        value={!!grapher.hideTitleAnnotation?.time}
+                        value={!!grapher.hideAnnotationFieldsInTitle?.time}
                         onValue={this.onToggleTitleAnnotationTime}
                     />
-                    <Toggle
-                        label="Don't prepend 'Change in' automatically (where possible)"
-                        value={!!grapher.hideTitleAnnotation?.change}
-                        onValue={this.onToggleTitleAnnotationChange}
-                    />
+                    {this.showChangeInPrefixToggle && (
+                        <Toggle
+                            label="Don't prepend 'Change in' in relative line charts"
+                            value={
+                                !!grapher.hideAnnotationFieldsInTitle
+                                    ?.changeInPrefix
+                            }
+                            onValue={this.onToggleTitleAnnotationChangeInPrefix}
+                        />
+                    )}
+                    <hr />
                     <AutoTextField
                         label="/grapher"
                         value={grapher.displaySlug}

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -1089,7 +1089,7 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
 
     async getFieldDefinitions() {
         const json = await fetch(
-            "https://files.ourworldindata.org/schemas/grapher-schema.002.json"
+            "https://files.ourworldindata.org/schemas/grapher-schema.003.json"
         ).then((response) => response.json())
         const fieldDescriptions = extractFieldDescriptionsFromSchema(json)
         runInAction(() => {

--- a/db/migration/1678783599815-SplitHideTitleAnnotationIntoMultipleFlags.ts
+++ b/db/migration/1678783599815-SplitHideTitleAnnotationIntoMultipleFlags.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class SplitHideTitleAnnotationIntoMultipleFlags1678783599815
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`
+            UPDATE charts
+            SET config = JSON_SET(config, "$.hideTitleAnnotations", JSON_OBJECT("entity", TRUE, "time", TRUE, "change", TRUE)),
+                config = JSON_REMOVE(config, "$.hideTitleAnnotation")
+            WHERE config->"$.hideTitleAnnotation" IS true
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`
+            UPDATE charts
+            SET config = JSON_SET(config, "$.hideTitleAnnotation", TRUE),
+                config = JSON_REMOVE(config, "$.hideTitleAnnotations")
+            WHERE (
+                config->"$.hideTitleAnnotations.entity" IS TRUE
+                OR config->"$.hideTitleAnnotations.time" IS TRUE
+                OR config->"$.hideTitleAnnotations.change" IS TRUE
+            )    
+        `)
+    }
+}

--- a/db/migration/1678783599815-SplitHideTitleAnnotationIntoMultipleFlags.ts
+++ b/db/migration/1678783599815-SplitHideTitleAnnotationIntoMultipleFlags.ts
@@ -6,19 +6,21 @@ export class SplitHideTitleAnnotationIntoMultipleFlags1678783599815
     public async up(queryRunner: QueryRunner): Promise<void> {
         queryRunner.query(`
             UPDATE charts
-            SET config = JSON_REPLACE(config, "$.hideTitleAnnotation", JSON_OBJECT("entity", TRUE, "time", TRUE, "change", TRUE))
-            WHERE config->"$.hideTitleAnnotation" IS true
+            SET config = JSON_SET(config, "$.hideAnnotationFieldsInTitle", JSON_OBJECT("entity", TRUE, "time", TRUE, "changeInPrefix", TRUE)),
+                config = JSON_REMOVE(config, "$.hideTitleAnnotation")
+            WHERE config->>"$.hideTitleAnnotation" = "true"
         `)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         queryRunner.query(`
             UPDATE charts
-            SET config = JSON_REPLACE(config, "$.hideTitleAnnotation", TRUE)
+            SET config = JSON_SET(config, "$.hideTitleAnnotation", TRUE),
+                config = JSON_REMOVE(config, "$.hideAnnotationFieldsInTitle")
             WHERE (
-                config->"$.hideTitleAnnotation.entity" IS TRUE
-                OR config->"$.hideTitleAnnotation.time" IS TRUE
-                OR config->"$.hideTitleAnnotation.change" IS TRUE
+                config->>"$.hideAnnotationFieldsInTitle.entity" = "true"
+                OR config->>"$.hideAnnotationFieldsInTitle.time" = "true"
+                OR config->>"$.hideAnnotationFieldsInTitle.changeInPrefix" = "true"
             )    
         `)
     }

--- a/db/migration/1678783599815-SplitHideTitleAnnotationIntoMultipleFlags.ts
+++ b/db/migration/1678783599815-SplitHideTitleAnnotationIntoMultipleFlags.ts
@@ -6,8 +6,7 @@ export class SplitHideTitleAnnotationIntoMultipleFlags1678783599815
     public async up(queryRunner: QueryRunner): Promise<void> {
         queryRunner.query(`
             UPDATE charts
-            SET config = JSON_SET(config, "$.hideTitleAnnotations", JSON_OBJECT("entity", TRUE, "time", TRUE, "change", TRUE)),
-                config = JSON_REMOVE(config, "$.hideTitleAnnotation")
+            SET config = JSON_REPLACE(config, "$.hideTitleAnnotation", JSON_OBJECT("entity", TRUE, "time", TRUE, "change", TRUE))
             WHERE config->"$.hideTitleAnnotation" IS true
         `)
     }
@@ -15,12 +14,11 @@ export class SplitHideTitleAnnotationIntoMultipleFlags1678783599815
     public async down(queryRunner: QueryRunner): Promise<void> {
         queryRunner.query(`
             UPDATE charts
-            SET config = JSON_SET(config, "$.hideTitleAnnotation", TRUE),
-                config = JSON_REMOVE(config, "$.hideTitleAnnotations")
+            SET config = JSON_REPLACE(config, "$.hideTitleAnnotation", TRUE)
             WHERE (
-                config->"$.hideTitleAnnotations.entity" IS TRUE
-                OR config->"$.hideTitleAnnotations.time" IS TRUE
-                OR config->"$.hideTitleAnnotations.change" IS TRUE
+                config->"$.hideTitleAnnotation.entity" IS TRUE
+                OR config->"$.hideTitleAnnotation.time" IS TRUE
+                OR config->"$.hideTitleAnnotation.change" IS TRUE
             )    
         `)
     }

--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -8,6 +8,7 @@ import {
 } from "@ourworldindata/grapher"
 import { SortBy, SortOrder } from "@ourworldindata/utils"
 import {
+    GridBoolean,
     BooleanCellDef,
     CellDef,
     EnumCellDef,
@@ -109,6 +110,14 @@ export const GrapherGrammar: Grammar = {
         ...BooleanCellDef,
         description: "Hide automatic time/entity",
         keyword: "hideTitleAnnotation",
+        parse: (value: any) => {
+            const parsedValue = value === GridBoolean.true
+            return {
+                entity: parsedValue,
+                time: parsedValue,
+                change: parsedValue,
+            }
+        },
     },
     backgroundSeriesLimit: {
         ...IntegerCellDef,

--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -106,16 +106,16 @@ export const GrapherGrammar: Grammar = {
         keyword: "sourceDesc",
         description: "Short comma-separated list of source names",
     },
-    hideTitleAnnotation: {
+    hideAnnotationFieldsInTitle: {
         ...BooleanCellDef,
         description: "Hide automatic time/entity",
-        keyword: "hideTitleAnnotation",
+        keyword: "hideAnnotationFieldsInTitle",
         parse: (value: any) => {
             const parsedValue = value === GridBoolean.true
             return {
                 entity: parsedValue,
                 time: parsedValue,
-                change: parsedValue,
+                changeInPrefix: parsedValue,
             }
         },
     },

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1217,9 +1217,14 @@ export class Grapher
         const showChangeInPrefix =
             !this.hideAnnotationFieldsInTitle?.changeInPrefix
 
+        const isFacetingEnabled =
+            this.selectedFacetStrategy &&
+            this.selectedFacetStrategy !== FacetStrategy.none
+
         if (
             this.tab === GrapherTabOption.chart &&
-            this.addCountryMode !== EntitySelectionMode.MultipleEntities &&
+            (this.addCountryMode !== EntitySelectionMode.MultipleEntities ||
+                isFacetingEnabled) &&
             selectedEntityNames.length === 1 &&
             (showEntityAnnotation || this.canChangeEntity)
         ) {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -299,7 +299,11 @@ export class Grapher
     @observable.ref subtitle = ""
     @observable.ref sourceDesc?: string = undefined
     @observable.ref note = ""
-    @observable.ref hideTitleAnnotation?: boolean = undefined
+    @observable hideTitleAnnotations?: {
+        entity?: boolean
+        time?: boolean
+        change?: boolean
+    } = undefined
     @observable.ref minTime?: TimeBound = undefined
     @observable.ref maxTime?: TimeBound = undefined
     @observable.ref timelineMinTime?: Time = undefined
@@ -1210,13 +1214,15 @@ export class Grapher
     @computed get currentTitle(): string {
         let text = this.displayTitle
         const selectedEntityNames = this.selection.selectedEntityNames
-        const showTitleAnnotation = !this.hideTitleAnnotation
+        const showEntityAnnotation = !this.hideTitleAnnotations?.entity
+        const showTimeAnnotation = !this.hideTitleAnnotations?.time
+        const showChangeAnnotation = !this.hideTitleAnnotations?.change
 
         if (
             this.tab === GrapherTabOption.chart &&
             this.addCountryMode !== EntitySelectionMode.MultipleEntities &&
             selectedEntityNames.length === 1 &&
-            (showTitleAnnotation || this.canChangeEntity)
+            (showEntityAnnotation || this.canChangeEntity)
         ) {
             const entityStr = selectedEntityNames[0]
             if (entityStr?.length) text = `${text}, ${entityStr}`
@@ -1225,13 +1231,13 @@ export class Grapher
         if (
             this.isLineChart &&
             this.isRelativeMode &&
-            (showTitleAnnotation || this.canToggleRelativeMode)
+            (showChangeAnnotation || this.canToggleRelativeMode)
         )
             text = "Change in " + lowerCaseFirstLetterUnlessAbbreviation(text)
 
         if (
             this.isReady &&
-            (showTitleAnnotation ||
+            (showTimeAnnotation ||
                 (this.hasTimeline &&
                     (this.isLineChartThatTurnedIntoDiscreteBar ||
                         this.isOnMapTab)))
@@ -2318,7 +2324,7 @@ export class Grapher
         this.dimensions = grapher.dimensions
         this.stackMode = grapher.stackMode
         this.hideTotalValueLabel = grapher.hideTotalValueLabel
-        this.hideTitleAnnotation = grapher.hideTitleAnnotation
+        this.hideTitleAnnotations = grapher.hideTitleAnnotations
         this.timelineMinTime = grapher.timelineMinTime
         this.timelineMaxTime = grapher.timelineMaxTime
         this.relatedQuestions = grapher.relatedQuestions

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -299,7 +299,7 @@ export class Grapher
     @observable.ref subtitle = ""
     @observable.ref sourceDesc?: string = undefined
     @observable.ref note = ""
-    @observable hideTitleAnnotations?: {
+    @observable hideTitleAnnotation?: {
         entity?: boolean
         time?: boolean
         change?: boolean
@@ -1212,11 +1212,13 @@ export class Grapher
     }
 
     @computed get currentTitle(): string {
+        console.log("IN CURR TITLE", this.hideTitleAnnotation)
+
         let text = this.displayTitle
         const selectedEntityNames = this.selection.selectedEntityNames
-        const showEntityAnnotation = !this.hideTitleAnnotations?.entity
-        const showTimeAnnotation = !this.hideTitleAnnotations?.time
-        const showChangeAnnotation = !this.hideTitleAnnotations?.change
+        const showEntityAnnotation = !this.hideTitleAnnotation?.entity
+        const showTimeAnnotation = !this.hideTitleAnnotation?.time
+        const showChangeAnnotation = !this.hideTitleAnnotation?.change
 
         if (
             this.tab === GrapherTabOption.chart &&
@@ -2324,7 +2326,7 @@ export class Grapher
         this.dimensions = grapher.dimensions
         this.stackMode = grapher.stackMode
         this.hideTotalValueLabel = grapher.hideTotalValueLabel
-        this.hideTitleAnnotations = grapher.hideTitleAnnotations
+        this.hideTitleAnnotation = grapher.hideTitleAnnotation
         this.timelineMinTime = grapher.timelineMinTime
         this.timelineMaxTime = grapher.timelineMaxTime
         this.relatedQuestions = grapher.relatedQuestions

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -84,6 +84,7 @@ import {
     ThereWasAProblemLoadingThisChart,
     SeriesColorMap,
     FacetAxisDomain,
+    AnnotationFieldsInTitle,
     DEFAULT_GRAPHER_WIDTH,
     DEFAULT_GRAPHER_HEIGHT,
 } from "../core/GrapherConstants"
@@ -299,11 +300,8 @@ export class Grapher
     @observable.ref subtitle = ""
     @observable.ref sourceDesc?: string = undefined
     @observable.ref note = ""
-    @observable hideTitleAnnotation?: {
-        entity?: boolean
-        time?: boolean
-        change?: boolean
-    } = undefined
+    @observable hideAnnotationFieldsInTitle?: AnnotationFieldsInTitle =
+        undefined
     @observable.ref minTime?: TimeBound = undefined
     @observable.ref maxTime?: TimeBound = undefined
     @observable.ref timelineMinTime?: Time = undefined
@@ -1212,13 +1210,12 @@ export class Grapher
     }
 
     @computed get currentTitle(): string {
-        console.log("IN CURR TITLE", this.hideTitleAnnotation)
-
         let text = this.displayTitle
         const selectedEntityNames = this.selection.selectedEntityNames
-        const showEntityAnnotation = !this.hideTitleAnnotation?.entity
-        const showTimeAnnotation = !this.hideTitleAnnotation?.time
-        const showChangeAnnotation = !this.hideTitleAnnotation?.change
+        const showEntityAnnotation = !this.hideAnnotationFieldsInTitle?.entity
+        const showTimeAnnotation = !this.hideAnnotationFieldsInTitle?.time
+        const showChangeInPrefix =
+            !this.hideAnnotationFieldsInTitle?.changeInPrefix
 
         if (
             this.tab === GrapherTabOption.chart &&
@@ -1230,11 +1227,7 @@ export class Grapher
             if (entityStr?.length) text = `${text}, ${entityStr}`
         }
 
-        if (
-            this.isLineChart &&
-            this.isRelativeMode &&
-            (showChangeAnnotation || this.canToggleRelativeMode)
-        )
+        if (this.isLineChart && this.isRelativeMode && showChangeInPrefix)
             text = "Change in " + lowerCaseFirstLetterUnlessAbbreviation(text)
 
         if (
@@ -2326,7 +2319,7 @@ export class Grapher
         this.dimensions = grapher.dimensions
         this.stackMode = grapher.stackMode
         this.hideTotalValueLabel = grapher.hideTotalValueLabel
-        this.hideTitleAnnotation = grapher.hideTitleAnnotation
+        this.hideAnnotationFieldsInTitle = grapher.hideAnnotationFieldsInTitle
         this.timelineMinTime = grapher.timelineMinTime
         this.timelineMaxTime = grapher.timelineMaxTime
         this.relatedQuestions = grapher.relatedQuestions

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -117,3 +117,9 @@ export enum Patterns {
     noDataPattern = "noDataPattern",
     noDataPatternForMapChart = "noDataPatternForMapChart",
 }
+
+export interface AnnotationFieldsInTitle {
+    entity?: boolean
+    time?: boolean
+    changeInPrefix?: boolean
+}

--- a/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
@@ -41,7 +41,11 @@ export interface GrapherInterface extends SortConfig {
     subtitle?: string
     sourceDesc?: string
     note?: string
-    hideTitleAnnotation?: boolean
+    hideTitleAnnotations?: {
+        entity?: boolean
+        time?: boolean
+        change?: boolean
+    }
     minTime?: TimeBound
     maxTime?: TimeBound
     timelineMinTime?: Time
@@ -135,7 +139,7 @@ export const grapherKeysToSerialize = [
     "subtitle",
     "sourceDesc",
     "note",
-    "hideTitleAnnotation",
+    "hideTitleAnnotations",
     "minTime",
     "maxTime",
     "timelineMinTime",

--- a/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
@@ -41,7 +41,7 @@ export interface GrapherInterface extends SortConfig {
     subtitle?: string
     sourceDesc?: string
     note?: string
-    hideTitleAnnotations?: {
+    hideTitleAnnotation?: {
         entity?: boolean
         time?: boolean
         change?: boolean
@@ -139,7 +139,7 @@ export const grapherKeysToSerialize = [
     "subtitle",
     "sourceDesc",
     "note",
-    "hideTitleAnnotations",
+    "hideTitleAnnotation",
     "minTime",
     "maxTime",
     "timelineMinTime",

--- a/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
@@ -139,7 +139,7 @@ export const grapherKeysToSerialize = [
     "subtitle",
     "sourceDesc",
     "note",
-    "hideTitleAnnotation",
+    "hideAnnotationFieldsInTitle",
     "minTime",
     "maxTime",
     "timelineMinTime",

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
@@ -612,7 +612,7 @@
             ],
             "description": "Start point of the initially selected time span."
         },
-        "hideTitleAnnotation": {
+        "hideAnnotationFieldsInTitle": {
             "type": "object",
             "description": "Whether to hide any automatically added title annotations like the selected year",
             "properties": {
@@ -626,9 +626,9 @@
                     "description": "Whether to hide the time annotation",
                     "default": false
                 },
-                "change": {
+                "changeInPrefix": {
                     "type": "boolean",
-                    "description": "Whether to prevent \"Change in\" to be automatically added to the title in relative mode",
+                    "description": "Whether to hide \"Change in\" in relative line charts",
                     "default": false
                 }
             }

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
@@ -612,7 +612,7 @@
             ],
             "description": "Start point of the initially selected time span."
         },
-        "hideTitleAnnotations": {
+        "hideTitleAnnotation": {
             "type": "object",
             "description": "Whether to hide any automatically added title annotations like the selected year",
             "properties": {

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
@@ -1,0 +1,765 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://files.ourworldindata.org/schemas/grapher-schema.003.json",
+    "$defs": {
+        "axis": {
+            "type": "object",
+            "properties": {
+                "removePointsOutsideDomain": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "label": {
+                    "type": "string",
+                    "description": "Axis label"
+                },
+                "min": {
+                    "type": "number",
+                    "description": "Minimum domain value of the axis"
+                },
+                "scaleType": {
+                    "type": "string",
+                    "description": "Toggle linear/logarithmic",
+                    "default": "linear",
+                    "enum": ["linear", "log"]
+                },
+                "max": {
+                    "type": "number",
+                    "description": "Maximum domain value of the axis"
+                },
+                "canChangeScaleType": {
+                    "type": "boolean",
+                    "description": "Allow user to change lin/log",
+                    "default": false
+                },
+                "facetDomain": {
+                    "type": "string",
+                    "description": "Whether the axis domain should be the same across faceted charts (if possible)",
+                    "enum": ["independent", "shared"]
+                }
+            },
+            "additionalProperties": false
+        },
+        "colorScale": {
+            "type": "object",
+            "description": "Color scale definition",
+            "properties": {
+                "customNumericLabels": {
+                    "type": "array",
+                    "description": "Custom labels for each numeric bin. Only applied when strategy is `manual`.\n`null` falls back to default label.\n",
+                    "items": {
+                        "type": ["string", "null"]
+                    }
+                },
+                "customCategoryColors": {
+                    "type": "object",
+                    "description": "Map of categorical values to colors. Colors are CSS colors, usually in the form `#aa9944`",
+                    "patternProperties": {
+                        ".*": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "baseColorScheme": {
+                    "type": "string",
+                    "description": "One of the predefined base color schemes",
+                    "default": "default",
+                    "enum": [
+                        "YlGn",
+                        "YlGnBu",
+                        "GnBu",
+                        "BuGn",
+                        "PuBuGn",
+                        "BuPu",
+                        "RdPu",
+                        "PuRd",
+                        "OrRd",
+                        "YlOrRd",
+                        "YlOrBr",
+                        "Purples",
+                        "Blues",
+                        "Greens",
+                        "Oranges",
+                        "Reds",
+                        "Greys",
+                        "PuOr",
+                        "BrBG",
+                        "PRGn",
+                        "PiYG",
+                        "RdBu",
+                        "RdGy",
+                        "RdYlBu",
+                        "Spectral",
+                        "RdYlGn",
+                        "Accent",
+                        "Dark2",
+                        "Paired",
+                        "Pastel1",
+                        "Pastel2",
+                        "Set1",
+                        "Set2",
+                        "Set3",
+                        "PuBu",
+                        "hsv-RdBu",
+                        "hsv-CyMg",
+                        "Magma",
+                        "Inferno",
+                        "Plasma",
+                        "Viridis",
+                        "continents",
+                        "stackedAreaDefault",
+                        "owid-distinct",
+                        "default"
+                    ]
+                },
+                "equalSizeBins": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether the visual scaling for the color legend is disabled."
+                },
+                "customHiddenCategories": {
+                    "type": "object",
+                    "description": "Allow hiding categories from the legend",
+                    "patternProperties": {
+                        ".*": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "binningStrategy": {
+                    "type": "string",
+                    "description": "The strategy for generating the bin boundaries",
+                    "default": "ckmeans",
+                    "enum": ["equalInterval", "quantiles", "ckmeans", "manual"]
+                },
+                "legendDescription": {
+                    "type": "string",
+                    "description": "A custom legend description. Only used in ScatterPlot legend titles for now."
+                },
+                "customNumericColors": {
+                    "type": "array",
+                    "description": "Override some or all colors for the numerical color legend.\nColors are CSS colors, usually in the form `#aa9944`\n`null` falls back the color scheme color.\n",
+                    "items": {
+                        "type": ["string", "null"]
+                    }
+                },
+                "customNumericValues": {
+                    "type": "array",
+                    "description": "Custom maximum brackets for each numeric bin. Only applied when strategy is `manual`",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "customNumericColorsActive": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether `customNumericColors` are used to override the color scheme"
+                },
+                "colorSchemeInvert": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Reverse the order of colors in the color scheme"
+                },
+                "customCategoryLabels": {
+                    "type": "object",
+                    "description": "Map of category values to color legend labels.",
+                    "patternProperties": {
+                        ".*": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "binningStrategyBinCount": {
+                    "type": "integer",
+                    "default": 5,
+                    "description": "The *suggested* number of bins for the automatic binning algorithm",
+                    "minimum": 0
+                },
+                "customNumericMinValue": {
+                    "type": "number",
+                    "description": "The minimum bracket of the first bin"
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "required": ["title", "version", "dimensions"],
+    "type": "object",
+    "description": "Our World In Data grapher configuration. Most of the fields can be left empty and will be\nfilled with reasonable default values.\n",
+    "properties": {
+        "$schema": {
+            "type": "string",
+            "description": "Url of the concrete schema version to use to validate this document",
+            "format": "uri",
+            "default": "https://files.ourworldindata.org/schemas/grapher-schema.003.json"
+        },
+        "id": {
+            "type": "integer",
+            "description": "Internal DB id. Useful internally for OWID but not required if just using grapher directly.",
+            "minimum": 0
+        },
+        "map": {
+            "type": "object",
+            "description": "Configuration of the world map chart",
+            "properties": {
+                "projection": {
+                    "type": "string",
+                    "description": "Slightly misnamed - this does not change the map projection but instead specifies which world area to focus on.",
+                    "enum": [
+                        "World",
+                        "Europe",
+                        "Africa",
+                        "Asia",
+                        "NortAmerica",
+                        "SouthAmerica",
+                        "Oceania"
+                    ],
+                    "default": "World"
+                },
+                "hideTimeline": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether the timeline should be hidden in the map view and thus the user not be able to change the year"
+                },
+                "colorScale": {
+                    "$ref": "#/$defs/colorScale"
+                },
+                "timeTolerance": {
+                    "type": "integer",
+                    "default": 0,
+                    "description": "Tolerance to use. If data points are missing for a time point, a match is accepted if it lies\nwithin the specified time period. The unit is the dominating time unit, usually years but can be days for\ndaily time series.\n",
+                    "minimum": 0
+                },
+                "tooltipUseCustomLabels": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Show the label from colorSchemeLabels in the tooltip instead of the numeric value"
+                },
+                "time": {
+                    "description": "Select a specific time to be displayed.",
+                    "default": "latest",
+                    "oneOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string",
+                            "enum": ["latest"]
+                        }
+                    ]
+                },
+                "variableId": {
+                    "type": "integer",
+                    "description": "Variable ID to show. TODO: remove this and use dimensions instead",
+                    "maximum": 2147483647,
+                    "minimum": 0
+                }
+            },
+            "additionalProperties": false
+        },
+        "maxTime": {
+            "description": "End point of the initially selected time span.",
+            "default": "latest",
+            "oneOf": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "string",
+                    "enum": ["latest", "earliest"]
+                }
+            ]
+        },
+        "subtitle": {
+            "type": "string",
+            "description": "The longer subtitle text to show beneath the title"
+        },
+        "selectedEntityNames": {
+            "type": "array",
+            "description": "The initial selection of entities",
+            "items": {
+                "type": ["string", "null"]
+            }
+        },
+        "baseColorScheme": {
+            "type": "string",
+            "default": "default",
+            "description": "The default color scheme if no color overrides are specified"
+        },
+        "yAxis": {
+            "$ref": "#/$defs/axis"
+        },
+        "tab": {
+            "type": "string",
+            "description": "The tab that is shown initially",
+            "default": "chart",
+            "enum": ["chart", "map", "sources", "download", "table"]
+        },
+        "matchingEntitiesOnly": {
+            "type": "boolean",
+            "default": false,
+            "description": "Exclude entities that do not belong in any color group"
+        },
+        "hasChartTab": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether to show the (non-map) chart tab"
+        },
+        "data": {
+            "type": "object",
+            "description": "Obsolete name - used only to store the available entities",
+            "properties": {
+                "availableEntities": {
+                    "type": "array",
+                    "description": "List of available entities",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "hideLegend": {
+            "type": "boolean",
+            "default": false
+        },
+        "hideLogo": {
+            "type": "boolean",
+            "default": false
+        },
+        "timelineMinTime": {
+            "type": "integer",
+            "description": "The lowest year to show in the timeline. If this is set then the user is not able to see\nany data before this year\n"
+        },
+        "variantName": {
+            "type": "string",
+            "description": "Optional internal variant name for distinguishing charts with the same title"
+        },
+        "hideTimeline": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to hide the timeline from the user. If it is hidden then the user can't change the time"
+        },
+        "originUrl": {
+            "type": "string",
+            "description": "The page containing this chart where more context can be found"
+        },
+        "colorScale": {
+            "$ref": "#/$defs/colorScale"
+        },
+        "scatterPointLabelStrategy": {
+            "type": "string",
+            "default": "year",
+            "description": "When a user hovers over a connected series line in a ScatterPlot we show\na label for each point. By default that value will be from the \"year\" column\nbut by changing this option the column used for the x or y axis could be used instead.\n",
+            "enum": ["x", "y", "year"]
+        },
+        "selectedFacetStrategy": {
+            "type": "string",
+            "default": "none",
+            "description": "The desired facetting strategy (none for no facetting)",
+            "enum": ["none", "entity", "metric"]
+        },
+        "sourceDesc": {
+            "type": "string",
+            "description": "Short comma-separated list of source names"
+        },
+        "isPublished": {
+            "type": "boolean",
+            "default": false,
+            "description": "Indicates if the chart is published on Our World In Data or still in draft"
+        },
+        "invertColorScheme": {
+            "type": "boolean",
+            "default": false,
+            "description": "Reverse the order of colors in the color scheme"
+        },
+        "hideRelativeToggle": {
+            "type": "boolean",
+            "description": "Whether to hide the relative mode UI toggle. Default depends on the chart type"
+        },
+        "comparisonLines": {
+            "description": "List of vertical comparison lines to draw",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "yEquals": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "slug": {
+            "type": "string",
+            "description": "Slug of the chart on Our World In Data"
+        },
+        "internalNotes": {
+            "type": "string"
+        },
+        "version": {
+            "type": "integer",
+            "default": 1,
+            "minimum": 0
+        },
+        "logo": {
+            "type": "string",
+            "description": "Which logo to show on the upper right side",
+            "default": "owid",
+            "enum": ["owid", "core+owid", "gv+owid"]
+        },
+        "entityType": {
+            "type": "string",
+            "default": "country",
+            "description": "Display string for naming the primary entities of the data. Default is 'country', but you can specify a different one such as 'state' or 'region'"
+        },
+        "note": {
+            "type": "string",
+            "description": "Note displayed in the footer of the chart. To be used for clarifications etc about the data."
+        },
+        "dimensions": {
+            "type": "array",
+            "description": "List of dimensions and their mapping to variables",
+            "items": {
+                "type": "object",
+                "required": ["property", "variableId"],
+                "properties": {
+                    "targetYear": {
+                        "type": "integer",
+                        "description": "Charts that can display more than one primary dimensions (i.e. scatter and marimekko)\nsometimes need to \"hardcode\" one dimension to a specific year. This happens e.g. when\nmixing a daily X variable in a scatter plot with a yearly one, e.g. population.\n"
+                    },
+                    "property": {
+                        "type": "string",
+                        "description": "Which dimension this property maps to",
+                        "enum": ["y", "x", "size", "color", "table"]
+                    },
+                    "display": {
+                        "type": "object",
+                        "properties": {
+                            "isProjection": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": "Indicates if this time series is a forward projection (if yes then this is rendered\ndifferently in e.g. line charts)\n"
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "The display string for this variable"
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Variable description",
+                                "$comment": "This is a new field that did not exist prior to November 2021 in the DB. It overrides the description on the variable DB table."
+                            },
+                            "tableDisplay": {
+                                "type": "object",
+                                "description": "Configuration for the table sheet for this variable",
+                                "properties": {
+                                    "hideAbsoluteChange": {
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "hideRelativeChange": {
+                                        "type": "boolean",
+                                        "default": false
+                                    }
+                                },
+                                "additionalProperties": false
+                            },
+                            "tolerance": {
+                                "type": "integer",
+                                "default": 0,
+                                "description": "Tolerance to use. If data points are missing for a time point, a match is accepted if it lies\nwithin the specified time period. The unit is the dominating time unit, either years or days.\n",
+                                "minimum": 0
+                            },
+                            "entityAnnotationsMap": {
+                                "type": "string",
+                                "description": "Entity annotations"
+                            },
+                            "yearIsDay": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": "Switch to indicate if the number in the year column represents a day (since zeroDay) or not i.e. a year"
+                            },
+                            "color": {
+                                "type": "string",
+                                "description": "Default color for this time series"
+                            },
+                            "includeInTable": {
+                                "type": "boolean",
+                                "default": true,
+                                "description": "Whether to render this time series in the table sheet"
+                            },
+                            "shortUnit": {
+                                "type": "string",
+                                "description": "Short unit symbol - This is used in tight UI spaces when the value is shown"
+                            },
+                            "conversionFactor": {
+                                "type": "number",
+                                "description": "Conversion factor to apply before showing values"
+                            },
+                            "unit": {
+                                "type": "string",
+                                "description": "Long unit text - This is shown in the UI when there is more space (e.g. tooltips) after values"
+                            },
+                            "numDecimalPlaces": {
+                                "type": "integer",
+                                "description": "Number of decimal places to show",
+                                "minimum": 0
+                            },
+                            "zeroDay": {
+                                "type": "string",
+                                "description": "Iso date day string for the starting date if yearIsDay is used"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "variableId": {
+                        "type": "integer",
+                        "description": "The variable id to get the values for this time series",
+                        "minimum": 0
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "selectedEntityIds": {
+            "type": "array",
+            "description": "The selected entities",
+            "items": {
+                "type": "integer",
+                "minimum": 0
+            }
+        },
+        "addCountryMode": {
+            "type": "string",
+            "description": "Whether the user can change countries, add additional ones or neither",
+            "default": "add-country",
+            "enum": ["add-country", "change-country", "disabled"]
+        },
+        "compareEndPointsOnly": {
+            "type": "boolean",
+            "default": false,
+            "description": "Drops in between points in scatter plots"
+        },
+        "selectedEntityColors": {
+            "type": "object",
+            "description": "Colors for selected entities",
+            "patternProperties": {
+                ".*": {
+                    "type": "string"
+                }
+            }
+        },
+        "relatedQuestions": {
+            "type": "array",
+            "description": "Links to related questions",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "text": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "title": {
+            "type": "string",
+            "description": "Big title text of the chart"
+        },
+        "type": {
+            "type": "string",
+            "description": "Which type of chart should be shown (hasMapChart can be used to always also show a map chart)",
+            "default": "LineChart",
+            "enum": [
+                "LineChart",
+                "ScatterPlot",
+                "TimeScatter",
+                "StackedArea",
+                "DiscreteBar",
+                "StackedDiscreteBar",
+                "SlopeChart",
+                "StackedBar",
+                "WorldMap",
+                "Marimekko"
+            ]
+        },
+        "hasMapTab": {
+            "type": "boolean",
+            "default": false,
+            "description": "Indicates if the map tab should be shown"
+        },
+        "stackMode": {
+            "type": ["string", "null"],
+            "description": "Stack mode. Only absolute and relative are actively used.",
+            "enum": ["absolute", "relative", "grouped", "stacked", null]
+        },
+        "minTime": {
+            "oneOf": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "string",
+                    "enum": ["latest", "earliest"]
+                }
+            ],
+            "description": "Start point of the initially selected time span."
+        },
+        "hideTitleAnnotations": {
+            "type": "object",
+            "description": "Whether to hide any automatically added title annotations like the selected year",
+            "properties": {
+                "entity": {
+                    "type": "boolean",
+                    "description": "Whether to hide the entity annotation",
+                    "default": false
+                },
+                "time": {
+                    "type": "boolean",
+                    "description": "Whether to hide the time annotation",
+                    "default": false
+                },
+                "change": {
+                    "type": "boolean",
+                    "description": "Whether to prevent \"Change in\" to be automatically added to the title in relative mode",
+                    "default": false
+                }
+            }
+        },
+        "excludedEntities": {
+            "type": "array",
+            "description": "Entities that should be excluded from the chart",
+            "items": {
+                "type": "integer",
+                "minimum": 0
+            }
+        },
+        "xAxis": {
+            "$ref": "#/$defs/axis"
+        },
+        "timelineMaxTime": {
+            "type": "integer",
+            "description": "The highest year to show in the timeline. If this is set then the user is not able to see\nany data after this year\n"
+        },
+        "hideConnectedScatterLines": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to hide connecting lines on scatter plots when a time range is selected"
+        },
+        "showNoDataArea": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether to show an area for entities that have no data (currently only used in marimekko charts)"
+        },
+        "zoomToSelection": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to zoom to the selected data points"
+        },
+        "showYearLabels": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to show year labels in bar charts"
+        },
+        "hideLinesOutsideTolerance": {
+            "type": "boolean",
+            "default": false,
+            "description": "Hide entities without data for full time span (within tolerance)"
+        },
+        "hideTotalValueLabel": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to hide the total value label (used on stacked discrete bar charts)"
+        },
+        "hideScatterLabels": {
+            "type": "boolean",
+            "default": false,
+            "description": "Hide entity names in Scatter plots"
+        },
+        "sortBy": {
+            "type": "string",
+            "description": "Sort criterium (used by stacked bar charts and marimekko)",
+            "default": "total",
+            "enum": ["column", "total", "entityName"]
+        },
+        "sortOrder": {
+            "type": "string",
+            "description": "Sort order (used by stacked bar charts and marimekko)",
+            "default": "desc",
+            "enum": ["desc", "asc"]
+        },
+        "sortColumnSlug": {
+            "description": "Sort column if sortBy is column (used by stacked bar charts and marimekko)",
+            "type": "string"
+        },
+        "hideFacetControl": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether to hide the faceting control"
+        },
+        "includedEntities": {
+            "type": "array",
+            "description": "Entities to include. Opposite of excludedEntities. If this is set then all entities not specified here are excluded.",
+            "items": {
+                "type": "number"
+            }
+        },
+        "entityTypePlural": {
+            "description": "Plural of the entity type (i.e. when entityType is 'country' this would be 'countries')",
+            "default": "countries",
+            "type": "string"
+        },
+        "isExplorable": {
+            "type": "boolean",
+            "default": false,
+            "description": "Legacy flag, should be removed",
+            "$comment": "Remove this flag once the codepaths that use it are deleted"
+        },
+        "details": {
+            "type": "object",
+            "description": "A list of definitions for the details on demand feature that shows on-hover explanations for terms used\nin subtitles and footnotes. Entries here have a hierarchy of category > term > detail information.\nThe syntax to use details on demand is similar to markdown links as follows:\n[visible text](hover::category::subcategory)\n",
+            "patternProperties": {
+                "^\\w+$": {
+                    "type": "object",
+                    "description": "Detail on Demand category",
+                    "patternProperties": {
+                        "^\\w+$": {
+                            "type": "object",
+                            "description": "Detail on Demand data",
+                            "properties": {
+                                "id": {
+                                    "type": "number",
+                                    "description": "The id of the Detail on Demand in our database"
+                                },
+                                "category": {
+                                    "type": "string",
+                                    "description": "The category of the Detail on Demand (same as the object key 2 levels higher up)"
+                                },
+                                "term": {
+                                    "type": "string",
+                                    "description": "The term identifier of the Detail on Demand (same as the object key 1 level higher up)"
+                                },
+                                "title": {
+                                    "type": "string",
+                                    "description": "Human readable title for the Detail on Demand term"
+                                },
+                                "content": {
+                                    "type": "string",
+                                    "description": "Content to be shown in the on-hover box. This can use a limited subset of markdown including bold, italic and links"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "additionalProperties": false
+}

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
@@ -543,7 +543,7 @@ properties:
                   - latest
                   - earliest
         description: Start point of the initially selected time span.
-    hideTitleAnnotation:
+    hideAnnotationFieldsInTitle:
         type: object
         description: Whether to hide any automatically added title annotations like the selected year
         properties:
@@ -555,9 +555,9 @@ properties:
                 type: boolean
                 description: Whether to hide the time annotation
                 default: false
-            change:
+            changeInPrefix:
                 type: boolean
-                description: Whether to prevent "Change in" to be automatically added to the title in relative mode
+                description: Whether to hide "Change in" in relative line charts
                 default: false
     excludedEntities:
         type: array

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
@@ -1,0 +1,670 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+$id: "https://files.ourworldindata.org/schemas/grapher-schema.003.json"
+$defs:
+    axis:
+        type: object
+        properties:
+            removePointsOutsideDomain:
+                type: boolean
+                default: false
+            label:
+                type: string
+                description: Axis label
+            min:
+                type: number
+                description: Minimum domain value of the axis
+            scaleType:
+                type: string
+                description: Toggle linear/logarithmic
+                default: linear
+                enum:
+                    - linear
+                    - log
+            max:
+                type: number
+                description: Maximum domain value of the axis
+            canChangeScaleType:
+                type: boolean
+                description: Allow user to change lin/log
+                default: false
+            facetDomain:
+                type: string
+                description: Whether the axis domain should be the same across faceted charts (if possible)
+                enum:
+                    - independent
+                    - shared
+        additionalProperties: false
+    colorScale:
+        type: object
+        description: Color scale definition
+        properties:
+            customNumericLabels:
+                type: array
+                description: |
+                    Custom labels for each numeric bin. Only applied when strategy is `manual`.
+                    `null` falls back to default label.
+                items:
+                    type:
+                        - string
+                        - "null"
+            customCategoryColors:
+                type: object
+                description: Map of categorical values to colors. Colors are CSS colors, usually in the form `#aa9944`
+                patternProperties:
+                    ".*":
+                        type: string
+            baseColorScheme:
+                type: string
+                description: One of the predefined base color schemes
+                default: default
+                enum:
+                    - YlGn
+                    - YlGnBu
+                    - GnBu
+                    - BuGn
+                    - PuBuGn
+                    - BuPu
+                    - RdPu
+                    - PuRd
+                    - OrRd
+                    - YlOrRd
+                    - YlOrBr
+                    - Purples
+                    - Blues
+                    - Greens
+                    - Oranges
+                    - Reds
+                    - Greys
+                    - PuOr
+                    - BrBG
+                    - PRGn
+                    - PiYG
+                    - RdBu
+                    - RdGy
+                    - RdYlBu
+                    - Spectral
+                    - RdYlGn
+                    - Accent
+                    - Dark2
+                    - Paired
+                    - Pastel1
+                    - Pastel2
+                    - Set1
+                    - Set2
+                    - Set3
+                    - PuBu
+                    - hsv-RdBu
+                    - hsv-CyMg
+                    - Magma
+                    - Inferno
+                    - Plasma
+                    - Viridis
+                    - continents
+                    - stackedAreaDefault
+                    - owid-distinct
+                    - default
+            equalSizeBins:
+                type: boolean
+                default: true
+                description: Whether the visual scaling for the color legend is disabled.
+            customHiddenCategories:
+                type: object
+                description: Allow hiding categories from the legend
+                patternProperties:
+                    ".*":
+                        type: boolean
+            binningStrategy:
+                type: string
+                description: The strategy for generating the bin boundaries
+                default: ckmeans
+                enum:
+                    - equalInterval
+                    - quantiles
+                    - ckmeans
+                    - manual
+            legendDescription:
+                type: string
+                description: A custom legend description. Only used in ScatterPlot legend titles for now.
+            customNumericColors:
+                type: array
+                description: |
+                    Override some or all colors for the numerical color legend.
+                    Colors are CSS colors, usually in the form `#aa9944`
+                    `null` falls back the color scheme color.
+                items:
+                    type:
+                        - string
+                        - "null"
+            customNumericValues:
+                type: array
+                description: Custom maximum brackets for each numeric bin. Only applied when strategy is `manual`
+                items:
+                    type: number
+            customNumericColorsActive:
+                type: boolean
+                default: false
+                description: Whether `customNumericColors` are used to override the color scheme
+            colorSchemeInvert:
+                type: boolean
+                default: false
+                description: Reverse the order of colors in the color scheme
+            customCategoryLabels:
+                type: object
+                description: Map of category values to color legend labels.
+                patternProperties:
+                    ".*":
+                        type: string
+            binningStrategyBinCount:
+                type: integer
+                default: 5
+                description: The *suggested* number of bins for the automatic binning algorithm
+                minimum: 0
+            customNumericMinValue:
+                type: number
+                description: The minimum bracket of the first bin
+        additionalProperties: false
+required:
+    - title
+    - version
+    - dimensions
+type: object
+description: |
+    Our World In Data grapher configuration. Most of the fields can be left empty and will be
+    filled with reasonable default values.
+properties:
+    $schema:
+        type: string
+        description: Url of the concrete schema version to use to validate this document
+        format: uri
+        default: "https://files.ourworldindata.org/schemas/grapher-schema.003.json"
+    id:
+        type: integer
+        description: Internal DB id. Useful internally for OWID but not required if just using grapher directly.
+        minimum: 0
+    map:
+        type: object
+        description: Configuration of the world map chart
+        properties:
+            projection:
+                type: string
+                description: Slightly misnamed - this does not change the map projection but instead specifies which world area to focus on.
+                enum:
+                    - World
+                    - Europe
+                    - Africa
+                    - Asia
+                    - NortAmerica
+                    - SouthAmerica
+                    - Oceania
+                default: World
+            hideTimeline:
+                type: boolean
+                default: false
+                description: Whether the timeline should be hidden in the map view and thus the user not be able to change the year
+            colorScale:
+                $ref: "#/$defs/colorScale"
+            timeTolerance:
+                type: integer
+                default: 0
+                description: |
+                    Tolerance to use. If data points are missing for a time point, a match is accepted if it lies
+                    within the specified time period. The unit is the dominating time unit, usually years but can be days for
+                    daily time series.
+                minimum: 0
+            tooltipUseCustomLabels:
+                type: boolean
+                default: false
+                description: Show the label from colorSchemeLabels in the tooltip instead of the numeric value
+            time:
+                description: Select a specific time to be displayed.
+                default: "latest"
+                oneOf:
+                    - type: number
+                    - type: string
+                      enum:
+                          - latest
+            variableId:
+                type: integer
+                description: "Variable ID to show. TODO: remove this and use dimensions instead"
+                maximum: 2147483647
+                minimum: 0
+        additionalProperties: false
+    maxTime:
+        description: End point of the initially selected time span.
+        default: latest
+        oneOf:
+            - type: number
+            - type: string
+              enum:
+                  - latest
+                  - earliest
+    subtitle:
+        type: string
+        description: The longer subtitle text to show beneath the title
+    selectedEntityNames:
+        type: array
+        description: The initial selection of entities
+        items:
+            type:
+                - string
+                - "null"
+    baseColorScheme:
+        type: string
+        default: default
+        description: The default color scheme if no color overrides are specified
+    yAxis:
+        $ref: "#/$defs/axis"
+    tab:
+        type: string
+        description: The tab that is shown initially
+        default: chart
+        enum:
+            - chart
+            - map
+            - sources
+            - download
+            - table
+    matchingEntitiesOnly:
+        type: boolean
+        default: false
+        description: Exclude entities that do not belong in any color group
+    hasChartTab:
+        type: boolean
+        default: true
+        description: Whether to show the (non-map) chart tab
+    data:
+        type: object
+        description: Obsolete name - used only to store the available entities
+        properties:
+            availableEntities:
+                type: array
+                description: List of available entities
+                items:
+                    type: string
+        additionalProperties: false
+    hideLegend:
+        type: boolean
+        default: false
+    hideLogo:
+        type: boolean
+        default: false
+    timelineMinTime:
+        type: integer
+        description: |
+            The lowest year to show in the timeline. If this is set then the user is not able to see
+            any data before this year
+    variantName:
+        type: string
+        description: "Optional internal variant name for distinguishing charts with the same title"
+    hideTimeline:
+        type: boolean
+        default: false
+        description: "Whether to hide the timeline from the user. If it is hidden then the user can't change the time"
+    originUrl:
+        type: string
+        description: The page containing this chart where more context can be found
+    colorScale:
+        $ref: "#/$defs/colorScale"
+    scatterPointLabelStrategy:
+        type: string
+        default: year
+        description: |
+            When a user hovers over a connected series line in a ScatterPlot we show
+            a label for each point. By default that value will be from the "year" column
+            but by changing this option the column used for the x or y axis could be used instead.
+        enum:
+            - x
+            - "y"
+            - year
+    selectedFacetStrategy:
+        type: string
+        default: none
+        description: The desired facetting strategy (none for no facetting)
+        enum:
+            - none
+            - entity
+            - metric
+    sourceDesc:
+        type: string
+        description: Short comma-separated list of source names
+    isPublished:
+        type: boolean
+        default: false
+        description: Indicates if the chart is published on Our World In Data or still in draft
+    invertColorScheme:
+        type: boolean
+        default: false
+        description: Reverse the order of colors in the color scheme
+    hideRelativeToggle:
+        type: boolean
+        description: Whether to hide the relative mode UI toggle. Default depends on the chart type
+    comparisonLines:
+        description: List of vertical comparison lines to draw
+        type: array
+        items:
+            type: object
+            properties:
+                label:
+                    type: string
+                yEquals:
+                    type: string
+            additionalProperties: false
+    slug:
+        type: string
+        description: Slug of the chart on Our World In Data
+    internalNotes:
+        type: string
+    version:
+        type: integer
+        default: 1
+        minimum: 0
+    logo:
+        type: string
+        description: Which logo to show on the upper right side
+        default: owid
+        enum:
+            - owid
+            - core+owid
+            - gv+owid
+    entityType:
+        type: string
+        default: country
+        description: Display string for naming the primary entities of the data. Default is 'country', but you can specify a different one such as 'state' or 'region'
+    note:
+        type: string
+        description: Note displayed in the footer of the chart. To be used for clarifications etc about the data.
+    dimensions:
+        type: array
+        description: List of dimensions and their mapping to variables
+        items:
+            type: object
+            required:
+                - property
+                - variableId
+            properties:
+                targetYear:
+                    type: integer
+                    description: |
+                        Charts that can display more than one primary dimensions (i.e. scatter and marimekko)
+                        sometimes need to "hardcode" one dimension to a specific year. This happens e.g. when
+                        mixing a daily X variable in a scatter plot with a yearly one, e.g. population.
+                property:
+                    type: string
+                    description: Which dimension this property maps to
+                    enum:
+                        - "y"
+                        - "x"
+                        - "size"
+                        - "color"
+                        - "table"
+                display:
+                    type: object
+                    properties:
+                        isProjection:
+                            type: boolean
+                            default: false
+                            description: |
+                                Indicates if this time series is a forward projection (if yes then this is rendered
+                                differently in e.g. line charts)
+                        name:
+                            type: string
+                            description: The display string for this variable
+                        description:
+                            type: string
+                            description: Variable description
+                            $comment: This is a new field that did not exist prior to November 2021 in the DB. It overrides the description on the variable DB table.
+                        tableDisplay:
+                            type: object
+                            description: Configuration for the table sheet for this variable
+                            properties:
+                                hideAbsoluteChange:
+                                    type: boolean
+                                    default: false
+                                hideRelativeChange:
+                                    type: boolean
+                                    default: false
+                            additionalProperties: false
+                        tolerance:
+                            type: integer
+                            default: 0
+                            description: |
+                                Tolerance to use. If data points are missing for a time point, a match is accepted if it lies
+                                within the specified time period. The unit is the dominating time unit, either years or days.
+                            minimum: 0
+                        entityAnnotationsMap:
+                            type: string
+                            description: Entity annotations
+                        yearIsDay:
+                            type: boolean
+                            default: false
+                            description: Switch to indicate if the number in the year column represents a day (since zeroDay) or not i.e. a year
+                        color:
+                            type: string
+                            description: Default color for this time series
+                        includeInTable:
+                            type: boolean
+                            default: true
+                            description: Whether to render this time series in the table sheet
+                        shortUnit:
+                            type: string
+                            description: Short unit symbol - This is used in tight UI spaces when the value is shown
+                        conversionFactor:
+                            type: number
+                            description: Conversion factor to apply before showing values
+                        unit:
+                            type: string
+                            description: Long unit text - This is shown in the UI when there is more space (e.g. tooltips) after values
+                        numDecimalPlaces:
+                            type: integer
+                            description: Number of decimal places to show
+                            minimum: 0
+                        zeroDay:
+                            type: string
+                            description: Iso date day string for the starting date if yearIsDay is used
+                    additionalProperties: false
+                variableId:
+                    type: integer
+                    description: The variable id to get the values for this time series
+                    minimum: 0
+            additionalProperties: false
+    selectedEntityIds:
+        type: array
+        description: The selected entities
+        items:
+            type: integer
+            minimum: 0
+    addCountryMode:
+        type: string
+        description: Whether the user can change countries, add additional ones or neither
+        default: add-country
+        enum:
+            - add-country
+            - change-country
+            - disabled
+    compareEndPointsOnly:
+        type: boolean
+        default: false
+        description: Drops in between points in scatter plots
+    selectedEntityColors:
+        type: object
+        description: Colors for selected entities
+        patternProperties:
+            ".*":
+                type: string
+    relatedQuestions:
+        type: array
+        description: Links to related questions
+        items:
+            type: object
+            properties:
+                url:
+                    type: string
+                text:
+                    type: string
+            additionalProperties: false
+    title:
+        type: string
+        description: Big title text of the chart
+    type:
+        type: string
+        description: Which type of chart should be shown (hasMapChart can be used to always also show a map chart)
+        default: LineChart
+        enum:
+            - LineChart
+            - ScatterPlot
+            - TimeScatter
+            - StackedArea
+            - DiscreteBar
+            - StackedDiscreteBar
+            - SlopeChart
+            - StackedBar
+            - WorldMap
+            - Marimekko
+    hasMapTab:
+        type: boolean
+        default: false
+        description: Indicates if the map tab should be shown
+    stackMode:
+        type:
+            - string
+            - "null"
+        description: Stack mode. Only absolute and relative are actively used.
+        enum:
+            - absolute
+            - relative
+            - grouped
+            - stacked
+            - null
+    minTime:
+        oneOf:
+            - type: number
+            - type: string
+              enum:
+                  - latest
+                  - earliest
+        description: Start point of the initially selected time span.
+    hideTitleAnnotations:
+        type: object
+        description: Whether to hide any automatically added title annotations like the selected year
+        properties:
+            entity:
+                type: boolean
+                description: Whether to hide the entity annotation
+                default: false
+            time:
+                type: boolean
+                description: Whether to hide the time annotation
+                default: false
+            change:
+                type: boolean
+                description: Whether to prevent "Change in" to be automatically added to the title in relative mode
+                default: false
+    excludedEntities:
+        type: array
+        description: Entities that should be excluded from the chart
+        items:
+            type: integer
+            minimum: 0
+    xAxis:
+        $ref: "#/$defs/axis"
+    timelineMaxTime:
+        type: integer
+        description: |
+            The highest year to show in the timeline. If this is set then the user is not able to see
+            any data after this year
+    hideConnectedScatterLines:
+        type: boolean
+        default: false
+        description: Whether to hide connecting lines on scatter plots when a time range is selected
+    showNoDataArea:
+        type: boolean
+        default: true
+        description: Whether to show an area for entities that have no data (currently only used in marimekko charts)
+    zoomToSelection:
+        type: boolean
+        default: false
+        description: Whether to zoom to the selected data points
+    showYearLabels:
+        type: boolean
+        default: false
+        description: Whether to show year labels in bar charts
+    hideLinesOutsideTolerance:
+        type: boolean
+        default: false
+        description: Hide entities without data for full time span (within tolerance)
+    hideTotalValueLabel:
+        type: boolean
+        default: false
+        description: Whether to hide the total value label (used on stacked discrete bar charts)
+    hideScatterLabels:
+        type: boolean
+        default: false
+        description: Hide entity names in Scatter plots
+    sortBy:
+        type: string
+        description: Sort criterium (used by stacked bar charts and marimekko)
+        default: total
+        enum:
+            - column
+            - total
+            - entityName
+    sortOrder:
+        type: string
+        description: Sort order (used by stacked bar charts and marimekko)
+        default: desc
+        enum:
+            - desc
+            - asc
+    sortColumnSlug:
+        description: Sort column if sortBy is column (used by stacked bar charts and marimekko)
+        type: string
+    hideFacetControl:
+        type: boolean
+        default: true
+        description: Whether to hide the faceting control
+    includedEntities:
+        type: array
+        description: Entities to include. Opposite of excludedEntities. If this is set then all entities not specified here are excluded.
+        items:
+            type: number
+    entityTypePlural:
+        description: Plural of the entity type (i.e. when entityType is 'country' this would be 'countries')
+        default: countries
+        type: string
+    isExplorable:
+        type: boolean
+        default: false
+        description: Legacy flag, should be removed
+        $comment: Remove this flag once the codepaths that use it are deleted
+    details:
+        type: object
+        description: |
+            A list of definitions for the details on demand feature that shows on-hover explanations for terms used
+            in subtitles and footnotes. Entries here have a hierarchy of category > term > detail information.
+            The syntax to use details on demand is similar to markdown links as follows:
+            [visible text](hover::category::subcategory)
+        patternProperties:
+            "^\\w+$":
+                type: object
+                description: Detail on Demand category
+                patternProperties:
+                    "^\\w+$":
+                        type: object
+                        description: Detail on Demand data
+                        properties:
+                            id:
+                                type: number
+                                description: The id of the Detail on Demand in our database
+                            category:
+                                type: string
+                                description: The category of the Detail on Demand (same as the object key 2 levels higher up)
+                            term:
+                                type: string
+                                description: The term identifier of the Detail on Demand (same as the object key 1 level higher up)
+                            title:
+                                type: string
+                                description: Human readable title for the Detail on Demand term
+                            content:
+                                type: string
+                                description: Content to be shown in the on-hover box. This can use a limited subset of markdown including bold, italic and links
+additionalProperties: false

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
@@ -543,7 +543,7 @@ properties:
                   - latest
                   - earliest
         description: Start point of the initially selected time span.
-    hideTitleAnnotations:
+    hideTitleAnnotation:
         type: object
         description: Whether to hide any automatically added title annotations like the selected year
         properties:


### PR DESCRIPTION
fixes #1094 

Splits the "Hide automatic time/entity" toggle into multiple controls, including:
- "Hide automatic entity (where possible)"
- "Hide automatic time (where possible)"
- "Don't prepend 'Change in' automatically (where possible)"

To do this, I have replaced `hideTitleAnnotation` with an object that holds three boolean properties, `entity`, `time` and `change`. I haven't changed the logic at all though. I've looked at some example charts and I couldn't find one where I thought updating the logic might be beneficial (doesn't mean these cases don't exist though).

Questionable:
- Wording
- Down migration (at the moment, if _any_ flag in the `hideTitleAnnotation` object is set to true, `hideTitleAnnotation` will be set to true)
- I created a new config schema and wrote a migration, but it's very well possible that I missed something here...

Open questions:
- The three toggles are pretty close to the URL field, which is a bit weird as they really belong to the Title text field. I didn't want to mess around with global css.. maybe we could simply move the toggles above the Title field? Or something else could be done? I am also happy to let this go if you don't think it matters.
- ~Do explorers need to be updated accordingly?~ I have updated the explorers in such a way that if someone sets `hideTitleAnnotation` to `true` in an explorer, all three fields (entity/time/change) will be set to true.