### PR TITLE
Fix nav issues

### DIFF
--- a/site/SiteNavigation.tsx
+++ b/site/SiteNavigation.tsx
@@ -52,12 +52,10 @@ export const SiteNavigation = ({ baseUrl }: { baseUrl: string }) => {
         }
     }
 
-    // Open / close overlay when query changes
+    // Open overlay back when query entered after pressing "esc"
     useEffect(() => {
         if (query) {
             setActiveMenu(Menu.Search)
-        } else {
-            closeOverlay()
         }
     }, [query])
 
@@ -151,10 +149,10 @@ export const SiteNavigation = ({ baseUrl }: { baseUrl: string }) => {
                         <div className="site-search-cta">
                             <SiteSearchNavigation
                                 query={query}
-                                isActive={menu === Menu.Search || !!query}
+                                isActive={menu === Menu.Search}
                                 setQuery={setQuery}
                                 onClose={closeOverlay}
-                                onToggle={() => toggleMenu(Menu.Search)}
+                                onActivate={() => setActiveMenu(Menu.Search)}
                             />
                             <SiteNavigationToggle
                                 isActive={menu === Menu.Subscribe}

--- a/site/SiteNavigationTopics.scss
+++ b/site/SiteNavigationTopics.scss
@@ -27,6 +27,7 @@
             list-style-type: none;
             > button {
                 @include h3-bold;
+                position: relative;
                 display: flex;
                 align-items: center;
                 justify-content: space-between;
@@ -39,6 +40,25 @@
                 background-color: transparent;
                 cursor: pointer;
                 border: none;
+                // pseudo elements for ensuring continuity of hover between
+                // bordering items while still having a visual gap between an
+                // active element and its adjacent siblings
+                &:before {
+                    position: absolute;
+                    content: "";
+                    top: -4px;
+                    left: 0;
+                    width: 100%;
+                    height: 4px;
+                }
+                &:after {
+                    position: absolute;
+                    content: "";
+                    bottom: -4px;
+                    left: 0;
+                    width: 100%;
+                    height: 4px;
+                }
                 svg {
                     margin-left: 24px;
                     margin-right: 8px;
@@ -105,18 +125,11 @@
         .SiteNavigationTopic {
             list-style-type: none;
             break-inside: avoid-column;
-            padding: 8px 0;
-            margin: 8px 0;
             @include body-3-medium;
-            &:first-child {
-                margin-top: 0;
-            }
-            &:last-child {
-                margin-bottom: 0;
-            }
             > a {
                 display: block;
                 color: $blue-90;
+                padding: 12px 0;
 
                 &:hover {
                     color: $blue-50;

--- a/site/SiteNavigationTopics.tsx
+++ b/site/SiteNavigationTopics.tsx
@@ -23,7 +23,7 @@ export const SiteNavigationTopics = ({
     className?: string
 }) => {
     const [activeCategory, setActiveCategory] =
-        useState<CategoryWithEntries | null>(null)
+        useState<CategoryWithEntries | null>(topics[0])
 
     const [numTopicColumns, setNumTopicColumns] = useState(1)
 

--- a/site/SiteSearchNavigation.tsx
+++ b/site/SiteSearchNavigation.tsx
@@ -12,13 +12,13 @@ export const SiteSearchNavigation = ({
     setQuery,
     isActive,
     onClose,
-    onToggle,
+    onActivate,
 }: {
     query: string
     setQuery: (query: string) => void
     isActive: boolean
     onClose: VoidFunction
-    onToggle: VoidFunction
+    onActivate: VoidFunction
 }) => {
     const [results, setResults] = React.useState<SiteSearchResults | null>(null)
     const inputRef = React.useRef<HTMLInputElement>(null)
@@ -53,6 +53,7 @@ export const SiteSearchNavigation = ({
                     name="search"
                     placeholder="Search for a topic or chart..."
                     onChange={(e) => setQuery(e.currentTarget.value)}
+                    onFocus={onActivate}
                     className={classnames({ active: isActive })}
                     value={query}
                     ref={inputRef}
@@ -74,14 +75,14 @@ export const SiteSearchNavigation = ({
             </div>
             {!isActive && (
                 <button
-                    onClick={onToggle}
+                    onClick={onActivate}
                     data-track-note="mobile-search-button"
                     className="SiteSearchNavigation__mobile-toggle hide-lg-up"
                 >
                     <FontAwesomeIcon icon={faSearch} />
                 </button>
             )}
-            {results && <SearchResults results={results} />}
+            {isActive && results && <SearchResults results={results} />}
         </>
     )
 }


### PR DESCRIPTION
- fix: opening another menu after running a search now properly closes the search results. As side-effects:
    - the search query is now kept while interacting with the nav
    - the search remains active (overlay on) when deleting the whole query. The search can still be fully deactivated by pressing "esc", clicking on the cross, clicking on the overlay or interacting with another menu element.

https://user-images.githubusercontent.com/13406362/226956667-0d2f2a32-0e7a-4839-9807-c3ecac079e05.mov

 _👆 the bug_

- feat: open first topic by default
- enhance(nav): ensure continuity of hover between bordering items