### PR TITLE
fix(datapage): add missing json config for multiembedder

### DIFF
--- a/site/DataPage.tsx
+++ b/site/DataPage.tsx
@@ -10,6 +10,7 @@ import {
     DataPageGdocContent,
     DataPageJson,
     OwidGdocInterface,
+    serializeJSONForHTML,
 } from "@ourworldindata/utils"
 import React from "react"
 import urljoin from "url-join"
@@ -79,6 +80,8 @@ export const DataPage = (props: {
         bakedGrapherURL: BAKED_GRAPHER_URL,
         adminBaseUrl: ADMIN_BASE_URL,
     }
+
+    const script = `const jsonConfig = ${serializeJSONForHTML(grapherConfig)};`
 
     return (
         <html>
@@ -165,6 +168,10 @@ export const DataPage = (props: {
                     baseUrl={baseUrl}
                     context={SiteFooterContext.dataPage}
                     isPreviewing={isPreviewing}
+                />
+                <script
+                    type="module"
+                    dangerouslySetInnerHTML={{ __html: script }}
                 />
             </body>
         </html>


### PR DESCRIPTION
Data page don't include the json config used by the multiEmbedder to render grapher charts. This PR adds it, similarly to how it is being done on grapher pages.

This affects all data page charts embedded on ourworldindata.org as well as other properties where `embedCharts.js` is used (e.g. sdg-tracker.org)