### PR TITLE
feat(gdocs): add cover color `sdg-color-landing-page`

### DIFF
--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1251,6 +1251,7 @@ export interface OwidGdocContent {
         | "sdg-color-15"
         | "sdg-color-16"
         | "sdg-color-17"
+        | "sdg-color-landing-page"
     "sticky-nav"?: []
     details?: DetailDictionary
 }

--- a/site/css/colors.scss
+++ b/site/css/colors.scss
@@ -100,4 +100,5 @@ $sdgColors: (
         // See also owidTypes.ts > OwidGdocContent > cover-color
         --sdg-color-#{$i}: #{$sdgColor};
     }
+    --sdg-color-landing-page: #ebeef2;
 }

--- a/site/gdocs/utils.tsx
+++ b/site/gdocs/utils.tsx
@@ -33,6 +33,7 @@ export const breadcrumbColorForCoverColor = (
         case "sdg-color-16": // blue
         case "sdg-color-17": // dark blue
             return "white"
+        case "sdg-color-landing-page": // light gray
         case "sdg-color-2": // orange
         case "sdg-color-7": // yellow
         case "sdg-color-11": // orange


### PR DESCRIPTION
Adds a light gray cover color to use for the sdg landing page.

![image](https://github.com/owid/owid-grapher/assets/2641501/b3716d4e-f936-4c6f-81e3-7ab4f7cd06eb)
