### PR TITLE
:bug: hotfix progress bar issue

### DIFF
--- a/baker/Deployer.ts
+++ b/baker/Deployer.ts
@@ -37,7 +37,7 @@ export class Deployer {
         this.progressBar = new ProgressBar(
             `Baking and deploying to ${target} [:bar] :current/:total :elapseds :name\n`,
             {
-                total: 25 + testSteps,
+                total: 24 + testSteps,
                 renderThrottle: 0, // print on every tick
                 stream: this.stream as unknown as WriteStream,
             }

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -1,5 +1,4 @@
 import fs from "fs-extra"
-import { WriteStream } from "tty"
 import { writeFile } from "node:fs/promises"
 import path from "path"
 import { glob } from "glob"
@@ -74,7 +73,6 @@ import {
     BAKED_BASE_URL,
     BAKED_GRAPHER_EXPORTS_BASE_URL,
 } from "../settings/clientSettings.js"
-import { ProgressStream } from "./ProgressStream.js"
 
 // These aren't all "wordpress" steps
 // But they're only run when you have the full stack available
@@ -123,7 +121,6 @@ export class SiteBaker {
     private bakedSiteDir: string
     baseUrl: string
     progressBar: ProgressBar
-    progressStream: ProgressStream
     explorerAdminServer: ExplorerAdminServer
     bakeSteps: BakeStepConfig
 
@@ -135,13 +132,10 @@ export class SiteBaker {
         this.bakedSiteDir = bakedSiteDir
         this.baseUrl = baseUrl
         this.bakeSteps = bakeSteps
-        this.progressStream = new ProgressStream(process.stdout)
         this.progressBar = new ProgressBar(
             "BakeAll [:bar] :current/:total :elapseds :name\n",
             {
                 total: getProgressBarTotal(bakeSteps),
-                renderThrottle: 0, // print on every tick
-                stream: this.progressStream as unknown as WriteStream,
             }
         )
         this.explorerAdminServer = new ExplorerAdminServer(GIT_CMS_DIR)
@@ -752,8 +746,6 @@ export class SiteBaker {
         await this.bakeWordpressPages()
         await this._bakeNonWordpressPages()
         this.flushCache()
-
-        this.progressStream.replay()
     }
 
     async ensureDir(relPath: string) {


### PR DESCRIPTION
Attempt to fix error we get from deploy queue

```
0|live-deploy-queue  | 2023-08-10T08:53:49: RangeError: Invalid array length
0|live-deploy-queue  | 2023-08-10T08:53:49:     at ProgressBar.render (/home/owid/live/node_modules/progress/lib/node-progress.js:160:14)
0|live-deploy-queue  | 2023-08-10T08:53:49:     at ProgressBar.tick (/home/owid/live/node_modules/progress/lib/node-progress.js:97:8)
0|live-deploy-queue  | 2023-08-10T08:53:49:     at SiteBaker.flushCache (/home/owid/live/baker/SiteBaker.tsx:847:26)
0|live-deploy-queue  | 2023-08-10T08:53:49:     at SiteBaker.bakeAll (/home/owid/live/baker/SiteBaker.tsx:750:14)
0|live-deploy-queue  | 2023-08-10T08:53:49:     at bakeAndDeploy (/home/owid/live/baker/DeployUtils.ts:47:25)
0|live-deploy-queue  | 2023-08-10T08:53:49:     at Timeout.deployIfQueueIsNotEmpty (/home/owid/live/baker/DeployUtils.ts:142:19)
0|live-deploy-queue  | 2023-08-10T08:53:49: Bugsnag.notify() was called before Bugsnag.start()
```

I couldn't replicate it locally, so this is more of a shot in the dark.