### PR TITLE
Font weight fixes

### DIFF
--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -98,7 +98,7 @@ $nav-height: 45px;
     section {
         h1 {
             font-size: 26px;
-            font-weight: 600;
+            font-weight: 700;
             line-height: 28px;
         }
 

--- a/adminSiteClient/styles/react-tag-autocomplete.scss
+++ b/adminSiteClient/styles/react-tag-autocomplete.scss
@@ -116,7 +116,7 @@
 .react-tags__suggestions li mark {
     text-decoration: underline;
     background: none;
-    font-weight: 600;
+    font-weight: 700;
 }
 
 .react-tags__suggestions li:hover {

--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.scss
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.scss
@@ -124,7 +124,7 @@ $zindex-dropdown: 100;
     }
 
     mark {
-        font-weight: 600;
+        font-weight: 700;
         background-color: #f9eec6;
         border-radius: 2px;
     }

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -154,7 +154,7 @@ $zindex-Tooltip: 20;
         font-size: 2em;
         margin-top: 0;
         margin-bottom: 0.8em;
-        font-weight: 500;
+        font-weight: 400;
         line-height: 1.1;
     }
 

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -137,6 +137,7 @@ class Label extends React.Component<{
                         {
                             fill: annotationColor,
                             className: "textAnnotation",
+                            style: { fontWeight: 300 },
                         }
                     )}
             </g>

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -137,7 +137,6 @@ class Label extends React.Component<{
                         {
                             fill: annotationColor,
                             className: "textAnnotation",
-                            style: { fontWeight: "lighter" },
                         }
                     )}
             </g>

--- a/site/PostCard/PostCard.scss
+++ b/site/PostCard/PostCard.scss
@@ -42,7 +42,6 @@
 
     .excerpt {
         margin-top: $vertical-spacing;
-        font-weight: lighter;
         line-height: 1.2;
     }
 

--- a/site/PostCard/PostCard.scss
+++ b/site/PostCard/PostCard.scss
@@ -43,6 +43,7 @@
     .excerpt {
         margin-top: $vertical-spacing;
         line-height: 1.2;
+        font-weight: 300;
     }
 
     .entry-meta {

--- a/site/SiteFooter.tsx
+++ b/site/SiteFooter.tsx
@@ -262,7 +262,6 @@ export const SiteFooter = (props: SiteFooterProps) => (
                                 , a registered charity in England and Wales
                                 (Charity Number 1186433).
                             </p>
-                            {/* <a href="/" className="owid-logo">Our World in Data</a> */}
                         </div>
                     </div>
                 </div>

--- a/site/css/footer.scss
+++ b/site/css/footer.scss
@@ -22,15 +22,6 @@
         }
     }
 
-    .owid-logo {
-        display: block;
-        font-size: 1.5rem;
-        font-weight: 300;
-        text-decoration: none;
-        color: $blue-90;
-        text-align: right;
-    }
-
     ul {
         list-style-type: none;
         margin-bottom: 1rem;

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -1202,7 +1202,6 @@ html:not(.js) {
             color: #002147;
             font-family: inherit;
             font-size: 1rem;
-            font-weight: 600;
 
             &:focus {
                 border-color: #002147;
@@ -1210,7 +1209,6 @@ html:not(.js) {
         }
 
         textarea {
-            font-weight: 400;
             font-size: 0.875rem;
             flex: 1;
             resize: none;

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -685,7 +685,7 @@ hr {
 
     h3 {
         font-size: 15px;
-        font-weight: 500;
+        font-weight: 400;
         margin-top: 2em;
         margin-bottom: 0;
         color: rgba(0, 0, 0, 0.65);


### PR DESCRIPTION
Fixes a few spots where we had specified font weights that we didn't support that [now look wrong with the "correct" font weight.
](https://github.com/owid/owid-grapher/pull/2518)
e.g. 

![image](https://github.com/owid/owid-grapher/assets/11844404/c1fe749f-cadd-4e5a-be0c-a60358fb10de)


