### PR TITLE
fix(stacked): make colour use consistent across faceted charts

### DIFF
--- a/packages/@ourworldindata/grapher/src/color/CategoricalColorAssigner.ts
+++ b/packages/@ourworldindata/grapher/src/color/CategoricalColorAssigner.ts
@@ -22,6 +22,8 @@ export interface CategoricalColorAssignerProps {
      * both states.
      */
     autoColorMapCache?: CategoricalColorMap
+
+    numColorsInUse?: number
 }
 
 /**
@@ -37,12 +39,14 @@ export class CategoricalColorAssigner {
     private invertColorScheme: boolean
     private colorMap: CategoricalColorMapReadonly
     private autoColorMapCache: CategoricalColorMap
+    private numColorsInUse?: number
 
     constructor(props: CategoricalColorAssignerProps) {
         this.colorScheme = props.colorScheme
         this.invertColorScheme = props.invertColorScheme ?? false
         this.colorMap = props.colorMap ?? new Map()
         this.autoColorMapCache = props.autoColorMapCache ?? new Map()
+        this.numColorsInUse = props.numColorsInUse
     }
 
     private get usedColors(): Color[] {
@@ -55,7 +59,11 @@ export class CategoricalColorAssigner {
 
     private get availableColors(): Color[] {
         // copy the colors array because we might need to reverse it
-        const colors = last(this.colorScheme.colorSets)?.slice() ?? []
+        const colors =
+            (this.numColorsInUse != undefined
+                ? this.colorScheme.getColors(this.numColorsInUse)
+                : last(this.colorScheme.colorSets)
+            )?.slice() ?? []
         if (this.invertColorScheme) colors.reverse()
         return colors
     }


### PR DESCRIPTION
fixed #2097 | fixes #2098 | fixes #2107

**Problem:** Colours are used inconsisently across faceted StackedArea/StackedBar charts

**Proposed solution:** `seriesColorMap` defined in `FacetChart` is used to cache colours globally and the `CategoricalColorAssigner` is used to actually assign colours to entities/variables (keyed by their series name, i.e. their entity or variable name).

(**Aside:** I had to add another prop to `CategoricalColorAssigner` to have control over the number of colours that we pick from – otherwise lots of charts would come back with different colour schemes that looked worse.)