### PR TITLE
Grapher redesign: Bug fixes

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -459,8 +459,8 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
                 (this.manager.hasTimeline
                     ? this.verticalPaddingSmall + TIMELINE_HEIGHT
                     : 0) -
-                this.verticalPadding -
                 // #5 Footer
+                this.verticalPadding -
                 this.footer.height -
                 // #6 [Related question]
                 (this.showRelatedQuestion
@@ -501,15 +501,15 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
                 {this.manager.isOnTableTab
                     ? this.renderDataTable()
                     : this.renderChartOrMap()}
+
+                {/* #4 [Timeline] */}
                 {this.manager.hasTimeline && (
                     <VerticalSpace height={this.verticalPaddingSmall} />
                 )}
-
-                {/* #4 [Timeline] */}
                 {this.manager.hasTimeline && this.renderTimeline()}
-                <VerticalSpace height={this.verticalPadding} />
 
                 {/* #5 Footer */}
+                <VerticalSpace height={this.verticalPadding} />
                 <Footer manager={this.manager} maxWidth={this.maxWidth} />
 
                 {/* #6 [Related question] */}

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2224,6 +2224,27 @@ export class Grapher
         this.isInFullScreenMode = !this.isInFullScreenMode
     }
 
+    @action.bound dismissFullScreen(): void {
+        // if a modal is open, dismiss it instead of exiting full-screen mode
+        if (this.isModalOpen) {
+            this.isSelectingData = false
+            this.isSourcesModalOpen = false
+            this.isEmbedModalOpen = false
+            this.isDownloadModalOpen = false
+        } else {
+            this.isInFullScreenMode = false
+        }
+    }
+
+    @computed private get isModalOpen(): boolean {
+        return (
+            this.isSelectingData ||
+            this.isSourcesModalOpen ||
+            this.isEmbedModalOpen ||
+            this.isDownloadModalOpen
+        )
+    }
+
     private renderError(): JSX.Element {
         return (
             <div
@@ -2314,7 +2335,8 @@ export class Grapher
         if (this.isInFullScreenMode) {
             return (
                 <FullScreen
-                    onDismiss={action(() => (this.isInFullScreenMode = false))}
+                    onDismiss={this.dismissFullScreen}
+                    overlayColor={this.isModalOpen ? "#999999" : "#fff"}
                 >
                     {this.renderGrapherComponent()}
                 </FullScreen>

--- a/packages/@ourworldindata/grapher/src/fullScreen/FullScreen.scss
+++ b/packages/@ourworldindata/grapher/src/fullScreen/FullScreen.scss
@@ -3,7 +3,6 @@
     top: 0;
     left: 0;
     z-index: $zindex-full-screen;
-    background: #fff;
     height: 100%;
     width: 100%;
 }

--- a/packages/@ourworldindata/grapher/src/fullScreen/FullScreen.tsx
+++ b/packages/@ourworldindata/grapher/src/fullScreen/FullScreen.tsx
@@ -7,6 +7,7 @@ import { BodyDiv } from "../bodyDiv/BodyDiv"
 export class FullScreen extends React.Component<{
     children: React.ReactNode
     onDismiss: () => void
+    overlayColor?: string
 }> {
     content: React.RefObject<HTMLDivElement> = React.createRef()
 
@@ -42,6 +43,9 @@ export class FullScreen extends React.Component<{
                     className="FullScreenOverlay"
                     role="dialog"
                     aria-modal="true"
+                    style={{
+                        backgroundColor: this.props.overlayColor ?? "#fff",
+                    }}
                 >
                     <div className="FullScreenContent" ref={this.content}>
                         {this.props.children}

--- a/packages/@ourworldindata/grapher/src/modal/EmbedModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/EmbedModal.scss
@@ -16,27 +16,28 @@ $zindex-embedMenu: 12;
 
 .embedMenu .embedCode {
     width: 100%;
+    padding: 16px 24px;
     border: 1px solid $light-stroke;
     background: $gray-10;
     display: flex;
     align-items: flex-start;
 }
 
-.embedMenu textarea {
-    resize: none;
-    padding: 1.33em 2em;
+.embedMenu code {
     width: 100%;
     border: none;
     background: none;
     color: $light-text;
-    font-family: monospace;
     font-size: 0.75em;
     line-height: 1.33;
+    word-break: break-word;
 }
 
 .embedMenu button {
+    flex: 0 0 64px;
     cursor: pointer;
-    padding: 1em 1.5em 0 0;
     color: $dark-text;
-    font-size: 14px;
+    padding: 0;
+    text-align: right;
+    font-size: 0.875em;
 }

--- a/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
@@ -24,6 +24,7 @@ interface EmbedModalProps {
 
 interface EmbedModalState {
     canWriteToClipboard: boolean
+    copied: boolean
 }
 
 @observer
@@ -38,6 +39,7 @@ export class EmbedModal extends React.Component<
 
         this.state = {
             canWriteToClipboard: false,
+            copied: false,
         }
     }
 
@@ -60,27 +62,17 @@ export class EmbedModal extends React.Component<
         return this.props.manager
     }
 
-    @action.bound resizeTextArea(): void {
-        if (this.textAreaRef.current) {
-            const textArea = this.textAreaRef.current
-            textArea.style.height = textArea.scrollHeight + "px"
-        }
-    }
-
     componentDidMount(): void {
         canWriteToClipboard().then((canWriteToClipboard) =>
             this.setState({ canWriteToClipboard })
         )
-        this.resizeTextArea()
     }
 
-    componentDidUpdate(): void {
-        this.resizeTextArea()
-    }
-
-    @action.bound async onCopyCodeSnippet(): Promise<void> {
+    @action.bound async copyCodeSnippet(): Promise<void> {
         try {
             await navigator.clipboard.writeText(this.codeSnippet)
+            this.setState({ copied: true })
+            setTimeout(() => this.setState({ copied: false }), 2000)
         } catch (err) {
             console.error(
                 "couldn't copy to clipboard using navigator.clipboard",
@@ -102,15 +94,14 @@ export class EmbedModal extends React.Component<
                 <div className="embedMenu">
                     <p>Paste this into any HTML page:</p>
                     <div className="embedCode">
-                        <textarea
-                            ref={this.textAreaRef}
-                            readOnly={true}
-                            onFocus={(evt): void => evt.currentTarget.select()}
-                            value={this.codeSnippet}
-                        />
+                        <code>{this.codeSnippet}</code>
                         {this.state.canWriteToClipboard && (
-                            <button onClick={this.onCopyCodeSnippet}>
-                                <FontAwesomeIcon icon={faCopy} />
+                            <button onClick={this.copyCodeSnippet}>
+                                {this.state.copied ? (
+                                    "Copied!"
+                                ) : (
+                                    <FontAwesomeIcon icon={faCopy} />
+                                )}
                             </button>
                         )}
                     </div>

--- a/packages/@ourworldindata/grapher/src/modal/Modal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/Modal.scss
@@ -1,9 +1,10 @@
 .modalOverlay {
     position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
+    // -1px to hide the border
+    top: -1px;
+    right: -1px;
+    bottom: -1px;
+    left: -1px;
     background-color: rgba(0, 0, 0, 0.4);
     z-index: $zindex-modal;
 


### PR DESCRIPTION
- When in full-screen mode and a modal is open, dismiss the modal when clicked outside of Grapher instead of exiting full-screen mode
- In full-screen mode, if a modal is open, make the overlay cover the whole screen (not only Grapher itself)
- Add feedback when copying the code snippet was successful