### PR TITLE
🐛 remove size suffix from migrated WP image filenames

### DIFF
--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -987,9 +987,13 @@ function cheerioToArchieML(
                             {
                                 type: "image",
                                 // src is the entire path. we only want the filename
-                                filename: path.basename(
-                                    image?.attribs["src"] ?? ""
-                                ),
+                                filename: path
+                                    .basename(image?.attribs["src"] ?? "")
+                                    .replace(
+                                        // removing size suffixes e.g. some_file-1280x840.png -> some_file.png
+                                        /-\d+x\d+\.(png|jpg|jpeg|gif|svg)$/,
+                                        ".$1"
+                                    ),
                                 alt: image?.attribs["alt"] ?? "",
                                 parseErrors: [],
                                 originalWidth: undefined,


### PR DESCRIPTION
Some images are saved in the WP html with dimension data appended to them.

e.g.

`causes-of-death-2048x1024.png`

Which was making its way into the archie, despite the fact that [we only uploaded the source images to WP](https://github.com/owid/owid-grapher/blob/a04b880d763d073fe21153ebc288932895785082/devTools/uploadWordpressImagesToObjStorage/upload-wordpress-images-to-obj-storage.ts#L97) when we backed them up to drive.

The fixes that.