### PR TITLE
Hide programmatic columns in tables

### DIFF
--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -722,6 +722,9 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
                 {
                     ...timeColumnOfValue.def,
                     slug: originalTimeSlug,
+                    display: {
+                        includeInTable: false,
+                    },
                 },
             ],
             `Interpolated values in column ${columnSlug} with tolerance ${tolerance} and appended column ${originalTimeSlug} with the original times`,

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -150,6 +150,7 @@ export const legacyToOwidTableAndDimensions = (
             columnStore[annotationColumnDef.slug] = entityNames.map(
                 (entityName) => annotationMap!.get(entityName)
             )
+            columnDefs.set(annotationColumnDef.slug, annotationColumnDef)
         }
 
         if (entityColorColumnSlug) {
@@ -639,6 +640,9 @@ const annotationMapAndDefFromOwidVariable = (
             slug,
             type: ColumnTypeNames.SeriesAnnotation,
             name: slug,
+            display: {
+                includeInTable: false,
+            },
         }
         return [annotationMap, columnDef]
     }

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -472,7 +472,6 @@ export class DataTable extends React.Component<{
         return this.table.columnsAsArray.filter(
             (column) =>
                 !skips.has(column.slug) &&
-                !column.slug.endsWith("-originalTime") &&
                 //  dim.property !== "color" &&
                 (column.display?.includeInTable ?? true)
         )

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -473,7 +473,6 @@ export class DataTable extends React.Component<{
             (column) =>
                 !skips.has(column.slug) &&
                 !column.slug.endsWith("-originalTime") &&
-                !column.slug.endsWith("-annotations") &&
                 //  dim.property !== "color" &&
                 (column.display?.includeInTable ?? true)
         )

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -473,6 +473,7 @@ export class DataTable extends React.Component<{
             (column) =>
                 !skips.has(column.slug) &&
                 !column.slug.endsWith("-originalTime") &&
+                !column.slug.endsWith("-annotations") &&
                 //  dim.property !== "color" &&
                 (column.display?.includeInTable ?? true)
         )


### PR DESCRIPTION
Variable-specific annotations are currently merged into the OwidTable using the naming convention `${id}-annotation`. There are also columns of the form `${id}-originalTime` that are currently omitted when displaying values in a table view, but perhaps there are others as well?

This PR adds the `-annotation` naming scheme to the list of columns to be omitted, but it might be better to come up with a consistent naming convention for programmatic columns so that we don't need to special case any future additions (or others that I've missed here).

One possibility would be renaming programmatic column slugs to something along the lines of `__${id}-${columnName}` and filtering based on the `/^__/`.

fixes #1275

