### PR TITLE
Turn faceting on by default for line charts and stacked charts

### DIFF
--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -253,6 +253,15 @@ class FacetSection extends React.Component<{ editor: ChartEditor }> {
                 </div>
                 <FieldsRow>
                     <Toggle
+                        label={`Hide facet control`}
+                        value={this.grapher.hideFacetControl || false}
+                        onValue={(value) => {
+                            this.grapher.hideFacetControl = value || undefined
+                        }}
+                    />
+                </FieldsRow>
+                <FieldsRow>
+                    <Toggle
                         label={`Facets have uniform y-axis`}
                         value={
                             yAxisConfig.facetDomain === FacetAxisDomain.shared

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1966,7 +1966,6 @@ export class Grapher
 
     @computed get showFacetControl(): boolean {
         let {
-            type,
             hideFacetControl,
             filledDimensions,
             yColumnSlugs,
@@ -1975,12 +1974,11 @@ export class Grapher
 
         // show facet control for some chart types by default
         if (hideFacetControl == undefined) {
-            hideFacetControl = ![
-                ChartTypeName.StackedArea,
-                ChartTypeName.StackedBar,
-                ChartTypeName.StackedDiscreteBar,
-                ChartTypeName.LineChart,
-            ].includes(type)
+            hideFacetControl =
+                !this.isStackedArea &&
+                !this.isStackedBar &&
+                !this.isStackedDiscreteBar &&
+                !this.isLineChart
         }
 
         const hasProjection = filledDimensions.some(

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1965,32 +1965,34 @@ export class Grapher
     }
 
     @computed get showFacetControl(): boolean {
-        let {
+        const {
             hideFacetControl,
             filledDimensions,
             yColumnSlugs,
             availableFacetStrategies,
+            isStackedArea,
+            isStackedBar,
+            isStackedDiscreteBar,
+            isLineChart,
         } = this
 
-        // show facet control for some chart types by default
-        if (hideFacetControl == undefined) {
-            hideFacetControl =
-                !this.isStackedArea &&
-                !this.isStackedBar &&
-                !this.isStackedDiscreteBar &&
-                !this.isLineChart
-        }
+        if (hideFacetControl != undefined) return !hideFacetControl
+
+        // heuristic: if the chart doesn't make sense unfaceted, then it probably
+        // also makes sense to let the user switch between entity/metric facets
+        if (!availableFacetStrategies.includes(FacetStrategy.none)) return true
+
+        const showFacetControlChartType =
+            isStackedArea || isStackedBar || isStackedDiscreteBar || isLineChart
 
         const hasProjection = filledDimensions.some(
             (dim) => dim.display.isProjection
         )
 
         return (
-            (!hasProjection || yColumnSlugs.length <= 2) &&
-            (!hideFacetControl ||
-                // heuristic: if the chart doesn't make sense unfaceted, then it probably
-                // also makes sense to let the user switch between entity/metric facets
-                !availableFacetStrategies.includes(FacetStrategy.none))
+            showFacetControlChartType &&
+            !hasProjection &&
+            yColumnSlugs.length <= 2
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1973,7 +1973,7 @@ export class Grapher
         } = this
 
         // show facet control for some chart types by default
-        if (hideFacetControl != undefined) {
+        if (hideFacetControl == undefined) {
             hideFacetControl = [
                 ChartTypeName.StackedArea,
                 ChartTypeName.StackedBar,

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1966,6 +1966,7 @@ export class Grapher
 
     @computed get showFacetControl(): boolean {
         let {
+            type,
             hideFacetControl,
             filledDimensions,
             yColumnSlugs,
@@ -1974,12 +1975,12 @@ export class Grapher
 
         // show facet control for some chart types by default
         if (hideFacetControl == undefined) {
-            hideFacetControl = [
+            hideFacetControl = ![
                 ChartTypeName.StackedArea,
                 ChartTypeName.StackedBar,
                 ChartTypeName.StackedDiscreteBar,
                 ChartTypeName.LineChart,
-            ].includes(this.type)
+            ].includes(type)
         }
 
         const hasProjection = filledDimensions.some(

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -382,7 +382,7 @@ export class Grapher
 
     @observable.ref annotation?: Annotation = undefined
 
-    @observable hideFacetControl?: boolean = true
+    @observable.ref hideFacetControl?: boolean = undefined
 
     // the desired faceting strategy, which might not be possible if we change the data
     @observable selectedFacetStrategy?: FacetStrategy = undefined
@@ -1965,11 +1965,33 @@ export class Grapher
     }
 
     @computed get showFacetControl(): boolean {
+        let {
+            hideFacetControl,
+            filledDimensions,
+            yColumnSlugs,
+            availableFacetStrategies,
+        } = this
+
+        // show facet control for some chart types by default
+        if (hideFacetControl != undefined) {
+            hideFacetControl = [
+                ChartTypeName.StackedArea,
+                ChartTypeName.StackedBar,
+                ChartTypeName.StackedDiscreteBar,
+                ChartTypeName.LineChart,
+            ].includes(this.type)
+        }
+
+        const hasProjection = filledDimensions.some(
+            (dim) => dim.display.isProjection
+        )
+
         return (
-            !this.hideFacetControl ||
-            // heuristic: if the chart doesn't make sense unfaceted, then it probably
-            // also makes sense to let the user switch between entity/metric facets
-            !this.availableFacetStrategies.includes(FacetStrategy.none)
+            (!hasProjection || yColumnSlugs.length <= 2) &&
+            (!hideFacetControl ||
+                // heuristic: if the chart doesn't make sense unfaceted, then it probably
+                // also makes sense to let the user switch between entity/metric facets
+                !availableFacetStrategies.includes(FacetStrategy.none))
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1991,8 +1991,7 @@ export class Grapher
 
         return (
             showFacetControlChartType &&
-            !hasProjection &&
-            yColumnSlugs.length <= 2
+            (!hasProjection || yColumnSlugs.length <= 2)
         )
     }
 


### PR DESCRIPTION
Faceting is turned on by default for the following chart types:

- [x] StackedArea
- [x] StackedBar
- [x] StackedDiscreteBar
- [x] LineChart

Things I did to make it work (see detailed descriptions below):

- [x] Do not turn on faceting by default for line charts with projections into the future
- [x] Expose the config option `hideFacetControl` to the author by adding a toggle to the "Faceting" admin section

### Issue: Projections into the future (in LineCharts)

- Problem: When line charts include projections into the future, then these are plotted as separate entities
- Solution: Turn faceting off for charts with projections (it would be nice to plot history and projection into a single chart when faceting but I don't think Grapher knows which variables belong together)

<details>
  <summary>Screenshot of a problematic chart</summary>
  
<img width="1211" alt="Screenshot 2023-04-18 at 15 56 35" src="https://user-images.githubusercontent.com/12461810/232800372-27882345-0342-4ca8-9bf8-c97bd1b8648d.png">

Link: https://ourworldindata.org/grapher/births-and-deaths-projected-to-2100?facet=metric&country=AND~AUS~AZE~BHS
</details>

### Issue: Overlapping labels (in StackedDiscreteBar charts)

- Problem: For many selected entities, individual sub-charts are extremely small and labels are not legible
- Solution: It's not a huge deal since by default the "All together"-faceting mode is on but I would want to manually hide the facet control for [these 35 charts](https://owid-datasette-y43qr.ondigitalocean.app/owid?sql=select%0D%0A++id,%0D%0A++slug,%0D%0A++json_array_length(config,+%22$.dimensions%22)+as+dimensionCount,%0D%0A++json_array_length(config,+%22$.selectedEntityNames%22)+as+selectedEntitiesCount%0D%0Afrom%0D%0A++charts%0D%0Awhere%0D%0A++type+%3D+%22StackedDiscreteBar%22%0D%0A++and+(%0D%0A++++(%0D%0A++++++dimensionCount+%3C%3D+4%0D%0A++++++and+selectedEntitiesCount+%3E+10%0D%0A++++)%0D%0A++++or+(%0D%0A++++++dimensionCount+%3E+4%0D%0A++++++and+dimensionCount+%3C%3D+9%0D%0A++++++and+selectedEntitiesCount+%3E+5%0D%0A++++)%0D%0A++++or+dimensionCount+%3E+10%0D%0A++)%0D%0Aorder+by%0D%0A++selectedEntitiesCount+desc) (I added an admin option to do this – this also gives authors more control over faceting in the future which is probably a good idea when we have faceting turned on by default more often)
- Aside: This is a general issue for this chart type, see [this chart](https://ourworldindata.org/grapher/population-young-working-old?country=CHN~JPN~KOR~USA~IND~ZAF~NGA~BRA~ZMB~KEN~ITA~ABW~Lower-middle-income+countries~MTQ~MYS~AUT~AIA~ASM~Africa+%28UN%29~DMA~COD~CYP~POL~PRI~RWA~KNA~TUN~TCA~UKR~ARE~GEO~GIB~GRL~GLP~SAU~SLE~SVN~ARG~HRV~CRI~Oceania+%28UN%29~PSE~PAN) for example (note that this is not the default view of the chart, I added many entities manually). But the problem is certainly more pronounced for faceted charts since space is much more constrained in that case.

<details>
  <summary>Screenshot of a problematic chart</summary>
  
<img width="748" alt="Screenshot 2023-04-18 at 17 10 44" src="https://user-images.githubusercontent.com/12461810/232822434-e7317f68-ac39-4abd-ba12-6e3264e24feb.png">

Link: https://ourworldindata.org/grapher/covid-variants-bar?stackMode=absolute&facet=metric&country=USA~GBR~ESP~ZAF~ITA~DEU~FRA~CAN~BEL~AUS
</details>
