### PR TITLE
fix(explorer): fix data loading issue in mixed-content explorers

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -461,6 +461,7 @@ export class Explorer
             ...this.explorerProgram.grapherConfigOnlyGrapherProps,
             bakedGrapherURL: BAKED_GRAPHER_URL,
             hideEntityControls: this.showExplorerControls,
+            manuallyProvideData: false,
         }
 
         grapher.setAuthoredVersion(config)
@@ -498,6 +499,7 @@ export class Explorer
             ...this.explorerProgram.grapherConfigOnlyGrapherProps,
             bakedGrapherURL: BAKED_GRAPHER_URL,
             hideEntityControls: this.showExplorerControls,
+            manuallyProvideData: false,
         }
 
         // set given variable IDs as dimensions to make Grapher


### PR DESCRIPTION
Fixes a data loading issue that only happens for mixed-content explorers that use grapher IDs as well as csv data to create charts.

- for csv data charts, `grapher.manuallyProvidedData` is true
- when switching to a grapher id chart, `grapher.manuallyProvidedData` was persisted
- as a result, no data would be downloaded for the chart (since grapher thinks the data is manually provided)