### PR TITLE
:bug: fix timeouts in bulk chart editor

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -295,7 +295,9 @@ const saveGrapher = async (
     transactionContext: db.TransactionContext,
     user: CurrentUser,
     newConfig: GrapherInterface,
-    existingConfig?: GrapherInterface
+    existingConfig?: GrapherInterface,
+    referencedVariablesMightChange: boolean = true // if the variables a chart uses can change then we need
+    // to update the latest country data which takes quite a long time (hundreds of ms)
 ) => {
     // Slugs need some special logic to ensure public urls remain consistent whenever possible
     async function isSlugUsedInRedirect() {
@@ -399,7 +401,7 @@ const saveGrapher = async (
     }
 
     // So we can generate country profiles including this chart data
-    if (newConfig.isPublished)
+    if (newConfig.isPublished && referencedVariablesMightChange)
         await denormalizeLatestCountryData(
             newConfig.dimensions!.map((d) => d.variableId)
         )
@@ -1597,7 +1599,8 @@ apiRouter.patch("/chart-bulk-update", async (req, res) => {
                 manager,
                 res.locals.user,
                 newConfig,
-                oldValuesConfigMap.get(id)
+                oldValuesConfigMap.get(id),
+                false
             )
         }
     })


### PR DESCRIPTION
The bulk chart editor sometimes timed out inside a transaction which is pretty nasty - the reason is that we use the normal saveGrapher function
 for each of the up to 50 charts that are submitted at one time. In saveGrapher we updated the latestCountryData which is a very expensive operation (hundreds of ms). This PR adds a flag that communicates if the referenced variables might change (the normal case in the chart editor) or not (the case in the bulk chart editor). This makes saving charts much faster, thus solving the timeout issues.