### PR TITLE
chore: add explorer variables table

### DIFF
--- a/db/migration/1689327366854-AddExplorerVariablesTable.ts
+++ b/db/migration/1689327366854-AddExplorerVariablesTable.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddExplorerVariablesTable1689327366854
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`-- sql
+          CREATE TABLE \`explorer_variables\` (
+            \`id\` int NOT NULL AUTO_INCREMENT,
+            \`explorerSlug\` varchar(150) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NOT NULL,
+            \`variableId\` int NOT NULL,
+            PRIMARY KEY (\`id\`),
+            KEY \`explorerSlug\` (\`explorerSlug\`),
+            KEY \`variableId\` (\`variableId\`),
+            CONSTRAINT \`explorer_variables_ibfk_1\` FOREIGN KEY (\`explorerSlug\`) REFERENCES \`explorers\` (\`slug\`) ON DELETE CASCADE ON UPDATE CASCADE,
+            CONSTRAINT \`explorer_variables_ibfk_2\` FOREIGN KEY (\`variableId\`) REFERENCES \`variables\` (\`id\`) ON DELETE RESTRICT ON UPDATE RESTRICT
+          )`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`DROP TABLE explorer_variables`)
+    }
+}


### PR DESCRIPTION
> **Warning**
> Not ready to be merged.

Adds a new table to the database that keeps track of indicators that are used in explorers.