### PR TITLE
fix: prevent interaction on read-only input field in entity picker (explorer)

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.scss
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.scss
@@ -101,6 +101,10 @@ $zindex-dropdown: 100;
         flex: 0;
         margin-right: 6px;
         align-items: center;
+
+        input {
+            pointer-events: none;
+        }
     }
 
     .info-container {


### PR DESCRIPTION
My second attempt to fix an issue described by Pablo R on [Slack](https://owid.slack.com/archives/C46U9LXRR/p1685453357565159) (my first attempt: #2260)

Fixes a small interaction issue of the entity picker in explorers:
- Clicking on an entity does not immediately select the checkbox. The checkbox is only checked after the mouse has left the input field (described by Pablo on [Slack](https://owid.slack.com/archives/C46U9LXRR/p1685453357565159))
