### PR TITLE
feat: load assets using relative urls

### DIFF
--- a/adminSiteServer/app.tsx
+++ b/adminSiteServer/app.tsx
@@ -101,10 +101,12 @@ export class OwidAdminApp {
         // Require authentication (only for /admin requests)
         app.use(authMiddleware)
 
+        app.use("/assets", express.static("dist/assets"))
+        app.use("/fonts", express.static("public/fonts"))
+
         app.use("/api", publicApiRouter.router)
         app.use("/admin/api", apiRouter.router)
         app.use("/admin/test", testPageRouter)
-        app.use("/admin/assets", express.static("dist/assets"))
         app.use("/admin/storybook", express.static(".storybook/build"))
         app.use("/admin", adminRouter)
 

--- a/site/viteUtils.tsx
+++ b/site/viteUtils.tsx
@@ -150,13 +150,17 @@ const prodAssets = (entry: string, baseUrl: string): Assets => {
     }
 }
 
-export const viteAssets = (entry: string) =>
-    ENV === "production" || VITE_PREVIEW
-        ? prodAssets(entry, BAKED_BASE_URL)
+const useProductionAssets = ENV === "production" || VITE_PREVIEW
+
+export const viteAssets = (entry: string, prodBaseUrl?: string) =>
+    useProductionAssets
+        ? prodAssets(entry, prodBaseUrl ?? "")
         : devAssets(entry, VITE_DEV_URL)
 
 export const generateEmbedSnippet = () => {
-    const assets = viteAssets(VITE_ASSET_SITE_ENTRY)
+    // Make sure we're using an absolute URL here, since we don't know in what context the embed snippet is used.
+    const assets = viteAssets(VITE_ASSET_SITE_ENTRY, BAKED_BASE_URL)
+
     const serializedAssets = [...assets.forHeader, ...assets.forFooter].map(
         (el) => ({
             tag: el.type,


### PR DESCRIPTION
Resolves #2112.

This is deployed on _staging_, and you can also have a look at https://64ef4a4cb5a812071aa03532--staging-owid.netlify.app/, which points to this specific Netlify deploy (incidentally, Cloudflare Pages has a similar concept for "URLs for past deploys").

All paths that we include in header and footer now - i.e. stylesheets, scripts, and preload directives - now use relative URLs of the form `/assets/admin.mjs`.

Cleverly, `/assets` is now also an endpoint in the admin server, such that we can easily serve these assets on the admin server, too. This actually has the added benefit that "breaking" changes to the admin can now go live immediately; before this, we were in a situation that the admin backend and frontend didn't match up for several minutes while deploying, which could rarely lead to problems and weird error messsages.

The `grapher/embedCharts.js` snippet, which we only use on the `/admin/test` route any more, still uses absolute URLs so it won't break if anyone else depends on it.

Before merging this, the nginx config files need to be adapted like so:
```diff
- location ~ ^/(admin|gdocs) {
+ location ~ ^/(admin|assets|fonts|gdocs) {
```

After that, run `sudo service nginx reload`.