### PR TITLE
refactor(dp): deduplicate grapher config

### DIFF
--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -198,6 +198,7 @@ export {
     type DataPageJson,
     type DataPageParseError,
     AllowedDataPageGdocFields,
+    type DataPageContentFields,
 } from "./owidTypes.js"
 
 export {

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1396,3 +1396,10 @@ export const DataPageJsonTypeObject = Type.Object(
 export type DataPageJson = Static<typeof DataPageJsonTypeObject>
 
 export type DataPageParseError = { message: string; path?: string }
+
+export interface DataPageContentFields {
+    datapageJson: DataPageJson
+    datapageGdoc?: OwidGdocInterface | null
+    datapageGdocContent?: DataPageGdocContent | null
+    isPreviewing?: boolean
+}

--- a/site/DataPage.tsx
+++ b/site/DataPage.tsx
@@ -81,8 +81,6 @@ export const DataPage = (props: {
         adminBaseUrl: ADMIN_BASE_URL,
     }
 
-    const script = `const jsonConfig = ${serializeJSONForHTML(grapherConfig)};`
-
     return (
         <html>
             <Head
@@ -146,7 +144,6 @@ export const DataPage = (props: {
                                         datapageJson,
                                         datapageGdoc,
                                         datapageGdocContent,
-                                        grapherConfig,
                                     }
                                 )}`,
                             }}
@@ -170,8 +167,11 @@ export const DataPage = (props: {
                     isPreviewing={isPreviewing}
                 />
                 <script
-                    type="module"
-                    dangerouslySetInnerHTML={{ __html: script }}
+                    dangerouslySetInnerHTML={{
+                        __html: `window._OWID_GRAPHER_CONFIG = ${serializeJSONForHTML(
+                            grapherConfig
+                        )}`,
+                    }}
                 />
             </body>
         </html>

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -22,6 +22,7 @@ import { CodeSnippet } from "./blocks/CodeSnippet.js"
 declare global {
     interface Window {
         _OWID_DATAPAGE_PROPS: any
+        _OWID_GRAPHER_CONFIG: GrapherInterface
     }
 }
 
@@ -681,9 +682,15 @@ export const DataPageContent = ({
 export const hydrateDataPageContent = (isPreviewing?: boolean) => {
     const wrapper = document.querySelector(`#${OWID_DATAPAGE_CONTENT_ROOT_ID}`)
     const props = window._OWID_DATAPAGE_PROPS
+    const grapherConfig = window._OWID_GRAPHER_CONFIG
+
     ReactDOM.hydrate(
         <DebugProvider debug={isPreviewing}>
-            <DataPageContent {...props} isPreviewing={isPreviewing} />
+            <DataPageContent
+                {...props}
+                grapherConfig={grapherConfig}
+                isPreviewing={isPreviewing}
+            />
         </DebugProvider>,
         wrapper
     )

--- a/site/DataPageContent.tsx
+++ b/site/DataPageContent.tsx
@@ -8,11 +8,7 @@ import { GrapherWithFallback } from "./GrapherWithFallback.js"
 import { formatAuthors } from "./clientFormatting.js"
 import { ArticleBlocks } from "./gdocs/ArticleBlocks.js"
 import { RelatedCharts } from "./blocks/RelatedCharts.js"
-import {
-    DataPageGdocContent,
-    DataPageJson,
-    OwidGdocInterface,
-} from "@ourworldindata/utils"
+import { DataPageContentFields } from "@ourworldindata/utils"
 import { AttachmentsContext, DocumentContext } from "./gdocs/OwidGdoc.js"
 import StickyNav from "./blocks/StickyNav.js"
 import cx from "classnames"
@@ -21,7 +17,7 @@ import { CodeSnippet } from "./blocks/CodeSnippet.js"
 
 declare global {
     interface Window {
-        _OWID_DATAPAGE_PROPS: any
+        _OWID_DATAPAGE_PROPS: DataPageContentFields
         _OWID_GRAPHER_CONFIG: GrapherInterface
     }
 }
@@ -34,12 +30,8 @@ export const DataPageContent = ({
     datapageGdocContent,
     grapherConfig,
     isPreviewing = false,
-}: {
-    datapageJson: DataPageJson
-    datapageGdoc?: OwidGdocInterface | null
-    datapageGdocContent?: DataPageGdocContent | null
+}: DataPageContentFields & {
     grapherConfig: GrapherInterface
-    isPreviewing: boolean
 }) => {
     const [grapher, setGrapher] = React.useState<Grapher | undefined>(undefined)
 


### PR DESCRIPTION
Follow up to #2350, which added the grapher config in the page for the multiEmbedder to consume - thus duplicating it with the grapher config passed within OWID_DATAPAGE_PROPS.

This PR unifies both sources and makes DataPageContent consume the same grapher config as Grapher components.