### PR TITLE
Always show entity annotation in chart titles when in add-country mode

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1222,7 +1222,9 @@ export class Grapher
             this.tab === GrapherTabOption.chart &&
             (seriesStrategy !== SeriesStrategy.entity || this.hideLegend) &&
             selectedEntityNames.length === 1 &&
-            (showEntityAnnotation || this.canChangeEntity)
+            (showEntityAnnotation ||
+                this.canChangeEntity ||
+                this.canSelectMultipleEntities)
         ) {
             const entityStr = selectedEntityNames[0]
             if (entityStr?.length) text = `${text}, ${entityStr}`


### PR DESCRIPTION
### Summary

Updates the chart title logic to prevent the entity annotation to be hidden when multiple entity selection mode is turned on.

### Background

I recently had a chat with Pablo A who noticed that manually hiding the entity annotation in a chart's title is not allowed for charts in 'change-country' mode but is allowed for charts in 'add-country' mode. That seemed inconsistent.

We have in fact [~30 stacked charts](https://owid-datasette-y43qr.ondigitalocean.app/owid?sql=select%0D%0A++id,%0D%0A++slug,%0D%0A++type%0D%0Afrom%0D%0A++charts%0D%0Awhere%0D%0A++(%0D%0A++++type+%3D+'StackedArea'%0D%0A++++or+type+%3D+'StackedBar'%0D%0A++)%0D%0A++AND+json_array_length(config,+%22$.data.availableEntities%22)+%3E+1%0D%0A++and+json_array_length(config,+%22$.dimensions%22)+%3E+1%0D%0A++and+(%0D%0A++++config+-%3E%3E+%22$.addCountryMode%22+is+null%0D%0A++++or+config+-%3E%3E+%22$.addCountryMode%22+%3D+'add-country'%0D%0A++)%0D%0A++and+config+-%3E%3E+%22$.hideAnnotationFieldsInTitle.entity%22+is+true%0D%0A++and+config+-%3E%3E+%22$.hideFacetControl%22+is+not+true) with an "Add country" button that currently don't show the entity annotation in the title. For example:

![Screenshot 2023-05-04 at 12 47 30](https://user-images.githubusercontent.com/12461810/236183238-430cf582-4575-4d98-b2aa-abf231458dfa.png)

We are here looking at "World" data – but this information is missing from the chart.

(Note that the default behaviour is to show the entity name in the title. These 35 charts have `hideAnnotationFieldsInTitle.entity` set to true.)

### Impact

The proposed change impacts 55 charts. Mostly stacked area/bar charts with the desired change. For example:

<img width="750" alt="Screenshot 2023-05-04 at 12 55 28" src="https://user-images.githubusercontent.com/12461810/236184571-f90b7871-b103-4bbe-9ced-f3de0ba741f3.png">

But some line charts (~23) are also impacted. These now carry duplicate information:

<img width="750" alt="Screenshot 2023-05-04 at 13 43 49" src="https://user-images.githubusercontent.com/12461810/236194433-24fb7204-dd67-4aea-88a4-b25cc8b0da01.png">
<img width="750" alt="Screenshot 2023-05-04 at 13 44 00" src="https://user-images.githubusercontent.com/12461810/236194438-9eca4f11-41e2-4dbe-96ce-775cd68bec39.png">

I think this is fine since it's not a correctness issue and the duplicate information isn't distracting. (Of course we could address this in code but I'm hesitant to add yet another special case to the current chart title logic that is already quite complex.)
