### PR TITLE
Add "Show selection only" toggle for tables

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -363,6 +363,7 @@ export class Grapher
     /** Hides the total value label that is normally displayed for stacked bar charts */
     @observable.ref hideTotalValueLabel?: boolean = undefined
     @observable.ref missingDataStrategy?: MissingDataStrategy = undefined
+    @observable.ref showSelectionOnlyInDataTable?: boolean = undefined
 
     @observable.ref xAxis = new AxisConfig(undefined, this)
     @observable.ref yAxis = new AxisConfig(undefined, this)

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -78,6 +78,7 @@ export interface DataTableManager {
     endTime?: Time
     startTime?: Time
     dataTableSlugs?: ColumnSlug[]
+    showSelectionOnlyInDataTable?: boolean
     isSmall?: boolean
     isMedium?: boolean
 }
@@ -87,6 +88,19 @@ export class DataTable extends React.Component<{
     manager?: DataTableManager
     bounds?: Bounds
 }> {
+    transformTable(table: OwidTable): OwidTable {
+        if (this.manager.showSelectionOnlyInDataTable) {
+            table = table.filterByEntityNames(
+                this.selectionArray.selectedEntityNames
+            )
+        }
+        return table
+    }
+
+    @computed get transformedTable(): OwidTable {
+        return this.transformTable(this.manager.table)
+    }
+
     @observable private storedState: DataTableState = {
         sort: DEFAULT_SORT_STATE,
     }
@@ -124,7 +138,7 @@ export class DataTable extends React.Component<{
     }
 
     @computed get table(): OwidTable {
-        return this.inputTable
+        return this.transformedTable
     }
 
     @computed get inputTable(): OwidTable {


### PR DESCRIPTION
Adds a "Show selection only" toggle for tables.

For now, only the ability has been added, but no toggle.

To do:

- [ ] Actually add the toggle (after Christian's changes have landed)
- [ ] What if the current selection is empty?