### PR TITLE
chore: fix type errors with TS 5.0

### DIFF
--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -1117,7 +1117,9 @@ export class CoreTable<
 
     replaceNonPositiveCellsForLogScale(columnSlugs: ColumnSlug[] = []): this {
         return this.replaceCells(columnSlugs, (val) =>
-            val <= 0 ? ErrorValueTypes.InvalidOnALogScale : val
+            typeof val !== "number" || val <= 0
+                ? ErrorValueTypes.InvalidOnALogScale
+                : val
         )
     }
 
@@ -1183,7 +1185,7 @@ export class CoreTable<
     filterNegatives(slug: ColumnSlug): this {
         return this.columnFilter(
             slug,
-            (value) => value >= 0,
+            (value) => typeof value === "number" && value >= 0,
             `Filter negative values for ${slug}`
         )
     }

--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -196,7 +196,9 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         // returning sorted rows.
         return this.sortedByTime.columnFilter(
             timeColumnSlug,
-            (time) => time >= adjustedStart && time <= adjustedEnd,
+            (time) =>
+                (time as number) >= adjustedStart &&
+                (time as number) <= adjustedEnd,
             `Keep only rows with Time between ${adjustedStart} - ${adjustedEnd}`
         )
     }

--- a/packages/@ourworldindata/grapher/src/color/ColorScaleBin.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScaleBin.ts
@@ -62,7 +62,7 @@ export class NumericBin extends AbstractColorScaleBin<NumericBinProps> {
     }
 
     contains(value: CoreValueType | undefined): boolean {
-        if (value === undefined) return false
+        if (typeof value !== "number") return false
 
         // In looking at this code, it is important to realise that `isOpenLeft`, `isOpenRight`,
         // and `isFirst` are _not_ mutually exclusive.


### PR DESCRIPTION
following up some breakages after #2016 

they didn't come up before because we're using `tsup` to build `packages/*`, which is currently still using TS 4.9