### PR TITLE
Improve chart title

### DIFF
--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -113,4 +113,29 @@ export class EditorFeatures {
                 this.grapher.isLineChart)
         )
     }
+
+    @computed get showChangeInPrefixToggle() {
+        return (
+            this.grapher.isLineChart &&
+            (this.grapher.isRelativeMode || this.grapher.canToggleRelativeMode)
+        )
+    }
+
+    @computed get showEntityAnnotationInTitleToggle() {
+        return (
+            !this.grapher.canChangeEntity &&
+            !this.grapher.canSelectMultipleEntities
+        )
+    }
+
+    @computed get showTimeAnnotationInTitleToggle() {
+        return (
+            !this.grapher.hasTimeline ||
+            !(
+                this.grapher.isDiscreteBar ||
+                this.grapher.isStackedDiscreteBar ||
+                this.grapher.isMarimekko
+            )
+        )
+    }
 }

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -88,6 +88,15 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
         return errorMessages
     }
 
+    @computed get showAnyAnnotationFieldInTitleToggle() {
+        const { features } = this.props.editor
+        return (
+            features.showEntityAnnotationInTitleToggle ||
+            features.showTimeAnnotationInTitleToggle ||
+            features.showChangeInPrefixToggle
+        )
+    }
+
     render() {
         const { grapher, references, features } = this.props.editor
         const { relatedQuestions } = grapher
@@ -104,9 +113,6 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                     {features.showEntityAnnotationInTitleToggle && (
                         <Toggle
                             label="Hide automatic entity"
-                            secondaryLabel={
-                                "Toggling to hide the entity only has an effect if there is an entity to be hidden."
-                            }
                             value={
                                 !!grapher.hideAnnotationFieldsInTitle?.entity
                             }
@@ -119,7 +125,7 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                             secondaryLabel={
                                 "Grapher ignores this toggle if hiding the time would cause " +
                                 "crucial information to be missing from the chart title. " +
-                                "This is the case for multi-year maps, discrete bar charts, and " +
+                                "This is the case for maps, discrete bar charts, and " +
                                 "Marimekko charts."
                             }
                             value={!!grapher.hideAnnotationFieldsInTitle?.time}
@@ -136,9 +142,7 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                             onValue={this.onToggleTitleAnnotationChangeInPrefix}
                         />
                     )}
-                    {(features.showEntityAnnotationInTitleToggle ||
-                        features.showTimeAnnotationInTitleToggle ||
-                        features.showChangeInPrefixToggle) && <hr />}
+                    {this.showAnyAnnotationFieldInTitleToggle && <hr />}
                     <AutoTextField
                         label="/grapher"
                         value={grapher.displaySlug}

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -88,16 +88,8 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
         return errorMessages
     }
 
-    @computed get showChangeInPrefixToggle() {
-        const { grapher } = this.props.editor
-        return (
-            grapher.isLineChart &&
-            (grapher.isRelativeMode || grapher.canToggleRelativeMode)
-        )
-    }
-
     render() {
-        const { grapher, references } = this.props.editor
+        const { grapher, references, features } = this.props.editor
         const { relatedQuestions } = grapher
 
         return (
@@ -109,17 +101,32 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                         auto={grapher.displayTitle}
                         softCharacterLimit={100}
                     />
-                    <Toggle
-                        label="Hide automatic entity (where possible)"
-                        value={!!grapher.hideAnnotationFieldsInTitle?.entity}
-                        onValue={this.onToggleTitleAnnotationEntity}
-                    />
-                    <Toggle
-                        label="Hide automatic time (where possible)"
-                        value={!!grapher.hideAnnotationFieldsInTitle?.time}
-                        onValue={this.onToggleTitleAnnotationTime}
-                    />
-                    {this.showChangeInPrefixToggle && (
+                    {features.showEntityAnnotationInTitleToggle && (
+                        <Toggle
+                            label="Hide automatic entity"
+                            secondaryLabel={
+                                "Toggling to hide the entity only has an effect if there is an entity to be hidden."
+                            }
+                            value={
+                                !!grapher.hideAnnotationFieldsInTitle?.entity
+                            }
+                            onValue={this.onToggleTitleAnnotationEntity}
+                        />
+                    )}
+                    {features.showTimeAnnotationInTitleToggle && (
+                        <Toggle
+                            label="Hide automatic time"
+                            secondaryLabel={
+                                "Grapher ignores this toggle if hiding the time would cause " +
+                                "crucial information to be missing from the chart title. " +
+                                "This is the case for multi-year maps, discrete bar charts, and " +
+                                "Marimekko charts."
+                            }
+                            value={!!grapher.hideAnnotationFieldsInTitle?.time}
+                            onValue={this.onToggleTitleAnnotationTime}
+                        />
+                    )}
+                    {features.showChangeInPrefixToggle && (
                         <Toggle
                             label="Don't prepend 'Change in' in relative line charts"
                             value={
@@ -129,7 +136,9 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                             onValue={this.onToggleTitleAnnotationChangeInPrefix}
                         />
                     )}
-                    <hr />
+                    {(features.showEntityAnnotationInTitleToggle ||
+                        features.showTimeAnnotationInTitleToggle ||
+                        features.showChangeInPrefixToggle) && <hr />}
                     <AutoTextField
                         label="/grapher"
                         value={grapher.displaySlug}

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -123,10 +123,9 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                         <Toggle
                             label="Hide automatic time"
                             secondaryLabel={
-                                "Grapher ignores this toggle if hiding the time would cause " +
-                                "crucial information to be missing from the chart title. " +
-                                "This is the case for maps, discrete bar charts, and " +
-                                "Marimekko charts."
+                                "Grapher makes sure to include the current time in the title if " +
+                                "omitting it would lead to SVG exports with no reference " +
+                                "to the time. In such cases, your preference is ignored."
                             }
                             value={!!grapher.hideAnnotationFieldsInTitle?.time}
                             onValue={this.onToggleTitleAnnotationTime}

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -477,6 +477,7 @@ interface ToggleProps {
     onValue: (value: boolean) => void
     disabled?: boolean
     title?: string
+    secondaryLabel?: string
 }
 
 export class Toggle extends React.Component<ToggleProps> {
@@ -499,6 +500,16 @@ export class Toggle extends React.Component<ToggleProps> {
                         {...passthroughProps}
                     />
                     {props.label}
+                    {props.secondaryLabel && (
+                        <>
+                            {" "}
+                            <FontAwesomeIcon
+                                icon={faCircleInfo}
+                                className="text-muted"
+                                title={props.secondaryLabel}
+                            />
+                        </>
+                    )}
                 </label>
             </div>
         )

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1228,7 +1228,11 @@ export class Grapher
             this.isReady &&
             (showTimeAnnotation ||
                 (this.hasTimeline &&
+                    // chart types that refer to the current time only in the timeline
                     (this.isLineChartThatTurnedIntoDiscreteBar ||
+                        this.isDiscreteBar ||
+                        this.isStackedDiscreteBar ||
+                        this.isMarimekko ||
                         this.isOnMapTab)))
         )
             text += this.timeTitleSuffix


### PR DESCRIPTION
resolves #2320 (not urgent)

Collection of small improvements around the annotation fields in chart titles:

- Add DiscreteBar, StackedDiscreteBar, and Marimekko charts to the list of chart types where hiding time is not allowed
    - These chart types only refer to the current time in the timeline (for SVG exports without controls, the current time would be missing if not mentioned in the title)
- Hide the "Hide automatic time" and "Hide automatic entity" toggles in cases where Grapher ignores their state
- Add help text to better explain the behaviour

----

The SVG tester fails four charts that I think should in fact all mention the time in the title.