### PR TITLE
feat(admin): add isTopic as property of a tag

### DIFF
--- a/adminSiteClient/TagEditPage.tsx
+++ b/adminSiteClient/TagEditPage.tsx
@@ -4,7 +4,13 @@ import { observable, computed, action, runInAction } from "mobx"
 import { Prompt, Redirect } from "react-router-dom"
 
 import { AdminLayout } from "./AdminLayout.js"
-import { BindString, NumericSelectField, FieldsRow, Timeago } from "./Forms.js"
+import {
+    BindString,
+    NumericSelectField,
+    FieldsRow,
+    Timeago,
+    Toggle,
+} from "./Forms.js"
 import { DatasetList, DatasetListItem } from "./DatasetList.js"
 import { ChartList, ChartListItem } from "./ChartList.js"
 import { TagBadge, Tag } from "./TagBadge.js"
@@ -21,11 +27,13 @@ interface TagPageData {
     children: Tag[]
     possibleParents: Tag[]
     isBulkImport: boolean
+    isTopic: boolean
 }
 
 class TagEditable {
     @observable name: string = ""
     @observable parentId?: number
+    @observable isTopic: boolean = false
 
     constructor(json: TagPageData) {
         for (const key in this) {
@@ -141,27 +149,40 @@ class TagEditor extends React.Component<{ tag: TagPageData }> {
                             helpText="Category names should ideally be unique across the database and able to be understood without context"
                         />
                         {!tag.isBulkImport && (
-                            <FieldsRow>
-                                <NumericSelectField
-                                    label="Parent Category"
-                                    value={newtag.parentId || -1}
-                                    options={[
-                                        { value: -1, label: "None" },
-                                    ].concat(
-                                        tag.possibleParents.map((p) => ({
-                                            value: p.id as number,
-                                            label: p.name,
-                                        }))
-                                    )}
-                                    onValue={this.onChooseParent}
-                                />
-                                <div>
-                                    <br />
-                                    {this.parentTag && (
-                                        <TagBadge tag={this.parentTag as Tag} />
-                                    )}
-                                </div>
-                            </FieldsRow>
+                            <>
+                                <FieldsRow>
+                                    <Toggle
+                                        value={!!newtag.isTopic}
+                                        onValue={(value) => {
+                                            newtag.isTopic = value
+                                        }}
+                                        label="Tag is a topic"
+                                    />
+                                </FieldsRow>
+                                <FieldsRow>
+                                    <NumericSelectField
+                                        label="Parent Category"
+                                        value={newtag.parentId || -1}
+                                        options={[
+                                            { value: -1, label: "None" },
+                                        ].concat(
+                                            tag.possibleParents.map((p) => ({
+                                                value: p.id as number,
+                                                label: p.name,
+                                            }))
+                                        )}
+                                        onValue={this.onChooseParent}
+                                    />
+                                    <div>
+                                        <br />
+                                        {this.parentTag && (
+                                            <TagBadge
+                                                tag={this.parentTag as Tag}
+                                            />
+                                        )}
+                                    </div>
+                                </FieldsRow>
+                            </>
                         )}
                         {!tag.isBulkImport && (
                             <div>

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -2072,7 +2072,7 @@ apiRouter.get("/tags/:tagId.json", async (req: Request, res: Response) => {
 
     const tag = await db.mysqlFirst(
         `
-        SELECT t.id, t.name, t.specialType, t.updatedAt, t.parentId, p.isBulkImport
+        SELECT t.id, t.name, t.specialType, t.updatedAt, t.parentId, t.isTopic, p.isBulkImport
         FROM tags t LEFT JOIN tags p ON t.parentId=p.id
         WHERE t.id = ?
     `,
@@ -2171,8 +2171,8 @@ apiRouter.put("/tags/:tagId", async (req: Request) => {
     const tagId = expectInt(req.params.tagId)
     const tag = (req.body as { tag: any }).tag
     await db.execute(
-        `UPDATE tags SET name=?, updatedAt=?, parentId=? WHERE id=?`,
-        [tag.name, new Date(), tag.parentId, tagId]
+        `UPDATE tags SET name=?, updatedAt=?, parentId=?, isTopic=? WHERE id=?`,
+        [tag.name, new Date(), tag.parentId, tag.isTopic, tagId]
     )
     return { success: true }
 })

--- a/db/migration/1692801236245-AddIsTopicToTag.ts
+++ b/db/migration/1692801236245-AddIsTopicToTag.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddIsTopicToTag1692801236245 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE tags
+            ADD COLUMN isTopic TINYINT(1) NOT NULL DEFAULT 0;
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE tags
+            DROP COLUMN isTopic;
+        `)
+    }
+}


### PR DESCRIPTION
Add `isTopic` property to tags to be able to differentiate topic tags from non-topic tags.

![Screenshot 2023-08-23 at 18.10.30.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0SFFiIjKuUK6UPYHVe6u/83caaa92-0735-4235-9c72-9ee426022652/Screenshot%202023-08-23%20at%2018.10.30.png)

This is useful for the [chart tagging effort](https://www.notion.so/owid/2023-08-22-Tagging-all-our-content-26b70903a88f4115bab88eb1c8d4b891?pvs=4#23834c1510bd4e73ba86a76a23fa5d13) where we need to identify charts that are not tagged with topic tags.

![Grapher tags.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0SFFiIjKuUK6UPYHVe6u/eb32f90d-c7b4-4947-8655-9c86ed9ac862/Grapher%20tags.png)
