### PR TITLE
Add admin option to anchor timeline selection to the latest year

### DIFF
--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -300,6 +300,10 @@ class TimelineSection extends React.Component<{ editor: ChartEditor }> {
         return this.grapher.timelineMaxTime
     }
 
+    @computed get isMaxTimeSetToLatest() {
+        return this.grapher.maxTime === TimeBoundValue.positiveInfinity
+    }
+
     @action.bound onMinTime(value: number | undefined) {
         this.grapher.minTime = value ?? TimeBoundValue.negativeInfinity
     }
@@ -349,6 +353,28 @@ class TimelineSection extends React.Component<{ editor: ChartEditor }> {
                         onValue={debounce(this.onMaxTime)}
                         allowNegative
                     />
+                </FieldsRow>
+                <FieldsRow>
+                    <Toggle
+                        label="Always show latest time point"
+                        value={this.isMaxTimeSetToLatest}
+                        onValue={(value) => {
+                            grapher.maxTime = value
+                                ? TimeBoundValue.positiveInfinity
+                                : undefined
+                        }}
+                    />
+                    {this.isMaxTimeSetToLatest && (
+                        <Toggle
+                            label="Collapse start with end time"
+                            value={grapher.maxTime === grapher.minTime}
+                            onValue={(value) => {
+                                grapher.minTime = value
+                                    ? grapher.maxTime
+                                    : undefined
+                            }}
+                        />
+                    )}
                 </FieldsRow>
                 {features.timelineRange && (
                     <FieldsRow>

--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -42,7 +42,7 @@ export class EditorFeatures {
     }
 
     @computed get timeDomain() {
-        return !this.grapher.isDiscreteBar
+        return !this.grapher.onlySingleTimeSelectionPossible
     }
 
     @computed get timelineRange() {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -924,7 +924,7 @@ export class Grapher
         return findClosestTime(this.times, this.endHandleTimeBound)
     }
 
-    @computed private get onlySingleTimeSelectionPossible(): boolean {
+    @computed get onlySingleTimeSelectionPossible(): boolean {
         return (
             this.isDiscreteBar ||
             this.isStackedDiscreteBar ||


### PR DESCRIPTION
fixes #2234

It turned out we don't really need this: https://owid.slack.com/archives/C0149NKLZAM/p1684741181013789?thread_ts=1684259337.995709&cid=C0149NKLZAM

We can reopen if we do need more control here
