### PR TITLE
Hide DoD superscript in static exports

### DIFF
--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -101,7 +101,10 @@ export class Footer extends React.Component<{
             maxWidth,
             fontSize,
             text: noteText,
-            detailsOrderedByReference: this.manager.detailsOrderedByReference,
+            detailsOrderedByReference: this.manager
+                .shouldIncludeDetailsInStaticExport
+                ? this.manager.detailsOrderedByReference
+                : [],
         })
     }
 

--- a/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
+++ b/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
@@ -14,4 +14,5 @@ export interface FooterManager {
     tabBounds?: Bounds
     details?: GrapherInterface["details"]
     detailsOrderedByReference?: { category: string; term: string }[]
+    shouldIncludeDetailsInStaticExport?: boolean
 }

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -94,7 +94,10 @@ export class Header extends React.Component<{
             fontSize: 0.8 * this.fontSize,
             text: this.subtitleText,
             lineHeight: 1.2,
-            detailsOrderedByReference: this.manager.detailsOrderedByReference,
+            detailsOrderedByReference: this.manager
+                .shouldIncludeDetailsInStaticExport
+                ? this.manager.detailsOrderedByReference
+                : [],
         })
     }
 

--- a/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
+++ b/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
@@ -11,4 +11,5 @@ export interface HeaderManager {
     canonicalUrl?: string
     tabBounds?: Bounds
     detailsOrderedByReference?: { category: string; term: string }[]
+    shouldIncludeDetailsInStaticExport?: boolean
 }


### PR DESCRIPTION
Pass an empty `detailsOrderedByReference` to `MarkdownTextWrap` when `shouldIncludeDetailsInStaticExport` is false.

This makes `MarkdownTextWrap.svgLines` follow its fallback behaviour which is to not append any new superscript tokens when it encounters DoD spans.

Staging example: 

https://ptolemy-owid.netlify.app/grapher/primary-energy-cons
https://ptolemy-owid.netlify.app/grapher/exports/primary-energy-cons.svg