### PR TITLE
fix(grapher): prevent content switchers from being hidden

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -251,19 +251,17 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         return !!showSelectEntitiesButton || !!showChangeEntityButton
     }
 
+    @computed get showSettingsMenuToggle(): boolean {
+        return (
+            !!this.manager.showSettingsMenuToggle &&
+            !!this.manager.isReady &&
+            !this.manager.isOnMapTab &&
+            !this.manager.isOnTableTab
+        )
+    }
+
     private renderControlsRow(): JSX.Element | null {
-        const {
-            showEntitySelector,
-            manager: {
-                isReady,
-                isOnMapTab,
-                isOnTableTab,
-                showSettingsMenuToggle,
-            },
-        } = this
-
-        if (!isReady || isOnMapTab || isOnTableTab) return null
-
+        const { showEntitySelector, showSettingsMenuToggle } = this
         return (
             <nav className="controlsRow">
                 <ContentSwitchers manager={this.manager} />


### PR DESCRIPTION
Fixes an issue where the entire controls row (including content switchers) was not being rendered when on the map or table tab