### PR TITLE
Always show missing data section in the admin for stacked area/bar charts

### DIFF
--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -1,5 +1,6 @@
 import { computed } from "mobx"
 import { ChartEditor } from "./ChartEditor.js"
+import { EntitySelectionMode } from "@ourworldindata/grapher"
 
 // Responsible for determining what parts of the editor should be shown, based on the
 // type of chart being edited
@@ -102,16 +103,26 @@ export class EditorFeatures {
     }
 
     @computed get canSpecifyMissingDataStrategy() {
-        return (
-            this.grapher.hasMultipleYColumns &&
-            (this.grapher.canChangeEntity ||
-                this.grapher.canSelectMultipleEntities) &&
-            (this.grapher.isStackedArea ||
-                this.grapher.isStackedBar ||
-                this.grapher.isStackedDiscreteBar ||
-                this.grapher.isDiscreteBar ||
-                this.grapher.isLineChart)
-        )
+        if (!this.grapher.hasMultipleYColumns) return false
+
+        if (this.grapher.isStackedArea || this.grapher.isStackedBar) {
+            return true
+        }
+
+        // for line charts and discrete bar charts, specifying a missing
+        // data strategy only makes sense if there are multiple entities
+        if (
+            this.grapher.isLineChart ||
+            this.grapher.isDiscreteBar ||
+            this.grapher.isStackedDiscreteBar
+        ) {
+            return (
+                this.grapher.canChangeEntity ||
+                this.grapher.canSelectMultipleEntities
+            )
+        }
+
+        return false
     }
 
     @computed get showChangeInPrefixToggle() {

--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -1,6 +1,5 @@
 import { computed } from "mobx"
 import { ChartEditor } from "./ChartEditor.js"
-import { EntitySelectionMode } from "@ourworldindata/grapher"
 
 // Responsible for determining what parts of the editor should be shown, based on the
 // type of chart being edited


### PR DESCRIPTION
- Problem: The data missing section does not show up for [this draft chart](https://staging.owid.cloud/admin/charts/6457/edit)
- Reason: The chart has a single entity, but the data missing section only shows up for charts with multiple entities
- Solution:
    - For line charts, discrete bar charts and stacked discrete bar charts, it makes sense to show the data missing section only if there are multiple entities
    - But for stacked area and stacked bar charts this is too restrictive as the data missing strategy not only shows/hides entities but also has an effect on visible charts