### PR TITLE
Allow authors to specify a center value for diverging map brackets

### DIFF
--- a/adminSiteClient/EditorColorScaleSection.tsx
+++ b/adminSiteClient/EditorColorScaleSection.tsx
@@ -26,6 +26,7 @@ import {
     TextField,
     ColorBox,
     BindAutoFloat,
+    BindFloat,
     BindString,
 } from "./Forms.js"
 import {
@@ -36,6 +37,7 @@ import {
 interface EditorColorScaleSectionFeatures {
     visualScaling: boolean
     legendDescription: boolean
+    centerValue: boolean
 }
 
 @observer
@@ -51,6 +53,7 @@ export class EditorColorScaleSection extends React.Component<{
             <React.Fragment>
                 <ColorsSection
                     scale={this.props.scale}
+                    features={this.props.features}
                     onChange={this.props.onChange}
                     chartType={this.props.chartType}
                     showLineChartColors={this.props.showLineChartColors}
@@ -130,6 +133,7 @@ class ColorLegendSection extends React.Component<{
 @observer
 class ColorsSection extends React.Component<{
     scale: ColorScale
+    features: EditorColorScaleSectionFeatures
     chartType: ChartTypeName
     showLineChartColors: boolean
     onChange?: () => void
@@ -201,7 +205,7 @@ class ColorsSection extends React.Component<{
     }
 
     render() {
-        const { scale, config } = this
+        const { scale, config, props } = this
 
         return (
             <Section name="Color scale">
@@ -253,6 +257,13 @@ class ColorsSection extends React.Component<{
                         label="Minimum value"
                         auto={scale.autoMinBinValue}
                     />
+                    {props.features.centerValue && (
+                        <BindFloat
+                            field="customNumericCenterValue"
+                            store={config}
+                            label="Center value"
+                        />
+                    )}
                     {!scale.isManualBuckets && (
                         <BindAutoFloat
                             field="binningStrategyBinCount"

--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -599,6 +599,7 @@ export class EditorCustomizeTab extends React.Component<{
                         features={{
                             visualScaling: true,
                             legendDescription: true,
+                            centerValue: false,
                         }}
                     />
                 )}

--- a/adminSiteClient/EditorMapTab.tsx
+++ b/adminSiteClient/EditorMapTab.tsx
@@ -1,6 +1,8 @@
 import {
+    BinningStrategy,
     ChartDimension,
     ChartTypeName,
+    ColorSchemes,
     MapChart,
     MapConfig,
     MapProjectionLabels,
@@ -186,9 +188,16 @@ export class EditorMapTab extends React.Component<{ editor: ChartEditor }> {
         const mapConfig = grapher.map
         const { mapColumnSlug } = grapher
         const mapChart = new MapChart({ manager: this.grapher })
-        const colorScale = mapChart.colorScale
+        const { colorScale, colorScaleConfig } = mapChart
+        const { baseColorScheme, binningStrategy } = colorScaleConfig
 
         const isReady = !!mapColumnSlug && grapher.table.has(mapColumnSlug)
+
+        const isDiverging = !!(
+            baseColorScheme && ColorSchemes[baseColorScheme].isDiverging
+        )
+        const centerValue =
+            isDiverging && binningStrategy === BinningStrategy.equalInterval
 
         return (
             <div className="EditorMapTab tab-pane">
@@ -206,6 +215,7 @@ export class EditorMapTab extends React.Component<{ editor: ChartEditor }> {
                             features={{
                                 visualScaling: true,
                                 legendDescription: false,
+                                centerValue,
                             }}
                         />
                         <TooltipSection mapConfig={mapConfig} />

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -487,6 +487,7 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
                             features={{
                                 visualScaling: true,
                                 legendDescription: false,
+                                centerValue: false,
                             }}
                             showLineChartColors={false}
                             onChange={this.onGenericRichEditorChange}
@@ -511,6 +512,7 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
                                 features={{
                                     visualScaling: true,
                                     legendDescription: false,
+                                    centerValue: false,
                                 }}
                                 showLineChartColors={grapher.isLineChart}
                                 onChange={this.onGenericRichEditorChange}

--- a/packages/@ourworldindata/grapher/src/color/BinningStrategies.test.ts
+++ b/packages/@ourworldindata/grapher/src/color/BinningStrategies.test.ts
@@ -123,6 +123,36 @@ describe("equalInterval strategy", () => {
         ).toEqual([200, 300])
     })
 
+    it("returns an even number of bins if centerBinValue is specified", () => {
+        expect(
+            getBinMaximums({
+                binningStrategy: BinningStrategy.equalInterval,
+                sortedValues: [48, 48.5, 50.1, 50.2, 51.9, 53],
+                binCount: 3,
+                centerBinValue: 50,
+            }).length
+        ).toEqual(4)
+    })
+
+    it("includes centerBinValue if specified", () => {
+        const sortedValues = [42, 48.5, 50.1, 50.2, 51.9, 52]
+        expect(
+            getBinMaximums({
+                binningStrategy: BinningStrategy.equalInterval,
+                sortedValues,
+                binCount: 4,
+            })
+        ).toEqual([45, 48, 51, 54])
+        expect(
+            getBinMaximums({
+                binningStrategy: BinningStrategy.equalInterval,
+                sortedValues,
+                binCount: 4,
+                centerBinValue: 50,
+            })
+        ).toEqual([44, 47, 50, 53])
+    })
+
     it("handles example", () => {
         expect(
             getBinMaximums({

--- a/packages/@ourworldindata/grapher/src/color/BinningStrategies.ts
+++ b/packages/@ourworldindata/grapher/src/color/BinningStrategies.ts
@@ -32,8 +32,9 @@ interface GetBinMaximumsWithStrategyArgs {
     binningStrategy: BinningStrategy
     sortedValues: number[]
     binCount: number
-    /** `minBinValue` is only used in the `equalInterval` binning strategy. */
+    /** `minBinValue` and `centerBinValue` are only used in the `equalInterval` binning strategy. */
     minBinValue?: number
+    centerBinValue?: number
 }
 
 // Some algorithms can create bins that start & end at the same value.
@@ -50,7 +51,13 @@ function normalizeBinValues(
 }
 
 export function getBinMaximums(args: GetBinMaximumsWithStrategyArgs): number[] {
-    const { binningStrategy, sortedValues, binCount, minBinValue } = args
+    const {
+        binningStrategy,
+        sortedValues,
+        binCount,
+        minBinValue,
+        centerBinValue,
+    } = args
     const valueCount = sortedValues.length
 
     if (valueCount < 1 || binCount < 1) return []
@@ -66,6 +73,38 @@ export function getBinMaximums(args: GetBinMaximumsWithStrategyArgs): number[] {
             range(1, binCount + 1).map((v) =>
                 quantile(sortedValues, v / binCount)
             ),
+            minBinValue
+        )
+    } else if (centerBinValue != undefined) {
+        // Equal-interval strategy by default, with a customized center value.
+        // If a custom center value is given, we construct bins in such a way
+        // that the center value is on the edge of a bin
+
+        // enforce an even bin count (necessary to ensure that colors are assigned correctly later on)
+        const corrBinCount = binCount % 2 === 1 ? binCount + 1 : binCount
+
+        const minValue = minBinValue ?? sortedValues[0] ?? 0
+        const binStepSize = calcEqualIntervalStepSize(
+            sortedValues,
+            corrBinCount,
+            minValue
+        )
+
+        const centerBinPosition = Math.ceil(
+            (centerBinValue - minValue) / binStepSize
+        )
+        const nBinsRight = corrBinCount - centerBinPosition
+        const nBinsLeft = centerBinPosition - 1
+
+        const leftBinValues = range(nBinsLeft, 0, -1).map(
+            (n) => centerBinValue - n * binStepSize
+        )
+        const rightBinValues = range(1, nBinsRight + 1).map(
+            (n) => centerBinValue + n * binStepSize
+        )
+
+        return normalizeBinValues(
+            [...leftBinValues, centerBinValue, ...rightBinValues],
             minBinValue
         )
     } else {

--- a/packages/@ourworldindata/grapher/src/color/ColorBrewerSchemes.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorBrewerSchemes.ts
@@ -2,60 +2,200 @@ import colorbrewer from "colorbrewer"
 import { Color } from "@ourworldindata/core-table"
 import { ColorSchemeInterface, ColorSchemeName } from "./ColorConstants"
 
-type ColorSchemeProps = { displayName: string; singleColorScale: boolean }
+type ColorSchemeProps = {
+    displayName: string
+    singleColorScale: boolean
+    isDiverging: boolean
+}
 
 const ColorBrewerSchemeIndex: {
     [key in ColorSchemeName]?: ColorSchemeProps
 } = {
-    YlGn: { displayName: "Yellow-Green shades", singleColorScale: true },
+    YlGn: {
+        displayName: "Yellow-Green shades",
+        singleColorScale: true,
+        isDiverging: false,
+    },
     YlGnBu: {
         displayName: "Yellow-Green-Blue shades",
         singleColorScale: false,
+        isDiverging: false,
     },
-    GnBu: { displayName: "Green-Blue shades", singleColorScale: true },
-    BuGn: { displayName: "Blue-Green shades", singleColorScale: true },
+    GnBu: {
+        displayName: "Green-Blue shades",
+        singleColorScale: true,
+        isDiverging: false,
+    },
+    BuGn: {
+        displayName: "Blue-Green shades",
+        singleColorScale: true,
+        isDiverging: false,
+    },
     PuBuGn: {
         displayName: "Purple-Blue-Green shades",
         singleColorScale: false,
+        isDiverging: false,
     },
-    BuPu: { displayName: "Blue-Purple shades", singleColorScale: true },
-    RdPu: { displayName: "Red-Purple shades", singleColorScale: true },
-    PuRd: { displayName: "Purple-Red shades", singleColorScale: true },
-    OrRd: { displayName: "Orange-Red shades", singleColorScale: true },
+    BuPu: {
+        displayName: "Blue-Purple shades",
+        singleColorScale: true,
+        isDiverging: false,
+    },
+    RdPu: {
+        displayName: "Red-Purple shades",
+        singleColorScale: true,
+        isDiverging: false,
+    },
+    PuRd: {
+        displayName: "Purple-Red shades",
+        singleColorScale: true,
+        isDiverging: false,
+    },
+    OrRd: {
+        displayName: "Orange-Red shades",
+        singleColorScale: true,
+        isDiverging: false,
+    },
     YlOrRd: {
         displayName: "Yellow-Orange-Red shades",
         singleColorScale: true,
+        isDiverging: false,
     },
     YlOrBr: {
         displayName: "Yellow-Orange-Brown shades",
         singleColorScale: true,
+        isDiverging: false,
     },
-    Purples: { displayName: "Purple shades", singleColorScale: true },
-    Blues: { displayName: "Blue shades", singleColorScale: true },
-    Greens: { displayName: "Green shades", singleColorScale: true },
-    Oranges: { displayName: "Orange shades", singleColorScale: true },
-    Reds: { displayName: "Red shades", singleColorScale: true },
-    Greys: { displayName: "Grey shades", singleColorScale: true },
-    PuOr: { displayName: "Purple-Orange", singleColorScale: false },
-    BrBG: { displayName: "Brown-Blue-Green", singleColorScale: false },
-    PRGn: { displayName: "Purple-Red-Green", singleColorScale: false },
-    PiYG: { displayName: "Magenta-Yellow-Green", singleColorScale: false },
-    RdBu: { displayName: "Red-Blue", singleColorScale: false },
-    RdGy: { displayName: "Red-Grey", singleColorScale: false },
-    RdYlBu: { displayName: "Red-Yellow-Blue", singleColorScale: false },
-    Spectral: { displayName: "Spectral colors", singleColorScale: false },
-    RdYlGn: { displayName: "Red-Yellow-Green", singleColorScale: false },
-    Accent: { displayName: "Accents", singleColorScale: false },
-    Dark2: { displayName: "Dark colors", singleColorScale: false },
-    Paired: { displayName: "Paired colors", singleColorScale: false },
-    Pastel1: { displayName: "Pastel 1 colors", singleColorScale: false },
-    Pastel2: { displayName: "Pastel 2 colors", singleColorScale: false },
-    Set1: { displayName: "Set 1 colors", singleColorScale: false },
-    Set2: { displayName: "Set 2 colors", singleColorScale: false },
-    Set3: { displayName: "Set 3 colors", singleColorScale: false },
-    PuBu: { displayName: "Purple-Blue shades", singleColorScale: true },
-    "hsv-RdBu": { displayName: "HSV Red-Blue", singleColorScale: false },
-    "hsv-CyMg": { displayName: "HSV Cyan-Magenta", singleColorScale: false },
+    Purples: {
+        displayName: "Purple shades",
+        singleColorScale: true,
+        isDiverging: false,
+    },
+    Blues: {
+        displayName: "Blue shades",
+        singleColorScale: true,
+        isDiverging: false,
+    },
+    Greens: {
+        displayName: "Green shades",
+        singleColorScale: true,
+        isDiverging: false,
+    },
+    Oranges: {
+        displayName: "Orange shades",
+        singleColorScale: true,
+        isDiverging: false,
+    },
+    Reds: {
+        displayName: "Red shades",
+        singleColorScale: true,
+        isDiverging: false,
+    },
+    Greys: {
+        displayName: "Grey shades",
+        singleColorScale: true,
+        isDiverging: false,
+    },
+    PuOr: {
+        displayName: "Purple-Orange",
+        singleColorScale: false,
+        isDiverging: false,
+    },
+    BrBG: {
+        displayName: "Brown-Blue-Green",
+        singleColorScale: false,
+        isDiverging: true,
+    },
+    PRGn: {
+        displayName: "Purple-Red-Green",
+        singleColorScale: false,
+        isDiverging: true,
+    },
+    PiYG: {
+        displayName: "Magenta-Yellow-Green",
+        singleColorScale: false,
+        isDiverging: true,
+    },
+    RdBu: {
+        displayName: "Red-Blue",
+        singleColorScale: false,
+        isDiverging: true,
+    },
+    RdGy: {
+        displayName: "Red-Grey",
+        singleColorScale: false,
+        isDiverging: true,
+    },
+    RdYlBu: {
+        displayName: "Red-Yellow-Blue",
+        singleColorScale: false,
+        isDiverging: true,
+    },
+    Spectral: {
+        displayName: "Spectral colors",
+        singleColorScale: false,
+        isDiverging: true,
+    },
+    RdYlGn: {
+        displayName: "Red-Yellow-Green",
+        singleColorScale: false,
+        isDiverging: true,
+    },
+    Accent: {
+        displayName: "Accents",
+        singleColorScale: false,
+        isDiverging: false,
+    },
+    Dark2: {
+        displayName: "Dark colors",
+        singleColorScale: false,
+        isDiverging: false,
+    },
+    Paired: {
+        displayName: "Paired colors",
+        singleColorScale: false,
+        isDiverging: false,
+    },
+    Pastel1: {
+        displayName: "Pastel 1 colors",
+        singleColorScale: false,
+        isDiverging: false,
+    },
+    Pastel2: {
+        displayName: "Pastel 2 colors",
+        singleColorScale: false,
+        isDiverging: false,
+    },
+    Set1: {
+        displayName: "Set 1 colors",
+        singleColorScale: false,
+        isDiverging: false,
+    },
+    Set2: {
+        displayName: "Set 2 colors",
+        singleColorScale: false,
+        isDiverging: false,
+    },
+    Set3: {
+        displayName: "Set 3 colors",
+        singleColorScale: false,
+        isDiverging: false,
+    },
+    PuBu: {
+        displayName: "Purple-Blue shades",
+        singleColorScale: true,
+        isDiverging: false,
+    },
+    "hsv-RdBu": {
+        displayName: "HSV Red-Blue",
+        singleColorScale: false,
+        isDiverging: false,
+    },
+    "hsv-CyMg": {
+        displayName: "HSV Cyan-Magenta",
+        singleColorScale: false,
+        isDiverging: false,
+    },
 } as const
 
 const brewerKeys = Object.keys(colorbrewer) as ColorSchemeName[]
@@ -74,5 +214,6 @@ export const ColorBrewerSchemes: ColorSchemeInterface[] = brewerKeys
             displayName: props.displayName,
             colorSets: colorSetsArray,
             singleColorScale: props.singleColorScale,
+            isDiverging: props.isDiverging,
         }
     })

--- a/packages/@ourworldindata/grapher/src/color/ColorConstants.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorConstants.ts
@@ -5,6 +5,7 @@ export interface ColorSchemeInterface {
     colorSets: Color[][] // Different color sets depending on how many distinct colors you want
     singleColorScale?: boolean
     isDistinct?: boolean
+    isDiverging?: boolean
     displayName?: string
 }
 

--- a/packages/@ourworldindata/grapher/src/color/ColorScale.test.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScale.test.ts
@@ -4,6 +4,8 @@ import { CoreTable, ErrorValueTypes } from "@ourworldindata/core-table"
 import { BinningStrategy } from "./BinningStrategy"
 import { ColorScale } from "./ColorScale"
 import { ColorScaleConfigInterface } from "./ColorScaleConfig"
+import { ColorSchemeName } from "./ColorConstants"
+import { NumericBin } from "./ColorScaleBin"
 
 const createColorScaleFromTable = (
     colorValuePairs: { value: number; color?: string }[],
@@ -125,6 +127,53 @@ describe(ColorScale, () => {
 
                 expect(scale.sortedNumericValuesWithoutOutliers).toEqual([1])
             })
+        })
+    })
+
+    describe("divergent color scale with custom center value", () => {
+        const colorScaleConfig: ColorScaleConfigInterface = {
+            binningStrategy: BinningStrategy.equalInterval,
+            baseColorScheme: ColorSchemeName.RdBu,
+            binningStrategyBinCount: 5,
+            customNumericCenterValue: 1,
+            customNumericValues: [],
+            customNumericLabels: [],
+            customNumericColorsActive: false,
+            customNumericColors: [],
+            customCategoryColors: {},
+            customCategoryLabels: {},
+            customHiddenCategories: {},
+            equalSizeBins: true,
+        }
+        const colorValuePairs = [
+            { value: -10 },
+            { value: 1.1 },
+            { value: 2.1 },
+            { value: 15 },
+        ]
+        const scale = createColorScaleFromTable(
+            colorValuePairs,
+            colorScaleConfig
+        )
+
+        it("returns an even number of bins", () => {
+            expect(scale.legendBins.length).toEqual(6) // the suggested bin count is 5
+        })
+        it("renders the custom center value as label", () => {
+            const centerBin = scale.legendBins[2] as NumericBin
+            expect(centerBin.max).toEqual(1)
+        })
+        it("returns correct bin indices", () => {
+            const bins = scale.legendBins
+            expect(scale.getBinForValue(-100)).toBeUndefined() // doesn't belong in any bin
+            expect(scale.getBinForValue(-10)).toEqual(bins[0])
+            expect(scale.getBinForValue(0)).toEqual(bins[2])
+            expect(scale.getBinForValue(0.9)).toEqual(bins[2])
+            expect(scale.getBinForValue(1)).toEqual(bins[2])
+            expect(scale.getBinForValue(1.1)).toEqual(bins[3])
+            expect(scale.getBinForValue(2)).toEqual(bins[3])
+            expect(scale.getBinForValue(3)).toEqual(bins[3])
+            expect(scale.getBinForValue(15)).toEqual(bins[5])
         })
     })
 

--- a/packages/@ourworldindata/grapher/src/color/ColorScale.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScale.ts
@@ -215,7 +215,7 @@ export class ColorScale {
             const absCenterOffset = Math.abs(centerOffset)
             let colors = colorScheme.getGradientColors(
                 bucketMaximums.length + absCenterOffset * 2,
-                { excludeMiddleColorForDivergingSchemes: true }
+                { balanced: true }
             )
             if (isColorSchemeInverted) reverse(colors)
             colors =

--- a/packages/@ourworldindata/grapher/src/color/ColorScale.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScale.ts
@@ -205,33 +205,33 @@ export class ColorScale {
             autoCenterBinIndex,
         } = this
 
-        const numColors = bucketMaximums.length + categoricalValues.length
-        const centerOffset =
-            centerBinIndex != undefined
-                ? centerBinIndex - autoCenterBinIndex
-                : 0
-
-        if (centerOffset === 0) {
-            const colors = colorScheme.getColors(numColors)
-            if (isColorSchemeInverted) reverse(colors)
-            return colors
-        } else {
-            // if a custom center value is given, we want to make sure that all bins
-            // to the left of the center bin have one hue, and all bins to the right
-            // of the center bin have another hue (only makes sense for diverging schemes).
-            // to so do, we request more colors than we need, and then shift colors to
-            // the left or to the right, thereby dropping colors at the start or at the end
-
+        // if a custom center value is given, we want to make sure that all bins
+        // to the left of the center bin have one hue, and all bins to the right
+        // of the center bin have another hue (only makes sense for diverging schemes).
+        // to so do, we request more colors than we need, and then shift colors to
+        // the left or to the right
+        if (colorScheme.isDiverging && centerBinIndex !== undefined) {
+            const centerOffset = centerBinIndex - autoCenterBinIndex
             const absCenterOffset = Math.abs(centerOffset)
-            const colors = colorScheme.getColors(
-                numColors + absCenterOffset * 2,
+            let colors = colorScheme.getGradientColors(
+                bucketMaximums.length + absCenterOffset * 2,
                 { excludeMiddleColorForDivergingSchemes: true }
             )
             if (isColorSchemeInverted) reverse(colors)
-            return centerOffset < 0
-                ? colors.slice(absCenterOffset * 2) // drop colors at the start
-                : colors.slice(0, colors.length - absCenterOffset * 2) // drop colors at the end
+            colors =
+                centerOffset < 0
+                    ? colors.slice(absCenterOffset * 2) // drop colors at the start
+                    : colors.slice(0, colors.length - absCenterOffset * 2) // drop colors at the end
+            if (categoricalValues.length) {
+                colors.push(...colorScheme.getColors(categoricalValues.length))
+            }
+            return colors
         }
+
+        const numColors = bucketMaximums.length + categoricalValues.length
+        const colors = colorScheme.getColors(numColors)
+        if (isColorSchemeInverted) reverse(colors)
+        return colors
     }
 
     @computed get autoCenterBinValue(): number {

--- a/packages/@ourworldindata/grapher/src/color/ColorScaleConfig.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScaleConfig.ts
@@ -43,6 +43,8 @@ export class ColorScaleConfigDefaults {
      */
     @observable customNumericLabels: (string | undefined | null)[] = []
 
+    @observable customNumericCenterValue?: number
+
     /** Whether `customNumericColors` are used to override the color scheme. */
     @observable customNumericColorsActive?: boolean = undefined
     /**

--- a/packages/@ourworldindata/grapher/src/color/ColorScheme.test.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScheme.test.ts
@@ -1,0 +1,74 @@
+#! /usr/bin/env jest
+
+import { ColorSchemeName } from "./ColorConstants"
+import { ColorScheme } from "./ColorScheme"
+import { ColorSchemes } from "./ColorSchemes"
+
+describe("continous color scheme", () => {
+    const Blues = ColorSchemes[ColorSchemeName.Blues]
+    const colorSet6 = Blues.colorSets[6]
+
+    const colorSets = []
+    colorSets[6] = colorSet6
+
+    const colorScheme = new ColorScheme(
+        Blues.name + "-6",
+        colorSets,
+        Blues.singleColorScale,
+        Blues.isDistinct,
+        Blues.isDiverging
+    )
+
+    it("can generate more colors", () => {
+        expect(colorScheme.getColors(8)).toEqual([
+            colorSet6[0],
+            colorSet6[1],
+            colorSet6[2],
+            colorSet6[3],
+            "rgb(78, 152, 202)",
+            colorSet6[4],
+            "rgb(29, 106, 173)",
+            colorSet6[5],
+        ])
+    })
+
+    it("can generate less colors", () => {
+        expect(colorScheme.getColors(4)).toEqual([
+            "rgb(239, 243, 255)", // light blue
+            "rgb(198, 219, 239)",
+            "rgb(158, 202, 225)",
+            "rgb(107, 174, 214)", // darker blue
+        ])
+    })
+})
+
+describe("diverging color scheme", () => {
+    const RbBu = ColorSchemes[ColorSchemeName.RdBu]
+    const colorSet6 = RbBu.colorSets[6]
+
+    const colorSets = []
+    colorSets[6] = colorSet6
+
+    const colorScheme = new ColorScheme(
+        RbBu.name + "-6",
+        colorSets,
+        RbBu.singleColorScale,
+        RbBu.isDistinct,
+        RbBu.isDiverging
+    )
+
+    it("can generate more colors while maintaining a balance between the two colors of diverging schemes", () => {
+        expect(colorScheme.getGradientColors(8, { balanced: true })).toEqual(
+            [
+                colorSet6[0],
+                "rgb(209, 81, 71)",
+                colorSet6[1],
+                colorSet6[2],
+                colorSet6[3],
+                colorSet6[4],
+                "rgb(68, 136, 190)",
+                colorSet6[5],
+            ]
+        )
+    })
+})

--- a/packages/@ourworldindata/grapher/src/color/ColorScheme.test.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScheme.test.ts
@@ -58,17 +58,15 @@ describe("diverging color scheme", () => {
     )
 
     it("can generate more colors while maintaining a balance between the two colors of diverging schemes", () => {
-        expect(colorScheme.getGradientColors(8, { balanced: true })).toEqual(
-            [
-                colorSet6[0],
-                "rgb(209, 81, 71)",
-                colorSet6[1],
-                colorSet6[2],
-                colorSet6[3],
-                colorSet6[4],
-                "rgb(68, 136, 190)",
-                colorSet6[5],
-            ]
-        )
+        expect(colorScheme.getGradientColors(8, { balanced: true })).toEqual([
+            colorSet6[0],
+            "rgb(209, 81, 71)",
+            colorSet6[1],
+            colorSet6[2],
+            colorSet6[3],
+            colorSet6[4],
+            "rgb(68, 136, 190)",
+            colorSet6[5],
+        ])
     })
 })

--- a/packages/@ourworldindata/grapher/src/color/ColorScheme.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScheme.ts
@@ -68,10 +68,7 @@ export class ColorScheme implements ColorSchemeInterface {
         return newColors
     }
 
-    getGradientColors(
-        numColors: number,
-        { balanced = false } = {}
-    ): Color[] {
+    getGradientColors(numColors: number, { balanced = false } = {}): Color[] {
         const { colorSets } = this
         if (colorSets[numColors]) return clone(colorSets[numColors])
         let colorSetsCopy = clone(colorSets)

--- a/packages/@ourworldindata/grapher/src/color/ColorScheme.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScheme.ts
@@ -32,17 +32,23 @@ export class ColorScheme implements ColorSchemeInterface {
     ): Color[] {
         const newColors = clone(shortColors)
 
-        while (newColors.length < numColors) {
-            for (let index = 0; index < newColors.length - 1; index += 2) {
-                if (insertionMode === "end" || insertionMode === "alternate") {
-                    insertInterpolatedColor(
-                        newColors,
-                        newColors.length - 1 - index
-                    )
+        if (insertionMode === "end") {
+            while (newColors.length < numColors) {
+                for (let index = newColors.length - 1; index > 0; index -= 1) {
+                    insertInterpolatedColor(newColors, index)
                     if (newColors.length >= numColors) break
                 }
-                if (insertionMode === "alternate") {
-                    insertInterpolatedColor(newColors, index + 1)
+            }
+        } else if (insertionMode === "alternate") {
+            while (newColors.length < numColors) {
+                const originalLength = newColors.length
+                for (let index = 1; index < originalLength; index += 2) {
+                    // insert at the end
+                    insertInterpolatedColor(newColors, newColors.length - index)
+                    if (newColors.length >= numColors) break
+
+                    // insert at the beginning
+                    insertInterpolatedColor(newColors, index)
                     if (newColors.length >= numColors) break
                 }
             }

--- a/packages/@ourworldindata/grapher/src/color/ColorScheme.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScheme.ts
@@ -70,18 +70,17 @@ export class ColorScheme implements ColorSchemeInterface {
 
     getGradientColors(
         numColors: number,
-        { excludeMiddleColorForDivergingSchemes = false } = {}
+        { balanced = false } = {}
     ): Color[] {
-        const { colorSets, isDiverging } = this
-
+        const { colorSets } = this
         if (colorSets[numColors]) return clone(colorSets[numColors])
-
         let colorSetsCopy = clone(colorSets)
-        // for diverging color schemes, the color sets with an odd number of colors
+
+        // for diverging color schemes, color sets with an odd number of colors
         // include a middle color (e.g. white in the case of the Red-Blue scheme) while
-        // the color sets with an even number of colors do not. to ensure that the middle
-        // color is not included, we improvise from a set with an even number of colors
-        if (isDiverging && excludeMiddleColorForDivergingSchemes) {
+        // color sets with an even number of colors do not. improvising from a set with
+        // an even number of colors ensures that the middle color is not included
+        if (balanced) {
             colorSetsCopy = colorSetsCopy.filter(
                 (set) => set && set.length % 2 === 0
             )
@@ -90,17 +89,13 @@ export class ColorScheme implements ColorSchemeInterface {
         const prevColors = colorSetsCopy
             .reverse()
             .find((set) => set && set.length < numColors)
-        if (prevColors) {
-            const insertionMode =
-                isDiverging && excludeMiddleColorForDivergingSchemes
-                    ? "alternate"
-                    : "end"
+        if (prevColors)
             return this.improviseGradientFromShorter(
                 prevColors,
                 numColors,
-                insertionMode
+                balanced ? "alternate" : "end"
             )
-        } else
+        else
             return this.improviseGradientFromLonger(
                 colorSets.find((set) => !!set) as Color[],
                 numColors

--- a/packages/@ourworldindata/grapher/src/color/ColorSchemes.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorSchemes.ts
@@ -102,7 +102,8 @@ const initAllSchemes = (): { [key in ColorSchemeName]: ColorScheme } => {
             scheme.displayName ?? scheme.name,
             scheme.colorSets,
             scheme.singleColorScale,
-            scheme.isDistinct
+            scheme.isDistinct,
+            scheme.isDiverging
         )
     })
     return colorSchemes as { [key in ColorSchemeName]: ColorScheme }

--- a/packages/@ourworldindata/grapher/src/color/ColorUtils.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorUtils.ts
@@ -77,3 +77,10 @@ export function darkenColorForText(colorHex: Color): Color {
 export function darkenColorForHighContrastText(colorHex: Color): Color {
     return darkenColorToTargetYiq(colorHex, 105)
 }
+
+export function insertInterpolatedColor(colors: Color[], index: number): void {
+    const startColor = rgb(colors[index - 1])
+    const endColor = rgb(colors[index])
+    const newColor = interpolate(startColor, endColor)(0.5)
+    colors.splice(index, 0, newColor)
+}


### PR DESCRIPTION
resolves #2166 (not urgent)

### Summary

Adds a new field to the admin that allows authors to specify a center value when using a diverging color scale for map brackets.

### Details

- The new field is only displayed when the binning strategy is "Equal-Interval" and the selected color scheme is a diverging color scheme
- Specifying a custom center value triggers the following chain of events:
    - Buckets are constructed in such a way that the center value is at the edge of a bucket (i.e. the center value is always displayed as a label)
    - The number of bins is forced to be even – this is  due to a technical constraint
    - Colors are assigned in such a way that all colors to the left of the center value have one hue and all colors to the right of the center value have a different hue (e.g. all bins to the left of the center value are blue-ish, all colors to the right are red-ish)

---

Not sure the solution I have come up with is the best we can do – let me know if you want to have a chat about it @marcelgerber 