### PR TITLE
fix(markdown): fix broken url parser

### DIFF
--- a/packages/@ourworldindata/utils/src/MarkdownTextWrap/parser.ts
+++ b/packages/@ourworldindata/utils/src/MarkdownTextWrap/parser.ts
@@ -240,7 +240,7 @@ const plainUrlParser = (): P.Parser<PlainUrl> =>
 
 // https://urlregex.com
 const urlRegex =
-    /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w\-]*))?)/
+    /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@~\.\w_]*)#?(?:[\.\!\/\\\w\-]*))?)/
 
 const nonBracketWordParser: (r: MdParser) => P.Parser<NonBracketWord> = () =>
     P.regex(/[^\[\]\s]+/).map((val) => ({ type: "text", value: val })) //  no brackets, no WS


### PR DESCRIPTION
See [Slack](https://owid.slack.com/archives/C46U9LXRR/p1688549094872669) | fixes #2402

Fixes an issue where tildes `~` in URLs break our markdown URL parser.