### PR TITLE
enhance: require choice of staging server with `make stage`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,6 @@
 # https://unix.stackexchange.com/questions/352316/finding-out-the-default-shell-of-a-user-within-a-shell-script
 LOGIN_SHELL = $(shell finger $(USER) | grep 'Shell:*' | cut -f3 -d ":")
 
-# what is the staging environment we should use
-STAGING ?= staging
-
 # setting .env variables as Make variables for validate.env targets
 # https://lithic.tech/blog/2020-05/makefile-dot-env/
 ifneq (,$(wildcard ./.env))
@@ -241,6 +238,11 @@ deploy:
 	yarn buildAndDeploySite live
 
 stage:
+	@if [[ ! "$(STAGING)" ]]; then \
+		echo 'ERROR: must set the staging environment'; \
+		echo '       e.g. STAGING=halley make stage'; \
+		exit 1; \
+	fi
 	@echo '==> Preparing to deploy to $(STAGING)'
 	@echo '==> Starting from a clean slate...'
 	rm -rf itsJustJavascript


### PR DESCRIPTION
Previously, `make stage` would stage to the "default" staging environment called `staging`.

With this change, you must explicitly tell it which environment you want. If you run `make stage` without setting the variable `STAGING`, you get a usage message.
