### PR TITLE
perf: improve performance of baking

### DIFF
--- a/baker/GrapherBakingUtils.ts
+++ b/baker/GrapherBakingUtils.ts
@@ -81,13 +81,11 @@ export const bakeGrapherUrls = async (urls: string[]) => {
     }
 
     if (toBake.length > 0) {
-        for (const grapherUrls of lodash.chunk(toBake, 5)) {
-            await bakeGraphersToSvgs(
-                grapherUrls,
-                `${BAKED_SITE_DIR}/exports`,
-                OPTIMIZE_SVG_EXPORTS
-            )
-        }
+        await bakeGraphersToSvgs(
+            toBake,
+            `${BAKED_SITE_DIR}/exports`,
+            OPTIMIZE_SVG_EXPORTS
+        )
     }
 }
 

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -90,6 +90,7 @@ const nonWordpressSteps = [
     "specialPages",
     "countries",
     "countryProfiles",
+    "explorers",
     "charts",
     "gdocPosts",
     "gdriveImages",
@@ -425,6 +426,16 @@ export class SiteBaker {
             await makeSitemap(this.explorerAdminServer)
         )
 
+        await this.stageWrite(
+            `${this.bakedSiteDir}/charts.html`,
+            await renderChartsPage(this.explorerAdminServer)
+        )
+        this.progressBar.tick({ name: "✅ baked special pages" })
+    }
+
+    private async bakeExplorers() {
+        if (!this.bakeSteps.has("explorers")) return
+
         await bakeAllExplorerRedirects(
             this.bakedSiteDir,
             this.explorerAdminServer
@@ -435,11 +446,7 @@ export class SiteBaker {
             this.explorerAdminServer
         )
 
-        await this.stageWrite(
-            `${this.bakedSiteDir}/charts.html`,
-            await renderChartsPage(this.explorerAdminServer)
-        )
-        this.progressBar.tick({ name: "✅ baked special pages" })
+        this.progressBar.tick({ name: "✅ baked explorers" })
     }
 
     private async validateGrapherDodReferences() {
@@ -709,6 +716,7 @@ export class SiteBaker {
         }
         await this.bakeSpecialPages()
         await this.bakeCountryProfiles()
+        await this.bakeExplorers()
         if (this.bakeSteps.has("charts")) {
             await bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers(
                 this.bakedSiteDir

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -621,7 +621,7 @@ export const renderExplorerPage = async (
         config.id = row.id // Ensure each grapher has an id
         config.adminBaseUrl = ADMIN_BASE_URL
         config.bakedGrapherURL = BAKED_GRAPHER_URL
-        return new Grapher(config).toObject()
+        return config
     }
     const grapherConfigs = grapherConfigRows.map(parseGrapherConfigFromRow)
     const partialGrapherConfigs = partialGrapherConfigRows

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -79,7 +79,6 @@ import { formatUrls, KEY_INSIGHTS_H2_CLASSNAME } from "../site/formatting.js"
 
 import {
     GrapherInterface,
-    Grapher,
     GrapherProgrammaticInterface,
 } from "@ourworldindata/grapher"
 import { ExplorerProgram } from "../explorer/ExplorerProgram.js"


### PR DESCRIPTION
Multiple optimisations in here:
- Explorers don't instantiate a `Grapher` object for each `grapherId` contained in it, which then requires downloading the data and metadata file for each of them [150s -> 30s]
- Rudimentarily parallelise `bakeEmbeds` some more by using `p-map` in a single thread [575s -> 412s on my local machine; mostly relevant for a first-time build]