### PR TITLE
:tada: chatGPT-based chart revisions

### DIFF
--- a/adminSiteClient/SuggestedChartRevision.ts
+++ b/adminSiteClient/SuggestedChartRevision.ts
@@ -30,4 +30,14 @@ export interface SuggestedChartRevisionSerialized {
     canReject?: boolean
     canFlag?: boolean
     canPending?: boolean
+
+    experimental?: {
+        gpt?: {
+            model?: string
+            suggestions?: {
+                title?: string
+                subtitle?: string
+            }[]
+        }
+    }
 }

--- a/adminSiteClient/SuggestedChartRevision.ts
+++ b/adminSiteClient/SuggestedChartRevision.ts
@@ -31,13 +31,18 @@ export interface SuggestedChartRevisionSerialized {
     canFlag?: boolean
     canPending?: boolean
 
-    experimental?: {
-        gpt?: {
-            model?: string
-            suggestions?: {
-                title?: string
-                subtitle?: string
-            }[]
-        }
+    experimental?: SuggestedChartRevisionExperimentalSerialized
+}
+
+export interface SuggestedChartRevisionExperimentalSerialized {
+    gpt?: {
+        model?: string
+        suggestions?: GPTSuggestionsSerialized[]
     }
+    [key: string]: any
+}
+
+export interface GPTSuggestionsSerialized {
+    title?: string
+    subtitle?: string
 }

--- a/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
+++ b/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
@@ -44,10 +44,7 @@ import {
     VisionDeficiencyDropdown,
     VisionDeficiencyEntity,
 } from "./VisionDeficiencies.js"
-import {
-    SuggestedChartRevisionSerialized,
-    SuggestedChartRevisionExperimentalSerialized,
-} from "./SuggestedChartRevision.js"
+import { SuggestedChartRevisionSerialized } from "./SuggestedChartRevision.js"
 import { match } from "ts-pattern"
 
 interface UserSelectOption {

--- a/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
+++ b/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
@@ -281,6 +281,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
         // if (status !== SuggestedChartRevisionStatus.pending) {
         //     this.numTotalRows -= 1
         // }
+        this.disableChatGPT()
         this.refresh()
     }
 
@@ -307,7 +308,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
         this.rerenderGraphers()
     }
 
-    @action.bound suggestionHasChatGPTField(): boolean {
+    @action.bound getGPTModelNameUsed(): string | undefined {
         const experimental = this.currentSuggestedChartRevision?.experimental
         const suggestions = experimental?.gpt?.suggestions
 
@@ -316,24 +317,30 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                 (suggestion) =>
                     suggestion.title !== undefined &&
                     suggestion.subtitle !== undefined
-            )
+            ) &&
+            experimental?.gpt?.model
         ) {
             console.log("GPT suggestions are available!")
-            return true
+            return experimental.gpt.model
         }
         console.log("NO GPT FIELD")
-        return false
+        return undefined
     }
 
     @action.bound resetChartConfigWithGPT() {
+        this.disableChatGPT()
+        this.refresh()
+    }
+
+    @action.bound disableChatGPT() {
         this.gptNum = 0
         this.gptNumDisp = 1
         this.usingGPT = false
-        this.refresh()
     }
 
     @action.bound onFirst() {
         if (!this.prevBtnIsDisabled) {
+            this.disableChatGPT()
             this.rowNum = 1
             this.refresh()
         }
@@ -341,6 +348,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
 
     @action.bound onPrev() {
         if (!this.prevBtnIsDisabled) {
+            this.disableChatGPT()
             this.rowNum = this.rowNumValid - 1
             this.refresh()
         }
@@ -348,6 +356,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
 
     @action.bound onNext() {
         if (!this.nextBtnIsDisabled) {
+            this.disableChatGPT()
             this.rowNum = this.rowNumValid + 1
             this.refresh()
         }
@@ -355,6 +364,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
 
     @action.bound onLast() {
         if (!this.nextBtnIsDisabled) {
+            this.disableChatGPT()
             this.rowNum = this.numAvailableRowsForSelectedUser
             this.refresh()
         }
@@ -362,6 +372,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
 
     @action.bound onRandom() {
         if (!this.randomBtnIsDisabled) {
+            this.disableChatGPT()
             this.rowNum = Math.floor(
                 Math.random() * this.numAvailableRowsForSelectedUser + 1
             )
@@ -610,7 +621,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
     renderGraphers() {
         // Render both charts next to each other
         console.log("renderGraphers")
-        const has_gpt = this.suggestionHasChatGPTField()
+        const gpt_model_name = this.getGPTModelNameUsed()
         return (
             <React.Fragment>
                 <div className="charts-view">
@@ -782,7 +793,6 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                                         </Link>
                                     </div>
                                     {/* GPT section */}
-                                    {this.suggestionHasChatGPTField()}
                                     <div
                                         style={{
                                             paddingRight: "1rem",
@@ -796,13 +806,19 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                                             onClick={
                                                 this.updateChartConfigWithGPT
                                             }
-                                            title="This is an experimental feature! It will replace the title and subtitle of the suggested chart with a new suggestion."
-                                            disabled={!has_gpt}
+                                            title="This is an experimental feature! It will replace the title and subtitle of the suggested chart with a new suggestion. You can go back to the original settings clicking on 'Reset'."
+                                            disabled={
+                                                gpt_model_name === undefined
+                                            }
                                         >
                                             <FontAwesomeIcon
                                                 icon={faMagicWandSparkles}
                                             />{" "}
-                                            chartGPT
+                                            {
+                                                gpt_model_name === undefined
+                                                    ? "chatGPT unavailable"
+                                                    : gpt_model_name //{this.usingGPT? ` #${this.gptNumDisp}` : ""}
+                                            }
                                             {this.usingGPT
                                                 ? ` #${this.gptNumDisp}`
                                                 : ""}

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -873,6 +873,9 @@ apiRouter.get(
 apiRouter.post(
     "/suggested-chart-revisions",
     async (req: Request, res: Response) => {
+
+        console.log("WE GETTING CLOSER 1")
+
         const messages: any[] = []
         const status = SuggestedChartRevisionStatus.pending
         const suggestedReason = req.body.suggestedReason
@@ -1240,10 +1243,12 @@ apiRouter.get(
 apiRouter.post(
     "/suggested-chart-revisions/:suggestedChartRevisionId/update",
     async (req: Request, res: Response) => {
+        console.log("WE GETTING CLOSER 2")
         const suggestedChartRevisionId = expectInt(
             req.params.suggestedChartRevisionId
         )
-        const { status, decisionReason } = req.body as {
+        const { suggestedConfig, status, decisionReason } = req.body as {
+            suggestedConfig: string
             status: string
             decisionReason: string
         }
@@ -1259,10 +1264,14 @@ apiRouter.post(
                     404
                 )
             }
-
-            suggestedChartRevision.suggestedConfig = JSON.parse(
-                suggestedChartRevision.suggestedConfig
-            )
+            if (suggestedConfig !== undefined && suggestedConfig !== null) {
+                suggestedChartRevision.suggestedConfig =
+                    JSON.parse(suggestedConfig)
+            } else {
+                suggestedChartRevision.suggestedConfig = JSON.parse(
+                    suggestedChartRevision.suggestedConfig
+                )
+            }
             suggestedChartRevision.originalConfig = JSON.parse(
                 suggestedChartRevision.originalConfig
             )
@@ -1299,11 +1308,12 @@ apiRouter.post(
             await t.execute(
                 `
                 UPDATE suggested_chart_revisions
-                SET status=?, decisionReason=?, updatedAt=?, updatedBy=?
+                SET status=?, suggestedConfig=?, decisionReason=?, updatedAt=?, updatedBy=?
                 WHERE id = ?
                 `,
                 [
                     status,
+                    suggestedChartRevision.suggestedConfig,
                     decisionReason,
                     new Date(),
                     res.locals.user.id,

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -802,6 +802,7 @@ apiRouter.get(
             SELECT scr.id, scr.chartId, scr.updatedAt, scr.createdAt,
                 scr.suggestedReason, scr.decisionReason, scr.status,
                 scr.suggestedConfig, scr.originalConfig, scr.changesInDataSummary,
+                scr.experimental,
                 createdByUser.id as createdById,
                 updatedByUser.id as updatedById,
                 createdByUser.fullName as createdByFullName,
@@ -841,6 +842,9 @@ apiRouter.get(
                 )
                 suggestedChartRevision.originalConfig = JSON.parse(
                     suggestedChartRevision.originalConfig
+                )
+                suggestedChartRevision.experimental = JSON.parse(
+                    suggestedChartRevision.experimental
                 )
                 suggestedChartRevision.canApprove =
                     SuggestedChartRevision.checkCanApprove(

--- a/db/model/SuggestedChartRevision.ts
+++ b/db/model/SuggestedChartRevision.ts
@@ -31,6 +31,8 @@ export class SuggestedChartRevision extends BaseEntity {
     canFlag?: boolean
     canPending?: boolean
 
+    @Column({ type: "json" }) experimental?: any
+
     static isValidStatus(status: SuggestedChartRevisionStatus): boolean {
         return Object.values(SuggestedChartRevisionStatus).includes(status)
     }

--- a/owid-grapher-local.session.sql
+++ b/owid-grapher-local.session.sql
@@ -1,1 +1,0 @@
-SELECT * FROM datasets LIMIT 10

--- a/owid-grapher-local.session.sql
+++ b/owid-grapher-local.session.sql
@@ -1,0 +1,1 @@
+SELECT * FROM datasets LIMIT 10


### PR DESCRIPTION
This PR adds new functionality to the chart revision tool: Now, users can see - if available - improvement suggestions by chat GPT. At the moment, these improvements only concern the FASTT.

These suggestions are generated on the ETL side, currently manually by users by executing `etl-chartgpt` in the command line.

If the user likes one of the recommended improvements by chat GPT, they can choose to update the chart FASTT with it.

In the preview below, the first revision has some available suggestions by chat GPT; the second and third do not have any.

https://github.com/owid/owid-grapher/assets/18101289/f4f0c28d-77fc-4e45-b505-8bf30145b6d3

ChatGPT revisions are stored in column `experimental` from table `suggested_chart_revisions`.

related issue: https://github.com/owid/etl/pull/1128

cc. @danyx23 