### PR TITLE
🎉 Allow for slashes in gdoc slugs for SDG subdirectory

### DIFF
--- a/adminSiteClient/GdocsSlug.tsx
+++ b/adminSiteClient/GdocsSlug.tsx
@@ -22,7 +22,7 @@ export const GdocsSlug = ({
         content: { title = "" },
         slug,
     } = gdoc
-    const slugFromTitle = slugify(title)
+    const slugFromTitle = slugify(title, true)
 
     useEffect(() => {
         if (gdoc.published) {
@@ -54,7 +54,7 @@ export const GdocsSlug = ({
                     <Input
                         addonBefore="ourworldindata.org/"
                         value={slug}
-                        onChange={(e) => setSlug(slugify(e.target.value))}
+                        onChange={(e) => setSlug(slugify(e.target.value, true))}
                         placeholder={slugFromTitle}
                         required
                         status={

--- a/adminSiteClient/gdocsValidation.ts
+++ b/adminSiteClient/gdocsValidation.ts
@@ -93,11 +93,11 @@ class SlugHandler extends AbstractHandler {
     handle(gdoc: OwidGdocInterface, messages: OwidGdocErrorMessage[]) {
         const { slug } = gdoc
         // !slug would be invalid, but we call setSlugSyncing(true) in GdocsSlug.tsx if that happens
-        if (slug && !slug.match(/^[a-z0-9-]+$/)) {
+        if (slug && !slug.match(/^[a-z0-9-_]+$/)) {
             messages.push({
                 property: "slug",
                 type: OwidGdocErrorMessageType.Error,
-                message: `Slug must only contain lowercase letters, numbers and hyphens`,
+                message: `Slug must only contain lowercase letters, numbers and hyphens. Double underscores are interpreted as slashes.`,
             })
         }
 

--- a/adminSiteClient/gdocsValidation.ts
+++ b/adminSiteClient/gdocsValidation.ts
@@ -93,7 +93,7 @@ class SlugHandler extends AbstractHandler {
     handle(gdoc: OwidGdocInterface, messages: OwidGdocErrorMessage[]) {
         const { slug } = gdoc
         // !slug would be invalid, but we call setSlugSyncing(true) in GdocsSlug.tsx if that happens
-        if (slug && !slug.match(/^[a-z0-9-_]+$/)) {
+        if (slug && !slug.match(/^[a-z0-9-\/]+$/)) {
             messages.push({
                 property: "slug",
                 type: OwidGdocErrorMessageType.Error,

--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -246,7 +246,7 @@ mockSiteRouter.get("/dods.json", async (_, res) => {
 })
 
 mockSiteRouter.get("/*", async (req, res) => {
-    const slug = req.path.replace(/^\//, "").replace("/", "__")
+    const slug = req.path.replace(/^\//, "")
 
     try {
         res.send(await renderGdocsPageBySlug(slug))

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -201,7 +201,8 @@ export class SiteBaker {
     // Bake an individual post/page
     async bakeGDocPost(post: OwidGdocPublished) {
         const html = renderGdoc(post)
-        const outPath = path.join(this.bakedSiteDir, `${post.slug}.html`)
+        const slugAsPath = post.slug.replaceAll("__", "/")
+        const outPath = path.join(this.bakedSiteDir, `${slugAsPath}.html`)
         await fs.mkdirp(path.dirname(outPath))
         await this.stageWrite(outPath, html)
     }

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -201,8 +201,7 @@ export class SiteBaker {
     // Bake an individual post/page
     async bakeGDocPost(post: OwidGdocPublished) {
         const html = renderGdoc(post)
-        const slugAsPath = post.slug.replaceAll("__", "/")
-        const outPath = path.join(this.bakedSiteDir, `${slugAsPath}.html`)
+        const outPath = path.join(this.bakedSiteDir, `${post.slug}.html`)
         await fs.mkdirp(path.dirname(outPath))
         await this.stageWrite(outPath, html)
     }

--- a/packages/@ourworldindata/utils/src/Util.test.ts
+++ b/packages/@ourworldindata/utils/src/Util.test.ts
@@ -524,6 +524,13 @@ describe("slugifySameCase", () => {
     cases.forEach(([input, output]) => {
         expect(slugifySameCase(input)).toBe(output)
     })
+
+    describe("it can allow slashes", () => {
+        expect(slugifySameCase("sdgs/energy", true)).toBe("sdgs/energy")
+        expect(slugifySameCase("sdgs/economic development", true)).toBe(
+            "sdgs/economic-development"
+        )
+    })
 })
 
 describe(greatestCommonDivisor, () => {

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -427,15 +427,23 @@ export const makeAnnotationsSlug = (columnSlug: string): string =>
     `${columnSlug}-annotations`
 
 // Take an arbitrary string and turn it into a nice url slug
-export const slugify = (str: string): string =>
-    slugifySameCase(str.toLowerCase())
+export const slugify = (str: string, allowSlashes?: boolean): string =>
+    slugifySameCase(str.toLowerCase(), allowSlashes)
 
-export const slugifySameCase = (str: string): string =>
-    str
+export const slugifySameCase = (
+    str: string,
+    allowSlashes: boolean = false
+): string => {
+    let slug = str
         .trim()
         .replace(/\s*\*.+\*/, "")
-        .replace(/[^\w- ]+/g, "")
+        .replace(/[^\w\- \/]+/g, "")
         .replace(/ +/g, "-")
+    if (!allowSlashes) {
+        slug = slug.replace(/\//g, "")
+    }
+    return slug
+}
 
 // Unique number for this execution context
 // Useful for coordinating between embeds to avoid conflicts in their ids


### PR DESCRIPTION
Resolves #2424

<img width="473" alt="image" src="https://github.com/owid/owid-grapher/assets/11844404/76a68580-733c-4600-b5e7-86a861bc446b">

https://ptolemy-owid.netlify.app/sdgs/test

https://ptolemy-owid.netlify.app/sdgs/energy

~Noticed in the [mockSiteRouter](https://github.com/owid/owid-grapher/blob/f06f445a02368edd59e3a9c493c89d98adaaf249/adminSiteServer/mockSiteRouter.tsx#L249C20-L249C20) that we already had this behaviour, so I extended it to work for baked gdocs, too.~

There's no UNIQUE constraint on slugs at the moment, presumably because we didn't want to initiate the slug with the google ID (the only unique value that we're guaranteed to have when first saving the entry in the DB)

But it might be nice to add that in at some point.