### PR TITLE
Handle error when archie parser fails

### DIFF
--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -1283,6 +1283,10 @@ main:not(.ChartEditorPage):not(.GdocsEditPage) {
 
     .GdocsEditPage__error-container {
         padding: 32px;
+
+        pre {
+            white-space: pre-line;
+        }
     }
 }
 

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -74,7 +74,6 @@ import {
     select,
     getTagsByPostId,
 } from "../db/model/Post.js"
-import { getErrors } from "../adminSiteClient/gdocsValidation.js"
 import {
     checkFullDeployFallback,
     checkHasChanges,
@@ -2692,7 +2691,7 @@ apiRouter.get("/gdocs/:id", async (req, res) => {
         res.set("Cache-Control", "no-store")
         res.send(gdoc)
     } catch (error) {
-        throw new JsonError(`Error fetching document ${error}`, 500)
+        res.status(500).json({ error: { message: String(error), status: 500 } })
     }
 })
 

--- a/adminSiteServer/app.tsx
+++ b/adminSiteServer/app.tsx
@@ -30,7 +30,7 @@ import { renderToHtmlPage } from "../serverUtils/serverUtil.js"
 import { publicApiRouter } from "./publicApiRouter.js"
 import { mockSiteRouter } from "./mockSiteRouter.js"
 import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants.js"
-import { GdocsContentSource, JsonError } from "@ourworldindata/utils"
+import { GdocsContentSource } from "@ourworldindata/utils"
 import OwidArticlePage from "../site/gdocs/OwidArticlePage.js"
 import { Gdoc } from "../db/model/Gdoc/Gdoc.js"
 

--- a/adminSiteServer/app.tsx
+++ b/adminSiteServer/app.tsx
@@ -30,7 +30,7 @@ import { renderToHtmlPage } from "../serverUtils/serverUtil.js"
 import { publicApiRouter } from "./publicApiRouter.js"
 import { mockSiteRouter } from "./mockSiteRouter.js"
 import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants.js"
-import { GdocsContentSource } from "@ourworldindata/utils"
+import { GdocsContentSource, JsonError } from "@ourworldindata/utils"
 import OwidArticlePage from "../site/gdocs/OwidArticlePage.js"
 import { Gdoc } from "../db/model/Gdoc/Gdoc.js"
 
@@ -120,21 +120,27 @@ export class OwidAdminApp {
 
         // Public preview of a Gdoc article
         app.get("/gdocs/:id/preview", async (req, res) => {
-            const gdoc = await Gdoc.getGdocFromContentSource(
-                req.params.id,
-                GdocsContentSource.Gdocs
-            )
-            res.set("X-Robots-Tag", "noindex")
-            res.send(
-                renderToHtmlPage(
-                    <OwidArticlePage
-                        baseUrl={BAKED_BASE_URL}
-                        article={gdoc}
-                        debug
-                        isPreviewing
-                    />
+            try {
+                const gdoc = await Gdoc.getGdocFromContentSource(
+                    req.params.id,
+                    GdocsContentSource.Gdocs
                 )
-            )
+                res.set("X-Robots-Tag", "noindex")
+                res.send(
+                    renderToHtmlPage(
+                        <OwidArticlePage
+                            baseUrl={BAKED_BASE_URL}
+                            article={gdoc}
+                            debug
+                            isPreviewing
+                        />
+                    )
+                )
+            } catch (error) {
+                res.status(500).json({
+                    error: { message: String(error), status: 500 },
+                })
+            }
         })
 
         // Send errors to Slack


### PR DESCRIPTION
Return the error to the client instead of crashing the server, so that parsing failures don't clog up the Slack error thread.