### PR TITLE
fix(explorer): prevent metric from being updated when entities are sorted

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -963,7 +963,10 @@ export class Explorer
     setEntityPicker({
         metric,
         sort,
-    }: { metric?: string; sort?: SortOrder } = {}) {
+    }: {
+        metric: string | undefined
+        sort?: SortOrder
+    }) {
         this.entityPickerMetric = metric
         if (sort) this.entityPickerSort = sort
     }

--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
@@ -494,7 +494,10 @@ export class EntityPicker extends React.Component<{
                     className="sort"
                     onClick={(): void => {
                         const sortOrder = toggleSort(this.sortOrder)
-                        this.manager.setEntityPicker?.({ sort: sortOrder })
+                        this.manager.setEntityPicker?.({
+                            metric: this.metric,
+                            sort: sortOrder,
+                        })
                         this.manager.analytics?.logEntityPickerEvent(
                             "sortOrder",
                             sortOrder

--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPickerConstants.ts
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPickerConstants.ts
@@ -6,7 +6,10 @@ import { SelectionArray } from "../../selection/SelectionArray"
 export interface EntityPickerManager {
     entityPickerMetric?: ColumnSlug
     entityPickerSort?: SortOrder
-    setEntityPicker?: (options: { metric?: string; sort?: SortOrder }) => void
+    setEntityPicker?: (options: {
+        metric: string | undefined
+        sort?: SortOrder
+    }) => void
     requiredColumnSlugs?: ColumnSlug[] // If this param is provided, and an entity does not have a value for 1+, it will show as unavailable.
     entityPickerColumnDefs?: CoreColumnDef[]
     entityPickerTable?: OwidTable


### PR DESCRIPTION
Fixes an issue where clicking the entity picker's sort icon would also update the metric to its default value ("Relevance")