### PR TITLE
fix(admin): allow to expand footer note field

### DIFF
--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -201,6 +201,7 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                         helpText="Any important clarification needed to avoid miscommunication"
                         softCharacterLimit={140}
                         errorMessage={this.errorMessages.note}
+                        textarea
                     />
                 </Section>
 


### PR DESCRIPTION
Requested by Fiona on [Slack](https://owid.slack.com/archives/C03NA1B2P1U/p1683105843805759?thread_ts=1682668766.796469&cid=C03NA1B2P1U)