### PR TITLE
Grapher redesign: Resize chart height based on the viewport in gdoc articles (on mobile)

### DIFF
--- a/site/blocks/KeyInsights.scss
+++ b/site/blocks/KeyInsights.scss
@@ -1,8 +1,14 @@
-$slide-content-height: $grapher-height;
-
 @import "react-horizontal-scrolling-menu/styles.css";
 
 .wp-block-owid-key-insights {
+    --slide-content-height: 575px; // keep in sync with $grapher-height
+
+    @include sm-only {
+        // 50px is the height of the header on mobile
+        // 1rem is additional padding
+        --slide-content-height: calc(100vh - 50px - 1rem);
+    }
+
     .react-horizontal-scrolling-menu--wrapper {
         position: relative;
     }
@@ -104,12 +110,12 @@ $slide-content-height: $grapher-height;
             }
         }
 
-        figure[data-grapher-src]:not(.grapherPreview) {
-            height: $slide-content-height;
+        figure.chart:not(.grapherPreview) {
+            height: var(--slide-content-height, $grapher-height);
         }
 
         @include sm-only {
-            figure[data-grapher-src] {
+            figure.chart {
                 // override default full-width behaviour
                 width: auto;
                 margin: auto;
@@ -119,7 +125,7 @@ $slide-content-height: $grapher-height;
         @include lg-up {
             .wp-block-columns.is-style-sticky-right .wp-block-column {
                 &:first-child {
-                    height: $slide-content-height;
+                    height: var(--slide-content-height, $grapher-height);
                     overflow-y: auto;
                     -webkit-mask-image: linear-gradient(
                         180deg,

--- a/site/gdocs/AllCharts.scss
+++ b/site/gdocs/AllCharts.scss
@@ -5,5 +5,13 @@
 
     figure[data-grapher-src] {
         height: $grapher-height;
+
+        @include sm-only {
+            // 50px is the height of the header on mobile
+            // 40px is the height of the gallery navigation
+            // 1rem is the margin between the figure and the gallery navigation
+            // 1rem is additional padding
+            height: calc(100vh - 90px - 2rem);
+        }
     }
 }

--- a/site/gdocs/Chart.scss
+++ b/site/gdocs/Chart.scss
@@ -1,0 +1,13 @@
+figure.chart {
+    height: $grapher-height;
+
+    @include sm-only {
+        // 50px is the height of the header on mobile
+        // 1rem is additional padding
+        height: calc(100vh - 50px - 1rem);
+    }
+}
+
+figure.explorer {
+    height: 700px;
+}

--- a/site/gdocs/Chart.tsx
+++ b/site/gdocs/Chart.tsx
@@ -38,7 +38,6 @@ export default function Chart({
     const resolvedUrl = linkedChart.resolvedUrl
     const isExplorer = url.isExplorer
     const hasControls = url.queryParams.hideControls !== "true"
-    const height = d.height || (isExplorer && hasControls ? 700 : 575)
 
     let config: GrapherProgrammaticInterface = {}
     const isCustomized = d.title || d.subtitle
@@ -86,6 +85,7 @@ export default function Chart({
             <figure
                 // Use unique `key` to force React to re-render tree
                 key={resolvedUrl}
+                className={isExplorer && hasControls ? "explorer" : "chart"}
                 data-grapher-src={isExplorer ? undefined : resolvedUrl}
                 data-explorer-src={isExplorer ? resolvedUrl : undefined}
                 data-grapher-config={
@@ -94,7 +94,7 @@ export default function Chart({
                 style={{
                     width: "100%",
                     border: "0px none",
-                    height,
+                    height: d.height,
                 }}
             />
             {d.caption ? (

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -504,6 +504,13 @@ h3.article-block__heading.has-supertitle {
             width: 100%;
             > figure {
                 margin: 0;
+
+                @include sm-only {
+                    // 50px is the height of the header on mobile
+                    // 65px is the height of the navigation
+                    // 1rem is additional padding
+                    height: calc(100vh - 115px - 1rem);
+                }
             }
         }
     }

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -86,6 +86,7 @@
 @import "./gdocs/AllCharts.scss";
 @import "./gdocs/AdditionalCharts.scss";
 @import "./gdocs/ResearchAndWriting.scss";
+@import "./gdocs/Chart.scss";
 @import "./DataPage.scss";
 @import "./DataPageContent.scss";
 @import "./ExpandableToggle.scss";


### PR DESCRIPTION
Sets the height of Grapher charts to the viewport height on smaller screens. Sometimes, the header and navigation are taken into account so that the full chart (and sometimes the navigation) are visible on the screen.

Updated components include:
- Stand-alone charts
- Charts in Key Insights block
- Charts in the All Charts block
- Charts in a Chart Story

Charts in the `Scroller />` component continue to have a fixed height.