### PR TITLE
fix: bake indicators used in explorers

### DIFF
--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -496,11 +496,12 @@ export const bakeSingleGrapherChart = async (
 export const bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers =
     async (bakedSiteDir: string) => {
         const variablesToBake: { varId: number }[] =
-            await db.queryMysql(`select distinct vars.varID as varId
-            from
-            charts c,
+            await db.queryMysql(`select vars.varID as varId
+            from charts c,
             json_table(c.config, '$.dimensions[*]' columns (varID integer path '$.variableId') ) as vars
-            where JSON_EXTRACT(c.config, '$.isPublished')=true`)
+            where JSON_EXTRACT(c.config, '$.isPublished')=true
+            union
+            select variableId as varId from explorer_variables`)
 
         const chartsToBake: { id: number; config: string; slug: string }[] =
             await db.queryMysql(`


### PR DESCRIPTION
Bakes indicators used in explorers.

Gets a list of indicators that are currently used in explorers from the `explorer_variables` table that is created in https://github.com/owid/owid-grapher/pull/2431 and populated in https://github.com/owid/automation/pull/8