### PR TITLE
Decouple grapher tagging from key chart sorting in "all charts" block

### DIFF
--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -11,7 +11,13 @@ import { observable, action } from "mobx"
 import { observer } from "mobx-react"
 import cx from "classnames"
 
-import { pick, capitalize, dayjs, Tippy } from "@ourworldindata/utils"
+import {
+    pick,
+    capitalize,
+    dayjs,
+    Tippy,
+    KeyChartLevel,
+} from "@ourworldindata/utils"
 import { Colorpicker } from "./Colorpicker.js"
 import {
     faCog,
@@ -1060,7 +1066,15 @@ export class EditableTags extends React.Component<{
     }
 
     @action.bound onToggleKey(index: number) {
-        this.tags[index].isKeyChart = !this.tags[index].isKeyChart
+        const currentKeyChartLevel =
+            this.tags[index].isKeyChart || KeyChartLevel.None
+
+        // We cycle through 4 states of key chart levels for a given topic / chart combination
+        this.tags[index].isKeyChart =
+            currentKeyChartLevel === KeyChartLevel.None
+                ? KeyChartLevel.Top
+                : currentKeyChartLevel - 1
+
         this.props.onSave(this.tags.filter(filterUncategorizedTag))
     }
 
@@ -1075,6 +1089,10 @@ export class EditableTags extends React.Component<{
 
     @action.bound onToggleEdit() {
         if (this.isEditing) {
+            // Add a default key chart level to new tags
+            this.tags.forEach(
+                (tag) => (tag.isKeyChart = tag.isKeyChart ?? KeyChartLevel.None)
+            )
             this.props.onSave(this.tags.filter(filterUncategorizedTag))
         }
         this.isEditing = !this.isEditing

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -1067,10 +1067,10 @@ export class EditableTags extends React.Component<{
 
     @action.bound onToggleKey(index: number) {
         const currentKeyChartLevel =
-            this.tags[index].isKeyChart || KeyChartLevel.None
+            this.tags[index].keyChartLevel || KeyChartLevel.None
 
         // We cycle through 4 states of key chart levels for a given topic / chart combination
-        this.tags[index].isKeyChart =
+        this.tags[index].keyChartLevel =
             currentKeyChartLevel === KeyChartLevel.None
                 ? KeyChartLevel.Top
                 : currentKeyChartLevel - 1
@@ -1091,7 +1091,9 @@ export class EditableTags extends React.Component<{
         if (this.isEditing) {
             // Add a default key chart level to new tags
             this.tags.forEach(
-                (tag) => (tag.isKeyChart = tag.isKeyChart ?? KeyChartLevel.None)
+                (tag) =>
+                    (tag.keyChartLevel =
+                        tag.keyChartLevel ?? KeyChartLevel.None)
             )
             this.props.onSave(this.tags.filter(filterUncategorizedTag))
         }

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -1125,7 +1125,8 @@ export class EditableTags extends React.Component<{
                         {tags.map((t, i) => (
                             <TagBadge
                                 onToggleKey={
-                                    hasKeyChartSupport
+                                    hasKeyChartSupport &&
+                                    filterUncategorizedTag(t)
                                         ? () => this.onToggleKey(i)
                                         : undefined
                                 }

--- a/adminSiteClient/TagBadge.tsx
+++ b/adminSiteClient/TagBadge.tsx
@@ -1,11 +1,10 @@
 import React from "react"
 import { observer } from "mobx-react"
-import { Tag } from "@ourworldindata/utils"
+import { KeyChartLevel, Tag } from "@ourworldindata/utils"
 
 import { Link } from "./Link.js"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
-import { faStar } from "@fortawesome/free-solid-svg-icons"
 import Tippy from "@tippyjs/react"
+import { TagBucketSortingIcon } from "./TagBucketSortingIcon.js"
 
 export type { Tag }
 
@@ -15,31 +14,44 @@ export class TagBadge extends React.Component<{
     onToggleKey?: () => void
     searchHighlight?: (text: string) => string | JSX.Element
 }> {
+    levelToDesc(level?: KeyChartLevel) {
+        switch (level) {
+            case KeyChartLevel.Bottom:
+                return "at the bottom"
+            case KeyChartLevel.Middle:
+                return "in the middle"
+            case KeyChartLevel.Top:
+                return "at the top"
+            default:
+                return ""
+        }
+    }
+
     render() {
         const { tag, searchHighlight, onToggleKey } = this.props
-        const classes = ["TagBadge"]
+        const keyChartLevelDesc =
+            tag.isKeyChart === KeyChartLevel.None
+                ? "Not a key chart, will be hidden in the all charts block of the topic page"
+                : `Chart will show ${this.levelToDesc(
+                      tag.isKeyChart
+                  )} of the all charts block on the topic page`
 
-        if (onToggleKey) {
-            classes.push("hasKeyChartSupport")
-            if (tag.isKeyChart) classes.push("isKeyChart")
-            return (
-                <Tippy
-                    content={`${
-                        tag.isKeyChart ? "⬇️ Demote from" : "⬆️ Promote to"
-                    } key charts on topic "${tag.name}"`}
-                >
-                    <span className={classes.join(" ")} onClick={onToggleKey}>
-                        {searchHighlight ? searchHighlight(tag.name) : tag.name}
-                        {tag.isKeyChart && <FontAwesomeIcon icon={faStar} />}
-                    </span>
-                </Tippy>
-            )
-        } else {
-            return (
-                <Link className="TagBadge" to={`/tags/${tag.id}`}>
+        return (
+            <span className="TagBadge">
+                <Link className="TagBadge__name" to={`/tags/${tag.id}`}>
                     {searchHighlight ? searchHighlight(tag.name) : tag.name}
                 </Link>
-            )
-        }
+                {onToggleKey ? (
+                    <Tippy content={`${keyChartLevelDesc} "${tag.name}"`}>
+                        <span
+                            className="TagBadge__sorting"
+                            onClick={onToggleKey}
+                        >
+                            <TagBucketSortingIcon level={tag.isKeyChart} />
+                        </span>
+                    </Tippy>
+                ) : null}
+            </span>
+        )
     }
 }

--- a/adminSiteClient/TagBadge.tsx
+++ b/adminSiteClient/TagBadge.tsx
@@ -30,10 +30,10 @@ export class TagBadge extends React.Component<{
     render() {
         const { tag, searchHighlight, onToggleKey } = this.props
         const keyChartLevelDesc =
-            tag.isKeyChart === KeyChartLevel.None
+            tag.keyChartLevel === KeyChartLevel.None
                 ? "Not a key chart, will be hidden in the all charts block of the topic page"
                 : `Chart will show ${this.levelToDesc(
-                      tag.isKeyChart
+                      tag.keyChartLevel
                   )} of the all charts block on the topic page`
 
         return (
@@ -47,7 +47,7 @@ export class TagBadge extends React.Component<{
                             className="TagBadge__sorting"
                             onClick={onToggleKey}
                         >
-                            <TagBucketSortingIcon level={tag.isKeyChart} />
+                            <TagBucketSortingIcon level={tag.keyChartLevel} />
                         </span>
                     </Tippy>
                 ) : null}

--- a/adminSiteClient/TagBucketSortingIcon.tsx
+++ b/adminSiteClient/TagBucketSortingIcon.tsx
@@ -1,0 +1,26 @@
+import React from "react"
+import { KeyChartLevel } from "@ourworldindata/utils"
+
+export const TagBucketSortingIcon = ({ level }: { level?: number }) => {
+    const width = 13
+
+    return level !== undefined ? (
+        <svg
+            width={width}
+            height="13"
+            viewBox={`0 0 ${width} 13`}
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            {Array.from({ length: 3 }, (_, idx) => (
+                <rect
+                    key={idx}
+                    y={(KeyChartLevel.Top - (idx + 1)) * 5} // idx: 0 1 2 -> y: 10 5 0
+                    width={width}
+                    height="3"
+                    fill={idx + 1 === level ? "#000000" : "#c1c1c1"}
+                />
+            ))}
+        </svg>
+    ) : null
+}

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -852,22 +852,31 @@ main:not(.ChartEditorPage):not(.GdocsEditPage) {
 
 .TagBadge {
     display: inline-block;
-    padding: 6px;
     border-radius: 5px;
+    border: 1px solid #eee;
     font-size: 0.8em;
     background-color: #eee;
-    color: #333;
     margin-right: 5px;
     margin-bottom: 5px;
-    cursor: pointer;
 
-    &.hasKeyChartSupport:hover {
-        background-color: #c0c0c0;
+    .TagBadge__name {
+        color: #333;
     }
 
-    &.isKeyChart {
-        svg {
-            margin-left: 5px;
+    .TagBadge__sorting,
+    .TagBadge__name {
+        display: inline-block;
+        padding: 6px;
+    }
+
+    .TagBadge__sorting {
+        border-top-right-radius: 5px;
+        border-bottom-right-radius: 5px;
+        background-color: #fff;
+        cursor: pointer;
+
+        &:hover {
+            background-color: #eee;
         }
     }
 }

--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -4,7 +4,7 @@ import { ALGOLIA_INDEXING } from "../../settings/serverSettings.js"
 import { getAlgoliaClient } from "./configureAlgolia.js"
 import { isPathRedirectedToExplorer } from "../../explorerAdminServer/ExplorerRedirects.js"
 import { ChartRecord } from "../../site/search/searchTypes.js"
-import { MarkdownTextWrap } from "@ourworldindata/utils"
+import { KeyChartLevel, MarkdownTextWrap } from "@ourworldindata/utils"
 import { Pageview } from "../../db/model/Pageview.js"
 import { Link } from "../../db/model/Link.js"
 
@@ -25,7 +25,7 @@ const getChartsRecords = async (): Promise<ChartRecord[]> => {
         c.publishedAt,
         c.updatedAt,
         JSON_ARRAYAGG(t.name) AS tags,
-        JSON_ARRAYAGG(IF(ct.isKeyChart, t.name, NULL)) AS keyChartForTags -- this results in an array that contains null entries, will have to filter them out
+        JSON_ARRAYAGG(IF(ct.keyChartLevel = ${KeyChartLevel.Top} , t.name, NULL)) AS keyChartForTags -- this results in an array that contains null entries, will have to filter them out
     FROM charts c
         LEFT JOIN chart_tags ct ON c.id = ct.chartId
         LEFT JOIN tags t on ct.tagId = t.id

--- a/db/migration/1692284452006-MoreGranularKeyChartSorting.ts
+++ b/db/migration/1692284452006-MoreGranularKeyChartSorting.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class MoreGranularKeyChartSorting1692284452006
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Update chart_tags table to rename isKeyChart to keyChartLevel
+        await queryRunner.query(`
+            ALTER TABLE chart_tags
+            RENAME COLUMN isKeyChart TO keyChartLevel
+        `)
+
+        // Update chart_tags table so that:
+        // - the legacy isKeyChart === 0 (false) becomes 2 (middle). In the
+        //   legacy system, non-key charts (0) were shown in the all charts
+        //   block. Some curation has been done already with this assumption in
+        //   mind, so we preserve the old behaviour through the migration, while
+        //   giving the tools to demote those charts if necessary.
+        // - and isKeyChart === 1 (true) becomes 3 (top)
+        await queryRunner.query(`
+            UPDATE chart_tags
+            SET keyChartLevel = keyChartLevel + 2
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE chart_tags
+            SET keyChartLevel = keyChartLevel - 2
+        `)
+
+        await queryRunner.query(`
+            ALTER TABLE chart_tags
+            RENAME COLUMN keyChartLevel TO isKeyChart
+        `)
+    }
+}

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -113,11 +113,15 @@ WHERE c.config -> "$.isPublished" = true
 
     static async setTags(chartId: number, tags: Tag[]): Promise<void> {
         await db.transaction(async (t) => {
-            const tagRows = tags.map((tag) => [tag.id, chartId, tag.isKeyChart])
+            const tagRows = tags.map((tag) => [
+                tag.id,
+                chartId,
+                tag.keyChartLevel,
+            ])
             await t.execute(`DELETE FROM chart_tags WHERE chartId=?`, [chartId])
             if (tagRows.length)
                 await t.execute(
-                    `INSERT INTO chart_tags (tagId, chartId, isKeyChart) VALUES ?`,
+                    `INSERT INTO chart_tags (tagId, chartId, keyChartLevel) VALUES ?`,
                     [tagRows]
                 )
 
@@ -141,7 +145,7 @@ WHERE c.config -> "$.isPublished" = true
         charts: { id: number; tags: any[] }[]
     ): Promise<void> {
         const chartTags = await db.queryMysql(`
-            SELECT ct.chartId, ct.tagId, ct.isKeyChart, t.name as tagName FROM chart_tags ct
+            SELECT ct.chartId, ct.tagId, ct.keyChartLevel, t.name as tagName FROM chart_tags ct
             JOIN charts c ON c.id=ct.chartId
             JOIN tags t ON t.id=ct.tagId
         `)
@@ -158,7 +162,7 @@ WHERE c.config -> "$.isPublished" = true
                 chart.tags.push({
                     id: ct.tagId,
                     name: ct.tagName,
-                    isKeyChart: ct.isKeyChart,
+                    keyChartLevel: ct.keyChartLevel,
                 })
         }
     }

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -113,11 +113,7 @@ WHERE c.config -> "$.isPublished" = true
 
     static async setTags(chartId: number, tags: Tag[]): Promise<void> {
         await db.transaction(async (t) => {
-            const tagRows = tags.map((tag) => [
-                tag.id,
-                chartId,
-                !!tag.isKeyChart,
-            ])
+            const tagRows = tags.map((tag) => [tag.id, chartId, tag.isKeyChart])
             await t.execute(`DELETE FROM chart_tags WHERE chartId=?`, [chartId])
             if (tagRows.length)
                 await t.execute(
@@ -162,7 +158,7 @@ WHERE c.config -> "$.isPublished" = true
                 chart.tags.push({
                     id: ct.tagId,
                     name: ct.tagName,
-                    isKeyChart: !!ct.isKeyChart,
+                    isKeyChart: ct.isKeyChart,
                 })
         }
     }

--- a/db/model/Gdoc/Gdoc.ts
+++ b/db/model/Gdoc/Gdoc.ts
@@ -892,7 +892,7 @@ export class Gdoc extends BaseEntity implements OwidGdocInterface {
         charts.config->>"$.slug" AS slug,
         charts.config->>"$.title" AS title,
         charts.config->>"$.variantName" AS variantName,
-        chart_tags.isKeyChart
+        chart_tags.keyChartLevel
         FROM charts
         INNER JOIN chart_tags ON charts.id=chart_tags.chartId
         WHERE chart_tags.tagId IN (?)

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -614,7 +614,7 @@ export const getRelatedCharts = async (
             charts.config->>"$.slug" AS slug,
             charts.config->>"$.title" AS title,
             charts.config->>"$.variantName" AS variantName,
-            chart_tags.isKeyChart
+            chart_tags.keyChartLevel
         FROM charts
         INNER JOIN chart_tags ON charts.id=chart_tags.chartId
         INNER JOIN post_tags ON chart_tags.tagId=post_tags.tag_id
@@ -637,7 +637,7 @@ export const getRelatedChartsForVariable = async (
                     charts.config->>"$.slug" AS slug,
                     charts.config->>"$.title" AS title,
                     charts.config->>"$.variantName" AS variantName,
-                    MAX(chart_tags.isKeyChart) as isKeyChart
+                    MAX(chart_tags.keyChartLevel) as keyChartLevel
                 FROM charts
                 INNER JOIN chart_tags ON charts.id=chart_tags.chartId
                 WHERE JSON_CONTAINS(config->'$.dimensions', '{"variableId":${variableId}}')

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -90,6 +90,7 @@ export {
     type IndexPost,
     type Integer,
     JsonError,
+    KeyChartLevel,
     type KeyInsight,
     type KeyValueProps,
     type OwidGdocContent,

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -188,8 +188,15 @@ export interface PostRowWithGdocPublishStatus extends PostRow {
     isGdocPublished: boolean
 }
 
+export enum KeyChartLevel {
+    None = 0, // not a key chart, will not show in the all charts block of the related topic page
+    Bottom = 1, // chart will show at the bottom of the all charts block
+    Middle = 2, // chart will show in the middle of the all charts block
+    Top = 3, // chart will show at the top of the all charts block
+}
+
 export interface Tag extends TagReactTagAutocomplete {
-    isKeyChart?: boolean
+    isKeyChart?: KeyChartLevel
 }
 
 export interface EntryMeta {

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -63,7 +63,7 @@ export interface BasicChartInformation {
 }
 
 export interface RelatedChart extends BasicChartInformation {
-    isKeyChart?: KeyChartLevel
+    keyChartLevel?: KeyChartLevel
 }
 
 export type OwidVariableId = Integer // remove.
@@ -196,7 +196,7 @@ export enum KeyChartLevel {
 }
 
 export interface Tag extends TagReactTagAutocomplete {
-    isKeyChart?: KeyChartLevel
+    keyChartLevel?: KeyChartLevel
 }
 
 export interface EntryMeta {

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -63,7 +63,7 @@ export interface BasicChartInformation {
 }
 
 export interface RelatedChart extends BasicChartInformation {
-    isKeyChart?: boolean
+    isKeyChart?: KeyChartLevel
 }
 
 export type OwidVariableId = Integer // remove.

--- a/site/GrapherPage.jsdom.test.tsx
+++ b/site/GrapherPage.jsdom.test.tsx
@@ -49,12 +49,12 @@ beforeAll(() => {
         {
             title: "Chart 1",
             slug: "chart-1",
-            isKeyChart: KeyChartLevel.Middle,
+            keyChartLevel: KeyChartLevel.Middle,
         },
         {
             title: "Chart 2",
             slug: "chart-2",
-            isKeyChart: KeyChartLevel.Top,
+            keyChartLevel: KeyChartLevel.Top,
         },
     ]
 })

--- a/site/GrapherPage.jsdom.test.tsx
+++ b/site/GrapherPage.jsdom.test.tsx
@@ -1,7 +1,12 @@
 #! /usr/bin/env jest
 
 import { GrapherInterface } from "@ourworldindata/grapher"
-import { DimensionProperty, PostRow, RelatedChart } from "@ourworldindata/utils"
+import {
+    DimensionProperty,
+    KeyChartLevel,
+    PostRow,
+    RelatedChart,
+} from "@ourworldindata/utils"
 import React from "react"
 import { ChartListItemVariant } from "./ChartListItemVariant.js"
 import { GrapherPage } from "./GrapherPage.js"
@@ -44,12 +49,12 @@ beforeAll(() => {
         {
             title: "Chart 1",
             slug: "chart-1",
-            isKeyChart: false,
+            isKeyChart: KeyChartLevel.Middle,
         },
         {
             title: "Chart 2",
             slug: "chart-2",
-            isKeyChart: true,
+            isKeyChart: KeyChartLevel.Top,
         },
     ]
 })

--- a/site/blocks/AllCharts.tsx
+++ b/site/blocks/AllCharts.tsx
@@ -9,7 +9,10 @@ export const AllCharts = ({ post }: { post: FullPost }) => {
         <>
             <h3>Interactive charts on {post.title}</h3>
             <div className={WP_BlockClass.FullContentWidth}>
-                <RelatedCharts charts={post.relatedCharts} />
+                <RelatedCharts
+                    showKeyChartsOnly={true}
+                    charts={post.relatedCharts}
+                />
             </div>
         </>
     )

--- a/site/blocks/RelatedCharts.jsdom.test.tsx
+++ b/site/blocks/RelatedCharts.jsdom.test.tsx
@@ -16,12 +16,12 @@ const charts = [
     {
         title: "Chart 1",
         slug: "chart-1",
-        isKeyChart: KeyChartLevel.Top,
+        keyChartLevel: KeyChartLevel.Top,
     },
     {
         title: "Chart 2",
         slug: "chart-2",
-        isKeyChart: KeyChartLevel.Top,
+        keyChartLevel: KeyChartLevel.Top,
     },
 ]
 

--- a/site/blocks/RelatedCharts.jsdom.test.tsx
+++ b/site/blocks/RelatedCharts.jsdom.test.tsx
@@ -16,7 +16,7 @@ const charts = [
     {
         title: "Chart 1",
         slug: "chart-1",
-        keyChartLevel: KeyChartLevel.Top,
+        keyChartLevel: KeyChartLevel.Middle,
     },
     {
         title: "Chart 2",
@@ -42,7 +42,7 @@ it("renders active chart links and loads respective chart on click", () => {
     ).toHaveLength(1)
 
     wrapper.find("a").forEach((link, idx) => {
-        // Chart 2 is a key chart, so the charts should be in reverse order: `Chart 2, Chart 1`
+        // Chart 2 has a higher priority, so the charts should be in reverse order: `Chart 2, Chart 1`
         const expectedChartIdx = 1 - idx
         link.simulate("click")
         expect(wrapper.find("figure")).toHaveLength(1)

--- a/site/blocks/RelatedCharts.jsdom.test.tsx
+++ b/site/blocks/RelatedCharts.jsdom.test.tsx
@@ -9,18 +9,19 @@ import {
     BAKED_BASE_URL,
     BAKED_GRAPHER_EXPORTS_BASE_URL,
 } from "../../settings/clientSettings.js"
+import { KeyChartLevel } from "@ourworldindata/utils"
 Enzyme.configure({ adapter: new Adapter() })
 
 const charts = [
     {
         title: "Chart 1",
         slug: "chart-1",
-        isKeyChart: false,
+        isKeyChart: KeyChartLevel.Top,
     },
     {
         title: "Chart 2",
         slug: "chart-2",
-        isKeyChart: true,
+        isKeyChart: KeyChartLevel.Top,
     },
 ]
 

--- a/site/blocks/RelatedCharts.tsx
+++ b/site/blocks/RelatedCharts.tsx
@@ -22,12 +22,12 @@ export const RelatedCharts = ({
     const isLastSlideActive = activeChartIdx === charts.length - 1
 
     const chartsToShow = showKeyChartsOnly
-        ? charts.filter((chart) => !!chart.isKeyChart)
+        ? charts.filter((chart) => !!chart.keyChartLevel)
         : charts
 
     const sortedCharts = orderBy(
         chartsToShow,
-        (chart) => chart.isKeyChart,
+        (chart) => chart.keyChartLevel,
         "desc"
     )
     const activeChartSlug = sortedCharts[activeChartIdx]?.slug

--- a/site/blocks/RelatedCharts.tsx
+++ b/site/blocks/RelatedCharts.tsx
@@ -18,9 +18,6 @@ export const RelatedCharts = ({
     const refChartContainer = useRef<HTMLDivElement>(null)
     const [activeChartIdx, setActiveChartIdx] = useState(0)
 
-    const isFirstSlideActive = activeChartIdx === 0
-    const isLastSlideActive = activeChartIdx === charts.length - 1
-
     const chartsToShow = showKeyChartsOnly
         ? charts.filter((chart) => !!chart.keyChartLevel)
         : charts
@@ -30,6 +27,9 @@ export const RelatedCharts = ({
         (chart) => chart.keyChartLevel,
         "desc"
     )
+
+    const isFirstSlideActive = activeChartIdx === 0
+    const isLastSlideActive = activeChartIdx === sortedCharts.length - 1
     const activeChartSlug = sortedCharts[activeChartIdx]?.slug
 
     const onClickItem = (event: React.MouseEvent, idx: number) => {
@@ -75,7 +75,9 @@ export const RelatedCharts = ({
                             direction={GalleryArrowDirection.prev}
                         ></GalleryArrow>
                         <div className="gallery-pagination">
-                            {`Chart ${activeChartIdx + 1} of ${charts.length}`}
+                            {`Chart ${activeChartIdx + 1} of ${
+                                sortedCharts.length
+                            }`}
                         </div>
                         <GalleryArrow
                             disabled={isLastSlideActive}

--- a/site/blocks/RelatedCharts.tsx
+++ b/site/blocks/RelatedCharts.tsx
@@ -8,14 +8,28 @@ import { BAKED_BASE_URL } from "../../settings/clientSettings.js"
 
 export const RELATED_CHARTS_CLASS_NAME = "related-charts"
 
-export const RelatedCharts = ({ charts }: { charts: RelatedChart[] }) => {
+export const RelatedCharts = ({
+    charts,
+    showKeyChartsOnly = false,
+}: {
+    charts: RelatedChart[]
+    showKeyChartsOnly?: boolean
+}) => {
     const refChartContainer = useRef<HTMLDivElement>(null)
     const [activeChartIdx, setActiveChartIdx] = useState(0)
 
     const isFirstSlideActive = activeChartIdx === 0
     const isLastSlideActive = activeChartIdx === charts.length - 1
 
-    const sortedCharts = orderBy(charts, (chart) => chart.isKeyChart, "desc")
+    const chartsToShow = showKeyChartsOnly
+        ? charts.filter((chart) => !!chart.isKeyChart)
+        : charts
+
+    const sortedCharts = orderBy(
+        chartsToShow,
+        (chart) => chart.isKeyChart,
+        "desc"
+    )
     const activeChartSlug = sortedCharts[activeChartIdx]?.slug
 
     const onClickItem = (event: React.MouseEvent, idx: number) => {
@@ -84,7 +98,7 @@ export const runRelatedCharts = (charts: RelatedChart[]) => {
     if (relatedChartsEl) {
         const relatedChartsWrapper = relatedChartsEl.parentElement
         ReactDOM.hydrate(
-            <RelatedCharts charts={charts} />,
+            <RelatedCharts showKeyChartsOnly={true} charts={charts} />,
             relatedChartsWrapper
         )
     }

--- a/site/gdocs/AllCharts.tsx
+++ b/site/gdocs/AllCharts.tsx
@@ -5,6 +5,7 @@ import {
     RelatedChart,
     Url,
     ALL_CHARTS_ID,
+    KeyChartLevel,
 } from "@ourworldindata/utils"
 import { AttachmentsContext } from "./OwidGdoc.js"
 import { RelatedCharts } from "../blocks/RelatedCharts.js"
@@ -28,7 +29,7 @@ function sortRelatedCharts(
             if (relatedChart) {
                 // a teeny hack to stop the RelatedCharts component from
                 // sorting these charts below the other key charts
-                relatedChart.isKeyChart = true
+                relatedChart.isKeyChart = KeyChartLevel.Top
                 sortedRelatedCharts.push(relatedChart)
             }
         }
@@ -54,7 +55,10 @@ export function AllCharts(props: AllChartsProps) {
                 {heading}
                 <a className="deep-link" href={`#${ALL_CHARTS_ID}`} />
             </h1>
-            <RelatedCharts charts={sortedRelatedCharts} />
+            <RelatedCharts
+                showKeyChartsOnly={true}
+                charts={sortedRelatedCharts}
+            />
         </div>
     )
 }

--- a/site/gdocs/AllCharts.tsx
+++ b/site/gdocs/AllCharts.tsx
@@ -29,7 +29,7 @@ function sortRelatedCharts(
             if (relatedChart) {
                 // a teeny hack to stop the RelatedCharts component from
                 // sorting these charts below the other key charts
-                relatedChart.isKeyChart = KeyChartLevel.Top
+                relatedChart.keyChartLevel = KeyChartLevel.Top
                 sortedRelatedCharts.push(relatedChart)
             }
         }


### PR DESCRIPTION
<!--
copilot:summary
-->
The main ambition of this PR is to decouple the tagging of charts from their promotion as key charts in the "all charts" block.
Charts can now be tagged without appearing in the "all charts" block.
In addition, there are now 3 levels of key charts: bottom, middle, and top.

<img width="1261" alt="Screenshot 2023-08-17 at 18 41 58" src="https://github.com/owid/owid-grapher/assets/13406362/f5821cbc-9bd5-47d5-aa40-0b73986dbe2c">

### <samp>🤖 Generated by Copilot at b7b4cf5</samp>

This pull request refactors the codebase to use a `keyChartLevel` property instead of a `isKeyChart` property for tagging and sorting charts on topic pages. The `keyChartLevel` property is an enum that allows more fine-grained control over the display of key charts. The pull request updates the UI components, the database schema and queries, the Algolia indexing logic, and the tests to handle the new property. It also adds a feature to the `RelatedCharts` component that allows it to only show key charts based on a prop.

-- 

### DB Migration
- "tagged" (0) becomes "tagged as key chart, positioned in the middle of the all charts block" (2)
- "tagged with key chart star" (1) becomes "tagged as key chart, positioned at the top of the all charts block" (3)
- `isKeyChart` becomes `keyChartLevel` and now ranges from 0 (not shown in the all charts block), to 1 (shown at the bottom) and ultimately 3 (shown at the top)

### Non-key charts are still visible on data pages

AllCharts blocks are used in multiple places: DataPage, DataPageV2, Wordpress entries, Wordpress topic pages, Gdoc topic pages. For now, we know we want to hide non key charts from three of these five contexts: Wordpress entries, Wordpress topic pages, Gdoc topic pages. This is done through the introduction a new prop on the RelatedCharts component `showOnlyKeyCharts`.

Ultimately, we might want to hide non-key charts in all these instances and only surface non-key charts in search. At this point, we might filter for key charts further up the execution chain and closer to the query, instead of filtering later near the rendering process in RelatedCharts.

### Demo
- gdoc topic page: PR #2557 - More granular sorting for all charts block ([edit](https://docs.google.com/document/d/1VFPH3BZlUay1YxPKPHvMZqtMAfWJwTtRN92Ct6duH44/edit), [preview](http://staging-site-all-charts-sorting/admin/gdocs/1VFPH3BZlUay1YxPKPHvMZqtMAfWJwTtRN92Ct6duH44/preview))
- wordpress entry: Causes of Deaths ([edit](https://staging.owid.cloud/wp/wp-admin/post.php?post=15277&action=edit), [preview](http://staging-site-all-charts-sorting/admin/posts/preview/15277)) 
- wordpress topic page: Causes of death (PR 2557) ([edit](https://staging.owid.cloud/wp/wp-admin/post.php?post=57862&action=edit), [preview](http://staging-site-all-charts-sorting/admin/posts/preview/57862))


