### PR TITLE
enhance: use new detect-country worker to detect country

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,7 +7,6 @@ jest.config.js
 knexfile.ts
 ormconfig.js
 postcss.config.js
-public/detect-country.js
 wordpress/web/wp/wp-includes/**
 wordpress/web/wp/wp-admin/**
 wordpress/web/app/plugins/**

--- a/baker/redirects.ts
+++ b/baker/redirects.ts
@@ -1,11 +1,6 @@
 import * as db from "../db/db.js"
 import * as wpdb from "../db/wpdb.js"
-import {
-    getCountryDetectionRedirects,
-    memoize,
-    JsonError,
-    Url,
-} from "@ourworldindata/utils"
+import { memoize, JsonError, Url } from "@ourworldindata/utils"
 import { isCanonicalInternalUrl } from "./formatting.js"
 import { resolveExplorerRedirect } from "./replaceExplorerRedirects.js"
 import { logErrorAndMaybeSendToBugsnag } from "../serverUtils/errorLog.js"
@@ -43,11 +38,10 @@ export const getRedirects = async () => {
 
         "/slides/* https://slides.ourworldindata.org/:splat 301",
         "/subscribe /#subscribe 301",
-    ]
 
-    getCountryDetectionRedirects().forEach((redirect) =>
-        redirects.push(redirect)
-    )
+        // Country detection
+        "/detect-country https://detect-country.owid.io 302",
+    ]
 
     // Redirects from Wordpress admin UI
     const rows = await wpdb.singleton.query(

--- a/baker/redirects.ts
+++ b/baker/redirects.ts
@@ -15,10 +15,6 @@ export const getRedirects = async () => {
         // RSS feed
         "/feed /atom.xml 302!",
 
-        // Backwards compatibility-- admin urls
-        "/wp-admin/* https://owid.cloud/wp/wp-admin/:splat 301",
-        "/grapher/admin/* https://owid.cloud/grapher/admin/:splat 301",
-
         // TODO: this should only get triggered by external hits (indexed .pdf files for instance)
         // and should be removed when no evidence of these inbound links can be found.
         "/wp-content/uploads/* /uploads/:splat 301",
@@ -36,11 +32,7 @@ export const getRedirects = async () => {
 
         // Backwards compatibility-- public urls
         "/entries/* /:splat 301",
-        "/entries /#entries 302",
-        "/data/food-agriculture/* /:splat 301",
-        "/data/political-regimes/* /:splat 301",
-        "/data/population-growth-vital-statistics/* /:splat 301",
-        "/data/growth-and-distribution-of-prosperity/* /:splat 301",
+        "/entries / 302",
         "/blog /latest 301",
         "/blog/* /latest/:splat 301",
 

--- a/packages/@ourworldindata/grapher/src/controls/globalEntitySelector/GlobalEntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/globalEntitySelector/GlobalEntitySelector.tsx
@@ -16,7 +16,7 @@ import {
     countries,
     throttle,
     noop,
-    getCountryCodeFromNetlifyRedirect,
+    getUserCountryInformation,
     sortBy,
     getWindowUrl,
     setWindowUrl,
@@ -184,11 +184,11 @@ export class GlobalEntitySelector extends React.Component<{
 
     @action.bound async populateLocalEntity(): Promise<void> {
         try {
-            const localCountryCode = await getCountryCodeFromNetlifyRedirect()
+            const localCountryCode = await getUserCountryInformation()
             if (!localCountryCode) return
 
             const country = allEntities.find(
-                (entity): boolean => entity.code === localCountryCode
+                (entity): boolean => entity.code === localCountryCode.code
             )
             if (country) this.localEntityName = country.name
         } catch (err) {}

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -160,6 +160,7 @@ import {
     EnrichedTopicPageIntroDownloadButton,
     EnrichedScrollerItem,
     EnrichedBlockKeyInsightsSlide,
+    UserCountryInformation,
 } from "./owidTypes.js"
 import { OwidVariableWithSource } from "./OwidVariable.js"
 import { PointVector } from "./PointVector.js"
@@ -559,13 +560,13 @@ export const fetchText = async (url: string): Promise<string> => {
     })
 }
 
-export const getCountryCodeFromNetlifyRedirect = async (): Promise<
-    string | undefined
+export const getUserCountryInformation = async (): Promise<
+    UserCountryInformation | undefined
 > =>
-    await fetch("/detect-country-redirect").then((res) => {
-        if (!res.ok) throw new Error("Couldn't retrieve country code")
-        return res.url.split("?")[1]
-    })
+    await fetch("/detect-country")
+        .then((res) => res.json())
+        .then((res) => res.country)
+        .catch(() => undefined)
 
 export const stripHTML = (html: string): string => striptags(html)
 

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -254,7 +254,7 @@ export {
     urlToSlug,
     trimObject,
     fetchText,
-    getCountryCodeFromNetlifyRedirect,
+    getUserCountryInformation,
     stripHTML,
     getRandomNumberGenerator,
     sampleFrom,

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -435,7 +435,6 @@ export {
     countries,
     type Country,
     getCountryBySlug,
-    getCountryDetectionRedirects,
     isCountryName,
     continents,
     type Continent,

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1514,3 +1514,11 @@ export interface DataPageV2ContentFields {
     // TODO: add gdocs for FAQs
     isPreviewing?: boolean
 }
+
+export interface UserCountryInformation {
+    code: string
+    name: string
+    short_code: string
+    slug: string
+    regions: string[] | null
+}

--- a/packages/@ourworldindata/utils/src/regions.test.ts
+++ b/packages/@ourworldindata/utils/src/regions.test.ts
@@ -1,1 +1,17 @@
 #! /usr/bin/env jest
+
+import { isCountryName, getCountryBySlug } from "./regions.js"
+
+it("isCountryName", () => {
+    expect(isCountryName("United States")).toEqual(true)
+    expect(isCountryName("Not a country")).toEqual(false)
+})
+
+it("getCountryBySlug", () => {
+    expect(getCountryBySlug("united-states")).toMatchObject({
+        name: "United States",
+        slug: "united-states",
+        code: "USA",
+    })
+    expect(getCountryBySlug("not-a-country")).toEqual(undefined)
+})

--- a/packages/@ourworldindata/utils/src/regions.test.ts
+++ b/packages/@ourworldindata/utils/src/regions.test.ts
@@ -1,9 +1,1 @@
 #! /usr/bin/env jest
-
-import { getCountryDetectionRedirects } from "./regions.js"
-
-it("generates correct country redirect urls for netlify", () => {
-    expect(getCountryDetectionRedirects()).toContain(
-        `/detect-country-redirect /detect-country.js?GBR 302! Country=gb`
-    )
-})

--- a/packages/@ourworldindata/utils/src/regions.ts
+++ b/packages/@ourworldindata/utils/src/regions.ts
@@ -76,13 +76,3 @@ export const isCountryName = (name: string): boolean =>
 
 export const getCountryBySlug = (slug: string): Country | undefined =>
     countriesBySlug[slug]
-
-export const getCountryDetectionRedirects = (): string[] =>
-    countries
-        .filter((country) => country.shortCode && country.code)
-        .map(
-            (country) =>
-                `/detect-country-redirect /detect-country.js?${
-                    country.code
-                } 302! Country=${country.shortCode!.toLowerCase()}`
-        )

--- a/public/detect-country.js
+++ b/public/detect-country.js
@@ -1,1 +1,0 @@
-// Netlify should have added country code to query string


### PR DESCRIPTION
Try this out at https://staging-owid.netlify.app/covid-vaccinations#select-countries-to-show-in-all-charts.

Uses https://detect-country.owid.io for country detection, rather than the existing Netlify-based redirects.

This is mostly part of #2061 since we can't use country-based redirects any more with CF Pages, but I thought to frontload it already.

The worker returns a bit more information which could be useful in the future (incl. regions that the user is in).

We're putting a 301 redirect so we can still use the hardcoded, relative `/detect-country` URL rather than needing to pass a setting forward into utils, which would be hard to do.

I also deleted some very outdated redirects while I was at it.