### PR TITLE
enhance: use flexbox to center full screen content

### DIFF
--- a/packages/@ourworldindata/grapher/src/fullScreen/FullScreen.scss
+++ b/packages/@ourworldindata/grapher/src/fullScreen/FullScreen.scss
@@ -5,11 +5,7 @@
     z-index: $zindex-full-screen;
     height: 100%;
     width: 100%;
-
-    .FullScreenContent {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-    }
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }


### PR DESCRIPTION
There is [an issue in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1610093) where our `getRelativeMouse` doesn't properly work in fullscreen mode, because `getScreenCTM()` doesn't factor in any transforms on the element.

Using flexbox fixes this, and in my view it also makes the centering code easier to grasp.