### PR TITLE
migrate: `selectedEntityIds` -> `selectedEntityNames`

### DIFF
--- a/db/migration/1661264304751-MigrateSelectedData.ts
+++ b/db/migration/1661264304751-MigrateSelectedData.ts
@@ -29,7 +29,12 @@ interface EntitySelection {
     color?: string
 }
 
-interface GrapherInterfaceBeforeMigration extends GrapherInterface {
+interface GrapherInterfaceAfterMigration extends GrapherInterface {
+    selectedEntityIds?: number[]
+}
+
+interface GrapherInterfaceBeforeMigration
+    extends GrapherInterfaceAfterMigration {
     selectedData?: EntitySelection[]
 }
 

--- a/db/migration/1681310285750-MigrateSelectedEntityIds.ts
+++ b/db/migration/1681310285750-MigrateSelectedEntityIds.ts
@@ -1,5 +1,9 @@
 import { MigrationInterface, QueryRunner } from "typeorm"
 
+/**
+ * BEFORE this migration, we had a legacy `selectedEntityIds` property on most old chart configs.
+ * It was used _only_ in case the `selectedEntityNames` property was not present.
+ */
 export class MigrateSelectedEntityIds1681310285750
     implements MigrationInterface
 {

--- a/db/migration/1681310285750-MigrateSelectedEntityIds.ts
+++ b/db/migration/1681310285750-MigrateSelectedEntityIds.ts
@@ -1,0 +1,68 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+import { entityNameById } from "./data/entityNameById.js"
+import { GrapherInterface } from "@ourworldindata/grapher"
+
+interface GrapherInterfaceBeforeMigration extends GrapherInterface {
+    selectedEntityIds?: number[]
+}
+
+export class MigrateSelectedEntityIds1681310285750
+    implements MigrationInterface
+{
+    static transformConfig(
+        legacyConfig: GrapherInterfaceBeforeMigration | undefined
+    ): GrapherInterface {
+        if (!legacyConfig || legacyConfig.selectedEntityNames !== null)
+            return legacyConfig ?? {}
+
+        const selectedEntityNames = legacyConfig.selectedEntityIds?.map(
+            (id) => {
+                const name = entityNameById[id]
+                if (!name) throw new Error(`Entity name not found for id ${id}`)
+                return name
+            }
+        )
+
+        return {
+            ...legacyConfig,
+            selectedEntityNames,
+            selectedEntityIds: undefined,
+        }
+    }
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const tables = {
+            charts: "config",
+            chart_revisions: "config",
+            suggested_chart_revisions: "suggestedConfig",
+        }
+
+        for (const [tableName, columnName] of Object.entries(tables)) {
+            const rows = await queryRunner.query(
+                `
+                SELECT id, ${columnName} AS json
+                FROM ${tableName}
+                WHERE JSON_CONTAINS_PATH(${columnName}, 'one', '$.selectedEntityIds')
+                `
+            )
+            for (const row of rows) {
+                const config = JSON.parse(
+                    row.json
+                ) as GrapherInterfaceBeforeMigration
+                const newConfig =
+                    MigrateSelectedEntityIds1681310285750.transformConfig(
+                        config
+                    )
+                await queryRunner.query(
+                    `UPDATE ${tableName} SET ${columnName} = ? WHERE id = ?`,
+                    [JSON.stringify(newConfig), row.id]
+                )
+            }
+        }
+    }
+
+    public async down(): Promise<void> {
+        // no going back!
+    }
+}

--- a/devTools/schemaProcessor/columns.json
+++ b/devTools/schemaProcessor/columns.json
@@ -599,11 +599,6 @@
         "editor": "numeric"
     },
     {
-        "type": "array",
-        "pointer": "/selectedEntityIds",
-        "editor": "primitiveListEditor"
-    },
-    {
         "type": "string",
         "pointer": "/addCountryMode",
         "default": "add-country",

--- a/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
@@ -132,7 +132,7 @@ const legacyConfig: Omit<LegacyGrapherInterface, "data"> &
             },
         ],
     ]),
-    selectedEntityIds: [207, 15],
+    selectedEntityNames: ["Iceland", "Afghanistan"],
 }
 
 it("can apply legacy chart dimension settings", () => {
@@ -170,7 +170,7 @@ it("can fallback to a ycolumn if a map variableId does not exist", () => {
 it("can generate a url with country selection even if there is no entity code", () => {
     const config = {
         ...legacyConfig,
-        selectedEntityIds: [],
+        selectedEntityNames: [],
     }
     const grapher = new Grapher(config)
     expect(grapher.queryStr).toBe("")
@@ -179,7 +179,7 @@ it("can generate a url with country selection even if there is no entity code", 
 
     const config2 = {
         ...legacyConfig,
-        selectedEntityIds: [],
+        selectedEntityNames: [],
     }
     metadata.dimensions.entities.values.find(
         (entity) => entity.id === 15

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -357,7 +357,6 @@ export class Grapher
     @observable selectedEntityColors: {
         [entityName: string]: string | undefined
     } = {}
-    @observable selectedEntityIds: EntityId[] = []
     @observable excludedEntities?: number[] = undefined
     /** IncludedEntities are ususally empty which means use all available entites. When
         includedEntities is set it means "only use these entities". excludedEntities
@@ -832,8 +831,6 @@ export class Grapher
     @action.bound private applyOriginalSelectionAsAuthored(): void {
         if (this.selectedEntityNames.length)
             this.selection.setSelectedEntities(this.selectedEntityNames)
-        else if (this.selectedEntityIds.length)
-            this.selection.setSelectedEntitiesByEntityId(this.selectedEntityIds)
     }
 
     @observable private _baseFontSize = BASE_FONT_SIZE
@@ -2362,18 +2359,19 @@ export class Grapher
         | undefined {
         const authoredConfig = this.legacyConfigAsAuthored
 
-        const originalSelectedEntityIds = authoredConfig.selectedEntityIds ?? []
-        const currentSelectedEntityIds = this.selection.allSelectedEntityIds
+        const originalSelectedEntityNames =
+            authoredConfig.selectedEntityNames ?? []
+        const currentSelectedEntityNames = this.selection.selectedEntityNames
 
-        const entityIdsThatTheUserDeselected = difference(
-            currentSelectedEntityIds,
-            originalSelectedEntityIds
+        const entityNamesThatTheUserDeselected = difference(
+            currentSelectedEntityNames,
+            originalSelectedEntityNames
         )
 
         if (
-            currentSelectedEntityIds.length !==
-                originalSelectedEntityIds.length ||
-            entityIdsThatTheUserDeselected.length
+            currentSelectedEntityNames.length !==
+                originalSelectedEntityNames.length ||
+            entityNamesThatTheUserDeselected.length
         )
             return this.selection.selectedEntityNames
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -112,7 +112,6 @@ import { ComparisonLineConfig } from "../scatterCharts/ComparisonLine"
 import {
     ColumnSlugs,
     Time,
-    EntityId,
     EntityName,
     OwidColumnDef,
     OwidVariableRow,

--- a/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
@@ -89,7 +89,6 @@ export interface GrapherInterface extends SortConfig {
     includedEntities?: number[]
     selectedEntityNames?: EntityName[]
     selectedEntityColors?: { [entityName: string]: string | undefined }
-    selectedEntityIds?: EntityId[]
     facet?: FacetStrategy
 
     xAxis?: Partial<AxisConfigInterface>
@@ -180,7 +179,6 @@ export const grapherKeysToSerialize = [
     "dimensions",
     "selectedEntityNames",
     "selectedEntityColors",
-    "selectedEntityIds",
     "sortBy",
     "sortOrder",
     "sortColumnSlug",

--- a/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
@@ -21,12 +21,7 @@ import { ComparisonLineConfig } from "../scatterCharts/ComparisonLine"
 import { LogoOption } from "../captionedChart/Logos"
 import { ColorScaleConfigInterface } from "../color/ColorScaleConfig"
 import { MapConfigWithLegacyInterface } from "../mapCharts/MapConfig"
-import {
-    ColumnSlugs,
-    Time,
-    EntityId,
-    EntityName,
-} from "@ourworldindata/core-table"
+import { ColumnSlugs, Time, EntityName } from "@ourworldindata/core-table"
 import { ColorSchemeName } from "../color/ColorConstants"
 
 // This configuration represents the entire persistent state of a grapher

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
@@ -531,14 +531,6 @@
                 "additionalProperties": false
             }
         },
-        "selectedEntityIds": {
-            "type": "array",
-            "description": "The selected entities",
-            "items": {
-                "type": "integer",
-                "minimum": 0
-            }
-        },
         "addCountryMode": {
             "type": "string",
             "description": "Whether the user can change countries, add additional ones or neither",

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
@@ -478,12 +478,6 @@ properties:
                     description: The variable id to get the values for this time series
                     minimum: 0
             additionalProperties: false
-    selectedEntityIds:
-        type: array
-        description: The selected entities
-        items:
-            type: integer
-            minimum: 0
     addCountryMode:
         type: string
         description: Whether the user can change countries, add additional ones or neither

--- a/packages/@ourworldindata/grapher/src/selection/SelectionArray.ts
+++ b/packages/@ourworldindata/grapher/src/selection/SelectionArray.ts
@@ -1,5 +1,5 @@
 import { EntityCode, EntityId, EntityName } from "@ourworldindata/core-table"
-import { difference, mapBy, isPresent } from "@ourworldindata/utils"
+import { difference, mapBy } from "@ourworldindata/utils"
 import { action, computed, observable } from "mobx"
 
 export interface Entity {

--- a/packages/@ourworldindata/grapher/src/selection/SelectionArray.ts
+++ b/packages/@ourworldindata/grapher/src/selection/SelectionArray.ts
@@ -71,13 +71,6 @@ export class SelectionArray {
         return new Set<EntityName>(this.selectedEntityNames)
     }
 
-    @computed get allSelectedEntityIds(): EntityId[] {
-        const map = this.entityNameToIdMap
-        return this.selectedEntityNames
-            .map((name) => map.get(name))
-            .filter(isPresent)
-    }
-
     // Clears and sets selected entities
     @action.bound setSelectedEntities(entityNames: EntityName[]): this {
         this.clearSelection()


### PR DESCRIPTION
Live on _tufte_.

Working towards #1245, getting rid of the legacy `selectedEntityIds` property.

## Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed7feeb</samp>

This pull request removes the legacy `selectedEntityIds` property from the chart config and replaces it with `selectedEntityNames`. It also simplifies and fixes some related code in the Grapher component and its tests. It includes a migration script to update the existing chart configs in the database.

## Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ed7feeb</samp>

*  Remove `selectedEntityIds` property from chart configs and use `selectedEntityNames` instead ([link](https://github.com/owid/owid-grapher/pull/2101/files?diff=unified&w=0#diff-1f81eee66852f273b4a979d1f514ea4ab09d8b07ef7744d1ee074e49519351daR1-R58), [link](https://github.com/owid/owid-grapher/pull/2101/files?diff=unified&w=0#diff-425e0b747326ad7cd66885bd74ba8ecb0cba01663a5925a4074d70ef3772f3a7L602-L606), [link](https://github.com/owid/owid-grapher/pull/2101/files?diff=unified&w=0#diff-971cc9fd921f240c7bcf62a8e6e647d58d7cab2afc5e58e752b5dabdd0bd09f9L360), [link](https://github.com/owid/owid-grapher/pull/2101/files?diff=unified&w=0#diff-971cc9fd921f240c7bcf62a8e6e647d58d7cab2afc5e58e752b5dabdd0bd09f9L2365-R2373), [link](https://github.com/owid/owid-grapher/pull/2101/files?diff=unified&w=0#diff-1b9afa0367b0a812c702de4c3d95e6c70e6270acc5d1d5022320c031bd3a7dc2L92), [link](https://github.com/owid/owid-grapher/pull/2101/files?diff=unified&w=0#diff-1b9afa0367b0a812c702de4c3d95e6c70e6270acc5d1d5022320c031bd3a7dc2L183), [link](https://github.com/owid/owid-grapher/pull/2101/files?diff=unified&w=0#diff-e938919628806d63deb623139192afabbc9d20764fadbb440819fc0076830cbfL534-L541), [link](https://github.com/owid/owid-grapher/pull/2101/files?diff=unified&w=0#diff-30a2b2a63f5fdf2e00869e877490f3a5709892f7cc0daa0265127c7889495925L481-L486))
*  Remove unused computed property `allSelectedEntityIds` from SelectionArray component ([link](https://github.com/owid/owid-grapher/pull/2101/files?diff=unified&w=0#diff-9ddfe5b5cb1d7554712cc1f29110fc02ccadebebf7529d3cf0401319d6d54db8L74-L80))
*  Remove branch that sets selection by entity ids from Grapher component ([link](https://github.com/owid/owid-grapher/pull/2101/files?diff=unified&w=0#diff-971cc9fd921f240c7bcf62a8e6e647d58d7cab2afc5e58e752b5dabdd0bd09f9L835-L836))
*  Update test cases to use `selectedEntityNames` in legacy configs ([link](https://github.com/owid/owid-grapher/pull/2101/files?diff=unified&w=0#diff-b0466bfea483dff581328c158aceab097b0d528c91ab12e37a546f9902ebc10bL135-R135), [link](https://github.com/owid/owid-grapher/pull/2101/files?diff=unified&w=0#diff-b0466bfea483dff581328c158aceab097b0d528c91ab12e37a546f9902ebc10bL173-R173), [link](https://github.com/owid/owid-grapher/pull/2101/files?diff=unified&w=0#diff-b0466bfea483dff581328c158aceab097b0d528c91ab12e37a546f9902ebc10bL182-R182))

### Poem

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ed7feeb</samp>

> _`Grapher` evolves_
> _Dropping `selectedEntityIds`_
> _Spring cleaning of code_