### PR TITLE
fix(explorer): show "No data" annotation in map tooltips

### DIFF
--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -1,5 +1,7 @@
 import React from "react"
+import { isNumber } from "lodash"
 import {
+    anyToString,
     Bounds,
     DEFAULT_BOUNDS,
     flatten,
@@ -326,7 +328,9 @@ export class MapChart
                 const label = bin?.label
                 if (label !== undefined && label !== "") return label
             }
-            return mapColumn?.formatValueLong(d) ?? ""
+            return isNumber(d)
+                ? mapColumn?.formatValueLong(d) ?? ""
+                : anyToString(d)
         }
     }
 

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -1,7 +1,7 @@
 import React from "react"
-import { isNumber } from "lodash"
 import {
     anyToString,
+    isNumber,
     Bounds,
     DEFAULT_BOUNDS,
     flatten,


### PR DESCRIPTION
fixes #2054 

The "No data" annotation in tooltips doesn't show up in explorers, see #2054 for screenshots.

The reason "No data" shows up in charts but not in explorers is that the respective data column in charts is of type `NumberOrStringColumn` while the data column in explorers is of type `NumericColumn`. The `formatValueLong` function behaves differently for `NumberOrStringColumn` and `NumericColumn`. In case of `NumberOrStringColumn`, string values are passed through, in case of `NumericColumn` string values are silenced (returns `""`). That's why the "No data" label doesn't show in explorer maps.

