### PR TITLE
:hammer: remove existence validation of data & metadata files on S3

### DIFF
--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -322,13 +322,6 @@ const _castDataDF = (df: pl.DataFrame): pl.DataFrame => {
     )
 }
 
-export const assertFileExistsInS3 = async (url: string): Promise<void> => {
-    const resp = await fetch(url, { method: "HEAD", keepalive: true })
-    if (resp.status !== 200) {
-        throw new Error("URL not found on S3: " + url)
-    }
-}
-
 const emptyDataDF = (): pl.DataFrame => {
     return _castDataDF(
         pl.DataFrame({


### PR DESCRIPTION
Right before baking grapher charts we check the existence of about 7000 variables that we use in charts. That means firing 2 * 7000 requests to S3 to ensure they all exist. This can take some time (>1min) and sometimes lead to a connection error.

Since we haven't run into any non-existing variables, it's probably safe to skip this step. Bugsnag should cover us if there are client errors with missing data.

EDIT: This is becoming increasingly annoying as we get more Buildkite fails. Either we merge this, or we start chunking it (which might slow it down).