### PR TITLE
Grapher redesign updates

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -173,8 +173,20 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         return !this.manager.isOnMapTab && hasStrategy
     }
 
-    @computed get showControlsRow(): boolean {
+    @computed get showContentSwitchers(): boolean {
         return (this.manager.availableTabs?.length ?? 0) > 1
+    }
+
+    @computed get showControls(): boolean {
+        return (
+            SettingsMenu.shouldShow(this.manager) ||
+            EntitySelectorToggle.shouldShow(this.manager) ||
+            MapProjectionMenu.shouldShow(this.manager)
+        )
+    }
+
+    @computed get showControlsRow(): boolean {
+        return this.showContentSwitchers || this.showControls
     }
 
     @computed get chartTypeName(): ChartTypeName {
@@ -228,9 +240,12 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
     }
 
     private renderControlsRow(): JSX.Element {
+        const { showContentSwitchers } = this
         return (
             <nav className="controlsRow">
-                <ContentSwitchers manager={this.manager} />
+                {showContentSwitchers && (
+                    <ContentSwitchers manager={this.manager} />
+                )}
                 <div className="controls">
                     <EntitySelectorToggle manager={this.manager} />
                     <SettingsMenu

--- a/packages/@ourworldindata/grapher/src/controls/Controls.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/Controls.tsx
@@ -329,6 +329,7 @@ export class SettingsMenu extends React.Component<{
             showZoomToggle,
             showNoDataAreaToggle,
             showFacetControl,
+            showFacetYDomainToggle,
             showAbsRelToggle,
         } = this
 
@@ -382,14 +383,15 @@ export class SettingsMenu extends React.Component<{
                             showAbsRelToggle ||
                             showZoomToggle ||
                             showNoDataAreaToggle ||
-                            showFacetControl
+                            showFacetControl ||
+                            showFacetYDomainToggle
                         }
                     >
                         {showFacetControl && (
-                            <>
-                                <FacetStrategySelector manager={manager} />
-                                <FacetYDomainToggle manager={manager} />
-                            </>
+                            <FacetStrategySelector manager={manager} />
+                        )}
+                        {showFacetYDomainToggle && (
+                            <FacetYDomainToggle manager={manager} />
                         )}
                         {showAbsRelToggle && <AbsRelToggle manager={manager} />}
                         {showNoDataAreaToggle && (


### PR DESCRIPTION
Additional bugfixes:
- show the Align Axes toggle even if there is only one choice for the current Faceting Mode (meaning the mode switcher is hidden)
- show the controls row if either the ContentSwitcher or ≥1 of the Control elements are visible