### PR TITLE
Show "Explore the data" button when embedded

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
@@ -23,7 +23,6 @@ export interface ActionButtonsManager extends ShareMenuManager {
     currentTab?: GrapherTabOption | GrapherTabOverlayOption
     isShareMenuActive?: boolean
     hideShareTabButton?: boolean
-    hideFullScreenButton?: boolean
     hideExploreTheDataButton?: boolean
     isInIFrame?: boolean
     canonicalUrl?: string
@@ -221,11 +220,12 @@ export class ActionButtons extends React.Component<{
     }
 
     @computed private get hasFullScreenButton(): boolean {
-        return !this.manager.hideFullScreenButton
+        return !this.manager.isInIFrame
     }
 
     @computed private get hasExploreTheDataButton(): boolean {
-        return !this.manager.hideExploreTheDataButton
+        const { manager } = this
+        return !manager.hideExploreTheDataButton || !!manager.isInIFrame
     }
 
     @computed private get buttonCount(): number {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -272,7 +272,6 @@ export interface GrapherProgrammaticInterface extends GrapherInterface {
     hasSourcesTab?: boolean
     hasDownloadTab?: boolean
     hideShareTabButton?: boolean
-    hideFullScreenButton?: boolean
     hideExploreTheDataButton?: boolean
     hideRelatedQuestion?: boolean
 
@@ -2870,7 +2869,6 @@ export class Grapher
     @observable hasSourcesTab = true
     @observable hasDownloadTab = true
     @observable hideShareTabButton = false
-    @observable hideFullScreenButton = false
     @observable hideExploreTheDataButton = true
     @observable hideRelatedQuestion = false
 }

--- a/site/gdocs/Chart.tsx
+++ b/site/gdocs/Chart.tsx
@@ -58,7 +58,6 @@ export default function Chart({
             ...listOfPartialGrapherConfigs,
             {
                 hideRelatedQuestion: true,
-                hideExploreTheDataButton: false,
                 hideShareTabButton: true,
             },
             {
@@ -77,6 +76,9 @@ export default function Chart({
         }
     }
 
+    // always show the "Explore the data" button
+    config.hideExploreTheDataButton = false
+
     return (
         <div
             className={cx(d.position, className)}
@@ -89,9 +91,7 @@ export default function Chart({
                 data-grapher-src={isExplorer ? undefined : resolvedUrl}
                 data-explorer-src={isExplorer ? resolvedUrl : undefined}
                 data-grapher-config={
-                    isCustomized && !isExplorer
-                        ? JSON.stringify(config)
-                        : undefined
+                    !isExplorer ? JSON.stringify(config) : undefined
                 }
                 style={{
                     width: "100%",


### PR DESCRIPTION
- show "Explore the data" button when embedded in gdoc articles (customised or not)
- show "Explore the data" button in iframes
- hide full-screen button in iframes