### PR TITLE
fix: do not push explorer changes in dev

### DIFF
--- a/explorerAdminClient/ExplorerCreatePage.tsx
+++ b/explorerAdminClient/ExplorerCreatePage.tsx
@@ -33,6 +33,7 @@ import {
     AutofillColDefCommand,
     SelectAllHitsCommand,
 } from "./ExplorerCommands.js"
+import { ENV } from "../settings/clientSettings.js"
 
 const RESERVED_NAMES = [DefaultNewExplorerSlug, "index", "new", "create"] // don't allow authors to save explorers with these names, otherwise might create some annoying situations.
 
@@ -182,11 +183,17 @@ export class ExplorerCreatePage extends React.Component<{
     }
 
     @action.bound private async save() {
-        const commitMessage = prompt(
-            `Enter a message describing this change. Your change will be pushed to the '${this.props.gitCmsBranchName}' on GitHub.`,
-            `Updated ${this.program.slug}`
-        )
-        if (!commitMessage) return
+        let commitMessage
+        if (ENV == "production") {
+            commitMessage = prompt(
+                `Enter a message describing this change. Your change will be pushed to the '${this.props.gitCmsBranchName}' on GitHub.`,
+                `Updated ${this.program.slug}`
+            )
+            if (!commitMessage) return
+        } else {
+            // will not get committed
+            commitMessage = "Dummy message"
+        }
         await this._save(this.program.slug, commitMessage)
     }
 


### PR DESCRIPTION
[Currently](Currently), when you modify explorers using the admin UI, it immediately writes and pushes these changes to production, regardless whether you are in a dev or staging environment.

This change fixes this for dev environments, by modifying the GitCmsServer to avoid doing Git operations (commit, push) if in a development environment.

Ideally we would do the same for staging. This would need us to be able to easily differentiate between prod and staging, which we can't easily do yet.
