### PR TITLE
fix(map-tooltip): show min/max label for correct bin

### DIFF
--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -601,10 +601,7 @@ export class MapChart
                 />
             )
 
-        const {
-            colorScale: { customNumericLabels },
-            tooltipState,
-        } = this
+        const { tooltipState } = this
 
         return (
             <g
@@ -620,7 +617,6 @@ export class MapChart
                         timeSeriesTable={this.inputTable}
                         formatValue={this.formatTooltipValue}
                         manager={this.manager}
-                        customValueLabels={customNumericLabels}
                         colorScaleManager={this}
                         targetTime={this.targetTime}
                     />

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
@@ -209,8 +209,12 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
             yColumn = this.sparklineTable.get(this.mapColumnSlug),
             minVal = min([yColumn.min, yAxisConfig?.min]),
             maxVal = max([yColumn.max, yAxisConfig?.max]),
-            minCustom = isNumber(minVal) && customValueLabels[minVal],
-            maxCustom = isNumber(maxVal) && customValueLabels[maxVal],
+            minCustom =
+                isNumber(minVal) &&
+                this.lineColorScale.getBinForValue(minVal)?.label,
+            maxCustom =
+                isNumber(maxVal) &&
+                this.lineColorScale.getBinForValue(maxVal)?.label,
             useCustom = isString(minCustom) && isString(maxCustom),
             minLabel = useCustom
                 ? minCustom

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
@@ -29,7 +29,6 @@ import { darkenColorForHighContrastText } from "../color/ColorUtils"
 interface MapTooltipProps {
     tooltipState: TooltipState<{ featureId: string; clickable: boolean }>
     manager: MapChartManager
-    customValueLabels: (string | undefined)[]
     colorScaleManager: ColorScaleManager
     formatValue: (d: PrimitiveType) => string
     timeSeriesTable: OwidTable
@@ -188,7 +187,6 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
         const {
             targetTime,
             formatValue,
-            customValueLabels,
             tooltipState: { target, position, fading },
         } = this.props
 


### PR DESCRIPTION
Fixes #2695.

The problem here is that, for the chart mentioned in #2695, we have `max = 1` by chance, and then that makes it so we use `customValueLabels[1]` as a max label.
However, instead we want to use the label for the bin for value 1...