### PR TITLE
Avoid repetitions in sources tab

### DIFF
--- a/packages/@ourworldindata/grapher/src/sourcesTab/SourcesTab.tsx
+++ b/packages/@ourworldindata/grapher/src/sourcesTab/SourcesTab.tsx
@@ -79,11 +79,15 @@ export class SourcesTab extends React.Component<{
                 : undefined)
 
         const citationProducer =
-            column.def.origins &&
-            column.def.origins.length &&
-            column.def.origins[0].citationProducer
-                ? column.def.origins[0].citationProducer
-                : undefined
+            column.def.origins && column.def.origins.length
+                ? [
+                      ...new Set(
+                          column.def.origins.map(
+                              (origin) => origin.citationProducer
+                          )
+                      ),
+                  ]
+                : []
 
         return (
             <div key={slug} className="datasource-wrapper">
@@ -138,13 +142,34 @@ export class SourcesTab extends React.Component<{
                                 <td>{column.unitConversionFactor}</td>
                             </tr>
                         ) : null}
-                        {attribution ? (
+                        {citationProducer.length > 0 ? (
                             <tr>
                                 <td>Data published by</td>
-                                <td>{attribution.join(", ")}</td>
+                                <td>
+                                    <ul>
+                                        {citationProducer.map(
+                                            (producer, index) => (
+                                                <li key={index}>{producer}</li>
+                                            )
+                                        )}
+                                    </ul>
+                                </td>
                             </tr>
                         ) : null}
                         {!attribution && source.dataPublishedBy ? (
+                            <tr>
+                                <td>Data published by</td>
+                                <td
+                                    dangerouslySetInnerHTML={{
+                                        __html: formatText(
+                                            source.dataPublishedBy
+                                        ),
+                                    }}
+                                />
+                            </tr>
+                        ) : null}
+                        {(!citationProducer || citationProducer.length === 0) &&
+                        source.dataPublishedBy ? (
                             <tr>
                                 <td>Data published by</td>
                                 <td
@@ -193,14 +218,6 @@ export class SourcesTab extends React.Component<{
                             __html: formatText(source.additionalInfo),
                         }}
                     />
-                )}
-                {citationProducer && (
-                    <p key={"citationProducer"}>
-                        <MarkdownTextWrap
-                            text={citationProducer}
-                            fontSize={12}
-                        />
-                    </p>
                 )}
             </div>
         )


### PR DESCRIPTION
I don't have much confidence on this PR (feel free to change it as you see fit), but the intention is the following:
* Field "Data published by" should avoid repeating entities, as it happens in, e.g. [this chart](https://owid.cloud/admin/charts/7079/edit), where we see "Data published by Fishcount, Fishcount, Fishcount" (because the indicator comes from three snapshots of the same producer).
* That field "Data published by", as far as I understand, should be the long citation of the sources, and should therefore correspond to ETL field `citation_producer`, instead of `attribution`.
* I think it's better to show citations as a list of bullet points instead of very long texts joined by "," or ";".
* I don't think we should show again `citation_producer` at the bottom of the sources tab for each variable. That information should already be displayed in "Data published by".

Please let me know if you think I misunderstood the meaning of some of the metadata fields, or if you disagree with this way of showing them in the old sources tab.