### PR TITLE
chore: use a sensible default for the image bucket path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ validate.env:
 create-if-missing.env.full:
 	@if test ! -f .env; then \
 		echo 'Copying .env.example-full --> .env'; \
-		cp .env.example-full .env; \
+		sed "s/IMAGE_HOSTING_BUCKET_PATH=.*/IMAGE_HOSTING_BUCKET_PATH=owid-image-upload\/dev-$(USER)/g" <.env.example-full >.env; \
 	fi
 
 validate.env.full:

--- a/site/README.md
+++ b/site/README.md
@@ -30,7 +30,7 @@ We chose to do it this way instead of via Google Drive File ID because it's easi
 
 We mirror these images to a Digital Ocean space (henceforth S3) to allow environments to have some amount of independence from one another. For OWID developers, the env variables needed for this functionality are stored in our password manager.
 
-It is recommended to use a unique folder in S3 for each environment. By convention, `dev-name` for your local development server, and one for your staging server too (e.g. `neurath`).
+It is recommended to use a unique folder in S3 for each environment. By convention, `dev-$NAME` for your local development server (when you run `make create-if-missing.env.full` for the first time, this will be generated based on your unix `$USER` variable by default), and one for your staging server too (e.g. `neurath`).
 
 ### Baking images
 


### PR DESCRIPTION
At the moment, when you run `make up.full` for the first time, it copies an template `.env` file for you that should work out of the box, except one setting must be set manually, the image bucket path.

This change sets it to `owid-image-upload/dev-<user>`, where `user` is the unix username of the current user.
