### PR TITLE
feat: change analytics flow to opt-in; use cookie-less tracking otherwise

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
@@ -4,7 +4,7 @@ const DEBUG = false
 
 // Add type information for dataLayer global provided by Google Tag Manager
 type WindowWithDataLayer = Window & {
-    dataLayer?: GAEvent[]
+    dataLayer?: (GAEvent | GAConsent)[]
 }
 declare const window: WindowWithDataLayer
 
@@ -42,6 +42,16 @@ interface GAEvent {
     eventTarget?: string
     grapherPath?: string
 }
+
+// taken from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/de66435d18fbdb2684947d16b5cd3a77f876324c/types/gtag.js/index.d.ts#L151-L156
+interface GAConsentParams {
+    ad_storage?: "granted" | "denied" | undefined
+    analytics_storage?: "granted" | "denied" | undefined
+    wait_for_update?: number | undefined
+    region?: string[] | undefined
+}
+
+type GAConsent = ["consent", "default" | "update", GAConsentParams]
 
 // Note: consent-based blocking dealt with at the Google Tag Manager level.
 // Events are discarded if consent not given.
@@ -162,5 +172,9 @@ export class GrapherAnalytics {
         }
 
         window.dataLayer?.push(event)
+    }
+
+    updateGAConsentSettings(consent: GAConsentParams): void {
+        window.dataLayer?.push(["consent", "update", consent])
     }
 }

--- a/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
@@ -175,6 +175,14 @@ export class GrapherAnalytics {
     }
 
     updateGAConsentSettings(consent: GAConsentParams): void {
-        window.dataLayer?.push(["consent", "update", consent])
+        function pushToDataLayer(..._args: any): void {
+            // Google Tag Manager is super weird here: it will not accept a normal array or object
+            // being pushed to dataLayer, it absolutely has to be an `Arguments` object.
+            // see https://stackoverflow.com/q/60400130/10670163
+
+            // eslint-disable-next-line prefer-rest-params
+            window.dataLayer?.push(arguments as unknown as GAConsent)
+        }
+        pushToDataLayer("consent", "default", consent)
     }
 }

--- a/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
@@ -183,6 +183,6 @@ export class GrapherAnalytics {
             // eslint-disable-next-line prefer-rest-params
             window.dataLayer?.push(arguments as unknown as GAConsent)
         }
-        pushToDataLayer("consent", "default", consent)
+        pushToDataLayer("consent", "update", consent)
     }
 }

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -50,6 +50,10 @@ export const DONATE_API_URL: string =
 export const RECAPTCHA_SITE_KEY: string =
     process.env.RECAPTCHA_SITE_KEY ?? "6LcJl5YUAAAAAATQ6F4vl9dAWRZeKPBm15MAZj4Q"
 
+// e.g. "GTM-N2D4V8S" (our production GTM container)
+export const GOOGLE_TAG_MANAGER_ID: string =
+    process.env.GOOGLE_TAG_MANAGER_ID ?? ""
+
 export const TOPICS_CONTENT_GRAPH: boolean =
     process.env.TOPICS_CONTENT_GRAPH === "true" ?? false
 

--- a/site/CookieNotice.tsx
+++ b/site/CookieNotice.tsx
@@ -36,13 +36,8 @@ export const CookieNotice = ({
                     </p>
                     <p className="cookie-notice__text">
                         By agreeing, you consent to our use of cookies and other
-                        tracking technologies.
-                    </p>
-                    <p className="cookie-notice__text">
-                        <a href="/privacy-policy">
-                            Read more about our use of cookies in our privacy
-                            policy.
-                        </a>
+                        tracking technologies according to{" "}
+                        <a href="/privacy-policy">our privacy policy</a>.
                     </p>
                 </div>
                 <div className="actions">

--- a/site/CookieNotice.tsx
+++ b/site/CookieNotice.tsx
@@ -35,8 +35,14 @@ export const CookieNotice = ({
                         website.
                     </p>
                     <p className="cookie-notice__text">
-                        By continuing without changing your cookie settings, we
-                        assume you agree to this.
+                        By agreeing, you consent to our use of cookies and other
+                        tracking technologies.
+                    </p>
+                    <p className="cookie-notice__text">
+                        <a href="/privacy-policy">
+                            Read more about our use of cookies in our privacy
+                            policy.
+                        </a>
                     </p>
                 </div>
                 <div className="actions">

--- a/site/CookieNotice.tsx
+++ b/site/CookieNotice.tsx
@@ -36,14 +36,24 @@ export const CookieNotice = ({
                     </p>
                     <p className="cookie-notice__text">
                         By agreeing, you consent to our use of cookies and other
-                        tracking technologies according to{" "}
+                        analytics tools according to{" "}
                         <a href="/privacy-policy">our privacy policy</a>.
                     </p>
                 </div>
                 <div className="actions">
-                    <a href="/privacy-policy" className="button">
-                        Manage preferences
-                    </a>
+                    <button
+                        className="button"
+                        onClick={() =>
+                            dispatch({
+                                type: Action.Reject,
+                                payload: { date: getTodayDate() },
+                            })
+                        }
+                        data-test="reject"
+                        data-track-note="cookie_notice"
+                    >
+                        No thanks
+                    </button>
                     <button
                         className="button accept"
                         onClick={() =>

--- a/site/CookiePreferencesManager.tsx
+++ b/site/CookiePreferencesManager.tsx
@@ -1,9 +1,10 @@
 import ReactDOM from "react-dom"
-import React, { useEffect, useReducer } from "react"
+import React, { useEffect, useMemo, useReducer } from "react"
 import Cookies from "js-cookie"
 import { CookiePreferences } from "../site/blocks/CookiePreferences.js"
 import { CookieNotice } from "../site/CookieNotice.js"
 import { dayjs } from "@ourworldindata/utils"
+import { SiteAnalytics } from "./SiteAnalytics.js"
 
 export enum PreferenceType {
     Analytics = "a",
@@ -33,6 +34,8 @@ interface State {
     date?: number
     preferences: Preference[]
 }
+
+const analytics = new SiteAnalytics()
 
 const defaultState: State = {
     preferences: [
@@ -65,6 +68,20 @@ export const CookiePreferencesManager = ({
             })
         }
     }, [state])
+
+    // Set GA consent
+    const analyticsConsent = useMemo(
+        () =>
+            getPreferenceValue(PreferenceType.Analytics, state.preferences)
+                ? "granted"
+                : "denied",
+        [state.preferences]
+    )
+    useEffect(() => {
+        analytics.updateGAConsentSettings({
+            analytics_storage: analyticsConsent,
+        })
+    }, [analyticsConsent])
 
     return (
         <div data-test-policy-date={POLICY_DATE} className="cookie-manager">

--- a/site/CookiePreferencesManager.tsx
+++ b/site/CookiePreferencesManager.tsx
@@ -15,6 +15,7 @@ export enum Action {
     Accept,
     TogglePreference,
     Reset,
+    Persist,
 }
 
 export interface Preference {
@@ -128,6 +129,11 @@ const reducer = (
             }
         case Action.Reset:
             return defaultState
+        case Action.Persist:
+            return {
+                ...state,
+                date: payload.date,
+            }
         default:
             return state
     }

--- a/site/CookiePreferencesManager.tsx
+++ b/site/CookiePreferencesManager.tsx
@@ -16,6 +16,7 @@ export enum Action {
     TogglePreference,
     Reset,
     Persist,
+    Reject,
 }
 
 export interface Preference {
@@ -133,6 +134,15 @@ const reducer = (
             return {
                 ...state,
                 date: payload.date,
+            }
+        case Action.Reject:
+            return {
+                date: payload.date,
+                preferences: updatePreference(
+                    PreferenceType.Analytics,
+                    false,
+                    state.preferences
+                ),
             }
         default:
             return state

--- a/site/CookiePreferencesManager.tsx
+++ b/site/CookiePreferencesManager.tsx
@@ -24,7 +24,7 @@ export interface Preference {
     value: boolean
 }
 
-export const POLICY_DATE: number = 20230725
+export const POLICY_DATE: number = 20201009
 export const DATE_FORMAT = "YYYYMMDD"
 const COOKIE_NAME = "cookie_preferences"
 const PREFERENCES_SEPARATOR = "|"

--- a/site/CookiePreferencesManager.tsx
+++ b/site/CookiePreferencesManager.tsx
@@ -21,7 +21,7 @@ export interface Preference {
     value: boolean
 }
 
-export const POLICY_DATE: number = 20201009
+export const POLICY_DATE: number = 20230725
 export const DATE_FORMAT = "YYYYMMDD"
 const COOKIE_NAME = "cookie_preferences"
 const PREFERENCES_SEPARATOR = "|"
@@ -38,7 +38,7 @@ const defaultState: State = {
     preferences: [
         {
             type: PreferenceType.Analytics,
-            value: true,
+            value: false,
         },
     ],
 }

--- a/site/CookiePreferencesManager.tsx
+++ b/site/CookiePreferencesManager.tsx
@@ -44,7 +44,7 @@ const defaultState: State = {
 }
 
 export const CookiePreferencesManager = ({
-    initialState = defaultState,
+    initialState,
 }: {
     initialState: State
 }) => {
@@ -117,7 +117,10 @@ const reducer = (
 }
 
 const getInitialState = (): State => {
-    return parseRawCookieValue(Cookies.get(COOKIE_NAME)) ?? defaultState
+    const cookieValue = parseRawCookieValue(Cookies.get(COOKIE_NAME))
+    if (!cookieValue || arePreferencesOutdated(cookieValue.date, POLICY_DATE))
+        return defaultState
+    return cookieValue
 }
 
 export const parseRawCookieValue = (cookieValue?: string) => {

--- a/site/Head.tsx
+++ b/site/Head.tsx
@@ -1,5 +1,33 @@
 import React from "react"
 import { VITE_ASSET_SITE_ENTRY, viteAssets } from "./viteUtils.js"
+import { GOOGLE_TAG_MANAGER_ID } from "../settings/clientSettings.js"
+
+export const GTMScriptTags = ({ gtmId }: { gtmId: string }) => {
+    if (!gtmId || /["']/.test(gtmId)) return null
+    return (
+        <>
+            <script
+                dangerouslySetInnerHTML={{
+                    __html: `/* Prepare Google Tag Manager */
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag("consent","default",{"ad_storage":"denied","analytics_storage":"denied"});
+`,
+                }}
+            />
+            <script
+                dangerouslySetInnerHTML={{
+                    __html: `/* Load Google Tag Manager */
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${gtmId}');`,
+                }}
+            />
+        </>
+    )
+}
 
 export const Head = (props: {
     canonicalUrl: string
@@ -55,6 +83,7 @@ export const Head = (props: {
             <meta name="twitter:image" content={imageUrl} />
             {stylesheets}
             {props.children}
+            <GTMScriptTags gtmId={GOOGLE_TAG_MANAGER_ID} />
         </head>
     )
 }

--- a/site/Head.tsx
+++ b/site/Head.tsx
@@ -11,7 +11,7 @@ export const GTMScriptTags = ({ gtmId }: { gtmId: string }) => {
                     __html: `/* Prepare Google Tag Manager */
 window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}
-gtag("consent","default",{"ad_storage":"denied","analytics_storage":"denied"});
+gtag("consent","default",{"ad_storage":"denied","analytics_storage":"denied","wait_for_update":1000});
 `,
                 }}
             />

--- a/site/blocks/CookiePreferences.scss
+++ b/site/blocks/CookiePreferences.scss
@@ -2,6 +2,10 @@
     @include block-spacing;
     border: 2px solid $oxford-blue;
 
+    h2 {
+        margin-top: 0;
+    }
+
     .last-updated {
         font-size: 0.9rem;
     }

--- a/site/blocks/CookiePreferences.tsx
+++ b/site/blocks/CookiePreferences.tsx
@@ -80,6 +80,7 @@ export const CookiePreferences = ({
 
     return ReactDOM.createPortal(
         <div data-test="cookie-preferences" className="cookie-preferences">
+            <h2>Cookie preferences</h2>
             <CookiePreference
                 title="Necessary cookies"
                 name="necessary"
@@ -107,10 +108,11 @@ export const CookiePreferences = ({
                     })
                 }
             >
-                We use these cookies to monitor website usage and performance,
-                helping us prioritize and demonstrate the reach of our work.{" "}
-                <br />
-                We are a non-profit and don't sell any of your data.
+                With your consent we use cookies to better understand how you
+                interact with our website. This helps us prioritize our work,
+                improve our navigation and search, and demonstrate the reach of
+                our work. As a non-profit organization we take your privacy
+                seriously and do not sell your data to any third parties.
             </CookiePreference>
             {date ? (
                 <div className="last-updated">

--- a/site/blocks/CookiePreferences.tsx
+++ b/site/blocks/CookiePreferences.tsx
@@ -122,17 +122,16 @@ export const CookiePreferences = ({
                     className="owid-button"
                     onClick={() =>
                         dispatch({
-                            type: Action.Accept,
+                            type: Action.Persist,
                             payload: { date: getTodayDate() },
                         })
                     }
-                    data-test="accept"
                     data-track-note={ANALYTICS_ACTION}
                 >
                     <span className="icon">
                         <FontAwesomeIcon icon={faCheck} />
                     </span>
-                    I agree
+                    Save preferences
                 </button>
             )}
         </div>,

--- a/site/blocks/CookiePreferences.tsx
+++ b/site/blocks/CookiePreferences.tsx
@@ -107,7 +107,10 @@ export const CookiePreferences = ({
                     })
                 }
             >
-                We use these cookies to monitor and improve website performance.
+                We use these cookies to monitor website usage and performance,
+                helping us prioritize and demonstrate the reach of our work.{" "}
+                <br />
+                We are a non-profit and don't sell any of your data.
             </CookiePreference>
             {date ? (
                 <div className="last-updated">

--- a/site/css/cookie-notice.scss
+++ b/site/css/cookie-notice.scss
@@ -29,9 +29,10 @@
     }
 
     .cookie-notice__text {
+        margin: 0;
+
         @include lg-up {
             text-align: left;
-            margin: 0;
         }
     }
 
@@ -57,7 +58,7 @@
         border: 2px solid rgba($text-color, 0.2);
         transition: border-color 150ms linear;
         margin-top: 8px;
-        min-width: 196px;
+        background-color: transparent;
 
         @include md-up {
             flex: 0;
@@ -83,6 +84,7 @@
         border-color: $oxford-blue;
         color: #fff;
         transition: background-color 150ms linear, border-color 150ms linear;
+        min-width: 196px;
 
         &:hover {
             background-color: $oxford-blue;

--- a/site/owid.entry.ts
+++ b/site/owid.entry.ts
@@ -19,11 +19,15 @@ import { Grapher, CookieKey } from "@ourworldindata/grapher"
 import { MultiEmbedderSingleton } from "../site/multiembedder/MultiEmbedder.js"
 import { CoreTable } from "@ourworldindata/core-table"
 import { SiteAnalytics } from "./SiteAnalytics.js"
-import Bugsnag from "@bugsnag/js"
+import Bugsnag, { BrowserConfig } from "@bugsnag/js"
 import BugsnagPluginReact from "@bugsnag/plugin-react"
 import BugsnagPerformance from "@bugsnag/browser-performance"
 import { runMonkeyPatchForGoogleTranslate } from "./hacks.js"
 import { runSiteFooterScripts } from "./runSiteFooterScripts.js"
+import {
+    PreferenceType,
+    getPreferenceValue,
+} from "./CookiePreferencesManager.js"
 
 declare let window: any
 window.Grapher = Grapher
@@ -46,11 +50,33 @@ runMonkeyPatchForGoogleTranslate()
 
 if (BUGSNAG_API_KEY) {
     try {
+        const analyticsConsent = getPreferenceValue(PreferenceType.Analytics)
+
+        let bugsnagUserInformation: Pick<
+            BrowserConfig,
+            "generateAnonymousId" | "user"
+        >
+        if (analyticsConsent) {
+            bugsnagUserInformation = {
+                generateAnonymousId: true, // gets saved to localStorage, which we only want if the user has consented to analytics
+            }
+        } else {
+            bugsnagUserInformation = {
+                generateAnonymousId: false,
+                user: {
+                    // generates a random 10-character string
+                    // we use it so we can at least identify multiple errors from the same user on a single page, albeit not across pages
+                    id: Math.random().toString(36).substring(2, 12),
+                },
+            }
+        }
+
         Bugsnag.start({
             apiKey: BUGSNAG_API_KEY,
             plugins: [new BugsnagPluginReact()],
             autoTrackSessions: false,
             collectUserIp: false,
+            ...bugsnagUserInformation,
         })
 
         const instrumentNetworkRequests = Math.random() < 0.05 // 5% sample rate
@@ -59,6 +85,7 @@ if (BUGSNAG_API_KEY) {
             autoInstrumentFullPageLoads: false, // TODO: We might want to sample some page loads in the future
             autoInstrumentRouteChanges: false,
             autoInstrumentNetworkRequests: instrumentNetworkRequests,
+            generateAnonymousId: false,
         })
     } catch (error) {
         console.error("Failed to initialize Bugsnag")

--- a/site/owid.entry.ts
+++ b/site/owid.entry.ts
@@ -49,6 +49,8 @@ if (BUGSNAG_API_KEY) {
         Bugsnag.start({
             apiKey: BUGSNAG_API_KEY,
             plugins: [new BugsnagPluginReact()],
+            autoTrackSessions: false,
+            collectUserIp: false,
         })
 
         const instrumentNetworkRequests = Math.random() < 0.05 // 5% sample rate

--- a/site/search/searchClient.ts
+++ b/site/search/searchClient.ts
@@ -25,8 +25,7 @@ const getInsightsClient = (): InsightsClient => {
         insightsClient("init", {
             appId: ALGOLIA_ID,
             apiKey: ALGOLIA_SEARCH_KEY,
-            userHasOptedOut: !getPreferenceValue(PreferenceType.Analytics),
-            useCookie: true, // insightsClient doesn't set the cookie when userHasOptedOut is true
+            useCookie: getPreferenceValue(PreferenceType.Analytics),
         })
         insightsInitialized = true
     }


### PR DESCRIPTION
Resolves #2441.

[A detailed description of what changes is in Notion.](https://www.notion.so/owid/2023-07-26-Proposed-analytics-behaviour-f358d586378b48819665362293d9bb87?pvs=4)

TODOs:
- [ ] (Maybe) Change the flow on the privacy policy page so the user _always_ has to click the "Save preferences" button, and clicks on the checkbox don't auto-persist.
    - I think the current behavior there could be confusing, because the "Save preferences" button just disappears and it isn't clear that they are in fact persisted automatically. 

TODOs when deploying:
- [ ] Notify `analytics-and-seo` Slack channel of the change, so we can check for the effects on metrics
- [x] Set `GOOGLE_TAG_MANAGER_ID` in `.env`
- [ ] Remove the injection of GTM from Netlify config
- [ ] Update GTM:
	- [ ] Remove all existing "Block if consent denied" exceptions from tags
	- [ ] Ensure that GA4 shows modelled behavior (see Section "Show or hide modeled data in reports" [here](https://support.google.com/analytics/answer/11161109)) - apparently it takes 7 days for the first modelled data to show up
