### PR TITLE
Render source fields as markdown instead of HTML

### DIFF
--- a/packages/@ourworldindata/grapher/src/sourcesTab/SourcesTab.tsx
+++ b/packages/@ourworldindata/grapher/src/sourcesTab/SourcesTab.tsx
@@ -2,7 +2,6 @@ import {
     Bounds,
     DEFAULT_BOUNDS,
     MarkdownTextWrap,
-    linkify,
     OwidOrigin,
     uniq,
     excludeNullish,
@@ -13,9 +12,6 @@ import { observer } from "mobx-react"
 import { faPencilAlt } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { CoreColumn, OwidColumnDef } from "@ourworldindata/core-table"
-
-const formatText = (s: string): string =>
-    linkify(s).replace(/(?:\r\n|\r|\n)/g, "<br/>")
 
 export interface SourcesTabManager {
     adminBaseUrl?: string
@@ -110,11 +106,12 @@ export class SourcesTab extends React.Component<{
                             // metadata V2 shortDescription
                             <tr>
                                 <td>Variable description</td>
-                                <td
-                                    dangerouslySetInnerHTML={{
-                                        __html: formatText(column.description),
-                                    }}
-                                />
+                                <td>
+                                    <MarkdownTextWrap
+                                        text={column.description}
+                                        fontSize={12}
+                                    />
+                                </td>
                             </tr>
                         ) : null}
                         {coverage ? (
@@ -162,35 +159,34 @@ export class SourcesTab extends React.Component<{
                         source.dataPublishedBy ? (
                             <tr>
                                 <td>Data published by</td>
-                                <td
-                                    dangerouslySetInnerHTML={{
-                                        __html: formatText(
-                                            source.dataPublishedBy
-                                        ),
-                                    }}
-                                />
+                                <td>
+                                    <MarkdownTextWrap
+                                        text={source.dataPublishedBy}
+                                        fontSize={12}
+                                    />
+                                </td>
                             </tr>
                         ) : null}
                         {source.dataPublisherSource ? (
                             <tr>
                                 <td>Data publisher's source</td>
-                                <td
-                                    dangerouslySetInnerHTML={{
-                                        __html: formatText(
-                                            source.dataPublisherSource
-                                        ),
-                                    }}
-                                />
+                                <td>
+                                    <MarkdownTextWrap
+                                        text={source.dataPublisherSource}
+                                        fontSize={12}
+                                    />
+                                </td>
                             </tr>
                         ) : null}
                         {source.link ? (
                             <tr>
                                 <td>Link</td>
-                                <td
-                                    dangerouslySetInnerHTML={{
-                                        __html: formatText(source.link),
-                                    }}
-                                />
+                                <td>
+                                    <MarkdownTextWrap
+                                        text={source.link}
+                                        fontSize={12}
+                                    />
+                                </td>
                             </tr>
                         ) : null}
                         {retrievedDate ? (
@@ -202,12 +198,12 @@ export class SourcesTab extends React.Component<{
                     </tbody>
                 </table>
                 {source.additionalInfo && (
-                    <p
-                        key={"additionalInfo"}
-                        dangerouslySetInnerHTML={{
-                            __html: formatText(source.additionalInfo),
-                        }}
-                    />
+                    <p key={"additionalInfo"}>
+                        <MarkdownTextWrap
+                            text={source.additionalInfo}
+                            fontSize={12}
+                        />
+                    </p>
                 )}
             </div>
         )

--- a/packages/@ourworldindata/utils/src/GdocsUtils.ts
+++ b/packages/@ourworldindata/utils/src/GdocsUtils.ts
@@ -166,7 +166,7 @@ const convertMarkdownNodeToSpan = (node: EveryMarkdownNode): Span[] => {
     //.otherwise(() => ({ spanType: "span-simple-text" as const, text: "" }))
 }
 
-const convertMarkdownNodesToSpans = (nodes: MarkdownRoot) =>
+const convertMarkdownNodesToSpans = (nodes: MarkdownRoot): Span[] =>
     nodes.children.flatMap(convertMarkdownNodeToSpan)
 
 export const markdownToEnrichedTextBlock = (

--- a/packages/@ourworldindata/utils/src/GdocsUtils.ts
+++ b/packages/@ourworldindata/utils/src/GdocsUtils.ts
@@ -1,8 +1,14 @@
 import { spansToUnformattedPlainText } from "./Util.js"
 import { gdocUrlRegex } from "./GdocsConstants.js"
-import { OwidGdocLinkJSON, Span } from "./owidTypes.js"
+import { EnrichedBlockText, OwidGdocLinkJSON, Span } from "./owidTypes.js"
 import { Url } from "./urls/Url.js"
 import urlSlug from "url-slug"
+import {
+    EveryMarkdownNode,
+    MarkdownRoot,
+    mdParser,
+} from "./MarkdownTextWrap/parser.js"
+import { P, match } from "ts-pattern"
 
 export function getLinkType(urlString: string): OwidGdocLinkJSON["linkType"] {
     const url = Url.fromURL(urlString)
@@ -39,4 +45,150 @@ export function getUrlTarget(urlString: string): string {
 
 export function convertHeadingTextToId(headingText: Span[]): string {
     return urlSlug(spansToUnformattedPlainText(headingText))
+}
+
+const convertMarkdownNodeToSpan = (node: EveryMarkdownNode): Span[] => {
+    return match(node)
+        .with(
+            {
+                type: "text",
+            },
+            (n) => [
+                {
+                    spanType: "span-simple-text" as const,
+                    text: n.value,
+                } as Span,
+            ]
+        )
+        .with(
+            {
+                type: "textSegments",
+            },
+            (n) => n.children.flatMap(convertMarkdownNodeToSpan) as Span[]
+        )
+        .with(
+            {
+                type: "newline",
+            },
+            () => [
+                {
+                    spanType: "span-simple-text" as const,
+                    text: "\n",
+                } as Span,
+            ]
+        )
+        .with(
+            {
+                type: "whitespace",
+            },
+            () => [
+                {
+                    spanType: "span-simple-text" as const,
+                    text: " ",
+                } as Span,
+            ]
+        )
+        .with(
+            {
+                type: "detailOnDemand",
+            },
+            (n) => [
+                {
+                    spanType: "span-dod" as const,
+                    id: n.term,
+                    children: n.children.flatMap(convertMarkdownNodeToSpan),
+                } as Span,
+            ]
+        )
+        .with(
+            {
+                type: "markdownLink",
+            },
+            (n) => [
+                {
+                    spanType: "span-link" as const,
+                    url: n.href,
+                    children: n.children.flatMap(convertMarkdownNodeToSpan),
+                } as Span,
+            ]
+        )
+        .with(
+            {
+                type: "plainUrl",
+            },
+            (n) => [
+                {
+                    spanType: "span-link" as const,
+                    url: n.href,
+                    children: [
+                        {
+                            spanType: "span-simple-text" as const,
+                            text: n.href,
+                        },
+                    ],
+                } as Span,
+            ]
+        )
+        .with(
+            {
+                type: "bold",
+            },
+            (n) => [
+                {
+                    spanType: "span-bold" as const,
+                    children: n.children.flatMap(convertMarkdownNodeToSpan),
+                } as Span,
+            ]
+        )
+        .with(
+            {
+                type: P.union("italic", "plainItalic", "italicWithoutBold"),
+            },
+            (n) => [
+                {
+                    spanType: "span-italic" as const,
+                    children: n.children.flatMap(convertMarkdownNodeToSpan),
+                } as Span,
+            ]
+        )
+        .with(
+            {
+                type: P.union("bold", "plainBold", "boldWithoutItalic"),
+            },
+            (n) => [
+                {
+                    spanType: "span-bold" as const,
+                    children: n.children.flatMap(convertMarkdownNodeToSpan),
+                } as Span,
+            ]
+        )
+        .exhaustive()
+    //.otherwise(() => ({ spanType: "span-simple-text" as const, text: "" }))
+}
+
+const convertMarkdownNodesToSpans = (nodes: MarkdownRoot) =>
+    nodes.children.flatMap(convertMarkdownNodeToSpan)
+
+export const markdownToEnrichedTextBlock = (
+    markdown: string
+): EnrichedBlockText => {
+    const parsedMarkdown = mdParser.markdown.parse(markdown)
+    if (parsedMarkdown.status) {
+        const spans = convertMarkdownNodesToSpans(parsedMarkdown.value)
+        return {
+            type: "text",
+            value: spans,
+            parseErrors: [],
+        }
+    } else
+        return {
+            type: "text",
+            value: [],
+            parseErrors: [
+                {
+                    message: `Failed to parse markdown - expected ${parsedMarkdown.expected} at ${parsedMarkdown.index}`,
+                    isWarning: false,
+                },
+            ],
+        }
 }

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -608,6 +608,7 @@ export {
     getUrlTarget,
     checkIsInternalLink,
     convertHeadingTextToId,
+    markdownToEnrichedTextBlock,
 } from "./GdocsUtils.js"
 
 export {

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -10,13 +10,9 @@ import { ArticleBlocks } from "./gdocs/ArticleBlocks.js"
 import { RelatedCharts } from "./blocks/RelatedCharts.js"
 import {
     DataPageV2ContentFields,
-    mdParser,
-    MarkdownRoot,
-    EveryMarkdownNode,
-    Span,
-    EnrichedBlockText,
     excludeNullish,
     slugify,
+    markdownToEnrichedTextBlock,
 } from "@ourworldindata/utils"
 import { AttachmentsContext, DocumentContext } from "./gdocs/OwidGdoc.js"
 import StickyNav from "./blocks/StickyNav.js"
@@ -31,151 +27,6 @@ declare global {
         _OWID_GRAPHER_CONFIG: GrapherInterface
     }
 }
-
-const convertMarkdownNodeToSpan = (node: EveryMarkdownNode): Span[] => {
-    return match(node)
-        .with(
-            {
-                type: "text",
-            },
-            (n) => [
-                {
-                    spanType: "span-simple-text" as const,
-                    text: n.value,
-                } as Span,
-            ]
-        )
-        .with(
-            {
-                type: "textSegments",
-            },
-            (n) => n.children.flatMap(convertMarkdownNodeToSpan) as Span[]
-        )
-        .with(
-            {
-                type: "newline",
-            },
-            () => [
-                {
-                    spanType: "span-simple-text" as const,
-                    text: "\n",
-                } as Span,
-            ]
-        )
-        .with(
-            {
-                type: "whitespace",
-            },
-            () => [
-                {
-                    spanType: "span-simple-text" as const,
-                    text: " ",
-                } as Span,
-            ]
-        )
-        .with(
-            {
-                type: "detailOnDemand",
-            },
-            (n) => [
-                {
-                    spanType: "span-dod" as const,
-                    id: n.term,
-                    children: n.children.flatMap(convertMarkdownNodeToSpan),
-                } as Span,
-            ]
-        )
-        .with(
-            {
-                type: "markdownLink",
-            },
-            (n) => [
-                {
-                    spanType: "span-link" as const,
-                    url: n.href,
-                    children: n.children.flatMap(convertMarkdownNodeToSpan),
-                } as Span,
-            ]
-        )
-        .with(
-            {
-                type: "plainUrl",
-            },
-            (n) => [
-                {
-                    spanType: "span-link" as const,
-                    url: n.href,
-                    children: [
-                        {
-                            spanType: "span-simple-text" as const,
-                            text: n.href,
-                        },
-                    ],
-                } as Span,
-            ]
-        )
-        .with(
-            {
-                type: "bold",
-            },
-            (n) => [
-                {
-                    spanType: "span-bold" as const,
-                    children: n.children.flatMap(convertMarkdownNodeToSpan),
-                } as Span,
-            ]
-        )
-        .with(
-            {
-                type: P.union("italic", "plainItalic", "italicWithoutBold"),
-            },
-            (n) => [
-                {
-                    spanType: "span-italic" as const,
-                    children: n.children.flatMap(convertMarkdownNodeToSpan),
-                } as Span,
-            ]
-        )
-        .with(
-            {
-                type: P.union("bold", "plainBold", "boldWithoutItalic"),
-            },
-            (n) => [
-                {
-                    spanType: "span-bold" as const,
-                    children: n.children.flatMap(convertMarkdownNodeToSpan),
-                } as Span,
-            ]
-        )
-        .exhaustive()
-    //.otherwise(() => ({ spanType: "span-simple-text" as const, text: "" }))
-}
-
-const convertMarkdownNodesToSpans = (nodes: MarkdownRoot) =>
-    nodes.children.flatMap(convertMarkdownNodeToSpan)
-
-const markdownToEnrichedTextBlock = (markdown: string): EnrichedBlockText => {
-    const parsedMarkdown = mdParser.markdown.parse(markdown)
-    if (parsedMarkdown.status) {
-        const spans = convertMarkdownNodesToSpans(parsedMarkdown.value)
-        return {
-            type: "text",
-            value: spans,
-            parseErrors: [],
-        }
-    } else
-        return {
-            type: "text",
-            value: [],
-            parseErrors: [
-                {
-                    message: `Failed to parse markdown - expected ${parsedMarkdown.expected} at ${parsedMarkdown.index}`,
-                    isWarning: false,
-                },
-            ],
-        }
-}
-
 export const OWID_DATAPAGE_CONTENT_ROOT_ID = "owid-datapageJson-root"
 
 export const DataPageV2Content = ({

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -20,7 +20,6 @@ import cx from "classnames"
 import { DebugProvider } from "./gdocs/DebugContext.js"
 import { CodeSnippet } from "./blocks/CodeSnippet.js"
 import dayjs from "dayjs"
-import { P, match } from "ts-pattern"
 declare global {
     interface Window {
         _OWID_DATAPAGEV2_PROPS: DataPageV2ContentFields


### PR DESCRIPTION
This PR switches the rendering of text from Source in the sources tab of Grapher from HTML to markdown. This is the companion PR for [this PR in the ETL](https://github.com/owid/etl/pull/1422) that converts legacy HTML to markdown in sources.

This PR implements #2520