### PR TITLE
Grapher and Explorer links tracking

### DIFF
--- a/adminSiteClient/GdocsSettingsForm.tsx
+++ b/adminSiteClient/GdocsSettingsForm.tsx
@@ -22,8 +22,13 @@ export const GdocsSettingsForm = ({
     setGdoc: (gdoc: OwidArticleType) => void
     errors?: OwidArticleErrorMessage[]
 }) => {
-    const attachmentMessages = errors?.filter((error) =>
-        ["linkedDocuments", "imageMetadata"].includes(error.property)
+    const attachmentMessages = errors?.filter(
+        (error) =>
+            ["linkedDocuments", "imageMetadata"].includes(error.property) ||
+            (error.property === "content" &&
+                error.message.startsWith("Grapher chart")) ||
+            (error.property === "content" &&
+                error.message.startsWith("Explorer chart"))
     )
     const attachmentErrors =
         attachmentMessages?.filter(

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -676,6 +676,16 @@ apiRouter.put("/charts/:chartId", async (req: Request, res: Response) => {
 
 apiRouter.delete("/charts/:chartId", async (req: Request, res: Response) => {
     const chart = await expectChartById(req.params.chartId)
+    const links = await Link.find({
+        where: { target: chart.slug },
+        relations: ["source"],
+    }).then((links) => links.filter((link) => link.source.published))
+    if (links.length) {
+        const sources = links.map((link) => link.source.slug).join(", ")
+        throw new Error(
+            `Cannot delete chart in-use in the following published documents: ${sources}`
+        )
+    }
 
     await db.transaction(async (t) => {
         await t.execute(`DELETE FROM chart_dimensions WHERE chartId=?`, [

--- a/adminSiteServer/app.tsx
+++ b/adminSiteServer/app.tsx
@@ -33,6 +33,7 @@ import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants.js"
 import { GdocsContentSource } from "@ourworldindata/utils"
 import OwidArticlePage from "../site/gdocs/OwidArticlePage.js"
 import { Gdoc } from "../db/model/Gdoc/Gdoc.js"
+import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer.js"
 
 // library does not provide type definitions
 // eslint-disable-next-line
@@ -120,8 +121,12 @@ export class OwidAdminApp {
 
         // Public preview of a Gdoc article
         app.get("/gdocs/:id/preview", async (req, res) => {
+            const adminExplorerServer = new ExplorerAdminServer(GIT_CMS_DIR)
+            const publishedExplorersBySlug =
+                await adminExplorerServer.getAllPublishedExplorersBySlug()
             const gdoc = await Gdoc.getGdocFromContentSource(
                 req.params.id,
+                publishedExplorersBySlug,
                 GdocsContentSource.Gdocs
             )
             res.set("X-Robots-Tag", "noindex")

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -231,7 +231,8 @@ export const renderFrontPage = async () => {
     let featuredWork: IndexPost[]
     try {
         const frontPageConfigGdoc = await Gdoc.getGdocFromContentSource(
-            GDOCS_HOMEPAGE_CONFIG_DOCUMENT_ID
+            GDOCS_HOMEPAGE_CONFIG_DOCUMENT_ID,
+            {}
         )
         const frontPageConfig: any = frontPageConfigGdoc.content
         const featuredPosts: { slug: string; position: number }[] =

--- a/db/migration/1679090531333-AddMoreLinkTypes.ts
+++ b/db/migration/1679090531333-AddMoreLinkTypes.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddMoreLinkTypes1679090531333 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(
+            `ALTER TABLE posts_gdocs_links MODIFY linkType ENUM('gdoc', 'url', 'grapher', 'explorer');`
+        )
+    }
+
+    public async down(): Promise<void> {
+        // There's no need to undo this
+    }
+}

--- a/db/model/Gdoc/Gdoc.ts
+++ b/db/model/Gdoc/Gdoc.ts
@@ -193,6 +193,7 @@ export class Gdoc extends BaseEntity implements OwidArticleType {
     }
 
     // If the node has a URL in it, create a Link object
+    // Assumes that the property will be named "url"
     extractLinkFromNode(node: OwidEnrichedArticleBlock | Span): Link | void {
         function getText(node: OwidEnrichedArticleBlock | Span): string {
             // Can add component-specific text accessors here
@@ -284,6 +285,8 @@ export class Gdoc extends BaseEntity implements OwidArticleType {
         await gdoc.loadLinkedDocuments()
         await gdoc.loadImageMetadata()
         await gdoc.validate()
+
+        console.log("gdoc.links", gdoc.links)
 
         return gdoc
     }

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -212,7 +212,7 @@ const parseChart = (raw: RawBlockChart): EnrichedBlockChart => {
                 ""
             )
 
-        const url = val.url
+        const url = extractUrl(val.url)
 
         const warnings: ParseError[] = []
 

--- a/db/model/Link.ts
+++ b/db/model/Link.ts
@@ -13,7 +13,7 @@ import { Gdoc } from "./Gdoc/Gdoc.js"
 export class Link extends BaseEntity implements OwidArticleLinkJSON {
     @PrimaryGeneratedColumn() id!: number
     @ManyToOne(() => Gdoc, (gdoc) => gdoc.id) source!: Relation<Gdoc>
-    @Column() linkType!: "gdoc" | "url"
+    @Column() linkType!: "gdoc" | "url" | "grapher" | "explorer"
     @Column() target!: string
     @Column() componentType!: string
     @Column() text!: string

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -43,6 +43,7 @@ import {
 } from "./contentGraph.js"
 import { TOPICS_CONTENT_GRAPH } from "../settings/clientSettings.js"
 import { Gdoc } from "./model/Gdoc/Gdoc.js"
+import { Link } from "./model/Link.js"
 
 let _knexInstance: Knex
 
@@ -632,6 +633,17 @@ export const getRelatedArticles = async (
     if (!chartRecord.payload.count) return
 
     const chart = chartRecord.payload.records[0]
+    const publishedLinksToChart = await Link.find({
+        where: { target: chart.slug, linkType: "grapher" },
+        relations: ["source"],
+    }).then((links) => links.filter((link) => link.source.published))
+
+    const publishedGdocPostsThatReferenceChart: PostReference[] =
+        publishedLinksToChart.map((link) => ({
+            id: link.source.id,
+            title: link.source.content.title!,
+            slug: link.source.slug,
+        }))
     const relatedArticles: PostReference[] = await Promise.all(
         chart.embeddedIn.map(async (postId: any) => {
             const postRecord = await graph.find(GraphType.Document, postId)
@@ -643,7 +655,7 @@ export const getRelatedArticles = async (
             }
         })
     )
-    return relatedArticles
+    return [...relatedArticles, ...publishedGdocPostsThatReferenceChart]
 }
 
 export const getBlockContent = async (

--- a/explorerAdminServer/ExplorerAdminServer.tsx
+++ b/explorerAdminServer/ExplorerAdminServer.tsx
@@ -8,7 +8,7 @@ import {
     ExplorersRouteResponse,
 } from "../explorer/ExplorerConstants.js"
 import simpleGit, { SimpleGit } from "simple-git"
-import { GitCommit } from "@ourworldindata/utils"
+import { GitCommit, keyBy } from "@ourworldindata/utils"
 
 export class ExplorerAdminServer {
     constructor(gitDir: string) {
@@ -75,6 +75,12 @@ export class ExplorerAdminServer {
     async getAllPublishedExplorers() {
         const explorers = await this.getAllExplorers()
         return explorers.filter((exp) => exp.isPublished)
+    }
+
+    async getAllPublishedExplorersBySlug() {
+        return this.getAllPublishedExplorers().then((publishedExplorers) =>
+            keyBy(publishedExplorers, "slug")
+        )
     }
 
     async getAllExplorers() {

--- a/packages/@ourworldindata/utils/src/GdocsUtils.ts
+++ b/packages/@ourworldindata/utils/src/GdocsUtils.ts
@@ -1,4 +1,5 @@
 import { OwidArticleLinkJSON } from "./owidTypes.js"
+import { Url } from "./urls/Url.js"
 
 // Works for:
 // https://docs.google.com/document/d/abcd1234/edit
@@ -7,9 +8,18 @@ import { OwidArticleLinkJSON } from "./owidTypes.js"
 // https://docs.google.com/document/u/0/d/abcd-1234/edit?usp=sharing
 export const gdocUrlRegex = /https:\/\/docs\.google\.com\/.+?\/([-\w]+)\/edit/
 
-export function getLinkType(url: string): OwidArticleLinkJSON["linkType"] {
-    if (url.match(gdocUrlRegex)) {
+export function getLinkType(
+    urlString: string
+): OwidArticleLinkJSON["linkType"] {
+    const url = Url.fromURL(urlString)
+    if (url.isGoogleDoc) {
         return "gdoc"
+    }
+    if (url.isGrapher) {
+        return "grapher"
+    }
+    if (url.isExplorer) {
+        return "explorer"
     }
     return "url"
 }
@@ -20,11 +30,17 @@ export function checkIsInternalLink(url: string): boolean {
     return false
 }
 
-export function getUrlTarget(url: string): string {
-    const gdocsMatch = url.match(gdocUrlRegex)
-    if (gdocsMatch) {
-        const [_, gdocId] = gdocsMatch
-        return gdocId
+export function getUrlTarget(urlString: string): string {
+    const url = Url.fromURL(urlString)
+    if (url.isGoogleDoc) {
+        const gdocsMatch = urlString.match(gdocUrlRegex)
+        if (gdocsMatch) {
+            const [_, gdocId] = gdocsMatch
+            return gdocId
+        }
     }
-    return url
+    if ((url.isGrapher || url.isExplorer) && url.slug) {
+        return url.slug
+    }
+    return urlString
 }

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -256,7 +256,7 @@ export interface ChartRecord {
 }
 
 export interface PostReference {
-    id: number
+    id: number | string
     title: string
     slug: string
 }

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -910,7 +910,7 @@ export interface OwidArticleTypeJSON
 
 export interface OwidArticleLinkJSON {
     source: OwidArticleType
-    linkType: "gdoc" | "url"
+    linkType: "gdoc" | "url" | "grapher" | "explorer"
     target: string
     componentType: string
     text: string

--- a/packages/@ourworldindata/utils/src/urls/Url.ts
+++ b/packages/@ourworldindata/utils/src/urls/Url.ts
@@ -1,4 +1,5 @@
 import urlParseLib from "url-parse"
+import { gdocUrlRegex } from "../GdocsUtils.js"
 
 import { excludeUndefined, omitUndefinedValues } from "../Util.js"
 
@@ -118,6 +119,10 @@ export class Url {
 
     get encodedQueryParams(): QueryParams {
         return strToQueryParams(this.queryStr, true)
+    }
+
+    get isGoogleDoc(): boolean {
+        return !!(this.pathname && gdocUrlRegex.test(this.pathname))
     }
 
     get isGrapher(): boolean {

--- a/site/gdocs/Chart.tsx
+++ b/site/gdocs/Chart.tsx
@@ -14,14 +14,6 @@ export default function Chart({
     const refChartContainer = useRef<HTMLDivElement>(null)
     useEmbedChart(0, refChartContainer)
 
-    // handle cases where url has been wrapped in an a tag
-    if (d.url.startsWith("<a href=")) {
-        const results = /<a [^>]+>(.*?)<\/a>/g.exec(d.url)
-        if (results && results.length > 1) {
-            d.url = results[1]
-        }
-    }
-
     const url = Url.fromURL(d.url)
     const isExplorer = url.isExplorer
     const hasControls = url.queryParams.hideControls !== "true"

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -252,8 +252,7 @@ h3.article-block__heading.has-supertitle {
 .article-block__chart {
     // width is necessary for containerNode.getBoundingClientRect() in Grapher.renderGrapherIntoContainer
     width: 100%;
-    margin-top: 24px;
-    margin-bottom: 32px;
+    margin: 24px 0 32px 0;
 
     figure {
         margin: 0;


### PR DESCRIPTION
Adds support for graphers and explorers to the Gdocs content graph via the `posts_gdocs_links` table. 

This allows us to validate pages (ensuring that the links point to existing charts) and pass metadata forward to the client to render prominent links (this part is still WIP)