### PR TITLE
style(explorer): minimal improvement of control bar layout

### DIFF
--- a/explorer/ExplorerControls.scss
+++ b/explorer/ExplorerControls.scss
@@ -12,6 +12,7 @@ $chart-border-radius: 2px;
 
     .ExplorerControl {
         flex: 1;
+        flex-basis: min-content; // only available in modern browsers
         display: flex;
         flex-direction: column;
         font-size: 13px;


### PR DESCRIPTION
See [Slack](https://owid.slack.com/archives/C46U9LXRR/p1687880966985589) | Currently deployed to [Kelley](https://kelley-owid.netlify.app/)

Before:
<img width="1213" alt="Screenshot 2023-06-28 at 08 20 50" src="https://github.com/owid/owid-grapher/assets/12461810/7429eeed-1801-4399-955f-d501ccb8d6cc">

After:
<img width="1213" alt="Screenshot 2023-06-28 at 08 48 46" src="https://github.com/owid/owid-grapher/assets/12461810/6f87f709-6b05-40d9-b519-d43d789aa16a">

For the example above, the change is positive. But I don't think this change is net positive. On smaller screens, radio and checkbox controls break too early when `text-basis` is set to `min-content` (`fit-content` also doesn't seem to work). Here is the Covid Explorer at 900px, for example:

Before:
<img width="898" alt="Screenshot 2023-06-28 at 12 37 49" src="https://github.com/owid/owid-grapher/assets/12461810/ab6c56ac-e558-4390-9f27-78c363dfa99a">

After:
<img width="898" alt="Screenshot 2023-06-28 at 12 37 43" src="https://github.com/owid/owid-grapher/assets/12461810/8fc35b80-2233-4cfd-951d-dc8871791827">

