### PR TITLE
StackedArea: Include all-zero series in the tooltip

### DIFF
--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -322,26 +322,29 @@ export class AbstractStackedChart
     }
 
     @computed get unstackedSeries(): readonly StackedSeries<number>[] {
-        return this.rawSeries.map((series) => {
-            const { isProjection, seriesName, rows } = series
+        return this.rawSeries
+            .filter((series) => series.rows.length > 0)
 
-            const points = rows.map((row) => {
+            .map((series) => {
+                const { isProjection, seriesName, rows } = series
+
+                const points = rows.map((row) => {
+                    return {
+                        position: row.time,
+                        time: row.time,
+                        value: row.value,
+                        valueOffset: 0,
+                    }
+                })
+
                 return {
-                    position: row.time,
-                    time: row.time,
-                    value: row.value,
-                    valueOffset: 0,
+                    seriesName,
+                    isProjection,
+                    points,
+                    isAllZeros: points.every((point) => point.value === 0),
+                    color: this.categoricalColorAssigner.assign(seriesName),
                 }
-            })
-
-            return {
-                seriesName,
-                isProjection,
-                points,
-                isAllZeros: points.every((point) => point.value === 0),
-                color: this.categoricalColorAssigner.assign(seriesName),
-            }
-        }) as StackedSeries<number>[]
+            }) as StackedSeries<number>[]
     }
 
     @computed get series(): readonly StackedSeries<number>[] {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -295,11 +295,6 @@ export class AbstractStackedChart
         return this.series.map((series) => series.color)
     }
 
-    /** Whether we want to display series with only zeroes. Defaults to true but e.g. StackedArea charts want to set this to false */
-    get showAllZeroSeries(): boolean {
-        return true
-    }
-
     @computed get availableFacetStrategies(): FacetStrategy[] {
         const strategies: FacetStrategy[] = []
 
@@ -327,29 +322,26 @@ export class AbstractStackedChart
     }
 
     @computed get unstackedSeries(): readonly StackedSeries<number>[] {
-        return this.rawSeries
-            .filter(
-                (series) =>
-                    series.rows.length &&
-                    (this.showAllZeroSeries ||
-                        series.rows.some((row) => row.value !== 0))
-            )
-            .map((series) => {
-                const { isProjection, seriesName, rows } = series
+        return this.rawSeries.map((series) => {
+            const { isProjection, seriesName, rows } = series
+
+            const points = rows.map((row) => {
                 return {
-                    seriesName,
-                    isProjection,
-                    points: rows.map((row) => {
-                        return {
-                            position: row.time,
-                            time: row.time,
-                            value: row.value,
-                            valueOffset: 0,
-                        }
-                    }),
-                    color: this.categoricalColorAssigner.assign(seriesName),
+                    position: row.time,
+                    time: row.time,
+                    value: row.value,
+                    valueOffset: 0,
                 }
-            }) as StackedSeries<number>[]
+            })
+
+            return {
+                seriesName,
+                isProjection,
+                points,
+                isAllZeros: points.every((point) => point.value === 0),
+                color: this.categoricalColorAssigner.assign(seriesName),
+            }
+        }) as StackedSeries<number>[]
     }
 
     @computed get series(): readonly StackedSeries<number>[] {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.test.ts
@@ -90,6 +90,21 @@ it("shows a failure message if there are columns but no series", () => {
     expect(chart.failMessage).toBeTruthy()
 })
 
+it("can filter a series when there are no points", () => {
+    const table = SynthesizeFruitTable({
+        entityCount: 2,
+        timeRange: [2000, 2003],
+    }).replaceRandomCells(6, [SampleColumnSlugs.Fruit])
+    const chart = new StackedAreaChart({
+        manager: {
+            selection: table.sampleEntityName(1),
+            table,
+        },
+    })
+
+    expect(chart.series.length).toEqual(0)
+})
+
 it("filters non-numeric values", () => {
     const table = SynthesizeFruitTableWithStringValues(
         {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.test.ts
@@ -90,21 +90,6 @@ it("shows a failure message if there are columns but no series", () => {
     expect(chart.failMessage).toBeTruthy()
 })
 
-it("can filter a series when there are no points", () => {
-    const table = SynthesizeFruitTable({
-        entityCount: 2,
-        timeRange: [2000, 2003],
-    }).replaceRandomCells(6, [SampleColumnSlugs.Fruit])
-    const chart = new StackedAreaChart({
-        manager: {
-            selection: table.sampleEntityName(1),
-            table,
-        },
-    })
-
-    expect(chart.series.length).toEqual(0)
-})
-
 it("filters non-numeric values", () => {
     const table = SynthesizeFruitTableWithStringValues(
         {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -116,10 +116,12 @@ class Areas extends React.Component<AreasProps> {
 
     @computed get placedSeriesArr(): StackedPlacedSeries<number>[] {
         const { seriesArr } = this.props
-        return seriesArr.map((series) => ({
-            ...series,
-            placedPoints: this.placeSeries(series),
-        }))
+        return seriesArr
+            .filter((series) => !series.isAllZeros)
+            .map((series) => ({
+                ...series,
+                placedPoints: this.placeSeries(series),
+            }))
     }
 
     @computed private get areas(): JSX.Element[] {
@@ -239,7 +241,9 @@ export class StackedAreaChart
                 seriesName: series.seriesName,
                 label: series.seriesName,
                 yValue: midpoints[index],
+                isAllZeros: series.isAllZeros,
             }))
+            .filter((series) => !series.isAllZeros)
             .reverse()
     }
 
@@ -346,7 +350,9 @@ export class StackedAreaChart
             <g className="hoverIndicator">
                 {series.map((series) => {
                     const point = series.points[hoveredPointIndex]
-                    return this.seriesIsBlur(series) || point.fake ? null : (
+                    return this.seriesIsBlur(series) ||
+                        point.fake ||
+                        point.value === 0 ? null : (
                         <circle
                             key={series.seriesName}
                             cx={horizontalAxis.place(point.position)}
@@ -542,10 +548,6 @@ export class StackedAreaChart
                 {this.tooltip}
             </g>
         )
-    }
-    /** Whether we want to display series with only zeroes (inherited). False for this class, true for others */
-    get showAllZeroSeries(): boolean {
-        return false
     }
 
     @computed get lineLegendX(): number {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedConstants.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedConstants.ts
@@ -20,6 +20,7 @@ export interface StackedSeries<PositionType extends StackedPointPositionType>
     points: StackedPoint<PositionType>[]
     columnSlug?: string
     isProjection?: boolean
+    isAllZeros?: boolean
 }
 
 export interface StackedPlacedSeries<


### PR DESCRIPTION
fixes #2129

### <samp>🤖 Generated by Copilot at 559784d</samp>

### Summary

This PR explicitly lists all-0 series in the tooltip.

### Screenshots

<img width="746" alt="Screenshot 2023-05-04 at 10 53 29" src="https://user-images.githubusercontent.com/12461810/236163469-761cc024-8a5e-47a4-816e-b1f13cd221f7.png">
<img width="746" alt="Screenshot 2023-05-04 at 10 53 39" src="https://user-images.githubusercontent.com/12461810/236163481-e058da4b-aca1-4e1a-93dd-84a4c75acd99.png">
<img width="746" alt="Screenshot 2023-05-04 at 11 00 01" src="https://user-images.githubusercontent.com/12461810/236163485-07000c51-7978-41df-a7f8-b552430a91d0.png">

### Walkthrough
*  Remove `showAllZeroSeries` getter from `AbstractStackedChart` and `StackedAreaChart` classes, as it is no longer used to control the display of zero series ([link](https://github.com/owid/owid-grapher/pull/2185/files?diff=unified&w=0#diff-963e473b7be396f92096d55035ba12bc6126b0e8a13061b46577a738578f34feL298-L302), [link](https://github.com/owid/owid-grapher/pull/2185/files?diff=unified&w=0#diff-b455f5ce2764b36dfd3161cdbe106293f4d22a090aa9025e3718f8a8755886feL546-L549))
* Add `isAllZeros` property to `StackedSeries` interface and `unstackedSeries` computed property of `AbstractStackedChart` class, to indicate whether a series has only zero values ([link](https://github.com/owid/owid-grapher/pull/2185/files?diff=unified&w=0#diff-641fe342947162da763f9b13c710b54219cb6b4aa80eef453d94d393dffaec97R23), [link](https://github.com/owid/owid-grapher/pull/2185/files?diff=unified&w=0#diff-963e473b7be396f92096d55035ba12bc6126b0e8a13061b46577a738578f34feL330-R344))
* Filter out zero series from `placedSeriesArr` computed property of `Areas` class, to avoid unnecessary placement calculation and rendering ([link](https://github.com/owid/owid-grapher/pull/2185/files?diff=unified&w=0#diff-b455f5ce2764b36dfd3161cdbe106293f4d22a090aa9025e3718f8a8755886feL119-R124))
* Filter out zero series from `legendItems` computed property of `StackedAreaChart` class, to hide them from the legend ([link](https://github.com/owid/owid-grapher/pull/2185/files?diff=unified&w=0#diff-b455f5ce2764b36dfd3161cdbe106293f4d22a090aa9025e3718f8a8755886feL242-R246))
* Skip rendering focus marks for zero series in `renderFocusMarks` method of `StackedAreaChart` class, to prevent invisible or overlapping circles ([link](https://github.com/owid/owid-grapher/pull/2185/files?diff=unified&w=0#diff-b455f5ce2764b36dfd3161cdbe106293f4d22a090aa9025e3718f8a8755886feL349-R355))

### Poem

> _`StackedSeries` change_
> _Zero series filtered out_
> _Clearer autumn chart_


