### PR TITLE
feature(baking): add variables.type column that explicitly specifies type information

### DIFF
--- a/db/Variable.test.ts
+++ b/db/Variable.test.ts
@@ -184,6 +184,7 @@ describe("getVariableData", () => {
             createdAt: date,
             updatedAt: date,
             datasetId: 0,
+            type: null,
             display: "{}",
             dimensions: "",
         }

--- a/db/migration/1679602891178-AddTypeColumnToVariables.ts
+++ b/db/migration/1679602891178-AddTypeColumnToVariables.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddTypeColumnToVariables1679602891178
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`
+        ALTER TABLE variables
+        ADD COLUMN type JSON;
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`
+        ALTER TABLE variables
+        DROP COLUMN type;
+        `)
+    }
+}

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -34,6 +34,7 @@ export interface VariableRow {
     datasetId: number
     sourceId: number
     display: OwidVariableDisplayConfigInterface
+    type: string | null
     coverage?: string
     timespan?: string
     columnOrder?: number
@@ -127,14 +128,16 @@ export async function getVariableMetadataFromMySQL(
         sourceName,
         sourceDescription,
         nonRedistributable,
+        type: variableType,
         display: displayJson,
         ...variable
     } = row
     const display = JSON.parse(displayJson)
     const partialSource: OwidSource = JSON.parse(sourceDescription)
+
     const variableMetadata: OwidVariableWithSourceAndType = {
         ...omitNullableValues(variable),
-        type: detectValuesType(variableData.values),
+        ...unrollType(variableType, variableData.values),
         nonRedistributable: Boolean(nonRedistributable),
         display,
         source: {
@@ -158,6 +161,17 @@ export async function getVariableMetadataFromMySQL(
             years: { values: years },
             entities: { values: entities },
         },
+    }
+}
+
+function unrollType(
+    variableType: string | null,
+    values: (string | number)[]
+): { type: OwidVariableTypeOptions; sort?: string[] } {
+    if (!variableType) {
+        return { type: detectValuesType(values) }
+    } else {
+        return JSON.parse(variableType)
     }
 }
 

--- a/packages/@ourworldindata/core-table/src/CoreColumnDef.ts
+++ b/packages/@ourworldindata/core-table/src/CoreColumnDef.ts
@@ -63,6 +63,9 @@ export interface CoreColumnDef extends ColumnColorScale {
     description?: string
     note?: string // Any internal notes the author wants to record for display in admin interfaces
 
+    // Sorted values (in case of ordinal data)
+    sort?: string[]
+
     // Color
     color?: Color // A column can have a fixed color for use in charts where the columns are series
 

--- a/packages/@ourworldindata/core-table/src/CoreColumnDef.ts
+++ b/packages/@ourworldindata/core-table/src/CoreColumnDef.ts
@@ -12,6 +12,7 @@ export enum ColumnTypeNames {
     Region = "Region",
     SeriesAnnotation = "SeriesAnnotation",
     Categorical = "Categorical",
+    Ordinal = "Ordinal",
     Continent = "Continent",
     EntityName = "EntityName",
     EntityId = "EntityId",

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -322,6 +322,10 @@ export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
         return new Set(this.uniqValues)
     }
 
+    @imemo get allowedValuesSorted(): string[] | undefined {
+        return this.def.sort
+    }
+
     /**
      * Returns all values including ErrorValues..
      * Normally you want just the valid values, like `[45000, 50000, ...]`. But sometimes you

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -533,6 +533,14 @@ class BooleanColumn extends AbstractCoreColumn<boolean> {
     }
 }
 
+class OrdinalColumn extends CategoricalColumn {
+    @imemo get sortedUniqNonEmptyStringVals(): string[] {
+        return this.allowedValuesSorted
+            ? this.allowedValuesSorted
+            : super.sortedUniqNonEmptyStringVals
+    }
+}
+
 abstract class AbstractColumnWithNumberFormatting<
     T extends PrimitiveType
 > extends AbstractCoreColumn<T> {
@@ -799,6 +807,7 @@ export const ColumnTypeMap = {
     String: StringColumn,
     SeriesAnnotation: SeriesAnnotationColumn,
     Categorical: CategoricalColumn,
+    Ordinal: OrdinalColumn,
     Region: RegionColumn,
     Continent: ContinentColumn,
     NumberOrString: NumberOrStringColumn,

--- a/packages/@ourworldindata/grapher/src/color/ColorScale.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScale.ts
@@ -130,7 +130,13 @@ export class ColorScale {
     }
 
     @computed private get categoricalValues(): any[] {
-        return this.colorScaleColumn?.sortedUniqNonEmptyStringVals ?? []
+        const { sortedUniqNonEmptyStringVals, allowedValuesSorted } =
+            this.colorScaleColumn ?? {}
+
+        if (allowedValuesSorted && allowedValuesSorted.length > 0)
+            return allowedValuesSorted
+
+        return sortedUniqNonEmptyStringVals ?? []
     }
 
     @computed private get colorScheme(): ColorScheme {

--- a/packages/@ourworldindata/grapher/src/color/ColorScale.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScale.ts
@@ -130,13 +130,7 @@ export class ColorScale {
     }
 
     @computed private get categoricalValues(): any[] {
-        const { sortedUniqNonEmptyStringVals, allowedValuesSorted } =
-            this.colorScaleColumn ?? {}
-
-        if (allowedValuesSorted && allowedValuesSorted.length > 0)
-            return allowedValuesSorted
-
-        return sortedUniqNonEmptyStringVals ?? []
+        return this.colorScaleColumn?.sortedUniqNonEmptyStringVals ?? []
     }
 
     @computed private get colorScheme(): ColorScheme {

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -545,8 +545,9 @@ const variableTypeToColumnType = (
     type: OwidVariableTypeOptions
 ): ColumnTypeNames => {
     switch (type) {
-        case "string":
         case "ordinal":
+            return ColumnTypeNames.Ordinal
+        case "string":
             return ColumnTypeNames.String
         case "float":
         case "int":

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -554,6 +554,7 @@ const columnDefFromOwidVariable = (
         source,
         display,
         nonRedistributable,
+        sort,
     } = variable
 
     // Without this the much used var 123 appears as "Countries Continent". We could rename in Grapher but not sure the effects of that.
@@ -582,6 +583,7 @@ const columnDefFromOwidVariable = (
         type: isContinent
             ? ColumnTypeNames.Continent
             : ColumnTypeNames.NumberOrString,
+        sort,
     }
 }
 

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -600,7 +600,9 @@ const columnDefFromOwidVariable = (
         owidVariableId: variable.id,
         type: isContinent
             ? ColumnTypeNames.Continent
-            : variableTypeToColumnType(type),
+            : type
+            ? variableTypeToColumnType(type)
+            : ColumnTypeNames.NumberOrString,
         sort,
     }
 }

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -31,6 +31,7 @@ import {
     ColumnSlug,
     EPOCH_DATE,
     OwidChartDimensionInterface,
+    OwidVariableTypeOptions,
 } from "@ourworldindata/utils"
 
 export const legacyToOwidTableAndDimensions = (
@@ -540,6 +541,22 @@ const fullJoinTables = (
     )
 }
 
+const variableTypeToColumnType = (
+    type: OwidVariableTypeOptions
+): ColumnTypeNames => {
+    switch (type) {
+        case "string":
+        case "ordinal":
+            return ColumnTypeNames.String
+        case "float":
+        case "int":
+            return ColumnTypeNames.Numeric
+        case "mixed":
+        default:
+            return ColumnTypeNames.NumberOrString
+    }
+}
+
 const columnDefFromOwidVariable = (
     variable: OwidVariableWithSourceAndDimension
 ): OwidColumnDef => {
@@ -555,6 +572,7 @@ const columnDefFromOwidVariable = (
         display,
         nonRedistributable,
         sort,
+        type,
     } = variable
 
     // Without this the much used var 123 appears as "Countries Continent". We could rename in Grapher but not sure the effects of that.
@@ -582,7 +600,7 @@ const columnDefFromOwidVariable = (
         owidVariableId: variable.id,
         type: isContinent
             ? ColumnTypeNames.Continent
-            : ColumnTypeNames.NumberOrString,
+            : variableTypeToColumnType(type),
         sort,
     }
 }

--- a/packages/@ourworldindata/utils/src/OwidVariable.ts
+++ b/packages/@ourworldindata/utils/src/OwidVariable.ts
@@ -61,7 +61,7 @@ export interface OwidVariableTypeFields {
     sort?: string[]
 }
 
-export interface OwidVariableWithSource {
+export type OwidVariableWithSource = {
     id: number
     name?: string
     description?: string
@@ -73,7 +73,7 @@ export interface OwidVariableWithSource {
     coverage?: string
     nonRedistributable?: boolean
     source?: OwidSource
-}
+} & OwidVariableTypeFields
 
 export type OwidVariableWithSourceAndDimension = OwidVariableWithSource & {
     dimensions: OwidVariableDimensions

--- a/packages/@ourworldindata/utils/src/OwidVariable.ts
+++ b/packages/@ourworldindata/utils/src/OwidVariable.ts
@@ -73,6 +73,7 @@ export type OwidVariableWithSource = {
     coverage?: string
     nonRedistributable?: boolean
     source?: OwidSource
+    type?: OwidVariableTypeOptions
 } & OwidVariableTypeFields
 
 export type OwidVariableWithSourceAndDimension = OwidVariableWithSource & {

--- a/packages/@ourworldindata/utils/src/OwidVariable.ts
+++ b/packages/@ourworldindata/utils/src/OwidVariable.ts
@@ -50,7 +50,16 @@ export class OwidVariableDisplayConfig
     }
 }
 
-export type OwidVariableTypeOptions = "string" | "float" | "int" | "mixed"
+export type OwidVariableTypeOptions =
+    | "string"
+    | "float"
+    | "int"
+    | "mixed"
+    | "ordinal"
+
+export interface OwidVariableTypeFields {
+    sort?: string[]
+}
 
 export interface OwidVariableWithSource {
     id: number
@@ -86,7 +95,7 @@ export type OwidVariableWithDataAndSource = OwidVariableWithSource &
 
 export type OwidVariableWithSourceAndType = OwidVariableWithSource & {
     type: OwidVariableTypeOptions
-}
+} & OwidVariableTypeFields
 
 export interface OwidVariableDimension {
     values: OwidVariableDimensionValuePartial[]


### PR DESCRIPTION
See the [original proposal](https://www.notion.so/owid/2023-03-10-Proposal-define-ordered-value-sets-for-ordinal-variables-dd15d4b5fdb74292b9420923981b2a1c).

Add column JSON column `variables.type` that can contain explicit type of a variable. Some examples are `{"type": "int"}`, `{"type": "string"}` or `{"type": "ordinal", "sort": ["Low", "Medium", "High"]}`. If null, then type is determined from data (as int, float, string or mixed) to be backward compatible.

If you're trying this locally, first apply the latest migration with `yarn buildTsc && yarn runDbMigrations` and then set `type` for income groups
```sql
update variables
set type = '{"type": "ordinal", "sort": ["Not categorized", "Low income", "Lower-middle income", "Upper-middle income", "High income"]}'
where id = 42563
```

Baked metadata file for that variable would then contain following fields:
```
{
  ...
  "type": "ordinal",
  "sort": ["Not categorized", "Low income", "Lower-middle income", "Upper-middle income", "High income"]
}
```

Related: #1692, #1324