### PR TITLE
Change default header background color for articles 

### DIFF
--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -7,7 +7,7 @@ import { gdocUrlRegex } from "./GdocsUtils.js"
 export const EPOCH_DATE = "2020-01-21"
 
 /** The "plot" is a chart without any header, footer or controls */
-export const IDEAL_PLOT_ASPECT_RATIO: number = 1.8
+export const IDEAL_PLOT_ASPECT_RATIO = 1.8
 
 export interface Box {
     x: number
@@ -1251,6 +1251,7 @@ export interface OwidGdocContent {
         | "sdg-color-15"
         | "sdg-color-16"
         | "sdg-color-17"
+        | "amber"
     "sticky-nav"?: []
     details?: DetailDictionary
 }

--- a/site/css/colors.scss
+++ b/site/css/colors.scss
@@ -96,8 +96,9 @@ $sdgColors: (
 );
 
 :root {
+    // See also owidTypes.ts > OwidGdocContent > cover-color
+    --amber: #{$amber};
     @each $i, $sdgColor in $sdgColors {
-        // See also owidTypes.ts > OwidGdocContent > cover-color
         --sdg-color-#{$i}: #{$sdgColor};
     }
 }

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -14,7 +14,7 @@ $banner-height: 200px;
     left: 0;
     right: 0;
     height: $banner-height;
-    background: #f7c020;
+    background: $blue-10;
     z-index: -1;
 }
 

--- a/site/gdocs/utils.tsx
+++ b/site/gdocs/utils.tsx
@@ -36,7 +36,8 @@ export const breadcrumbColorForCoverColor = (
         case "sdg-color-2": // orange
         case "sdg-color-7": // yellow
         case "sdg-color-11": // orange
-        case undefined: // default cover color: yellow
+        case "amber": // amber
+        case undefined: // default cover color: blue-10
             return "blue"
     }
 }


### PR DESCRIPTION
This changes the default color from a bright yellow to a more subtle blue. We would like to use this color for the SDG pages, and think it makes sense as the default generally for all articles, although we may revisit this at some point. 

See Marwa's comment on it in slack [here](https://owid.slack.com/archives/C040429G2SD/p1689233175622379).

<img width="1432" alt="Screen Shot 2023-07-13 at 12 30 43 PM" src="https://github.com/owid/owid-grapher/assets/1074773/13db0e76-e384-4e77-a26f-3c43e3727f96">
