### PR TITLE
feat: enable relative mode for stacked bar charts

### DIFF
--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -73,6 +73,7 @@ export class EditorFeatures {
     @computed get relativeModeToggle() {
         return (
             this.grapher.isStackedArea ||
+            this.grapher.isStackedBar ||
             this.grapher.isStackedDiscreteBar ||
             this.grapher.isLineChart ||
             this.grapher.isScatter ||

--- a/db/migration/1680180863525-HideRelativeToggleStackedBar.ts
+++ b/db/migration/1680180863525-HideRelativeToggleStackedBar.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class HideRelativeToggleStackedBar1680180863525
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+        UPDATE charts
+        SET config = JSON_SET(config, "$.hideRelativeToggle", TRUE)
+        WHERE config->>"$.type" = "StackedBar"
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+        UPDATE charts
+        SET config = JSON_REMOVE(config, "$.hideRelativeToggle")
+        WHERE config->>"$.type" = "StackedBar"
+        `)
+    }
+}

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2506,6 +2506,7 @@ export class Grapher
             return this.xOverrideTime === undefined && this.hasTimeline
         return (
             this.isStackedArea ||
+            this.isStackedBar ||
             this.isStackedDiscreteBar ||
             this.isScatter ||
             this.isLineChart ||


### PR DESCRIPTION
Fixes #2051

I added a migration so that all existing stacked bar charts remain unchanged.
Before merging, we will have to also update the following explorers which use StackedBar charts:
```sh
> rg -cl StackedBar

explorers/new-flu-explorer-draft.explorer.tsv:8
explorers/monkeypox.explorer.tsv:4
explorers/natural-disasters.explorer.tsv:223
```

Also, note that in relative mode, #1865 gets even worse: All years with a total of zero will be completely dropped (because the percentage cannot be computed for them), no matter what.