### PR TITLE
Homepage copy: clearer distinction with featured/latest work

### DIFF
--- a/site/FrontPage.tsx
+++ b/site/FrontPage.tsx
@@ -198,7 +198,7 @@ export const FrontPage = (props: {
                                             data-track-note="homepage-see-all-explainers"
                                         >
                                             <div className="label">
-                                                See our latest work
+                                                See all of our work
                                             </div>
                                             <div className="icon">
                                                 <FontAwesomeIcon

--- a/site/FrontPage.tsx
+++ b/site/FrontPage.tsx
@@ -198,7 +198,7 @@ export const FrontPage = (props: {
                                             data-track-note="homepage-see-all-explainers"
                                         >
                                             <div className="label">
-                                                See all of our latest work
+                                                See our latest work
                                             </div>
                                             <div className="icon">
                                                 <FontAwesomeIcon


### PR DESCRIPTION
Now that we show featured work on the homepage, having the button read "See all of our latest work" implies that the content above it is a subset of our latest work, which isn't necessarily true. 

This is a tiny edit to change the button to read "See all of our work" which doesn't suffer from the same issue. 