### PR TITLE
Some small Gdocs improvements

### DIFF
--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -212,7 +212,11 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
             <AdminLayout title="Preview error" noSidebar fixedNav={false}>
                 <main className="GdocsEditPage">
                     <div className="GdocsEditPage__error-container">
-                        <p>Something went wrong preparing the article.</p>
+                        <p>
+                            Something went wrong preparing the article{" "}
+                            <GdocsEditLink gdocId={id} />
+                        </p>
+
                         <pre>{criticalErrorMessage}</pre>
                         <p>
                             Ask a dev for help if necessary, and reload this

--- a/site/css/page.scss
+++ b/site/css/page.scss
@@ -123,6 +123,11 @@
                 @include display-1-semibold;
                 margin-top: 2rem;
                 margin-bottom: 0;
+
+                @include sm-only {
+                    font-size: 32px;
+                    margin-top: 0;
+                }
             }
         }
 

--- a/site/css/topic-page.scss
+++ b/site/css/topic-page.scss
@@ -11,6 +11,19 @@
         @include body-1-regular;
     }
 
+    @include sm-only {
+        .large-banner .article-header {
+            padding: 24px 16px 16px 16px;
+            .authors-byline {
+                font-size: 0.875rem;
+            }
+        }
+    }
+
+    .tools {
+        display: none;
+    }
+
     h2 {
         @include h1-semibold;
     }

--- a/site/gdocs/AllCharts.scss
+++ b/site/gdocs/AllCharts.scss
@@ -1,5 +1,5 @@
 .article-block__all-charts {
-    h2 {
+    h1.h1-semibold {
         text-align: center;
     }
 

--- a/site/gdocs/AllCharts.tsx
+++ b/site/gdocs/AllCharts.tsx
@@ -47,13 +47,13 @@ export function AllCharts(props: AllChartsProps) {
     const sortedRelatedCharts = sortRelatedCharts(relatedCharts, topSlugs)
     return (
         <div className={cx(className)}>
-            <h2
+            <h1
                 className="article-block__heading h1-semibold"
                 id={ALL_CHARTS_ID}
             >
                 {heading}
                 <a className="deep-link" href={`#${ALL_CHARTS_ID}`} />
-            </h2>
+            </h1>
             <RelatedCharts charts={sortedRelatedCharts} />
         </div>
     )

--- a/site/gdocs/AllCharts.tsx
+++ b/site/gdocs/AllCharts.tsx
@@ -47,8 +47,12 @@ export function AllCharts(props: AllChartsProps) {
     const sortedRelatedCharts = sortRelatedCharts(relatedCharts, topSlugs)
     return (
         <div className={cx(className)}>
-            <h2 className="h1-semibold" id={ALL_CHARTS_ID}>
+            <h2
+                className="article-block__heading h1-semibold"
+                id={ALL_CHARTS_ID}
+            >
                 {heading}
+                <a className="deep-link" href={`#${ALL_CHARTS_ID}`} />
             </h2>
             <RelatedCharts charts={sortedRelatedCharts} />
         </div>

--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -270,6 +270,10 @@ export default function ArticleBlock({
                 id={convertHeadingTextToId(block.text)}
             >
                 {renderSpans(block.text)}
+                <a
+                    className="deep-link"
+                    href={`#${convertHeadingTextToId(block.text)}`}
+                />
             </h1>
         ))
         .with({ type: "heading", level: 2 }, (block) => {
@@ -306,6 +310,7 @@ export default function ArticleBlock({
                             </div>
                         ) : null}
                         {renderSpans(text)}
+                        <a className="deep-link" href={`#${id}`} />
                     </h2>
                 </>
             )
@@ -338,6 +343,7 @@ export default function ArticleBlock({
                         </div>
                     ) : null}
                     {renderSpans(text)}
+                    <a className="deep-link" href={`#${id}`} />
                 </h3>
             )
         })

--- a/site/gdocs/KeyInsights.tsx
+++ b/site/gdocs/KeyInsights.tsx
@@ -50,13 +50,13 @@ export const KeyInsights = ({
     }
     return (
         <div className={className}>
-            <h2
+            <h1
                 className="article-block__heading h1-semibold"
                 id={KEY_INSIGHTS_ID}
             >
                 {heading}
                 <a className="deep-link" href={`#${KEY_INSIGHTS_ID}`} />
-            </h2>
+            </h1>
             <div className={KEY_INSIGHTS_CLASS_NAME}>
                 <div>
                     <KeyInsightsThumbs

--- a/site/gdocs/KeyInsights.tsx
+++ b/site/gdocs/KeyInsights.tsx
@@ -50,8 +50,12 @@ export const KeyInsights = ({
     }
     return (
         <div className={className}>
-            <h2 className="h1-semibold" id={KEY_INSIGHTS_ID}>
+            <h2
+                className="article-block__heading h1-semibold"
+                id={KEY_INSIGHTS_ID}
+            >
                 {heading}
+                <a className="deep-link" href={`#${KEY_INSIGHTS_ID}`} />
             </h2>
             <div className={KEY_INSIGHTS_CLASS_NAME}>
                 <div>

--- a/site/gdocs/ResearchAndWriting.scss
+++ b/site/gdocs/ResearchAndWriting.scss
@@ -5,6 +5,11 @@
         text-align: center;
         font-size: 32px;
         margin-bottom: 40px;
+
+        .deep-link {
+            position: absolute;
+            margin-top: 1em;
+        }
         // Only the first large thumbnail, the "shorts" section has a margin
         // so the second thumbnail doesn't need any
         + .research-and-writing-link {

--- a/site/gdocs/ResearchAndWriting.scss
+++ b/site/gdocs/ResearchAndWriting.scss
@@ -1,15 +1,11 @@
 .article-block__research-and-writing {
     margin-bottom: 40px;
 
-    > h2 {
+    > h1 {
         text-align: center;
         font-size: 32px;
         margin-bottom: 40px;
 
-        .deep-link {
-            position: absolute;
-            margin-top: 1em;
-        }
         // Only the first large thumbnail, the "shorts" section has a margin
         // so the second thumbnail doesn't need any
         + .research-and-writing-link {

--- a/site/gdocs/ResearchAndWriting.tsx
+++ b/site/gdocs/ResearchAndWriting.tsx
@@ -85,6 +85,7 @@ export function ResearchAndWriting(props: ResearchAndWritingProps) {
                 id={RESEARCH_AND_WRITING_ID}
             >
                 Research & Writing
+                <a className="deep-link" href={`#${RESEARCH_AND_WRITING_ID}`} />
             </h2>
             <ResearchAndWritingLinkContainer
                 className="span-cols-6 span-md-cols-6 span-sm-cols-12"

--- a/site/gdocs/ResearchAndWriting.tsx
+++ b/site/gdocs/ResearchAndWriting.tsx
@@ -80,13 +80,13 @@ export function ResearchAndWriting(props: ResearchAndWritingProps) {
     const { primary, secondary, more, rows, className } = props
     return (
         <div className={cx(className, "grid")}>
-            <h2
-                className="span-cols-12 display-1-semibold"
+            <h1
+                className="article-block__heading span-cols-12 h1-semibold"
                 id={RESEARCH_AND_WRITING_ID}
             >
                 Research & Writing
                 <a className="deep-link" href={`#${RESEARCH_AND_WRITING_ID}`} />
-            </h2>
+            </h1>
             <ResearchAndWritingLinkContainer
                 className="span-cols-6 span-md-cols-6 span-sm-cols-12"
                 {...primary}

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -87,6 +87,7 @@ h3.article-block__heading {
 .article-block__sticky-left,
 .article-block__sticky-right {
     @include md-up {
+        .article-block__heading:first-child,
         .article-block__image:first-child {
             margin-top: 0;
         }

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -48,6 +48,28 @@ $banner-height: 200px;
     margin-top: 0;
 }
 
+.article-block__heading:hover {
+    a.deep-link {
+        opacity: 1;
+    }
+}
+
+h1.article-block__heading {
+    a.deep-link {
+        height: 20px;
+    }
+}
+h2.article-block__heading {
+    a.deep-link {
+        height: 18px;
+    }
+}
+h3.article-block__heading {
+    a.deep-link {
+        height: 16px;
+    }
+}
+
 .article-block__image {
     width: 100%;
     margin: 32px 0;

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -48,25 +48,43 @@ $banner-height: 200px;
     margin-top: 0;
 }
 
-.article-block__heading:hover {
+.article-block__heading {
     a.deep-link {
-        opacity: 1;
+        position: absolute;
+    }
+
+    &:hover {
+        a.deep-link {
+            opacity: 1;
+        }
     }
 }
 
 h1.article-block__heading {
     a.deep-link {
-        height: 20px;
+        margin-top: 16px;
+        height: 16px;
+        @include sm-only {
+            margin-top: 10px;
+        }
     }
 }
 h2.article-block__heading {
     a.deep-link {
-        height: 18px;
+        margin-top: 11px;
+        height: 14px;
+        @include sm-only {
+            margin-top: 10px;
+        }
     }
 }
 h3.article-block__heading {
     a.deep-link {
-        height: 16px;
+        margin-top: 8px;
+        height: 12px;
+        @include sm-only {
+            margin-top: 10px;
+        }
     }
 }
 

--- a/site/gdocs/topic-page.scss
+++ b/site/gdocs/topic-page.scss
@@ -125,7 +125,7 @@
 
 .article-block__key-insights {
     @include sm-only {
-        h2 {
+        h1 {
             font-size: 1.625rem;
         }
     }
@@ -179,11 +179,6 @@
         // Countering the gray-section padding to make this have 32px 16px
         margin-top: -16px;
         margin-bottom: 16px;
-
-        .deep-link {
-            position: absolute;
-            margin-top: 0.75em;
-        }
     }
 
     .article-block__text,

--- a/site/gdocs/topic-page.scss
+++ b/site/gdocs/topic-page.scss
@@ -179,6 +179,11 @@
         // Countering the gray-section padding to make this have 32px 16px
         margin-top: -16px;
         margin-bottom: 16px;
+
+        .deep-link {
+            position: absolute;
+            margin-top: 0.75em;
+        }
     }
 
     .article-block__text,

--- a/site/gdocs/topic-page.scss
+++ b/site/gdocs/topic-page.scss
@@ -23,6 +23,10 @@
     .topic-page-header__byline a {
         color: $blue-60;
         margin-bottom: 34px;
+        @include sm-only {
+            margin-bottom: 16px;
+            font-size: 0.875rem;
+        }
     }
 
     .topic-page-header__byline a:hover {


### PR DESCRIPTION
## Adds an edit link to the critical error screen
<img width="611" alt="image" src="https://github.com/owid/owid-grapher/assets/11844404/986eb954-7529-412a-91d1-f18ae72f17ef">

## Fixes the heading sizes for topic pages @sm
<img width="373" alt="image" src="https://github.com/owid/owid-grapher/assets/11844404/bc7b12e8-6183-46a0-8853-55b0b9addbe2">

## Adds anchor links to headings

https://github.com/owid/owid-grapher/assets/11844404/5382fcb4-3ea2-4c83-81b4-536ee642cd7f

