### PR TITLE
enhance(admin): persist entities when changing the chart type

### DIFF
--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -86,7 +86,7 @@ class DimensionSlotView extends React.Component<{
         const { availableEntityNames, availableEntityNameSet } = selection
 
         if (grapher.isScatter || grapher.isSlopeChart || grapher.isMarimekko) {
-            // chart types that display all entities by default shouldn't specifically select any
+            // chart types that display all entities by default shouldn't select any by default
             selection.clearSelection()
         } else if (
             grapher.yColumnsFromDimensions.length > 1 &&
@@ -105,7 +105,7 @@ class DimensionSlotView extends React.Component<{
         } else {
             // stacked charts or charts with a single y-dimension should select multiple entities by default.
             // if possible, the currently selected entities are persisted, otherwise a random sample is selected
-            if (selection.numSelectedEntities === 0) {
+            if (selection.numSelectedEntities <= 1) {
                 selection.setSelectedEntities(
                     availableEntityNames.length > 10
                         ? sampleSize(availableEntityNames, 4)

--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -86,23 +86,32 @@ class DimensionSlotView extends React.Component<{
         const { availableEntityNames, availableEntityNameSet } = selection
 
         if (grapher.isScatter || grapher.isSlopeChart || grapher.isMarimekko) {
+            // chart types that display all entities by default shouldn't specifically select any
             selection.clearSelection()
         } else if (
             grapher.yColumnsFromDimensions.length > 1 &&
             !grapher.isStackedArea &&
             !grapher.isStackedBar
         ) {
-            const entity = availableEntityNameSet.has(WorldEntityName)
-                ? WorldEntityName
-                : sample(availableEntityNames)
-            if (entity) selection.setSelectedEntities([entity])
+            // non-stacked charts with multiple y-dimensions should select a single entity by default.
+            // if possible, the currently selected entity is persisted, otherwise "World" is preferred
+            if (selection.numSelectedEntities !== 1) {
+                const entity = availableEntityNameSet.has(WorldEntityName)
+                    ? WorldEntityName
+                    : sample(availableEntityNames)
+                if (entity) selection.setSelectedEntities([entity])
+            }
             grapher.addCountryMode = EntitySelectionMode.SingleEntity
         } else {
-            selection.setSelectedEntities(
-                availableEntityNames.length > 10
-                    ? sampleSize(availableEntityNames, 4)
-                    : availableEntityNames
-            )
+            // stacked charts or charts with a single y-dimension should select multiple entities by default.
+            // if possible, the currently selected entities are persisted, otherwise a random sample is selected
+            if (selection.numSelectedEntities === 0) {
+                selection.setSelectedEntities(
+                    availableEntityNames.length > 10
+                        ? sampleSize(availableEntityNames, 4)
+                        : availableEntityNames
+                )
+            }
             grapher.addCountryMode = EntitySelectionMode.MultipleEntities
         }
     }


### PR DESCRIPTION
### Problem

- When changing chart types (or adding y-dimensions), a random sample of entities are selected
- Apparently, that's annoying for authors; they would prefer to have entities persisted if possible (see [Slack](https://owid.slack.com/archives/C0149NKLZAM/p1696419244456579))

### Solution

- Only sample entities when none are selected
