### PR TITLE
:sparkles: cache gdrive images etags to improve resizing speed

### DIFF
--- a/baker/GDriveImagesBaker.tsx
+++ b/baker/GDriveImagesBaker.tsx
@@ -1,0 +1,135 @@
+import fs from "fs-extra"
+import path from "path"
+import { chunk } from "lodash"
+import * as db from "../db/db.js"
+import {
+    IMAGE_HOSTING_CDN_URL,
+    IMAGE_HOSTING_BUCKET_SUBFOLDER_PATH,
+} from "../settings/serverSettings.js"
+
+import {
+    ImageMetadata,
+    getFilenameAsPng,
+    retryPromise,
+} from "@ourworldindata/utils"
+import { Image } from "../db/model/Image.js"
+import sharp from "sharp"
+import { BAKED_BASE_URL } from "../settings/clientSettings.js"
+
+export const bakeDriveImages = async (bakedSiteDir: string) => {
+    // Get all GDocs images, download locally and resize them
+    const images: Image[] = await db
+        .queryMysql(
+            `SELECT * FROM images WHERE id IN (SELECT DISTINCT imageId FROM posts_gdocs_x_images)`
+        )
+        .then((results: ImageMetadata[]) =>
+            results.map((result) => Image.create<Image>(result))
+        )
+
+    const imagesDirectory = path.join(bakedSiteDir, "images", "published")
+
+    // TODO: chunking caused issues so we disable it here by setting chunk size to 1 for now.
+    // Either switch to rclone-ing all files before baking, or switching to Cloudflare Images.
+    const imageChunks = chunk(images, 2)
+    for (const imageChunk of imageChunks) {
+        await Promise.all(
+            imageChunk.map(async (image) => {
+                const remoteFilePath = path.join(
+                    IMAGE_HOSTING_CDN_URL,
+                    IMAGE_HOSTING_BUCKET_SUBFOLDER_PATH,
+                    image.filename
+                )
+                const localImagePath = path.join(
+                    imagesDirectory,
+                    image.filename
+                )
+                const localImageEtagPath = localImagePath + ".etag"
+
+                // If the image already exists locally, try to use its etag
+                const existingEtag = await Promise.all([
+                    fs.exists(localImagePath),
+                    fs.exists(localImageEtagPath),
+                ]).then(([exists, etagExists]) =>
+                    exists && etagExists
+                        ? fs.readFile(localImageEtagPath, "utf8")
+                        : ""
+                )
+
+                const response = await retryPromise(() =>
+                    fetch(remoteFilePath, {
+                        headers: {
+                            "If-None-Match": existingEtag,
+                        },
+                    })
+                )
+
+                // Image has not been modified, skip
+                if (response.status === 304) {
+                    return
+                }
+
+                if (!response.ok) {
+                    throw new Error(
+                        `Fetching image failed: ${response.status} ${response.statusText} ${response.url}`
+                    )
+                }
+
+                let buffer = Buffer.from(await response.arrayBuffer())
+
+                if (!image.isSvg) {
+                    await Promise.all(
+                        image.sizes!.map((width) => {
+                            const localResizedFilepath = path.join(
+                                imagesDirectory,
+                                `${image.filenameWithoutExtension}_${width}.webp`
+                            )
+                            return sharp(buffer)
+                                .resize(width)
+                                .webp({
+                                    lossless: true,
+                                })
+                                .toFile(localResizedFilepath)
+                        })
+                    )
+                } else {
+                    // A PNG alternative to the SVG for the "Download image" link
+                    const pngFilename = getFilenameAsPng(image.filename)
+                    await sharp(buffer)
+                        .resize(2000)
+                        .png()
+                        .toFile(path.join(imagesDirectory, pngFilename))
+
+                    // Import the site's webfonts
+                    const svg = buffer
+                        .toString()
+                        .replace(
+                            /(<svg.*?>)/,
+                            `$1<defs><style>@import url(${BAKED_BASE_URL}/fonts.css)</style></defs>`
+                        )
+                    buffer = Buffer.from(svg)
+                }
+                // For SVG, and a non-webp fallback copy of the image
+                await fs.writeFile(
+                    path.join(imagesDirectory, image.filename),
+                    buffer
+                )
+
+                // Save the etag to a sidecar
+                await fs.writeFile(
+                    localImageEtagPath,
+                    readEtagFromHeader(response),
+                    "utf8"
+                )
+            })
+        )
+    }
+}
+
+const readEtagFromHeader = (response: Response) => {
+    const etag = response.headers.get("etag")
+    if (!etag) {
+        throw new Error("No etag header found")
+    }
+    // strip extra quotes from etag
+    return etag.replace(/^"|"$/g, "")
+}

--- a/baker/GDriveImagesBaker.tsx
+++ b/baker/GDriveImagesBaker.tsx
@@ -1,6 +1,5 @@
 import fs from "fs-extra"
 import path from "path"
-import { chunk } from "lodash"
 import * as db from "../db/db.js"
 import {
     IMAGE_HOSTING_CDN_URL,
@@ -14,6 +13,7 @@ import {
 } from "@ourworldindata/utils"
 import { Image } from "../db/model/Image.js"
 import sharp from "sharp"
+import pMap from "p-map"
 import { BAKED_BASE_URL } from "../settings/clientSettings.js"
 
 export const bakeDriveImages = async (bakedSiteDir: string) => {
@@ -28,100 +28,96 @@ export const bakeDriveImages = async (bakedSiteDir: string) => {
 
     const imagesDirectory = path.join(bakedSiteDir, "images", "published")
 
-    // If this causes timeout errors, try decreasing the chunk size (2 should be safe)
-    const imageChunks = chunk(images, 5)
-    for (const imageChunk of imageChunks) {
-        await Promise.all(
-            imageChunk.map(async (image) => {
-                const remoteFilePath = path.join(
-                    IMAGE_HOSTING_CDN_URL,
-                    IMAGE_HOSTING_BUCKET_SUBFOLDER_PATH,
-                    image.filename
-                )
-                const localImagePath = path.join(
-                    imagesDirectory,
-                    image.filename
-                )
-                const localImageEtagPath = localImagePath + ".etag"
+    // If this causes timeout errors, try decreasing concurrency (2 should be safe)
+    await pMap(
+        images,
+        async (image) => {
+            const remoteFilePath = path.join(
+                IMAGE_HOSTING_CDN_URL,
+                IMAGE_HOSTING_BUCKET_SUBFOLDER_PATH,
+                image.filename
+            )
+            const localImagePath = path.join(imagesDirectory, image.filename)
+            const localImageEtagPath = localImagePath + ".etag"
 
-                // If the image already exists locally, try to use its etag
-                const existingEtag = await Promise.all([
-                    fs.exists(localImagePath),
-                    fs.exists(localImageEtagPath),
-                ]).then(([exists, etagExists]) =>
-                    exists && etagExists
-                        ? fs.readFile(localImageEtagPath, "utf8")
-                        : ""
-                )
+            // If the image already exists locally, try to use its etag
+            const existingEtag = await Promise.all([
+                fs.exists(localImagePath),
+                fs.exists(localImageEtagPath),
+            ]).then(([exists, etagExists]) =>
+                exists && etagExists
+                    ? fs.readFile(localImageEtagPath, "utf8")
+                    : ""
+            )
 
-                const response = await retryPromise(() =>
-                    fetch(remoteFilePath, {
-                        headers: {
-                            "If-None-Match": existingEtag,
-                        },
+            const response = await retryPromise(() =>
+                fetch(remoteFilePath, {
+                    headers: {
+                        "If-None-Match": existingEtag,
+                    },
+                })
+            )
+
+            // Image has not been modified, skip
+            if (response.status === 304) {
+                return
+            }
+
+            if (!response.ok) {
+                throw new Error(
+                    `Fetching image failed: ${response.status} ${response.statusText} ${response.url}`
+                )
+            }
+
+            let buffer = Buffer.from(await response.arrayBuffer())
+
+            if (!image.isSvg) {
+                await Promise.all(
+                    image.sizes!.map((width) => {
+                        const localResizedFilepath = path.join(
+                            imagesDirectory,
+                            `${image.filenameWithoutExtension}_${width}.webp`
+                        )
+                        return sharp(buffer)
+                            .resize(width)
+                            .webp({
+                                lossless: true,
+                            })
+                            .toFile(localResizedFilepath)
                     })
                 )
+            } else {
+                // A PNG alternative to the SVG for the "Download image" link
+                const pngFilename = getFilenameAsPng(image.filename)
+                await sharp(buffer)
+                    .resize(2000)
+                    .png()
+                    .toFile(path.join(imagesDirectory, pngFilename))
 
-                // Image has not been modified, skip
-                if (response.status === 304) {
-                    return
-                }
-
-                if (!response.ok) {
-                    throw new Error(
-                        `Fetching image failed: ${response.status} ${response.statusText} ${response.url}`
+                // Import the site's webfonts
+                const svg = buffer
+                    .toString()
+                    .replace(
+                        /(<svg.*?>)/,
+                        `$1<defs><style>@import url(${BAKED_BASE_URL}/fonts.css)</style></defs>`
                     )
-                }
+                buffer = Buffer.from(svg)
+            }
+            // For SVG, and a non-webp fallback copy of the image
+            await fs.writeFile(
+                path.join(imagesDirectory, image.filename),
+                buffer
+            )
 
-                let buffer = Buffer.from(await response.arrayBuffer())
-
-                if (!image.isSvg) {
-                    await Promise.all(
-                        image.sizes!.map((width) => {
-                            const localResizedFilepath = path.join(
-                                imagesDirectory,
-                                `${image.filenameWithoutExtension}_${width}.webp`
-                            )
-                            return sharp(buffer)
-                                .resize(width)
-                                .webp({
-                                    lossless: true,
-                                })
-                                .toFile(localResizedFilepath)
-                        })
-                    )
-                } else {
-                    // A PNG alternative to the SVG for the "Download image" link
-                    const pngFilename = getFilenameAsPng(image.filename)
-                    await sharp(buffer)
-                        .resize(2000)
-                        .png()
-                        .toFile(path.join(imagesDirectory, pngFilename))
-
-                    // Import the site's webfonts
-                    const svg = buffer
-                        .toString()
-                        .replace(
-                            /(<svg.*?>)/,
-                            `$1<defs><style>@import url(${BAKED_BASE_URL}/fonts.css)</style></defs>`
-                        )
-                    buffer = Buffer.from(svg)
-                }
-                // For SVG, and a non-webp fallback copy of the image
-                await fs.writeFile(
-                    path.join(imagesDirectory, image.filename),
-                    buffer
-                )
-
-                // Save the etag to a sidecar
-                await fs.writeFile(
-                    localImageEtagPath,
-                    readEtagFromHeader(response),
-                    "utf8"
-                )
-            })
-        )
-    }
+            // Save the etag to a sidecar
+            await fs.writeFile(
+                localImageEtagPath,
+                readEtagFromHeader(response),
+                "utf8"
+            )
+        },
+        { concurrency: 5 }
+    )
 }
 
 const readEtagFromHeader = (response: Response) => {

--- a/baker/GDriveImagesBaker.tsx
+++ b/baker/GDriveImagesBaker.tsx
@@ -28,9 +28,8 @@ export const bakeDriveImages = async (bakedSiteDir: string) => {
 
     const imagesDirectory = path.join(bakedSiteDir, "images", "published")
 
-    // TODO: chunking caused issues so we disable it here by setting chunk size to 1 for now.
-    // Either switch to rclone-ing all files before baking, or switching to Cloudflare Images.
-    const imageChunks = chunk(images, 2)
+    // If this causes timeout errors, try decreasing the chunk size (2 should be safe)
+    const imageChunks = chunk(images, 5)
     for (const imageChunk of imageChunks) {
         await Promise.all(
             imageChunk.map(async (image) => {

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -1,8 +1,7 @@
 import fs from "fs-extra"
-import { writeFile } from "node:fs/promises"
 import path from "path"
 import { glob } from "glob"
-import { keyBy, without, uniq, mapValues, chunk, pick } from "lodash"
+import { keyBy, without, uniq, mapValues, pick } from "lodash"
 import cheerio from "cheerio"
 import ProgressBar from "progress"
 import * as wpdb from "../db/wpdb.js"
@@ -11,8 +10,6 @@ import {
     BLOG_POSTS_PER_PAGE,
     BASE_DIR,
     WORDPRESS_DIR,
-    IMAGE_HOSTING_CDN_URL,
-    IMAGE_HOSTING_BUCKET_SUBFOLDER_PATH,
     GDOCS_DETAILS_ON_DEMAND_ID,
     BAKED_GRAPHER_URL,
 } from "../settings/serverSettings.js"
@@ -41,16 +38,14 @@ import {
 } from "../baker/GrapherBakingUtils.js"
 import { makeSitemap } from "../baker/sitemap.js"
 import { bakeCountries } from "../baker/countryProfiles.js"
+import { bakeDriveImages } from "../baker/GDriveImagesBaker.js"
 import {
     countries,
     FullPost,
     OwidGdocPublished,
-    ImageMetadata,
     clone,
-    getFilenameAsPng,
     extractDetailsFromSyntax,
     LinkedChart,
-    retryPromise,
 } from "@ourworldindata/utils"
 import { execWrapper } from "../db/execWrapper.js"
 import { countryProfileSpecs } from "../site/countryProfileProjects.js"
@@ -66,7 +61,6 @@ import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer.
 import { postsTable } from "../db/model/Post.js"
 import { Gdoc } from "../db/model/Gdoc/Gdoc.js"
 import { Image } from "../db/model/Image.js"
-import sharp from "sharp"
 import { generateEmbedSnippet } from "../site/viteUtils.js"
 import { logErrorAndMaybeSendToBugsnag } from "../serverUtils/errorLog.js"
 import { Chart } from "../db/model/Chart.js"
@@ -594,112 +588,8 @@ export class SiteBaker {
 
     private async bakeDriveImages() {
         if (!this.bakeSteps.has("gdriveImages")) return
-        const images: Image[] = await db
-            .queryMysql(
-                `SELECT * FROM images WHERE id IN (SELECT DISTINCT imageId FROM posts_gdocs_x_images)`
-            )
-            .then((results: ImageMetadata[]) =>
-                results.map((result) => Image.create<Image>(result))
-            )
-
-        this.ensureDir("images/published")
-        const imagesDirectory = path.join(
-            this.bakedSiteDir,
-            "images",
-            "published"
-        )
-
-        // TODO: chunking caused issues so we disable it here by setting chunk size to 1 for now.
-        // Either switch to rclone-ing all files before baking, or switching to Cloudflare Images.
-        const imageChunks = chunk(images, 2)
-        for (const imageChunk of imageChunks) {
-            await Promise.all(
-                imageChunk.map(async (image) => {
-                    const remoteFilePath = path.join(
-                        IMAGE_HOSTING_CDN_URL,
-                        IMAGE_HOSTING_BUCKET_SUBFOLDER_PATH,
-                        image.filename
-                    )
-                    const localImagePath = path.join(
-                        imagesDirectory,
-                        image.filename
-                    )
-                    const localImageEtagPath = localImagePath + ".etag"
-
-                    // If the image already exists locally, try to use its etag
-                    const existingEtag =
-                        fs.existsSync(localImagePath) &&
-                        fs.existsSync(localImageEtagPath)
-                            ? await fs.readFile(localImageEtagPath, "utf8")
-                            : ""
-
-                    const response = await retryPromise(() =>
-                        fetch(remoteFilePath, {
-                            headers: {
-                                "If-None-Match": existingEtag,
-                            },
-                        })
-                    )
-
-                    // Image has not been modified, skip
-                    if (response.status === 304) {
-                        return
-                    }
-
-                    if (!response.ok) {
-                        throw new Error(
-                            `Fetching image failed: ${response.status} ${response.statusText} ${response.url}`
-                        )
-                    }
-
-                    let buffer = Buffer.from(await response.arrayBuffer())
-
-                    if (!image.isSvg) {
-                        await Promise.all(
-                            image.sizes!.map((width) => {
-                                const localResizedFilepath = path.join(
-                                    imagesDirectory,
-                                    `${image.filenameWithoutExtension}_${width}.webp`
-                                )
-                                return sharp(buffer)
-                                    .resize(width)
-                                    .webp({
-                                        lossless: true,
-                                    })
-                                    .toFile(localResizedFilepath)
-                            })
-                        )
-                    } else {
-                        // A PNG alternative to the SVG for the "Download image" link
-                        const pngFilename = getFilenameAsPng(image.filename)
-                        await sharp(buffer)
-                            .resize(2000)
-                            .png()
-                            .toFile(path.join(imagesDirectory, pngFilename))
-
-                        // Import the site's webfonts
-                        const svg = buffer
-                            .toString()
-                            .replace(
-                                /(<svg.*?>)/,
-                                `$1<defs><style>@import url(${BAKED_BASE_URL}/fonts.css)</style></defs>`
-                            )
-                        buffer = Buffer.from(svg)
-                    }
-                    // For SVG, and a non-webp fallback copy of the image
-                    await writeFile(
-                        path.join(imagesDirectory, image.filename),
-                        buffer
-                    )
-
-                    // Save the etag to a sidecar, strip extra quotes
-                    const etag = response.headers
-                        .get("etag")!
-                        .replace(/^"|"$/g, "")
-                    await fs.writeFile(localImageEtagPath, etag, "utf8")
-                })
-            )
-        }
+        await this.ensureDir("images/published")
+        await bakeDriveImages(this.bakedSiteDir)
         this.progressBar.tick({ name: "✅ baked google drive images" })
     }
 


### PR DESCRIPTION
* DigitalOcean spaces return `etag` in the header
* Save this etag in a sidecar `image_filename.etag`
* When baking gdrive images, send this etag as `If-None-Match` and skip image baking if we get 304 back
* (DigitalOcean Spaces return etag with extra quotes, we need to strip them)

Can be tested with `yarn buildLocalBake --steps gdriveImages`.

I kept it in the `SiteBaker.tsx` file, but maybe it's time to move gdrive image baking code to its own file.