### PR TITLE
Grapher redesign: Bug fixes and improvements

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.scss
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.scss
@@ -15,15 +15,6 @@ $controlRowHeight: 32px; // keep in sync with CONTROLS_ROW_HEIGHT
     width: 100%;
     display: flex;
     justify-content: space-between;
-
-    button.configure {
-        text-transform: uppercase;
-        color: #777;
-        font-size: 0.8em;
-        height: $controlRowHeight - 1;
-        line-height: $controlRowHeight;
-        padding: 0;
-    }
 }
 
 .relatedQuestion {

--- a/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
@@ -78,21 +78,12 @@ export class ActionButtons extends React.Component<{
         return width + (buttonCount - 1) * PADDING_BETWEEN_BUTTONS
     }
 
-    @computed private get showButtonLabels(): boolean {
-        const { maxWidth, widthWithButtonLabels } = this
-        return widthWithButtonLabels <= maxWidth
-    }
-
-    @computed get width(): number {
+    @computed get widthWithIconsOnly(): number {
         const {
             buttonCount,
-            showButtonLabels,
-            widthWithButtonLabels,
             hasExploreTheDataButton,
             exploreTheDataButtonWidth,
         } = this
-
-        if (showButtonLabels) return widthWithButtonLabels
 
         if (hasExploreTheDataButton) {
             // the "Explore the data" label is always shown
@@ -107,6 +98,17 @@ export class ActionButtons extends React.Component<{
                 (buttonCount - 1) * PADDING_BETWEEN_BUTTONS
             )
         }
+    }
+
+    @computed get showButtonLabels(): boolean {
+        const { maxWidth, widthWithButtonLabels } = this
+        return widthWithButtonLabels <= maxWidth
+    }
+
+    @computed get width(): number {
+        const { showButtonLabels, widthWithButtonLabels, widthWithIconsOnly } =
+            this
+        return showButtonLabels ? widthWithButtonLabels : widthWithIconsOnly
     }
 
     private static computeButtonWidth(label: string): number {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2015,6 +2015,12 @@ export class Grapher
                 category: "Chart",
             },
             {
+                combo: "w",
+                fn: (): void => this.toggleFullScreenMode(),
+                title: `Toggle full-screen mode`,
+                category: "Chart",
+            },
+            {
                 combo: "esc",
                 fn: (): void => this.clearErrors(),
             },

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -112,7 +112,7 @@ $zindex-controls-drawer: 140;
     container-name: grapher;
 
     // use box-shadow instead of border to make sure the border is in the foreground
-    box-shadow: inset 0 0 0 1px $frame-color; // equivalent to `border: 1px solid $frame-color`
+    box-shadow: 0 0 0 1px $frame-color; // equivalent to `border: 1px solid $frame-color`
     z-index: $zindex-chart;
 
     * {

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -185,19 +185,37 @@ export class Footer<
         return !!this.noteText
     }
 
+    @computed private get actionButtonsWidthWithIconsOnly(): number {
+        return new ActionButtons({
+            manager: this.manager,
+            maxWidth: this.maxWidth,
+        }).widthWithIconsOnly
+    }
+
     @computed private get useFullWidthSources(): boolean {
-        const { hasNote, sourcesFontSize, maxWidth, sourcesText } = this
+        const {
+            hasNote,
+            sourcesFontSize,
+            maxWidth,
+            sourcesText,
+            actionButtonsWidthWithIconsOnly,
+        } = this
         if (hasNote) return true
         const sourcesWidth = Bounds.forText(sourcesText, {
             fontSize: sourcesFontSize,
         }).width
-        return sourcesWidth > 2 * maxWidth
+        return sourcesWidth > 2 * (maxWidth - actionButtonsWidthWithIconsOnly)
     }
 
     @computed private get useFullWidthNote(): boolean {
-        const { fontSize, maxWidth, noteText } = this
+        const {
+            fontSize,
+            maxWidth,
+            noteText,
+            actionButtonsWidthWithIconsOnly,
+        } = this
         const noteWidth = Bounds.forText(noteText, { fontSize }).width
-        return noteWidth > 2 * maxWidth
+        return noteWidth > 2 * (maxWidth - actionButtonsWidthWithIconsOnly)
     }
 
     @computed protected get sourcesMaxWidth(): number {

--- a/packages/@ourworldindata/grapher/src/fullScreen/FullScreen.tsx
+++ b/packages/@ourworldindata/grapher/src/fullScreen/FullScreen.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { action } from "mobx"
 import { observer } from "mobx-react"
 import { BodyDiv } from "../bodyDiv/BodyDiv"
+import { GRAPHER_SETTINGS_DRAWER_ID } from "../core/GrapherConstants"
 
 @observer
 export class FullScreen extends React.Component<{
@@ -12,10 +13,15 @@ export class FullScreen extends React.Component<{
     content: React.RefObject<HTMLDivElement> = React.createRef()
 
     @action.bound onDocumentClick(e: React.MouseEvent): void {
-        // check if the click was outside of the modal
+        const settingsDrawer = document.getElementById(
+            GRAPHER_SETTINGS_DRAWER_ID
+        )
         if (
             this.content?.current &&
+            // check if the click was outside of the modal
             !this.content.current.contains(e.target as Node) &&
+            // check if the click was outside of the settings drawer
+            (!settingsDrawer || !settingsDrawer.contains(e.target as Node)) &&
             // check that the target is still mounted to the document; we also get click events on nodes that have since been removed by React
             document.contains(e.target as Node)
         )

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -538,7 +538,7 @@ export enum ChartControlKeyword {
     xLogLinearSelector = "xLogLinearSelector",
     yLogLinearSelector = "yLogLinearSelector",
     mapProjectionMenu = "mapProjectionMenu",
-    tableFilterToggle = "​​tableFilterToggle",
+    tableFilterToggle = "tableFilterToggle",
 }
 
 export enum ChartTabKeyword {


### PR DESCRIPTION
- improve footer layout on smaller screens
- prevent full-screen mode to be exited when interacting with options in settings drawer ([Slack](https://owid.slack.com/archives/C05S2V4D2HZ/p1694698070089929))
- ensure grapher frame is visible at all times