### PR TITLE
Grapher redesign: prevent license from wrapping

### DIFF
--- a/packages/@ourworldindata/grapher/src/footer/Footer.scss
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.scss
@@ -32,11 +32,15 @@
         display: inline-block;
     }
 
-    .license a {
-        text-decoration: none;
+    .license {
+        white-space: nowrap;
 
-        &:hover {
-            text-decoration: underline;
+        a {
+            text-decoration: none;
+
+            &:hover {
+                text-decoration: underline;
+            }
         }
     }
 


### PR DESCRIPTION
The license and origin url should never wrap. Since we're not using TextWrap to render the license and origin URL, the license – in rare cases – incorrectly breaks into a second line.
