### PR TITLE
🐝 actions: make eslint action fail on warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,7 @@ module.exports = {
         "@typescript-eslint/no-non-null-assertion": "off", // TODO: enable this rule
         "@typescript-eslint/no-this-alias": "warn",
         "@typescript-eslint/no-unused-vars": [
-            "error",
+            "warn",
             { varsIgnorePattern: "^_", argsIgnorePattern: "^_" },
         ],
         "@typescript-eslint/no-use-before-define": "off", // This was useful in the past with var and variable hoisting changing depending on scope but AFAIK typescript deals with this in a sane way and we can leave this off

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,8 @@ jobs:
             - uses: ./.github/actions/setup-node-yarn-deps
 
             - name: Run eslint
-              run: yarn testLint
+              # the --max-warnings makes eslint exit with non-zero exit code even for warnings
+              run: yarn testLint --max-warnings=0
 
     # Runs `bundlewatch` on the code to see if our Vite build assets exceed a given file size.
     bundlewatch:


### PR DESCRIPTION
Having the `@typescript-eslint/no-unused-vars` be an error is quite annoying in local development.

The comprise here is to make it into a warning again, but have the eslint action fail on warning already. This we can do because right now, our code has no linting errors and no warnings.

It's worth a try, can totally revert this if it turns out to be annoying.