### PR TITLE
Update narrative charts for the new designs

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -163,7 +163,9 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
     }
 
     @computed protected get chartHeight(): number {
-        const verticalSpacingsCount = this.manager.showTimeline ? 4 : 3
+        let verticalSpacingsCount = 2
+        if (this.manager.showTimeline) verticalSpacingsCount += 1
+        if (this.showControlsRow) verticalSpacingsCount += 1
 
         return Math.floor(
             this.bounds.height -
@@ -193,6 +195,10 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
             !!this.manager.facetStrategy &&
             this.manager.facetStrategy !== FacetStrategy.none
         return !this.manager.isOnMapTab && hasStrategy
+    }
+
+    @computed get showControlsRow(): boolean {
+        return (this.manager.availableTabs?.length ?? 0) > 1
     }
 
     renderChart(): JSX.Element {
@@ -359,24 +365,22 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         )
     }
 
-    private maybeRenderRelatedQuestion(): JSX.Element | null {
+    private renderRelatedQuestion(): JSX.Element {
         const { relatedQuestions } = this.manager
-        if (this.showRelatedQuestion)
-            return (
-                <div className="relatedQuestion">
-                    Related:&nbsp;
-                    <a
-                        href={relatedQuestions![0].url}
-                        target="_blank"
-                        rel="noopener"
-                        data-track-note="chart_click_related"
-                    >
-                        {relatedQuestions![0].text}
-                    </a>
-                    <FontAwesomeIcon icon={faExternalLinkAlt} />
-                </div>
-            )
-        return null
+        return (
+            <div className="relatedQuestion">
+                Related:&nbsp;
+                <a
+                    href={relatedQuestions![0].url}
+                    target="_blank"
+                    rel="noopener"
+                    data-track-note="chart_click_related"
+                >
+                    {relatedQuestions![0].text}
+                </a>
+                <FontAwesomeIcon icon={faExternalLinkAlt} />
+            </div>
+        )
     }
 
     private renderLoadingIndicator(): JSX.Element {
@@ -427,16 +431,14 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         )
     }
 
-    private maybeRenderTimeline(): JSX.Element | null {
-        if (this.manager.showTimeline)
-            return (
-                <TimelineComponent
-                    timelineController={this.manager.timelineController!}
-                    height={TIMELINE_HEIGHT}
-                    maxWidth={this.maxWidth}
-                />
-            )
-        return null
+    private renderTimeline(): JSX.Element {
+        return (
+            <TimelineComponent
+                timelineController={this.manager.timelineController!}
+                height={TIMELINE_HEIGHT}
+                maxWidth={this.maxWidth}
+            />
+        )
     }
 
     private renderVerticalSpace(): JSX.Element {
@@ -454,17 +456,17 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         return (
             <>
                 <Header manager={this.manager} maxWidth={this.maxWidth} />
-                {this.renderVerticalSpace()}
-                {this.renderControlsRow()}
+                {this.showControlsRow && this.renderVerticalSpace()}
+                {this.showControlsRow && this.renderControlsRow()}
                 {this.renderVerticalSpace()}
                 {this.manager.isOnTableTab
                     ? this.renderDataTable()
                     : this.renderChartOrMap()}
                 {this.manager.showTimeline && this.renderVerticalSpace()}
-                {this.maybeRenderTimeline()}
+                {this.manager.showTimeline && this.renderTimeline()}
                 {this.renderVerticalSpace()}
                 <Footer manager={this.manager} maxWidth={this.maxWidth} />
-                {this.maybeRenderRelatedQuestion()}
+                {this.showRelatedQuestion && this.renderRelatedQuestion()}
             </>
         )
     }

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -163,17 +163,17 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
     }
 
     @computed protected get chartHeight(): number {
-        let verticalSpacingsCount = 2
-        if (this.manager.showTimeline) verticalSpacingsCount += 1
-        if (this.showControlsRow) verticalSpacingsCount += 1
-
         return Math.floor(
             this.bounds.height -
                 2 * FRAME_PADDING -
-                verticalSpacingsCount * VERTICAL_SPACING -
+                2 * VERTICAL_SPACING -
                 this.header.height -
-                CONTROLS_ROW_HEIGHT -
-                (this.manager.showTimeline ? TIMELINE_HEIGHT : 0) -
+                (this.showControlsRow
+                    ? VERTICAL_SPACING + CONTROLS_ROW_HEIGHT
+                    : 0) -
+                (this.manager.showTimeline
+                    ? VERTICAL_SPACING + TIMELINE_HEIGHT
+                    : 0) -
                 this.footer.height -
                 (this.showRelatedQuestion ? RELATED_QUESTION_HEIGHT : 0)
         )

--- a/packages/@ourworldindata/grapher/src/controls/ActionButtons.scss
+++ b/packages/@ourworldindata/grapher/src/controls/ActionButtons.scss
@@ -30,6 +30,7 @@ $paddingBetweenIconAndLabel: 4px; // keep in sync with PADDING_BETWEEN_ICON_AND_
         position: relative;
         padding: 0;
         cursor: inherit;
+        color: $dark-text;
 
         svg {
             width: 14px;

--- a/packages/@ourworldindata/grapher/src/controls/ActionButtons.scss
+++ b/packages/@ourworldindata/grapher/src/controls/ActionButtons.scss
@@ -23,7 +23,9 @@ $paddingBetweenIconAndLabel: 4px; // keep in sync with PADDING_BETWEEN_ICON_AND_
         margin-left: $paddingBetweenButtons;
     }
 
-    li button {
+    li button,
+    li a,
+    li a:visited {
         display: block;
         height: 100%;
         width: 100%;
@@ -40,6 +42,21 @@ $paddingBetweenIconAndLabel: 4px; // keep in sync with PADDING_BETWEEN_ICON_AND_
         .label {
             display: inline-block;
             margin-left: $paddingBetweenIconAndLabel;
+        }
+    }
+
+    li a {
+        padding: 8px;
+        padding-left: 12px;
+
+        svg {
+            position: relative;
+            top: 1px;
+        }
+
+        .label {
+            margin: 0;
+            margin-right: $paddingBetweenIconAndLabel;
         }
     }
 }

--- a/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
@@ -21,6 +21,7 @@ export interface ActionButtonsManager extends ShareMenuManager {
     currentTab?: GrapherTabOption | GrapherTabOverlayOption
     isShareMenuActive?: boolean
     hideShareTabButton?: boolean
+    hideEnterFullScreenButton?: boolean
     hideExploreTheDataButton?: boolean
     isInIFrame?: boolean
     canonicalUrl?: string
@@ -197,7 +198,7 @@ export class ActionButtons extends React.Component<{
     }
 
     @computed private get hasEnterFullScreenButton(): boolean {
-        return !this.manager.isInIFrame
+        return !this.manager.hideEnterFullScreenButton
     }
 
     @computed private get hasExploreTheDataButton(): boolean {

--- a/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
@@ -10,6 +10,7 @@ import {
     faShareNodes,
     faExpand,
     faDownload,
+    faArrowRight,
     IconDefinition,
 } from "@fortawesome/free-solid-svg-icons"
 import { ShareMenu, ShareMenuManager } from "./ShareMenu"
@@ -20,6 +21,7 @@ export interface ActionButtonsManager extends ShareMenuManager {
     currentTab?: GrapherTabOption | GrapherTabOverlayOption
     isShareMenuActive?: boolean
     hideShareTabButton?: boolean
+    hideExploreTheDataButton?: boolean
     isInIFrame?: boolean
     canonicalUrl?: string
 }
@@ -59,9 +61,11 @@ export class ActionButtons extends React.Component<{
             hasDownloadButton,
             hasShareButton,
             hasEnterFullScreenButton,
+            hasExploreTheDataButton,
             downloadButtonWithLabelWidth,
             shareButtonWithLabelWidth,
             enterFullScreenButtonWithLabelWidth,
+            exploreTheDataButtonWithLabelWidth,
         } = this
 
         let width = 0
@@ -74,6 +78,9 @@ export class ActionButtons extends React.Component<{
         if (hasEnterFullScreenButton) {
             width += enterFullScreenButtonWithLabelWidth
         }
+        if (hasExploreTheDataButton) {
+            width += exploreTheDataButtonWithLabelWidth
+        }
 
         return width + (buttonCount - 1) * PADDING_BETWEEN_BUTTONS
     }
@@ -85,10 +92,23 @@ export class ActionButtons extends React.Component<{
     }
 
     @computed get width(): number {
-        const { buttonCount, showButtonLabels, widthWithButtonLabels } = this
+        const {
+            buttonCount,
+            showButtonLabels,
+            widthWithButtonLabels,
+            hasExploreTheDataButton,
+            exploreTheDataButtonWidth,
+        } = this
 
-        if (showButtonLabels) {
-            return widthWithButtonLabels
+        if (showButtonLabels) return widthWithButtonLabels
+
+        if (hasExploreTheDataButton) {
+            // the "Explore the data" label is always shown
+            return (
+                exploreTheDataButtonWidth +
+                (buttonCount - 1) * BUTTON_WIDTH_ICON_ONLY +
+                (buttonCount - 1) * PADDING_BETWEEN_BUTTONS
+            )
         } else {
             return (
                 buttonCount * BUTTON_WIDTH_ICON_ONLY +
@@ -114,6 +134,10 @@ export class ActionButtons extends React.Component<{
 
     @computed private get enterFullScreenButtonWithLabelWidth(): number {
         return ActionButtons.computeButtonWidth("Enter full-screen")
+    }
+
+    @computed private get exploreTheDataButtonWithLabelWidth(): number {
+        return ActionButtons.computeButtonWidth("Explore the data")
     }
 
     @computed private get downloadButtonWidth(): number {
@@ -146,6 +170,14 @@ export class ActionButtons extends React.Component<{
         return enterFullScreenButtonWithLabelWidth
     }
 
+    // the "Explore the data" button is never shown without a label
+    @computed private get exploreTheDataButtonWidth(): number {
+        const { hasExploreTheDataButton, exploreTheDataButtonWithLabelWidth } =
+            this
+        if (!hasExploreTheDataButton) return 0
+        return exploreTheDataButtonWithLabelWidth
+    }
+
     @action.bound onShareMenu(): void {
         this.manager.isShareMenuActive = !this.manager.isShareMenuActive
     }
@@ -168,11 +200,16 @@ export class ActionButtons extends React.Component<{
         return !this.manager.isInIFrame
     }
 
+    @computed private get hasExploreTheDataButton(): boolean {
+        return !this.manager.hideExploreTheDataButton
+    }
+
     @computed private get buttonCount(): number {
         let count = 0
         if (this.hasDownloadButton) count += 1
         if (this.hasShareButton) count += 1
         if (this.hasEnterFullScreenButton) count += 1
+        if (this.hasExploreTheDataButton) count += 1
         return count
     }
 
@@ -226,6 +263,26 @@ export class ActionButtons extends React.Component<{
                             // eslint-disable-next-line
                             onClick={() => {}}
                         />
+                    )}
+                    {this.hasExploreTheDataButton && (
+                        <li
+                            className="clickable"
+                            style={{
+                                height: BUTTON_HEIGHT,
+                                width: this.exploreTheDataButtonWidth,
+                            }}
+                        >
+                            <a
+                                title="Explore the data"
+                                data-track-note="chart_click_exploredata"
+                                href={manager.canonicalUrl}
+                                target="_blank"
+                                rel="noopener"
+                            >
+                                <div className="label">Explore the data</div>
+                                <FontAwesomeIcon icon={faArrowRight} />
+                            </a>
+                        </li>
                     )}
                 </ul>
                 {shareMenuElement}

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -260,6 +260,7 @@ export interface GrapherProgrammaticInterface extends GrapherInterface {
     hasSourcesTab?: boolean
     hasDownloadTab?: boolean
     hideShareTabButton?: boolean
+    hideExploreTheDataButton?: boolean
     hideRelatedQuestion?: boolean
 
     getGrapherInstance?: (instance: Grapher) => void
@@ -2695,6 +2696,7 @@ export class Grapher
     @observable hasSourcesTab = true
     @observable hasDownloadTab = true
     @observable hideShareTabButton = false
+    @observable hideExploreTheDataButton = true
     @observable hideRelatedQuestion = false
 }
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -260,6 +260,7 @@ export interface GrapherProgrammaticInterface extends GrapherInterface {
     hasSourcesTab?: boolean
     hasDownloadTab?: boolean
     hideShareTabButton?: boolean
+    hideEnterFullScreenButton?: boolean
     hideExploreTheDataButton?: boolean
     hideRelatedQuestion?: boolean
 
@@ -2696,6 +2697,7 @@ export class Grapher
     @observable hasSourcesTab = true
     @observable hasDownloadTab = true
     @observable hideShareTabButton = false
+    @observable hideEnterFullScreenButton = false
     @observable hideExploreTheDataButton = true
     @observable hideRelatedQuestion = false
 }

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -155,6 +155,4 @@ export const grapherInterfaceWithHiddenTabsOnly: GrapherProgrammaticInterface =
         hasChartTab: false,
         hasMapTab: false,
         hasTableTab: false,
-        hasDownloadTab: false,
-        hideShareTabButton: true,
     }

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -533,7 +533,6 @@ export enum ChartTabKeyword {
     chart = "chart",
     map = "map",
     table = "table",
-    download = "download",
 }
 
 export type RawBlockChartValue = {

--- a/site/gdocs/Chart.tsx
+++ b/site/gdocs/Chart.tsx
@@ -47,7 +47,7 @@ export default function Chart({
             !showAllControls ? grapherInterfaceWithHiddenControlsOnly : {},
             !showAllTabs ? grapherInterfaceWithHiddenTabsOnly : {},
             ...listOfPartialGrapherConfigs,
-            { hideRelatedQuestion: true },
+            { hideRelatedQuestion: true, hideExploreTheDataButton: false },
             {
                 title: d.title,
                 subtitle: d.subtitle,

--- a/site/gdocs/Chart.tsx
+++ b/site/gdocs/Chart.tsx
@@ -47,7 +47,11 @@ export default function Chart({
             !showAllControls ? grapherInterfaceWithHiddenControlsOnly : {},
             !showAllTabs ? grapherInterfaceWithHiddenTabsOnly : {},
             ...listOfPartialGrapherConfigs,
-            { hideRelatedQuestion: true, hideExploreTheDataButton: false },
+            {
+                hideRelatedQuestion: true,
+                hideExploreTheDataButton: false,
+                hideShareTabButton: true,
+            },
             {
                 title: d.title,
                 subtitle: d.subtitle,
@@ -136,9 +140,6 @@ const mapKeywordToGrapherConfig = (
 
         case ChartTabKeyword.table:
             return { hasTableTab: true }
-
-        case ChartTabKeyword.download:
-            return { hasDownloadTab: true }
 
         default:
             return null


### PR DESCRIPTION
### Summary

- Hide content switchers for narrative charts if only one
- Add "Explore the data" button that links to the grapher/data page
- Always show "Download" and "Enter full-screen" action buttons