### PR TITLE
refactor(explorer): always act on two-dimensional arrays

### DIFF
--- a/devTools/explorerTools/rewriteAllExplorers.ts
+++ b/devTools/explorerTools/rewriteAllExplorers.ts
@@ -1,0 +1,21 @@
+import { ExplorerAdminServer } from "../../explorerAdminServer/ExplorerAdminServer.js"
+import { GIT_CMS_DIR } from "../../gitCms/GitCmsConstants.js"
+import fs from "fs-extra"
+import path from "path"
+
+// Useful to ensure that our explorer serialization and deserialization is idempotent,
+// i.e. that there is no git diff (except for maybe whitespace) between the original
+// and the saved version.
+// Caution, this operates on your local owid-content directory.
+const rewriteAllExplorers = async () => {
+    const explorerServer = new ExplorerAdminServer(GIT_CMS_DIR)
+    const allExplorers = await explorerServer.getAllExplorers()
+    for (const explorer of allExplorers) {
+        const fullPath = path.join(GIT_CMS_DIR, explorer.fullPath)
+        console.log("Rewriting", fullPath)
+        await fs.writeFile(fullPath, explorer.toString())
+    }
+    console.log("Finished rewriting", allExplorers.length, "explorers")
+}
+
+rewriteAllExplorers()

--- a/devTools/explorerTools/tsconfig.json
+++ b/devTools/explorerTools/tsconfig.json
@@ -4,5 +4,9 @@
         "outDir": "../../itsJustJavascript/devTools/explorerTools",
         "rootDir": "."
     },
-    "references": [{ "path": "../../gitCms" }, { "path": "../../explorer" }]
+    "references": [
+        { "path": "../../gitCms" },
+        { "path": "../../explorer" },
+        { "path": "../../explorerAdminServer" }
+    ]
 }

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -208,7 +208,7 @@ export class ExplorerProgram extends GridProgram {
         )
         if (keywordIndex === -1) return undefined
         return this.getBlock(keywordIndex)
-            .map((row) => row.join(this.cellDelimiter))
+            ?.map((row) => row.join(this.cellDelimiter))
             .join("\n")
     }
 
@@ -237,8 +237,8 @@ export class ExplorerProgram extends GridProgram {
         for (const row of colDefsRows) {
             const tableSlugs = matrix[row].slice(1)
             const columnDefinitions: CoreColumnDef[] =
-                columnDefinitionsFromInput(this.getBlock(row)).map((row) =>
-                    trimAndParseObject(row, ColumnGrammar)
+                columnDefinitionsFromInput(this.getBlock(row) ?? "").map(
+                    (row) => trimAndParseObject(row, ColumnGrammar)
                 )
             if (tableSlugs.length === 0)
                 columnDefs.set(undefined, columnDefinitions)

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -234,7 +234,7 @@ export class ExplorerProgram extends GridProgram {
             ExplorerGrammar.columns.keyword
         )
 
-        const matrix = this.asArrays
+        const matrix = this.matrix
         for (const row of colDefsRows) {
             const tableSlugs = matrix[row].slice(1)
             const columnDefinitions: CoreColumnDef[] =

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -1,5 +1,5 @@
 import {
-    columnDefinitionsFromDelimited,
+    columnDefinitionsFromInput,
     CoreColumnDef,
     CoreMatrix,
     CoreTable,
@@ -39,7 +39,7 @@ export const EXPLORER_FILE_SUFFIX = ".explorer.tsv"
 export interface TableDef {
     url?: string
     columnDefinitions?: CoreColumnDef[]
-    inlineData?: string
+    inlineData?: string[][]
 }
 
 interface ExplorerGrapherInterface extends GrapherInterface {
@@ -156,9 +156,7 @@ export class ExplorerProgram extends GridProgram {
     }
 
     get selection() {
-        return this.getLine(ExplorerGrammar.selection.keyword)
-            ?.split(this.cellDelimiter)
-            .slice(1)
+        return this.getLine(ExplorerGrammar.selection.keyword)?.slice(1)
     }
 
     get pickerColumnSlugs() {
@@ -210,6 +208,8 @@ export class ExplorerProgram extends GridProgram {
         )
         if (keywordIndex === -1) return undefined
         return this.getBlock(keywordIndex)
+            .map((row) => row.join(this.cellDelimiter))
+            .join("\n")
     }
 
     get grapherCount() {
@@ -217,15 +217,14 @@ export class ExplorerProgram extends GridProgram {
     }
 
     get tableCount() {
-        return this.lines.filter((line) =>
-            line.startsWith(ExplorerGrammar.table.keyword)
-        ).length
+        return this.getRowNumbersStartingWith(ExplorerGrammar.table.keyword)
+            .length
     }
 
     get tableSlugs(): (TableSlug | undefined)[] {
         return this.lines
-            .filter((line) => line.startsWith(ExplorerGrammar.table.keyword))
-            .map((line) => line.split(this.cellDelimiter)[2])
+            .filter((line) => line[0] === ExplorerGrammar.table.keyword)
+            .map((line) => line[2])
     }
 
     get columnDefsByTableSlug(): Map<TableSlug | undefined, CoreColumnDef[]> {
@@ -234,11 +233,11 @@ export class ExplorerProgram extends GridProgram {
             ExplorerGrammar.columns.keyword
         )
 
-        const matrix = this.matrix
+        const matrix = this.lines
         for (const row of colDefsRows) {
             const tableSlugs = matrix[row].slice(1)
             const columnDefinitions: CoreColumnDef[] =
-                columnDefinitionsFromDelimited(this.getBlock(row)).map((row) =>
+                columnDefinitionsFromInput(this.getBlock(row)).map((row) =>
                     trimAndParseObject(row, ColumnGrammar)
                 )
             if (tableSlugs.length === 0)
@@ -290,14 +289,14 @@ export class ExplorerProgram extends GridProgram {
                 colDefsRow,
                 new CoreTable(clone.getBlock(colDefsRow))
                     .concat([missing])
-                    .toTsv()
+                    .toMatrix()
             )
         else
             clone.appendBlock(
                 `${ExplorerGrammar.columns.keyword}${
                     tableSlug ? this.cellDelimiter + tableSlug : ""
                 }`,
-                missing.toTsv()
+                missing.toMatrix()
             )
         return clone
     }
@@ -368,9 +367,7 @@ export class ExplorerProgram extends GridProgram {
         if (tableDefRow === -1) return undefined
 
         const inlineData = this.getBlock(tableDefRow)
-        let url = inlineData
-            ? undefined
-            : this.lines[tableDefRow].split(this.cellDelimiter)[1]
+        let url = inlineData ? undefined : this.lines[tableDefRow][1]
 
         if (url && !url.startsWith("http")) {
             const owidDatasetSlug = encodeURIComponent(url)

--- a/explorerAdminClient/ExplorerCreatePage.tsx
+++ b/explorerAdminClient/ExplorerCreatePage.tsx
@@ -326,7 +326,7 @@ class HotEditor extends React.Component<{
         const { program, programOnDisk } = this
 
         // replace literal `\n` with newlines
-        const data = program.asArrays.map((row) =>
+        const data = program.matrix.map((row) =>
             row.map((cell) => cell.replace(/\\n/g, "\n"))
         )
 

--- a/explorerAdminClient/ExplorerCreatePage.tsx
+++ b/explorerAdminClient/ExplorerCreatePage.tsx
@@ -326,7 +326,7 @@ class HotEditor extends React.Component<{
         const { program, programOnDisk } = this
 
         // replace literal `\n` with newlines
-        const data = program.matrix.map((row) =>
+        const data = program.lines.map((row) =>
             row.map((cell) => cell.replace(/\\n/g, "\n"))
         )
 

--- a/gridLang/GridProgram.test.ts
+++ b/gridLang/GridProgram.test.ts
@@ -41,7 +41,7 @@ columns\tb`
         )
 
         it("can get blocks", () => {
-            expect(program.getBlock(0)).toEqual(`slug\ncountry`)
+            expect(program.getBlock(0)).toEqual([["slug"], ["country"]])
         })
 
         it("can search", () => {
@@ -54,8 +54,10 @@ columns\tb`
         })
 
         it("can update blocks", () => {
-            const newBlock = `slug\tname
-country\tCountry`
+            const newBlock = [
+                ["slug", "name"],
+                ["country", "Country"],
+            ]
             const newProgram = program.updateBlock(0, newBlock)
             expect(newProgram.getBlock(0)).toEqual(newBlock)
         })

--- a/gridLang/GridProgram.ts
+++ b/gridLang/GridProgram.ts
@@ -82,7 +82,7 @@ export class GridProgram {
     }
 
     private ring(position: CellPosition) {
-        const matrix = this.asArrays
+        const matrix = this.matrix
         const numRows = matrix.length
         if (!numRows)
             return (function* generator() {
@@ -212,7 +212,7 @@ export class GridProgram {
         return line ? line[position.column] : undefined
     }
 
-    @imemo private get matrix() {
+    @imemo get matrix(): string[][] {
         return this.lines.map((line) => line.split(this.cellDelimiter))
     }
 
@@ -299,26 +299,22 @@ export class GridProgram {
         words.every((word, index) => word === undefined || line[index] === word)
 
     getRowMatchingWords(...words: (string | undefined)[]): number {
-        return this.asArrays.findIndex((line) =>
+        return this.matrix.findIndex((line) =>
             GridProgram.lineMatchesWords(line, words)
         )
     }
 
     getAllRowsMatchingWords(...words: (string | undefined)[]): number[] {
         const rows: number[] = []
-        this.asArrays.forEach((line: string[], rowIndex: number) => {
+        this.matrix.forEach((line: string[], rowIndex: number) => {
             if (GridProgram.lineMatchesWords(line, words)) rows.push(rowIndex)
         })
         return rows
     }
 
-    get asArrays(): string[][] {
-        return this.lines.map((line) => line.split(this.cellDelimiter))
-    }
-
     // The max number of columns in any row when you view a program as a spreadsheet
     get width() {
-        return Math.max(...this.asArrays.map((arr) => arr.length))
+        return Math.max(...this.matrix.map((arr) => arr.length))
     }
 
     toString() {
@@ -326,7 +322,7 @@ export class GridProgram {
     }
 
     protected prettify() {
-        return trimMatrix(this.asArrays)
+        return trimMatrix(this.matrix)
             .map((line) => line.join(this.cellDelimiter))
             .join(this.nodeDelimiter)
     }

--- a/gridLang/GridProgram.ts
+++ b/gridLang/GridProgram.ts
@@ -1,6 +1,5 @@
 import { trimMatrix } from "@ourworldindata/core-table"
 import {
-    imemo,
     isPresent,
     GitCommit,
     SerializedGridProgram,
@@ -16,6 +15,7 @@ import {
     Origin,
     ParsedCell,
 } from "./GridLangConstants.js"
+import { tsvToMatrix } from "./GrammarUtils.js"
 
 /**
  * Block location for the below would be like (numRows = 2)
@@ -36,7 +36,7 @@ export class GridProgram {
         lastCommit?: GitCommit,
         grammar?: CellDef
     ) {
-        this.lines = tsv.replace(/\r/g, "").split(this.nodeDelimiter)
+        this.lines = tsvToMatrix(tsv.replace(/\r/g, ""))
         this.slug = slug
         this.lastCommit = lastCommit
         this.grammar = grammar
@@ -53,7 +53,7 @@ export class GridProgram {
     private nodeDelimiter = GRID_NODE_DELIMITER
     cellDelimiter = GRID_CELL_DELIMITER
     private edgeDelimiter = GRID_EDGE_DELIMITER
-    lines: string[]
+    lines: string[][]
 
     toJson(): SerializedGridProgram {
         return {
@@ -82,8 +82,8 @@ export class GridProgram {
     }
 
     private ring(position: CellPosition) {
-        const matrix = this.matrix
-        const numRows = matrix.length
+        const lines = this.lines
+        const numRows = lines.length
         if (!numRows)
             return (function* generator() {
                 // no rows to iterate over
@@ -96,7 +96,7 @@ export class GridProgram {
         }
         if (pointer.row >= numRows) pointer.endRow = numRows - 1
 
-        const lastLine = matrix[pointer.endRow]
+        const lastLine = lines[pointer.endRow]
         pointer.endCol =
             lastLine[pointer.endCol] === undefined
                 ? lastLine.length
@@ -112,8 +112,8 @@ export class GridProgram {
                 pointer.started = true
 
                 if (
-                    matrix[pointer.row] === undefined ||
-                    matrix[pointer.row][pointer.column] === undefined
+                    lines[pointer.row] === undefined ||
+                    lines[pointer.row][pointer.column] === undefined
                 ) {
                     pointer.row++
                     pointer.column = 0
@@ -168,52 +168,43 @@ export class GridProgram {
     get tuplesObject() {
         const obj: { [key: string]: any } = {}
         this.lines
-            .filter((line) => !line.startsWith(this.edgeDelimiter))
+            .filter((line) => line[0] !== "")
             .forEach((line) => {
-                const words = line.split(this.cellDelimiter)
-                const key = words.shift()
-                if (key) obj[key.trim()] = words.join(this.cellDelimiter).trim()
+                const [key, ...rest] = line
+                if (key) obj[key.trim()] = rest.join(this.cellDelimiter).trim()
             })
         return obj
     }
 
     getLine(keyword: string) {
-        return this.lines.find((line) =>
-            line.startsWith(keyword + this.cellDelimiter)
-        )
+        return this.lines.find((line) => line[0] === keyword)
     }
 
     getLineValue(keyword: string) {
         const line = this.getLine(keyword)
-        return line ? line.split(this.cellDelimiter)[1] : undefined
+        return line?.[1]
     }
 
     protected getBlockLocation(blockRowNumber: number): BlockLocation {
         const startRow = blockRowNumber + 1
         let numRows = this.lines
             .slice(startRow)
-            .findIndex((line) => line && !line.startsWith(this.edgeDelimiter))
+            .findIndex((line) => line.length && line[0] !== "")
         if (numRows === -1) numRows = this.lines.slice(startRow).length
         return { startRow, endRow: startRow + numRows, numRows }
     }
 
     protected getKeywordIndex(key: string) {
-        return this.lines.findIndex(
-            (line) => line.startsWith(key + this.cellDelimiter) || line === key
-        )
+        return this.lines.findIndex((line) => line[0] === key)
     }
 
     getCell(position: CellPosition): ParsedCell {
-        return new GridCell(this.matrix, position, this.grammar!)
+        return new GridCell(this.lines, position, this.grammar!)
     }
 
     getCellContents(position: CellPosition) {
-        const line = this.matrix[position.row]
+        const line = this.lines[position.row]
         return line ? line[position.column] : undefined
-    }
-
-    @imemo get matrix(): string[][] {
-        return this.lines.map((line) => line.split(this.cellDelimiter))
     }
 
     deleteBlock(row?: number) {
@@ -232,25 +223,21 @@ export class GridProgram {
     }
 
     appendLine(line: string) {
-        this.lines.push(line)
+        this.lines.push(line.split(this.cellDelimiter))
         return this
     }
 
     // todo: make immutable and return a new copy
     setCell(row: number, col: number, value: string) {
-        const line = this.lines[row]
-        const words = line.split(this.cellDelimiter)
-        words[col] = value
-        this.lines[row] = words.join(this.cellDelimiter)
+        this.lines[row][col] = value
         return this
     }
 
     setLineValue(key: string, value: string | undefined) {
         const index = this.getKeywordIndex(key)
-        const newLine = `${key}${this.cellDelimiter}${value}`
-        if (index === -1 && value !== undefined) this.lines.push(newLine)
+        if (index === -1 && value !== undefined) this.lines.push([key, value])
         else if (value === undefined) this.deleteLine(index)
-        else this.lines[index] = newLine
+        else this.lines[index] = [key, value]
         return this
     }
 
@@ -258,37 +245,27 @@ export class GridProgram {
         const location = this.getBlockLocation(keywordIndex)
         return this.lines
             .slice(location.startRow, location.endRow)
-            .map((line) => line.substr(1))
-            .join(this.nodeDelimiter)
+            .map((line) => line.slice(1))
     }
 
-    updateBlock(rowNumber: number, value: string) {
+    updateBlock(rowNumber: number, value: string[][]) {
         const location = this.getBlockLocation(rowNumber)
         this.lines.splice(
             location.startRow,
             location.numRows,
-            ...value
-                .split(this.nodeDelimiter)
-                .map((line) => this.edgeDelimiter + line)
+            ...value.map((line) => ["", ...line])
         )
         return this
     }
 
-    protected appendBlock(key: string, value: string) {
-        this.lines.push(key)
-        value
-            .split(this.nodeDelimiter)
-            .forEach((line) => this.lines.push(this.edgeDelimiter + line))
+    protected appendBlock(key: string, value: string[][]) {
+        this.lines.push([key])
+        value.forEach((line) => this.lines.push(["", ...line]))
     }
 
     getRowNumbersStartingWith(startsWith: string) {
         return this.lines
-            .map((line, index) =>
-                line.startsWith(startsWith + this.cellDelimiter) ||
-                line === startsWith
-                    ? index
-                    : null
-            )
+            .map((line, index) => (line[0] === startsWith ? index : null))
             .filter(isPresent)
     }
 
@@ -299,14 +276,14 @@ export class GridProgram {
         words.every((word, index) => word === undefined || line[index] === word)
 
     getRowMatchingWords(...words: (string | undefined)[]): number {
-        return this.matrix.findIndex((line) =>
+        return this.lines.findIndex((line) =>
             GridProgram.lineMatchesWords(line, words)
         )
     }
 
     getAllRowsMatchingWords(...words: (string | undefined)[]): number[] {
         const rows: number[] = []
-        this.matrix.forEach((line: string[], rowIndex: number) => {
+        this.lines.forEach((line: string[], rowIndex: number) => {
             if (GridProgram.lineMatchesWords(line, words)) rows.push(rowIndex)
         })
         return rows
@@ -314,7 +291,7 @@ export class GridProgram {
 
     // The max number of columns in any row when you view a program as a spreadsheet
     get width() {
-        return Math.max(...this.matrix.map((arr) => arr.length))
+        return Math.max(...this.lines.map((arr) => arr.length))
     }
 
     toString() {
@@ -322,7 +299,7 @@ export class GridProgram {
     }
 
     protected prettify() {
-        return trimMatrix(this.matrix)
+        return trimMatrix(this.lines)
             .map((line) => line.join(this.cellDelimiter))
             .join(this.nodeDelimiter)
     }

--- a/gridLang/GridProgram.ts
+++ b/gridLang/GridProgram.ts
@@ -185,11 +185,14 @@ export class GridProgram {
         return line?.[1]
     }
 
-    protected getBlockLocation(blockRowNumber: number): BlockLocation {
+    protected getBlockLocation(
+        blockRowNumber: number
+    ): BlockLocation | undefined {
         const startRow = blockRowNumber + 1
         let numRows = this.lines
             .slice(startRow)
             .findIndex((line) => line.length && line[0] !== "")
+        if (numRows === 0) return undefined
         if (numRows === -1) numRows = this.lines.slice(startRow).length
         return { startRow, endRow: startRow + numRows, numRows }
     }
@@ -243,6 +246,7 @@ export class GridProgram {
 
     getBlock(keywordIndex: number) {
         const location = this.getBlockLocation(keywordIndex)
+        if (!location) return undefined
         return this.lines
             .slice(location.startRow, location.endRow)
             .map((line) => line.slice(1))
@@ -250,6 +254,7 @@ export class GridProgram {
 
     updateBlock(rowNumber: number, value: string[][]) {
         const location = this.getBlockLocation(rowNumber)
+        if (!location) throw new Error("Block not found")
         this.lines.splice(
             location.startRow,
             location.numRows,

--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -107,7 +107,7 @@ export class CoreTable<
         this.parent = parent as this
         this.inputColumnDefs =
             typeof inputColumnDefs === "string"
-                ? columnDefinitionsFromDelimited<COL_DEF_TYPE>(inputColumnDefs)
+                ? columnDefinitionsFromInput<COL_DEF_TYPE>(inputColumnDefs)
                 : inputColumnDefs
 
         // If any values were passed in, copy those to column store now and then remove them from column definitions.
@@ -1543,10 +1543,10 @@ class FilterMask {
  *
  * todo: define all column def property types
  */
-export const columnDefinitionsFromDelimited = <T extends CoreRow>(
-    delimited: string
+export const columnDefinitionsFromInput = <T extends CoreRow>(
+    input: CoreTableInputOption
 ): T[] =>
-    new CoreTable<T>(delimited.trim()).columnFilter(
+    new CoreTable<T>(input).columnFilter(
         "slug",
         (value) => !!value,
         "Keep only column defs with a slug"

--- a/packages/@ourworldindata/core-table/src/index.ts
+++ b/packages/@ourworldindata/core-table/src/index.ts
@@ -1,4 +1,4 @@
-export { CoreTable, columnDefinitionsFromDelimited } from "./CoreTable.js"
+export { CoreTable, columnDefinitionsFromInput } from "./CoreTable.js"
 export {
     SynthesizeNonCountryTable,
     SampleColumnSlugs,


### PR DESCRIPTION
When looking at the explorer code, I found that ExplorerProgram/GridProgram acts on both one-dimensional arrays (`this.lines: string[]`) and two-dimensional arrays (both `this.matrix` and `this.asArray: string[][]`), but **the two could go out of sync** 😱 

That's because `this.matrix` is memoized, but `this.lines` can change (well, only in the Admin, really), and in that case `this.matrix` is not properly updated.

This is madness, and so I decided to fix this from the bottom, by using two-dimensional arrays all the way.

I sure hope our test coverage here is good 🙏🏻 