### PR TITLE
2227-datapages-automatically-populate-all-charts-block

### DIFF
--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -120,6 +120,14 @@ export const renderDataPageOrGrapherPage = async (
             />
         )
 
+    // Enrich the datapage JSON with all the published charts this variable is
+    // being used in (aka "related charts") if none have been defined manually.
+    // We also want to exclude from the list the chart that is displayed at the
+    // top of the page to avoid the unnecessary redundancy.
+    datapageJson.relatedCharts =
+        datapageJson.relatedCharts ??
+        (await getRelatedChartsForVariable(id, [grapher.id]))
+
     // Compliment the text-only content from the JSON with rich text from the
     // companion gdoc, if any
     const datapageGdoc = await getDatapageGdoc(

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -18,6 +18,7 @@ import {
 import {
     getRelatedArticles,
     getRelatedCharts,
+    getRelatedChartsForVariable,
     isWordpressAPIEnabled,
     isWordpressDBEnabled,
 } from "../db/wpdb.js"
@@ -218,6 +219,14 @@ export const renderPreviewDataPageOrGrapherPage = async (
         !datapageJson.showDataPageOnChartIds.includes(grapher.id)
     )
         return renderGrapherPage(grapher)
+
+    // Enrich the datapage JSON with all the published charts this variable is
+    // being used in (aka "related charts") if none have been defined manually.
+    // We also want to exclude from the list the chart that is displayed at the
+    // top of the page to avoid the unnecessary redundancy.
+    datapageJson.relatedCharts =
+        datapageJson.relatedCharts ??
+        (await getRelatedChartsForVariable(id, [grapher.id]))
 
     if (!datapageJson.googleDocEditLink)
         return renderToHtmlPage(

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -622,6 +622,30 @@ export const getRelatedCharts = async (
         ORDER BY title ASC
     `)
 
+export const getRelatedChartsForVariable = async (
+    variableId: number,
+    chartIdsToExclude: number[] = []
+): Promise<RelatedChart[]> => {
+    const excludeChartIds =
+        chartIdsToExclude.length > 0
+            ? `AND charts.id NOT IN (${chartIdsToExclude.join(", ")})`
+            : ""
+
+    return db.queryMysql(`
+                SELECT DISTINCT
+                    charts.config->>"$.slug" AS slug,
+                    charts.config->>"$.title" AS title,
+                    charts.config->>"$.variantName" AS variantName,
+                    chart_tags.isKeyChart
+                FROM charts
+                INNER JOIN chart_tags ON charts.id=chart_tags.chartId
+                WHERE JSON_CONTAINS(config->'$.dimensions', '{"variableId":${variableId}}')
+                AND charts.config->>"$.isPublished" = "true"
+                ${excludeChartIds}
+                ORDER BY title ASC
+            `)
+}
+
 export const getRelatedArticles = async (
     chartId: number
 ): Promise<PostReference[] | undefined> => {

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1245,12 +1245,13 @@ export const DataPageJsonTypeObject = Type.Object(
                 content: Type.Optional(Type.String()),
             })
         ),
-        relatedCharts: Type.Optional(Type.Array(
+        relatedCharts: Type.Optional(
+            Type.Array(
                 Type.Object({
                     title: Type.String(),
                     slug: Type.String(),
                 })
-            ),
+            )
         ),
         datasetName: Type.String(),
         datasetFeaturedVariables: Type.Optional(

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1245,14 +1245,13 @@ export const DataPageJsonTypeObject = Type.Object(
                 content: Type.Optional(Type.String()),
             })
         ),
-        relatedCharts: Type.Object({
-            items: Type.Array(
+        relatedCharts: Type.Optional(Type.Array(
                 Type.Object({
                     title: Type.String(),
                     slug: Type.String(),
                 })
             ),
-        }),
+        ),
         datasetName: Type.String(),
         datasetFeaturedVariables: Type.Optional(
             Type.Array(

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -292,18 +292,19 @@ export const DataPageContent = ({
                     <div className="DataPageContent__section-border wrapper">
                         <hr />
                     </div>
-                    {datapageJson.relatedCharts.items.length > 0 && (
+                    {datapageJson.relatedCharts &&
+                    datapageJson.relatedCharts.length > 0 ? (
                         <div className="related-charts__wrapper wrapper">
                             <h2 className="related-charts__title">
                                 Explore charts that include this data
                             </h2>
                             <div>
                                 <RelatedCharts
-                                    charts={datapageJson.relatedCharts.items}
+                                    charts={datapageJson.relatedCharts}
                                 />
                             </div>
                         </div>
-                    )}
+                    ) : null}
                     {datapageGdocContent?.faqs && (
                         <>
                             <div className="gray-wrapper">
@@ -383,8 +384,8 @@ export const DataPageContent = ({
                                         )}
                                     </div>
                                     <div>
-                                        {!!datapageJson.datasetFeaturedVariables
-                                            ?.length && (
+                                        {datapageJson.datasetFeaturedVariables
+                                            ?.length ? (
                                             <div
                                                 style={{ marginBottom: "24px" }}
                                             >
@@ -420,7 +421,7 @@ export const DataPageContent = ({
                                                     )}
                                                 </ul>
                                             </div>
-                                        )}
+                                        ) : null}
                                         <div
                                             className="key-info--gridded grid grid-cols-2"
                                             style={{ marginBottom: "24px" }}


### PR DESCRIPTION
see #2227 
_Note: this stacked PR doesn't target master._

- [x] <!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 34041ac</samp>

This pull request adds a feature to automatically fetch and display related charts for datapages and graphers based on the variable id. It implements a new function `getRelatedChartsForVariable` in `db/wpdb.ts` to query the database, and modifies the `DataPageContent` and `GrapherBaker` components to use the results. It also updates the `DataPageJsonTypeObject` type definition to reflect the changes.
- [x] is the branch up-to-date with master?
- [x] what problem is being solved here?
Authors need to manually specify the list of charts a variable is used in, when this could be automated
- [x] what solution has been chosen?
Getting the list of related charts from the database
- [x] are there other solutions?
- [x] is the scope clear, well-defined and small?
- [x] could a flow chart / sequence diagram / architecture diagram help?
- [x] what is the happy path?
  - do not add / remove the `relatedCharts` key in the JSON ([example](https://github.com/owid/owid-content/blob/master/datapages/587683.json)).
  - (optional) set `"status":"published` in the data page JSON
  - ⚠️ If editing the JSON for testing, do it on staging or locally but do not commit). _This has been done on the staging site already, but probably needs to be done again if further pushes reset the owid-content repo._
  - see the "Related charts" section be populated by charts ([preview](http://staging-site-2227-datapages-automatically-populate-all-charts-b/admin/grapher/banana-production), [baked](http://staging-site-2227-datapages-automatically-populate-all-charts-b/grapher/banana-production))
- [x] could the code be easier to read and understand?
- [x] can I help increase our confidence in the implementation by contributing tests?
- [x] should some errors be made more prominent?
- [x] what is missing, what should have been added / done / changed but hasn't?

When going live:
- [ ] un-nest `relatedCharts.items` in all datapage JSON (or remove them?)