### PR TITLE
fix: Fix wordpress posts missing in the sitemap by making the posts_with_gdoc_publish_status easier to use

### DIFF
--- a/db/migration/1676022628012-AddPostsWithGdocPublishStatusView.ts
+++ b/db/migration/1676022628012-AddPostsWithGdocPublishStatusView.ts
@@ -14,7 +14,7 @@ export class AddPostsWithGdocPublishStatusView1676022628012
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`-- sql
-        drop view posts_with_gdoc_publish_status;
+        drop view if exists posts_with_gdoc_publish_status;
         `)
     }
 }

--- a/db/migration/1683308571747-RecreatePostsWithGdocPublishStatusSaferWithCoalesce.ts
+++ b/db/migration/1683308571747-RecreatePostsWithGdocPublishStatusSaferWithCoalesce.ts
@@ -1,9 +1,6 @@
 import { MigrationInterface, QueryRunner } from "typeorm"
 
-// We have to recreate this because new columns were added in the
-// AddUpdatedAtInWordpressToPosts1676042584151 and AddCreatedAtToPosts1676470290267
-// migrations
-export class RecreatePostsWithGdocPublishStatusView1678398619296
+export class RecreatePostsWithGdocPublishStatusSaferWithCoalesce1683308571747
     implements MigrationInterface
 {
     public async up(queryRunner: QueryRunner): Promise<void> {
@@ -12,7 +9,7 @@ export class RecreatePostsWithGdocPublishStatusView1678398619296
         `)
         await queryRunner.query(`-- sql
         create view posts_with_gdoc_publish_status as
-            select p.*, pg.published as isGdocPublished from posts p
+            select p.*, coalesce(pg.published, false) as isGdocPublished from posts p
             left join posts_gdocs pg on p.gdocSuccessorId = pg.id COLLATE utf8mb4_0900_ai_ci
             order by pg.published desc;
         `)


### PR DESCRIPTION
The view tried to join on the posts_gdocs table and then gave as the isGdocPublished field a nullable boolean. This is easy to use incorrectly so this fix adds COALESCE(false).

This fixes wordpress posts not showing up in the sitemap anymore.