### PR TITLE
fix: hide No Data item in scatterplot legends

### DIFF
--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -54,7 +54,7 @@ import {
 import { DualAxisComponent } from "../axis/AxisViews"
 import { DualAxis, HorizontalAxis, VerticalAxis } from "../axis/Axis"
 
-import { ColorScale, ColorScaleManager } from "../color/ColorScale"
+import { ColorScale, ColorScaleManager, NO_DATA_LABEL } from "../color/ColorScale"
 import { AxisConfig } from "../axis/AxisConfig"
 import { ChartInterface } from "../chart/ChartInterface"
 import {
@@ -567,7 +567,7 @@ export class ScatterPlotChart
         return this.colorScale.legendBins.filter(
             (bin) =>
                 this.colorsInUse.includes(bin.color) &&
-                !bin.label?.match(/no data/i)
+                bin.label !== NO_DATA_LABEL
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -54,7 +54,11 @@ import {
 import { DualAxisComponent } from "../axis/AxisViews"
 import { DualAxis, HorizontalAxis, VerticalAxis } from "../axis/Axis"
 
-import { ColorScale, ColorScaleManager, NO_DATA_LABEL } from "../color/ColorScale"
+import {
+    ColorScale,
+    ColorScaleManager,
+    NO_DATA_LABEL,
+} from "../color/ColorScale"
 import { AxisConfig } from "../axis/AxisConfig"
 import { ChartInterface } from "../chart/ChartInterface"
 import {

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -564,8 +564,10 @@ export class ScatterPlotChart
     }
 
     @computed get legendItems(): ColorScaleBin[] {
-        return this.colorScale.legendBins.filter((bin) =>
-            this.colorsInUse.includes(bin.color)
+        return this.colorScale.legendBins.filter(
+            (bin) =>
+                this.colorsInUse.includes(bin.color) &&
+                !bin.label?.match(/no data/i)
         )
     }
 


### PR DESCRIPTION
This PR offers a partial solution to issue #1167 by hiding the No Data label that appears in the legend for scatterplots when aggregates are part of the data set. It's unresolved whether anything should be done to hide the actual bubbles for regions (especially for the World dot which will typically dwarf all other country sizes).

The "No Data" item is being filtered out based on the `label` value of the legend's ColorScaleBin meaning this will break if it's ever renamed (e.g. to "Other" as proposed in #1306).
