### PR TITLE
enhance(table): display header and footer

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -135,7 +135,7 @@ import ReactDOM from "react-dom"
 import { observer } from "mobx-react"
 import "d3-transition"
 import { SourcesTab, SourcesTabManager } from "../sourcesTab/SourcesTab"
-import { DataTable, DataTableManager } from "../dataTable/DataTable"
+import { DataTableManager } from "../dataTable/DataTable"
 import { MapChartManager } from "../mapCharts/MapChartConstants"
 import { MapChart } from "../mapCharts/MapChart"
 import { DiscreteBarChartManager } from "../barCharts/DiscreteBarChartConstants"
@@ -587,12 +587,16 @@ export class Grapher
         ) as TimeBounds
     }
 
-    @computed private get isChartOrMapTab(): boolean {
+    @computed get isOnChartOrMapTab(): boolean {
         return this.tab === GrapherTabOption.chart || this.isOnMapTab
     }
 
-    @computed private get isOnMapTab(): boolean {
+    @computed get isOnMapTab(): boolean {
         return this.tab === GrapherTabOption.map
+    }
+
+    @computed get isOnTableTab(): boolean {
+        return this.tab === GrapherTabOption.table
     }
 
     @computed get yAxisConfig(): Readonly<AxisConfigInterface> {
@@ -643,7 +647,7 @@ export class Grapher
     @computed
     get tableAfterAuthorTimelineAndActiveChartTransform(): OwidTable {
         const table = this.tableAfterAuthorTimelineFilter
-        if (!this.isReady || !this.isChartOrMapTab) return table
+        if (!this.isReady || !this.isOnChartOrMapTab) return table
         return this.chartInstance.transformTable(table)
     }
 
@@ -1804,26 +1808,8 @@ export class Grapher
         this.popups = this.popups.filter((d) => !(d.type === vnodeType))
     }
 
-    @computed private get isOnTableTab(): boolean {
-        return this.tab === GrapherTabOption.table
-    }
-
     private renderPrimaryTab(): JSX.Element | undefined {
-        if (this.isChartOrMapTab) return <CaptionedChart manager={this} />
-
-        const { tabBounds } = this
-        if (this.isOnTableTab)
-            // todo: should this "Div" and styling just be in DataTable class?
-            return (
-                <div
-                    className="tableTab"
-                    style={{ ...tabBounds.toCSS(), position: "absolute" }}
-                >
-                    <DataTable bounds={tabBounds} manager={this} />
-                </div>
-            )
-
-        return undefined
+        return <CaptionedChart manager={this} />
     }
 
     private renderOverlayTab(): JSX.Element | undefined {

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -70,7 +70,7 @@ const inverseSortOrder = (order: SortOrder): SortOrder =>
 
 export interface DataTableManager {
     table: OwidTable
-    entityType: string
+    entityType?: string
     endTime?: Time
     startTime?: Time
     dataTableSlugs?: ColumnSlug[]
@@ -135,11 +135,11 @@ export class DataTable extends React.Component<{
     }
 
     @computed private get entityType(): string {
-        return this.manager.entityType
+        return this.manager.entityType ?? "country or region"
     }
 
     @computed private get entitiesAreCountryLike(): boolean {
-        return !!this.manager.entityType.match(/\bcountry\b/i)
+        return !!this.entityType.match(/\bcountry\b/i)
     }
 
     @computed private get sortValueMapper(): (
@@ -413,8 +413,8 @@ export class DataTable extends React.Component<{
         return (
             <div
                 style={{
-                    width: "100%",
-                    height: "100%",
+                    width: `${this.bounds.width}px`,
+                    height: `${this.bounds.height}px`,
                     overflow: "auto",
                 }}
             >


### PR DESCRIPTION
### Summary

Displays header and footer when on the Table tab

### Technical details

- Rendering the table is moved into the `CaptionedChart`
- The data table is rendered into the chart area, similar to a map or a chart