### PR TITLE
WIP: Changes needed by automated staging servers

### DIFF
--- a/adminSiteServer/adminRouter.tsx
+++ b/adminSiteServer/adminRouter.tsx
@@ -104,10 +104,15 @@ adminRouter.post(
                 req.body.username,
                 req.body.password
             )
+            // secure cookie if in production and using https
+            // our staging servers use http and `production`, so passing insecure
+            // cookie wouldn't work
+            const secure = ENV === "production" && req.protocol !== "http"
+
             res.cookie("sessionid", session.id, {
                 httpOnly: true,
                 sameSite: "lax",
-                secure: ENV === "production",
+                secure: secure,
             })
             res.redirect((req.query.next as string) || "/admin")
         } catch (err) {

--- a/baker/buildLocalBake.ts
+++ b/baker/buildLocalBake.ts
@@ -9,12 +9,8 @@ import { BAKED_BASE_URL } from "../settings/serverSettings.js"
 
 // TODO: use env BAKED_BASE_URL=http://mojmir-staging-1, otherwise it might be inconsistent
 const bakeDomainToFolder = async (
-<<<<<<< Updated upstream
-    baseUrl = "http://localhost:3000/",
-=======
     baseUrl = BAKED_BASE_URL,
     // baseUrl = "http://localhost:3000/",
->>>>>>> Stashed changes
     dir = "localBake"
 ) => {
     dir = normalize(dir)

--- a/baker/buildLocalBake.ts
+++ b/baker/buildLocalBake.ts
@@ -5,8 +5,16 @@ import { SiteBaker } from "./SiteBaker.js"
 import * as fs from "fs-extra"
 import { normalize } from "path"
 
+import { BAKED_BASE_URL } from "../settings/serverSettings.js"
+
+// TODO: use env BAKED_BASE_URL=http://mojmir-staging-1, otherwise it might be inconsistent
 const bakeDomainToFolder = async (
+<<<<<<< Updated upstream
     baseUrl = "http://localhost:3000/",
+=======
+    baseUrl = BAKED_BASE_URL,
+    // baseUrl = "http://localhost:3000/",
+>>>>>>> Stashed changes
     dir = "localBake"
 ) => {
     dir = normalize(dir)


### PR DESCRIPTION
Small changes required for the ops work [on staging servers](https://github.com/owid/ops/pull/53)

* use insecure cookie if using HTTP protocol and `ENV=production` (for staging server behind Tailscale) 