### PR TITLE
🐛 fix double-URI-encoding of image src in lightbox

### DIFF
--- a/site/Lightbox.tsx
+++ b/site/Lightbox.tsx
@@ -121,7 +121,7 @@ const Image = ({
                 className={cx({
                     "lightbox__img--is-svg": src.endsWith(".svg"),
                 })}
-                src={encodeURI(src)}
+                src={src}
                 alt={alt}
                 style={{ opacity: !isLoaded ? 0 : 1, transition: "opacity 1s" }}
             />
@@ -145,7 +145,9 @@ export const runLightbox = () => {
 
         img.classList.add("lightbox-enabled")
         img.addEventListener("click", () => {
-            const imgSrc = img.getAttribute("data-high-res-src") ?? img.src
+            // getAttribute doesn't automatically URI encode values, img.src does
+            const highResSrc = img.getAttribute("data-high-res-src")
+            const imgSrc = highResSrc ? encodeURI(highResSrc) : img.src
             const imgAlt = img.alt
             if (imgSrc) {
                 ReactDOM.render(


### PR DESCRIPTION
The [recent fix for filenames with spaces in them](https://github.com/owid/owid-grapher/pull/2497/files) introduced a sneaky little bug to `runLightbox` causing [lightbox views not to work](https://ourworldindata.org/limits-personal-experience) in Gdocs.

Extracting the src for the image from `img.src` automatically URI encodes the output

So when we changed `<Image />` to automatically URIEncode whichever `imgSrc` was passed to it, we were _double_ encoding the string in the cases where it was coming from `img.src`

`getAttribute` doesn't automatically URI encode strings, so we still need to make sure those strings are encoded.

https://github.com/owid/owid-grapher/assets/11844404/b66b2c33-3600-45ac-810b-005a41a55943

To test this behaviour you can run the following in your browser's console on any real webpage (running in `about:blank` doesn't create the image properly):
```js
let img = document.createElement('img') 
img.src = "something with spaces" 
console.log("img.src", img.src)
console.log("img.getAttribute('src')", img.getAttribute('src'))

```

