### PR TITLE
style(explorer): improve layout of explorer controls

### DIFF
--- a/explorer/ExplorerControls.scss
+++ b/explorer/ExplorerControls.scss
@@ -5,22 +5,21 @@ $chart-border-radius: 2px;
     $selected-option-color: #243d60;
 
     display: flex;
-    justify-content: space-between;
     background: white;
     border-radius: $chart-border-radius;
     box-shadow: $light-shadow;
     padding: 0 14px;
 
     .ExplorerControl {
+        flex: 1;
         display: flex;
         flex-direction: column;
         font-size: 13px;
         color: $option-color;
-        max-width: 22%;
         margin-right: 10px;
 
-        padding-top: 11px;
-        padding-bottom: 4px;
+        padding-top: 8px;
+        padding-bottom: 8px;
 
         &:last-child {
             margin-right: 0;
@@ -132,8 +131,8 @@ $chart-border-radius: 2px;
 .ExplorerDropdown {
     font-size: 13px;
     font-weight: 400;
-    width: 200px;
-    max-width: 100%;
+    min-width: 120px;
+    max-width: min(200px, 100%);
 }
 
 @keyframes slideUp {


### PR DESCRIPTION
Brought up by Pablo A on [Slack](https://owid.slack.com/archives/C0149NKLZAM/p1685466231179289)

Would be nice to ship something that makes the inequality explorer look nicer before it launches later in June.

### Summary

Improves the layout of explorer controls:
- Removes the "space-between" flex-layout (the "space-between" layout lead to one control on the left and another control on the right in case of two controls)
- Assigns equal space to each control and allows a control to fill its space (before, a max-width on the control lead to text being wrapped when it didn't need to)

### Examples with Screenshots

<details>
<summary><b>Inequality explorer (the reason this came up)</b></summary>

Before:
<img width="1214" alt="_before" src="https://github.com/owid/owid-grapher/assets/12461810/640705cf-9768-414a-87c5-85ce60c947ef">

After:
<img width="1212" alt="_after" src="https://github.com/owid/owid-grapher/assets/12461810/b02181b1-ff03-4c6e-a40b-74db46e71eb9">

</details>

<details>
<summary><b>Migration explorer (three controls)</b></summary>

Before:
<img width="1212" alt="Screenshot 2023-05-31 at 14 07 44" src="https://github.com/owid/owid-grapher/assets/12461810/82a442d7-d490-47f2-a95c-0fa8f0d9fef2">

After:
<img width="1212" alt="Screenshot 2023-05-31 at 14 07 29" src="https://github.com/owid/owid-grapher/assets/12461810/7fd32641-cde8-4a15-8228-f22e47506019">

</details>

<details>
<summary><b>Covid explorer (four controls)</b></summary>

Before:
<img width="1212" alt="Screenshot 2023-05-31 at 14 09 00" src="https://github.com/owid/owid-grapher/assets/12461810/3fa6b4e5-b3a9-4c01-a161-966986f2ce4f">

After:
<img width="1212" alt="Screenshot 2023-05-31 at 14 08 43" src="https://github.com/owid/owid-grapher/assets/12461810/5ded1783-b784-49e8-b4ab-42641aa5301d">

</details>

<details>
<summary><b>CO2 explorer (five controls)</b></summary>

Before:
<img width="1212" alt="Screenshot 2023-05-31 at 14 09 26" src="https://github.com/owid/owid-grapher/assets/12461810/f525c8d4-d433-46e1-a4eb-8cccf1e59dbf">

After:
<img width="1212" alt="Screenshot 2023-05-31 at 14 09 14" src="https://github.com/owid/owid-grapher/assets/12461810/10af1b2a-702c-4344-b9c3-5ff1680dfa79">

</details>

<details>
<summary><b>CO2 explorer (smallest possible desktop screen)</b></summary>

Before (two screenshots since the UI spilled over):
<img width="812" alt="Screenshot 2023-05-31 at 14 11 10" src="https://github.com/owid/owid-grapher/assets/12461810/21e6b17a-cb0b-41a2-aad4-afd758bcfe90">
<img width="812" alt="Screenshot 2023-05-31 at 14 12 01" src="https://github.com/owid/owid-grapher/assets/12461810/70803679-4a59-4b3d-954c-0b3ba3f0c8b9">

After:
<img width="812" alt="Screenshot 2023-05-31 at 14 11 34" src="https://github.com/owid/owid-grapher/assets/12461810/6d63eaa7-f86d-42b2-a99d-44deffa3b6a6">

</details>

### Conclusion

- Explorers with two controls look much better (in my opinion)
- For explorers with three or more controls (e.g. Covid explorer), the control bar looks a bit more cramped since the controls on the left (tick boxes) are given more space (not sure how to address this without micro-managing)

I think the changes are net positive but happy to rethink!

Deployed to [Kelley](https://kelley.owid.cloud/admin/explorers)