### PR TITLE
1947 data page part2: google doc rendering and 90% section coverage

### DIFF
--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -69,7 +69,10 @@ export const renderDataPageOrGrapherPage = async (
             // We only want to render datapages on selected charts, even if the
             // variable found on the chart has a datapage configuration.
             datapage.showDataPageOnChartIds?.includes(grapher.id) &&
-            (datapage.status === "published" || isPreviewing)
+            isPreviewing
+            // todo: we're not ready to publish datapages yet, so we only want to
+            // render them if we're previewing.
+            // (datapage.status === "published" || isPreviewing)
         ) {
             return renderToHtmlPage(
                 <DataPage

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -105,6 +105,10 @@
         border-left: 1px solid $blue-20;
         @include row-gap(24px);
         align-self: flex-start;
+
+        a {
+            @include owid-link-90;
+        }
     }
 
     .key-info__data {

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -354,6 +354,22 @@
             }
         }
 
+        .variable-processing-info__header {
+            @include overline-black-caps;
+            color: $blue-50;
+            text-transform: uppercase;
+            margin: 16px 0 8px;
+        }
+
+        .variable-processing-info__description {
+            .article-block__text,
+            .article-block__list,
+            .article-block__html,
+            .article-block__numbered-list {
+                @include body-3-medium;
+            }
+        }
+
         .metrics-list__header {
             @include h4-semibold;
             margin: 0;

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -145,4 +145,85 @@
             color: $blue-50;
         }
     }
+
+    .DataPageContent__section-border {
+        hr {
+            border-top: 1px solid $blue-20;
+            padding: 0;
+            margin: 0;
+        }
+    }
+
+    .related-data {
+        padding-top: 48px;
+        padding-bottom: 48px;
+
+        h2 {
+            @include h2-bold;
+            margin: 0;
+        }
+
+        .related-data__items {
+            @include grid(9);
+        }
+
+        .related-data__item--padded {
+            padding: 24px;
+            background-color: $blue-10;
+        }
+
+        .related-data__type {
+            @include overline-black-caps;
+            color: $blue-50;
+            flex: 1;
+        }
+
+        h3 {
+            @include h3-bold;
+            margin: 0;
+            color: $blue-90;
+        }
+
+        h4 {
+            @include h4-semibold;
+            margin: 0;
+            color: $blue-90;
+        }
+
+        .related-data__source {
+            @include h3-bold;
+            color: $blue-50;
+            margin: 0;
+        }
+
+        .related-data__content {
+            @include body-3-medium;
+            color: $blue-60;
+            margin-top: 8px;
+        }
+
+        .related-data__items {
+            > div {
+                display: grid;
+                row-gap: 24px;
+            }
+
+            > div:nth-child(1) {
+                .related-data__item {
+                    display: flex;
+                    flex-direction: column;
+                    height: 100%;
+                }
+            }
+
+            > div:nth-child(3) {
+                height: fit-content;
+                .related-data__source {
+                    @include body-3-medium;
+                    color: $blue-60;
+                    margin-top: 4px;
+                }
+            }
+        }
+    }
 }

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -18,12 +18,12 @@
         h1 {
             @include display-2-semibold;
             display: inline;
-            margin: 0;
+            margin: 0 16px 0 0;
         }
         .source {
+            display: inline-block;
             @include body-1-regular;
             color: $blue-50;
-            margin-left: 16px;
         }
     }
 

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -98,6 +98,13 @@
         }
     }
 
+    .key-info__description-source {
+        margin-top: 8px;
+        .article-block__text {
+            @include body-2-regular;
+        }
+    }
+
     .key-info__right {
         grid-column: 9 / span 3;
         display: flex;

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -308,10 +308,9 @@
             }
         }
 
-        .data-collection__key-info {
+        .key-info--gridded {
             gap: 24px;
             row-gap: 16px;
-            margin-bottom: 24px;
         }
 
         .data-collection__code-link {
@@ -323,6 +322,31 @@
 
             svg {
                 margin-right: 8px;
+            }
+        }
+
+        .sources {
+            margin-top: 48px;
+        }
+
+        .sources__heading {
+            @include h3-bold;
+            margin: 0;
+        }
+
+        .sources__item .ExpandableAnimatedToggle {
+            > button {
+                padding-top: 16px;
+                padding-bottom: 16px;
+            }
+            .content-wrapper {
+                padding-bottom: 16px;
+            }
+        }
+
+        .sources__item + .sources__item {
+            .ExpandableAnimatedToggle {
+                border-top: 0;
             }
         }
     }

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -3,6 +3,10 @@
 }
 
 .DataPageContent {
+    .article-block__list {
+        @include HACK-fix-bullets-outside;
+    }
+
     .header__wrapper {
         @include grid(12);
         padding-top: 48px;
@@ -78,7 +82,6 @@
             margin: 0;
         }
         ul {
-            margin-left: 16px;
             @include row-gap(16px);
             li {
                 @include body-2-regular;

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -227,10 +227,22 @@
         }
     }
 
-    .faqs {
-        h2 {
+    .faq {
+        > h2 {
             @include h2-bold;
             margin: 0;
+        }
+
+        .faq__items > *:first-child {
+            margin-top: 0;
+        }
+
+        .article-block__text,
+        .article-block__list,
+        .article-block__html,
+        .article-block__numbered-list {
+            @include body-2-regular;
+            color: $blue-60;
         }
     }
 }

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -105,16 +105,15 @@
         border-left: 1px solid $blue-20;
         @include row-gap(24px);
         align-self: flex-start;
-
-        a {
-            @include owid-link-90;
-        }
     }
 
     .key-info__data {
         @include body-3-medium;
         .title {
             color: $blue-50;
+        }
+        a {
+            @include owid-link-90;
         }
     }
 
@@ -247,6 +246,84 @@
         .article-block__numbered-list {
             @include body-2-regular;
             color: $blue-60;
+        }
+    }
+
+    .dataset {
+        h2 {
+            @include h2-bold;
+            margin: 0;
+        }
+
+        .data-collection {
+            display: flex;
+            flex-direction: column;
+            @include row-gap(32px);
+            background-color: $white;
+            margin: 24px -24px 0;
+            padding: 24px;
+        }
+
+        .data-collection__header {
+            @include overline-black-caps;
+            color: $blue-50;
+            text-transform: uppercase;
+            margin-bottom: 16px;
+        }
+
+        .data-collection__name {
+            @include h3-bold;
+            margin: 0;
+
+            svg {
+                margin-right: 8px;
+            }
+        }
+
+        .data-collection__description {
+            @include body-3-medium;
+            color: $blue-60;
+            margin-top: 8px;
+
+            > *:first-child {
+                margin-top: 0;
+            }
+
+            > *:last-child {
+                margin-bottom: 0;
+            }
+        }
+
+        .metrics-list__header {
+            @include h4-semibold;
+            margin: 0;
+            color: $blue-50;
+        }
+
+        .featured-variables {
+            list-style-type: none;
+            @include body-3-medium;
+            li {
+                margin-top: 8px;
+            }
+        }
+
+        .data-collection__key-info {
+            gap: 24px;
+            row-gap: 16px;
+            margin-bottom: 24px;
+        }
+
+        .data-collection__code-link {
+            display: inline-block;
+            padding: 8px;
+            background-color: $blue-10;
+            @include body-3-medium;
+            color: $blue-90;
+
+            svg {
+                margin-right: 8px;
+            }
         }
     }
 }

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -81,6 +81,7 @@
             margin-left: 16px;
             @include row-gap(16px);
             li {
+                @include body-2-regular;
                 display: list-item;
             }
         }

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -230,6 +230,46 @@
         }
     }
 
+    .related-charts-wrapper {
+        padding-top: 48px;
+        padding-bottom: 48px;
+
+        h2 {
+            @include h2-bold;
+            margin: 0 0 32px;
+        }
+
+        // copied from content.scss
+        .wp-block-columns {
+            @include grid(12);
+
+            // default is first column is full-width, second column should be empty
+            .wp-block-column {
+                grid-column: 1 / 13;
+                // necessary for Grapher resizing in all column-types
+                width: 100%;
+            }
+
+            @include md-up {
+                &.is-style-sticky-right {
+                    .wp-block-column:nth-child(1) {
+                        grid-column: 1 / 6;
+                    }
+                    .wp-block-column:nth-child(2) {
+                        grid-column: 6 / 13;
+                    }
+                    .wp-block-column .wp-sticky-container {
+                        @include sticky-child;
+                    }
+                }
+            }
+        }
+
+        figure[data-grapher-src] {
+            height: 575px;
+        }
+    }
+
     .faq {
         > h2 {
             @include h2-bold;

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -322,9 +322,12 @@
         }
 
         .data-collection__description {
-            @include body-3-medium;
-            color: $blue-60;
             margin-top: 8px;
+            color: $blue-60;
+
+            .article-block__text {
+                @include body-3-medium;
+            }
 
             > *:first-child {
                 margin-top: 0;

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -103,7 +103,10 @@
 
     .key-info__description-source {
         margin-top: 8px;
-        .article-block__text {
+        .article-block__text,
+        .article-block__list,
+        .article-block__html,
+        .article-block__numbered-list {
             @include body-2-regular;
         }
     }
@@ -335,7 +338,10 @@
             margin-top: 8px;
             color: $blue-60;
 
-            .article-block__text {
+            .article-block__text,
+            .article-block__list,
+            .article-block__html,
+            .article-block__numbered-list {
                 @include body-3-medium;
             }
 
@@ -381,6 +387,13 @@
 
         .sources {
             margin-top: 48px;
+
+            .article-block__text,
+            .article-block__list,
+            .article-block__html,
+            .article-block__numbered-list {
+                @include body-2-regular;
+            }
         }
 
         .sources__heading {

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -113,4 +113,36 @@
             color: $blue-50;
         }
     }
+
+    .related-research {
+        padding-top: 48px;
+        padding-bottom: 48px;
+        background-color: $white;
+        h2 {
+            @include h2-bold;
+            margin: 0;
+        }
+
+        .related-research__items {
+            @include grid(9);
+            row-gap: 24px;
+        }
+
+        .related-research__item {
+            @include grid(4);
+            &:hover h3 {
+                text-decoration: underline;
+            }
+        }
+
+        h3 {
+            @include h3-bold;
+            margin: 0;
+            color: $blue-90;
+        }
+
+        .authors {
+            color: $blue-50;
+        }
+    }
 }

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -226,4 +226,11 @@
             }
         }
     }
+
+    .faqs {
+        h2 {
+            @include h2-bold;
+            margin: 0;
+        }
+    }
 }

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -319,16 +319,14 @@ export const DataPageContent = ({
                                         <FontAwesomeIcon icon={faTable} />
                                         <span
                                             dangerouslySetInnerHTML={{
-                                                __html: datapage.dataset
-                                                    .datasetName,
+                                                __html: datapage.datasetName,
                                             }}
                                         />
                                     </div>
                                     <div
                                         className="data-collection__description"
                                         dangerouslySetInnerHTML={{
-                                            __html: datapage.dataset
-                                                .datasetDescription,
+                                            __html: datapage.datasetDescription,
                                         }}
                                     />
                                 </div>
@@ -339,7 +337,7 @@ export const DataPageContent = ({
                                             collection:
                                         </h4>
                                         <ul className="featured-variables">
-                                            {datapage.dataset.datasetFeaturedVariables.map(
+                                            {datapage.datasetFeaturedVariables.map(
                                                 (
                                                     variable: any,
                                                     idx: number
@@ -387,7 +385,7 @@ export const DataPageContent = ({
                                             <div>
                                                 <a
                                                     href={
-                                                        datapage.dataset
+                                                        datapage
                                                             .datasetLicenseLink
                                                             .url
                                                     }
@@ -395,7 +393,7 @@ export const DataPageContent = ({
                                                     rel="noreferrer"
                                                 >
                                                     {
-                                                        datapage.dataset
+                                                        datapage
                                                             .datasetLicenseLink
                                                             .title
                                                     }
@@ -403,11 +401,9 @@ export const DataPageContent = ({
                                             </div>
                                         </div>
                                     </div>
-                                    {datapage.dataset?.datasetCodeUrl && (
+                                    {datapage.datasetCodeUrl && (
                                         <a
-                                            href={
-                                                datapage.dataset.datasetCodeUrl
-                                            }
+                                            href={datapage.datasetCodeUrl}
                                             className="data-collection__code-link"
                                         >
                                             <FontAwesomeIcon icon={faGithub} />

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -398,6 +398,33 @@ export const DataPageContent = ({
                                             )
                                         }
                                     />
+                                    <FallbackGdocFieldExplain
+                                        googleDocEditLink={
+                                            datapage.googleDocEditLink
+                                        }
+                                        fieldName="datasetVariableProcessingInfo"
+                                        level="info"
+                                        render={(fallback) =>
+                                            gdocKeyedBlocks?.datasetVariableProcessingInfo ? (
+                                                <div>
+                                                    <div className="variable-processing-info__header">
+                                                        Particular steps taken
+                                                        to prepare this metric:
+                                                    </div>
+                                                    <div className="variable-processing-info__description">
+                                                        <ArticleBlocks
+                                                            blocks={
+                                                                gdocKeyedBlocks.datasetVariableProcessingInfo
+                                                            }
+                                                            containerType="datapage"
+                                                        />
+                                                    </div>
+                                                </div>
+                                            ) : (
+                                                fallback
+                                            )
+                                        }
+                                    />
                                 </div>
                                 <div>
                                     <div style={{ marginBottom: "24px" }}>

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -118,8 +118,8 @@ export const DataPageContent = ({
                                     }}
                                 />
                             )}
-                            {!!datapage.faqs?.items?.length && (
-                                <a className="learn-more" href="#faq">
+                            {faqsArticle?.content.body && (
+                                <a className="learn-more" href="#faqs">
                                     Learn more in the FAQs
                                     <FontAwesomeIcon icon={faArrowDown} />
                                 </a>
@@ -267,26 +267,26 @@ export const DataPageContent = ({
                         </div>
                     </div>
                 )}
-                <div
-                    style={{
-                        backgroundColor: "#f7f7f7",
-                        padding: "48px 0",
-                    }}
-                >
-                    <div className="faq grid wrapper">
-                        <h2 className="span-cols-2">
-                            What you should know about this data
-                        </h2>
-                        <div className="faq__items grid grid-cols-8 span-cols-8">
-                            {faqsArticle?.content.body && (
+                {faqsArticle?.content.body && (
+                    <div
+                        style={{
+                            backgroundColor: "#f7f7f7",
+                            padding: "48px 0",
+                        }}
+                    >
+                        <div className="faq grid wrapper">
+                            <h2 className="span-cols-2" id="faqs">
+                                What you should know about this data
+                            </h2>
+                            <div className="faq__items grid grid-cols-8 span-cols-8">
                                 <ArticleBlocks
                                     blocks={faqsArticle.content.body}
                                     containerType="datapage"
                                 />
-                            )}
+                            </div>
                         </div>
                     </div>
-                </div>
+                )}
                 <div
                     className="DataPageContent__section-border wrapper"
                     style={{

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -451,40 +451,6 @@ export const DataPageContent = ({
                                                             </div>
                                                             <div className="key-info__data">
                                                                 <div className="title">
-                                                                    Licence
-                                                                </div>
-                                                                <div>
-                                                                    <a
-                                                                        href={
-                                                                            source
-                                                                                .licenseLink
-                                                                                .url
-                                                                        }
-                                                                        target="_blank"
-                                                                        rel="noreferrer"
-                                                                    >
-                                                                        {
-                                                                            source
-                                                                                .licenseLink
-                                                                                .title
-                                                                        }
-                                                                    </a>
-                                                                </div>
-                                                            </div>
-                                                            <div className="key-info__data">
-                                                                <div className="title">
-                                                                    Next
-                                                                    expected
-                                                                    update
-                                                                </div>
-                                                                <div>
-                                                                    {
-                                                                        source.nextUpdate
-                                                                    }
-                                                                </div>
-                                                            </div>
-                                                            <div className="key-info__data">
-                                                                <div className="title">
                                                                     Retrieved
                                                                     from
                                                                 </div>

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -450,54 +450,95 @@ export const DataPageContent = ({
                                     This data is based on the following sources:
                                 </h3>
                                 <div className="span-cols-6">
-                                    {datapage.sources.map((source: any) => (
-                                        <div
-                                            className="sources__item"
-                                            key={source.sourceName}
-                                        >
-                                            <ExpandableAnimatedToggle
-                                                label={source.sourceName}
-                                                contentHtml={
-                                                    source.sourceDescription
-                                                }
-                                                content={
-                                                    source.sourceRetrievedOn && (
-                                                        <div className="key-info--gridded grid grid-cols-2">
-                                                            <div className="key-info__data">
-                                                                <div className="title">
-                                                                    Retrieved on
-                                                                </div>
-                                                                <div>
-                                                                    {
-                                                                        source.sourceRetrievedOn
-                                                                    }
-                                                                </div>
-                                                            </div>
-                                                            <div className="key-info__data">
-                                                                <div className="title">
-                                                                    Retrieved
-                                                                    from
-                                                                </div>
-                                                                <div>
-                                                                    <a
-                                                                        href={
-                                                                            source.sourceRetrievedFromUrl
+                                    {datapage.sources.map(
+                                        (source: any, idx: number) => (
+                                            <div
+                                                className="sources__item"
+                                                key={source.sourceName}
+                                            >
+                                                <ExpandableAnimatedToggle
+                                                    label={source.sourceName}
+                                                    content={
+                                                        <>
+                                                            <>
+                                                                {gdocKeyedBlocks?.[
+                                                                    `sourceDescription${
+                                                                        idx + 1
+                                                                    }`
+                                                                ] ? (
+                                                                    <ArticleBlocks
+                                                                        blocks={
+                                                                            gdocKeyedBlocks[
+                                                                                `sourceDescription${
+                                                                                    idx +
+                                                                                    1
+                                                                                }`
+                                                                            ]
                                                                         }
-                                                                        target="_blank"
-                                                                        rel="noreferrer"
+                                                                        containerType="datapage"
+                                                                    />
+                                                                ) : (
+                                                                    <span
+                                                                        style={{
+                                                                            color: "red",
+                                                                        }}
                                                                     >
-                                                                        {
-                                                                            source.sourceRetrievedFromUrl
-                                                                        }
-                                                                    </a>
-                                                                </div>
-                                                            </div>
-                                                        </div>
-                                                    )
-                                                }
-                                            />
-                                        </div>
-                                    ))}
+                                                                        {`Edit in
+                                                                        google
+                                                                        doc by
+                                                                        adding a
+                                                                        "sourceDescription${
+                                                                            idx +
+                                                                            1
+                                                                        }"
+                                                                        heading
+                                                                        1.`}
+                                                                    </span>
+                                                                )}
+                                                            </>
+                                                            <>
+                                                                {source.sourceRetrievedOn &&
+                                                                    source.sourceRetrievedFrom && (
+                                                                        <div className="key-info--gridded grid grid-cols-2">
+                                                                            <div className="key-info__data">
+                                                                                <div className="title">
+                                                                                    Retrieved
+                                                                                    on
+                                                                                </div>
+                                                                                <div>
+                                                                                    {
+                                                                                        source.sourceRetrievedOn
+                                                                                    }
+                                                                                </div>
+                                                                            </div>
+                                                                            <div className="key-info__data">
+                                                                                <div className="title">
+                                                                                    Retrieved
+                                                                                    from
+                                                                                </div>
+                                                                                <div>
+                                                                                    <a
+                                                                                        href={
+                                                                                            source.sourceRetrievedFromUrl
+                                                                                        }
+                                                                                        target="_blank"
+                                                                                        rel="noreferrer"
+                                                                                    >
+                                                                                        {
+                                                                                            source.sourceRetrievedFromUrl
+                                                                                        }
+                                                                                    </a>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    )}
+                                                            </>
+                                                        </>
+                                                    }
+                                                />
+                                            </div>
+                                        )
+                                    )}
                                 </div>
                             </div>
                         )}

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -43,7 +43,11 @@ export const DataPageContent = ({
                         <div className="supertitle">DATA</div>
                         <h1>{datapage.title}</h1>
                         <span className="source">
-                            {datapage.sourceShortName}
+                            {datapage.variantDescription1 &&
+                            datapage.variantDescription2
+                                ? `${datapage.variantDescription1} - ${datapage.variantDescription2}`
+                                : datapage.variantDescription1 ||
+                                  datapage.variantDescription2}
                         </span>
                     </div>
                     <div className="header__right">

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -124,18 +124,16 @@ export const DataPageContent = ({
                                     <FontAwesomeIcon icon={faArrowDown} />
                                 </a>
                             )}
-                            {datapage.sourceVariableDescription?.title &&
-                                datapage.sourceVariableDescription?.content && (
+                            {datapage.descriptionFromSource?.title &&
+                                datapage.descriptionFromSource?.content && (
                                     <div style={{ marginTop: 8 }}>
                                         <ExpandableAnimatedToggle
                                             label={
-                                                datapage
-                                                    .sourceVariableDescription
+                                                datapage.descriptionFromSource
                                                     .title
                                             }
                                             contentHtml={
-                                                datapage
-                                                    .sourceVariableDescription
+                                                datapage.descriptionFromSource
                                                     .content
                                             }
                                         />
@@ -339,7 +337,7 @@ export const DataPageContent = ({
                                             collection:
                                         </h4>
                                         <ul className="featured-variables">
-                                            {datapage.dataset.featuredVariables.map(
+                                            {datapage.dataset.datasetFeaturedVariables.map(
                                                 (
                                                     variable: any,
                                                     idx: number
@@ -403,9 +401,11 @@ export const DataPageContent = ({
                                             </div>
                                         </div>
                                     </div>
-                                    {datapage.dataset?.codeUrl && (
+                                    {datapage.dataset?.datasetCodeUrl && (
                                         <a
-                                            href={datapage.dataset.codeUrl}
+                                            href={
+                                                datapage.dataset.datasetCodeUrl
+                                            }
                                             className="data-collection__code-link"
                                         >
                                             <FontAwesomeIcon icon={faGithub} />
@@ -429,13 +429,15 @@ export const DataPageContent = ({
                                     {datapage.sources.map((source: any) => (
                                         <div
                                             className="sources__item"
-                                            key={source.name}
+                                            key={source.sourceName}
                                         >
                                             <ExpandableAnimatedToggle
-                                                label={source.name}
-                                                contentHtml={source.description}
+                                                label={source.sourceName}
+                                                contentHtml={
+                                                    source.sourceDescription
+                                                }
                                                 content={
-                                                    source.retrievedOn && (
+                                                    source.sourceRetrievedOn && (
                                                         <div className="key-info--gridded grid grid-cols-2">
                                                             <div className="key-info__data">
                                                                 <div className="title">
@@ -443,7 +445,7 @@ export const DataPageContent = ({
                                                                 </div>
                                                                 <div>
                                                                     {
-                                                                        source.retrievedOn
+                                                                        source.sourceRetrievedOn
                                                                     }
                                                                 </div>
                                                             </div>
@@ -489,13 +491,13 @@ export const DataPageContent = ({
                                                                 <div>
                                                                     <a
                                                                         href={
-                                                                            source.retrievedFromUrl
+                                                                            source.sourceRetrievedFromUrl
                                                                         }
                                                                         target="_blank"
                                                                         rel="noreferrer"
                                                                     >
                                                                         {
-                                                                            source.retrievedFromUrl
+                                                                            source.sourceRetrievedFromUrl
                                                                         }
                                                                     </a>
                                                                 </div>

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -5,6 +5,7 @@ import { Grapher, GrapherInterface } from "@ourworldindata/grapher"
 import { ExpandableAnimatedToggle } from "./ExpandableAnimatedToggle.js"
 import ReactDOM from "react-dom"
 import { GrapherWithFallback } from "./GrapherWithFallback.js"
+import { formatAuthors } from "./clientFormatting.js"
 
 declare global {
     interface Window {
@@ -134,6 +135,30 @@ export const DataPageContent = ({
                                 <div>{datapage.nextUpdate}</div>
                             </div>
                         </div>
+                    </div>
+                </div>
+                <div className="related-research grid wrapper">
+                    <h2 className="span-cols-3">
+                        Related research and writing
+                    </h2>
+                    <div className="related-research__items span-cols-9">
+                        {datapage.relatedResearch.map((research: any) => (
+                            <a
+                                href={research.url}
+                                key={research.url}
+                                className="related-research__item span-cols-4"
+                            >
+                                <img src={research.imageUrl} alt="" />
+                                <div className="span-cols-3">
+                                    <h3>{research.title}</h3>
+                                    <div className="authors body-3-medium-italic">
+                                        {formatAuthors({
+                                            authors: research.authors,
+                                        })}
+                                    </div>
+                                </div>
+                            </a>
+                        ))}
                     </div>
                 </div>
             </div>

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -78,13 +78,13 @@ export const DataPageContent = ({
         }
 
         if (
-            !datapage.faqsGoogleDocEditLink ||
-            getLinkType(datapage.faqsGoogleDocEditLink) !== "gdoc"
+            !datapage.googleDocEditLink ||
+            getLinkType(datapage.googleDocEditLink) !== "gdoc"
         )
             return
-        const googleDocId = getUrlTarget(datapage.faqsGoogleDocEditLink)
+        const googleDocId = getUrlTarget(datapage.googleDocEditLink)
         fetchGdocKeyedContent(googleDocId)
-    }, [datapage.faqsGoogleDocEditLink])
+    }, [datapage.googleDocEditLink])
 
     return (
         <>

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -131,37 +131,57 @@ export const DataPageContent = ({
                     <div className="key-info__wrapper wrapper">
                         <div className="key-info__left">
                             <h2>Key information</h2>
-                            {gdocKeyedBlocks?.keyInfoText && (
-                                <ArticleBlocks
-                                    blocks={gdocKeyedBlocks.keyInfoText}
-                                    containerType="datapage"
-                                />
-                            )}
+                            <FallbackGdocFieldExplain
+                                googleDocEditLink={datapage.googleDocEditLink}
+                                fieldName="keyInfoText"
+                                level="error"
+                                render={(fallback) =>
+                                    gdocKeyedBlocks?.keyInfoText ? (
+                                        <ArticleBlocks
+                                            blocks={gdocKeyedBlocks.keyInfoText}
+                                            containerType="datapage"
+                                        />
+                                    ) : (
+                                        fallback
+                                    )
+                                }
+                            />
+
                             {gdocKeyedBlocks?.faqs && (
                                 <a className="learn-more" href="#faqs">
                                     Learn more in the FAQs
                                     <FontAwesomeIcon icon={faArrowDown} />
                                 </a>
                             )}
-                            {datapage.descriptionFromSource?.title &&
-                                gdocKeyedBlocks?.descriptionFromSource && (
-                                    <div className="key-info__description-source">
-                                        <ExpandableAnimatedToggle
-                                            label={
-                                                datapage.descriptionFromSource
-                                                    .title
-                                            }
-                                            content={
-                                                <ArticleBlocks
-                                                    blocks={
-                                                        gdocKeyedBlocks.descriptionFromSource
-                                                    }
-                                                    containerType="datapage"
-                                                />
-                                            }
-                                        />
-                                    </div>
-                                )}
+                            <FallbackGdocFieldExplain
+                                googleDocEditLink={datapage.googleDocEditLink}
+                                fieldName="descriptionFromSource"
+                                level="info"
+                                render={(fallback) =>
+                                    datapage.descriptionFromSource?.title &&
+                                    gdocKeyedBlocks?.descriptionFromSource ? (
+                                        <div className="key-info__description-source">
+                                            <ExpandableAnimatedToggle
+                                                label={
+                                                    datapage
+                                                        .descriptionFromSource
+                                                        .title
+                                                }
+                                                content={
+                                                    <ArticleBlocks
+                                                        blocks={
+                                                            gdocKeyedBlocks.descriptionFromSource
+                                                        }
+                                                        containerType="datapage"
+                                                    />
+                                                }
+                                            />
+                                        </div>
+                                    ) : (
+                                        fallback
+                                    )
+                                }
+                            />
                         </div>
                         <div className="key-info__right">
                             <div className="key-info__data">
@@ -290,34 +310,45 @@ export const DataPageContent = ({
                         </div>
                     </div>
                 )}
-                {gdocKeyedBlocks?.faqs && (
-                    <div
-                        style={{
-                            backgroundColor: "#f7f7f7",
-                            padding: "48px 0",
-                        }}
-                    >
-                        <div className="faq grid wrapper">
-                            <h2 className="span-cols-2" id="faqs">
-                                What you should know about this data
-                            </h2>
-                            <div className="faq__items grid grid-cols-8 span-cols-8">
-                                <ArticleBlocks
-                                    blocks={gdocKeyedBlocks.faqs}
-                                    containerType="datapage"
-                                />
-                            </div>
-                        </div>
-                    </div>
-                )}
-                <div
-                    className="DataPageContent__section-border wrapper"
-                    style={{
-                        backgroundColor: "#f7f7f7",
-                    }}
-                >
-                    <hr />
-                </div>
+                <FallbackGdocFieldExplain
+                    googleDocEditLink={datapage.googleDocEditLink}
+                    fieldName="faqs"
+                    level="info"
+                    render={(fallback) =>
+                        gdocKeyedBlocks?.faqs ? (
+                            <>
+                                <div
+                                    style={{
+                                        backgroundColor: "#f7f7f7",
+                                        padding: "48px 0",
+                                    }}
+                                >
+                                    <div className="faq grid wrapper">
+                                        <h2 className="span-cols-2" id="faqs">
+                                            What you should know about this data
+                                        </h2>
+                                        <div className="faq__items grid grid-cols-8 span-cols-8">
+                                            <ArticleBlocks
+                                                blocks={gdocKeyedBlocks.faqs}
+                                                containerType="datapage"
+                                            />
+                                        </div>
+                                    </div>
+                                </div>
+                                <div
+                                    className="DataPageContent__section-border wrapper"
+                                    style={{
+                                        backgroundColor: "#f7f7f7",
+                                    }}
+                                >
+                                    <hr />
+                                </div>
+                            </>
+                        ) : (
+                            fallback
+                        )
+                    }
+                />
                 <div
                     style={{
                         backgroundColor: "#f7f7f7",
@@ -346,16 +377,27 @@ export const DataPageContent = ({
                                             }}
                                         />
                                     </div>
-                                    {gdocKeyedBlocks?.datasetDescription && (
-                                        <div className="data-collection__description">
-                                            <ArticleBlocks
-                                                blocks={
-                                                    gdocKeyedBlocks.datasetDescription
-                                                }
-                                                containerType="datapage"
-                                            />
-                                        </div>
-                                    )}
+                                    <FallbackGdocFieldExplain
+                                        googleDocEditLink={
+                                            datapage.googleDocEditLink
+                                        }
+                                        fieldName="datasetDescription"
+                                        level="error"
+                                        render={(fallback) =>
+                                            gdocKeyedBlocks?.datasetDescription ? (
+                                                <div className="data-collection__description">
+                                                    <ArticleBlocks
+                                                        blocks={
+                                                            gdocKeyedBlocks.datasetDescription
+                                                        }
+                                                        containerType="datapage"
+                                                    />
+                                                </div>
+                                            ) : (
+                                                fallback
+                                            )
+                                        }
+                                    />
                                 </div>
                                 <div>
                                     <div style={{ marginBottom: "24px" }}>
@@ -468,8 +510,9 @@ export const DataPageContent = ({
                                                                 fieldName={`sourceDescription${
                                                                     idx + 1
                                                                 }`}
+                                                                level="info"
                                                                 render={(
-                                                                    fallback: JSX.Element
+                                                                    fallback
                                                                 ) =>
                                                                     gdocKeyedBlocks?.[
                                                                         `sourceDescription${

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -10,6 +10,8 @@ import {
     GdocsContentSource,
     OwidArticleType,
     getArticleFromJSON,
+    getLinkType,
+    getUrlTarget,
 } from "@ourworldindata/utils"
 import { ArticleBlocks } from "./gdocs/ArticleBlocks.js"
 
@@ -47,8 +49,14 @@ export const DataPageContent = ({
             const json = await response.json()
             setFaqsArticle(getArticleFromJSON(json))
         }
-        if (!datapage.faqsGoogleDocId) return
-        fetchFaqsArticle(datapage.faqsGoogleDocId)
+
+        if (
+            !datapage.faqsGoogleDocEditLink ||
+            getLinkType(datapage.faqsGoogleDocEditLink) !== "gdoc"
+        )
+            return
+        const googleDocId = getUrlTarget(datapage.faqsGoogleDocEditLink)
+        fetchFaqsArticle(googleDocId)
     })
 
     return (

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -143,7 +143,9 @@ export const DataPageContent = ({
                         <div className="key-info__right">
                             <div className="key-info__data">
                                 <div className="title">Source</div>
-                                <div className="name">{sourceShortName}</div>
+                                <div className="name">
+                                    {datapage.nameOfSource}
+                                </div>
                                 {datapage.owidProcessingLevel && (
                                     <div
                                         dangerouslySetInnerHTML={{

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -17,6 +17,7 @@ import { ArticleBlocks } from "./gdocs/ArticleBlocks.js"
 import { faTable } from "@fortawesome/free-solid-svg-icons/faTable"
 import { faGithub } from "@fortawesome/free-brands-svg-icons/faGithub"
 import { RelatedCharts } from "./blocks/RelatedCharts.js"
+import { FallbackGdocFieldExplain } from "./FallbackFieldExplain.js"
 
 declare global {
     interface Window {
@@ -460,42 +461,38 @@ export const DataPageContent = ({
                                                     label={source.sourceName}
                                                     content={
                                                         <>
-                                                            <>
-                                                                {gdocKeyedBlocks?.[
-                                                                    `sourceDescription${
-                                                                        idx + 1
-                                                                    }`
-                                                                ] ? (
-                                                                    <ArticleBlocks
-                                                                        blocks={
-                                                                            gdocKeyedBlocks[
-                                                                                `sourceDescription${
-                                                                                    idx +
-                                                                                    1
-                                                                                }`
-                                                                            ]
-                                                                        }
-                                                                        containerType="datapage"
-                                                                    />
-                                                                ) : (
-                                                                    <span
-                                                                        style={{
-                                                                            color: "red",
-                                                                        }}
-                                                                    >
-                                                                        {`Edit in
-                                                                        google
-                                                                        doc by
-                                                                        adding a
-                                                                        "sourceDescription${
+                                                            <FallbackGdocFieldExplain
+                                                                googleDocEditLink={
+                                                                    datapage.googleDocEditLink
+                                                                }
+                                                                fieldName={`sourceDescription${
+                                                                    idx + 1
+                                                                }`}
+                                                                render={(
+                                                                    fallback: JSX.Element
+                                                                ) =>
+                                                                    gdocKeyedBlocks?.[
+                                                                        `sourceDescription${
                                                                             idx +
                                                                             1
-                                                                        }"
-                                                                        heading
-                                                                        1.`}
-                                                                    </span>
-                                                                )}
-                                                            </>
+                                                                        }`
+                                                                    ] ? (
+                                                                        <ArticleBlocks
+                                                                            blocks={
+                                                                                gdocKeyedBlocks[
+                                                                                    `sourceDescription${
+                                                                                        idx +
+                                                                                        1
+                                                                                    }`
+                                                                                ]
+                                                                            }
+                                                                            containerType="datapage"
+                                                                        />
+                                                                    ) : (
+                                                                        fallback
+                                                                    )
+                                                                }
+                                                            />
                                                             <>
                                                                 {source.sourceRetrievedOn &&
                                                                     source.sourceRetrievedFrom && (

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -263,11 +263,11 @@ export const DataPageContent = ({
                         padding: "48px 0",
                     }}
                 >
-                    <div className="faqs grid wrapper">
+                    <div className="faq grid wrapper">
                         <h2 className="span-cols-2">
                             What you should know about this data
                         </h2>
-                        <div className="faqs__items grid grid-cols-8 span-cols-8">
+                        <div className="faq__items grid grid-cols-8 span-cols-8">
                             {faqsArticle?.content.body && (
                                 <ArticleBlocks
                                     blocks={faqsArticle.content.body}

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -72,13 +72,13 @@ export const DataPageContent = ({
                     <div className="header__left">
                         <div className="supertitle">DATA</div>
                         <h1>{datapage.title}</h1>
-                        <span className="source">
+                        <div className="source">
                             {datapage.variantDescription1 &&
                             datapage.variantDescription2
                                 ? `${datapage.variantDescription1} - ${datapage.variantDescription2}`
                                 : datapage.variantDescription1 ||
                                   datapage.variantDescription2}
-                        </span>
+                        </div>
                     </div>
                     <div className="header__right">
                         <div className="label">

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -57,7 +57,7 @@ export const DataPageContent = ({
             return
         const googleDocId = getUrlTarget(datapage.faqsGoogleDocEditLink)
         fetchFaqsArticle(googleDocId)
-    })
+    }, [datapage.faqsGoogleDocEditLink])
 
     return (
         <>

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -165,6 +165,65 @@ export const DataPageContent = ({
                         ))}
                     </div>
                 </div>
+                <div className="DataPageContent__section-border wrapper">
+                    <hr />
+                </div>
+                <div className="related-data wrapper grid">
+                    <h2 className="span-cols-3">Related data</h2>
+                    <div className="related-data__items span-cols-9">
+                        <div className="span-cols-3">
+                            <a
+                                href={datapage.relatedData[0].url}
+                                key={datapage.relatedData[0].url}
+                                className="related-data__item related-data__item--padded"
+                            >
+                                <div className="related-data__type">
+                                    {datapage.relatedData[0].type}
+                                </div>
+                                <h3>{datapage.relatedData[0].title}</h3>
+                                <div className="related-data__source">
+                                    {datapage.relatedData[0].source}
+                                </div>
+                                <div className="related-data__content">
+                                    {datapage.relatedData[0].content}
+                                </div>
+                            </a>
+                        </div>
+                        <div className="span-cols-3">
+                            {datapage.relatedData
+                                .slice(1, 3)
+                                .map((data: any) => (
+                                    <a
+                                        href={data.url}
+                                        key={data.url}
+                                        className="related-data__item related-data__item--padded"
+                                    >
+                                        <h3>{data.title}</h3>
+                                        <div className="related-data__source">
+                                            {data.source}
+                                        </div>
+                                        <div className="related-data__content">
+                                            {data.content}
+                                        </div>
+                                    </a>
+                                ))}
+                        </div>
+                        <div className="span-cols-3">
+                            {datapage.relatedData.slice(3).map((data: any) => (
+                                <a
+                                    href={data.url}
+                                    key={data.url}
+                                    className="related-data__item"
+                                >
+                                    <h4>{data.title}</h4>
+                                    <div className="related-data__source">
+                                        {data.source}
+                                    </div>
+                                </a>
+                            ))}
+                        </div>
+                    </div>
+                </div>
             </div>
         </>
     )

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -341,12 +341,16 @@ export const DataPageContent = ({
                                             }}
                                         />
                                     </div>
-                                    <div
-                                        className="data-collection__description"
-                                        dangerouslySetInnerHTML={{
-                                            __html: datapage.datasetDescription,
-                                        }}
-                                    />
+                                    {gdocKeyedBlocks?.datasetDescription && (
+                                        <div className="data-collection__description">
+                                            <ArticleBlocks
+                                                blocks={
+                                                    gdocKeyedBlocks.datasetDescription
+                                                }
+                                                containerType="datapage"
+                                            />
+                                        </div>
+                                    )}
                                 </div>
                                 <div>
                                     <div style={{ marginBottom: "24px" }}>

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -130,11 +130,10 @@ export const DataPageContent = ({
                     <div className="key-info__wrapper wrapper">
                         <div className="key-info__left">
                             <h2>Key information</h2>
-                            {datapage.keyInfoText && (
-                                <div
-                                    dangerouslySetInnerHTML={{
-                                        __html: datapage.keyInfoText,
-                                    }}
+                            {gdocKeyedBlocks?.keyInfoText && (
+                                <ArticleBlocks
+                                    blocks={gdocKeyedBlocks.keyInfoText}
+                                    containerType="datapage"
                                 />
                             )}
                             {gdocKeyedBlocks?.faqs && (

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -16,6 +16,7 @@ import {
 import { ArticleBlocks } from "./gdocs/ArticleBlocks.js"
 import { faTable } from "@fortawesome/free-solid-svg-icons/faTable"
 import { faGithub } from "@fortawesome/free-brands-svg-icons/faGithub"
+import { RelatedCharts } from "./blocks/RelatedCharts.js"
 
 declare global {
     interface Window {
@@ -256,6 +257,16 @@ export const DataPageContent = ({
                 <div className="DataPageContent__section-border wrapper">
                     <hr />
                 </div>
+                {datapage.relatedCharts.items.length > 0 && (
+                    <div className="related-charts-wrapper wrapper">
+                        <h2>Explore charts that include this data</h2>
+                        <div>
+                            <RelatedCharts
+                                charts={datapage.relatedCharts.items}
+                            />
+                        </div>
+                    </div>
+                )}
                 <div
                     style={{
                         backgroundColor: "#f7f7f7",

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -132,7 +132,7 @@ export const DataPageContent = ({
                                                     .sourceVariableDescription
                                                     .title
                                             }
-                                            content={
+                                            contentHtml={
                                                 datapage
                                                     .sourceVariableDescription
                                                     .content
@@ -355,7 +355,10 @@ export const DataPageContent = ({
                                             )}
                                         </ul>
                                     </div>
-                                    <div className="data-collection__key-info grid grid-cols-2">
+                                    <div
+                                        className="key-info--gridded grid grid-cols-2"
+                                        style={{ marginBottom: "24px" }}
+                                    >
                                         <div className="key-info__data">
                                             <div className="title">
                                                 Last updated
@@ -406,6 +409,95 @@ export const DataPageContent = ({
                                 />
                             </div>
                         </div>
+                        {datapage.sources.length > 0 && (
+                            <div className="sources grid span-cols-12">
+                                <h3 className="sources__heading span-cols-3">
+                                    This data is based on the following sources:
+                                </h3>
+                                <div className="span-cols-6">
+                                    {datapage.sources.map((source: any) => (
+                                        <div
+                                            className="sources__item"
+                                            key={source.name}
+                                        >
+                                            <ExpandableAnimatedToggle
+                                                label={source.name}
+                                                contentHtml={source.description}
+                                                content={
+                                                    source.retrievedOn && (
+                                                        <div className="key-info--gridded grid grid-cols-2">
+                                                            <div className="key-info__data">
+                                                                <div className="title">
+                                                                    Retrieved on
+                                                                </div>
+                                                                <div>
+                                                                    {
+                                                                        source.retrievedOn
+                                                                    }
+                                                                </div>
+                                                            </div>
+                                                            <div className="key-info__data">
+                                                                <div className="title">
+                                                                    Licence
+                                                                </div>
+                                                                <div>
+                                                                    <a
+                                                                        href={
+                                                                            source
+                                                                                .licenseLink
+                                                                                .url
+                                                                        }
+                                                                        target="_blank"
+                                                                        rel="noreferrer"
+                                                                    >
+                                                                        {
+                                                                            source
+                                                                                .licenseLink
+                                                                                .title
+                                                                        }
+                                                                    </a>
+                                                                </div>
+                                                            </div>
+                                                            <div className="key-info__data">
+                                                                <div className="title">
+                                                                    Next
+                                                                    expected
+                                                                    update
+                                                                </div>
+                                                                <div>
+                                                                    {
+                                                                        source.nextUpdate
+                                                                    }
+                                                                </div>
+                                                            </div>
+                                                            <div className="key-info__data">
+                                                                <div className="title">
+                                                                    Retrieved
+                                                                    from
+                                                                </div>
+                                                                <div>
+                                                                    <a
+                                                                        href={
+                                                                            source.retrievedFromUrl
+                                                                        }
+                                                                        target="_blank"
+                                                                        rel="noreferrer"
+                                                                    >
+                                                                        {
+                                                                            source.retrievedFromUrl
+                                                                        }
+                                                                    </a>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    )
+                                                }
+                                            />
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
                     </div>
                 </div>
             </div>

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -14,6 +14,8 @@ import {
     getUrlTarget,
 } from "@ourworldindata/utils"
 import { ArticleBlocks } from "./gdocs/ArticleBlocks.js"
+import { faTable } from "@fortawesome/free-solid-svg-icons/faTable"
+import { faGithub } from "@fortawesome/free-brands-svg-icons/faGithub"
 
 declare global {
     interface Window {
@@ -34,6 +36,11 @@ export const DataPageContent = ({
     const [faqsArticle, setFaqsArticle] = React.useState<
         OwidArticleType | undefined
     >(undefined)
+
+    const sourceShortName =
+        datapage.variantDescription1 && datapage.variantDescription2
+            ? `${datapage.variantDescription1} - ${datapage.variantDescription2}`
+            : datapage.variantDescription1 || datapage.variantDescription2
 
     // Initialize the grapher for client-side rendering
     useEffect(() => {
@@ -72,13 +79,7 @@ export const DataPageContent = ({
                     <div className="header__left">
                         <div className="supertitle">DATA</div>
                         <h1>{datapage.title}</h1>
-                        <div className="source">
-                            {datapage.variantDescription1 &&
-                            datapage.variantDescription2
-                                ? `${datapage.variantDescription1} - ${datapage.variantDescription2}`
-                                : datapage.variantDescription1 ||
-                                  datapage.variantDescription2}
-                        </div>
+                        <div className="source">{sourceShortName}</div>
                     </div>
                     <div className="header__right">
                         <div className="label">
@@ -143,9 +144,7 @@ export const DataPageContent = ({
                         <div className="key-info__right">
                             <div className="key-info__data">
                                 <div className="title">Source</div>
-                                <div className="name">
-                                    {datapage.sourceShortName}
-                                </div>
+                                <div className="name">{sourceShortName}</div>
                                 {datapage.owidProcessingLevel && (
                                     <div
                                         dangerouslySetInnerHTML={{
@@ -274,6 +273,138 @@ export const DataPageContent = ({
                                     containerType="datapage"
                                 />
                             )}
+                        </div>
+                    </div>
+                </div>
+                <div
+                    className="DataPageContent__section-border wrapper"
+                    style={{
+                        backgroundColor: "#f7f7f7",
+                    }}
+                >
+                    <hr />
+                </div>
+                <div
+                    style={{
+                        backgroundColor: "#f7f7f7",
+                        padding: "48px 0",
+                    }}
+                >
+                    <div className="dataset grid wrapper">
+                        <h2 className="span-cols-3">Sources and Processing</h2>
+                        <div className="dataset__content span-cols-6">
+                            <div className="body-2-regular">
+                                In preparing data for our visualizations, Our
+                                World in Data prepares datasets from original
+                                data obtained from one or more data providers.
+                            </div>
+                            <div className="data-collection">
+                                <div>
+                                    <div className="data-collection__header">
+                                        This metric was prepared as part of the
+                                        following dataset:
+                                    </div>
+                                    <div className="data-collection__name">
+                                        <FontAwesomeIcon icon={faTable} />
+                                        <span
+                                            dangerouslySetInnerHTML={{
+                                                __html: datapage.dataset
+                                                    .datasetName,
+                                            }}
+                                        />
+                                    </div>
+                                    <div
+                                        className="data-collection__description"
+                                        dangerouslySetInnerHTML={{
+                                            __html: datapage.dataset
+                                                .datasetDescription,
+                                        }}
+                                    />
+                                </div>
+                                <div>
+                                    <div style={{ marginBottom: "24px" }}>
+                                        <h4 className="metrics-list__header">
+                                            Metrics included in this data
+                                            collection:
+                                        </h4>
+                                        <ul className="featured-variables">
+                                            {datapage.dataset.featuredVariables.map(
+                                                (
+                                                    variable: any,
+                                                    idx: number
+                                                ) => (
+                                                    <li
+                                                        className="featured-variables__item"
+                                                        key={
+                                                            variable.variableName
+                                                        }
+                                                    >
+                                                        {idx !== 0 ? (
+                                                            variable.variableName
+                                                        ) : (
+                                                            <strong>
+                                                                {`${variable.variableName} `}
+                                                                <em>
+                                                                    (currently
+                                                                    viewing)
+                                                                </em>
+                                                            </strong>
+                                                        )}
+                                                    </li>
+                                                )
+                                            )}
+                                        </ul>
+                                    </div>
+                                    <div className="data-collection__key-info grid grid-cols-2">
+                                        <div className="key-info__data">
+                                            <div className="title">
+                                                Last updated
+                                            </div>
+                                            <div>{datapage.lastUpdated}</div>
+                                        </div>
+                                        <div className="key-info__data">
+                                            <div className="title">
+                                                Next expected update
+                                            </div>
+                                            <div>{datapage.nextUpdate}</div>
+                                        </div>
+                                        <div className="key-info__data">
+                                            <div className="title">Licence</div>
+                                            <div>
+                                                <a
+                                                    href={
+                                                        datapage.dataset
+                                                            .datasetLicenseLink
+                                                            .url
+                                                    }
+                                                    target="_blank"
+                                                    rel="noreferrer"
+                                                >
+                                                    {
+                                                        datapage.dataset
+                                                            .datasetLicenseLink
+                                                            .title
+                                                    }
+                                                </a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    {datapage.dataset?.codeUrl && (
+                                        <a
+                                            href={datapage.dataset.codeUrl}
+                                            className="data-collection__code-link"
+                                        >
+                                            <FontAwesomeIcon icon={faGithub} />
+                                            See the code used to prepare this
+                                            dataset
+                                        </a>
+                                    )}
+                                </div>
+                                <ExpandableAnimatedToggle
+                                    label="Download all metrics"
+                                    content="TBD"
+                                />
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -143,16 +143,20 @@ export const DataPageContent = ({
                                 </a>
                             )}
                             {datapage.descriptionFromSource?.title &&
-                                datapage.descriptionFromSource?.content && (
-                                    <div style={{ marginTop: 8 }}>
+                                gdocKeyedBlocks?.descriptionFromSource && (
+                                    <div className="key-info__description-source">
                                         <ExpandableAnimatedToggle
                                             label={
                                                 datapage.descriptionFromSource
                                                     .title
                                             }
-                                            contentHtml={
-                                                datapage.descriptionFromSource
-                                                    .content
+                                            content={
+                                                <ArticleBlocks
+                                                    blocks={
+                                                        gdocKeyedBlocks.descriptionFromSource
+                                                    }
+                                                    containerType="datapage"
+                                                />
                                             }
                                         />
                                     </div>

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -6,6 +6,12 @@ import { ExpandableAnimatedToggle } from "./ExpandableAnimatedToggle.js"
 import ReactDOM from "react-dom"
 import { GrapherWithFallback } from "./GrapherWithFallback.js"
 import { formatAuthors } from "./clientFormatting.js"
+import {
+    GdocsContentSource,
+    OwidArticleType,
+    getArticleFromJSON,
+} from "@ourworldindata/utils"
+import { ArticleBlocks } from "./gdocs/ArticleBlocks.js"
 
 declare global {
     interface Window {
@@ -23,11 +29,27 @@ export const DataPageContent = ({
     grapherConfig: GrapherInterface
 }) => {
     const [grapher, setGrapher] = React.useState<Grapher | undefined>(undefined)
+    const [faqsArticle, setFaqsArticle] = React.useState<
+        OwidArticleType | undefined
+    >(undefined)
 
     // Initialize the grapher for client-side rendering
     useEffect(() => {
         setGrapher(new Grapher(grapherConfig))
     }, [grapherConfig])
+
+    // Not suitable for production, only for prototyping
+    useEffect(() => {
+        const fetchFaqsArticle = async (googleDocId: string) => {
+            const response = await fetch(
+                `/admin/api/gdocs/${googleDocId}?contentSource=${GdocsContentSource.Gdocs}`
+            )
+            const json = await response.json()
+            setFaqsArticle(getArticleFromJSON(json))
+        }
+        if (!datapage.faqsGoogleDocId) return
+        fetchFaqsArticle(datapage.faqsGoogleDocId)
+    })
 
     return (
         <>
@@ -221,6 +243,29 @@ export const DataPageContent = ({
                                     </div>
                                 </a>
                             ))}
+                        </div>
+                    </div>
+                </div>
+                <div className="DataPageContent__section-border wrapper">
+                    <hr />
+                </div>
+                <div
+                    style={{
+                        backgroundColor: "#f7f7f7",
+                        padding: "48px 0",
+                    }}
+                >
+                    <div className="faqs grid wrapper">
+                        <h2 className="span-cols-2">
+                            What you should know about this data
+                        </h2>
+                        <div className="faqs__items grid grid-cols-8 span-cols-8">
+                            {faqsArticle?.content.body && (
+                                <ArticleBlocks
+                                    blocks={faqsArticle.content.body}
+                                    containerType="datapage"
+                                />
+                            )}
                         </div>
                     </div>
                 </div>

--- a/site/ExpandableAnimatedToggle.scss
+++ b/site/ExpandableAnimatedToggle.scss
@@ -21,7 +21,16 @@
         font-size: 0.75em;
         margin: 0 12px;
     }
-    .content {
+    .content-wrapper {
         padding-bottom: 12px;
+    }
+
+    .content__html {
+        > *:first-child {
+            margin-top: 0;
+        }
+        > *:last-child {
+            margin-bottom: 0;
+        }
     }
 }

--- a/site/ExpandableAnimatedToggle.scss
+++ b/site/ExpandableAnimatedToggle.scss
@@ -17,7 +17,7 @@
         @include h4-semibold;
         margin: 0;
     }
-    svg {
+    .ExpandableAnimatedToggle__icon {
         font-size: 0.75em;
         margin: 0 12px;
     }

--- a/site/ExpandableAnimatedToggle.tsx
+++ b/site/ExpandableAnimatedToggle.tsx
@@ -5,10 +5,12 @@ import AnimateHeight from "react-animate-height"
 
 export const ExpandableAnimatedToggle = ({
     label,
+    contentHtml = "",
     content,
 }: {
     label: string
-    content: any
+    contentHtml?: string
+    content?: React.ReactNode
 }) => {
     const [height, setHeight] = useState<"auto" | 0>(0)
 
@@ -23,10 +25,13 @@ export const ExpandableAnimatedToggle = ({
                 <FontAwesomeIcon icon={faPlus} />
             </button>
             <AnimateHeight height={height} animateOpacity>
-                <div
-                    className="content"
-                    dangerouslySetInnerHTML={{ __html: content }}
-                />
+                <div className="content-wrapper">
+                    <div
+                        className="content__html"
+                        dangerouslySetInnerHTML={{ __html: contentHtml }}
+                    />
+                    {content}
+                </div>
             </AnimateHeight>
         </div>
     )

--- a/site/ExpandableAnimatedToggle.tsx
+++ b/site/ExpandableAnimatedToggle.tsx
@@ -20,7 +20,10 @@ export const ExpandableAnimatedToggle = ({
         <div className="ExpandableAnimatedToggle">
             <button onClick={toggle}>
                 <h4>{label}</h4>
-                <FontAwesomeIcon icon={faPlus} />
+                <FontAwesomeIcon
+                    className="ExpandableAnimatedToggle__icon"
+                    icon={faPlus}
+                />
             </button>
             <AnimateHeight height={height} animateOpacity>
                 <div className="content-wrapper">{content}</div>

--- a/site/ExpandableAnimatedToggle.tsx
+++ b/site/ExpandableAnimatedToggle.tsx
@@ -5,11 +5,9 @@ import AnimateHeight from "react-animate-height"
 
 export const ExpandableAnimatedToggle = ({
     label,
-    contentHtml = "",
     content,
 }: {
     label: string
-    contentHtml?: string
     content?: React.ReactNode
 }) => {
     const [height, setHeight] = useState<"auto" | 0>(0)
@@ -25,13 +23,7 @@ export const ExpandableAnimatedToggle = ({
                 <FontAwesomeIcon icon={faPlus} />
             </button>
             <AnimateHeight height={height} animateOpacity>
-                <div className="content-wrapper">
-                    <div
-                        className="content__html"
-                        dangerouslySetInnerHTML={{ __html: contentHtml }}
-                    />
-                    {content}
-                </div>
+                <div className="content-wrapper">{content}</div>
             </AnimateHeight>
         </div>
     )

--- a/site/FallbackFieldExplain.tsx
+++ b/site/FallbackFieldExplain.tsx
@@ -7,12 +7,12 @@ export const FallbackGdocFieldExplain = ({
     fieldName,
     googleDocEditLink,
     render,
-    level = "info",
+    level,
 }: {
     fieldName: string
     googleDocEditLink: string
     render: (fallback: JSX.Element) => JSX.Element
-    level?: "info" | "error"
+    level: "info" | "error"
 }) => {
     const icon = level === "info" ? faExclamationCircle : faExclamationTriangle
     const styles =
@@ -22,8 +22,8 @@ export const FallbackGdocFieldExplain = ({
                   borderColor: "#91caff",
               }
             : {
-                  backgroundColor: "#fffbe6",
-                  borderColor: "#ffe58f",
+                  backgroundColor: "#fff2f0",
+                  borderColor: "#ffccc7",
               }
 
     return render(
@@ -33,6 +33,7 @@ export const FallbackGdocFieldExplain = ({
                 padding: "8px 12px",
                 border: `1px solid ${styles.borderColor}`,
                 borderRadius: 8,
+                margin: "8px 0",
             }}
         >
             <FontAwesomeIcon style={{ marginRight: 8 }} icon={icon} /> Edit in
@@ -40,7 +41,7 @@ export const FallbackGdocFieldExplain = ({
             <a href={googleDocEditLink} target="_blank" rel="noreferrer">
                 google doc
             </a>{" "}
-            by adding a "{fieldName}" heading 1
+            by adding content below a "{fieldName}" heading 1
         </div>
     )
 }

--- a/site/FallbackFieldExplain.tsx
+++ b/site/FallbackFieldExplain.tsx
@@ -1,0 +1,46 @@
+import React from "react"
+import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons/faExclamationCircle"
+import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons/faExclamationTriangle"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
+
+export const FallbackGdocFieldExplain = ({
+    fieldName,
+    googleDocEditLink,
+    render,
+    level = "info",
+}: {
+    fieldName: string
+    googleDocEditLink: string
+    render: (fallback: JSX.Element) => JSX.Element
+    level?: "info" | "error"
+}) => {
+    const icon = level === "info" ? faExclamationCircle : faExclamationTriangle
+    const styles =
+        level === "info"
+            ? {
+                  backgroundColor: "#e6f4ff",
+                  borderColor: "#91caff",
+              }
+            : {
+                  backgroundColor: "#fffbe6",
+                  borderColor: "#ffe58f",
+              }
+
+    return render(
+        <div
+            style={{
+                backgroundColor: styles.backgroundColor,
+                padding: "8px 12px",
+                border: `1px solid ${styles.borderColor}`,
+                borderRadius: 8,
+            }}
+        >
+            <FontAwesomeIcon style={{ marginRight: 8 }} icon={icon} /> Edit in
+            the{" "}
+            <a href={googleDocEditLink} target="_blank" rel="noreferrer">
+                google doc
+            </a>{" "}
+            by adding a "{fieldName}" heading 1
+        </div>
+    )
+}

--- a/site/css/mixins.scss
+++ b/site/css/mixins.scss
@@ -333,3 +333,8 @@
         display: none;
     }
 }
+
+// should be removed when fixed in centered-article
+@mixin HACK-fix-bullets-outside {
+    margin-left: 16px;
+}

--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -75,6 +75,7 @@ const layouts: { [key in Container]: Layouts} = {
     },
     ["datapage"]: {
         ["default"]: "col-start-2 span-cols-6",
+        ["chart"]: "col-start-1 span-cols-8",
     },
     ["sticky-right-left-column"]: {
         ["chart"]: "span-cols-5 col-start-1 span-md-cols-10 col-md-start-2 span-sm-cols-12 col-sm-start-1",

--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -34,6 +34,7 @@ export type Container =
     | "sticky-left-right-column"
     | "side-by-side"
     | "summary"
+    | "datapage"
 
 // Each container must have a default layout, usually just full-width
 type Layouts = { default: string; [key: string]: string }
@@ -71,6 +72,9 @@ const layouts: { [key in Container]: Layouts} = {
         ["sticky-right-right-column"]: "span-cols-7 span-md-cols-12",
         ["sticky-right"]: "grid span-cols-12 col-start-2",
         ["text"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
+    },
+    ["datapage"]: {
+        ["default"]: "col-start-2 span-cols-6",
     },
     ["sticky-right-left-column"]: {
         ["chart"]: "span-cols-5 col-start-1 span-md-cols-10 col-md-start-2 span-sm-cols-12 col-sm-start-1",

--- a/site/gdocs/Chart.tsx
+++ b/site/gdocs/Chart.tsx
@@ -31,6 +31,7 @@ export default function Chart({
         <div
             className={cx(d.position, className)}
             style={{ gridRow: d.row, gridColumn: d.column }}
+            ref={refChartContainer}
         >
             <figure
                 // Use unique `key` to force React to re-render tree

--- a/site/gdocs/Image.tsx
+++ b/site/gdocs/Image.tsx
@@ -38,6 +38,7 @@ const containerSizes: Record<ImageParentContainer, string> = {
     ["side-by-side"]: gridSpan6,
     ["summary"]: gridSpan6,
     ["thumbnail"]: "350px",
+    ["datapage"]: gridSpan6,
 }
 
 export default function Image(props: {


### PR DESCRIPTION
Follow up to #2075, addressing #1947

- Test URL: https://exemplars.owid.cloud/admin/grapher/co-emissions-per-capita
- Test JSON: https://github.com/owid/owid-content/blob/staging/datapages/538918.json

Re-affirming the intention to "get pixels on the screen" so authors can start creating data pages and getting a sense for whether the editorial model works.

- Adding most of the remaining blocks
- Downgrading from "could potentially be published" to "will only work as a high-fidelity internal preview"
- Rendering sections of rich text from individual google docs, parsed and transformed through the new gdoc pipeline. This is rendered client-side only, using an admin route (so not suitable for production).
- Code quality is also sub-par, not too much time should be spent evaluating it as this stage.
- known issue: `isKeyChart` demotes a chart instead of promoting it. This feature might not be necessary.

TODO
- [x] add gdoc editing to all longer sections (e.g. key info, sources)
