### PR TITLE
fix stacked area/bar selection on hover over legend items

### DIFF
--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -220,7 +220,7 @@ export class StackedAreaChart
         ])
         if (externalLegendFocusBin) {
             focusedSeriesNames.push(
-                ...this.series
+                ...this.rawSeries
                     .map((s) => s.seriesName)
                     .filter((name) => externalLegendFocusBin.contains(name))
             )

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -169,7 +169,7 @@ export class StackedBarChart
                   )
         if (externalLegendFocusBin) {
             hoverKeys.push(
-                ...this.series
+                ...this.rawSeries
                     .map((g) => g.seriesName)
                     .filter((name) => externalLegendFocusBin.contains(name))
             )


### PR DESCRIPTION
fixes #2100 

### Summary

🐛📊🌈 <-- copilot thought of this (and also gave an explanation, see below)

Fixes a problem in StackedArea and StackedBar charts where hovering over an entity in the legend didn't grey out all other entities. Here, Italy is hovered over:

<img width="897" alt="231427953-9c7b9121-4305-440c-bb08-02f496f8109e" src="https://user-images.githubusercontent.com/12461810/232486693-4dfab2ec-a66c-4975-a737-e645f99744bf.png">

This happened because Italy isn't shown in the "Nuclear" chart as it has no data for that variable. Previously, focused entities have been picked from `series`. Switching to `rawSeries` fixes the problem since `rawSeries` contains all data.

-----

Emoji legend (generated by copilot):

1.  🐛 - This emoji represents a bug fix, which is the main purpose of these changes. The bug was causing the wrong series to be highlighted on the stacked area and bar charts when using an external legend.
2.  📊 - This emoji represents a chart or graph, which is the type of component that these changes affect. The stacked area and bar charts are both chart components that use an external legend to display the series names and colors.
3.  🌈 - This emoji represents a rainbow or color, which is a relevant aspect of these changes. The highlighting feature of the external legend and the chart components depends on the color of the series, and these changes ensure that the correct color is used for the correct series.