### PR TITLE
migrate: get rid of `$.map.variableId` in favor of `$.map.columnSlug`

### DIFF
--- a/adminSiteClient/EditorMapTab.tsx
+++ b/adminSiteClient/EditorMapTab.tsx
@@ -6,31 +6,21 @@ import {
     MapProjectionLabels,
     MapProjectionName,
 } from "@ourworldindata/grapher"
-import {
-    isEmpty,
-    OwidVariableId,
-    ToleranceStrategy,
-} from "@ourworldindata/utils"
+import { ColumnSlug, isEmpty, ToleranceStrategy } from "@ourworldindata/utils"
 import { action, computed } from "mobx"
 import { observer } from "mobx-react"
 import React from "react"
 import { ChartEditor } from "./ChartEditor.js"
 import { EditorColorScaleSection } from "./EditorColorScaleSection.js"
-import {
-    NumberField,
-    NumericSelectField,
-    Section,
-    SelectField,
-    Toggle,
-} from "./Forms.js"
+import { NumberField, Section, SelectField, Toggle } from "./Forms.js"
 
 @observer
 class VariableSection extends React.Component<{
     mapConfig: MapConfig
     filledDimensions: ChartDimension[]
 }> {
-    @action.bound onVariableId(variableId: OwidVariableId) {
-        this.props.mapConfig.columnSlug = variableId.toString()
+    @action.bound onColumnSlug(columnSlug: ColumnSlug) {
+        this.props.mapConfig.columnSlug = columnSlug
     }
 
     @action.bound onProjection(projection: string | undefined) {
@@ -52,18 +42,14 @@ class VariableSection extends React.Component<{
 
         return (
             <Section name="Map">
-                <NumericSelectField
+                <SelectField
                     label="Indicator"
-                    value={
-                        mapConfig.columnSlug
-                            ? parseInt(mapConfig.columnSlug)
-                            : undefined
-                    }
+                    value={mapConfig.columnSlug}
                     options={filledDimensions.map((d) => ({
-                        value: d.variableId,
+                        value: d.columnSlug,
                         label: d.column.displayName,
                     }))}
-                    onValue={this.onVariableId}
+                    onValue={this.onColumnSlug}
                 />
                 <SelectField
                     label="Region"

--- a/adminSiteClient/VariablesAnnotationPage.tsx
+++ b/adminSiteClient/VariablesAnnotationPage.tsx
@@ -147,7 +147,7 @@ const config: GrapherConfigGridEditorConfig = {
         version: 1,
         dimensions: [{ property: DimensionProperty.y, variableId: id }],
         map: {
-            variableId: id,
+            columnSlug: `${id}`,
         },
     }),
 }

--- a/adminSiteClient/VariablesAnnotationPage.tsx
+++ b/adminSiteClient/VariablesAnnotationPage.tsx
@@ -146,9 +146,6 @@ const config: GrapherConfigGridEditorConfig = {
     finalVariableLayerModificationFn: (id: number) => ({
         version: 1,
         dimensions: [{ property: DimensionProperty.y, variableId: id }],
-        map: {
-            columnSlug: `${id}`,
-        },
     }),
 }
 

--- a/db/migration/1690810237148-RemoveMapVariableId.ts
+++ b/db/migration/1690810237148-RemoveMapVariableId.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class RemoveMapVariableId1690810237148 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const tables = {
+            suggested_chart_revisions: "suggestedConfig",
+            chart_revisions: "config",
+            charts: "config",
+        }
+
+        for (const [tableName, columnName] of Object.entries(tables)) {
+            await queryRunner.query(`-- sql
+                UPDATE ${tableName}
+                SET ${columnName} = JSON_REMOVE(
+                    JSON_SET(
+                        ${columnName},
+                        "$.map.columnSlug",
+                        CAST(${columnName} ->> "$.map.variableId" AS CHAR(10))
+                    ),
+                    "$.map.variableId"
+                )
+                WHERE ${columnName} ->> "$.map.variableId" IS NOT NULL
+            `)
+        }
+    }
+
+    public async down(_queryRunner: QueryRunner): Promise<void> {
+        return
+    }
+}

--- a/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
@@ -904,14 +904,6 @@ describe("year parameter (applies to map only)", () => {
     })
 })
 
-// TODO migrate the database property
-it("migrates map.targetYear correctly", () => {
-    const grapher = new Grapher({
-        map: { targetYear: 2005 } as any,
-    })
-    expect(grapher.map.time).toEqual(2005)
-})
-
 it("correctly identifies activeColumnSlugs", () => {
     const table =
         new OwidTable(`entityName,entityId,entityColor,year,gdp,gdp-annotations,child_mortality,population,continent,happiness

--- a/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherInterface.ts
@@ -22,7 +22,7 @@ import {
 import { ComparisonLineConfig } from "../scatterCharts/ComparisonLine"
 import { LogoOption } from "../captionedChart/Logos"
 import { ColorScaleConfigInterface } from "../color/ColorScaleConfig"
-import { MapConfigWithLegacyInterface } from "../mapCharts/MapConfig"
+import { MapConfigInterface } from "../mapCharts/MapConfig"
 import { ColumnSlugs, Time, EntityName } from "@ourworldindata/core-table"
 import { ColorSchemeName } from "../color/ColorConstants"
 
@@ -90,7 +90,7 @@ export interface GrapherInterface extends SortConfig {
     xAxis?: Partial<AxisConfigInterface>
     yAxis?: Partial<AxisConfigInterface>
     colorScale?: Partial<ColorScaleConfigInterface>
-    map?: Partial<MapConfigWithLegacyInterface>
+    map?: Partial<MapConfigInterface>
 
     // When we move graphers to Git, and remove dimensions, we can clean this up.
     ySlugs?: ColumnSlugs

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapConfig.test.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapConfig.test.ts
@@ -14,11 +14,3 @@ it("can serialize for saving", () => {
         projection: "Africa",
     })
 })
-
-it("works with legacy variableId", () => {
-    const map = new MapConfig({ variableId: 23 })
-    expect(map.columnSlug).toEqual("23")
-    expect(map.toObject()).toEqual({
-        variableId: 23,
-    })
-})

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapConfig.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapConfig.ts
@@ -33,45 +33,24 @@ class MapConfigDefaults {
 
 export type MapConfigInterface = MapConfigDefaults
 
-export interface MapConfigWithLegacyInterface extends MapConfigInterface {
-    variableId?: OwidVariableId
-    targetYear?: number
-}
-
 export class MapConfig extends MapConfigDefaults implements Persistable {
-    updateFromObject(obj: Partial<MapConfigWithLegacyInterface>): void {
-        // Migrate variableIds to columnSlugs
-        if (obj.variableId && !obj.columnSlug)
-            obj.columnSlug = obj.variableId.toString()
-
+    updateFromObject(obj: Partial<MapConfigInterface>): void {
         updatePersistables(this, obj)
 
-        // Migrate "targetYear" to "time"
-        // TODO migrate the database property instead
-        if (obj.targetYear)
-            this.time = maxTimeBoundFromJSONOrPositiveInfinity(obj.targetYear)
-        else if (obj.time)
+        if (obj.time)
             this.time = maxTimeBoundFromJSONOrPositiveInfinity(obj.time)
     }
 
-    toObject(): NoUndefinedValues<MapConfigWithLegacyInterface> {
-        const obj = objectWithPersistablesToObject(
-            this
-        ) as MapConfigWithLegacyInterface
+    toObject(): NoUndefinedValues<MapConfigInterface> {
+        const obj = objectWithPersistablesToObject(this) as MapConfigInterface
         deleteRuntimeAndUnchangedProps(obj, new MapConfigDefaults())
 
         if (obj.time) obj.time = maxTimeToJSON(this.time) as any
 
-        if (obj.columnSlug) {
-            // Restore variableId for legacy for now
-            obj.variableId = parseInt(obj.columnSlug)
-            delete obj.columnSlug
-        }
-
         return trimObject(obj)
     }
 
-    constructor(obj?: Partial<MapConfigWithLegacyInterface>) {
+    constructor(obj?: Partial<MapConfigInterface>) {
         super()
         if (obj) this.updateFromObject(obj)
     }

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapConfig.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapConfig.ts
@@ -3,7 +3,6 @@ import { MapProjectionName } from "./MapProjections"
 import { ColorScaleConfig } from "../color/ColorScaleConfig"
 import {
     ColumnSlug,
-    OwidVariableId,
     Persistable,
     updatePersistables,
     objectWithPersistablesToObject,

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
@@ -258,15 +258,9 @@ properties:
                     - type: string
                       enum:
                           - latest
-            variableId:
-                # TODO: remove this once we have a convention of using the first y dimension instead"
-                type: integer
-                description: "Variable ID to show."
-                maximum: 2147483647
-                minimum: 0
             columnSlug:
                 # TODO: remove this once we have a convention of using the first y dimension instead
-                description: "Variable ID to show (similar to variableId)."
+                description: "Column to show in the map tab. Can be a column slug (e.g. in explorers) or a variable ID (as string)."
                 type: string
         additionalProperties: false
     maxTime:


### PR DESCRIPTION
Gets rid of some legacy conversion code.

I went for `columnSlug` over `variableId` because it's more flexible in general, and can in theory be used in explorers, too.