### PR TITLE
🐛 fix duplicates in related charts on grapher pages, alphabetise

### DIFF
--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -35,6 +35,7 @@ import {
     OwidGdocPublished,
     orderBy,
     IMAGES_DIRECTORY,
+    uniqBy,
 } from "@ourworldindata/utils"
 import { Topic } from "@ourworldindata/grapher"
 import {
@@ -678,7 +679,13 @@ export const getRelatedArticles = async (
             }
         })
     )
-    return [...relatedArticles, ...publishedGdocPostsThatReferenceChart]
+    return uniqBy(
+        [...relatedArticles, ...publishedGdocPostsThatReferenceChart],
+        "slug"
+    ).sort(
+        // Alphabetise
+        (a, b) => (a.title.toLowerCase() > b.title.toLowerCase() ? 1 : -1)
+    )
 }
 
 export const getBlockContent = async (


### PR DESCRIPTION
Before:
<img width="754" alt="Screenshot 2023-07-20 at 2 53 31 PM" src="https://github.com/owid/owid-grapher/assets/11844404/305b0371-1399-4332-9d49-9a11c95e9112">


After:
<img width="766" alt="Screenshot 2023-07-20 at 2 53 15 PM" src="https://github.com/owid/owid-grapher/assets/11844404/18f55acd-ba51-4db4-a5f4-3f7341caafae">


