### PR TITLE
:bug: a single failing WP->Gdoc migration should not stop the entire queue

### DIFF
--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -21,6 +21,7 @@ import {
 
 const migrate = async (): Promise<void> => {
     const writeToFile = false
+    const errors = []
     await db.getConnection()
 
     const posts = await Post.select(
@@ -147,7 +148,7 @@ const migrate = async (): Promise<void> => {
             }
         } catch (e) {
             console.error("Caught an exception", post.id)
-            throw e
+            errors.push(e)
         }
     }
 
@@ -160,6 +161,11 @@ const migrate = async (): Promise<void> => {
     // }
 
     await db.closeTypeOrmAndKnexConnections()
+
+    if (errors.length > 0) {
+        console.error("Errors", errors)
+        throw new Error(`${errors.length} items had errors`)
+    }
 }
 
 migrate()


### PR DESCRIPTION
This fixes the first part of #2487, namely the fact that WP->Gdoc migration queue stops if there is an exception. With this PR, if migrating a post leads to an exception, this exception is no longer immediately re-thrown but instead collected and the remaining items processed. In the end we print the exceptions and throw one exception to make the status code non-zero.