### PR TITLE
feat(gdocs): breadcrumbs

### DIFF
--- a/adminSiteClient/GdocsBreadcrumbsInput.tsx
+++ b/adminSiteClient/GdocsBreadcrumbsInput.tsx
@@ -85,7 +85,7 @@ export const GdocsBreadcrumbsInput = ({
     }
 
     return (
-        <>
+        <div className="form-group">
             Breadcrumbs
             {gdoc.breadcrumbs?.map((item, i) => (
                 <BreadcrumbLine
@@ -96,15 +96,20 @@ export const GdocsBreadcrumbsInput = ({
                     urlFieldDisabled={i === gdoc.breadcrumbs!.length - 1}
                 />
             ))}
-            <Button
-                type="dashed"
-                onClick={() =>
-                    setBreadcrumbs([...(gdoc.breadcrumbs ?? []), { label: "" }])
-                }
-            >
-                <FontAwesomeIcon icon={faPlus} className="mr-1" /> Add
-                breadcrumb
-            </Button>
-        </>
+            <div>
+                <Button
+                    type="dashed"
+                    onClick={() =>
+                        setBreadcrumbs([
+                            ...(gdoc.breadcrumbs ?? []),
+                            { label: "" },
+                        ])
+                    }
+                >
+                    <FontAwesomeIcon icon={faPlus} className="mr-1" /> Add
+                    breadcrumb
+                </Button>
+            </div>
+        </div>
     )
 }

--- a/adminSiteClient/GdocsBreadcrumbsInput.tsx
+++ b/adminSiteClient/GdocsBreadcrumbsInput.tsx
@@ -41,6 +41,7 @@ export const BreadcrumbLine = ({
                         }
                         disabled={isLastBreadcrumbItem}
                         status={hrefError?.type}
+                        placeholder="e.g. /poverty"
                     />
                     {hrefError && <GdocsErrorHelp error={hrefError} />}
                 </Col>

--- a/adminSiteClient/GdocsBreadcrumbsInput.tsx
+++ b/adminSiteClient/GdocsBreadcrumbsInput.tsx
@@ -12,10 +12,12 @@ export const BreadcrumbLine = ({
     item,
     setItem,
     removeItem,
+    urlFieldDisabled,
 }: {
     item: BreadcrumbItem
     setItem: (item: BreadcrumbItem) => void
     removeItem: () => void
+    urlFieldDisabled?: boolean
 }) => {
     return (
         <div className="my-2">
@@ -23,10 +25,15 @@ export const BreadcrumbLine = ({
                 <Col span={11}>
                     <Input
                         addonBefore="URL"
-                        value={item.href}
+                        value={
+                            urlFieldDisabled
+                                ? "The last breadcrumb isn't clickable"
+                                : item.href
+                        }
                         onChange={(e) =>
                             setItem({ ...item, href: e.target.value })
                         }
+                        disabled={urlFieldDisabled}
                     />
                 </Col>
                 <Col span={11}>
@@ -57,8 +64,13 @@ export const GdocsBreadcrumbsInput = ({
     setCurrentGdoc: (gdoc: OwidGdocInterface) => void
     errors?: OwidGdocErrorMessage[]
 }) => {
-    const setBreadcrumbs = (breadcrumbs: BreadcrumbItem[]) =>
+    const setBreadcrumbs = (breadcrumbs: BreadcrumbItem[]) => {
+        if (breadcrumbs?.length) {
+            // The last breadcrumb is not clickable, so we don't need a URL
+            breadcrumbs[breadcrumbs.length - 1].href = undefined
+        }
         setCurrentGdoc({ ...gdoc, breadcrumbs })
+    }
 
     const setItemAtIndex = (item: BreadcrumbItem, i: number) => {
         const breadcrumbs = gdoc.breadcrumbs ?? []
@@ -81,6 +93,7 @@ export const GdocsBreadcrumbsInput = ({
                     setItem={(item) => setItemAtIndex(item, i)}
                     removeItem={() => removeItemAtIndex(i)}
                     key={i}
+                    urlFieldDisabled={i === gdoc.breadcrumbs!.length - 1}
                 />
             ))}
             <Button

--- a/adminSiteClient/GdocsBreadcrumbsInput.tsx
+++ b/adminSiteClient/GdocsBreadcrumbsInput.tsx
@@ -74,13 +74,13 @@ export const GdocsBreadcrumbsInput = ({
     }
 
     const setItemAtIndex = (item: BreadcrumbItem, i: number) => {
-        const breadcrumbs = gdoc.breadcrumbs ?? []
+        const breadcrumbs = [...(gdoc.breadcrumbs ?? [])]
         breadcrumbs[i] = item
         setBreadcrumbs(breadcrumbs)
     }
 
     const removeItemAtIndex = (i: number) => {
-        const breadcrumbs = gdoc.breadcrumbs ?? []
+        const breadcrumbs = [...(gdoc.breadcrumbs ?? [])]
         breadcrumbs.splice(i, 1)
         setBreadcrumbs(breadcrumbs)
     }

--- a/adminSiteClient/GdocsBreadcrumbsInput.tsx
+++ b/adminSiteClient/GdocsBreadcrumbsInput.tsx
@@ -1,0 +1,97 @@
+import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import {
+    BreadcrumbItem,
+    OwidGdocErrorMessage,
+    OwidGdocInterface,
+} from "@ourworldindata/utils"
+import { Button, Col, Input, Row } from "antd"
+import React from "react"
+
+export const BreadcrumbLine = ({
+    item,
+    setItem,
+    removeItem,
+}: {
+    item: BreadcrumbItem
+    setItem: (item: BreadcrumbItem) => void
+    removeItem: () => void
+}) => {
+    return (
+        <div className="my-2">
+            <Row gutter={8}>
+                <Col span={11}>
+                    <Input
+                        addonBefore="URL"
+                        value={item.href}
+                        onChange={(e) =>
+                            setItem({ ...item, href: e.target.value })
+                        }
+                    />
+                </Col>
+                <Col span={11}>
+                    <Input
+                        addonBefore="Label"
+                        value={item.label}
+                        onChange={(e) =>
+                            setItem({ ...item, label: e.target.value })
+                        }
+                    />
+                </Col>
+                <Col span={2}>
+                    <Button danger onClick={removeItem}>
+                        <FontAwesomeIcon icon={faTrash} />
+                    </Button>
+                </Col>
+            </Row>
+        </div>
+    )
+}
+
+export const GdocsBreadcrumbsInput = ({
+    gdoc,
+    setCurrentGdoc,
+    errors,
+}: {
+    gdoc: OwidGdocInterface
+    setCurrentGdoc: (gdoc: OwidGdocInterface) => void
+    errors?: OwidGdocErrorMessage[]
+}) => {
+    const setBreadcrumbs = (breadcrumbs: BreadcrumbItem[]) =>
+        setCurrentGdoc({ ...gdoc, breadcrumbs })
+
+    const setItemAtIndex = (item: BreadcrumbItem, i: number) => {
+        const breadcrumbs = gdoc.breadcrumbs ?? []
+        breadcrumbs[i] = item
+        setBreadcrumbs(breadcrumbs)
+    }
+
+    const removeItemAtIndex = (i: number) => {
+        const breadcrumbs = gdoc.breadcrumbs ?? []
+        breadcrumbs.splice(i, 1)
+        setBreadcrumbs(breadcrumbs)
+    }
+
+    return (
+        <>
+            Breadcrumbs
+            {gdoc.breadcrumbs?.map((item, i) => (
+                <BreadcrumbLine
+                    item={item}
+                    setItem={(item) => setItemAtIndex(item, i)}
+                    removeItem={() => removeItemAtIndex(i)}
+                    key={i}
+                />
+            ))}
+            <Button
+                type="dashed"
+                onClick={() =>
+                    setBreadcrumbs([...(gdoc.breadcrumbs ?? []), { label: "" }])
+                }
+            >
+                <FontAwesomeIcon icon={faPlus} className="mr-1" /> Add
+                breadcrumb
+            </Button>
+        </>
+    )
+}

--- a/adminSiteClient/GdocsBreadcrumbsInput.tsx
+++ b/adminSiteClient/GdocsBreadcrumbsInput.tsx
@@ -12,12 +12,12 @@ export const BreadcrumbLine = ({
     item,
     setItem,
     removeItem,
-    urlFieldDisabled,
+    isLastBreadcrumbItem,
 }: {
     item: BreadcrumbItem
     setItem: (item: BreadcrumbItem) => void
     removeItem: () => void
-    urlFieldDisabled?: boolean
+    isLastBreadcrumbItem?: boolean
 }) => {
     return (
         <div className="my-2">
@@ -26,14 +26,14 @@ export const BreadcrumbLine = ({
                     <Input
                         addonBefore="URL"
                         value={
-                            urlFieldDisabled
+                            isLastBreadcrumbItem
                                 ? "The last breadcrumb isn't clickable"
                                 : item.href
                         }
                         onChange={(e) =>
                             setItem({ ...item, href: e.target.value })
                         }
-                        disabled={urlFieldDisabled}
+                        disabled={isLastBreadcrumbItem}
                     />
                 </Col>
                 <Col span={11}>
@@ -42,6 +42,11 @@ export const BreadcrumbLine = ({
                         value={item.label}
                         onChange={(e) =>
                             setItem({ ...item, label: e.target.value })
+                        }
+                        placeholder={
+                            isLastBreadcrumbItem
+                                ? "Concise version of the article's title"
+                                : undefined
                         }
                     />
                 </Col>
@@ -87,23 +92,14 @@ export const GdocsBreadcrumbsInput = ({
 
     return (
         <div className="form-group">
-            Breadcrumbs
-            {gdoc.breadcrumbs?.map((item, i) => (
-                <BreadcrumbLine
-                    item={item}
-                    setItem={(item) => setItemAtIndex(item, i)}
-                    removeItem={() => removeItemAtIndex(i)}
-                    key={i}
-                    urlFieldDisabled={i === gdoc.breadcrumbs!.length - 1}
-                />
-            ))}
-            <div>
+            <div className="d-flex justify-content-between">
+                Breadcrumbs
                 <Button
                     type="dashed"
                     onClick={() =>
                         setBreadcrumbs([
-                            ...(gdoc.breadcrumbs ?? []),
                             { label: "" },
+                            ...(gdoc.breadcrumbs ?? []),
                         ])
                     }
                 >
@@ -111,6 +107,16 @@ export const GdocsBreadcrumbsInput = ({
                     breadcrumb
                 </Button>
             </div>
+            {gdoc.breadcrumbs?.map((item, i) => (
+                <BreadcrumbLine
+                    item={item}
+                    setItem={(item) => setItemAtIndex(item, i)}
+                    removeItem={() => removeItemAtIndex(i)}
+                    key={i}
+                    isLastBreadcrumbItem={i === gdoc.breadcrumbs!.length - 1}
+                />
+            ))}
+            {!gdoc.breadcrumbs?.length && <i>No breadcrumbs</i>}
         </div>
     )
 }

--- a/adminSiteClient/GdocsBreadcrumbsInput.tsx
+++ b/adminSiteClient/GdocsBreadcrumbsInput.tsx
@@ -7,17 +7,23 @@ import {
 } from "@ourworldindata/utils"
 import { Button, Col, Input, Row } from "antd"
 import React from "react"
+import { getPropertyMostCriticalError } from "./gdocsValidation.js"
+import { GdocsErrorHelp } from "./GdocsErrorHelp.js"
 
 export const BreadcrumbLine = ({
     item,
     setItem,
     removeItem,
     isLastBreadcrumbItem,
+    labelError,
+    hrefError,
 }: {
     item: BreadcrumbItem
     setItem: (item: BreadcrumbItem) => void
     removeItem: () => void
     isLastBreadcrumbItem?: boolean
+    labelError?: OwidGdocErrorMessage
+    hrefError?: OwidGdocErrorMessage
 }) => {
     return (
         <div className="my-2">
@@ -34,7 +40,9 @@ export const BreadcrumbLine = ({
                             setItem({ ...item, href: e.target.value })
                         }
                         disabled={isLastBreadcrumbItem}
+                        status={hrefError?.type}
                     />
+                    {hrefError && <GdocsErrorHelp error={hrefError} />}
                 </Col>
                 <Col span={11}>
                     <Input
@@ -48,7 +56,9 @@ export const BreadcrumbLine = ({
                                 ? "Concise version of the article's title"
                                 : undefined
                         }
+                        status={labelError?.type}
                     />
+                    {labelError && <GdocsErrorHelp error={labelError} />}
                 </Col>
                 <Col span={2}>
                     <Button danger onClick={removeItem}>
@@ -113,6 +123,14 @@ export const GdocsBreadcrumbsInput = ({
                     setItem={(item) => setItemAtIndex(item, i)}
                     removeItem={() => removeItemAtIndex(i)}
                     key={i}
+                    labelError={getPropertyMostCriticalError(
+                        `breadcrumbs[${i}].label`,
+                        errors
+                    )}
+                    hrefError={getPropertyMostCriticalError(
+                        `breadcrumbs[${i}].href`,
+                        errors
+                    )}
                     isLastBreadcrumbItem={i === gdoc.breadcrumbs!.length - 1}
                 />
             ))}

--- a/adminSiteClient/GdocsBreadcrumbsInput.tsx
+++ b/adminSiteClient/GdocsBreadcrumbsInput.tsx
@@ -64,11 +64,12 @@ export const GdocsBreadcrumbsInput = ({
     setCurrentGdoc: (gdoc: OwidGdocInterface) => void
     errors?: OwidGdocErrorMessage[]
 }) => {
-    const setBreadcrumbs = (breadcrumbs: BreadcrumbItem[]) => {
+    const setBreadcrumbs = (breadcrumbs: BreadcrumbItem[] | undefined) => {
         if (breadcrumbs?.length) {
             // The last breadcrumb is not clickable, so we don't need a URL
             breadcrumbs[breadcrumbs.length - 1].href = undefined
-        }
+        } else breadcrumbs = undefined
+
         setCurrentGdoc({ ...gdoc, breadcrumbs })
     }
 

--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -146,6 +146,7 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                     "published",
                     "publishedAt",
                     "publicationContext",
+                    "breadcrumbs",
                 ]),
             }))
         }

--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -392,7 +392,8 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                     onLoad={onIframeLoad}
                     src={`/gdocs/${currentGdoc.id}/preview#owid-document-root`}
                     style={{ width: "100%", border: "none" }}
-                    key={currentGdoc.revisionId}
+                    // use `updatedAt` as a proxy for when database-level settings such as breadcrumbs have changed
+                    key={`${currentGdoc.revisionId}-${originalGdoc?.updatedAt}`}
                 />
 
                 {currentGdoc.published && (

--- a/adminSiteClient/GdocsSettingsForm.tsx
+++ b/adminSiteClient/GdocsSettingsForm.tsx
@@ -9,6 +9,7 @@ import {
 import { GdocsDateline } from "./GdocsDateline.js"
 import { GdocsPublicationContext } from "./GdocsPublicationContext.js"
 import { Alert } from "antd"
+import { GdocsBreadcrumbsInput } from "./GdocsBreadcrumbsInput.js"
 
 export const GdocsSettingsForm = ({
     gdoc,
@@ -113,6 +114,11 @@ export const GdocsSettingsForm = ({
                     description="An optional property to override the excerpt of this post in our atom feed, which is used for the newsletter"
                 />
             </div>
+            <GdocsBreadcrumbsInput
+                gdoc={gdoc}
+                errors={errors}
+                setCurrentGdoc={setCurrentGdoc}
+            />
         </form>
     ) : null
 }

--- a/adminSiteClient/gdocsValidation.ts
+++ b/adminSiteClient/gdocsValidation.ts
@@ -6,6 +6,7 @@ import {
     OwidGdocType,
     checkIsOwidGdocType,
     traverseEnrichedBlocks,
+    OwidGdocErrorMessageProperty,
 } from "@ourworldindata/utils"
 
 interface Handler {
@@ -225,12 +226,12 @@ export const getErrors = (gdoc: OwidGdocInterface): OwidGdocErrorMessage[] => {
 
 export const getPropertyFirstErrorOfType = (
     type: OwidGdocErrorMessageType,
-    property: keyof OwidGdocInterface | keyof OwidGdocContent,
+    property: OwidGdocErrorMessageProperty,
     errors?: OwidGdocErrorMessage[]
 ) => errors?.find((error) => error.property === property && error.type === type)
 
 export const getPropertyMostCriticalError = (
-    property: keyof OwidGdocInterface | keyof OwidGdocContent,
+    property: OwidGdocErrorMessageProperty,
     errors: OwidGdocErrorMessage[] | undefined
 ): OwidGdocErrorMessage | undefined => {
     return (

--- a/adminSiteClient/gdocsValidation.ts
+++ b/adminSiteClient/gdocsValidation.ts
@@ -120,6 +120,42 @@ class PublishedAtHandler extends AbstractHandler {
     }
 }
 
+class BreadcrumbsHandler extends AbstractHandler {
+    handle(gdoc: OwidGdocInterface, messages: OwidGdocErrorMessage[]) {
+        const { breadcrumbs } = gdoc
+
+        if (breadcrumbs) {
+            for (const [i, breadcrumb] of breadcrumbs.entries()) {
+                if (!breadcrumb.label) {
+                    messages.push({
+                        property: `breadcrumbs[${i}].label`,
+                        type: OwidGdocErrorMessageType.Error,
+                        message: `Breadcrumb must have a label`,
+                    })
+                }
+
+                // Last item can be missing a href
+                if (!breadcrumb.href && i !== breadcrumbs.length - 1) {
+                    messages.push({
+                        property: `breadcrumbs[${i}].href`,
+                        type: OwidGdocErrorMessageType.Error,
+                        message: `Breadcrumb must have a url`,
+                    })
+                }
+                if (breadcrumb.href && !breadcrumb.href.startsWith("/")) {
+                    messages.push({
+                        property: `breadcrumbs[${i}].href`,
+                        type: OwidGdocErrorMessageType.Error,
+                        message: `Breadcrumb url must start with a /`,
+                    })
+                }
+            }
+        }
+
+        return super.handle(gdoc, messages)
+    }
+}
+
 export class ExcerptHandler extends AbstractHandler {
     static maxLength = 150
     handle(gdoc: OwidGdocInterface, messages: OwidGdocErrorMessage[]) {
@@ -214,6 +250,7 @@ export const getErrors = (gdoc: OwidGdocInterface): OwidGdocErrorMessage[] => {
         .setNext(new RSSFieldsHandler())
         .setNext(new SlugHandler())
         .setNext(new PublishedAtHandler())
+        .setNext(new BreadcrumbsHandler())
         .setNext(new ExcerptHandler())
         .setNext(new AttachmentsHandler())
         .setNext(new DocumentTypeHandler())

--- a/db/migration/1687851686136-GdocsAddBreadcrumbsColumn.ts
+++ b/db/migration/1687851686136-GdocsAddBreadcrumbsColumn.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class GdocsAddBreadcrumbsColumn1687851686136
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`-- sql
+            ALTER TABLE posts_gdocs ADD COLUMN breadcrumbs JSON`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`-- sql
+            ALTER TABLE posts_gdocs DROP COLUMN breadcrumbs`)
+    }
+}

--- a/db/model/Gdoc/Gdoc.ts
+++ b/db/model/Gdoc/Gdoc.ts
@@ -34,6 +34,7 @@ import {
     EnrichedBlockResearchAndWritingLink,
     traverseEnrichedSpan,
     RelatedChart,
+    BreadcrumbItem,
 } from "@ourworldindata/utils"
 import {
     BAKED_GRAPHER_URL,
@@ -89,6 +90,9 @@ export class Gdoc extends BaseEntity implements OwidGdocInterface {
     @Column({ type: Date, nullable: true }) publishedAt: Date | null = null
     @UpdateDateColumn({ nullable: true }) updatedAt: Date | null = null
     @Column({ type: String, nullable: true }) revisionId: string | null = null
+    @Column({ type: "json", nullable: true }) breadcrumbs:
+        | BreadcrumbItem[]
+        | null = null
 
     @ManyToMany(() => Tag)
     @JoinTable({

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -93,6 +93,7 @@ export {
     type OwidGdocContent,
     type LinkedChart,
     OwidGdocPublicationContext,
+    type OwidGdocErrorMessageProperty,
     type OwidGdocErrorMessage,
     OwidGdocErrorMessageType,
     type OwidGdocLinkJSON,

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -202,6 +202,7 @@ export {
     type RawBlockResearchAndWritingRow,
     type EnrichedBlockAlign,
     type RawBlockAlign,
+    type BreadcrumbItem,
 } from "./owidTypes.js"
 
 export {

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -103,6 +103,11 @@ export interface FormattingOptions {
     footnotes?: boolean
 }
 
+export interface BreadcrumbItem {
+    label: string
+    href: string
+}
+
 export interface KeyValueProps {
     [key: string]: string | boolean | undefined
 }
@@ -1153,6 +1158,7 @@ export interface OwidGdocInterface {
     updatedAt: Date | null
     publicationContext: OwidGdocPublicationContext
     revisionId: string | null
+    breadcrumbs?: BreadcrumbItem[] | null
     linkedCharts?: Record<string, LinkedChart>
     linkedDocuments?: Record<string, OwidGdocInterface>
     relatedCharts?: RelatedChart[]

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -105,7 +105,7 @@ export interface FormattingOptions {
 
 export interface BreadcrumbItem {
     label: string
-    href: string
+    href?: string
 }
 
 export interface KeyValueProps {

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1172,8 +1172,12 @@ export enum OwidGdocErrorMessageType {
     Warning = "warning",
 }
 
+export type OwidGdocProperty = keyof OwidGdocInterface | keyof OwidGdocContent
+export type OwidGdocErrorMessageProperty =
+    | OwidGdocProperty
+    | `${OwidGdocProperty}${string}` // also allows for nesting, like `breadcrumbs[0].label`
 export interface OwidGdocErrorMessage {
-    property: keyof OwidGdocInterface | keyof OwidGdocContent
+    property: OwidGdocErrorMessageProperty
     type: OwidGdocErrorMessageType
     message: string
 }

--- a/site/Breadcrumb/Breadcrumb.tsx
+++ b/site/Breadcrumb/Breadcrumb.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { SubNavId } from "@ourworldindata/utils"
+import { SubNavId, BreadcrumbItem } from "@ourworldindata/utils"
 import { getSubnavItem, SubnavItem, subnavs } from "../SiteSubnavigation.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faAngleRight } from "@fortawesome/free-solid-svg-icons"
@@ -20,7 +20,7 @@ export const getSubnavParent = (
 export const getBreadcrumbItems = (
     subnavCurrentId: string | undefined,
     subnavItems: SubnavItem[]
-): SubnavItem[] | undefined => {
+): BreadcrumbItem[] | undefined => {
     const breadcrumb = []
     let currentItem = getSubnavItem(subnavCurrentId, subnavItems)
     if (!currentItem) return

--- a/site/Breadcrumb/Breadcrumb.tsx
+++ b/site/Breadcrumb/Breadcrumb.tsx
@@ -34,13 +34,7 @@ export const getBreadcrumbItems = (
     return breadcrumb.reverse()
 }
 
-const BreadcrumbSeparator = () => (
-    <span className="separator">
-        <FontAwesomeIcon icon={faAngleRight} />
-    </span>
-)
-
-export const Breadcrumb = ({
+export const BreadcrumbsFromSubnav = ({
     subnavId,
     subnavCurrentId,
 }: {
@@ -52,23 +46,44 @@ export const Breadcrumb = ({
         : null
 
     return breadcrumbItems ? (
-        <div className="breadcrumb">
-            <a href="/">Home</a>
-            <BreadcrumbSeparator />
-            {breadcrumbItems.map((item, idx) => (
-                <React.Fragment key={item.href}>
-                    {idx !== breadcrumbItems.length - 1 ? (
-                        <>
-                            <a data-track-note="breadcrumb" href={item.href}>
-                                {item.label}
-                            </a>
-                            <BreadcrumbSeparator />
-                        </>
-                    ) : (
-                        <span>{item.label}</span>
-                    )}
-                </React.Fragment>
-            ))}
-        </div>
+        <Breadcrumbs items={breadcrumbItems} className="breadcrumb" />
     ) : null
 }
+
+const BreadcrumbSeparator = () => (
+    <span className="separator">
+        <FontAwesomeIcon icon={faAngleRight} />
+    </span>
+)
+
+export const Breadcrumbs = ({
+    items,
+    className,
+}: {
+    items: BreadcrumbItem[]
+    className: string
+}) => (
+    <div className={className}>
+        <a href="/">Home</a>
+        <BreadcrumbSeparator />
+        {items.map((item, idx) => {
+            const isLast = idx === items.length - 1
+
+            const breadcrumb =
+                !isLast && item.href ? (
+                    <a href={item.href} data-track-note="breadcrumb">
+                        {item.label}
+                    </a>
+                ) : (
+                    <span>{item.label}</span>
+                )
+
+            return (
+                <React.Fragment key={item.label}>
+                    {breadcrumb}
+                    {!isLast && <BreadcrumbSeparator />}
+                </React.Fragment>
+            )
+        })}
+    </div>
+)

--- a/site/LongFormPage.tsx
+++ b/site/LongFormPage.tsx
@@ -16,7 +16,7 @@ import {
     TocHeading,
     omit,
 } from "@ourworldindata/utils"
-import { Breadcrumb } from "./Breadcrumb/Breadcrumb.js"
+import { BreadcrumbsFromSubnav } from "./Breadcrumb/Breadcrumb.js"
 import { Byline } from "./Byline.js"
 import { PageInfo } from "./PageInfo.js"
 import { BackToTopic } from "./BackToTopic.js"
@@ -155,7 +155,7 @@ export const LongFormPage = (props: {
                                     )}
                                     <h1 className="entry-title">{pageTitle}</h1>
                                     {!isPost && formattingOptions.subnavId && (
-                                        <Breadcrumb
+                                        <BreadcrumbsFromSubnav
                                             subnavId={
                                                 formattingOptions.subnavId
                                             }

--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -44,6 +44,7 @@ export function OwidGdoc({
     content,
     publishedAt,
     slug,
+    breadcrumbs,
     linkedCharts = {},
     linkedDocuments = {},
     imageMetadata = {},
@@ -92,6 +93,7 @@ export function OwidGdoc({
                         content={content}
                         authors={content.authors}
                         publishedAt={publishedAt}
+                        breadcrumbs={breadcrumbs ?? undefined}
                     />
                     {content.type === "topic-page" && stickyNavLinks ? (
                         <nav className="sticky-nav sticky-nav--dark span-cols-14 grid grid-cols-12-full-width">

--- a/site/gdocs/OwidGdocHeader.tsx
+++ b/site/gdocs/OwidGdocHeader.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import {
+    BreadcrumbItem,
     OwidGdocContent,
     OwidGdocType,
     formatDate,
@@ -9,19 +10,25 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faBook } from "@fortawesome/free-solid-svg-icons"
 import { faCreativeCommons } from "@fortawesome/free-brands-svg-icons"
 import Image from "./Image.js"
+import { Breadcrumbs } from "../Breadcrumb/Breadcrumb.js"
+import { breadcrumbColorForCoverColor } from "./utils.js"
 
 function OwidArticleHeader({
     content,
     authors,
     publishedAt,
+    breadcrumbs,
 }: {
     content: OwidGdocContent
     authors: string[]
     publishedAt: Date | null
+    breadcrumbs?: BreadcrumbItem[]
 }) {
     const coverStyle = content["cover-color"]
         ? { backgroundColor: `var(--${content["cover-color"]})` }
         : undefined
+
+    const breadcrumbColor = breadcrumbColorForCoverColor(content["cover-color"])
 
     return (
         <>
@@ -38,6 +45,14 @@ function OwidArticleHeader({
                     />
                 </div>
             ) : null}
+            {breadcrumbs?.length && (
+                <div className="centered-article-header__breadcrumbs-container col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
+                    <Breadcrumbs
+                        items={breadcrumbs}
+                        className={`centered-article-header__breadcrumbs breadcrumbs-${breadcrumbColor}`}
+                    />
+                </div>
+            )}
             <header className="centered-article-header align-center grid grid-cols-8 col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
                 <div className="centered-article-header__title-container col-start-2 span-cols-6">
                     {content.supertitle ? (
@@ -123,6 +138,7 @@ export function OwidGdocHeader(props: {
     content: OwidGdocContent
     authors: string[]
     publishedAt: Date | null
+    breadcrumbs?: BreadcrumbItem[]
 }) {
     if (props.content.type === OwidGdocType.Article)
         return <OwidArticleHeader {...props} />

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -154,6 +154,36 @@ h3.article-block__heading.has-supertitle {
     }
 }
 
+.centered-article-header__breadcrumbs-container {
+    .centered-article-header__breadcrumbs {
+        &.breadcrumbs-white {
+            color: $white;
+        }
+        &.breadcrumbs-blue {
+            color: $blue-100;
+        }
+
+        position: absolute;
+        margin-top: 40px;
+        font-size: 1rem;
+        a {
+            @include owid-link-90;
+            color: inherit;
+
+            &:visited,
+            &:hover {
+                color: inherit;
+            }
+        }
+
+        .separator {
+            margin: 0 0.5rem;
+            vertical-align: -0.0625em;
+            opacity: 0.7;
+        }
+    }
+}
+
 .centered-article-header__title-container {
     .centered-article-header__supertitle {
         @include overline-black-caps;

--- a/site/gdocs/utils.tsx
+++ b/site/gdocs/utils.tsx
@@ -8,9 +8,38 @@ import {
     OwidGdocInterface,
     ImageMetadata,
     LinkedChart,
+    OwidGdocContent,
 } from "@ourworldindata/utils"
 import { match } from "ts-pattern"
 import { AttachmentsContext } from "./OwidGdoc.js"
+
+export const breadcrumbColorForCoverColor = (
+    coverColor: OwidGdocContent["cover-color"]
+): "white" | "blue" => {
+    // exhaustive list of all possible cover colors
+    switch (coverColor) {
+        case "sdg-color-1": // red
+        case "sdg-color-4": // red
+        case "sdg-color-5": // orange-red
+        case "sdg-color-6": // light blue
+        case "sdg-color-8": // dark red
+        case "sdg-color-9": // orange
+        case "sdg-color-10": // purple
+        case "sdg-color-12": // yellow-brown
+        case "sdg-color-13": // dark green
+        case "sdg-color-14": // blue
+        case "sdg-color-15": // light green
+        case "sdg-color-16": // blue
+        case "sdg-color-17": // dark blue
+            return "white"
+        case "sdg-color-2": // orange
+        case "sdg-color-3": // green
+        case "sdg-color-7": // yellow
+        case "sdg-color-11": // orange
+        case undefined: // default cover color: yellow
+            return "blue"
+    }
+}
 
 export const useLinkedDocument = (
     url: string


### PR DESCRIPTION
Part of #2331.

Breadcrumbs are specified on the new `posts_gdocs.breadcrumbs` column, which is a (nullable) JSON array and is of the form:
```json
[
  { "href": "/sdg", "label": "SDG Tracker" },
  { "label": "Goal 1: No poverty" }
]
```

We then automatically choose a color for the breadcrumbs out of `[white, blue]` depending on the `cover-color`, which is just a list of 17 constant colors at the moment.

TODOs:
- [x] #2393 blocks this
- [x] Add a way to set breadcrumbs from the admin

![image](https://github.com/owid/owid-grapher/assets/2641501/ceaa54f5-bd8b-4492-81d4-9aa2908ecd25)

![image](https://github.com/owid/owid-grapher/assets/2641501/3fc51cec-9ecb-4b1b-b61d-5d2035e9a964)

![image](https://github.com/owid/owid-grapher/assets/2641501/bc83a968-2407-4d71-b22b-01916266ba70)

