### PR TITLE
feat(grapher): add markdown support for sources text

### DIFF
--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -85,13 +85,12 @@ export class Footer extends React.Component<{
         return 0.7 * (this.manager.fontSize ?? BASE_FONT_SIZE)
     }
 
-    @computed private get sources(): TextWrap {
+    @computed private get sources(): MarkdownTextWrap {
         const { maxWidth, fontSize, sourcesText } = this
-        return new TextWrap({
+        return new MarkdownTextWrap({
             maxWidth,
             fontSize,
             text: sourcesText,
-            linkifyText: true,
         })
     }
 
@@ -153,7 +152,7 @@ export class Footer extends React.Component<{
         return (
             <g className="SourcesFooter" style={{ fill: "#777" }}>
                 <g style={{ fill: "#777" }}>
-                    {sources.render(targetX, targetY)}
+                    {sources.renderSVG(targetX, targetY)}
                 </g>
                 {note.renderSVG(targetX, targetY + sources.height + paraMargin)}
                 {isCompact
@@ -241,9 +240,7 @@ export class Footer extends React.Component<{
                 style={{ color: "#777" }}
             >
                 {this.isCompact && license}
-                <p style={this.sources.htmlStyle}>
-                    {this.sources.renderHTML()}
-                </p>
+                <p style={this.sources.style}>{this.sources.renderHTML()}</p>
                 {this.note && (
                     <p style={this.note.style}>{this.note.renderHTML()}</p>
                 )}

--- a/packages/@ourworldindata/utils/src/MarkdownTextWrap/MarkdownTextWrap.tsx
+++ b/packages/@ourworldindata/utils/src/MarkdownTextWrap/MarkdownTextWrap.tsx
@@ -624,7 +624,7 @@ export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
     @computed get width(): number {
         const { htmlLines } = this
         const lineLengths = htmlLines.map((tokens) =>
-            tokens.reduce((acc, token) => acc + token.width, 0)
+            sumBy(tokens, (token) => token.width)
         )
         return max(lineLengths) ?? 0
     }

--- a/packages/@ourworldindata/utils/src/MarkdownTextWrap/MarkdownTextWrap.tsx
+++ b/packages/@ourworldindata/utils/src/MarkdownTextWrap/MarkdownTextWrap.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties } from "react"
 import { computed } from "mobx"
 import { EveryMarkdownNode, MarkdownRoot, mdParser } from "./parser"
-import { excludeUndefined, last, sum, imemo, max } from "../Util.js"
+import { excludeUndefined, last, sum, sumBy, imemo, max } from "../Util.js"
 import { Bounds, FontFamily } from "../Bounds.js"
 import { TextWrap } from "../TextWrap/TextWrap.js"
 

--- a/packages/@ourworldindata/utils/src/MarkdownTextWrap/MarkdownTextWrap.tsx
+++ b/packages/@ourworldindata/utils/src/MarkdownTextWrap/MarkdownTextWrap.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties } from "react"
 import { computed } from "mobx"
 import { EveryMarkdownNode, MarkdownRoot, mdParser } from "./parser"
-import { excludeUndefined, last, sum, imemo } from "../Util.js"
+import { excludeUndefined, last, sum, imemo, max } from "../Util.js"
 import { Bounds, FontFamily } from "../Bounds.js"
 import { TextWrap } from "../TextWrap/TextWrap.js"
 
@@ -619,6 +619,14 @@ export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
         const tokens = parsimmonToTextTokens(this.ast, this.fontParams)
         const tokensWithReferenceNumbers = appendReferenceNumbers(tokens)
         return splitIntoLines(tokensWithReferenceNumbers, this.maxWidth)
+    }
+
+    @computed get width(): number {
+        const { htmlLines } = this
+        const lineLengths = htmlLines.map((tokens) =>
+            tokens.reduce((acc, token) => acc + token.width, 0)
+        )
+        return max(lineLengths) ?? 0
     }
 
     @computed get height(): number {


### PR DESCRIPTION
Requested by Joe on [Slack](https://owid.slack.com/archives/C46U9LXRR/p1687335978710619)

### Summary

Adds markdown support for the "Source" text in the footer. The main reason for doing this is to add support for Markdown links.

### Details

- No migration needed: Previously the text was "linkified" (links were detected and wrapped in an anchor tag). Markdown picks up plain text links as well, so existing charts should be fine
- We should consider inlining links in SVG exports (open issue: #2348)