### PR TITLE
🎉 obfuscate gdoc links in baked articles

### DIFF
--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -15,10 +15,7 @@ import {
     OwidGdocType,
 } from "@ourworldindata/utils"
 import { CodeSnippet } from "../blocks/CodeSnippet.js"
-import {
-    ADMIN_BASE_URL,
-    BAKED_BASE_URL,
-} from "../../settings/clientSettings.js"
+import { BAKED_BASE_URL } from "../../settings/clientSettings.js"
 import { formatAuthors } from "../clientFormatting.js"
 import { DebugProvider } from "./DebugContext.js"
 import { OwidGdocHeader } from "./OwidGdocHeader.js"
@@ -55,7 +52,6 @@ const citationDescriptionsByArticleType: Record<OwidGdocType, string> = {
 }
 
 export function OwidGdoc({
-    id,
     content,
     publishedAt,
     slug,
@@ -97,19 +93,11 @@ export function OwidGdoc({
         >
             <DocumentContext.Provider value={{ isPreviewing }}>
                 <div id="gdoc-admin-bar">
-                    <a
-                        target="_blank"
-                        rel="noreferrer noopener"
-                        href={`https://docs.google.com/document/d/${id}/edit`}
-                    >
+                    <a href="#" id="gdoc">
                         Gdoc
                     </a>
                     <span>/</span>
-                    <a
-                        target="_blank"
-                        rel="noreferrer noopener"
-                        href={`${ADMIN_BASE_URL}/admin/gdocs/${id}/preview`}
-                    >
+                    <a href="#" id="admin">
                         Admin
                     </a>
                 </div>

--- a/site/owid.entry.ts
+++ b/site/owid.entry.ts
@@ -14,7 +14,11 @@ import { runCountryProfilePage } from "./runCountryProfilePage.js"
 import { runTableOfContents } from "./TableOfContents.js"
 import { runRelatedCharts } from "./blocks/RelatedCharts.js"
 import { Explorer } from "../explorer/Explorer.js"
-import { ENV, BUGSNAG_API_KEY } from "../settings/clientSettings.js"
+import {
+    ENV,
+    BUGSNAG_API_KEY,
+    ADMIN_BASE_URL,
+} from "../settings/clientSettings.js"
 import { Grapher, CookieKey } from "@ourworldindata/grapher"
 import { MultiEmbedderSingleton } from "../site/multiembedder/MultiEmbedder.js"
 import { CoreTable } from "@ourworldindata/core-table"
@@ -98,7 +102,22 @@ try {
         const adminbar = document.getElementById("wpadminbar")
         if (adminbar) adminbar.style.display = ""
         const gdocAdminBar = document.getElementById("gdoc-admin-bar")
-        if (gdocAdminBar) gdocAdminBar.style.display = "initial"
+        if (gdocAdminBar) {
+            gdocAdminBar.style.display = "initial"
+            const id = window._OWID_GDOC_PROPS?.id
+            if (id) {
+                const gdocLink = `https://docs.google.com/document/d/${id}/edit`
+                const adminLink = `${ADMIN_BASE_URL}/admin/gdocs/${id}/preview`
+                const admin = gdocAdminBar.querySelector("#admin")
+                const gdoc = gdocAdminBar.querySelector("#gdoc")
+                if (admin && gdoc) {
+                    admin.setAttribute("href", adminLink)
+                    admin.setAttribute("target", "_blank")
+                    gdoc.setAttribute("href", gdocLink)
+                    gdoc.setAttribute("target", "_blank")
+                }
+            }
+        }
     }
 } catch {}
 


### PR DESCRIPTION
These links aren't confidential, but we've seen a small surge of people asking for permission to view the documents since introducing these admin links. Hopefully removing the URLs directly from the source will help quell that.