### PR TITLE
datapages: "reuse our work" block

### DIFF
--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1370,6 +1370,8 @@ export const DataPageJsonTypeObject = Type.Object(
                 sourceRetrievedFromUrl: Type.Optional(Type.String()),
             })
         ),
+        citationData: Type.Optional(Type.String()),
+        citationDatapage: Type.Optional(Type.String()),
     },
     // We are not allowing to have any additional properties in the JSON file,
     // in part because the JSON is added as-is to the page source for hydration,

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -141,11 +141,12 @@
             @include owid-link-90;
             color: inherit;
         }
-        > div:last-child {
-            white-space: nowrap;
-            text-overflow: ellipsis;
-            overflow: hidden;
-        }
+    }
+
+    .key-data--hide-overflow div:last-child {
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
     }
 
     .key-data__title {

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -340,7 +340,8 @@
     }
 
     .data-sources__heading,
-    .data-processing__heading {
+    .data-processing__heading,
+    .citations__heading {
         @include h3-bold;
         margin: 0 0 24px;
     }
@@ -349,11 +350,14 @@
         margin-top: 32px;
     }
 
-    .data-processing__content {
+    .data-processing__content,
+    .reuse__content {
         margin-bottom: 24px;
     }
 
-    .data-processing__paragraph {
+    .data-processing__paragraph,
+    .reuse__paragraph,
+    .citation__paragraph {
         @include body-3-medium;
         margin: 0 0 16px;
     }
@@ -370,7 +374,8 @@
         padding: 24px;
     }
 
-    .variable-processing-info__header {
+    .variable-processing-info__header,
+    .citation__how-to-header {
         @include overline-black-caps;
         text-transform: uppercase;
         margin: 0 0 8px;
@@ -388,6 +393,33 @@
 
         > *:last-child {
             margin-bottom: 0;
+        }
+    }
+
+    .reuse__title {
+        @include datapage-section-title;
+    }
+
+    .reuse__content,
+    .citation__paragraph {
+        color: $blue-60;
+    }
+
+    .reuse__link {
+        @include owid-link-60;
+    }
+
+    .citations {
+        margin-top: 16px;
+    }
+
+    .citations-section {
+        &:first-child {
+            margin-bottom: 32px;
+        }
+        &:not(:first-child) {
+            padding-top: 32px;
+            border-top: 1px solid $blue-20;
         }
     }
 }

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -616,58 +616,66 @@ export const DataPageContent = ({
                                         </p>
                                     </div>
                                 </div>
-                                <div className="citations grid span-cols-12">
-                                    <h3 className="citations__heading span-cols-2 span-lg-cols-3 col-md-start-2 span-md-cols-10 col-sm-start-1 span-sm-cols-12">
-                                        Citations
-                                    </h3>
-                                    <div className="col-start-4 span-cols-6 col-lg-start-5 span-lg-cols-7 col-md-start-2 span-md-cols-10 col-sm-start-1 span-sm-cols-12">
-                                        {datapageJson.citationData && (
-                                            <div className="citations-section">
-                                                <h5 className="citation__how-to-header">
-                                                    How to cite this data
-                                                </h5>
-                                                <p className="citation__paragraph">
-                                                    If you are using the data
-                                                    indicator for analysis or
-                                                    for your own visualizations,
-                                                    please cite both the
-                                                    underlying data source(s)
-                                                    and{" "}
-                                                    <em>Our World in Data</em>{" "}
-                                                    using the following
-                                                    citation:
-                                                </p>
-                                                <CodeSnippet
-                                                    code={
-                                                        datapageJson.citationData
-                                                    }
-                                                    theme="light"
-                                                />
-                                            </div>
-                                        )}
-                                        {datapageJson.citationDatapage && (
-                                            <div className="citations-section">
-                                                <h5 className="citation__how-to-header">
-                                                    How to cite this page
-                                                </h5>
-                                                <p className="citation__paragraph">
-                                                    To cite this page overall,
-                                                    including any descriptions
-                                                    of the data authored by{" "}
-                                                    <em>Our World in Data</em>,
-                                                    please use the following
-                                                    citation:
-                                                </p>
-                                                <CodeSnippet
-                                                    code={
-                                                        datapageJson.citationDatapage
-                                                    }
-                                                    theme="light"
-                                                />
-                                            </div>
-                                        )}
+                                {(datapageJson.citationData ||
+                                    datapageJson.citationDatapage) && (
+                                    <div className="citations grid span-cols-12">
+                                        <h3 className="citations__heading span-cols-2 span-lg-cols-3 col-md-start-2 span-md-cols-10 col-sm-start-1 span-sm-cols-12">
+                                            Citations
+                                        </h3>
+                                        <div className="col-start-4 span-cols-6 col-lg-start-5 span-lg-cols-7 col-md-start-2 span-md-cols-10 col-sm-start-1 span-sm-cols-12">
+                                            {datapageJson.citationData && (
+                                                <div className="citations-section">
+                                                    <h5 className="citation__how-to-header">
+                                                        How to cite this data
+                                                    </h5>
+                                                    <p className="citation__paragraph">
+                                                        If you are using the
+                                                        data indicator for
+                                                        analysis or for your own
+                                                        visualizations, please
+                                                        cite both the underlying
+                                                        data source(s) and{" "}
+                                                        <em>
+                                                            Our World in Data
+                                                        </em>{" "}
+                                                        using the following
+                                                        citation:
+                                                    </p>
+                                                    <CodeSnippet
+                                                        code={
+                                                            datapageJson.citationData
+                                                        }
+                                                        theme="light"
+                                                    />
+                                                </div>
+                                            )}
+                                            {datapageJson.citationDatapage && (
+                                                <div className="citations-section">
+                                                    <h5 className="citation__how-to-header">
+                                                        How to cite this page
+                                                    </h5>
+                                                    <p className="citation__paragraph">
+                                                        To cite this page
+                                                        overall, including any
+                                                        descriptions of the data
+                                                        authored by{" "}
+                                                        <em>
+                                                            Our World in Data
+                                                        </em>
+                                                        , please use the
+                                                        following citation:
+                                                    </p>
+                                                    <CodeSnippet
+                                                        code={
+                                                            datapageJson.citationDatapage
+                                                        }
+                                                        theme="light"
+                                                    />
+                                                </div>
+                                            )}
+                                        </div>
                                     </div>
-                                </div>
+                                )}
                             </div>
                         </div>
                     </div>

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -61,7 +61,7 @@ export const DataPageContent = ({
 
     const stickyNavLinks = [
         {
-            text: "Explore the data",
+            text: "Explore the Data",
             target: "#explore-the-data",
         },
         {
@@ -629,12 +629,12 @@ export const DataPageContent = ({
                                                         How to cite this data
                                                     </h5>
                                                     <p className="citation__paragraph">
-                                                        If you are using the
-                                                        data indicator for
-                                                        analysis or for your own
-                                                        visualizations, please
-                                                        cite both the underlying
-                                                        data source(s) and{" "}
+                                                        If you are using this
+                                                        data for analysis or for
+                                                        your own visualizations,
+                                                        please cite both the
+                                                        underlying data
+                                                        source(s) and{" "}
                                                         <em>
                                                             Our World in Data
                                                         </em>{" "}

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -17,6 +17,7 @@ import { AttachmentsContext, DocumentContext } from "./gdocs/OwidGdoc.js"
 import StickyNav from "./blocks/StickyNav.js"
 import cx from "classnames"
 import { DebugProvider } from "./gdocs/DebugContext.js"
+import { CodeSnippet } from "./blocks/CodeSnippet.js"
 
 declare global {
     interface Window {
@@ -620,33 +621,51 @@ export const DataPageContent = ({
                                         Citations
                                     </h3>
                                     <div className="col-start-4 span-cols-6 col-lg-start-5 span-lg-cols-7 col-md-start-2 span-md-cols-10 col-sm-start-1 span-sm-cols-12">
-                                        <div className="citations-section">
-                                            <h5 className="citation__how-to-header">
-                                                How to cite this data
-                                            </h5>
-                                            <p className="citation__paragraph">
-                                                If you are using the data
-                                                indicator for analysis or for
-                                                your own visualizations, please
-                                                cite both the underlying data
-                                                source(s) and{" "}
-                                                <em>Our World in Data</em> using
-                                                the following citation:
-                                            </p>
-                                        </div>
-                                        <div className="citations-section">
-                                            <h5 className="citation__how-to-header">
-                                                How to cite this page
-                                            </h5>
-                                            <p className="citation__paragraph">
-                                                To cite this page overall,
-                                                including any descriptions of
-                                                the data authored by{" "}
-                                                <em>Our World in Data</em>,
-                                                please use the following
-                                                citation:
-                                            </p>
-                                        </div>
+                                        {datapageJson.citationData && (
+                                            <div className="citations-section">
+                                                <h5 className="citation__how-to-header">
+                                                    How to cite this data
+                                                </h5>
+                                                <p className="citation__paragraph">
+                                                    If you are using the data
+                                                    indicator for analysis or
+                                                    for your own visualizations,
+                                                    please cite both the
+                                                    underlying data source(s)
+                                                    and{" "}
+                                                    <em>Our World in Data</em>{" "}
+                                                    using the following
+                                                    citation:
+                                                </p>
+                                                <CodeSnippet
+                                                    code={
+                                                        datapageJson.citationData
+                                                    }
+                                                    theme="light"
+                                                />
+                                            </div>
+                                        )}
+                                        {datapageJson.citationDatapage && (
+                                            <div className="citations-section">
+                                                <h5 className="citation__how-to-header">
+                                                    How to cite this page
+                                                </h5>
+                                                <p className="citation__paragraph">
+                                                    To cite this page overall,
+                                                    including any descriptions
+                                                    of the data authored by{" "}
+                                                    <em>Our World in Data</em>,
+                                                    please use the following
+                                                    citation:
+                                                </p>
+                                                <CodeSnippet
+                                                    code={
+                                                        datapageJson.citationDatapage
+                                                    }
+                                                    theme="light"
+                                                />
+                                            </div>
+                                        )}
                                     </div>
                                 </div>
                             </div>

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -71,6 +71,7 @@ export const DataPageContent = ({
         { text: "All Charts", target: "#all-charts" },
         { text: "FAQs", target: "#faqs" },
         { text: "Sources & Processing", target: "#sources-and-processing" },
+        { text: "Reuse This Work", target: "#reuse-this-work" },
     ]
 
     const hasRelatedDataFeatured = datapageJson.relatedData?.some(
@@ -574,6 +575,80 @@ export const DataPageContent = ({
                                         </div>
                                     </div>
                                 )}
+                            </div>
+                            <div className="section-wrapper grid">
+                                <h2
+                                    className="reuse__title span-cols-2 span-lg-cols-3 col-md-start-2 span-md-cols-10 col-sm-start-1 span-sm-cols-12"
+                                    id="reuse-this-work"
+                                >
+                                    Reuse this work freely
+                                </h2>
+                                <div className="col-start-4 span-cols-6 col-lg-start-5 span-lg-cols-7 col-md-start-2 span-md-cols-10 col-sm-start-1 span-sm-cols-12">
+                                    <div className="reuse__content">
+                                        <p className="reuse__paragraph">
+                                            All visualizations, data, and code
+                                            produced by Our World in Data are
+                                            completely open access under the{" "}
+                                            <a
+                                                href="https://creativecommons.org/licenses/by/4.0/"
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className="reuse__link"
+                                            >
+                                                Creative Commons BY license
+                                            </a>
+                                            . You have the permission to use,
+                                            distribute, and reproduce these in
+                                            any medium, provided the source and
+                                            authors are credited.
+                                        </p>
+                                        <p className="reuse__paragraph">
+                                            Our work would not be possible
+                                            without the original data providers
+                                            we rely on, so we ask you to always
+                                            cite them appropriately and to
+                                            respect their license terms. This is
+                                            crucial to allow data providers to
+                                            continue doing their work,
+                                            enhancing, maintaining and updating
+                                            valuable data.
+                                        </p>
+                                    </div>
+                                </div>
+                                <div className="citations grid span-cols-12">
+                                    <h3 className="citations__heading span-cols-2 span-lg-cols-3 col-md-start-2 span-md-cols-10 col-sm-start-1 span-sm-cols-12">
+                                        Citations
+                                    </h3>
+                                    <div className="col-start-4 span-cols-6 col-lg-start-5 span-lg-cols-7 col-md-start-2 span-md-cols-10 col-sm-start-1 span-sm-cols-12">
+                                        <div className="citations-section">
+                                            <h5 className="citation__how-to-header">
+                                                How to cite this data
+                                            </h5>
+                                            <p className="citation__paragraph">
+                                                If you are using the data
+                                                indicator for analysis or for
+                                                your own visualizations, please
+                                                cite both the underlying data
+                                                source(s) and{" "}
+                                                <em>Our World in Data</em> using
+                                                the following citation:
+                                            </p>
+                                        </div>
+                                        <div className="citations-section">
+                                            <h5 className="citation__how-to-header">
+                                                How to cite this page
+                                            </h5>
+                                            <p className="citation__paragraph">
+                                                To cite this page overall,
+                                                including any descriptions of
+                                                the data authored by{" "}
+                                                <em>Our World in Data</em>,
+                                                please use the following
+                                                citation:
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -483,7 +483,7 @@ export const DataPageContent = ({
                                                                                         </div>
                                                                                     )}
                                                                                     {source.sourceRetrievedFromUrl && (
-                                                                                        <div className="key-data">
+                                                                                        <div className="key-data key-data--hide-overflow">
                                                                                             <div className="key-data__title--dark">
                                                                                                 Retrieved
                                                                                                 from

--- a/site/blocks/CodeSnippet.tsx
+++ b/site/blocks/CodeSnippet.tsx
@@ -6,7 +6,13 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faCopy } from "@fortawesome/free-solid-svg-icons"
 import { canWriteToClipboard } from "@ourworldindata/utils"
 
-export const CodeSnippet = (props: { code: string }) => {
+export const CodeSnippet = ({
+    code,
+    theme = "dark",
+}: {
+    code: string
+    theme?: "dark" | "light"
+}) => {
     const [canCopy, setCanCopy] = useState(false)
     const [hasCopied, setHasCopied] = useState(false)
 
@@ -16,7 +22,7 @@ export const CodeSnippet = (props: { code: string }) => {
 
     const copy = async () => {
         try {
-            await navigator.clipboard.writeText(props.code)
+            await navigator.clipboard.writeText(code)
             setHasCopied(true)
             // reset CSS animation
             setTimeout(() => setHasCopied(false), 10)
@@ -29,9 +35,9 @@ export const CodeSnippet = (props: { code: string }) => {
     }
 
     return (
-        <div className="wp-code-snippet">
+        <div className={`wp-code-snippet wp-code-snippet--${theme}`}>
             <pre className="wp-block-code">
-                <code>{props.code}</code>
+                <code>{code}</code>
             </pre>
             {canCopy && (
                 <button

--- a/site/blocks/code-snippet.scss
+++ b/site/blocks/code-snippet.scss
@@ -1,6 +1,7 @@
 .wp-code-snippet {
     position: relative;
     margin-bottom: 32px;
+    font-size: 12px;
 
     pre {
         background-color: $gray-10;
@@ -50,5 +51,11 @@
             opacity: 1;
             transition: none;
         }
+    }
+}
+
+.wp-code-snippet--light {
+    pre {
+        background-color: $white;
     }
 }


### PR DESCRIPTION
![Screenshot 2023-06-15 at 09.37.15.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0SFFiIjKuUK6UPYHVe6u/adc66f64-bc56-4c2e-a0fc-1dcdcedbcd95/Screenshot%202023-06-15%20at%2009.37.15.png)

<!--
copilot:summary
-->
### <samp>🤖 Inspired by Copilot at 78d6d34</samp>

This pull request adds a new feature to the data page that shows how to reuse and cite the data and data page. It updated the `CodeSnippet` component to supports different themes and styles. It also updates the `DataPageJsonTypeObject` type to include citation fields. It modifies the files `site/blocks/code-snippet.scss`, `site/blocks/CodeSnippet.tsx`, `site/DataPageContent.scss`, `site/DataPageContent.tsx`, and `packages/@ourworldindata/utils/src/owidTypes.ts`.
- [x] is the branch up-to-date with master?
- [x] what problem is being solved here?
- [x] what solution has been chosen?
Reuse the `CodeSnippet` component, by adding a "light" theme.
- [x] are there other solutions?
- [x] is the scope clear, well-defined and small?
Add the last data page section: "Reuse this work freely"
- [x] could a flow chart / sequence diagram / architecture diagram help?
- [x] what is the happy path?
  - go to http://staging-site-datapages/admin/grapher/banana-production
  - scroll down to the bottom of the page
- [x] could the code be easier to read and understand?
- [x] can I help increase our confidence in the implementation by contributing tests?
- [x] should some errors be made more prominent?
- [x] what is missing, what should have been added / done / changed but hasn't?
  - [x] sticky nav link