### PR TITLE
🔨 disable `no-inferrable-types`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
         "@typescript-eslint/no-explicit-any": "off", // TODO: enable this rule
         "@typescript-eslint/no-for-in-array": "warn",
         "@typescript-eslint/no-non-null-assertion": "off", // TODO: enable this rule
+        "@typescript-eslint/no-inferrable-types": "off", // typeorm needs types to be explicitly set, even when they're inferrable
         "@typescript-eslint/no-unused-vars": [
             "warn",
             { varsIgnorePattern: "^_", argsIgnorePattern: "^_" },


### PR DESCRIPTION
Something recently changed with eslint causing it to start [removing inferrable type annotations](https://typescript-eslint.io/rules/no-inferrable-types/) 

e.g.

```typescript

const obviouslyANumber: number = 1

// changes to

const obviouslyANumber = 1
```

But this breaks TypeORM which requires these annotations

e.g.

```typescript
@Column() slug: string = ""
```

With them removed, the Grapher admin throws an error as soon as you try to load it:

```
DataTypeNotSupportedError: Data type "Object" in "Gdoc.slug" is not supported by "mysql" database.
```

So this PR disables this rule for our project.