### PR TITLE
feat(newsletter): bring back subscribe button to site tools

### DIFF
--- a/site/NewsletterSubscription.tsx
+++ b/site/NewsletterSubscription.tsx
@@ -18,7 +18,6 @@ export const NewsletterSubscription = ({
     const [isOpen, setIsOpen] = useState(false)
 
     const subscribeText = "Subscribe"
-    const closeText = "Close"
 
     return (
         <div className={`newsletter-subscription${isOpen ? " active" : ""}`}>

--- a/site/NewsletterSubscription.tsx
+++ b/site/NewsletterSubscription.tsx
@@ -31,35 +31,27 @@ export const NewsletterSubscription = ({
                         }}
                     />
                     <div className="box">
-                        <button
-                            aria-label={closeText}
-                            className="close"
-                            data-track-note="dialog_close_newsletter"
-                            onClick={() => {
-                                setIsOpen(false)
-                            }}
-                        >
-                            <FontAwesomeIcon icon={faTimes} />
-                            {closeText}
-                        </button>
                         <NewsletterSubscriptionForm context={context} />
                     </div>
                 </>
             )}
-            <button
-                aria-label={subscribeText}
-                className="prompt"
-                data-track-note="dialog_open_newsletter"
-                onClick={() => {
-                    setIsOpen(!isOpen)
-                }}
-            >
-                <span className="hide-lg-down">{subscribeText}</span>
-                <FontAwesomeIcon
-                    className="hide-lg-up"
-                    icon={faEnvelopeOpenText}
-                />
-            </button>
+            {isOpen ? (
+                <button className="prompt" onClick={() => setIsOpen(false)}>
+                    <FontAwesomeIcon icon={faTimes} /> Close
+                </button>
+            ) : (
+                <button
+                    aria-label={subscribeText}
+                    className="prompt"
+                    data-track-note="dialog_open_newsletter"
+                    onClick={() => {
+                        setIsOpen(!isOpen)
+                    }}
+                >
+                    <FontAwesomeIcon icon={faEnvelopeOpenText} />
+                    {subscribeText}
+                </button>
+            )}
         </div>
     )
 }

--- a/site/SiteNavigation.scss
+++ b/site/SiteNavigation.scss
@@ -150,7 +150,7 @@
                 position: absolute;
                 top: calc(100% + $header-border-height);
                 right: 0;
-                width: 411px;
+                width: 411px; // see popover-box-styles mixin
                 @include sm-only {
                     margin-right: -16px;
                     width: 100vw;

--- a/site/SiteTools.tsx
+++ b/site/SiteTools.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom"
 import { FeedbackPrompt } from "./Feedback.js"
 import { ScrollDirection, useScrollDirection } from "./hooks.js"
 import {
+    NewsletterSubscription,
     NewsletterSubscriptionForm,
     NewsletterSubscriptionContext,
 } from "./NewsletterSubscription.js"
@@ -20,6 +21,9 @@ const SiteTools = () => {
                 (scrollDirection === ScrollDirection.Down && " hide") || ""
             }`}
         >
+            <NewsletterSubscription
+                context={NewsletterSubscriptionContext.Floating}
+            />
             <FeedbackPrompt />
             <a className="prompt" data-track-note="page_open_jobs" href="/jobs">
                 <FontAwesomeIcon icon={faHandshake} /> Jobs

--- a/site/SiteTools.tsx
+++ b/site/SiteTools.tsx
@@ -7,8 +7,8 @@ import {
     NewsletterSubscriptionForm,
     NewsletterSubscriptionContext,
 } from "./NewsletterSubscription.js"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
-import { faHandshake } from "@fortawesome/free-solid-svg-icons"
+// import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
+// import { faHandshake } from "@fortawesome/free-solid-svg-icons"
 
 const SITE_TOOLS_CLASS = "site-tools"
 
@@ -25,9 +25,9 @@ const SiteTools = () => {
                 context={NewsletterSubscriptionContext.Floating}
             />
             <FeedbackPrompt />
-            <a className="prompt" data-track-note="page_open_jobs" href="/jobs">
+            {/* <a className="prompt" data-track-note="page_open_jobs" href="/jobs">
                 <FontAwesomeIcon icon={faHandshake} /> Jobs
-            </a>
+            </a> */}
         </div>
     )
 }

--- a/site/css/mixins.scss
+++ b/site/css/mixins.scss
@@ -161,7 +161,7 @@
 
 @mixin popover-box-styles {
     border-radius: 3px;
-    width: 23rem;
+    width: 411px; // see SiteNavigationToggle__dropdown
     box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.15), 0 3px 15px rgba(0, 0, 0, 0.25);
     background: hsla(0, 0%, 100%, 0.98);
     color: #333;

--- a/site/css/newsletter-subscription.scss
+++ b/site/css/newsletter-subscription.scss
@@ -66,3 +66,7 @@
 .homepage-subscribe .newsletter-subscription {
     flex: 1;
 }
+
+.site-tools .newsletter-subscription form {
+    padding: 32px 40px;
+}

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -1150,7 +1150,7 @@ html:not(.js) {
 }
 
 .FeedbackForm {
-    height: calc(100vh - 100px);
+    height: calc(100vh - 155px);
     max-height: 700px;
     transition: opacity 0.25s ease-in-out;
 


### PR DESCRIPTION
- bring back subscribe button to site tools in the bottom right corner ([slack](https://owid.slack.com/archives/CLDM2AWCD/p1691577698885519))

![Screenshot 2023-08-09 at 15.39.14.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0SFFiIjKuUK6UPYHVe6u/42e67fc2-c62a-4e12-b144-c18eb02a31e6/Screenshot%202023-08-09%20at%2015.39.14.png)

- harmonize width of popups
- fix feedback popup height on shorter screens

![Screenshot 2023-08-09 at 14.57.37.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0SFFiIjKuUK6UPYHVe6u/eb6a0c3d-4a23-4428-858b-7e935c402239/Screenshot%202023-08-09%20at%2014.57.37.png)


- hide "Jobs" CTA