### PR TITLE
fix: remove underline from facet control options

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/Controls.scss
+++ b/packages/@ourworldindata/grapher/src/controls/Controls.scss
@@ -49,6 +49,10 @@ $zindex-ControlsFooter: 2;
 
     background: #ffffff;
     margin: 0px 0px;
+
+    > a {
+        text-decoration: none;
+    }
 }
 
 .FacetStrategyLabel {


### PR DESCRIPTION
relates to #1339 

Fixes an issue where facet control labels were underlined when embedded in an article.