### PR TITLE
:hammer: make posts_gdocs_links.target TEXT type instead of varchar(2047)

### DIFF
--- a/db/migration/1696940352033-PostsGdocsLinksLongerTargetField.ts
+++ b/db/migration/1696940352033-PostsGdocsLinksLongerTargetField.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class PostsGdocsLinksLongerTargetField1696940352033
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(
+            `ALTER TABLE posts_gdocs_links
+            MODIFY target TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NOT NULL;`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(
+            `ALTER TABLE posts_gdocs_links
+            MODIFY target varchar(2047) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NOT NULL;`
+        )
+    }
+}


### PR DESCRIPTION
We ran into this with this [document](https://docs.google.com/document/d/1vkvQehkmXKV_mS2hFw1COZCGQYxC1aadis1-9WbHN9I/edit) and link

```
https://books.google.co.uk/books?id=hWlZTVgLmAkC&pg=PT172&lpg=PT172&dq=%E2%80%9CI+expect+you%E2%80%99re+keen+to+hear+what+effect+it+had+on+my+health,+this+decision+of+mine+to+leave?+Well,+no+sooner+had+I+left+behind+the+oppressive+atmosphere+of+the+city+and+that+reek+of+smoking+cookers+which+pour+out,+along+with+a+cloud+of+ashes,+all+the+poisonous+fumes+they%E2%80%99ve+accumulated+in+their+interiors+whenever+they%E2%80%99re+started+up,+than+I+noticed+the+change+in+my+condition+at+once.+You+can+imagine+how+much+stronger+I+felt+after+reaching+my+vineyards!+I+fairly+waded+into+my+food+%E2%80%93+talk+about+animals+just+turned+out+on+to+spring+grass!+So+by+now+I+am+quite+my+old+self+again.+That+feeling+of+listlessness,+being+bodily+ill+at+ease+and+mentally+inefficient,+didn%E2%80%99t+last.+I%E2%80%99m+beginning+to+get+down+to+some+whole-hearted+work.%E2%80%9D&source=bl&ots=FMMqRVO131&sig=ACfU3U26fktITfAHHfuJ6IlvxxKKqgh1qQ&hl=en&sa=X&ved=2ahUKEwio9qu78vjwAhUHCsAKHXoCAR8Q6AEwAHoECAIQAw#v=onepage&q=%E2%80%9CI%20expect%20you%E2%80%99re%20keen%20to%20hear%20what%20effect%20it%20had%20on%20my%20health%2C%20this%20decision%20of%20mine%20to%20leave%3F%20Well%2C%20no%20sooner%20had%20I%20left%20behind%20the%20oppressive%20atmosphere%20of%20the%20city%20and%20that%20reek%20of%20smoking%20cookers%20which%20pour%20out%2C%20along%20with%20a%20cloud%20of%20ashes%2C%20all%20the%20poisonous%20fumes%20they%E2%80%99ve%20accumulated%20in%20their%20interiors%20whenever%20they%E2%80%99re%20started%20up%2C%20than%20I%20noticed%20the%20change%20in%20my%20condition%20at%20once.%20You%20can%20imagine%20how%20much%20stronger%20I%20felt%20after%20reaching%20my%20vineyards!%20I%20fairly%20waded%20into%20my%20food%20%E2%80%93%20talk%20about%20animals%20just%20turned%20out%20on%20to%20spring%20grass!%20So%20by%20now%20I%20am%20quite%20my%20old%20self%20again.%20That%20feeling%20of%20listlessness%2C%20being%20bodily%20ill%20at%20ease%20and%20mentally%20inefficient%2C%20didn%E2%80%99t%20last.%20I%E2%80%99m%20beginning%20to%20get%20down%20to%20some%20whole-hearted%20work.%E2%80%9D&f=false
```