### PR TITLE
Track querystrings and hashes, fix grapher embeds with old slugs

### DIFF
--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -325,6 +325,7 @@ export class SiteBaker {
                 mapValues(results, (cur) => ({
                     originalSlug: cur.slug,
                     resolvedUrl: `${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${cur.slug}`,
+                    queryString: "",
                     title: cur.title || "",
                     thumbnail:
                         cur.thumbnail ||
@@ -340,6 +341,7 @@ export class SiteBaker {
                         [cur.slug]: {
                             originalSlug: cur.slug,
                             resolvedUrl: `${BAKED_GRAPHER_URL}/${cur.config.slug}`,
+                            queryString: "",
                             title: cur.config.title || "",
                             thumbnail: `${BAKED_GRAPHER_EXPORTS_BASE_URL}/${cur.config.slug}.svg`,
                         },

--- a/db/migration/1689019238688-LinkQueryString.ts
+++ b/db/migration/1689019238688-LinkQueryString.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class LinkQueryString1689019238688 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE posts_gdocs_links ADD COLUMN queryString VARCHAR(2047) NOT NULL;`
+        )
+        await queryRunner.query(
+            `ALTER TABLE posts_gdocs_links ADD COLUMN hash VARCHAR(2047) NOT NULL;`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE posts_gdocs_links DROP COLUMN queryString;`
+        )
+        await queryRunner.query(
+            `ALTER TABLE posts_gdocs_links DROP COLUMN hash;`
+        )
+    }
+}

--- a/db/model/Gdoc/Gdoc.ts
+++ b/db/model/Gdoc/Gdoc.ts
@@ -17,7 +17,6 @@ import {
     GdocsContentSource,
     JsonError,
     getUrlTarget,
-    getLinkType,
     keyBy,
     excludeNull,
     ImageMetadata,
@@ -55,7 +54,6 @@ import {
     BAKED_GRAPHER_EXPORTS_BASE_URL,
 } from "../../../settings/clientSettings.js"
 import { EXPLORERS_ROUTE_FOLDER } from "../../../explorer/ExplorerConstants.js"
-import { formatUrls } from "../../../site/formatting.js"
 import { parseDetails } from "./rawToEnriched.js"
 import { match, P } from "ts-pattern"
 import {

--- a/db/model/Link.ts
+++ b/db/model/Link.ts
@@ -7,8 +7,9 @@ import {
     Relation,
     In,
 } from "typeorm"
-import { OwidGdocLinkJSON } from "@ourworldindata/utils"
+import { OwidGdocLinkJSON, getLinkType, Url } from "@ourworldindata/utils"
 import { Gdoc } from "./Gdoc/Gdoc.js"
+import { formatUrls } from "../../site/formatting.js"
 
 @Entity("posts_gdocs_links")
 export class Link extends BaseEntity implements OwidGdocLinkJSON {
@@ -16,6 +17,8 @@ export class Link extends BaseEntity implements OwidGdocLinkJSON {
     @ManyToOne(() => Gdoc, (gdoc) => gdoc.id) source!: Relation<Gdoc>
     @Column() linkType!: "gdoc" | "url" | "grapher" | "explorer"
     @Column() target!: string
+    @Column() queryString!: string
+    @Column() hash!: string
     @Column() componentType!: string
     @Column() text!: string
 
@@ -27,5 +30,36 @@ export class Link extends BaseEntity implements OwidGdocLinkJSON {
             where: { target: In(ids), linkType },
             relations: ["source"],
         }).then((links) => links.filter((link) => link.source.published))
+    }
+
+    static createFromUrl({
+        url,
+        source,
+        text = "",
+        componentType = "",
+    }: {
+        url: string
+        source: Gdoc
+        text?: string
+        componentType?: string
+    }): Link {
+        const formattedUrl = formatUrls(url)
+        const urlObject = Url.fromURL(formattedUrl)
+        const linkType = getLinkType(formattedUrl)
+        const target =
+            linkType === "grapher" || linkType === "explorer"
+                ? urlObject.slug
+                : urlObject.originAndPath
+        const queryString = urlObject.queryStr
+        const hash = urlObject.hash
+        return Link.create({
+            target,
+            linkType,
+            queryString,
+            hash,
+            source,
+            text,
+            componentType,
+        })
     }
 }

--- a/db/model/Link.ts
+++ b/db/model/Link.ts
@@ -7,7 +7,12 @@ import {
     Relation,
     In,
 } from "typeorm"
-import { OwidGdocLinkJSON, getLinkType, Url } from "@ourworldindata/utils"
+import {
+    OwidGdocLinkJSON,
+    getLinkType,
+    Url,
+    getUrlTarget,
+} from "@ourworldindata/utils"
 import { Gdoc } from "./Gdoc/Gdoc.js"
 import { formatUrls } from "../../site/formatting.js"
 
@@ -46,10 +51,7 @@ export class Link extends BaseEntity implements OwidGdocLinkJSON {
         const formattedUrl = formatUrls(url)
         const urlObject = Url.fromURL(formattedUrl)
         const linkType = getLinkType(formattedUrl)
-        const target =
-            linkType === "grapher" || linkType === "explorer"
-                ? urlObject.slug
-                : urlObject.originAndPath
+        const target = getUrlTarget(formattedUrl)
         const queryString = urlObject.queryStr
         const hash = urlObject.hash
         return Link.create({

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1138,6 +1138,7 @@ export interface OwidGdocTag {
 export interface LinkedChart {
     originalSlug: string
     resolvedUrl: string
+    queryString: string
     title: string
     thumbnail?: string
 }

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1138,7 +1138,6 @@ export interface OwidGdocTag {
 export interface LinkedChart {
     originalSlug: string
     resolvedUrl: string
-    queryString: string
     title: string
     thumbnail?: string
 }

--- a/site/gdocs/Chart.tsx
+++ b/site/gdocs/Chart.tsx
@@ -13,7 +13,7 @@ import {
     Url,
     merge,
 } from "@ourworldindata/utils"
-import { renderSpans } from "./utils.js"
+import { renderSpans, useLinkedChart } from "./utils.js"
 import cx from "classnames"
 
 export default function Chart({
@@ -27,6 +27,11 @@ export default function Chart({
     useEmbedChart(0, refChartContainer)
 
     const url = Url.fromURL(d.url)
+    // url may point to an old slug, useLinkedChart resolves these redirects
+    const { linkedChart } = useLinkedChart(url.slug!)
+    if (!linkedChart) return null
+    const resolvedUrl = `${linkedChart.resolvedUrl}${linkedChart.queryString}`
+
     const isExplorer = url.isExplorer
     const hasControls = url.queryParams.hideControls !== "true"
     const height = d.height || (isExplorer && hasControls ? 700 : 575)
@@ -72,9 +77,9 @@ export default function Chart({
         >
             <figure
                 // Use unique `key` to force React to re-render tree
-                key={d.url}
-                data-grapher-src={isExplorer ? undefined : d.url}
-                data-explorer-src={isExplorer ? d.url : undefined}
+                key={resolvedUrl}
+                data-grapher-src={isExplorer ? undefined : resolvedUrl}
+                data-explorer-src={isExplorer ? resolvedUrl : undefined}
                 data-grapher-config={
                     isCustomized && !isExplorer
                         ? JSON.stringify(config)

--- a/site/gdocs/Chart.tsx
+++ b/site/gdocs/Chart.tsx
@@ -26,12 +26,16 @@ export default function Chart({
     const refChartContainer = useRef<HTMLDivElement>(null)
     useEmbedChart(0, refChartContainer)
 
-    const url = Url.fromURL(d.url)
-    // url may point to an old slug, useLinkedChart resolves these redirects
-    const { linkedChart } = useLinkedChart(url.slug!)
+    // d.url may use an old slug that has since had a redirect created for it
+    // useLinkedChart references a hashmap that has resolved these old slugs to their current chart
+    // It also extracts the queryString from d.url (if present) and appends it to linkedChart.resolvedUrl
+    // This means we can link to the same chart multiple times with different querystrings
+    // and it should all resolve correctly via the same linkedChart
+    const { linkedChart } = useLinkedChart(d.url)
     if (!linkedChart) return null
-    const resolvedUrl = `${linkedChart.resolvedUrl}${linkedChart.queryString}`
 
+    const url = Url.fromURL(d.url)
+    const resolvedUrl = linkedChart.resolvedUrl
     const isExplorer = url.isExplorer
     const hasControls = url.queryParams.hideControls !== "true"
     const height = d.height || (isExplorer && hasControls ? 700 : 575)

--- a/site/gdocs/ProminentLink.tsx
+++ b/site/gdocs/ProminentLink.tsx
@@ -50,7 +50,7 @@ export const ProminentLink = (props: {
         description = description ?? linkedDocument?.content.excerpt
         thumbnail = thumbnail ?? linkedDocument?.content["featured-image"]
     } else if (linkType === "grapher" || linkType === "explorer") {
-        href = `${linkedChart?.resolvedUrl}`
+        href = `${linkedChart?.resolvedUrl}${linkedChart?.queryString}`
         title = title ?? linkedChart?.title
         thumbnail = thumbnail ?? linkedChart?.thumbnail
         description =

--- a/site/gdocs/ProminentLink.tsx
+++ b/site/gdocs/ProminentLink.tsx
@@ -50,11 +50,11 @@ export const ProminentLink = (props: {
         description = description ?? linkedDocument?.content.excerpt
         thumbnail = thumbnail ?? linkedDocument?.content["featured-image"]
     } else if (linkType === "grapher" || linkType === "explorer") {
-        href = `${linkedChart?.resolvedUrl}${linkedChart?.queryString}`
+        href = `${linkedChart?.resolvedUrl}`
         title = title ?? linkedChart?.title
         thumbnail = thumbnail ?? linkedChart?.thumbnail
         description =
-            // Adding extra context for graphers by default.
+            // Adding extra context for graphers by default
             // Not needed for Explorers as their titles are self-explanatory
             description ?? linkType === "grapher"
                 ? "See the data in our interactive visualization"

--- a/site/gdocs/utils.tsx
+++ b/site/gdocs/utils.tsx
@@ -45,19 +45,31 @@ export const breadcrumbColorForCoverColor = (
 export const useLinkedDocument = (
     url: string
 ): { linkedDocument?: OwidGdocInterface; errorMessage?: string } => {
-    let errorMessage: string | undefined = undefined
     const { linkedDocuments } = useContext(AttachmentsContext)
-    const urlTarget = getUrlTarget(url)
+    let errorMessage: string | undefined = undefined
+    let linkedDocument: OwidGdocInterface | undefined = undefined
     const linkType = getLinkType(url)
-    const linkedDocument = linkedDocuments?.[urlTarget]
-    if (linkType === "gdoc") {
-        if (!linkedDocument) {
-            errorMessage = `Google doc URL ${url} isn't registered.`
-        } else if (!linkedDocument.published) {
-            errorMessage = `Article with slug "${linkedDocument.slug}" isn't published.`
-        }
+    if (linkType !== "gdoc") {
+        return { linkedDocument }
     }
-    return { linkedDocument, errorMessage }
+
+    const urlObj = Url.fromURL(url)
+    const queryString = urlObj.queryStr
+    const hash = urlObj.hash
+    const urlTarget = getUrlTarget(url)
+    linkedDocument = linkedDocuments?.[urlTarget]
+    if (!linkedDocument) {
+        errorMessage = `Google doc URL ${url} isn't registered.`
+    } else if (!linkedDocument.published) {
+        errorMessage = `Article with slug "${linkedDocument.slug}" isn't published.`
+    }
+    return {
+        linkedDocument: {
+            ...linkedDocument,
+            slug: `${linkedDocument.slug}${queryString}${hash}`,
+        },
+        errorMessage,
+    }
 }
 
 export const useLinkedChart = (

--- a/site/gdocs/utils.tsx
+++ b/site/gdocs/utils.tsx
@@ -76,17 +76,16 @@ export const useLinkedChart = (
     url: string
 ): { linkedChart?: LinkedChart; errorMessage?: string } => {
     const { linkedCharts } = useContext(AttachmentsContext)
-    let errorMessage: string | undefined = undefined
-    let linkedChart: LinkedChart | undefined = undefined
     const linkType = getLinkType(url)
-    if (linkType !== "grapher" && linkType !== "explorer")
-        return { linkedChart }
+    if (linkType !== "grapher" && linkType !== "explorer") return {}
 
     const queryString = Url.fromURL(url).queryStr
     const urlTarget = getUrlTarget(url)
-    linkedChart = linkedCharts?.[urlTarget]
+    const linkedChart = linkedCharts?.[urlTarget]
     if (!linkedChart) {
-        errorMessage = `${linkType} chart with slug ${urlTarget} not found`
+        return {
+            errorMessage: `${linkType} chart with slug ${urlTarget} not found`,
+        }
     }
 
     return {
@@ -96,7 +95,6 @@ export const useLinkedChart = (
             // Instead we get the querystring from the original URL and append it to resolvedUrl
             resolvedUrl: `${linkedChart.resolvedUrl}${queryString}`,
         },
-        errorMessage,
     }
 }
 

--- a/site/gdocs/utils.tsx
+++ b/site/gdocs/utils.tsx
@@ -103,7 +103,10 @@ const LinkedA = ({ span }: { span: SpanLink }): JSX.Element => {
     }
     if (linkedChart) {
         return (
-            <a href={linkedChart.resolvedUrl} className="span-link">
+            <a
+                href={`${linkedChart.resolvedUrl}${linkedChart.queryString}`}
+                className="span-link"
+            >
                 {renderSpans(span.children)}
             </a>
         )


### PR DESCRIPTION
Our `posts_gdocs_links` table wasn't tracking query strings or hashes. 

This meant they would get stripped if you were using `useLinkedChart` (e.g. in `LinkedA` or `ProminentLink`)

This adds those two columns to the table and passes them through to the FE so that `useLinkedChart` works correctly.

It also updates `Chart.tsx` to use `useLinkedChart` so that referencing grapher URLs that have redirects will resolve to the correct URL.

[Document to test with](https://docs.google.com/document/d/1MfJkgmcH8-wM0Rd4AcksSrGaw6Hh4Uyrx2aouGge3gM/edit)