### PR TITLE
Miscellaneous Tooltip Bugfixes

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -524,6 +524,9 @@ export class LineChart
                 ? `% change since ${formatColumn.formatTime(startTime)}`
                 : unitLabel
         const subtitleFormat = subtitle === unitLabel ? "unit" : undefined
+        const footer = sortedData.some((series) => series.isProjection)
+            ? `Values are extrapolations projected from available data.`
+            : undefined
 
         return (
             <Tooltip
@@ -538,6 +541,8 @@ export class LineChart
                 title={formattedTime}
                 subtitle={subtitle}
                 subtitleFormat={subtitleFormat}
+                footer={footer}
+                footerFormat="stripes"
                 dissolve={fading}
             >
                 <TooltipTable

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -544,7 +544,8 @@ export class LineChart
                     columns={columns}
                     rows={compact(
                         sortedData.map((series) => {
-                            const { seriesName: name } = series
+                            const { seriesName: name, isProjection: striped } =
+                                series
                             const annotation =
                                 this.getAnnotationsForSeries(name)
 
@@ -569,7 +570,14 @@ export class LineChart
                                 point?.colorValue as undefined | number,
                             ]
 
-                            return { name, annotation, swatch, blurred, values }
+                            return {
+                                name,
+                                annotation,
+                                swatch,
+                                blurred,
+                                striped,
+                                values,
+                            }
                         })
                     )}
                 />

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -525,7 +525,7 @@ export class LineChart
                 : unitLabel
         const subtitleFormat = subtitle === unitLabel ? "unit" : undefined
         const footer = sortedData.some((series) => series.isProjection)
-            ? `Values are extrapolations projected from available data.`
+            ? `Projected data`
             : undefined
 
         return (

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -5,7 +5,7 @@ import {
     mapValues,
     sum,
     guid,
-    compact,
+    excludeNullish,
     values,
     getRelativeMouse,
     pointsToPath,
@@ -506,10 +506,15 @@ export class LineChart
                 null // If neither series matches, exclude the entity from the tooltip altogether
         )
 
-        const sortedData = sortBy(compact(values(seriesSegments)), (series) => {
-            const value = series.points.find((point) => point.x === target.x)
-            return value !== undefined ? -value.y : Infinity
-        })
+        const sortedData = sortBy(
+            excludeNullish(values(seriesSegments)),
+            (series) => {
+                const value = series.points.find(
+                    (point) => point.x === target.x
+                )
+                return value !== undefined ? -value.y : Infinity
+            }
+        )
 
         const formattedTime = formatColumn.formatTime(target.x),
             { unit, shortUnit } = formatColumn,
@@ -547,44 +552,40 @@ export class LineChart
             >
                 <TooltipTable
                     columns={columns}
-                    rows={compact(
-                        sortedData.map((series) => {
-                            const { seriesName: name, isProjection: striped } =
-                                series
-                            const annotation =
-                                this.getAnnotationsForSeries(name)
+                    rows={sortedData.map((series) => {
+                        const { seriesName: name, isProjection: striped } =
+                            series
+                        const annotation = this.getAnnotationsForSeries(name)
 
-                            const point = series.points.find(
-                                (point) => point.x === target.x
-                            )
+                        const point = series.points.find(
+                            (point) => point.x === target.x
+                        )
 
-                            const blurred =
-                                this.seriesIsBlurred(series) ||
-                                point === undefined
+                        const blurred =
+                            this.seriesIsBlurred(series) || point === undefined
 
-                            const swatch = blurred
-                                ? BLUR_LINE_COLOR
-                                : this.hasColorScale
-                                ? darkenColorForLine(
-                                      this.getColorScaleColor(point?.colorValue)
-                                  )
-                                : series.color
+                        const swatch = blurred
+                            ? BLUR_LINE_COLOR
+                            : this.hasColorScale
+                            ? darkenColorForLine(
+                                  this.getColorScaleColor(point?.colorValue)
+                              )
+                            : series.color
 
-                            const values = [
-                                point?.y,
-                                point?.colorValue as undefined | number,
-                            ]
+                        const values = [
+                            point?.y,
+                            point?.colorValue as undefined | number,
+                        ]
 
-                            return {
-                                name,
-                                annotation,
-                                swatch,
-                                blurred,
-                                striped,
-                                values,
-                            }
-                        })
-                    )}
+                        return {
+                            name,
+                            annotation,
+                            swatch,
+                            blurred,
+                            striped,
+                            values,
+                        }
+                    })}
                 />
             </Tooltip>
         )

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.scss
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.scss
@@ -1,3 +1,6 @@
+$inset: 15px; // space between the sparkline and tooltip frame
+$nudge: 3px; // step away from the axis
+
 .sparkline {
     padding-bottom: 4px;
 
@@ -31,9 +34,28 @@
         stroke: #dadada;
     }
 
-    .min-max-labels text {
-        font: 700 10px Lato;
-        text-anchor: end;
-        fill: #787878;
+    .axis-label {
+        &.max {
+            transform: translate(calc(100% - $inset - $nudge), $inset - $nudge);
+        }
+
+        &.min {
+            transform: translate(
+                calc(100% - $inset - $nudge),
+                calc(100% - $inset - 2 * $nudge)
+            );
+        }
+
+        text {
+            font: 400 10px Lato;
+            letter-spacing: 0.01em;
+            font-style: italic;
+            text-anchor: end;
+            fill: #787878;
+            &.outline {
+                stroke: rgba(255, 255, 255, 0.85);
+                stroke-width: 2px;
+            }
+        }
     }
 }

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
@@ -194,7 +194,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
         const { timeColumn } = mapTable
         const displayTime = !timeColumn.isMissing
             ? timeColumn.formatValue(targetTime)
-            : targetTime
+            : targetTime?.toString()
         const displayDatumTime =
             timeColumn && datum
                 ? timeColumn.formatValue(datum?.time)
@@ -235,7 +235,8 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                 title={target?.featureId}
                 subtitle={datum ? displayDatumTime : displayTime}
                 subtitleFormat={notice ? "notice" : undefined}
-                notice={notice}
+                footer={notice}
+                footerFormat="notice"
                 dissolve={fading}
             >
                 <TooltipValue

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
@@ -38,7 +38,7 @@ interface MapTooltipProps {
 
 const SPARKLINE_WIDTH = 250
 const SPARKLINE_HEIGHT = 87
-const SPARKLINE_PADDING = 15
+const SPARKLINE_PADDING = 15 // same as $inset in scss
 
 @observer
 export class MapTooltip extends React.Component<MapTooltipProps> {
@@ -277,28 +277,16 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                                     bottom: 3,
                                 })}
                             />
-                            <g className="min-max-labels">
-                                {maxLabel != minLabel && (
-                                    <text
-                                        x={
-                                            SPARKLINE_WIDTH -
-                                            SPARKLINE_PADDING -
-                                            3
-                                        }
-                                        y={0.75 * SPARKLINE_PADDING}
-                                    >
-                                        {maxLabel}
-                                    </text>
-                                )}
-                                <text
-                                    x={SPARKLINE_WIDTH - SPARKLINE_PADDING - 3}
-                                    y={
-                                        SPARKLINE_HEIGHT -
-                                        1.45 * SPARKLINE_PADDING
-                                    }
-                                >
-                                    {minLabel}
-                                </text>
+
+                            {maxLabel !== minLabel && (
+                                <g className="max axis-label">
+                                    <text>{maxLabel}</text>
+                                </g>
+                            )}
+
+                            <g className="min axis-label">
+                                <text className="outline">{minLabel}</text>
+                                <text>{minLabel}</text>
                             </g>
                         </svg>
                     </div>

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -855,7 +855,8 @@ export class ScatterPlotChart
                 title={target.series.label}
                 subtitle={timeLabel}
                 dissolve={fading}
-                notice={targetNotice}
+                footer={targetNotice}
+                footerFormat="notice"
             >
                 <TooltipValueRange
                     column={xColumn}

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -10,7 +10,7 @@ import { quantize, interpolate } from "d3-interpolate"
 import {
     intersection,
     without,
-    compact,
+    excludeNullish,
     uniq,
     first,
     last,
@@ -798,7 +798,7 @@ export class ScatterPlotChart
             tooltipState: { target, position, fading },
         } = this
         const points = target.series.points ?? []
-        const values = compact(uniq([first(points), last(points)]))
+        const values = excludeNullish(uniq([first(points), last(points)]))
 
         let { startTime, endTime } = this.manager
         const { x: xStart, y: yStart } = first(values)?.time ?? {},
@@ -835,7 +835,7 @@ export class ScatterPlotChart
         }
 
         const { isRelativeMode } = this.manager,
-            timeRange = uniq(compact([startTime, endTime]))
+            timeRange = uniq(excludeNullish([startTime, endTime]))
                 .map((t) => this.yColumn.formatTime(t))
                 .join(" to "),
             targetNotice =
@@ -870,7 +870,7 @@ export class ScatterPlotChart
                 />
                 <TooltipValueRange
                     column={this.sizeColumn}
-                    values={compact(values.map((v) => v.size))}
+                    values={excludeNullish(values.map((v) => v.size))}
                 />
             </Tooltip>
         )

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -804,13 +804,13 @@ export class ScatterPlotChart
         const { x: xStart, y: yStart } = first(values)?.time ?? {},
             { x: xEnd, y: yEnd } = last(values)?.time ?? {}
 
-        let xValues = values.map((v) => v.x),
+        let xValues = xStart === xEnd ? [values[0].x] : values.map((v) => v.x),
             xNoticeNeeded =
                 (xStart !== undefined && xStart != startTime && xStart) ||
                 (xEnd !== undefined && xEnd != endTime && xEnd),
             xNotice = xNoticeNeeded ? [xStart, xEnd] : []
 
-        let yValues = values.map((v) => v.y),
+        let yValues = yStart === yEnd ? [values[0].y] : values.map((v) => v.y),
             yNoticeNeeded =
                 (yStart !== undefined && yStart != startTime && yStart) ||
                 (yEnd !== undefined && yEnd != endTime && yEnd),
@@ -818,17 +818,15 @@ export class ScatterPlotChart
 
         // handle the special case where the same variable is used for both axes
         // with a different year's value on each
-        if (xColumn.def.datasetId === yColumn.def.datasetId) {
-            const xTime = xColumn.def.targetTime ?? this.manager.endTime,
-                yTime = yColumn.def.targetTime ?? this.manager.endTime
-
-            if (xTime != yTime && isNumber(xTime) && isNumber(yTime)) {
-                startTime = min([xTime, yTime])
-                endTime = max([xTime, yTime])
-                xValues =
-                    xTime < yTime
-                        ? [values[0]?.x, values[0]?.y]
-                        : [values[0]?.y, values[0]?.x]
+        if (
+            xColumn.def.datasetId === yColumn.def.datasetId &&
+            points.length == 1
+        ) {
+            const { x, y, time } = points[0]
+            if (time.x != time.y && isNumber(time.x) && isNumber(time.y)) {
+                startTime = min([time.x, time.y])
+                endTime = max([time.x, time.y])
+                xValues = time.x < time.y ? [x, y] : [y, x]
                 xNotice = yNotice = yValues = []
                 xNoticeNeeded = yNoticeNeeded = false
             }

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -27,6 +27,7 @@ import {
     groupBy,
     sampleFrom,
     intersectionOfSets,
+    min,
     max,
     PointVector,
     Bounds,
@@ -729,7 +730,6 @@ export class ScatterPlotChart
             arrowLegend,
             sizeLegend,
             sidebarWidth,
-            tooltipState: { target, position, fading },
             comparisonLines,
             legendDimensions,
         } = this
@@ -738,31 +738,6 @@ export class ScatterPlotChart
         const arrowLegendY = sizeLegend
             ? sizeLegendY + sizeLegend.height + 15
             : sizeLegendY
-
-        const points = target?.series.points ?? []
-        const values = compact(uniq([first(points), last(points)]))
-
-        const { startTime, endTime, isRelativeMode } = this.manager,
-            { x: xStart, y: yStart } = first(values)?.time ?? {},
-            { x: xEnd, y: yEnd } = last(values)?.time ?? {}
-
-        const xNoticeNeeded =
-                (xStart !== undefined && xStart != startTime && xStart) ||
-                (xEnd !== undefined && xEnd != endTime && xEnd),
-            xNotice = xNoticeNeeded ? [xStart, xEnd] : []
-
-        const yNoticeNeeded =
-                (yStart !== undefined && yStart != startTime && yStart) ||
-                (yEnd !== undefined && yEnd != endTime && yEnd),
-            yNotice = yNoticeNeeded ? [yStart, yEnd] : []
-
-        const timeRange = uniq(compact([startTime, endTime]))
-                .map((t) => this.yColumn.formatTime(t))
-                .join(" to "),
-            targetNotice =
-                xNoticeNeeded || yNoticeNeeded ? timeRange : undefined,
-            timeLabel =
-                timeRange + (isRelativeMode ? " (avg. annual change)" : "")
 
         return (
             <g className="ScatterPlot" onMouseMove={this.onScatterMouseMove}>
@@ -809,37 +784,94 @@ export class ScatterPlotChart
                         </g>
                     </>
                 )}
-                {target && (
-                    <Tooltip
-                        id="scatterTooltip"
-                        tooltipManager={this.manager}
-                        x={position.x}
-                        y={position.y}
-                        offsetX={20}
-                        offsetY={-16}
-                        style={{ maxWidth: "250px" }}
-                        title={target.series.label}
-                        subtitle={timeLabel}
-                        dissolve={fading}
-                        notice={targetNotice}
-                    >
-                        <TooltipValueRange
-                            column={this.xColumn}
-                            values={values.map((v) => v.x)}
-                            notice={xNotice}
-                        />
-                        <TooltipValueRange
-                            column={this.yColumn}
-                            values={values.map((v) => v.y)}
-                            notice={yNotice}
-                        />
-                        <TooltipValueRange
-                            column={this.sizeColumn}
-                            values={compact(values.map((v) => v.size))}
-                        />
-                    </Tooltip>
-                )}
+                {this.tooltip}
             </g>
+        )
+    }
+
+    @computed get tooltip(): JSX.Element | null {
+        if (!this.tooltipState.target) return null
+
+        const {
+            xColumn,
+            yColumn,
+            tooltipState: { target, position, fading },
+        } = this
+        const points = target.series.points ?? []
+        const values = compact(uniq([first(points), last(points)]))
+
+        let { startTime, endTime } = this.manager
+        const { x: xStart, y: yStart } = first(values)?.time ?? {},
+            { x: xEnd, y: yEnd } = last(values)?.time ?? {}
+
+        let xValues = values.map((v) => v.x),
+            xNoticeNeeded =
+                (xStart !== undefined && xStart != startTime && xStart) ||
+                (xEnd !== undefined && xEnd != endTime && xEnd),
+            xNotice = xNoticeNeeded ? [xStart, xEnd] : []
+
+        let yValues = values.map((v) => v.y),
+            yNoticeNeeded =
+                (yStart !== undefined && yStart != startTime && yStart) ||
+                (yEnd !== undefined && yEnd != endTime && yEnd),
+            yNotice = yNoticeNeeded ? [yStart, yEnd] : []
+
+        // handle the special case where the same variable is used for both axes
+        // with a different year's value on each
+        if (xColumn.def.datasetId === yColumn.def.datasetId) {
+            const xTime = xColumn.def.targetTime ?? this.manager.endTime,
+                yTime = yColumn.def.targetTime ?? this.manager.endTime
+
+            if (xTime != yTime && isNumber(xTime) && isNumber(yTime)) {
+                startTime = min([xTime, yTime])
+                endTime = max([xTime, yTime])
+                xValues =
+                    xTime < yTime
+                        ? [values[0]?.x, values[0]?.y]
+                        : [values[0]?.y, values[0]?.x]
+                xNotice = yNotice = yValues = []
+                xNoticeNeeded = yNoticeNeeded = false
+            }
+        }
+
+        const { isRelativeMode } = this.manager,
+            timeRange = uniq(compact([startTime, endTime]))
+                .map((t) => this.yColumn.formatTime(t))
+                .join(" to "),
+            targetNotice =
+                xNoticeNeeded || yNoticeNeeded ? timeRange : undefined,
+            timeLabel =
+                timeRange + (isRelativeMode ? " (avg. annual change)" : "")
+
+        return (
+            <Tooltip
+                id="scatterTooltip"
+                tooltipManager={this.manager}
+                x={position.x}
+                y={position.y}
+                offsetX={20}
+                offsetY={-16}
+                style={{ maxWidth: "250px" }}
+                title={target.series.label}
+                subtitle={timeLabel}
+                dissolve={fading}
+                notice={targetNotice}
+            >
+                <TooltipValueRange
+                    column={xColumn}
+                    values={xValues}
+                    notice={xNotice}
+                />
+                <TooltipValueRange
+                    column={yColumn}
+                    values={yValues}
+                    notice={yNotice}
+                />
+                <TooltipValueRange
+                    column={this.sizeColumn}
+                    values={compact(values.map((v) => v.size))}
+                />
+            </Tooltip>
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -960,7 +960,8 @@ export class MarimekkoChart
                         offsetY={-16}
                         title={entityName}
                         subtitle={timeColumn.formatValue(endTime)}
-                        notice={notice}
+                        footer={notice}
+                        footerFormat="notice"
                         dissolve={fading}
                     >
                         {yValues.map(({ name, value, notice }) => (

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -727,7 +727,8 @@ export class StackedDiscreteBarChart
                     title={target.entityName}
                     subtitle={unit != shortUnit ? unit : undefined}
                     subtitleFormat="unit"
-                    notice={notice}
+                    footer={notice}
+                    footerFormat="notice"
                     dissolve={fading}
                 >
                     <TooltipTable

--- a/packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss
+++ b/packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss
@@ -198,7 +198,7 @@
             td.series-name {
                 padding-right: 0.9em;
                 line-height: 16px;
-
+                width: 100%;
                 .parenthetical {
                     color: $grey;
                 }
@@ -313,24 +313,13 @@
             }
         }
 
-        // the 'click to select' prompt in MapTooltip
-        .callout {
-            margin: 0.28em;
-            text-align: center;
-            font-weight: $bold;
-            font-size: 12px;
-            font-style: italic;
-            letter-spacing: 0.01em;
-            color: $grey;
-        }
-
         .hoverIndicator circle {
             stroke-width: 1;
             r: 5px;
         }
     }
 
-    // tolerance captions w/ circle-i icon
+    // tolerance captions w/ circle-i icon or projection warning with striped swatch
     .endmatter {
         position: relative;
         color: $grey;
@@ -338,9 +327,15 @@
         border-radius: 0 0 3px 3px;
         border-top: 1px solid $light-grey;
 
-        svg {
+        .icon {
             position: absolute;
             width: 12px;
+
+            &.stripes {
+                content: " ";
+                height: 12px;
+                @include diagonal-background($grey, white);
+            }
         }
 
         p {
@@ -348,26 +343,21 @@
             letter-spacing: 0.01em;
             line-height: 15px;
             margin: 0;
-            padding-left: 19px;
             max-width: 260px;
+        }
 
-            &.prompt {
-                padding-left: 0;
-                text-align: center;
-                font-weight: $bold;
-                font-size: 12px;
-                font-style: italic;
-                letter-spacing: 0.01em;
-                color: $grey;
+        // add boilerplate around time value for tolerance notices
+        p.notice {
+            &::before {
+                content: "Data not available for ";
+            }
+            &::after {
+                content: ". Showing closest available data point instead";
             }
         }
 
-        p.time-notice + p.prompt {
-            border-top: 2px solid $light-grey;
-            padding-top: 0.3em;
-            margin-top: 0.35em;
-            margin-left: 19px;
-            text-align: left;
+        .icon ~ p {
+            padding-left: 19px;
         }
     }
 

--- a/packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss
+++ b/packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss
@@ -21,6 +21,16 @@
     font-family: $sans-serif-font-stack;
     font-size: 16px;
 
+    @mixin diagonal-background($background, $color) {
+        background: repeating-linear-gradient(
+            -45deg,
+            $background,
+            $background 16%,
+            $color 16%,
+            $color 25%
+        );
+    }
+
     .frontmatter {
         background: $background-fill;
         color: black;
@@ -181,6 +191,7 @@
                     display: inline-block;
                     margin-right: 0.3em;
                     text-align: left;
+                    position: relative;
                 }
             }
 
@@ -286,6 +297,19 @@
                 td.series-color {
                     display: none;
                 }
+            }
+
+            // overlay a diagonal line pattern on striped swatches
+            tr.striped .series-color .swatch::before {
+                content: " ";
+                position: absolute;
+                width: 100%;
+                height: 100%;
+                @include diagonal-background(transparent, white);
+            }
+
+            tr.striped.blurred .series-color .swatch::before {
+                @include diagonal-background($grey, white);
             }
         }
 

--- a/packages/@ourworldindata/grapher/src/tooltip/Tooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/tooltip/Tooltip.tsx
@@ -9,6 +9,10 @@ import { TooltipProps, TooltipManager, TooltipFadeMode } from "./TooltipProps"
 export * from "./TooltipContents.js"
 
 export const TOOLTIP_FADE_DURATION = 400 // $fade-time + $fade-delay in scss
+const TOOLTIP_ICON = {
+    notice: <FontAwesomeIcon className="notice icon" icon={faInfoCircle} />,
+    stripes: <div className="stripes icon"></div>,
+}
 
 export class TooltipState<T> {
     @observable position = new PointVector(0, 0)
@@ -82,8 +86,8 @@ class TooltipCard extends React.Component<
             title,
             subtitle,
             subtitleFormat,
-            notice,
-            prompt,
+            footer,
+            footerFormat,
             dissolve,
             children,
             offsetX = 0,
@@ -150,27 +154,17 @@ class TooltipCard extends React.Component<
                         {title && <div className="title">{title}</div>}
                         {subtitle && (
                             <div className="subtitle">
-                                {timeNotice && (
-                                    <FontAwesomeIcon icon={faInfoCircle} />
-                                )}
+                                {timeNotice && TOOLTIP_ICON.notice}
                                 <span>{subtitle}</span>
                             </div>
                         )}
                     </div>
                 )}
                 {children && <div className="content">{children}</div>}
-                {(notice || prompt) && (
+                {footer && (
                     <div className="endmatter">
-                        {notice && (
-                            <>
-                                <FontAwesomeIcon icon={faInfoCircle} />
-                                <p className="time-notice">
-                                    Data not available for {notice}. Showing
-                                    closest available data point instead.
-                                </p>
-                            </>
-                        )}
-                        {prompt && <p className="prompt">{prompt}</p>}
+                        {footerFormat && TOOLTIP_ICON[footerFormat]}
+                        <p className={footerFormat}>{footer}</p>
                     </div>
                 )}
             </div>

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
@@ -177,7 +177,7 @@ export class TooltipTable extends React.Component<TooltipTableProps> {
                             swatch = "transparent",
                         } = row
                         const [_m, seriesName, seriesParenthetical] =
-                            name.match(/^(.*?)((:?\s*\(([^()]*)\))+)?$/) ?? []
+                            name.match(/^(.*?)(\(([^()]*)\))?$/) ?? []
 
                         return (
                             <tr

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
@@ -170,6 +170,7 @@ export class TooltipTable extends React.Component<TooltipTableProps> {
                             name,
                             focused,
                             blurred,
+                            striped,
                             annotation,
                             values,
                             notice,
@@ -181,7 +182,11 @@ export class TooltipTable extends React.Component<TooltipTableProps> {
                         return (
                             <tr
                                 key={name}
-                                className={classnames({ focused, blurred })}
+                                className={classnames({
+                                    focused,
+                                    blurred,
+                                    striped,
+                                })}
                             >
                                 <td className="series-color">
                                     <div

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
@@ -177,7 +177,7 @@ export class TooltipTable extends React.Component<TooltipTableProps> {
                             swatch = "transparent",
                         } = row
                         const [_m, seriesName, seriesParenthetical] =
-                            name.match(/^(.*?)(\(([^()]*)\))?$/) ?? []
+                            name.match(/^(.*?)(\([^()]*\))?$/) ?? []
 
                         return (
                             <tr

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
@@ -176,7 +176,7 @@ export class TooltipTable extends React.Component<TooltipTableProps> {
                             swatch = "transparent",
                         } = row
                         const [_m, seriesName, seriesParenthetical] =
-                            name.match(/^(.*?)(\(.*)?$/) ?? []
+                            name.match(/^(.*?)((:?\s*\(([^()]*)\))+)?$/) ?? []
 
                         return (
                             <tr

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
@@ -59,7 +59,8 @@ export class TooltipValueRange extends React.Component<TooltipValueRangeProps> {
                 column.formatValueShort(v)
             ),
             [firstTerm, lastTerm] =
-                // TODO: would be nicer to actually measure the typeset text
+                // TODO: would be nicer to actually measure the typeset text but we would need to
+                // add Lato's metrics to the `string-pixel-width` module to use Bounds.forText
                 sum([firstValue?.length, lastValue?.length]) > 20
                     ? values.map((v) =>
                           column.formatValueShortWithAbbreviations(v)

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipProps.ts
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipProps.ts
@@ -55,6 +55,7 @@ export interface TooltipTableRow {
     swatch?: string // css color string for the series's swatch
     focused?: boolean // highlighted (based on hovered series in chart)
     blurred?: boolean // greyed out (typically due to missing data)
+    striped?: boolean // use textured swatch (to show data is extrapolated)
     notice?: string | number // actual year data was drawn (when ≠ target year)
     values: (string | number | undefined)[]
 }

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipProps.ts
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipProps.ts
@@ -19,9 +19,9 @@ export interface TooltipProps {
     offsetYDirection?: "upward" | "downward"
     title?: string | number // header text
     subtitle?: string | number // header deck
-    subtitleFormat?: "unit" | "notice" // optional postprocessing for subtitle
-    notice?: string | number // target year displayed in footer tolerance text
-    prompt?: string // freeform message displayed in footer
+    subtitleFormat?: "notice" | "unit" // optional postprocessing for subtitle
+    footer?: string // target year for tolerance notice or freeform contents
+    footerFormat?: "notice" | "stripes" // add icon for tolerance or projection
     style?: React.CSSProperties // css overrides (particularly width/maxWidth)
     dissolve?: TooltipFadeMode // flag that the tooltip should begin fading out
     tooltipManager: TooltipManager


### PR DESCRIPTION
The PR cleans up some lingering issues with the new tooltip component:
1. Improved specificity for dimming out parentheticals in entity names
   - the previous regex would greedily include anything from the first `(` character to the `)` at the end of the line, even if the parenthetical was followed by non-parenthesized text <br><img width="323" alt="image" src="https://github.com/owid/owid-grapher/assets/469523/365767fa-20d2-450e-b1b7-f070aa00d0c2">
1. Scatterplots that plot a single indicator on both axes to compare different years now use the 'range'-style tooltip to show the change over time
   - http://staging-site-tooltips-misc-bugfixes/grapher/homicide-rate-1990-vs-2019 <br> <img width="286" alt="image" src="https://github.com/owid/owid-grapher/assets/469523/ca17414a-e4ed-42a7-b722-c3997e7876c1">
1. Improved rendering on line charts with projections
   - duplicate rows were being displayed if the projection went both into the past and the future of the concrete data
   - when hovering over a projection, the corresponding color swatch in the tooltip now uses the same dotted-line texture as the chart
   - http://staging-site-tooltips-misc-bugfixes/grapher/income-share-top-1-before-tax-wid-extrapolations?country=USA~ITA~GBR~CAN <br> <img width="222" alt="image" src="https://github.com/owid/owid-grapher/assets/469523/388251f4-4bad-49c5-8546-b7e31bfedfbd">


1. The min & max labels on the map tooltip's sparkline can occasionally collide with the plotted data (especially the min label since it's inside the axes). The labels now have a thin white outline around them to improve contrast between the text and the overlapping line and the font weight has been lightened to minimize the amount of data blocked by the outline.
   - http://staging-site-tooltips-misc-bugfixes/grapher/annual-change-renewables <br> <img width="262" alt="image" src="https://github.com/owid/owid-grapher/assets/469523/6284f70a-9d53-4486-a725-55173a4f2c34">
