### PR TITLE
fix inconsistent entity colours when switching faceting on or off

### DIFF
--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
@@ -210,7 +210,7 @@ export class FacetChart
     }
 
     // Passing this color map is important to ensure that all facets use the same entity colors
-    seriesColorMap: SeriesColorMap = new Map()
+    seriesColorMap: SeriesColorMap = this.manager?.seriesColorMap ?? new Map()
 
     /**
      * Holds the intermediate render properties for chart views, before axes are synchronized,


### PR DESCRIPTION
fixes #2102 

### Problem

When selecting a second entity in StackedArea charts, then entity colours would change for no good reason.

### Investigation

- The colour cache `seriesColorMap` exists in `Grapher` as well as `FacetChart`
- If viewing a single entity, faceting is turned off -> `seriesColorMap` in Grapher is used
- If faceting is then turned on (by selecting a second entity), previous colour assignments are thrown away as `seriesColorMap` is initialised again in `FacetChart`

--> take the "current" `seriesColorMap` into account when initialising it in `FacetChart`