### PR TITLE
Fix entity type in explorers

### DIFF
--- a/explorer/ExplorerGrammar.ts
+++ b/explorer/ExplorerGrammar.ts
@@ -151,13 +151,6 @@ export const ExplorerGrammar: Grammar = {
         description:
             "Default is 'country', but you can specify a different one such as 'state' or 'region'.",
     },
-    entityTypePlural: {
-        ...StringCellDef,
-        keyword: "entityTypePlural",
-        valuePlaceholder: "regions",
-        description:
-            "Default is 'countries'. Should match the specified `entityType`.",
-    },
     pickerColumnSlugs: {
         ...SlugsDeclarationCellDef,
         keyword: "pickerColumnSlugs",

--- a/explorer/ExplorerGrammar.ts
+++ b/explorer/ExplorerGrammar.ts
@@ -151,6 +151,13 @@ export const ExplorerGrammar: Grammar = {
         description:
             "Default is 'country', but you can specify a different one such as 'state' or 'region'.",
     },
+    entityTypePlural: {
+        ...StringCellDef,
+        keyword: "entityTypePlural",
+        valuePlaceholder: "regions",
+        description:
+            "Default is 'countries'. Should match the specified `entityType`.",
+    },
     pickerColumnSlugs: {
         ...SlugsDeclarationCellDef,
         keyword: "pickerColumnSlugs",

--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -148,6 +148,18 @@ export const GrapherGrammar: Grammar = {
         description: "Whether the chart should be faceted or not",
         terminalOptions: toTerminalOptions(Object.values(FacetStrategy)),
     },
+    entityType: {
+        ...StringCellDef,
+        keyword: "entityType",
+        description:
+            "Default is 'country', but you can specify a different one such as 'state' or 'region'.",
+    },
+    entityTypePlural: {
+        ...StringCellDef,
+        keyword: "entityTypePlural",
+        description:
+            "Default is 'countries'. Should match the specified `entityType`.",
+    },
     baseColorScheme: {
         ...EnumCellDef,
         keyword: "baseColorScheme",

--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -154,12 +154,6 @@ export const GrapherGrammar: Grammar = {
         description:
             "Default is 'country', but you can specify a different one such as 'state' or 'region'.",
     },
-    entityTypePlural: {
-        ...StringCellDef,
-        keyword: "entityTypePlural",
-        description:
-            "Default is 'countries'. Should match the specified `entityType`.",
-    },
     baseColorScheme: {
         ...EnumCellDef,
         keyword: "baseColorScheme",


### PR DESCRIPTION
fixes #2170

The `entityType` specified in the `ExplorerGrammar` of explorers didn't get passed through to Grapher because `entityType` wasn't specified in the `GrapherGrammar`. This has been fixed.

The example explorer mentioned in the issue is still not _really_ fixed because the dropdown is now labelled "Split by item" but this will be fixed once #2175 is merged.

<img width="893" alt="Screenshot 2023-05-02 at 17 21 10" src="https://user-images.githubusercontent.com/12461810/235710985-899b6648-bd9e-43d1-8f87-70eb3db8d53f.png">
