### PR TITLE
feat(explorer): detect local country in entity picker

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
@@ -231,23 +231,30 @@ export class EntityPicker extends React.Component<{
 
     @computed private get searchResults(): EntityOptionWithMetricValue[] {
         if (this.searchInput) return this.fuzzy.search(this.searchInput)
-        const { selectionSet } = this
+        const {
+            entitiesWithMetricValue,
+            sortOrder,
+            selectionSet,
+            pickerTable,
+        } = this
 
         // Show the selected up top and in order.
         const sorted = sortByUndefinedLast(
-            this.entitiesWithMetricValue,
+            entitiesWithMetricValue,
             (option) => option.plotValue,
-            this.sortOrder
+            sortOrder
         )
 
-        const [selected, unselected] = partition(sorted, (option) =>
+        let [selected, unselected] = partition(sorted, (option) =>
             selectionSet.has(option.entityName)
         )
-        const unselectedSorted = sortByUndefinedLast(
-            unselected,
-            (option) => option.localEntitiesIndex
-        )
-        return [...selected, ...unselectedSorted]
+        if (pickerTable === undefined) {
+            unselected = sortByUndefinedLast(
+                unselected,
+                (option) => option.localEntitiesIndex
+            )
+        }
+        return [...selected, ...unselected]
     }
 
     private normalizeFocusIndex(index: number): number | undefined {

--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
@@ -7,7 +7,11 @@ import classnames from "classnames"
 import { scaleLinear, ScaleLinear } from "d3-scale"
 import Select from "react-select"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
-import { faMapPin, faSearch, faTimes } from "@fortawesome/free-solid-svg-icons"
+import {
+    faLocationDot,
+    faSearch,
+    faTimes,
+} from "@fortawesome/free-solid-svg-icons"
 import { FuzzySearch } from "../../controls/FuzzySearch"
 import {
     partition,
@@ -686,7 +690,9 @@ class PickerOption extends React.Component<PickerOptionProps> {
                                     undefined && (
                                     <FontAwesomeIcon
                                         style={{ marginLeft: 5 }}
-                                        icon={faMapPin}
+                                        icon={faLocationDot}
+                                        opacity={0.9}
+                                        color="slategrey"
                                     />
                                 )}
                             </div>

--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
@@ -673,10 +673,15 @@ class PickerOption extends React.Component<PickerOptionProps> {
                     </div>
                     <div className="info-container">
                         <div className="labels-container">
-                            <div className="name">{highlight(entityName)}</div>
-                            {optionWithMetricValue.isLocalCountry && (
-                                <FontAwesomeIcon icon={faLocationArrow} />
-                            )}
+                            <div className="name">
+                                {highlight(entityName)}
+                                {optionWithMetricValue.isLocalCountry && (
+                                    <FontAwesomeIcon
+                                        style={{ marginLeft: 5 }}
+                                        icon={faLocationArrow}
+                                    />
+                                )}
+                            </div>
                             {plotValue !== undefined && (
                                 <div className="metric">{metricValue}</div>
                             )}


### PR DESCRIPTION
## Auto-generated summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f861bcb</samp>

Added a feature to show the user's country as the first option in the `EntityPicker` component. This makes it easier for users to select their own country when exploring data on the grapher. Used existing utility functions to get the country code and name from the request headers and a country list.