### PR TITLE
refactor(grapher): prepare for rearranging the chart layout

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -38,6 +38,8 @@ import {
     FacetStrategyDropdown,
     FacetStrategyDropdownManager,
     NoDataAreaToggle,
+    FooterControls,
+    FooterControlsManager,
 } from "../controls/Controls"
 import { ScaleSelector } from "../controls/ScaleSelector"
 import { AddEntityButton } from "../controls/AddEntityButton"
@@ -56,7 +58,8 @@ export interface CaptionedChartManager
         HeaderManager,
         FacetYDomainToggleManager,
         FacetStrategyDropdownManager,
-        DataTableManager {
+        DataTableManager,
+        FooterControlsManager {
     containerElement?: HTMLDivElement
     tabBounds?: Bounds
     fontSize?: number
@@ -410,6 +413,7 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
                     </div>
                 )}
                 <Footer manager={this.manager} maxWidth={maxWidth} />
+                <FooterControls manager={this.manager} />
             </>
         )
     }

--- a/packages/@ourworldindata/grapher/src/controls/Controls.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/Controls.tsx
@@ -14,6 +14,7 @@ import {
     FacetAxisDomain,
     FacetStrategy,
     GrapherTabOption,
+    GrapherTabOverlayOption,
     RelatedQuestionsConfig,
     StackMode,
 } from "../core/GrapherConstants"
@@ -271,7 +272,8 @@ export interface FooterControlsManager extends ShareMenuManager {
     isShareMenuActive?: boolean
     isSelectingData?: boolean
     availableTabs?: GrapherTabOption[]
-    currentTab?: GrapherTabOption
+    availableTabOverlays?: GrapherTabOverlayOption[]
+    currentTab?: GrapherTabOption | GrapherTabOverlayOption
     isInIFrame?: boolean
     canonicalUrl?: string
     showTimeline?: boolean
@@ -300,39 +302,74 @@ export class FooterControls extends React.Component<{
         return this.manager.availableTabs || []
     }
 
+    @computed private get availableTabOverlays(): GrapherTabOverlayOption[] {
+        return this.manager.availableTabOverlays || []
+    }
+
+    @computed private get hasSourcesOverlayTab(): boolean {
+        return this.availableTabOverlays.includes(
+            GrapherTabOverlayOption.sources
+        )
+    }
+
+    @computed private get hasDownloadOverlayTab(): boolean {
+        return this.availableTabOverlays.includes(
+            GrapherTabOverlayOption.download
+        )
+    }
+
     private _getTabsElement(): JSX.Element {
         const { manager } = this
         return (
             <nav className="tabs">
                 <ul>
-                    {this.availableTabs.map((tabName) => {
-                        return tabName !== GrapherTabOption.download ? (
-                            <li
-                                key={tabName}
-                                className={
-                                    "tab clickable" +
-                                    (tabName === manager.currentTab
-                                        ? " active"
-                                        : "")
-                                }
+                    {this.availableTabs.map((tabName) => (
+                        <li
+                            key={tabName}
+                            className={
+                                "tab clickable" +
+                                (tabName === manager.currentTab
+                                    ? " active"
+                                    : "")
+                            }
+                        >
+                            <a
+                                onClick={(): void => {
+                                    manager.currentTab = tabName
+                                }}
+                                data-track-note={"chart_click_" + tabName}
                             >
-                                <a
-                                    onClick={(): void => {
-                                        manager.currentTab = tabName
-                                    }}
-                                    data-track-note={"chart_click_" + tabName}
-                                >
-                                    {tabName}
-                                </a>
-                            </li>
-                        ) : null
-                    })}
-                    {manager.hasDownloadTab && (
+                                {tabName}
+                            </a>
+                        </li>
+                    ))}
+                    {this.hasSourcesOverlayTab && (
+                        <li
+                            className={
+                                "tab clickable" +
+                                (manager.currentTab ===
+                                GrapherTabOverlayOption.sources
+                                    ? " active"
+                                    : "")
+                            }
+                        >
+                            <a
+                                onClick={(): void => {
+                                    manager.currentTab =
+                                        GrapherTabOverlayOption.sources
+                                }}
+                                data-track-note={"chart_click_sources"}
+                            >
+                                Sources
+                            </a>
+                        </li>
+                    )}
+                    {this.hasDownloadOverlayTab && (
                         <li
                             className={
                                 "tab clickable icon download-tab-button" +
                                 (manager.currentTab ===
-                                GrapherTabOption.download
+                                GrapherTabOverlayOption.download
                                     ? " active"
                                     : "")
                             }
@@ -340,9 +377,11 @@ export class FooterControls extends React.Component<{
                         >
                             <a
                                 data-track-note="chart_click_download"
-                                onClick={(): GrapherTabOption =>
+                                onClick={():
+                                    | GrapherTabOption
+                                    | GrapherTabOverlayOption =>
                                     (manager.currentTab =
-                                        GrapherTabOption.download)
+                                        GrapherTabOverlayOption.download)
                                 }
                             >
                                 <FontAwesomeIcon icon={faDownload} /> Download
@@ -360,33 +399,19 @@ export class FooterControls extends React.Component<{
                             </a>
                         </li>
                     )}
-                    {manager.isInIFrame &&
-                        (this.availableTabs.length > 0 ? (
-                            <li className="clickable icon icon-only">
-                                <a
-                                    title="Open chart in new tab"
-                                    href={manager.canonicalUrl}
-                                    data-track-note="chart_click_newtab"
-                                    target="_blank"
-                                    rel="noopener"
-                                >
-                                    <FontAwesomeIcon icon={faExpand} />
-                                </a>
-                            </li>
-                        ) : (
-                            <li className="clickable icon open-in-another-tab-button">
-                                <a
-                                    title="Open chart in new tab"
-                                    href={manager.canonicalUrl}
-                                    data-track-note="chart_click_newtab"
-                                    target="_blank"
-                                    rel="noopener"
-                                >
-                                    Explore data
-                                    <FontAwesomeIcon icon={faExternalLinkAlt} />
-                                </a>
-                            </li>
-                        ))}
+                    {manager.isInIFrame && (
+                        <li className="clickable icon icon-only">
+                            <a
+                                title="Open chart in new tab"
+                                href={manager.canonicalUrl}
+                                data-track-note="chart_click_newtab"
+                                target="_blank"
+                                rel="noopener"
+                            >
+                                <FontAwesomeIcon icon={faExpand} />
+                            </a>
+                        </li>
+                    )}
                 </ul>
             </nav>
         )

--- a/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
@@ -4,6 +4,7 @@ import {
     ChartTypeName,
     EntitySelectionMode,
     GrapherTabOption,
+    GrapherTabOverlayOption,
     ScaleType,
 } from "./GrapherConstants"
 import {
@@ -220,11 +221,11 @@ describe("hasTimeline", () => {
         const grapher = new Grapher(legacyConfig)
         grapher.type = ChartTypeName.LineChart
 
-        grapher.currentTab = GrapherTabOption.sources
+        grapher.currentTab = GrapherTabOverlayOption.sources
         expect(grapher.hasTimeline).toBeTruthy()
         expect(grapher.showTimeline).toBeFalsy()
 
-        grapher.currentTab = GrapherTabOption.download
+        grapher.currentTab = GrapherTabOverlayOption.download
         expect(grapher.hasTimeline).toBeTruthy()
         expect(grapher.showTimeline).toBeFalsy()
     })

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -77,9 +77,12 @@ export type SeriesColorMap = Map<SeriesName, Color>
 export enum GrapherTabOption {
     chart = "chart",
     map = "map",
+    table = "table",
+}
+
+export enum GrapherTabOverlayOption {
     sources = "sources",
     download = "download",
-    table = "table",
 }
 
 export enum ScaleType {

--- a/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
@@ -8,6 +8,7 @@ import {
     FacetStrategy,
     MissingDataStrategy,
     AnnotationFieldsInTitle,
+    GrapherTabOverlayOption,
 } from "./GrapherConstants"
 import { AxisConfigInterface } from "../axis/AxisConfigInterface"
 import {
@@ -61,7 +62,7 @@ export interface GrapherInterface extends SortConfig {
     hasChartTab?: boolean
     hasMapTab?: boolean
     tab?: GrapherTabOption
-    overlay?: GrapherTabOption
+    overlay?: GrapherTabOverlayOption
     relatedQuestions?: RelatedQuestionsConfig[]
     details?: DetailDictionary
     internalNotes?: string

--- a/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
+++ b/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
@@ -1,6 +1,10 @@
 import { TooltipManager } from "../tooltip/TooltipProps"
 import { Bounds } from "@ourworldindata/utils"
 import { GrapherInterface } from "../core/GrapherInterface"
+import {
+    GrapherTabOption,
+    GrapherTabOverlayOption,
+} from "../core/GrapherConstants"
 
 export interface FooterManager {
     fontSize?: number
@@ -8,7 +12,7 @@ export interface FooterManager {
     note?: string
     hasOWIDLogo?: boolean
     originUrlWithProtocol?: string
-    currentTab?: string
+    currentTab?: GrapherTabOption | GrapherTabOverlayOption
     tooltips?: TooltipManager["tooltips"]
     tabBounds?: Bounds
     details?: GrapherInterface["details"]

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChartConstants.ts
@@ -4,7 +4,12 @@ import { MapProjectionName } from "./MapProjections"
 import { ChartManager } from "../chart/ChartManager"
 import { MapConfig } from "./MapConfig"
 import { Color, Time } from "@ourworldindata/core-table"
-import { ChartTypeName, SeriesName } from "../core/GrapherConstants"
+import {
+    ChartTypeName,
+    GrapherTabOption,
+    GrapherTabOverlayOption,
+    SeriesName,
+} from "../core/GrapherConstants"
 import { ChartSeries } from "../chart/ChartInterface"
 
 export type GeoFeature = GeoJSON.Feature<GeoJSON.GeometryObject>
@@ -50,7 +55,7 @@ export interface RenderFeature {
 export interface MapChartManager extends ChartManager {
     mapColumnSlug?: ColumnSlug
     mapIsClickable?: boolean
-    currentTab?: string // Used to switch to chart tab on map click
+    currentTab?: GrapherTabOption | GrapherTabOverlayOption // Used to switch to chart tab on map click
     type?: ChartTypeName // Used to determine the "Click to select" text in MapTooltip
     isLineChartThatTurnedIntoDiscreteBar?: boolean // Used to determine whether to reset the timeline on map click
     hasTimeline?: boolean // Used to determine whether to reset the timeline on map click

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1660,3 +1660,10 @@ export function filterValidStringValues<ValidValue extends string>(
 
     return filteredValues
 }
+
+export function includesWithTypeGuard<TItem>(
+    array: TItem[],
+    item: unknown
+): item is TItem {
+    return array.includes(item as any)
+}

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -320,6 +320,7 @@ export {
     type NodeWithUrl,
     filterValidStringValues,
     traverseEnrichedSpan,
+    includesWithTypeGuard,
 } from "./Util.js"
 
 export {


### PR DESCRIPTION
### Summary

Refactor that prepares for a rearrangement of the chart layout.

### Technical Details

Two things have been done:
- "Normal" tabs (future content switchers, i.e. table/map/chart) are more clearly separated from overlay tabs (sources, download)
- The `FooterControls` component (including the tab panel and timeline) has been moved into `CaptionedChart`

The `CaptionedChart` component now renders everything inside the Grapher frame, from top to bottom:

[Chart title]
[Chart subtitle]
[Controls]
[Chart area]
[Sources & Notes]
[Timeline]
[Tabs]