### PR TITLE
✨ index posts_gdocs.updatedAt

### DIFF
--- a/db/migration/1695651135934-IndexUpdatedAt.ts
+++ b/db/migration/1695651135934-IndexUpdatedAt.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class IndexUpdatedAt1695651135934 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(
+            `ALTER TABLE posts_gdocs ADD INDEX idx_updatedAt (updatedAt);`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(
+            `ALTER TABLE posts_gdocs DROP INDEX idx_updatedAt (updatedAt);`
+        )
+    }
+}


### PR DESCRIPTION
I was encountering issues where the [GdocsIndexPage](https://github.com/owid/owid-grapher/blob/64753e3738cf19033fda6dd5c651473717950807/adminSiteClient/GdocsIndexPage.tsx#L101) wasn't loading for me due to an MySQL sort_buffer overflow:

```json
{
  "code": "ER_OUT_OF_SORTMEMORY",
  "errno": 1038,
  "sqlMessage": "Out of sort memory, consider increasing server sort buffer size",
  "sqlState": "HY001",
  "index": 0
}
```

```sql
 SELECT `Gdoc`.`id`                     AS `Gdoc_id`,
       `Gdoc`.`slug`                    AS `Gdoc_slug`,
       `Gdoc`.`content`                 AS `Gdoc_content`,
       `Gdoc`.`published`               AS `Gdoc_published`,
       `Gdoc`.`publicationcontext`      AS `Gdoc_publicationContext`,
       `Gdoc`.`createdat`               AS `Gdoc_createdAt`,
       `Gdoc`.`publishedat`             AS `Gdoc_publishedAt`,
       `Gdoc`.`updatedat`               AS `Gdoc_updatedAt`,
       `Gdoc`.`revisionid`              AS `Gdoc_revisionId`,
       `Gdoc`.`breadcrumbs`             AS `Gdoc_breadcrumbs`,
       `Gdoc__Gdoc_tags`.`id`           AS `Gdoc__Gdoc_tags_id`,
       `Gdoc__Gdoc_tags`.`name`         AS `Gdoc__Gdoc_tags_name`,
       `Gdoc__Gdoc_tags`.`createdat`    AS `Gdoc__Gdoc_tags_createdAt`,
       `Gdoc__Gdoc_tags`.`updatedat`    AS `Gdoc__Gdoc_tags_updatedAt`,
       `Gdoc__Gdoc_tags`.`parentid`     AS `Gdoc__Gdoc_tags_parentId`,
       `Gdoc__Gdoc_tags`.`isbulkimport` AS `Gdoc__Gdoc_tags_isBulkImport`,
       `Gdoc__Gdoc_tags`.`specialtype`  AS `Gdoc__Gdoc_tags_specialType`
FROM   `posts_gdocs` `Gdoc`
       LEFT JOIN `posts_gdocs_x_tags` `Gdoc_Gdoc__Gdoc_tags`
              ON `Gdoc_Gdoc__Gdoc_tags`.`gdocid` = `Gdoc`.`id`
       LEFT JOIN `tags` `Gdoc__Gdoc_tags`
              ON `Gdoc__Gdoc_tags`.`id` = `Gdoc_Gdoc__Gdoc_tags`.`tagid`
ORDER  BY `Gdoc`.`updatedat` DESC  
```


Adding this index _may_ help fix the problem, though I still intermittently get the issue.

In either case, it's a good idea to index this column seeing as we do an `ORDER BY` on it, but I'll wait to see if there are further optimizations we should make before committing anything.