### PR TITLE
:hammer: fix fields in grapher configs that should not exist

### DIFF
--- a/db/migration/1686644029475-ChartsFixSchemaViolations.ts
+++ b/db/migration/1686644029475-ChartsFixSchemaViolations.ts
@@ -54,6 +54,15 @@ export class ChartsFixSchemaViolations1686644029475
             delete chart.config.bakedGrapherURL
             delete chart.config.adminBaseUrl
 
+            // drop null values in selectedEntityNames array
+            if (chart.config.selectedEntityNames) {
+                chart.config.selectedEntityNames =
+                    chart.config.selectedEntityNames.filter(
+                        (name: string) => name !== null
+                    )
+            }
+
+
             // If the chart has changed then add it to the list of charts to return
             const serializedChart = {
                 id: chart.id,
@@ -101,5 +110,7 @@ export class ChartsFixSchemaViolations1686644029475
         }
     }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {}
+    public async down(_queryRunner: QueryRunner): Promise<void> {
+        return // es-lint complains on empty async functions
+    }
 }

--- a/db/migration/1686644029475-ChartsFixSchemaViolations.ts
+++ b/db/migration/1686644029475-ChartsFixSchemaViolations.ts
@@ -62,6 +62,9 @@ export class ChartsFixSchemaViolations1686644029475
                     )
             }
 
+            // at the top level, drop details if it exists (legacy Details on Demand before we had global ones)
+            delete chart.config.details
+
 
             // If the chart has changed then add it to the list of charts to return
             const serializedChart = {

--- a/db/migration/1686644029475-ChartsFixSchemaViolations.ts
+++ b/db/migration/1686644029475-ChartsFixSchemaViolations.ts
@@ -1,0 +1,105 @@
+import { cloneDeep } from "lodash"
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class ChartsFixSchemaViolations1686644029475
+    implements MigrationInterface
+{
+    private fixConfigs(
+        charts: { id: number; config: Record<string, any> }[]
+    ): { id: number; config: string }[] {
+        const fixedCharts: { id: number; config: string }[] = []
+        for (const oldChart of charts) {
+            const chart = cloneDeep(oldChart)
+            // Make sure that every chart in the db has an id field in the config
+            if (!chart.config.id) {
+                chart.config.id = chart.id
+            }
+
+            // In the dimensions array, remove all fields "id", "chartId", "order")
+            // and drop display->shortUnit if it is null and targetYear if it is null
+            if (chart.config.dimensions) {
+                for (const dimension of chart.config.dimensions) {
+                    delete dimension.id
+                    delete dimension.chartId
+                    delete dimension.order
+
+                    if (dimension.display) {
+                        if (dimension.display.shortUnit === null) {
+                            delete dimension.display.shortUnit
+                        }
+                    }
+                    if (dimension.targetYear === null) {
+                        delete dimension.targetYear
+                    }
+                }
+            }
+            // In map, remove "columnSlug"
+            if (chart.config.map) {
+                delete chart.config.map.columnSlug
+                // Drop field if map.time is null
+                if (chart.config.map.time === null) {
+                    delete chart.config.map.time
+                }
+            }
+
+            // Drop null values in these fields: maxTime, timelineMaxTime
+            if (chart.config.maxTime === null) {
+                delete chart.config.maxTime
+            }
+            if (chart.config.timelineMaxTime === null) {
+                delete chart.config.timelineMaxTime
+            }
+
+            // at the top level drop bakedGrapherURL, adminBaseUrl
+            delete chart.config.bakedGrapherURL
+            delete chart.config.adminBaseUrl
+
+            // If the chart has changed then add it to the list of charts to return
+            const serializedChart = {
+                id: chart.id,
+                config: JSON.stringify(chart.config),
+            }
+            if (serializedChart.config !== JSON.stringify(oldChart.config)) {
+                fixedCharts.push(serializedChart)
+            }
+        }
+        return fixedCharts
+    }
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const tables = {
+            suggested_chart_revisions: "suggestedConfig",
+            chart_revisions: "config",
+            charts: "config",
+        }
+
+        for (const [tableName, columnName] of Object.entries(tables)) {
+            const chartsPrimitive: { id: number; config: string }[] =
+                await queryRunner.query(
+                    `select id, ${columnName} as config from ${tableName}`
+                )
+            const charts: { id: number; config: Record<string, any> }[] =
+                chartsPrimitive.map((chart) => ({
+                    id: chart.id,
+                    config: JSON.parse(chart.config),
+                }))
+
+            const fixedCharts = this.fixConfigs(charts)
+            // update the charts
+            for (const chart of fixedCharts) {
+                await queryRunner.query(
+                    `update ${tableName} set ${columnName} = ? where id = ?`,
+                    [chart.config, chart.id]
+                )
+            }
+            console.log(`Updated ${fixedCharts.length} charts in ${tableName}`)
+
+            // now update all json configs to include a new field $schema with the current schema url https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            await queryRunner.query(
+                `update ${tableName} set ${columnName} = JSON_SET(${columnName}, "$.$schema", "https://files.ourworldindata.org/schemas/grapher-schema.003.json")`
+            )
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/db/migration/1686644029475-ChartsFixSchemaViolations.ts
+++ b/db/migration/1686644029475-ChartsFixSchemaViolations.ts
@@ -65,7 +65,6 @@ export class ChartsFixSchemaViolations1686644029475
             // at the top level, drop details if it exists (legacy Details on Demand before we had global ones)
             delete chart.config.details
 
-
             // If the chart has changed then add it to the list of charts to return
             const serializedChart = {
                 id: chart.id,

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
@@ -675,35 +675,4 @@ properties:
         default: false
         description: Legacy flag, should be removed
         $comment: Remove this flag once the codepaths that use it are deleted
-    details:
-        type: object
-        description: |
-            A list of definitions for the details on demand feature that shows on-hover explanations for terms used
-            in subtitles and footnotes. Entries here have a hierarchy of category > term > detail information.
-            The syntax to use details on demand is similar to markdown links as follows:
-            [visible text](hover::category::subcategory)
-        patternProperties:
-            "^\\w+$":
-                type: object
-                description: Detail on Demand category
-                patternProperties:
-                    "^\\w+$":
-                        type: object
-                        description: Detail on Demand data
-                        properties:
-                            id:
-                                type: number
-                                description: The id of the Detail on Demand in our database
-                            category:
-                                type: string
-                                description: The category of the Detail on Demand (same as the object key 2 levels higher up)
-                            term:
-                                type: string
-                                description: The term identifier of the Detail on Demand (same as the object key 1 level higher up)
-                            title:
-                                type: string
-                                description: Human readable title for the Detail on Demand term
-                            content:
-                                type: string
-                                description: Content to be shown in the on-hover box. This can use a limited subset of markdown including bold, italic and links
 additionalProperties: false

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
@@ -282,7 +282,6 @@ properties:
         items:
             type:
                 - string
-                - "null"
     baseColorScheme:
         type: string
         default: default


### PR DESCRIPTION
Because we don't have continuous schema checking, we accumulated a few violations to our current schema. This migration fixes the open issues that exist at the moment - they are all nonsensical fields or null values in places where they shouldn't exist.