### PR TITLE
feat(gdocs): add hide-citation Archie field

### DIFF
--- a/db/model/Gdoc/archieToGdoc.ts
+++ b/db/model/Gdoc/archieToGdoc.ts
@@ -43,7 +43,7 @@ function* owidArticleToArchieMLStringGenerator(
     yield* propertyToArchieMLString("type", article)
     // TODO: inline refs
     yieldMultiBlockPropertyIfDefined("summary", article, article.summary)
-    yieldMultiBlockPropertyIfDefined("citation", article, article.summary)
+    yield* propertyToArchieMLString("hide-citation", article)
     yield* propertyToArchieMLString("cover-image", article)
     yield* propertyToArchieMLString("cover-color", article)
     yield* propertyToArchieMLString("featured-image", article)

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1275,7 +1275,7 @@ export interface OwidGdocContent {
     excerpt?: string
     refs?: { definitions: RefDictionary; errors: OwidGdocErrorMessage[] }
     summary?: EnrichedBlockText[]
-    citation?: EnrichedBlockSimpleText[]
+    "hide-citation"?: boolean
     toc?: TocHeadingWithTitleSupertitle[]
     "cover-image"?: string
     "featured-image"?: string

--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -150,22 +150,24 @@ export function OwidGdoc({
                         <Footnotes definitions={content.refs.definitions} />
                     ) : null}
 
-                    <section
-                        id={CITATION_ID}
-                        className="grid grid-cols-12-full-width col-start-1 col-end-limit"
-                    >
-                        <div className="col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
-                            <h3>Cite this work</h3>
-                            <p>{citationDescription}</p>
-                            <div>
-                                <CodeSnippet code={citationText} />
+                    {!content["hide-citation"] && (
+                        <section
+                            id={CITATION_ID}
+                            className="grid grid-cols-12-full-width col-start-1 col-end-limit"
+                        >
+                            <div className="col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
+                                <h3>Cite this work</h3>
+                                <p>{citationDescription}</p>
+                                <div>
+                                    <CodeSnippet code={citationText} />
+                                </div>
+                                <p>BibTeX citation</p>
+                                <div>
+                                    <CodeSnippet code={bibtex} />
+                                </div>
                             </div>
-                            <p>BibTeX citation</p>
-                            <div>
-                                <CodeSnippet code={bibtex} />
-                            </div>
-                        </div>
-                    </section>
+                        </section>
+                    )}
 
                     <section
                         id={LICENSE_ID}

--- a/site/gdocs/OwidGdocHeader.tsx
+++ b/site/gdocs/OwidGdocHeader.tsx
@@ -92,13 +92,15 @@ function OwidArticleHeader({
                         </div>
                     </div>
                     <div className="span-cols-1 span-sm-cols-2">
-                        <a
-                            href="#article-citation"
-                            className="body-1-regular display-block"
-                        >
-                            <FontAwesomeIcon icon={faBook} />
-                            Cite this article
-                        </a>
+                        {!content["hide-citation"] && (
+                            <a
+                                href="#article-citation"
+                                className="body-1-regular display-block"
+                            >
+                                <FontAwesomeIcon icon={faBook} />
+                                Cite this article
+                            </a>
+                        )}
 
                         <a
                             href="#article-licence"


### PR DESCRIPTION
It doesn't make sense for institutional writing to be cited. This PR adds a `hide-citation` frontmatter field to hide the citation information at the bottom of documents. It also hides the link to that block in the header of articles. 


![Screenshot 2023-10-03 at 15.20.01.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0SFFiIjKuUK6UPYHVe6u/aaa3df16-a2ae-4b03-808b-f1bc698494dd/Screenshot%202023-10-03%20at%2015.20.01.png)

I repurposed the `citation` field, which no longer seemed to be used.

see https://owid.slack.com/archives/C03G5HF66DD/p1696318369852199
