### PR TITLE
fix: remove `s-maxage` header

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,14 +1,12 @@
 /*
-    Cache-Control: public, max-age=0, s-maxage=31556926, must-revalidate
-
-/
+    Cache-Control: public, max-age=0, must-revalidate
     Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
 
 /grapher/*
-  Access-Control-Allow-Origin: *
+    Access-Control-Allow-Origin: *
 
 /explorers/*
-  Access-Control-Allow-Origin: *
+    Access-Control-Allow-Origin: *
 
 /headerMenu.json
-  Access-Control-Allow-Origin: *
+    Access-Control-Allow-Origin: *


### PR DESCRIPTION
After identifying this [major cache issue on Slack](https://owid.slack.com/archives/CQQUA2C2U/p1678902021418709).

This is the cache config [as used by Netlify by default](https://www.netlify.com/blog/2017/02/23/better-living-through-caching/) (so I guess we could also just drop the header? but maybe good to be explicit about it).