### PR TITLE
fix(wp): load nvm to run postUpdateHook

### DIFF
--- a/wordpress/web/app/plugins/owid/owid.php
+++ b/wordpress/web/app/plugins/owid/owid.php
@@ -296,7 +296,6 @@ function build_static($post_ID, $post_after, $post_before)
         $post_before->post_status == "publish"
     ) {
         $current_user = wp_get_current_user();
-        putenv('PATH=' . getenv('PATH') . ':/bin:/usr/local/bin:/usr/bin');
         // Unsets colliding .env variables between PHP and node apps
         // The DB password did not collide and hence were not listed here (DB_PASS (node) vs DB_PASSWORD (php))
         // todo: cleanup, this doesn't make sense anymore since node and php env vars have now different names
@@ -307,7 +306,7 @@ function build_static($post_ID, $post_after, $post_before)
         $cmd =
             "cd " .
             ABSPATH .
-            "codelink && yarn runPostUpdateHook " .
+            "codelink && . ~/.bashrc && yarn runPostUpdateHook " .
             escapeshellarg($current_user->user_email) .
             " " .
             escapeshellarg($current_user->display_name) .


### PR DESCRIPTION
Loads nvm's yarn before running the postUpdateHook.


https://github.com/owid/owid-grapher/assets/13406362/569f33f6-d030-422a-b108-fca66c6f2a93


Somehow, setting up NVM_DIR and running `~/.nvm/nvm.sh` didn't do the trick, hence the sourcing of .bashrc. There is a return for non-interactive shells right after NVM loads so running .bashrc is equivalent to loading NVM.

Note: staging still has a system version of node/yarn in /usr/bin which gives false positives if not looking carefully at which version is running.

Bug report: [slack](https://owid.slack.com/archives/CQQUA2C2U/p1691140007969139)