### PR TITLE
enhance: sort explorers by title

### DIFF
--- a/explorerAdminServer/ExplorerAdminServer.tsx
+++ b/explorerAdminServer/ExplorerAdminServer.tsx
@@ -8,7 +8,7 @@ import {
     ExplorersRouteResponse,
 } from "../explorer/ExplorerConstants.js"
 import { simpleGit, SimpleGit } from "simple-git"
-import { GitCommit, keyBy } from "@ourworldindata/utils"
+import { GitCommit, keyBy, sortBy } from "@ourworldindata/utils"
 import { Dictionary } from "lodash"
 
 export class ExplorerAdminServer {
@@ -79,7 +79,8 @@ export class ExplorerAdminServer {
 
     async getAllPublishedExplorers() {
         const explorers = await this.getAllExplorers()
-        return explorers.filter((exp) => exp.isPublished)
+        const publishedExplorers = explorers.filter((exp) => exp.isPublished)
+        return sortBy(publishedExplorers, (exp) => exp.explorerTitle)
     }
 
     async getAllPublishedExplorersBySlug() {


### PR DESCRIPTION
fixes #2401

Sorts explorers on https://ourworldindata.org/charts by their title:

<img width="1164" alt="Screenshot 2023-07-10 at 10 46 46" src="https://github.com/owid/owid-grapher/assets/12461810/543667ec-bdc8-4bf8-b310-78a3085ddc75">
