### PR TITLE
feat(dp): add support for image in related data block

### DIFF
--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -284,6 +284,11 @@
         flex: 1;
     }
 
+    .related-data-item__image {
+        align-self: flex-start;
+        margin-bottom: 16px;
+    }
+
     .related-data-item--small {
         .related-data-item__title {
             @include h4-semibold;

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -237,6 +237,16 @@ export const DataPageContent = ({
                                     <div className="related-data-item__type">
                                         {datapageJson.relatedData[0].type}
                                     </div>
+                                    {datapageJson.relatedData[0].imageUrl && (
+                                        <img
+                                            src={
+                                                datapageJson.relatedData[0]
+                                                    .imageUrl
+                                            }
+                                            className="related-data-item__image"
+                                            alt=""
+                                        />
+                                    )}
                                     <h3 className="related-data-item__title">
                                         {datapageJson.relatedData[0].title}
                                     </h3>


### PR DESCRIPTION

<img width="328" alt="Screenshot 2023-05-25 at 14 29 46" src="https://github.com/owid/owid-grapher/assets/13406362/c221ccf2-9382-4b56-a2a3-353f7363dcc6">
<img width="331" alt="Screenshot 2023-05-25 at 14 30 31" src="https://github.com/owid/owid-grapher/assets/13406362/952d1f6a-d181-42c9-b92d-6b72a3a1d466">


- [x] <!--
copilot:summary
-->
### <samp>🤖 Inspired by Copilot at ad8cd91</samp>

This pull request adds images to the first item of the related data block on the data page. It modifies `site/DataPageContent.scss` and `site/DataPageContent.tsx` to create and style the image elements.
- [x] is the branch up-to-date with master?
- [x] what problem is being solved here?
Image was defined in the data page JSON but not displayed.
- [x] what solution has been chosen?
Image source is still hotlinked from Wordpress. I refrained from engineering something bigger here until the role of the ETL becomes clearer in the generation of this block and its source of truth.
- [x] are there other solutions?
- [x] is the scope clear, well-defined and small?
- [x] could a flow chart / sequence diagram / architecture diagram help?
- [x] what is the happy path?
  - Add an image to the first related data item in the data page JSON (⚠️ do not commit if testing)
  - Preview
- [x] could the code be easier to read and understand?
- [x] can I help increase our confidence in the implementation by contributing tests?
- [x] should some errors be made more prominent?
- [x] what is missing, what should have been added / done / changed but hasn't?