### PR TITLE
:bug: return string id if entity is not in MySQL

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -125,9 +125,14 @@ export const legacyToOwidTableAndDimensions = (
         )
         const entityIds = variable.data.entities ?? []
         const entityNames = entityIds.map(
-            (id) => entityMetaById[id].name ?? id.toString()
+            // if entityMetaById[id] does not exist, then we don't have entity
+            // from variable metadata in MySQL. This can happen because we take
+            // data from S3 and metadata from MySQL. After we unify it, it should
+            // no longer be a problem
+            (id) => entityMetaById[id]?.name ?? id.toString()
         )
-        const entityCodes = entityIds.map((id) => entityMetaById[id].code)
+        // see comment above about entityMetaById[id]
+        const entityCodes = entityIds.map((id) => entityMetaById[id]?.code)
 
         // If there is a conversionFactor, apply it.
         let values = variable.data.values || []
@@ -155,7 +160,8 @@ export const legacyToOwidTableAndDimensions = (
 
         if (entityColorColumnSlug) {
             columnStore[entityColorColumnSlug] = entityIds.map((entityId) => {
-                const entityName = entityMetaById[entityId].name
+                // see comment above about entityMetaById[id]
+                const entityName = entityMetaById[entityId]?.name
                 const selectedEntityColors = grapherConfig.selectedEntityColors
                 return entityName && selectedEntityColors
                     ? selectedEntityColors[entityName]


### PR DESCRIPTION
This fixes a nasty bug that was [happening here](https://buildkite.com/our-world-in-data/grapher-automated-staging-environment/builds/442#01887733-fbba-431f-99ed-8b09650fff0a). The problem is that we take data from S3 and metadata from MySQL, this can cause discrepancy **on staging servers** and some entities on S3 might not be in `entities` table in MySQL.

This is a hotfix to make builds on staging work. It shouldn't affect production. Entity ids are so annoying, world would be much better without them.