### PR TITLE
fix: show entityType editor in admin in more cases

### DIFF
--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -592,7 +592,7 @@ export class EditorCustomizeTab extends React.Component<{
                         }}
                     />
                 )}
-                {(features.hideLegend || features.entityType) && (
+                {features.hideLegend && (
                     <Section name="Legend">
                         <FieldsRow>
                             {features.hideLegend && (
@@ -606,20 +606,18 @@ export class EditorCustomizeTab extends React.Component<{
                                 />
                             )}
                         </FieldsRow>
-                        {features.entityType && (
-                            <FieldsRow>
-                                <BindString
-                                    label="Entity name (singular)"
-                                    field="entityType"
-                                    store={grapher}
-                                />
-                                <BindString
-                                    label="Entity name (plural)"
-                                    field="entityTypePlural"
-                                    store={grapher}
-                                />
-                            </FieldsRow>
-                        )}
+                        <FieldsRow>
+                            <BindString
+                                label="Entity name (singular)"
+                                field="entityType"
+                                store={grapher}
+                            />
+                            <BindString
+                                label="Entity name (plural)"
+                                field="entityTypePlural"
+                                store={grapher}
+                            />
+                        </FieldsRow>
                     </Section>
                 )}
                 {features.relativeModeToggle && (

--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -66,10 +66,6 @@ export class EditorFeatures {
         return this.grapher.isStackedArea
     }
 
-    @computed get entityType() {
-        return this.grapher.addCountryMode !== EntitySelectionMode.Disabled
-    }
-
     @computed get relativeModeToggle() {
         return (
             this.grapher.isStackedArea ||


### PR DESCRIPTION
Currently, we only show the `entityType` editor in the admin when entity selection is enabled. But now that we enable faceting for more cases, those cases also need an `entityType`.

This change makes `entityType` editable in more cases, even if entity selection is not enabled for a chart.

See: #2146
