### PR TITLE
Grapher redesign: Improve mobile view

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.scss
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.scss
@@ -1,6 +1,6 @@
 // keep in sync with constant values in CaptionedChart.tsx
 $framePadding: 16px; // keep in sync with FRAME_PADDING
-$controlRowHeight: 34px; // keep in sync with CONTROLS_ROW_HEIGHT
+$controlRowHeight: 32px; // keep in sync with CONTROLS_ROW_HEIGHT
 
 .HeaderHTML,
 .SourcesFooterHTML {

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -22,7 +22,6 @@ import {
     Patterns,
     RelatedQuestionsConfig,
     STATIC_EXPORT_DETAIL_SPACING,
-    SizeVariant,
 } from "../core/GrapherConstants"
 import { MapChartManager } from "../mapCharts/MapChartConstants"
 import { ChartManager } from "../chart/ChartManager"
@@ -74,7 +73,6 @@ export interface CaptionedChartManager
         ContentSwitchersManager {
     containerElement?: HTMLDivElement
     tabBounds?: Bounds
-    sizeVariant?: SizeVariant
     fontSize?: number
     bakedGrapherURL?: string
     tab?: GrapherTabOption
@@ -105,6 +103,8 @@ export interface CaptionedChartManager
     hasRelatedQuestion?: boolean
     isRelatedQuestionTargetDifferentFromCurrentPage?: boolean
     relatedQuestions?: RelatedQuestionsConfig[]
+    isSmall?: boolean
+    isMedium?: boolean
 }
 
 interface CaptionedChartProps {
@@ -131,20 +131,16 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         return this.props.maxWidth ?? this.bounds.width - 2 * FRAME_PADDING
     }
 
-    @computed protected get sizeVariant(): SizeVariant {
-        return this.manager.sizeVariant ?? SizeVariant.base
-    }
-
     @computed protected get verticalPadding(): number {
-        return this.sizeVariant === SizeVariant.base ? 12 : 8
+        return this.manager.isMedium ? 8 : 12
     }
 
     @computed protected get verticalPaddingSmall(): number {
-        return this.sizeVariant === SizeVariant.sm ? 4 : 8
+        return this.manager.isSmall ? 4 : 8
     }
 
     @computed protected get relatedQuestionHeight(): number {
-        return this.sizeVariant === SizeVariant.base ? 28 : 24
+        return this.manager.isMedium ? 24 : 28
     }
 
     @computed protected get header(): Header {

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -115,7 +115,7 @@ interface CaptionedChartProps {
 
 // keep in sync with sass variables in CaptionedChart.scss
 const FRAME_PADDING = 16
-const CONTROLS_ROW_HEIGHT = 34
+const CONTROLS_ROW_HEIGHT = 32
 
 @observer
 export class CaptionedChart extends React.Component<CaptionedChartProps> {

--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
@@ -1,6 +1,6 @@
 $borderWidth: 1px;
 $borderRadius: 4px;
-$gap: 2px;
+$gap: 1.5px;
 
 .ContentSwitchers {
     list-style: none;

--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
@@ -28,8 +28,11 @@ $gap: 1.5px;
         padding: 0 16px;
         cursor: default;
 
+        .label {
+            margin-left: 6px;
+        }
+
         svg {
-            margin-right: 6px;
             color: $info-icon;
         }
     }

--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
@@ -7,7 +7,7 @@ import {
     faEarthAmericas,
     faChartLine,
 } from "@fortawesome/free-solid-svg-icons"
-import { GrapherTabOption, SizeVariant } from "../core/GrapherConstants"
+import { GrapherTabOption } from "../core/GrapherConstants"
 
 const icons = {
     [GrapherTabOption.table]: faTable,
@@ -18,7 +18,8 @@ const icons = {
 export interface ContentSwitchersManager {
     availableTabs?: GrapherTabOption[]
     tab?: GrapherTabOption
-    sizeVariant?: SizeVariant
+    isNarrow?: boolean
+    isMedium?: boolean
 }
 
 @observer
@@ -29,26 +30,24 @@ export class ContentSwitchers extends React.Component<{
         return this.props.manager
     }
 
-    @computed private get sizeVariant(): SizeVariant {
-        return this.manager.sizeVariant ?? SizeVariant.base
-    }
-
     @computed private get availableTabs(): GrapherTabOption[] {
         return this.manager.availableTabs || []
     }
 
     render(): JSX.Element {
-        const { manager, sizeVariant } = this
-        const { sm, md } = SizeVariant
-        const isNarrow = sizeVariant === sm || sizeVariant === md
+        const { manager } = this
         return (
-            <ul className={"ContentSwitchers" + (isNarrow ? " narrow" : "")}>
+            <ul
+                className={
+                    "ContentSwitchers" +
+                    (manager.isMedium && !manager.isNarrow ? " narrow" : "")
+                }
+            >
                 {this.availableTabs.map((tab) => (
                     <Tab
                         key={tab}
                         tab={tab}
                         isActive={tab === manager.tab}
-                        sizeVariant={sizeVariant}
                         onClick={(): void => {
                             manager.tab = tab
                         }}
@@ -62,7 +61,6 @@ export class ContentSwitchers extends React.Component<{
 function Tab(props: {
     tab: GrapherTabOption
     isActive?: boolean
-    sizeVariant?: SizeVariant
     onClick?: React.MouseEventHandler<HTMLAnchorElement>
 }): JSX.Element {
     const className = "tab clickable" + (props.isActive ? " active" : "")

--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
@@ -51,6 +51,7 @@ export class ContentSwitchers extends React.Component<{
                         onClick={(): void => {
                             manager.tab = tab
                         }}
+                        showLabel={!manager.isNarrow}
                     />
                 ))}
             </ul>
@@ -62,6 +63,7 @@ function Tab(props: {
     tab: GrapherTabOption
     isActive?: boolean
     onClick?: React.MouseEventHandler<HTMLAnchorElement>
+    showLabel?: boolean
 }): JSX.Element {
     const className = "tab clickable" + (props.isActive ? " active" : "")
     return (
@@ -71,7 +73,7 @@ function Tab(props: {
                 data-track-note={"chart_click_" + props.tab}
             >
                 <FontAwesomeIcon icon={icons[props.tab]} />
-                {props.tab}
+                {props.showLabel && <span className="label">{props.tab}</span>}
             </a>
         </li>
     )

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2309,7 +2309,7 @@ export class Grapher
         const containerStyle = {
             width: this.renderWidth,
             height: this.renderHeight,
-            fontSize: this.baseFontSize,
+            fontSize: Math.min(16, this.baseFontSize), // cap font size at 16px
         }
 
         return (

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2386,7 +2386,8 @@ export class Grapher
     @action.bound private setBaseFontSize(): void {
         const { renderWidth } = this
         if (renderWidth <= 400) this.baseFontSize = 14
-        else this.baseFontSize = 16
+        else if (renderWidth < 1080) this.baseFontSize = 16
+        else if (renderWidth >= 1080) this.baseFontSize = 18
     }
 
     // The size variant is used throughout Grapher to determine font sizes, line heights, margins, etc.

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -89,7 +89,6 @@ import {
     SeriesStrategy,
     getVariableDataRoute,
     getVariableMetadataRoute,
-    SizeVariant,
 } from "../core/GrapherConstants"
 import Cookies from "js-cookie"
 import {
@@ -889,7 +888,6 @@ export class Grapher
     }
 
     @observable.ref baseFontSize = BASE_FONT_SIZE
-    @observable.ref sizeVariant = SizeVariant.base
 
     // Ready to go iff we have retrieved data for every variable associated with the chart
     @computed get isReady(): boolean {
@@ -2390,18 +2388,20 @@ export class Grapher
         else if (renderWidth >= 1080) this.baseFontSize = 18
     }
 
-    // The size variant is used throughout Grapher to determine font sizes, line heights, margins, etc.
-    @action.bound setSizeVariant(): void {
-        const { renderWidth } = this
-        // When embedded, charts are rendered into a 12-column grid.
-        // The size variant pixel thresholds are based on these breakpoints.
-        // The size variant is `sm` if the chart is rendered into 6 or 7 columns
-        // (e.g. side-by-side charts or charts in the All Charts block)
-        if (renderWidth <= 740) this.sizeVariant = SizeVariant.sm
-        // The size variant is `md` if the chart is rendered into 8 columns
-        // (e.g. stand-alone charts in the main text of an article)
-        else if (renderWidth <= 840) this.sizeVariant = SizeVariant.md
-        else this.sizeVariant = SizeVariant.base
+    @computed get isNarrow(): boolean {
+        return this.renderWidth <= 400
+    }
+
+    // Small charts are rendered into 6 or 7 columns in a 12-column grid layout
+    // (e.g. side-by-side charts or charts in the All Charts block)
+    @computed get isSmall(): boolean {
+        return this.renderWidth <= 740
+    }
+
+    // Medium charts are rendered into 8 columns in a 12-column grid layout
+    // (e.g. stand-alone charts in the main text of an article)
+    @computed get isMedium(): boolean {
+        return this.renderWidth <= 840
     }
 
     // Binds chart properties to global window title and URL. This should only
@@ -2442,7 +2442,6 @@ export class Grapher
 
     componentDidMount(): void {
         this.setBaseFontSize()
-        this.setSizeVariant()
         this.setUpIntersectionObserver()
         this.setUpWindowResizeEventHandler()
         exposeInstanceOnWindow(this, "grapher")
@@ -2481,7 +2480,6 @@ export class Grapher
 
     componentDidUpdate(): void {
         this.setBaseFontSize()
-        this.setSizeVariant()
     }
 
     componentDidCatch(error: Error): void {

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -29,11 +29,6 @@ export const DEFAULT_GRAPHER_HEIGHT = 600
 
 export const STATIC_EXPORT_DETAIL_SPACING = 8
 
-export enum SizeVariant {
-    sm = "sm",
-    md = "md",
-    base = "base",
-}
 export enum CookieKey {
     isAdmin = "isAdmin",
 }

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -40,7 +40,6 @@ import {
 } from "@ourworldindata/utils"
 import { makeSelectionArray } from "../chart/ChartUtils"
 import { SelectionArray } from "../selection/SelectionArray"
-import { SizeVariant } from "../core/GrapherConstants"
 
 interface DataTableState {
     sort: DataTableSortState
@@ -79,7 +78,8 @@ export interface DataTableManager {
     endTime?: Time
     startTime?: Time
     dataTableSlugs?: ColumnSlug[]
-    sizeVariant?: SizeVariant
+    isSmall?: boolean
+    isMedium?: boolean
 }
 
 @observer
@@ -89,10 +89,6 @@ export class DataTable extends React.Component<{
 }> {
     @observable private storedState: DataTableState = {
         sort: DEFAULT_SORT_STATE,
-    }
-
-    @computed private get sizeVariant(): SizeVariant {
-        return this.manager.sizeVariant ?? SizeVariant.base
     }
 
     @computed private get tableState(): DataTableState {
@@ -448,18 +444,11 @@ export class DataTable extends React.Component<{
     }
 
     @computed private get tableCaptionPaddingTop(): number {
-        const { sizeVariant } = this
-        return sizeVariant === SizeVariant.sm || sizeVariant === SizeVariant.md
-            ? 2
-            : 4
+        return this.manager.isMedium ? 2 : 4
     }
 
     @computed private get tableCaptionPaddingBottom(): number {
-        return {
-            [SizeVariant.sm]: 4,
-            [SizeVariant.md]: 8,
-            [SizeVariant.base]: 12,
-        }[this.sizeVariant]
+        return this.manager.isSmall ? 4 : this.manager.isMedium ? 8 : 12
     }
 
     @computed private get tableCaption(): JSX.Element | null {

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -10,7 +10,6 @@ import {
     MarkdownTextWrap,
 } from "@ourworldindata/utils"
 import { Tooltip } from "../tooltip/Tooltip"
-import { SizeVariant } from "../core/GrapherConstants"
 import { FooterManager } from "./FooterManager"
 import { ActionButtons } from "../controls/ActionButtons"
 
@@ -68,10 +67,6 @@ export class Footer<
 
     @computed protected get manager(): FooterManager {
         return this.props.manager
-    }
-
-    @computed protected get sizeVariant(): SizeVariant {
-        return this.manager.sizeVariant ?? SizeVariant.base
     }
 
     @computed protected get maxWidth(): number {
@@ -174,18 +169,15 @@ export class Footer<
     }
 
     @computed private get lineHeight(): number {
-        return this.sizeVariant === SizeVariant.sm ? 1.1 : 1.2
+        return this.manager.isSmall ? 1.1 : 1.2
     }
 
     @computed protected get fontSize(): number {
-        return this.sizeVariant === SizeVariant.sm ||
-            this.sizeVariant === SizeVariant.md
-            ? 11
-            : 12
+        return this.manager.isMedium ? 11 : 12
     }
 
     @computed protected get sourcesFontSize(): number {
-        return this.sizeVariant === SizeVariant.sm ? 12 : 13
+        return this.manager.isSmall ? 12 : 13
     }
 
     @computed private get hasNote(): boolean {

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -6,12 +6,11 @@ import {
     TextWrap,
     Bounds,
     DEFAULT_BOUNDS,
-    getFontScale,
     getRelativeMouse,
     MarkdownTextWrap,
 } from "@ourworldindata/utils"
 import { Tooltip } from "../tooltip/Tooltip"
-import { BASE_FONT_SIZE, SizeVariant } from "../core/GrapherConstants"
+import { SizeVariant } from "../core/GrapherConstants"
 import { FooterManager } from "./FooterManager"
 import { ActionButtons } from "../controls/ActionButtons"
 
@@ -179,20 +178,14 @@ export class Footer<
     }
 
     @computed protected get fontSize(): number {
-        const fontScale =
-            this.sizeVariant === SizeVariant.sm ||
+        return this.sizeVariant === SizeVariant.sm ||
             this.sizeVariant === SizeVariant.md
-                ? getFontScale(11)
-                : getFontScale(12)
-        return fontScale * (this.manager.fontSize ?? BASE_FONT_SIZE)
+            ? 11
+            : 12
     }
 
     @computed protected get sourcesFontSize(): number {
-        const fontScale =
-            this.sizeVariant === SizeVariant.sm
-                ? getFontScale(12)
-                : getFontScale(13)
-        return fontScale * (this.manager.fontSize ?? BASE_FONT_SIZE)
+        return this.sizeVariant === SizeVariant.sm ? 12 : 13
     }
 
     @computed private get hasNote(): boolean {

--- a/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
+++ b/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
@@ -4,7 +4,6 @@ import { ActionButtonsManager } from "../controls/ActionButtons"
 import { SizeVariant } from "../core/GrapherConstants"
 
 export interface FooterManager extends TooltipManager, ActionButtonsManager {
-    fontSize?: number
     sourcesLine?: string
     note?: string
     hasOWIDLogo?: boolean

--- a/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
+++ b/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
@@ -1,7 +1,6 @@
 import { TooltipManager } from "../tooltip/TooltipProps"
 import { GrapherInterface } from "../core/GrapherInterface"
 import { ActionButtonsManager } from "../controls/ActionButtons"
-import { SizeVariant } from "../core/GrapherConstants"
 
 export interface FooterManager extends TooltipManager, ActionButtonsManager {
     sourcesLine?: string
@@ -11,6 +10,7 @@ export interface FooterManager extends TooltipManager, ActionButtonsManager {
     details?: GrapherInterface["details"]
     detailsOrderedByReference?: Set<string>
     shouldIncludeDetailsInStaticExport?: boolean
-    sizeVariant?: SizeVariant
     isSourcesModalOpen?: boolean
+    isSmall?: boolean
+    isMedium?: boolean
 }

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -8,7 +8,6 @@ import { computed } from "mobx"
 import { observer } from "mobx-react"
 import { Logo } from "../captionedChart/Logos"
 import { HeaderManager } from "./HeaderManager"
-import { SizeVariant } from "../core/GrapherConstants"
 
 @observer
 export class Header extends React.Component<{
@@ -17,10 +16,6 @@ export class Header extends React.Component<{
 }> {
     @computed private get manager(): HeaderManager {
         return this.props.manager
-    }
-
-    @computed protected get sizeVariant(): SizeVariant {
-        return this.manager.sizeVariant ?? SizeVariant.base
     }
 
     @computed protected get maxWidth(): number {
@@ -36,10 +31,10 @@ export class Header extends React.Component<{
     }
 
     @computed get logo(): Logo | undefined {
-        const { manager, sizeVariant } = this
+        const { manager } = this
         if (manager.hideLogo) return undefined
 
-        const heightScale = sizeVariant === SizeVariant.sm ? 0.775 : 1
+        const heightScale = this.manager.isSmall ? 0.775 : 1
         return new Logo({
             logo: manager.logo as any,
             isLink: !!manager.shouldLinkToOwid,
@@ -56,17 +51,16 @@ export class Header extends React.Component<{
     }
 
     @computed get title(): TextWrap {
-        const { logoWidth, sizeVariant } = this
-        const fontSize =
-            sizeVariant === SizeVariant.sm
-                ? 18
-                : sizeVariant === SizeVariant.md
-                ? 20
-                : 24
+        const { logoWidth } = this
+        const fontSize = this.manager.isSmall
+            ? 18
+            : this.manager.isMedium
+            ? 20
+            : 24
         return new TextWrap({
             maxWidth: this.maxWidth - logoWidth - 24,
             fontWeight: 400,
-            lineHeight: sizeVariant === SizeVariant.sm ? 1.1 : 1.2,
+            lineHeight: this.manager.isSmall ? 1.1 : 1.2,
             fontSize,
             text: this.titleText,
         })
@@ -84,14 +78,12 @@ export class Header extends React.Component<{
     }
 
     @computed get subtitle(): MarkdownTextWrap {
-        const { sizeVariant } = this
-        const fontSize =
-            sizeVariant === SizeVariant.sm
-                ? 12
-                : sizeVariant === SizeVariant.md
-                ? 13
-                : 14
-        const lineHeight = sizeVariant === SizeVariant.base ? 1.28571 : 1.2
+        const fontSize = this.manager.isSmall
+            ? 12
+            : this.manager.isMedium
+            ? 13
+            : 14
+        const lineHeight = this.manager.isMedium ? 1.2 : 1.28571
         return new MarkdownTextWrap({
             maxWidth: this.subtitleWidth,
             fontSize,

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -3,13 +3,12 @@ import {
     TextWrap,
     DEFAULT_BOUNDS,
     MarkdownTextWrap,
-    getFontScale,
 } from "@ourworldindata/utils"
 import { computed } from "mobx"
 import { observer } from "mobx-react"
 import { Logo } from "../captionedChart/Logos"
 import { HeaderManager } from "./HeaderManager"
-import { BASE_FONT_SIZE, SizeVariant } from "../core/GrapherConstants"
+import { SizeVariant } from "../core/GrapherConstants"
 
 @observer
 export class Header extends React.Component<{
@@ -18,10 +17,6 @@ export class Header extends React.Component<{
 }> {
     @computed private get manager(): HeaderManager {
         return this.props.manager
-    }
-
-    @computed private get fontSize(): number {
-        return this.manager.fontSize ?? BASE_FONT_SIZE
     }
 
     @computed protected get sizeVariant(): SizeVariant {
@@ -62,17 +57,17 @@ export class Header extends React.Component<{
 
     @computed get title(): TextWrap {
         const { logoWidth, sizeVariant } = this
-        const fontScale =
+        const fontSize =
             sizeVariant === SizeVariant.sm
-                ? getFontScale(18)
+                ? 18
                 : sizeVariant === SizeVariant.md
-                ? getFontScale(20)
-                : getFontScale(24)
+                ? 20
+                : 24
         return new TextWrap({
             maxWidth: this.maxWidth - logoWidth - 24,
             fontWeight: 400,
             lineHeight: sizeVariant === SizeVariant.sm ? 1.1 : 1.2,
-            fontSize: fontScale * this.fontSize,
+            fontSize,
             text: this.titleText,
         })
     }
@@ -90,16 +85,16 @@ export class Header extends React.Component<{
 
     @computed get subtitle(): MarkdownTextWrap {
         const { sizeVariant } = this
-        const fontScale =
+        const fontSize =
             sizeVariant === SizeVariant.sm
-                ? getFontScale(12)
+                ? 12
                 : sizeVariant === SizeVariant.md
-                ? getFontScale(13)
-                : getFontScale(14)
+                ? 13
+                : 14
         const lineHeight = sizeVariant === SizeVariant.base ? 1.28571 : 1.2
         return new MarkdownTextWrap({
             maxWidth: this.subtitleWidth,
-            fontSize: fontScale * this.fontSize,
+            fontSize,
             text: this.subtitleText,
             lineHeight,
             detailsOrderedByReference: this.manager

--- a/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
+++ b/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
@@ -2,7 +2,6 @@ import { Bounds } from "@ourworldindata/utils"
 import { SizeVariant } from "../core/GrapherConstants"
 
 export interface HeaderManager {
-    fontSize?: number
     currentTitle?: string
     subtitle?: string
     hideLogo?: boolean

--- a/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
+++ b/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
@@ -1,5 +1,4 @@
 import { Bounds } from "@ourworldindata/utils"
-import { SizeVariant } from "../core/GrapherConstants"
 
 export interface HeaderManager {
     currentTitle?: string
@@ -12,5 +11,6 @@ export interface HeaderManager {
     detailsOrderedByReference?: Set<string>
     shouldIncludeDetailsInStaticExport?: boolean
     isExportingtoSvgOrPng?: boolean
-    sizeVariant?: SizeVariant
+    isSmall?: boolean
+    isMedium?: boolean
 }

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -43,12 +43,16 @@
             0px 6px 13px 0px rgba(49, 37, 2, 0.03),
             0px 93px 37px 0px rgba(49, 37, 2, 0.01),
             0px 145px 41px 0px rgba(49, 37, 2, 0);
-        max-height: 72px;
     }
 
     .grouped-menu-content {
         flex: 1;
         padding: 0 1.5em;
+
+        @media (max-width: 400px) {
+            padding-left: 1em;
+            padding-right: 0.5em;
+        }
 
         .title {
             margin: 0;
@@ -90,17 +94,16 @@
         .title {
             margin: 0;
             font-family: $serif-font-stack;
-            font-size: 1rem;
+            font-size: 1em;
             font-weight: 600;
             line-height: 1.5;
         }
 
         p {
-            font-size: 0.9375em;
+            font-size: 0.875em;
             margin: 0.5em 0 0;
             opacity: 0.9;
             color: $light-text;
-            font-size: 0.875rem;
             font-weight: 500;
             line-height: 1.5;
             letter-spacing: 0.14px;

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -210,9 +210,26 @@ export class DownloadModal extends React.Component<DownloadModalProps> {
     }
 
     private renderReady(): JSX.Element {
-        const { manager, svgPreviewUrl } = this
+        const { manager, svgPreviewUrl, tabBounds, targetWidth, targetHeight } =
+            this
         const pngPreviewUrl = this.pngPreviewUrl || this.fallbackPngUrl
+
+        let previewWidth: number
+        let previewHeight: number
+        const boundScalar = 0.17
+        if (tabBounds.width / tabBounds.height > targetWidth / targetHeight) {
+            previewHeight = Math.min(72, tabBounds.height * boundScalar)
+            previewWidth = (targetWidth / targetHeight) * previewHeight
+        } else {
+            previewWidth = Math.min(102, tabBounds.width * boundScalar)
+            previewHeight = (targetHeight / targetWidth) * previewWidth
+        }
+
         const imgStyle = {
+            minWidth: previewWidth,
+            minHeight: previewHeight,
+            maxWidth: previewWidth,
+            maxHeight: previewHeight,
             opacity: this.isReady ? 1 : 0,
         }
 

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.scss
@@ -59,6 +59,7 @@
 .datasource-wrapper a {
     text-decoration: underline;
     color: inherit;
+    word-break: break-word;
 }
 
 .datasource-property {

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1664,10 +1664,6 @@ export function filterValidStringValues<ValidValue extends string>(
     return filteredValues
 }
 
-export function getFontScale(size: number, base = 16): number {
-    return size / base
-}
-
 // TODO: type this correctly once we have moved types into their own top level package
 export function mergePartialGrapherConfigs<T extends Record<string, any>>(
     ...grapherConfigs: (T | undefined)[]

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -329,7 +329,6 @@ export {
     type NodeWithUrl,
     filterValidStringValues,
     traverseEnrichedSpan,
-    getFontScale,
     mergePartialGrapherConfigs,
     getOriginAttributionFragments,
     getAttributionFromVariable,

--- a/site/css/chart.scss
+++ b/site/css/chart.scss
@@ -19,7 +19,7 @@
 
     // Charts shouldn't be below this height in any circumstance, whether mobile or not.
     // Except in iframes, where we override this.
-    min-height: 480px;
+    min-height: 540px;
 
     // On small viewports always use the full available height.
     // We only leave space for the mobile header and fill the rest.


### PR DESCRIPTION
Improves Grapher charts on mobile.

- hides chart/map/table label on mobile
- increases the minimum height from 480px to 540px
- makes control row a little smaller
- improves Download modal on smaller screens