### PR TITLE
:hammer: use nocache when fetching variable data & metadata in admin

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -11,14 +11,14 @@ import {
     BAKE_ON_CHANGE,
     BAKED_BASE_URL,
     ADMIN_BASE_URL,
+    DATA_API_URL,
 } from "../settings/serverSettings.js"
 import { expectInt, isValidSlug } from "../serverUtils/serverUtil.js"
 import { OldChart, Chart, getGrapherById } from "../db/model/Chart.js"
 import { Request, Response, CurrentUser } from "./authentication.js"
 import {
     getMergedGrapherConfigForVariable,
-    getVariableData,
-    getVariableMetadata,
+    fetchS3MetadataByPath,
 } from "../db/model/Variable.js"
 import {
     applyPatch,
@@ -49,6 +49,8 @@ import {
 import {
     GrapherInterface,
     grapherKeysToSerialize,
+    getVariableDataRoute,
+    getVariableMetadataRoute,
 } from "@ourworldindata/grapher"
 import {
     CountryNameFormat,
@@ -695,7 +697,9 @@ apiRouter.get(
             )
         const variableId = parseInt(variableStr)
         if (isNaN(variableId)) throw new JsonError("Invalid variable id")
-        return (await getVariableData(variableId)).data
+        res.redirect(
+            getVariableDataRoute(DATA_API_URL, variableId) + "?nocache"
+        )
     }
 )
 
@@ -710,8 +714,9 @@ apiRouter.get(
             )
         const variableId = parseInt(variableStr)
         if (isNaN(variableId)) throw new JsonError("Invalid variable id")
-        const variableData = await getVariableData(variableId)
-        return variableData.metadata
+        res.redirect(
+            getVariableMetadataRoute(DATA_API_URL, variableId) + "?nocache"
+        )
     }
 )
 
@@ -1695,7 +1700,9 @@ apiRouter.get(
     async (req: Request, res: Response) => {
         const variableId = expectInt(req.params.variableId)
 
-        const variable = await getVariableMetadata(variableId)
+        const variable = await fetchS3MetadataByPath(
+            getVariableMetadataRoute(DATA_API_URL, variableId) + "?nocache"
+        )
 
         const charts = await db.queryMysql(
             `

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -19,6 +19,7 @@ import { Request, Response, CurrentUser } from "./authentication.js"
 import {
     getMergedGrapherConfigForVariable,
     fetchS3MetadataByPath,
+    fetchS3DataValuesByPath,
 } from "../db/model/Variable.js"
 import {
     applyPatch,
@@ -697,7 +698,7 @@ apiRouter.get(
             )
         const variableId = parseInt(variableStr)
         if (isNaN(variableId)) throw new JsonError("Invalid variable id")
-        res.redirect(
+        return await fetchS3DataValuesByPath(
             getVariableDataRoute(DATA_API_URL, variableId) + "?nocache"
         )
     }
@@ -714,7 +715,7 @@ apiRouter.get(
             )
         const variableId = parseInt(variableStr)
         if (isNaN(variableId)) throw new JsonError("Invalid variable id")
-        res.redirect(
+        return await fetchS3MetadataByPath(
             getVariableMetadataRoute(DATA_API_URL, variableId) + "?nocache"
         )
     }

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -408,7 +408,12 @@ export const fetchS3Values = async (
 export const fetchS3DataValuesByPath = async (
     dataPath: string
 ): Promise<OwidVariableMixedData> => {
-    const resp = await retryPromise(() => fetch(dataPath, { keepalive: true }))
+    const resp = await retryPromise(
+        () => fetch(dataPath, { keepalive: true }),
+        3,
+        true,
+        200
+    )
     if (!resp.ok) {
         throw new Error(
             `Error fetching data from S3 for ${dataPath}: ${resp.status} ${resp.statusText}`
@@ -420,8 +425,11 @@ export const fetchS3DataValuesByPath = async (
 export const fetchS3MetadataByPath = async (
     metadataPath: string
 ): Promise<OwidVariableWithSourceAndDimension> => {
-    const resp = await retryPromise(() =>
-        fetch(metadataPath, { keepalive: true })
+    const resp = await retryPromise(
+        () => fetch(metadataPath, { keepalive: true }),
+        3,
+        true,
+        200
     )
     if (!resp.ok) {
         throw new Error(

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -150,10 +150,7 @@ export async function getMergedGrapherConfigForVariable(
 export async function getVariableMetadata(
     variableId: number
 ): Promise<OwidVariableWithSourceAndDimension> {
-    const { metadataPath } = await getOwidVariableDataAndMetadataPath(
-        variableId
-    )
-
+    const metadataPath = getVariableMetadataRoute(DATA_API_URL, variableId)
     const metadata = await fetchS3MetadataByPath(metadataPath)
     return metadata
 }
@@ -161,9 +158,8 @@ export async function getVariableMetadata(
 export async function getVariableData(
     variableId: number
 ): Promise<OwidVariableDataMetadataDimensions> {
-    const { dataPath, metadataPath } = await getOwidVariableDataAndMetadataPath(
-        variableId
-    )
+    const dataPath = getVariableDataRoute(DATA_API_URL, variableId)
+    const metadataPath = getVariableMetadataRoute(DATA_API_URL, variableId)
 
     const [data, metadata] = await Promise.all([
         fetchS3DataValuesByPath(dataPath),
@@ -401,15 +397,6 @@ export const dataAsDF = async (
     return _dataAsDFfromS3(variableIds)
 }
 
-export const getOwidVariableDataAndMetadataPath = async (
-    variableId: OwidVariableId
-): Promise<{ dataPath: string; metadataPath: string }> => {
-    return {
-        dataPath: getVariableDataRoute(DATA_API_URL, variableId),
-        metadataPath: getVariableMetadataRoute(DATA_API_URL, variableId),
-    }
-}
-
 export const fetchS3Values = async (
     variableId: OwidVariableId
 ): Promise<OwidVariableMixedData> => {
@@ -438,7 +425,7 @@ export const fetchS3MetadataByPath = async (
     )
     if (!resp.ok) {
         throw new Error(
-            `Error fetching data from S3 for ${metadataPath}: ${resp.status} ${resp.statusText}`
+            `Error fetching metadata from S3 for ${metadataPath}: ${resp.status} ${resp.statusText}`
         )
     }
     return resp.json()

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -410,9 +410,10 @@ export const fetchS3DataValuesByPath = async (
 ): Promise<OwidVariableMixedData> => {
     const resp = await retryPromise(
         () => fetch(dataPath, { keepalive: true }),
-        3,
-        true,
-        200
+        {
+            maxRetries: 3,
+            exponentialBackoff: true,
+        }
     )
     if (!resp.ok) {
         throw new Error(
@@ -429,9 +430,10 @@ export const fetchS3MetadataByPath = async (
 ): Promise<OwidVariableWithSourceAndDimension> => {
     const resp = await retryPromise(
         () => fetch(metadataPath, { keepalive: true }),
-        3,
-        true,
-        200
+        {
+            maxRetries: 3,
+            exponentialBackoff: true,
+        }
     )
     if (!resp.ok) {
         throw new Error(

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -416,7 +416,9 @@ export const fetchS3DataValuesByPath = async (
     )
     if (!resp.ok) {
         throw new Error(
-            `Error fetching data from S3 for ${dataPath}: ${resp.status} ${resp.statusText}`
+            `Error fetching data from S3 for ${dataPath}: ${resp.status} ${
+                resp.statusText
+            } ${await resp.text()}`
         )
     }
     return resp.json()
@@ -433,7 +435,9 @@ export const fetchS3MetadataByPath = async (
     )
     if (!resp.ok) {
         throw new Error(
-            `Error fetching metadata from S3 for ${metadataPath}: ${resp.status} ${resp.statusText}`
+            `Error fetching metadata from S3 for ${metadataPath}: ${
+                resp.status
+            } ${resp.statusText} ${await resp.text()}`
         )
     }
     return resp.json()

--- a/packages/@ourworldindata/utils/src/Util.test.ts
+++ b/packages/@ourworldindata/utils/src/Util.test.ts
@@ -212,17 +212,23 @@ describe(retryPromise, () => {
 
     it("resolves when promise succeeds first-time", async () => {
         const promiseGetter = resolveAfterNthRetry(0, "success")
-        expect(retryPromise(promiseGetter, 1)).resolves.toEqual("success")
+        expect(retryPromise(promiseGetter, { maxRetries: 1 })).resolves.toEqual(
+            "success"
+        )
     })
 
     it("resolves when promise succeeds before retry limit", async () => {
         const promiseGetter = resolveAfterNthRetry(2, "success")
-        expect(retryPromise(promiseGetter, 3)).resolves.toEqual("success")
+        expect(retryPromise(promiseGetter, { maxRetries: 3 })).resolves.toEqual(
+            "success"
+        )
     })
 
     it("rejects when promise doesn't succeed within retry limit", async () => {
         const promiseGetter = resolveAfterNthRetry(3, "success")
-        expect(retryPromise(promiseGetter, 3)).rejects.toBeUndefined()
+        expect(
+            retryPromise(promiseGetter, { maxRetries: 3 })
+        ).rejects.toBeUndefined()
     })
 })
 

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -765,17 +765,28 @@ export const addDays = (date: Date, days: number): Date => {
     return newDate
 }
 
+export const sleep = (ms: number): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve, ms))
+
 export async function retryPromise<T>(
     promiseGetter: () => Promise<T>,
-    maxRetries: number = 3
+    maxRetries: number = 3,
+    exponentialBackoff: boolean = false, // New optional argument
+    initialDelay: number = 200 // Initial delay in ms
 ): Promise<T> {
     let retried = 0
     let lastError
+    let delay = initialDelay // Starting delay time
+
     while (retried++ < maxRetries) {
         try {
             return await promiseGetter()
         } catch (error) {
             lastError = error
+            if (exponentialBackoff && retried < maxRetries) {
+                await sleep(delay) // You'll have to implement the sleep function
+                delay *= 2 // Double the delay for next retry
+            }
         }
     }
     throw lastError

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -775,9 +775,9 @@ export async function retryPromise<T>(
         exponentialBackoff = false,
         initialDelay = 200,
     }: {
-        maxRetries?: number;
-        exponentialBackoff?: boolean;
-        initialDelay?: number;
+        maxRetries?: number
+        exponentialBackoff?: boolean
+        initialDelay?: number
     } = {}
 ): Promise<T> {
     let retried = 0

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -771,12 +771,12 @@ export const sleep = (ms: number): Promise<void> =>
 export async function retryPromise<T>(
     promiseGetter: () => Promise<T>,
     maxRetries: number = 3,
-    exponentialBackoff: boolean = false, // New optional argument
+    exponentialBackoff: boolean = false,
     initialDelay: number = 200 // Initial delay in ms
 ): Promise<T> {
     let retried = 0
     let lastError
-    let delay = initialDelay // Starting delay time
+    let delay = initialDelay
 
     while (retried++ < maxRetries) {
         try {
@@ -784,7 +784,7 @@ export async function retryPromise<T>(
         } catch (error) {
             lastError = error
             if (exponentialBackoff && retried < maxRetries) {
-                await sleep(delay) // You'll have to implement the sleep function
+                await sleep(delay)
                 delay *= 2 // Double the delay for next retry
             }
         }

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -770,9 +770,15 @@ export const sleep = (ms: number): Promise<void> =>
 
 export async function retryPromise<T>(
     promiseGetter: () => Promise<T>,
-    maxRetries: number = 3,
-    exponentialBackoff: boolean = false,
-    initialDelay: number = 200 // Initial delay in ms
+    {
+        maxRetries = 3,
+        exponentialBackoff = false,
+        initialDelay = 200,
+    }: {
+        maxRetries?: number;
+        exponentialBackoff?: boolean;
+        initialDelay?: number;
+    } = {}
 ): Promise<T> {
     let retried = 0
     let lastError


### PR DESCRIPTION
Data and metadata might get cached for 5 minutes by CF worker at the moment. This is typically not a problem, but it was annoying when I was fine-tuning the description in admin coming from ETL. This PR adds `nocache` header and ~switches to redirects for more transparency (we could even remove the admin variables endpoint and fetch directly from Data API, but I was afraid of side effects).~

Also adds exponential backoff to `retryPromise` which seems to have some effect [against 502 errors](https://github.com/owid/owid-grapher/issues/2585).