### PR TITLE
feat(analytics): send events to Google Analytics 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
         "@types/fs-extra": "^11.0.1",
         "@types/fuzzyset": "^1.0.2",
         "@types/glob": "^8.0.0",
-        "@types/google.analytics": "^0.0.40",
         "@types/html-to-text": "^8.1.1",
         "@types/js-cookie": "^3.0.2",
         "@types/jsonwebtoken": "^9.0.0",

--- a/packages/@ourworldindata/grapher/package.json
+++ b/packages/@ourworldindata/grapher/package.json
@@ -57,7 +57,6 @@
     "@types/d3-format": "^2",
     "@types/enzyme": "^3.10.12",
     "@types/enzyme-adapter-react-16": "^1.0.6",
-    "@types/gtag.js": "^0.0.12",
     "@types/jest": "^29.0.3",
     "@types/js-cookie": "^3.0.2",
     "@types/mousetrap": "^1.6.9",

--- a/packages/@ourworldindata/grapher/package.json
+++ b/packages/@ourworldindata/grapher/package.json
@@ -57,7 +57,7 @@
     "@types/d3-format": "^2",
     "@types/enzyme": "^3.10.12",
     "@types/enzyme-adapter-react-16": "^1.0.6",
-    "@types/google.analytics": "^0.0.40",
+    "@types/gtag.js": "^0.0.12",
     "@types/jest": "^29.0.3",
     "@types/js-cookie": "^3.0.2",
     "@types/mousetrap": "^1.6.9",

--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
@@ -57,10 +57,6 @@ export class EntityPicker extends React.Component<{
     manager: EntityPickerManager
     isDropdownMenu?: boolean
 }> {
-    @computed private get analyticsNamespace(): string {
-        return this.manager.analyticsNamespace ?? ""
-    }
-
     @observable private searchInput?: string
     @observable
     private searchInputRef: React.RefObject<HTMLInputElement> =
@@ -91,7 +87,6 @@ export class EntityPicker extends React.Component<{
         // Clear search input
         this.searchInput = ""
         this.manager.analytics?.logEntityPickerEvent(
-            this.analyticsNamespace,
             checked ? "select" : "deselect",
             name
         )
@@ -267,11 +262,7 @@ export class EntityPicker extends React.Component<{
                 const name = this.focusedOption
                 this.selectEntity(name)
                 this.clearSearchInput()
-                this.manager.analytics?.logEntityPickerEvent(
-                    this.analyticsNamespace,
-                    "enter",
-                    name
-                )
+                this.manager.analytics?.logEntityPickerEvent("enter", name)
                 break
             case "ArrowUp":
                 this.focusOptionDirection(FocusDirection.up)
@@ -402,11 +393,7 @@ export class EntityPicker extends React.Component<{
                 ? SortOrder.desc
                 : SortOrder.asc,
         })
-        this.manager.analytics?.logEntityPickerEvent(
-            this.analyticsNamespace,
-            "sortBy",
-            columnSlug
-        )
+        this.manager.analytics?.logEntityPickerEvent("sortBy", columnSlug)
     }
 
     private isColumnTypeNumeric(col: CoreColumn | undefined): boolean {
@@ -454,7 +441,6 @@ export class EntityPicker extends React.Component<{
                         const sortOrder = toggleSort(this.sortOrder)
                         this.manager.setEntityPicker?.({ sort: sortOrder })
                         this.manager.analytics?.logEntityPickerEvent(
-                            this.analyticsNamespace,
                             "sortOrder",
                             sortOrder
                         )
@@ -500,7 +486,7 @@ export class EntityPicker extends React.Component<{
                         onFocus={this.onSearchFocus}
                         onBlur={this.onSearchBlur}
                         ref={this.searchInputRef}
-                        data-track-note={`${this.analyticsNamespace}-picker-search-input`}
+                        data-track-note={`picker-search-input`}
                     />
                     <div className="search-icon">
                         <FontAwesomeIcon icon={faSearch} />
@@ -571,7 +557,7 @@ export class EntityPicker extends React.Component<{
                                 <div
                                     title={selectedDebugMessage}
                                     className="ClearSelectionButton"
-                                    data-track-note={`${this.analyticsNamespace}-clear-selection`}
+                                    data-track-note={`entity-picker-clear-selection`}
                                     onClick={(): void =>
                                         selection.clearSelection()
                                     }

--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPickerConstants.ts
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPickerConstants.ts
@@ -14,5 +14,4 @@ export interface EntityPickerManager {
     grapherTable?: OwidTable
     selection: SelectionArray
     analytics?: GrapherAnalytics
-    analyticsNamespace?: string
 }

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2542,7 +2542,7 @@ export class Grapher
     timelineController = new TimelineController(this)
 
     onPlay(): void {
-        this.analytics.logGrapherTimelinePlay(this.slug)
+        this.analytics.logSiteClick("timeline-play", undefined, this.slug)
     }
 
     // todo: restore this behavior??

--- a/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
@@ -2,7 +2,14 @@ import { findDOMParent } from "@ourworldindata/utils"
 
 const DEBUG = false
 
-// TypeScript implicitly imports @types/amplitude-js and @types/google.analytics
+// Add type information for dataLayer global provided by Google Tag Manager
+declare global {
+    interface Window {
+        dataLayer?: GAEvent[]
+    }
+}
+
+// TypeScript implicitly imports @types/amplitude-js
 // so we have proper types for window.amplitude and window.ga
 
 enum Categories {
@@ -26,6 +33,12 @@ type countrySelectorEvent =
     | "deselect"
     | "sortBy"
     | "sortOrder"
+
+interface GAEvent {
+    event: string
+    eventAction?: string
+    eventTarget?: string
+}
 
 // Note: consent-based blocking dealt with at the Google Tag Manager level.
 // Events are discarded if consent not given.
@@ -142,12 +155,6 @@ export class GrapherAnalytics {
             return
         }
 
-        if (!window.gtag) return
-
-        window.gtag("event", event.eventAction, {
-            event_category: event.eventCategory,
-            event_label: event.eventLabel,
-            value: event.eventValue,
-        })
+        window.dataLayer?.push({ event: event.eventCategory, ...event })
     }
 }

--- a/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
@@ -3,10 +3,8 @@ import { findDOMParent } from "@ourworldindata/utils"
 const DEBUG = false
 
 // Add type information for dataLayer global provided by Google Tag Manager
-declare global {
-    interface Window {
-        dataLayer?: GAEvent[]
-    }
+type WindowWithDataLayer = Window & {
+    dataLayer?: GAEvent[]
 }
 
 // TypeScript implicitly imports @types/amplitude-js
@@ -166,6 +164,6 @@ export class GrapherAnalytics {
             return
         }
 
-        window.dataLayer?.push(event)
+        ;(window as WindowWithDataLayer).dataLayer?.push(event)
     }
 }

--- a/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
@@ -5,15 +5,6 @@ const DEBUG = false
 // TypeScript implicitly imports @types/amplitude-js and @types/google.analytics
 // so we have proper types for window.amplitude and window.ga
 
-// Docs on GA's event interface: https://developers.google.com/analytics/devguides/collection/analyticsjs/events
-interface GAEvent {
-    hitType: string
-    eventCategory: string
-    eventAction: string
-    eventLabel?: string
-    eventValue?: number
-}
-
 enum Categories {
     GrapherError = "GrapherErrors",
     GrapherUsage = "GrapherUsage",
@@ -139,8 +130,7 @@ export class GrapherAnalytics {
         eventValue?: number
     ): void {
         // Todo: send the Grapher (or site) version to Git
-        const event: GAEvent = {
-            hitType: "event",
+        const event = {
             eventCategory,
             eventAction,
             eventLabel,
@@ -152,17 +142,12 @@ export class GrapherAnalytics {
             return
         }
 
-        if (!window.ga) return
+        if (!window.gtag) return
 
-        // https://developers.google.com/analytics/devguides/collection/analyticsjs/ga-object-methods-reference
-        window.ga(function () {
-            const tracker = window.ga.getAll()[0]
-            // @types/google.analytics seems to suggest this usage is invalid but we know Google
-            // Analytics logs these events correctly.
-            // I have avoided changing the implementation for now, but we should look into this as
-            // we use Google Analytics more.
-            // -@danielgavrilov 2020-04-23
-            if (tracker) tracker.send(event as any)
+        window.gtag("event", event.eventAction, {
+            event_category: event.eventCategory,
+            event_label: event.eventLabel,
+            value: event.eventValue,
         })
     }
 }

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -69,7 +69,7 @@ export {
     type GrapherManager,
     getErrorMessageRelatedQuestionUrl,
 } from "./core/Grapher"
-export { GrapherAnalytics } from "./core/GrapherAnalytics"
+export { GrapherAnalytics, EventCategory } from "./core/GrapherAnalytics"
 export {
     type GrapherInterface,
     type GrapherQueryParams,

--- a/site/AnnotatingDataValue.tsx
+++ b/site/AnnotatingDataValue.tsx
@@ -4,12 +4,9 @@ import { Grapher } from "@ourworldindata/grapher"
 import { BLOCK_WRAPPER_DATATYPE, DataValueProps } from "@ourworldindata/utils"
 import React, { useEffect, useState } from "react"
 import ReactDOM from "react-dom"
-import { ENV } from "../settings/clientSettings.js"
 import { DataValue, processTemplate } from "./DataValue.js"
-import { SiteAnalytics } from "./SiteAnalytics.js"
 
 const AnnotatingDataValue_name = "AnnotatingDataValue"
-const analytics = new SiteAnalytics(ENV)
 
 export const AnnotatingDataValue = ({
     dataValueProps,
@@ -26,7 +23,6 @@ export const AnnotatingDataValue = ({
             entityName: dataValueProps.entityName,
             year: Number(dataValueProps.year),
         })
-        analytics.logDataValueAnnotate(label)
     }
 
     useEffect(() => {

--- a/site/SiteAnalytics.ts
+++ b/site/SiteAnalytics.ts
@@ -1,17 +1,28 @@
-import { GrapherAnalytics } from "@ourworldindata/grapher"
+import { GrapherAnalytics, EventCategory } from "@ourworldindata/grapher"
 
 export class SiteAnalytics extends GrapherAnalytics {
     logCovidCountryProfileSearch(country: string) {
-        this.logToGA("COVID_COUNTRY_PROFILE_SEARCH", country)
+        this.logToGA({
+            event: EventCategory.CountryProfileSearch,
+            eventContext: country,
+        })
     }
 
     logPageNotFoundError(url: string) {
         this.logToAmplitude("NOT_FOUND", { href: url })
-        this.logToGA("Errors", "NotFound", url)
+        this.logToGA({
+            event: EventCategory.SiteError,
+            eventAction: "not_found",
+            eventContext: url,
+        })
     }
 
     logChartsPageSearchQuery(query: string) {
-        this.logToGA("ChartsPage", "Filter", query)
+        this.logToGA({
+            event: EventCategory.Filter,
+            eventAction: "charts-page",
+            eventContext: query,
+        })
     }
 
     logPageLoad() {

--- a/site/SiteAnalytics.ts
+++ b/site/SiteAnalytics.ts
@@ -17,8 +17,4 @@ export class SiteAnalytics extends GrapherAnalytics {
     logPageLoad() {
         this.logToAmplitude("OWID_PAGE_LOAD")
     }
-
-    logDataValueAnnotate(label: string) {
-        this.logToGA("Hover", "data-value-annotate", label)
-    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4814,7 +4814,7 @@ __metadata:
     "@types/d3-format": ^2
     "@types/enzyme": ^3.10.12
     "@types/enzyme-adapter-react-16": ^1.0.6
-    "@types/google.analytics": ^0.0.40
+    "@types/gtag.js": ^0.0.12
     "@types/jest": ^29.0.3
     "@types/js-cookie": ^3.0.2
     "@types/mousetrap": ^1.6.9
@@ -5766,19 +5766,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/google.analytics@npm:^0.0.40":
-  version: 0.0.40
-  resolution: "@types/google.analytics@npm:0.0.40"
-  checksum: 7c9b1c63b049f1018a30ed4ff193fbe76d3eee6d98c268346da82095709f1822e50e7130373187219dee765a5d10ed32d58962ff21801b39b219d1932f62ccdc
-  languageName: node
-  linkType: hard
-
 "@types/graceful-fs@npm:^4.1.3":
   version: 4.1.5
   resolution: "@types/graceful-fs@npm:4.1.5"
   dependencies:
     "@types/node": "*"
   checksum: d076bb61f45d0fc42dee496ef8b1c2f8742e15d5e47e90e20d0243386e426c04d4efd408a48875ab432f7960b4ce3414db20ed0fbbfc7bcc89d84e574f6e045a
+  languageName: node
+  linkType: hard
+
+"@types/gtag.js@npm:^0.0.12":
+  version: 0.0.12
+  resolution: "@types/gtag.js@npm:0.0.12"
+  checksum: 34efc27fbfd0013255b8bfd4af38ded9d5a6ba761130c76f17fd3a9585d83acc88d8005aab667cfec4bdec0e7c7217f689739799a8f61aed0edb929be58b162e
   languageName: node
   linkType: hard
 
@@ -13745,7 +13745,6 @@ __metadata:
     "@types/fuzzyset": ^1.0.2
     "@types/geojson": ^7946.0.10
     "@types/glob": ^8.0.0
-    "@types/google.analytics": ^0.0.40
     "@types/html-to-text": ^8.1.1
     "@types/jest": ^29.0.3
     "@types/js-cookie": ^3.0.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -4814,7 +4814,6 @@ __metadata:
     "@types/d3-format": ^2
     "@types/enzyme": ^3.10.12
     "@types/enzyme-adapter-react-16": ^1.0.6
-    "@types/gtag.js": ^0.0.12
     "@types/jest": ^29.0.3
     "@types/js-cookie": ^3.0.2
     "@types/mousetrap": ^1.6.9
@@ -5772,13 +5771,6 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: d076bb61f45d0fc42dee496ef8b1c2f8742e15d5e47e90e20d0243386e426c04d4efd408a48875ab432f7960b4ce3414db20ed0fbbfc7bcc89d84e574f6e045a
-  languageName: node
-  linkType: hard
-
-"@types/gtag.js@npm:^0.0.12":
-  version: 0.0.12
-  resolution: "@types/gtag.js@npm:0.0.12"
-  checksum: 34efc27fbfd0013255b8bfd4af38ded9d5a6ba761130c76f17fd3a9585d83acc88d8005aab667cfec4bdec0e7c7217f689739799a8f61aed0edb929be58b162e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #1402

Things done in here:
- Send events to Google Tag Manager, which is then set up to forward these to GA4
- Send events in the new format, where they're only mainly identified by the event name (which used to be the event category)
- Use a new format for event names: `owid.event_name_in_snake_case`
- Drop a very small amount of events

TODOs:
- [ ] In GTM, forward all `owid\..*` events to GA4 (see my staging environment)
- [ ] In Netlify, add a script snippet `window.dataLayer = window.dataLayer || []` _before_ the GTM snippet
- [ ] (stretch goal) Include a `grapherSlug` with `owid.site_click` events we send, whenever the click is happening inside a grapher frame
- [ ] Open question: Should we drop Amplitude, or is it still useful?