### PR TITLE
🐛 fix Grapher WP ReusableBlock resolver bug

### DIFF
--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -30,7 +30,7 @@ type ReplacerFunction = (
     _match: string,
     _firstPattern: string,
     _offset: number,
-    fullString: string,
+    _fullString: string,
     matches: Record<string, string>
 ) => string
 
@@ -45,12 +45,11 @@ function buildReplacerFunction(
         _match: string,
         _firstPattern: string,
         _offset: number,
-        fullString: string,
+        _fullString: string,
         matches: Record<string, string>
     ) => {
         const block = blocks[matches["id"].toString()]
-        if (block) return block.post_content
-        else return fullString
+        return block ? block.post_content : ""
     }
 }
 


### PR DESCRIPTION
Our WP article "Loneliness and Social Connection" (id: 29766) was referring to a reusable block that doesn't exist `<!-- wp:block {"ref":24797} /-->`

This surfaced a bug with the grapher sync code where this tag was getting resolved to the entire text, which then caused a recursion until the `recursionLevelsRemaining` condition tripped.

Now reusable block tags that have IDs that we can't resolve, simply get replaced with `""`