### PR TITLE
fix(devtools): source .env when running sync s3 images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ refresh.wp:
 
 sync-images:
 	@echo '==> Syncing S3 images'
-	./devTools/docker/sync-s3-images.sh
+	@. ./.env && ./devTools/docker/sync-s3-images.sh
 
 refresh.full: refresh refresh.wp
 

--- a/devTools/docker/sync-s3-images.sh
+++ b/devTools/docker/sync-s3-images.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-if [[ -n "$IMAGE_HOSTING_BUCKET_PATH" ]]; then
+if [[ -z "$IMAGE_HOSTING_BUCKET_PATH" ]]; then
   echo 'Please set IMAGE_HOSTING_BUCKET_PATH in .env'
   exit 1
 fi


### PR DESCRIPTION
We weren't sourcing `.env` when running `sync-s3-images` and there was also a small bug in checking env. With this PR I can run `make refresh` successfully (after setting `IMAGE_HOSTING_BUCKET_PATH` in `.env`)