### PR TITLE
🐛 fix formatUrls when WORDPRESS_URL is undefined

### DIFF
--- a/site/formatting.tsx
+++ b/site/formatting.tsx
@@ -26,12 +26,19 @@ export const SUMMARY_CLASSNAME = "wp-block-owid-summary"
 export const RESEARCH_AND_WRITING_CLASSNAME = "wp-block-research-and-writing"
 export const KEY_INSIGHTS_H2_CLASSNAME = "key-insights-heading"
 
-export const formatUrls = (html: string) =>
-    html
-        .replace(new RegExp(WORDPRESS_URL, "g"), BAKED_BASE_URL)
+export const formatUrls = (html: string) => {
+    let formatted = html
         .replace(new RegExp("https?://owid.cloud", "g"), BAKED_BASE_URL)
         .replace(new RegExp("https?://ourworldindata.org", "g"), BAKED_BASE_URL)
         .replace(new RegExp("/app/uploads", "g"), "/uploads")
+    if (WORDPRESS_URL) {
+        formatted = formatted.replace(
+            new RegExp(WORDPRESS_URL, "g"),
+            BAKED_BASE_URL
+        )
+    }
+    return formatted
+}
 
 export const splitContentIntoSectionsAndColumns = (
     cheerioEl: CheerioStatic


### PR DESCRIPTION
`formatUrls` is called by our `Link` model, which is used in our `Gdoc` model.

It assumed `WORDPRESS_URL` was defined which was resulting in `new RegExp(undefined, "g")` (aka `/(?:)/g`) to be called on every URL, inserting `BAKED_BASE_URL` in between every single character in each URL.

e.g.

```
HELLO

Hhttp://localhost:3030Ehttp://localhost:3030Lhttp://localhost:3030Lhttp://localhost:3030O
```

This fixes that so we only do that replacement if `WORDPRESS_URL` is defined.



