### PR TITLE
fix(explorer): fix layout issue with long checkbox label

### DIFF
--- a/explorer/ExplorerControls.scss
+++ b/explorer/ExplorerControls.scss
@@ -28,7 +28,9 @@ $chart-border-radius: 2px;
 
         .HiddenControlHeader {
             // Don't show hidden label in desktop but preserve space for it so options are aligned.
-            opacity: 0;
+            visibility: hidden;
+            height: 1.6em; // this is the line height
+            height: 1lh; // only available in very modern browsers
         }
 
         input {


### PR DESCRIPTION
Fixes a layout issue [reported by Joe](https://owid.slack.com/archives/C46U9LXRR/p1680348369866029):

![image](https://user-images.githubusercontent.com/2641501/229453825-9ec5e4ee-81d4-4b70-b48c-89523b07b82d.png)

What happened is that we always were displaying the checkbox label as a hidden header, also, which was then wrapping around and moving the checkbox itself around.