### PR TITLE
:tada: Add related research and writing via content graph to data pages

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -15,3 +15,4 @@ wordpress/web/wp/wp-content/**
 wordpress/vendor/**
 packages/@ourworldindata/*/dist/
 dist/
+.vscode/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,9 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
             "type": "node"
         },
         {
@@ -21,6 +24,10 @@
             "request": "launch",
             "name": "Jest Test current file",
             "program": "${workspaceFolder}/node_modules/.bin/jest",
+            "args": [
+                "${fileBasenameNoExtension}.js",
+                "--watch"
+            ],
             "args": [
                 "${fileBasenameNoExtension}.js",
                 "--watch"
@@ -70,7 +77,7 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "type": "node"
+            "type": "node",
         },
         {
             "name": "Run SVGTester",
@@ -79,7 +86,14 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
             "type": "node",
+            "args": [
+                "-g",
+                "367"
+            ]
             "args": [
                 "-g",
                 "367"
@@ -90,7 +104,6 @@
             "program": "${workspaceFolder}/itsJustJavascript/adminSiteServer/app.js",
             "request": "launch",
             "type": "node",
-            "runtimeExecutable": "/home/daniel/.local/share/fnm/node-versions/v18.16.0/installation/bin/node"
         },
         {
             "name": "Attach to node",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,9 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
             "type": "node"
         },
         {
@@ -21,6 +24,10 @@
             "request": "launch",
             "name": "Jest Test current file",
             "program": "${workspaceFolder}/node_modules/.bin/jest",
+            "args": [
+                "${fileBasenameNoExtension}.js",
+                "--watch"
+            ],
             "args": [
                 "${fileBasenameNoExtension}.js",
                 "--watch"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,9 +13,6 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "skipFiles": [
-                "<node_internals>/**"
-            ],
             "type": "node"
         },
         {
@@ -24,10 +21,6 @@
             "request": "launch",
             "name": "Jest Test current file",
             "program": "${workspaceFolder}/node_modules/.bin/jest",
-            "args": [
-                "${fileBasenameNoExtension}.js",
-                "--watch"
-            ],
             "args": [
                 "${fileBasenameNoExtension}.js",
                 "--watch"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -96,7 +96,8 @@
             "name": "Launch admin server",
             "program": "${workspaceFolder}/itsJustJavascript/adminSiteServer/app.js",
             "request": "launch",
-            "type": "node"
+            "type": "node",
+            "runtimeExecutable": "/home/daniel/.local/share/fnm/node-versions/v18.16.0/installation/bin/node"
         },
         {
             "name": "Attach to node",

--- a/Makefile
+++ b/Makefile
@@ -24,23 +24,24 @@ help:
 	@echo 'Available commands:'
 	@echo
 	@echo '  GRAPHER ONLY'
-	@echo '  make up            start dev environment via docker-compose and tmux'
-	@echo '  make down          stop any services still running'
-	@echo '  make refresh       (while up) download a new grapher snapshot and update MySQL'
-	@echo '  make migrate       (while up) run any outstanding db migrations'
-	@echo '  make test          run full suite (except db tests) of CI checks including unit tests'
-	@echo '  make dbtest        run db test suite that needs a running mysql db'
-	@echo '  make svgtest       compare current rendering against reference SVGs'
+	@echo '  make up                start dev environment via docker-compose and tmux'
+	@echo '  make down              stop any services still running'
+	@echo '  make refresh           (while up) download a new grapher snapshot and update MySQL'
+	@echo '  make refresh.pageviews (while up) download and load pageviews from the private datasette instance'
+	@echo '  make migrate           (while up) run any outstanding db migrations'
+	@echo '  make test              run full suite (except db tests) of CI checks including unit tests'
+	@echo '  make dbtest            run db test suite that needs a running mysql db'
+	@echo '  make svgtest           compare current rendering against reference SVGs'
 	@echo
 	@echo '  GRAPHER + WORDPRESS (staff-only)'
-	@echo '  make up.full       start dev environment via docker-compose and tmux'
-	@echo '  make down.full     stop any services still running'
-	@echo '  make refresh.wp    download a new wordpress snapshot and update MySQL'
-	@echo '  make refresh.full  do a full MySQL update of both wordpress and grapher'
+	@echo '  make up.full           start dev environment via docker-compose and tmux'
+	@echo '  make down.full         stop any services still running'
+	@echo '  make refresh.wp        download a new wordpress snapshot and update MySQL'
+	@echo '  make refresh.full      do a full MySQL update of both wordpress and grapher'
 	@echo
 	@echo '  OPS (staff-only)'
-	@echo '  make deploy        Deploy your local site to production'
-	@echo '  make stage         Deploy your local site to staging'
+	@echo '  make deploy            Deploy your local site to production'
+	@echo '  make stage             Deploy your local site to staging'
 	@echo
 
 up: export DEBUG = 'knex:query'
@@ -135,6 +136,10 @@ refresh:
 
 	@echo '==> Updating grapher database'
 	@. ./.env && DATA_FOLDER=tmp-downloads ./devTools/docker/refresh-grapher-data.sh
+
+refresh.pageviews:
+	@echo '==> Refreshing pageviews'
+	yarn && yarn buildTsc && yarn refreshPageviews
 
 refresh.wp:
 	@echo '==> Downloading wordpress data'

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -28,6 +28,7 @@ import {
     getRelatedArticles,
     getRelatedCharts,
     getRelatedChartsForVariable,
+    getRelatedResearchAndWritingForVariable,
     isWordpressAPIEnabled,
     isWordpressDBEnabled,
 } from "../db/wpdb.js"
@@ -272,6 +273,10 @@ export async function renderDataPageV2({
         variableId,
         grapher && "id" in grapher ? [grapher.id as number] : []
     )
+
+    datapageData.relatedResearch =
+        await getRelatedResearchAndWritingForVariable(variableId)
+
     return renderToHtmlPage(
         <DataPageV2
             grapher={grapher}

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -228,7 +228,7 @@ export async function renderDataPageV2({
     }
     const datapageData = await getDatapageDataV2(
         variableMetadata,
-        grapherConfigForVariable ?? {}
+        grapher ?? {}
     )
 
     const firstTopicTag = datapageData.topicTagsLinks?.[0]

--- a/db/migration/1692042923850-AddPostsLinks.ts
+++ b/db/migration/1692042923850-AddPostsLinks.ts
@@ -7,7 +7,7 @@ export class AddPostsLinks1692042923850 implements MigrationInterface {
                 id int NOT NULL AUTO_INCREMENT,
                 sourceId int NOT NULL,
                 target varchar(2047) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NOT NULL,
-                linkType enum('url','grapher','explorer') CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs DEFAULT NULL,
+                linkType enum('url','grapher','explorer', 'gdoc') CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs DEFAULT NULL,
                 componentType varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NOT NULL,
                 text varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NOT NULL,
                 queryString varchar(2047) COLLATE utf8mb4_0900_as_cs NOT NULL,

--- a/db/migration/1692042923850-AddPostsLinks.ts
+++ b/db/migration/1692042923850-AddPostsLinks.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddPostsLinks1692042923850 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`-- sql
+            CREATE TABLE posts_links (
+                id int NOT NULL AUTO_INCREMENT,
+                sourceId int NOT NULL,
+                target varchar(2047) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NOT NULL,
+                linkType enum('url','grapher','explorer') CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs DEFAULT NULL,
+                componentType varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NOT NULL,
+                text varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NOT NULL,
+                queryString varchar(2047) COLLATE utf8mb4_0900_as_cs NOT NULL,
+                hash varchar(2047) COLLATE utf8mb4_0900_as_cs NOT NULL,
+                PRIMARY KEY (id),
+                KEY sourceId (sourceId),
+                CONSTRAINT posts_links_ibfk_1 FOREIGN KEY (sourceId) REFERENCES posts (id)
+                ) ENGINE=InnoDB;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`-- sql
+            DROP TABLE IF EXISTS posts_links;
+        `)
+    }
+}

--- a/db/model/PostLink.ts
+++ b/db/model/PostLink.ts
@@ -1,6 +1,7 @@
 import { Entity, PrimaryGeneratedColumn, Column, BaseEntity } from "typeorm"
 import { formatUrls } from "../../site/formatting.js"
-import { getLinkType, Url, getUrlTarget } from "@ourworldindata/utils"
+import { Url } from "@ourworldindata/utils"
+import { getLinkType, getUrlTarget } from "@ourworldindata/components"
 
 @Entity("posts_links")
 export class PostLink extends BaseEntity {

--- a/db/model/PostLink.ts
+++ b/db/model/PostLink.ts
@@ -1,0 +1,46 @@
+import { Entity, PrimaryGeneratedColumn, Column, BaseEntity } from "typeorm"
+import { formatUrls } from "../../site/formatting.js"
+import { getLinkType, Url, getUrlTarget } from "@ourworldindata/utils"
+
+@Entity("posts_links")
+export class PostLink extends BaseEntity {
+    @PrimaryGeneratedColumn() id!: number
+    // TODO: posts is not a TypeORM but a Knex class so we can't use a TypeORM relationship here yet
+
+    @Column({ type: "int", nullable: false }) sourceId!: number
+
+    @Column() linkType!: "gdoc" | "url" | "grapher" | "explorer"
+    @Column() target!: string
+    @Column() queryString!: string
+    @Column() hash!: string
+    @Column() componentType!: string
+    @Column() text!: string
+
+    static createFromUrl({
+        url,
+        sourceId,
+        text = "",
+        componentType = "",
+    }: {
+        url: string
+        sourceId: number
+        text?: string
+        componentType?: string
+    }): PostLink {
+        const formattedUrl = formatUrls(url)
+        const urlObject = Url.fromURL(formattedUrl)
+        const linkType = getLinkType(formattedUrl)
+        const target = getUrlTarget(formattedUrl)
+        const queryString = urlObject.queryStr
+        const hash = urlObject.hash
+        return PostLink.create({
+            target,
+            linkType,
+            queryString,
+            hash,
+            sourceId,
+            text,
+            componentType,
+        })
+    }
+}

--- a/db/refreshPageviewsFromDatasette.ts
+++ b/db/refreshPageviewsFromDatasette.ts
@@ -8,7 +8,9 @@ async function downloadAndInsertCSV(): Promise<void> {
     const response = await fetch(csvUrl)
 
     if (!response.ok) {
-        throw new Error(`Failed to fetch CSV: ${response.statusText}`)
+        throw new Error(
+            `Failed to fetch CSV: ${response.statusText} from ${csvUrl}`
+        )
     }
 
     const csvText = await response.text()

--- a/db/refreshPageviewsFromDatasette.ts
+++ b/db/refreshPageviewsFromDatasette.ts
@@ -1,0 +1,47 @@
+// index.ts
+import fetch from "node-fetch"
+import Papa from "papaparse"
+import * as db from "./db.js"
+
+async function downloadAndInsertCSV(): Promise<void> {
+    const csvUrl = "http://datasette-private/owid/pageviews.csv?_size=max"
+    const response = await fetch(csvUrl)
+
+    if (!response.ok) {
+        throw new Error(`Failed to fetch CSV: ${response.statusText}`)
+    }
+
+    const csvText = await response.text()
+    const parsedData = Papa.parse(csvText, {
+        header: true,
+    })
+
+    if (parsedData.errors.length > 1) {
+        console.error("Errors while parsing CSV:", parsedData.errors)
+        return
+    }
+
+    const onlyValidRows = [...parsedData.data].filter(
+        (row) => Object.keys(row as any).length === 5
+    ) as any[]
+
+    console.log("Parsed CSV data:", onlyValidRows.length, "rows")
+    console.log("Columns:", parsedData.meta.fields)
+
+    await db.knexRaw("TRUNCATE TABLE pageviews")
+
+    await db.knexInstance().batchInsert("pageviews", onlyValidRows)
+    console.log("CSV data inserted successfully!")
+}
+
+const main = async (): Promise<void> => {
+    try {
+        await downloadAndInsertCSV()
+    } catch (e) {
+        console.error(e)
+    } finally {
+        await db.closeTypeOrmAndKnexConnections()
+    }
+}
+
+main()

--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -299,7 +299,7 @@ const syncPostsToGrapher = async (): Promise<void> => {
             featured_image: post.featured_image || "",
         }
     }) as PostRow[]
-    const postLinks = await dataSource.getRepository(PostLink).find()
+    const postLinks = await PostLink.find()
     const postLinksById = groupBy(postLinks, (link) => link.sourceId)
 
     const linksToAdd: PostLink[] = []

--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -3,15 +3,7 @@
 
 import * as wpdb from "./wpdb.js"
 import * as db from "./db.js"
-import {
-    chunk,
-    differenceOfSets,
-    excludeNullish,
-    groupBy,
-    keyBy,
-    maxBy,
-    PostRow,
-} from "@ourworldindata/utils"
+import { excludeNullish, groupBy, keyBy, PostRow } from "@ourworldindata/utils"
 import { postsTable, select } from "./model/Post.js"
 import { PostLink } from "./model/PostLink.js"
 import { dataSource } from "./dataSource.js"
@@ -112,7 +104,7 @@ export async function buildReusableBlocksResolver(): Promise<BlockResolveFunctio
         replaceReusableBlocksRecursive(content, replacerFunction)
 }
 
-export const postLinkCompareStringGenerator = (item: PostLink) =>
+export const postLinkCompareStringGenerator = (item: PostLink): string =>
     `${item.linkType} - ${item.target} - ${item.hash} - ${item.queryString}`
 
 export function getLinksToAddAndRemoveForPost(

--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -6,7 +6,6 @@ import * as db from "./db.js"
 import { excludeNullish, groupBy, keyBy, PostRow } from "@ourworldindata/utils"
 import { postsTable, select } from "./model/Post.js"
 import { PostLink } from "./model/PostLink.js"
-import { dataSource } from "./dataSource.js"
 
 const zeroDateString = "0000-00-00 00:00:00"
 

--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -151,7 +151,7 @@ export function getLinksToAddAndRemoveForPost(
                 : undefined
         )
     )
-    const linksInDocument = groupBy(
+    const linksInDocument = keyBy(
         [
             ...allHrefs.map((link) => PostLink.createFromUrl(link)),
             ...allSrcs.map((link) => PostLink.createFromUrl(link)),
@@ -165,11 +165,11 @@ export function getLinksToAddAndRemoveForPost(
 
     // This is doing a set difference, but we want to do the set operation on a subset
     // of fields (the ones we stringify into the compare key) while retaining the full
-    // object so that we can e.g. delete efficiently by id later on
+    // object so that we can e.g. delete efficiently by id later on.
     for (const [linkInDocCompareKey, linkInDoc] of Object.entries(
         linksInDocument
     ))
-        if (!(linkInDocCompareKey in linksInDb)) linksToAdd.push(...linkInDoc)
+        if (!(linkInDocCompareKey in linksInDb)) linksToAdd.push(linkInDoc)
     for (const [linkInDbCompareKey, linkInDb] of Object.entries(linksInDb))
         if (!(linkInDbCompareKey in linksInDocument))
             linksToDelete.push(...linkInDb)

--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -308,7 +308,7 @@ const syncPostsToGrapher = async (): Promise<void> => {
         }
     }) as PostRow[]
     const postLinks = await dataSource.getRepository(PostLink).find()
-    const postLinksById = groupBy(postLinks, (link) => link.id)
+    const postLinksById = groupBy(postLinks, (link) => link.sourceId)
 
     const linksToAdd: PostLink[] = []
     const linksToDelete: PostLink[] = []

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -693,7 +693,7 @@ export const getRelatedResearchAndWritingForVariable = async (
                 p.featured_image as thumbnail,
                 coalesce(pv.views_365d, 0) as pageviews,
                 'wordpress' as post_source,
-                (select JSON_ARRAYAGG(t.name)
+                (select coalesce(JSON_ARRAYAGG(t.name), JSON_ARRAY())
                     from post_tags pt
                     join tags t on pt.tag_id = t.id
                     where pt.post_id = p.id
@@ -739,7 +739,7 @@ export const getRelatedResearchAndWritingForVariable = async (
                 p.content ->> '$."featured-image"' as thumbnail,
                 coalesce(pv.views_365d, 0) as pageviews,
                 'gdocs' as post_source,
-                (select JSON_ARRAYAGG(t.name)
+                (select coalesce(JSON_ARRAYAGG(t.name), JSON_ARRAY())
                     from posts_gdocs_x_tags pt
                     join tags t on pt.tagId = t.id
                     where pt.gdocId = p.id

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -690,7 +690,7 @@ export const getRelatedResearchAndWritingForVariable = async (
                 coalesce(csr.chart_id, c.id) as chartId,
                 p.authors as authors,
                 '' as thumbnail, -- TODO: add thumbnail once we have it
-                pv.views_365d as pageviews,
+                coalesce(pv.views_365d, 0) as pageviews,
                 'wordpress' as post_source
             from
                 posts_links pl
@@ -729,7 +729,7 @@ export const getRelatedResearchAndWritingForVariable = async (
                 coalesce(csr.chart_id, c.id) as chartId,
                 p.content ->> '$.authors' as authors,
                 p.content ->> '$."featured-image"' as thumbnail,
-                pv.views_365d as pageviews,
+                coalesce(pv.views_365d, 0) as pageviews,
                 'gdocs' as post_source
             from
                 posts_gdocs_links pl

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -689,7 +689,7 @@ export const getRelatedResearchAndWritingForVariable = async (
                 p.slug as postSlug,
                 coalesce(csr.chart_id, c.id) as chartId,
                 p.authors as authors,
-                '' as thumbnail, -- TODO: add thumbnail once we have it
+                p.featured_image as thumbnail,
                 coalesce(pv.views_365d, 0) as pageviews,
                 'wordpress' as post_source
             from

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "fixPrettierAll": "yarn prettier --write \"**/*.{tsx,ts,jsx,js,json,md,html,css,scss,yml}\"",
         "runRegionsUpdater": "node --enable-source-maps ./itsJustJavascript/devTools/regionsUpdater/update.js",
         "runDbMigrations": "yarn typeorm migration:run -d itsJustJavascript/db/dataSource.js",
+        "refreshPageviews": "node --enable-source-maps ./itsJustJavascript/db/refreshPageviewsFromDatasette.js",
         "revertLastDbMigration": "yarn typeorm migration:revert -d itsJustJavascript/db/dataSource.js",
         "runPostUpdateHook": "node --enable-source-maps ./itsJustJavascript/baker/postUpdatedHook.js",
         "startAdminServer": "node --enable-source-maps ./itsJustJavascript/adminSiteServer/app.js",

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1606,6 +1606,7 @@ export interface DataPageRelatedResearch {
     url: string
     authors: string[]
     imageUrl: string
+    tags: string[]
 }
 
 export interface DataPageRelatedData {

--- a/site/DataPageV2.tsx
+++ b/site/DataPageV2.tsx
@@ -135,6 +135,7 @@ export const DataPageV2 = (props: {
                                     {
                                         datapageData,
                                         faqEntries,
+                                        canonicalUrl,
                                     }
                                 )}`,
                             }}

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -24,12 +24,8 @@ import { AttachmentsContext, DocumentContext } from "./gdocs/OwidGdoc.js"
 import StickyNav from "./blocks/StickyNav.js"
 import cx from "classnames"
 import { DebugProvider } from "./gdocs/DebugContext.js"
-import Image from "./gdocs/Image.js"
 import dayjs from "dayjs"
-import {
-    IMAGE_HOSTING_BUCKET_SUBFOLDER_PATH,
-    IMAGE_HOSTING_CDN_URL,
-} from "../settings/clientSettings.js"
+import { IMAGE_HOSTING_CDN_URL } from "../settings/clientSettings.js"
 declare global {
     interface Window {
         _OWID_DATAPAGEV2_PROPS: DataPageV2ContentFields

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -304,9 +304,16 @@ export const DataPageV2Content = ({
                                                     </figure> */}
                                                     {/* // TODO: switch this to use the Image component and put the required information for the thumbnails into hte attachment context or similar */}
                                                     <img
-                                                        src={encodeURI(
-                                                            `${IMAGE_HOSTING_CDN_URL}/production/${research.imageUrl}`
-                                                        )}
+                                                        src={
+                                                            research.imageUrl &&
+                                                            research.imageUrl.startsWith(
+                                                                "http"
+                                                            )
+                                                                ? research.imageUrl
+                                                                : encodeURI(
+                                                                      `${IMAGE_HOSTING_CDN_URL}/production/${research.imageUrl}`
+                                                                  )
+                                                        }
                                                         alt=""
                                                         className="span-lg-cols-2 span-sm-cols-3"
                                                     />

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -191,6 +191,19 @@ export const DataPageV2Content = ({
         ? `“Data Page: ${datapageData.title}”, part of the following publication: ${datapageData.primaryTopic.citation}. Data adapted from ${producers}. Retrieved from ${canonicalUrl} [online resource]`
         : `“Data Page: ${datapageData.title}”. Our World in Data (${currentYear}). Data adapted from ${producers}. Retrieved from ${canonicalUrl} [online resource]`
 
+    const relatedResearchCandidates = datapageData.relatedResearch
+    const relatedResearch =
+        relatedResearchCandidates.length > 10 //&&
+            ? //datapageData.primaryTopic?.topicTag
+              relatedResearchCandidates.filter((research) =>
+                  research.tags.includes(
+                      datapageData.primaryTopic?.topicTag ?? "Economic Growth"
+                  )
+              )
+            : relatedResearchCandidates
+    // TODO: if there are more than 10 pages and the data page has topic tags, only show then ones that have overlap
+    // TODO: mark topic pages
+
     return (
         <AttachmentsContext.Provider
             value={{
@@ -272,24 +285,22 @@ export const DataPageV2Content = ({
                         />
                     </div>
                     <div className="wrapper">
-                        {datapageData.relatedResearch &&
-                            datapageData.relatedResearch.length > 0 && (
-                                <div className="section-wrapper grid">
-                                    <h2
-                                        className="related-research__title span-cols-3 span-lg-cols-12"
-                                        id="research-and-writing"
-                                    >
-                                        Related research and writing
-                                    </h2>
-                                    <div className="related-research__items grid grid-cols-9 grid-lg-cols-12 span-cols-9 span-lg-cols-12">
-                                        {datapageData.relatedResearch.map(
-                                            (research) => (
-                                                <a
-                                                    href={research.url}
-                                                    key={research.url}
-                                                    className="related-research__item grid grid-cols-4 grid-lg-cols-6 grid-sm-cols-12 span-cols-4 span-lg-cols-6 span-sm-cols-12"
-                                                >
-                                                    {/* <figure>
+                        {relatedResearch && relatedResearch.length > 0 && (
+                            <div className="section-wrapper grid">
+                                <h2
+                                    className="related-research__title span-cols-3 span-lg-cols-12"
+                                    id="research-and-writing"
+                                >
+                                    Related research and writing
+                                </h2>
+                                <div className="related-research__items grid grid-cols-9 grid-lg-cols-12 span-cols-9 span-lg-cols-12">
+                                    {relatedResearch.map((research) => (
+                                        <a
+                                            href={research.url}
+                                            key={research.url}
+                                            className="related-research__item grid grid-cols-4 grid-lg-cols-6 grid-sm-cols-12 span-cols-4 span-lg-cols-6 span-sm-cols-12"
+                                        >
+                                            {/* <figure>
                                                         <Image
                                                             filename={
                                                                 research.imageUrl
@@ -302,41 +313,40 @@ export const DataPageV2Content = ({
                                                             }
                                                         />
                                                     </figure> */}
-                                                    {/* // TODO: switch this to use the Image component and put the required information for the thumbnails into hte attachment context or similar */}
-                                                    <img
-                                                        src={
-                                                            research.imageUrl &&
-                                                            research.imageUrl.startsWith(
-                                                                "http"
-                                                            )
-                                                                ? research.imageUrl
-                                                                : encodeURI(
-                                                                      `${IMAGE_HOSTING_CDN_URL}/production/${research.imageUrl}`
-                                                                  )
-                                                        }
-                                                        alt=""
-                                                        className="span-lg-cols-2 span-sm-cols-3"
-                                                    />
-                                                    <div className="span-cols-3 span-lg-cols-4 span-sm-cols-9">
-                                                        <h3 className="related-article__title">
-                                                            {research.title}
-                                                        </h3>
-                                                        <div className="related-article__authors body-3-medium-italic">
-                                                            {research.authors &&
-                                                                research.authors
-                                                                    .length &&
-                                                                formatAuthors({
-                                                                    authors:
-                                                                        research.authors,
-                                                                })}
-                                                        </div>
-                                                    </div>
-                                                </a>
-                                            )
-                                        )}
-                                    </div>
+                                            {/* // TODO: switch this to use the Image component and put the required information for the thumbnails into hte attachment context or similar */}
+                                            <img
+                                                src={
+                                                    research.imageUrl &&
+                                                    research.imageUrl.startsWith(
+                                                        "http"
+                                                    )
+                                                        ? research.imageUrl
+                                                        : encodeURI(
+                                                              `${IMAGE_HOSTING_CDN_URL}/production/${research.imageUrl}`
+                                                          )
+                                                }
+                                                alt=""
+                                                className="span-lg-cols-2 span-sm-cols-3"
+                                            />
+                                            <div className="span-cols-3 span-lg-cols-4 span-sm-cols-9">
+                                                <h3 className="related-article__title">
+                                                    {research.title}
+                                                </h3>
+                                                <div className="related-article__authors body-3-medium-italic">
+                                                    {research.authors &&
+                                                        research.authors
+                                                            .length &&
+                                                        formatAuthors({
+                                                            authors:
+                                                                research.authors,
+                                                        })}
+                                                </div>
+                                            </div>
+                                        </a>
+                                    ))}
                                 </div>
-                            )}
+                            </div>
+                        )}
                         {!!datapageData.relatedData?.length && (
                             <div className="section-wrapper grid">
                                 <h2

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -282,7 +282,7 @@ export const DataPageV2Content = ({
                                     </h2>
                                     <div className="related-research__items grid grid-cols-9 grid-lg-cols-12 span-cols-9 span-lg-cols-12">
                                         {datapageData.relatedResearch.map(
-                                            (research: any) => (
+                                            (research) => (
                                                 <a
                                                     href={research.url}
                                                     key={research.url}
@@ -298,10 +298,13 @@ export const DataPageV2Content = ({
                                                             {research.title}
                                                         </h3>
                                                         <div className="related-article__authors body-3-medium-italic">
-                                                            {formatAuthors({
-                                                                authors:
-                                                                    research.authors,
-                                                            })}
+                                                            {research.authors &&
+                                                                research.authors
+                                                                    .length &&
+                                                                formatAuthors({
+                                                                    authors:
+                                                                        research.authors,
+                                                                })}
                                                         </div>
                                                     </div>
                                                 </a>

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -196,9 +196,13 @@ export const DataPageV2Content = ({
     const relatedResearch =
         relatedResearchCandidates.length > 10 &&
         datapageData.topicTagsLinks?.length
-            ? relatedResearchCandidates.filter((research) =>
-                  intersection([research.tags, datapageData.topicTagsLinks])
-              )
+            ? relatedResearchCandidates.filter((research) => {
+                  const shared = intersection(
+                      research.tags,
+                      datapageData.topicTagsLinks ?? []
+                  )
+                  return shared.length > 0
+              })
             : relatedResearchCandidates
     // TODO: mark topic pages
 

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -19,6 +19,7 @@ import {
     uniq,
     pick,
     formatAuthors,
+    intersection,
 } from "@ourworldindata/utils"
 import { AttachmentsContext, DocumentContext } from "./gdocs/OwidGdoc.js"
 import StickyNav from "./blocks/StickyNav.js"
@@ -193,15 +194,12 @@ export const DataPageV2Content = ({
 
     const relatedResearchCandidates = datapageData.relatedResearch
     const relatedResearch =
-        relatedResearchCandidates.length > 10 //&&
-            ? //datapageData.primaryTopic?.topicTag
-              relatedResearchCandidates.filter((research) =>
-                  research.tags.includes(
-                      datapageData.primaryTopic?.topicTag ?? "Economic Growth"
-                  )
+        relatedResearchCandidates.length > 10 &&
+        datapageData.topicTagsLinks?.length
+            ? relatedResearchCandidates.filter((research) =>
+                  intersection([research.tags, datapageData.topicTagsLinks])
               )
             : relatedResearchCandidates
-    // TODO: if there are more than 10 pages and the data page has topic tags, only show then ones that have overlap
     // TODO: mark topic pages
 
     return (

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -24,7 +24,12 @@ import { AttachmentsContext, DocumentContext } from "./gdocs/OwidGdoc.js"
 import StickyNav from "./blocks/StickyNav.js"
 import cx from "classnames"
 import { DebugProvider } from "./gdocs/DebugContext.js"
+import Image from "./gdocs/Image.js"
 import dayjs from "dayjs"
+import {
+    IMAGE_HOSTING_BUCKET_SUBFOLDER_PATH,
+    IMAGE_HOSTING_CDN_URL,
+} from "../settings/clientSettings.js"
 declare global {
     interface Window {
         _OWID_DATAPAGEV2_PROPS: DataPageV2ContentFields
@@ -288,8 +293,24 @@ export const DataPageV2Content = ({
                                                     key={research.url}
                                                     className="related-research__item grid grid-cols-4 grid-lg-cols-6 grid-sm-cols-12 span-cols-4 span-lg-cols-6 span-sm-cols-12"
                                                 >
+                                                    {/* <figure>
+                                                        <Image
+                                                            filename={
+                                                                research.imageUrl
+                                                            }
+                                                            shouldLightbox={
+                                                                false
+                                                            }
+                                                            containerType={
+                                                                "thumbnail"
+                                                            }
+                                                        />
+                                                    </figure> */}
+                                                    {/* // TODO: switch this to use the Image component and put the required information for the thumbnails into hte attachment context or similar */}
                                                     <img
-                                                        src={research.imageUrl}
+                                                        src={encodeURI(
+                                                            `${IMAGE_HOSTING_CDN_URL}/production/${research.imageUrl}`
+                                                        )}
                                                         alt=""
                                                         className="span-lg-cols-2 span-sm-cols-3"
                                                     />

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -194,7 +194,7 @@ export const DataPageV2Content = ({
 
     const relatedResearchCandidates = datapageData.relatedResearch
     const relatedResearch =
-        relatedResearchCandidates.length > 10 &&
+        relatedResearchCandidates.length > 3 &&
         datapageData.topicTagsLinks?.length
             ? relatedResearchCandidates.filter((research) => {
                   const shared = intersection(

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -204,6 +204,17 @@ export const DataPageV2Content = ({
                   return shared.length > 0
               })
             : relatedResearchCandidates
+    for (const item of relatedResearch) {
+        // TODO: these are workarounds to not link to the (not really existing) template pages for energy or co2
+        // country profiles but instead to the topic page at the country selector.
+        if (item.url === "/co2-country-profile")
+            item.url =
+                "/co2-and-greenhouse-gas-emissions#co2-and-greenhouse-gas-emissions-country-profiles"
+        else if (item.url === "/energy-country-profile")
+            item.url = "/energy#country-profiles"
+        else if (item.url === "/coronavirus-country-profile")
+            item.url = "/coronavirus#coronavirus-country-profiles"
+    }
     // TODO: mark topic pages
 
     return (

--- a/site/blocks/RelatedCharts.tsx
+++ b/site/blocks/RelatedCharts.tsx
@@ -42,7 +42,24 @@ export const RelatedCharts = ({
 
     useEmbedChart(activeChartIdx, refChartContainer)
 
-    return (
+    const singleChartView = (
+        <div className={RELATED_CHARTS_CLASS_NAME}>
+            <div className="grid grid-cols-12">
+                <div
+                    className="related-charts__chart span-cols-7 span-md-cols-12"
+                    ref={refChartContainer}
+                >
+                    <figure
+                        // Use unique `key` to force React to re-render tree
+                        key={activeChartSlug}
+                        data-grapher-src={`${BAKED_BASE_URL}/grapher/${activeChartSlug}`}
+                    />
+                </div>
+            </div>
+        </div>
+    )
+
+    const multipleChartsView = (
         <div className={RELATED_CHARTS_CLASS_NAME}>
             <div className="grid grid-cols-12">
                 <div className="related-charts__thumbnails span-cols-5 span-md-cols-12">
@@ -91,6 +108,8 @@ export const RelatedCharts = ({
             </div>
         </div>
     )
+
+    return charts.length === 1 ? singleChartView : multipleChartsView
 }
 
 export const runRelatedCharts = (charts: RelatedChart[]) => {


### PR DESCRIPTION
This PR implements #2379. It adds the missing link in our db from wordpress posts to charts that are used there. It then uses this new posts_links table together with the existing posts_gdocs_links table to find the related writing for a data page by going from indciator id -> charts using this indicator -> articles using this indicator.

The posts_links table was modelled on the posts_gdocs_links table as I thought that uniformity is more important than the optimal layout here. Extracting the links is a bit crudely done ATM in that it just uses regex's on the raw html tag instead of parsing the html and querying for a tags. The latter would give us the text content of the content that establishes the links which is probably often useful, but it would complicate and slow down the script. I'd like to hear your opinions on whether this should switch to proper parsing and filling richer information into the DB.

The thumbnail rendering is also a bit ad-hoc. We have an Image component but that one is built for use in gdocs and we need to show thumbnails for both WP posts and Gdocs articles.

To rank related research and writing we use the pageviews table. This is empty by default in dev environments and so this PR adds a make command to refresh pageviews (fetched from datasette-private)

- [ ] ❗ after merging this to production, run the db/syncPostsToGrapher.js script to fill the new relationship table!