### PR TITLE
🐛 Exclude gdocs with future `publishedAt` dates from baking and atom feed

### DIFF
--- a/db/model/Gdoc/Gdoc.ts
+++ b/db/model/Gdoc/Gdoc.ts
@@ -852,7 +852,10 @@ export class Gdoc extends BaseEntity implements OwidGdocInterface {
         // the database dependent on the mapping function, which is more practical
         // but also makes it less of a source of truth when considered in isolation.
         return Gdoc.find({
-            where: { published: true },
+            where: {
+                published: true,
+                publishedAt: LessThanOrEqual(new Date()),
+            },
             relations: ["tags"],
         }).then((gdocs) =>
             gdocs.filter(

--- a/db/model/Gdoc/Gdoc.ts
+++ b/db/model/Gdoc/Gdoc.ts
@@ -6,6 +6,7 @@ import {
     PrimaryColumn,
     ManyToMany,
     JoinTable,
+    LessThanOrEqual,
 } from "typeorm"
 import {
     OwidGdocTag,
@@ -860,10 +861,14 @@ export class Gdoc extends BaseEntity implements OwidGdocInterface {
         ) as Promise<(OwidGdocPublished & Gdoc)[]>
     }
 
+    /**
+     * Excludes published listed Gdocs with a publication date in the future
+     */
     static async getListedGdocs(): Promise<(Gdoc & OwidGdocPublished)[]> {
         return Gdoc.findBy({
             published: true,
             publicationContext: OwidGdocPublicationContext.listed,
+            publishedAt: LessThanOrEqual(new Date()),
         }) as Promise<(Gdoc & OwidGdocPublished)[]>
     }
 


### PR DESCRIPTION
Encountered an issue where a post that was scheduled for Monday was featured in the atom feed.

This PR as is will fix that from happening (but in general I don't think we should/can schedule posts currently)

If we want to do this properly, we'll need to tighten up the way we handle times with the datepicker. 

Currently our DB is in UTC, but the times that the antd DatePicker chooses seem to be kind of random. The hour varies depending on which day you pick. If we want to schedule posts we'd want to be able to specify this or standardize it with a clearly specified explanation in the UI.

