### PR TITLE
Prevent faceting in relative mode when facets would show a single entity or metric

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2040,15 +2040,22 @@ export class Grapher
     }
 
     @computed private get hasSingleMetricInFacets(): boolean {
-        if (this.isStackedDiscreteBar) {
-            return this.selectedFacetStrategy !== FacetStrategy.none
+        const {
+            isStackedDiscreteBar,
+            isStackedArea,
+            isStackedBar,
+            selectedFacetStrategy,
+            hasMultipleYColumns,
+        } = this
+
+        if (isStackedDiscreteBar) {
+            return selectedFacetStrategy !== FacetStrategy.none
         }
 
-        if (this.isStackedArea || this.isStackedBar) {
+        if (isStackedArea || isStackedBar) {
             return (
-                this.facetStrategy === FacetStrategy.metric ||
-                (this.facetStrategy === FacetStrategy.entity &&
-                    !this.hasMultipleYColumns)
+                selectedFacetStrategy === FacetStrategy.entity &&
+                !hasMultipleYColumns
             )
         }
 
@@ -2056,11 +2063,17 @@ export class Grapher
     }
 
     @computed private get hasSingleEntityInFacets(): boolean {
-        if (this.isStackedArea || this.isStackedBar) {
+        const {
+            isStackedArea,
+            isStackedBar,
+            selectedFacetStrategy,
+            selection,
+        } = this
+
+        if (isStackedArea || isStackedBar) {
             return (
-                this.facetStrategy === FacetStrategy.entity ||
-                (this.facetStrategy === FacetStrategy.metric &&
-                    this.selection.numSelectedEntities === 1)
+                selectedFacetStrategy === FacetStrategy.metric &&
+                selection.numSelectedEntities === 1
             )
         }
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2040,10 +2040,19 @@ export class Grapher
     }
 
     @computed private get hasSingleMetricInFacets(): boolean {
-        return (
-            this.isStackedDiscreteBar &&
-            this.selectedFacetStrategy !== FacetStrategy.none
-        )
+        if (this.isStackedDiscreteBar) {
+            return this.selectedFacetStrategy !== FacetStrategy.none
+        }
+
+        if (this.isStackedArea || this.isStackedBar) {
+            return (
+                this.facetStrategy === FacetStrategy.metric ||
+                (this.facetStrategy === FacetStrategy.entity &&
+                    this.validDimensions.length === 1)
+            )
+        }
+
+        return false
     }
 
     @computed private get hasSingleEntityInFacets(): boolean {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2044,18 +2044,17 @@ export class Grapher
             isStackedDiscreteBar,
             isStackedArea,
             isStackedBar,
-            selectedFacetStrategy,
+            facetStrategy,
             hasMultipleYColumns,
         } = this
 
         if (isStackedDiscreteBar) {
-            return selectedFacetStrategy !== FacetStrategy.none
+            return facetStrategy !== FacetStrategy.none
         }
 
         if (isStackedArea || isStackedBar) {
             return (
-                selectedFacetStrategy === FacetStrategy.entity &&
-                !hasMultipleYColumns
+                facetStrategy === FacetStrategy.entity && !hasMultipleYColumns
             )
         }
 
@@ -2063,16 +2062,11 @@ export class Grapher
     }
 
     @computed private get hasSingleEntityInFacets(): boolean {
-        const {
-            isStackedArea,
-            isStackedBar,
-            selectedFacetStrategy,
-            selection,
-        } = this
+        const { isStackedArea, isStackedBar, facetStrategy, selection } = this
 
         if (isStackedArea || isStackedBar) {
             return (
-                selectedFacetStrategy === FacetStrategy.metric &&
+                facetStrategy === FacetStrategy.metric &&
                 selection.numSelectedEntities === 1
             )
         }

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2048,7 +2048,7 @@ export class Grapher
             return (
                 this.facetStrategy === FacetStrategy.metric ||
                 (this.facetStrategy === FacetStrategy.entity &&
-                    this.validDimensions.length === 1)
+                    !this.hasMultipleYColumns)
             )
         }
 
@@ -2056,11 +2056,15 @@ export class Grapher
     }
 
     @computed private get hasSingleEntityInFacets(): boolean {
-        return (
-            (this.isStackedArea || this.isStackedBar) &&
-            this.selection.numSelectedEntities === 1 &&
-            this.facetStrategy === FacetStrategy.metric
-        )
+        if (this.isStackedArea || this.isStackedBar) {
+            return (
+                this.facetStrategy === FacetStrategy.entity ||
+                (this.facetStrategy === FacetStrategy.metric &&
+                    this.selection.numSelectedEntities === 1)
+            )
+        }
+
+        return false
     }
 
     @computed get availableFacetStrategies(): FacetStrategy[] {


### PR DESCRIPTION
fixes #2095 (again)

**Problem:** Faceting does not make sense for charts in relative mode when the resulting facets show a single metric or entity

**Solution:**
- Hide the relative toggle in such cases
- Switch to absolute mode for faceting when necessary

