### PR TITLE
fix(grapher): reset timeline on map click for collapsed line charts

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -927,8 +927,8 @@ export class Grapher
     }
 
     @action.bound resetHandleTimeBounds(): void {
-        this.startHandleTimeBound = this.timelineMinTime || -Infinity
-        this.endHandleTimeBound = this.timelineMaxTime || Infinity
+        this.startHandleTimeBound = this.timelineMinTime ?? -Infinity
+        this.endHandleTimeBound = this.timelineMaxTime ?? Infinity
     }
 
     // Keeps a running cache of series colors at the Grapher level.

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -926,6 +926,11 @@ export class Grapher
         return this.timelineHandleTimeBounds[1]
     }
 
+    @action.bound resetHandleTimeBounds(): void {
+        this.startHandleTimeBound = this.timelineMinTime || -Infinity
+        this.endHandleTimeBound = this.timelineMaxTime || Infinity
+    }
+
     // Keeps a running cache of series colors at the Grapher level.
     seriesColorMap: SeriesColorMap = new Map()
 

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -297,10 +297,9 @@ export class MapChart
             this.manager.currentTab = GrapherTabOption.chart
             if (
                 this.manager.isLineChartThatTurnedIntoDiscreteBar &&
-                this.manager.hasTimeline &&
-                this.manager.resetHandleTimeBounds
+                this.manager.hasTimeline
             ) {
-                this.manager.resetHandleTimeBounds()
+                this.manager.resetHandleTimeBounds?.()
             }
         } else this.selectionArray.toggleSelection(entityName)
     }

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -295,6 +295,13 @@ export class MapChart
         if (!ev.shiftKey) {
             this.selectionArray.setSelectedEntities([entityName])
             this.manager.currentTab = GrapherTabOption.chart
+            if (
+                this.manager.isLineChartThatTurnedIntoDiscreteBar &&
+                this.manager.hasTimeline &&
+                this.manager.resetHandleTimeBounds
+            ) {
+                this.manager.resetHandleTimeBounds()
+            }
         } else this.selectionArray.toggleSelection(entityName)
     }
 

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChartConstants.ts
@@ -51,6 +51,9 @@ export interface MapChartManager extends ChartManager {
     mapIsClickable?: boolean
     currentTab?: string // Used to switch to chart tab on map click
     type?: ChartTypeName // Used to determine the "Click to select" text in MapTooltip
+    isLineChartThatTurnedIntoDiscreteBar?: boolean // Used to determine whether to reset the timeline on map click
+    hasTimeline?: boolean // Used to determine whether to reset the timeline on map click
+    resetHandleTimeBounds?: () => void // Used to reset the timeline on map click
     mapConfig?: MapConfig
     endTime?: Time
 }


### PR DESCRIPTION
fixes #2309

For collapsed line charts, clicking on a country in a map currently displays a discrete bar chart with a single bar. It makes more sense to show the full time range instead.