### PR TITLE
Ensure x-axis in stacked bar charts is linear

### DIFF
--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -586,6 +586,10 @@ export class StackedBarChart
     defaultBaseColorScheme = ColorSchemeName.stackedAreaDefault
 
     @computed get series(): readonly StackedSeries<number>[] {
-        return stackSeries(withMissingValuesAsZeroes(this.unstackedSeries))
+        return stackSeries(
+            withMissingValuesAsZeroes(this.unstackedSeries, {
+                enforceUniformSpacing: true,
+            })
+        )
     }
 }

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -262,7 +262,8 @@ export class StackedBarChart
             point: series.points.find((bar) => bar.position === hoverTime),
         }))
         const totalValue = sum(seriesRows.map((bar) => bar.point?.value ?? 0))
-        const showTotalValue: boolean = seriesRows.length > 1
+        const allFake = seriesRows.every((bar) => bar.point?.fake)
+        const showTotalValue = seriesRows.length > 1 && !allFake
         return (
             <Tooltip
                 id={this.renderUid}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -27,6 +27,7 @@ import { ColorSchemeName } from "../color/ColorConstants"
 import { stackSeries, withMissingValuesAsZeroes } from "./StackedUtils"
 import { makeClipPath } from "../chart/ChartUtils"
 import { ColorScaleConfigDefaults } from "../color/ColorScaleConfig"
+import { ColumnTypeMap } from "@ourworldindata/core-table"
 
 interface StackedBarSegmentProps extends React.SVGAttributes<SVGGElement> {
     bar: StackedPoint<Time>
@@ -587,9 +588,14 @@ export class StackedBarChart
     defaultBaseColorScheme = ColorSchemeName.stackedAreaDefault
 
     @computed get series(): readonly StackedSeries<number>[] {
+        // TODO: remove once monthly data is supported (https://github.com/owid/owid-grapher/issues/2007)
+        const enforceUniformSpacing = !(
+            this.transformedTable.timeColumn instanceof ColumnTypeMap.Day
+        )
+
         return stackSeries(
             withMissingValuesAsZeroes(this.unstackedSeries, {
-                enforceUniformSpacing: true,
+                enforceUniformSpacing,
             })
         )
     }

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.test.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.test.ts
@@ -43,6 +43,7 @@ describe(withUniformSpacing, () => {
         expect(withUniformSpacing([1, 2, 4, 8])).toEqual([
             1, 2, 3, 4, 5, 6, 7, 8,
         ])
+        expect(withUniformSpacing([7, 12, 17])).toEqual([7, 12, 17])
     })
 })
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.test.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.test.ts
@@ -18,12 +18,33 @@ const seriesArr = [
         color: "red",
         points: [{ position: 2000, time: 2000, value: 2, valueOffset: 0 }],
     },
+    {
+        seriesName: "France",
+        columnSlug: "var",
+        color: "red",
+        points: [
+            { position: 2000, time: 2000, value: 6, valueOffset: 0 },
+            { position: 2003, time: 2003, value: 4, valueOffset: 0 },
+        ],
+    },
 ]
 
 it("can add fake points", () => {
     expect(seriesArr[1].points[1]).toEqual(undefined)
     const series = withMissingValuesAsZeroes(seriesArr)
     expect(series[1].points[1].position).toEqual(2002)
+})
+
+it("can enforce uniform spacing on the x-axis", () => {
+    expect(seriesArr[1].points[1]).toEqual(undefined)
+    expect(seriesArr[1].points[2]).toEqual(undefined)
+    expect(seriesArr[1].points[3]).toEqual(undefined)
+    const series = withMissingValuesAsZeroes(seriesArr, {
+        enforceUniformSpacing: true,
+    })
+    expect(series[1].points[1].position).toEqual(2001)
+    expect(series[1].points[2].position).toEqual(2002)
+    expect(series[1].points[3].position).toEqual(2003)
 })
 
 it("can stack series", () => {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.test.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.test.ts
@@ -1,6 +1,10 @@
 #! /usr/bin/env jest
 
-import { stackSeries, withMissingValuesAsZeroes } from "./StackedUtils"
+import {
+    stackSeries,
+    withMissingValuesAsZeroes,
+    withUniformSpacing,
+} from "./StackedUtils"
 
 const seriesArr = [
     {
@@ -29,26 +33,43 @@ const seriesArr = [
     },
 ]
 
-it("can add fake points", () => {
-    expect(seriesArr[1].points[1]).toEqual(undefined)
-    const series = withMissingValuesAsZeroes(seriesArr)
-    expect(series[1].points[1].position).toEqual(2002)
-})
-
-it("can enforce uniform spacing on the x-axis", () => {
-    expect(seriesArr[1].points[1]).toEqual(undefined)
-    expect(seriesArr[1].points[2]).toEqual(undefined)
-    expect(seriesArr[1].points[3]).toEqual(undefined)
-    const series = withMissingValuesAsZeroes(seriesArr, {
-        enforceUniformSpacing: true,
+describe(withUniformSpacing, () => {
+    it("can add values to make an array evenly spaced", () => {
+        expect(withUniformSpacing([])).toEqual([])
+        expect(withUniformSpacing([5])).toEqual([5])
+        expect(withUniformSpacing([5, 10])).toEqual([5, 10])
+        expect(withUniformSpacing([5, 10, 15])).toEqual([5, 10, 15])
+        expect(withUniformSpacing([2, 4, 8])).toEqual([2, 4, 6, 8])
+        expect(withUniformSpacing([1, 2, 4, 8])).toEqual([
+            1, 2, 3, 4, 5, 6, 7, 8,
+        ])
     })
-    expect(series[1].points[1].position).toEqual(2001)
-    expect(series[1].points[2].position).toEqual(2002)
-    expect(series[1].points[3].position).toEqual(2003)
 })
 
-it("can stack series", () => {
-    expect(seriesArr[1].points[0].valueOffset).toEqual(0)
-    const series = stackSeries(withMissingValuesAsZeroes(seriesArr))
-    expect(series[1].points[0].valueOffset).toEqual(10)
+describe(withMissingValuesAsZeroes, () => {
+    it("can add fake points", () => {
+        expect(seriesArr[1].points[1]).toEqual(undefined)
+        const series = withMissingValuesAsZeroes(seriesArr)
+        expect(series[1].points[1].position).toEqual(2002)
+    })
+
+    it("can enforce uniform spacing on the x-axis", () => {
+        expect(seriesArr[1].points[1]).toEqual(undefined)
+        expect(seriesArr[1].points[2]).toEqual(undefined)
+        expect(seriesArr[1].points[3]).toEqual(undefined)
+        const series = withMissingValuesAsZeroes(seriesArr, {
+            enforceUniformSpacing: true,
+        })
+        expect(series[1].points[1].position).toEqual(2001)
+        expect(series[1].points[2].position).toEqual(2002)
+        expect(series[1].points[3].position).toEqual(2003)
+    })
+})
+
+describe(stackSeries, () => {
+    it("can stack series", () => {
+        expect(seriesArr[1].points[0].valueOffset).toEqual(0)
+        const series = stackSeries(withMissingValuesAsZeroes(seriesArr))
+        expect(series[1].points[0].valueOffset).toEqual(10)
+    })
 })

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.ts
@@ -32,12 +32,7 @@ function withUniformSpacing(values: number[]): number[] {
         .slice(0, -1)
         .map((xVal, index) => values[index + 1] - xVal)
     const gcd = findGreatestCommonDivisorOfArray(deltas)
-
-    // might lead to non-uniform spacing at the end but ensures that we end on the last given value
-    const evenlySpacedValues = range(values[0], values[values.length - 1], gcd)
-    evenlySpacedValues.push(values[values.length - 1])
-
-    return evenlySpacedValues
+    return range(values[0], values[values.length - 1] + gcd, gcd)
 }
 
 // Adds a Y = 0 value for each missing x value (where X is usually Time)

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.ts
@@ -6,6 +6,7 @@ import {
     range,
     isArrayOfNumbers,
     findGreatestCommonDivisorOfArray,
+    rollingMap,
 } from "@ourworldindata/utils"
 import { StackedPointPositionType, StackedSeries } from "./StackedConstants"
 
@@ -27,11 +28,10 @@ export const stackSeries = <PositionType extends StackedPointPositionType>(
 }
 
 // Makes sure that values are evenly spaced
-function withUniformSpacing(values: number[]): number[] {
-    const deltas = values
-        .slice(0, -1)
-        .map((xVal, index) => values[index + 1] - xVal)
+export function withUniformSpacing(values: number[]): number[] {
+    const deltas = rollingMap(values, (a, b) => b - a)
     const gcd = findGreatestCommonDivisorOfArray(deltas)
+    if (gcd == null) return values
     return range(values[0], values[values.length - 1] + gcd, gcd)
 }
 

--- a/packages/@ourworldindata/utils/src/Util.test.ts
+++ b/packages/@ourworldindata/utils/src/Util.test.ts
@@ -530,6 +530,15 @@ describe(greatestCommonDivisor, () => {
         expect(greatestCommonDivisor(6, 8)).toEqual(2)
         expect(greatestCommonDivisor(6, 6)).toEqual(6)
     })
+
+    it("works with negative numbers", () => {
+        expect(greatestCommonDivisor(-10, 5)).toEqual(5)
+        expect(greatestCommonDivisor(-5, 10)).toEqual(5)
+        expect(greatestCommonDivisor(10, -5)).toEqual(5)
+        expect(greatestCommonDivisor(5, -10)).toEqual(5)
+        expect(greatestCommonDivisor(-10, -5)).toEqual(5)
+        expect(greatestCommonDivisor(-5, -10)).toEqual(5)
+    })
 })
 
 describe(findGreatestCommonDivisorOfArray, () => {
@@ -537,5 +546,6 @@ describe(findGreatestCommonDivisorOfArray, () => {
         expect(findGreatestCommonDivisorOfArray([6, 9, 12])).toEqual(3)
         expect(findGreatestCommonDivisorOfArray([6, 8, 12])).toEqual(2)
         expect(findGreatestCommonDivisorOfArray([6, 6, 6])).toEqual(6)
+        expect(findGreatestCommonDivisorOfArray([15])).toEqual(15)
     })
 })

--- a/packages/@ourworldindata/utils/src/Util.test.ts
+++ b/packages/@ourworldindata/utils/src/Util.test.ts
@@ -25,6 +25,8 @@ import {
     urlToSlug,
     toRectangularMatrix,
     slugifySameCase,
+    greatestCommonDivisor,
+    findGreatestCommonDivisorOfArray,
 } from "./Util.js"
 import { SortOrder } from "./owidTypes.js"
 
@@ -519,5 +521,21 @@ describe("slugifySameCase", () => {
 
     cases.forEach(([input, output]) => {
         expect(slugifySameCase(input)).toBe(output)
+    })
+})
+
+describe(greatestCommonDivisor, () => {
+    it("returns the greatest common divisor of two numbers", () => {
+        expect(greatestCommonDivisor(6, 9)).toEqual(3)
+        expect(greatestCommonDivisor(6, 8)).toEqual(2)
+        expect(greatestCommonDivisor(6, 6)).toEqual(6)
+    })
+})
+
+describe(findGreatestCommonDivisorOfArray, () => {
+    it("returns the greatest common divisor of an array of numbers", () => {
+        expect(findGreatestCommonDivisorOfArray([6, 9, 12])).toEqual(3)
+        expect(findGreatestCommonDivisorOfArray([6, 8, 12])).toEqual(2)
+        expect(findGreatestCommonDivisorOfArray([6, 6, 6])).toEqual(6)
     })
 })

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1412,4 +1412,20 @@ export function checkIsOwidGdocType(
     documentType: unknown
 ): documentType is OwidGdocType {
     return Object.values(OwidGdocType).includes(documentType as any)
+
+export function isArrayOfNumbers(arr: unknown[]): arr is number[] {
+    return arr.every((item) => typeof item === "number")
+}
+
+export function greatestCommonDivisor(a: number, b: number): number {
+    if (a === 0) return b
+    return greatestCommonDivisor(b % a, a)
+}
+
+export function findGreatestCommonDivisorOfArray(arr: number[]): number {
+    let result = arr[0]
+    for (let i = 1; i < arr.length; i++) {
+        result = greatestCommonDivisor(result, arr[i])
+    }
+    return result
 }

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1412,6 +1412,7 @@ export function checkIsOwidGdocType(
     documentType: unknown
 ): documentType is OwidGdocType {
     return Object.values(OwidGdocType).includes(documentType as any)
+}
 
 export function isArrayOfNumbers(arr: unknown[]): arr is number[] {
     return arr.every((item) => typeof item === "number")

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1418,14 +1418,12 @@ export function isArrayOfNumbers(arr: unknown[]): arr is number[] {
 }
 
 export function greatestCommonDivisor(a: number, b: number): number {
-    if (a === 0) return b
+    if (a === 0) return Math.abs(b)
     return greatestCommonDivisor(b % a, a)
 }
 
-export function findGreatestCommonDivisorOfArray(arr: number[]): number {
-    let result = arr[0]
-    for (let i = 1; i < arr.length; i++) {
-        result = greatestCommonDivisor(result, arr[i])
-    }
-    return result
+export function findGreatestCommonDivisorOfArray(arr: number[]): number | null {
+    if (arr.length === 0) return null
+    if (arr.includes(1)) return 1
+    return uniq(arr).reduce((acc, num) => greatestCommonDivisor(acc, num))
 }

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -276,6 +276,9 @@ export {
     spansToUnformattedPlainText,
     findDuplicates,
     checkIsOwidGdocType,
+    isArrayOfNumbers,
+    greatestCommonDivisor,
+    findGreatestCommonDivisorOfArray,
 } from "./Util.js"
 
 export {


### PR DESCRIPTION
fixes #1865

### Problem

If observations are unevenly spaced, stacked bar charts end up with a non-linear x-axis.

### Solution

To enforce uniform spacing along the axis, this PR implements [Marcel's suggestion](https://github.com/owid/owid-grapher/issues/1865#issue-1548859529) that involves computed the greatest common divisor. In Marcel's words, the gist of it is:

> ```
> given sortedYears = [1940, 1960, 1970, 1985]
> compute deltas = [20, 10, 15]
> compute gcd(deltas) = 5
> => the "minimum display interval" is 5 in this case
> => show 1940, 1945, 1950, 1955, 1960, 1965, ..., 1985 on the x axis
> ```

### Weirdnesses

The SVG tester comes back with one problematic chart:

<img width="773" alt="Screenshot 2023-04-06 at 14 35 02" src="https://user-images.githubusercontent.com/12461810/230393720-a2f825da-60b1-4ab3-becc-4da69cd96fdc.png">

**Problem:** This chart shows monthly data but since we currently have no native way to represent monthly data, this data is treated as daily data where only the 15th of every month is assigned a data point. Working with daily measurements becomes a problem here because slightly different deltas (number of days between measurements, i.e. 28, 30 or 31 days) lead to a small greatest common divisor (=1), and this leads in turn to many fake data point added (one for every day!).

**Possible Solutions:** This would be solved by making monthly data a first-class citizen as suggested in [this issue](https://github.com/owid/owid-grapher/issues/2007). Going forward, we could either:
- Bench this PR and wait for #2007 to be implemented
- Accept that this chart is going to look weird until we implement #2007 
- Wait for #2007 to be implemented but add some ugly/hacky code to make this chart look ok in the mean time
- Add an option to opt out of the new behaviour of enforcing linear x-axis