### PR TITLE
refactor: get rid of unused `isMediaCard` prop

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -241,7 +241,6 @@ export interface GrapherProgrammaticInterface extends GrapherInterface {
     owidDataset?: MultipleOwidVariableDataDimensionsMap // This is temporarily used for testing. Will be removed
     manuallyProvideData?: boolean // This will be removed.
     queryStr?: string
-    isMediaCard?: boolean
     bounds?: Bounds
     table?: OwidTable
     bakedGrapherURL?: string
@@ -705,7 +704,6 @@ export class Grapher
         return this.tableAfterAllTransformsAndFilters
     }
 
-    @observable.ref isMediaCard = false
     @observable.ref isExportingtoSvgOrPng = false
     tooltips?: TooltipManager["tooltips"] = observable.map({}, { deep: false })
     @observable isPlaying = false
@@ -838,8 +836,7 @@ export class Grapher
     @observable private _baseFontSize = BASE_FONT_SIZE
 
     @computed get baseFontSize(): number {
-        if (this.isMediaCard) return 24
-        else if (this.isExportingtoSvgOrPng) return 18
+        if (this.isExportingtoSvgOrPng) return 18
         return this._baseFontSize
     }
 
@@ -1528,9 +1525,7 @@ export class Grapher
     }
 
     @computed get idealBounds(): Bounds {
-        return this.isMediaCard
-            ? new Bounds(0, 0, 1200, 630)
-            : new Bounds(0, 0, DEFAULT_GRAPHER_WIDTH, DEFAULT_GRAPHER_HEIGHT)
+        return new Bounds(0, 0, DEFAULT_GRAPHER_WIDTH, DEFAULT_GRAPHER_HEIGHT)
     }
 
     @computed get hasYDimension(): boolean {

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -131,8 +131,6 @@ export class Footer extends React.Component<{
     }
 
     @computed get height(): number {
-        if (this.manager.isMediaCard) return 0
-
         const { sources, note, licenseAndOriginUrl, isCompact, paraMargin } =
             this
         return (
@@ -142,9 +140,7 @@ export class Footer extends React.Component<{
         )
     }
 
-    renderStatic(targetX: number, targetY: number): JSX.Element | null {
-        if (this.manager.isMediaCard) return null
-
+    renderStatic(targetX: number, targetY: number): JSX.Element {
         const {
             sources,
             note,

--- a/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
+++ b/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
@@ -8,7 +8,6 @@ export interface FooterManager {
     note?: string
     hasOWIDLogo?: boolean
     originUrlWithProtocol?: string
-    isMediaCard?: boolean
     currentTab?: string
     tooltips?: TooltipManager["tooltips"]
     tabBounds?: Bounds

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -102,18 +102,14 @@ export class Header extends React.Component<{
     }
 
     @computed get height(): number {
-        if (this.manager.isMediaCard) return 0
-
         return Math.max(
             this.title.height + this.subtitle.height + this.titleMarginBottom,
             this.logoHeight
         )
     }
 
-    renderStatic(x: number, y: number): JSX.Element | null {
+    renderStatic(x: number, y: number): JSX.Element {
         const { title, logo, subtitle, manager, maxWidth } = this
-
-        if (manager.isMediaCard) return null
 
         return (
             <g className="HeaderView">

--- a/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
+++ b/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
@@ -6,7 +6,6 @@ export interface HeaderManager {
     subtitle?: string
     hideLogo?: boolean
     shouldLinkToOwid?: boolean
-    isMediaCard?: boolean
     logo?: string
     canonicalUrl?: string
     tabBounds?: Bounds


### PR DESCRIPTION
It has been unused for five years (!) (dd6a541c6c4bd5dd2f41e57b8cce62984b61e7cc), and its implementation is quite broken anyway.