### PR TITLE
fix(grapher): show entity in title for faceted single-entity charts

### DIFF
--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -546,7 +546,7 @@ export class DiscreteBarChart
         return this.transformedTable.get(this.colorColumnSlug)
     }
 
-    @computed private get seriesStrategy(): SeriesStrategy {
+    @computed get seriesStrategy(): SeriesStrategy {
         const autoStrategy = autoDetectSeriesStrategy(this.manager, true)
         // TODO this is an inconsistency between LineChart and DiscreteBar.
         // We should probably make it consistent at some point.

--- a/packages/@ourworldindata/grapher/src/chart/ChartInterface.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartInterface.ts
@@ -1,5 +1,9 @@
 import { Color, OwidTable } from "@ourworldindata/core-table"
-import { FacetStrategy, SeriesName } from "../core/GrapherConstants"
+import {
+    FacetStrategy,
+    SeriesName,
+    SeriesStrategy,
+} from "../core/GrapherConstants"
 import { ColorScale } from "../color/ColorScale"
 import { HorizontalAxis, VerticalAxis } from "../axis/Axis"
 import { HorizontalColorLegendManager } from "../horizontalColorLegend/HorizontalColorLegends"
@@ -22,6 +26,7 @@ export interface ChartInterface {
 
     colorScale?: ColorScale
 
+    seriesStrategy?: SeriesStrategy
     series: readonly ChartSeries[] // This points to the marks that the chart will render. They don't have to be placed yet. Standardized as part of the interface as a development aid.
     // Todo: should all charts additionally have a placedSeries: ChartPlacedSeries[] getter?
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -84,6 +84,7 @@ import {
     AnnotationFieldsInTitle,
     DEFAULT_GRAPHER_WIDTH,
     DEFAULT_GRAPHER_HEIGHT,
+    SeriesStrategy,
 } from "../core/GrapherConstants"
 import Cookies from "js-cookie"
 import {
@@ -162,7 +163,10 @@ import { ColorSchemeName } from "../color/ColorConstants"
 import { Entity, SelectionArray } from "../selection/SelectionArray"
 import { legacyToOwidTableAndDimensions } from "./LegacyToOwidTable"
 import { ScatterPlotManager } from "../scatterCharts/ScatterPlotChartConstants"
-import { autoDetectYColumnSlugs } from "../chart/ChartUtils"
+import {
+    autoDetectSeriesStrategy,
+    autoDetectYColumnSlugs,
+} from "../chart/ChartUtils"
 import classNames from "classnames"
 import { GrapherAnalytics } from "./GrapherAnalytics"
 import { legacyToCurrentGrapherQueryParams } from "./GrapherUrlMigrations"
@@ -1211,10 +1215,13 @@ export class Grapher
         const showChangeInPrefix =
             !this.hideAnnotationFieldsInTitle?.changeInPrefix
 
+        const seriesStrategy =
+            this.chartInstance.seriesStrategy ||
+            autoDetectSeriesStrategy(this, true)
+
         if (
             this.tab === GrapherTabOption.chart &&
-            (this.addCountryMode !== EntitySelectionMode.MultipleEntities ||
-                this.facetStrategy === FacetStrategy.none) &&
+            (seriesStrategy !== SeriesStrategy.entity || this.hideLegend) &&
             selectedEntityNames.length === 1 &&
             (showEntityAnnotation || this.canChangeEntity)
         ) {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1211,14 +1211,10 @@ export class Grapher
         const showChangeInPrefix =
             !this.hideAnnotationFieldsInTitle?.changeInPrefix
 
-        const isFacetingEnabled =
-            this.selectedFacetStrategy &&
-            this.selectedFacetStrategy !== FacetStrategy.none
-
         if (
             this.tab === GrapherTabOption.chart &&
             (this.addCountryMode !== EntitySelectionMode.MultipleEntities ||
-                isFacetingEnabled) &&
+                this.facetStrategy === FacetStrategy.none) &&
             selectedEntityNames.length === 1 &&
             (showEntityAnnotation || this.canChangeEntity)
         ) {


### PR DESCRIPTION
fixes #1542 

### Problem

Entity name does not show up in chart titles for faceted single-entity StackedArea charts. This has been fixed for explorers a few days ago, but the issue persists in grapher charts.

### Example charts

- Explorer: https://ourworldindata.org/explorers/population-and-demography?Metric=Population+by+broad+age+group&Sex=Both+sexes&Age+group=Total&Projection+Scenario=None&country=~AFG (this works at the moment and shouldn't break again)
- Grapher chart: https://owid.cloud/admin/charts/298/edit – go to the "Data" tab, change selection to "User can add and remove data", notice that "Sweden" is not displayed in the title anymore (this is broken at the moment and should be fixed)

### Solution

These are the offending lines:

https://github.com/owid/owid-grapher/blob/553d923e3b103621e18b332ba7c3f9e89441a510/packages/%40ourworldindata/grapher/src/core/Grapher.tsx#L1220-L1221

Instead, it should be:
```js
(this.addCountryMode !== EntitySelectionMode.MultipleEntities ||
                this.facetStrategy === FacetStrategy.none)
```
(in plain words, this reads something like: "usually, don't show the entity name in the title when multi-entity selection is enabled _except_ faceting is currently inactive (because in that case, we are looking at a single entity)")

I hope I got it right this time, it's the first time I have to correct code that I put in myself!