### PR TITLE
Supress cache info on yarn install

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,12 @@
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-3.3.0.cjs
+
+logFilters:
+    # A package cannot be found in the cache for the given package and will be fetched from its remote location.
+    - code: YN0013
+      level: discard
+
+    # A package will need to be built
+    - code: YN0007
+      level: discard


### PR DESCRIPTION
Each yarn install from a fresh machine blasts around 13,000 of these warnings:

`YN0013:  | xml-name-validator@npm:4.0.0 can't be found in the cache will be fetched from the remote registry`

This is something like 1.5MB of redundant data.

The [logFilters variable](https://yarnpkg.com/configuration/yarnrc/#logFilters) reassigns log output that matches, from one log level to another. 

This PR changes two messages to `discard`, which yarn then skips logging.