### PR TITLE
feat(gdocs): New block `align`

### DIFF
--- a/adminSiteClient/gdocsValidation.ts
+++ b/adminSiteClient/gdocsValidation.ts
@@ -34,15 +34,17 @@ class BodyHandler extends AbstractHandler {
             messages.push(getMissingContentPropertyError("body"))
         } else {
             for (const block of body) {
-                messages.push(
-                    ...block.parseErrors.map((parseError) => ({
-                        message: parseError.message,
-                        type: parseError.isWarning
-                            ? OwidGdocErrorMessageType.Warning
-                            : OwidGdocErrorMessageType.Error,
-                        property: "body" as const,
-                    }))
-                )
+                traverseEnrichedBlocks(block, (block) => {
+                    messages.push(
+                        ...block.parseErrors.map((parseError) => ({
+                            message: parseError.message,
+                            type: parseError.isWarning
+                                ? OwidGdocErrorMessageType.Warning
+                                : OwidGdocErrorMessageType.Error,
+                            property: "body" as const,
+                        }))
+                    )
+                })
             }
         }
 

--- a/db/model/Gdoc/Gdoc.ts
+++ b/db/model/Gdoc/Gdoc.ts
@@ -572,6 +572,7 @@ export class Gdoc extends BaseEntity implements OwidGdocInterface {
                     // their children may contain urls, but they'll be addressed by traverseEnrichedBlocks
                     type: P.union(
                         "additional-charts",
+                        "align",
                         "aside",
                         "callout",
                         "expandable-paragraph",

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -34,6 +34,7 @@ import {
 } from "@ourworldindata/utils"
 import { spanToHtmlString } from "./gdocUtils.js"
 import { match, P } from "ts-pattern"
+import { RawBlockAlign } from "@ourworldindata/utils/dist/owidTypes.js"
 
 function spansToHtmlText(spans: Span[]): string {
     return spans.map(spanToHtmlString).join("")
@@ -362,5 +363,14 @@ export function enrichedBlockToRawBlock(
                 }
             }
         )
+        .with({ type: "align" }, (b): RawBlockAlign => {
+            return {
+                type: b.type,
+                value: {
+                    alignment: b.alignment as string,
+                    content: b.content.map(enrichedBlockToRawBlock),
+                },
+            }
+        })
         .exhaustive()
 }

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -2,6 +2,7 @@ import {
     BlockImageSize,
     EnrichedBlockChart,
     EnrichedBlockText,
+    HorizontalAlign,
     OwidEnrichedGdocBlock,
     Span,
     SpanSimpleText,
@@ -410,5 +411,11 @@ export const enrichedBlockExamples: Record<
                 ],
             },
         ],
+    },
+    align: {
+        type: "align",
+        alignment: HorizontalAlign.center,
+        content: [enrichedBlockText],
+        parseErrors: [],
     },
 }

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -30,6 +30,7 @@ import {
     RawBlockTopicPageIntro,
     RawBlockExpandableParagraph,
 } from "@ourworldindata/utils"
+import { RawBlockAlign } from "@ourworldindata/utils/dist/owidTypes.js"
 import { match } from "ts-pattern"
 
 export function appendDotEndIfMultiline(
@@ -507,6 +508,20 @@ function* rawResearchAndWritingToArchieMLString(
     yield "{}"
 }
 
+function* rawBlockAlignToArchieMLString(
+    block: RawBlockAlign
+): Generator<string, void, undefined> {
+    yield "{.align}"
+    yield* propertyToArchieMLString("alignment", block.value)
+
+    yield "[.+content]"
+    for (const content of block.value.content) {
+        yield* OwidRawGdocBlockToArchieMLStringGenerator(content)
+    }
+    yield "[]"
+    yield "{}"
+}
+
 export function* OwidRawGdocBlockToArchieMLStringGenerator(
     block: OwidRawGdocBlock
 ): Generator<string, void, undefined> {
@@ -565,6 +580,7 @@ export function* OwidRawGdocBlockToArchieMLStringGenerator(
             { type: "research-and-writing" },
             rawResearchAndWritingToArchieMLString
         )
+        .with({ type: "align" }, rawBlockAlignToArchieMLString)
         .exhaustive()
     yield* content
 }

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1540,6 +1540,12 @@ export function traverseEnrichedBlocks(
                 traverseEnrichedBlocks(textBlock, callback, spanCallback)
             })
         })
+        .with({ type: "align" }, (align) => {
+            callback(align)
+            align.content.forEach((node) => {
+                traverseEnrichedBlocks(node, callback, spanCallback)
+            })
+        })
         .with(
             {
                 type: P.union(
@@ -1557,8 +1563,7 @@ export function traverseEnrichedBlocks(
                     "sdg-grid",
                     "sdg-toc",
                     "topic-page-intro",
-                    "all-charts",
-                    "align"
+                    "all-charts"
                 ),
             },
             callback

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1557,7 +1557,8 @@ export function traverseEnrichedBlocks(
                     "sdg-grid",
                     "sdg-toc",
                     "topic-page-intro",
-                    "all-charts"
+                    "all-charts",
+                    "align"
                 ),
             },
             callback

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -199,6 +199,9 @@ export {
     type DataPageParseError,
     AllowedDataPageGdocFields,
     type DataPageContentFields,
+    type RawBlockResearchAndWritingRow,
+    type EnrichedBlockAlign,
+    type RawBlockAlign,
 } from "./owidTypes.js"
 
 export {

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1022,6 +1022,20 @@ export type EnrichedBlockExpandableParagraph = {
     items: OwidEnrichedGdocBlock[]
 } & EnrichedBlockWithParseErrors
 
+export type RawBlockAlign = {
+    type: "align"
+    value: {
+        alignment: string
+        content: OwidRawGdocBlock[]
+    }
+}
+
+export type EnrichedBlockAlign = {
+    type: "align"
+    alignment: HorizontalAlign
+    content: OwidEnrichedGdocBlock[]
+} & EnrichedBlockWithParseErrors
+
 export type Ref = {
     id: string
     // Can be -1
@@ -1065,6 +1079,7 @@ export type OwidRawGdocBlock =
     | RawBlockExpandableParagraph
     | RawBlockTopicPageIntro
     | RawBlockKeyInsights
+    | RawBlockAlign
 
 export type OwidEnrichedGdocBlock =
     | EnrichedBlockAllCharts
@@ -1097,6 +1112,7 @@ export type OwidEnrichedGdocBlock =
     | EnrichedBlockTopicPageIntro
     | EnrichedBlockKeyInsights
     | EnrichedBlockResearchAndWriting
+    | EnrichedBlockAlign
 
 export enum OwidGdocPublicationContext {
     unlisted = "unlisted",

--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -51,6 +51,7 @@ type Layouts = { default: string; [key: string]: string }
 // prettier-ignore
 const layouts: { [key in Container]: Layouts} = {
     ["default"]: {
+        ["align"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["all-charts"]: "col-start-2 span-cols-12",
         ["aside-left"]: "col-start-2 span-cols-3 span-md-cols-10 col-md-start-3",
         ["aside-right"]: "col-start-11 span-cols-3 span-md-cols-10 col-md-start-3",
@@ -529,6 +530,18 @@ export default function ArticleBlock({
                 {...block}
                 className={getLayout("research-and-writing", containerType)}
             />
+        ))
+        .with({ type: "align" }, (block) => (
+            <div
+                className={cx(
+                    `align-${block.alignment}`,
+                    getLayout("align", containerType)
+                )}
+            >
+                {block.content.map((b, i) => (
+                    <ArticleBlock key={i} b={b} />
+                ))}
+            </div>
         ))
         .exhaustive()
 

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -87,17 +87,6 @@ h2.article-block__heading.has-supertitle {
         color: $blue-50;
         margin-bottom: 8px;
     }
-
-    // Center the next three subsequent paragraphs 🥴
-    + .article-block__text {
-        text-align: center;
-        + .article-block__text {
-            text-align: center;
-            + .article-block__text {
-                text-align: center;
-            }
-        }
-    }
 }
 
 .centered-article-container > .article-block__divider {

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -578,6 +578,20 @@ h3.article-block__heading.has-supertitle {
     }
 }
 
+.article-block__align {
+    &.align-left {
+        text-align: left;
+    }
+
+    &.align-center {
+        text-align: center;
+    }
+
+    &.align-right {
+        text-align: right;
+    }
+}
+
 .html-table {
     @include body-3-medium;
     border-collapse: collapse;


### PR DESCRIPTION
As part of #2331.

This is my first ever gdocs block, so I'm putting it out for review already so I know more when working on future blocks.

Example ArchieML:
```
{.align}
alignment: center

[.+content]
Centered text
[]
{}

```

Test document that you can use: https://docs.google.com/document/d/1rR5dbQeINJJL3nsv-wchL8aqjhCjwU3Hp7nWG8l29wY/edit

<img width="682" alt="image" src="https://github.com/owid/owid-grapher/assets/2641501/afbe6e69-c968-40cf-b812-8b10fb530bdb">

## Open questions:
- The block only sets `text-align`, which means that only text is affected, not chart blocks, images, etc.
  The block can, however, contain these because I don't enforce block types that go into the block. Should I??
