### PR TITLE
fix(search): search copes better with browser translation

### DIFF
--- a/site/search/Autocomplete.tsx
+++ b/site/search/Autocomplete.tsx
@@ -148,7 +148,11 @@ const AlgoliaSource: AutocompleteSource<BaseItem> = {
                     : pageTypeDisplayNames[item.type as PageType]
 
             return (
-                <div className="aa-ItemWrapper">
+                <div
+                    className="aa-ItemWrapper"
+                    key={item.title as string}
+                    translate="no"
+                >
                     <span>
                         <components.Highlight
                             hit={item}


### PR DESCRIPTION
We were getting many warnings logged to Bugsnag for the oldschool React issue with browser translation (https://github.com/facebook/react/issues/11538), to do with the `<Highlight>` component.

Translating search is a bit weird anyhow, since the user needs to enter the search terms in English (which they might not realize; but there's not much we can do about that), and highlighting terms also is based on the English text.

The solution I came up with here is also not very consistent because it translates "Featured searches", then doesn't translate the autocomplete entries, but does translate the results on the "full" search page.

But anyhow, that also works reasonably well and the underlying errors are fixed now at least.