### PR TITLE
Grapher redesign updates (ii2

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/Controls.scss
+++ b/packages/@ourworldindata/grapher/src/controls/Controls.scss
@@ -209,6 +209,16 @@ nav.controlsRow .controls {
             background: rgba(0, 0, 0, 0.2);
             z-index: $zindex-controls-backdrop;
         }
+
+        .config-switch {
+            label > svg {
+                display: none;
+            }
+
+            .config-subtitle {
+                display: block;
+            }
+        }
     }
 
     .settings-menu-contents {
@@ -372,6 +382,10 @@ nav.controlsRow .controls {
                             height: 13px;
                             padding: 0 0.333em;
                         }
+                    }
+
+                    .config-subtitle {
+                        display: none;
                     }
 
                     input {

--- a/packages/@ourworldindata/grapher/src/controls/Controls.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/Controls.tsx
@@ -541,6 +541,7 @@ export class LabeledSwitch extends React.Component<{
                         </Tippy>
                     )}
                 </label>
+                {tooltip && <div className="config-subtitle">{tooltip}</div>}
             </div>
         )
     }


### PR DESCRIPTION
- [x] display on-off switch description in tooltip for dropdown but inlined for drawer 
- [ ] change "Dots sized by" to "Circles sized by" in scatterplots
     - [ ] look into overflow clipping the sidebars in places where they overlap the buttons in the lower right
 - [ ] switch relativeToggle tooltip based on chart type:
     - scatter: annual change
     - line: relative change
     - else: relative vs abs. values
- [ ] dismiss drop-down menu on document clicks
- [ ] hide chart settings when in table view [here](http://staging-site-grapher-redesign/grapher/annual-growth-income-consumption-poorest-vs-total-population?tab=table&country=MLT~CHN~IND~FRA~RUS)
- [ ] don't show table's filter-to-selection toggle if the selection is empty in a scatterplot

- [ ] can the `Edit <entities>` button also special-case the default "countries or regions" to be "countries?"
- [ ] coordinate the label-collapse logic in the controls-row for narrow screens
    - [ ] maybe move Entities menu button into drawer?
    - [ ] prevent content-switchers from ever wrapping
- [ ] why do the map scale bars keep catching hovers while the timeline is being dragged?
