### PR TITLE
Script to sync images from prod S3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ migrate:
 	@echo '==> Running DB migrations'
 	yarn && yarn buildTsc && yarn runDbMigrations
 
-refresh:
+refresh: sync-images
 	@echo '==> Downloading chart data'
 	./devTools/docker/download-grapher-mysql.sh
 
@@ -147,6 +147,10 @@ refresh.wp:
 
 	@echo '==> Updating wordpress data'
 	@. ./.env && DATA_FOLDER=tmp-downloads ./devTools/docker/refresh-wordpress-data.sh
+
+sync-images:
+	@echo '==> Syncing S3 images'
+	./devTools/docker/sync-s3-images.sh
 
 refresh.full: refresh refresh.wp
 

--- a/devTools/docker/sync-s3-images.sh
+++ b/devTools/docker/sync-s3-images.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env  bash
+
+# This script assumes that you have ssh access to the OWID production db server at live-db.owid.io It will
+# fail if you don't have these credentials
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+s3cmd sync s3://owid-image-upload/production/ s3://$IMAGE_HOSTING_BUCKET_PATH/


### PR DESCRIPTION
Our refresh scripts were failing because the Grapher DB's `images` table is a record of files that have been uploaded to its S3 `owid-image-upload` bucket.

Each environment has its own folder in the bucket, so if we are resetting an environment's DB to be the same as prod's, we need to do the same for its images folder.