### PR TITLE
:bug: show source publishedBy alongside origin.fullCitation

### DIFF
--- a/packages/@ourworldindata/grapher/src/sourcesTab/SourcesTab.tsx
+++ b/packages/@ourworldindata/grapher/src/sourcesTab/SourcesTab.tsx
@@ -97,6 +97,12 @@ export class SourcesTab extends React.Component<{
                       )
                   )
                 : []
+
+        const publishedByArray = [
+            ...(source.dataPublishedBy ? [source.dataPublishedBy] : []),
+            ...citationFull,
+        ]
+
         return (
             <div key={slug} className="datasource-wrapper">
                 <h2>
@@ -151,23 +157,23 @@ export class SourcesTab extends React.Component<{
                                 <td>{column.unitConversionFactor}</td>
                             </tr>
                         ) : null}
-                        {citationFull.length === 1 ? (
+                        {publishedByArray.length === 1 ? (
                             <tr>
                                 <td>Data published by</td>
                                 <td>
                                     <MarkdownTextWrap
-                                        text={citationFull[0]}
+                                        text={publishedByArray[0]}
                                         fontSize={12}
                                     />
                                 </td>
                             </tr>
                         ) : null}
-                        {citationFull.length > 1 ? (
+                        {publishedByArray.length > 1 ? (
                             <tr>
                                 <td>Data published by</td>
                                 <td>
                                     <ul>
-                                        {citationFull.map(
+                                        {publishedByArray.map(
                                             (
                                                 citation: string,
                                                 index: number
@@ -181,18 +187,6 @@ export class SourcesTab extends React.Component<{
                                             )
                                         )}
                                     </ul>
-                                </td>
-                            </tr>
-                        ) : null}
-                        {(!citationFull || citationFull.length === 0) &&
-                        source.dataPublishedBy ? (
-                            <tr>
-                                <td>Data published by</td>
-                                <td>
-                                    <HtmlOrMarkdownText
-                                        text={source.dataPublishedBy}
-                                        fontSize={12}
-                                    />
                                 </td>
                             </tr>
                         ) : null}


### PR DESCRIPTION
If the indicator uses both source and origins, we will show only origins full citation. This became visible when we [started adding population](https://github.com/owid/etl/pull/1528#issuecomment-1733741544) to per-capita indicators. Here's an [example](http://staging-site-mojmir/admin/charts/4466/edit).