### PR TITLE
Remove topic page annoucements from automated immediate newsletter

### DIFF
--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -15,6 +15,7 @@ import {
     renderBlogByPageNum,
     countryProfileCountryPage,
     renderExplorerPage,
+    makeAtomFeedNoTopicPages,
 } from "../baker/siteRenderers.js"
 import {
     BAKED_BASE_URL,
@@ -64,6 +65,11 @@ mockSiteRouter.get("/sitemap.xml", async (req, res) => {
 mockSiteRouter.get("/atom.xml", async (req, res) => {
     res.set("Content-Type", "application/xml")
     res.send(await makeAtomFeed())
+})
+
+mockSiteRouter.get("/atom-no-topic-pages.xml", async (req, res) => {
+    res.set("Content-Type", "application/xml")
+    res.send(await makeAtomFeedNoTopicPages())
 })
 
 mockSiteRouter.get("/entries-by-year", async (req, res) =>

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -32,6 +32,7 @@ import {
     flushCache as siteBakingFlushCache,
     renderPost,
     renderGdoc,
+    makeAtomFeedNoTopicPages,
 } from "../baker/siteRenderers.js"
 import {
     bakeGrapherUrls,
@@ -586,6 +587,10 @@ export class SiteBaker {
         await this.stageWrite(
             `${this.bakedSiteDir}/atom.xml`,
             await makeAtomFeed()
+        )
+        await this.stageWrite(
+            `${this.bakedSiteDir}/atom-no-topic-pages.xml`,
+            await makeAtomFeedNoTopicPages()
         )
         this.progressBar.tick({ name: "✅ baked rss" })
     }

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -350,7 +350,7 @@ export async function makeAtomFeed() {
 // pages announcemements are sent out manually.
 export async function makeAtomFeedNoTopicPages() {
     const posts = (await getBlogIndex())
-        .filter((post: IndexPost) => post.type != OwidGdocType.TopicPage)
+        .filter((post: IndexPost) => post.type !== OwidGdocType.TopicPage)
         .slice(0, 10)
     return makeAtomFeedFromPosts(posts)
 }

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -54,6 +54,7 @@ import {
     Url,
     IndexPost,
     mergePartialGrapherConfigs,
+    OwidGdocType,
 } from "@ourworldindata/utils"
 import { CountryProfileSpec } from "../site/countryProfileProjects.js"
 import { formatPost } from "./formatWordpressPost.js"
@@ -341,7 +342,20 @@ export const renderNotFoundPage = () =>
 
 export async function makeAtomFeed() {
     const posts = (await getBlogIndex()).slice(0, 10)
+    return makeAtomFeedFromPosts(posts)
+}
 
+// We don't want to include topic pages in the atom feed that is being consumed
+// by Mailchimp for sending the "immediate update" newsletter. Instead topic
+// pages announcemements are sent out manually.
+export async function makeAtomFeedNoTopicPages() {
+    const posts = (await getBlogIndex())
+        .filter((post: IndexPost) => post.type != OwidGdocType.TopicPage)
+        .slice(0, 10)
+    return makeAtomFeedFromPosts(posts)
+}
+
+export async function makeAtomFeedFromPosts(posts: IndexPost[]) {
     const feed = `<?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
 <title>Our World in Data</title>

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -347,7 +347,7 @@ export async function makeAtomFeed() {
 
 // We don't want to include topic pages in the atom feed that is being consumed
 // by Mailchimp for sending the "immediate update" newsletter. Instead topic
-// pages announcemements are sent out manually.
+// pages announcements are sent out manually.
 export async function makeAtomFeedNoTopicPages() {
     const posts = (await getBlogIndex())
         .filter((post: IndexPost) => post.type !== OwidGdocType.TopicPage)

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -777,6 +777,7 @@ export const mapGdocsToWordpressPosts = (
     return gdocs.map((gdoc) => ({
         title: gdoc.content["atom-title"] || gdoc.content.title,
         slug: gdoc.slug,
+        type: gdoc.content.type,
         date: gdoc.publishedAt,
         modifiedDate: gdoc.updatedAt,
         authors: gdoc.content.authors,

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -293,6 +293,7 @@ export interface KeyInsight {
 export interface IndexPost {
     title: string
     slug: string
+    type?: WP_PostType | OwidGdocType
     date: Date
     modifiedDate: Date
     authors: string[]
@@ -302,7 +303,6 @@ export interface IndexPost {
 
 export interface FullPost extends IndexPost {
     id: number
-    type: WP_PostType
     path: string
     content: string
     thumbnailUrl?: string


### PR DESCRIPTION
Problem: topic page announcements in the immediate newsletter are not sufficiently engaging.

Solution: remove them from the feed used by Mailchimp to send new issues of the immediate newsletter automatically. We still want to provide the full feed for RSS subscribers, so this PR creates an additional atom feed for Mailcihmp only, from which topic pages are excluded.

<img width="1421" alt="Screenshot 2023-08-15 at 14 42 21" src="https://github.com/owid/owid-grapher/assets/13406362/432d7c9f-c3eb-45cd-bb01-95701891c35e">

Staging feed URLs:
- http://staging-site-newsletter-no-topic-pages/atom-no-topic-pages.xml
- http://staging-site-newsletter-no-topic-pages/atom.xml
