### PR TITLE
fix(cf): redirect grapher to lowercase slug

### DIFF
--- a/_routes.json
+++ b/_routes.json
@@ -1,5 +1,5 @@
 {
     "version": 1,
     "include": ["/grapher/*"],
-    "exclude": []
+    "exclude": ["/grapher/embedCharts.js"]
 }

--- a/functions/grapher/[slug].ts
+++ b/functions/grapher/[slug].ts
@@ -7,6 +7,12 @@ export const onRequestGet: PagesFunction = async (context) => {
 
     const slug = params.slug as string
     const url = new URL(request.url)
+
+    // Redirect to lowercase slug
+    if (url.pathname !== url.pathname.toLowerCase()) {
+        return Response.redirect(url.pathname.toLowerCase() + url.search, 301)
+    }
+
     const { search } = url
 
     const grapherPageResp = await env.ASSETS.fetch(url, { redirect: "manual" })

--- a/functions/grapher/[slug].ts
+++ b/functions/grapher/[slug].ts
@@ -8,14 +8,16 @@ export const onRequestGet: PagesFunction = async (context) => {
     const slug = params.slug as string
     const url = new URL(request.url)
 
-    // Redirect to lowercase slug
+    // All our grapher slugs are lowercase by convention.
+    // To allow incoming links that may contain uppercase characters to work, we redirect to the lowercase version.
+    // We do this before we even know that the page exists, so even if we redirect it might still be a 404, or go into another redirect.
     if (
         url.pathname !== url.pathname.toLowerCase() &&
         url.pathname !== "/grapher/embedCharts.js"
     ) {
         const redirUrl = url.pathname.toLowerCase() + url.search
         return new Response(null, {
-            status: 301,
+            status: 302,
             headers: { Location: redirUrl },
         })
     }

--- a/functions/grapher/[slug].ts
+++ b/functions/grapher/[slug].ts
@@ -10,7 +10,11 @@ export const onRequestGet: PagesFunction = async (context) => {
 
     // Redirect to lowercase slug
     if (url.pathname !== url.pathname.toLowerCase()) {
-        return Response.redirect(url.pathname.toLowerCase() + url.search, 301)
+        const redirUrl = url.pathname.toLowerCase() + url.search
+        return new Response(null, {
+            status: 301,
+            headers: { Location: redirUrl },
+        })
     }
 
     const { search } = url

--- a/functions/grapher/[slug].ts
+++ b/functions/grapher/[slug].ts
@@ -9,7 +9,10 @@ export const onRequestGet: PagesFunction = async (context) => {
     const url = new URL(request.url)
 
     // Redirect to lowercase slug
-    if (url.pathname !== url.pathname.toLowerCase()) {
+    if (
+        url.pathname !== url.pathname.toLowerCase() &&
+        url.pathname !== "/grapher/embedCharts.js"
+    ) {
         const redirUrl = url.pathname.toLowerCase() + url.search
         return new Response(null, {
             status: 301,


### PR DESCRIPTION
Always redirect incoming grapher URL requests that contain any uppercase letters to the lowercase version.

We do this even though we don't even know whether the page exists, so this might still end up in a 404.