### PR TITLE
feat(admin): support custom "Split by metric" label

### DIFF
--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -634,7 +634,7 @@ export class EditorCustomizeTab extends React.Component<{
                                         Split by <s>metric</s>
                                     </>
                                 }
-                                field="yVariableType"
+                                field="facettingLabelByYVariables"
                                 store={grapher}
                                 helpText={
                                     "When facetting is active, one option is to split " +

--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -629,9 +629,19 @@ export class EditorCustomizeTab extends React.Component<{
                     {features.canCustomizeVariableType && (
                         <FieldsRow>
                             <BindString
-                                label="Group name for y-variables"
+                                label={
+                                    <>
+                                        Split by <s>metric</s>
+                                    </>
+                                }
                                 field="yVariableType"
                                 store={grapher}
+                                helpText={
+                                    "When facetting is active, one option is to split " +
+                                    "by entity/country, the other is by metric. This option  " +
+                                    'lets you override "metric" with a custom word like ' +
+                                    '"products" or "species".'
+                                }
                             />
                         </FieldsRow>
                     )}

--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -626,6 +626,15 @@ export class EditorCustomizeTab extends React.Component<{
                             store={grapher}
                         />
                     </FieldsRow>
+                    {features.canCustomizeVariableType && (
+                        <FieldsRow>
+                            <BindString
+                                label="Group name for y-variables"
+                                field="yVariableType"
+                                store={grapher}
+                            />
+                        </FieldsRow>
+                    )}
                 </Section>
                 {features.relativeModeToggle && (
                     <Section name="Controls">

--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -97,6 +97,10 @@ export class EditorFeatures {
         return this.grapher.isStackedDiscreteBar
     }
 
+    @computed get canCustomizeVariableType() {
+        return this.grapher.hasMultipleYColumns
+    }
+
     @computed get canSpecifyMissingDataStrategy() {
         return (
             this.grapher.hasMultipleYColumns &&

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -30,7 +30,7 @@ export class FieldsRow extends React.Component<{ children: React.ReactNode }> {
 }
 
 interface TextFieldProps extends React.HTMLAttributes<HTMLInputElement> {
-    label?: string
+    label?: React.ReactNode
     secondaryLabel?: string
     value: string | undefined
     onValue: (value: string) => void
@@ -678,7 +678,7 @@ export class AutoTextField extends React.Component<AutoTextFieldProps> {
 export class BindString extends React.Component<{
     field: string
     store: Record<string, any>
-    label?: string
+    label?: React.ReactNode
     secondaryLabel?: string
     placeholder?: string
     helpText?: string

--- a/packages/@ourworldindata/grapher/src/controls/Controls.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/Controls.tsx
@@ -164,6 +164,7 @@ export interface FacetStrategyDropdownManager {
     facetStrategy?: FacetStrategy
     showFacetControl?: boolean
     entityType?: string
+    yVariableType?: string
 }
 
 // A drop-down button that, when clicked, shows a hovering visual display
@@ -198,10 +199,12 @@ export class FacetStrategyDropdown extends React.Component<{
     @computed get facetStrategyLabels(): { [key in FacetStrategy]: string } {
         const entityType = this.props.manager.entityType ?? "country or region"
 
+        const yVariableType = this.props.manager.yVariableType ?? "metric"
+
         return {
             [FacetStrategy.none]: "All together",
             [FacetStrategy.entity]: `Split by ${entityType}`,
-            [FacetStrategy.metric]: "Split by metric",
+            [FacetStrategy.metric]: `Split by ${yVariableType}`,
         }
     }
 

--- a/packages/@ourworldindata/grapher/src/controls/Controls.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/Controls.tsx
@@ -164,7 +164,7 @@ export interface FacetStrategyDropdownManager {
     facetStrategy?: FacetStrategy
     showFacetControl?: boolean
     entityType?: string
-    yVariableType?: string
+    facettingLabelByYVariables?: string
 }
 
 // A drop-down button that, when clicked, shows a hovering visual display
@@ -199,12 +199,13 @@ export class FacetStrategyDropdown extends React.Component<{
     @computed get facetStrategyLabels(): { [key in FacetStrategy]: string } {
         const entityType = this.props.manager.entityType ?? "country or region"
 
-        const yVariableType = this.props.manager.yVariableType ?? "metric"
+        const facettingLabelByYVariables =
+            this.props.manager.facettingLabelByYVariables ?? "metric"
 
         return {
             [FacetStrategy.none]: "All together",
             [FacetStrategy.entity]: `Split by ${entityType}`,
-            [FacetStrategy.metric]: `Split by ${yVariableType}`,
+            [FacetStrategy.metric]: `Split by ${facettingLabelByYVariables}`,
         }
     }
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -314,6 +314,7 @@ export class Grapher
     @observable.ref hideRelativeToggle? = true
     @observable.ref entityType = "country or region"
     @observable.ref entityTypePlural = "countries or regions"
+    @observable.ref yVariableType = "metric"
     @observable.ref hideTimeline?: boolean = undefined
     @observable.ref hideScatterLabels?: boolean = undefined
     @observable.ref zoomToSelection?: boolean = undefined

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -314,7 +314,7 @@ export class Grapher
     @observable.ref hideRelativeToggle? = true
     @observable.ref entityType = "country or region"
     @observable.ref entityTypePlural = "countries or regions"
-    @observable.ref yVariableType = "metric"
+    @observable.ref facettingLabelByYVariables = "metric"
     @observable.ref hideTimeline?: boolean = undefined
     @observable.ref hideScatterLabels?: boolean = undefined
     @observable.ref zoomToSelection?: boolean = undefined

--- a/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
@@ -149,6 +149,7 @@ export const grapherKeysToSerialize = [
     "hideRelativeToggle",
     "entityType",
     "entityTypePlural",
+    "yVariableType",
     "hideTimeline",
     "zoomToSelection",
     "showYearLabels",

--- a/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
@@ -149,7 +149,7 @@ export const grapherKeysToSerialize = [
     "hideRelativeToggle",
     "entityType",
     "entityTypePlural",
-    "yVariableType",
+    "facettingLabelByYVariables",
     "hideTimeline",
     "zoomToSelection",
     "showYearLabels",

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
@@ -422,7 +422,7 @@
             "default": "country or region",
             "description": "Display string for naming the primary entities of the data. Default is 'country or region', but you can specify a different one such as 'state' or 'region'"
         },
-        "yVariableType": {
+        "facettingLabelByYVariables": {
             "type": "string",
             "default": "metric",
             "description": "Display string for the type of y-variables when multiple are in use (e.g. for variables 'Eggs', 'Fish' and 'Chicken', this would be 'product')"

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
@@ -422,6 +422,11 @@
             "default": "country or region",
             "description": "Display string for naming the primary entities of the data. Default is 'country or region', but you can specify a different one such as 'state' or 'region'"
         },
+        "yVariableType": {
+            "type": "string",
+            "default": "metric",
+            "description": "Display string for the type of y-variables when multiple are in use (e.g. for variables 'Eggs', 'Fish' and 'Chicken', this would be 'product')"
+        },
         "note": {
             "type": "string",
             "description": "Note displayed in the footer of the chart. To be used for clarifications etc about the data."

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
@@ -425,7 +425,7 @@
         "facettingLabelByYVariables": {
             "type": "string",
             "default": "metric",
-            "description": "Display string for the type of y-variables when multiple are in use (e.g. for variables 'Eggs', 'Fish' and 'Chicken', this would be 'product')"
+            "description": "Display string that replaces 'metric' in the 'Split by metric' label in facet controls (e.g. 'product' displays 'Split by product')"
         },
         "note": {
             "type": "string",

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
@@ -381,6 +381,10 @@ properties:
         type: string
         default: country or region
         description: Display string for naming the primary entities of the data. Default is 'country or region', but you can specify a different one such as 'state' or 'region'
+    yVariableType:
+        type: string
+        default: metric
+        description: Display string for the type of y-variables when multiple are in use (e.g. for variables 'Eggs', 'Fish' and 'Chicken', this would be 'product')
     note:
         type: string
         description: Note displayed in the footer of the chart. To be used for clarifications etc about the data.

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
@@ -381,7 +381,7 @@ properties:
         type: string
         default: country or region
         description: Display string for naming the primary entities of the data. Default is 'country or region', but you can specify a different one such as 'state' or 'region'
-    yVariableType:
+    facettingLabelByYVariables:
         type: string
         default: metric
         description: Display string for the type of y-variables when multiple are in use (e.g. for variables 'Eggs', 'Fish' and 'Chicken', this would be 'product')

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
@@ -384,7 +384,7 @@ properties:
     facettingLabelByYVariables:
         type: string
         default: metric
-        description: Display string for the type of y-variables when multiple are in use (e.g. for variables 'Eggs', 'Fish' and 'Chicken', this would be 'product')
+        description: Display string that replaces 'metric' in the 'Split by metric' label in facet controls (e.g. 'product' displays 'Split by product')
     note:
         type: string
         description: Note displayed in the footer of the chart. To be used for clarifications etc about the data.


### PR DESCRIPTION
fixes #2163 

### <samp>🤖 Generated by Copilot at 52d1bbf</samp>

### Summary

This pull request adds a new field to the admin that allows to customise the name of the y-variable type when multiple y-variables are in use. The default is "metric". This is used to customise the "Split by metric" label for faceting.

<img width="481" alt="Screenshot 2023-06-05 at 16 21 40" src="https://github.com/owid/owid-grapher/assets/12461810/601edafa-793d-4911-955a-447327b64fb1">

The config field is called `facettingLabelByYVariables`
