### PR TITLE
fix(gdocs): use correct name for hydrated element

### DIFF
--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -340,7 +340,7 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                     resets on every change)
                 */}
                 <iframe
-                    src={`/gdocs/${currentGdoc.id}/preview#owid-article-root`}
+                    src={`/gdocs/${currentGdoc.id}/preview#owid-document-root`}
                     style={{ width: "100%", border: "none" }}
                     key={currentGdoc.revisionId}
                 />

--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -163,7 +163,7 @@ export function OwidGdoc({
 }
 
 export const hydrateOwidGdoc = (debug?: boolean, isPreviewing?: boolean) => {
-    const wrapper = document.querySelector("#owid-article-root")
+    const wrapper = document.querySelector("#owid-document-root")
     const props = getOwidGdocFromJSON(window._OWID_GDOC_PROPS)
     ReactDOM.hydrate(
         <React.StrictMode>


### PR DESCRIPTION
I know nothing about how this works, but this has recently been renamed and is currently breaking hydration in prod...