### PR TITLE
:hammer: replace variables.dataPath and variables.metadataPath by env DATA_API_URL

### DIFF
--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -294,15 +294,15 @@ const renderGrapherPage = async (grapher: GrapherInterface) => {
     )
 }
 
-interface BakeVariableDataArguments {
+interface CheckVariableDataArguments {
     bakedSiteDir: string
     checksumsDir: string
     variableId: number
 }
 
-export const bakeVariableData = async (
-    bakeArgs: BakeVariableDataArguments
-): Promise<BakeVariableDataArguments> => {
+export const checkVariableData = async (
+    bakeArgs: CheckVariableDataArguments
+): Promise<CheckVariableDataArguments> => {
     const { dataPath, metadataPath } = await getOwidVariableDataAndMetadataPath(
         bakeArgs.variableId
     )
@@ -415,10 +415,9 @@ export const bakeAllPublishedChartsVariableDataAndMetadata = async (
         }
     )
 
-    // NOTE: we don't bake data, just make sure it exists on S3
     await Promise.all(
         variableIds.map(async (variableId) => {
-            await bakeVariableData({
+            await checkVariableData({
                 bakedSiteDir,
                 variableId,
                 checksumsDir,

--- a/db/Variable.test.ts
+++ b/db/Variable.test.ts
@@ -37,14 +37,6 @@ describe("writeVariableCSV", () => {
         const spy = jest.spyOn(Variable, "readSQLasDF")
         if (variablesDf) spy.mockResolvedValueOnce(variablesDf)
 
-        jest.spyOn(db, "queryMysql").mockResolvedValueOnce(
-            [
-                { id: 1, dataPath: "datapath1", metadataPath: "datapath1" },
-                { id: 2, dataPath: "datapath2", metadataPath: "datapath2" },
-                { id: 3, dataPath: "datapath3", metadataPath: "datapath3" },
-            ].filter((row) => variableIds.includes(row.id))
-        )
-
         if (s3data) mockS3data(s3data)
 
         let out = ""

--- a/db/migration/1691071996006-RemoveDataPathandMetadataPathFromVariables.ts
+++ b/db/migration/1691071996006-RemoveDataPathandMetadataPathFromVariables.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class RemoveDataPathandMetadataPathFromVariables1691071996006
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE variables
+              DROP COLUMN dataPath,
+              DROP COLUMN metadataPath;
+            `
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE variables
+              ADD COLUMN dataPath TEXT,
+              ADD COLUMN metadataPath TEXT;
+            `
+        )
+
+        await queryRunner.query(`
+            UPDATE variables SET
+                dataPath = CONCAT('https://api.ourworldindata.org/v1/indicators/', id, '.data.json'),
+                metadataPath = CONCAT('https://api.ourworldindata.org/v1/indicators/', id, '.metadata.json')
+            `)
+    }
+}

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -146,7 +146,7 @@ export async function getVariableData(
     )
 
     const [data, metadata] = await Promise.all([
-        fetchS3ValuesByPath(dataPath),
+        fetchS3DataValuesByPath(dataPath),
         fetchS3MetadataByPath(metadataPath),
     ])
 
@@ -438,10 +438,10 @@ export const fetchS3Values = async (
     if (!metadataPath) {
         throw new Error(`Missing metadataPath for variable ${variableId}`)
     }
-    return fetchS3ValuesByPath(dataPath)
+    return fetchS3DataValuesByPath(dataPath)
 }
 
-export const fetchS3ValuesByPath = async (
+export const fetchS3DataValuesByPath = async (
     dataPath: string
 ): Promise<OwidVariableMixedData> => {
     const resp = await retryPromise(() => fetch(dataPath, { keepalive: true }))

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -14,8 +14,13 @@ import {
     retryPromise,
     OwidLicense,
 } from "@ourworldindata/utils"
-import { GrapherInterface } from "@ourworldindata/grapher"
+import {
+    GrapherInterface,
+    getVariableDataRoute,
+    getVariableMetadataRoute,
+} from "@ourworldindata/grapher"
 import pl from "nodejs-polars"
+import { DATA_API_URL } from "../../settings/serverSettings.js"
 
 export interface VariableRow {
     id: number
@@ -34,8 +39,6 @@ export interface VariableRow {
     timespan?: string
     columnOrder?: number
     catalogPath?: string
-    dataPath?: string
-    metadataPath?: string
     dimensions?: Dimensions
     schemaVersion?: number
     processingLevel?: "minor" | "major"
@@ -385,60 +388,24 @@ export const _dataAsDFfromS3 = async (
 export const dataAsDF = async (
     variableIds: OwidVariableId[]
 ): Promise<pl.DataFrame> => {
-    // return variables values as a DataFrame from S3
-    const rows = await db.queryMysql(
-        `
-    SELECT
-        id,
-        dataPath
-    FROM variables
-    WHERE id in (?)
-    `,
-        [variableIds]
-    )
-
-    // variables with dataPath are stored in S3
-    const variableIdsWithDataPath = rows
-        .filter((row: any) => row.dataPath)
-        .map((row: any) => row.id)
-
-    const variableIdsWithoutDataPath = rows
-        .filter((row: any) => !row.dataPath)
-        .map((row: any) => row.id)
-
-    // variables without dataPath shouldn't exist!
-    if (variableIdsWithoutDataPath.length > 0)
-        throw new Error(
-            `Variables ${variableIdsWithoutDataPath} are missing dataPath`
-        )
-
-    return _dataAsDFfromS3(variableIdsWithDataPath)
+    return _dataAsDFfromS3(variableIds)
 }
 
 export const getOwidVariableDataAndMetadataPath = async (
     variableId: OwidVariableId
 ): Promise<{ dataPath: string; metadataPath: string }> => {
-    // NOTE: refactor this with Variable object in TypeORM
-    const row = await db.mysqlFirst(
-        `SELECT dataPath, metadataPath FROM variables WHERE id = ?`,
-        [variableId]
-    )
-    return { dataPath: row.dataPath, metadataPath: row.metadataPath }
+    return {
+        dataPath: getVariableDataRoute(DATA_API_URL, variableId),
+        metadataPath: getVariableMetadataRoute(DATA_API_URL, variableId),
+    }
 }
 
 export const fetchS3Values = async (
     variableId: OwidVariableId
 ): Promise<OwidVariableMixedData> => {
-    const { dataPath, metadataPath } = await getOwidVariableDataAndMetadataPath(
-        variableId
+    return fetchS3DataValuesByPath(
+        getVariableDataRoute(DATA_API_URL, variableId)
     )
-    if (!dataPath) {
-        throw new Error(`Missing dataPath for variable ${variableId}`)
-    }
-    if (!metadataPath) {
-        throw new Error(`Missing metadataPath for variable ${variableId}`)
-    }
-    return fetchS3DataValuesByPath(dataPath)
 }
 
 export const fetchS3DataValuesByPath = async (

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -119,10 +119,6 @@ export const DEPLOY_PENDING_FILE_PATH: string =
     serverSettings.DEPLOY_PENDING_FILE_PATH ?? `${BASE_DIR}/.pending`
 export const CLOUDFLARE_AUD: string = serverSettings.CLOUDFLARE_AUD ?? ""
 
-export const DATA_FILES_CHECKSUMS_DIRECTORY: string =
-    serverSettings.DATA_FILES_CHECKSUMS_DIRECTORY ??
-    `${BASE_DIR}/data_files_checksums`
-
 // Either remote catalog `https://owid-catalog.nyc3.digitaloceanspaces.com/` or local catalog `.../etl/data/`
 // Note that Cloudflare proxy on `https://catalog.ourworldindata.org` does not support range requests yet
 // It is empty (turned off) by default for now, in the future it should be
@@ -169,3 +165,5 @@ export const IMAGE_HOSTING_SPACE_ACCESS_KEY_ID: string =
     serverSettings.IMAGE_HOSTING_SPACE_ACCESS_KEY_ID || ""
 export const IMAGE_HOSTING_SPACE_SECRET_ACCESS_KEY: string =
     serverSettings.IMAGE_HOSTING_SPACE_SECRET_ACCESS_KEY || ""
+
+export const DATA_API_URL: string = clientSettings.DATA_API_URL


### PR DESCRIPTION
https://github.com/owid/owid-grapher/issues/2474#issue-1815448106

Columns `variables.dataPath` and `variables.metadataPath` were useful for transitioning to Data API, but they're just complicating things now that we have cloudflare workers with fallbacks.

This PR unifies how we get JSON files for variables across our repo and removes those columns.