### PR TITLE
Site touchups

### DIFF
--- a/site/gdocs/AllCharts.scss
+++ b/site/gdocs/AllCharts.scss
@@ -1,6 +1,6 @@
 .article-block__all-charts {
     h1.h1-semibold {
-        text-align: center;
+        margin-bottom: 40px;
     }
 
     figure[data-grapher-src] {

--- a/site/gdocs/Footnotes.tsx
+++ b/site/gdocs/Footnotes.tsx
@@ -1,6 +1,7 @@
 import { ENDNOTES_ID, RefDictionary } from "@ourworldindata/utils"
 import React from "react"
 import ArticleBlock from "./ArticleBlock.js"
+import cx from "classnames"
 
 export default function Footnotes({
     definitions,
@@ -10,12 +11,19 @@ export default function Footnotes({
     if (!definitions) {
         return null
     }
+
+    const definitionsArray = Object.values(definitions)
     return (
         <section className="footnote-container grid grid-cols-12-full-width col-start-1 col-end-limit">
             <div className="col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
                 <h3 id={ENDNOTES_ID}>Endnotes</h3>
-                <ol className="footnote-list">
-                    {Object.values(definitions)
+                <ol
+                    className={cx("footnote-list", {
+                        "footnote-list--single-column":
+                            definitionsArray.length === 1,
+                    })}
+                >
+                    {definitionsArray
                         .sort((a, b) => a.index - b.index)
                         .map((ref) => {
                             return (

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -15,11 +15,12 @@
 }
 
 .centered-article-container {
+    // !important because we never want this to be overwritten
     .ref {
-        color: $vermillion;
-        text-decoration: none;
+        color: $vermillion !important;
+        text-decoration: none !important;
         &:visited {
-            color: $vermillion;
+            color: $vermillion !important;
         }
     }
 }

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -329,6 +329,9 @@ h3.article-block__heading.has-supertitle {
     }
     .footnote-list {
         column-count: 2;
+        &.footnote-list--single-column {
+            column-count: 1;
+        }
         column-span: none;
         column-gap: 48px;
         color: $blue-60;

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -502,7 +502,7 @@ h3.article-block__heading.has-supertitle {
 .article-block__explorer {
     // width is necessary for containerNode.getBoundingClientRect() in Grapher.renderGrapherIntoContainer
     width: 100%;
-    margin: 24px 0 48px 0;
+    margin: 16px 0 48px 0;
 
     figure {
         margin: 0;

--- a/site/gdocs/topic-page.scss
+++ b/site/gdocs/topic-page.scss
@@ -178,7 +178,7 @@
     margin-top: 8px;
 }
 
-.article-block__gray-section {
+.centered-article-container--topic-page .article-block__gray-section {
     > h1 {
         // Countering the gray-section padding to make this have 32px 16px
         margin-top: -16px;

--- a/site/gdocs/topic-page.scss
+++ b/site/gdocs/topic-page.scss
@@ -173,12 +173,22 @@
     }
 }
 
+// small amount of extra padding to match figma designs which is 40px total for key-insights heading
+.article-block__heading + .wp-block-owid-key-insights {
+    margin-top: 8px;
+}
+
 .article-block__gray-section {
     > h1 {
-        text-align: center;
         // Countering the gray-section padding to make this have 32px 16px
         margin-top: -16px;
         margin-bottom: 16px;
+
+        // Special exception for the "Explore data on Blah" heading (which is a gdoc .article-block__heading)
+        // so that it's left-aligned like the rest of the topic page component headings
+        &[id^="explore"] {
+            grid-column-start: 2;
+        }
     }
 
     .article-block__text,


### PR DESCRIPTION
A few topic page changes requested by Marwa, and a bug I noticed with refs in the topic page intro.

## topic page intro ref styles
![ref before after](https://github.com/owid/owid-grapher/assets/11844404/db4bd1ad-0982-417b-824a-40b6c0ca7d7c)

## topic page heading alignment
![topic page left-aligned headers](https://github.com/owid/owid-grapher/assets/11844404/c9032532-a9fe-49da-8262-24ceb13228d2)

## endnotes single-column
![image](https://github.com/owid/owid-grapher/assets/11844404/23da237f-a73f-48b5-990c-a6fa54cf7fee)


