### PR TITLE
fix(StackedArea): render the bottom series only within the domain of data availability

### DIFF
--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -79,9 +79,9 @@ class Areas extends React.Component<AreasProps> {
             // We only have one point, so make it so it stretches out over the whole x axis range
             // There are two cases here that we need to consider:
             // (1) In unfaceted charts, the x domain will be a single year, so we need to ensure that the area stretches
-            //     out over the full range of the x axis. We do this using AxisAlign.start and AxisAlign.end.
+            //     out over the full range of the x axis.
             // (2) In faceted charts, the x domain may span multiple years, so we need to ensure that the area stretches
-            //     out only over year - 0.5 to year + 0.5, making sure we don't put points outside the x range.
+            //     out only over year - 0.5 to year + 0.5, additionally making sure we don't put points outside the x range.
             //
             // -@marcelgerber, 2023-04-24
             const point = series.points[0]
@@ -134,9 +134,12 @@ class Areas extends React.Component<AreasProps> {
                 prevPoints = placedSeriesArr[index - 1].placedPoints
             } else {
                 prevPoints = prevPoints = [
-                    [placedPoints[0][0], verticalAxis.range[0]],
                     [
-                        lastOfNonEmptyArray(placedPoints)[0],
+                        placedPoints[0][0], // placed x coord of first (= leftmost) point in chart
+                        verticalAxis.range[0],
+                    ],
+                    [
+                        lastOfNonEmptyArray(placedPoints)[0], // placed x coord of last (= rightmost) point in chart
                         verticalAxis.range[0],
                     ],
                 ]

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -29,7 +29,12 @@ import {
     AbstractStackedChart,
     AbstractStackedChartProps,
 } from "../stackedCharts/AbstractStackedChart"
-import { StackedPoint, StackedSeries } from "./StackedConstants"
+import {
+    StackedPlacedPoint,
+    StackedPlacedSeries,
+    StackedPoint,
+    StackedSeries,
+} from "./StackedConstants"
 import { stackSeries, withMissingValuesAsZeroes } from "./StackedUtils"
 import { makeClipPath } from "../chart/ChartUtils"
 import { bind } from "decko"
@@ -51,7 +56,7 @@ class Areas extends React.Component<AreasProps> {
         )
     }
 
-    @bind placePoint(point: StackedPoint<number>): [number, number] {
+    @bind placePoint(point: StackedPoint<number>): StackedPlacedPoint {
         const { dualAxis } = this.props
         const { horizontalAxis, verticalAxis } = dualAxis
         return [
@@ -60,62 +65,83 @@ class Areas extends React.Component<AreasProps> {
         ]
     }
 
-    @computed private get areas(): JSX.Element[] {
-        const { dualAxis, seriesArr } = this.props
+    // This places a whole series, but the points only represent the top of the area.
+    // Later steps are necessary to display them as a filled area.
+    @bind placeSeries(
+        series: StackedSeries<number>
+    ): Array<StackedPlacedPoint> {
+        const { dualAxis } = this.props
         const { horizontalAxis, verticalAxis } = dualAxis
 
-        // Stacked area chart stacks each series upon the previous series, so we must keep track of the last point set we used
-        let prevPoints = [] as Array<[number, number]>
-        return seriesArr.map((series) => {
-            let mainPoints: [number, number][] = []
-            if (series.points.length > 1) {
-                mainPoints = series.points.map(this.placePoint)
-            } else if (series.points.length === 1) {
-                // We only have one point, so make it so it stretches out over the whole x axis range
-                // There are two cases here that we need to consider:
-                // (1) In unfaceted charts, the x domain will be a single year, so we need to ensure that the area stretches
-                //     out over the full range of the x axis. We do this using AxisAlign.start and AxisAlign.end.
-                // (2) In faceted charts, the x domain may span multiple years, so we need to ensure that the area stretches
-                //     out only over year - 0.5 to year + 0.5, making sure we don't put points outside the x range.
-                //
-                // -@marcelgerber, 2023-04-24
-                const point = series.points[0]
-                const y = verticalAxis.place(point.value + point.valueOffset)
-                const singleValueXDomain =
-                    horizontalAxis.domain[0] === horizontalAxis.domain[1]
+        if (series.points.length > 1) {
+            return series.points.map(this.placePoint)
+        } else if (series.points.length === 1) {
+            // We only have one point, so make it so it stretches out over the whole x axis range
+            // There are two cases here that we need to consider:
+            // (1) In unfaceted charts, the x domain will be a single year, so we need to ensure that the area stretches
+            //     out over the full range of the x axis. We do this using AxisAlign.start and AxisAlign.end.
+            // (2) In faceted charts, the x domain may span multiple years, so we need to ensure that the area stretches
+            //     out only over year - 0.5 to year + 0.5, making sure we don't put points outside the x range.
+            //
+            // -@marcelgerber, 2023-04-24
+            const point = series.points[0]
+            const y = verticalAxis.place(point.value + point.valueOffset)
+            const singleValueXDomain =
+                horizontalAxis.domain[0] === horizontalAxis.domain[1]
 
-                if (singleValueXDomain) {
-                    // Case (1)
-                    mainPoints = [
-                        [horizontalAxis.range[0], y],
-                        [horizontalAxis.range[1], y],
-                    ]
-                } else {
-                    // Case (2)
-                    const leftX = Math.max(
-                        horizontalAxis.place(point.position - 0.5),
-                        horizontalAxis.range[0]
-                    )
-                    const rightX = Math.min(
-                        horizontalAxis.place(point.position + 0.5),
-                        horizontalAxis.range[1]
-                    )
+            if (singleValueXDomain) {
+                // Case (1)
+                return [
+                    [horizontalAxis.range[0], y],
+                    [horizontalAxis.range[1], y],
+                ]
+            } else {
+                // Case (2)
+                const leftX = Math.max(
+                    horizontalAxis.place(point.position - 0.5),
+                    horizontalAxis.range[0]
+                )
+                const rightX = Math.min(
+                    horizontalAxis.place(point.position + 0.5),
+                    horizontalAxis.range[1]
+                )
 
-                    mainPoints = [
-                        [leftX, y],
-                        [rightX, y],
-                    ]
-                }
-            }
-            if (!prevPoints.length && mainPoints.length) {
-                // If we're rendering the first series, we need to add a point at the bottom left and bottom right
-                prevPoints = [
-                    [mainPoints[0][0], verticalAxis.range[0]],
-                    [lastOfNonEmptyArray(mainPoints)[0], verticalAxis.range[0]],
+                return [
+                    [leftX, y],
+                    [rightX, y],
                 ]
             }
-            const points = mainPoints.concat(reverse(clone(prevPoints)) as any)
-            prevPoints = mainPoints
+        } else return []
+    }
+
+    @computed get placedSeriesArr(): StackedPlacedSeries<number>[] {
+        const { seriesArr } = this.props
+        return seriesArr.map((series) => ({
+            ...series,
+            placedPoints: this.placeSeries(series),
+        }))
+    }
+
+    @computed private get areas(): JSX.Element[] {
+        const { placedSeriesArr } = this
+        const { dualAxis } = this.props
+        const { verticalAxis } = dualAxis
+
+        return placedSeriesArr.map((series, index) => {
+            const { placedPoints } = series
+            let prevPoints: Array<StackedPlacedPoint>
+            if (index > 0) {
+                prevPoints = placedSeriesArr[index - 1].placedPoints
+            } else {
+                prevPoints = prevPoints = [
+                    [placedPoints[0][0], verticalAxis.range[0]],
+                    [
+                        lastOfNonEmptyArray(placedPoints)[0],
+                        verticalAxis.range[0],
+                    ],
+                ]
+            }
+            const points = [...placedPoints, ...reverse(clone(prevPoints))]
 
             return (
                 <path
@@ -132,19 +158,21 @@ class Areas extends React.Component<AreasProps> {
     }
 
     @computed private get borders(): JSX.Element[] {
-        const { seriesArr } = this.props
+        const { placedSeriesArr } = this
 
-        return seriesArr.map((series) => {
-            const points = series.points.map(this.placePoint)
-
+        return placedSeriesArr.map((placedSeries) => {
             return (
                 <path
-                    className={makeSafeForCSS(series.seriesName) + "-border"}
-                    key={series.seriesName + "-border"}
+                    className={
+                        makeSafeForCSS(placedSeries.seriesName) + "-border"
+                    }
+                    key={placedSeries.seriesName + "-border"}
                     strokeLinecap="round"
-                    d={pointsToPath(points)}
+                    d={pointsToPath(placedSeries.placedPoints)}
                     stroke={rgb(
-                        this.seriesIsBlur(series) ? BLUR_COLOR : series.color
+                        this.seriesIsBlur(placedSeries)
+                            ? BLUR_COLOR
+                            : placedSeries.color
                     )
                         .darker(0.5)
                         .toString()}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -10,7 +10,7 @@ import {
     excludeUndefined,
     isMobile,
     Time,
-    AxisAlign,
+    lastOfNonEmptyArray,
 } from "@ourworldindata/utils"
 import { computed, action, observable } from "mobx"
 import { SeriesName } from "../core/GrapherConstants"
@@ -111,7 +111,7 @@ class Areas extends React.Component<AreasProps> {
                 // If we're rendering the first series, we need to add a point at the bottom left and bottom right
                 prevPoints = [
                     [mainPoints[0][0], verticalAxis.range[0]],
-                    [mainPoints.at(-1)![0], verticalAxis.range[0]],
+                    [lastOfNonEmptyArray(mainPoints)[0], verticalAxis.range[0]],
                 ]
             }
             const points = mainPoints.concat(reverse(clone(prevPoints)) as any)
@@ -132,18 +132,10 @@ class Areas extends React.Component<AreasProps> {
     }
 
     @computed private get borders(): JSX.Element[] {
-        const { dualAxis, seriesArr } = this.props
-        const { horizontalAxis, verticalAxis } = dualAxis
+        const { seriesArr } = this.props
 
-        // Stacked area chart stacks each series upon the previous series, so we must keep track of the last point set we used
         return seriesArr.map((series) => {
-            const points = series.points.map(
-                (point) =>
-                    [
-                        horizontalAxis.place(point.position),
-                        verticalAxis.place(point.value + point.valueOffset),
-                    ] as [number, number]
-            )
+            const points = series.points.map(this.placePoint)
 
             return (
                 <path

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedConstants.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedConstants.ts
@@ -4,6 +4,8 @@ import { SeriesName } from "../core/GrapherConstants"
 
 export type StackedPointPositionType = string | number
 
+export type StackedPlacedPoint = [number, number]
+
 // PositionType can be categorical (e.g. country names), or ordinal (e.g. years).
 export interface StackedPoint<PositionType extends StackedPointPositionType> {
     position: PositionType
@@ -18,6 +20,12 @@ export interface StackedSeries<PositionType extends StackedPointPositionType>
     points: StackedPoint<PositionType>[]
     columnSlug?: string
     isProjection?: boolean
+}
+
+export interface StackedPlacedSeries<
+    PositionType extends StackedPointPositionType
+> extends StackedSeries<PositionType> {
+    placedPoints: Array<StackedPlacedPoint>
 }
 
 export interface StackedRawSeries<


### PR DESCRIPTION
Fixes #2133.

In working on this I noticed a bunch more issues in this, so this ended up as a bit of a refactor.
It also got quite a bit more complex sadly, so if you see any way to simplify any of this (or add helpful comments at the very least) then please do let me know!

Before/afters (left/right):
![image](https://user-images.githubusercontent.com/2641501/234106429-dbea6b3b-30ef-432e-9d36-da3bd9ca4651.png)
⬆️ Here, the red incline on the left/right is misleading.

![image](https://user-images.githubusercontent.com/2641501/234106547-7f56716a-40a6-4451-ab0c-fa106d58c0f6.png)
⬆️ Here, there's no data for Afghanistan for years <2000, but we're displaying it as if there was data.

The SVG tester comes back with many errors sadly, but these are only rounding errors as far as I can see.