### PR TITLE
:hammer: we had  a /feed to /atom.xml redirect but were missing /feed/

### DIFF
--- a/baker/redirects.ts
+++ b/baker/redirects.ts
@@ -9,6 +9,7 @@ export const getRedirects = async () => {
     const staticRedirects = [
         // RSS feed
         "/feed /atom.xml 302",
+        "/feed/ /atom.xml 302",
 
         // Entries and blog (we should keep these for a while)
         "/entries / 302",


### PR DESCRIPTION
we had a /feed to /atom.xml redirect but were missing /feed/ to also redirect in that style. When looking at the CF 404 pages we noticed that this url is hit a noticeable number of times.