### PR TITLE
fix(facet): hide facet control for line charts with projections

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1971,7 +1971,6 @@ export class Grapher
         const {
             hideFacetControl,
             filledDimensions,
-            yColumnSlugs,
             availableFacetStrategies,
             isStackedArea,
             isStackedBar,
@@ -1992,10 +1991,7 @@ export class Grapher
             (dim) => dim.display.isProjection
         )
 
-        return (
-            showFacetControlChartType &&
-            (!hasProjection || yColumnSlugs.length <= 2)
-        )
+        return showFacetControlChartType && !hasProjection
     }
 
     @action.bound private toggleFacetControlVisibility(): void {


### PR DESCRIPTION
Don't turn on faceting by default for line charts with projections.

Because some have suboptimal colour assignments, others have confusing legends:

<img width="736" alt="Screenshot 2023-04-27 at 15 59 44" src="https://user-images.githubusercontent.com/12461810/234886050-b8fc82dc-b142-402b-af1b-a3fdb8a124a6.png">
<img width="736" alt="Screenshot 2023-04-27 at 16 00 35" src="https://user-images.githubusercontent.com/12461810/234886055-088db6ba-217e-4be2-84d3-a29af0b1f095.png">


