### PR TITLE
:bug: crude fix for map color animation resulting in wrong colors

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -573,6 +573,7 @@ export class Explorer
         grapher.reset()
         this.updateGrapherFromExplorerCommon()
         grapher.updateFromObject(config)
+        grapher.forceDisableIntroAnimation = true
         await grapher.downloadLegacyDataFromOwidVariableIds()
 
         let grapherTable = grapher.inputTable

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -398,6 +398,12 @@ export class Grapher
     @observable sortBy?: SortBy
     @observable sortOrder?: SortOrder
     @observable sortColumnSlug?: string
+    // TODO: this is a crude fix that is used to turn off the intro
+    // animation in maps (fading colors in from gray) because
+    // they end up with the wrong target colors (i.e. the colors
+    // are initially correct but then the animation screws them up).
+    // This flag can be removed once the animation bug is properly fixed.
+    @observable forceDisableIntroAnimation: boolean = false
 
     owidDataset?: MultipleOwidVariableDataDimensionsMap = undefined // This is used for passing data for testing
 
@@ -1608,7 +1614,7 @@ export class Grapher
     }
 
     @computed get disableIntroAnimation(): boolean {
-        return this.isExportingtoSvgOrPng
+        return this.isExportingtoSvgOrPng || this.forceDisableIntroAnimation
     }
 
     @computed get mapConfig(): MapConfig {


### PR DESCRIPTION
This fixes #2633 but does it in a crude way by turning off all intro animations in explorers