### PR TITLE
Add Origin class and fields

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -1742,9 +1742,17 @@ apiRouter.get(
 
         variable.display = JSON.parse(variable.display)
 
+        // TODO: support multiple sources
         variable.source = await db.mysqlFirst(
             `SELECT id, name FROM sources AS s WHERE id = ?`,
             variable.sourceId
+        )
+
+        variable.origins = await db.queryMysql(
+            `SELECT * from origins o
+             join origins_variables ov on o.id = ov.originId
+             where ov.variableId = ?`,
+            [variableId]
         )
 
         const charts = await db.queryMysql(
@@ -1908,6 +1916,7 @@ apiRouter.get("/datasets/:datasetId.json", async (req: Request) => {
 
     dataset.variables = variables
 
+    // TODO: support multiple sources
     // Currently for backwards compatibility datasets can still have multiple sources
     // but the UI presents only a single item of source metadata, we use the first source
     const sources = await db.queryMysql(

--- a/adminSiteServer/gitDataExport.ts
+++ b/adminSiteServer/gitDataExport.ts
@@ -14,6 +14,7 @@ import { execFormatted } from "../db/execWrapper.js"
 import { JsonError } from "@ourworldindata/utils"
 
 const datasetToReadme = async (dataset: Dataset): Promise<string> => {
+    // TODO: add origins here
     const source = await Source.findOneBy({ datasetId: dataset.id })
     return `# ${dataset.name}\n\n${
         (source && source.description && source.description.additionalInfo) ||

--- a/db/Variable.test.ts
+++ b/db/Variable.test.ts
@@ -198,6 +198,12 @@ describe("getVariableData", () => {
         mockS3data(s3data)
         jest.spyOn(db, "mysqlFirst").mockResolvedValueOnce(variableResult)
         jest.spyOn(db, "queryMysql").mockResolvedValueOnce([
+            {
+                id: 1,
+                datasetTitleOwid: "dataset title",
+            },
+        ])
+        jest.spyOn(db, "queryMysql").mockResolvedValueOnce([
             { id: 1, name: "UK", code: "code" },
         ])
 
@@ -226,6 +232,12 @@ describe("getVariableData", () => {
                     name: "source",
                     retrievedDate: "",
                 },
+                origins: [
+                    {
+                        id: 1,
+                        datasetTitleOwid: "dataset title",
+                    },
+                ],
                 type: "int",
                 unit: "",
                 updatedAt: date,

--- a/db/migration/1687770112891-CreateOriginsTable.ts
+++ b/db/migration/1687770112891-CreateOriginsTable.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CreateOriginsTable1687770112891 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+        CREATE TABLE origins (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            datasetTitleOwid VARCHAR(512),
+            datasetDescriptionOwid TEXT,
+            datasetDescriptionProducer TEXT,
+            producer VARCHAR(255),
+            citationProducer TEXT,
+            datasetUrlMain TEXT,
+            datasetUrlDownload TEXT,
+            dateAccessed DATE,
+            datePublished DATE
+        );
+        `)
+
+        // create index on datasetTitleOwid for faster lookups
+        // ideally we'd have unique index on all columns, but we'd be over 3072 bytes limit
+        await queryRunner.query(`-- sql
+        CREATE INDEX idx_datasetTitleOwid ON origins(datasetTitleOwid);`)
+
+        await queryRunner.query(`-- sql
+        CREATE TABLE origins_variables (
+            originId INT,
+            variableId INT,
+            PRIMARY KEY (originId, variableId),
+            FOREIGN KEY (originId) REFERENCES origins(id),
+            FOREIGN KEY (variableId) REFERENCES variables(id)
+        );
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+        DROP TABLE IF EXISTS origins_variables;
+        `)
+        await queryRunner.query(`-- sql
+        DROP TABLE IF EXISTS origins;
+        `)
+    }
+}

--- a/db/migration/1687770112891-CreateOriginsTable.ts
+++ b/db/migration/1687770112891-CreateOriginsTable.ts
@@ -13,7 +13,7 @@ export class CreateOriginsTable1687770112891 implements MigrationInterface {
             datasetUrlMain TEXT,
             datasetUrlDownload TEXT,
             dateAccessed DATE,
-            datePublished DATE
+            datePublished VARCHAR(10)
         );
         `)
 

--- a/db/migration/1688372371221-AddPresentationToVariables.ts
+++ b/db/migration/1688372371221-AddPresentationToVariables.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddPresentationToVariables1688372371221
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE variables
+              ADD COLUMN schemaVersion int,
+              ADD COLUMN processingLevel varchar(255),
+              ADD COLUMN presentation JSON;
+            `
+        )
+
+        await queryRunner.query(
+            `ALTER TABLE variables
+            ADD CONSTRAINT processing_level_check
+            CHECK (processingLevel IN ('minor', 'medium', 'major'));
+            `
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE variables
+              DROP COLUMN schemaVersion,
+              DROP COLUMN processingLevel,
+              DROP COLUMN presentation;
+            `
+        )
+    }
+}

--- a/db/migration/1688372371221-AddPresentationToVariables.ts
+++ b/db/migration/1688372371221-AddPresentationToVariables.ts
@@ -6,26 +6,50 @@ export class AddPresentationToVariables1688372371221
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(
             `ALTER TABLE variables
-              ADD COLUMN schemaVersion int,
-              ADD COLUMN processingLevel varchar(255),
-              ADD COLUMN presentation JSON;
-            `
+                ADD COLUMN schemaVersion INT,
+                ADD COLUMN processingLevel ENUM('minor', 'medium', 'major'),
+                ADD COLUMN processingLog JSON,
+                ADD COLUMN titlePublic TEXT,
+                ADD COLUMN titleVariant TEXT,
+                ADD COLUMN producerShort TEXT,
+                ADD COLUMN citationInline TEXT,
+                ADD COLUMN descriptionShort TEXT,
+                ADD COLUMN descriptionFromProducer TEXT,
+                -- ADD COLUMN topicTagsLinks JSON,
+                ADD COLUMN keyInfoText TEXT,
+                ADD COLUMN processingInfo TEXT,
+                ADD COLUMN licenses JSON;`
         )
-
-        await queryRunner.query(
-            `ALTER TABLE variables
-            ADD CONSTRAINT processing_level_check
-            CHECK (processingLevel IN ('minor', 'medium', 'major'));
-            `
-        )
+        await queryRunner.query(`
+        CREATE TABLE posts_gdocs_variables (
+            gdocId varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NOT NULL,
+            variableId INT NOT NULL,
+            fragmentId VARCHAR(255) NOT NULL,
+            PRIMARY KEY (gdocId, fragmentId, variableId),
+            FOREIGN KEY (gdocId) REFERENCES posts_gdocs(id),
+            FOREIGN KEY (variableId) REFERENCES variables(id)
+        )`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+        DROP TABLE IF EXISTS posts_gdocs_variables;`)
+
         await queryRunner.query(
             `ALTER TABLE variables
-              DROP COLUMN schemaVersion,
-              DROP COLUMN processingLevel,
-              DROP COLUMN presentation;
+                DROP COLUMN schemaVersion,
+                DROP COLUMN processingLevel,
+                DROP COLUMN processingLog,
+                DROP COLUMN titlePublic,
+                DROP COLUMN titleVariant,
+                DROP COLUMN producerShort,
+                DROP COLUMN citationInline,
+                DROP COLUMN descriptionShort,
+                DROP COLUMN descriptionFromProducer,
+                -- DROP COLUMN topicTagsLinks,
+                DROP COLUMN keyInfoText,
+                DROP COLUMN processingInfo,
+                DROP COLUMN licenses;
             `
         )
     }

--- a/db/migration/1688372371221-AddPresentationToVariables.ts
+++ b/db/migration/1688372371221-AddPresentationToVariables.ts
@@ -21,7 +21,7 @@ export class AddPresentationToVariables1688372371221
                 ADD COLUMN licenses JSON;`
         )
         await queryRunner.query(`
-        CREATE TABLE posts_gdocs_variables (
+        CREATE TABLE posts_gdocs_variables_faqs (
             gdocId varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NOT NULL,
             variableId INT NOT NULL,
             fragmentId VARCHAR(255) NOT NULL,
@@ -33,7 +33,7 @@ export class AddPresentationToVariables1688372371221
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-        DROP TABLE IF EXISTS posts_gdocs_variables;`)
+        DROP TABLE IF EXISTS posts_gdocs_variables_faqs;`)
 
         await queryRunner.query(
             `ALTER TABLE variables

--- a/db/model/Origin.ts
+++ b/db/model/Origin.ts
@@ -1,0 +1,21 @@
+import { Entity, PrimaryGeneratedColumn, Column, BaseEntity } from "typeorm"
+
+@Entity("origins")
+export class Origin extends BaseEntity {
+    @PrimaryGeneratedColumn() id!: number
+    @Column({ type: "varchar", nullable: true }) datasetTitleOwid!:
+        | string
+        | null
+    @Column({ type: "text", nullable: true }) datasetDescriptionOwid!:
+        | string
+        | null
+    @Column({ type: "text", nullable: true }) datasetDescriptionProducer!:
+        | string
+        | null
+    @Column({ type: "varchar", nullable: true }) producer!: string | null
+    @Column({ type: "text", nullable: true }) citationProducer!: string | null
+    @Column({ type: "text", nullable: true }) datasetUrlMain!: string | null
+    @Column({ type: "text", nullable: true }) datasetUrlDownload!: string | null
+    @Column({ type: "date", nullable: true }) dateAccessed!: Date | null
+    @Column({ type: "varchar", nullable: true }) datePublished!: string | null
+}

--- a/db/model/Origin.ts
+++ b/db/model/Origin.ts
@@ -18,4 +18,7 @@ export class Origin extends BaseEntity {
     @Column({ type: "text", nullable: true }) datasetUrlDownload!: string | null
     @Column({ type: "date", nullable: true }) dateAccessed!: Date | null
     @Column({ type: "varchar", nullable: true }) datePublished!: string | null
+    // Note: there is an N:M relationship between origins and variables but
+    // because variables is not a typeORM class but a knew class we don't
+    // expose it here.
 }

--- a/packages/@ourworldindata/core-table/src/CoreColumnDef.ts
+++ b/packages/@ourworldindata/core-table/src/CoreColumnDef.ts
@@ -2,6 +2,7 @@ import {
     ColumnSlug,
     OwidVariableDisplayConfigInterface,
     ToleranceStrategy,
+    OwidOrigin,
 } from "@ourworldindata/utils"
 import { CoreValueType, Color } from "./CoreTableConstants.js"
 
@@ -67,12 +68,15 @@ export interface CoreColumnDef extends ColumnColorScale {
     color?: Color // A column can have a fixed color for use in charts where the columns are series
 
     // Source information used for display only
+    // TODO: support multiple sources
     sourceName?: string
     sourceLink?: string
     dataPublishedBy?: string
     dataPublisherSource?: string
     retrievedDate?: string
     additionalInfo?: string
+
+    origins?: OwidOrigin[]
 
     // Dataset information
     datasetId?: number

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -402,6 +402,7 @@ export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
         return this.jsType === "string" ? values.sort() : sortNumeric(values)
     }
 
+    // TODO: support multiple sources
     get source(): OwidSource {
         const { def } = this
         return {

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -558,6 +558,7 @@ const columnDefFromOwidVariable = (
         datasetId,
         datasetName,
         source,
+        origins,
         display,
         nonRedistributable,
     } = variable
@@ -578,12 +579,14 @@ const columnDefFromOwidVariable = (
         datasetName,
         display,
         nonRedistributable,
+        // TODO: support multiple sources
         sourceLink: source?.link,
         sourceName: source?.name,
         dataPublishedBy: source?.dataPublishedBy,
         dataPublisherSource: source?.dataPublisherSource,
         retrievedDate: source?.retrievedDate,
         additionalInfo: source?.additionalInfo,
+        origins,
         owidVariableId: variable.id,
         type: isContinent
             ? ColumnTypeNames.Continent

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -28,6 +28,7 @@ export class Footer extends React.Component<{
 
     @computed private get sourcesText(): string {
         const sourcesLine = this.manager.sourcesLine
+        // TODO: support multiple sources and also origins
         return sourcesLine ? `Source: ${sourcesLine}` : ""
     }
 

--- a/packages/@ourworldindata/grapher/src/sourcesTab/SourcesTab.tsx
+++ b/packages/@ourworldindata/grapher/src/sourcesTab/SourcesTab.tsx
@@ -29,6 +29,7 @@ export class SourcesTab extends React.Component<{
     }
 
     private renderSource(column: CoreColumn): JSX.Element {
+        // TODO: support multiple sources and also origins
         const { slug, source, def } = column
         const { datasetId, coverage } = def as OwidColumnDef
 

--- a/packages/@ourworldindata/utils/src/OwidOrigin.ts
+++ b/packages/@ourworldindata/utils/src/OwidOrigin.ts
@@ -1,0 +1,13 @@
+export interface OwidOrigin {
+    id?: number
+    datasetTitleOwid?: string
+    datasetDescriptionOwid?: string
+    datasetDescriptionProducer?: string
+    producer?: string
+    citationProducer?: string
+    datasetUrlMain?: string
+    datasetUrlDownload?: string
+    dateAccessed?: Date
+    datePublished?: string
+
+}

--- a/packages/@ourworldindata/utils/src/OwidOrigin.ts
+++ b/packages/@ourworldindata/utils/src/OwidOrigin.ts
@@ -9,5 +9,4 @@ export interface OwidOrigin {
     datasetUrlDownload?: string
     dateAccessed?: Date
     datePublished?: string
-
 }

--- a/packages/@ourworldindata/utils/src/OwidVariable.ts
+++ b/packages/@ourworldindata/utils/src/OwidVariable.ts
@@ -8,6 +8,7 @@ import {
     deleteRuntimeAndUnchangedProps,
 } from "./persistable/Persistable.js"
 import { OwidSource } from "./OwidSource.js"
+import { OwidOrigin } from "./OwidOrigin.js"
 import {
     OwidVariableDataTableConfigInteface,
     OwidVariableDisplayConfigInterface,
@@ -63,7 +64,9 @@ export interface OwidVariableWithSource {
     datasetId?: number
     coverage?: string
     nonRedistributable?: boolean
+    // TODO: support multiple sources
     source?: OwidSource
+    origins?: OwidOrigin[]
 }
 
 export type OwidVariableWithSourceAndDimension = OwidVariableWithSource & {

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -397,6 +397,7 @@ export type {
 } from "./dayjs.js"
 
 export type { OwidSource } from "./OwidSource.js"
+export type { OwidOrigin } from "./OwidOrigin.js"
 export {
     formatValue,
     checkIsVeryShortUnit,


### PR DESCRIPTION
Based on a previous PR that adds a new database table for Origin, this PR 
adds the db interface classes and related fields for using Origin as the modern
replacement for Source. 

Origins are not yet used in the sources tab - this will be done later on