### PR TITLE
feat(map): give authors more control over tolerance

### DIFF
--- a/adminSiteClient/EditorMapTab.tsx
+++ b/adminSiteClient/EditorMapTab.tsx
@@ -92,11 +92,11 @@ class TimelineSection extends React.Component<{ mapConfig: MapConfig }> {
         this.props.mapConfig.timeTolerance = tolerance
     }
 
-    get timeToleranceStrategyOptions(): {
+    get toleranceStrategyOptions(): {
         value: ToleranceStrategy
         label: string
     }[] {
-        const timeToleranceStrategyLabels = {
+        const toleranceStrategyLabels = {
             [ToleranceStrategy.closest]:
                 "Closest: Consider data points in the past and future",
             [ToleranceStrategy.backwards]:
@@ -108,13 +108,13 @@ class TimelineSection extends React.Component<{ mapConfig: MapConfig }> {
         return Object.values(ToleranceStrategy).map(
             (val: ToleranceStrategy) => ({
                 value: val,
-                label: timeToleranceStrategyLabels[val],
+                label: toleranceStrategyLabels[val],
             })
         )
     }
 
-    @action.bound onSelectTimeToleranceStrategy(value: string | undefined) {
-        this.props.mapConfig.timeToleranceStrategy = value as ToleranceStrategy
+    @action.bound onSelectToleranceStrategy(value: string | undefined) {
+        this.props.mapConfig.toleranceStrategy = value as ToleranceStrategy
     }
 
     render() {
@@ -141,9 +141,9 @@ class TimelineSection extends React.Component<{ mapConfig: MapConfig }> {
                 {(mapConfig.timeTolerance || 0) > 0 && (
                     <SelectField
                         label="Tolerance strategy"
-                        value={mapConfig.timeToleranceStrategy}
-                        options={this.timeToleranceStrategyOptions}
-                        onValue={this.onSelectTimeToleranceStrategy}
+                        value={mapConfig.toleranceStrategy}
+                        options={this.toleranceStrategyOptions}
+                        onValue={this.onSelectToleranceStrategy}
                     />
                 )}
             </Section>

--- a/adminSiteClient/EditorMapTab.tsx
+++ b/adminSiteClient/EditorMapTab.tsx
@@ -9,7 +9,7 @@ import {
 import {
     isEmpty,
     OwidVariableId,
-    TimeToleranceStrategy,
+    ToleranceStrategy,
 } from "@ourworldindata/utils"
 import { action, computed } from "mobx"
 import { observer } from "mobx-react"
@@ -93,20 +93,20 @@ class TimelineSection extends React.Component<{ mapConfig: MapConfig }> {
     }
 
     get timeToleranceStrategyOptions(): {
-        value: TimeToleranceStrategy
+        value: ToleranceStrategy
         label: string
     }[] {
         const timeToleranceStrategyLabels = {
-            [TimeToleranceStrategy.closest]:
+            [ToleranceStrategy.closest]:
                 "Closest: Consider data points in the past and future",
-            [TimeToleranceStrategy.backwards]:
+            [ToleranceStrategy.backwards]:
                 "Backwards: Only consider data points in the past",
-            [TimeToleranceStrategy.forwards]:
+            [ToleranceStrategy.forwards]:
                 "Forwards: Only consider data points in the future",
         }
 
-        return Object.values(TimeToleranceStrategy).map(
-            (val: TimeToleranceStrategy) => ({
+        return Object.values(ToleranceStrategy).map(
+            (val: ToleranceStrategy) => ({
                 value: val,
                 label: timeToleranceStrategyLabels[val],
             })
@@ -114,8 +114,7 @@ class TimelineSection extends React.Component<{ mapConfig: MapConfig }> {
     }
 
     @action.bound onSelectTimeToleranceStrategy(value: string | undefined) {
-        this.props.mapConfig.timeToleranceStrategy =
-            value as TimeToleranceStrategy
+        this.props.mapConfig.timeToleranceStrategy = value as ToleranceStrategy
     }
 
     render() {

--- a/adminSiteClient/EditorMapTab.tsx
+++ b/adminSiteClient/EditorMapTab.tsx
@@ -6,7 +6,11 @@ import {
     MapProjectionLabels,
     MapProjectionName,
 } from "@ourworldindata/grapher"
-import { isEmpty, OwidVariableId } from "@ourworldindata/utils"
+import {
+    isEmpty,
+    OwidVariableId,
+    TimeToleranceStrategy,
+} from "@ourworldindata/utils"
 import { action, computed } from "mobx"
 import { observer } from "mobx-react"
 import React from "react"
@@ -88,6 +92,32 @@ class TimelineSection extends React.Component<{ mapConfig: MapConfig }> {
         this.props.mapConfig.timeTolerance = tolerance
     }
 
+    get timeToleranceStrategyOptions(): {
+        value: TimeToleranceStrategy
+        label: string
+    }[] {
+        const timeToleranceStrategyLabels = {
+            [TimeToleranceStrategy.closest]:
+                "Closest: Consider data points in the past and future",
+            [TimeToleranceStrategy.backwards]:
+                "Backwards: Only consider data points in the past",
+            [TimeToleranceStrategy.forwards]:
+                "Forwards: Only consider data points in the future",
+        }
+
+        return Object.values(TimeToleranceStrategy).map(
+            (val: TimeToleranceStrategy) => ({
+                value: val,
+                label: timeToleranceStrategyLabels[val],
+            })
+        )
+    }
+
+    @action.bound onSelectTimeToleranceStrategy(value: string | undefined) {
+        this.props.mapConfig.timeToleranceStrategy =
+            value as TimeToleranceStrategy
+    }
+
     render() {
         const { mapConfig } = this.props
         return (
@@ -109,6 +139,14 @@ class TimelineSection extends React.Component<{ mapConfig: MapConfig }> {
                     onValue={this.onTolerance}
                     helpText="Specify a range of years from which to pull data. For example, if the map shows 1990 and tolerance is set to 1, then data from 1989 or 1991 will be shown if no data is available for 1990."
                 />
+                {(mapConfig.timeTolerance || 0) > 0 && (
+                    <SelectField
+                        label="Tolerance strategy"
+                        value={mapConfig.timeToleranceStrategy}
+                        options={this.timeToleranceStrategyOptions}
+                        onValue={this.onSelectTimeToleranceStrategy}
+                    />
+                )}
             </Section>
         )
     }

--- a/explorer/ColumnGrammar.ts
+++ b/explorer/ColumnGrammar.ts
@@ -3,7 +3,7 @@ import {
     ColumnTypeNames,
 } from "@ourworldindata/core-table"
 import { BinningStrategy, ColorSchemeName } from "@ourworldindata/grapher"
-import { TimeToleranceStrategy } from "@ourworldindata/utils"
+import { ToleranceStrategy } from "@ourworldindata/utils"
 import {
     BooleanCellDef,
     EnumCellDef,
@@ -52,13 +52,11 @@ export const ColumnGrammar: Grammar = {
     toleranceStrategy: {
         ...EnumCellDef,
         keyword: "toleranceStrategy",
-        terminalOptions: Object.values(TimeToleranceStrategy).map(
-            (strategy) => ({
-                keyword: strategy,
-                description: "",
-                cssClass: "",
-            })
-        ),
+        terminalOptions: Object.values(ToleranceStrategy).map((strategy) => ({
+            keyword: strategy,
+            description: "",
+            cssClass: "",
+        })),
         description: "The tolerance strategy to use",
     },
     description: {

--- a/explorer/ColumnGrammar.ts
+++ b/explorer/ColumnGrammar.ts
@@ -3,6 +3,7 @@ import {
     ColumnTypeNames,
 } from "@ourworldindata/core-table"
 import { BinningStrategy, ColorSchemeName } from "@ourworldindata/grapher"
+import { TimeToleranceStrategy } from "@ourworldindata/utils"
 import {
     BooleanCellDef,
     EnumCellDef,
@@ -47,6 +48,18 @@ export const ColumnGrammar: Grammar = {
         keyword: "tolerance",
         description:
             "Set this to interpolate missing values as long as they are within this range of an actual value.",
+    },
+    toleranceStrategy: {
+        ...EnumCellDef,
+        keyword: "toleranceStrategy",
+        terminalOptions: Object.values(TimeToleranceStrategy).map(
+            (strategy) => ({
+                keyword: strategy,
+                description: "",
+                cssClass: "",
+            })
+        ),
+        description: "The tolerance strategy to use",
     },
     description: {
         ...StringCellDef,

--- a/packages/@ourworldindata/core-table/src/CoreColumnDef.ts
+++ b/packages/@ourworldindata/core-table/src/CoreColumnDef.ts
@@ -1,6 +1,7 @@
 import {
     ColumnSlug,
     OwidVariableDisplayConfigInterface,
+    TimeToleranceStrategy,
 } from "@ourworldindata/utils"
 import { CoreValueType, Color } from "./CoreTableConstants.js"
 
@@ -54,6 +55,7 @@ export interface CoreColumnDef extends ColumnColorScale {
     // Computational
     transform?: string // Code that maps to a CoreTable transform
     tolerance?: number // If set, some charts can use this for an interpolation strategy.
+    toleranceStrategy?: TimeToleranceStrategy // Tolerance strategy to use for interpolation
     skipParsing?: boolean // If set, the values will never run through the type parser
 
     // Column information used for display only

--- a/packages/@ourworldindata/core-table/src/CoreColumnDef.ts
+++ b/packages/@ourworldindata/core-table/src/CoreColumnDef.ts
@@ -1,7 +1,7 @@
 import {
     ColumnSlug,
     OwidVariableDisplayConfigInterface,
-    TimeToleranceStrategy,
+    ToleranceStrategy,
 } from "@ourworldindata/utils"
 import { CoreValueType, Color } from "./CoreTableConstants.js"
 
@@ -55,7 +55,7 @@ export interface CoreColumnDef extends ColumnColorScale {
     // Computational
     transform?: string // Code that maps to a CoreTable transform
     tolerance?: number // If set, some charts can use this for an interpolation strategy.
-    toleranceStrategy?: TimeToleranceStrategy // Tolerance strategy to use for interpolation
+    toleranceStrategy?: ToleranceStrategy // Tolerance strategy to use for interpolation
     skipParsing?: boolean // If set, the values will never run through the type parser
 
     // Column information used for display only

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -22,6 +22,7 @@ import {
     ColumnSlug,
     PrimitiveType,
     imemo,
+    TimeToleranceStrategy,
 } from "@ourworldindata/utils"
 import { CoreTable } from "./CoreTable.js"
 import { Time, JsTypes, CoreValueType } from "./CoreTableConstants.js"
@@ -153,6 +154,10 @@ export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
 
     @imemo get tolerance(): number {
         return this.display?.tolerance ?? this.def.tolerance ?? 0
+    }
+
+    @imemo get toleranceStrategy(): TimeToleranceStrategy | undefined {
+        return this.def.toleranceStrategy
     }
 
     @imemo get domain(): [JS_TYPE, JS_TYPE] {

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -22,7 +22,7 @@ import {
     ColumnSlug,
     PrimitiveType,
     imemo,
-    TimeToleranceStrategy,
+    ToleranceStrategy,
 } from "@ourworldindata/utils"
 import { CoreTable } from "./CoreTable.js"
 import { Time, JsTypes, CoreValueType } from "./CoreTableConstants.js"
@@ -156,7 +156,7 @@ export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
         return this.display?.tolerance ?? this.def.tolerance ?? 0
     }
 
-    @imemo get toleranceStrategy(): TimeToleranceStrategy | undefined {
+    @imemo get toleranceStrategy(): ToleranceStrategy | undefined {
         return this.def.toleranceStrategy
     }
 

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.test.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.test.ts
@@ -146,40 +146,70 @@ describe(toleranceInterpolation, () => {
 
     it("interpolates values in both directions", () => {
         const valuesAsc = [
+            ErrorValueTypes.MissingValuePlaceholder,
             1,
             ErrorValueTypes.MissingValuePlaceholder,
             ErrorValueTypes.MissingValuePlaceholder,
             2,
+            ErrorValueTypes.MissingValuePlaceholder,
         ]
-        const timesAsc = [0, 1, 2, 3]
+        const timesAsc = [0, 1, 2, 3, 4, 5]
         const tolerance = 1
         toleranceInterpolation(valuesAsc, timesAsc, {
             timeToleranceForwards: tolerance,
             timeToleranceBackwards: tolerance,
         })
-        expect(valuesAsc).toEqual([1, 1, 2, 2])
+        expect(valuesAsc).toEqual([1, 1, 1, 2, 2, 2])
     })
 
     it("interpolates values in the backwards direction", () => {
-        const valuesAsc = [1, ErrorValueTypes.MissingValuePlaceholder, 2]
-        const timesAsc = [0, 1, 2]
+        const valuesAsc = [
+            ErrorValueTypes.MissingValuePlaceholder,
+            1,
+            ErrorValueTypes.MissingValuePlaceholder,
+            ErrorValueTypes.MissingValuePlaceholder,
+            2,
+            ErrorValueTypes.MissingValuePlaceholder,
+        ]
+        const timesAsc = [0, 1, 2, 3, 4, 5]
         const tolerance = 1
         toleranceInterpolation(valuesAsc, timesAsc, {
             timeToleranceForwards: 0,
             timeToleranceBackwards: tolerance,
         })
-        expect(valuesAsc).toEqual([1, 1, 2])
+        expect(valuesAsc).toEqual([
+            ErrorValueTypes.NoValueWithinTolerance,
+            1,
+            1,
+            ErrorValueTypes.NoValueWithinTolerance,
+            2,
+            2,
+        ])
     })
 
     it("interpolates values in the forwards direction", () => {
-        const valuesAsc = [1, ErrorValueTypes.MissingValuePlaceholder, 2]
-        const timesAsc = [0, 1, 2]
+        const valuesAsc = [
+            ErrorValueTypes.MissingValuePlaceholder,
+            1,
+            ErrorValueTypes.MissingValuePlaceholder,
+            ErrorValueTypes.MissingValuePlaceholder,
+            2,
+            ErrorValueTypes.MissingValuePlaceholder,
+        ]
+        const timesAsc = [0, 1, 2, 3, 4, 5]
         const tolerance = 1
         toleranceInterpolation(valuesAsc, timesAsc, {
             timeToleranceForwards: tolerance,
             timeToleranceBackwards: 0,
         })
-        expect(valuesAsc).toEqual([1, 2, 2])
+        expect(valuesAsc).toEqual([
+            1,
+            1,
+            ErrorValueTypes.NoValueWithinTolerance,
+            2,
+            2,
+            ErrorValueTypes.NoValueWithinTolerance,
+        ])
     })
 })
 

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.test.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.test.ts
@@ -143,6 +143,44 @@ describe(toleranceInterpolation, () => {
             2,
         ])
     })
+
+    it("interpolates values in both directions", () => {
+        const valuesAsc = [
+            1,
+            ErrorValueTypes.MissingValuePlaceholder,
+            ErrorValueTypes.MissingValuePlaceholder,
+            2,
+        ]
+        const timesAsc = [0, 1, 2, 3]
+        const tolerance = 1
+        toleranceInterpolation(valuesAsc, timesAsc, {
+            timeToleranceForwards: tolerance,
+            timeToleranceBackwards: tolerance,
+        })
+        expect(valuesAsc).toEqual([1, 1, 2, 2])
+    })
+
+    it("interpolates values in the backwards direction", () => {
+        const valuesAsc = [1, ErrorValueTypes.MissingValuePlaceholder, 2]
+        const timesAsc = [0, 1, 2]
+        const tolerance = 1
+        toleranceInterpolation(valuesAsc, timesAsc, {
+            timeToleranceForwards: 0,
+            timeToleranceBackwards: tolerance,
+        })
+        expect(valuesAsc).toEqual([1, 1, 2])
+    })
+
+    it("interpolates values in the forwards direction", () => {
+        const valuesAsc = [1, ErrorValueTypes.MissingValuePlaceholder, 2]
+        const timesAsc = [0, 1, 2]
+        const tolerance = 1
+        toleranceInterpolation(valuesAsc, timesAsc, {
+            timeToleranceForwards: tolerance,
+            timeToleranceBackwards: 0,
+        })
+        expect(valuesAsc).toEqual([1, 2, 2])
+    })
 })
 
 describe(linearInterpolation, () => {

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.test.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.test.ts
@@ -129,7 +129,10 @@ describe(toleranceInterpolation, () => {
         toleranceInterpolation(
             valuesAsc,
             timesAsc,
-            { timeTolerance: tolerance },
+            {
+                timeToleranceForwards: tolerance,
+                timeToleranceBackwards: tolerance,
+            },
             0,
             3
         )

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
@@ -285,10 +285,7 @@ export function toleranceInterpolation(
 
     for (let index = start; index < end; index++) {
         const currentValue = valuesSortedByTimeAsc[index]
-        if (
-            context.timeToleranceBackwards > 0 &&
-            isNotErrorValueOrEmptyCell(currentValue)
-        ) {
+        if (isNotErrorValueOrEmptyCell(currentValue)) {
             prevNonBlankIndex = index
             continue
         }

--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -647,7 +647,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     interpolateColumnWithTolerance(
         columnSlug: ColumnSlug,
         toleranceOverride?: number,
-        toleranceStrategy?: TimeToleranceStrategy
+        toleranceStrategyOverride?: TimeToleranceStrategy
     ): this {
         // If the column doesn't exist, return the table unchanged.
         if (!this.has(columnSlug)) return this
@@ -655,6 +655,10 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         const column = this.get(columnSlug)
         const columnDef = column.def as OwidColumnDef
         const tolerance = toleranceOverride ?? column.tolerance ?? 0
+        const toleranceStrategy =
+            toleranceStrategyOverride ??
+            column.toleranceStrategy ??
+            TimeToleranceStrategy.closest
 
         const timeColumnOfTable = !this.timeColumn.isMissing
             ? this.timeColumn

--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -22,7 +22,7 @@ import {
     TimeBound,
     ColumnSlug,
     imemo,
-    TimeToleranceStrategy,
+    ToleranceStrategy,
 } from "@ourworldindata/utils"
 import {
     Integer,
@@ -647,7 +647,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     interpolateColumnWithTolerance(
         columnSlug: ColumnSlug,
         toleranceOverride?: number,
-        toleranceStrategyOverride?: TimeToleranceStrategy
+        toleranceStrategyOverride?: ToleranceStrategy
     ): this {
         // If the column doesn't exist, return the table unchanged.
         if (!this.has(columnSlug)) return this
@@ -658,7 +658,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         const toleranceStrategy =
             toleranceStrategyOverride ??
             column.toleranceStrategy ??
-            TimeToleranceStrategy.closest
+            ToleranceStrategy.closest
 
         const timeColumnOfTable = !this.timeColumn.isMissing
             ? this.timeColumn
@@ -680,13 +680,13 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
 
             const interpolateInBothDirections =
                 !toleranceStrategy ||
-                toleranceStrategy === TimeToleranceStrategy.closest
+                toleranceStrategy === ToleranceStrategy.closest
             const interpolateBackwards =
                 interpolateInBothDirections ||
-                toleranceStrategy === TimeToleranceStrategy.backwards
+                toleranceStrategy === ToleranceStrategy.backwards
             const interpolateForwards =
                 interpolateInBothDirections ||
-                toleranceStrategy === TimeToleranceStrategy.forwards
+                toleranceStrategy === ToleranceStrategy.forwards
 
             const interpolationResult = this.interpolate(
                 withAllRows,

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -180,7 +180,7 @@ export class MapChart
             .interpolateColumnWithTolerance(
                 this.mapColumnSlug,
                 this.mapConfig.timeTolerance,
-                this.mapConfig.timeToleranceStrategy
+                this.mapConfig.toleranceStrategy
             )
     }
 

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -179,7 +179,8 @@ export class MapChart
             .dropRowsWithErrorValuesForColumn(this.mapColumnSlug)
             .interpolateColumnWithTolerance(
                 this.mapColumnSlug,
-                this.mapConfig.timeTolerance
+                this.mapConfig.timeTolerance,
+                this.mapConfig.timeToleranceStrategy
             )
     }
 

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapConfig.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapConfig.ts
@@ -22,7 +22,7 @@ class MapConfigDefaults {
     @observable columnSlug?: ColumnSlug
     @observable time?: number
     @observable timeTolerance?: number
-    @observable timeToleranceStrategy?: ToleranceStrategy
+    @observable toleranceStrategy?: ToleranceStrategy
     @observable hideTimeline?: boolean
     @observable projection = MapProjectionName.World
 

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapConfig.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapConfig.ts
@@ -12,7 +12,7 @@ import {
     maxTimeToJSON,
     trimObject,
     NoUndefinedValues,
-    TimeToleranceStrategy,
+    ToleranceStrategy,
 } from "@ourworldindata/utils"
 
 // MapConfig holds the data and underlying logic needed by MapTab.
@@ -22,7 +22,7 @@ class MapConfigDefaults {
     @observable columnSlug?: ColumnSlug
     @observable time?: number
     @observable timeTolerance?: number
-    @observable timeToleranceStrategy?: TimeToleranceStrategy
+    @observable timeToleranceStrategy?: ToleranceStrategy
     @observable hideTimeline?: boolean
     @observable projection = MapProjectionName.World
 

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapConfig.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapConfig.ts
@@ -12,6 +12,7 @@ import {
     maxTimeToJSON,
     trimObject,
     NoUndefinedValues,
+    TimeToleranceStrategy,
 } from "@ourworldindata/utils"
 
 // MapConfig holds the data and underlying logic needed by MapTab.
@@ -21,6 +22,7 @@ class MapConfigDefaults {
     @observable columnSlug?: ColumnSlug
     @observable time?: number
     @observable timeTolerance?: number
+    @observable timeToleranceStrategy?: TimeToleranceStrategy
     @observable hideTimeline?: boolean
     @observable projection = MapProjectionName.World
 

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.json
@@ -230,12 +230,6 @@
                     "description": "Tolerance to use. If data points are missing for a time point, a match is accepted if it lies\nwithin the specified time period. The unit is the dominating time unit, usually years but can be days for\ndaily time series.\n",
                     "minimum": 0
                 },
-                "toleranceStrategy": {
-                    "type": "string",
-                    "description": "Tolerance strategy to use. Options include accepting matches that are \"closest\" to the time point in question\n(going forwards and backwards in time), and accepting matches that lie in the past (\"backwards\") or\nthe future (\"forwards\").\n",
-                    "enum": ["closest", "forwards", "backwards"],
-                    "default": "closest"
-                },
                 "tooltipUseCustomLabels": {
                     "type": "boolean",
                     "default": false,

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.json
@@ -230,6 +230,12 @@
                     "description": "Tolerance to use. If data points are missing for a time point, a match is accepted if it lies\nwithin the specified time period. The unit is the dominating time unit, usually years but can be days for\ndaily time series.\n",
                     "minimum": 0
                 },
+                "timeToleranceStrategy": {
+                    "type": "string",
+                    "description": "Tolerance strategy to use. Options include accepting matches that are \"closest\" to the time point in question\n(going forwards and backwards in time), and accepting matches that lie in the past (\"backwards\") or\nthe future (\"forwards\").\n",
+                    "enum": ["closest", "forwards", "backwards"],
+                    "default": "closest"
+                },
                 "tooltipUseCustomLabels": {
                     "type": "boolean",
                     "default": false,
@@ -712,11 +718,11 @@
             "patternProperties": {
                 "^\\w+$": {
                     "type": "object",
-                    "description": "Details on Demand category",
+                    "description": "Detail on Demand category",
                     "patternProperties": {
                         "^\\w+$": {
                             "type": "object",
-                            "description": "Details on Demand data",
+                            "description": "Detail on Demand data",
                             "properties": {
                                 "id": {
                                     "type": "number",

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.json
@@ -230,7 +230,7 @@
                     "description": "Tolerance to use. If data points are missing for a time point, a match is accepted if it lies\nwithin the specified time period. The unit is the dominating time unit, usually years but can be days for\ndaily time series.\n",
                     "minimum": 0
                 },
-                "timeToleranceStrategy": {
+                "toleranceStrategy": {
                     "type": "string",
                     "description": "Tolerance strategy to use. Options include accepting matches that are \"closest\" to the time point in question\n(going forwards and backwards in time), and accepting matches that lie in the past (\"backwards\") or\nthe future (\"forwards\").\n",
                     "enum": ["closest", "forwards", "backwards"],

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.yaml
@@ -211,17 +211,6 @@ properties:
                     within the specified time period. The unit is the dominating time unit, usually years but can be days for
                     daily time series.
                 minimum: 0
-            toleranceStrategy:
-                type: string
-                description: |
-                    Tolerance strategy to use. Options include accepting matches that are "closest" to the time point in question
-                    (going forwards and backwards in time), and accepting matches that lie in the past ("backwards") or
-                    the future ("forwards").
-                enum:
-                    - closest
-                    - forwards
-                    - backwards
-                default: closest
             tooltipUseCustomLabels:
                 type: boolean
                 default: false

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.yaml
@@ -211,7 +211,7 @@ properties:
                     within the specified time period. The unit is the dominating time unit, usually years but can be days for
                     daily time series.
                 minimum: 0
-            timeToleranceStrategy:
+            toleranceStrategy:
                 type: string
                 description: |
                     Tolerance strategy to use. Options include accepting matches that are "closest" to the time point in question

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.yaml
@@ -211,6 +211,17 @@ properties:
                     within the specified time period. The unit is the dominating time unit, usually years but can be days for
                     daily time series.
                 minimum: 0
+            timeToleranceStrategy:
+                type: string
+                description: |
+                    Tolerance strategy to use. Options include accepting matches that are "closest" to the time point in question
+                    (going forwards and backwards in time), and accepting matches that lie in the past ("backwards") or
+                    the future ("forwards").
+                enum:
+                    - closest
+                    - forwards
+                    - backwards
+                default: closest
             tooltipUseCustomLabels:
                 type: boolean
                 default: false

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
@@ -230,6 +230,12 @@
                     "description": "Tolerance to use. If data points are missing for a time point, a match is accepted if it lies\nwithin the specified time period. The unit is the dominating time unit, usually years but can be days for\ndaily time series.\n",
                     "minimum": 0
                 },
+                "toleranceStrategy": {
+                    "type": "string",
+                    "description": "Tolerance strategy to use. Options include accepting matches that are \"closest\" to the time point in question\n(going forwards and backwards in time), and accepting matches that lie in the past (\"backwards\") or\nthe future (\"forwards\").\n",
+                    "enum": ["closest", "forwards", "backwards"],
+                    "default": "closest"
+                },
                 "tooltipUseCustomLabels": {
                     "type": "boolean",
                     "default": false,

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
@@ -211,6 +211,17 @@ properties:
                     within the specified time period. The unit is the dominating time unit, usually years but can be days for
                     daily time series.
                 minimum: 0
+            toleranceStrategy:
+                type: string
+                description: |
+                    Tolerance strategy to use. Options include accepting matches that are "closest" to the time point in question
+                    (going forwards and backwards in time), and accepting matches that lie in the past ("backwards") or
+                    the future ("forwards").
+                enum:
+                    - closest
+                    - forwards
+                    - backwards
+                default: closest
             tooltipUseCustomLabels:
                 type: boolean
                 default: false

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -163,7 +163,7 @@ export {
     WP_PostType,
     type Year,
     type PostRowWithGdocPublishStatus,
-    TimeToleranceStrategy,
+    ToleranceStrategy,
 } from "./owidTypes.js"
 
 export {

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -163,6 +163,7 @@ export {
     WP_PostType,
     type Year,
     type PostRowWithGdocPublishStatus,
+    TimeToleranceStrategy,
 } from "./owidTypes.js"
 
 export {

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1035,7 +1035,7 @@ export enum TimeBoundValue {
 /**
  * Time tolerance strategy used for maps
  */
-export enum TimeToleranceStrategy {
+export enum ToleranceStrategy {
     closest = "closest",
     backwards = "backwards",
     forwards = "forwards",

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1031,3 +1031,12 @@ export enum TimeBoundValue {
     negativeInfinity = -Infinity,
     positiveInfinity = Infinity,
 }
+
+/**
+ * Time tolerance strategy used for maps
+ */
+export enum TimeToleranceStrategy {
+    closest = "closest",
+    backwards = "backwards",
+    forwards = "forwards",
+}


### PR DESCRIPTION
fixes #1182 

### Problem

Grapher currently employs a `closest` strategy to fill missing data values that works in both directions, i.e. backwards and forwards in time. This is sometimes not appropriate and produces misleading charts, see #1182.

### Solution

Add an option to the admin that allows to control whether the tolerance should be applied backwards in time, or forwards in time, or in both directions.

To do so, a new property `map.timeToleranceStrategy` is added to to chart config with three options:
- `closest` (default): Look for data values in both direction (current behaviour)
- `backwards`: Only look for data points in the past
- `forwards`: Only look for data points in the future

#### Rejected alternatives

- Instead of specifying a strategy, we could also present two number fields to the author, "Backward tolerance" and "Forward tolerance". This would be more powerful, but it wasn't requested and I can't think of a use case where this would make sense. (Also, this would likely require another db migration). So, I opted for the simpler, more common use case for now.

### Example charts:

- https://ourworldindata.org/explorers/coronavirus-data-explorer?tab=map&time=latest&facet=none&Interval=Cumulative&Relative+to+Population=true&Color+by+test+positivity=false&country=USA~BRA~JPN~DEU&Metric=People+vaccinated
- https://ourworldindata.org/grapher/youngest-age-covid-vaccination?time=earliest

### To do

- [x] Add new option to admin and apply changes
- [x] Only show option when appropriate
- [x] Explorer

### Caveats/Weirdnesses

- The explorer doesn't allow to set the tolerance on the map level, as far as I know. To make the tolerance strategy work for explorers, I thus implemented tolerance strategy on the variable level as well (but it's only used for maps at the moment).