### PR TITLE
Adjust facet control design to accommodate entity types of arbitrary length

### DIFF
--- a/db/migration/1684922736595-CleanUpEntityTypes.ts
+++ b/db/migration/1684922736595-CleanUpEntityTypes.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CleanUpEntityTypes1684922736595 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+          UPDATE charts
+          SET config = JSON_REMOVE(config, "$.entityType", "$.entityTypePlural")
+          WHERE config->>"$.entityType" = 'country or region'
+          OR config->>"$.entityType" = 'country/region'
+          OR config->>"$.entityType" = 'region/country'
+          OR config->>"$.entityType" = 'country / region'
+      `)
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    public async down(): Promise<void> {}
+}

--- a/devTools/schemaProcessor/columns.json
+++ b/devTools/schemaProcessor/columns.json
@@ -493,7 +493,7 @@
     {
         "type": "string",
         "pointer": "/entityType",
-        "default": "country",
+        "default": "country or region",
         "editor": "textfield"
     },
     {
@@ -801,7 +801,7 @@
     {
         "type": "string",
         "pointer": "/entityTypePlural",
-        "default": "countries",
+        "default": "countries or regions",
         "editor": "textfield"
     }
 ]

--- a/explorer/ExplorerGrammar.ts
+++ b/explorer/ExplorerGrammar.ts
@@ -149,7 +149,7 @@ export const ExplorerGrammar: Grammar = {
         keyword: "entityType",
         valuePlaceholder: "region",
         description:
-            "Default is 'country', but you can specify a different one such as 'state' or 'region'.",
+            "Default is 'country or region', but you can specify a different one such as 'state' or 'region'.",
     },
     pickerColumnSlugs: {
         ...SlugsDeclarationCellDef,

--- a/packages/@ourworldindata/grapher/src/controls/CollapsibleList/CollapsibleList.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/CollapsibleList/CollapsibleList.tsx
@@ -10,6 +10,8 @@ interface ListChild {
     child: ReactNode
 }
 
+export const MoreButtonContext = React.createContext({ isWithinMoreMenu: false })
+
 /** A UI component inspired by the "Priority+ Navbar" or "Progressively Collapsing Navbar"*/
 @observer
 export class CollapsibleList extends React.Component<{
@@ -118,18 +120,20 @@ export class CollapsibleList extends React.Component<{
                                 : "hidden",
                         }}
                     >
-                        <MoreButton
-                            options={this.dropdownItems.map(
-                                (item): JSX.Element => (
-                                    <li
-                                        key={item.index}
-                                        className="list-item dropdown"
-                                    >
-                                        {item.child}
-                                    </li>
-                                )
-                            )}
-                        />
+                        <MoreButtonContext.Provider value={{ isWithinMoreMenu: true }}>
+                            <MoreButton
+                                options={this.dropdownItems.map(
+                                    (item): JSX.Element => (
+                                        <li
+                                            key={item.index}
+                                            className="list-item dropdown"
+                                        >
+                                            {item.child}
+                                        </li>
+                                    )
+                                )}
+                            />
+                        </MoreButtonContext.Provider>
                     </li>
                     {/* Invisibly render dropdown items such that we can measure their clientWidth, too */}
                     {this.dropdownItems.map(

--- a/packages/@ourworldindata/grapher/src/controls/CollapsibleList/CollapsibleList.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/CollapsibleList/CollapsibleList.tsx
@@ -10,7 +10,9 @@ interface ListChild {
     child: ReactNode
 }
 
-export const MoreButtonContext = React.createContext({ isWithinMoreMenu: false })
+export const MoreButtonContext = React.createContext({
+    isWithinMoreMenu: false,
+})
 
 /** A UI component inspired by the "Priority+ Navbar" or "Progressively Collapsing Navbar"*/
 @observer
@@ -120,7 +122,9 @@ export class CollapsibleList extends React.Component<{
                                 : "hidden",
                         }}
                     >
-                        <MoreButtonContext.Provider value={{ isWithinMoreMenu: true }}>
+                        <MoreButtonContext.Provider
+                            value={{ isWithinMoreMenu: true }}
+                        >
                             <MoreButton
                                 options={this.dropdownItems.map(
                                     (item): JSX.Element => (

--- a/packages/@ourworldindata/grapher/src/controls/Controls.scss
+++ b/packages/@ourworldindata/grapher/src/controls/Controls.scss
@@ -17,7 +17,6 @@ $zindex-ControlsFooter: 2;
 
 // the fake dropdown menu
 .FacetStrategyDropdown {
-    width: 160px;
     font-family: "Lato";
     font-size: 12px;
     font-weight: bold;
@@ -31,6 +30,7 @@ $zindex-ControlsFooter: 2;
 // the chevron
 .FacetStrategyDropdown div {
     float: right;
+    margin-left: 8px;
 }
 
 // the pop-up list of options
@@ -44,7 +44,6 @@ $zindex-ControlsFooter: 2;
 
     position: static;
     width: 96px;
-    height: 68px;
     left: 4px;
     top: 4px;
 
@@ -63,9 +62,9 @@ $zindex-ControlsFooter: 2;
     font-style: normal;
     font-weight: bold;
     font-size: 12px;
-    line-height: 20px;
+    line-height: 1.2;
 
-    margin: 2px 0px;
+    margin-top: 4px;
 }
 
 .selected .FacetStrategyLabel {

--- a/packages/@ourworldindata/grapher/src/controls/Controls.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/Controls.tsx
@@ -21,6 +21,7 @@ import { ShareMenu, ShareMenuManager } from "./ShareMenu"
 import { TimelineController } from "../timeline/TimelineController"
 import { AxisConfig } from "../axis/AxisConfig"
 import { Tippy } from "@ourworldindata/utils"
+import { MoreButtonContext } from "./CollapsibleList/CollapsibleList"
 import classnames from "classnames"
 
 export interface NoDataAreaToggleManager {
@@ -171,8 +172,12 @@ export interface FacetStrategyDropdownManager {
 export class FacetStrategyDropdown extends React.Component<{
     manager: FacetStrategyDropdownManager
 }> {
+    static contextType = MoreButtonContext
+
     render(): JSX.Element {
-        return (
+        return this.context.isWithinMoreMenu ? (
+            <div style={{ whiteSpace: "normal" }}>{this.content}</div>
+        ) : (
             <Tippy
                 content={this.content}
                 interactive={true}

--- a/packages/@ourworldindata/grapher/src/controls/Controls.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/Controls.tsx
@@ -20,7 +20,7 @@ import {
 import { ShareMenu, ShareMenuManager } from "./ShareMenu"
 import { TimelineController } from "../timeline/TimelineController"
 import { AxisConfig } from "../axis/AxisConfig"
-import { Tippy, Bounds } from "@ourworldindata/utils"
+import { Tippy } from "@ourworldindata/utils"
 import classnames from "classnames"
 
 export interface NoDataAreaToggleManager {
@@ -180,10 +180,7 @@ export class FacetStrategyDropdown extends React.Component<{
                 placement={"bottom-start"}
                 arrow={false}
             >
-                <div
-                    className="FacetStrategyDropdown"
-                    style={{ width: this.dropDownWidth }}
-                >
+                <div className="FacetStrategyDropdown">
                     {this.facetStrategyLabels[this.facetStrategy]}
                     <div>
                         <FontAwesomeIcon icon={faChevronDown} />
@@ -194,15 +191,11 @@ export class FacetStrategyDropdown extends React.Component<{
     }
 
     @computed get facetStrategyLabels(): { [key in FacetStrategy]: string } {
-        // arbitrary entity names can be too long for our current design; as a trade-off,
-        // we accept them only if they are not too long, otherwise we just use "item"
         const entityType = this.props.manager.entityType ?? "country"
-        const entityLabel =
-            entityType.length > "country".length ? "item" : entityType
 
         return {
             [FacetStrategy.none]: "All together",
-            [FacetStrategy.entity]: `Split by ${entityLabel}`,
+            [FacetStrategy.entity]: `Split by ${entityType}`,
             [FacetStrategy.metric]: "Split by metric",
         }
     }
@@ -215,18 +208,6 @@ export class FacetStrategyDropdown extends React.Component<{
                 FacetStrategy.metric,
             ]
         )
-    }
-
-    @computed get dropDownWidth(): string {
-        const maxWidth = Math.max(
-            ...this.strategies.map(
-                (s) =>
-                    Bounds.forText(this.facetStrategyLabels[s], {
-                        fontSize: 12,
-                    }).width
-            )
-        )
-        return `${maxWidth + 45}px` // leave room for the chevron
     }
 
     // A hovering visual display giving options to be selected from
@@ -261,10 +242,10 @@ export class FacetStrategyDropdown extends React.Component<{
                             this.props.manager.facetStrategy = value
                         }}
                     >
-                        <div className="FacetStrategyLabel">{label}</div>
                         <div className={`FacetStrategyPreview-parent`}>
                             {children}
                         </div>
+                        <div className="FacetStrategyLabel">{label}</div>
                     </a>
                 </div>
             )

--- a/packages/@ourworldindata/grapher/src/controls/Controls.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/Controls.tsx
@@ -191,7 +191,7 @@ export class FacetStrategyDropdown extends React.Component<{
     }
 
     @computed get facetStrategyLabels(): { [key in FacetStrategy]: string } {
-        const entityType = this.props.manager.entityType ?? "country"
+        const entityType = this.props.manager.entityType ?? "country or region"
 
         return {
             [FacetStrategy.none]: "All together",

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -312,8 +312,8 @@ export class Grapher
     @observable.ref logo?: LogoOption = undefined
     @observable.ref hideLogo?: boolean = undefined
     @observable.ref hideRelativeToggle? = true
-    @observable.ref entityType = "country"
-    @observable.ref entityTypePlural = "countries"
+    @observable.ref entityType = "country or region"
+    @observable.ref entityTypePlural = "countries or regions"
     @observable.ref hideTimeline?: boolean = undefined
     @observable.ref hideScatterLabels?: boolean = undefined
     @observable.ref zoomToSelection?: boolean = undefined

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -128,7 +128,7 @@ export class DataTable extends React.Component<{
         return (
             this.props.manager ?? {
                 table: BlankOwidTable(),
-                entityType: "country",
+                entityType: "country or region",
             }
         )
     }
@@ -196,6 +196,7 @@ export class DataTable extends React.Component<{
     private get entityHeader(): JSX.Element {
         const { sort } = this.tableState
         return (
+            // TODO
             <ColumnHeader
                 key="entity"
                 sortable={true}

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -196,7 +196,6 @@ export class DataTable extends React.Component<{
     private get entityHeader(): JSX.Element {
         const { sort } = this.tableState
         return (
-            // TODO
             <ColumnHeader
                 key="entity"
                 sortable={true}

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
@@ -419,8 +419,8 @@
         },
         "entityType": {
             "type": "string",
-            "default": "country",
-            "description": "Display string for naming the primary entities of the data. Default is 'country', but you can specify a different one such as 'state' or 'region'"
+            "default": "country or region",
+            "description": "Display string for naming the primary entities of the data. Default is 'country or region', but you can specify a different one such as 'state' or 'region'"
         },
         "note": {
             "type": "string",

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
@@ -379,8 +379,8 @@ properties:
             - gv+owid
     entityType:
         type: string
-        default: country
-        description: Display string for naming the primary entities of the data. Default is 'country', but you can specify a different one such as 'state' or 'region'
+        default: country or region
+        description: Display string for naming the primary entities of the data. Default is 'country or region', but you can specify a different one such as 'state' or 'region'
     note:
         type: string
         description: Note displayed in the footer of the chart. To be used for clarifications etc about the data.

--- a/packages/@ourworldindata/grapher/src/selection/SelectionArray.ts
+++ b/packages/@ourworldindata/grapher/src/selection/SelectionArray.ts
@@ -12,7 +12,7 @@ export class SelectionArray {
     constructor(
         selectedEntityNames: EntityName[] = [],
         availableEntities: Entity[] = [],
-        entityType = "country"
+        entityType = "country or region"
     ) {
         this.selectedEntityNames = selectedEntityNames.slice()
         this.availableEntities = availableEntities.slice()


### PR DESCRIPTION
fixes #2159 | fixes #2173 | [Slack discussion](https://owid.slack.com/archives/C5BDCB2R3/p1682701879020779)

This PR solves two problems:
- Overwriting the default entity type "country" can lead to a confusing UI
- "Country" is a poor default since most of our charts contain countries and regions

### Problem 1: Overwriting the default entity type "country" can lead to a confusing UI

See #2159 for a description of the problem

This PR implements the following design that was suggested by Matt:

<img width="867" alt="Screenshot 2023-05-02 at 12 56 41" src="https://user-images.githubusercontent.com/12461810/235648345-17b87199-2f42-480d-9bfd-64887c48d3d1.png">

#### Technical details

- The height of the tooltip expands as necessary to make "Split by [...]" fit (used to be fixed height)
- The width of the dropdown control expands as necessary to make "Split by [...]" fit (used to be fixed width)
- Length constraint on `entityType` is dropped (I checked the [longest entity types currently in use](https://owid-datasette-y43qr.ondigitalocean.app/owid?sql=select%0D%0A++entityType,%0D%0A++LENGTH(entityType)+char_count%0D%0Afrom%0D%0A++(%0D%0A++++select%0D%0A++++++id,%0D%0A++++++config+-%3E%3E+%22entityType%22+as+entityType%0D%0A++++from%0D%0A++++++charts%0D%0A++++where%0D%0A++++++entityType+is+not+null%0D%0A++)%0D%0Agroup+by%0D%0A++entityType%0D%0Aorder+by%0D%0A++char_count+desc) to make sure this look ok)

#### Screenshots

New design on desktop:

<img width="868" alt="Screenshot 2023-05-02 at 14 35 21" src="https://user-images.githubusercontent.com/12461810/235667508-2edf6de5-743a-48d2-a8e4-6ba0fe6b6701.png">

New design on mobile (iPhone SE, 375x667)

<img width="362" alt="Screenshot 2023-05-24 at 13 46 17" src="https://github.com/owid/owid-grapher/assets/12461810/1626dbbf-c6f5-457a-bc93-e03b1942d4b7">

Not optimal that the facet control is hidden on smaller screens in the default case.

---

### Problem 2: "Country" is a poor default since most of our charts contain countries and regions

See #2173 for a description of the problem

A better default is "country or region", as suggested by Ed on [Slack](https://owid.slack.com/archives/C5BDCB2R3/p1682701879020779)

#### Changes

- Default entity type is changed from "country" to "country or region"
- Default entity type (plural) is changed from "countries" to "countries or regions"

Note that `entityTypePlural` is only used in scatter plots at the moment:

<img width="700" alt="Screenshot 2023-05-02 at 12 40 32" src="https://user-images.githubusercontent.com/12461810/235649545-4caf197d-af0c-4d32-b491-1cec24ca07f4.png">

I'm happy to clean up entity types of existing charts once this is merged.
 