### PR TITLE
feature: github action to destroy staging by sending signal to buildkite API

### DIFF
--- a/.github/scripts/buildkite_destroy_staging.py
+++ b/.github/scripts/buildkite_destroy_staging.py
@@ -1,0 +1,30 @@
+import json
+import os
+
+import requests
+
+organization_slug = "our-world-in-data"
+pipeline_slug = "grapher-destroy-staging-environment"
+api_access_token = os.environ["BUILDKITE_API_ACCESS_TOKEN"]
+
+url = f"https://api.buildkite.com/v2/organizations/{organization_slug}/pipelines/{pipeline_slug}/builds"
+
+headers = {
+    "Content-Type": "application/json",
+    "Authorization": f"Bearer {api_access_token}",
+}
+
+payload = {
+    "commit": "HEAD",
+    "branch": os.environ["TARGET_BRANCH"],
+    "message": "Triggered build via Github action in owid-grapher repository",
+}
+
+response = requests.post(url, headers=headers, data=json.dumps(payload))
+
+if response.status_code == 201:
+    print("Build successfully triggered!")
+    print(json.dumps(response.json(), indent=2))
+else:
+    print(f"Error: {response.status_code}")
+    print(response.text)

--- a/.github/workflows/buildkite.yml
+++ b/.github/workflows/buildkite.yml
@@ -1,0 +1,28 @@
+name: Buildkite
+
+on:
+    pull_request:
+        types:
+            - closed
+
+jobs:
+    destroy_staging:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out repository
+              uses: actions/checkout@v3
+
+            - name: Set up Python
+              uses: actions/setup-python@v2
+              with:
+                  python-version: 3.x
+
+            - name: Install dependencies
+              run: pip install requests
+
+            - name: Run script
+              env:
+                  BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.BUILDKITE_API_ACCESS_TOKEN }}
+                  TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
+              run: |
+                  python .github/scripts/buildkite_destroy_staging.py


### PR DESCRIPTION
Github action that is triggered on pull request close and starts [grapher-destroy-staging-environment`](https://buildkite.com/our-world-in-data/grapher-destroy-staging-environment) pipeline on Buildkite through its API.

Closes issue https://github.com/owid/ops/issues/64