### PR TITLE
fix(dp): remove duplicate all charts

### DIFF
--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -632,7 +632,7 @@ export const getRelatedChartsForVariable = async (
             : ""
 
     return db.queryMysql(`
-                SELECT DISTINCT
+                SELECT
                     charts.config->>"$.slug" AS slug,
                     charts.config->>"$.title" AS title,
                     charts.config->>"$.variantName" AS variantName,

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -636,12 +636,13 @@ export const getRelatedChartsForVariable = async (
                     charts.config->>"$.slug" AS slug,
                     charts.config->>"$.title" AS title,
                     charts.config->>"$.variantName" AS variantName,
-                    chart_tags.isKeyChart
+                    MAX(chart_tags.isKeyChart) as isKeyChart
                 FROM charts
                 INNER JOIN chart_tags ON charts.id=chart_tags.chartId
                 WHERE JSON_CONTAINS(config->'$.dimensions', '{"variableId":${variableId}}')
                 AND charts.config->>"$.isPublished" = "true"
                 ${excludeChartIds}
+                GROUP BY charts.id
                 ORDER BY title ASC
             `)
 }


### PR DESCRIPTION
Removes duplicate charts in the all charts block on data pages by listing a chart only once, even if it is key chart on a topic, and non key chart on others.

Testing: search for "share in poverty relative to different poverty thresholds" in the all charts block on:
- [live](https://owid.cloud/admin/grapher/share-of-population-in-extreme-poverty): 2 identical charts ❌
- [staging](http://staging-site-datapages/admin/grapher/share-of-population-in-extreme-poverty): 1 single chart ✅

<img width="1440" alt="Screenshot 2023-06-26 at 15 10 24" src="https://github.com/owid/owid-grapher/assets/13406362/4ed2366d-f1ec-4f45-93ef-37b219a06aeb">


We could push this further by aggregating using SUM instead of MAX, thus promoting a chart which is key chart on multiple topics further up. However, this would require further changes in downstream code to change the type of isKeyChart to number (and rename accordingly, e.g. countKeyChart)
