### PR TITLE
fix(explorer): fix small interaction issues when selecting an entity

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
@@ -444,7 +444,7 @@ export class EntityPicker extends React.Component<{
                     styles={getStylesForTargetHeight(26)}
                     isSearchable={false}
                     isLoading={this.manager.entityPickerTableIsLoading}
-                    onKeyDown={(event) => {
+                    onKeyDown={(event): void => {
                         event.stopPropagation()
                     }}
                 />

--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
@@ -444,6 +444,9 @@ export class EntityPicker extends React.Component<{
                     styles={getStylesForTargetHeight(26)}
                     isSearchable={false}
                     isLoading={this.manager.entityPickerTableIsLoading}
+                    onKeyDown={(event) => {
+                        event.stopPropagation()
+                    }}
                 />
                 <span
                     className="sort"
@@ -600,7 +603,6 @@ interface PickerOptionProps {
 class PickerOption extends React.Component<PickerOptionProps> {
     @bind onClick(event: React.MouseEvent<HTMLLabelElement, MouseEvent>): void {
         event.stopPropagation()
-        event.preventDefault()
         this.props.onChange(
             this.props.optionWithMetricValue.entityName,
             !this.props.isSelected


### PR DESCRIPTION
fixes an issue mentioned on [Slack](https://owid.slack.com/archives/C46U9LXRR/p1685453357565159) and one more that I came across while looking into this

Fixes two small interaction issues of the entity picker:
- Clicking on an entity does not immediately select the checkbox. The checkbox is only checked after the mouse has left the input field (described by Pablo on [Slack](https://owid.slack.com/archives/C46U9LXRR/p1685453357565159))
- When navigating the "Sort by" dropdown using arrow keys, the entity picker beneath also reacts to pressing arrow keys