### PR TITLE
🎉 make the mockSiteRouter available on prod

### DIFF
--- a/adminSiteServer/app.tsx
+++ b/adminSiteServer/app.tsx
@@ -156,8 +156,7 @@ export class OwidAdminApp {
         // error handler if it exists.
         if (bugsnagMiddleware) app.use(bugsnagMiddleware.errorHandler)
 
-        // todo: we probably always want to have this, and can remove the isDev
-        if (this.options.isDev) app.use("/", mockSiteRouter)
+        app.use("/", mockSiteRouter)
 
         // Give full error messages, including in production
         app.use(this.errorHandler)


### PR DESCRIPTION
We have some weird issues with gdocs at the moment where slugs to published gdoc articles aren't resolving to anything. Sometimes this [wordpress routing logic](https://github.com/owid/owid-grapher/blob/dbc3ce7b9a20c4ace19bbcf2d16fd8cead5c1ce9/wordpress/web/app/themes/owid-theme/singular.php#L10) steps in and loads a preview from an article published at the same slug instead.

Wondering if we should finally follow up on this TODO and simply use the mock site router everywhere.

This would allow us to visit `owid.cloud/atom.xml` and view published gdocs, for example.

Not sure what the downsides/risks are - I don't have a super in-depth understanding of how our deployed admin server works (for instance, what's redirecting [owid.cloud/grapher/](https://owid.cloud/grapher/share-with-anxiety-disorders) atm?)

So just making this PR as a space to have the conversation 🙂 