### PR TITLE
:hammer: remove unique name-namespace constraint from datasets table

### DIFF
--- a/db/migration/1693214165208-UpdateDatasetsNameConstraint.ts
+++ b/db/migration/1693214165208-UpdateDatasetsNameConstraint.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class UpdateDatasetsNameConstraint1693214165208
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE datasets
+            DROP INDEX datasets_name_namespace_d3d60d22_uniq;
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE datasets
+            ADD UNIQUE KEY datasets_name_namespace_d3d60d22_uniq (name, namespace);
+        `)
+    }
+}


### PR DESCRIPTION
Fix for https://github.com/owid/etl/issues/1544.

Remove unique index `datasets_name_namespace_d3d60d22_uniq (name, namespace)`. We already have a constraint on `(shortName, namespace, version)` and want to have datasets with the same title but different versions.