### PR TITLE
Grapher redesign: Data table

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -400,7 +400,7 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
             ...this.boundsForChartArea.toCSS(),
         }
         return (
-            <div style={containerStyle}>
+            <div className="DataTableContainer" style={containerStyle}>
                 <DataTable bounds={boundsForChartArea} manager={this.manager} />
             </div>
         )

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -41,7 +41,7 @@ $xxlg: 1536px;
 // These should be between 0–100 in order to avoid conflicting with
 // site dropdowns, search overlays, etc.
 $zindex-chart: 1;
-$zindex-tab: 1;
+$zindex-table: 1;
 $zindex-global-entity-select: 11;
 $zindex-Tooltip: 20;
 $zindex-modal: 30;
@@ -184,6 +184,10 @@ $zindex-full-screen: 2000;
 
     .unstroked {
         display: none;
+    }
+
+    .DataTableContainer {
+        z-index: $zindex-table;
     }
 }
 

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -185,12 +185,6 @@ $zindex-full-screen: 2000;
     .unstroked {
         display: none;
     }
-
-    .DownloadModalContent,
-    .tableTab,
-    .SourcesModalContent {
-        z-index: $zindex-tab;
-    }
 }
 
 .GrapherComponent.isExportingToSvgOrPng {

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
@@ -4,7 +4,11 @@ import React from "react"
 
 import { DataTable } from "./DataTable"
 import { ChartTypeName, GrapherTabOption } from "../core/GrapherConstants"
-import { childMortalityGrapher, IncompleteDataTable } from "./DataTable.sample"
+import {
+    childMortalityGrapher,
+    IncompleteDataTable,
+    DataTableWithAggregates,
+} from "./DataTable.sample"
 
 import Enzyme, { ReactWrapper } from "enzyme"
 import Adapter from "enzyme-adapter-react-16"
@@ -111,11 +115,9 @@ describe("when the table doesn't have data for all rows", () => {
         expect(view.find("tbody .dimension").at(0).first().text()).toBe("")
     })
 
-    it("renders a tolerance notice when data is not from targetYear", () => {
+    it("renders an info icon when data is not from targetYear", () => {
         const toleranceNotices = view.find(".closest-time-notice-icon")
         expect(toleranceNotices.length).toBe(2)
-        expect(toleranceNotices.at(0).text()).toContain("2001") // first column
-        expect(toleranceNotices.at(1).text()).toContain("2009") // second column
     })
 
     it("renders a data value for the column with targetTime 2010", () => {
@@ -129,5 +131,20 @@ describe("when the table doesn't have data for all rows", () => {
         expect(timeHeaders.length).toBe(2)
         expect(timeHeaders.at(0).text()).toBe("2000")
         expect(timeHeaders.at(1).text()).toBe("2010")
+    })
+})
+
+describe("when the table has aggregates", () => {
+    let view: ReactWrapper
+    beforeAll(() => {
+        const grapher = DataTableWithAggregates()
+        view = Enzyme.mount(<DataTable manager={grapher} />)
+    })
+
+    it("renders a title row for countries and regions", () => {
+        const titleRows = view.find("tbody .title")
+        expect(titleRows).toHaveLength(2)
+        expect(titleRows.at(0).text()).toBe("Country")
+        expect(titleRows.at(1).text()).toBe("Region")
     })
 })

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
@@ -22,25 +22,25 @@ describe("when you render a table", () => {
     })
 
     it("renders a table", () => {
-        expect(view.find("table.data-table")).toHaveLength(1)
+        expect(view.find("table")).toHaveLength(1)
     })
 
     it("renders a Country header", () => {
         expect(view.find("thead th.entity").text()).toContain("Country")
     })
 
-    it("renders a variable name in header", () => {
-        const cell = view.find("thead th.dimension .name")
+    it("renders a variable name in the caption", () => {
+        const cell = view.find(".DataTable .caption")
         expect(cell.text()).toContain("Child mortality")
     })
 
-    it("renders a unit name in header", () => {
-        const cell = view.find("thead th.dimension .unit")
+    it("renders a unit name in the caption", () => {
+        const cell = view.find(".DataTable .caption .unit")
         expect(cell.text()).toContain("percent")
     })
 
-    it("renders 'percent' in the column header when unit is '%'", () => {
-        const cell = view.find("thead th.dimension .unit")
+    it("renders 'percent' in the caption when unit is '%'", () => {
+        const cell = view.find(".DataTable .caption .unit")
         expect(cell.text()).toContain("percent")
     })
 

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
@@ -8,6 +8,7 @@ import {
     childMortalityGrapher,
     IncompleteDataTable,
     DataTableWithAggregates,
+    DataTableWithMultipleVariablesAndMultipleYears,
 } from "./DataTable.sample"
 
 import Enzyme, { ReactWrapper } from "enzyme"
@@ -76,15 +77,6 @@ describe("when you select a range of years", () => {
         view = Enzyme.mount(<DataTable manager={grapher} />)
     })
 
-    it("header is split into two rows", () => {
-        expect(view.find("thead tr")).toHaveLength(2)
-    })
-
-    it("entity header cell spans 2 rows", () => {
-        const cell = view.find("thead .entity").first()
-        expect(cell.prop("rowSpan")).toBe(2)
-    })
-
     it("renders start values", () => {
         const cell = view.find("tbody .dimension-start").first()
         expect(cell.text()).toBe("22.45%")
@@ -146,5 +138,17 @@ describe("when the table has aggregates", () => {
         expect(titleRows).toHaveLength(2)
         expect(titleRows.at(0).text()).toBe("Country")
         expect(titleRows.at(1).text()).toBe("Region")
+    })
+})
+
+describe("when the table has multiple variables and multiple years", () => {
+    let view: ReactWrapper
+    beforeAll(() => {
+        const grapher = DataTableWithMultipleVariablesAndMultipleYears()
+        view = Enzyme.mount(<DataTable manager={grapher} />)
+    })
+
+    it("header is split into two rows", () => {
+        expect(view.find("thead tr")).toHaveLength(2)
     })
 })

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.sample.ts
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.sample.ts
@@ -146,8 +146,7 @@ export const DataTableWithAggregates = (
     props: Partial<GrapherInterface> = {}
 ): Grapher =>
     new Grapher({
-        hasMapTab: true,
-        tab: GrapherTabOption.map,
+        tab: GrapherTabOption.table,
         dimensions: [
             {
                 variableId: 104402,
@@ -187,6 +186,100 @@ export const DataTableWithAggregates = (
                                         code: "AFG",
                                     },
                                     { name: "Iceland", id: 207, code: "ICE" },
+                                    {
+                                        name: "World",
+                                        id: 355,
+                                        code: "OWID_WRL",
+                                    },
+                                ],
+                            },
+                            years: {
+                                values: [
+                                    {
+                                        id: 1950,
+                                    },
+                                    {
+                                        id: 2005,
+                                    },
+                                    {
+                                        id: 2019,
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            ],
+        ]),
+    })
+
+export const DataTableWithMultipleVariablesAndMultipleYears = (
+    props: Partial<GrapherInterface> = {}
+): Grapher =>
+    new Grapher({
+        tab: GrapherTabOption.table,
+        dimensions: [
+            {
+                variableId: 514050,
+                property: DimensionProperty.y,
+            },
+            {
+                variableId: 472265,
+                property: DimensionProperty.y,
+            },
+        ],
+        ...props,
+        owidDataset: new Map([
+            [
+                514050,
+                {
+                    data: {
+                        years: [1950, 2005, 2019],
+                        entities: [355, 355, 355],
+                        values: [10, 20, 30],
+                    },
+                    metadata: {
+                        id: 514050,
+                        dimensions: {
+                            entities: {
+                                values: [
+                                    {
+                                        name: "World",
+                                        id: 355,
+                                        code: "OWID_WRL",
+                                    },
+                                ],
+                            },
+                            years: {
+                                values: [
+                                    {
+                                        id: 1950,
+                                    },
+                                    {
+                                        id: 2005,
+                                    },
+                                    {
+                                        id: 2019,
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            ],
+            [
+                472265,
+                {
+                    data: {
+                        years: [1950, 2005, 2019],
+                        entities: [355, 355, 355],
+                        values: [5, 15, 10],
+                    },
+                    metadata: {
+                        id: 472265,
+                        dimensions: {
+                            entities: {
+                                values: [
                                     {
                                         name: "World",
                                         id: 355,

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.sample.ts
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.sample.ts
@@ -141,3 +141,75 @@ export const IncompleteDataTable = (
             ],
         ]),
     })
+
+export const DataTableWithAggregates = (
+    props: Partial<GrapherInterface> = {}
+): Grapher =>
+    new Grapher({
+        hasMapTab: true,
+        tab: GrapherTabOption.map,
+        dimensions: [
+            {
+                variableId: 104402,
+                property: DimensionProperty.y,
+            },
+        ],
+        ...props,
+        owidDataset: new Map([
+            [
+                104402,
+                {
+                    data: {
+                        years: [
+                            1950, 1950, 1950, 2005, 2005, 2005, 2019, 2019,
+                            2019,
+                        ],
+                        entities: [15, 207, 355, 15, 207, 355, 15, 207, 355],
+                        values: [
+                            224.45, 333.68, 456.33, 295.59, 246.12, 298.87,
+                            215.59, 226.12, 450.87,
+                        ],
+                    },
+                    metadata: {
+                        id: 104402,
+                        display: {
+                            name: "Child mortality",
+                            unit: "%",
+                            shortUnit: "%",
+                            conversionFactor: 0.1,
+                        },
+                        dimensions: {
+                            entities: {
+                                values: [
+                                    {
+                                        name: "Afghanistan",
+                                        id: 15,
+                                        code: "AFG",
+                                    },
+                                    { name: "Iceland", id: 207, code: "ICE" },
+                                    {
+                                        name: "World",
+                                        id: 355,
+                                        code: "OWID_WRL",
+                                    },
+                                ],
+                            },
+                            years: {
+                                values: [
+                                    {
+                                        id: 1950,
+                                    },
+                                    {
+                                        id: 2005,
+                                    },
+                                    {
+                                        id: 2019,
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            ],
+        ]),
+    })

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
@@ -167,7 +167,8 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
         }
     }
 
-    tbody tr:not(.title):nth-child(2n + 1) td {
+    tbody.hasAggregateRows tr:nth-child(2n + 1) td,
+    tbody:not(.hasAggregateRows) tr:nth-child(2n) td {
         background-color: rgba(247, 247, 247);
     }
 

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
@@ -6,13 +6,30 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
     justify-content: center;
     background: rgba(255, 255, 255, 0.95);
     text-align: center;
-}
-
-.DataTableContainer {
     border-bottom: $cell-border;
 }
 
-.DataTableContainer .data-table {
+.DataTableContainer .DataTable {
+    width: 100%;
+    height: 100%;
+    display: flex; // necessary to make .table-wrapper scrollable
+    flex-direction: column;
+
+    .caption {
+        flex-shrink: 0;
+        text-align: left;
+
+        .unit {
+            color: #858585;
+        }
+    }
+
+    .table-wrapper {
+        overflow: auto;
+    }
+}
+
+.DataTableContainer table {
     thead {
         position: sticky;
         z-index: 20;
@@ -35,7 +52,7 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
     }
 }
 
-.data-table {
+.DataTableContainer table {
     font-size: 0.9375rem;
     line-height: 1.333em;
     border: none;

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
@@ -27,7 +27,7 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
     .title td:first-child {
         position: sticky;
         left: 0;
-        z-index: 1;
+        z-index: 10;
     }
 
     th.entity {

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
@@ -17,7 +17,6 @@ $cell-border: 1px solid #f2f2f2;
     .caption {
         flex-shrink: 0;
         font-weight: 700;
-        margin-bottom: 4px;
 
         .unit {
             color: $light-text;

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
@@ -1,12 +1,11 @@
-$cell-border: 1px solid rgba(0, 0, 0, 0.08);
+$cell-border: 1px solid #f2f2f2;
 
 .DataTableContainer {
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(255, 255, 255, 0.95);
-    text-align: center;
-    border-bottom: $cell-border;
+    color: $dark-text;
+    font-size: 0.875em;
 }
 
 .DataTableContainer .DataTable {
@@ -17,15 +16,18 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
 
     .caption {
         flex-shrink: 0;
-        text-align: left;
+        font-weight: 700;
+        margin-bottom: 4px;
 
         .unit {
-            color: #858585;
+            color: $light-text;
+            font-weight: 500;
         }
     }
 
     .table-wrapper {
         overflow: auto;
+        border: $cell-border;
     }
 }
 
@@ -41,6 +43,7 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
     }
 
     .entity,
+    .above-entity,
     .title td:first-child {
         position: sticky;
         left: 0;
@@ -53,34 +56,41 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
 }
 
 .DataTableContainer table {
-    font-size: 0.9375rem;
     line-height: 1.333em;
     border: none;
     background: white;
     width: 100%;
     border-collapse: separate;
     border-spacing: 0px;
-    box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 2px 0px,
-        rgba(0, 0, 0, 0.25) 0px 2px 2px 0px;
 
-    thead tr:last-child th,
+    thead tr th,
     th.entity {
         border-bottom: $cell-border;
     }
 
     tr th:first-child,
     tr td:first-child {
-        padding-left: 15px;
+        padding-left: 16px;
     }
 
     tr th:last-child,
     tr td:last-child {
-        padding-right: 15px;
+        padding-right: 16px;
     }
 
-    thead tr:first-child th {
+    thead tr th {
         padding-top: 8px;
         padding-bottom: 8px;
+    }
+
+    th.entity,
+    th.subdimension {
+        padding-top: 10px;
+        padding-bottom: 10px;
+    }
+
+    thead th {
+        background-color: #f7f7f7;
     }
 
     th {
@@ -94,10 +104,6 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
         padding-top: 8px;
     }
 
-    tr:last-child td {
-        padding-bottom: 15px;
-    }
-
     th.sortable {
         cursor: pointer;
     }
@@ -107,29 +113,24 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
     }
 
     th.sortable:hover {
-        background-color: rgb(245, 245, 245);
+        background-color: #e7e7e7;
+        border-color: #e7e7e7;
     }
 
     th,
     td {
-        padding-left: 15px;
-        padding-right: 15px;
+        padding-left: 16px;
+        padding-right: 16px;
 
         &:not(.entity) {
             vertical-align: bottom;
+            white-space: nowrap;
         }
     }
 
     th.dimension {
-        text-align: center;
-
-        > div {
-            min-height: 35px;
-        }
-    }
-
-    th.subdimension {
-        border-right: $cell-border;
+        text-align: left;
+        font-weight: 700;
     }
 
     .deltaColumn {
@@ -137,7 +138,8 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
     }
 
     th.entity,
-    td.entity {
+    td.entity,
+    th.above-entity {
         border-right: $cell-border;
     }
 
@@ -152,27 +154,16 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
         min-width: 56px;
     }
 
-    th.lastSubdimension {
-        border-right: none;
-    }
-
-    th:last-child,
-    td:last-child {
-        border-right: none;
-    }
-
     td {
         padding-top: 3px;
         padding-bottom: 3px;
     }
 
     .title td {
-        background: #e7e7e7;
-
-        &:first-child {
-            text-align: left;
-            font-weight: 700;
-        }
+        background-color: #e7e7e7;
+        text-align: left;
+        padding-top: 8px;
+        padding-bottom: 8px;
     }
 
     tbody tr {
@@ -184,18 +175,13 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
         }
     }
 
-    tbody.hasAggregateRows tr:nth-child(2n + 1) td,
-    tbody:not(.hasAggregateRows) tr:nth-child(2n) td {
-        background-color: rgba(247, 247, 247);
-    }
-
-    tbody tr:not(.title):hover td {
-        background-color: rgba(241, 241, 241);
+    tbody.hasTitleRows tr:not(.title):nth-child(2n + 1) td,
+    tbody:not(.hasTitleRows) tr:nth-child(2n) td {
+        background-color: #f7f7f7;
     }
 
     .entity {
         text-align: left;
-        font-weight: 700;
     }
 
     .dimension {
@@ -208,23 +194,21 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
         .unit,
         .time {
             font-weight: 700;
-            opacity: 0.5;
             padding-bottom: 3px;
+            color: #a1a1a1;
         }
     }
 
     .closest-time-notice-icon {
-        opacity: 0.5;
-        font-size: 13px;
         cursor: default;
 
         .icon {
-            font-size: 0.75rem;
-            opacity: 0.6;
+            font-size: 12px;
+            color: #dadada;
         }
 
         & + span {
-            margin-left: 8px;
+            margin-left: 6px;
         }
     }
 
@@ -237,25 +221,35 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
 
     th.sortable > div {
         display: flex;
-        align-items: end;
-        justify-content: space-between;
+        align-items: start;
+        justify-content: flex-end;
+        gap: 6px;
+    }
 
-        :first-child {
-            flex-grow: 1;
-        }
+    th.sortable.entity > div {
+        justify-content: flex-start;
     }
 
     th .sort-icon {
-        opacity: 0.15;
-        padding-left: 5px;
+        color: #c6c6c6;
+        font-size: 13px;
 
         &.active {
-            opacity: 1 !important;
+            color: $dark-text !important;
         }
     }
 
     th:hover .sort-icon {
-        opacity: 0.6;
+        color: $info-icon;
+    }
+
+    tbody tr td {
+        padding-top: 8px;
+        padding-bottom: 8px;
+    }
+
+    tbody tr.title td {
+        font-weight: 700;
     }
 }
 

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
@@ -1,6 +1,6 @@
 $cell-border: 1px solid rgba(0, 0, 0, 0.08);
 
-.tableTab {
+.DataTableContainer {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -8,11 +8,11 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
     text-align: center;
 }
 
-.tableTab {
+.DataTableContainer {
     border-bottom: $cell-border;
 }
 
-.tableTab .data-table {
+.DataTableContainer .data-table {
     thead {
         position: sticky;
         z-index: 20;

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
@@ -31,30 +31,6 @@ $cell-border: 1px solid #f2f2f2;
 }
 
 .DataTableContainer table {
-    thead {
-        position: sticky;
-        z-index: 20;
-        top: 0;
-    }
-
-    th {
-        white-space: nowrap;
-    }
-
-    .entity,
-    .above-entity,
-    .title td:first-child {
-        position: sticky;
-        left: 0;
-        z-index: 10;
-    }
-
-    th.entity {
-        top: 0;
-    }
-}
-
-.DataTableContainer table {
     line-height: 1.333em;
     border: none;
     background: white;
@@ -62,193 +38,149 @@ $cell-border: 1px solid #f2f2f2;
     border-collapse: separate;
     border-spacing: 0px;
 
-    thead tr th,
-    th.entity {
-        border-bottom: $cell-border;
+    // make header sticky
+    thead {
+        position: sticky;
+        z-index: 20;
+        top: 0;
     }
 
-    tr th:first-child,
-    tr td:first-child {
-        padding-left: 16px;
-    }
-
-    tr th:last-child,
-    tr td:last-child {
-        padding-right: 16px;
-    }
-
-    thead tr th {
-        padding-top: 8px;
-        padding-bottom: 8px;
+    // make entity column and entity header sticky
+    .entity,
+    .above-entity {
+        position: sticky;
+        left: 0;
+        z-index: 10;
+        background-color: #fff;
     }
 
     th.entity,
-    th.subdimension {
-        padding-top: 10px;
-        padding-bottom: 10px;
-    }
-
-    thead th {
+    th.above-entity {
+        top: 0;
         background-color: #f7f7f7;
     }
 
-    th {
-        padding-top: 8px;
-        padding-bottom: 8px;
-        vertical-align: bottom;
-        line-height: 19px;
+    // make title row sticky
+    tr.title td:first-child {
+        position: sticky;
+        left: 0;
+        z-index: 10;
     }
 
-    tr:first-child td {
-        padding-top: 8px;
-    }
-
-    th.sortable {
-        cursor: pointer;
-    }
-
-    th {
-        background-color: white;
-    }
-
-    th.sortable:hover {
-        background-color: #e7e7e7;
-        border-color: #e7e7e7;
-    }
-
+    // applies to all cells
     th,
     td {
-        padding-left: 16px;
-        padding-right: 16px;
+        padding: 8px 16px;
+        white-space: nowrap;
 
         &:not(.entity) {
             vertical-align: bottom;
-            white-space: nowrap;
+            text-align: right;
         }
     }
 
-    th.dimension {
-        text-align: left;
-        font-weight: 700;
-    }
-
-    .deltaColumn {
-        min-width: 145px;
-    }
-
-    th.entity,
-    td.entity,
-    th.above-entity {
+    // adds border on the right of the entity column
+    .entity,
+    .above-entity {
         border-right: $cell-border;
     }
 
-    tr > .dimension-start ~ .dimension-start,
+    // adds a border on the right of each dimension column
+    tr > td.dimension-start ~ td.dimension-start,
     tr > th.dimension ~ th.dimension,
     tr > th.firstSubdimension ~ th.firstSubdimension {
         border-left: $cell-border;
     }
 
-    th.firstSubdimension div,
-    th.endSubdimension div {
-        min-width: 56px;
-    }
-
-    td {
-        padding-top: 3px;
-        padding-bottom: 3px;
-    }
-
-    .title td {
-        background-color: #e7e7e7;
-        text-align: left;
-        padding-top: 8px;
-        padding-bottom: 8px;
-    }
-
-    tbody tr {
-        padding-top: 20px;
-        padding-bottom: 20px;
-
-        td {
-            background-color: white;
-        }
-    }
-
-    tbody.hasTitleRows tr:not(.title):nth-child(2n + 1) td,
-    tbody:not(.hasTitleRows) tr:nth-child(2n) td {
-        background-color: #f7f7f7;
-    }
-
-    .entity {
-        text-align: left;
-    }
-
-    .dimension {
-        text-align: right;
-
-        .divider {
-            opacity: 0.25;
-        }
-
-        .unit,
-        .time {
+    thead {
+        th {
+            background-color: #f7f7f7;
+            line-height: 19px;
+            border-bottom: $cell-border;
             font-weight: 700;
-            padding-bottom: 3px;
-            color: #a1a1a1;
+            vertical-align: bottom;
+
+            &.dimension,
+            &.entity,
+            &.subdimension {
+                padding-top: 10px;
+                padding-bottom: 10px;
+            }
+
+            &.dimension {
+                text-align: left;
+
+                .description {
+                    color: #a1a1a1;
+                }
+            }
+        }
+
+        th.sortable {
+            cursor: pointer;
+
+            &:hover {
+                background-color: #e7e7e7;
+                border-color: #e7e7e7;
+            }
+
+            > div {
+                display: flex;
+                align-items: start;
+                justify-content: flex-end;
+                gap: 6px;
+            }
+
+            &.entity > div {
+                justify-content: flex-start;
+            }
+
+            .sort-icon {
+                color: #c6c6c6;
+                font-size: 13px;
+                width: 19px;
+                text-align: right;
+
+                &.active {
+                    color: $dark-text !important;
+                }
+            }
+
+            &:hover .sort-icon {
+                color: $info-icon;
+            }
         }
     }
 
-    .closest-time-notice-icon {
-        cursor: default;
-
-        .icon {
-            font-size: 12px;
-            color: #dadada;
+    tbody {
+        // alternating row colors
+        &.hasTitleRows tr:not(.title):nth-child(2n + 1) td,
+        &:not(.hasTitleRows) tr:nth-child(2n) td {
+            background-color: #f7f7f7;
         }
 
-        & + span {
-            margin-left: 6px;
+        td.entity {
+            white-space: normal;
         }
-    }
 
-    .range-time {
-        opacity: 0.5;
-        font-size: 13px;
-        padding-bottom: 4px;
-        padding-left: 2px;
-    }
-
-    th.sortable > div {
-        display: flex;
-        align-items: start;
-        justify-content: flex-end;
-        gap: 6px;
-    }
-
-    th.sortable.entity > div {
-        justify-content: flex-start;
-    }
-
-    th .sort-icon {
-        color: #c6c6c6;
-        font-size: 13px;
-
-        &.active {
-            color: $dark-text !important;
+        tr.title td {
+            text-align: left;
+            background-color: #e7e7e7;
+            font-weight: 700;
         }
-    }
 
-    th:hover .sort-icon {
-        color: $info-icon;
-    }
+        .closest-time-notice-icon {
+            cursor: default;
 
-    tbody tr td {
-        padding-top: 8px;
-        padding-bottom: 8px;
-    }
+            .icon {
+                font-size: 12px;
+                color: #dadada;
+            }
 
-    tbody tr.title td {
-        font-weight: 700;
+            & + span {
+                margin-left: 6px;
+            }
+        }
     }
 }
 

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
@@ -27,7 +27,7 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
     .title td:first-child {
         position: sticky;
         left: 0;
-        z-index: 10;
+        z-index: 1;
     }
 
     th.entity {

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
@@ -23,7 +23,8 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
         white-space: nowrap;
     }
 
-    .entity {
+    .entity,
+    .title td:first-child {
         position: sticky;
         left: 0;
         z-index: 10;
@@ -148,6 +149,15 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
         padding-bottom: 3px;
     }
 
+    .title td {
+        background: #e7e7e7;
+
+        &:first-child {
+            text-align: left;
+            font-weight: 700;
+        }
+    }
+
     tbody tr {
         padding-top: 20px;
         padding-bottom: 20px;
@@ -157,26 +167,17 @@ $cell-border: 1px solid rgba(0, 0, 0, 0.08);
         }
     }
 
-    tbody tr:nth-child(2n) td {
+    tbody tr:not(.title):nth-child(2n + 1) td {
         background-color: rgba(247, 247, 247);
     }
 
-    tbody tr:hover td {
+    tbody tr:not(.title):hover td {
         background-color: rgba(241, 241, 241);
     }
 
     .entity {
         text-align: left;
         font-weight: 700;
-    }
-
-    tr:not(.aggregate) + tr.aggregate > td {
-        border-top: 6px solid #aaa;
-    }
-
-    .aggregate .entity {
-        font-style: italic;
-        font-weight: 400;
     }
 
     .dimension {

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -441,6 +441,7 @@ export class DataTable extends React.Component<{
     }
 
     render(): JSX.Element {
+        const { hasAggregateRows } = this
         return (
             <div
                 style={{
@@ -451,7 +452,7 @@ export class DataTable extends React.Component<{
             >
                 <table className="data-table">
                     <thead>{this.headerRow}</thead>
-                    <tbody>
+                    <tbody className={classnames({ hasAggregateRows })}>
                         {this.titleEntityRow}
                         {this.valueEntityRows}
                         {this.titleAggregateRow}

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -427,7 +427,7 @@ export class DataTable extends React.Component<{
             <tr className="title">
                 <td>Region</td>
                 {range(this.numberOfColumnsWidthValues).map((i) => (
-                     <td key={i} />
+                    <td key={i} />
                 ))}
             </tr>
         )

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -864,6 +864,7 @@ export class DataTable extends React.Component<{
 
     @computed private get showTitleRows(): boolean {
         return (
+            this.entitiesAreCountryLike &&
             this.displayEntityRows.length > 0 &&
             this.displayAggregateRows.length > 0
         )

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -238,7 +238,7 @@ export class DataTable extends React.Component<{
             const dimensionHeaderText = (
                 <React.Fragment>
                     <div className="name">{upperFirst(display.columnName)}</div>
-                    <div>
+                    <div className="description">
                         <span className="unit">{display.unit}</span>{" "}
                         <span className="divider">
                             {display.unit && targetTime !== undefined && "•"}

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -414,8 +414,8 @@ export class DataTable extends React.Component<{
         return (
             <tr className="title">
                 <td>Country</td>
-                {range(this.numberOfColumnsWidthValues).map(() => (
-                    <td />
+                {range(this.numberOfColumnsWidthValues).map((i) => (
+                    <td key={i} />
                 ))}
             </tr>
         )
@@ -426,8 +426,8 @@ export class DataTable extends React.Component<{
         return (
             <tr className="title">
                 <td>Region</td>
-                {range(this.numberOfColumnsWidthValues).map(() => (
-                    <td />
+                {range(this.numberOfColumnsWidthValues).map((i) => (
+                     <td key={i} />
                 ))}
             </tr>
         )

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -40,6 +40,7 @@ import {
 } from "@ourworldindata/utils"
 import { makeSelectionArray } from "../chart/ChartUtils"
 import { SelectionArray } from "../selection/SelectionArray"
+import { SizeVariant } from "../core/GrapherConstants"
 
 interface DataTableState {
     sort: DataTableSortState
@@ -78,6 +79,7 @@ export interface DataTableManager {
     endTime?: Time
     startTime?: Time
     dataTableSlugs?: ColumnSlug[]
+    sizeVariant?: SizeVariant
 }
 
 @observer
@@ -87,6 +89,10 @@ export class DataTable extends React.Component<{
 }> {
     @observable private storedState: DataTableState = {
         sort: DEFAULT_SORT_STATE,
+    }
+
+    @computed private get sizeVariant(): SizeVariant {
+        return this.manager.sizeVariant ?? SizeVariant.base
     }
 
     @computed private get tableState(): DataTableState {
@@ -454,11 +460,30 @@ export class DataTable extends React.Component<{
         )
     }
 
+    @computed private get tableCaptionPaddingTop(): number {
+        const { sizeVariant } = this
+        return sizeVariant === SizeVariant.sm || sizeVariant === SizeVariant.md
+            ? 2
+            : 4
+    }
+
+    @computed private get tableCaptionPaddingBottom(): number {
+        return {
+            [SizeVariant.sm]: 4,
+            [SizeVariant.md]: 8,
+            [SizeVariant.base]: 12,
+        }[this.sizeVariant]
+    }
+
     @computed private get tableCaption(): JSX.Element | null {
         if (this.hasDimensionHeaders) return null
         const singleDimension = this.displayDimensions[0]
+        const style: React.CSSProperties = {
+            paddingTop: this.tableCaptionPaddingTop,
+            paddingBottom: this.tableCaptionPaddingBottom,
+        }
         return singleDimension ? (
-            <div className="caption">
+            <div className="caption" style={style}>
                 {singleDimension.display.columnName}{" "}
                 {singleDimension.display.unit && (
                     <span className="unit">{singleDimension.display.unit}</span>

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -186,8 +186,9 @@ export class DataTable extends React.Component<{
     }
 
     @computed private get hasSubheaders(): boolean {
-        return this.displayDimensions.some(
-            (header) => header.columns.length > 1
+        return (
+            !this.hasDimensionHeaders ||
+            this.displayDimensions.some((header) => header.columns.length > 1)
         )
     }
 
@@ -229,7 +230,6 @@ export class DataTable extends React.Component<{
 
     private get dimensionHeaders(): JSX.Element[] | null {
         const { sort } = this.tableState
-        if (!this.hasDimensionHeaders) return null
         return this.displayDimensions.map((dim, dimIndex) => {
             const { coreTableColumn, display } = dim
             const targetTime =
@@ -260,7 +260,6 @@ export class DataTable extends React.Component<{
                         this.updateSort(dimIndex, SingleValueKey.single)
                     }
                 },
-                rowSpan: this.hasSubheaders && dim.columns.length < 2 ? 2 : 1,
                 colSpan: dim.columns.length,
                 headerText: dimensionHeaderText,
                 colType: "dimension" as const,
@@ -301,35 +300,23 @@ export class DataTable extends React.Component<{
 
     private get headerRow(): JSX.Element {
         const { hasDimensionHeaders, hasSubheaders } = this
-
-        if (hasDimensionHeaders && hasSubheaders) {
-            return (
-                <>
-                    <tr>
-                        <th className="above-entity" />
-                        {this.dimensionHeaders}
-                    </tr>
-                    <tr>
-                        {this.entityHeader}
-                        {this.dimensionSubheaders}
-                    </tr>
-                </>
-            )
-        }
-
-        if (hasSubheaders) {
-            return (
+        return hasDimensionHeaders && hasSubheaders ? (
+            <>
+                <tr>
+                    <th className="above-entity" />
+                    {this.dimensionHeaders}
+                </tr>
                 <tr>
                     {this.entityHeader}
                     {this.dimensionSubheaders}
                 </tr>
-            )
-        }
-
-        return (
+            </>
+        ) : (
             <tr>
                 {this.entityHeader}
-                {this.dimensionHeaders}
+                {hasSubheaders
+                    ? this.dimensionSubheaders
+                    : this.dimensionHeaders}
             </tr>
         )
     }

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.scss
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.scss
@@ -86,6 +86,7 @@ $timelineHeight: 32px;
             background-color: #4e4e4e;
             color: #fff;
             border-radius: 4px;
+            width: max-content;
         }
 
         > .handle-label-arrow {


### PR DESCRIPTION
Redesign of data tables

- [x] Render "Country" and "Region" title rows to separate countries from aggregates if applicable
- [x] Render info icon without showing the actual time point in the cell
- [x] If a single indicator, show its name & unit above the table
- [x] Update style