### PR TITLE
fix: check for cookie access before accessing them

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -752,7 +752,15 @@ export class Grapher
     @computed get showAdminControls(): boolean {
         // This cookie is set by visiting ourworldindata.org/identifyadmin on the static site.
         // There is an iframe on owid.cloud to trigger a visit to that page.
-        return !!Cookies.get(CookieKey.isAdmin)
+
+        try {
+            // Cookie access can be restricted by iframe sandboxing, in which case the below code will throw an error
+            // see https://github.com/owid/owid-grapher/pull/2452
+
+            return !!Cookies.get(CookieKey.isAdmin)
+        } catch {
+            return false
+        }
     }
 
     @action.bound

--- a/site/CookiePreferencesManager.tsx
+++ b/site/CookiePreferencesManager.tsx
@@ -150,7 +150,14 @@ const reducer = (
 }
 
 const getInitialState = (): State => {
-    const cookieValue = parseRawCookieValue(Cookies.get(COOKIE_NAME))
+    let cookieValue = undefined
+    try {
+        // Cookie access can be restricted by iframe sandboxing, in which case the below code will throw an error
+        // see https://github.com/owid/owid-grapher/pull/2452
+
+        cookieValue = parseRawCookieValue(Cookies.get(COOKIE_NAME))
+    } catch {}
+
     if (!cookieValue || arePreferencesOutdated(cookieValue.date, POLICY_DATE))
         return defaultState
     return cookieValue

--- a/site/owid.entry.ts
+++ b/site/owid.entry.ts
@@ -96,13 +96,18 @@ const analytics = new SiteAnalytics(ENV)
 
 document.querySelector("html")?.classList.add("js")
 
-if (
-    document.cookie.includes("wordpress") ||
-    document.cookie.includes("wp-settings") ||
-    document.cookie.includes(CookieKey.isAdmin)
-) {
-    const adminbar = document.getElementById("wpadminbar")
-    if (adminbar) adminbar.style.display = ""
-}
+try {
+    // Cookie access can be restricted by iframe sandboxing, in which case the below code will throw an error
+    // see https://github.com/owid/owid-grapher/pull/2452
+
+    if (
+        document.cookie.includes("wordpress") ||
+        document.cookie.includes("wp-settings") ||
+        document.cookie.includes(CookieKey.isAdmin)
+    ) {
+        const adminbar = document.getElementById("wpadminbar")
+        if (adminbar) adminbar.style.display = ""
+    }
+} catch {}
 
 analytics.startClickTracking()


### PR DESCRIPTION
Fixes a [Bugsnag error](https://app.bugsnag.com/our-world-in-data/our-world-in-data-website/errors/64b67b9d62bfc7000803bd76).

If any OWID page is embedded within a sandboxed iframe without the `allow-same-origin` permission, then any attempt to access `document.cookie` will throw an exception that is currently unhandled.
Such a iframe snippet could look like this: `<iframe src="https://ourworldindata.org/poverty" sandbox="allow-scripts" />`

Demo CodeSandbox: https://codesandbox.io/s/owid-sandboxed-iframe-6vtmvf?file=/index.html