### PR TITLE
fix(scatter): hide arrow legend when not useful

### DIFF
--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -42,7 +42,7 @@ import {
     defaultIfErrorValue,
     isNotErrorValue,
     CoreColumn,
-    ColumnTypeMap
+    ColumnTypeMap,
 } from "@ourworldindata/core-table"
 import {
     ConnectedScatterLegend,

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -42,6 +42,7 @@ import {
     defaultIfErrorValue,
     isNotErrorValue,
     CoreColumn,
+    ColumnTypeMap
 } from "@ourworldindata/core-table"
 import {
     ConnectedScatterLegend,
@@ -425,6 +426,8 @@ export class ScatterPlotChart
     @computed private get arrowLegend(): ConnectedScatterLegend | undefined {
         if (
             this.displayStartTime === this.displayEndTime ||
+            this.xColumn instanceof ColumnTypeMap.Time ||
+            this.yColumn instanceof ColumnTypeMap.Time ||
             this.manager.isRelativeMode
         )
             return undefined


### PR DESCRIPTION
Brought up by Matt on [Slack](https://owid.slack.com/archives/C04VBQ00HQR/p1684275787159579)