### PR TITLE
revert: revert interaction fix for entity picker in explorers

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
@@ -603,6 +603,7 @@ interface PickerOptionProps {
 class PickerOption extends React.Component<PickerOptionProps> {
     @bind onClick(event: React.MouseEvent<HTMLLabelElement, MouseEvent>): void {
         event.stopPropagation()
+        event.preventDefault()
         this.props.onChange(
             this.props.optionWithMetricValue.entityName,
             !this.props.isSelected


### PR DESCRIPTION
This reverts the "fix" from #2260. Removing `preventDefault` had some adverse effects...