### PR TITLE
enhance(chart_revision): add summary text, large viz option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ up.full: require create-if-missing.env.full wordpress/.env tmp-downloads/owid_ch
 
 migrate:
 	@echo '==> Running DB migrations'
-	@. ./.env && yarn && yarn buildTsc && yarn runDbMigrations
+	yarn && yarn buildTsc && yarn runDbMigrations
 
 refresh: sync-images
 	@echo '==> Downloading chart data'

--- a/adminSiteClient/SuggestedChartRevision.ts
+++ b/adminSiteClient/SuggestedChartRevision.ts
@@ -24,6 +24,7 @@ export interface SuggestedChartRevisionSerialized {
     status: SuggestedChartRevisionStatus
     suggestedReason?: string
     decisionReason?: string
+    changesInDataSummary?: string
 
     canApprove?: boolean
     canReject?: boolean

--- a/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
+++ b/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
@@ -367,30 +367,35 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                             Upload revisions
                         </Link>
                     </h1>
-                    <p>
-                        Use this tool to approve or reject chart revisions that
-                        have been suggested by an automated bulk update script.
-                        The purpose of this tool is to provide a layer of
-                        quality assurance for our charts that are updated by
-                        automated scripts. This tool is a work in progress.
-                        Start a thread in{" "}
-                        <a
-                            href="https://owid.slack.com/messages/tech-issues/"
-                            rel="noreferrer"
-                            target="_blank"
-                        >
-                            #tech-issues
-                        </a>{" "}
-                        if you find a bug, want to request a feature, or have
-                        other feedback.
-                    </p>
-                    <p className="text-danger">
-                        WARNING: This tool is new and may contain bugs that
-                        cause unexpected behavior. Use with caution.
-                    </p>
+                    <div>
+                        <p>
+                            Use this tool to approve or reject chart revisions
+                            that have been suggested by an automated bulk update
+                            script. The purpose of this tool is to provide a
+                            layer of quality assurance for our charts that are
+                            updated by automated scripts. This tool is a work in
+                            progress. Start a thread in{" "}
+                            <a
+                                href="https://owid.slack.com/messages/tech-issues/"
+                                rel="noreferrer"
+                                target="_blank"
+                            >
+                                #tech-issues
+                            </a>{" "}
+                            if you find a bug, want to request a feature, or
+                            have other feedback.
+                        </p>
 
-                    {this.renderReadme()}
-                    {this.renderSettings()}
+                        <p className="text-danger">
+                            WARNING: This tool is new and may contain bugs that
+                            cause unexpected behavior. Use with caution.
+                        </p>
+                    </div>
+
+                    <div style={{ paddingBottom: 10 }}>
+                        {this.renderReadme()}
+                        {this.renderSettings()}
+                    </div>
 
                     {this.numTotalRows > 0 || !this.listMode ? (
                         this.renderApprovalTool()
@@ -419,7 +424,6 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
             this.suggestedChartRevision && this.suggestedChartRevision.status
         return (
             <React.Fragment>
-                {this.renderControls()}
                 <h1>
                     Suggested revision{" "}
                     {this.suggestedChartRevision
@@ -456,6 +460,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                     </span>
                 </h1>
                 {this.renderGraphers()}
+                {this.renderControls()}
                 {this.renderMeta()}
             </React.Fragment>
         )
@@ -464,25 +469,24 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
     renderReadme() {
         return (
             <div className="collapsible">
-                <h1>
-                    README
-                    <button
-                        className="btn btn-outline-dark"
-                        type="button"
-                        onClick={this.onToggleShowReadme}
-                        aria-expanded={this.showReadme}
-                        title="Show/hide README"
-                        style={{ marginLeft: "10px" }}
-                    >
-                        {this.showReadme ? "Hide" : "Show"}
-                    </button>
-                </h1>
+                <button
+                    className="btn btn-outline-dark"
+                    type="button"
+                    onClick={this.onToggleShowReadme}
+                    aria-expanded={this.showReadme}
+                    title="Show/hide README"
+                    style={{ marginLeft: "10px" }}
+                >
+                    {this.showReadme
+                        ? "Hide instructions"
+                        : "Show instructions"}
+                </button>
                 <div
                     className={`readme ${
                         this.showReadme ? "show" : "collapse"
                     }`}
                 >
-                    <h2>Terminology</h2>
+                    <h5>Terminology</h5>
                     <ul>
                         <li>
                             <b>Suggested chart revision.</b> A suggested chart
@@ -504,7 +508,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                             exists on the OWID website.
                         </li>
                     </ul>
-                    <h2>How to use</h2>
+                    <h5>How to use</h5>
                     <p>
                         You are shown one suggested chart revision at a time,
                         alongside the corresponding original chart as it was
@@ -616,7 +620,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                             reject it.
                         </li>
                     </ol>
-                    <h2>Other useful information</h2>
+                    <h5>Other useful information</h5>
                     <ul>
                         <li>
                             When you click the{" "}
@@ -767,19 +771,16 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
     renderSettings() {
         return (
             <div className="collapsible">
-                <h1>
-                    Settings
-                    <button
-                        className="btn btn-outline-dark"
-                        type="button"
-                        aria-expanded={this.showSettings}
-                        onClick={this.onToggleShowSettings}
-                        title="Show/hide settings"
-                        style={{ marginLeft: "10px" }}
-                    >
-                        {this.showSettings ? "Hide" : "Show"}
-                    </button>
-                </h1>
+                <button
+                    className="btn btn-outline-dark"
+                    type="button"
+                    aria-expanded={this.showSettings}
+                    onClick={this.onToggleShowSettings}
+                    title="Show/hide settings"
+                    style={{ marginLeft: "10px" }}
+                >
+                    {this.showSettings ? "Hide" : "Change settings"}
+                </button>
                 <div
                     className={`settings ${
                         this.showSettings ? "show" : "collapse"
@@ -1017,7 +1018,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                     <div
                         className="chart-view"
                         style={{
-                            height: this.grapherBounds.height + 100,
+                            height: this.grapherBounds.height + 50,
                             width: this.grapherBounds.width,
                         }}
                     >
@@ -1060,7 +1061,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                         <div
                             className="chart-view"
                             style={{
-                                height: this.grapherBounds.height + 100,
+                                height: this.grapherBounds.height + 50,
                                 width: this.grapherBounds.width,
                             }}
                         >
@@ -1103,7 +1104,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                     <div
                         className="chart-view"
                         style={{
-                            height: this.grapherBounds.height + 100,
+                            height: this.grapherBounds.height + 50,
                             width: this.grapherBounds.width,
                         }}
                     >
@@ -1272,167 +1273,182 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
         )
     }
 
+    renderControlsButtons() {
+        return (
+            <div className="buttons">
+                {this.listMode && (
+                    <React.Fragment>
+                        <button
+                            className="btn btn-outline-dark"
+                            onClick={this.onFirst}
+                            title="Go to first suggestion"
+                            disabled={this.prevBtnIsDisabled}
+                            aria-disabled={this.prevBtnIsDisabled}
+                            style={{
+                                pointerEvents: this.prevBtnIsDisabled
+                                    ? "none"
+                                    : undefined,
+                            }}
+                        >
+                            <FontAwesomeIcon icon={faAngleDoubleLeft} />
+                        </button>
+                        <button
+                            className="btn btn-outline-dark"
+                            onClick={this.onPrev}
+                            title="Go to previous suggestion"
+                            disabled={this.prevBtnIsDisabled}
+                            aria-disabled={this.prevBtnIsDisabled}
+                            style={{
+                                pointerEvents: this.prevBtnIsDisabled
+                                    ? "none"
+                                    : undefined,
+                            }}
+                        >
+                            <FontAwesomeIcon icon={faAngleLeft} />
+                        </button>
+                    </React.Fragment>
+                )}
+                <button
+                    className="btn btn-outline-danger"
+                    onClick={this.onRejectSuggestedChartRevision}
+                    title="Reject the suggestion, keeping the original chart as it is"
+                    disabled={this.rejectButtonIsDisabled}
+                    aria-disabled={this.rejectButtonIsDisabled}
+                    style={{
+                        pointerEvents: this.rejectButtonIsDisabled
+                            ? "none"
+                            : undefined,
+                    }}
+                >
+                    <SuggestedChartRevisionStatusIcon
+                        status={SuggestedChartRevisionStatus.rejected}
+                        setColor={false}
+                    />{" "}
+                    Reject
+                </button>
+                <button
+                    className="btn btn-outline-warning"
+                    onClick={this.onFlagSuggestedChartRevision}
+                    title="Flag the suggestion for further inspection, keeping the original chart as it is"
+                    disabled={this.flagButtonIsDisabled}
+                    aria-disabled={this.flagButtonIsDisabled}
+                    style={{
+                        pointerEvents: this.flagButtonIsDisabled
+                            ? "none"
+                            : undefined,
+                    }}
+                >
+                    <SuggestedChartRevisionStatusIcon
+                        status={SuggestedChartRevisionStatus.flagged}
+                        setColor={false}
+                    />{" "}
+                    Flag
+                </button>
+                <button
+                    className="btn btn-outline-primary"
+                    onClick={this.onApproveSuggestedChartRevision}
+                    title="Approve the suggestion, replacing the original chart with the suggested chart (also republishes the chart)"
+                    disabled={this.approveButtonIsDisabled}
+                    aria-disabled={this.approveButtonIsDisabled}
+                    style={{
+                        pointerEvents: this.approveButtonIsDisabled
+                            ? "none"
+                            : undefined,
+                    }}
+                >
+                    <SuggestedChartRevisionStatusIcon
+                        status={SuggestedChartRevisionStatus.approved}
+                        setColor={false}
+                    />{" "}
+                    Approve
+                </button>
+                {this.listMode && (
+                    <React.Fragment>
+                        <button
+                            className="btn btn-outline-dark"
+                            onClick={this.onNext}
+                            title="Go to next suggestion"
+                            disabled={this.nextBtnIsDisabled}
+                            aria-disabled={this.nextBtnIsDisabled}
+                            style={{
+                                pointerEvents: this.nextBtnIsDisabled
+                                    ? "none"
+                                    : undefined,
+                            }}
+                        >
+                            <FontAwesomeIcon icon={faAngleRight} />
+                        </button>
+                        <button
+                            className="btn btn-outline-dark"
+                            onClick={this.onLast}
+                            title="Go to last suggestion"
+                            disabled={this.nextBtnIsDisabled}
+                            aria-disabled={this.nextBtnIsDisabled}
+                            style={{
+                                pointerEvents: this.nextBtnIsDisabled
+                                    ? "none"
+                                    : undefined,
+                            }}
+                        >
+                            <FontAwesomeIcon icon={faAngleDoubleRight} />
+                        </button>
+                        <button
+                            className="btn btn-outline-dark"
+                            onClick={this.onRandom}
+                            title="Go to random suggestion"
+                            disabled={this.randomBtnIsDisabled}
+                            aria-disabled={this.randomBtnIsDisabled}
+                            style={{
+                                pointerEvents: this.randomBtnIsDisabled
+                                    ? "none"
+                                    : undefined,
+                            }}
+                        >
+                            <FontAwesomeIcon icon={faRandom} />
+                        </button>
+                    </React.Fragment>
+                )}
+            </div>
+        )
+    }
+
+    renderControlsNotes() {
+        return (
+            <TextAreaField
+                label="Notes"
+                placeholder="e.g. why are you rejecting this suggested revision?"
+                value={this.decisionReasonInput}
+                onValue={this.onDecisionReasonInput}
+                disabled={!this._isGraphersSet}
+            />
+        )
+    }
+
+    renderControlsNumberOfRevisions() {
+        return (
+            this.listMode && (
+                <div className="row-input">
+                    <span>Suggested revision</span>
+                    <NumberField
+                        value={this.rowNumValid}
+                        onValue={this.onRowNumInput}
+                    />
+                    <span>
+                        of {this.numTotalRows}
+                        {this.showPendingOnly ? " remaining" : ""} (
+                        <Link to="/suggested-chart-revisions">View all</Link>)
+                    </span>
+                </div>
+            )
+        )
+    }
+
     renderControls() {
         return (
             <div className="controls">
-                {this.listMode && (
-                    <div className="row-input">
-                        <span>Suggested revision</span>
-                        <NumberField
-                            value={this.rowNumValid}
-                            onValue={this.onRowNumInput}
-                        />
-                        <span>
-                            of {this.numTotalRows}
-                            {this.showPendingOnly ? " remaining" : ""} (
-                            <Link to="/suggested-chart-revisions">
-                                View all
-                            </Link>
-                            )
-                        </span>
-                    </div>
-                )}
-                <div className="buttons">
-                    {this.listMode && (
-                        <React.Fragment>
-                            <button
-                                className="btn btn-outline-dark"
-                                onClick={this.onFirst}
-                                title="Go to first suggestion"
-                                disabled={this.prevBtnIsDisabled}
-                                aria-disabled={this.prevBtnIsDisabled}
-                                style={{
-                                    pointerEvents: this.prevBtnIsDisabled
-                                        ? "none"
-                                        : undefined,
-                                }}
-                            >
-                                <FontAwesomeIcon icon={faAngleDoubleLeft} />
-                            </button>
-                            <button
-                                className="btn btn-outline-dark"
-                                onClick={this.onPrev}
-                                title="Go to previous suggestion"
-                                disabled={this.prevBtnIsDisabled}
-                                aria-disabled={this.prevBtnIsDisabled}
-                                style={{
-                                    pointerEvents: this.prevBtnIsDisabled
-                                        ? "none"
-                                        : undefined,
-                                }}
-                            >
-                                <FontAwesomeIcon icon={faAngleLeft} />
-                            </button>
-                        </React.Fragment>
-                    )}
-                    <button
-                        className="btn btn-outline-danger"
-                        onClick={this.onRejectSuggestedChartRevision}
-                        title="Reject the suggestion, keeping the original chart as it is"
-                        disabled={this.rejectButtonIsDisabled}
-                        aria-disabled={this.rejectButtonIsDisabled}
-                        style={{
-                            pointerEvents: this.rejectButtonIsDisabled
-                                ? "none"
-                                : undefined,
-                        }}
-                    >
-                        <SuggestedChartRevisionStatusIcon
-                            status={SuggestedChartRevisionStatus.rejected}
-                            setColor={false}
-                        />{" "}
-                        Reject
-                    </button>
-                    <button
-                        className="btn btn-outline-warning"
-                        onClick={this.onFlagSuggestedChartRevision}
-                        title="Flag the suggestion for further inspection, keeping the original chart as it is"
-                        disabled={this.flagButtonIsDisabled}
-                        aria-disabled={this.flagButtonIsDisabled}
-                        style={{
-                            pointerEvents: this.flagButtonIsDisabled
-                                ? "none"
-                                : undefined,
-                        }}
-                    >
-                        <SuggestedChartRevisionStatusIcon
-                            status={SuggestedChartRevisionStatus.flagged}
-                            setColor={false}
-                        />{" "}
-                        Flag
-                    </button>
-                    <button
-                        className="btn btn-outline-primary"
-                        onClick={this.onApproveSuggestedChartRevision}
-                        title="Approve the suggestion, replacing the original chart with the suggested chart (also republishes the chart)"
-                        disabled={this.approveButtonIsDisabled}
-                        aria-disabled={this.approveButtonIsDisabled}
-                        style={{
-                            pointerEvents: this.approveButtonIsDisabled
-                                ? "none"
-                                : undefined,
-                        }}
-                    >
-                        <SuggestedChartRevisionStatusIcon
-                            status={SuggestedChartRevisionStatus.approved}
-                            setColor={false}
-                        />{" "}
-                        Approve
-                    </button>
-                    {this.listMode && (
-                        <React.Fragment>
-                            <button
-                                className="btn btn-outline-dark"
-                                onClick={this.onNext}
-                                title="Go to next suggestion"
-                                disabled={this.nextBtnIsDisabled}
-                                aria-disabled={this.nextBtnIsDisabled}
-                                style={{
-                                    pointerEvents: this.nextBtnIsDisabled
-                                        ? "none"
-                                        : undefined,
-                                }}
-                            >
-                                <FontAwesomeIcon icon={faAngleRight} />
-                            </button>
-                            <button
-                                className="btn btn-outline-dark"
-                                onClick={this.onLast}
-                                title="Go to last suggestion"
-                                disabled={this.nextBtnIsDisabled}
-                                aria-disabled={this.nextBtnIsDisabled}
-                                style={{
-                                    pointerEvents: this.nextBtnIsDisabled
-                                        ? "none"
-                                        : undefined,
-                                }}
-                            >
-                                <FontAwesomeIcon icon={faAngleDoubleRight} />
-                            </button>
-                            <button
-                                className="btn btn-outline-dark"
-                                onClick={this.onRandom}
-                                title="Go to random suggestion"
-                                disabled={this.randomBtnIsDisabled}
-                                aria-disabled={this.randomBtnIsDisabled}
-                                style={{
-                                    pointerEvents: this.randomBtnIsDisabled
-                                        ? "none"
-                                        : undefined,
-                                }}
-                            >
-                                <FontAwesomeIcon icon={faRandom} />
-                            </button>
-                        </React.Fragment>
-                    )}
-                </div>
-                <TextAreaField
-                    label="Notes"
-                    placeholder="e.g. why are you rejecting this suggested revision?"
-                    value={this.decisionReasonInput}
-                    onValue={this.onDecisionReasonInput}
-                    disabled={!this._isGraphersSet}
-                />
+                {this.renderControlsNotes()}
+                {this.renderControlsButtons()}
+                {this.renderControlsNumberOfRevisions()}
             </div>
         )
     }

--- a/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
+++ b/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
@@ -1214,7 +1214,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                     {this.renderReferences()}
                 </div>
                 <div className="changes_summary">
-                    <h2>Changes summary</h2>{" "}
+                    <h2>Variable changes</h2>{" "}
                     {this.suggestedChartRevision &&
                     this.suggestedChartRevision.changesInDataSummary ? (
                         <div

--- a/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
+++ b/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
@@ -102,8 +102,10 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
         } else {
             if (this.desktopPreviewSize === "small") {
                 bounds = new Bounds(0, 0, 600, 450)
-            } else {
+            } else if (this.desktopPreviewSize === "normal") {
                 bounds = new Bounds(0, 0, 800, 600)
+            } else {
+                bounds = new Bounds(0, 0, 1200, 900)
             }
         }
         return bounds
@@ -857,6 +859,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                                 options={[
                                     { label: "Small", value: "small" },
                                     { label: "Normal", value: "normal" },
+                                    { label: "Large", value: "large" },
                                 ]}
                                 value={this.desktopPreviewSize}
                                 onChange={this.onChangeDesktopPreviewSize}
@@ -1208,6 +1211,13 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                 <div className="references">
                     <h5>References to original chart</h5>
                     {this.renderReferences()}
+                </div>
+                <div className="changes_summary">
+                    <h5>Changes summary</h5>{" "}
+                    {this.suggestedChartRevision &&
+                    this.suggestedChartRevision.changesInDataSummary
+                        ? this.suggestedChartRevision.changesInDataSummary
+                        : "No summary provided."}
                 </div>
             </React.Fragment>
         )

--- a/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
+++ b/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import { observer } from "mobx-react"
 import { observable, computed, action, runInAction } from "mobx"
 import { Link } from "react-router-dom"
@@ -350,7 +350,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                 noSidebar
             >
                 <main className="SuggestedChartRevisionApproverPage">
-                    <h3>
+                    <h1>
                         Approval tool for suggested chart revisions
                         <Link
                             className="btn btn-outline-primary"
@@ -366,7 +366,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                         >
                             Upload revisions
                         </Link>
-                    </h3>
+                    </h1>
                     <p>
                         Use this tool to approve or reject chart revisions that
                         have been suggested by an automated bulk update script.
@@ -388,6 +388,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                         WARNING: This tool is new and may contain bugs that
                         cause unexpected behavior. Use with caution.
                     </p>
+
                     {this.renderReadme()}
                     {this.renderSettings()}
 
@@ -419,7 +420,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
         return (
             <React.Fragment>
                 {this.renderControls()}
-                <h3>
+                <h1>
                     Suggested revision{" "}
                     {this.suggestedChartRevision
                         ? this.suggestedChartRevision.id
@@ -453,7 +454,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                             ""
                         )}
                     </span>
-                </h3>
+                </h1>
                 {this.renderGraphers()}
                 {this.renderMeta()}
             </React.Fragment>
@@ -463,7 +464,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
     renderReadme() {
         return (
             <div className="collapsible">
-                <h3>
+                <h1>
                     README
                     <button
                         className="btn btn-outline-dark"
@@ -475,13 +476,13 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                     >
                         {this.showReadme ? "Hide" : "Show"}
                     </button>
-                </h3>
+                </h1>
                 <div
                     className={`readme ${
                         this.showReadme ? "show" : "collapse"
                     }`}
                 >
-                    <h5>Terminology</h5>
+                    <h2>Terminology</h2>
                     <ul>
                         <li>
                             <b>Suggested chart revision.</b> A suggested chart
@@ -503,7 +504,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                             exists on the OWID website.
                         </li>
                     </ul>
-                    <h5>How to use</h5>
+                    <h2>How to use</h2>
                     <p>
                         You are shown one suggested chart revision at a time,
                         alongside the corresponding original chart as it was
@@ -615,7 +616,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                             reject it.
                         </li>
                     </ol>
-                    <h5>Other useful information</h5>
+                    <h2>Other useful information</h2>
                     <ul>
                         <li>
                             When you click the{" "}
@@ -766,7 +767,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
     renderSettings() {
         return (
             <div className="collapsible">
-                <h3>
+                <h1>
                     Settings
                     <button
                         className="btn btn-outline-dark"
@@ -778,7 +779,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                     >
                         {this.showSettings ? "Hide" : "Show"}
                     </button>
-                </h3>
+                </h1>
                 <div
                     className={`settings ${
                         this.showSettings ? "show" : "collapse"
@@ -1023,7 +1024,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                         {this.suggestedChartRevision && (
                             <React.Fragment>
                                 <div className="header">
-                                    <h5>Original chart</h5>
+                                    <h2>Original chart</h2>
                                     <span className="text-muted">
                                         {`(#${this.suggestedChartRevision.chartId}, V${this.suggestedChartRevision.originalConfig.version})`}
                                     </span>
@@ -1066,7 +1067,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                             {this.suggestedChartRevision && (
                                 <React.Fragment>
                                     <div className="header">
-                                        <h5>Existing chart</h5>
+                                        <h2>Existing chart</h2>
                                         <span className="text-muted">
                                             {`(#${this.suggestedChartRevision.chartId}, V${this.suggestedChartRevision.existingConfig.version})`}
                                         </span>
@@ -1109,7 +1110,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                         {this.suggestedChartRevision && (
                             <React.Fragment>
                                 <div className="header">
-                                    <h5>Suggested chart</h5>
+                                    <h2>Suggested chart</h2>
                                     <span className="text-muted">
                                         {`(#${this.suggestedChartRevision.chartId}, V${this.suggestedChartRevision.suggestedConfig.version})`}
                                     </span>
@@ -1158,7 +1159,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
         return (
             <React.Fragment>
                 <div>
-                    <h5>Metadata</h5>
+                    <h2>Metadata</h2>
                     <ul className="meta">
                         <li>
                             <b>Suggested revision ID:</b>{" "}
@@ -1209,15 +1210,22 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                     </ul>
                 </div>
                 <div className="references">
-                    <h5>References to original chart</h5>
+                    <h2>References to original chart</h2>
                     {this.renderReferences()}
                 </div>
                 <div className="changes_summary">
-                    <h5>Changes summary</h5>{" "}
+                    <h2>Changes summary</h2>{" "}
                     {this.suggestedChartRevision &&
-                    this.suggestedChartRevision.changesInDataSummary
-                        ? this.suggestedChartRevision.changesInDataSummary
-                        : "No summary provided."}
+                    this.suggestedChartRevision.changesInDataSummary ? (
+                        <div
+                            dangerouslySetInnerHTML={{
+                                __html: this.suggestedChartRevision
+                                    .changesInDataSummary,
+                            }}
+                        ></div>
+                    ) : (
+                        "No summary provided."
+                    )}
                 </div>
             </React.Fragment>
         )

--- a/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
+++ b/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"
+import React from "react"
 import { observer } from "mobx-react"
 import { observable, computed, action, runInAction } from "mobx"
 import { Link } from "react-router-dom"

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -965,11 +965,23 @@ main:not(.ChartEditorPage):not(.GdocsEditPage) {
     flex-direction: column;
     flex-grow: 1;
 
-    .collapsible {
+    .params {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-evenly;
         background-color: #f9f9f9;
         padding: 1.2em;
         border-radius: 0.4em;
         margin: 0.4em 0;
+        // box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+    }
+
+    .collapsible {
+        padding: 0.2em 0em;
+        // background-color: #f9f9f9;
+        // padding: 0.5em;
+        // border-radius: 0.4em;
+        // margin: 0.4em 0;
     }
 
     .readme {
@@ -1071,6 +1083,7 @@ main:not(.ChartEditorPage):not(.GdocsEditPage) {
             flex-wrap: wrap;
             align-items: center;
             justify-content: center;
+            padding-top: 0.5rem;
 
             .form-group {
                 width: 80px;

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -755,7 +755,7 @@ apiRouter.get(
             `
             SELECT scr.id, scr.chartId, scr.updatedAt, scr.createdAt,
                 scr.suggestedReason, scr.decisionReason, scr.status,
-                scr.suggestedConfig, scr.originalConfig,
+                scr.suggestedConfig, scr.originalConfig, scr.changesInDataSummary,
                 createdByUser.id as createdById,
                 updatedByUser.id as updatedById,
                 createdByUser.fullName as createdByFullName,
@@ -827,6 +827,9 @@ apiRouter.post(
         const status = SuggestedChartRevisionStatus.pending
         const suggestedReason = req.body.suggestedReason
             ? String(req.body.suggestedReason)
+            : null
+        const changesInDataSummary = req.body.changesInDataSummary
+            ? String(req.body.changesInDataSummary)
             : null
         const convertStringsToNull =
             typeof req.body.convertStringsToNull == "boolean"
@@ -1086,6 +1089,7 @@ apiRouter.post(
                         JSON.stringify(suggestedConfig),
                         JSON.stringify(originalConfig),
                         suggestedReason,
+                        changesInDataSummary,
                         status,
                         res.locals.user.id,
                         new Date(),
@@ -1098,7 +1102,7 @@ apiRouter.post(
             const result = await t.execute(
                 `
                 INSERT INTO suggested_chart_revisions
-                (chartId, suggestedConfig, originalConfig, suggestedReason, status, createdBy, createdAt, updatedAt)
+                (chartId, suggestedConfig, originalConfig, suggestedReason, changesInDataSummary, status, createdBy, createdAt, updatedAt)
                 VALUES
                 ?
                 `,
@@ -1135,7 +1139,7 @@ apiRouter.get(
             `
             SELECT scr.id, scr.chartId, scr.updatedAt, scr.createdAt,
                 scr.suggestedReason, scr.decisionReason, scr.status,
-                scr.suggestedConfig, scr.originalConfig,
+                scr.suggestedConfig, scr.changesInDataSummary, scr.originalConfig,
                 createdByUser.id as createdById,
                 updatedByUser.id as updatedById,
                 createdByUser.fullName as createdByFullName,

--- a/db/model/SuggestedChartRevision.ts
+++ b/db/model/SuggestedChartRevision.ts
@@ -19,6 +19,7 @@ export class SuggestedChartRevision extends BaseEntity {
     status!: SuggestedChartRevisionStatus
 
     @Column({ default: "" }) suggestedReason!: string
+    @Column({ default: "" }) changesInDataSummary!: string
     @Column({ default: "" }) decisionReason!: string
     @Column() createdAt!: Date
     @Column() updatedAt!: Date


### PR DESCRIPTION
For the chart revision tool I am working on surfacing details on what is changing in the chart. To this end, I have added a new field `changesInDataSummary` to our database table `suggested_chart_revisions`.

Now we need to allocate some space on the grapher side to surface this.

This PR:

- Adds HTML field to surface the value of `suggested_chart_revisions`.
- Additionally, I am adding the option to have preview size `"Large"`, too.
- Change heading tags: `<h3>` → `<h1>` and `<h5>` → `<h2>`.

Parallel work on the ETL-side: https://github.com/owid/etl/pull/987