### PR TITLE
🎉 Rich text in gdoc footnotes

### DIFF
--- a/adminSiteClient/GdocsSettingsForm.tsx
+++ b/adminSiteClient/GdocsSettingsForm.tsx
@@ -31,6 +31,7 @@ export const GdocsSettingsForm = ({
                 "linkedCharts",
                 "details",
                 "body",
+                "refs",
             ].includes(property)
         ),
         "type"

--- a/db/model/Gdoc/Gdoc.ts
+++ b/db/model/Gdoc/Gdoc.ts
@@ -331,21 +331,29 @@ export class Gdoc extends BaseEntity implements OwidGdocInterface {
 
     get links(): Link[] {
         const links: Link[] = []
+        const blocksToTraverse: OwidEnrichedGdocBlock[] = []
         if (this.content.body) {
-            this.content.body.map((node) =>
-                traverseEnrichedBlocks(
-                    node,
-                    (node) => {
-                        const extractedLinks = this.extractLinksFromNode(node)
-                        if (extractedLinks) links.push(...extractedLinks)
-                    },
-                    (span) => {
-                        const link = this.extractLinkFromSpan(span)
-                        if (link) links.push(link)
-                    }
-                )
-            )
+            blocksToTraverse.push(...this.content.body)
         }
+        if (this.content.refs?.definitions) {
+            const refBlocks = Object.values(
+                this.content.refs.definitions
+            ).flatMap((definition) => definition.content)
+            blocksToTraverse.push(...refBlocks)
+        }
+        blocksToTraverse.map((node) =>
+            traverseEnrichedBlocks(
+                node,
+                (node) => {
+                    const extractedLinks = this.extractLinksFromNode(node)
+                    if (extractedLinks) links.push(...extractedLinks)
+                },
+                (span) => {
+                    const link = this.extractLinkFromSpan(span)
+                    if (link) links.push(link)
+                }
+            )
+        )
         return links
     }
 

--- a/db/model/Gdoc/archieToEnriched.test.ts
+++ b/db/model/Gdoc/archieToEnriched.test.ts
@@ -1,0 +1,32 @@
+import { extractRefs } from "./archieToEnriched.js"
+
+it("Can extract a ref from some text", () => {
+    expect(
+        extractRefs(`I am a thing{ref}some_id{/ref} and some follow up`)
+    ).toEqual({
+        extractedText: `I am a thing<a class="ref" href="#note-1"><sup>1</sup></a> and some follow up`,
+        refsByFirstAppearance: new Set(["some_id"]),
+    })
+})
+
+it("Can extract multiple refs from some text", () => {
+    expect(
+        extractRefs(
+            `I am a thing{ref}some_id{/ref} and some follow up{ref}another_id{/ref}`
+        )
+    ).toEqual({
+        extractedText: `I am a thing<a class="ref" href="#note-1"><sup>1</sup></a> and some follow up<a class="ref" href="#note-2"><sup>2</sup></a>`,
+        refsByFirstAppearance: new Set(["some_id", "another_id"]),
+    })
+})
+
+it("Can extract multiple refs from some text and refer to an earlier footnote when a ref id is repeated", () => {
+    expect(
+        extractRefs(
+            `I am a thing{ref}some_id{/ref} and some follow up{ref}another_id{/ref}. I refer to a ref that has already been referenced once{ref}some_id{/ref}`
+        )
+    ).toEqual({
+        extractedText: `I am a thing<a class="ref" href="#note-1"><sup>1</sup></a> and some follow up<a class="ref" href="#note-2"><sup>2</sup></a>. I refer to a ref that has already been referenced once<a class="ref" href="#note-1"><sup>1</sup></a>`,
+        refsByFirstAppearance: new Set(["some_id", "another_id"]),
+    })
+})

--- a/db/model/Gdoc/archieToEnriched.test.ts
+++ b/db/model/Gdoc/archieToEnriched.test.ts
@@ -6,6 +6,7 @@ it("Can extract a ref from some text", () => {
     ).toEqual({
         extractedText: `I am a thing<a class="ref" href="#note-1"><sup>1</sup></a> and some follow up`,
         refsByFirstAppearance: new Set(["some_id"]),
+        parsedInlineRefs: {},
     })
 })
 
@@ -17,6 +18,7 @@ it("Can extract multiple refs from some text", () => {
     ).toEqual({
         extractedText: `I am a thing<a class="ref" href="#note-1"><sup>1</sup></a> and some follow up<a class="ref" href="#note-2"><sup>2</sup></a>`,
         refsByFirstAppearance: new Set(["some_id", "another_id"]),
+        parsedInlineRefs: {},
     })
 })
 
@@ -28,5 +30,164 @@ it("Can extract multiple refs from some text and refer to an earlier footnote wh
     ).toEqual({
         extractedText: `I am a thing<a class="ref" href="#note-1"><sup>1</sup></a> and some follow up<a class="ref" href="#note-2"><sup>2</sup></a>. I refer to a ref that has already been referenced once<a class="ref" href="#note-1"><sup>1</sup></a>`,
         refsByFirstAppearance: new Set(["some_id", "another_id"]),
+        parsedInlineRefs: {},
+    })
+})
+
+it("Can extract an inline ref", () => {
+    expect(extractRefs(`I am a thing{ref}I am an inline ref{/ref}`)).toEqual({
+        extractedText: `I am a thing<a class="ref" href="#note-1"><sup>1</sup></a>`,
+        refsByFirstAppearance: new Set([
+            "796885412908186a5e57f2e753ab697b85666afe",
+        ]),
+        parsedInlineRefs: {
+            definitions: {
+                "796885412908186a5e57f2e753ab697b85666afe": {
+                    content: [
+                        {
+                            parseErrors: [],
+                            type: "text",
+                            value: [
+                                {
+                                    spanType: "span-simple-text",
+                                    text: "I am an inline ref",
+                                },
+                            ],
+                        },
+                    ],
+                    id: "796885412908186a5e57f2e753ab697b85666afe",
+                    index: 0,
+                    parseErrors: [],
+                },
+            },
+            errors: [],
+        },
+    })
+})
+
+it("Can extract an inline ref and an ID ref", () => {
+    expect(
+        extractRefs(
+            `I am a thing{ref}I am an inline ref{/ref} and another thing{ref}some_id{/ref}`
+        )
+    ).toEqual({
+        extractedText: `I am a thing<a class="ref" href="#note-1"><sup>1</sup></a> and another thing<a class="ref" href="#note-2"><sup>2</sup></a>`,
+        refsByFirstAppearance: new Set([
+            "796885412908186a5e57f2e753ab697b85666afe",
+            "some_id",
+        ]),
+        parsedInlineRefs: {
+            definitions: {
+                "796885412908186a5e57f2e753ab697b85666afe": {
+                    content: [
+                        {
+                            parseErrors: [],
+                            type: "text",
+                            value: [
+                                {
+                                    spanType: "span-simple-text",
+                                    text: "I am an inline ref",
+                                },
+                            ],
+                        },
+                    ],
+                    id: "796885412908186a5e57f2e753ab697b85666afe",
+                    index: 0,
+                    parseErrors: [],
+                },
+            },
+            errors: [],
+        },
+    })
+})
+
+it("Can extract an inline ref and an ID ref and then refer back to a previous inline ref with identical content", () => {
+    expect(
+        extractRefs(
+            `I am a thing{ref}I am an inline ref{/ref} and another thing{ref}some_id{/ref} and me again{ref}I am an inline ref{/ref}`
+        )
+    ).toEqual({
+        extractedText: `I am a thing<a class="ref" href="#note-1"><sup>1</sup></a> and another thing<a class="ref" href="#note-2"><sup>2</sup></a> and me again<a class="ref" href="#note-1"><sup>1</sup></a>`,
+        refsByFirstAppearance: new Set([
+            "796885412908186a5e57f2e753ab697b85666afe",
+            "some_id",
+        ]),
+        parsedInlineRefs: {
+            definitions: {
+                "796885412908186a5e57f2e753ab697b85666afe": {
+                    content: [
+                        {
+                            parseErrors: [],
+                            type: "text",
+                            value: [
+                                {
+                                    spanType: "span-simple-text",
+                                    text: "I am an inline ref",
+                                },
+                            ],
+                        },
+                    ],
+                    id: "796885412908186a5e57f2e753ab697b85666afe",
+                    index: 0,
+                    parseErrors: [],
+                },
+            },
+            errors: [],
+        },
+    })
+})
+
+it("Can index intermingled inline and ID refs correctly", () => {
+    expect(
+        extractRefs(
+            `I am a thing{ref}some_id{/ref} and another thing{ref}An inline ref{/ref} with more {ref}another_id{/ref} and even more{ref}Another inline ref{/ref}`
+        )
+    ).toEqual({
+        extractedText: `I am a thing<a class="ref" href="#note-1"><sup>1</sup></a> and another thing<a class="ref" href="#note-2"><sup>2</sup></a> with more <a class="ref" href="#note-3"><sup>3</sup></a> and even more<a class="ref" href="#note-4"><sup>4</sup></a>`,
+        refsByFirstAppearance: new Set([
+            "some_id",
+            "3d708842b0da8d18eabe4d2212ba27646ed20f49",
+            "another_id",
+            "f5c4fee26da4a46180cef44bc019ec072ec66f3f",
+        ]),
+        parsedInlineRefs: {
+            definitions: {
+                "3d708842b0da8d18eabe4d2212ba27646ed20f49": {
+                    content: [
+                        {
+                            parseErrors: [],
+                            type: "text",
+                            value: [
+                                {
+                                    spanType: "span-simple-text",
+                                    text: "An inline ref",
+                                },
+                            ],
+                        },
+                    ],
+                    id: "3d708842b0da8d18eabe4d2212ba27646ed20f49",
+                    index: 1,
+                    parseErrors: [],
+                },
+                f5c4fee26da4a46180cef44bc019ec072ec66f3f: {
+                    content: [
+                        {
+                            parseErrors: [],
+                            type: "text",
+                            value: [
+                                {
+                                    spanType: "span-simple-text",
+                                    text: "Another inline ref",
+                                },
+                            ],
+                        },
+                    ],
+                    id: "f5c4fee26da4a46180cef44bc019ec072ec66f3f",
+                    index: 3,
+                    parseErrors: [],
+                },
+            },
+            errors: [],
+        },
     })
 })

--- a/db/model/Gdoc/archieToEnriched.ts
+++ b/db/model/Gdoc/archieToEnriched.ts
@@ -156,6 +156,13 @@ export function extractRefs(text: string): {
     const rawRefStrings: string[] =
         text.match(new RegExp(RefRegExp, "gims")) ?? []
     for (const rawRef of rawRefStrings) {
+        // Transitional code for published articles with old-style refs
+        // Strip them out of the text till we can republish the article with the new style
+        // Remove this block once the transition is done
+        if (rawRef.includes(" ")) {
+            extractedText = extractedText.replace(rawRef, ``)
+            continue
+        }
         // This will always exist as it's the same as the RegExp from above
         const match = rawRef.match(new RegExp(RefRegExp)) as RegExpMatchArray
         const id = match[1]

--- a/db/model/Gdoc/archieToEnriched.ts
+++ b/db/model/Gdoc/archieToEnriched.ts
@@ -170,11 +170,11 @@ export function extractRefs(text: string): {
         const match = rawRef.match(
             new RegExp(RefRegExp, "ims")
         ) as RegExpMatchArray
-        const contents = match[1]
+        const contentOrId = match[1]
 
         const id = isInlineRef
-            ? createHash("sha1").update(contents).digest("hex")
-            : contents
+            ? createHash("sha1").update(contentOrId).digest("hex")
+            : contentOrId
 
         refsByFirstAppearance.add(id)
         const index = [...refsByFirstAppearance].indexOf(id)
@@ -199,7 +199,7 @@ export function extractRefs(text: string): {
                 [.refs]
                 id: ${id}
                 [.+content]
-                ${contents}
+                ${contentOrId}
                 []
                 []
             `)

--- a/db/model/Gdoc/archieToEnriched.ts
+++ b/db/model/Gdoc/archieToEnriched.ts
@@ -20,8 +20,6 @@ import {
     ENDNOTES_ID,
     CITATION_ID,
     LICENSE_ID,
-    RefDictionary,
-    merge,
 } from "@ourworldindata/utils"
 import { parseRawBlocksToEnrichedBlocks, parseRefs } from "./rawToEnriched.js"
 import urlSlug from "url-slug"

--- a/db/model/Gdoc/archieToEnriched.ts
+++ b/db/model/Gdoc/archieToEnriched.ts
@@ -192,11 +192,6 @@ export const archieToEnriched = (text: string): OwidGdocContent => {
         blocks.map(parseRawBlocksToEnrichedBlocks)
     )
 
-    console.log(
-        "JSON.stringify(parsed.refs, null, 2)",
-        JSON.stringify(parsed.refs, null, 2)
-    )
-
     parsed.summary = parsed.summary?.map((html: RawBlockText) =>
         htmlToEnrichedTextBlock(html.value)
     )

--- a/db/model/Gdoc/archieToEnriched.ts
+++ b/db/model/Gdoc/archieToEnriched.ts
@@ -233,7 +233,7 @@ export const archieToEnriched = (text: string): OwidGdocContent => {
     parsed.toc = generateToc(parsed.body)
 
     const parsedRefs = parseRefs({
-        refs: [...Array.from(parsed.refs), ...rawInlineRefs],
+        refs: [...(parsed.refs ?? []), ...rawInlineRefs],
         refsByFirstAppearance,
     })
     parsed.refs = parsedRefs

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -1346,11 +1346,9 @@ function parseResearchAndWritingBlock(
 export function parseRefs({
     refs,
     refsByFirstAppearance,
-    isInline = false,
 }: {
     refs: unknown
     refsByFirstAppearance: Set<string>
-    isInline?: boolean
 }): { definitions: RefDictionary; errors: OwidGdocErrorMessage[] } {
     const parsedRefs: RefDictionary = {}
     const refErrors: OwidGdocErrorMessage[] = []
@@ -1413,19 +1411,17 @@ export function parseRefs({
         }
     }
 
-    if (!isInline) {
-        refErrors.push(
-            ...[...refsByFirstAppearance]
-                .filter((ref) => !parsedRefs[ref])
-                .map(
-                    (undefinedRef): OwidGdocErrorMessage => ({
-                        message: `"${undefinedRef}" is used as a ref ID but no definition for this ref has been written.`,
-                        property: "refs",
-                        type: OwidGdocErrorMessageType.Error,
-                    })
-                )
-        )
-    }
+    refErrors.push(
+        ...[...refsByFirstAppearance]
+            .filter((ref) => !parsedRefs[ref])
+            .map(
+                (undefinedRef): OwidGdocErrorMessage => ({
+                    message: `"${undefinedRef}" is used as a ref ID but no definition for this ref has been written.`,
+                    property: "refs",
+                    type: OwidGdocErrorMessageType.Error,
+                })
+            )
+    )
 
     return { definitions: parsedRefs, errors: refErrors }
 }

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -1343,10 +1343,15 @@ function parseResearchAndWritingBlock(
     }
 }
 
-export function parseRefs(
-    refs: unknown,
+export function parseRefs({
+    refs,
+    refsByFirstAppearance,
+    isInline = false,
+}: {
+    refs: unknown
     refsByFirstAppearance: Set<string>
-): { definitions: RefDictionary; errors: OwidGdocErrorMessage[] } {
+    isInline?: boolean
+}): { definitions: RefDictionary; errors: OwidGdocErrorMessage[] } {
     const parsedRefs: RefDictionary = {}
     const refErrors: OwidGdocErrorMessage[] = []
 
@@ -1408,17 +1413,19 @@ export function parseRefs(
         }
     }
 
-    refErrors.push(
-        ...[...refsByFirstAppearance]
-            .filter((ref) => !parsedRefs[ref])
-            .map(
-                (undefinedRef): OwidGdocErrorMessage => ({
-                    message: `"${undefinedRef}" is used as a ref ID but no definition for this ref has been written.`,
-                    property: "refs",
-                    type: OwidGdocErrorMessageType.Error,
-                })
-            )
-    )
+    if (!isInline) {
+        refErrors.push(
+            ...[...refsByFirstAppearance]
+                .filter((ref) => !parsedRefs[ref])
+                .map(
+                    (undefinedRef): OwidGdocErrorMessage => ({
+                        message: `"${undefinedRef}" is used as a ref ID but no definition for this ref has been written.`,
+                        property: "refs",
+                        type: OwidGdocErrorMessageType.Error,
+                    })
+                )
+        )
+    }
 
     return { definitions: parsedRefs, errors: refErrors }
 }

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -150,6 +150,8 @@ export {
     type RawDetail,
     type RawSDGGridItem,
     type RelatedChart,
+    type Ref,
+    type RefDictionary,
     ScaleType,
     type SerializedGridProgram,
     SiteFooterContext,

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1028,7 +1028,9 @@ export type Ref = {
     parseErrors: ParseError[]
 }
 
-export type RefDictionary = Record<string, Ref>
+export type RefDictionary = {
+    [refId: string]: Ref
+}
 
 export type OwidRawGdocBlock =
     | RawBlockAllCharts
@@ -1195,7 +1197,7 @@ export interface OwidGdocContent {
     authors: string[]
     dateline?: string
     excerpt?: string
-    refs?: RefDictionary
+    refs?: { definitions: RefDictionary; errors: OwidGdocErrorMessage[] }
     summary?: EnrichedBlockText[]
     citation?: EnrichedBlockSimpleText[]
     toc?: TocHeadingWithTitleSupertitle[]

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1195,7 +1195,7 @@ export interface OwidGdocContent {
     authors: string[]
     dateline?: string
     excerpt?: string
-    refs?: OwidEnrichedGdocBlock[][]
+    refs?: RefDictionary
     summary?: EnrichedBlockText[]
     citation?: EnrichedBlockSimpleText[]
     toc?: TocHeadingWithTitleSupertitle[]

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1185,7 +1185,7 @@ export interface OwidGdocContent {
     authors: string[]
     dateline?: string
     excerpt?: string
-    refs?: EnrichedBlockText[]
+    refs?: OwidEnrichedGdocBlock[][]
     summary?: EnrichedBlockText[]
     citation?: EnrichedBlockSimpleText[]
     toc?: TocHeadingWithTitleSupertitle[]

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1020,6 +1020,16 @@ export type EnrichedBlockExpandableParagraph = {
     items: OwidEnrichedGdocBlock[]
 } & EnrichedBlockWithParseErrors
 
+export type Ref = {
+    id: string
+    // Can be -1
+    index: number
+    content: OwidEnrichedGdocBlock[]
+    parseErrors: ParseError[]
+}
+
+export type RefDictionary = Record<string, Ref>
+
 export type OwidRawGdocBlock =
     | RawBlockAllCharts
     | RawBlockAside

--- a/site/gdocs/Footnotes.tsx
+++ b/site/gdocs/Footnotes.tsx
@@ -15,19 +15,21 @@ export default function Footnotes({
             <div className="col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
                 <h3 id={ENDNOTES_ID}>Endnotes</h3>
                 <ol className="footnote-list">
-                    {Object.values(definitions).map((ref) => {
-                        return (
-                            <li
-                                id={`note-${ref.index + 1}`}
-                                key={ref.index}
-                                className="footnote-list__footnote"
-                            >
-                                {ref.content.map((block, i) => (
-                                    <ArticleBlock key={i} b={block} />
-                                ))}
-                            </li>
-                        )
-                    })}
+                    {Object.values(definitions)
+                        .sort((a, b) => a.index - b.index)
+                        .map((ref) => {
+                            return (
+                                <li
+                                    id={`note-${ref.index + 1}`}
+                                    key={ref.index}
+                                    className="footnote-list__footnote"
+                                >
+                                    {ref.content.map((block, i) => (
+                                        <ArticleBlock key={i} b={block} />
+                                    ))}
+                                </li>
+                            )
+                        })}
                 </ol>
             </div>
         </section>

--- a/site/gdocs/Footnotes.tsx
+++ b/site/gdocs/Footnotes.tsx
@@ -1,8 +1,8 @@
-import { EnrichedBlockText, ENDNOTES_ID } from "@ourworldindata/utils"
+import { OwidEnrichedGdocBlock, ENDNOTES_ID } from "@ourworldindata/utils"
 import React from "react"
-import Paragraph from "./Paragraph.js"
+import ArticleBlock from "./ArticleBlock.js"
 
-export default function Footnotes({ d }: { d: EnrichedBlockText[] }) {
+export default function Footnotes({ d }: { d: OwidEnrichedGdocBlock[][] }) {
     if (!d || !d.length) {
         return null
     }
@@ -11,14 +11,16 @@ export default function Footnotes({ d }: { d: EnrichedBlockText[] }) {
             <div className="col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
                 <h3 id={ENDNOTES_ID}>Endnotes</h3>
                 <ol className="footnote-list">
-                    {d.map((footnote: EnrichedBlockText, i: number) => {
+                    {d.map((blocks: OwidEnrichedGdocBlock[], i: number) => {
                         return (
                             <li
                                 id={`note-${i + 1}`}
                                 key={i}
                                 className="footnote-list__footnote"
                             >
-                                <Paragraph d={footnote} />
+                                {blocks.map((block, i) => (
+                                    <ArticleBlock key={i} b={block} />
+                                ))}
                             </li>
                         )
                     })}

--- a/site/gdocs/Footnotes.tsx
+++ b/site/gdocs/Footnotes.tsx
@@ -1,9 +1,9 @@
-import { OwidEnrichedGdocBlock, ENDNOTES_ID } from "@ourworldindata/utils"
+import { ENDNOTES_ID, RefDictionary } from "@ourworldindata/utils"
 import React from "react"
 import ArticleBlock from "./ArticleBlock.js"
 
-export default function Footnotes({ d }: { d: OwidEnrichedGdocBlock[][] }) {
-    if (!d || !d.length) {
+export default function Footnotes({ d }: { d: RefDictionary }) {
+    if (!d) {
         return null
     }
     return (
@@ -11,14 +11,14 @@ export default function Footnotes({ d }: { d: OwidEnrichedGdocBlock[][] }) {
             <div className="col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
                 <h3 id={ENDNOTES_ID}>Endnotes</h3>
                 <ol className="footnote-list">
-                    {d.map((blocks: OwidEnrichedGdocBlock[], i: number) => {
+                    {Object.values(d).map((ref) => {
                         return (
                             <li
-                                id={`note-${i + 1}`}
-                                key={i}
+                                id={`note-${ref.index + 1}`}
+                                key={ref.index}
                                 className="footnote-list__footnote"
                             >
-                                {blocks.map((block, i) => (
+                                {ref.content.map((block, i) => (
                                     <ArticleBlock key={i} b={block} />
                                 ))}
                             </li>

--- a/site/gdocs/Footnotes.tsx
+++ b/site/gdocs/Footnotes.tsx
@@ -2,8 +2,12 @@ import { ENDNOTES_ID, RefDictionary } from "@ourworldindata/utils"
 import React from "react"
 import ArticleBlock from "./ArticleBlock.js"
 
-export default function Footnotes({ d }: { d: RefDictionary }) {
-    if (!d) {
+export default function Footnotes({
+    definitions,
+}: {
+    definitions: RefDictionary
+}) {
+    if (!definitions) {
         return null
     }
     return (
@@ -11,7 +15,7 @@ export default function Footnotes({ d }: { d: RefDictionary }) {
             <div className="col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
                 <h3 id={ENDNOTES_ID}>Endnotes</h3>
                 <ol className="footnote-list">
-                    {Object.values(d).map((ref) => {
+                    {Object.values(definitions).map((ref) => {
                         return (
                             <li
                                 id={`note-${ref.index + 1}`}

--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -121,7 +121,9 @@ export function OwidGdoc({
                         />
                     ) : null}
 
-                    {content.refs ? <Footnotes d={content.refs} /> : null}
+                    {content.refs?.definitions ? (
+                        <Footnotes definitions={content.refs.definitions} />
+                    ) : null}
 
                     <section
                         id={CITATION_ID}

--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -11,6 +11,7 @@ import {
     RelatedChart,
     CITATION_ID,
     LICENSE_ID,
+    isEmpty,
 } from "@ourworldindata/utils"
 import { CodeSnippet } from "../blocks/CodeSnippet.js"
 import { BAKED_BASE_URL } from "../../settings/clientSettings.js"
@@ -121,7 +122,7 @@ export function OwidGdoc({
                         />
                     ) : null}
 
-                    {content.refs?.definitions ? (
+                    {content.refs && !isEmpty(content.refs.definitions) ? (
                         <Footnotes definitions={content.refs.definitions} />
                     ) : null}
 

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -231,6 +231,13 @@ h3.article-block__heading.has-supertitle {
                 margin-left: 0;
             }
         }
+
+        .article-block__text,
+        .article-block__list,
+        .article-block__html,
+        .article-block__numbered-list {
+            @include body-3-medium;
+        }
     }
 }
 

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -895,6 +895,13 @@ article.page .authors-byline .citation-note:hover {
                 margin-top: 1em;
             }
         }
+
+        .article-block__text,
+        .article-block__list,
+        .article-block__html,
+        .article-block__numbered-list {
+            @include body-3-medium;
+        }
     }
 }
 


### PR DESCRIPTION
Resolves #2299

Changes refs to use a ID reference system instead of defining them inline.

Upsides:
- Multi-line refs in lists without messing up parsing. 
- Define a ref once and use it multiple times throughout an article.

We have three articles that are published with the old ref style. **Instead of writing a complex migration for them, I've opted to simply strip the refs out of the article during baking.** Once this PR is merged we can update the 3 source docs and republish them.

# Archie example
```
[.refs]
[.refs]
id: example_id
[.+content]
I am a ref
[]

id: multiline_id
[.+content]
I am a ref with [links](https://en.wikipedia.org/wiki/Wiki)

And multiple lines

And formatting

And
A list
whoa

[]
[]

[+.body]

If this works it’ll be great{ref}Some more inline stuff{/ref}

blah{ref}multiline_id{/ref}

blah blah{ref}example_id{/ref}

And an old style ref{ref}The [blah](https://en.wikipedia.org/wiki/Main_Page) of the blah blah has been known to blah.

I go multiple lines too{/ref}

And one more {ref}Some more inline stuff{/ref}

[]
```

# Preview example
![image](https://github.com/owid/owid-grapher/assets/11844404/ec131f8e-f408-449c-8fc3-3a6c70e0e8ab)
