### PR TITLE
fix(explorer): reset time when single-year view is not meaningful

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -18,6 +18,7 @@ import {
     GrapherManager,
     GrapherProgrammaticInterface,
     GrapherQueryParams,
+    GrapherTabOption,
     SelectionArray,
     setSelectedEntityNamesParam,
     SlideShowController,
@@ -339,6 +340,18 @@ export class Explorer
         newGrapherParams.tab = this.grapher.availableTabs.includes(previousTab)
             ? previousTab
             : this.grapher.availableTabs[0]
+
+        // reset the time for charts where a single-year view is not meaningful
+        if (
+            previousTab === GrapherTabOption.map &&
+            newGrapherParams.tab === GrapherTabOption.chart &&
+            (this.grapher.isLineChart ||
+                this.grapher.isStackedArea ||
+                this.grapher.isStackedBar ||
+                this.grapher.isSlopeChart)
+        ) {
+            newGrapherParams.time = undefined
+        }
 
         this.grapher.populateFromQueryParams(newGrapherParams)
     }


### PR DESCRIPTION
fixes #1693

Explorers persist the time when switching charts. This makes sense for most cases, but it can sometimes lead to sub-optimal chart views, such as collapsed line charts or stacked bar charts with only a single year. This came up in #1693, specifically for the case where switching from a map (i.e. single-year view) to a chart led to a collapsed line chart.