### PR TITLE
fix(explorer): only set `isReady` after inputTable is fully loaded and transformed

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -570,7 +570,6 @@ export class Explorer
         config.dimensions = dimensions
         if (config.ySlugs && yVariableIds) config.ySlugs += " " + yVariableIds
 
-        grapher._isReadyOverride = false
         grapher.setAuthoredVersion(config)
         grapher.reset()
         this.updateGrapherFromExplorerCommon()
@@ -616,7 +615,6 @@ export class Explorer
         })
 
         this.setGrapherTable(grapherTable)
-        grapher._isReadyOverride = true
     }
 
     @action.bound private updateGrapherFromExplorerUsingColumnSlugs() {

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -570,6 +570,7 @@ export class Explorer
         config.dimensions = dimensions
         if (config.ySlugs && yVariableIds) config.ySlugs += " " + yVariableIds
 
+        grapher._isReadyOverride = false
         grapher.setAuthoredVersion(config)
         grapher.reset()
         this.updateGrapherFromExplorerCommon()
@@ -615,6 +616,7 @@ export class Explorer
         })
 
         this.setGrapherTable(grapherTable)
+        grapher._isReadyOverride = true
     }
 
     @action.bound private updateGrapherFromExplorerUsingColumnSlugs() {

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -570,51 +570,55 @@ export class Explorer
         config.dimensions = dimensions
         if (config.ySlugs && yVariableIds) config.ySlugs += " " + yVariableIds
 
+        const inputTableTransformer = (table: OwidTable) => {
+            // add transformed (and intermediate) columns to the grapher table
+            if (uniqueSlugsInGrapherRow.length) {
+                const allColumnSlugs = uniq(
+                    uniqueSlugsInGrapherRow.flatMap((slug) => [
+                        ...this.getBaseColumnsForColumnWithTransform(slug),
+                        slug,
+                    ])
+                )
+                const existingColumnSlugs = table.columnSlugs
+                const outstandingColumnSlugs = allColumnSlugs.filter(
+                    (slug) => !existingColumnSlugs.includes(slug)
+                )
+                const requiredColumnDefs = outstandingColumnSlugs
+                    .map(
+                        (slug) =>
+                            this.columnDefsWithoutTableSlugByIdOrSlug[slug]
+                    )
+                    .filter(identity)
+                table = table.appendColumns(requiredColumnDefs)
+            }
+
+            // update column definitions with manually provided properties
+            table = table.updateDefs((def: OwidColumnDef) => {
+                const manuallyProvidedDef =
+                    this.columnDefsWithoutTableSlugByIdOrSlug[def.slug] ?? {}
+                const mergedDef = { ...def, ...manuallyProvidedDef }
+
+                // update display properties
+                mergedDef.display = mergedDef.display ?? {}
+                if (manuallyProvidedDef.name)
+                    mergedDef.display.name = manuallyProvidedDef.name
+                if (manuallyProvidedDef.unit)
+                    mergedDef.display.unit = manuallyProvidedDef.unit
+                if (manuallyProvidedDef.shortUnit)
+                    mergedDef.display.shortUnit = manuallyProvidedDef.shortUnit
+
+                return mergedDef
+            })
+            return table
+        }
+
         grapher.setAuthoredVersion(config)
         grapher.reset()
         this.updateGrapherFromExplorerCommon()
         grapher.updateFromObject(config)
-        await grapher.downloadLegacyDataFromOwidVariableIds()
-
-        let grapherTable = grapher.inputTable
-
-        // add transformed (and intermediate) columns to the grapher table
-        if (uniqueSlugsInGrapherRow.length) {
-            const allColumnSlugs = uniq(
-                uniqueSlugsInGrapherRow.flatMap((slug) => [
-                    ...this.getBaseColumnsForColumnWithTransform(slug),
-                    slug,
-                ])
-            )
-            const existingColumnSlugs = grapherTable.columnSlugs
-            const outstandingColumnSlugs = allColumnSlugs.filter(
-                (slug) => !existingColumnSlugs.includes(slug)
-            )
-            const requiredColumnDefs = outstandingColumnSlugs
-                .map((slug) => this.columnDefsWithoutTableSlugByIdOrSlug[slug])
-                .filter(identity)
-            grapherTable = grapherTable.appendColumns(requiredColumnDefs)
-        }
-
-        // update column definitions with manually provided properties
-        grapherTable = grapherTable.updateDefs((def: OwidColumnDef) => {
-            const manuallyProvidedDef =
-                this.columnDefsWithoutTableSlugByIdOrSlug[def.slug] ?? {}
-            const mergedDef = { ...def, ...manuallyProvidedDef }
-
-            // update display properties
-            mergedDef.display = mergedDef.display ?? {}
-            if (manuallyProvidedDef.name)
-                mergedDef.display.name = manuallyProvidedDef.name
-            if (manuallyProvidedDef.unit)
-                mergedDef.display.unit = manuallyProvidedDef.unit
-            if (manuallyProvidedDef.shortUnit)
-                mergedDef.display.shortUnit = manuallyProvidedDef.shortUnit
-
-            return mergedDef
-        })
-
-        this.setGrapherTable(grapherTable)
+        await grapher.downloadLegacyDataFromOwidVariableIds(
+            inputTableTransformer
+        )
     }
 
     @action.bound private updateGrapherFromExplorerUsingColumnSlugs() {

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -574,7 +574,6 @@ export class Explorer
         grapher.reset()
         this.updateGrapherFromExplorerCommon()
         grapher.updateFromObject(config)
-        grapher.forceDisableIntroAnimation = true
         await grapher.downloadLegacyDataFromOwidVariableIds()
 
         let grapherTable = grapher.inputTable

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -399,8 +399,6 @@ export class Grapher
     @observable sortOrder?: SortOrder
     @observable sortColumnSlug?: string
 
-    @observable _isReadyOverride: boolean = true
-
     owidDataset?: MultipleOwidVariableDataDimensionsMap = undefined // This is used for passing data for testing
 
     manuallyProvideData? = false // This will be removed.
@@ -876,7 +874,7 @@ export class Grapher
 
     // Ready to go iff we have retrieved data for every variable associated with the chart
     @computed get isReady(): boolean {
-        return this._isReadyOverride && this.whatAreWeWaitingFor === ""
+        return this.whatAreWeWaitingFor === ""
     }
 
     @computed get whatAreWeWaitingFor(): string {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -399,6 +399,8 @@ export class Grapher
     @observable sortOrder?: SortOrder
     @observable sortColumnSlug?: string
 
+    @observable _isReadyOverride: boolean = true
+
     owidDataset?: MultipleOwidVariableDataDimensionsMap = undefined // This is used for passing data for testing
 
     manuallyProvideData? = false // This will be removed.
@@ -874,7 +876,7 @@ export class Grapher
 
     // Ready to go iff we have retrieved data for every variable associated with the chart
     @computed get isReady(): boolean {
-        return this.whatAreWeWaitingFor === ""
+        return this._isReadyOverride && this.whatAreWeWaitingFor === ""
     }
 
     @computed get whatAreWeWaitingFor(): string {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -398,12 +398,6 @@ export class Grapher
     @observable sortBy?: SortBy
     @observable sortOrder?: SortOrder
     @observable sortColumnSlug?: string
-    // TODO: this is a crude fix that is used to turn off the intro
-    // animation in maps (fading colors in from gray) because
-    // they end up with the wrong target colors (i.e. the colors
-    // are initially correct but then the animation screws them up).
-    // This flag can be removed once the animation bug is properly fixed.
-    @observable forceDisableIntroAnimation: boolean = false
 
     owidDataset?: MultipleOwidVariableDataDimensionsMap = undefined // This is used for passing data for testing
 
@@ -1614,7 +1608,7 @@ export class Grapher
     }
 
     @computed get disableIntroAnimation(): boolean {
-        return this.isExportingtoSvgOrPng || this.forceDisableIntroAnimation
+        return this.isExportingtoSvgOrPng
     }
 
     @computed get mapConfig(): MapConfig {


### PR DESCRIPTION
Fixes #2633, in a different way.

## How does #2633 happen in the first place

There is the `grapher.isReady` property which indicates whether we're ready for rendering: https://github.com/owid/owid-grapher/blob/64753e3738cf19033fda6dd5c651473717950807/packages/%40ourworldindata/grapher/src/core/Grapher.tsx#L881-L901

The way it works is that the property is true once all variables are loaded and available on `inputTable`.

We "await" `isReady` in a very crude way, and only render an interactive grapher once it turns to true: https://github.com/owid/owid-grapher/blob/64753e3738cf19033fda6dd5c651473717950807/packages/%40ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx#L388-L390

However, in the case of indicator-based explorers, we first load the variables and then manually set some properties on `inputTable` afterwards: https://github.com/owid/owid-grapher/blob/64753e3738cf19033fda6dd5c651473717950807/explorer/Explorer.tsx#L578-L618

To be exact:
- Line 578 fetches variables and then updates `inputTable` -> `isReady` turns true after that line
- Line 618 updates `inputTable` again

I _think_ that we have some expectations for `inputTable` to not substantially change after `isReady` fires.

## How I fixed it

I actually put two different ways to fix it here, although one is perhaps more hacky:
- In 92282fbde432af8fed440bc5c4a3189a86b14f7b, I introduced a `_isReadyOverride` property, which can be used to delay the moment when `isReady` "fires" until after the table is fully updated (a bit hacky).
- In 522b329e9a9619765518ab20bc33d5349ba154dd, I introduced an optional `inputTableTransformer` function that can be passed along, and that then can transform the table _before_ it is first assigned to `inputTable`.