### PR TITLE
fix(explorer): make preview work for unsaved explorers

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -1770,6 +1770,27 @@ apiRouter.get(
     }
 )
 
+// Used in explorer preview
+apiRouter.get(
+    "/variables/:variableId.grapherConfig.json",
+    async (req: Request, res: Response) => {
+        const variableId = expectInt(req.params.variableId)
+
+        const variable = await db.mysqlFirst(
+            `SELECT id, grapherConfig FROM variables WHERE id=?`,
+            [variableId]
+        )
+
+        if (!variable) {
+            throw new JsonError(`No variable by id '${variableId}'`, 404)
+        }
+
+        const config = JSON.parse(variable.grapherConfig)
+        config.id = variable.id
+        return config
+    }
+)
+
 apiRouter.put("/variables/:variableId", async (req: Request) => {
     const variableId = expectInt(req.params.variableId)
     const variable = (req.body as { variable: VariableSingleMeta }).variable

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1651,3 +1651,9 @@ export function filterValidStringValues<ValidValue extends string>(
 
     return filteredValues
 }
+
+export function isSettledPromiseFulfilled<T>(
+    result: PromiseSettledResult<T>
+): result is PromiseFulfilledResult<T> {
+    return result.status === "fulfilled"
+}

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -318,6 +318,7 @@ export {
     type NodeWithUrl,
     filterValidStringValues,
     traverseEnrichedSpan,
+    isSettledPromiseFulfilled,
 } from "./Util.js"
 
 export {


### PR DESCRIPTION
fixes #1818

### Problem

- The live preview does not work for unsaved explorers that refer to grapher config IDs or rely on partial grapher configs
   - applies to new explorers that have never been saved
   - applies to existing explorers with unsaved changes

- Core problem:
    - Grapher configs are baked into the explorer page in a server-side step – this only happens when the explorer is saved
    - If not saved, these configs are missing in the live preview, meaning that nothing or only a partial explorer can be shown

- This has been known to be a problem for a while; however, note that the bug has a different quality for indicator-based explorers and partial grapher configs:
    - in the case of grapher id-based explorers, the preview of a new explorer does not show anything until saved
    - in the case of indicator-based explorers, the preview of an unsaved explorer does show _something_ but that _something_ might be incorrect as partial grapher configs have not been applied yet

### Proposed solution 

- The live preview parses available inlined configs and fetches missing configs if necessary

Not optimal since:
- Live preview and actual explorers sometimes have different code paths
    - Although to publish an explorer, it must be saved so that an author will see the "actual" preview eventually (by "actual" preview, I mean a preview that does not rely on additional requests to get missing configs)
- Fetching from the admin endpoints in `Explorer.tsx` does not feel clean 

### Alternatives

- Do not bake grapher configs and always fetch them late -> degrades user experience since rendering the chart title immediately wouldn't be possible
- Store one "new" explorer per user and bake configs of grapher IDs before saving -> seems weird and complicated
- Continue baking configs the way we do but "patch up" the live preview by fetching configs that are missing -> this is what I opted for

---

I don't know how often authors work on unsaved explorers. Also, although indicator-based explorers can theoretically suffer from this problem, they won't for some time because we don't have any partial grapher configs at the moment. We could leave this PR as a draft and revisit it when there is a more pressing need to solve this problem. Happy to discuss this!
