### PR TITLE
enhance: Hide the Covid-19 alert banner on every page

### DIFF
--- a/site/AlertBanner.tsx
+++ b/site/AlertBanner.tsx
@@ -1,6 +1,9 @@
 import React from "react"
 
 export const AlertBanner = () => {
+    // 2023-03-23: This banner is now disabled, since we no longer want to highlight
+    // the COVID-19 data this way. If we don't reuse this banner later for something
+    // else, we can eventually delete it.
     return (
         <div className="alert-banner">
             <div className="content">

--- a/site/SiteHeader.tsx
+++ b/site/SiteHeader.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import { AlertBanner } from "./AlertBanner.js"
 import { SiteNavigation } from "./SiteNavigation.js"
 
 interface SiteHeaderProps {
@@ -12,6 +11,5 @@ export const SiteHeader = (props: SiteHeaderProps) => (
         <div className="site-navigation-root">
             <SiteNavigation baseUrl={props.baseUrl} />
         </div>
-        {props.hideAlertBanner !== true && <AlertBanner />}
     </header>
 )


### PR DESCRIPTION
This change simply removes the alert banner from the site, but leaves the `AlertBanner` class around for us to reuse later if we want to.
