### PR TITLE
fix(nav): overlay above sticky components

### DIFF
--- a/site/css/page.scss
+++ b/site/css/page.scss
@@ -203,7 +203,7 @@
     position: sticky;
     top: 0;
     background-color: #ebeef2;
-    z-index: 10;
+    z-index: $zindex-global-entity-select;
     > ul {
         display: flex;
         flex-direction: row;

--- a/site/css/variables.scss
+++ b/site/css/variables.scss
@@ -155,7 +155,7 @@ $zindex-sidebar: 20;
 $zindex-popover: 100;
 $zindex-search-overlay: 100;
 $zindex-cookie-notice: 110;
-$zindex-nav-dropdown: 120;
+$zindex-site-header: 120;
 $zindex-tooltip: 1070;
 $zindex-lightbox: 99998;
 $zindex-adminbar: 99999;

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -257,7 +257,8 @@ h6:hover .deep-link {
 .site-header {
     position: relative;
     // Must be specified for the header (and its sub-elements, e.g. topics menu)
-    // to be on top of the sticky nav, charts and global entity selector.
+    // to be on top of the sticky nav, charts and global entity selector, while
+    // allowing (DoD) tooltips to be on top of the header
     z-index: $zindex-site-header;
 }
 

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -256,9 +256,9 @@ h6:hover .deep-link {
 --------------------------------------------- */
 .site-header {
     position: relative;
-    // Must be specified for the search overlay to stack above Grapher charts,
-    // but below Tippy tooltips
-    z-index: 2;
+    // Must be specified for the header (and its sub-elements, e.g. topics menu)
+    // to be on top of the sticky nav, charts and global entity selector.
+    z-index: $zindex-site-header;
 }
 
 /* Homepage


### PR DESCRIPTION
closes #2219 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cd7f7c1</samp>

### Summary
🔧🆕🔄

<!--
1.  🔧 for using a variable instead of a hard-coded value, which implies a refactor or improvement of the code quality and maintainability.
2.  🆕 for adding a new variable to the `variables.scss` file, which implies a new feature or enhancement of the functionality or appearance of the website.
3.  🔄 for changing the value of the `z-index` property of the `.site-header` class, which implies a change or update of the existing code or behavior of the website.
-->
This pull request updates the `z-index` values of the `.site-header` and `.global-entity-select` classes to use variables defined in the `variables.scss` file. This improves the code consistency and maintainability, and ensures that these elements are always on top of other page elements.

> _`z-index` values_
> _use variables for clarity_
> _autumn leaves don't clash_

### Walkthrough
*  Introduce a new variable `$zindex-site-header` to set the `z-index` of the `.site-header` class ([link](https://github.com/owid/owid-grapher/pull/2220/files?diff=unified&w=0#diff-30875ba9e2517cbe50451135acc94200aa84003952699a4219a2a4c816f58679L158-R158))
*  Replace the hard-coded `z-index` of the `.site-header` class with the new variable in the `owid.scss` file ([link](https://github.com/owid/owid-grapher/pull/2220/files?diff=unified&w=0#diff-2aeb7d25329a6e1bf9d2bfdc39804f872861f81039617f60753b85135b22b80fL259-R261))
*  Replace the hard-coded `z-index` of the `.global-entity-select` class with an existing variable `$zindex-global-entity-select` in the `page.scss` file ([link](https://github.com/owid/owid-grapher/pull/2220/files?diff=unified&w=0#diff-d8e1f636175824be11e60de2f8c8dffba4d4299292f234a7dd781975e7d19a67L206-R206))

