### PR TITLE
fix(map): fix wording issue in map tooltips

### DIFF
--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
@@ -186,12 +186,18 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
     }
 
     render(): JSX.Element {
-        const { tooltipTarget, mapTable, datum, lineColorScale } = this
+        const {
+            tooltipTarget,
+            mapTable,
+            datum,
+            lineColorScale,
+            hasTimeSeriesData,
+        } = this
         const { isEntityClickable, targetTime, manager } = this.props
 
         // Only LineChart and ScatterPlot allow `mapIsClickable`
         const clickToSelectMessage =
-            manager.type === ChartTypeName.LineChart
+            manager.type === ChartTypeName.LineChart && hasTimeSeriesData
                 ? "Click for change over time"
                 : "Click to select"
 


### PR DESCRIPTION
As requested by Saloni on [Slack](https://owid.slack.com/archives/C46U9LXRR/p1684778544175229)

Render "Click to select" instead of "Click for change over time" when there is no time series data