### PR TITLE
refactor(gdocs): only fetch the images we need

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -2725,7 +2725,8 @@ apiRouter.put("/gdocs/:id", async (req, res) => {
     const filenames = nextGdoc.filenames
 
     if (filenames.length && nextGdoc.published) {
-        const images = await imageStore.syncImagesToS3(filenames)
+        await imageStore.fetchImageMetadata(filenames)
+        const images = await imageStore.syncImagesToS3()
         for (const image of images) {
             if (image) {
                 try {

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -74,7 +74,6 @@ import {
     select,
     getTagsByPostId,
 } from "../db/model/Post.js"
-import { getErrors } from "../adminSiteClient/gdocsValidation.js"
 import {
     checkFullDeployFallback,
     checkHasChanges,

--- a/db/model/Gdoc/Gdoc.ts
+++ b/db/model/Gdoc/Gdoc.ts
@@ -157,9 +157,9 @@ export class Gdoc extends BaseEntity implements OwidArticleType {
         const filenamesToLoad: string[] = [...this.filenames, ...covers]
 
         if (filenamesToLoad.length) {
-            await imageStore.fetchImageMetadata()
+            await imageStore.fetchImageMetadata(filenamesToLoad)
             const images = await imageStore
-                .syncImagesToS3(filenamesToLoad)
+                .syncImagesToS3()
                 .then(excludeUndefined)
             this.imageMetadata = keyBy(images, "filename")
         }


### PR DESCRIPTION
After migrating all 3200 WP images to Drive, a performance bottleneck in the current image syncing strategy was exposed due to GDrive's max pagesize of 1000.

Previous strategy: 
1. Extract image filenames from GDoc
2. Request **all images** from GDrive
3. Index them in memory
4. Validate the images that the GDoc references
5. Sync them to S3

New strategy is basically the same, except now we only request the _referenced images_ from GDrive.

Effectively:
```
OLD:
loadImages()
syncImages(filenames)

NEW:
loadImages(filenames)
syncImages()
```

I don't know why I didn't do it this way initially. I think I thought caching all the metadata in memory would work better for baking, but the baking method we went with made caching redundant, so 🤷 