### PR TITLE
:bug: enable Bugsnag for deploy queue

### DIFF
--- a/baker/startDeployQueueServer.ts
+++ b/baker/startDeployQueueServer.ts
@@ -1,5 +1,9 @@
 import fs from "fs-extra"
-import { DEPLOY_QUEUE_FILE_PATH } from "../settings/serverSettings.js"
+import Bugsnag from "@bugsnag/js"
+import {
+    DEPLOY_QUEUE_FILE_PATH,
+    BUGSNAG_NODE_API_KEY,
+} from "../settings/serverSettings.js"
 import { deployIfQueueIsNotEmpty } from "./DeployUtils.js"
 import * as db from "../db/db.js"
 // Ensure db is cleaned up on PM2 stop / restart / reload and cmd/ctrl + c
@@ -12,6 +16,13 @@ const main = async () => {
             `No deploy queue file found in: ${DEPLOY_QUEUE_FILE_PATH}`
         )
         process.exit(1)
+    }
+
+    if (BUGSNAG_NODE_API_KEY) {
+        Bugsnag.start({
+            apiKey: BUGSNAG_NODE_API_KEY,
+            context: "deploy-queue",
+        })
     }
 
     await db.getConnection()


### PR DESCRIPTION
`deploy-queue` process doesn't start bugsnag and we don't get any errors from failed deploys.