### PR TITLE
test(explorer): fix failing explorer test

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -18,6 +18,7 @@ import {
     GrapherManager,
     GrapherProgrammaticInterface,
     GrapherQueryParams,
+    GrapherTabOption,
     SelectionArray,
     setSelectedEntityNamesParam,
     SlideShowController,
@@ -335,10 +336,13 @@ export class Explorer
         this.updateGrapherFromExplorer()
 
         // preserve the previous tab if that's still available in the new view;
-        // and use the first tab otherwise
+        // and use the first tab otherwise, ignoring the table
+        const tabsWithoutTable = this.grapher.availableTabs.filter(
+            (tab) => tab !== GrapherTabOption.table
+        )
         newGrapherParams.tab = this.grapher.availableTabs.includes(previousTab)
             ? previousTab
-            : this.grapher.availableTabs[0]
+            : tabsWithoutTable[0] ?? GrapherTabOption.table
 
         this.grapher.populateFromQueryParams(newGrapherParams)
     }


### PR DESCRIPTION
- Explorers try to persist the current tab
- But if the current tab does not exist for the chart that the user switched to, then by default the first tab in `availableTabs` is shown
- This used to be `chart` but now it's `table`
- Hence the failing test