### PR TITLE
Display aggregates separately in tables

### DIFF
--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
@@ -93,7 +93,7 @@ describe("when you select a range of years", () => {
 
     it("renders absolute change values", () => {
         const cell = view.find("tbody .dimension-delta").first()
-        expect(cell.text()).toBe("-0.89 pp")
+        expect(cell.text()).toBe("-0.89\u00a0pp") // uses no-break space separator
     })
 
     it("renders relative change values", () => {

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
@@ -41,7 +41,7 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
 
 .data-table {
     font-size: 0.9375rem;
-    line-height: 16px;
+    line-height: 1.333em;
     border: none;
     background: white;
     width: 100%;
@@ -101,6 +101,10 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
     td {
         padding-left: 15px;
         padding-right: 15px;
+
+        &:not(.entity) {
+            vertical-align: bottom;
+        }
     }
 
     th.dimension {

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
@@ -197,10 +197,6 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
             opacity: 0.5;
             padding-bottom: 3px;
         }
-
-        > span:last-child {
-            white-space: nowrap;
-        }
     }
 
     .closest-time-notice-icon {

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
@@ -193,6 +193,10 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
             opacity: 0.5;
             padding-bottom: 3px;
         }
+
+        > span:last-child {
+            white-space: nowrap;
+        }
     }
 
     .closest-time-notice-icon {

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
@@ -45,6 +45,7 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
     border: none;
     background: white;
     width: 100%;
+    border-collapse: collapse;
     border-spacing: 0px;
     box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 2px 0px,
         rgba(0, 0, 0, 0.25) 0px 2px 2px 0px;
@@ -168,6 +169,15 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
     .entity {
         text-align: left;
         font-weight: 700;
+    }
+
+    tr:not(.aggregate) + tr.aggregate {
+        border-top: 6px solid #aaa;
+    }
+
+    .aggregate .entity {
+        font-style: italic;
+        font-weight: 400;
     }
 
     .dimension {

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
@@ -201,13 +201,16 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
 
     .closest-time-notice-icon {
         opacity: 0.5;
-        padding-right: 8px;
         font-size: 13px;
         cursor: default;
 
         .icon {
             font-size: 0.75rem;
             opacity: 0.6;
+        }
+
+        & + span {
+            margin-left: 8px;
         }
     }
 

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
@@ -13,29 +13,24 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
 }
 
 .tableTab .data-table {
-    th {
+    thead {
         position: sticky;
-        z-index: 10;
+        z-index: 20;
+        top: 0;
+    }
+
+    th {
         white-space: nowrap;
-
-        &.dimension,
-        &.entity {
-            top: 0;
-        }
-
-        &.entity {
-            z-index: 11;
-        }
-
-        &.subdimension {
-            top: 53px;
-        }
     }
 
     .entity {
         position: sticky;
         left: 0;
         z-index: 10;
+    }
+
+    th.entity {
+        top: 0;
     }
 }
 
@@ -45,7 +40,7 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
     border: none;
     background: white;
     width: 100%;
-    border-collapse: collapse;
+    border-collapse: separate;
     border-spacing: 0px;
     box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 2px 0px,
         rgba(0, 0, 0, 0.25) 0px 2px 2px 0px;

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -138,6 +138,10 @@ export class DataTable extends React.Component<{
         return this.manager.entityType
     }
 
+    @computed private get entitiesAreCountryLike(): boolean {
+        return !!this.manager.entityType.match(/\bcountry\b/i)
+    }
+
     @computed private get sortValueMapper(): (
         row: DataTableRow
     ) => number | string {
@@ -364,7 +368,7 @@ export class DataTable extends React.Component<{
                 key={row.entityName}
                 className={classnames({
                     aggregate:
-                        this.manager.entityType.match(/\bcountry\b/i) &&
+                        this.entitiesAreCountryLike &&
                         !isCountryName(row.entityName),
                 })}
             >

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -31,8 +31,7 @@ import {
     ColumnSlug,
     TickFormattingOptions,
     Tippy,
-    countries,
-    historicalCountries,
+    isCountryName,
 } from "@ourworldindata/utils"
 import { SortIcon } from "../controls/SortIcon"
 import { makeSelectionArray } from "../chart/ChartUtils"
@@ -68,14 +67,6 @@ const columnNameByType: Record<ColumnKey, string> = {
 
 const inverseSortOrder = (order: SortOrder): SortOrder =>
     order === SortOrder.asc ? SortOrder.desc : SortOrder.asc
-
-const countryNames = countries
-    .map((c) => c.name)
-    .concat(
-        historicalCountries
-            .map((c) => [c.name, ...(c.variantNames ?? [])])
-            .flat()
-    )
 
 export interface DataTableManager {
     table: OwidTable
@@ -184,7 +175,7 @@ export class DataTable extends React.Component<{
         row: DataTableRow
     ) => number {
         return (row: DataTableRow): number =>
-            countryNames.includes(row.entityName) ? 0 : 1
+            isCountryName(row.entityName) ? 0 : 1
     }
 
     @computed private get hasSubheaders(): boolean {
@@ -374,7 +365,7 @@ export class DataTable extends React.Component<{
                 className={classnames({
                     aggregate:
                         this.manager.entityType == "country" &&
-                        !countryNames.includes(row.entityName),
+                        !isCountryName(row.entityName),
                 })}
             >
                 <td

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -364,7 +364,7 @@ export class DataTable extends React.Component<{
                 key={row.entityName}
                 className={classnames({
                     aggregate:
-                        this.manager.entityType == "country" &&
+                        this.manager.entityType.match(/\bcountry\b/i) &&
                         !isCountryName(row.entityName),
                 })}
             >

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -528,6 +528,7 @@ export class DataTable extends React.Component<{
             : column.formatValueShort(value, {
                   numberAbbreviation: false,
                   trailingZeroes: true,
+                  useNoBreakSpace: true,
                   ...formattingOverrides,
               })
     }

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -69,9 +69,13 @@ const columnNameByType: Record<ColumnKey, string> = {
 const inverseSortOrder = (order: SortOrder): SortOrder =>
     order === SortOrder.asc ? SortOrder.desc : SortOrder.asc
 
-const countryNames = countries.map(c => c.name).concat(
-    historicalCountries.map(c => [c.name, ...(c.variantNames ?? [])]).flat()
-)
+const countryNames = countries
+    .map((c) => c.name)
+    .concat(
+        historicalCountries
+            .map((c) => [c.name, ...(c.variantNames ?? [])])
+            .flat()
+    )
 
 export interface DataTableManager {
     table: OwidTable

--- a/packages/@ourworldindata/utils/src/formatValue.ts
+++ b/packages/@ourworldindata/utils/src/formatValue.ts
@@ -6,6 +6,7 @@ export interface TickFormattingOptions {
     unit?: string
     trailingZeroes?: boolean
     spaceBeforeUnit?: boolean
+    useNoBreakSpace?: boolean
     showPlus?: boolean
     numberAbbreviation?: "short" | "long" | false
 }
@@ -126,6 +127,7 @@ function postprocessString({
     string,
     numberAbbreviation,
     spaceBeforeUnit,
+    useNoBreakSpace,
     unit,
     value,
     numDecimalPlaces,
@@ -133,6 +135,7 @@ function postprocessString({
     string: string
     numberAbbreviation: "long" | "short" | false
     spaceBeforeUnit: boolean
+    useNoBreakSpace: boolean
     unit: string
     value: number
     numDecimalPlaces: number
@@ -153,7 +156,8 @@ function postprocessString({
     }
 
     if (unit && !checkIsUnitCurrency(unit)) {
-        const appendage = spaceBeforeUnit ? ` ${unit}` : unit
+        const spaceCharacter = useNoBreakSpace ? "\u00a0" : " "
+        const appendage = spaceBeforeUnit ? spaceCharacter + unit : unit
         output += appendage
     }
 
@@ -166,6 +170,7 @@ export function formatValue(
         trailingZeroes = false,
         unit = "",
         spaceBeforeUnit = !checkIsUnitPercent(unit),
+        useNoBreakSpace = false,
         showPlus = false,
         numDecimalPlaces = 2,
         numberAbbreviation = "long",
@@ -195,6 +200,7 @@ export function formatValue(
         string: formattedString,
         numberAbbreviation,
         spaceBeforeUnit,
+        useNoBreakSpace,
         unit,
         value,
         numDecimalPlaces,

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -392,6 +392,7 @@ export {
     type Country,
     getCountryBySlug,
     getCountryDetectionRedirects,
+    isCountryName,
     continents,
     type Continent,
     aggregates,

--- a/packages/@ourworldindata/utils/src/regions.ts
+++ b/packages/@ourworldindata/utils/src/regions.ts
@@ -67,6 +67,13 @@ const countriesBySlug: Record<string, Country> = Object.fromEntries(
     countries.map((country) => [country.slug, country])
 )
 
+const currentAndHistoricalCountryNames = regions
+    .filter(({ regionType }) => regionType === "country")
+    .map(({ name }) => name)
+
+export const isCountryName = (name: string): boolean =>
+    currentAndHistoricalCountryNames.includes(name)
+
 export const getCountryBySlug = (slug: string): Country | undefined =>
     countriesBySlug[slug]
 


### PR DESCRIPTION
Implements the proposal sketched in #1876 to group countries and aggregates into separate regions within the table. Countries are always listed first and their names are styled in bold. Aggregates are moved to the end of the table and their names are italicized. When the table is sorted by a column, the two groupings within the table are sorted independently.

## Additional styling tweaks

To improve the readability of individual rows, the formatter now takes an option to use a no-break space to join the value and its unit, preventing awkward cases with unstable vertical baselines such as:
<img width="594" alt="image" src="https://user-images.githubusercontent.com/469523/231165432-7de73aed-7a4b-4718-ad4e-910d80b17018.png">

Vertically aligning cells to the bottom of the cell improves the chances that numerals will all be on the same line regardless of the presence of a data-not-available annotation:
<img width="546" alt="image" src="https://user-images.githubusercontent.com/469523/231166051-c5d24a64-a6da-4004-8b54-874a08eb9dc7.png">

A new formatting option that applies to [formatValue](https://github.com/owid/owid-grapher/blob/master/packages/%40ourworldindata/utils/src/formatValue.ts) and friends is the optional boolean flag `useNoBreakSpace`. It is `false` by default and only applies in cases where `spaceBeforeUnit` is `true`. If a no-break space is requested, a `\00a0` space will be used instead of the standard `\u0020`.

## Design questions

- Should the divider between the countries & aggregates sections have a text label along the lines of "Other groupings"?
- Should the header for the entities column retitle itself from "Countries" to something else ("Aggregates"? "Other regions"?) when the user scrolls into the aggregate section?

## Preview

The above screenshots come from:
http://staging-site-restyle-aggregates-in-tables/grapher/kaya-identity-co2?tab=table

Also note that for tables whose `entityType` doesn't [contain the string `country`](https://github.com/owid/owid-grapher/issues/2173), the country-vs-aggregate sorting and styling isn't applied:
http://staging-site-restyle-aggregates-in-tables/grapher/artificial-intelligence-training-computation?tab=table