### PR TITLE
Various bug fixes for Grapher redesign project

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/ActionButtons.scss
+++ b/packages/@ourworldindata/grapher/src/controls/ActionButtons.scss
@@ -12,6 +12,7 @@ $paddingLeftRight: 12px; // keep in sync with PADDING_LEFT_RIGHT
     ul {
         list-style: none;
         height: $actionButtonHeight;
+        padding: 0;
     }
 
     li {

--- a/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
@@ -90,11 +90,9 @@ export class ActionButtons extends React.Component<{
     }
 
     @computed private get showButtonLabels(): boolean {
-        const { availableWidth, sizeVariant, widthWithButtonLabels, maxWidth } =
-            this
+        const { availableWidth, sizeVariant, widthWithButtonLabels } = this
         if (sizeVariant !== SizeVariant.lg) return false
-        if (widthWithButtonLabels <= availableWidth) return true
-        return widthWithButtonLabels < 0.33 * maxWidth
+        return widthWithButtonLabels <= availableWidth
     }
 
     @computed get width(): number {

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -444,7 +444,7 @@ export class MapChart
     }
 
     @computed get choroplethMapBounds(): Bounds {
-        return this.bounds.padBottom(this.legendHeight + 15)
+        return this.bounds.padBottom(this.legendHeight + 4)
     }
 
     @computed get projection(): MapProjectionName {

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -2,6 +2,7 @@
     height: calc(100% - 14px);
     overflow-y: auto;
     color: $dark-text;
+    padding-bottom: 1em;
 
     .grouped-menu-section {
         h2 {


### PR DESCRIPTION
- prevent grapher to overflow in admin
- add padding that was missing (visible after scroll)
- only label action buttons if there is enough space