### PR TITLE
feat(images): use cloudflare images to serve images

### DIFF
--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -621,22 +621,7 @@ export class SiteBaker {
                         })
                         .then((arrayBuffer) => Buffer.from(arrayBuffer))
                         .then(async (buffer) => {
-                            if (!image.isSvg) {
-                                await Promise.all(
-                                    image.sizes!.map((width) => {
-                                        const localResizedFilepath = path.join(
-                                            imagesDirectory,
-                                            `${image.filenameWithoutExtension}_${width}.webp`
-                                        )
-                                        return sharp(buffer)
-                                            .resize(width)
-                                            .webp({
-                                                lossless: true,
-                                            })
-                                            .toFile(localResizedFilepath)
-                                    })
-                                )
-                            } else {
+                            if (image.isSvg) {
                                 // A PNG alternative to the SVG for the "Download image" link
                                 const pngFilename = getFilenameAsPng(
                                     image.filename

--- a/packages/@ourworldindata/utils/src/image.ts
+++ b/packages/@ourworldindata/utils/src/image.ts
@@ -41,13 +41,14 @@ export function getSizes(
 
 export function generateSrcSet(
     sizes: number[],
-    filename: ImageMetadata["filename"]
+    filename: ImageMetadata["filename"],
+    baseUrl: string
 ): string {
     return sizes
         .map((size) => {
-            const path = `/images/published/${getFilenameWithoutExtension(
+            const path = `${baseUrl}${getFilenameWithoutExtension(
                 filename
-            )}_${size}.webp`
+            )}/w=${size}`
             return `${encodeURI(path)} ${size}w`
         })
         .join(", ")

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -72,6 +72,11 @@ export const IMAGE_HOSTING_BUCKET_PATH: string =
 export const IMAGE_HOSTING_BUCKET_SUBFOLDER_PATH: string =
     IMAGE_HOSTING_BUCKET_PATH.slice(IMAGE_HOSTING_BUCKET_PATH.indexOf("/") + 1)
 
+// CloudFlare Images format is imagedelivery.net/{account_id}/{image_id}/{variant}
+export const IMAGE_BASE_URL: string =
+    process.env.IMAGE_BASE_URL ??
+    "https://imagedelivery.net/qLq-8BTgXU8yG0N6HnOy8g/"
+
 // Fast-track settings, by default points to staging version. You need Tailscale to access it.
 export const FASTTRACK_URL: string =
     process.env.FASTTRACK_URL ?? "http://owid-analytics:8083/"

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -169,3 +169,8 @@ export const IMAGE_HOSTING_SPACE_ACCESS_KEY_ID: string =
     serverSettings.IMAGE_HOSTING_SPACE_ACCESS_KEY_ID || ""
 export const IMAGE_HOSTING_SPACE_SECRET_ACCESS_KEY: string =
     serverSettings.IMAGE_HOSTING_SPACE_SECRET_ACCESS_KEY || ""
+
+export const CLOUDFLARE_IMAGES_ACCOUNT_ID =
+    serverSettings.CLOUDFLARE_IMAGES_ACCOUNT_ID ?? ""
+export const CLOUDFLARE_IMAGES_API_KEY =
+    serverSettings.CLOUDFLARE_IMAGES_API_KEY ?? ""

--- a/site/gdocs/Image.tsx
+++ b/site/gdocs/Image.tsx
@@ -8,6 +8,7 @@ import {
 import { LIGHTBOX_IMAGE_CLASS } from "../Lightbox.js"
 import cx from "classnames"
 import {
+    IMAGE_BASE_URL,
     IMAGE_HOSTING_BUCKET_SUBFOLDER_PATH,
     IMAGE_HOSTING_CDN_URL,
 } from "../../settings/clientSettings.js"
@@ -115,7 +116,7 @@ export default function Image(props: {
     }
 
     const sizes = getSizes(image.originalWidth)
-    const srcSet = generateSrcSet(sizes, filename)
+    const srcSet = generateSrcSet(sizes, filename, IMAGE_BASE_URL)
     const imageSrc = `${IMAGES_DIRECTORY}${filename}`
 
     return (


### PR DESCRIPTION
[CloudFlare Images](https://www.cloudflare.com/developer-platform/cloudflare-images/) is a CF service to store images and resize them on demand.
It delivers images in AVIF / WebP / PNG format, transparently, depending on what the target browser supports.
Pricing is a flat $1 / 100,000 images served.

---

Example pages:
- [Article: Rise of social media](http://staging-site-cloudflare-images/rise-of-social-media)
- [Topic page: Poverty](http://staging-site-cloudflare-images/poverty)

---

There are still some problems:
- [ ] There is a `uploadToCloudflareImages` method (that only works if the file is already in DO Spaces), but there is not yet an automated way to ensure that new images are uploaded
	- [ ] In particular, this would have to check which images are already uploaded, which we currently don't do
- [ ] There are some images where the filename contains spaces or other special characters like an em-dash, these are currently not uploaded to CF Images yet
	- [ ] Some are also too big (over 10,000 pixels wide, e.g. [this one](https://ourworldindata.org/images/published/the-history-of-global-inequality-featured-image.png))
- [ ] Unsure what to do about staging environments?
- [ ] Cloudflare Images cannot serve unchanged original files, which we probably want to do, at least for download inside the lightbox
	- Currently this is solved by hosting the original files on `/images/published/` as before, but that means that we're still fetching all images from S3, which is the baking step we want to get rid of
	- I guess we can also just point to the DigitalOcean CDN URL for the original?
- [x] Sometimes fetching an image for the first time on a certain edge server takes a bit of time (especially for large source images); but that shouldn't be a huge problem for us since we have few images that are hit often, and subsequent requests are really fast