### PR TITLE
hot fix(explorer): prevent HotTable context menu from disappearing

### DIFF
--- a/explorerAdminClient/ExplorerCreatePage.tsx
+++ b/explorerAdminClient/ExplorerCreatePage.tsx
@@ -288,11 +288,15 @@ export class ExplorerCreatePage extends React.Component<{
                     <a className="PreviewLink" href={previewLink}>
                         Visit preview
                     </a>
-                    {program.whyIsExplorerProgramInvalid && (
+                    {/* Disabled for now since this piece of code causes an issue where
+                    the HotTable's context menu disappears right after opening it.
+                    The reason for that is that program.whyIsExplorerProgramInvalid
+                    refreshes every few seconds, which causes the HotTable to re-render. */}
+                    {/* {program.whyIsExplorerProgramInvalid && (
                         <div className="WhyIsExplorerProgramInvalid">
                             {program.whyIsExplorerProgramInvalid}
                         </div>
-                    )}
+                    )} */}
                 </main>
             </>
         )


### PR DESCRIPTION
Fixes an issue where the HotTable's context menu would disappear immediately after opening it, making it impossible to interact with it. (Video posted on [Slack](https://owid.slack.com/archives/C46U9LXRR/p1693396303506069))

What appears to be the reason is that `program. whyIsExplorerProgramInvalid` refreshes every few seconds (I don't know why), which causes the whole render function to re-run and `<HotTable />` to re-render. When `<HotTable />` is re-rendered, the context menu is closed.

For now, I simply commented out the piece of code that causes the problem. I'll look at it again when I have some more time.