### PR TITLE
🎉 Add gdoc quick edit buttons for logged-in admins

### DIFF
--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -15,7 +15,10 @@ import {
     OwidGdocType,
 } from "@ourworldindata/utils"
 import { CodeSnippet } from "../blocks/CodeSnippet.js"
-import { BAKED_BASE_URL } from "../../settings/clientSettings.js"
+import {
+    ADMIN_BASE_URL,
+    BAKED_BASE_URL,
+} from "../../settings/clientSettings.js"
 import { formatAuthors } from "../clientFormatting.js"
 import { DebugProvider } from "./DebugContext.js"
 import { OwidGdocHeader } from "./OwidGdocHeader.js"
@@ -52,6 +55,7 @@ const citationDescriptionsByArticleType: Record<OwidGdocType, string> = {
 }
 
 export function OwidGdoc({
+    id,
     content,
     publishedAt,
     slug,
@@ -92,6 +96,23 @@ export function OwidGdoc({
             }}
         >
             <DocumentContext.Provider value={{ isPreviewing }}>
+                <div id="gdoc-admin-bar">
+                    <a
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        href={`https://docs.google.com/document/d/${id}/edit`}
+                    >
+                        Gdoc
+                    </a>
+                    <span>/</span>
+                    <a
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        href={`${ADMIN_BASE_URL}/admin/gdocs/${id}/preview`}
+                    >
+                        Admin
+                    </a>
+                </div>
                 <article
                     className={cx(
                         "centered-article-container grid grid-cols-12-full-width",

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -1,3 +1,19 @@
+#gdoc-admin-bar {
+    display: none;
+    position: absolute;
+    right: 8px;
+    margin-top: 8px;
+    opacity: 0.7;
+    z-index: $zindex-adminbar;
+    a {
+        color: $blue-30;
+    }
+    span {
+        color: $blue-60;
+        margin: 0 4px;
+    }
+}
+
 .centered-article-container {
     .ref {
         color: $vermillion;

--- a/site/owid.entry.ts
+++ b/site/owid.entry.ts
@@ -97,6 +97,8 @@ try {
     ) {
         const adminbar = document.getElementById("wpadminbar")
         if (adminbar) adminbar.style.display = ""
+        const gdocAdminBar = document.getElementById("gdoc-admin-bar")
+        if (gdocAdminBar) gdocAdminBar.style.display = "initial"
     }
 } catch {}
 


### PR DESCRIPTION
Adds two buttons to make it easier to update articles from the published page, like we have for WordPress pages.

`position: absolute` (instead of `fixed`) so that it doesn't obscure the nav in the rare case you're logged in on mobile.

![image](https://github.com/owid/owid-grapher/assets/11844404/1df56917-c568-41f7-8520-fa0792736ffa)
![image](https://github.com/owid/owid-grapher/assets/11844404/0a5cdb76-35b6-4fbd-baf9-7257d32ab750)
