### PR TITLE
enhance: show timeline for DiscreteBar charts

### DIFF
--- a/db/migration/1680614452457-HideTimelineForDiscreteBarCharts.ts
+++ b/db/migration/1680614452457-HideTimelineForDiscreteBarCharts.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class HideTimelineForDiscreteBarCharts1680614452457
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE charts
+            SET config = JSON_SET(config, "$.hideTimeline", TRUE)
+            WHERE config->>"$.type" = "DiscreteBar"
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE charts
+            SET config = JSON_REMOVE(config, "$.hideTimeline")
+            WHERE config->>"$.type" = "DiscreteBar"
+        `)
+    }
+}

--- a/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
@@ -201,12 +201,8 @@ describe("hasTimeline", () => {
         expect(grapher.hasTimeline).toBeTruthy()
         grapher.type = ChartTypeName.StackedBar
         expect(grapher.hasTimeline).toBeTruthy()
-    })
-
-    it("charts without timeline", () => {
-        const grapher = new Grapher(legacyConfig)
         grapher.type = ChartTypeName.DiscreteBar
-        expect(grapher.hasTimeline).toBeFalsy()
+        expect(grapher.hasTimeline).toBeTruthy()
     })
 
     it("map tab has timeline even if chart doesn't", () => {
@@ -218,14 +214,6 @@ describe("hasTimeline", () => {
         expect(grapher.hasTimeline).toBeTruthy()
         grapher.map.hideTimeline = true
         expect(grapher.hasTimeline).toBeFalsy()
-    })
-
-    it("table tab has timeline even if chart doesn't", () => {
-        const grapher = new Grapher(legacyConfig)
-        grapher.type = ChartTypeName.DiscreteBar
-        expect(grapher.hasTimeline).toBeFalsy()
-        grapher.tab = GrapherTabOption.table
-        expect(grapher.hasTimeline).toBeTruthy()
     })
 
     it("source and download tabs do not show a timeline", () => {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1262,11 +1262,8 @@ export class Grapher
 
             // use the chart-level `hideTimeline` option for the table, too
             case GrapherTabOption.table:
-                return !this.hideTimeline
-
-            // StackedBar, StackedArea, and DiscreteBar charts never display a timeline
             case GrapherTabOption.chart:
-                return !this.hideTimeline && !this.isDiscreteBar
+                return !this.hideTimeline
 
             default:
                 return false


### PR DESCRIPTION
fixes #2060 

Adds the ability to show a timeline for discrete bar charts.

Tasks:
- [x] Allow to show a timeline for discrete bar charts
- [x] Update tests (all charts have a timeline now, so I actually ended up deleting few tests)
- [x] Write a migration to make sure timelines don't suddenly show up for existing discrete bar charts (more of a precaution, I actually found only [a single chart](https://ourworldindata.org/grapher/largest-impact-craters?time=latest&country=Acraman+%28Australia%29~Araguainha+%28Brazil%29~Charlevoix+%28Canada%29~Beaverhead+%28United+States%29~Chesapeake+Bay+%28United+States%29~Chicxulub+%28Mexico%29~Kara+%28Russia%29~Kara-Kul+%28Tajikistan%29~Manicouagan+%28Canada%29~Mj%C3%B8lnir+%28Norway%29~Woodleigh+%28Australia%29~Vredefort+%28South+Africa%29~Tookoonooka+%28Australia%29~Sudbury+%28Canada%29~Siljan+%28Sweden%29~Saint+Martin+%28Canada%29~Puchezh-Katunki+%28Russia%29~Popigai+%28Russia%29~Morokweng+%28South+Africa%29~Montagnais+%28Canada%29) where this was relevant (but there might be more))