### PR TITLE
feat(explorer): allow indicator metadata to be overwritten

### DIFF
--- a/explorer/ColumnGrammar.ts
+++ b/explorer/ColumnGrammar.ts
@@ -16,6 +16,11 @@ import {
 } from "../gridLang/GridLangConstants.js"
 
 export const ColumnGrammar: Grammar = {
+    indicatorId: {
+        ...IntegerCellDef,
+        keyword: "indicatorId",
+        description: "Numerical indicator ID",
+    },
     slug: {
         ...SlugDeclarationCellDef,
         keyword: "slug",

--- a/explorer/ColumnGrammar.ts
+++ b/explorer/ColumnGrammar.ts
@@ -16,10 +16,10 @@ import {
 } from "../gridLang/GridLangConstants.js"
 
 export const ColumnGrammar: Grammar = {
-    indicatorId: {
+    variableId: {
         ...IntegerCellDef,
-        keyword: "indicatorId",
-        description: "Numerical indicator ID",
+        keyword: "variableId",
+        description: "Numerical variable ID",
     },
     slug: {
         ...SlugDeclarationCellDef,

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -4,7 +4,7 @@ import {
     BlankOwidTable,
     ColumnTypeNames,
     CoreColumnDef,
-    extractDataSlugsFromTransform,
+    extractPotentialDataSlugsFromTransform,
     isNotErrorValue,
     OwidColumnDef,
     OwidTable,
@@ -419,7 +419,8 @@ export class Explorer
     ): string[] {
         const def = this.columnDefsNotLinkedToTableByIdOrSlug[slug] ?? {}
         if (!def.transform) return baseColumns
-        const dataSlugs = extractDataSlugsFromTransform(def.transform)
+        const dataSlugs =
+            extractPotentialDataSlugsFromTransform(def.transform) ?? []
         for (let i = 0; i < dataSlugs.length; i++) {
             this.getBaseColumnsForColumnWithTransform(dataSlugs[i], baseColumns)
             baseColumns.push(dataSlugs[i]) // deepest dependency at the start of the array

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -529,14 +529,20 @@ export class Explorer
                 .map((id) => parseInt(id, 10))
                 .filter((id) => !isNaN(id))
             baseVariableIds.forEach((variableId) => {
-                dimensions.push({
-                    variableId: variableId,
-                    property: DimensionProperty.table, // no specific dimension
-                })
+                const hasDimension = dimensions.some(
+                    (d) => d.variableId === variableId
+                )
+                if (!hasDimension) {
+                    dimensions.push({
+                        variableId: variableId,
+                        property: DimensionProperty.table, // no specific dimension
+                    })
+                }
             })
         }
 
         config.dimensions = dimensions
+        if (config.ySlugs && yVariableIds) config.ySlugs += " " + yVariableIds
 
         grapher.setAuthoredVersion(config)
         grapher.reset()

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -37,7 +37,6 @@ import {
     isInIFrame,
     keyBy,
     keyMap,
-    omit,
     omitUndefinedValues,
     PromiseCache,
     PromiseSwitcher,
@@ -364,19 +363,9 @@ export class Explorer
                 this.updateGrapherFromExplorerUsingIndicatorIds()
                 break
             case ExplorerChartCreationMode.FromExplorerTableColumnSlugs:
-                this.updateGrapherFromExplorerUsingManuallyProvidedData()
+                this.updateGrapherFromExplorerUsingColumnSlugs()
                 break
         }
-    }
-
-    @computed private get grapherConfigFromExplorerOnlyGrapherProps() {
-        return omit(this.explorerProgram.grapherConfig, [
-            "yIndicatorIds",
-            "xIndicatorId",
-            "colorIndicatorId",
-            "sizeIndicatorId",
-            "mapTargetTime",
-        ])
     }
 
     @action.bound private updateGrapherFromExplorerCommon() {
@@ -457,7 +446,7 @@ export class Explorer
 
         const config: GrapherProgrammaticInterface = {
             ...grapherConfig,
-            ...this.grapherConfigFromExplorerOnlyGrapherProps,
+            ...this.explorerProgram.grapherConfigOnlyGrapherProps,
             bakedGrapherURL: BAKED_GRAPHER_URL,
             hideEntityControls: this.showExplorerControls,
         }
@@ -484,7 +473,7 @@ export class Explorer
         } = this.explorerProgram.grapherConfig
 
         const config: GrapherProgrammaticInterface = {
-            ...this.grapherConfigFromExplorerOnlyGrapherProps,
+            ...this.explorerProgram.grapherConfigOnlyGrapherProps,
             bakedGrapherURL: BAKED_GRAPHER_URL,
             hideEntityControls: this.showExplorerControls,
         }
@@ -532,7 +521,7 @@ export class Explorer
                     this.getBaseIndicatorIdsForColumnWithTransform
                 )
             )
-                .map(parseInt)
+                .map((id) => parseInt(id, 10))
                 .filter((id) => !isNaN(id))
             // add all indicator ids that the given slugs depend on to the config
             baseIndicatorIds.forEach((indicatorId) => {
@@ -592,13 +581,13 @@ export class Explorer
         this.setGrapherTable(grapherTable)
     }
 
-    @action.bound private updateGrapherFromExplorerUsingManuallyProvidedData() {
+    @action.bound private updateGrapherFromExplorerUsingColumnSlugs() {
         const grapher = this.grapher
         if (!grapher) return
         const { tableSlug } = this.explorerProgram.grapherConfig
 
         const config: GrapherProgrammaticInterface = {
-            ...this.grapherConfigFromExplorerOnlyGrapherProps,
+            ...this.explorerProgram.grapherConfigOnlyGrapherProps,
             bakedGrapherURL: BAKED_GRAPHER_URL,
             hideEntityControls: this.showExplorerControls,
             manuallyProvideData: true,

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -435,9 +435,7 @@ export class Explorer
     // respectively, then getBaseIndicatorIdsForColumnWithTransform('slug')
     // returns ['539022', '170775'] as these are the IDs of the two indicators
     // that the 'slug' column depends on
-    @action.bound private getBaseIndicatorIdsForColumnWithTransform(
-        slug: string
-    ): string[] {
+    private getBaseIndicatorIdsForColumnWithTransform(slug: string): string[] {
         const { columnDefsWithoutTableSlug } = this.explorerProgram
         const baseIndicatorIdsAndColumnSlugs =
             this.getBaseColumnsForColumnWithTransform(slug)
@@ -544,8 +542,8 @@ export class Explorer
         // find all indicators the the transformed columns depend on and add them to the dimensions array
         if (uniqueSlugsInGrapherRow.length) {
             const baseIndicatorIds = uniq(
-                uniqueSlugsInGrapherRow.flatMap(
-                    this.getBaseIndicatorIdsForColumnWithTransform
+                uniqueSlugsInGrapherRow.flatMap((slug) =>
+                    this.getBaseIndicatorIdsForColumnWithTransform(slug)
                 )
             )
                 .map((id) => parseInt(id, 10))

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -418,13 +418,10 @@ export class Explorer
         if (!def?.transform) return []
         const dataSlugs =
             extractPotentialDataSlugsFromTransform(def.transform) ?? []
-        for (const dataSlug of dataSlugs) {
-            return [
-                ...this.getBaseColumnsForColumnWithTransform(dataSlug),
-                dataSlug,
-            ]
-        }
-        return []
+        return dataSlugs.flatMap((dataSlug) => [
+            ...this.getBaseColumnsForColumnWithTransform(dataSlug),
+            dataSlug,
+        ])
     }
 
     @action.bound private getBaseIndicatorIdsForColumnWithTransform(

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -5,7 +5,6 @@ import {
     ColumnTypeNames,
     CoreColumnDef,
     extractPotentialDataSlugsFromTransform,
-    isNotErrorValue,
     OwidColumnDef,
     OwidTable,
     SortOrder,
@@ -54,7 +53,6 @@ import React from "react"
 import ReactDOM from "react-dom"
 import { ExplorerControlBar, ExplorerControlPanel } from "./ExplorerControls.js"
 import { ExplorerProgram } from "./ExplorerProgram.js"
-import { GrapherGrammar } from "./GrapherGrammar.js"
 import {
     ADMIN_BASE_URL,
     BAKED_BASE_URL,
@@ -341,26 +339,8 @@ export class Explorer
         this.explorerProgram.constructTable(slug)
     )
 
-    // for backward compatibility, we currently support explorers
-    // that use Grapher IDs as well as CSV data files to create charts,
-    // but we plan to drop support for mixed-content explorers in the future
-    @computed private get chartCreationMode(): ExplorerChartCreationMode {
-        const { decisionMatrix, grapherConfig } = this.explorerProgram
-        const { grapherId } = grapherConfig
-        const yVariableIdsColumn = decisionMatrix.table.get(
-            GrapherGrammar.yVariableIds.keyword
-        )
-        // referring to a variable in a single row triggers
-        // ExplorerChartCreationMode.FromVariableIds for all rows
-        if (yVariableIdsColumn.numValues)
-            return ExplorerChartCreationMode.FromVariableIds
-        if (grapherId && isNotErrorValue(grapherId))
-            return ExplorerChartCreationMode.FromGrapherId
-        return ExplorerChartCreationMode.FromExplorerTableColumnSlugs
-    }
-
     @action.bound private updateGrapherFromExplorer() {
-        switch (this.chartCreationMode) {
+        switch (this.explorerProgram.chartCreationMode) {
             case ExplorerChartCreationMode.FromGrapherId:
                 this.updateGrapherFromExplorerUsingGrapherId()
                 break

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -53,11 +53,9 @@ import { action, computed, observable, reaction } from "mobx"
 import { observer } from "mobx-react"
 import React from "react"
 import ReactDOM from "react-dom"
-import {
-    ExplorerControlBar,
-    ExplorerControlPanel,
-} from "../explorer/ExplorerControls.js"
-import { ExplorerProgram } from "../explorer/ExplorerProgram.js"
+import { ExplorerControlBar, ExplorerControlPanel } from "./ExplorerControls.js"
+import { ExplorerProgram } from "./ExplorerProgram.js"
+import { GrapherGrammar } from "./GrapherGrammar.js"
 import {
     ADMIN_BASE_URL,
     BAKED_BASE_URL,
@@ -345,12 +343,14 @@ export class Explorer
     )
 
     @computed private get chartCreationMode(): ExplorerChartCreationMode {
-        const { decisionMatrix } = this.explorerProgram
-        const { grapherId, yIndicatorIds } = decisionMatrix.table.firstRow
-
+        const { decisionMatrix, grapherConfig } = this.explorerProgram
+        const { grapherId } = grapherConfig
+        const yIndicatorIdsColumn = decisionMatrix.table.get(
+            GrapherGrammar.yIndicatorIds.keyword
+        )
         if (grapherId && isNotErrorValue(grapherId))
             return ExplorerChartCreationMode.FromGrapherId
-        if (yIndicatorIds?.length)
+        if (yIndicatorIdsColumn.numValues)
             return ExplorerChartCreationMode.FromIndicatorIds
         return ExplorerChartCreationMode.FromExplorerTableColumnSlugs
     }

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -341,16 +341,21 @@ export class Explorer
         this.explorerProgram.constructTable(slug)
     )
 
+    // for backward compatibility, we currently support explorers
+    // that use Grapher IDs as well as CSV data files to create charts,
+    // but we plan to drop support for mixed-content explorers in the future
     @computed private get chartCreationMode(): ExplorerChartCreationMode {
         const { decisionMatrix, grapherConfig } = this.explorerProgram
         const { grapherId } = grapherConfig
         const yIndicatorIdsColumn = decisionMatrix.table.get(
             GrapherGrammar.yIndicatorIds.keyword
         )
-        if (grapherId && isNotErrorValue(grapherId))
-            return ExplorerChartCreationMode.FromGrapherId
+        // referring to an indicator in a single row triggers
+        // ExplorerChartCreationMode.FromIndicatorIds for all rows
         if (yIndicatorIdsColumn.numValues)
             return ExplorerChartCreationMode.FromIndicatorIds
+        if (grapherId && isNotErrorValue(grapherId))
+            return ExplorerChartCreationMode.FromGrapherId
         return ExplorerChartCreationMode.FromExplorerTableColumnSlugs
     }
 

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -326,10 +326,10 @@ export class ExplorerProgram extends GridProgram {
 
     get grapherConfigOnlyGrapherProps() {
         return omit(this.grapherConfig, [
-            GrapherGrammar.yIndicatorIds.keyword,
-            GrapherGrammar.xIndicatorId.keyword,
-            GrapherGrammar.colorIndicatorId.keyword,
-            GrapherGrammar.sizeIndicatorId.keyword,
+            GrapherGrammar.yVariableIds.keyword,
+            GrapherGrammar.xVariableId.keyword,
+            GrapherGrammar.colorVariableId.keyword,
+            GrapherGrammar.sizeVariableId.keyword,
             GrapherGrammar.mapTargetTime.keyword,
         ])
     }
@@ -429,27 +429,27 @@ const parseColumnDefs = (block: string[][]): OwidColumnDef[] => {
         .appendColumnsIfNew([
             { slug: "slug", type: ColumnTypeNames.String, name: "slug" },
             {
-                slug: "indicatorId",
+                slug: "variableId",
                 type: ColumnTypeNames.Numeric,
-                name: "indicatorId",
+                name: "variableId",
             },
         ])
-        .renameColumn("indicatorId", "owidVariableId")
+        .renameColumn("variableId", "owidVariableId")
         .combineColumns(
             ["slug", "owidVariableId"],
             {
-                slug: "slugOrIndicatorId",
+                slug: "slugOrVariableId",
                 type: ColumnTypeNames.String,
-                name: "slugOrIndicatorId",
+                name: "slugOrVariableId",
             },
             (values) => values.slug ?? values.owidVariableId?.toString()
         )
         .columnFilter(
-            "slugOrIndicatorId",
+            "slugOrVariableId",
             (value: CoreValueType) => !!value,
-            "Keep only column defs with a slug or indicator id"
+            "Keep only column defs with a slug or variable id"
         )
-        .dropColumns(["slugOrIndicatorId"])
+        .dropColumns(["slugOrVariableId"])
     return columnsTable.rows.map((row) => {
         // ignore slug if a variable id is given
         if (

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -254,7 +254,7 @@ export class ExplorerProgram extends GridProgram {
         return columnDefs
     }
 
-    get columnDefsNotLinkedToTable(): OwidColumnDef[] {
+    get columnDefsWithoutTableSlug(): OwidColumnDef[] {
         return this.columnDefsByTableSlug.get(undefined) ?? []
     }
 
@@ -442,7 +442,7 @@ const parseColumnDefs = (block: string[][]): OwidColumnDef[] => {
                 type: ColumnTypeNames.String,
                 name: "slugOrIndicatorId",
             },
-            (values) => values.slug ?? values.owidVariableId.toString()
+            (values) => values.slug ?? values.owidVariableId?.toString()
         )
         .columnFilter(
             "slugOrIndicatorId",

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -7,6 +7,7 @@ import {
     OwidColumnDef,
     OwidTable,
     TableSlug,
+    isNotErrorValueOrEmptyCell,
 } from "@ourworldindata/core-table"
 import { FacetAxisDomain, GrapherInterface } from "@ourworldindata/grapher"
 import {
@@ -440,7 +441,11 @@ const parseColumnDefs = (block: string[][]): OwidColumnDef[] => {
         .dropColumns(["slugOrIndicatorId"])
     return columnsTable.rows.map((row) => {
         // ignore slug if a variable id is given
-        if (row.owidVariableId && row.slug) delete row.slug
+        if (
+            isNotErrorValueOrEmptyCell(row.owidVariableId) &&
+            isNotErrorValueOrEmptyCell(row.slug)
+        )
+            delete row.slug
         return trimAndParseObject(row, ColumnGrammar)
     })
 }

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -16,6 +16,7 @@ import {
     SerializedGridProgram,
     SubNavId,
     trimObject,
+    omit,
 } from "@ourworldindata/utils"
 import {
     CellDef,
@@ -321,6 +322,16 @@ export class ExplorerProgram extends GridProgram {
         }
 
         return rootObject
+    }
+
+    get grapherConfigOnlyGrapherProps() {
+        return omit(this.grapherConfig, [
+            GrapherGrammar.yIndicatorIds.keyword,
+            GrapherGrammar.xIndicatorId.keyword,
+            GrapherGrammar.colorIndicatorId.keyword,
+            GrapherGrammar.sizeIndicatorId.keyword,
+            GrapherGrammar.mapTargetTime.keyword,
+        ])
     }
 
     /**

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -7,7 +7,7 @@ import {
     OwidColumnDef,
     OwidTable,
     TableSlug,
-    isNotErrorValueOrEmptyCell,
+    isNotErrorValue,
 } from "@ourworldindata/core-table"
 import { FacetAxisDomain, GrapherInterface } from "@ourworldindata/grapher"
 import {
@@ -442,8 +442,9 @@ const parseColumnDefs = (block: string[][]): OwidColumnDef[] => {
     return columnsTable.rows.map((row) => {
         // ignore slug if a variable id is given
         if (
-            isNotErrorValueOrEmptyCell(row.owidVariableId) &&
-            isNotErrorValueOrEmptyCell(row.slug)
+            row.owidVariableId &&
+            isNotErrorValue(row.owidVariableId) &&
+            row.slug
         )
             delete row.slug
         return trimAndParseObject(row, ColumnGrammar)

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -442,7 +442,7 @@ const parseColumnDefs = (block: string[][]): OwidColumnDef[] => {
                 type: ColumnTypeNames.String,
                 name: "slugOrVariableId",
             },
-            (values) => values.slug ?? values.owidVariableId?.toString()
+            (values) => values.slug || values.owidVariableId?.toString()
         )
         .columnFilter(
             "slugOrVariableId",

--- a/explorerAdminClient/ExplorerCreatePage.scss
+++ b/explorerAdminClient/ExplorerCreatePage.scss
@@ -32,6 +32,17 @@
     right: 10px;
 }
 
+.WhyIsExplorerProgramInvalid {
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+    background-color: #fff;
+    max-width: 310px;
+    padding: 4px 8px;
+    font-weight: bold;
+    border: 4px solid #ce261e;
+}
+
 // Hide the noisy arrow in the autocomplete dropdown.
 .handsontable {
     .htAutocompleteArrow {

--- a/explorerAdminClient/ExplorerCreatePage.tsx
+++ b/explorerAdminClient/ExplorerCreatePage.tsx
@@ -288,6 +288,11 @@ export class ExplorerCreatePage extends React.Component<{
                     <a className="PreviewLink" href={previewLink}>
                         Visit preview
                     </a>
+                    {program.whyIsExplorerProgramInvalid && (
+                        <div className="WhyIsExplorerProgramInvalid">
+                            {program.whyIsExplorerProgramInvalid}
+                        </div>
+                    )}
                 </main>
             </>
         )

--- a/packages/@ourworldindata/core-table/src/CoreColumnDef.ts
+++ b/packages/@ourworldindata/core-table/src/CoreColumnDef.ts
@@ -54,7 +54,6 @@ export interface CoreColumnDef extends ColumnColorScale {
 
     // Computational
     transform?: string // Code that maps to a CoreTable transform
-    transformHasRun?: boolean // If true, the transform has been applied
     tolerance?: number // If set, some charts can use this for an interpolation strategy.
     toleranceStrategy?: ToleranceStrategy // Tolerance strategy to use for interpolation
     skipParsing?: boolean // If set, the values will never run through the type parser

--- a/packages/@ourworldindata/core-table/src/CoreColumnDef.ts
+++ b/packages/@ourworldindata/core-table/src/CoreColumnDef.ts
@@ -54,6 +54,7 @@ export interface CoreColumnDef extends ColumnColorScale {
 
     // Computational
     transform?: string // Code that maps to a CoreTable transform
+    transformHasRun?: boolean // If true, the transform has been applied
     tolerance?: number // If set, some charts can use this for an interpolation strategy.
     toleranceStrategy?: ToleranceStrategy // Tolerance strategy to use for interpolation
     skipParsing?: boolean // If set, the values will never run through the type parser

--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -203,10 +203,14 @@ export class CoreTable<
             )
 
         const columnsFromTransforms = inputColumnDefs.filter(
-            (def) => def.transform && !def.transformHasRun
+            (def) => def.transform && !this.get(def.slug).transformHasRun
         ) // todo: sort by graph dependency order
-        if (columnsFromTransforms.length)
+        if (columnsFromTransforms.length) {
             columnStore = applyTransforms(columnStore, columnsFromTransforms)
+            columnsFromTransforms.map((def) => {
+                this.get(def.slug).transformHasRun = true
+            })
+        }
 
         return advancedOptions.filterMask
             ? advancedOptions.filterMask.apply(columnStore)

--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -203,13 +203,10 @@ export class CoreTable<
             )
 
         const columnsFromTransforms = inputColumnDefs.filter(
-            (def) => def.transform && !this.get(def.slug).transformHasRun
+            (def) => def.transform && !def.transformHasRun
         ) // todo: sort by graph dependency order
         if (columnsFromTransforms.length) {
             columnStore = applyTransforms(columnStore, columnsFromTransforms)
-            columnsFromTransforms.map((def) => {
-                this.get(def.slug).transformHasRun = true
-            })
         }
 
         return advancedOptions.filterMask

--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -184,7 +184,6 @@ export class CoreTable<
             valuesFromColumnDefs,
             inputColumnsToParsedColumnStore,
             inputColumnDefs,
-            isRoot,
             advancedOptions,
         } = this
 
@@ -203,11 +202,10 @@ export class CoreTable<
                 inputColumnsToParsedColumnStore
             )
 
-        // NB: transforms are *only* run on the root table for now. They will not be rerun later on (after adding or filtering rows, for example)
         const columnsFromTransforms = inputColumnDefs.filter(
-            (def) => def.transform
+            (def) => def.transform && !def.transformHasRun
         ) // todo: sort by graph dependency order
-        if (isRoot && columnsFromTransforms.length)
+        if (columnsFromTransforms.length)
             columnStore = applyTransforms(columnStore, columnsFromTransforms)
 
         return advancedOptions.filterMask

--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -1115,6 +1115,28 @@ export class CoreTable<
         )
     }
 
+    combineColumns(
+        columnSlugs: ColumnSlug[],
+        def: COL_DEF_TYPE,
+        combineFn: (values: Record<ColumnSlug, CoreValueType>) => CoreValueType
+    ): this {
+        if (columnSlugs.length === 0) return this
+        const newStore: CoreColumnStore = { ...this.columnStore }
+        newStore[def.slug] = this.indices.map((index) => {
+            const values: Record<ColumnSlug, CoreValueType> = {}
+            columnSlugs.forEach((slug) => {
+                values[slug] = this.get(slug).valuesIncludingErrorValues[index]
+            })
+            return combineFn(values)
+        })
+        return this.transform(
+            newStore,
+            [...this.defs, def],
+            `Combined columns '${columnSlugs.join(", ")}' into '${def.slug}'`,
+            TransformType.CombineColumns
+        )
+    }
+
     replaceNonPositiveCellsForLogScale(columnSlugs: ColumnSlug[] = []): this {
         return this.replaceCells(columnSlugs, (val) =>
             typeof val !== "number" || val <= 0

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -50,8 +50,6 @@ export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
     def: CoreColumnDef
     table: CoreTable
 
-    transformHasRun = false // true if the transform has been applied
-
     constructor(table: CoreTable, def: CoreColumnDef) {
         this.table = table
         this.def = def

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -50,6 +50,8 @@ export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
     def: CoreColumnDef
     table: CoreTable
 
+    transformHasRun = false // true if the transform has been applied
+
     constructor(table: CoreTable, def: CoreColumnDef) {
         this.table = table
         this.def = def

--- a/packages/@ourworldindata/core-table/src/CoreTableConstants.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableConstants.ts
@@ -60,6 +60,7 @@ export enum TransformType {
     UpdateColumnDefsAndApply = "UpdateColumnDefsAndApply", // use this for updates that add a column transform fn.
     RenameColumns = "RenameColumns",
     InverseFilterColumns = "InverseFilterColumns",
+    CombineColumns = "CombineColumns",
 }
 
 export enum JsTypes {

--- a/packages/@ourworldindata/core-table/src/OwidTableConstants.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTableConstants.ts
@@ -24,7 +24,7 @@ export type EntityId = number
 
 // Todo: coverage, datasetId, and datasetName can just be on source, right? or should we flatten source onto this?
 export interface OwidColumnDef extends CoreColumnDef {
-    owidVariableId?: number // todo: remove after data 2.0
+    owidVariableId?: number
     coverage?: string
     datasetId?: number
     datasetName?: string

--- a/packages/@ourworldindata/core-table/src/Transforms.test.ts
+++ b/packages/@ourworldindata/core-table/src/Transforms.test.ts
@@ -142,7 +142,7 @@ describe(extractPotentialDataSlugsFromTransform, () => {
             extractPotentialDataSlugsFromTransform(
                 "slug where entity isNot France"
             )
-        ).toStrictEqual(["slug", "entity"]) // entity is expected to be returned as this _might_ be a data slug
+        ).toStrictEqual(["slug", "entity"])
     })
     it("extracts a unique list of data slugs", () => {
         expect(

--- a/packages/@ourworldindata/core-table/src/Transforms.ts
+++ b/packages/@ourworldindata/core-table/src/Transforms.ts
@@ -419,13 +419,14 @@ export const applyTransforms = (
     defs: CoreColumnDef[]
 ): CoreColumnStore => {
     for (const def of defs) {
-        if (!def.transform) continue
+        if (!def.transform || def.transformHasRun) continue
         const { transformName, params = [] } =
             extractTransformNameAndParams(def.transform!) ?? {}
         if (!transformName) continue
         const { fn } = availableTransforms[transformName]
         try {
             columnStore[def.slug] = fn(columnStore, ...params)
+            def.transformHasRun = true
         } catch (err) {
             console.error(
                 `Error performing transform '${def.transform}' for column '${

--- a/packages/@ourworldindata/core-table/src/Transforms.ts
+++ b/packages/@ourworldindata/core-table/src/Transforms.ts
@@ -420,14 +420,13 @@ export const applyTransforms = (
 ): CoreColumnStore => {
     for (let i = 0; i < defs.length; i++) {
         const def = defs[i]
-        if (!def.transform || def.transformHasRun) continue
+        if (!def.transform) continue
         const { transformName, params = [] } =
             extractTransformNameAndParams(def.transform!) ?? {}
         if (!transformName) continue
         const { fn } = availableTransforms[transformName]
         try {
             columnStore[def.slug] = fn(columnStore, ...params)
-            def.transformHasRun = true
         } catch (err) {
             console.error(
                 `Error performing transform '${def.transform}' for column '${

--- a/packages/@ourworldindata/core-table/src/index.ts
+++ b/packages/@ourworldindata/core-table/src/index.ts
@@ -124,4 +124,5 @@ export {
     computeRollingAverage,
     AvailableTransforms,
     applyTransforms,
+    extractDataSlugsFromTransform,
 } from "./Transforms.js"

--- a/packages/@ourworldindata/core-table/src/index.ts
+++ b/packages/@ourworldindata/core-table/src/index.ts
@@ -124,5 +124,5 @@ export {
     computeRollingAverage,
     AvailableTransforms,
     applyTransforms,
-    extractDataSlugsFromTransform,
+    extractPotentialDataSlugsFromTransform,
 } from "./Transforms.js"

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -581,6 +581,19 @@ export class Grapher
         }
     }
 
+    @action.bound fireWhenReady(fn: (grapher: Grapher) => void): void {
+        if (this.isReady) fn(this)
+        else {
+            this.disposers.push(
+                autorun(() => {
+                    if (this.isReady) {
+                        fn(this)
+                    }
+                })
+            )
+        }
+    }
+
     @action.bound private setTimeFromTimeQueryParam(time: string): void {
         this.timelineHandleTimeBounds = getTimeDomainFromQueryString(time).map(
             (time) => findClosestTime(this.times, time) ?? time

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -581,19 +581,6 @@ export class Grapher
         }
     }
 
-    @action.bound fireWhenReady(fn: (grapher: Grapher) => void): void {
-        if (this.isReady) fn(this)
-        else {
-            this.disposers.push(
-                autorun(() => {
-                    if (this.isReady) {
-                        fn(this)
-                    }
-                })
-            )
-        }
-    }
-
     @action.bound private setTimeFromTimeQueryParam(time: string): void {
         this.timelineHandleTimeBounds = getTimeDomainFromQueryString(time).map(
             (time) => findClosestTime(this.times, time) ?? time
@@ -754,7 +741,7 @@ export class Grapher
     }
 
     @action.bound
-    private async downloadLegacyDataFromOwidVariableIds(): Promise<void> {
+    async downloadLegacyDataFromOwidVariableIds(): Promise<void> {
         if (this.variableIds.length === 0)
             // No data to download
             return


### PR DESCRIPTION
relates to #2313

### Summary

Allows indicator metadata in explorers to be overwritten. (Technically, column definitions are overwritten.) New columns that are derived from indicators can be added using the `transform` keyword.

### Walkthrough

#### Overwriting metadata

- if a `columns` block is not linked to a table (i.e. the cell next to the `columns` keyword is empty), then the manually provided column definitions map to the indicators referenced in the `graphers` block to create charts
- mapping is done via a new column called `indicatorId` that is added to the `columns` grammar
- the manually provided column definition for an indicator is merged with the original column definition of that indicator

#### Adding derived columns

- add a new column that is derived from indicators by adding an entry to the `columns` block that has a `slug` and a `transform`
- the `transform` string can refer to indicators by id, e.g. `multiplyBy 539022 2` multiples the indicator with id `539022` by 2
- to create a chart from a derived column, refer to it by slug in the `ySlugs` column

### Screenshots

<img width="988" alt="Screenshot 2023-06-26 at 15 49 43" src="https://github.com/owid/owid-grapher/assets/12461810/ce1eaf59-aa82-4c82-83d8-529da34da371">

### To do

- [x] Chart creation mode: Be more explicit about what is supported and what is not (explain that multi-content explorers are meant to be dropped in the future #2374)
- [x] Rename indicator to variable