### PR TITLE
Grapher redesign: Papercuts

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
@@ -62,6 +62,8 @@ $gap: 1.5px;
     }
 }
 
-.ContentSwitchers.narrow li > a {
-    padding: 0 8px;
+&.GrapherComponentMedium {
+    .ContentSwitchers:not(.iconOnly) li > a {
+        padding: 0 8px;
+    }
 }

--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
@@ -28,6 +28,10 @@ $gap: 1.5px;
         padding: 0 16px;
         cursor: default;
 
+        &:hover {
+            background-color: $hover-fill;
+        }
+
         .label {
             margin-left: 6px;
         }
@@ -37,27 +41,36 @@ $gap: 1.5px;
         }
     }
 
-    li + li::after {
-        content: "";
-        display: block;
-        width: 1px;
-        height: calc(100% - 12px);
-        position: absolute;
-        top: 6px;
-        left: -0.5px;
-        background-color: $light-stroke;
-    }
-
-    li > a:hover {
-        background-color: $hover-fill;
-    }
-
     li.active > a {
         color: $active-text;
         background-color: $active-fill;
 
         svg {
             color: $active-knob;
+        }
+    }
+
+    // separators between tabs that are hidden on hover and when a tab is active
+    li:not(:hover):not(.active) {
+        @mixin separator {
+            content: "";
+            display: block;
+            width: 0.5px;
+            height: calc(100% - 12px);
+            position: absolute;
+            top: 6px;
+            background-color: $light-stroke;
+            z-index: -1;
+        }
+
+        &:not(:first-child)::before {
+            @include separator;
+            left: -0.5px;
+        }
+
+        &:not(:last-child)::after {
+            @include separator;
+            right: -0.5px;
         }
     }
 }

--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { computed } from "mobx"
 import { observer } from "mobx-react"
+import classnames from "classnames"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import {
     faTable,
@@ -19,7 +20,6 @@ export interface ContentSwitchersManager {
     availableTabs?: GrapherTabOption[]
     tab?: GrapherTabOption
     isNarrow?: boolean
-    isMedium?: boolean
 }
 
 @observer
@@ -34,14 +34,18 @@ export class ContentSwitchers extends React.Component<{
         return this.manager.availableTabs || []
     }
 
+    @computed private get showTabLabels(): boolean {
+        return !this.manager.isNarrow
+    }
+
     render(): JSX.Element {
         const { manager } = this
         return (
             <ul
-                className={
-                    "ContentSwitchers" +
-                    (manager.isMedium && !manager.isNarrow ? " narrow" : "")
-                }
+                className={classnames({
+                    ContentSwitchers: true,
+                    iconOnly: !this.showTabLabels,
+                })}
             >
                 {this.availableTabs.map((tab) => (
                     <Tab
@@ -51,7 +55,7 @@ export class ContentSwitchers extends React.Component<{
                         onClick={(): void => {
                             manager.tab = tab
                         }}
-                        showLabel={!manager.isNarrow}
+                        showLabel={this.showTabLabels}
                     />
                 ))}
             </ul>

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -173,7 +173,7 @@ import {
     autoDetectSeriesStrategy,
     autoDetectYColumnSlugs,
 } from "../chart/ChartUtils"
-import classNames from "classnames"
+import classnames from "classnames"
 import { GrapherAnalytics } from "./GrapherAnalytics"
 import { legacyToCurrentGrapherQueryParams } from "./GrapherUrlMigrations"
 import { ChartInterface } from "../chart/ChartInterface"
@@ -2317,11 +2317,14 @@ export class Grapher
     }
 
     private renderGrapherComponent(): JSX.Element {
-        const containerClasses = classNames(
-            "GrapherComponent",
-            this.isExportingtoSvgOrPng && "isExportingToSvgOrPng",
-            this.isPortrait && "GrapherPortraitClass"
-        )
+        const containerClasses = classnames({
+            GrapherComponent: true,
+            GrapherPortraitClass: this.isPortrait,
+            isExportingToSvgOrPng: this.isExportingtoSvgOrPng,
+            GrapherComponentNarrow: this.isNarrow,
+            GrapherComponentSmall: this.isSmall,
+            GrapherComponentMedium: this.isMedium,
+        })
 
         const containerStyle = {
             width: this.renderWidth,

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
@@ -137,7 +137,7 @@ describe("when the table has aggregates", () => {
         const titleRows = view.find("tbody .title")
         expect(titleRows).toHaveLength(2)
         expect(titleRows.at(0).text()).toBe("Country")
-        expect(titleRows.at(1).text()).toBe("Region")
+        expect(titleRows.at(1).text()).toBe("Other")
     })
 })
 

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -428,7 +428,7 @@ export class DataTable extends React.Component<{
         if (!this.showTitleRows) return null
         return (
             <tr className="title">
-                <td>Region</td>
+                <td>Other</td>
                 {range(this.numberOfColumnsWidthValues).map((i) => (
                     <td key={i} />
                 ))}

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -580,9 +580,10 @@ export class StaticFooter extends Footer<StaticFooterProps> {
 
     @computed protected get licenseAndOriginUrlText(): string {
         const { finalUrl, finalUrlText, licenseText, licenseUrl } = this
-        const licenseSvg = `<a target="_blank" style="fill: #5b5b5b;" href="${licenseUrl}">${licenseText}</a>`
+        const linkStyle = "fill: #5b5b5b; text-decoration: underline;"
+        const licenseSvg = `<a target="_blank" style="${linkStyle}" href="${licenseUrl}">${licenseText}</a>`
         if (!finalUrlText) return licenseSvg
-        const originUrlSvg = `<a target="_blank" style="fill: #5b5b5b; text-decoration: underline;" href="${finalUrl}">${finalUrlText}</a>`
+        const originUrlSvg = `<a target="_blank" style="${linkStyle}" href="${finalUrl}">${finalUrlText}</a>`
         return [originUrlSvg, licenseSvg].join(" | ")
     }
 

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -73,11 +73,12 @@ export class Footer<
         return this.props.maxWidth ?? DEFAULT_BOUNDS.width
     }
 
+    @computed protected get sourcesLine(): string {
+        return this.manager.sourcesLine?.replace(/\r\n|\n|\r/g, "") ?? ""
+    }
+
     @computed protected get sourcesText(): string {
-        const sourcesLine = this.manager.sourcesLine
-        return sourcesLine
-            ? `Data source: ${sourcesLine} - Learn more about this data`
-            : ""
+        return `Data source: ${this.sourcesLine} - Learn more about this data`
     }
 
     @computed protected get noteText(): string {
@@ -352,7 +353,7 @@ export class Footer<
 
     private renderSources(): JSX.Element | null {
         const sources = new MarkdownTextWrap({
-            text: `**Data source:** ${this.manager.sourcesLine}`,
+            text: `**Data source:** ${this.sourcesLine}`,
             maxWidth: this.sourcesMaxWidth,
             fontSize: this.sourcesFontSize,
             lineHeight: this.lineHeight,
@@ -588,8 +589,7 @@ export class StaticFooter extends Footer<StaticFooterProps> {
     }
 
     @computed protected get sourcesText(): string {
-        const sourcesLine = this.manager.sourcesLine
-        return sourcesLine ? `**Data source:** ${sourcesLine}` : ""
+        return `**Data source:** ${this.sourcesLine}`
     }
 
     @computed protected get fontSize(): number {

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.scss
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.scss
@@ -104,13 +104,16 @@ $timelineHeight: 32px;
         position: absolute;
         height: 2px;
         background: #a4b6ca;
+        padding: 10px 0;
+
+        &:hover {
+            height: 3px;
+        }
 
         cursor: grab;
         &:active {
             cursor: grabbing;
         }
-
-        padding: 10px 0;
     }
 
     .handle,


### PR DESCRIPTION
Collection of fixes and improvements

- remove line breaks from sources text
- underline "CC BY" link in static charts
- rename "Region" to "Other" in data tables (for non-country entities)
- expose grapher size as css classes
- hide separators between tabs on hover
- increase timeline height on hover