### PR TITLE
fix(facet): preserve relative mode after faceting

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2030,7 +2030,10 @@ export class Grapher
         } = this
 
         if (isStackedDiscreteBar) {
-            return selectedFacetStrategy !== FacetStrategy.none
+            return (
+                selectedFacetStrategy === FacetStrategy.entity ||
+                selectedFacetStrategy === FacetStrategy.metric
+            )
         }
 
         if (isStackedArea || isStackedBar) {


### PR DESCRIPTION
fixes #2158

### Summary

- We don't allow relative mode in some cases, in particular when faceting
- Grapher didn't restore relative mode correctly when switching from a faceted view (where absolute mode was enforced) to the normal view
- Fixed by removing hacky code that manipulated `stackMode` in the facetStrategy setter

### Caveat

`hasSingleMetricInFacets`, `hasSingleEntityInFacets` and `isStackedChartSplitByMetric` should ideally be using `facetControl` (not `selectedFacetControl`) but we can't because that would result in a cyclic dependency.