### PR TITLE
🐛 pre-fetch linkedCharts before baking

### DIFF
--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -14,6 +14,7 @@ import {
     IMAGE_HOSTING_CDN_URL,
     IMAGE_HOSTING_BUCKET_SUBFOLDER_PATH,
     GDOCS_DETAILS_ON_DEMAND_ID,
+    BAKED_GRAPHER_URL,
 } from "../settings/serverSettings.js"
 
 import {
@@ -47,6 +48,7 @@ import {
     clone,
     getFilenameAsPng,
     extractDetailsFromSyntax,
+    LinkedChart,
 } from "@ourworldindata/utils"
 import { execWrapper } from "../db/execWrapper.js"
 import { countryProfileSpecs } from "../site/countryProfileProjects.js"
@@ -65,6 +67,12 @@ import { Image } from "../db/model/Image.js"
 import sharp from "sharp"
 import { generateEmbedSnippet } from "../site/viteUtils.js"
 import { logErrorAndMaybeSendToBugsnag } from "../serverUtils/errorLog.js"
+import { Chart } from "../db/model/Chart.js"
+import { GrapherInterface } from "@ourworldindata/grapher"
+import {
+    BAKED_BASE_URL,
+    BAKED_GRAPHER_EXPORTS_BASE_URL,
+} from "../settings/clientSettings.js"
 
 // These aren't all "wordpress" steps
 // But they're only run when you have the full stack available
@@ -307,17 +315,55 @@ export class SiteBaker {
         if (!this.bakeSteps.has("gdocPosts")) return
         const publishedGdocs = await Gdoc.getPublishedGdocs()
 
-        // Prefetch publishedGdocs and imageMetadata instead of each instance fetching
+        // Prefetch publishedGdocs, imageMetadata, and linkedCharts instead of each instance fetching
         const publishedGdocsDictionary = keyBy(publishedGdocs.map(clone), "id")
         const imageMetadataDictionary = await Image.find().then((images) =>
             keyBy(images, "filename")
+        )
+        const publishedExplorersBySlug = await this.explorerAdminServer
+            .getAllPublishedExplorersBySlugCached()
+            .then((results) =>
+                Object.values(results).reduce(
+                    (acc, cur) => ({
+                        ...acc,
+                        [cur.slug]: {
+                            originalSlug: cur.slug,
+                            resolvedUrl: `${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${cur.slug}`,
+                            title: cur.title || "",
+                            thumbnail:
+                                cur.thumbnail ||
+                                `${BAKED_BASE_URL}/default-thumbnail.jpg`,
+                        },
+                    }),
+                    {} as Record<string, LinkedChart>
+                )
+            )
+        // Includes redirects
+        const publishedChartsBySlug = await Chart.mapSlugsToConfigs().then(
+            (results) =>
+                results.reduce(
+                    (acc, cur) => ({
+                        ...acc,
+                        [cur.slug]: {
+                            originalSlug: cur.slug,
+                            resolvedUrl: `${BAKED_GRAPHER_URL}/${cur.config.slug}`,
+                            title: cur.config.title || "",
+                            thumbnail: `${BAKED_GRAPHER_EXPORTS_BASE_URL}/${cur.slug}.svg`,
+                        },
+                    }),
+                    {} as Record<string, LinkedChart>
+                )
         )
 
         for (const publishedGdoc of publishedGdocs) {
             publishedGdoc.imageMetadata = imageMetadataDictionary
             publishedGdoc.linkedDocuments = publishedGdocsDictionary
-            const publishedExplorersBySlug =
-                await this.explorerAdminServer.getAllPublishedExplorersBySlugCached()
+            publishedGdoc.linkedCharts = {
+                ...publishedChartsBySlug,
+                ...publishedExplorersBySlug,
+            }
+            // this is a no-op if the gdoc doesn't have an all-chart block
+            await publishedGdoc.loadRelatedCharts()
 
             await publishedGdoc.validate(publishedExplorersBySlug)
             if (publishedGdoc.errors.length) {

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -68,7 +68,6 @@ import sharp from "sharp"
 import { generateEmbedSnippet } from "../site/viteUtils.js"
 import { logErrorAndMaybeSendToBugsnag } from "../serverUtils/errorLog.js"
 import { Chart } from "../db/model/Chart.js"
-import { GrapherInterface } from "@ourworldindata/grapher"
 import {
     BAKED_BASE_URL,
     BAKED_GRAPHER_EXPORTS_BASE_URL,

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -2,7 +2,7 @@ import fs from "fs-extra"
 import { writeFile } from "node:fs/promises"
 import path from "path"
 import { glob } from "glob"
-import { keyBy, without, uniq } from "lodash"
+import { keyBy, without, uniq, mapValues } from "lodash"
 import cheerio from "cheerio"
 import ProgressBar from "progress"
 import * as wpdb from "../db/wpdb.js"
@@ -322,20 +322,14 @@ export class SiteBaker {
         const publishedExplorersBySlug = await this.explorerAdminServer
             .getAllPublishedExplorersBySlugCached()
             .then((results) =>
-                Object.values(results).reduce(
-                    (acc, cur) => ({
-                        ...acc,
-                        [cur.slug]: {
-                            originalSlug: cur.slug,
-                            resolvedUrl: `${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${cur.slug}`,
-                            title: cur.title || "",
-                            thumbnail:
-                                cur.thumbnail ||
-                                `${BAKED_BASE_URL}/default-thumbnail.jpg`,
-                        },
-                    }),
-                    {} as Record<string, LinkedChart>
-                )
+                mapValues(results, (cur) => ({
+                    originalSlug: cur.slug,
+                    resolvedUrl: `${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${cur.slug}`,
+                    title: cur.title || "",
+                    thumbnail:
+                        cur.thumbnail ||
+                        `${BAKED_BASE_URL}/default-thumbnail.jpg`,
+                }))
             )
         // Includes redirects
         const publishedChartsBySlug = await Chart.mapSlugsToConfigs().then(
@@ -347,7 +341,7 @@ export class SiteBaker {
                             originalSlug: cur.slug,
                             resolvedUrl: `${BAKED_GRAPHER_URL}/${cur.config.slug}`,
                             title: cur.config.title || "",
-                            thumbnail: `${BAKED_GRAPHER_EXPORTS_BASE_URL}/${cur.slug}.svg`,
+                            thumbnail: `${BAKED_GRAPHER_EXPORTS_BASE_URL}/${cur.config.slug}.svg`,
                         },
                     }),
                     {} as Record<string, LinkedChart>

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -16,7 +16,7 @@ import {
     MultipleOwidVariableDataDimensionsMap,
     Tag,
 } from "@ourworldindata/utils"
-import { Grapher, GrapherInterface } from "@ourworldindata/grapher"
+import { GrapherInterface } from "@ourworldindata/grapher"
 
 // XXX hardcoded filtering to public parent tags
 const PUBLIC_TAG_PARENT_IDS = [

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -80,8 +80,8 @@ export class Chart extends BaseEntity {
             .queryMysql(
                 `
 SELECT csr.slug AS slug, c.config AS config, c.id AS id
-FROM chart_slug_redirects AS csr
-JOIN charts AS c
+FROM chart_slug_redirects csr
+JOIN charts c
 ON csr.chart_id = c.id
 WHERE c.config -> "$.isPublished" = true
 UNION

--- a/db/model/Gdoc/Gdoc.ts
+++ b/db/model/Gdoc/Gdoc.ts
@@ -294,19 +294,22 @@ export class Gdoc extends BaseEntity implements OwidGdocInterface {
         )
 
         const linkedGrapherCharts = await Promise.all(
-            [...uniqueSlugsByLinkType.grapher.values()].map(async (slug) => {
-                const chartId = slugToIdMap[slug]
-                const chart = await Chart.findOneBy({ id: chartId })
-                if (!chart) return
-                const resolvedSlug = chart.config.slug ?? ""
-                const linkedChart: LinkedChart = {
-                    slug: resolvedSlug,
-                    title: chart?.config.title ?? "",
-                    path: `${BAKED_GRAPHER_URL}/${slug}`,
-                    thumbnail: `${BAKED_GRAPHER_EXPORTS_BASE_URL}/${chart?.config.slug}.svg`,
+            [...uniqueSlugsByLinkType.grapher.values()].map(
+                async (originalSlug) => {
+                    const chartId = slugToIdMap[originalSlug]
+                    const chart = await Chart.findOneBy({ id: chartId })
+                    if (!chart) return
+                    const resolvedSlug = chart.config.slug ?? ""
+                    const resolvedTitle = chart.config.title ?? ""
+                    const linkedChart: LinkedChart = {
+                        originalSlug,
+                        title: resolvedTitle,
+                        resolvedUrl: `${BAKED_GRAPHER_URL}/${resolvedSlug}`,
+                        thumbnail: `${BAKED_GRAPHER_EXPORTS_BASE_URL}/${resolvedSlug}.svg`,
+                    }
+                    return linkedChart
                 }
-                return linkedChart
-            })
+            )
         ).then(excludeNullish)
 
         const linkedExplorerCharts = await Promise.all(
@@ -314,9 +317,10 @@ export class Gdoc extends BaseEntity implements OwidGdocInterface {
                 const explorer = publishedExplorersBySlug[slug]
                 if (!explorer) return
                 const linkedChart: LinkedChart = {
-                    slug,
+                    // we are assuming explorer slugs won't change
+                    originalSlug: slug,
                     title: explorer?.explorerTitle ?? "",
-                    path: `${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${slug}`,
+                    resolvedUrl: `${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${slug}`,
                     thumbnail: `${BAKED_BASE_URL}/default-thumbnail.jpg`,
                 }
                 return linkedChart
@@ -325,7 +329,7 @@ export class Gdoc extends BaseEntity implements OwidGdocInterface {
 
         this.linkedCharts = keyBy(
             [...linkedGrapherCharts, ...linkedExplorerCharts],
-            "slug"
+            "originalSlug"
         )
     }
 

--- a/db/model/Gdoc/Gdoc.ts
+++ b/db/model/Gdoc/Gdoc.ts
@@ -297,6 +297,7 @@ export class Gdoc extends BaseEntity implements OwidGdocInterface {
             [...uniqueSlugsByLinkType.grapher.values()].map(
                 async (originalSlug) => {
                     const chartId = slugToIdMap[originalSlug]
+                    if (!chartId) return
                     const chart = await Chart.findOneBy({ id: chartId })
                     if (!chart) return
                     const resolvedSlug = chart.config.slug ?? ""

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1113,8 +1113,8 @@ export interface OwidGdocTag {
 
 // A minimal object containing metadata needed for rendering prominent links etc in the client
 export interface LinkedChart {
-    slug: string
-    path: string
+    originalSlug: string
+    resolvedUrl: string
     title: string
     thumbnail?: string
 }

--- a/site/gdocs/ProminentLink.tsx
+++ b/site/gdocs/ProminentLink.tsx
@@ -50,7 +50,7 @@ export const ProminentLink = (props: {
         description = description ?? linkedDocument?.content.excerpt
         thumbnail = thumbnail ?? linkedDocument?.content["featured-image"]
     } else if (linkType === "grapher" || linkType === "explorer") {
-        href = `${linkedChart?.path}`
+        href = `${linkedChart?.resolvedUrl}`
         title = title ?? linkedChart?.title
         thumbnail = thumbnail ?? linkedChart?.thumbnail
         description =

--- a/site/gdocs/utils.tsx
+++ b/site/gdocs/utils.tsx
@@ -74,7 +74,7 @@ const LinkedA = ({ span }: { span: SpanLink }): JSX.Element => {
     }
     if (linkedChart) {
         return (
-            <a href={`/${linkedChart.slug}`} className="span-link">
+            <a href={linkedChart.resolvedUrl} className="span-link">
                 {renderSpans(span.children)}
             </a>
         )


### PR DESCRIPTION
Found a pretty glaring oversight in the Gdoc baking process - we weren't including `linkedCharts`, which are needed to resolve any URLs / metadata to charts/explorers within a Gdoc.

It's a slightly more involved process because we need to resolve redirects first.

e.g. if a gdoc has a prominent link:

```
{.prominent-link}
url: https://ourworldindata.org/grapher/some-slug
{}
```
We use that slug to get the title and thumbnail for the prominent link.

If we update that slug, a redirect is created and we have to then resolve that redirect first before we can fetch the correct metadata.

An individual Gdoc already can already do this by calling `loadLinkedCharts`, but I didn't want to call that once per document so I fetch every single published chart & explorer and attach them instead. 

The reason we don't just do that all the time is because, for previews, we need to pass `linkedCharts` (along with the rest of the Gdoc) to the browser so passing 5000 grapher configs isn't really feasible.