### PR TITLE
1871 lift content headings one level up

### DIFF
--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -672,10 +672,10 @@ const parseHeading = (raw: RawBlockHeading): EnrichedBlockHeading => {
             message: "Header level property is missing",
         })
     const level = parseInt(raw.value.level, 10)
-    if (level < 1 || level > 6)
+    if (level < 1 || level > 5)
         return createError({
             message:
-                "Header level property is outside the valid range between 1 and 6",
+                "Header level property is outside the valid range between 1 and 5",
         })
 
     return {

--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -299,17 +299,6 @@ export default function ArticleBlock({
                 {renderSpans(block.text)}
             </h5>
         ))
-        .with({ type: "heading", level: 6 }, (block) => (
-            <h6
-                className={cx(
-                    "overline-black-caps",
-                    getLayout("heading", containerType)
-                )}
-                id={urlSlug(spansToUnformattedPlainText(block.text))}
-            >
-                {renderSpans(block.text)}
-            </h6>
-        ))
         .with(
             { type: "heading" },
             // during parsing we take care of level being in a valid range

--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -200,7 +200,7 @@ export default function ArticleBlock({
         .with({ type: "heading", level: 1 }, (block) => (
             <h1
                 className={cx(
-                    "display-2-semibold",
+                    "h1-semibold",
                     getLayout("heading", containerType)
                 )}
                 id={urlSlug(spansToUnformattedPlainText(block.text))}
@@ -226,7 +226,7 @@ export default function ArticleBlock({
                     ) : null}
                     <h2
                         className={cx(
-                            "h1-semibold",
+                            "h2-bold",
                             getLayout("heading", containerType),
                             {
                                 "has-supertitle": supertitle
@@ -258,7 +258,7 @@ export default function ArticleBlock({
             return (
                 <h3
                     className={cx(
-                        "h2-bold",
+                        "h3-bold",
                         getLayout("heading", containerType),
                         {
                             "has-supertitle": supertitle
@@ -279,7 +279,10 @@ export default function ArticleBlock({
         })
         .with({ type: "heading", level: 4 }, (block) => (
             <h4
-                className={cx("h3-bold", getLayout("heading", containerType))}
+                className={cx(
+                    "h4-semibold",
+                    getLayout("heading", containerType)
+                )}
                 id={urlSlug(spansToUnformattedPlainText(block.text))}
             >
                 {renderSpans(block.text)}
@@ -288,7 +291,7 @@ export default function ArticleBlock({
         .with({ type: "heading", level: 5 }, (block) => (
             <h5
                 className={cx(
-                    "h4-semibold",
+                    "overline-black-caps",
                     getLayout("heading", containerType)
                 )}
                 id={urlSlug(spansToUnformattedPlainText(block.text))}


### PR DESCRIPTION
see #1871 and companion PR for backported content #1953 

- Updates to existing source gdocs need to be done in parallel, manually.
- Authors need to be notified of the change: headings in content should now start at level 1 (and not 2, as historically done)