### PR TITLE
:sparkles: Disable variable metadata fields in admin

### DIFF
--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -80,7 +80,6 @@ class DatasetEditable {
 class DatasetTagEditor extends React.Component<{
     newDataset: DatasetEditable
     availableTags: { id: number; name: string; parentName: string }[]
-    isBulkImport: boolean
 }> {
     @action.bound onSaveTags(tags: Tag[]) {
         this.props.newDataset.tags = tags
@@ -337,7 +336,6 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                                 <DatasetTagEditor
                                     newDataset={newDataset}
                                     availableTags={dataset.availableTags}
-                                    isBulkImport={isBulkImport}
                                 />
                                 <FieldsRow>
                                     <Toggle
@@ -358,7 +356,6 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                                         value={newDataset.nonRedistributable}
                                         onValue={(v) => {
                                             newDataset.nonRedistributable = v
-                                            if (v) newDataset.isPrivate = true
                                         }}
                                     />
                                 </FieldsRow>
@@ -400,13 +397,11 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                                 />
                             </div>
                         </div>
-                        {!isBulkImport && (
-                            <input
-                                type="submit"
-                                className="btn btn-success"
-                                value="Update dataset"
-                            />
-                        )}
+                        <input
+                            type="submit"
+                            className="btn btn-success"
+                            value="Update dataset"
+                        />
                     </form>
                 </section>
                 <section>

--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -204,36 +204,6 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
         )}`
     }
 
-    @computed get zipFileUrl() {
-        return "/"
-    }
-
-    async uploadZip(file: File) {
-        const json = await this.context.admin.requestJSON(
-            `/api/datasets/${this.props.dataset.id}/uploadZip`,
-            file,
-            "PUT"
-        )
-        if (json.success) {
-            this.props.dataset.zipFile = { filename: file.name }
-        }
-    }
-
-    @action.bound onChooseZip(ev: { target: HTMLInputElement }) {
-        if (!ev.target.files) return
-
-        const file = ev.target.files[0]
-        this.uploadZip(file)
-    }
-
-    @action.bound startChooseZip() {
-        const input = document.createElement("input")
-        input.type = "file"
-        input.accept = ".zip"
-        input.addEventListener("change", this.onChooseZip as any)
-        input.click()
-    }
-
     render() {
         if (this.isDeleted) return <Redirect to="/datasets" />
 

--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -241,6 +241,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
         const { dataset } = this.props
         const { newDataset } = this
         const isBulkImport = dataset.namespace !== "owid"
+        const isDisabled = true
 
         return (
             <main className="DatasetEditPage">
@@ -284,15 +285,6 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                             additional-material.zip
                         </Link>
                     )}
-                    {!isBulkImport && (
-                        <button
-                            className="btn btn-secondary"
-                            onClick={this.startChooseZip}
-                        >
-                            <FontAwesomeIcon icon={faUpload} />{" "}
-                            {dataset.zipFile ? "Overwrite Zip" : "Upload Zip"}
-                        </button>
-                    )}
                 </section>
                 <section>
                     <h3>Dataset metadata</h3>
@@ -302,18 +294,10 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                             this.save()
                         }}
                     >
-                        {isBulkImport ? (
-                            <p>
-                                This dataset came from an automated import, so
-                                we can't change the original metadata manually.
-                            </p>
-                        ) : (
-                            <p>
-                                The core metadata for the dataset. It's
-                                important to keep this in a standardized style
-                                across datasets.
-                            </p>
-                        )}
+                        <p>
+                            Metadata is non-editable and can be only changed in
+                            ETL.
+                        </p>
                         <div className="row">
                             <div className="col">
                                 <BindString
@@ -321,7 +305,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                                     store={newDataset}
                                     label="Name"
                                     secondaryLabel="DB field: datasets.name"
-                                    disabled={isBulkImport}
+                                    disabled={isDisabled}
                                     helpText="Short name for this dataset, followed by the source and year. Example: Government Revenue Data – ICTD (2016)"
                                 />
                                 <BindString
@@ -330,7 +314,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                                     label="Description"
                                     secondaryLabel="DB field: sources.description ->> '$.additionalInfo' - only the lowest id source is shown!"
                                     textarea
-                                    disabled={isBulkImport}
+                                    disabled={isDisabled}
                                     helpText="Describe the dataset and the methodology used in its construction. This can be as long and detailed as you like."
                                     rows={10}
                                 />
@@ -339,7 +323,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                                     store={newDataset.source}
                                     label="Link"
                                     secondaryLabel="DB field: sources.description ->> '$.link' - only the lowest id source is shown!"
-                                    disabled={isBulkImport}
+                                    disabled={isDisabled}
                                     helpText="Link to the publication from which we retrieved this data"
                                 />
                                 <BindString
@@ -347,7 +331,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                                     store={newDataset.source}
                                     label="Retrieved"
                                     secondaryLabel="DB field: sources.description ->> '$.retrievedDate' - only the lowest id source is shown!"
-                                    disabled={isBulkImport}
+                                    disabled={isDisabled}
                                     helpText="Date when this data was obtained by us. Date format should always be YYYY-MM-DD."
                                 />
                                 <DatasetTagEditor
@@ -363,7 +347,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                                             (newDataset.isPrivate = !v)
                                         }
                                         disabled={
-                                            isBulkImport ||
+                                            isDisabled ||
                                             newDataset.nonRedistributable
                                         }
                                     />
@@ -376,7 +360,6 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                                             newDataset.nonRedistributable = v
                                             if (v) newDataset.isPrivate = true
                                         }}
-                                        disabled={isBulkImport}
                                     />
                                 </FieldsRow>
                             </div>
@@ -387,7 +370,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                                     store={newDataset.source}
                                     label="Source name"
                                     secondaryLabel="DB field: sources.description ->> '$.name' - only the lowest id source is shown!"
-                                    disabled={isBulkImport}
+                                    disabled={isDisabled}
                                     helpText={`Short citation of the main sources, to be displayed on the charts. Additional sources (e.g. population denominator) should not be included. Use semi-colons to separate multiple sources e.g. "UN (2022); World Bank (2022)". For institutional datasets or reports, use "Institution, Project (year or vintage)" e.g. "IHME, Global Burden of Disease (2019)". For data we have modified extensively, use "Our World in Data based on X (year)" e.g. "Our World in Data based on Pew Research Center (2022)". For academic papers, use "Authors (year)" e.g. "Arroyo-Abad and Lindert (2016)".`}
                                 />
 
@@ -396,7 +379,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                                     store={newDataset.source}
                                     label="Data published by"
                                     secondaryLabel="DB field: sources.description ->> '$.dataPublishedBy' - only the lowest id source is shown!"
-                                    disabled={isBulkImport}
+                                    disabled={isDisabled}
                                     helpText={`Full citation of main and additional sources. For academic papers, institutional datasets, and reports, use the complete citation recommended by the publisher. For data we have modified extensively, use "Our World in Data based on X (year) and Y (year)" e.g. "Our World in Data based on Pew Research Center (2022) and UN (2022)".`}
                                 />
                                 <BindString
@@ -404,7 +387,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                                     store={newDataset.source}
                                     label="Data publisher's source"
                                     secondaryLabel="DB field: sources.description ->> '$.dataPublisherSource' - only the lowest id source is shown!"
-                                    disabled={isBulkImport}
+                                    disabled={isDisabled}
                                     helpText={`Optional field. Basic indication of how the publisher collected this data e.g. "Survey data". Anything longer than a line should go in the dataset description.`}
                                 />
                                 <BindString
@@ -413,7 +396,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                                     label="Internal notes"
                                     secondaryLabel="DB field: datasets.description"
                                     textarea
-                                    disabled={isBulkImport}
+                                    disabled={isDisabled}
                                 />
                             </div>
                         </div>

--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -21,7 +21,7 @@ import { Tag } from "./TagBadge.js"
 import { VariableList, VariableListItem } from "./VariableList.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
-import { faDownload, faUpload } from "@fortawesome/free-solid-svg-icons"
+import { faDownload } from "@fortawesome/free-solid-svg-icons"
 import { faGithub } from "@fortawesome/free-brands-svg-icons"
 
 interface DatasetPageData {

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -850,6 +850,7 @@ export class BindFloat<
     store: T
     label?: string
     helpText?: string
+    disabled?: boolean
 }> {
     @action.bound onValue(value: number | undefined) {
         this.props.store[this.props.field] = value as any

--- a/adminSiteClient/VariableEditPage.tsx
+++ b/adminSiteClient/VariableEditPage.tsx
@@ -107,7 +107,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
     render() {
         const { variable } = this.props
         const { newVariable } = this
-        const isBulkImport = variable.datasetNamespace !== "owid"
+        const isDisabled = true
 
         if (this.isDeleted)
             return <Redirect to={`/datasets/${variable.datasetId}`} />
@@ -139,28 +139,21 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                         >
                             <section>
                                 <h3>Indicator metadata</h3>
-                                {isBulkImport ? (
-                                    <p>
-                                        This indicator came from an automated
-                                        import, so we can't change the original
-                                        metadata manually.
-                                    </p>
-                                ) : (
-                                    <p>
-                                        The core metadata for the indicator.
-                                        It's important to keep this consistent.
-                                    </p>
-                                )}
+                                <p>
+                                    Metadata is non-editable and can be only
+                                    changed in ETL.
+                                </p>
                                 <BindString
                                     field="name"
                                     store={newVariable}
                                     label="Indicator Name"
-                                    disabled={isBulkImport}
+                                    disabled={isDisabled}
                                 />
                                 <BindString
                                     label="Display name"
                                     field="name"
                                     store={newVariable.display}
+                                    disabled={isDisabled}
                                 />
                                 <FieldsRow>
                                     <BindString
@@ -168,12 +161,14 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                         field="unit"
                                         store={newVariable.display}
                                         placeholder={newVariable.unit}
+                                        disabled={isDisabled}
                                     />
                                     <BindString
                                         label="Short (axis) unit"
                                         field="shortUnit"
                                         store={newVariable.display}
                                         placeholder={newVariable.shortUnit}
+                                        disabled={isDisabled}
                                     />
                                 </FieldsRow>
                                 <FieldsRow>
@@ -182,12 +177,14 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                         field="numDecimalPlaces"
                                         store={newVariable.display}
                                         helpText={`A negative number here will round integers`}
+                                        disabled={isDisabled}
                                     />
                                     <BindFloat
                                         label="Unit conversion factor"
                                         field="conversionFactor"
                                         store={newVariable.display}
                                         helpText={`Multiply all values by this amount`}
+                                        disabled={isDisabled}
                                     />
                                 </FieldsRow>
                                 <FieldsRow>
@@ -201,14 +198,16 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                                 value)
                                         }
                                         label="Treat year column as day series"
+                                        disabled={isDisabled}
                                     />
                                     <BindString
                                         label="Zero Day as YYYY-MM-DD"
                                         field="zeroDay"
                                         store={newVariable.display}
-                                        disabled={
-                                            !newVariable.display.yearIsDay
-                                        }
+                                        // disabled={
+                                        //     !newVariable.display.yearIsDay
+                                        // }
+                                        disabled={isDisabled}
                                         placeholder={
                                             newVariable.display.yearIsDay
                                                 ? EPOCH_DATE
@@ -228,6 +227,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                                 value)
                                         }
                                         label="Include in table"
+                                        disabled={isDisabled}
                                     />
                                 </FieldsRow>
                                 <BindString
@@ -235,7 +235,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                     store={newVariable}
                                     label="Description"
                                     textarea
-                                    disabled={isBulkImport}
+                                    disabled={isDisabled}
                                 />
                                 <BindString
                                     field="entityAnnotationsMap"
@@ -243,7 +243,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                     store={newVariable.display}
                                     label="Entity annotations"
                                     textarea
-                                    disabled={isBulkImport}
+                                    disabled={isDisabled}
                                     helpText="Additional text to show next to entity labels. Each note should be in a separate line."
                                 />
                             </section>
@@ -251,6 +251,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                 type="submit"
                                 className="btn btn-success"
                                 value="Update variable"
+                                disabled={isDisabled}
                             />
                         </form>
                     </div>

--- a/adminSiteClient/VariableEditPage.tsx
+++ b/adminSiteClient/VariableEditPage.tsx
@@ -84,26 +84,6 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
         )
     }
 
-    async delete() {
-        const { variable } = this.props
-        if (
-            !window.confirm(
-                `Really delete the indicator ${variable.name}? This action cannot be undone!`
-            )
-        )
-            return
-
-        const json = await this.context.admin.requestJSON(
-            `/api/variables/${variable.id}`,
-            {},
-            "DELETE"
-        )
-
-        if (json.success) {
-            this.isDeleted = true
-        }
-    }
-
     render() {
         const { variable } = this.props
         const { newVariable } = this
@@ -131,12 +111,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                 </ol>
                 <div className="row">
                     <div className="col">
-                        <form
-                            onSubmit={(e) => {
-                                e.preventDefault()
-                                this.save()
-                            }}
-                        >
+                        <form>
                             <section>
                                 <h3>Indicator metadata</h3>
                                 <p>
@@ -247,12 +222,6 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                     helpText="Additional text to show next to entity labels. Each note should be in a separate line."
                                 />
                             </section>
-                            <input
-                                type="submit"
-                                className="btn btn-success"
-                                value="Update variable"
-                                disabled={isDisabled}
-                            />
                         </form>
                     </div>
                     {this.grapher && (
@@ -278,19 +247,6 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                 </section>
             </main>
         )
-    }
-
-    async save() {
-        const { variable } = this.props
-        const json = await this.context.admin.requestJSON(
-            `/api/variables/${variable.id}`,
-            { variable: this.newVariable },
-            "PUT"
-        )
-
-        if (json.success) {
-            Object.assign(this.props.variable, this.newVariable)
-        }
     }
 
     @computed private get grapherConfig(): GrapherInterface {

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -1735,46 +1735,6 @@ apiRouter.get(
     }
 )
 
-apiRouter.put("/variables/:variableId", async (req: Request) => {
-    const variableId = expectInt(req.params.variableId)
-    const variable = (req.body as { variable: VariableSingleMeta }).variable
-
-    await db.execute(
-        `UPDATE variables SET name=?, description=?, updatedAt=?, display=? WHERE id = ?`,
-        [
-            variable.name,
-            variable.description,
-            new Date(),
-            JSON.stringify(variable.display),
-            variableId,
-        ]
-    )
-
-    return { success: true }
-})
-
-apiRouter.delete("/variables/:variableId", async (req: Request) => {
-    const variableId = expectInt(req.params.variableId)
-
-    const variable = await db.mysqlFirst(
-        `SELECT datasets.namespace FROM variables JOIN datasets ON variables.datasetId=datasets.id WHERE variables.id=?`,
-        [variableId]
-    )
-
-    if (!variable) throw new JsonError(`No variable by id ${variableId}`, 404)
-    else if (variable.namespace !== "owid")
-        throw new JsonError(`Cannot delete bulk import variable`, 400)
-
-    await db.transaction(async (t) => {
-        await t.execute(`DELETE FROM data_values WHERE variableId=?`, [
-            variableId,
-        ])
-        await t.execute(`DELETE FROM variables WHERE id=?`, [variableId])
-    })
-
-    return { success: true }
-})
-
 apiRouter.get("/datasets.json", async (req) => {
     const datasets = await db.queryMysql(`
         WITH variable_counts AS (
@@ -1932,6 +1892,8 @@ apiRouter.get("/datasets/:datasetId.json", async (req: Request) => {
 })
 
 apiRouter.put("/datasets/:datasetId", async (req: Request, res: Response) => {
+    // Only updates `nonRedistributable` and `tags`, other fields come from ETL
+    // and are not editable
     const datasetId = expectInt(req.params.datasetId)
     const dataset = await Dataset.findOneBy({ id: datasetId })
     if (!dataset) throw new JsonError(`No dataset by id ${datasetId}`, 404)
@@ -1942,18 +1904,12 @@ apiRouter.put("/datasets/:datasetId", async (req: Request, res: Response) => {
             `
             UPDATE datasets
             SET
-                name=?,
-                description=?,
-                isPrivate=?,
                 nonRedistributable=?,
                 metadataEditedAt=?,
                 metadataEditedByUserId=?
             WHERE id=?
             `,
             [
-                newDataset.name,
-                newDataset.description || "",
-                newDataset.isPrivate,
                 newDataset.nonRedistributable,
                 new Date(),
                 res.locals.user.id,
@@ -1970,14 +1926,6 @@ apiRouter.put("/datasets/:datasetId", async (req: Request, res: Response) => {
                 `INSERT INTO dataset_tags (tagId, datasetId) VALUES ?`,
                 [tagRows]
             )
-
-        const source = newDataset.source
-        const description = lodash.omit(source, ["name", "id"])
-        await t.execute(`UPDATE sources SET name=?, description=? WHERE id=?`, [
-            source.name,
-            JSON.stringify(description),
-            source.id,
-        ])
     })
 
     // Note: not currently in transaction
@@ -2018,26 +1966,6 @@ apiRouter.post(
         await Dataset.setTags(datasetId, req.body.tagIds)
 
         return { success: true }
-    }
-)
-
-apiRouter.router.put(
-    "/datasets/:datasetId/uploadZip",
-    express.raw({ type: "application/zip", limit: "50mb" }),
-    async (req: Request, res: Response) => {
-        const datasetId = expectInt(req.params.datasetId)
-
-        await db.transaction(async (t) => {
-            await t.execute(`DELETE FROM dataset_files WHERE datasetId=?`, [
-                datasetId,
-            ])
-            await t.execute(
-                `INSERT INTO dataset_files (datasetId, filename, file) VALUES (?, ?, ?)`,
-                [datasetId, "additional-material.zip", req.body]
-            )
-        })
-
-        res.send({ success: true })
     }
 )
 

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -2,7 +2,6 @@
 
 import * as lodash from "lodash"
 import { transaction } from "../db/db.js"
-import express from "express"
 import * as db from "../db/db.js"
 import { imageStore } from "../db/model/Image.js"
 import { GdocXImage } from "../db/model/GdocXImage.js"
@@ -1683,21 +1682,6 @@ ORDER BY usageCount DESC`
 
     return rows
 })
-
-interface VariableSingleMeta {
-    id: number
-    name: string
-    unit: string
-    shortUnit: string
-    description: string
-
-    datasetId: number
-    datasetName: string
-    datasetNamespace: string
-
-    vardata: string
-    display: any
-}
 
 // Used in VariableEditPage
 apiRouter.get(


### PR DESCRIPTION
Disable all variable metadata fields. These fields should be only set in ETL / fast-track, otherwise we risk overwriting manual updates by automatic ETL run.

I didn't disable "Redistribution is prohibited" field for dataset. We don't have that setting in ETL (therefore we don't overwrite it) and I thought it could be useful? We could also move it to ETL and remove the `Update` button altogether.