### PR TITLE
Entry Emulator - All Charts

### DIFF
--- a/adminSiteClient/ChartList.tsx
+++ b/adminSiteClient/ChartList.tsx
@@ -1,11 +1,10 @@
 import React from "react"
 import { observer } from "mobx-react"
 import { runInAction, observable } from "mobx"
-import { Tag } from "./TagBadge.js"
 import { bind } from "decko"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import { ChartTypeName, GrapherInterface } from "@ourworldindata/grapher"
-import { startCase } from "@ourworldindata/utils"
+import { startCase, ChartTagJoin } from "@ourworldindata/utils"
 import { References, getFullReferencesCount } from "./ChartEditor.js"
 import { ChartRow } from "./ChartRow.js"
 
@@ -29,7 +28,7 @@ export interface ChartListItem {
     publishedBy: string
     isExplorable: boolean
 
-    tags: Tag[]
+    tags: ChartTagJoin[]
 }
 
 @observer
@@ -41,7 +40,7 @@ export class ChartList extends React.Component<{
     static contextType = AdminAppContext
     context!: AdminAppContextType
 
-    @observable availableTags: Tag[] = []
+    @observable availableTags: ChartTagJoin[] = []
 
     async fetchRefs(grapherId: number | undefined): Promise<References> {
         const { admin } = this.context

--- a/adminSiteClient/ChartRow.tsx
+++ b/adminSiteClient/ChartRow.tsx
@@ -3,7 +3,6 @@ import { observer } from "mobx-react"
 import { action, runInAction } from "mobx"
 import * as lodash from "lodash"
 import { Link } from "./Link.js"
-import { Tag } from "./TagBadge.js"
 import { Timeago } from "./Forms.js"
 import { EditableTags } from "./EditableTags.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
@@ -12,19 +11,19 @@ import {
     BAKED_GRAPHER_URL,
 } from "../settings/clientSettings.js"
 import { ChartListItem, showChartType } from "./ChartList.js"
-import { TaggableType } from "@ourworldindata/utils"
+import { TaggableType, ChartTagJoin } from "@ourworldindata/utils"
 
 @observer
 export class ChartRow extends React.Component<{
     chart: ChartListItem
     searchHighlight?: (text: string) => string | JSX.Element
-    availableTags: Tag[]
+    availableTags: ChartTagJoin[]
     onDelete: (chart: ChartListItem) => void
 }> {
     static contextType = AdminAppContext
     context!: AdminAppContextType
 
-    async saveTags(tags: Tag[]) {
+    async saveTags(tags: ChartTagJoin[]) {
         const { chart } = this.props
         const json = await this.context.admin.requestJSON(
             `/api/charts/${chart.id}/setTags`,
@@ -36,7 +35,7 @@ export class ChartRow extends React.Component<{
         }
     }
 
-    @action.bound onSaveTags(tags: Tag[]) {
+    @action.bound onSaveTags(tags: ChartTagJoin[]) {
         this.saveTags(tags)
     }
 

--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -5,14 +5,13 @@ import * as lodash from "lodash"
 import { Prompt, Redirect } from "react-router-dom"
 import filenamify from "filenamify"
 
-import { OwidSource } from "@ourworldindata/utils"
+import { OwidSource, ChartTagJoin } from "@ourworldindata/utils"
 
 import { AdminLayout } from "./AdminLayout.js"
 import { Link } from "./Link.js"
 import { BindString, Toggle, FieldsRow, Timeago } from "./Forms.js"
 import { EditableTags } from "./EditableTags.js"
 import { ChartList, ChartListItem } from "./ChartList.js"
-import { Tag } from "./TagBadge.js"
 import { VariableList, VariableListItem } from "./VariableList.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
@@ -61,7 +60,7 @@ class DatasetEditable {
         additionalInfo: "",
     }
 
-    @observable tags: Tag[] = []
+    @observable tags: ChartTagJoin[] = []
 
     constructor(json: DatasetPageData) {
         for (const key in this) {
@@ -78,7 +77,7 @@ class DatasetTagEditor extends React.Component<{
     newDataset: DatasetEditable
     availableTags: { id: number; name: string; parentName: string }[]
 }> {
-    @action.bound onSaveTags(tags: Tag[]) {
+    @action.bound onSaveTags(tags: ChartTagJoin[]) {
         this.props.newDataset.tags = tags
     }
 

--- a/adminSiteClient/DatasetList.tsx
+++ b/adminSiteClient/DatasetList.tsx
@@ -5,7 +5,7 @@ import * as lodash from "lodash"
 import { bind } from "decko"
 
 import { Link } from "./Link.js"
-import { Tag } from "./TagBadge.js"
+import { ChartTagJoin } from "@ourworldindata/utils"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import { Timeago } from "./Forms.js"
 import { EditableTags } from "./EditableTags.js"
@@ -20,7 +20,7 @@ export interface DatasetListItem {
     dataEditedByUserName: string
     metadataEditedAt: Date
     metadataEditedByUserName: string
-    tags: Tag[]
+    tags: ChartTagJoin[]
     isPrivate: boolean
     nonRedistributable: boolean
     version: string
@@ -30,13 +30,13 @@ export interface DatasetListItem {
 @observer
 class DatasetRow extends React.Component<{
     dataset: DatasetListItem
-    availableTags: Tag[]
+    availableTags: ChartTagJoin[]
     searchHighlight?: (text: string) => string | JSX.Element
 }> {
     static contextType = AdminAppContext
     context!: AdminAppContextType
 
-    async saveTags(tags: Tag[]) {
+    async saveTags(tags: ChartTagJoin[]) {
         const { dataset } = this.props
         const json = await this.context.admin.requestJSON(
             `/api/datasets/${dataset.id}/setTags`,
@@ -48,7 +48,7 @@ class DatasetRow extends React.Component<{
         }
     }
 
-    @action.bound onSaveTags(tags: Tag[]) {
+    @action.bound onSaveTags(tags: ChartTagJoin[]) {
         this.saveTags(tags)
     }
 
@@ -105,7 +105,7 @@ export class DatasetList extends React.Component<{
     static contextType = AdminAppContext
     context!: AdminAppContextType
 
-    @observable availableTags: Tag[] = []
+    @observable availableTags: ChartTagJoin[] = []
 
     @bind async getTags() {
         const json = await this.context.admin.getJSON("/api/tags.json")

--- a/adminSiteClient/EditTags.tsx
+++ b/adminSiteClient/EditTags.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { action } from "mobx"
 import { observer } from "mobx-react"
-import { Tag } from "./TagBadge.js"
+import { ChartTagJoin } from "@ourworldindata/utils"
 import {
     ReactTags,
     ReactTagsAPI,
@@ -10,10 +10,10 @@ import {
 
 @observer
 export class EditTags extends React.Component<{
-    tags: Tag[]
-    suggestions: Tag[]
+    tags: ChartTagJoin[]
+    suggestions: ChartTagJoin[]
     onDelete: (index: number) => void
-    onAdd: (tag: Tag) => void
+    onAdd: (tag: ChartTagJoin) => void
     onSave: () => void
 }> {
     dismissable: boolean = true
@@ -66,7 +66,10 @@ export class EditTags extends React.Component<{
     }
 }
 
-const convertTagToAutocomplete = (t: Tag) => ({ value: t.id, label: t.name })
+const convertTagToAutocomplete = (t: ChartTagJoin) => ({
+    value: t.id,
+    label: t.name,
+})
 const convertAutocompleteTotag = (t: TagAutocomplete) => ({
     id: t.value as number,
     name: t.label,

--- a/adminSiteClient/EditableTags.tsx
+++ b/adminSiteClient/EditableTags.tsx
@@ -2,7 +2,11 @@ import React from "react"
 import * as lodash from "lodash"
 import { observable, action } from "mobx"
 import { observer } from "mobx-react"
-import { KeyChartLevel, Tag, TaggableType } from "@ourworldindata/utils"
+import {
+    KeyChartLevel,
+    TaggableType,
+    ChartTagJoin,
+} from "@ourworldindata/utils"
 import { TagBadge } from "./TagBadge.js"
 import { EditTags } from "./EditTags.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
@@ -16,9 +20,9 @@ interface TaggableItem {
 
 @observer
 export class EditableTags extends React.Component<{
-    tags: Tag[]
-    suggestions: Tag[]
-    onSave: (tags: Tag[]) => void
+    tags: ChartTagJoin[]
+    suggestions: ChartTagJoin[]
+    onSave: (tags: ChartTagJoin[]) => void
     disabled?: boolean
     hasKeyChartSupport?: boolean
     hasSuggestionsSupport?: boolean
@@ -30,9 +34,9 @@ export class EditableTags extends React.Component<{
     @observable isEditing: boolean = false
     base: React.RefObject<HTMLDivElement> = React.createRef()
 
-    @observable tags: Tag[] = lodash.clone(this.props.tags)
+    @observable tags: ChartTagJoin[] = lodash.clone(this.props.tags)
 
-    @action.bound onAddTag(tag: Tag) {
+    @action.bound onAddTag(tag: ChartTagJoin) {
         this.tags.push(tag)
         this.tags = lodash
             // we only want to keep one occurrence of the same tag, whether
@@ -88,9 +92,10 @@ export class EditableTags extends React.Component<{
         const { taggable } = this.props
         if (!taggable?.id) return
 
-        const json: Record<"topics", Tag[]> = await this.context.admin.getJSON(
-            `/api/gpt/suggest-topics/${taggable.type}/${taggable.id}.json`
-        )
+        const json: Record<"topics", ChartTagJoin[]> =
+            await this.context.admin.getJSON(
+                `/api/gpt/suggest-topics/${taggable.type}/${taggable.id}.json`
+            )
 
         if (!json?.topics?.length) return
 
@@ -182,21 +187,21 @@ export class EditableTags extends React.Component<{
     }
 }
 
-const filterUncategorizedTag = (t: Tag) => t.name !== "Uncategorized"
+const filterUncategorizedTag = (t: ChartTagJoin) => t.name !== "Uncategorized"
 
-const filterUnlistedTag = (t: Tag) => t.name !== "Unlisted"
+const filterUnlistedTag = (t: ChartTagJoin) => t.name !== "Unlisted"
 
-const setDefaultKeyChartLevel = (t: Tag) => {
+const setDefaultKeyChartLevel = (t: ChartTagJoin) => {
     if (t.keyChartLevel === undefined) t.keyChartLevel = KeyChartLevel.None
     return t
 }
 
-const setTagStatusToPending = (t: Tag) => {
+const setTagStatusToPending = (t: ChartTagJoin) => {
     t.isApproved = false
     return t
 }
 
-const setTagStatusToApprovedIfUnset = (t: Tag) => {
+const setTagStatusToApprovedIfUnset = (t: ChartTagJoin) => {
     if (t.isApproved === undefined) t.isApproved = true
     return t
 }

--- a/adminSiteClient/GdocsIndexPage.tsx
+++ b/adminSiteClient/GdocsIndexPage.tsx
@@ -11,7 +11,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import {
-    OwidGdocTag,
+    Tag,
     OwidGdocInterface,
     OwidGdocType,
 } from "@ourworldindata/utils"
@@ -116,7 +116,7 @@ export class GdocsIndexPage extends React.Component<GdocsMatchProps> {
     }
 
     @computed
-    get tags(): OwidGdocTag[] {
+    get tags(): Tag[] {
         return this.context?.availableTags || []
     }
 

--- a/adminSiteClient/GdocsIndexPage.tsx
+++ b/adminSiteClient/GdocsIndexPage.tsx
@@ -10,11 +10,7 @@ import {
     faPuzzlePiece,
 } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
-import {
-    Tag,
-    OwidGdocInterface,
-    OwidGdocType,
-} from "@ourworldindata/utils"
+import { Tag, OwidGdocInterface, OwidGdocType } from "@ourworldindata/utils"
 import { Route, RouteComponentProps } from "react-router-dom"
 import { Link } from "./Link.js"
 import { GdocsAdd } from "./GdocsAdd.js"

--- a/adminSiteClient/GdocsStore.tsx
+++ b/adminSiteClient/GdocsStore.tsx
@@ -4,7 +4,7 @@ import {
     getOwidGdocFromJSON,
     OwidGdocInterface,
     OwidGdocJSON,
-    OwidGdocTag,
+    Tag,
 } from "@ourworldindata/utils"
 import { AdminAppContext } from "./AdminAppContext.js"
 import { Admin } from "./Admin.js"
@@ -18,7 +18,7 @@ import { Admin } from "./Admin.js"
  */
 export class GdocsStore {
     @observable gdocs: OwidGdocInterface[] = []
-    @observable availableTags: OwidGdocTag[] = []
+    @observable availableTags: Tag[] = []
     admin: Admin
 
     constructor(admin: Admin) {
@@ -74,7 +74,7 @@ export class GdocsStore {
     }
 
     @action
-    async updateTags(gdoc: OwidGdocInterface, tags: OwidGdocTag[]) {
+    async updateTags(gdoc: OwidGdocInterface, tags: Tag[]) {
         const json = await this.admin.requestJSON(
             `/api/gdocs/${gdoc.id}/setTags`,
             { tagIds: tags.map((t) => t.id) },

--- a/adminSiteClient/PostsIndexPage.tsx
+++ b/adminSiteClient/PostsIndexPage.tsx
@@ -9,10 +9,9 @@ import { AdminLayout } from "./AdminLayout.js"
 import { SearchField, FieldsRow, Timeago } from "./Forms.js"
 import { EditableTags } from "./EditableTags.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
-import { WORDPRESS_URL } from "../settings/clientSettings.js"
+import { ADMIN_BASE_URL, WORDPRESS_URL } from "../settings/clientSettings.js"
 import { Tag } from "./TagBadge.js"
 import { match } from "ts-pattern"
-import { Link } from "./Link.js"
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import {
@@ -134,14 +133,14 @@ class PostRow extends React.Component<PostRowProps> {
             .with(GdocStatus.CONVERTING, () => <span>Converting...</span>)
             .with(GdocStatus.CONVERTED, () => (
                 <>
-                    <Link
-                        to={`gdocs/${post.gdocSuccessorId}/preview`}
+                    <a
+                        href={`${ADMIN_BASE_URL}/admin/gdocs/${post.gdocSuccessorId}/preview`}
                         className="btn btn-primary"
                     >
                         <>
                             <FontAwesomeIcon icon={faEye} /> Preview
                         </>
-                    </Link>
+                    </a>
                     <button
                         onClick={this.onRecreateGdoc}
                         className="btn btn-primary alert-danger"

--- a/adminSiteClient/PostsIndexPage.tsx
+++ b/adminSiteClient/PostsIndexPage.tsx
@@ -5,12 +5,12 @@ import fuzzysort from "fuzzysort"
 import * as lodash from "lodash"
 
 import { highlight as fuzzyHighlight } from "@ourworldindata/grapher"
+import { ChartTagJoin, Tag } from "@ourworldindata/utils"
 import { AdminLayout } from "./AdminLayout.js"
 import { SearchField, FieldsRow, Timeago } from "./Forms.js"
 import { EditableTags } from "./EditableTags.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import { ADMIN_BASE_URL, WORDPRESS_URL } from "../settings/clientSettings.js"
-import { Tag } from "./TagBadge.js"
 import { match } from "ts-pattern"
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
@@ -27,7 +27,7 @@ interface PostIndexMeta {
     status: string
     authors: string[]
     updatedAtInWordpress: string
-    tags: Tag[]
+    tags: ChartTagJoin[]
     gdocSuccessorId: string | undefined
 }
 
@@ -62,7 +62,7 @@ class PostRow extends React.Component<PostRowProps> {
             : GdocStatus.MISSING
     }
 
-    async saveTags(tags: Tag[]) {
+    async saveTags(tags: ChartTagJoin[]) {
         const { post } = this.props
         const json = await this.context.admin.requestJSON(
             `/api/posts/${post.id}/setTags`,
@@ -74,7 +74,7 @@ class PostRow extends React.Component<PostRowProps> {
         }
     }
 
-    @action.bound onSaveTags(tags: Tag[]) {
+    @action.bound onSaveTags(tags: ChartTagJoin[]) {
         this.saveTags(tags)
     }
 

--- a/adminSiteClient/TagBadge.tsx
+++ b/adminSiteClient/TagBadge.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { observer } from "mobx-react"
-import { KeyChartLevel, Tag } from "@ourworldindata/utils"
+import { KeyChartLevel, ChartTagJoin } from "@ourworldindata/utils"
 
 import { Link } from "./Link.js"
 import Tippy from "@tippyjs/react"
@@ -9,11 +9,9 @@ import cx from "classnames"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faClock } from "@fortawesome/free-solid-svg-icons"
 
-export type { Tag }
-
 @observer
 export class TagBadge extends React.Component<{
-    tag: Tag
+    tag: ChartTagJoin
     onToggleKey?: () => void
     onApprove?: () => void
     searchHighlight?: (text: string) => string | JSX.Element

--- a/adminSiteClient/TagEditPage.tsx
+++ b/adminSiteClient/TagEditPage.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { observer } from "mobx-react"
 import { observable, computed, action, runInAction } from "mobx"
 import { Prompt, Redirect } from "react-router-dom"
-
+import { ChartTagJoin } from "@ourworldindata/utils"
 import { AdminLayout } from "./AdminLayout.js"
 import {
     BindString,
@@ -13,7 +13,7 @@ import {
 } from "./Forms.js"
 import { DatasetList, DatasetListItem } from "./DatasetList.js"
 import { ChartList, ChartListItem } from "./ChartList.js"
-import { TagBadge, Tag } from "./TagBadge.js"
+import { TagBadge } from "./TagBadge.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 
 interface TagPageData {
@@ -24,8 +24,8 @@ interface TagPageData {
     updatedAt: string
     datasets: DatasetListItem[]
     charts: ChartListItem[]
-    children: Tag[]
-    possibleParents: Tag[]
+    children: ChartTagJoin[]
+    possibleParents: ChartTagJoin[]
     isBulkImport: boolean
     isTopic: boolean
 }
@@ -177,7 +177,10 @@ class TagEditor extends React.Component<{ tag: TagPageData }> {
                                         <br />
                                         {this.parentTag && (
                                             <TagBadge
-                                                tag={this.parentTag as Tag}
+                                                tag={
+                                                    this
+                                                        .parentTag as ChartTagJoin
+                                                }
                                             />
                                         )}
                                     </div>
@@ -209,7 +212,7 @@ class TagEditor extends React.Component<{ tag: TagPageData }> {
                     <section>
                         <h3>Subcategories</h3>
                         {tag.children.map((c) => (
-                            <TagBadge tag={c as Tag} key={c.id} />
+                            <TagBadge tag={c as ChartTagJoin} key={c.id} />
                         ))}
                     </section>
                 )}

--- a/adminSiteClient/TagsIndexPage.tsx
+++ b/adminSiteClient/TagsIndexPage.tsx
@@ -5,7 +5,8 @@ import * as lodash from "lodash"
 import { Redirect } from "react-router-dom"
 import { AdminLayout } from "./AdminLayout.js"
 import { FieldsRow, Modal, TextField } from "./Forms.js"
-import { TagBadge, Tag } from "./TagBadge.js"
+import { Tag, ChartTagJoin } from "@ourworldindata/utils"
+import { TagBadge } from "./TagBadge.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 
 interface TagListItem {
@@ -143,7 +144,10 @@ export class TagsIndexPage extends React.Component {
                         <section>
                             <h4>Top-Level Categories</h4>
                             {parentCategories.map((parent) => (
-                                <TagBadge key={parent.id} tag={parent as Tag} />
+                                <TagBadge
+                                    key={parent.id}
+                                    tag={parent as ChartTagJoin}
+                                />
                             ))}
                             <button
                                 className="btn btn-default"

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -46,8 +46,8 @@ import {
     OwidVariableWithSource,
     OwidChartDimensionInterface,
     DimensionProperty,
-    Tag,
     TaggableType,
+    ChartTagJoin,
 } from "@ourworldindata/utils"
 import {
     GrapherInterface,
@@ -2616,7 +2616,7 @@ apiRouter.post(
 
 apiRouter.get(
     `/gpt/suggest-topics/${TaggableType.Charts}/:chartId.json`,
-    async (req: Request, res: Response): Promise<Record<"topics", Tag[]>> => {
+    async (req: Request): Promise<Record<"topics", ChartTagJoin[]>> => {
         const chartId = parseIntOrUndefined(req.params.chartId)
         if (!chartId) throw new JsonError(`Invalid chart ID`, 400)
 

--- a/baker/formatWordpressPost.tsx
+++ b/baker/formatWordpressPost.tsx
@@ -275,7 +275,6 @@ export const formatWordpressPost = async (
     const cheerioEl = cheerio.load(html)
 
     // Related charts
-    console.log("post.relatedCharts", post.relatedCharts)
     if (
         !countryProfileSpecs.some(
             (spec) => post.slug === spec.landingPageSlug

--- a/baker/formatWordpressPost.tsx
+++ b/baker/formatWordpressPost.tsx
@@ -275,6 +275,7 @@ export const formatWordpressPost = async (
     const cheerioEl = cheerio.load(html)
 
     // Related charts
+    console.log("post.relatedCharts", post.relatedCharts)
     if (
         !countryProfileSpecs.some(
             (spec) => post.slug === spec.landingPageSlug

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -9,7 +9,7 @@ import {
     OwidGdocType,
     RelatedChart,
     EnrichedBlockAllCharts,
-    traverseEnrichedBlocks,
+    UnwrapPromise,
 } from "@ourworldindata/utils"
 import * as Post from "./model/Post.js"
 import fs from "fs"
@@ -19,7 +19,7 @@ import {
     convertAllWpComponentsToArchieMLBlocks,
     adjustHeadingLevels,
 } from "./model/Gdoc/htmlToEnriched.js"
-import { getRelatedCharts } from "./wpdb.js"
+import { getPostTags, getRelatedCharts } from "./wpdb.js"
 
 // Hard-coded slugs to avoid WP dependency
 // headerMenu.json minus gdoc topic page slugs and wp topic page slugs
@@ -168,16 +168,20 @@ const migrate = async (): Promise<void> => {
         "excerpt",
         "created_at_in_wordpress",
         "updated_at"
-    ).from(db.knexTable(Post.postsTable)) //.where("id", "=", "41094"))
+    ).from(db.knexTable(Post.postsTable).where("id", "=", "29766"))
 
     for (const post of posts) {
         try {
             const isEntry = entries.has(post.slug)
             const text = post.content
             let relatedCharts: RelatedChart[] = []
+            let tags: UnwrapPromise<typeof getPostTags> = []
             if (isEntry) {
                 relatedCharts = await getRelatedCharts(post.id)
+                tags = await getPostTags(post.id)
             }
+
+            console.log("tags", tags)
 
             // We don't get the first and last nodes if they are comments.
             // This can cause issues with the wp:components so here we wrap

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -22,7 +22,7 @@ import {
 import { getRelatedCharts } from "./wpdb.js"
 
 // Hard-coded slugs to avoid WP dependency
-// headerMenu.json - gdoc topic page slugs and wp topic page slugs
+// headerMenu.json minus gdoc topic page slugs and wp topic page slugs
 const entries = new Set([
     "population",
     "population-change",
@@ -202,39 +202,15 @@ const migrate = async (): Promise<void> => {
             // This function iterates all blocks recursively and adjusts the heading levels inline
             adjustHeadingLevels(archieMlBodyElements)
 
-            // Insert automatic all-charts block if no manually-set block is specified
-            // Assume the first heading is after the intro paragraph
             if (relatedCharts.length) {
-                let hasManuallySetAllChartsBlock = false
-                let index = 0
-                let indexOfFirstHeading = -1
-                archieMlBodyElements.forEach((node) =>
-                    traverseEnrichedBlocks(node, (block) => {
-                        if (block.type === "all-charts") {
-                            hasManuallySetAllChartsBlock = true
-                        } else if (
-                            block.type === "heading" &&
-                            indexOfFirstHeading === -1
-                        ) {
-                            indexOfFirstHeading = index
-                        }
-                        index++
-                    })
-                )
-                if (!hasManuallySetAllChartsBlock) {
-                    const allChartsBlock: EnrichedBlockAllCharts = {
-                        type: "all-charts",
-                        parseErrors: [],
-                        heading: `Interactive Charts on ${post.title}`,
-                        top: [],
-                    }
-
-                    archieMlBodyElements.splice(
-                        indexOfFirstHeading,
-                        0,
-                        allChartsBlock
-                    )
+                const allChartsBlock: EnrichedBlockAllCharts = {
+                    type: "all-charts",
+                    parseErrors: [],
+                    heading: `Interactive Charts on ${post.title}`,
+                    top: [],
                 }
+
+                archieMlBodyElements.push(allChartsBlock)
             }
 
             const errors = parsedResult.errors

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -18,6 +18,7 @@ import {
 } from "./model/Gdoc/htmlToEnriched.js"
 
 // Hard-coded slugs to avoid WP dependency
+// headerMenu.json - gdoc topic page slugs and wp topic page slugs
 const entries = new Set([
     "population",
     "population-change",
@@ -163,7 +164,7 @@ const migrate = async (): Promise<void> => {
         "excerpt",
         "created_at_in_wordpress",
         "updated_at"
-    ).from(db.knexTable(Post.postsTable)) //.where("id", "=", "38189")
+    ).from(db.knexTable(Post.postsTable).where("id", "=", "1441"))
 
     for (const post of posts) {
         try {

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -9,7 +9,6 @@ import {
     OwidGdocType,
     RelatedChart,
     EnrichedBlockAllCharts,
-    UnwrapPromise,
 } from "@ourworldindata/utils"
 import * as Post from "./model/Post.js"
 import fs from "fs"
@@ -19,7 +18,7 @@ import {
     convertAllWpComponentsToArchieMLBlocks,
     adjustHeadingLevels,
 } from "./model/Gdoc/htmlToEnriched.js"
-import { getPostTags, getRelatedCharts } from "./wpdb.js"
+import { getRelatedCharts } from "./wpdb.js"
 
 // Hard-coded slugs to avoid WP dependency
 // headerMenu.json minus gdoc topic page slugs and wp topic page slugs
@@ -175,13 +174,9 @@ const migrate = async (): Promise<void> => {
             const isEntry = entries.has(post.slug)
             const text = post.content
             let relatedCharts: RelatedChart[] = []
-            let tags: UnwrapPromise<typeof getPostTags> = []
             if (isEntry) {
                 relatedCharts = await getRelatedCharts(post.id)
-                tags = await getPostTags(post.id)
             }
-
-            console.log("tags", tags)
 
             // We don't get the first and last nodes if they are comments.
             // This can cause issues with the wp:components so here we wrap

--- a/db/model/Gdoc/Gdoc.ts
+++ b/db/model/Gdoc/Gdoc.ts
@@ -8,7 +8,7 @@ import {
     JoinTable,
 } from "typeorm"
 import {
-    OwidGdocTag,
+    Tag as TagInterface,
     LinkedChart,
     type OwidGdocContent,
     OwidGdocInterface,
@@ -64,7 +64,7 @@ import {
 import { getConnection } from "../../db.js"
 
 @Entity("tags")
-export class Tag extends BaseEntity implements OwidGdocTag {
+export class Tag extends BaseEntity implements TagInterface {
     static table = "tags"
     @PrimaryColumn() id!: number
     @Column() name!: string
@@ -72,6 +72,7 @@ export class Tag extends BaseEntity implements OwidGdocTag {
     @Column({ nullable: true }) updatedAt!: Date
     @Column({ nullable: true }) parentId!: number
     @Column() isBulkImport!: boolean
+    @Column() isTopic!: boolean
     @Column() specialType!: string
     @ManyToMany(() => Gdoc, (gdoc) => gdoc.tags)
     gdocs!: Gdoc[]

--- a/db/model/Gdoc/Gdoc.ts
+++ b/db/model/Gdoc/Gdoc.ts
@@ -94,7 +94,7 @@ export class Gdoc extends BaseEntity implements OwidGdocInterface {
         | BreadcrumbItem[]
         | null = null
 
-    @ManyToMany(() => Tag)
+    @ManyToMany(() => Tag, { cascade: true })
     @JoinTable({
         name: "posts_gdocs_x_tags",
         joinColumn: { name: "gdocId", referencedColumnName: "id" },

--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -32,6 +32,9 @@ import {
     checkNodeIsSpanLink,
     Url,
     EnrichedBlockCallout,
+    EnrichedBlockAllCharts,
+    EnrichedBlockExpandableParagraph,
+    EnrichedBlockGraySection,
 } from "@ourworldindata/utils"
 import { match, P } from "ts-pattern"
 import {
@@ -698,6 +701,33 @@ function finishWpComponent(
             return {
                 errors: [error],
                 content: [],
+            }
+        })
+        .with("owid/additional-information", () => {
+            const heading: EnrichedBlockHeading = {
+                type: "heading",
+                level: 2,
+                text: [
+                    {
+                        spanType: "span-simple-text",
+                        text: "Additional information",
+                    },
+                ],
+                parseErrors: [],
+            }
+            const expandableParagraph: EnrichedBlockExpandableParagraph = {
+                type: "expandable-paragraph",
+                items: content.content.slice(1) as OwidEnrichedGdocBlock[],
+                parseErrors: [],
+            }
+            const graySection: EnrichedBlockGraySection = {
+                type: "gray-section",
+                parseErrors: [],
+                items: [heading, expandableParagraph],
+            }
+            return {
+                errors: [],
+                content: [graySection],
             }
         })
         .otherwise(() => {

--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -74,9 +74,22 @@ export function consolidateSpans(
             if (currentBlock === undefined) {
                 currentBlock = block
             } else {
+                const consolidatedValue: Span[] = [...currentBlock.value]
+                // If there's no space between the two blocks, add one
+                const hasSpace =
+                    spansToSimpleString(currentBlock.value).endsWith(" ") ||
+                    spansToSimpleString(block.value).startsWith(" ")
+                if (!hasSpace) {
+                    consolidatedValue.push({
+                        spanType: "span-simple-text",
+                        text: " ",
+                    })
+                }
+                consolidatedValue.push(...block.value)
+
                 currentBlock = {
                     type: "text",
-                    value: [...currentBlock.value, ...block.value],
+                    value: consolidatedValue,
                     parseErrors: [
                         ...currentBlock.parseErrors,
                         ...block.parseErrors,
@@ -832,6 +845,8 @@ function cheerioToArchieML(
                         content: [callout],
                     }
                 } else if (className.includes("pcrm")) {
+                    // pcrm stands for "preliminary collection of relevant material" which was used to designate entries
+                    // that weren't fully polished, but then became a way to create a general-purpose "warning box".
                     const unwrapped = unwrapElementWithContext(element)
                     const first = unwrapped.content[0] as OwidEnrichedGdocBlock
                     const hasHeading = first.type === "heading"

--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -299,10 +299,10 @@ interface ParseContext {
 const wpTagRegex =
     /wp:(?<tag>([\w\/-]+))\s*(?<attributes>{.*})?\s*(?<isVoidElement>\/)?$/
 
-/** Unwraps a CheerioElement in the sense that it applies cheerioelementsToArchieML
-    on the children, returning the result. In effect this "removes" an html element
-    like a div that we don't care about in it's own, and where instead we just want to handle
-    the children. */
+/** Unwraps a CheerioElement in the sense that it applies
+    cheerioElementsToArchieML on the children, returning the result. In effect
+    this "removes" an html element like a div that we don't care about on its
+    own, and where instead we just want to handle the children. */
 function unwrapElement(
     element: CheerioElement,
     context: ParseContext

--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -32,7 +32,6 @@ import {
     checkNodeIsSpanLink,
     Url,
     EnrichedBlockCallout,
-    EnrichedBlockAllCharts,
     EnrichedBlockExpandableParagraph,
     EnrichedBlockGraySection,
 } from "@ourworldindata/utils"

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -31,6 +31,7 @@ export const getTagsByPostId = async (): Promise<
 
     return tagsByPostId
 }
+
 export const setTags = async (
     postId: number,
     tagIds: number[]

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -37,6 +37,7 @@ import {
     IMAGES_DIRECTORY,
     uniqBy,
     OwidGdocType,
+    Tag,
 } from "@ourworldindata/utils"
 import { Topic } from "@ourworldindata/grapher"
 import {
@@ -623,6 +624,16 @@ export const getRelatedCharts = async (
         AND charts.config->>"$.isPublished" = "true"
         ORDER BY title ASC
     `)
+
+export const getPostTags = async (
+    postId: number
+): Promise<Pick<Tag, "id" | "name">[]> => {
+    return await db
+        .knexTable("post_tags")
+        .select("tags.id", "tags.name")
+        .where({ post_id: postId })
+        .join("tags", "tags.id", "=", "post_tags.tag_id")
+}
 
 export const getRelatedChartsForVariable = async (
     variableId: number,

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -104,7 +104,7 @@ export {
     OwidGdocErrorMessageType,
     type OwidGdocLinkJSON,
     type OwidGdocInterface,
-    type OwidGdocTag,
+    type Tag,
     OwidGdocType,
     type OwidGdocStickyNavItem,
     type OwidGdocJSON,
@@ -183,7 +183,8 @@ export {
     type SpanUnderline,
     SubNavId,
     SuggestedChartRevisionStatus,
-    type Tag,
+    type ChartTag,
+    type ChartTagJoin,
     TaggableType,
     type Time,
     type TimeBound,
@@ -220,6 +221,7 @@ export {
     type EnrichedBlockAlign,
     type RawBlockAlign,
     type BreadcrumbItem,
+    type UnwrapPromise,
 } from "./owidTypes.js"
 
 export {

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -221,7 +221,6 @@ export {
     type EnrichedBlockAlign,
     type RawBlockAlign,
     type BreadcrumbItem,
-    type UnwrapPromise,
 } from "./owidTypes.js"
 
 export {

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1608,7 +1608,3 @@ export interface UserCountryInformation {
     slug: string
     regions: string[] | null
 }
-
-/** Extract the return type from a function that returns a promise */
-export type UnwrapPromise<T extends (...args: any) => Promise<any>> =
-    ReturnType<T> extends Promise<infer U> ? U : never

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -194,12 +194,42 @@ export enum KeyChartLevel {
     Top = 3, // chart will show at the top of the all charts block
 }
 
+/** the entity in the `tags` table */
 export interface Tag {
     id: number
     name: string
+    createdAt: Date
+    updatedAt: Date
+    parentId: number
+    isBulkImport: boolean
+    specialType: string
+    isTopic: boolean
+}
+
+/** the entity in the `chart_tags` table */
+export interface ChartTag {
+    id: number
+    tagId: string
     keyChartLevel?: KeyChartLevel
+    createdAt: Date
+    updatedAt: Date | null
     isApproved?: boolean
 }
+
+/** the entity in the `post_tags` table */
+export interface PostTag {
+    post_id: number
+    tag_id: number
+    createdAt: Date
+    updatedAt: Date | null
+}
+
+/**
+ * A common minimal union of the tag entity and the chart_tags table.
+ * Needed if you're using the TagBagde component.
+ */
+export type ChartTagJoin = Pick<Tag, "id" | "name"> &
+    Pick<ChartTag, "isApproved" | "keyChartLevel">
 
 export enum TaggableType {
     Charts = "charts",
@@ -1192,16 +1222,6 @@ export enum OwidGdocPublicationContext {
     listed = "listed",
 }
 
-export interface OwidGdocTag {
-    id: number
-    name: string
-    createdAt: Date
-    updatedAt: Date
-    parentId: number
-    isBulkImport: boolean
-    specialType: string
-}
-
 // A minimal object containing metadata needed for rendering prominent links etc in the client
 export interface LinkedChart {
     originalSlug: string
@@ -1232,7 +1252,7 @@ export interface OwidGdocInterface {
     relatedCharts?: RelatedChart[]
     imageMetadata?: Record<string, ImageMetadata>
     errors?: OwidGdocErrorMessage[]
-    tags?: OwidGdocTag[]
+    tags?: Tag[]
 }
 
 export enum OwidGdocErrorMessageType {
@@ -1588,3 +1608,7 @@ export interface UserCountryInformation {
     slug: string
     regions: string[] | null
 }
+
+/** Extract the return type from a function that returns a promise */
+export type UnwrapPromise<T extends (...args: any) => Promise<any>> =
+    ReturnType<T> extends Promise<infer U> ? U : never

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -225,8 +225,8 @@ export interface PostTag {
 }
 
 /**
- * A common minimal union of the tag entity and the chart_tags table.
- * Needed if you're using the TagBagde component.
+ * A common minimal union of the tags and chart_tags entities.
+ * Used anywhere we're using the TagBadge component.
  */
 export type ChartTagJoin = Pick<Tag, "id" | "name"> &
     Pick<ChartTag, "isApproved" | "keyChartLevel">

--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -80,6 +80,7 @@ export function OwidGdoc({
     year = {${publishedAt?.getFullYear()}},
     note = {${BAKED_BASE_URL}/${slug}}
 }`
+
     const stickyNavLinks = content["sticky-nav"]
 
     return (


### PR DESCRIPTION
Migrating the all charts block from entries into the Gdocs flow.

If we're on an entry with related charts, we add the block to the archie content before the first heading (which we assume to be after any introductory paragraphs)

I needed to handle the pcrm blocks in order to do this, because otherwise it was putting the all-charts block before their h3's, which wasn't right.

There are some newline parsing issues in the `htmlToEnriched` code, but fixing them would require refactoring a bunch of code with unknown consequences so I figured it's best to leave it alone since we'll be able to fix it easily in the gdoc once it's migrated.

## Before:
![qoe before](https://github.com/owid/owid-grapher/assets/11844404/07ab9824-5a66-48ee-9f44-ac386e07ec3e)

## After:
![qoe after](https://github.com/owid/owid-grapher/assets/11844404/862e7586-9a96-4c15-8302-e2167d18938f)


## Extra
I also fixed a little bug where the Preview button on the `/admin/posts` page was navigating to `/admin/posts/gdocs/some_id/preview` instead of `/admin/gdocs/some_id/preview`
![preview button highlight](https://github.com/owid/owid-grapher/assets/11844404/da6a2f35-220c-41c1-b564-4ebf100a3e70)
