### PR TITLE
Add schema property to Grapher

### DIFF
--- a/db/migration/1689156258161-AddMissingSchemaURLsToConfigs.ts
+++ b/db/migration/1689156258161-AddMissingSchemaURLsToConfigs.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddMissingSchemaURLsToConfigs1689156258161
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const tables = {
+            suggested_chart_revisions: "suggestedConfig",
+            chart_revisions: "config",
+            charts: "config",
+        }
+
+        for (const [tableName, columnName] of Object.entries(tables)) {
+            // updates the $schema field of all configs to the current schema url https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            // (not all configs are missing this field, but it's easier to just update all of them)
+            await queryRunner.query(
+                `update ${tableName} set ${columnName} = JSON_SET(${columnName}, "$.$schema", "https://files.ourworldindata.org/schemas/grapher-schema.003.json")`
+            )
+        }
+    }
+
+    public async down(_queryRunner: QueryRunner): Promise<void> {
+        return // es-lint complains on empty async functions
+    }
+}

--- a/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
@@ -2,6 +2,7 @@
 import { Grapher, GrapherProgrammaticInterface } from "../core/Grapher"
 import {
     ChartTypeName,
+    DEFAULT_GRAPHER_CONFIG_SCHEMA,
     EntitySelectionMode,
     GrapherTabOption,
     ScaleType,
@@ -75,17 +76,24 @@ it("can get dimension slots", () => {
     expect(grapher.dimensionSlots.length).toBe(4)
 })
 
-it("an empty Grapher serializes to an empty object", () => {
-    expect(new Grapher().toObject()).toEqual({})
+it("an empty Grapher serializes to an object that includes only the schema", () => {
+    expect(new Grapher().toObject()).toEqual({
+        $schema: DEFAULT_GRAPHER_CONFIG_SCHEMA,
+    })
 })
 
 it("a bad chart type does not crash grapher", () => {
-    const input = { type: "fff" as any }
+    const input = {
+        $schema: DEFAULT_GRAPHER_CONFIG_SCHEMA,
+        type: "fff" as any,
+    }
     expect(new Grapher(input).toObject()).toEqual(input)
 })
 
-it("does not preserve defaults in the object", () => {
-    expect(new Grapher({ tab: GrapherTabOption.chart }).toObject()).toEqual({})
+it("does not preserve defaults in the object (except for the schema)", () => {
+    expect(new Grapher({ tab: GrapherTabOption.chart }).toObject()).toEqual({
+        $schema: DEFAULT_GRAPHER_CONFIG_SCHEMA,
+    })
 })
 
 const unit = "% of children under 5"

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -80,6 +80,7 @@ import {
     FacetAxisDomain,
     AnnotationFieldsInTitle,
     MissingDataStrategy,
+    DEFAULT_GRAPHER_CONFIG_SCHEMA,
     DEFAULT_GRAPHER_WIDTH,
     DEFAULT_GRAPHER_HEIGHT,
     SeriesStrategy,
@@ -303,6 +304,7 @@ export class Grapher
         FacetChartManager,
         MapChartManager
 {
+    @observable.ref $schema = DEFAULT_GRAPHER_CONFIG_SCHEMA
     @observable.ref type = ChartTypeName.LineChart
     @observable.ref id?: number = undefined
     @observable.ref version = 1
@@ -472,6 +474,9 @@ export class Grapher
         obj.selectedEntityNames = this.selection.selectedEntityNames
 
         deleteRuntimeAndUnchangedProps(obj, defaultObject)
+
+        // always include the schema, even if it's the default
+        obj.$schema = this.$schema || DEFAULT_GRAPHER_CONFIG_SCHEMA
 
         // todo: nulls got into the DB for this one. we can remove after moving Graphers from DB.
         if (obj.stackMode === null) delete obj.stackMode

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -21,6 +21,9 @@ export const GRAPHER_PAGE_BODY_CLASS = "StandaloneGrapherOrExplorerPage"
 
 export const GRAPHER_IS_IN_IFRAME_CLASS = "IsInIframe"
 
+export const DEFAULT_GRAPHER_CONFIG_SCHEMA =
+    "https://files.ourworldindata.org/schemas/grapher-schema.003.json"
+
 export const DEFAULT_GRAPHER_WIDTH = 850
 export const DEFAULT_GRAPHER_HEIGHT = 600
 

--- a/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
@@ -30,6 +30,7 @@ import { ColorSchemeName } from "../color/ColorConstants"
 // Ideally, this is also all of the interaction state: when a grapher is saved and loaded again
 // under the same rendering conditions it ought to remain visually identical
 export interface GrapherInterface extends SortConfig {
+    $schema?: string
     type?: ChartTypeName
     id?: number
     version?: number
@@ -125,6 +126,7 @@ export interface LegacyGrapherQueryParams extends GrapherQueryParams {
 
 // Another approach we may want to try is this: https://github.com/mobxjs/serializr
 export const grapherKeysToSerialize = [
+    "$schema",
     "type",
     "id",
     "version",

--- a/packages/@ourworldindata/grapher/src/schema/README.md
+++ b/packages/@ourworldindata/grapher/src/schema/README.md
@@ -8,4 +8,11 @@ and upload them to S3 so they can be accessed publicly.
 
 Breaking changes should be done by renaming the schema file to an increased version number. Make sure to also rename the authorative url
 inside the schema file (the "$id" field at the top level) to point to the new version number json. Then write the migrations from the last to
-the current version of the schema, including the migration of pointing to the URL of the new schema version.
+the current version of the schema, including the migration of pointing to the URL of the new schema version. Also update `DEFAULT_GRAPHER_CONFIG_SCHEMA` in `GrapherConstants.ts` to point to the new schema version number url.
+
+Checklist for breaking changes:
+
+-   Rename the schema file to an increased version number
+-   Rename the authorative url inside the schema file to point to the new version number json
+-   Write the migrations from the last to the current version of the schema, including the migration of pointing to the URL of the new schema version
+-   Update `DEFAULT_GRAPHER_CONFIG_SCHEMA` in `GrapherConstants.ts` to point to the new schema version number url


### PR DESCRIPTION
We recently introduced the `$schema` field in Grapher configs that points to the json schema that the config is checked against. This PR makes Grapher aware that the schema field exists such that:
- New charts are being assigned a schema
- Updated charts keep their schema

The `$schema` property is special because we always want it to be present, even if it is the default. (Grapher doesn't usually include default values in configs.) This means that we loose the beauty of having an empty Grapher serialize to an empty object :(

Aside: I called the new Grapher property `$schema` (with `$`) to make it clear that this maps to the `$schema` config field but I can see how that might be controversial.