### PR TITLE
Entry Emulator - Edit Notice

### DIFF
--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -736,7 +736,7 @@ function cheerioToArchieML(
         // Special handling for a unique span that we use to mark the first published date
         if (
             span.spanType === "span-simple-text" &&
-            span.text.trim().match(/^This (entry|article) was first published/)
+            span.text.trim().match(/published/)
         ) {
             const callout: EnrichedBlockCallout = {
                 type: "callout",

--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -732,13 +732,29 @@ function cheerioToArchieML(
         unwrapElement(element, context)
 
     const span = cheerioToSpan(element)
-    if (span)
+    if (span) {
+        // Special handling for a unique span that we use to mark the first published date
+        if (
+            span.spanType === "span-simple-text" &&
+            span.text.trim().match(/^This (entry|article) was first published/)
+        ) {
+            const callout: EnrichedBlockCallout = {
+                type: "callout",
+                title: "",
+                text: [{ type: "text", value: [span], parseErrors: [] }],
+                parseErrors: [],
+            }
+            return {
+                errors: [],
+                content: [callout],
+            }
+        }
         return {
             errors: [],
             // TODO: below should be a list of spans and a rich text block
             content: [{ type: "text", value: [span], parseErrors: [] }],
         }
-    else if (element.type === "tag") {
+    } else if (element.type === "tag") {
         context.htmlTagCounts[element.tagName] =
             (context.htmlTagCounts[element.tagName] ?? 0) + 1
         const result: BlockParseResult<ArchieBlockOrWpComponent> = match(


### PR DESCRIPTION
Many of our entries and articles have notices at the beginning saying when they were first published and last updated. 

In our old articles, these sentences were lifted into the article header, but the wp migration was putting them unceremoniously into the article body.

This PR adds code which identifies these phrases and puts them in a callout.

## Before
<img width="634" alt="image" src="https://github.com/owid/owid-grapher/assets/11844404/3f04a95f-7ffa-47a5-9b42-d28f49adb234">


## After
<img width="632" alt="image" src="https://github.com/owid/owid-grapher/assets/11844404/80575934-d4a7-42ff-9f1e-f95fbdbdfd40">
