### PR TITLE
chore(grapher): add population id

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1389,7 +1389,8 @@ export class Grapher
         const isPopulationVariableId = (id: string): boolean =>
             id === "525709" || // "Population (historical + projections), Gapminder, HYDE & UN"
             id === "525711" || // "Population (historical estimates), Gapminder, HYDE & UN"
-            id === "597929" // "Population (various sources, 2023.1)"
+            id === "597929" || // "Population (various sources, 2023.1)"
+            id === "597930" // "Population (various sources, 2023.1)"
 
         const columnSlugs = [...yColumnSlugs]
 


### PR DESCRIPTION
Discussion on [Slack](https://owid.slack.com/archives/C46U9LXRR/p1670855145129159)

Adds variable 597930 to the list of variable IDs whose source shouldn't be mentioned in the footer when used in Scatter plots and Marimekko charts.

I wasn't sure whether to add 597930 to the list or replace 597929 with 597930. 597929 seems to be still in use, so I opted for the former. And should we also replace 597929 with 597930 here? https://github.com/owid/owid-grapher/blob/a47c39ea877c26818882eb6926b0f46295e493c8/adminSiteClient/EditorBasicTab.tsx#L312

I want to merge this today, so the fix goes live. Can you have a quick look at this when you're back on Monday, @marcelgerber? Thank you!