### PR TITLE
🔨 use cached explorers during baking gdocs

### DIFF
--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -317,7 +317,7 @@ export class SiteBaker {
             publishedGdoc.imageMetadata = imageMetadataDictionary
             publishedGdoc.linkedDocuments = publishedGdocsDictionary
             const publishedExplorersBySlug =
-                await this.explorerAdminServer.getAllPublishedExplorersBySlug()
+                await this.explorerAdminServer.getAllPublishedExplorersBySlugCached()
 
             await publishedGdoc.validate(publishedExplorersBySlug)
             if (publishedGdoc.errors.length) {


### PR DESCRIPTION
Fixes https://github.com/owid/owid-grapher/issues/2346, maybe

Running two test bakes on Ptolemy:

Average gdoc bake time:
before: `3572ms`
after: `591ms`

We should update `explorerAdminServer` to use the DB, but until then, this will have to suffice.