### PR TITLE
enhance(build): bakeAll during localBake

### DIFF
--- a/baker/buildLocalBake.ts
+++ b/baker/buildLocalBake.ts
@@ -14,10 +14,8 @@ const bakeDomainToFolder = async (
     dir = normalize(dir)
     fs.mkdirp(dir)
     const baker = new SiteBaker(dir, baseUrl, bakeSteps)
-    console.log(
-        `Baking site sans Wordpress with baseUrl '${baseUrl}' to dir '${dir}'`
-    )
-    await baker.bakeNonWordpressPages()
+    console.log(`Baking site locally with baseUrl '${baseUrl}' to dir '${dir}'`)
+    await baker.bakeAll()
 }
 
 yargs(hideBin(process.argv))


### PR DESCRIPTION
With the --steps feature, we can be more granular and might want to bake assets (from bakeWordpressPages) and charts