### PR TITLE
Upgrade tag autocomplete + UX

### DIFF
--- a/adminSiteClient/EditTags.tsx
+++ b/adminSiteClient/EditTags.tsx
@@ -2,7 +2,8 @@ import React from "react"
 import { action } from "mobx"
 import { observer } from "mobx-react"
 import { Tag } from "./TagBadge.js"
-import ReactTags from "react-tag-autocomplete"
+import { ReactTags } from "react-tag-autocomplete"
+import { Tag as TagAutocomplete } from "react-tag-autocomplete"
 
 @observer
 export class EditTags extends React.Component<{
@@ -23,6 +24,10 @@ export class EditTags extends React.Component<{
         this.dismissable = false
     }
 
+    onAdd = (tag: TagAutocomplete) => {
+        this.props.onAdd(convertAutocompleteTotag(tag))
+    }
+
     componentDidMount() {
         document.addEventListener("click", this.onClickSomewhere)
     }
@@ -36,13 +41,18 @@ export class EditTags extends React.Component<{
         return (
             <div className="EditTags" onClick={this.onClick}>
                 <ReactTags
-                    tags={tags}
-                    suggestions={suggestions}
-                    onAddition={this.props.onAdd}
+                    selected={tags.map(convertTagToAutocomplete)}
+                    suggestions={suggestions.map(convertTagToAutocomplete)}
+                    onAdd={this.onAdd}
                     onDelete={this.props.onDelete}
-                    minQueryLength={1}
                 />
             </div>
         )
     }
 }
+
+const convertTagToAutocomplete = (t: Tag) => ({ value: t.id, label: t.name })
+const convertAutocompleteTotag = (t: TagAutocomplete) => ({
+    id: t.value as number,
+    name: t.label,
+})

--- a/adminSiteClient/EditTags.tsx
+++ b/adminSiteClient/EditTags.tsx
@@ -25,17 +25,25 @@ export class EditTags extends React.Component<{
         this.dismissable = false
     }
 
+    @action.bound onKeyDown(e: KeyboardEvent) {
+        if (e.key === "Escape") {
+            this.props.onSave()
+        }
+    }
+
     onAdd = (tag: TagAutocomplete) => {
         this.props.onAdd(convertAutocompleteTotag(tag))
     }
 
     componentDidMount() {
         document.addEventListener("click", this.onClickSomewhere)
+        document.addEventListener("keydown", this.onKeyDown)
         this.reactTagsApi.current?.input?.focus()
     }
 
     componentWillUnmount() {
         document.removeEventListener("click", this.onClickSomewhere)
+        document.removeEventListener("keydown", this.onKeyDown)
     }
 
     render() {

--- a/adminSiteClient/EditTags.tsx
+++ b/adminSiteClient/EditTags.tsx
@@ -45,6 +45,7 @@ export class EditTags extends React.Component<{
                 <ReactTags
                     selected={tags.map(convertTagToAutocomplete)}
                     suggestions={suggestions.map(convertTagToAutocomplete)}
+                    activateFirstOption
                     onAdd={this.onAdd}
                     onDelete={this.props.onDelete}
                     ref={this.reactTagsApi}

--- a/adminSiteClient/EditTags.tsx
+++ b/adminSiteClient/EditTags.tsx
@@ -1,9 +1,12 @@
-import React, { useRef } from "react"
+import React from "react"
 import { action } from "mobx"
 import { observer } from "mobx-react"
 import { Tag } from "./TagBadge.js"
-import { ReactTags, ReactTagsAPI } from "react-tag-autocomplete"
-import { Tag as TagAutocomplete } from "react-tag-autocomplete"
+import {
+    ReactTags,
+    ReactTagsAPI,
+    Tag as TagAutocomplete,
+} from "react-tag-autocomplete"
 
 @observer
 export class EditTags extends React.Component<{

--- a/adminSiteClient/EditTags.tsx
+++ b/adminSiteClient/EditTags.tsx
@@ -1,8 +1,8 @@
-import React from "react"
+import React, { useRef } from "react"
 import { action } from "mobx"
 import { observer } from "mobx-react"
 import { Tag } from "./TagBadge.js"
-import { ReactTags } from "react-tag-autocomplete"
+import { ReactTags, ReactTagsAPI } from "react-tag-autocomplete"
 import { Tag as TagAutocomplete } from "react-tag-autocomplete"
 
 @observer
@@ -14,6 +14,7 @@ export class EditTags extends React.Component<{
     onSave: () => void
 }> {
     dismissable: boolean = true
+    reactTagsApi = React.createRef<ReactTagsAPI>()
 
     @action.bound onClickSomewhere() {
         if (this.dismissable) this.props.onSave()
@@ -30,6 +31,7 @@ export class EditTags extends React.Component<{
 
     componentDidMount() {
         document.addEventListener("click", this.onClickSomewhere)
+        this.reactTagsApi.current?.input?.focus()
     }
 
     componentWillUnmount() {
@@ -45,6 +47,7 @@ export class EditTags extends React.Component<{
                     suggestions={suggestions.map(convertTagToAutocomplete)}
                     onAdd={this.onAdd}
                     onDelete={this.props.onDelete}
+                    ref={this.reactTagsApi}
                 />
             </div>
         )

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -894,17 +894,6 @@ main:not(.ChartEditorPage):not(.GdocsEditPage) {
     }
 }
 
-.EditableTags {
-    button {
-        opacity: 0.8;
-    }
-
-    // Tweak to stop suggestions overlapping "Add new tag" in another tag input below
-    .react-tags__suggestions {
-        z-index: 10;
-    }
-}
-
 .EditableTags__action {
     padding-left: 6px;
     &:focus {

--- a/adminSiteClient/styles/react-tag-autocomplete.scss
+++ b/adminSiteClient/styles/react-tag-autocomplete.scss
@@ -1,134 +1,172 @@
-// Styles taken from https://github.com/i-like-robots/react-tags/blob/main/example/styles.css
+// Styles taken from https://github.com/i-like-robots/react-tag-autocomplete/blob/main/example/src/styles.css
 
 .react-tags {
     position: relative;
-    padding: 6px 0 0 6px;
-    border: 1px solid #d1d1d1;
-    background-color: #fff;
-    border-radius: 1px;
-
+    padding: 0.25rem 0 0 0.25rem;
+    border: 2px solid #afb8c1;
+    border-radius: 6px;
+    background: #ffffff;
     /* shared font styles */
-    font-size: 1em;
+    font-size: 1rem;
     line-height: 1.2;
-
     /* clicking anywhere will focus the input */
     cursor: text;
 }
 
-.react-tags.is-focused {
-    border-color: #b1b1b1;
+.react-tags.is-active {
+    border-color: #4f46e5;
 }
 
-.react-tags__selected {
+.react-tags.is-disabled {
+    opacity: 0.75;
+    background-color: #eaeef2;
+    /* Prevent any clicking on the component */
+    pointer-events: none;
+    cursor: not-allowed;
+}
+
+.react-tags.is-invalid {
+    border-color: #fd5956;
+    box-shadow: 0 0 0 2px rgba(253, 86, 83, 0.25);
+}
+
+.react-tags__label {
+    position: absolute;
+    left: -10000px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+
+.react-tags__list {
+    /* Do not use display: contents, it's too buggy */
     display: inline;
+    padding: 0;
 }
 
-.react-tags__selected-tag {
-    display: inline-block;
-    box-sizing: border-box;
-    margin: 0 6px 6px 0;
-    padding: 6px 8px;
-    border: 1px solid #d1d1d1;
-    border-radius: 2px;
-    background: #f1f1f1;
+.react-tags__list-item {
+    display: inline;
+    list-style: none;
+}
 
+.react-tags__tag {
+    margin: 0 0.25rem 0.25rem 0;
+    padding: 0.375rem 0.5rem;
+    border: 0;
+    border-radius: 3px;
+    background: #eaeef2;
     /* match the font styles */
     font-size: inherit;
     line-height: inherit;
 }
 
-.react-tags__selected-tag:after {
-    content: "\2715";
-    color: #aaa;
-    margin-left: 8px;
+.react-tags__tag:hover {
+    color: #ffffff;
+    background-color: #4f46e5;
 }
 
-.react-tags__selected-tag:hover,
-.react-tags__selected-tag:focus {
-    border-color: #b1b1b1;
-}
-
-.react-tags__search {
+.react-tags__tag::after {
+    content: "";
     display: inline-block;
+    width: 0.65rem;
+    height: 0.65rem;
+    clip-path: polygon(
+        10% 0,
+        0 10%,
+        40% 50%,
+        0 90%,
+        10% 100%,
+        50% 60%,
+        90% 100%,
+        100% 90%,
+        60% 50%,
+        100% 10%,
+        90% 0,
+        50% 40%
+    );
+    margin-left: 0.5rem;
+    font-size: 0.875rem;
+    background-color: #7c7d86;
+}
 
+.react-tags__tag:hover::after {
+    background-color: #ffffff;
+}
+
+.react-tags__combobox {
+    display: inline-block;
     /* match tag layout */
-    padding: 7px 2px;
-    margin-bottom: 6px;
-
-    /* prevent autoresize overflowing the container */
+    padding: 0.375rem 0.25rem;
+    margin-bottom: 0.25rem;
+    /* prevents autoresize overflowing the container */
     max-width: 100%;
 }
 
-@media screen and (min-width: 30em) {
-    .react-tags__search {
-        /* this will become the offsetParent for suggestions */
-        position: relative;
-    }
-}
-
-.react-tags__search-input {
+.react-tags__combobox-input {
     /* prevent autoresize overflowing the container */
     max-width: 100%;
-
     /* remove styles and layout from this element */
     margin: 0;
     padding: 0;
     border: 0;
     outline: none;
-
+    background: none;
     /* match the font styles */
     font-size: inherit;
     line-height: inherit;
 }
 
-.react-tags__search-input::-ms-clear {
-    display: none;
+.react-tags__combobox-input::placeholder {
+    color: #7c7d86;
+    opacity: 1;
 }
 
-.react-tags__suggestions {
+.react-tags__listbox {
     position: absolute;
-    top: 100%;
-    left: 0;
-    width: 100%;
+    z-index: 1;
+    top: calc(100% + 5px);
+    /* Negate the border width on the container */
+    left: -2px;
+    right: -2px;
+    max-height: 12.5rem;
+    overflow-y: auto;
+    background: #ffffff;
+    border: 1px solid #afb8c1;
+    border-radius: 6px;
+    box-shadow: rgba(0, 0, 0, 0.1) 0 10px 15px -4px,
+        rgba(0, 0, 0, 0.05) 0 4px 6px -2px;
 }
 
-@media screen and (min-width: 30em) {
-    .react-tags__suggestions {
-        width: 240px;
-    }
+.react-tags__listbox-option {
+    padding: 0.375rem 0.5rem;
 }
 
-.react-tags__suggestions ul {
-    margin: 4px -1px;
-    padding: 0;
-    list-style: none;
-    background: white;
-    border: 1px solid #d1d1d1;
-    border-radius: 2px;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
-}
-
-.react-tags__suggestions li {
-    border-bottom: 1px solid #ddd;
-    padding: 6px 8px;
-}
-
-.react-tags__suggestions li mark {
-    text-decoration: underline;
-    background: none;
-    font-weight: 700;
-}
-
-.react-tags__suggestions li:hover {
+.react-tags__listbox-option:hover {
     cursor: pointer;
-    background: #eee;
+    background: #eaeef2;
 }
 
-.react-tags__suggestions li.is-active {
-    background: #b7cfe0;
+.react-tags__listbox-option:not([aria-disabled="true"]).is-active {
+    background: #4f46e5;
+    color: #ffffff;
 }
 
-.react-tags__suggestions li.is-disabled {
-    opacity: 0.5;
-    cursor: auto;
+.react-tags__listbox-option[aria-disabled="true"] {
+    color: #7c7d86;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+.react-tags__listbox-option[aria-selected="true"]::after {
+    content: "✓";
+    margin-left: 0.5rem;
+}
+
+.react-tags__listbox-option[aria-selected="true"]:not(.is-active)::after {
+    color: #4f46e5;
+}
+
+.react-tags__listbox-option-highlight {
+    background-color: #ffdd00;
 }

--- a/adminSiteClient/styles/react-tag-autocomplete.scss
+++ b/adminSiteClient/styles/react-tag-autocomplete.scss
@@ -14,7 +14,7 @@
 }
 
 .react-tags.is-active {
-    border-color: #4f46e5;
+    border-color: #007bff;
 }
 
 .react-tags.is-disabled {
@@ -63,7 +63,7 @@
 
 .react-tags__tag:hover {
     color: #ffffff;
-    background-color: #4f46e5;
+    background-color: #dc3545;
 }
 
 .react-tags__tag::after {
@@ -148,7 +148,7 @@
 }
 
 .react-tags__listbox-option:not([aria-disabled="true"]).is-active {
-    background: #4f46e5;
+    background: #007bff;
     color: #ffffff;
 }
 
@@ -164,7 +164,7 @@
 }
 
 .react-tags__listbox-option[aria-selected="true"]:not(.is-active)::after {
-    color: #4f46e5;
+    color: #007bff;
 }
 
 .react-tags__listbox-option-highlight {

--- a/adminSiteClient/styles/react-tag-autocomplete.scss
+++ b/adminSiteClient/styles/react-tag-autocomplete.scss
@@ -148,8 +148,7 @@
 }
 
 .react-tags__listbox-option:not([aria-disabled="true"]).is-active {
-    background: #007bff;
-    color: #ffffff;
+    background: #eaeef2;
 }
 
 .react-tags__listbox-option[aria-disabled="true"] {

--- a/adminSiteClient/styles/react-tag-autocomplete.scss
+++ b/adminSiteClient/styles/react-tag-autocomplete.scss
@@ -168,5 +168,7 @@
 }
 
 .react-tags__listbox-option-highlight {
-    background-color: #ffdd00;
+    padding: 0;
+    background-color: transparent;
+    font-weight: bold;
 }

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -98,7 +98,6 @@ import { In } from "typeorm"
 import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants.js"
 import { logErrorAndMaybeSendToBugsnag } from "../serverUtils/errorLog.js"
 import { TaggableType } from "../adminSiteClient/EditableTags.js"
-import { Tag as TagReactTagAutocomplete } from "react-tag-autocomplete"
 import { OpenAI } from "openai"
 
 const apiRouter = new FunctionalRouter()
@@ -2621,7 +2620,7 @@ apiRouter.get(
                 404
             )
 
-        const topics: TagReactTagAutocomplete[] = await db.queryMysql(`
+        const topics: Tag[] = await db.queryMysql(`
             SELECT t.id, t.name
             FROM tags t 
             WHERE t.isTopic IS TRUE
@@ -2661,7 +2660,7 @@ apiRouter.get(
         const json = completion.choices[0]?.message?.content
         if (!json) throw new JsonError("No response from GPT", 500)
 
-        const selectedTopics: TagReactTagAutocomplete[] = JSON.parse(json)
+        const selectedTopics: Tag[] = JSON.parse(json)
 
         // We only want to return topics that are in the list of possible
         // topics, in case of hallucinations

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
         "react-recaptcha": "^2.3.10",
         "react-router-dom": "^5.3.1",
         "react-select": "^5.7.3",
-        "react-tag-autocomplete": "^6.3.0",
+        "react-tag-autocomplete": "^7.1.0",
         "react-zoom-pan-pinch": "^2.1.3",
         "reflect-metadata": "^0.1.13",
         "rxjs": "6",

--- a/packages/@ourworldindata/utils/package.json
+++ b/packages/@ourworldindata/utils/package.json
@@ -25,7 +25,7 @@
     "parsimmon": "^1.18.1",
     "react": "^16.14.0",
     "react-select": "^5.7.3",
-    "react-tag-autocomplete": "^6.3.0",
+    "react-tag-autocomplete": "^7.1.0",
     "s-expression": "^3.1.1",
     "string-pixel-width": "^1.10.0",
     "striptags": "^3.2.0",

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -195,7 +195,9 @@ export enum KeyChartLevel {
     Top = 3, // chart will show at the top of the all charts block
 }
 
-export interface Tag extends TagReactTagAutocomplete {
+export interface Tag {
+    id: number
+    name: string
     keyChartLevel?: KeyChartLevel
     isApproved?: boolean
 }

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1,4 +1,3 @@
-import { Tag as TagReactTagAutocomplete } from "react-tag-autocomplete"
 import { ImageMetadata } from "./image.js"
 import { Static, Type } from "@sinclair/typebox"
 import { gdocUrlRegex } from "./GdocsConstants.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5043,7 +5043,7 @@ __metadata:
     parsimmon: ^1.18.1
     react: ^16.14.0
     react-select: ^5.7.3
-    react-tag-autocomplete: ^6.3.0
+    react-tag-autocomplete: ^7.1.0
     s-expression: ^3.1.1
     string-pixel-width: ^1.10.0
     striptags: ^3.2.0
@@ -14089,7 +14089,7 @@ __metadata:
     react-recaptcha: ^2.3.10
     react-router-dom: ^5.3.1
     react-select: ^5.7.3
-    react-tag-autocomplete: ^6.3.0
+    react-tag-autocomplete: ^7.1.0
     react-zoom-pan-pinch: ^2.1.3
     reflect-metadata: ^0.1.13
     rxjs: 6
@@ -21590,14 +21590,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-tag-autocomplete@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "react-tag-autocomplete@npm:6.3.0"
+"react-tag-autocomplete@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "react-tag-autocomplete@npm:7.1.0"
   peerDependencies:
-    prop-types: ^15.5.0
-    react: ^16.5.0 || ^17.0.0
-    react-dom: ^16.5.0 || ^17.0.0
-  checksum: c1d76319d0ba9635ad51f1dd0308fbe55ced3b4e2164a5f3055c80c4ae32c0139745ad9ccc2e5c32ce970f3c331445a36f1a5e458a4a93f942019b9848da192d
+    react: ^18.0.0
+  checksum: 9648dc2f3529bfdb330c9481d094fc937f27f1b628ec057c6eb1731365880e3e45cf88b90349d5575ed8944c9c850592c2b094c8caf12b0d84eb329d7f2a60a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
![Screenshot 2023-09-12 at 19.28.08.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0SFFiIjKuUK6UPYHVe6u/88e65dfa-52e3-4f8c-8fcf-7cb937299cf5/Screenshot%202023-09-12%20at%2019.28.08.png)

see [demo](https://owid.slack.com/archives/C014SGT6W9X/p1694539715117499)

- reduce guessing by seeing all tags available
- autofocus for speeding up keyboard filtering
- validate selection by pressing "esc"
- improved styles
