### PR TITLE
:sparkles: add default for `minTime` to chart config schema

### DIFF
--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.001.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.001.json
@@ -21,7 +21,10 @@
                     "type": "string",
                     "description": "Toggle linear/logarithmic",
                     "default": "linear",
-                    "enum": ["linear", "log"]
+                    "enum": [
+                        "linear",
+                        "log"
+                    ]
                 },
                 "max": {
                     "type": "number",
@@ -35,7 +38,10 @@
                 "facetDomain": {
                     "type": "string",
                     "description": "Whether the axis domain should be the same across faceted charts (if possible)",
-                    "enum": ["independent", "shared"]
+                    "enum": [
+                        "independent",
+                        "shared"
+                    ]
                 }
             },
             "additionalProperties": false
@@ -48,7 +54,10 @@
                     "type": "array",
                     "description": "Custom labels for each numeric bin. Only applied when strategy is `manual`.\n`null` falls back to default label.\n",
                     "items": {
-                        "type": ["string", "null"]
+                        "type": [
+                            "string",
+                            "null"
+                        ]
                     }
                 },
                 "customCategoryColors": {
@@ -130,7 +139,12 @@
                     "type": "string",
                     "description": "The strategy for generating the bin boundaries",
                     "default": "ckmeans",
-                    "enum": ["equalInterval", "quantiles", "ckmeans", "manual"]
+                    "enum": [
+                        "equalInterval",
+                        "quantiles",
+                        "ckmeans",
+                        "manual"
+                    ]
                 },
                 "legendDescription": {
                     "type": "string",
@@ -140,7 +154,10 @@
                     "type": "array",
                     "description": "Override some or all colors for the numerical color legend.\nColors are CSS colors, usually in the form `#aa9944`\n`null` falls back the color scheme color.\n",
                     "items": {
-                        "type": ["string", "null"]
+                        "type": [
+                            "string",
+                            "null"
+                        ]
                     }
                 },
                 "customNumericValues": {
@@ -183,7 +200,11 @@
             "additionalProperties": false
         }
     },
-    "required": ["title", "version", "dimensions"],
+    "required": [
+        "title",
+        "version",
+        "dimensions"
+    ],
     "type": "object",
     "description": "Our World In Data grapher configuration. Most of the fields can be left empty and will be\nfilled with reasonable default values.\n",
     "properties": {
@@ -244,7 +265,9 @@
                         },
                         {
                             "type": "string",
-                            "enum": ["latest"]
+                            "enum": [
+                                "latest"
+                            ]
                         }
                     ]
                 },
@@ -266,7 +289,10 @@
                 },
                 {
                     "type": "string",
-                    "enum": ["latest", "earliest"]
+                    "enum": [
+                        "latest",
+                        "earliest"
+                    ]
                 }
             ]
         },
@@ -278,7 +304,10 @@
             "type": "array",
             "description": "The initial selection of entities",
             "items": {
-                "type": ["string", "null"]
+                "type": [
+                    "string",
+                    "null"
+                ]
             }
         },
         "baseColorScheme": {
@@ -293,7 +322,13 @@
             "type": "string",
             "description": "The tab that is shown initially",
             "default": "chart",
-            "enum": ["chart", "map", "sources", "download", "table"]
+            "enum": [
+                "chart",
+                "map",
+                "sources",
+                "download",
+                "table"
+            ]
         },
         "selectedData": {
             "type": "array",
@@ -371,13 +406,21 @@
             "type": "string",
             "default": "year",
             "description": "When a user hovers over a connected series line in a ScatterPlot we show\na label for each point. By default that value will be from the \"year\" column\nbut by changing this option the column used for the x or y axis could be used instead.\n",
-            "enum": ["x", "y", "year"]
+            "enum": [
+                "x",
+                "y",
+                "year"
+            ]
         },
         "selectedFacetStrategy": {
             "type": "string",
             "default": "none",
             "description": "The desired facetting strategy (none for no facetting)",
-            "enum": ["none", "entity", "metric"]
+            "enum": [
+                "none",
+                "entity",
+                "metric"
+            ]
         },
         "sourceDesc": {
             "type": "string",
@@ -429,7 +472,11 @@
             "type": "string",
             "description": "Which logo to show on the upper right side",
             "default": "owid",
-            "enum": ["owid", "core+owid", "gv+owid"]
+            "enum": [
+                "owid",
+                "core+owid",
+                "gv+owid"
+            ]
         },
         "entityType": {
             "type": "string",
@@ -445,7 +492,10 @@
             "description": "List of dimensions and their mapping to variables",
             "items": {
                 "type": "object",
-                "required": ["property", "variableId"],
+                "required": [
+                    "property",
+                    "variableId"
+                ],
                 "properties": {
                     "targetYear": {
                         "type": "integer",
@@ -454,7 +504,13 @@
                     "property": {
                         "type": "string",
                         "description": "Which dimension this property maps to",
-                        "enum": ["y", "x", "size", "color", "table"]
+                        "enum": [
+                            "y",
+                            "x",
+                            "size",
+                            "color",
+                            "table"
+                        ]
                     },
                     "display": {
                         "type": "object",
@@ -557,7 +613,11 @@
             "type": "string",
             "description": "Whether the user can change countries, add additional ones or neither",
             "default": "add-country",
-            "enum": ["add-country", "change-country", "disabled"]
+            "enum": [
+                "add-country",
+                "change-country",
+                "disabled"
+            ]
         },
         "compareEndPointsOnly": {
             "type": "boolean",
@@ -616,21 +676,34 @@
             "description": "Indicates if the map tab should be shown"
         },
         "stackMode": {
-            "type": ["string", "null"],
+            "type": [
+                "string",
+                "null"
+            ],
             "description": "Stack mode. Only absolute and relative are actively used.",
-            "enum": ["absolute", "relative", "grouped", "stacked", null]
+            "enum": [
+                "absolute",
+                "relative",
+                "grouped",
+                "stacked",
+                null
+            ]
         },
         "minTime": {
+            "description": "Start point of the initially selected time span.",
+            "default": "earliest",
             "oneOf": [
                 {
                     "type": "number"
                 },
                 {
                     "type": "string",
-                    "enum": ["latest", "earliest"]
+                    "enum": [
+                        "latest",
+                        "earliest"
+                    ]
                 }
             ],
-            "description": "Start point of the initially selected time span."
         },
         "hideTitleAnnotation": {
             "type": "boolean",
@@ -686,13 +759,20 @@
             "type": "string",
             "description": "Sort criterium (used by stacked bar charts and marimekko)",
             "default": "total",
-            "enum": ["column", "total", "entityName"]
+            "enum": [
+                "column",
+                "total",
+                "entityName"
+            ]
         },
         "sortOrder": {
             "type": "string",
             "description": "Sort order (used by stacked bar charts and marimekko)",
             "default": "desc",
-            "enum": ["desc", "asc"]
+            "enum": [
+                "desc",
+                "asc"
+            ]
         },
         "sortColumnSlug": {
             "description": "Sort column if sortBy is column (used by stacked bar charts and marimekko)",

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.001.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.001.json
@@ -21,10 +21,7 @@
                     "type": "string",
                     "description": "Toggle linear/logarithmic",
                     "default": "linear",
-                    "enum": [
-                        "linear",
-                        "log"
-                    ]
+                    "enum": ["linear", "log"]
                 },
                 "max": {
                     "type": "number",
@@ -38,10 +35,7 @@
                 "facetDomain": {
                     "type": "string",
                     "description": "Whether the axis domain should be the same across faceted charts (if possible)",
-                    "enum": [
-                        "independent",
-                        "shared"
-                    ]
+                    "enum": ["independent", "shared"]
                 }
             },
             "additionalProperties": false
@@ -54,10 +48,7 @@
                     "type": "array",
                     "description": "Custom labels for each numeric bin. Only applied when strategy is `manual`.\n`null` falls back to default label.\n",
                     "items": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
+                        "type": ["string", "null"]
                     }
                 },
                 "customCategoryColors": {
@@ -139,12 +130,7 @@
                     "type": "string",
                     "description": "The strategy for generating the bin boundaries",
                     "default": "ckmeans",
-                    "enum": [
-                        "equalInterval",
-                        "quantiles",
-                        "ckmeans",
-                        "manual"
-                    ]
+                    "enum": ["equalInterval", "quantiles", "ckmeans", "manual"]
                 },
                 "legendDescription": {
                     "type": "string",
@@ -154,10 +140,7 @@
                     "type": "array",
                     "description": "Override some or all colors for the numerical color legend.\nColors are CSS colors, usually in the form `#aa9944`\n`null` falls back the color scheme color.\n",
                     "items": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
+                        "type": ["string", "null"]
                     }
                 },
                 "customNumericValues": {
@@ -200,11 +183,7 @@
             "additionalProperties": false
         }
     },
-    "required": [
-        "title",
-        "version",
-        "dimensions"
-    ],
+    "required": ["title", "version", "dimensions"],
     "type": "object",
     "description": "Our World In Data grapher configuration. Most of the fields can be left empty and will be\nfilled with reasonable default values.\n",
     "properties": {
@@ -265,9 +244,7 @@
                         },
                         {
                             "type": "string",
-                            "enum": [
-                                "latest"
-                            ]
+                            "enum": ["latest"]
                         }
                     ]
                 },
@@ -289,10 +266,7 @@
                 },
                 {
                     "type": "string",
-                    "enum": [
-                        "latest",
-                        "earliest"
-                    ]
+                    "enum": ["latest", "earliest"]
                 }
             ]
         },
@@ -304,10 +278,7 @@
             "type": "array",
             "description": "The initial selection of entities",
             "items": {
-                "type": [
-                    "string",
-                    "null"
-                ]
+                "type": ["string", "null"]
             }
         },
         "baseColorScheme": {
@@ -322,13 +293,7 @@
             "type": "string",
             "description": "The tab that is shown initially",
             "default": "chart",
-            "enum": [
-                "chart",
-                "map",
-                "sources",
-                "download",
-                "table"
-            ]
+            "enum": ["chart", "map", "sources", "download", "table"]
         },
         "selectedData": {
             "type": "array",
@@ -406,21 +371,13 @@
             "type": "string",
             "default": "year",
             "description": "When a user hovers over a connected series line in a ScatterPlot we show\na label for each point. By default that value will be from the \"year\" column\nbut by changing this option the column used for the x or y axis could be used instead.\n",
-            "enum": [
-                "x",
-                "y",
-                "year"
-            ]
+            "enum": ["x", "y", "year"]
         },
         "selectedFacetStrategy": {
             "type": "string",
             "default": "none",
             "description": "The desired facetting strategy (none for no facetting)",
-            "enum": [
-                "none",
-                "entity",
-                "metric"
-            ]
+            "enum": ["none", "entity", "metric"]
         },
         "sourceDesc": {
             "type": "string",
@@ -472,11 +429,7 @@
             "type": "string",
             "description": "Which logo to show on the upper right side",
             "default": "owid",
-            "enum": [
-                "owid",
-                "core+owid",
-                "gv+owid"
-            ]
+            "enum": ["owid", "core+owid", "gv+owid"]
         },
         "entityType": {
             "type": "string",
@@ -492,10 +445,7 @@
             "description": "List of dimensions and their mapping to variables",
             "items": {
                 "type": "object",
-                "required": [
-                    "property",
-                    "variableId"
-                ],
+                "required": ["property", "variableId"],
                 "properties": {
                     "targetYear": {
                         "type": "integer",
@@ -504,13 +454,7 @@
                     "property": {
                         "type": "string",
                         "description": "Which dimension this property maps to",
-                        "enum": [
-                            "y",
-                            "x",
-                            "size",
-                            "color",
-                            "table"
-                        ]
+                        "enum": ["y", "x", "size", "color", "table"]
                     },
                     "display": {
                         "type": "object",
@@ -613,11 +557,7 @@
             "type": "string",
             "description": "Whether the user can change countries, add additional ones or neither",
             "default": "add-country",
-            "enum": [
-                "add-country",
-                "change-country",
-                "disabled"
-            ]
+            "enum": ["add-country", "change-country", "disabled"]
         },
         "compareEndPointsOnly": {
             "type": "boolean",
@@ -676,18 +616,9 @@
             "description": "Indicates if the map tab should be shown"
         },
         "stackMode": {
-            "type": [
-                "string",
-                "null"
-            ],
+            "type": ["string", "null"],
             "description": "Stack mode. Only absolute and relative are actively used.",
-            "enum": [
-                "absolute",
-                "relative",
-                "grouped",
-                "stacked",
-                null
-            ]
+            "enum": ["absolute", "relative", "grouped", "stacked", null]
         },
         "minTime": {
             "description": "Start point of the initially selected time span.",
@@ -698,12 +629,9 @@
                 },
                 {
                     "type": "string",
-                    "enum": [
-                        "latest",
-                        "earliest"
-                    ]
+                    "enum": ["latest", "earliest"]
                 }
-            ],
+            ]
         },
         "hideTitleAnnotation": {
             "type": "boolean",
@@ -759,20 +687,13 @@
             "type": "string",
             "description": "Sort criterium (used by stacked bar charts and marimekko)",
             "default": "total",
-            "enum": [
-                "column",
-                "total",
-                "entityName"
-            ]
+            "enum": ["column", "total", "entityName"]
         },
         "sortOrder": {
             "type": "string",
             "description": "Sort order (used by stacked bar charts and marimekko)",
             "default": "desc",
-            "enum": [
-                "desc",
-                "asc"
-            ]
+            "enum": ["desc", "asc"]
         },
         "sortColumnSlug": {
             "description": "Sort column if sortBy is column (used by stacked bar charts and marimekko)",

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.001.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.001.yaml
@@ -550,13 +550,14 @@ properties:
             - stacked
             - null
     minTime:
+        description: Start point of the initially selected time span.
+        default: earliest
         oneOf:
             - type: number
             - type: string
               enum:
                   - latest
                   - earliest
-        description: Start point of the initially selected time span.
     hideTitleAnnotation:
         type: boolean
         default: false

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.json
@@ -21,10 +21,7 @@
                     "type": "string",
                     "description": "Toggle linear/logarithmic",
                     "default": "linear",
-                    "enum": [
-                        "linear",
-                        "log"
-                    ]
+                    "enum": ["linear", "log"]
                 },
                 "max": {
                     "type": "number",
@@ -38,10 +35,7 @@
                 "facetDomain": {
                     "type": "string",
                     "description": "Whether the axis domain should be the same across faceted charts (if possible)",
-                    "enum": [
-                        "independent",
-                        "shared"
-                    ]
+                    "enum": ["independent", "shared"]
                 }
             },
             "additionalProperties": false
@@ -54,10 +48,7 @@
                     "type": "array",
                     "description": "Custom labels for each numeric bin. Only applied when strategy is `manual`.\n`null` falls back to default label.\n",
                     "items": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
+                        "type": ["string", "null"]
                     }
                 },
                 "customCategoryColors": {
@@ -139,12 +130,7 @@
                     "type": "string",
                     "description": "The strategy for generating the bin boundaries",
                     "default": "ckmeans",
-                    "enum": [
-                        "equalInterval",
-                        "quantiles",
-                        "ckmeans",
-                        "manual"
-                    ]
+                    "enum": ["equalInterval", "quantiles", "ckmeans", "manual"]
                 },
                 "legendDescription": {
                     "type": "string",
@@ -154,10 +140,7 @@
                     "type": "array",
                     "description": "Override some or all colors for the numerical color legend.\nColors are CSS colors, usually in the form `#aa9944`\n`null` falls back the color scheme color.\n",
                     "items": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
+                        "type": ["string", "null"]
                     }
                 },
                 "customNumericValues": {
@@ -200,11 +183,7 @@
             "additionalProperties": false
         }
     },
-    "required": [
-        "title",
-        "version",
-        "dimensions"
-    ],
+    "required": ["title", "version", "dimensions"],
     "type": "object",
     "description": "Our World In Data grapher configuration. Most of the fields can be left empty and will be\nfilled with reasonable default values.\n",
     "properties": {
@@ -265,9 +244,7 @@
                         },
                         {
                             "type": "string",
-                            "enum": [
-                                "latest"
-                            ]
+                            "enum": ["latest"]
                         }
                     ]
                 },
@@ -289,10 +266,7 @@
                 },
                 {
                     "type": "string",
-                    "enum": [
-                        "latest",
-                        "earliest"
-                    ]
+                    "enum": ["latest", "earliest"]
                 }
             ]
         },
@@ -304,10 +278,7 @@
             "type": "array",
             "description": "The initial selection of entities",
             "items": {
-                "type": [
-                    "string",
-                    "null"
-                ]
+                "type": ["string", "null"]
             }
         },
         "baseColorScheme": {
@@ -322,13 +293,7 @@
             "type": "string",
             "description": "The tab that is shown initially",
             "default": "chart",
-            "enum": [
-                "chart",
-                "map",
-                "sources",
-                "download",
-                "table"
-            ]
+            "enum": ["chart", "map", "sources", "download", "table"]
         },
         "matchingEntitiesOnly": {
             "type": "boolean",
@@ -386,21 +351,13 @@
             "type": "string",
             "default": "year",
             "description": "When a user hovers over a connected series line in a ScatterPlot we show\na label for each point. By default that value will be from the \"year\" column\nbut by changing this option the column used for the x or y axis could be used instead.\n",
-            "enum": [
-                "x",
-                "y",
-                "year"
-            ]
+            "enum": ["x", "y", "year"]
         },
         "selectedFacetStrategy": {
             "type": "string",
             "default": "none",
             "description": "The desired facetting strategy (none for no facetting)",
-            "enum": [
-                "none",
-                "entity",
-                "metric"
-            ]
+            "enum": ["none", "entity", "metric"]
         },
         "sourceDesc": {
             "type": "string",
@@ -452,11 +409,7 @@
             "type": "string",
             "description": "Which logo to show on the upper right side",
             "default": "owid",
-            "enum": [
-                "owid",
-                "core+owid",
-                "gv+owid"
-            ]
+            "enum": ["owid", "core+owid", "gv+owid"]
         },
         "entityType": {
             "type": "string",
@@ -472,10 +425,7 @@
             "description": "List of dimensions and their mapping to variables",
             "items": {
                 "type": "object",
-                "required": [
-                    "property",
-                    "variableId"
-                ],
+                "required": ["property", "variableId"],
                 "properties": {
                     "targetYear": {
                         "type": "integer",
@@ -484,13 +434,7 @@
                     "property": {
                         "type": "string",
                         "description": "Which dimension this property maps to",
-                        "enum": [
-                            "y",
-                            "x",
-                            "size",
-                            "color",
-                            "table"
-                        ]
+                        "enum": ["y", "x", "size", "color", "table"]
                     },
                     "display": {
                         "type": "object",
@@ -593,11 +537,7 @@
             "type": "string",
             "description": "Whether the user can change countries, add additional ones or neither",
             "default": "add-country",
-            "enum": [
-                "add-country",
-                "change-country",
-                "disabled"
-            ]
+            "enum": ["add-country", "change-country", "disabled"]
         },
         "compareEndPointsOnly": {
             "type": "boolean",
@@ -656,18 +596,9 @@
             "description": "Indicates if the map tab should be shown"
         },
         "stackMode": {
-            "type": [
-                "string",
-                "null"
-            ],
+            "type": ["string", "null"],
             "description": "Stack mode. Only absolute and relative are actively used.",
-            "enum": [
-                "absolute",
-                "relative",
-                "grouped",
-                "stacked",
-                null
-            ]
+            "enum": ["absolute", "relative", "grouped", "stacked", null]
         },
         "minTime": {
             "description": "Start point of the initially selected time span.",
@@ -678,12 +609,9 @@
                 },
                 {
                     "type": "string",
-                    "enum": [
-                        "latest",
-                        "earliest"
-                    ]
+                    "enum": ["latest", "earliest"]
                 }
-            ],
+            ]
         },
         "hideTitleAnnotation": {
             "type": "boolean",
@@ -744,20 +672,13 @@
             "type": "string",
             "description": "Sort criterium (used by stacked bar charts and marimekko)",
             "default": "total",
-            "enum": [
-                "column",
-                "total",
-                "entityName"
-            ]
+            "enum": ["column", "total", "entityName"]
         },
         "sortOrder": {
             "type": "string",
             "description": "Sort order (used by stacked bar charts and marimekko)",
             "default": "desc",
-            "enum": [
-                "desc",
-                "asc"
-            ]
+            "enum": ["desc", "asc"]
         },
         "sortColumnSlug": {
             "description": "Sort column if sortBy is column (used by stacked bar charts and marimekko)",

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.json
@@ -21,7 +21,10 @@
                     "type": "string",
                     "description": "Toggle linear/logarithmic",
                     "default": "linear",
-                    "enum": ["linear", "log"]
+                    "enum": [
+                        "linear",
+                        "log"
+                    ]
                 },
                 "max": {
                     "type": "number",
@@ -35,7 +38,10 @@
                 "facetDomain": {
                     "type": "string",
                     "description": "Whether the axis domain should be the same across faceted charts (if possible)",
-                    "enum": ["independent", "shared"]
+                    "enum": [
+                        "independent",
+                        "shared"
+                    ]
                 }
             },
             "additionalProperties": false
@@ -48,7 +54,10 @@
                     "type": "array",
                     "description": "Custom labels for each numeric bin. Only applied when strategy is `manual`.\n`null` falls back to default label.\n",
                     "items": {
-                        "type": ["string", "null"]
+                        "type": [
+                            "string",
+                            "null"
+                        ]
                     }
                 },
                 "customCategoryColors": {
@@ -130,7 +139,12 @@
                     "type": "string",
                     "description": "The strategy for generating the bin boundaries",
                     "default": "ckmeans",
-                    "enum": ["equalInterval", "quantiles", "ckmeans", "manual"]
+                    "enum": [
+                        "equalInterval",
+                        "quantiles",
+                        "ckmeans",
+                        "manual"
+                    ]
                 },
                 "legendDescription": {
                     "type": "string",
@@ -140,7 +154,10 @@
                     "type": "array",
                     "description": "Override some or all colors for the numerical color legend.\nColors are CSS colors, usually in the form `#aa9944`\n`null` falls back the color scheme color.\n",
                     "items": {
-                        "type": ["string", "null"]
+                        "type": [
+                            "string",
+                            "null"
+                        ]
                     }
                 },
                 "customNumericValues": {
@@ -183,7 +200,11 @@
             "additionalProperties": false
         }
     },
-    "required": ["title", "version", "dimensions"],
+    "required": [
+        "title",
+        "version",
+        "dimensions"
+    ],
     "type": "object",
     "description": "Our World In Data grapher configuration. Most of the fields can be left empty and will be\nfilled with reasonable default values.\n",
     "properties": {
@@ -244,7 +265,9 @@
                         },
                         {
                             "type": "string",
-                            "enum": ["latest"]
+                            "enum": [
+                                "latest"
+                            ]
                         }
                     ]
                 },
@@ -266,7 +289,10 @@
                 },
                 {
                     "type": "string",
-                    "enum": ["latest", "earliest"]
+                    "enum": [
+                        "latest",
+                        "earliest"
+                    ]
                 }
             ]
         },
@@ -278,7 +304,10 @@
             "type": "array",
             "description": "The initial selection of entities",
             "items": {
-                "type": ["string", "null"]
+                "type": [
+                    "string",
+                    "null"
+                ]
             }
         },
         "baseColorScheme": {
@@ -293,7 +322,13 @@
             "type": "string",
             "description": "The tab that is shown initially",
             "default": "chart",
-            "enum": ["chart", "map", "sources", "download", "table"]
+            "enum": [
+                "chart",
+                "map",
+                "sources",
+                "download",
+                "table"
+            ]
         },
         "matchingEntitiesOnly": {
             "type": "boolean",
@@ -351,13 +386,21 @@
             "type": "string",
             "default": "year",
             "description": "When a user hovers over a connected series line in a ScatterPlot we show\na label for each point. By default that value will be from the \"year\" column\nbut by changing this option the column used for the x or y axis could be used instead.\n",
-            "enum": ["x", "y", "year"]
+            "enum": [
+                "x",
+                "y",
+                "year"
+            ]
         },
         "selectedFacetStrategy": {
             "type": "string",
             "default": "none",
             "description": "The desired facetting strategy (none for no facetting)",
-            "enum": ["none", "entity", "metric"]
+            "enum": [
+                "none",
+                "entity",
+                "metric"
+            ]
         },
         "sourceDesc": {
             "type": "string",
@@ -409,7 +452,11 @@
             "type": "string",
             "description": "Which logo to show on the upper right side",
             "default": "owid",
-            "enum": ["owid", "core+owid", "gv+owid"]
+            "enum": [
+                "owid",
+                "core+owid",
+                "gv+owid"
+            ]
         },
         "entityType": {
             "type": "string",
@@ -425,7 +472,10 @@
             "description": "List of dimensions and their mapping to variables",
             "items": {
                 "type": "object",
-                "required": ["property", "variableId"],
+                "required": [
+                    "property",
+                    "variableId"
+                ],
                 "properties": {
                     "targetYear": {
                         "type": "integer",
@@ -434,7 +484,13 @@
                     "property": {
                         "type": "string",
                         "description": "Which dimension this property maps to",
-                        "enum": ["y", "x", "size", "color", "table"]
+                        "enum": [
+                            "y",
+                            "x",
+                            "size",
+                            "color",
+                            "table"
+                        ]
                     },
                     "display": {
                         "type": "object",
@@ -537,7 +593,11 @@
             "type": "string",
             "description": "Whether the user can change countries, add additional ones or neither",
             "default": "add-country",
-            "enum": ["add-country", "change-country", "disabled"]
+            "enum": [
+                "add-country",
+                "change-country",
+                "disabled"
+            ]
         },
         "compareEndPointsOnly": {
             "type": "boolean",
@@ -596,21 +656,34 @@
             "description": "Indicates if the map tab should be shown"
         },
         "stackMode": {
-            "type": ["string", "null"],
+            "type": [
+                "string",
+                "null"
+            ],
             "description": "Stack mode. Only absolute and relative are actively used.",
-            "enum": ["absolute", "relative", "grouped", "stacked", null]
+            "enum": [
+                "absolute",
+                "relative",
+                "grouped",
+                "stacked",
+                null
+            ]
         },
         "minTime": {
+            "description": "Start point of the initially selected time span.",
+            "default": "earliest",
             "oneOf": [
                 {
                     "type": "number"
                 },
                 {
                     "type": "string",
-                    "enum": ["latest", "earliest"]
+                    "enum": [
+                        "latest",
+                        "earliest"
+                    ]
                 }
             ],
-            "description": "Start point of the initially selected time span."
         },
         "hideTitleAnnotation": {
             "type": "boolean",
@@ -671,13 +744,20 @@
             "type": "string",
             "description": "Sort criterium (used by stacked bar charts and marimekko)",
             "default": "total",
-            "enum": ["column", "total", "entityName"]
+            "enum": [
+                "column",
+                "total",
+                "entityName"
+            ]
         },
         "sortOrder": {
             "type": "string",
             "description": "Sort order (used by stacked bar charts and marimekko)",
             "default": "desc",
-            "enum": ["desc", "asc"]
+            "enum": [
+                "desc",
+                "asc"
+            ]
         },
         "sortColumnSlug": {
             "description": "Sort column if sortBy is column (used by stacked bar charts and marimekko)",

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.002.yaml
@@ -536,13 +536,14 @@ properties:
             - stacked
             - null
     minTime:
+        description: Start point of the initially selected time span.
+        default: earliest
         oneOf:
             - type: number
             - type: string
               enum:
                   - latest
                   - earliest
-        description: Start point of the initially selected time span.
     hideTitleAnnotation:
         type: boolean
         default: false

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
@@ -21,10 +21,7 @@
                     "type": "string",
                     "description": "Toggle linear/logarithmic",
                     "default": "linear",
-                    "enum": [
-                        "linear",
-                        "log"
-                    ]
+                    "enum": ["linear", "log"]
                 },
                 "max": {
                     "type": "number",
@@ -38,10 +35,7 @@
                 "facetDomain": {
                     "type": "string",
                     "description": "Whether the axis domain should be the same across faceted charts (if possible)",
-                    "enum": [
-                        "independent",
-                        "shared"
-                    ]
+                    "enum": ["independent", "shared"]
                 }
             },
             "additionalProperties": false
@@ -54,10 +48,7 @@
                     "type": "array",
                     "description": "Custom labels for each numeric bin. Only applied when strategy is `manual`.\n`null` falls back to default label.\n",
                     "items": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
+                        "type": ["string", "null"]
                     }
                 },
                 "customCategoryColors": {
@@ -139,12 +130,7 @@
                     "type": "string",
                     "description": "The strategy for generating the bin boundaries",
                     "default": "ckmeans",
-                    "enum": [
-                        "equalInterval",
-                        "quantiles",
-                        "ckmeans",
-                        "manual"
-                    ]
+                    "enum": ["equalInterval", "quantiles", "ckmeans", "manual"]
                 },
                 "legendDescription": {
                     "type": "string",
@@ -154,10 +140,7 @@
                     "type": "array",
                     "description": "Override some or all colors for the numerical color legend.\nColors are CSS colors, usually in the form `#aa9944`\n`null` falls back the color scheme color.\n",
                     "items": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
+                        "type": ["string", "null"]
                     }
                 },
                 "customNumericValues": {
@@ -200,11 +183,7 @@
             "additionalProperties": false
         }
     },
-    "required": [
-        "title",
-        "version",
-        "dimensions"
-    ],
+    "required": ["title", "version", "dimensions"],
     "type": "object",
     "description": "Our World In Data grapher configuration. Most of the fields can be left empty and will be\nfilled with reasonable default values.\n",
     "properties": {
@@ -254,11 +233,7 @@
                 "toleranceStrategy": {
                     "type": "string",
                     "description": "Tolerance strategy to use. Options include accepting matches that are \"closest\" to the time point in question\n(going forwards and backwards in time), and accepting matches that lie in the past (\"backwards\") or\nthe future (\"forwards\").\n",
-                    "enum": [
-                        "closest",
-                        "forwards",
-                        "backwards"
-                    ],
+                    "enum": ["closest", "forwards", "backwards"],
                     "default": "closest"
                 },
                 "tooltipUseCustomLabels": {
@@ -275,9 +250,7 @@
                         },
                         {
                             "type": "string",
-                            "enum": [
-                                "latest"
-                            ]
+                            "enum": ["latest"]
                         }
                     ]
                 },
@@ -299,10 +272,7 @@
                 },
                 {
                     "type": "string",
-                    "enum": [
-                        "latest",
-                        "earliest"
-                    ]
+                    "enum": ["latest", "earliest"]
                 }
             ]
         },
@@ -314,10 +284,7 @@
             "type": "array",
             "description": "The initial selection of entities",
             "items": {
-                "type": [
-                    "string",
-                    "null"
-                ]
+                "type": ["string", "null"]
             }
         },
         "baseColorScheme": {
@@ -332,13 +299,7 @@
             "type": "string",
             "description": "The tab that is shown initially",
             "default": "chart",
-            "enum": [
-                "chart",
-                "map",
-                "sources",
-                "download",
-                "table"
-            ]
+            "enum": ["chart", "map", "sources", "download", "table"]
         },
         "matchingEntitiesOnly": {
             "type": "boolean",
@@ -396,21 +357,13 @@
             "type": "string",
             "default": "year",
             "description": "When a user hovers over a connected series line in a ScatterPlot we show\na label for each point. By default that value will be from the \"year\" column\nbut by changing this option the column used for the x or y axis could be used instead.\n",
-            "enum": [
-                "x",
-                "y",
-                "year"
-            ]
+            "enum": ["x", "y", "year"]
         },
         "selectedFacetStrategy": {
             "type": "string",
             "default": "none",
             "description": "The desired facetting strategy (none for no facetting)",
-            "enum": [
-                "none",
-                "entity",
-                "metric"
-            ]
+            "enum": ["none", "entity", "metric"]
         },
         "sourceDesc": {
             "type": "string",
@@ -462,11 +415,7 @@
             "type": "string",
             "description": "Which logo to show on the upper right side",
             "default": "owid",
-            "enum": [
-                "owid",
-                "core+owid",
-                "gv+owid"
-            ]
+            "enum": ["owid", "core+owid", "gv+owid"]
         },
         "entityType": {
             "type": "string",
@@ -482,10 +431,7 @@
             "description": "List of dimensions and their mapping to variables",
             "items": {
                 "type": "object",
-                "required": [
-                    "property",
-                    "variableId"
-                ],
+                "required": ["property", "variableId"],
                 "properties": {
                     "targetYear": {
                         "type": "integer",
@@ -494,13 +440,7 @@
                     "property": {
                         "type": "string",
                         "description": "Which dimension this property maps to",
-                        "enum": [
-                            "y",
-                            "x",
-                            "size",
-                            "color",
-                            "table"
-                        ]
+                        "enum": ["y", "x", "size", "color", "table"]
                     },
                     "display": {
                         "type": "object",
@@ -595,11 +535,7 @@
             "type": "string",
             "description": "Whether the user can change countries, add additional ones or neither",
             "default": "add-country",
-            "enum": [
-                "add-country",
-                "change-country",
-                "disabled"
-            ]
+            "enum": ["add-country", "change-country", "disabled"]
         },
         "compareEndPointsOnly": {
             "type": "boolean",
@@ -658,18 +594,9 @@
             "description": "Indicates if the map tab should be shown"
         },
         "stackMode": {
-            "type": [
-                "string",
-                "null"
-            ],
+            "type": ["string", "null"],
             "description": "Stack mode. Only absolute and relative are actively used.",
-            "enum": [
-                "absolute",
-                "relative",
-                "grouped",
-                "stacked",
-                null
-            ]
+            "enum": ["absolute", "relative", "grouped", "stacked", null]
         },
         "minTime": {
             "description": "Start point of the initially selected time span.",
@@ -680,12 +607,9 @@
                 },
                 {
                     "type": "string",
-                    "enum": [
-                        "latest",
-                        "earliest"
-                    ]
+                    "enum": ["latest", "earliest"]
                 }
-            ],
+            ]
         },
         "hideAnnotationFieldsInTitle": {
             "type": "object",
@@ -762,20 +686,13 @@
             "type": "string",
             "description": "Sort criterium (used by stacked bar charts and marimekko)",
             "default": "total",
-            "enum": [
-                "column",
-                "total",
-                "entityName"
-            ]
+            "enum": ["column", "total", "entityName"]
         },
         "sortOrder": {
             "type": "string",
             "description": "Sort order (used by stacked bar charts and marimekko)",
             "default": "desc",
-            "enum": [
-                "desc",
-                "asc"
-            ]
+            "enum": ["desc", "asc"]
         },
         "sortColumnSlug": {
             "description": "Sort column if sortBy is column (used by stacked bar charts and marimekko)",

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.json
@@ -21,7 +21,10 @@
                     "type": "string",
                     "description": "Toggle linear/logarithmic",
                     "default": "linear",
-                    "enum": ["linear", "log"]
+                    "enum": [
+                        "linear",
+                        "log"
+                    ]
                 },
                 "max": {
                     "type": "number",
@@ -35,7 +38,10 @@
                 "facetDomain": {
                     "type": "string",
                     "description": "Whether the axis domain should be the same across faceted charts (if possible)",
-                    "enum": ["independent", "shared"]
+                    "enum": [
+                        "independent",
+                        "shared"
+                    ]
                 }
             },
             "additionalProperties": false
@@ -48,7 +54,10 @@
                     "type": "array",
                     "description": "Custom labels for each numeric bin. Only applied when strategy is `manual`.\n`null` falls back to default label.\n",
                     "items": {
-                        "type": ["string", "null"]
+                        "type": [
+                            "string",
+                            "null"
+                        ]
                     }
                 },
                 "customCategoryColors": {
@@ -130,7 +139,12 @@
                     "type": "string",
                     "description": "The strategy for generating the bin boundaries",
                     "default": "ckmeans",
-                    "enum": ["equalInterval", "quantiles", "ckmeans", "manual"]
+                    "enum": [
+                        "equalInterval",
+                        "quantiles",
+                        "ckmeans",
+                        "manual"
+                    ]
                 },
                 "legendDescription": {
                     "type": "string",
@@ -140,7 +154,10 @@
                     "type": "array",
                     "description": "Override some or all colors for the numerical color legend.\nColors are CSS colors, usually in the form `#aa9944`\n`null` falls back the color scheme color.\n",
                     "items": {
-                        "type": ["string", "null"]
+                        "type": [
+                            "string",
+                            "null"
+                        ]
                     }
                 },
                 "customNumericValues": {
@@ -183,7 +200,11 @@
             "additionalProperties": false
         }
     },
-    "required": ["title", "version", "dimensions"],
+    "required": [
+        "title",
+        "version",
+        "dimensions"
+    ],
     "type": "object",
     "description": "Our World In Data grapher configuration. Most of the fields can be left empty and will be\nfilled with reasonable default values.\n",
     "properties": {
@@ -233,7 +254,11 @@
                 "toleranceStrategy": {
                     "type": "string",
                     "description": "Tolerance strategy to use. Options include accepting matches that are \"closest\" to the time point in question\n(going forwards and backwards in time), and accepting matches that lie in the past (\"backwards\") or\nthe future (\"forwards\").\n",
-                    "enum": ["closest", "forwards", "backwards"],
+                    "enum": [
+                        "closest",
+                        "forwards",
+                        "backwards"
+                    ],
                     "default": "closest"
                 },
                 "tooltipUseCustomLabels": {
@@ -250,7 +275,9 @@
                         },
                         {
                             "type": "string",
-                            "enum": ["latest"]
+                            "enum": [
+                                "latest"
+                            ]
                         }
                     ]
                 },
@@ -272,7 +299,10 @@
                 },
                 {
                     "type": "string",
-                    "enum": ["latest", "earliest"]
+                    "enum": [
+                        "latest",
+                        "earliest"
+                    ]
                 }
             ]
         },
@@ -284,7 +314,10 @@
             "type": "array",
             "description": "The initial selection of entities",
             "items": {
-                "type": ["string", "null"]
+                "type": [
+                    "string",
+                    "null"
+                ]
             }
         },
         "baseColorScheme": {
@@ -299,7 +332,13 @@
             "type": "string",
             "description": "The tab that is shown initially",
             "default": "chart",
-            "enum": ["chart", "map", "sources", "download", "table"]
+            "enum": [
+                "chart",
+                "map",
+                "sources",
+                "download",
+                "table"
+            ]
         },
         "matchingEntitiesOnly": {
             "type": "boolean",
@@ -357,13 +396,21 @@
             "type": "string",
             "default": "year",
             "description": "When a user hovers over a connected series line in a ScatterPlot we show\na label for each point. By default that value will be from the \"year\" column\nbut by changing this option the column used for the x or y axis could be used instead.\n",
-            "enum": ["x", "y", "year"]
+            "enum": [
+                "x",
+                "y",
+                "year"
+            ]
         },
         "selectedFacetStrategy": {
             "type": "string",
             "default": "none",
             "description": "The desired facetting strategy (none for no facetting)",
-            "enum": ["none", "entity", "metric"]
+            "enum": [
+                "none",
+                "entity",
+                "metric"
+            ]
         },
         "sourceDesc": {
             "type": "string",
@@ -415,7 +462,11 @@
             "type": "string",
             "description": "Which logo to show on the upper right side",
             "default": "owid",
-            "enum": ["owid", "core+owid", "gv+owid"]
+            "enum": [
+                "owid",
+                "core+owid",
+                "gv+owid"
+            ]
         },
         "entityType": {
             "type": "string",
@@ -431,7 +482,10 @@
             "description": "List of dimensions and their mapping to variables",
             "items": {
                 "type": "object",
-                "required": ["property", "variableId"],
+                "required": [
+                    "property",
+                    "variableId"
+                ],
                 "properties": {
                     "targetYear": {
                         "type": "integer",
@@ -440,7 +494,13 @@
                     "property": {
                         "type": "string",
                         "description": "Which dimension this property maps to",
-                        "enum": ["y", "x", "size", "color", "table"]
+                        "enum": [
+                            "y",
+                            "x",
+                            "size",
+                            "color",
+                            "table"
+                        ]
                     },
                     "display": {
                         "type": "object",
@@ -535,7 +595,11 @@
             "type": "string",
             "description": "Whether the user can change countries, add additional ones or neither",
             "default": "add-country",
-            "enum": ["add-country", "change-country", "disabled"]
+            "enum": [
+                "add-country",
+                "change-country",
+                "disabled"
+            ]
         },
         "compareEndPointsOnly": {
             "type": "boolean",
@@ -594,21 +658,34 @@
             "description": "Indicates if the map tab should be shown"
         },
         "stackMode": {
-            "type": ["string", "null"],
+            "type": [
+                "string",
+                "null"
+            ],
             "description": "Stack mode. Only absolute and relative are actively used.",
-            "enum": ["absolute", "relative", "grouped", "stacked", null]
+            "enum": [
+                "absolute",
+                "relative",
+                "grouped",
+                "stacked",
+                null
+            ]
         },
         "minTime": {
+            "description": "Start point of the initially selected time span.",
+            "default": "earliest",
             "oneOf": [
                 {
                     "type": "number"
                 },
                 {
                     "type": "string",
-                    "enum": ["latest", "earliest"]
+                    "enum": [
+                        "latest",
+                        "earliest"
+                    ]
                 }
             ],
-            "description": "Start point of the initially selected time span."
         },
         "hideAnnotationFieldsInTitle": {
             "type": "object",
@@ -685,13 +762,20 @@
             "type": "string",
             "description": "Sort criterium (used by stacked bar charts and marimekko)",
             "default": "total",
-            "enum": ["column", "total", "entityName"]
+            "enum": [
+                "column",
+                "total",
+                "entityName"
+            ]
         },
         "sortOrder": {
             "type": "string",
             "description": "Sort order (used by stacked bar charts and marimekko)",
             "default": "desc",
-            "enum": ["desc", "asc"]
+            "enum": [
+                "desc",
+                "asc"
+            ]
         },
         "sortColumnSlug": {
             "description": "Sort column if sortBy is column (used by stacked bar charts and marimekko)",

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
@@ -541,13 +541,14 @@ properties:
             - stacked
             - null
     minTime:
+        description: Start point of the initially selected time span.
+        default: earliest
         oneOf:
             - type: number
             - type: string
               enum:
                   - latest
                   - earliest
-        description: Start point of the initially selected time span.
     hideAnnotationFieldsInTitle:
         type: object
         description: Whether to hide any automatically added title annotations like the selected year


### PR DESCRIPTION
Add missing default values for `minTime` to chart config schema.

I also added linebreaks, which should make diffs easier to read in the future. Unsure if the previous styling was on purpose.