### PR TITLE
enhance(explorer): add warning for mixed-content explorers

### DIFF
--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -254,17 +254,30 @@ export class ExplorerProgram extends GridProgram {
     }
 
     get whyIsExplorerProgramInvalid(): string {
-        const { table } = this.decisionMatrix
+        const {
+            chartCreationMode,
+            decisionMatrix: { table },
+        } = this
+        const { FromVariableIds, FromGrapherId, FromExplorerTableColumnSlugs } =
+            ExplorerChartCreationMode
+
+        const grapherIdColumn = table.get(GrapherGrammar.grapherId.keyword)
+        const tableSlugColumn = table.get(GrapherGrammar.tableSlug.keyword)
+        const hasGrapherId = grapherIdColumn.numValues > 0
+        const hasCsvData = tableSlugColumn.numValues > 0 || this.tableCount > 0
+
+        if (chartCreationMode === FromVariableIds && hasGrapherId)
+            return "Using variables IDs and Grapher IDs to create charts is not supported."
+
+        if (chartCreationMode === FromVariableIds && hasCsvData)
+            return "Using variable IDs and CSV data files to create charts is not supported."
+
         if (
-            this.chartCreationMode === ExplorerChartCreationMode.FromVariableIds
-        ) {
-            const grapherIdColumn = table.get(GrapherGrammar.grapherId.keyword)
-            if (grapherIdColumn.numValues)
-                return "When using variable IDs to create charts, you cannot also use Grapher IDs."
-            const tableSlugColumn = table.get(GrapherGrammar.tableSlug.keyword)
-            if (tableSlugColumn.numValues || this.tableCount)
-                return "When using variable IDs to create charts, you cannot also use tabular data."
-        }
+            (chartCreationMode === FromGrapherId && hasCsvData) ||
+            (chartCreationMode === FromExplorerTableColumnSlugs && hasGrapherId)
+        )
+            return "Using Grapher IDs and CSV data files to create charts is deprecated."
+
         return ""
     }
 

--- a/explorerAdminClient/ExplorerCreatePage.scss
+++ b/explorerAdminClient/ExplorerCreatePage.scss
@@ -40,7 +40,7 @@
     max-width: 310px;
     padding: 4px 8px;
     font-weight: bold;
-    border: 4px solid #ce261e;
+    border: 4px solid orange;
 }
 
 // Hide the noisy arrow in the autocomplete dropdown.


### PR DESCRIPTION
resolves #2504

Adds a warning for mixed-content explorers that use Grapher IDs as well as CSV data files to create charts. We plan to drop support for mixed-content explorers soon-ish.