### PR TITLE
feat(explorer): add duplicate transform

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -544,7 +544,7 @@ export class Explorer
             [...ySlugs.split(" "), xSlug, colorSlug, sizeSlug].filter(identity)
         ) as string[]
 
-        // find all variables the the transformed columns depend on and add them to the dimensions array
+        // find all variables that the transformed columns depend on and add them to the dimensions array
         if (uniqueSlugsInGrapherRow.length) {
             const baseVariableIds = uniq(
                 uniqueSlugsInGrapherRow.flatMap((slug) =>
@@ -577,24 +577,6 @@ export class Explorer
 
         let grapherTable = grapher.inputTable
 
-        // update column definitions with manually provided properties
-        grapherTable = grapherTable.updateDefs((def: OwidColumnDef) => {
-            const manuallyProvidedDef =
-                this.columnDefsWithoutTableSlugByIdOrSlug[def.slug] ?? {}
-            const mergedDef = { ...def, ...manuallyProvidedDef }
-
-            // update display properties
-            mergedDef.display = mergedDef.display ?? {}
-            if (manuallyProvidedDef.name)
-                mergedDef.display.name = manuallyProvidedDef.name
-            if (manuallyProvidedDef.unit)
-                mergedDef.display.unit = manuallyProvidedDef.unit
-            if (manuallyProvidedDef.shortUnit)
-                mergedDef.display.shortUnit = manuallyProvidedDef.shortUnit
-
-            return mergedDef
-        })
-
         // add transformed (and intermediate) columns to the grapher table
         if (uniqueSlugsInGrapherRow.length) {
             const allColumnSlugs = uniq(
@@ -612,6 +594,24 @@ export class Explorer
                 .filter(identity)
             grapherTable = grapherTable.appendColumns(requiredColumnDefs)
         }
+
+        // update column definitions with manually provided properties
+        grapherTable = grapherTable.updateDefs((def: OwidColumnDef) => {
+            const manuallyProvidedDef =
+                this.columnDefsWithoutTableSlugByIdOrSlug[def.slug] ?? {}
+            const mergedDef = { ...def, ...manuallyProvidedDef }
+
+            // update display properties
+            mergedDef.display = mergedDef.display ?? {}
+            if (manuallyProvidedDef.name)
+                mergedDef.display.name = manuallyProvidedDef.name
+            if (manuallyProvidedDef.unit)
+                mergedDef.display.unit = manuallyProvidedDef.unit
+            if (manuallyProvidedDef.shortUnit)
+                mergedDef.display.shortUnit = manuallyProvidedDef.shortUnit
+
+            return mergedDef
+        })
 
         this.setGrapherTable(grapherTable)
     }

--- a/packages/@ourworldindata/core-table/src/CoreTable.test.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.test.ts
@@ -82,6 +82,42 @@ popChange,Pop change,percentChange time country population 2`
                 ).toEqual(expected.slice(1))
             })
         })
+
+        describe("copies data & metadata for duplicate transform", () => {
+            const table = new CoreTable(
+                `country,population
+iceland,1
+iceland,2
+france,50
+france,60`,
+                [
+                    {
+                        slug: "country",
+                        name: "Region",
+                    },
+                    {
+                        slug: "population",
+                        name: "Population in 2020",
+                        type: ColumnTypeNames.Integer,
+                    },
+                    {
+                        slug: "pop2",
+                        transform: "duplicate population",
+                    },
+                ]
+            )
+            const expected = [1, 2, 50, 60]
+            it("runs transforms correctly", () => {
+                expect(table.get("pop2").valuesIncludingErrorValues).toEqual(
+                    expected
+                )
+
+                expect(table.get("pop2").def.name).toEqual("Population in 2020")
+                expect(table.get("pop2").def.type).toEqual(
+                    ColumnTypeNames.Integer
+                )
+            })
+        })
     })
 
     it("can create an empty table", () => {

--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -114,13 +114,12 @@ export class CoreTable<
         this.inputColumnDefs = this.inputColumnDefs.map((def) => {
             if (!def.transform) return def
             const transform = extractTransformNameAndParams(def.transform)
-            if (!transform || transform.transformName !== "duplicate")
-                return def
+            if (transform?.transformName !== "duplicate") return def
+
             const sourceSlug = transform.params[0]
             const sourceDef = this.inputColumnDefs.find(
                 (def) => def.slug === sourceSlug
             )
-            if (!sourceDef) return def
             return { ...sourceDef, ...def }
         })
 

--- a/packages/@ourworldindata/core-table/src/Transforms.ts
+++ b/packages/@ourworldindata/core-table/src/Transforms.ts
@@ -1,4 +1,10 @@
-import { flatten, ColumnSlug, zip, uniq } from "@ourworldindata/utils"
+import {
+    flatten,
+    ColumnSlug,
+    zip,
+    uniq,
+    cloneDeep,
+} from "@ourworldindata/utils"
 import { CoreColumnStore, Time, CoreValueType } from "./CoreTableConstants.js"
 import { CoreColumnDef } from "./CoreColumnDef.js"
 import {
@@ -386,20 +392,29 @@ const asPercentageOf: Transform = {
             .map((num: any) => (typeof num === "number" ? 100 * num : num)),
 }
 
+const duplicate: Transform = {
+    params: [{ type: TransformParamType.DataSlug }],
+    fn: (
+        columnStore: CoreColumnStore,
+        columnSlug: ColumnSlug
+    ): CoreValueType[] => cloneDeep(columnStore[columnSlug]),
+}
+
 const availableTransforms: Record<string, Transform> = {
-    asPercentageOf: asPercentageOf,
-    timeSinceEntityExceededThreshold: timeSinceEntityExceededThreshold,
-    divideBy: divideBy,
-    rollingAverage: rollingAverage,
-    percentChange: percentChange,
-    multiplyBy: multiplyBy,
-    subtract: subtract,
-    where: where,
+    asPercentageOf,
+    timeSinceEntityExceededThreshold,
+    divideBy,
+    rollingAverage,
+    percentChange,
+    multiplyBy,
+    subtract,
+    where,
+    duplicate,
 } as const
 
 export const AvailableTransforms = Object.keys(availableTransforms)
 
-const extractTransformNameAndParams = (
+export const extractTransformNameAndParams = (
     transform: string
 ): { transformName: string; params: string[] } | undefined => {
     const words = transform.split(" ")


### PR DESCRIPTION
Resolves #2514

- Adds a `duplicate` transform that is useful in explorers
- The duplicate transform is special: It operates on data values and touches column definitions
- For example, a column with transform `duplicate my-slug` inherits all metadata (and data) from the `my-slug` column