### PR TITLE
Grapher redesign: Bug fixes

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -89,6 +89,7 @@ import {
     SeriesStrategy,
     getVariableDataRoute,
     getVariableMetadataRoute,
+    GRAPHER_FRAME_PADDING,
 } from "../core/GrapherConstants"
 import Cookies from "js-cookie"
 import {
@@ -1202,7 +1203,8 @@ export class Grapher
             return new MarkdownTextWrap({
                 text,
                 fontSize: 12,
-                maxWidth: this.idealBounds.width,
+                // leave room for padding on the left and right
+                maxWidth: this.idealBounds.width - 2 * GRAPHER_FRAME_PADDING,
                 lineHeight: 1.2,
                 style: {
                     fill: "#5b5b5b",

--- a/packages/@ourworldindata/grapher/src/footer/Footer.scss
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.scss
@@ -19,7 +19,7 @@
     }
 
     .sources a.learn-more-about-data,
-    .note a {
+    .note a:not(.dod-span) {
         text-decoration: underline;
 
         &:hover {

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
@@ -27,17 +27,24 @@ export interface SourcesModalManager {
 const HtmlOrMarkdownText = (props: {
     text: string
     fontSize: number
+    lineHeight?: number
 }): JSX.Element => {
     // check the text for closing a, li or p tags. If
     // one is found, render using dangerouslySetInnerHTML,
     // othewise use MarkdownTextWrap
-    const { text, fontSize } = props
+    const { text, fontSize, lineHeight } = props
     const htmlRegex = /<\/(a|li|p)>/
     const match = text.match(htmlRegex)
     if (match) {
         return <span dangerouslySetInnerHTML={{ __html: text }} />
     } else {
-        return <MarkdownTextWrap text={text} fontSize={fontSize} />
+        return (
+            <MarkdownTextWrap
+                text={text}
+                fontSize={fontSize}
+                lineHeight={lineHeight}
+            />
+        )
     }
 }
 
@@ -66,6 +73,9 @@ export class SourcesModal extends React.Component<{
         // in columnDefFromOwidVariable in packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
         const { slug, source, def } = column
         const { datasetId, coverage } = def as OwidColumnDef
+
+        const fontSize = 13
+        const lineHeight = 1.3846153846
 
         // there will not be a datasetId for explorers that define the FASTT in TSV
         const editUrl =
@@ -122,8 +132,9 @@ export class SourcesModal extends React.Component<{
                                 <td>Variable description</td>
                                 <td>
                                     <MarkdownTextWrap
-                                        text={column.def.descriptionShort}
-                                        fontSize={12}
+                                        text={column.def.descriptionShort.trim()}
+                                        fontSize={fontSize}
+                                        lineHeight={lineHeight}
                                     />
                                 </td>
                             </tr>
@@ -135,8 +146,9 @@ export class SourcesModal extends React.Component<{
                                 <td>Variable description</td>
                                 <td>
                                     <HtmlOrMarkdownText
-                                        text={column.description}
-                                        fontSize={12}
+                                        text={column.description.trim()}
+                                        fontSize={fontSize}
+                                        lineHeight={lineHeight}
                                     />
                                 </td>
                             </tr>
@@ -165,7 +177,8 @@ export class SourcesModal extends React.Component<{
                                 <td>
                                     <MarkdownTextWrap
                                         text={citationFull[0]}
-                                        fontSize={12}
+                                        fontSize={fontSize}
+                                        lineHeight={lineHeight}
                                     />
                                 </td>
                             </tr>
@@ -183,7 +196,8 @@ export class SourcesModal extends React.Component<{
                                                 <li key={index}>
                                                     <MarkdownTextWrap
                                                         text={citation}
-                                                        fontSize={12}
+                                                        fontSize={fontSize}
+                                                        lineHeight={lineHeight}
                                                     />
                                                 </li>
                                             )
@@ -199,7 +213,8 @@ export class SourcesModal extends React.Component<{
                                 <td>
                                     <HtmlOrMarkdownText
                                         text={source.dataPublishedBy}
-                                        fontSize={12}
+                                        fontSize={fontSize}
+                                        lineHeight={lineHeight}
                                     />
                                 </td>
                             </tr>
@@ -210,7 +225,8 @@ export class SourcesModal extends React.Component<{
                                 <td>
                                     <HtmlOrMarkdownText
                                         text={source.dataPublisherSource}
-                                        fontSize={12}
+                                        fontSize={fontSize}
+                                        lineHeight={lineHeight}
                                     />
                                 </td>
                             </tr>
@@ -221,7 +237,8 @@ export class SourcesModal extends React.Component<{
                                 <td>
                                     <HtmlOrMarkdownText
                                         text={source.link}
-                                        fontSize={12}
+                                        fontSize={fontSize}
+                                        lineHeight={lineHeight}
                                     />
                                 </td>
                             </tr>
@@ -238,7 +255,8 @@ export class SourcesModal extends React.Component<{
                     <p key={"additionalInfo"}>
                         <HtmlOrMarkdownText
                             text={source.additionalInfo}
-                            fontSize={12}
+                            fontSize={fontSize}
+                            lineHeight={lineHeight}
                         />
                     </p>
                 )}


### PR DESCRIPTION
Another set of bug fixes, including:

- updates font size and line height in the Sources modal
- prevent DoDs in the note text to have two underlines
- prevent details rendered at the bottom of static charts to be cut off