### PR TITLE
enhance(gdocs): more prominent doc errors

### DIFF
--- a/adminSiteClient/GdocsSettingsForm.tsx
+++ b/adminSiteClient/GdocsSettingsForm.tsx
@@ -1,9 +1,5 @@
 import React from "react"
-import {
-    OwidGdocInterface,
-    OwidGdocErrorMessage,
-    groupBy,
-} from "@ourworldindata/utils"
+import { OwidGdocInterface, OwidGdocErrorMessage } from "@ourworldindata/utils"
 import { ExcerptHandler } from "./gdocsValidation.js"
 import { GdocsSlug } from "./GdocsSlug.js"
 import {
@@ -12,6 +8,7 @@ import {
 } from "./GdocsSettingsContentField.js"
 import { GdocsDateline } from "./GdocsDateline.js"
 import { GdocsPublicationContext } from "./GdocsPublicationContext.js"
+import { Alert } from "antd"
 
 export const GdocsSettingsForm = ({
     gdoc,
@@ -22,46 +19,34 @@ export const GdocsSettingsForm = ({
     setCurrentGdoc: (gdoc: OwidGdocInterface) => void
     errors?: OwidGdocErrorMessage[]
 }) => {
-    // These errors don't have a specific form field to render them in. We just show them at the bottom of the drawer
-    const errorsToShowInDrawer = groupBy(
-        (errors || []).filter(({ property }) =>
-            [
-                "content",
-                "linkedDocuments",
-                "linkedCharts",
-                "details",
-                "body",
-                "refs",
-                "imageMetadata",
-            ].includes(property)
-        ),
-        "type"
+    // These errors don't have a specific form field to render them in. We just show them at the top of the drawer
+    const errorsToShowInDrawer = (errors || []).filter(({ property }) =>
+        [
+            "content",
+            "linkedDocuments",
+            "linkedCharts",
+            "details",
+            "body",
+            "refs",
+            "imageMetadata",
+        ].includes(property)
     )
 
     return gdoc ? (
         <form className="GdocsSettingsForm">
-            <div className="form-group">
-                {errorsToShowInDrawer.error?.length ? (
-                    <>
-                        <p>Document errors</p>
-                        <ul>
-                            {errorsToShowInDrawer.error.map((error) => (
-                                <li key={error.message}>{error.message}</li>
-                            ))}
-                        </ul>
-                    </>
-                ) : null}
-                {errorsToShowInDrawer.warning?.length ? (
-                    <>
-                        <p>Document warnings</p>
-                        <ul>
-                            {errorsToShowInDrawer.warning.map((error) => (
-                                <li key={error.message}>{error.message}</li>
-                            ))}
-                        </ul>
-                    </>
-                ) : null}
-            </div>
+            {errorsToShowInDrawer.length ? (
+                <div className="form-group">
+                    {errorsToShowInDrawer.map((error) => (
+                        <Alert
+                            message={error.message}
+                            type={error.type}
+                            key={error.message}
+                            className="GdocsSettingsForm__alert"
+                            showIcon
+                        />
+                    ))}
+                </div>
+            ) : null}
             <GdocsSettingsContentField
                 property="title"
                 gdoc={gdoc}

--- a/adminSiteClient/GdocsSettingsForm.tsx
+++ b/adminSiteClient/GdocsSettingsForm.tsx
@@ -40,6 +40,28 @@ export const GdocsSettingsForm = ({
 
     return gdoc ? (
         <form className="GdocsSettingsForm">
+            <div className="form-group">
+                {errorsToShowInDrawer.error?.length ? (
+                    <>
+                        <p>Document errors</p>
+                        <ul>
+                            {errorsToShowInDrawer.error.map((error) => (
+                                <li key={error.message}>{error.message}</li>
+                            ))}
+                        </ul>
+                    </>
+                ) : null}
+                {errorsToShowInDrawer.warning?.length ? (
+                    <>
+                        <p>Document warnings</p>
+                        <ul>
+                            {errorsToShowInDrawer.warning.map((error) => (
+                                <li key={error.message}>{error.message}</li>
+                            ))}
+                        </ul>
+                    </>
+                ) : null}
+            </div>
             <GdocsSettingsContentField
                 property="title"
                 gdoc={gdoc}
@@ -105,28 +127,6 @@ export const GdocsSettingsForm = ({
                     errors={errors}
                     description="An optional property to override the excerpt of this post in our atom feed, which is used for the newsletter"
                 />
-            </div>
-            <div className="form-group">
-                {errorsToShowInDrawer.error?.length ? (
-                    <>
-                        <p>Document errors</p>
-                        <ul>
-                            {errorsToShowInDrawer.error.map((error) => (
-                                <li key={error.message}>{error.message}</li>
-                            ))}
-                        </ul>
-                    </>
-                ) : null}
-                {errorsToShowInDrawer.warning?.length ? (
-                    <>
-                        <p>Document warnings</p>
-                        <ul>
-                            {errorsToShowInDrawer.warning.map((error) => (
-                                <li key={error.message}>{error.message}</li>
-                            ))}
-                        </ul>
-                    </>
-                ) : null}
             </div>
         </form>
     ) : null

--- a/adminSiteClient/IconBadge.tsx
+++ b/adminSiteClient/IconBadge.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import {
     faExclamationTriangle,
-    faExclamationCircle,
+    faCircleXmark,
 } from "@fortawesome/free-solid-svg-icons"
 import { OwidGdocErrorMessageType } from "@ourworldindata/utils"
 import { Badge } from "antd"
@@ -22,7 +22,7 @@ export const IconBadge = ({
             icon = faExclamationTriangle
             break
         case OwidGdocErrorMessageType.Error:
-            icon = faExclamationCircle
+            icon = faCircleXmark
             break
     }
 

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -1234,6 +1234,10 @@ main:not(.ChartEditorPage):not(.GdocsEditPage) {
     }
 }
 
+.GdocsSettingsForm__alert {
+    margin-bottom: 8px;
+}
+
 .GdocsEditPage {
     .anticon svg {
         vertical-align: unset; // undo reboot.css


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 _Inspired_ by Copilot at 9ec42dc</samp>

This pull request enhances the visibility of document errors and warnings in the `GdocsSettingsForm` component. 

It uses the `Alert` component from `antd` library, and changes the error icon in the settings badge for consistency.

### Before
<img width="1440" alt="Screenshot 2023-06-28 at 15 40 00" src="https://github.com/owid/owid-grapher/assets/13406362/547749eb-eef6-4ec8-b737-eddc251f1186">

### After
<img width="1440" alt="Screenshot 2023-06-28 at 15 37 28" src="https://github.com/owid/owid-grapher/assets/13406362/fe05096b-b35e-4f0f-9212-5d717c85d753">

### Resources
Testing document (with errors): https://docs.google.com/document/d/17C9xaT09iSMGCQ-tTfGgYJYpR6rs3D6XdLsFhB6ELOs/edit
