### PR TITLE
Fixes bug where narrative charts stopped responding to gdoc changes

### DIFF
--- a/site/gdocs/Chart.tsx
+++ b/site/gdocs/Chart.tsx
@@ -43,10 +43,9 @@ export default function Chart({
             .filter(identity) as GrapherProgrammaticInterface[]
 
         config = merge(
-            !showAllControls
-                ? { ...grapherInterfaceWithHiddenControlsOnly }
-                : {},
-            !showAllTabs ? { ...grapherInterfaceWithHiddenTabsOnly } : {},
+            {},
+            !showAllControls ? grapherInterfaceWithHiddenControlsOnly : {},
+            !showAllTabs ? grapherInterfaceWithHiddenTabsOnly : {},
             ...listOfPartialGrapherConfigs,
             { hideRelatedQuestion: true },
             {

--- a/site/gdocs/Chart.tsx
+++ b/site/gdocs/Chart.tsx
@@ -43,8 +43,10 @@ export default function Chart({
             .filter(identity) as GrapherProgrammaticInterface[]
 
         config = merge(
-            !showAllControls ? grapherInterfaceWithHiddenControlsOnly : {},
-            !showAllTabs ? grapherInterfaceWithHiddenTabsOnly : {},
+            !showAllControls
+                ? { ...grapherInterfaceWithHiddenControlsOnly }
+                : {},
+            !showAllTabs ? { ...grapherInterfaceWithHiddenTabsOnly } : {},
             ...listOfPartialGrapherConfigs,
             { hideRelatedQuestion: true },
             {


### PR DESCRIPTION
Sometimes narrative charts stopped reacting to changes made in the source gdoc, first described by Joe on [Slack](https://owid.slack.com/archives/C46U9LXRR/p1688466499021549).

### How to reproduce the problem

- Add a chart with a custom title to a gdoc
- Note that all controls are hidden
- Configure the chart to show a particular control, e.g. the `entitySelector`
- Note that the entity selector is visible
- Edit the gdoc to hide the entity selector by removing the `entitySelector` keyword
- Note that the entity selector is still visible
- Note that the console logs a hydration diff:
    - On the server: `hideEntityControls` is `false`
    - On the client: `hideEntityControls` is `true`

### Why this happened

- The `merge` function merges all objects into the first one
- `grapherInterfaceWithHiddenControlsOnly` was thus updated on each iteration, and the mutated `grapherInterfaceWithHiddenControlsOnly` lingered around
- This led to unexpected errors (like the one described)
- This only happened on the server and not on the client, hence the hydration diff
