### PR TITLE
Topic page fixes

### DIFF
--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -1144,5 +1144,5 @@ export class Button extends React.Component<{
 }
 
 export const Help = ({ children }: { children: React.ReactNode }) => (
-    <small className="form-text text-muted">{children}</small>
+    <small className="form-text text-muted mb-4">{children}</small>
 )

--- a/adminSiteClient/GdocsIndexPage.tsx
+++ b/adminSiteClient/GdocsIndexPage.tsx
@@ -227,7 +227,7 @@ export class GdocsIndexPage extends React.Component<GdocsMatchProps> {
                                         className="gdoc-index-item__title"
                                         title="Preview article"
                                     >
-                                        {gdoc.content.title}
+                                        {gdoc.content.title || "Untitled"}
                                     </h5>
                                 </Link>
                                 <GdocsEditLink gdocId={gdoc.id} />

--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -18,6 +18,7 @@ import {
     OwidGdocJSON,
     OwidGdocErrorMessage,
     OwidGdocErrorMessageType,
+    slugify,
 } from "@ourworldindata/utils"
 import { Button, Col, Drawer, Row, Space, Tag, Typography } from "antd"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
@@ -167,9 +168,11 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
         cancelAllRequests()
         // set to today if not specified
         const publishedAt = currentGdoc.publishedAt ?? new Date()
+        const slug = currentGdoc.slug ?? slugify(`${currentGdoc.content.title}`)
         const publishedGdoc = await store.publish({
             ...currentGdoc,
             publishedAt,
+            slug,
         })
         setGdoc({ original: publishedGdoc, current: publishedGdoc })
         openSuccessNotification()

--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -168,7 +168,7 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
         cancelAllRequests()
         // set to today if not specified
         const publishedAt = currentGdoc.publishedAt ?? new Date()
-        const slug = currentGdoc.slug ?? slugify(`${currentGdoc.content.title}`)
+        const slug = currentGdoc.slug || slugify(`${currentGdoc.content.title}`)
         const publishedGdoc = await store.publish({
             ...currentGdoc,
             publishedAt,

--- a/adminSiteClient/GdocsSettingsContentField.tsx
+++ b/adminSiteClient/GdocsSettingsContentField.tsx
@@ -10,12 +10,14 @@ import { GdocsEditLink } from "./GdocsEditLink.js"
 import { GdocsErrorHelp } from "./GdocsErrorHelp.js"
 import { getPropertyMostCriticalError } from "./gdocsValidation.js"
 import { TextAreaProps } from "antd/lib/input/TextArea.js"
+import { Help } from "./Forms.js"
 
 export const GdocsSettingsContentField = ({
     gdoc,
     property,
     render = (props) => <GdocsSettingsTextField {...props} />,
     errors,
+    description,
 }: {
     gdoc: OwidGdocInterface
     property: keyof OwidGdocContent
@@ -29,6 +31,7 @@ export const GdocsSettingsContentField = ({
         errorType?: OwidGdocErrorMessageType
     }) => JSX.Element
     errors?: OwidGdocErrorMessage[]
+    description?: string
 }) => {
     const error = getPropertyMostCriticalError(property, errors)
 
@@ -45,8 +48,8 @@ export const GdocsSettingsContentField = ({
                     errorType: error?.type,
                 })}
             </div>
-
             <GdocsErrorHelp error={error} />
+            {description ? <Help>{description}</Help> : null}
         </div>
     )
 }

--- a/adminSiteClient/GdocsSettingsForm.tsx
+++ b/adminSiteClient/GdocsSettingsForm.tsx
@@ -32,6 +32,7 @@ export const GdocsSettingsForm = ({
                 "details",
                 "body",
                 "refs",
+                "imageMetadata",
             ].includes(property)
         ),
         "type"

--- a/adminSiteClient/GdocsSettingsForm.tsx
+++ b/adminSiteClient/GdocsSettingsForm.tsx
@@ -44,6 +44,20 @@ export const GdocsSettingsForm = ({
                 gdoc={gdoc}
                 errors={errors}
             />
+            <GdocsSettingsContentField
+                property="excerpt"
+                gdoc={gdoc}
+                errors={errors}
+                render={(props) => (
+                    <GdocsSettingsTextArea
+                        {...props}
+                        inputProps={{
+                            showCount: true,
+                            maxLength: ExcerptHandler.maxLength,
+                        }}
+                    />
+                )}
+            />
             <div className="form-group">
                 <GdocsSlug
                     gdoc={gdoc}
@@ -78,21 +92,19 @@ export const GdocsSettingsForm = ({
                     gdoc={gdoc}
                     setCurrentGdoc={setCurrentGdoc}
                 />
+                <GdocsSettingsContentField
+                    property="atom-title"
+                    gdoc={gdoc}
+                    errors={errors}
+                    description="An optional property to override the title of this post in our atom feed, which is used for the newsletter"
+                />
+                <GdocsSettingsContentField
+                    property="atom-excerpt"
+                    gdoc={gdoc}
+                    errors={errors}
+                    description="An optional property to override the excerpt of this post in our atom feed, which is used for the newsletter"
+                />
             </div>
-            <GdocsSettingsContentField
-                property="excerpt"
-                gdoc={gdoc}
-                errors={errors}
-                render={(props) => (
-                    <GdocsSettingsTextArea
-                        {...props}
-                        inputProps={{
-                            showCount: true,
-                            maxLength: ExcerptHandler.maxLength,
-                        }}
-                    />
-                )}
-            />
             <div className="form-group">
                 {errorsToShowInDrawer.error?.length ? (
                     <>

--- a/adminSiteClient/gdocsValidation.ts
+++ b/adminSiteClient/gdocsValidation.ts
@@ -61,6 +61,31 @@ class TitleHandler extends AbstractHandler {
     }
 }
 
+class RSSFieldsHandler extends AbstractHandler {
+    handle(gdoc: OwidGdocInterface, messages: OwidGdocErrorMessage[]) {
+        const rssTitle = gdoc.content["atom-title"]
+        const rssExcerpt = gdoc.content["atom-excerpt"]
+
+        if (rssTitle && typeof rssTitle !== "string") {
+            messages.push({
+                property: "atom-title",
+                message: "atom-title must be a string",
+                type: OwidGdocErrorMessageType.Error,
+            })
+        }
+
+        if (rssExcerpt && typeof rssExcerpt !== "string") {
+            messages.push({
+                property: "atom-excerpt",
+                message: "atom-excerpt must be a string",
+                type: OwidGdocErrorMessageType.Error,
+            })
+        }
+
+        return super.handle(gdoc, messages)
+    }
+}
+
 class SlugHandler extends AbstractHandler {
     handle(gdoc: OwidGdocInterface, messages: OwidGdocErrorMessage[]) {
         const { slug } = gdoc
@@ -183,6 +208,7 @@ export const getErrors = (gdoc: OwidGdocInterface): OwidGdocErrorMessage[] => {
 
     bodyHandler
         .setNext(new TitleHandler())
+        .setNext(new RSSFieldsHandler())
         .setNext(new SlugHandler())
         .setNext(new PublishedAtHandler())
         .setNext(new ExcerptHandler())

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -2765,10 +2765,24 @@ apiRouter.put("/gdocs/:id", async (req, res) => {
 
     if (isEmpty(nextGdocJSON)) {
         const newGdoc = new Gdoc(id)
-        // this will fail if the gdoc already exists, as opposed to a call to
-        // newGdoc.save().
+        // this will fail if the gdoc already exists, as opposed to a call to newGdoc.save()
         await dataSource.getRepository(Gdoc).insert(newGdoc)
-        return newGdoc
+
+        const publishedExplorersBySlug =
+            await explorerAdminServer.getAllPublishedExplorersBySlugCached()
+
+        const initData = await Gdoc.getGdocFromContentSource(
+            id,
+            publishedExplorersBySlug,
+            GdocsContentSource.Gdocs
+        )
+
+        const updated = await dataSource
+            .getRepository(Gdoc)
+            .create(initData)
+            .save()
+
+        return updated
     }
 
     const prevGdoc = await Gdoc.findOneBy({ id })

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -2746,6 +2746,9 @@ apiRouter.get("/gdocs/:id", async (req, res) => {
             publishedExplorersBySlug,
             contentSource
         )
+        if (!gdoc.published) {
+            await dataSource.getRepository(Gdoc).create(gdoc).save()
+        }
         res.set("Cache-Control", "no-store")
         res.send(gdoc)
     } catch (error) {

--- a/db/gdocTests.test.ts
+++ b/db/gdocTests.test.ts
@@ -99,10 +99,15 @@ level: 2
             '<a href="https://ourworldindata.org/grapher/annual-number-of-births-by-world-region">Annual number of births</a>',
             '<a href="https://ourworldindata.org/grapher/fish-catch-gear-type?stackMode=relative&country=~OWID_WRL">Fish catch by gear type</a>',
         ]
-        const archieMLString = `[.additional-charts]
+        // gdocToArchie wraps Google Docs lists with the [.list] tag,
+        // so there, it doesn't need to be explicitly set in the gdoc
+        // But when we're writing this archie for tests, we *do* need to explicitly write the tag
+        const archieMLString = `{.additional-charts}
+[.list]
 * ${links[0]}
 * ${links[1]}
 []
+{}
 `
         const doc = getArchieMLDocWithContent(archieMLString)
         const article = archieToEnriched(doc)
@@ -142,7 +147,9 @@ level: 2
 
         const expectedRawBlock: RawBlockAdditionalCharts = {
             type: "additional-charts",
-            value: links,
+            value: {
+                list: links,
+            },
         }
 
         const serializedRawBlock =

--- a/db/model/Gdoc/Gdoc.ts
+++ b/db/model/Gdoc/Gdoc.ts
@@ -523,13 +523,8 @@ export class Gdoc extends BaseEntity implements OwidGdocInterface {
             .with({ type: "key-insights" }, (node) => {
                 const links: Link[] = []
 
+                // insights content is traversed by traverseEnrichedBlocks
                 node.insights.forEach((insight) => {
-                    insight.content.forEach((block) => {
-                        const insightContentLinks =
-                            this.extractLinksFromNode(block)
-                        if (insightContentLinks)
-                            links.push(...insightContentLinks)
-                    })
                     if (insight.url) {
                         const insightLink = Link.create({
                             linkType: getLinkType(insight.url),
@@ -574,7 +569,7 @@ export class Gdoc extends BaseEntity implements OwidGdocInterface {
             .with(
                 {
                     // no urls directly on any of these components
-                    // their children may contain urls, but they'll be addressed by traverse
+                    // their children may contain urls, but they'll be addressed by traverseEnrichedBlocks
                     type: P.union(
                         "additional-charts",
                         "aside",

--- a/db/model/Gdoc/archieToEnriched.ts
+++ b/db/model/Gdoc/archieToEnriched.ts
@@ -106,11 +106,11 @@ function generateStickyNav(
                 target: `#${ENDNOTES_ID}`,
             },
             {
-                text: "Cite this work",
+                text: "Cite This Work",
                 target: `#${CITATION_ID}`,
             },
             {
-                text: "Reuse this work",
+                text: "Reuse This Work",
                 target: `#${LICENSE_ID}`,
             },
         ]

--- a/db/model/Gdoc/archieToEnriched.ts
+++ b/db/model/Gdoc/archieToEnriched.ts
@@ -20,6 +20,7 @@ import {
     ENDNOTES_ID,
     CITATION_ID,
     LICENSE_ID,
+    RESEARCH_AND_WRITING_ID,
     checkIsPlainObjectWithGuard,
 } from "@ourworldindata/utils"
 import { parseRawBlocksToEnrichedBlocks, parseRefs } from "./rawToEnriched.js"
@@ -45,7 +46,7 @@ function generateStickyNav(
         ["acknowledgements"]: "Acknowledgements",
         ["country-profiles"]: "Country Profiles",
         ["explore"]: "Data Explorer",
-        ["research-writing"]: "Research & Writing",
+        [RESEARCH_AND_WRITING_ID]: "Research & Writing",
         [ALL_CHARTS_ID]: "Charts",
         [CITATION_ID]: "Cite This Work",
         [ENDNOTES_ID]: "Endnotes",
@@ -88,6 +89,12 @@ function generateStickyNav(
                     target: `#${ALL_CHARTS_ID}`,
                 })
             }
+            if (node.type === "research-and-writing") {
+                stickyNavItems.push({
+                    text: headingToIdMap[RESEARCH_AND_WRITING_ID],
+                    target: `#${RESEARCH_AND_WRITING_ID}`,
+                })
+            }
             return node
         })
     )
@@ -95,12 +102,16 @@ function generateStickyNav(
     stickyNavItems.push(
         ...[
             {
+                text: "Endnotes",
+                target: `#${ENDNOTES_ID}`,
+            },
+            {
                 text: "Cite this work",
-                target: "#article-citation",
+                target: `#${CITATION_ID}`,
             },
             {
                 text: "Reuse this work",
-                target: "#article-licence",
+                target: `#${LICENSE_ID}`,
             },
         ]
     )

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -348,7 +348,12 @@ export function enrichedBlockToRawBlock(
                     value: {
                         primary: enrichedLinkToRawLink(b.primary),
                         secondary: enrichedLinkToRawLink(b.secondary),
-                        more: b.more.map(enrichedLinkToRawLink),
+                        more: {
+                            heading: b.more.heading,
+                            articles: b.more.articles.map(
+                                enrichedLinkToRawLink
+                            ),
+                        },
                         rows: b.rows.map(({ heading, articles }) => ({
                             heading: heading,
                             articles: articles.map(enrichedLinkToRawLink),

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -81,10 +81,13 @@ export function enrichedBlockToRawBlock(
                 type: b.type,
                 value: {
                     title: b.title,
-                    text: b.text.map((enrichedTextBlock) => ({
-                        type: "text",
-                        value: spansToHtmlText(enrichedTextBlock.value),
-                    })),
+                    text: b.text.map(
+                        (enriched) =>
+                            enrichedBlockToRawBlock(enriched) as
+                                | RawBlockText
+                                | RawBlockList
+                                | RawBlockHeading
+                    ),
                 },
             })
         )

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -125,9 +125,11 @@ export function enrichedBlockToRawBlock(
                 value: b.items.map((item) => ({
                     narrative: spansToHtmlText(item.narrative.value),
                     chart: item.chart.url,
-                    technical: item.technical.map((t) =>
-                        spansToHtmlText(t.value)
-                    ),
+                    technical: {
+                        list: item.technical.map((t) =>
+                            spansToHtmlText(t.value)
+                        ),
+                    },
                 })),
             })
         )

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -70,7 +70,9 @@ export function enrichedBlockToRawBlock(
             { type: "additional-charts" },
             (b): RawBlockAdditionalCharts => ({
                 type: b.type,
-                value: b.items.map(spansToHtmlText),
+                value: {
+                    list: b.items.map(spansToHtmlText),
+                },
             })
         )
         .with(
@@ -253,13 +255,6 @@ export function enrichedBlockToRawBlock(
             (b): RawBlockMissingData => ({
                 type: b.type,
                 value: b.value,
-            })
-        )
-        .with(
-            { type: "additional-charts" },
-            (b): RawBlockAdditionalCharts => ({
-                type: b.type,
-                value: b.items.map(spansToHtmlText),
             })
         )
         .with(

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -364,29 +364,32 @@ export const enrichedBlockExamples: Record<
                 url: "https://docs.google.com/document/d/abcd",
             },
         },
-        more: [
-            {
-                value: {
-                    url: "https://docs.google.com/document/d/abcd",
+        more: {
+            heading: "More Key Articles on Poverty",
+            articles: [
+                {
+                    value: {
+                        url: "https://docs.google.com/document/d/abcd",
+                    },
                 },
-            },
-            {
-                value: {
-                    url: "https://ourworldindata.org/a-wordpress-article",
-                    title: "A wordpress article",
-                    authors: ["Max Roser"],
-                    filename: "some_image.png",
+                {
+                    value: {
+                        url: "https://ourworldindata.org/a-wordpress-article",
+                        title: "A wordpress article",
+                        authors: ["Max Roser"],
+                        filename: "some_image.png",
+                    },
                 },
-            },
-            {
-                value: {
-                    url: "https://ourworldindata.org/another-wordpress-article",
-                    title: "Another wordpress article",
-                    authors: ["Max Roser"],
-                    filename: "another_image.png",
+                {
+                    value: {
+                        url: "https://ourworldindata.org/another-wordpress-article",
+                        title: "Another wordpress article",
+                        authors: ["Max Roser"],
+                        filename: "another_image.png",
+                    },
                 },
-            },
-        ],
+            ],
+        },
         rows: [
             {
                 heading: "More articles on this topic",

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -116,6 +116,17 @@ export const enrichedBlockExamples: Record<
                 ],
                 parseErrors: [],
             },
+            {
+                type: "list",
+                items: [enrichedBlockText],
+                parseErrors: [],
+            },
+            {
+                type: "heading",
+                level: 1,
+                text: [spanSimpleText],
+                parseErrors: [],
+            },
         ],
         title: "Hey, listen!",
     },

--- a/db/model/Gdoc/gdocUtils.ts
+++ b/db/model/Gdoc/gdocUtils.ts
@@ -142,7 +142,7 @@ export const getAllLinksFromResearchAndWritingBlock = (
     const allLinks = excludeNullish([
         primary,
         secondary,
-        ...more,
+        ...more.articles,
         ...rowArticles,
     ])
     return allLinks

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -126,8 +126,8 @@ function* rawBlockChartStoryToArchieMLString(
             yield* propertyToArchieMLString("narrative", item)
             yield* propertyToArchieMLString("chart", item)
             // TODO: we might need to reverse some regex sanitization here (e.g. colons?)
-            if (item.technical) {
-                yield* listToArchieMLString(item.technical, "technical")
+            if (item.technical?.list) {
+                yield* listToArchieMLString(item.technical.list, "list")
             }
         }
     }
@@ -368,13 +368,11 @@ function* rawBlockMissingDataToArchieMLString(): Generator<
 function* rawBlockAdditionalChartsToArchieMLString(
     block: RawBlockAdditionalCharts
 ): Generator<string, void, undefined> {
-    yield "[.additional-charts]"
+    yield "{.additional-charts}"
     if (block.value.list) {
-        for (const listItem of block.value.list) {
-            yield `* ${listItem}`
-        }
+        listToArchieMLString(block.value.list, "list")
     }
-    yield "[]"
+    yield "{}"
 }
 
 function* RawBlockExpandableParagraphToArchieMLString(

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -369,8 +369,8 @@ function* rawBlockAdditionalChartsToArchieMLString(
     block: RawBlockAdditionalCharts
 ): Generator<string, void, undefined> {
     yield "[.additional-charts]"
-    if (typeof block.value !== "string") {
-        for (const listItem of block.value) {
+    if (block.value.list) {
+        for (const listItem of block.value.list) {
             yield `* ${listItem}`
         }
     }

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -479,11 +479,16 @@ function* rawResearchAndWritingToArchieMLString(
         yield "{}"
     }
     if (more) {
-        yield "[.more]"
-        for (const link of more) {
-            yield* rawLinkToArchie(link)
+        yield "{.more}"
+        yield* propertyToArchieMLString("heading", more)
+        if (more.articles) {
+            yield "[.articles]"
+            for (const link of more.articles) {
+                yield* rawLinkToArchie(link)
+            }
+            yield "[]"
         }
-        yield "[]"
+        yield "{}"
     }
     if (rows) {
         yield "[.rows]"

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -142,8 +142,8 @@ function* rawBlockCalloutToArchieMLString(
     if (typeof block.value !== "string") {
         yield* propertyToArchieMLString("title", block.value)
         yield "[.+text]"
-        for (const rawBlockText of block.value.text) {
-            yield rawBlockText.value
+        for (const rawBlock of block.value.text) {
+            yield* OwidRawGdocBlockToArchieMLStringGenerator(rawBlock)
         }
         yield "[]"
     }

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -125,10 +125,11 @@ function* rawBlockChartStoryToArchieMLString(
         for (const item of block.value) {
             yield* propertyToArchieMLString("narrative", item)
             yield* propertyToArchieMLString("chart", item)
-            // TODO: we might need to reverse some regex sanitization here (e.g. colons?)
+            yield "{.technical}"
             if (item.technical?.list) {
                 yield* listToArchieMLString(item.technical.list, "list")
             }
+            yield "{}"
         }
     }
     yield "[]"
@@ -370,7 +371,7 @@ function* rawBlockAdditionalChartsToArchieMLString(
 ): Generator<string, void, undefined> {
     yield "{.additional-charts}"
     if (block.value.list) {
-        listToArchieMLString(block.value.list, "list")
+        yield* listToArchieMLString(block.value.list, "list")
     }
     yield "{}"
 }

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -1401,8 +1401,10 @@ export function parseRefs({
                         `A ref with ID "${ref.id}" has been defined but isn't used in this document`
                     )
                 }
-                if (!isArray(ref.content)) {
-                    pushRefError(`Ref with ID ${ref.id} has no content`)
+                if (!isArray(ref.content) || !ref.content.length) {
+                    pushRefError(
+                        `Ref with ID ${ref.id} has no content. Make sure the ID is defined and it has a [.+content] block`
+                    )
                 } else {
                     ref.content.forEach((block: OwidRawGdocBlock) => {
                         match(block)

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -461,8 +461,8 @@ const parseChartStory = (raw: RawBlockChartStory): EnrichedBlockChartStory => {
             return {
                 narrative: htmlToEnrichedTextBlock(item.narrative),
                 chart: { type: "chart", url: chart, parseErrors: [] },
-                technical: item.technical
-                    ? item.technical.map(htmlToEnrichedTextBlock)
+                technical: item.technical?.list
+                    ? item.technical.list.map(htmlToEnrichedTextBlock)
                     : [],
             }
         }

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -220,10 +220,19 @@ function parseAdditionalCharts(
         parseErrors: [error],
     })
 
-    if (!isArray(raw.value))
-        return createError({ message: "Value is not a list" })
+    if (!isArray(raw.value.list))
+        return createError({ message: "Block does not contain a list" })
 
-    const items = raw.value.map(htmlToSpans)
+    for (const item of raw.value.list) {
+        if (typeof item !== "string")
+            return createError({
+                message: `Item in list with value "${JSON.stringify(
+                    item
+                )}" isn't a plain string.`,
+            })
+    }
+
+    const items = raw.value.list.map(htmlToSpans)
 
     return {
         type: "additional-charts",

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -88,6 +88,7 @@ import {
     EnrichedBlockAllCharts,
     RefDictionary,
     OwidGdocErrorMessageType,
+    excludeNullish,
 } from "@ourworldindata/utils"
 import {
     extractUrl,
@@ -977,12 +978,23 @@ function parseCallout(raw: RawBlockCallout): EnrichedBlockCallout {
                 "Text must be provided as an array e.g. inside a [.+text] block",
         })
     }
-    const enrichedTextBlocks = raw.value.text.map(parseText)
+    for (const block of raw.value.text) {
+        if (!["text", "list", "heading"].includes(block.type)) {
+            return createError({
+                message:
+                    "Callout blocks can only contain text, lists, and headings",
+            })
+        }
+    }
+
+    const enrichedTextBlocks = raw.value.text.map(
+        parseRawBlocksToEnrichedBlocks
+    ) as (EnrichedBlockText | EnrichedBlockList | EnrichedBlockHeading | null)[]
 
     return {
         type: "callout",
         parseErrors: [],
-        text: enrichedTextBlocks,
+        text: excludeNullish(enrichedTextBlocks),
         title: raw.value.title,
     }
 }

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -220,6 +220,11 @@ function parseAdditionalCharts(
         parseErrors: [error],
     })
 
+    if (isArray(raw.value))
+        return createError({
+            message: `additional-charts block is using an array tag (e.g. [.additional-charts]). Please update it to use curly braces (e.g. {.additional-charts})`,
+        })
+
     if (!isArray(raw.value.list))
         return createError({ message: "Block does not contain a list" })
 
@@ -457,6 +462,10 @@ const parseChartStory = (raw: RawBlockChartStory): EnrichedBlockChartStory => {
                 return {
                     message:
                         "Item is missing chart property or it is not a string value",
+                }
+            if (isArray(item?.technical))
+                return {
+                    message: `Item's technical tag is an array (e.g. "[.technical]"). Please update this tag to use curly braces (e.g. {.technical})`,
                 }
             return {
                 narrative: htmlToEnrichedTextBlock(item.narrative),

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -1,4 +1,5 @@
 import { decodeHTML } from "entities"
+import path from "path"
 import { DatabaseConnection } from "./DatabaseConnection.js"
 import {
     WORDPRESS_DB_NAME,
@@ -34,6 +35,7 @@ import {
     IndexPost,
     OwidGdocPublished,
     orderBy,
+    IMAGES_DIRECTORY,
 } from "@ourworldindata/utils"
 import { Topic } from "@ourworldindata/grapher"
 import {
@@ -766,15 +768,19 @@ export const mapGdocsToWordpressPosts = (
     gdocs: OwidGdocPublished[]
 ): IndexPost[] => {
     return gdocs.map((gdoc) => ({
-        title: gdoc.content.title,
+        title: gdoc.content["atom-title"] || gdoc.content.title,
         slug: gdoc.slug,
         date: gdoc.publishedAt,
         modifiedDate: gdoc.updatedAt,
         authors: gdoc.content.authors,
-        excerpt: gdoc.content.excerpt,
-        imageUrl:
-            gdoc.content["featured-image"] ||
-            `${BAKED_BASE_URL}/default-thumbnail.jpg`,
+        excerpt: gdoc.content["atom-excerpt"] || gdoc.content.excerpt,
+        imageUrl: gdoc.content["featured-image"]
+            ? path.join(
+                  BAKED_BASE_URL,
+                  IMAGES_DIRECTORY,
+                  gdoc.content["featured-image"]
+              )
+            : path.join(BAKED_BASE_URL, `default-thumbnail.jpg`),
     }))
 }
 

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -1,5 +1,4 @@
 import { decodeHTML } from "entities"
-import path from "path"
 import { DatabaseConnection } from "./DatabaseConnection.js"
 import {
     WORDPRESS_DB_NAME,
@@ -775,12 +774,8 @@ export const mapGdocsToWordpressPosts = (
         authors: gdoc.content.authors,
         excerpt: gdoc.content["atom-excerpt"] || gdoc.content.excerpt,
         imageUrl: gdoc.content["featured-image"]
-            ? path.join(
-                  BAKED_BASE_URL,
-                  IMAGES_DIRECTORY,
-                  gdoc.content["featured-image"]
-              )
-            : path.join(BAKED_BASE_URL, `default-thumbnail.jpg`),
+            ? `${BAKED_BASE_URL}${IMAGES_DIRECTORY}${gdoc.content["featured-image"]}`
+            : `${BAKED_BASE_URL}/default-thumbnail.jpg`,
     }))
 }
 

--- a/explorer/Explorer.scss
+++ b/explorer/Explorer.scss
@@ -39,6 +39,10 @@ html.IsInIframe #ExplorerContainer {
     .ExplorerSubtitle {
         color: #7a899e;
         font-size: 13px;
+
+        a {
+            @include owid-link-60;
+        }
     }
 }
 

--- a/packages/@ourworldindata/grapher/src/controls/CollapsibleList/CollapsibleList.scss
+++ b/packages/@ourworldindata/grapher/src/controls/CollapsibleList/CollapsibleList.scss
@@ -3,6 +3,8 @@
 
     ul {
         list-style: none;
+        display: flex;
+        flex-wrap: wrap;
         > .list-item {
             display: inline-block;
 

--- a/packages/@ourworldindata/utils/src/GdocsUtils.ts
+++ b/packages/@ourworldindata/utils/src/GdocsUtils.ts
@@ -10,6 +10,8 @@ export const LICENSE_ID = "article-licence"
 export const CITATION_ID = "article-citation"
 export const ENDNOTES_ID = "article-endnotes"
 
+export const IMAGES_DIRECTORY = "/images/published/"
+
 // Works for:
 // https://docs.google.com/document/d/abcd1234
 // https://docs.google.com/document/d/abcd1234/

--- a/packages/@ourworldindata/utils/src/GdocsUtils.ts
+++ b/packages/@ourworldindata/utils/src/GdocsUtils.ts
@@ -9,6 +9,7 @@ export const KEY_INSIGHTS_ID = "key-insights"
 export const LICENSE_ID = "article-licence"
 export const CITATION_ID = "article-citation"
 export const ENDNOTES_ID = "article-endnotes"
+export const RESEARCH_AND_WRITING_ID = "research-writing"
 
 export const IMAGES_DIRECTORY = "/images/published/"
 

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -582,6 +582,7 @@ export {
     CITATION_ID,
     ENDNOTES_ID,
     KEY_INSIGHTS_ID,
+    IMAGES_DIRECTORY,
     gdocUrlRegex,
     detailOnDemandRegex,
     getLinkType,

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -582,6 +582,7 @@ export {
     CITATION_ID,
     ENDNOTES_ID,
     KEY_INSIGHTS_ID,
+    RESEARCH_AND_WRITING_ID,
     IMAGES_DIRECTORY,
     gdocUrlRegex,
     detailOnDemandRegex,

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -583,7 +583,7 @@ export type EnrichedBlockScroller = {
 export type RawChartStoryValue = {
     narrative?: string
     chart?: string
-    technical?: string[]
+    technical?: { list?: string[] }
 }
 
 export type RawBlockChartStory = {

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1203,6 +1203,8 @@ export interface OwidGdocContent {
     toc?: TocHeadingWithTitleSupertitle[]
     "cover-image"?: string
     "featured-image"?: string
+    "atom-title"?: string
+    "atom-excerpt"?: string
     "cover-color"?:
         | "sdg-color-1"
         | "sdg-color-2"

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1002,7 +1002,9 @@ export type EnrichedBlockMissingData = {
 
 export type RawBlockAdditionalCharts = {
     type: "additional-charts"
-    value: string[]
+    value: {
+        list?: string[]
+    }
 }
 
 export type EnrichedBlockAdditionalCharts = {

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -857,14 +857,14 @@ export type RawBlockCallout = {
     type: "callout"
     value: {
         title?: string
-        text: RawBlockText[]
+        text: (RawBlockText | RawBlockHeading | RawBlockList)[]
     }
 }
 
 export type EnrichedBlockCallout = {
     type: "callout"
     title?: string
-    text: EnrichedBlockText[]
+    text: (EnrichedBlockText | EnrichedBlockHeading | EnrichedBlockList)[]
 } & EnrichedBlockWithParseErrors
 
 export type RawBlockTopicPageIntro = {

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -952,7 +952,7 @@ export type RawBlockResearchAndWriting = {
     value: {
         primary?: RawBlockResearchAndWritingLink
         secondary?: RawBlockResearchAndWritingLink
-        more?: RawBlockResearchAndWritingLink[]
+        more?: RawBlockResearchAndWritingRow
         rows?: RawBlockResearchAndWritingRow[]
     }
 }
@@ -976,7 +976,7 @@ export type EnrichedBlockResearchAndWriting = {
     type: "research-and-writing"
     primary: EnrichedBlockResearchAndWritingLink
     secondary: EnrichedBlockResearchAndWritingLink
-    more: EnrichedBlockResearchAndWritingLink[]
+    more: EnrichedBlockResearchAndWritingRow
     rows: EnrichedBlockResearchAndWritingRow[]
 } & EnrichedBlockWithParseErrors
 

--- a/site/blocks/KeyInsights.scss
+++ b/site/blocks/KeyInsights.scss
@@ -29,6 +29,7 @@ $slide-content-height: $grapher-height;
         transition: all 0.2s;
         cursor: pointer;
         animation: fadeIn 850ms;
+        color: $blue-90;
 
         &:hover {
             color: $blue-60;
@@ -41,14 +42,6 @@ $slide-content-height: $grapher-height;
             }
             border-right: 1px solid $blue-10;
             clip-path: inset(0 -2.5rem 0 0);
-            &:after {
-                content: "";
-                position: absolute;
-                right: -100%;
-                height: 100%;
-                background: linear-gradient(to right, white, #fff0);
-                width: 100%;
-            }
         }
         &.right {
             right: 0;
@@ -57,14 +50,6 @@ $slide-content-height: $grapher-height;
             }
             border-left: 1px solid $blue-10;
             clip-path: inset(0 0 0 -2.5rem);
-            &:after {
-                content: "";
-                position: absolute;
-                left: -100%;
-                height: 100%;
-                background: linear-gradient(to left, white, #fff0);
-                width: 100%;
-            }
         }
     }
 

--- a/site/css/mixins.scss
+++ b/site/css/mixins.scss
@@ -368,6 +368,7 @@
 
 @mixin expandable-paragraph__expand-button--full {
     display: block;
+    height: 40px;
     @include sm-up {
         display: inline-block;
     }

--- a/site/gdocs/AdditionalCharts.scss
+++ b/site/gdocs/AdditionalCharts.scss
@@ -1,4 +1,5 @@
 .article-block__additional-charts {
+    margin-bottom: 24px;
     h4 {
         @include h3-bold;
         margin: 0 0 16px;

--- a/site/gdocs/AllCharts.tsx
+++ b/site/gdocs/AllCharts.tsx
@@ -47,7 +47,7 @@ export function AllCharts(props: AllChartsProps) {
     const sortedRelatedCharts = sortRelatedCharts(relatedCharts, topSlugs)
     return (
         <div className={cx(className)}>
-            <h2 className="display-2-semibold" id={ALL_CHARTS_ID}>
+            <h2 className="h1-semibold" id={ALL_CHARTS_ID}>
                 {heading}
             </h2>
             <RelatedCharts charts={sortedRelatedCharts} />

--- a/site/gdocs/Image.tsx
+++ b/site/gdocs/Image.tsx
@@ -3,6 +3,7 @@ import {
     getSizes,
     generateSrcSet,
     getFilenameWithoutExtension,
+    IMAGES_DIRECTORY,
 } from "@ourworldindata/utils"
 import { LIGHTBOX_IMAGE_CLASS } from "../Lightbox.js"
 import cx from "classnames"
@@ -14,8 +15,6 @@ import { DocumentContext } from "./OwidGdoc.js"
 import { Container } from "./ArticleBlock.js"
 import { useImage } from "./utils.js"
 import { BlockErrorFallback } from "./BlockErrorBoundary.js"
-
-export const IMAGES_DIRECTORY = "/images/published/"
 
 // generates rules that tell the browser:
 // below the medium breakpoint, the image will be 95vw wide

--- a/site/gdocs/KeyInsights.tsx
+++ b/site/gdocs/KeyInsights.tsx
@@ -50,7 +50,7 @@ export const KeyInsights = ({
     }
     return (
         <div className={cx(className, KEY_INSIGHTS_CLASS_NAME)}>
-            <h2 className="display-2-semibold" id={KEY_INSIGHTS_ID}>
+            <h2 className="h1-semibold" id={KEY_INSIGHTS_ID}>
                 {heading}
             </h2>
             <div>

--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -154,7 +154,7 @@ export function OwidGdoc({
                         id={LICENSE_ID}
                         className="grid grid-cols-12-full-width col-start-1 col-end-limit"
                     >
-                        <div className="col-start-6 span-cols-4 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
+                        <div className="col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
                             <img
                                 src={`${BAKED_BASE_URL}/owid-logo.svg`}
                                 className="img-raw"

--- a/site/gdocs/OwidGdocHeader.tsx
+++ b/site/gdocs/OwidGdocHeader.tsx
@@ -107,7 +107,7 @@ function OwidTopicPageHeader({
             <p className="topic-page-header__subtitle body-1-regular col-start-2 span-cols-8">
                 {content.subtitle}
             </p>
-            <p className="topic-page-header__byline col-start-2 span-cols-8">
+            <p className="topic-page-header__byline col-start-2 span-cols-8 col-sm-start-2 span-sm-cols-12">
                 {"By "}
                 <a href="/team">
                     {formatAuthors({

--- a/site/gdocs/OwidGdocPage.tsx
+++ b/site/gdocs/OwidGdocPage.tsx
@@ -10,9 +10,9 @@ import {
     OwidGdocInterface,
     SiteFooterContext,
     getFilenameAsPng,
+    IMAGES_DIRECTORY,
 } from "@ourworldindata/utils"
 import { DebugProvider } from "./DebugContext.js"
-import { IMAGES_DIRECTORY } from "./Image.js"
 
 declare global {
     interface Window {

--- a/site/gdocs/ResearchAndWriting.scss
+++ b/site/gdocs/ResearchAndWriting.scss
@@ -5,6 +5,13 @@
         text-align: center;
         font-size: 32px;
         margin-bottom: 40px;
+        // Only the first large thumbnail, the "shorts" section has a margin
+        // so the second thumbnail doesn't need any
+        + .research-and-writing-link {
+            @include md-down {
+                margin-bottom: 16px;
+            }
+        }
     }
 }
 
@@ -13,6 +20,7 @@
     background: $gray-10;
     h5 {
         margin: 0;
+        color: $blue-50;
     }
 
     @include md-down {
@@ -111,4 +119,9 @@
 .research-and-writing-link--error {
     background-color: rgba(255, 0, 0, 0.1);
     padding: 24px;
+}
+
+.article-block__gray-section + .article-block__research-and-writing {
+    // Compensating for non-collapsing margins
+    margin-top: -32px;
 }

--- a/site/gdocs/ResearchAndWriting.tsx
+++ b/site/gdocs/ResearchAndWriting.tsx
@@ -96,8 +96,8 @@ export function ResearchAndWriting(props: ResearchAndWritingProps) {
             />
             <div className="span-cols-3 span-md-cols-12">
                 <div className="research-and-writing-more">
-                    <h5 className="overline-black-caps">Shorts</h5>
-                    {more.map((link, i) => (
+                    <h5 className="overline-black-caps">{more.heading}</h5>
+                    {more.articles.map((link, i) => (
                         <ResearchAndWritingLinkContainer
                             shouldHideThumbnail
                             shouldHideSubtitle

--- a/site/gdocs/ResearchAndWriting.tsx
+++ b/site/gdocs/ResearchAndWriting.tsx
@@ -84,7 +84,7 @@ export function ResearchAndWriting(props: ResearchAndWritingProps) {
                 className="span-cols-12 display-1-semibold"
                 id={RESEARCH_AND_WRITING_ID}
             >
-                Research & writing
+                Research & Writing
             </h2>
             <ResearchAndWritingLinkContainer
                 className="span-cols-6 span-md-cols-6 span-sm-cols-12"

--- a/site/gdocs/ResearchAndWriting.tsx
+++ b/site/gdocs/ResearchAndWriting.tsx
@@ -3,6 +3,7 @@ import cx from "classnames"
 import {
     EnrichedBlockResearchAndWriting,
     EnrichedBlockResearchAndWritingLink,
+    RESEARCH_AND_WRITING_ID,
 } from "@ourworldindata/utils"
 import { useLinkedDocument } from "./utils.js"
 import { formatAuthors } from "../clientFormatting.js"
@@ -81,7 +82,7 @@ export function ResearchAndWriting(props: ResearchAndWritingProps) {
         <div className={cx(className, "grid")}>
             <h2
                 className="span-cols-12 display-1-semibold"
-                id="research-writing"
+                id={RESEARCH_AND_WRITING_ID}
             >
                 Research & writing
             </h2>

--- a/site/gdocs/TopicPageIntro.tsx
+++ b/site/gdocs/TopicPageIntro.tsx
@@ -21,7 +21,7 @@ function TopicPageRelatedTopic({
         return <li>{errorMessage}</li>
     }
     const topicText = linkedDocument?.content.title || text
-    const topicUrl = `/${linkedDocument?.slug}` || url
+    const topicUrl = linkedDocument?.slug ? `/${linkedDocument?.slug}` : url
     return (
         <li>
             <a href={topicUrl}>{topicText}</a>

--- a/site/gdocs/TopicPageIntro.tsx
+++ b/site/gdocs/TopicPageIntro.tsx
@@ -40,7 +40,13 @@ export function TopicPageIntro(props: TopicPageIntroProps) {
             <div className="topic-page-intro__links col-start-9 span-cols-4 col-md-start-1 span-md-cols-12">
                 {props.downloadButton ? (
                     <div className="topic-page-intro__download-button">
-                        <a>{props.downloadButton.text}</a>
+                        <a
+                            href={props.downloadButton.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            {props.downloadButton.text}
+                        </a>
                     </div>
                 ) : null}
                 {props.relatedTopics?.length ? (

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -528,6 +528,7 @@ h3.article-block__heading.has-supertitle {
     h4 {
         color: $blue-90;
         margin-bottom: 8px;
+        margin-top: 8px;
     }
     a {
         @include owid-link-90;
@@ -537,6 +538,13 @@ h3.article-block__heading.has-supertitle {
     padding: 16px 24px;
     border-radius: 8px;
     margin: 32px 0;
+    p:last-child {
+        margin-bottom: 8px;
+    }
+
+    + .article-block__horizontal-rule {
+        margin-top: 24px;
+    }
 }
 
 .article-block__sticky-right,

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -245,13 +245,14 @@ h3.article-block__heading.has-supertitle {
     padding-top: 48px;
     h3 {
         margin-top: 0;
-        text-align: center;
     }
     p {
         margin-bottom: 16px;
+        color: $blue-90;
     }
     div:last-of-type .wp-code-snippet {
         margin-bottom: 0;
+        font-size: 0.875rem;
     }
     > div:last-child {
         padding-bottom: 48px;
@@ -506,7 +507,7 @@ h3.article-block__heading.has-supertitle {
 .article-block__gray-section {
     background-color: $gray-10;
     padding: 48px 0;
-    margin: 32px 0;
+    margin: 24px 0;
 
     > *:first-child {
         margin-top: 0;

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -245,6 +245,7 @@ h3.article-block__heading.has-supertitle {
     padding-top: 48px;
     h3 {
         margin-top: 0;
+        text-align: center;
     }
     p {
         margin-bottom: 16px;

--- a/site/gdocs/topic-page.scss
+++ b/site/gdocs/topic-page.scss
@@ -127,11 +127,20 @@
         }
         ul {
             margin-bottom: 32px;
-            padding-left: 40px;
             li {
                 @include body-2-regular;
                 margin-bottom: 8px;
             }
+        }
+    }
+
+    .article-block__callout {
+        h5 {
+            text-align: center;
+            letter-spacing: 10%;
+            margin-bottom: 24px;
+            padding-bottom: 24px;
+            border-bottom: 1px solid $blue-20;
         }
     }
 }

--- a/site/gdocs/topic-page.scss
+++ b/site/gdocs/topic-page.scss
@@ -9,6 +9,10 @@
 
     h1 {
         margin-bottom: 0;
+        @include sm-only {
+            font-size: 2rem;
+            margin-top: 24px;
+        }
     }
 
     .topic-page-header__subtitle {
@@ -30,6 +34,10 @@
 
 .article-block__topic-page-intro {
     margin-top: 48px;
+
+    @include sm-only {
+        margin-top: 24px;
+    }
 
     .topic-page-intro__content {
         p:first-child {
@@ -110,6 +118,12 @@
 }
 
 .article-block__key-insights {
+    @include sm-only {
+        h2 {
+            font-size: 1.625rem;
+        }
+    }
+
     figure {
         margin: 0;
     }
@@ -148,6 +162,16 @@
 .article-block__gray-section {
     h1 {
         text-align: center;
+        // Countering the gray-section padding to make this have 32px 16px
+        margin-top: -16px;
+        margin-bottom: 16px;
+    }
+
+    .article-block__text,
+    .article-block__list,
+    .article-block__html,
+    .article-block__numbered-list {
+        @include body-3-medium;
     }
 }
 

--- a/site/gdocs/topic-page.scss
+++ b/site/gdocs/topic-page.scss
@@ -19,12 +19,14 @@
         margin: 0;
     }
 
-    .topic-page-header__byline {
+    p.topic-page-header__byline,
+    .topic-page-header__byline a {
         color: $blue-60;
         margin-bottom: 34px;
-        a {
-            @include owid-link-60;
-        }
+    }
+
+    .topic-page-header__byline a:hover {
+        color: $vermillion;
     }
 
     + .sticky-nav {

--- a/site/gdocs/topic-page.scss
+++ b/site/gdocs/topic-page.scss
@@ -185,3 +185,7 @@
         margin-top: 0;
     }
 }
+
+.centered-article-container--topic-page #article-citation h3 {
+    text-align: left;
+}

--- a/site/gdocs/topic-page.scss
+++ b/site/gdocs/topic-page.scss
@@ -86,6 +86,10 @@
                     color: $blue-90;
                     position: relative;
 
+                    &:hover {
+                        text-decoration: underline;
+                    }
+
                     &:after {
                         content: "";
                         background-color: $blue-90;

--- a/site/gdocs/topic-page.scss
+++ b/site/gdocs/topic-page.scss
@@ -139,6 +139,14 @@
         @include md-up {
             padding-right: 16px;
         }
+
+        @include sm-only {
+            margin-bottom: 24px;
+            .content > *:last-child {
+                margin-bottom: 0;
+            }
+        }
+
         ul {
             margin-bottom: 32px;
             li {

--- a/site/gdocs/topic-page.scss
+++ b/site/gdocs/topic-page.scss
@@ -170,7 +170,7 @@
 }
 
 .article-block__gray-section {
-    h1 {
+    > h1 {
         text-align: center;
         // Countering the gray-section padding to make this have 32px 16px
         margin-top: -16px;

--- a/site/gdocs/utils.tsx
+++ b/site/gdocs/utils.tsx
@@ -74,7 +74,7 @@ const LinkedA = ({ span }: { span: SpanLink }): JSX.Element => {
     }
     if (linkedChart) {
         return (
-            <a href={`/grapher/${linkedChart.slug}`} className="span-link">
+            <a href={linkedChart.resolvedUrl} className="span-link">
                 {renderSpans(span.children)}
             </a>
         )

--- a/site/gdocs/utils.tsx
+++ b/site/gdocs/utils.tsx
@@ -74,7 +74,7 @@ const LinkedA = ({ span }: { span: SpanLink }): JSX.Element => {
     }
     if (linkedChart) {
         return (
-            <a href={linkedChart.resolvedUrl} className="span-link">
+            <a href={`/grapher/${linkedChart.slug}`} className="span-link">
                 {renderSpans(span.children)}
             </a>
         )


### PR DESCRIPTION
Fixes  #2256

1. Correctly provision all-charts block with `relatedCharts` when baking
2. Show "Untitled" if a registered document doesn't yet have a title (so you can still click on it)
3. Set slug correctly
4. CSS touchups
5. Auto-update unpublished gdocs on GET
6. Fix archie for nested lists in `additional-charts` and `chart-story`
   - This doesn't require a migration because it only affects the raw shape. This means it will have to be fixed in the source gdoc before one can republish, but I've explained that explicitly in the error messages.

![image](https://github.com/owid/owid-grapher/assets/11844404/60930b29-9643-4d66-860a-8ad75277e10c)


![image](https://github.com/owid/owid-grapher/assets/11844404/854fabb9-b6d4-45e2-90a0-43c0e08d9c89)
