### PR TITLE
enhance(tag): give unlisted precedence over public tags for charts

### DIFF
--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -1128,7 +1128,8 @@ export class EditableTags extends React.Component<{
                             <TagBadge
                                 onToggleKey={
                                     hasKeyChartSupport &&
-                                    filterUncategorizedTag(t)
+                                    filterUncategorizedTag(t) &&
+                                    filterUnlistedTag(t)
                                         ? () => this.onToggleKey(i)
                                         : undefined
                                 }
@@ -1168,3 +1169,5 @@ export class Button extends React.Component<{
 export const Help = ({ children }: { children: React.ReactNode }) => (
     <small className="form-text text-muted mb-4">{children}</small>
 )
+
+const filterUnlistedTag = (t: Tag) => t.name !== "Unlisted"

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -138,9 +138,6 @@ WHERE c.config -> "$.isPublished" = true
                 : parentIds.some((t) =>
                       PUBLIC_TAG_PARENT_IDS.includes(t.parentId)
                   )
-                ? true
-                : false
-
             await t.execute("update charts set is_indexable = ? where id = ?", [
                 isIndexable,
                 chartId,

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -130,9 +130,16 @@ WHERE c.config -> "$.isPublished" = true
                       tags.map((t) => t.id),
                   ])) as { parentId: number }[])
                 : []
-            const isIndexable = parentIds.some((t) =>
-                PUBLIC_TAG_PARENT_IDS.includes(t.parentId)
-            )
+
+            // A chart is indexable if it is not tagged "Unlisted" and has at
+            // least one public parent tag
+            const isIndexable = tags.some((t) => t.name === "Unlisted")
+                ? false
+                : parentIds.some((t) =>
+                      PUBLIC_TAG_PARENT_IDS.includes(t.parentId)
+                  )
+                ? true
+                : false
 
             await t.execute("update charts set is_indexable = ? where id = ?", [
                 isIndexable,


### PR DESCRIPTION
I suggest giving "unlisted" precedence over public parent tags, so marking a chart "Unlisted" is predictable and guarantees exclusion from /charts and searches.

Currently, charts tagged with "unlisted" can still be visible in search and on the /charts page. 

![Screenshot 2023-09-07 at 16.46.55.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0SFFiIjKuUK6UPYHVe6u/eb9902e6-92e4-4f7a-ad91-4c847cce6f57/Screenshot%202023-09-07%20at%2016.46.55.png)


This is due to "unlisted" having a lower priority than the presence of public parent tags, which currently take precedence in determining visibility.

E.g.:
- unlisted + core-econ = congruent because core-econ is not a public tag
- unlisted + homicides = incongruent because homicides is a topic tag, and will take precedence over "unlisted".

As part of proj-tagging, we've [made sure that no chart tagged with "unlisted" also had a public parent tag](https://www.notion.so/owid/2023-08-22-Tagging-all-our-content-26b70903a88f4115bab88eb1c8d4b891?pvs=4#e0c9e29b3df3421599b98e2b16f106e6).

This check is not enforced, so the combination of "unlisted" with a public tag may exist in the future.

This PR allows "Unlisted" to coexist with e.g. topic tags, all the while keeping charts hidden from search and /charts.