### PR TITLE
Grapher redesign: Improve full-screen mode

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -134,26 +134,19 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
     }
 
     @computed protected get sizeVariant(): SizeVariant {
-        return this.manager.sizeVariant ?? SizeVariant.lg
+        return this.manager.sizeVariant ?? SizeVariant.base
     }
 
     @computed protected get verticalPadding(): number {
-        const { sizeVariant } = this
-        const { xs, sm, md, lg } = SizeVariant
-        return {
-            [xs]: 8,
-            [sm]: 8,
-            [md]: 12,
-            [lg]: 12,
-        }[sizeVariant]
+        return this.sizeVariant === SizeVariant.base ? 12 : 8
     }
 
     @computed protected get verticalPaddingSmall(): number {
-        return this.sizeVariant === SizeVariant.xs ? 4 : 8
+        return this.sizeVariant === SizeVariant.sm ? 4 : 8
     }
 
     @computed protected get relatedQuestionHeight(): number {
-        return this.sizeVariant === SizeVariant.lg ? 28 : 24
+        return this.sizeVariant === SizeVariant.base ? 28 : 24
     }
 
     @computed protected get header(): Header {

--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
@@ -25,7 +25,7 @@ $gap: 2px;
         height: $controlRowHeight - 2 * ($borderWidth + $gap);
         line-height: $controlRowHeight - 2 * ($borderWidth + $gap);
         border-radius: $borderRadius - $gap;
-        padding: 0 8px;
+        padding: 0 16px;
 
         svg {
             margin-right: 6px;
@@ -58,6 +58,6 @@ $gap: 2px;
     }
 }
 
-.ContentSwitchers.wide li > a {
-    padding: 0 16px;
+.ContentSwitchers.narrow li > a {
+    padding: 0 8px;
 }

--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
@@ -30,7 +30,7 @@ export class ContentSwitchers extends React.Component<{
     }
 
     @computed private get sizeVariant(): SizeVariant {
-        return this.manager.sizeVariant || SizeVariant.lg
+        return this.manager.sizeVariant ?? SizeVariant.base
     }
 
     @computed private get availableTabs(): GrapherTabOption[] {
@@ -39,10 +39,10 @@ export class ContentSwitchers extends React.Component<{
 
     render(): JSX.Element {
         const { manager, sizeVariant } = this
-        const isWide =
-            sizeVariant === SizeVariant.md || sizeVariant === SizeVariant.lg
+        const { sm, md } = SizeVariant
+        const isNarrow = sizeVariant === sm || sizeVariant === md
         return (
-            <ul className={"ContentSwitchers" + (isWide ? " wide" : "")}>
+            <ul className={"ContentSwitchers" + (isNarrow ? " narrow" : "")}>
                 {this.availableTabs.map((tab) => (
                     <Tab
                         key={tab}

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1920,10 +1920,6 @@ export class Grapher
         this.uncaughtError = undefined
     }
 
-    private renderPrimaryTab(): JSX.Element {
-        return <CaptionedChart manager={this} />
-    }
-
     private get commandPalette(): JSX.Element | null {
         return this.props.enableKeyboardShortcuts ? (
             <CommandPalette commands={this.keyboardShortcuts} display="none" />
@@ -2329,8 +2325,8 @@ export class Grapher
 
     render(): JSX.Element | undefined {
         // TODO how to handle errors in exports?
-        // TODO tidy this up
-        if (this.isExportingtoSvgOrPng) return this.renderPrimaryTab() // todo: remove this? should have a simple toStaticSVG for importing.
+        // TODO remove this? should have a simple toStaticSVG for exporting
+        if (this.isExportingtoSvgOrPng) return <CaptionedChart manager={this} />
 
         if (this.isInFullScreenMode)
             return (
@@ -2347,7 +2343,7 @@ export class Grapher
     private renderReady(): JSX.Element {
         return (
             <>
-                {this.hasBeenVisible && this.renderPrimaryTab()}
+                {this.hasBeenVisible && <CaptionedChart manager={this} />}
                 <TooltipContainer
                     containerWidth={this.renderWidth}
                     containerHeight={this.renderHeight}

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -30,10 +30,9 @@ export const DEFAULT_GRAPHER_HEIGHT = 600
 export const STATIC_EXPORT_DETAIL_SPACING = 24
 
 export enum SizeVariant {
-    xs = "xs",
     sm = "sm",
     md = "md",
-    lg = "lg",
+    base = "base",
 }
 export enum CookieKey {
     isAdmin = "isAdmin",

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -90,6 +90,7 @@ $zindex-full-screen: 2000;
 @import "../controls/entityPicker/EntityPicker.scss";
 @import "../controls/globalEntitySelector/GlobalEntitySelector.scss";
 @import "../sparkBars/SparkBars.scss";
+@import "../fullScreen/FullScreen.scss";
 
 .GrapherComponent,
 .GrapherComponent p,
@@ -198,16 +199,6 @@ $zindex-full-screen: 2000;
 
 .Tooltip {
     z-index: $zindex-Tooltip;
-}
-
-.FullScreen {
-    position: fixed;
-    top: 0;
-    left: 0;
-    z-index: $zindex-full-screen;
-    background: rgba(0, 0, 0, 0.3);
-    height: 100%;
-    width: 100%;
 }
 
 .markdown-text-wrap__line {

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -16,7 +16,8 @@ import { FooterManager } from "./FooterManager"
 import { ActionButtons } from "../controls/ActionButtons"
 
 /*
-The footer contains the sources, the note (optional), the action buttons and the license (CC BY) and origin URL (optional).
+
+The footer contains the sources, the note (optional), the action buttons and the license and origin URL (optional).
 
 If all elements exist, they are laid out as follows:
 +-------------------------------------------------------+
@@ -27,7 +28,16 @@ If all elements exist, they are laid out as follows:
 |  Origin URL | CC BY                |                  |
 +-------------------------------------------------------+
 
-If the origin url and license are short enough to be placed next to the sources, they are:
+If the note is long, it is placed below the sources:
++-------------------------------------------------------+
+|  Sources                                              |
++-------------------------------------------------------+
+|  Note                                                 |
++------------------------------------+------------------+
+|  Origin URL | CC BY                |  Action buttons  |
++------------------------------------+------------------+
+
+If the origin url and license are short enough, they are placed next to the sources:
 +------------------------------+------------------------+
 |  Sources                     |    Origin URL | CC BY  |
 +------------------------------+-----+------------------+
@@ -40,6 +50,7 @@ If the note is missing and the sources text is not too long, the sources are pla
 +------------------------------------+  Action buttons  |
 |  Origin URL | CC BY                |                  |
 +-------------------------------------------------------+
+
 */
 
 // keep in sync with sass variables in Footer.scss

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -60,7 +60,7 @@ export class Footer<
     }
 
     @computed protected get sizeVariant(): SizeVariant {
-        return this.manager.sizeVariant ?? SizeVariant.lg
+        return this.manager.sizeVariant ?? SizeVariant.base
     }
 
     @computed protected get maxWidth(): number {
@@ -163,13 +163,13 @@ export class Footer<
     }
 
     @computed private get lineHeight(): number {
-        return this.sizeVariant === SizeVariant.xs ? 1.1 : 1.2
+        return this.sizeVariant === SizeVariant.sm ? 1.1 : 1.2
     }
 
     @computed protected get fontSize(): number {
         const fontScale =
-            this.sizeVariant === SizeVariant.xs ||
-            this.sizeVariant === SizeVariant.sm
+            this.sizeVariant === SizeVariant.sm ||
+            this.sizeVariant === SizeVariant.md
                 ? getFontScale(11)
                 : getFontScale(12)
         return fontScale * (this.manager.fontSize ?? BASE_FONT_SIZE)
@@ -177,7 +177,7 @@ export class Footer<
 
     @computed protected get sourcesFontSize(): number {
         const fontScale =
-            this.sizeVariant === SizeVariant.xs
+            this.sizeVariant === SizeVariant.sm
                 ? getFontScale(12)
                 : getFontScale(13)
         return fontScale * (this.manager.fontSize ?? BASE_FONT_SIZE)

--- a/packages/@ourworldindata/grapher/src/fullScreen/FullScreen.scss
+++ b/packages/@ourworldindata/grapher/src/fullScreen/FullScreen.scss
@@ -1,0 +1,16 @@
+.FullScreenOverlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: $zindex-full-screen;
+    background: #fff;
+    height: 100%;
+    width: 100%;
+}
+
+.FullScreenContent {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}

--- a/packages/@ourworldindata/grapher/src/fullScreen/FullScreen.tsx
+++ b/packages/@ourworldindata/grapher/src/fullScreen/FullScreen.tsx
@@ -8,32 +8,44 @@ export class FullScreen extends React.Component<{
     children: React.ReactNode
     onDismiss: () => void
 }> {
-    overlay: React.RefObject<HTMLDivElement> = React.createRef()
+    content: React.RefObject<HTMLDivElement> = React.createRef()
+
+    @action.bound onDocumentClick(e: MouseEvent): void {
+        // check if the click was outside of the modal
+        if (
+            this.content?.current &&
+            !this.content.current.contains(e.target as Node) &&
+            // check that the target is still mounted to the document; we also get click events on nodes that have since been removed by React
+            document.contains(e.target as Node)
+        )
+            this.props.onDismiss()
+    }
+
+    @action.bound onDocumentKeyDown(e: KeyboardEvent): void {
+        if (e.key === "Escape") this.props.onDismiss()
+    }
 
     componentDidMount(): void {
-        this.overlay.current?.focus()
+        document.addEventListener("click", this.onDocumentClick)
+        document.addEventListener("keydown", this.onDocumentKeyDown)
     }
 
     componentWillUnmount(): void {
-        this.overlay.current?.blur()
-    }
-
-    @action.bound onKeyDown(e: React.KeyboardEvent<HTMLElement>): void {
-        if (e.key === "Escape") this.props.onDismiss()
+        document.removeEventListener("click", this.onDocumentClick)
+        document.removeEventListener("keydown", this.onDocumentKeyDown)
     }
 
     render() {
         return (
             <BodyDiv>
                 <div
-                    ref={this.overlay}
-                    className="FullScreen"
+                    className="FullScreenOverlay"
                     role="dialog"
                     aria-modal="true"
-                    tabIndex={-1}
-                    onKeyDown={this.onKeyDown}
                 >
-                    {this.props.children}
+                    <div className="FullScreenContent" ref={this.content}>
+                        {this.props.children}
+                    </div>
                 </div>
             </BodyDiv>
         )

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -25,7 +25,7 @@ export class Header extends React.Component<{
     }
 
     @computed protected get sizeVariant(): SizeVariant {
-        return this.manager.sizeVariant ?? SizeVariant.lg
+        return this.manager.sizeVariant ?? SizeVariant.base
     }
 
     @computed protected get maxWidth(): number {
@@ -44,7 +44,7 @@ export class Header extends React.Component<{
         const { manager, sizeVariant } = this
         if (manager.hideLogo) return undefined
 
-        const heightScale = sizeVariant === SizeVariant.xs ? 0.775 : 1
+        const heightScale = sizeVariant === SizeVariant.sm ? 0.775 : 1
         return new Logo({
             logo: manager.logo as any,
             isLink: !!manager.shouldLinkToOwid,
@@ -63,15 +63,15 @@ export class Header extends React.Component<{
     @computed get title(): TextWrap {
         const { logoWidth, sizeVariant } = this
         const fontScale =
-            sizeVariant === SizeVariant.xs
+            sizeVariant === SizeVariant.sm
                 ? getFontScale(18)
-                : sizeVariant === SizeVariant.sm
+                : sizeVariant === SizeVariant.md
                 ? getFontScale(20)
                 : getFontScale(24)
         return new TextWrap({
             maxWidth: this.maxWidth - logoWidth - 24,
             fontWeight: 400,
-            lineHeight: sizeVariant === SizeVariant.xs ? 1.1 : 1.2,
+            lineHeight: sizeVariant === SizeVariant.sm ? 1.1 : 1.2,
             fontSize: fontScale * this.fontSize,
             text: this.titleText,
         })
@@ -91,15 +91,12 @@ export class Header extends React.Component<{
     @computed get subtitle(): MarkdownTextWrap {
         const { sizeVariant } = this
         const fontScale =
-            sizeVariant === SizeVariant.xs
+            sizeVariant === SizeVariant.sm
                 ? getFontScale(12)
-                : sizeVariant === SizeVariant.sm
+                : sizeVariant === SizeVariant.md
                 ? getFontScale(13)
                 : getFontScale(14)
-        const lineHeight =
-            sizeVariant === SizeVariant.md || sizeVariant === SizeVariant.lg
-                ? 1.28571
-                : 1.2
+        const lineHeight = sizeVariant === SizeVariant.base ? 1.28571 : 1.2
         return new MarkdownTextWrap({
             maxWidth: this.subtitleWidth,
             fontSize: fontScale * this.fontSize,


### PR DESCRIPTION
- Doesn't take up all the space so that full-screen mode can be dismissed by clicking outside of the grapher component
    - On smaller screens, full-screen mode uses all the space that is available
- If the screen is large, use ideal bounds rather than using up all space
- PR also includes a refactor of the `sizeVariant`