### PR TITLE
fix(algolia): fix chart indexing failure

### DIFF
--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -100,4 +100,9 @@ const indexChartsToAlgolia = async () => {
     await db.closeTypeOrmAndKnexConnections()
 }
 
+process.on("unhandledRejection", (e) => {
+    console.error(e)
+    process.exit(1)
+})
+
 indexChartsToAlgolia()

--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -35,7 +35,16 @@ const getChartsRecords = async (): Promise<ChartRecord[]> => {
     `)
 
     for (const c of chartsToIndex) {
-        c.availableEntities = JSON.parse(c.availableEntities)
+        // This is a very rough way to check for the Algolia record size limit, but it's better than the update failing
+        if (c.availableEntities.length < 12000)
+            c.availableEntities = JSON.parse(c.availableEntities)
+        else {
+            console.info(
+                `Chart ${c.id} has too many entities, skipping its entities`
+            )
+            c.availableEntities = []
+        }
+
         c.tags = JSON.parse(c.tags)
         c.keyChartForTags = JSON.parse(c.keyChartForTags).filter(
             (t: string | null) => t

--- a/baker/algolia/indexToAlgolia.tsx
+++ b/baker/algolia/indexToAlgolia.tsx
@@ -232,4 +232,9 @@ const indexToAlgolia = async () => {
     await db.closeTypeOrmAndKnexConnections()
 }
 
+process.on("unhandledRejection", (e) => {
+    console.error(e)
+    process.exit(1)
+})
+
 indexToAlgolia()


### PR DESCRIPTION
So, we have this chart https://owid.cloud/admin/charts/6061/edit which has lots and lots of `availableEntities` in the database, and which was causing our Algolia updates to fail because the max record size is 20,000 bytes.

I opted to just include an empty `availableEntities` array in this case for now to fix; `availableEntities` is the least important property anyway.