### PR TITLE
perf: rewrite CoreTable.complete to be more performant

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
         "express": "^4.18.1",
         "express-async-errors": "^3.1.1",
         "express-rate-limit": "^5.1.3",
-        "fast-cartesian": "^5.1.0",
         "filenamify": "^4.1.0",
         "fortune": "^5.5.17",
         "fs-extra": "^11.1.1",

--- a/packages/@ourworldindata/core-table/package.json
+++ b/packages/@ourworldindata/core-table/package.json
@@ -16,8 +16,7 @@
   "dependencies": {
     "@ourworldindata/utils": "workspace:^",
     "d3": "^6.1.1",
-    "dayjs": "^1.11.5",
-    "fast-cartesian": "^5.1.0"
+    "dayjs": "^1.11.5"
   },
   "devDependencies": {
     "@types/d3": "^6",

--- a/packages/@ourworldindata/core-table/src/CoreTable.test.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.test.ts
@@ -329,7 +329,37 @@ uk,2001`
     const table = new CoreTable(csv)
     expect(table.numRows).toEqual(3)
     const completed = table.complete(["country", "year"])
+
     expect(completed.numRows).toEqual(6)
+    expect(completed.rows).toEqual(
+        expect.arrayContaining([
+            // compare in any order
+            { country: "usa", year: 2000 },
+            { country: "usa", year: 2001 },
+            { country: "usa", year: 2002 },
+            { country: "uk", year: 2000 },
+            { country: "uk", year: 2001 },
+            { country: "uk", year: 2002 },
+        ])
+    )
+})
+
+it("can sort a table", () => {
+    const table = new CoreTable(`country,year,population
+uk,1800,100
+iceland,1700,200
+iceland,1800,300
+uk,1700,400
+germany,1400,500`)
+
+    const sorted = table.sortBy(["country", "year"])
+    expect(sorted.rows).toEqual([
+        { country: "germany", year: 1400, population: 500 },
+        { country: "iceland", year: 1700, population: 200 },
+        { country: "iceland", year: 1800, population: 300 },
+        { country: "uk", year: 1700, population: 400 },
+        { country: "uk", year: 1800, population: 100 },
+    ])
 })
 
 describe("adding rows", () => {

--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -1452,6 +1452,8 @@ export class CoreTable<
         const col1 = this.get(slug1)
         const col2 = this.get(slug2)
 
+        // The output table will have exactly this many rows, since we assume that [col1, col2] are primary keys
+        // (i.e. there are no two rows with the same key), and every combination that doesn't exist yet we will add.
         const cartesianProductSize = col1.numUniqs * col2.numUniqs
         if (this.numRows >= cartesianProductSize) {
             if (this.numRows > cartesianProductSize)
@@ -1479,6 +1481,7 @@ export class CoreTable<
         // See https://jsperf.app/zudoye.
         const rowsToAddCol1 = []
         const rowsToAddCol2 = []
+        // Add rows for all combinations of values that are not contained in `existingRowValues`.
         for (const val1 of col1.uniqValuesAsSet) {
             const existingVals2 = existingRowValues.get(val1)
             for (const val2 of col2.uniqValuesAsSet) {

--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -1637,6 +1637,11 @@ class FilterMask {
             this.numRows,
             keepIndexes.length
         )
+        if (keepIndexes.length === this.numRows) {
+            console.timeEnd("apply mask")
+            return columnStore
+        }
+
         Object.keys(columnStore).forEach((slug) => {
             const originalColumn = columnStore[slug]
             const newColumn: CoreValueType[] = new Array(keepIndexes.length)

--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -1448,23 +1448,18 @@ export class CoreTable<
         if (columnSlugs.length !== 2)
             throw new Error("Can only run complete() for exactly 2 columns")
 
-        console.time("c")
         const [slug1, slug2] = columnSlugs
         const col1 = this.get(slug1)
         const col2 = this.get(slug2)
 
         const cartesianProductSize = col1.numUniqs * col2.numUniqs
-        console.timeLog("c", "got sizes")
         if (this.numRows >= cartesianProductSize) {
             if (this.numRows > cartesianProductSize)
                 throw new Error("Table has more rows than expected")
 
-            console.timeLog("c", "skip", cartesianProductSize, this.numRows)
-            console.timeEnd("c")
             // Table is already complete
             return this
         }
-        console.timeLog("c", "got cols")
 
         // Map that points from a value in col1 to a set of values in col2.
         // It's filled with all the values that already exist in the table, so we
@@ -1477,8 +1472,6 @@ export class CoreTable<
                 existingRowValues.set(val1, new Set())
             existingRowValues.get(val1)!.add(val2)
         }
-
-        console.timeLog("c", "got existing rows")
 
         // The below code should be as performant as possible, since it's often iterating over hundreds of thousands of rows.
         // The below implementation has been benchmarked against a few alternatives (using flatMap, map, and Array.from), and
@@ -1499,21 +1492,16 @@ export class CoreTable<
             [slug1]: rowsToAddCol1,
             [slug2]: rowsToAddCol2,
         }
-        console.timeLog("c", "built rowsToAdd")
         const appendTable = new (this.constructor as typeof CoreTable)(
             appendColumnStore,
             this.defs,
             { parent: this }
         )
 
-        console.timeLog("c", "built appendTable")
-        const ret = this.concat(
+        return this.concat(
             [appendTable],
             `Append missing combos of ${columnSlugs}`
         )
-        console.timeLog("c", "appended rows")
-        console.timeEnd("c")
-        return ret
     }
 
     leftJoin(rightTable: CoreTable, by?: ColumnSlug[]): this {
@@ -1626,21 +1614,11 @@ class FilterMask {
 
     apply(columnStore: CoreColumnStore): CoreColumnStore {
         const columnsObject: CoreColumnStore = {}
-        console.time("apply mask")
         const keepIndexes: number[] = []
         for (let i = 0; i < this.numRows; i++) {
             if (this.mask[i]) keepIndexes.push(i)
         }
-        console.timeLog(
-            "apply mask",
-            "got keepIndexes",
-            this.numRows,
-            keepIndexes.length
-        )
-        if (keepIndexes.length === this.numRows) {
-            console.timeEnd("apply mask")
-            return columnStore
-        }
+        if (keepIndexes.length === this.numRows) return columnStore
 
         Object.keys(columnStore).forEach((slug) => {
             const originalColumn = columnStore[slug]
@@ -1651,7 +1629,6 @@ class FilterMask {
 
             columnsObject[slug] = newColumn
         })
-        console.timeEnd("apply mask")
         return columnsObject
     }
 }

--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -1453,8 +1453,8 @@ export class CoreTable<
         const col1 = this.get(slug1)
         const col2 = this.get(slug2)
 
-        const cartesianProductSize =
-            col1.uniqValues.length * col2.uniqValues.length
+        const cartesianProductSize = col1.numUniqs * col2.numUniqs
+        console.timeLog("c", "got sizes")
         if (this.numRows >= cartesianProductSize) {
             if (this.numRows > cartesianProductSize)
                 throw new Error("Table has more rows than expected")
@@ -1486,9 +1486,9 @@ export class CoreTable<
         // See https://jsperf.app/zudoye.
         const rowsToAddCol1 = []
         const rowsToAddCol2 = []
-        for (const val1 of col1.uniqValues) {
+        for (const val1 of col1.uniqValuesAsSet) {
             const existingVals2 = existingRowValues.get(val1)
-            for (const val2 of col2.uniqValues) {
+            for (const val2 of col2.uniqValuesAsSet) {
                 if (!existingVals2?.has(val2)) {
                     rowsToAddCol1.push(val1)
                     rowsToAddCol2.push(val2)

--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -1626,11 +1626,27 @@ class FilterMask {
 
     apply(columnStore: CoreColumnStore): CoreColumnStore {
         const columnsObject: CoreColumnStore = {}
+        console.time("apply mask")
+        const keepIndexes: number[] = []
+        for (let i = 0; i < this.numRows; i++) {
+            if (this.mask[i]) keepIndexes.push(i)
+        }
+        console.timeLog(
+            "apply mask",
+            "got keepIndexes",
+            this.numRows,
+            keepIndexes.length
+        )
         Object.keys(columnStore).forEach((slug) => {
-            columnsObject[slug] = columnStore[slug].filter(
-                (slug, index) => this.mask[index]
-            )
+            const originalColumn = columnStore[slug]
+            const newColumn: CoreValueType[] = new Array(keepIndexes.length)
+            for (let i = 0; i < keepIndexes.length; i++) {
+                newColumn[i] = originalColumn[keepIndexes[i]]
+            }
+
+            columnsObject[slug] = newColumn
         })
+        console.timeEnd("apply mask")
         return columnsObject
     }
 }

--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -949,7 +949,11 @@ export class CoreTable<
 
     appendRows(rows: ROW_TYPE[], opDescription: string): this {
         return this.concat(
-            [new (this.constructor as any)(rows, this.defs) as CoreTable],
+            [
+                new (this.constructor as typeof CoreTable)(rows, this.defs, {
+                    parent: this,
+                }),
+            ],
             opDescription
         )
     }
@@ -1496,10 +1500,11 @@ export class CoreTable<
             [slug2]: rowsToAddCol2,
         }
         console.timeLog("c", "built rowsToAdd")
-        const appendTable = new (this.constructor as typeof CoreTable<
-            any,
-            any
-        >)(appendColumnStore, this.defs, { parent: this })
+        const appendTable = new (this.constructor as typeof CoreTable)(
+            appendColumnStore,
+            this.defs,
+            { parent: this }
+        )
 
         console.timeLog("c", "built appendTable")
         const ret = this.concat(

--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -57,7 +57,6 @@ import {
     getDropIndexes,
     parseDelimited,
     rowsFromMatrix,
-    cartesianProduct,
     sortColumnStore,
     emptyColumnsInFirstRowInDelimited,
     truncate,

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -323,11 +323,17 @@ export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
     }
 
     @imemo get uniqValues(): JS_TYPE[] {
-        return uniq(this.values)
+        const set = this.uniqValuesAsSet
+
+        // Turn into array, faster than spread operator
+        const arr = new Array(set.size)
+        let i = 0
+        set.forEach((val) => (arr[i++] = val))
+        return arr
     }
 
     @imemo get uniqValuesAsSet(): Set<JS_TYPE> {
-        return new Set(this.uniqValues)
+        return new Set(this.values)
     }
 
     /**
@@ -394,7 +400,7 @@ export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
     }
 
     @imemo get numUniqs(): number {
-        return this.uniqValues.length
+        return this.uniqValuesAsSet.size
     }
 
     @imemo get valuesAscending(): JS_TYPE[] {

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.test.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.test.ts
@@ -18,7 +18,6 @@ import {
     concatColumnStores,
     guessColumnDefFromSlugAndRow,
     standardizeSlugs,
-    cartesianProduct,
 } from "./CoreTableUtils.js"
 import { ErrorValueTypes } from "./ErrorValues.js"
 import { imemo } from "@ourworldindata/utils"
@@ -502,23 +501,5 @@ describe(concatColumnStores, () => {
                 ErrorValueTypes.MissingValuePlaceholder,
             ],
         })
-    })
-})
-
-describe(cartesianProduct, () => {
-    it("correctly calculates a cartesian product", () => {
-        const a = [1, 2, 3]
-        const b = ["a", "b"]
-
-        const product = cartesianProduct<string | number>(a, b)
-
-        expect(product).toEqual([
-            [1, "a"],
-            [1, "b"],
-            [2, "a"],
-            [2, "b"],
-            [3, "a"],
-            [3, "b"],
-        ])
     })
 })

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
@@ -8,7 +8,6 @@ import {
     slugifySameCase,
     toString,
     ColumnSlug,
-    isEqual,
 } from "@ourworldindata/utils"
 import {
     CoreColumnStore,
@@ -626,8 +625,19 @@ export const sortColumnStore = (
     const len = firstCol.length
     const newOrder = range(0, len).sort(makeSortByFn(columnStore, slugs))
 
-    // Column store is already sorted
-    if (isEqual(newOrder, range(0, len))) return columnStore
+    // Check if column store is already sorted (which is the case if newOrder is monotonically increasing).
+    // If it's not sorted, we will detect that within the first iterations usually.
+    let isSorted = true
+    let prev = -1
+    for (const newIndex of newOrder) {
+        if (newIndex < prev) {
+            isSorted = false
+            break
+        }
+        prev = newIndex
+    }
+    // Column store is already sorted; return existing store unchanged
+    if (isSorted) return columnStore
 
     const newStore: CoreColumnStore = {}
     Object.keys(columnStore).forEach((slug) => {

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
@@ -8,6 +8,7 @@ import {
     slugifySameCase,
     toString,
     ColumnSlug,
+    isEqual,
 } from "@ourworldindata/utils"
 import {
     CoreColumnStore,
@@ -624,6 +625,10 @@ export const sortColumnStore = (
     if (!firstCol) return {}
     const len = firstCol.length
     const newOrder = range(0, len).sort(makeSortByFn(columnStore, slugs))
+
+    // Column store is already sorted
+    if (isEqual(newOrder, range(0, len))) return columnStore
+
     const newStore: CoreColumnStore = {}
     Object.keys(columnStore).forEach((slug) => {
         newStore[slug] = applyNewSortOrder(columnStore[slug], newOrder)

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
@@ -2,7 +2,6 @@ import { dsvFormat, DSVParsedArray } from "d3-dsv"
 import {
     findIndexFast,
     first,
-    flatten,
     max,
     range,
     sampleFrom,
@@ -369,20 +368,6 @@ export const makeKeyFn =
         columnSlugs
             .map((slug) => toString(columnStore[slug][rowIndex]))
             .join(" ")
-
-export const appendRowsToColumnStore = (
-    columnStore: CoreColumnStore,
-    rows: CoreRow[]
-): CoreColumnStore => {
-    const slugs = Object.keys(columnStore)
-    const newColumnStore = columnStore
-    slugs.forEach((slug) => {
-        newColumnStore[slug] = columnStore[slug].concat(
-            rows.map((row) => row[slug])
-        )
-    })
-    return newColumnStore
-}
 
 const getColumnStoreLength = (store: CoreColumnStore): number => {
     return max(Object.values(store).map((v) => v.length)) ?? 0

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
@@ -1,5 +1,4 @@
 import { dsvFormat, DSVParsedArray } from "d3-dsv"
-import fastCartesian from "fast-cartesian"
 import {
     findIndexFast,
     first,
@@ -623,10 +622,6 @@ export const trimArray = (arr: any[]): any[] => {
         if (!isCellEmpty(arr[rightIndex])) break
     }
     return arr.slice(0, rightIndex + 1)
-}
-
-export function cartesianProduct<T>(...allEntries: T[][]): T[][] {
-    return fastCartesian(allEntries)
 }
 
 const applyNewSortOrder = (arr: any[], newOrder: number[]): any[] =>

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
@@ -626,7 +626,7 @@ export const sortColumnStore = (
     const newOrder = range(0, len).sort(makeSortByFn(columnStore, slugs))
 
     // Check if column store is already sorted (which is the case if newOrder is equal to range(0, startLen)).
-    // If it's not sorted, we will detect that within the first iterations usually.
+    // If it's not sorted, we will detect that within the first few iterations usually.
     let isSorted = true
     for (let i = 0; i <= len; i++) {
         if (newOrder[i] !== i) {
@@ -638,8 +638,8 @@ export const sortColumnStore = (
     if (isSorted) return columnStore
 
     const newStore: CoreColumnStore = {}
-    Object.keys(columnStore).forEach((slug) => {
-        newStore[slug] = applyNewSortOrder(columnStore[slug], newOrder)
+    Object.entries(columnStore).forEach(([slug, colValues]) => {
+        newStore[slug] = applyNewSortOrder(colValues, newOrder)
     })
     return newStore
 }

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
@@ -625,16 +625,14 @@ export const sortColumnStore = (
     const len = firstCol.length
     const newOrder = range(0, len).sort(makeSortByFn(columnStore, slugs))
 
-    // Check if column store is already sorted (which is the case if newOrder is monotonically increasing).
+    // Check if column store is already sorted (which is the case if newOrder is equal to range(0, startLen)).
     // If it's not sorted, we will detect that within the first iterations usually.
     let isSorted = true
-    let prev = -1
-    for (const newIndex of newOrder) {
-        if (newIndex < prev) {
+    for (let i = 0; i <= len; i++) {
+        if (newOrder[i] !== i) {
             isSorted = false
             break
         }
-        prev = newIndex
     }
     // Column store is already sorted; return existing store unchanged
     if (isSorted) return columnStore

--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -65,7 +65,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     }
 
     @imemo get availableEntityNameSet(): Set<string> {
-        return new Set<string>(this.entityNameColumn.uniqValues)
+        return this.entityNameColumn.uniqValuesAsSet
     }
 
     // todo: can we remove at some point?

--- a/packages/@ourworldindata/core-table/src/index.ts
+++ b/packages/@ourworldindata/core-table/src/index.ts
@@ -88,7 +88,6 @@ export {
     toleranceInterpolation,
     interpolateRowValuesWithTolerance,
     makeKeyFn,
-    appendRowsToColumnStore,
     concatColumnStores,
     rowsToColumnStore,
     autodetectColumnDefs,

--- a/packages/@ourworldindata/core-table/src/index.ts
+++ b/packages/@ourworldindata/core-table/src/index.ts
@@ -107,7 +107,6 @@ export {
     isCellEmpty,
     trimEmptyRows,
     trimArray,
-    cartesianProduct,
     sortColumnStore,
     emptyColumnsInFirstRowInDelimited,
 } from "./CoreTableUtils.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4781,7 +4781,6 @@ __metadata:
     d3: ^6.1.1
     dayjs: ^1.11.5
     eslint: ^8.32.0
-    fast-cartesian: ^5.1.0
     typescript: ~5.2.2
   languageName: unknown
   linkType: soft
@@ -12212,13 +12211,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-cartesian@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "fast-cartesian@npm:5.1.0"
-  checksum: f269d5b7afe6ca9276c4ef9aef4bb7a78b3150ee6d0fda75fcb9bef0da40cc62591b59785b3edd66898196400528f747851cb2ed0f3e4fde37554ddefa9035e0
-  languageName: node
-  linkType: hard
-
 "fast-content-type-parse@npm:^1.0.0":
   version: 1.0.0
   resolution: "fast-content-type-parse@npm:1.0.0"
@@ -13766,7 +13758,6 @@ __metadata:
     express: ^4.18.1
     express-async-errors: ^3.1.1
     express-rate-limit: ^5.1.3
-    fast-cartesian: ^5.1.0
     filenamify: ^4.1.0
     fortune: ^5.5.17
     fs-extra: ^11.1.1


### PR DESCRIPTION
While working on Cloudflare Workers, I realized that `CoreTable.complete` takes up a non-trivial amount of time.

Seeing that we only ever call `complete` with exactly 2 columns, and that the current implementation was written in a way that supports an arbitrary number of cols (which makes everything trickier), I rewrote it to only ever support 2 columns, but in a way more performant way.

I benchmarked this on https://ourworldindata.org/grapher/life-expectancy-vs-gdp-per-capita:
The two invocations of `complete()` took **385ms** before; and now take **85ms**. And that's on a very fast M2 Max; I expect the difference to be similarly large on other machines too.

Here's also a (manual) timing output for localhost:
```
http://localhost:3030/grapher/life-expectancy-vs-gdp-per-capita

15:56:52.155 CoreTable.ts:1452 c: 0.009765625 ms got cols
15:56:52.168 CoreTable.ts:1474 c: 12.537109375 ms filled map
15:56:52.174 CoreTable.ts:1482 c: 18.829833984375 ms removed rows
15:56:52.184 CoreTable.ts:1494 c: 28.27490234375 ms built rows
15:56:52.219 CoreTable.ts:1499 c: 63.19384765625 ms appended rows
15:56:52.219 CoreTable.ts:1500 c: 63.3369140625 ms
---
# Second call, this time on an already-complete table
15:56:52.285 CoreTable.ts:1452 c: 0.005126953125 ms got cols
15:56:52.306 CoreTable.ts:1460 c: 21.652099609375 ms skip 256634 256634
15:56:52.306 CoreTable.ts:1461 c: 21.774169921875 ms
```

Another big performance difference can be seen in the SVG Tester; on current master the "Generating SVGs" phase is taking **17-18mins**, on this branch it's taking around **10-13mins**. ⚡ 

## TODOs
- [x] Implement daniel's suggestion below
- [x] Check: Why are we often running `complete()` twice on the same table? Where the second one is already complete?
  - => We're running up to three `interpolate...()` calls in `ScatterPlot.transformTable()`
- [x] `appendRows()` is still taking a long time, can we optimize it further?