### PR TITLE
Data table enhancements & layout fixes

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -228,27 +228,24 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
     }
 
     private renderControlsRow(): JSX.Element {
-        const showControls = !this.manager.isOnTableTab
         return (
             <nav className="controlsRow">
                 <ContentSwitchers manager={this.manager} />
-                {showControls && (
-                    <div className="controls">
-                        <EntitySelectorToggle manager={this.manager} />
-                        <SettingsMenu
-                            manager={this.manager}
-                            top={
-                                FRAME_PADDING +
-                                this.header.height +
-                                this.verticalPadding +
-                                CONTROLS_ROW_HEIGHT +
-                                4 // margin between button and menu
-                            }
-                            bottom={FRAME_PADDING}
-                        />
-                        <MapProjectionMenu manager={this.manager} />
-                    </div>
-                )}
+                <div className="controls">
+                    <EntitySelectorToggle manager={this.manager} />
+                    <SettingsMenu
+                        manager={this.manager}
+                        top={
+                            FRAME_PADDING +
+                            this.header.height +
+                            this.verticalPadding +
+                            CONTROLS_ROW_HEIGHT +
+                            4 // margin between button and menu
+                        }
+                        bottom={FRAME_PADDING}
+                    />
+                    <MapProjectionMenu manager={this.manager} />
+                </div>
             </nav>
         )
     }

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -359,6 +359,7 @@ export class Grapher
     /** Hides the total value label that is normally displayed for stacked bar charts */
     @observable.ref hideTotalValueLabel?: boolean = undefined
     @observable.ref missingDataStrategy?: MissingDataStrategy = undefined
+    @observable.ref showSelectionOnlyInDataTable?: boolean = undefined
 
     @observable.ref xAxis = new AxisConfig(undefined, this)
     @observable.ref yAxis = new AxisConfig(undefined, this)

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1998,12 +1998,6 @@ export class Grapher
                 category: "Chart",
             },
             {
-                combo: "space",
-                fn: (): void => this.toggleFullScreenMode(),
-                title: "Toggle full-screen mode",
-                category: "Chart",
-            },
-            {
                 combo: "esc",
                 fn: (): void => this.clearErrors(),
             },

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.scss
@@ -129,7 +129,7 @@
 
                     .description {
                         color: #a1a1a1;
-                        text-align: right;
+                        text-align: left;
                     }
                 }
             }

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -78,6 +78,9 @@ export interface DataTableManager {
     endTime?: Time
     startTime?: Time
     dataTableSlugs?: ColumnSlug[]
+    showSelectionOnlyInDataTable?: boolean
+    isSmall?: boolean
+    isMedium?: boolean
 }
 
 @observer
@@ -85,6 +88,19 @@ export class DataTable extends React.Component<{
     manager?: DataTableManager
     bounds?: Bounds
 }> {
+    transformTable(table: OwidTable): OwidTable {
+        if (this.manager.showSelectionOnlyInDataTable) {
+            table = table.filterByEntityNames(
+                this.selectionArray.selectedEntityNames
+            )
+        }
+        return table
+    }
+
+    @computed get transformedTable(): OwidTable {
+        return this.transformTable(this.manager.table)
+    }
+
     @observable private storedState: DataTableState = {
         sort: DEFAULT_SORT_STATE,
     }
@@ -122,7 +138,7 @@ export class DataTable extends React.Component<{
     }
 
     @computed get table(): OwidTable {
-        return this.inputTable
+        return this.transformedTable
     }
 
     @computed get inputTable(): OwidTable {


### PR DESCRIPTION
This PR adds a UI for #2602 to the Settings menu, fixes an alignment problem in multi-line table headers, and removes the spacebar keyboard shortcut for toggling full-screen mode in the interest of accessibility (i.e., not interfering with the default space/shift-space shortcuts for page-down/page-up)