### PR TITLE
fix(gdoc): unstable publication time triggers duplicate Mailchimp newsletter

### DIFF
--- a/adminSiteClient/GdocsDateline.tsx
+++ b/adminSiteClient/GdocsDateline.tsx
@@ -49,6 +49,12 @@ export const GdocsDateline = ({
                         format="ddd, MMM D, YYYY"
                         id="publishedAt"
                         status={publishedAtError?.type}
+                        // The "Today" button has been disabled because it sets
+                        // the time to the current time. This time change makes
+                        // it all the way to the atom feed, which is then
+                        // interpreted by MailChimp's RSS-to-Email as a new
+                        // article.
+                        showToday={false}
                     />
                     <GdocsErrorHelp
                         error={publishedAtError}

--- a/adminSiteClient/GdocsDateline.tsx
+++ b/adminSiteClient/GdocsDateline.tsx
@@ -25,7 +25,7 @@ export const GdocsDateline = ({
     const onChangePublishedAt = (publishedAt: Dayjs | null) => {
         setCurrentGdoc({
             ...gdoc,
-            publishedAt: publishedAt?.utc(true).toDate() || null,
+            publishedAt: publishedAt?.toDate() || null,
         })
     }
 
@@ -45,9 +45,7 @@ export const GdocsDateline = ({
                     <label htmlFor="publishedAt">Publication date</label>
                     <DatePicker
                         onChange={onChangePublishedAt}
-                        value={
-                            publishedAt ? dayjs(publishedAt).local() : undefined
-                        }
+                        value={publishedAt ? dayjs(publishedAt) : undefined}
                         format="ddd, MMM D, YYYY"
                         id="publishedAt"
                         status={publishedAtError?.type}

--- a/adminSiteClient/GdocsPublicationContext.tsx
+++ b/adminSiteClient/GdocsPublicationContext.tsx
@@ -26,13 +26,14 @@ export const GdocsPublicationContext = ({
         <>
             <Row>
                 <Col>
-                    <label htmlFor="publishedAt" className="mr-3">
+                    <label htmlFor="publicationContext" className="mr-3">
                         Publication context
                     </label>
                     <Radio.Group
                         onChange={onChange}
                         value={publicationContext}
                         optionType="button"
+                        id="publicationContext"
                     >
                         <Radio value={OwidGdocPublicationContext.unlisted}>
                             {OwidGdocPublicationContext.unlisted}


### PR DESCRIPTION
Interacting with the gdocs date picker changes the underlying time, in addition to the visible date. This change makes it all the way to the atom feed, which is then interpreted by Mailchimp RSS-to-Email feature as a new article to be sent.

This happens in two instances.

1. Interacting with the date picker calendar, e.g. going from Oct 11, to Oct 10 and back to Oct 11:

```
publishedAt Wed Oct 11 2023 00:59:53 GMT+0100 (British Summer Time)
publishedAt Tue Oct 10 2023 01:59:53 GMT+0100 (British Summer Time)
publishedAt Wed Oct 11 2023 02:59:53 GMT+0100 (British Summer Time)
```

Notice how that third time is now 02:59:53 vs 00:59:53 originally.

2. Pressing the "Today" button sets the time to the current time

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0SFFiIjKuUK6UPYHVe6u/ae75feef-7dba-48dd-8405-56e0246f08e8/image.png)

This PR fixes 1 and removes the "Today" button so that the time remains unchanged from the first publishing event.

see [slack](https://owid.slack.com/archives/C024KJV3L4D/p1696341737523549)