### PR TITLE
feat(gdocs-admin): allow saving gdocs as draft

### DIFF
--- a/adminSiteClient/GdocsDiff.tsx
+++ b/adminSiteClient/GdocsDiff.tsx
@@ -17,6 +17,7 @@ export const GdocsDiff = ({
                 "imageMetadata",
                 "linkedCharts",
                 "linkedDocuments",
+                "relatedCharts",
             ]),
             null,
             2
@@ -27,6 +28,7 @@ export const GdocsDiff = ({
                 "imageMetadata",
                 "linkedCharts",
                 "linkedDocuments",
+                "relatedCharts",
             ]),
             null,
             2

--- a/adminSiteClient/GdocsDiff.tsx
+++ b/adminSiteClient/GdocsDiff.tsx
@@ -3,6 +3,16 @@ import ReactDiffViewer, { DiffMethod } from "react-diff-viewer"
 import { stringify } from "safe-stable-stringify"
 import { omit, OwidGdocInterface } from "@ourworldindata/utils"
 
+// Non-deterministic values which shouldn't be displayed in the diff viewer
+// Errors are already shown in the settings drawer, so we don't show those either
+export const GDOC_DIFF_OMITTABLE_PROPERTIES = [
+    "errors",
+    "imageMetadata",
+    "linkedCharts",
+    "linkedDocuments",
+    "relatedCharts",
+]
+
 export const GdocsDiff = ({
     originalGdoc,
     currentGdoc,
@@ -12,24 +22,12 @@ export const GdocsDiff = ({
 }) => (
     <ReactDiffViewer
         oldValue={stringify(
-            omit(originalGdoc, [
-                "errors",
-                "imageMetadata",
-                "linkedCharts",
-                "linkedDocuments",
-                "relatedCharts",
-            ]),
+            omit(originalGdoc, GDOC_DIFF_OMITTABLE_PROPERTIES),
             null,
             2
         )}
         newValue={stringify(
-            omit(currentGdoc, [
-                "errors",
-                "imageMetadata",
-                "linkedCharts",
-                "linkedDocuments",
-                "relatedCharts",
-            ]),
+            omit(currentGdoc, GDOC_DIFF_OMITTABLE_PROPERTIES),
             null,
             2
         )}

--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -175,6 +175,18 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
             (error) => error.type === OwidGdocErrorMessageType.Error
         ) ?? false
 
+    const saveDraft = async () => {
+        if (!currentGdoc) return
+        cancelAllRequests()
+
+        if (currentGdoc.published)
+            throw new Error("Cannot save a published doc as a draft")
+
+        const updatedGdoc = await store.update(currentGdoc)
+        setGdoc({ original: updatedGdoc, current: updatedGdoc })
+        openSuccessNotification("draft")
+    }
+
     const doPublish = async () => {
         if (!currentGdoc) return
         cancelAllRequests()
@@ -187,7 +199,7 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
             slug,
         })
         setGdoc({ original: publishedGdoc, current: publishedGdoc })
-        openSuccessNotification()
+        openSuccessNotification("published")
     }
 
     const doUnpublish = async () => {
@@ -195,7 +207,7 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
         cancelAllRequests()
         const unpublishedGdoc = await store.unpublish(currentGdoc)
         setGdoc({ original: unpublishedGdoc, current: unpublishedGdoc })
-        openSuccessNotification()
+        openSuccessNotification("unpublished")
     }
 
     const onDelete = async () => {
@@ -307,6 +319,7 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                                 isLightningUpdate={isLightningUpdate}
                                 setDiffOpen={setDiffOpen}
                                 doPublish={doPublish}
+                                saveDraft={saveDraft}
                             />
                             <IconBadge
                                 status={

--- a/adminSiteClient/GdocsSaveButtons.tsx
+++ b/adminSiteClient/GdocsSaveButtons.tsx
@@ -18,6 +18,7 @@ export const GdocsSaveButtons = ({
     hasChanges,
     isLightningUpdate,
     doPublish,
+    saveDraft,
 }: {
     published: boolean
     originalGdoc: OwidGdocInterface | undefined
@@ -29,6 +30,7 @@ export const GdocsSaveButtons = ({
     isLightningUpdate: boolean
     setDiffOpen: (open: boolean) => void
     doPublish: VoidFunction
+    saveDraft: VoidFunction
 }) => {
     const confirmPublish = async () => {
         const styleDiff = hasChanges
@@ -91,6 +93,11 @@ export const GdocsSaveButtons = ({
     return (
         <>
             <Space>
+                {!published && (
+                    <Button disabled={!hasChanges} onClick={saveDraft}>
+                        Save draft
+                    </Button>
+                )}
                 <Badge {...badgeProps}>
                     {/* #gdocsvalidationclient: prevent saving published articles with errors */}
                     <Button

--- a/adminSiteClient/gdocsDeploy.ts
+++ b/adminSiteClient/gdocsDeploy.ts
@@ -4,6 +4,7 @@ import {
     isEqual,
     omit,
 } from "@ourworldindata/utils"
+import { GDOC_DIFF_OMITTABLE_PROPERTIES } from "./GdocsDiff.js"
 
 export const checkFullDeployFallback = (
     prevGdoc: OwidGdocInterface,
@@ -70,19 +71,6 @@ export const checkHasChanges = (
     nextGdoc: OwidGdocInterface
 ) =>
     !isEqual(
-        // Ignore non-deterministic attachments
-        omit(prevGdoc, [
-            "linkedDocuments",
-            "imageMetadata",
-            "linkedCharts",
-            "relatedCharts",
-            "errors",
-        ]),
-        omit(nextGdoc, [
-            "linkedDocuments",
-            "imageMetadata",
-            "linkedCharts",
-            "relatedCharts",
-            "errors",
-        ])
+        omit(prevGdoc, GDOC_DIFF_OMITTABLE_PROPERTIES),
+        omit(nextGdoc, GDOC_DIFF_OMITTABLE_PROPERTIES)
     )

--- a/adminSiteClient/gdocsNotifications.tsx
+++ b/adminSiteClient/gdocsNotifications.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { notification } from "antd"
 import { OwidGdocErrorMessageType } from "@ourworldindata/utils"
+import { match } from "ts-pattern"
 
 type NotificationType = "success" | "info" | OwidGdocErrorMessageType
 const openNotification = (
@@ -16,15 +17,28 @@ const openNotification = (
     })
 }
 
-export const openSuccessNotification = () => {
-    openNotification(
-        "success",
-        "Document saved",
-        <span>
-            Your changes have been scheduled for publication.{" "}
-            <a href="/admin/deploys" target="deploy">
-                Check deploy progress
-            </a>
-        </span>
-    )
+type SuccessNotificationType = "draft" | "published" | "unpublished"
+
+export const openSuccessNotification = (type: SuccessNotificationType) => {
+    const content = match(type)
+        .with("draft", () => "Your changes have been saved as a draft.")
+        .with("published", () => (
+            <>
+                Your changes have been scheduled for publication.{" "}
+                <a href="/admin/deploys" target="deploy">
+                    Check deploy progress
+                </a>
+            </>
+        ))
+        .with("unpublished", () => (
+            <>
+                Your changes have been scheduled for unpublishing.{" "}
+                <a href="/admin/deploys" target="deploy">
+                    Check deploy progress
+                </a>
+            </>
+        ))
+        .exhaustive()
+
+    openNotification("success", "Document saved", <span>{content}</span>)
 }


### PR DESCRIPTION
Fixes #2393 

![image](https://github.com/owid/owid-grapher/assets/2641501/0119b732-d7e8-4b98-bb9a-9cb02181173c)

- There is now a "Save draft" button in the top toolbar, which is only shown when the document is currently unpublished.
- It is used to persist changes made to the slug (and some other properties), which before could only be applied by publishing.
- Saving as draft is possible even if there are document errors.