### PR TITLE
Fix table header icons

### DIFF
--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
@@ -65,7 +65,7 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
     }
 
     thead tr:first-child th {
-        padding-top: 10px;
+        padding-top: 8px;
         padding-bottom: 8px;
     }
 
@@ -73,6 +73,7 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
         padding-top: 8px;
         padding-bottom: 8px;
         vertical-align: bottom;
+        line-height: 19px;
     }
 
     tr:first-child td {
@@ -203,7 +204,7 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
         padding-left: 2px;
     }
 
-    th.sortable > div{
+    th.sortable > div {
         display: flex;
         align-items: end;
         justify-content: space-between;

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
@@ -203,8 +203,13 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
         padding-left: 2px;
     }
 
+    th.sortable > div{
+        display: flex;
+        align-items: end;
+        justify-content: space-between;
+    }
+
     th .sort-icon {
-        float: right;
         opacity: 0.15;
         padding-left: 5px;
 

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
@@ -208,6 +208,10 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
         display: flex;
         align-items: end;
         justify-content: space-between;
+
+        :first-child {
+            flex-grow: 1;
+        }
     }
 
     th .sort-icon {


### PR DESCRIPTION
This PR uses flexbox rather than `float` to position the sort icon in the headers of data tables. I'd love to hear reports of regressions or unintended consequences on other pages.

Fixes https://github.com/owid/owid-grapher/issues/2047

## Example 1
https://ourworldindata.org/grapher/compare-sources-working-hours?tab=table&country=~ESP

#### Before
<img width="678" alt="image" src="https://user-images.githubusercontent.com/469523/228074394-eeac9850-11f2-4eff-991c-c8f9e19d774d.png">

#### After
<img width="664" alt="image" src="https://user-images.githubusercontent.com/469523/228074436-9cb741d2-65f0-4c03-a502-1313d1f118e9.png">

## Example 2
https://ourworldindata.org/grapher/kaya-identity-co2?tab=table&time=earliest&country=~DZA

#### Before
<img width="681" alt="image" src="https://user-images.githubusercontent.com/469523/228074622-4a319422-86aa-4ba4-83b6-30760afe5720.png">

#### After
<img width="722" alt="image" src="https://user-images.githubusercontent.com/469523/228074547-bc3d76f2-5efa-47af-a970-cef3c30264ed.png">
