### PR TITLE
enhance(schema): sync default grapher config to digital ocean

### DIFF
--- a/.github/workflows/sync-grapher-schema-to-digital-ocean.yml
+++ b/.github/workflows/sync-grapher-schema-to-digital-ocean.yml
@@ -11,6 +11,10 @@ jobs:
         steps:
             - name: Checkout Repository
               uses: actions/checkout@master
+
+            - uses: ./.github/actions/setup-node-yarn-deps
+            - uses: ./.github/actions/build-tsc
+
             - uses: hustcer/setup-nu@v3
               with:
                   version: "0.80" # Don't use 0.80 here, as it was a float number and will be convert to 0.8, you can use v0.80/0.80.0 or '0.80'
@@ -23,6 +27,19 @@ jobs:
                       | save -f ($yaml.name
                           | path parse
                           | upsert extension "json"
+                          | path join) })
+              shell: nu {0}
+            # Construct default config objects for all grapher schemas in the schema directory (should only be one)
+            - run: |
+                  (ls packages/@ourworldindata/grapher/src/schema/grapher-schema.*.json
+                  | each {|json|
+                      node itsJustJavascript/devTools/schema/generate-default-object-from-schema.js $json.name
+                      | save -f ($json.name
+                          | path parse
+                          | upsert stem ($json.name
+                              | path parse
+                              | get stem
+                              | str replace 'grapher-schema' 'grapher-schema.default')
                           | path join) })
               shell: nu {0}
             # Get all files in the schema directory that end with digits.json or digits.yaml and

--- a/devTools/schema/generate-default-object-from-schema.ts
+++ b/devTools/schema/generate-default-object-from-schema.ts
@@ -1,0 +1,64 @@
+#! /usr/bin/env node
+
+import parseArgs from "minimist"
+import fs from "fs-extra"
+
+function generateDefaultObjectFromSchema(
+    schema: Record<string, any>,
+    defs: Record<string, any> = {}
+) {
+    const defaultObject: Record<string, any> = {}
+    if (schema.type === "object") {
+        for (let key in schema.properties) {
+            // substitute $ref with the actual definition
+            const ref = schema.properties[key].$ref
+            if (ref != undefined) {
+                const regex = /#\/\$defs\/([a-zA-Z]+)/
+                const [_, defKey] = ref.match(regex) ?? []
+                const def = defs[defKey]
+                if (def == undefined)
+                    throw new Error(`Definition "${ref}" not found`)
+                schema.properties[key] = def
+            }
+
+            if (schema.properties[key].type === "object") {
+                const defaults = generateDefaultObjectFromSchema(
+                    schema.properties[key],
+                    defs
+                )
+                if (Object.keys(defaults).length) defaultObject[key] = defaults
+            } else if (schema.properties[key].default != undefined) {
+                defaultObject[key] = schema.properties[key].default
+            }
+        }
+    }
+    return defaultObject
+}
+
+async function main(parsedArgs: parseArgs.ParsedArgs) {
+    const schemaFilename = parsedArgs._[0]
+    if (schemaFilename == undefined) {
+        help()
+        process.exit(0)
+    }
+
+    let schema = fs.readJSONSync(schemaFilename)
+    const defs = schema.$defs || {}
+    const defaultObject = generateDefaultObjectFromSchema(schema, defs)
+    process.stdout.write(JSON.stringify(defaultObject, undefined, 2))
+}
+
+function help() {
+    console.log(`generate-default-object-from-schema.ts - utility to generate an object with all default values that are given in a JSON schema
+
+Usage:
+  generate-default-object-from-schema.js <schema.json>`)
+}
+
+const parsedArgs = parseArgs(process.argv.slice(2))
+if (parsedArgs["h"] || parsedArgs["help"]) {
+    help()
+    process.exit(0)
+} else {
+    main(parsedArgs)
+}

--- a/devTools/schema/tsconfig.json
+++ b/devTools/schema/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../tsconfigs/tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "../../itsJustJavascript/devTools/schema",
+        "rootDir": "."
+    },
+    "references": []
+}

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
@@ -200,7 +200,7 @@ properties:
         type: string
         description: Url of the concrete schema version to use to validate this document
         format: uri
-        default: "https://files.ourworldindata.org/schemas/grapher-schema.003.json"
+        default: "https://files.ourworldindata.org/schemas/grapher-schema.latest.json"
     id:
         type: integer
         description: Internal DB id. Useful internally for OWID but not required if just using grapher directly.

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
@@ -200,7 +200,7 @@ properties:
         type: string
         description: Url of the concrete schema version to use to validate this document
         format: uri
-        default: "https://files.ourworldindata.org/schemas/grapher-schema.latest.json"
+        default: "https://files.ourworldindata.org/schemas/grapher-schema.003.json"
     id:
         type: integer
         description: Internal DB id. Useful internally for OWID but not required if just using grapher directly.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
         { "path": "./adminSiteClient" },
         { "path": "./adminSiteServer" },
         { "path": "./devTools/svgTester" },
+        { "path": "./devTools/schema" },
         { "path": "./devTools/schemaProcessor" },
         { "path": "./devTools/dodParserTestGenerator" },
         { "path": "./devTools/uploadWordpressImagesToObjStorage" },


### PR DESCRIPTION
Discussion on [Slack](https://owid.slack.com/archives/C04VBQ00HQR/p1687879630078009)

### Summary

This PR updates the GitHub action that syncs grapher schemas to DO. It creates an additional JSON file named `grapher-schema.default.{XXX,latest}.json` that is the default grapher config object derived from the current schema. The default grapher object is then available under `https://files.ourworldindata.org/schemas/grapher-schema.default.{XXX,latest}.json`.

### Background

I want to use the default grapher config object to create an additional column in the Datasette charts table, maybe named `configWithDefaults`, that fills in missing values with defaults from our schema. See: https://github.com/owid/owid-datasette/pull/19

### Technical details

- Arrays are ignored when creating the default object. For example, some properties of items in the `dimensions` array do have default values, but that is not reflected in the default grapher config object