### PR TITLE
fix(Variable): limit concurrent requests to avoid 429 errors from rate limiting by Cloudflare

### DIFF
--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -230,42 +230,12 @@ export const bakeAllPublishedChartsVariableDataAndMetadata = async (
         checksumsDir,
     }))
 
-    if (MAX_NUM_BAKE_PROCESSES == 1) {
-        await Promise.all(
-            jobs.map(async (job) => {
-                await bakeVariableData(job)
-                progressBar.tick({ name: `variableid ${job.variableId}` })
-            })
-        )
-    } else {
-        const poolOptions = {
-            minWorkers: 2,
-            maxWorkers: MAX_NUM_BAKE_PROCESSES,
-            // using `process` instead of worker threads is necessary for DuckDB to work
-            workerType: "process",
-        } as workerpool.WorkerPoolOptions
-        const pool = workerpool.pool(__dirname + "/worker.js", poolOptions)
-        const jobs: BakeVariableDataArguments[] = variableIds.map(
-            (variableId) => ({
-                bakedSiteDir,
-                variableId,
-                checksumsDir,
-            })
-        )
-        try {
-            await Promise.all(
-                jobs.map((job) =>
-                    pool.exec("bakeVariableData", [job]).then((job) =>
-                        progressBar.tick({
-                            name: `variableid ${job.variableId}`,
-                        })
-                    )
-                )
-            )
-        } finally {
-            await pool.terminate(true)
-        }
-    }
+    await Promise.all(
+        jobs.map(async (job) => {
+            await bakeVariableData(job)
+            progressBar.tick({ name: `variableid ${job.variableId}` })
+        })
+    )
 }
 
 export interface BakeSingleGrapherChartArguments {

--- a/baker/worker.ts
+++ b/baker/worker.ts
@@ -6,6 +6,5 @@ import * as grapherBaker from "./GrapherBaker.js"
 
 // create a worker and register public functions
 workerpool.worker({
-    bakeVariableData: grapherBaker.bakeVariableData,
     bakeSingleGrapherChart: grapherBaker.bakeSingleGrapherChart,
 })


### PR DESCRIPTION
We're occasionally running into 429 errors caused by Cloudflare's rate limiting. This PR is more gentle and uses max 5 sockets to limit concurrency. It also drops `nocache` from URL - that's no longer an issue since TTL is now 5 min.

I've tested this against staging worker and didn't get 429 with this config. This wouldn't be necessary if we used S3 URLs directly, but it's safer to go one step at a time rather than rushing into them.