### PR TITLE
feat(vite): allow running vite in preview mode

### DIFF
--- a/adminSiteServer/IndexPage.tsx
+++ b/adminSiteServer/IndexPage.tsx
@@ -4,14 +4,14 @@ import {
     GITHUB_USERNAME,
     DATA_API_FOR_ADMIN_UI,
 } from "../settings/serverSettings.js"
-import { viteAssets } from "../site/viteUtils.js"
+import { VITE_ASSET_ADMIN_ENTRY, viteAssets } from "../site/viteUtils.js"
 
 export const IndexPage = (props: {
     username: string
     isSuperuser: boolean
     gitCmsBranchName: string
 }) => {
-    const assets = viteAssets("adminSiteClient/admin.entry.ts")
+    const assets = viteAssets(VITE_ASSET_ADMIN_ENTRY)
     const script = `
         window.isEditor = true
         window.admin = new Admin({ username: "${

--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -191,6 +191,8 @@ mockSiteRouter.use(
     express.static(path.join(BAKED_SITE_DIR, "exports"))
 )
 
+mockSiteRouter.use("/assets", express.static("dist/assets"))
+
 mockSiteRouter.use("/grapher/exports/:slug.svg", async (req, res) => {
     const grapher = await OldChart.getBySlug(req.params.slug)
     const vardata = await grapher.getVariableData()

--- a/devTools/vite/startVite.sh
+++ b/devTools/vite/startVite.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+if [ "$VITE_PREVIEW" = "true" ]; then
+    echo "Starting Vite build for preview mode"
+    yarn vite build
+else
+    echo "Starting Vite in dev mode"
+    yarn vite dev
+fi

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "startTscServer": "tsc -b -verbose -watch",
         "startViteServer": "vite dev",
         "startWordpressPlugin": "cd ./wordpress/web/app/plugins/owid && yarn && yarn start",
-        "startSiteFront": "yarn startViteServer",
+        "startSiteFront": "./devTools/vite/startVite.sh",
         "startLocalBakeServer": "http-server ./localBake -p 3000",
         "testBundlewatch": "yarn buildVite && bundlewatch --config .bundlewatch.config.json",
         "testCypress": "yarn cypress open --project devTools --config-file cypress/cypress.json",

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -24,6 +24,9 @@ export const DATA_API_FOR_ADMIN_UI: string | undefined =
     serverSettings.DATA_API_FOR_ADMIN_UI
 export const BAKED_BASE_URL: string = clientSettings.BAKED_BASE_URL
 
+export const VITE_PREVIEW: boolean =
+    serverSettings.VITE_PREVIEW === "true" ?? false
+
 export const ADMIN_BASE_URL: string = clientSettings.ADMIN_BASE_URL
 export const WORDPRESS_URL: string = clientSettings.WORDPRESS_URL
 

--- a/site/Head.tsx
+++ b/site/Head.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { viteAssets } from "./viteUtils.js"
+import { VITE_ASSET_SITE_ENTRY, viteAssets } from "./viteUtils.js"
 
 export const Head = (props: {
     canonicalUrl: string
@@ -20,7 +20,7 @@ export const Head = (props: {
         "Research and data to make progress against the world’s largest problems"
     const imageUrl = props.imageUrl || `${baseUrl}/default-thumbnail.jpg`
 
-    const stylesheets = viteAssets("site/owid.entry.ts").forHeader
+    const stylesheets = viteAssets(VITE_ASSET_SITE_ENTRY).forHeader
 
     return (
         <head>

--- a/site/SiteFooter.tsx
+++ b/site/SiteFooter.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faAngleRight } from "@fortawesome/free-solid-svg-icons"
 import { SiteFooterContext } from "@ourworldindata/utils"
-import { viteAssets } from "./viteUtils.js"
+import { VITE_ASSET_SITE_ENTRY, viteAssets } from "./viteUtils.js"
 
 interface SiteFooterProps {
     hideDonate?: boolean
@@ -260,7 +260,7 @@ export const SiteFooter = (props: SiteFooterProps) => (
                 </div>
             </div>
             <div className="site-tools" />
-            {viteAssets("site/owid.entry.ts").forFooter}
+            {viteAssets(VITE_ASSET_SITE_ENTRY).forFooter}
             <script
                 type="module"
                 dangerouslySetInnerHTML={{

--- a/site/viteUtils.tsx
+++ b/site/viteUtils.tsx
@@ -1,7 +1,11 @@
 import React from "react"
 import findBaseDir from "../settings/findBaseDir.js"
 import fs from "fs-extra"
-import { ENV, BAKED_BASE_URL } from "../settings/serverSettings.js"
+import {
+    ENV,
+    BAKED_BASE_URL,
+    VITE_PREVIEW,
+} from "../settings/serverSettings.js"
 import { GOOGLE_FONTS_URL, POLYFILL_URL } from "./SiteConstants.js"
 import type { Manifest } from "vite"
 import { sortBy } from "@ourworldindata/utils"
@@ -153,7 +157,7 @@ const prodAssets = (entry: string, baseUrl: string): Assets => {
 }
 
 export const viteAssets = (entry: string) =>
-    ENV === "production"
+    ENV === "production" || VITE_PREVIEW
         ? prodAssets(entry, BAKED_BASE_URL)
         : devAssets(entry, VITE_DEV_URL)
 

--- a/site/viteUtils.tsx
+++ b/site/viteUtils.tsx
@@ -138,7 +138,8 @@ const prodAssets = (entry: string, baseUrl: string): Assets => {
         manifest = fs.readJSONSync(manifestPath) as Manifest
     } catch (err) {
         throw new Error(
-            `Could not read build manifest ('${manifestPath}'), which is required for production.`,
+            `Could not read build manifest ('${manifestPath}'), which is required for production.
+            If you're running in VITE_PREVIEW mode, wait for the build to finish and then reload this page.`,
             { cause: err }
         )
     }

--- a/site/viteUtils.tsx
+++ b/site/viteUtils.tsx
@@ -8,8 +8,8 @@ import { sortBy } from "@ourworldindata/utils"
 
 const VITE_DEV_URL = process.env.VITE_DEV_URL ?? "http://localhost:8090"
 
-export const VITE_SITE_ASSET = "site/owid.entry.ts"
-export const VITE_ADMIN_ASSET = "admin/admin.entry.ts"
+export const VITE_ASSET_SITE_ENTRY = "site/owid.entry.ts"
+export const VITE_ASSET_ADMIN_ENTRY = "adminSiteClient/admin.entry.ts"
 
 // We ALWAYS load Google Fonts and polyfills.
 
@@ -158,7 +158,7 @@ export const viteAssets = (entry: string) =>
         : devAssets(entry, VITE_DEV_URL)
 
 export const generateEmbedSnippet = () => {
-    const assets = viteAssets("site/owid.entry.ts")
+    const assets = viteAssets(VITE_ASSET_SITE_ENTRY)
     const serializedAssets = [...assets.forHeader, ...assets.forFooter].map(
         (el) => ({
             tag: el.type,

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -3,7 +3,10 @@ import pluginReact from "@vitejs/plugin-react"
 import pluginChecker from "vite-plugin-checker"
 import { warmup as pluginWarmup } from "vite-plugin-warmup"
 import * as clientSettings from "./settings/clientSettings.js"
-import { VITE_SITE_ASSET } from "./site/viteUtils.js"
+import {
+    VITE_ASSET_ADMIN_ENTRY,
+    VITE_ASSET_SITE_ENTRY,
+} from "./site/viteUtils.js"
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -45,8 +48,8 @@ export default defineConfig({
         rollupOptions: {
             cache: false, // https://github.com/vitejs/vite/issues/2433#issuecomment-1361094727
             input: {
-                owid: "./site/owid.entry.ts",
-                admin: "./adminSiteClient/admin.entry.ts",
+                owid: VITE_ASSET_SITE_ENTRY,
+                admin: VITE_ASSET_ADMIN_ENTRY,
             },
             output: {
                 /**
@@ -99,7 +102,7 @@ export default defineConfig({
                 tsconfigPath: "tsconfig.vite-checker.json",
             },
         }),
-        pluginWarmup({ clientFiles: [VITE_SITE_ASSET] }),
+        pluginWarmup({ clientFiles: [VITE_ASSET_SITE_ENTRY] }),
     ],
     server: {
         port: 8090,


### PR DESCRIPTION
By running `VITE_PREVIEW=true make up`, we'll now be running vite in production mode, meaning:
- Vite runs a proper production build (which will take some seconds!), which is not live-reloading
- It will then run off these assets
- Browser load times will be way faster, because we're only loading two or three files in this case

If `VITE_PREVIEW` is not specified, then everything runs just as it does currently, i.e. with a Vite HMR server.