### PR TITLE
fix(explorer): persist country selection between grapher views

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -490,7 +490,6 @@ export class Explorer
     }
 
     onChangeChoice = (choiceTitle: string) => (value: string) => {
-        console.log({ choiceTitle, value })
         const { currentlySelectedGrapherRow } = this.explorerProgram
         this.explorerProgram.decisionMatrix.setValueCommand(choiceTitle, value)
         if (currentlySelectedGrapherRow)

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -301,6 +301,7 @@ export class Explorer
             ...this.persistedGrapherQueryParamsBySelectedRow.get(
                 this.explorerProgram.currentlySelectedGrapherRow
             ),
+            country: oldGrapherParams.country,
             region: oldGrapherParams.region,
             time: this.grapher.timeParam,
         }
@@ -489,6 +490,7 @@ export class Explorer
     }
 
     onChangeChoice = (choiceTitle: string) => (value: string) => {
+        console.log({ choiceTitle, value })
         const { currentlySelectedGrapherRow } = this.explorerProgram
         this.explorerProgram.decisionMatrix.setValueCommand(choiceTitle, value)
         if (currentlySelectedGrapherRow)


### PR DESCRIPTION
fixes a bug described by Pablo on [Slack](https://owid.slack.com/archives/C46U9LXRR/p1685515462501279?thread_ts=1685453357.565159&cid=C46U9LXRR)

To reproduce:
- Go to https://ourworldindata.org/explorers/crop-yields
- Choose crop Cassava
- Unselect all default countries and select Vietnam
- Change to crop Almonds
- Note that Grapher shows default countries
- Change to crop Cassava
- Note that Grapher shows Vietnam
- Refresh page
- Change to crop Almonds
- Note that Grapher shows Vietnam

The reason for this behaviour is that Grapher remembers previous Grapher views. Some things are persisted across views like the time, for example. Persisting the country fixes this bug but not sure if this has any adverse effect?