### PR TITLE
fix(md-parser): can parse a link inside parens

### DIFF
--- a/packages/@ourworldindata/utils/src/MarkdownTextWrap/parser.test.ts
+++ b/packages/@ourworldindata/utils/src/MarkdownTextWrap/parser.test.ts
@@ -9,7 +9,11 @@ describe("mdast parsers", () => {
                 children: [
                     {
                         type: "text",
-                        value: "[some",
+                        value: "[",
+                    },
+                    {
+                        type: "text",
+                        value: "some",
                     },
                     {
                         type: "whitespace",
@@ -17,7 +21,11 @@ describe("mdast parsers", () => {
 
                     {
                         type: "text",
-                        value: "text]",
+                        value: "text",
+                    },
+                    {
+                        type: "text",
+                        value: "]",
                     },
                 ],
             },
@@ -893,6 +901,34 @@ how **are** you?`)
                     {
                         type: "text",
                         value: "but-the-newline-should-be-tracked-separately",
+                    },
+                ],
+            },
+        })
+    })
+    it("parses link inside parentheses", () => {
+        expect(mdParser.markdown.parse("([link](www.google.com))")).toEqual({
+            status: true,
+            value: {
+                type: "MarkdownRoot",
+                children: [
+                    {
+                        type: "text",
+                        value: "(",
+                    },
+                    {
+                        type: "markdownLink",
+                        children: [
+                            {
+                                type: "text",
+                                value: "link",
+                            },
+                        ],
+                        href: "www.google.com",
+                    },
+                    {
+                        type: "text",
+                        value: ")",
                     },
                 ],
             },

--- a/packages/@ourworldindata/utils/src/MarkdownTextWrap/parser.test.ts
+++ b/packages/@ourworldindata/utils/src/MarkdownTextWrap/parser.test.ts
@@ -934,4 +934,19 @@ how **are** you?`)
             },
         })
     })
+
+    it("parses too many underscores as text", () => {
+        expect(mdParser.markdown.parse("____abc__")).toEqual({
+            status: true,
+            value: {
+                type: "MarkdownRoot",
+                children: [
+                    {
+                        type: "text",
+                        value: "____abc__",
+                    },
+                ],
+            },
+        })
+    })
 })

--- a/packages/@ourworldindata/utils/src/MarkdownTextWrap/parser.test.ts
+++ b/packages/@ourworldindata/utils/src/MarkdownTextWrap/parser.test.ts
@@ -977,23 +977,7 @@ how **are** you?`)
                         children: [
                             {
                                 type: "text",
-                                value: "l",
-                            },
-                            {
-                                type: "text",
-                                value: "(",
-                            },
-                            {
-                                type: "text",
-                                value: "i",
-                            },
-                            {
-                                type: "text",
-                                value: ")",
-                            },
-                            {
-                                type: "text",
-                                value: "nk",
+                                value: "l(i)nk",
                             },
                         ],
                         href: "www.google.com",

--- a/packages/@ourworldindata/utils/src/MarkdownTextWrap/parser.test.ts
+++ b/packages/@ourworldindata/utils/src/MarkdownTextWrap/parser.test.ts
@@ -906,6 +906,34 @@ how **are** you?`)
             },
         })
     })
+    it("parses link inside brackets", () => {
+        expect(mdParser.markdown.parse("[[link](www.google.com)]")).toEqual({
+            status: true,
+            value: {
+                type: "MarkdownRoot",
+                children: [
+                    {
+                        type: "text",
+                        value: "[",
+                    },
+                    {
+                        type: "markdownLink",
+                        children: [
+                            {
+                                type: "text",
+                                value: "link",
+                            },
+                        ],
+                        href: "www.google.com",
+                    },
+                    {
+                        type: "text",
+                        value: "]",
+                    },
+                ],
+            },
+        })
+    })
     it("parses link inside parentheses", () => {
         expect(mdParser.markdown.parse("([link](www.google.com))")).toEqual({
             status: true,
@@ -922,6 +950,50 @@ how **are** you?`)
                             {
                                 type: "text",
                                 value: "link",
+                            },
+                        ],
+                        href: "www.google.com",
+                    },
+                    {
+                        type: "text",
+                        value: ")",
+                    },
+                ],
+            },
+        })
+    })
+    it("parses parens inside link inside parentheses", () => {
+        expect(mdParser.markdown.parse("([l(i)nk](www.google.com))")).toEqual({
+            status: true,
+            value: {
+                type: "MarkdownRoot",
+                children: [
+                    {
+                        type: "text",
+                        value: "(",
+                    },
+                    {
+                        type: "markdownLink",
+                        children: [
+                            {
+                                type: "text",
+                                value: "l",
+                            },
+                            {
+                                type: "text",
+                                value: "(",
+                            },
+                            {
+                                type: "text",
+                                value: "i",
+                            },
+                            {
+                                type: "text",
+                                value: ")",
+                            },
+                            {
+                                type: "text",
+                                value: "nk",
                             },
                         ],
                         href: "www.google.com",

--- a/packages/@ourworldindata/utils/src/MarkdownTextWrap/parser.ts
+++ b/packages/@ourworldindata/utils/src/MarkdownTextWrap/parser.ts
@@ -211,8 +211,11 @@ export type EveryMarkdownNode =
 // #endregion
 
 //#region Terminal parsers
-const fallbackTextParser = (): P.Parser<Text> =>
-    P.regex(/[^\s]+/).map((val) => ({ type: "text", value: val }))
+const wordWithoutParensParser = (): P.Parser<Text> =>
+    P.regex(/[^\s\(\)\[\]]+/).map((val) => ({ type: "text", value: val }))
+
+const singleParenParser = (): P.Parser<Text> =>
+    P.regex(/[\(\)\[\]]/).map((val) => ({ type: "text", value: val }))
 
 const newlineParser = (): P.Parser<Newline> =>
     P.regex(/\n/).result({ type: "newline" })
@@ -262,8 +265,8 @@ const nonDoubleStarWordParser: (
 ) => P.Parser<NonDoubleStarWord> = () =>
     P.regex(/([^*\s]|\*(?!\*))+/).map((val) => ({ type: "text", value: val })) // no WS, no **
 
-const nonStylingCharactersParser: (r: MdParser) => P.Parser<Text> = () =>
-    P.regex(/[^\s*_]+/).map((value) => ({ type: "text", value })) // Consume up to * or _
+const nonSpecialCharactersParser: (r: MdParser) => P.Parser<Text> = () =>
+    P.regex(/[^\s*_\(\)\[\]]+/).map((value) => ({ type: "text", value })) // Consume up to one of *_()[]
 
 const dodCategoryParser: (r: MdParser) => P.Parser<DodCategory> = () =>
     P.regex(/([^\(\):\s]|:(?!:))+/).map((val) => ({
@@ -386,7 +389,7 @@ const boldContentParser: (r: MdParser) => P.Parser<BoldContent> = (
         r.detailOnDemand,
         r.markdownLink,
         r.plainUrl,
-        r.nonStylingCharacters
+        r.nonSpecialCharacters
     )
 
 const boldParser: (r: MdParser) => P.Parser<Bold> = (r: MdParser) =>
@@ -430,7 +433,7 @@ const italicWithoutBoldContentParser: (
         r.detailOnDemand,
         r.markdownLink,
         r.plainUrl,
-        r.nonStylingCharacters
+        r.nonSpecialCharacters
     )
 
 const italicWithoutBoldParser: (r: MdParser) => P.Parser<ItalicWithoutBold> = (
@@ -455,7 +458,7 @@ const italicContentParser: (r: MdParser) => P.Parser<ItalicContent> = (
         r.detailOnDemand,
         r.markdownLink,
         r.plainUrl,
-        r.nonStylingCharacters
+        r.nonSpecialCharacters
     )
 
 const italicParser: (r: MdParser) => P.Parser<Italic> = (r: MdParser) =>
@@ -506,9 +509,10 @@ const markdownParser: (r: MdParser) => P.Parser<MarkdownRoot> = (r) =>
         r.bold,
         r.italic,
         // Consume up to ** or _, if possible
-        r.nonStylingCharacters,
+        r.nonSpecialCharacters,
         // Otherwise consume everything
-        r.fallbackText
+        r.wordWithoutParens,
+        r.singleParen
     )
         .atLeast(1)
         .map(
@@ -530,7 +534,8 @@ const languageParts = {
     italic: italicParser,
     plainBold: plainBoldParser,
     plainItalic: plainItalicParser,
-    fallbackText: fallbackTextParser,
+    wordWithoutParens: wordWithoutParensParser,
+    singleParen: singleParenParser,
     // Utility parsers below - these will never be tried on the top level because text covers everything else
     detailOnDemandContent: detailOnDemandContentParser,
     markdownLinkContent: markdownLinkContentParser,
@@ -546,7 +551,7 @@ const languageParts = {
     nonParensWord: nonParensWordParser,
     nonDoubleColonOrParensWord: nonDoubleColonOrParensWordParser,
     nonDoubleStarWord: nonDoubleStarWordParser,
-    nonStylingCharacters: nonStylingCharactersParser,
+    nonSpecialCharacters: nonSpecialCharactersParser,
     nonSingleUnderscoreWord: nonSingleUnderscoreWordParser,
     dodCategory: dodCategoryParser,
     dodTerm: dodTermParser,


### PR DESCRIPTION
Fixes #2318.

Changes it so parens and brackets (`()[]`) are always consumed a single token at a time, and never as part of a word. This fixes the underlying issue.
The tokens we get out of that are now slightly different - as you can see in the one test case I had to adapt - but that shouldn't make any difference when rendered.