### PR TITLE
🐛 tighten gdoc regex to not match on sheets links

### DIFF
--- a/packages/@ourworldindata/utils/src/GdocsConstants.ts
+++ b/packages/@ourworldindata/utils/src/GdocsConstants.ts
@@ -8,25 +8,27 @@ export const ENDNOTES_ID = "article-endnotes"
 export const RESEARCH_AND_WRITING_ID = "research-writing"
 
 export const IMAGES_DIRECTORY = "/images/published/"
-// Works for:
-// https://docs.google.com/document/d/abcd1234
-// https://docs.google.com/document/d/abcd1234/
-// https://docs.google.com/document/d/abcd1234/edit
-// https://docs.google.com/document/d/abcd-1234/edit
-// https://docs.google.com/document/u/0/d/abcd-1234/edit
-// https://docs.google.com/document/u/0/d/abcd-1234/edit?usp=sharing
 
-// Excludes:
-// https://docs.google.com/spreadsheets/d/abcd1234
-
+/** Works for:
+ * https://docs.google.com/document/d/abcd1234
+ * https://docs.google.com/document/d/abcd1234/
+ * https://docs.google.com/document/d/abcd1234/edit
+ * https://docs.google.com/document/d/abcd-1234/edit
+ * https://docs.google.com/document/u/0/d/abcd-1234/edit
+ * https://docs.google.com/document/u/0/d/abcd-1234/edit?usp=sharing
+ * Excludes:
+ * https://docs.google.com/spreadsheets/d/abcd1234
+ */
 export const gdocUrlRegex =
     /https:\/\/docs\.google\.com\/document(?:\/u\/\d)?\/d\/([-\w]+)\/?(edit)?#?/
-export const gdocIdRegex = /^[0-9A-Za-z\-_]{44}$/
-// Works for:
-// #dod:text
-// #dod:text-hyphenated
-// #dod:text_underscored
-// #dod:text_underscored-and-hyphenated
-// Duplicated in parser.ts
 
+export const gdocIdRegex = /^[0-9A-Za-z\-_]{44}$/
+
+/** Works for:
+ * #dod:text
+ * #dod:text-hyphenated
+ * #dod:text_underscored
+ * #dod:text_underscored-and-hyphenated
+ * Duplicated in parser.ts
+ */
 export const detailOnDemandRegex = /#dod:([\w\-_]+)/

--- a/packages/@ourworldindata/utils/src/GdocsConstants.ts
+++ b/packages/@ourworldindata/utils/src/GdocsConstants.ts
@@ -16,8 +16,11 @@ export const IMAGES_DIRECTORY = "/images/published/"
 // https://docs.google.com/document/u/0/d/abcd-1234/edit
 // https://docs.google.com/document/u/0/d/abcd-1234/edit?usp=sharing
 
+// Excludes:
+// https://docs.google.com/spreadsheets/d/abcd1234
+
 export const gdocUrlRegex =
-    /https:\/\/docs\.google\.com\/.+?\/d\/([-\w]+)\/?(edit)?#?/
+    /https:\/\/docs\.google\.com\/document(?:\/u\/\d)?\/d\/([-\w]+)\/?(edit)?#?/
 export const gdocIdRegex = /^[0-9A-Za-z\-_]{44}$/
 // Works for:
 // #dod:text


### PR DESCRIPTION
This RegEx was catching a spreadsheet link Hannah had included in the [article on deforestation](https://ourworldindata.org/deforestation) and causing Gdoc validation to complain about linking to an article that hadn't been registered.

This PR updates the RegEx to require the `/document/` resource be specified, and uses a more specific non-capturing group to handle the optional google account information that may be contained in the link.

To test, I extracted all the docs.google.com URLs we have in prod and ran them on [regex101.com](https://regex101.com). The spreadsheet URL was the only one that didn't match.

And here is the link working correctly now:

![image](https://github.com/owid/owid-grapher/assets/11844404/fbb1aa31-2916-41dc-8ff2-dfe447137054)


