### PR TITLE
Grapher redesign updates (v)

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,6 @@
         "googleapis": "^108.0.0",
         "handsontable": "^12.3.3",
         "html-to-text": "^8.2.0",
-        "indefinite": "^2.4.3",
         "instantsearch.js": "^4.56.9",
         "js-base64": "^3.7.2",
         "js-cookie": "^3.0.1",

--- a/packages/@ourworldindata/grapher/package.json
+++ b/packages/@ourworldindata/grapher/package.json
@@ -35,6 +35,7 @@
     "decko": "^1.2.0",
     "expr-eval": "^2.0.2",
     "fuzzysort": "^1.1.4",
+    "indefinite": "^2.4.3",
     "js-cookie": "^3.0.1",
     "mobx": "^5.15.7",
     "mobx-formatters": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4921,6 +4921,7 @@ __metadata:
     eslint-plugin-react-hooks: ^4.6.0
     expr-eval: ^2.0.2
     fuzzysort: ^1.1.4
+    indefinite: ^2.4.3
     jest: ^29.7.0
     jest-environment-jsdom: ^29.7.0
     js-cookie: ^3.0.1
@@ -13958,7 +13959,6 @@ __metadata:
     handsontable: ^12.3.3
     html-to-text: ^8.2.0
     http-server: ^14.1.1
-    indefinite: ^2.4.3
     instantsearch.js: ^4.56.9
     jest: ^29.7.0
     jest-environment-jsdom: ^29.7.0


### PR DESCRIPTION
Move a grapher-specific dependency (`indefinite`) into the grapher package rather than keeping it in the repo root.