### PR TITLE
fix(explorers): respect entity type when explorers are embedded

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -75,7 +75,7 @@ export interface ExplorerProps extends SerializedGridProgram {
     isInStandalonePage?: boolean
     isPreview?: boolean
     canonicalUrl?: string
-    selection?: SelectionArray
+    selectedEntityNames?: string[]
 }
 
 const renderLivePreviewVersion = (props: ExplorerProps) => {
@@ -170,13 +170,11 @@ export class Explorer
     // only used for the checkbox at the bottom of the embed dialog
     @observable embedDialogHideControls = true
 
-    selection =
-        this.props.selection ??
-        new SelectionArray(
-            this.explorerProgram.selection,
-            undefined,
-            this.explorerProgram.entityType
-        )
+    selection = new SelectionArray(
+        this.props.selectedEntityNames ?? this.explorerProgram.selection,
+        undefined,
+        this.explorerProgram.entityType
+    )
 
     @observable.ref grapher?: Grapher
 
@@ -198,10 +196,10 @@ export class Explorer
 
         let url = Url.fromQueryParams(this.initialQueryParams)
 
-        if (this.props.selection?.hasSelection) {
+        if (this.props.selectedEntityNames?.length) {
             url = setSelectedEntityNamesParam(
                 url,
-                this.props.selection.selectedEntityNames
+                this.props.selectedEntityNames
             )
         }
 

--- a/site/multiembedder/MultiEmbedder.tsx
+++ b/site/multiembedder/MultiEmbedder.tsx
@@ -164,17 +164,17 @@ class MultiEmbedder {
                     bakedGrapherURL: BAKED_GRAPHER_URL,
                 }))
             }
+            const selection = new SelectionArray(
+                this.selection.selectedEntityNames
+            )
             const props: ExplorerProps = {
                 ...common,
                 ...deserializeJSONFromHTML(html, EMBEDDED_EXPLORER_DELIMITER),
                 grapherConfigs,
                 queryStr,
-                selection: new SelectionArray(
-                    this.selection.selectedEntityNames
-                ),
+                selectedEntityNames: selection.selectedEntityNames,
             }
-            if (props.selection)
-                this.graphersAndExplorersToUpdate.add(props.selection)
+            if (selection) this.graphersAndExplorersToUpdate.add(selection)
             ReactDOM.render(<Explorer {...props} />, figure)
         } else {
             figure.classList.remove("grapherPreview")


### PR DESCRIPTION
fixes #1008 

Makes embedded explorers respect the entity type.

Instead of passing a selection array to explorers, we only pass the selected entity names, then construct the selection array in the explorer component with the correct entity type. 