### PR TITLE
:bug: fix broken data loading in prod

### DIFF
--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -93,11 +93,11 @@ export function OwidGdoc({
         >
             <DocumentContext.Provider value={{ isPreviewing }}>
                 <div id="gdoc-admin-bar">
-                    <a href="#" id="gdoc">
+                    <a href="#" id="gdoc-link">
                         Gdoc
                     </a>
                     <span>/</span>
-                    <a href="#" id="admin">
+                    <a href="#" id="admin-link">
                         Admin
                     </a>
                 </div>

--- a/site/owid.entry.ts
+++ b/site/owid.entry.ts
@@ -108,8 +108,8 @@ try {
             if (id) {
                 const gdocLink = `https://docs.google.com/document/d/${id}/edit`
                 const adminLink = `${ADMIN_BASE_URL}/admin/gdocs/${id}/preview`
-                const admin = gdocAdminBar.querySelector("#admin")
-                const gdoc = gdocAdminBar.querySelector("#gdoc")
+                const admin = gdocAdminBar.querySelector("#admin-link")
+                const gdoc = gdocAdminBar.querySelector("#gdoc-link")
                 if (admin && gdoc) {
                     admin.setAttribute("href", adminLink)
                     admin.setAttribute("target", "_blank")


### PR DESCRIPTION
Pages that were coming from gdocs recently got a new a link to edit them. This a link had the id #admin. Unfortunately, this means that window.admin in grapher all of a sudden resolves to true on these pages, but this is the [(admittedly poorly constructed) check](https://github.com/owid/owid-grapher/blob/5b26bb0c0e7255b3b4c377df440f71c94e100c65/packages/%40ourworldindata/grapher/src/core/Grapher.tsx#L749) that grapher does to figure out if data should be loaded via the admin or from the data url location.