### PR TITLE
enhance: refine breadcrumb positioning logic

### DIFF
--- a/site/gdocs/OwidGdocHeader.tsx
+++ b/site/gdocs/OwidGdocHeader.tsx
@@ -30,8 +30,6 @@ function OwidArticleHeader({
         : undefined
 
     const breadcrumbColor = breadcrumbColorForCoverColor(content["cover-color"])
-    const areBreadcrumbsLong =
-        breadcrumbs && breadcrumbs.map((bc) => bc.label).join("").length > 50
 
     return (
         <>
@@ -58,10 +56,6 @@ function OwidArticleHeader({
             )}
             <header
                 className={cx(
-                    {
-                        "centered-article-header--has-long-breadcrumbs":
-                            areBreadcrumbsLong,
-                    },
                     "centered-article-header align-center grid grid-cols-8 col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12"
                 )}
             >

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -44,12 +44,6 @@ $banner-height: 200px;
     padding-top: 48px;
 }
 
-.centered-article-header--has-long-breadcrumbs {
-    @include sm-only {
-        margin-top: 100px;
-    }
-}
-
 .article-block__text {
     margin-top: 0;
 }

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -163,8 +163,16 @@ h3.article-block__heading.has-supertitle {
             color: $blue-100;
         }
 
-        position: absolute;
-        margin-top: 40px;
+        // Idea here: By using this positioning, we can have the breadcrumbs
+        // take up exactly: (number of lines - 1) * line-height
+        // in height, effectively, such that the header is always the same height
+        // unless the breadcrumbs are longer than a single line.
+        $header-breadcrumb-margin-top: 40px;
+        margin-top: $header-breadcrumb-margin-top;
+        margin-bottom: calc(-1.6em - $header-breadcrumb-margin-top);
+        // lh is a relatively recent CSS unit, so we use ems as a fallback in the rule above
+        margin-bottom: calc(-1lh - $header-breadcrumb-margin-top);
+
         font-size: 1rem;
         a {
             @include owid-link-90;


### PR DESCRIPTION
As you already noticed, ike, there's some overflowing of the breadcrumbs into nothingness on small screens.
This adds a positioning logic that makes breadcrumbs take as much space as they need, while still maintaining the overall layout.

With one line: 
![image](https://github.com/owid/owid-grapher/assets/2641501/e4fd74d9-3354-4ad2-aee5-5f878adbd3c7)

With two lines:
![image](https://github.com/owid/owid-grapher/assets/2641501/31a511ab-27f2-4188-884d-0d264e9ae088)
