### PR TITLE
:bug: add retries to bakeDriveImages

### DIFF
--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -49,6 +49,7 @@ import {
     getFilenameAsPng,
     extractDetailsFromSyntax,
     LinkedChart,
+    retryPromise,
 } from "@ourworldindata/utils"
 import { execWrapper } from "../db/execWrapper.js"
 import { countryProfileSpecs } from "../site/countryProfileProjects.js"
@@ -600,7 +601,7 @@ export class SiteBaker {
 
         // TODO: chunking caused issues so we disable it here by setting chunk size to 1 for now.
         // Either switch to rclone-ing all files before baking, or switching to Cloudflare Images.
-        const imageChunks = chunk(images, 1)
+        const imageChunks = chunk(images, 2)
         for (const imageChunk of imageChunks) {
             await Promise.all(
                 imageChunk.map(async (image) => {
@@ -609,7 +610,7 @@ export class SiteBaker {
                         IMAGE_HOSTING_BUCKET_SUBFOLDER_PATH,
                         image.filename
                     )
-                    return fetch(remoteFilePath)
+                    return retryPromise(() => fetch(remoteFilePath))
                         .then((response) => {
                             if (!response.ok) {
                                 throw new Error(


### PR DESCRIPTION
Revert to using 2 workers for baking images and add retries. 

Performance:
1 worker: 275s
2 workers: 200s
3 workers: 183s