### PR TITLE
enhance(algolia): index gdoc topic pages as such

### DIFF
--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -101,10 +101,10 @@ export const configureAlgolia = async () => {
         attributesToSnippet: ["excerpt:20", "content:20"],
         attributeForDistinct: "slug",
         attributesForFaceting: [
-            "type",
-            "searchable(tags)",
-            "searchable(authors)",
-            "documentType",
+            "afterDistinct(type)",
+            "afterDistinct(searchable(tags))",
+            "afterDistinct(searchable(authors))",
+            "afterDistinct(documentType)",
         ],
         disableExactOnAttributes: ["tags"],
     })

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -104,6 +104,7 @@ export const configureAlgolia = async () => {
             "type",
             "searchable(tags)",
             "searchable(authors)",
+            "documentType",
         ],
         disableExactOnAttributes: ["tags"],
     })

--- a/baker/algolia/indexToAlgolia.tsx
+++ b/baker/algolia/indexToAlgolia.tsx
@@ -61,6 +61,7 @@ function generateCountryRecords(
             title: country.name,
             content: `All available indicators for ${country.name}.`,
             views_7d: pageviews[`/country/${country.slug}`]?.views_7d ?? 0,
+            documentType: "country-page" as const,
         }
         const score = computeScore(record)
         return { ...record, score }
@@ -127,6 +128,7 @@ async function generateWordpressRecords(
                 content: c,
                 tags: tags.map((t) => t.name),
                 views_7d: pageviews[`/${post.path}`]?.views_7d ?? 0,
+                documentType: "wordpress" as const,
             }
             const score = computeScore(record)
             records.push({ ...record, score })
@@ -178,6 +180,7 @@ function generateGdocRecords(
                 date: gdoc.publishedAt!.toISOString(),
                 modifiedDate: gdoc.updatedAt!.toISOString(),
                 tags: gdoc.tags.map((t) => t.name),
+                documentType: "gdoc" as const,
                 // authors: gdoc.content.byline, // different format
             }
             const score = computeScore(record)

--- a/baker/algolia/indexToAlgolia.tsx
+++ b/baker/algolia/indexToAlgolia.tsx
@@ -8,6 +8,7 @@ import {
     FormattedPost,
     isEmpty,
     keyBy,
+    OwidGdocType,
     type RawPageview,
 } from "@ourworldindata/utils"
 import { formatPost } from "../formatWordpressPost.js"
@@ -37,20 +38,6 @@ const getPostTags = async (postId: number) => {
         .select("tags.id", "tags.name")
         .where({ post_id: postId })
         .join("tags", "tags.id", "=", "post_tags.tag_id")) as Tag[]
-}
-
-const getPostTypeAndImportance = (
-    post: FormattedPost,
-    tags: Tag[]
-): TypeAndImportance => {
-    if (post.slug.startsWith("about/") || post.slug === "about")
-        return { type: "about", importance: 1 }
-    if (post.slug.match(/\bfaqs?\b/i)) return { type: "faq", importance: 1 }
-    if (post.type === "post") return { type: "article", importance: 0 }
-    if (tags.some((t) => t.name === "Entries"))
-        return { type: "topic", importance: 3 }
-
-    return { type: "other", importance: 0 }
 }
 
 const computeScore = (record: Omit<PageRecord, "score">): number => {
@@ -95,6 +82,20 @@ async function generateWordpressRecords(
     postsApi: wpdb.PostAPI[],
     pageviews: Record<string, RawPageview>
 ): Promise<PageRecord[]> {
+    const getPostTypeAndImportance = (
+        post: FormattedPost,
+        tags: Tag[]
+    ): TypeAndImportance => {
+        if (post.slug.startsWith("about/") || post.slug === "about")
+            return { type: "about", importance: 1 }
+        if (post.slug.match(/\bfaqs?\b/i)) return { type: "faq", importance: 1 }
+        if (post.type === "post") return { type: "article", importance: 0 }
+        if (tags.some((t) => t.name === "Entries"))
+            return { type: "topic", importance: 3 }
+
+        return { type: "other", importance: 0 }
+    }
+
     const records: PageRecord[] = []
 
     for (const postApi of postsApi) {
@@ -139,6 +140,19 @@ function generateGdocRecords(
     gdocs: Gdoc[],
     pageviews: Record<string, RawPageview>
 ): PageRecord[] {
+    const getPostTypeAndImportance = (gdoc: Gdoc): TypeAndImportance => {
+        switch (gdoc.content.type) {
+            case OwidGdocType.TopicPage:
+                return { type: "topic", importance: 3 }
+            case OwidGdocType.Fragment:
+                // this should not happen because we filter out fragments; but we want to have an exhaustive switch/case so we include it
+                return { type: "other", importance: 0 }
+            case OwidGdocType.Article:
+            case undefined:
+                return { type: "article", importance: 0 }
+        }
+    }
+
     const records: PageRecord[] = []
     for (const gdoc of gdocs) {
         if (!gdoc.content.body) continue
@@ -149,13 +163,13 @@ function generateGdocRecords(
             </div>
         )
         const chunks = generateChunksFromHtmlText(renderedPostContent)
+        const postTypeAndImportance = getPostTypeAndImportance(gdoc)
         let i = 0
 
         for (const chunk of chunks) {
             const record = {
                 objectID: `${gdoc.id}-c${i}`,
-                type: "article" as const, // Gdocs can only be articles for now
-                importance: 0, // Gdocs can only be articles for now
+                ...postTypeAndImportance,
                 slug: gdoc.slug,
                 title: gdoc.content.title || "",
                 content: chunk,

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -23,6 +23,7 @@ export interface PageRecord {
     date?: string
     modifiedDate?: string
     tags?: string[]
+    documentType?: "wordpress" | "gdoc" | "country-page"
 }
 
 export type AlgoliaMatchLevel = "none" | "full" | "partial"


### PR DESCRIPTION
Two things here:
- When Ike first wrote gdocs indexing to Algolia, there were only articles. Now there's also topic pages, so treat them as such.

The other two changes only affect the Algolia dashboard for now, and make it a bit easier to figure out what's going on from the dashboard:
- We now include a `documentType` field in the index, which can be one of "gdoc", "wordpress", "country-page".
  - It is never surfaced anywhere, but I included it in facet-able attributes so we can filter by it in the Algolia dashboard.
- The other tiny change in here is adding a `afterDistinct` to facet-able attributes; this makes it so the result counts are reflecting reality (because we're now counting articles that match, not chunks that match)