### PR TITLE
enhance(explorer): always show an explicit "sort by name" option in explorer entity picker

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -7,6 +7,7 @@ import {
     extractPotentialDataSlugsFromTransform,
     OwidColumnDef,
     OwidTable,
+    OwidTableSlugs,
     SortOrder,
     TableSlug,
 } from "@ourworldindata/core-table"
@@ -1036,7 +1037,9 @@ export class Explorer
             ])
             return allColumnDefs.filter(
                 (def) =>
-                    def.type === undefined || !discardColumnTypes.has(def.type)
+                    (def.type === undefined ||
+                        !discardColumnTypes.has(def.type)) &&
+                    def.slug !== undefined
             )
         }
     }

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -952,14 +952,14 @@ export class Explorer
     })
 
     private updateEntityPickerTable(): void {
-        if (this.entityPickerMetric) {
-            this.entityPickerTableIsLoading = true
-            this.futureEntityPickerTable.set(
-                this.tableLoader.get(
-                    this.getTableSlugOfColumnSlug(this.entityPickerMetric)
-                )
-            )
-        }
+        // If we don't currently have a entity picker metric, then set pickerTable to the currently-used table anyways,
+        // so that when we start sorting by entity name we can infer that the column is a string column immediately.
+        const tableSlugToLoad = this.entityPickerMetric
+            ? this.getTableSlugOfColumnSlug(this.entityPickerMetric)
+            : this.explorerProgram.grapherConfig.tableSlug
+
+        this.entityPickerTableIsLoading = true
+        this.futureEntityPickerTable.set(this.tableLoader.get(tableSlugToLoad))
     }
 
     setEntityPicker({

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -7,7 +7,6 @@ import {
     extractPotentialDataSlugsFromTransform,
     OwidColumnDef,
     OwidTable,
-    OwidTableSlugs,
     SortOrder,
     TableSlug,
 } from "@ourworldindata/core-table"

--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
@@ -21,6 +21,8 @@ import {
     getUserCountryInformation,
     regions,
     sortBy,
+    upperFirst,
+    compact,
 } from "@ourworldindata/utils"
 import { VerticalScrollContainer } from "../../controls/VerticalScrollContainer"
 import { SortIcon } from "../../controls/SortIcon"
@@ -120,8 +122,16 @@ export class EntityPicker extends React.Component<{
         label: string
         value: string | undefined
     }[] {
-        return [
+        const entityNameColumn = this.grapherTable?.entityNameColumn
+        const entityNameColumnInPickerColumnDefs = !!this.pickerColumnDefs.find(
+            (col) => col.slug === entityNameColumn?.slug
+        )
+        return compact([
             { label: "Relevance", value: undefined },
+            !entityNameColumnInPickerColumnDefs && {
+                label: upperFirst(this.manager.entityType) ?? "Name",
+                value: entityNameColumn?.slug,
+            },
             ...this.pickerColumnDefs.map(
                 (
                     col
@@ -135,11 +145,13 @@ export class EntityPicker extends React.Component<{
                     }
                 }
             ),
-        ]
+        ])
     }
 
     private getColumn(slug: ColumnSlug | undefined): CoreColumn | undefined {
         if (slug === undefined) return undefined
+        if (slug === OwidTableSlugs.entityName)
+            return this.manager.grapherTable?.entityNameColumn
         return this.manager.entityPickerTable?.get(slug)
     }
 
@@ -461,12 +473,7 @@ export class EntityPicker extends React.Component<{
     }
 
     private get pickerMenu(): JSX.Element | null {
-        if (
-            this.isDropdownMenu ||
-            !this.manager.entityPickerColumnDefs ||
-            this.manager.entityPickerColumnDefs.length === 0
-        )
-            return null
+        if (this.isDropdownMenu) return null
         return (
             <div className="MetricSettings">
                 <span className="mainLabel">Sort by</span>


### PR DESCRIPTION
Makes it so there's always the option to sort by entity name, even if that's not explicitly specified in `pickerColumnSlugs`.