### PR TITLE
✨ : use ResizeObserver to observe Grapher/Explorer container size

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -72,6 +72,7 @@ import {
     explorerUrlMigrationsById,
     migrateExplorerUrl,
 } from "./urlMigrations/ExplorerUrlMigrations.js"
+import Bugsnag from "@bugsnag/js"
 
 export interface ExplorerProps extends SerializedGridProgram {
     grapherConfigs?: GrapherInterface[]
@@ -259,11 +260,16 @@ export class Explorer
             this.disposers.push(() => {
                 resizeObserver.disconnect()
             })
-        } else if (typeof window === "object" && typeof document === "object") {
+        } else if (
+            typeof window === "object" &&
+            typeof document === "object" &&
+            !navigator.userAgent.includes("jsdom")
+        ) {
             // only show the warning when we're in something that roughly resembles a browser
             console.warn(
                 "ResizeObserver not available; the explorer will not be responsive to window resizes"
             )
+            Bugsnag?.notify("ResizeObserver not available")
 
             this.onResize() // fire once to initialize, at least
         }

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -250,14 +250,23 @@ export class Explorer
     }
 
     private attachEventListeners() {
-        const onResizeThrottled = debounce(this.onResize, 200, {
-            leading: true,
-        })
-        const resizeObserver = new ResizeObserver(onResizeThrottled)
-        resizeObserver.observe(this.grapherContainerRef.current!)
-        this.disposers.push(() => {
-            resizeObserver.disconnect()
-        })
+        if (typeof window !== "undefined" && "ResizeObserver" in window) {
+            const onResizeThrottled = debounce(this.onResize, 200, {
+                leading: true,
+            })
+            const resizeObserver = new ResizeObserver(onResizeThrottled)
+            resizeObserver.observe(this.grapherContainerRef.current!)
+            this.disposers.push(() => {
+                resizeObserver.disconnect()
+            })
+        } else if (typeof window === "object" && typeof document === "object") {
+            // only show the warning when we're in something that roughly resembles a browser
+            console.warn(
+                "ResizeObserver not available; the explorer will not be responsive to window resizes"
+            )
+
+            this.onResize() // fire once to initialize, at least
+        }
 
         // We always prefer the entity picker metric to be sourced from the currently displayed table.
         // To do this properly, we need to also react to the table changing.

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -41,7 +41,6 @@ import {
     PromiseSwitcher,
     SerializedGridProgram,
     setWindowUrl,
-    throttle,
     uniq,
     uniqBy,
     Url,
@@ -220,10 +219,8 @@ export class Explorer
         this.grapher?.populateFromQueryParams(url.queryParams)
 
         exposeInstanceOnWindow(this, "explorer")
-        this.onResize() // call resize for the first time to initialize chart
-        this.updateEntityPickerTable() // call for the first time to initialize EntityPicker
-
         this.attachEventListeners()
+        this.updateEntityPickerTable() // call for the first time to initialize EntityPicker
     }
 
     componentDidUpdate() {
@@ -253,11 +250,13 @@ export class Explorer
     }
 
     private attachEventListeners() {
-        this.onResizeThrottled = throttle(this.onResize, 100)
-        window.addEventListener("resize", this.onResizeThrottled)
+        const onResizeThrottled = debounce(this.onResize, 200, {
+            leading: true,
+        })
+        const resizeObserver = new ResizeObserver(onResizeThrottled)
+        resizeObserver.observe(this.grapherContainerRef.current!)
         this.disposers.push(() => {
-            if (this.onResizeThrottled !== undefined)
-                window.removeEventListener("resize", this.onResizeThrottled)
+            resizeObserver.disconnect()
         })
 
         // We always prefer the entity picker metric to be sourced from the currently displayed table.
@@ -790,13 +789,15 @@ export class Explorer
         )
     }
 
-    private onResizeThrottled?: () => void
-
     @action.bound private toggleMobileControls() {
         this.showMobileControlsPopup = !this.showMobileControlsPopup
     }
 
     @action.bound private onResize() {
+        // Don't bother rendering if the container is hidden
+        // see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
+        if (this.grapherContainerRef.current?.offsetParent === null) return
+
         const oldIsNarrow = this.isNarrow
         this.isNarrow = isNarrow()
         this.updateGrapherBounds()

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1656,10 +1656,18 @@ export class Grapher
                 React.Fragment
         }
 
-        const setBoundsFromContainerAndRender = (): void => {
+        const setBoundsFromContainerAndRender = (
+            entries: ResizeObserverEntry[]
+        ): void => {
+            const entry = entries[0] // We always observe exactly one element
+
+            // Don't bother rendering if the container is hidden
+            // see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
+            if ((entry.target as HTMLElement).offsetParent === null) return
+
             const props: GrapherProgrammaticInterface = {
                 ...config,
-                bounds: Bounds.fromRect(containerNode.getBoundingClientRect()),
+                bounds: Bounds.fromRect(entry.contentRect),
             }
             ReactDOM.render(
                 <ErrorBoundary>
@@ -1669,11 +1677,10 @@ export class Grapher
             )
         }
 
-        setBoundsFromContainerAndRender()
-        window.addEventListener(
-            "resize",
-            debounce(setBoundsFromContainerAndRender, 400)
+        const resizeObserver = new ResizeObserver(
+            debounce(setBoundsFromContainerAndRender, 400, { leading: true })
         )
+        resizeObserver.observe(containerNode)
 
         return grapherInstanceRef.current
     }

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1659,7 +1659,11 @@ export class Grapher
         const setBoundsFromContainerAndRender = (
             entries: ResizeObserverEntry[]
         ): void => {
-            const entry = entries[0] // We always observe exactly one element
+            const entry = entries?.[0] // We always observe exactly one element
+            if (!entry)
+                throw new Error(
+                    "Couldn't resize grapher, expected exactly one ResizeObserverEntry"
+                )
 
             // Don't bother rendering if the container is hidden
             // see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
@@ -1678,6 +1682,7 @@ export class Grapher
         }
 
         const resizeObserver = new ResizeObserver(
+            // Use a leading debounce to render immediately upon first load, and also immediately upon orientation change on mobile
             debounce(setBoundsFromContainerAndRender, 400, { leading: true })
         )
         resizeObserver.observe(containerNode)

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1689,11 +1689,16 @@ export class Grapher
                 })
             )
             resizeObserver.observe(containerNode)
-        } else if (typeof window === "object" && typeof document === "object") {
+        } else if (
+            typeof window === "object" &&
+            typeof document === "object" &&
+            !navigator.userAgent.includes("jsdom")
+        ) {
             // only show the warning when we're in something that roughly resembles a browser
             console.warn(
                 "ResizeObserver not available; grapher will not be able to render"
             )
+            Bugsnag?.notify("ResizeObserver not available")
         }
 
         return grapherInstanceRef.current

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1681,11 +1681,20 @@ export class Grapher
             )
         }
 
-        const resizeObserver = new ResizeObserver(
-            // Use a leading debounce to render immediately upon first load, and also immediately upon orientation change on mobile
-            debounce(setBoundsFromContainerAndRender, 400, { leading: true })
-        )
-        resizeObserver.observe(containerNode)
+        if (typeof window !== "undefined" && "ResizeObserver" in window) {
+            const resizeObserver = new ResizeObserver(
+                // Use a leading debounce to render immediately upon first load, and also immediately upon orientation change on mobile
+                debounce(setBoundsFromContainerAndRender, 400, {
+                    leading: true,
+                })
+            )
+            resizeObserver.observe(containerNode)
+        } else if (typeof window === "object" && typeof document === "object") {
+            // only show the warning when we're in something that roughly resembles a browser
+            console.warn(
+                "ResizeObserver not available; grapher will not be able to render"
+            )
+        }
 
         return grapherInstanceRef.current
     }

--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
@@ -190,9 +190,12 @@ export class FacetChart
     @computed private get gridParams(): GridParameters {
         const count = this.facetCount
         const { width, height } = this.bounds
+
+        const aspectRatio = width / height // can be NaN if height is 0, which can happen when the chart is temporarily hidden
+
         return getIdealGridParams({
             count,
-            containerAspectRatio: width / height,
+            containerAspectRatio: isNaN(aspectRatio) ? 1 : aspectRatio,
             idealAspectRatio: IDEAL_PLOT_ASPECT_RATIO,
         })
     }

--- a/site/multiembedder/MultiEmbedder.tsx
+++ b/site/multiembedder/MultiEmbedder.tsx
@@ -37,6 +37,7 @@ import {
     BAKED_GRAPHER_URL,
 } from "../../settings/clientSettings.js"
 import { hydrateAnnotatingDataValue } from "../AnnotatingDataValue.js"
+import Bugsnag from "@bugsnag/js"
 
 const figuresFromDOM = (
     container: HTMLElement | Document = document,
@@ -73,11 +74,16 @@ class MultiEmbedder {
                     rootMargin: "200%",
                 }
             )
-        } else if (typeof window === "object" && typeof document === "object") {
+        } else if (
+            typeof window === "object" &&
+            typeof document === "object" &&
+            !navigator.userAgent.includes("jsdom")
+        ) {
             // only show the warning when we're in something that roughly resembles a browser
             console.warn(
                 "IntersectionObserver not available; interactive embeds won't load on this page"
             )
+            Bugsnag?.notify("IntersectionObserver not available")
         }
     }
 


### PR DESCRIPTION
Fixes #1929 by using `ResizeObserver` to observe size changes of both graphers and explorers.
Similar to #2002 back in the day, this is changing a critical code path in the loading of graphers/explorers, but all went well back then so let's hope it does now, too 🙏🏻 

A cool benefit actually is that ResizeObservers fire only when necessary: If the window size changes but the size of the grapher component is unaffected, then the callback doesn't fire at all.

TODOs:
- [x] Properly test this
- [x] Is `debounce(..., { leading: true })` the right thing to be using here?
	- Yes it is, and it has the added benefit that it resizes immediately upon orientation change on mobile
- [x] Is there a way to set a disposer of `resizeObserver.disconnect()`? Probably not because it's static?
- [x] Test this in old browsers; they should be covered by polyfill.io already but better be safe
	- Tested in Firefox 61 and Safari 12