### PR TITLE
:honeybee: reinforce that tmux should run a normal shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ up: require create-if-missing.env tmp-downloads/owid_chartdata.sql.gz
 	tmux new-session -s grapher \
 		-n docker 'docker-compose -f docker-compose.grapher.yml up' \; \
 			set remain-on-exit on \; \
+		set-option -g default-shell $(LOGIN_SHELL) \; \
 		new-window -n admin \
 			'devTools/docker/wait-for-mysql.sh && yarn run tsc-watch -b --onSuccess "yarn startAdminServer"' \; \
 			set remain-on-exit on \; \
@@ -106,6 +107,7 @@ up.full: require create-if-missing.env.full wordpress/.env tmp-downloads/owid_ch
 	tmux new-session -s grapher \
 		-n docker 'docker-compose -f docker-compose.full.yml up' \; \
 			set remain-on-exit on \; \
+		set-option -g default-shell $(LOGIN_SHELL) \; \
 		new-window -n admin \
 			'devTools/docker/wait-for-mysql.sh && yarn run tsc-watch -b --onSuccess "yarn startAdminServer"' \; \
 			set remain-on-exit on \; \


### PR DESCRIPTION
This is to allow running "make up" and "make up.full" from non-standard shells like nushell. In nushell's case, it does not support the && operator, which makes tons of things break.

Since nushell can not be a default login shell, it will be nicely overridden here.
