### PR TITLE
redesign: render thumbnails at a larger font size

### DIFF
--- a/functions/_common/grapherRenderer.ts
+++ b/functions/_common/grapherRenderer.ts
@@ -46,7 +46,7 @@ const TWITTER_OPTIONS: ImageOptions = {
     svgWidth: 800,
     svgHeight: 418,
     details: false,
-    fontSize: 24,
+    fontSize: 21,
 }
 
 const OPEN_GRAPH_OPTIONS: ImageOptions = {
@@ -56,7 +56,7 @@ const OPEN_GRAPH_OPTIONS: ImageOptions = {
     svgWidth: 800,
     svgHeight: 418,
     details: false,
-    fontSize: 24,
+    fontSize: 21,
 }
 
 let initialized = false
@@ -160,6 +160,7 @@ async function fetchAndRenderGrapherToSvg({
         queryStr: "?" + searchParams.toString(),
         bounds,
     })
+    grapher.isGeneratingThumbnail = true
     grapher.shouldIncludeDetailsInStaticExport = options.details
     grapher.baseFontSize = options.fontSize
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -760,6 +760,8 @@ export class Grapher
     }
 
     @observable.ref isExportingtoSvgOrPng = false
+    @observable.ref isGeneratingThumbnail = false
+
     tooltips?: TooltipManager["tooltips"] = observable.map({}, { deep: false })
     @observable isPlaying = false
     @observable.ref isSelectingData = false

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -649,6 +649,10 @@ export class StaticFooter extends Footer<StaticFooterProps> {
     }
 
     @computed protected get fontSize(): number {
+        // respect base font size for thumbnails
+        if (this.manager.isGeneratingThumbnail) {
+            return (13 / 16) * (this.manager.fontSize ?? 16)
+        }
         return 13
     }
 

--- a/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
+++ b/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
@@ -14,4 +14,6 @@ export interface FooterManager extends TooltipManager, ActionButtonsManager {
     isSmall?: boolean
     isMedium?: boolean
     framePaddingHorizontal?: number
+    isGeneratingThumbnail?: boolean
+    fontSize?: number
 }

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -99,7 +99,9 @@ export class Header<
     }
 
     @computed get subtitle(): MarkdownTextWrap {
-        const fontSize = this.manager.isSmall
+        const fontSize = this.manager.isGeneratingThumbnail
+            ? (14 / 16) * (this.manager.fontSize ?? 16) // respect base font size for thumbnails
+            : this.manager.isSmall
             ? 12
             : this.manager.isMedium
             ? 13
@@ -205,7 +207,7 @@ interface StaticHeaderProps extends HeaderProps {
 @observer
 export class StaticHeader extends Header<StaticHeaderProps> {
     @computed get title(): TextWrap {
-        const { logoWidth, titleText } = this
+        const { logoWidth, titleText, manager } = this
 
         const makeTitle = (fontSize: number): TextWrap =>
             new TextWrap({
@@ -217,7 +219,9 @@ export class StaticHeader extends Header<StaticHeaderProps> {
             })
 
         // try to fit the title into a single line if possible-- but not if it would make the text too small
-        const initialFontSize = 24
+        const initialFontSize = manager.isGeneratingThumbnail
+            ? (24 / 16) * (manager.fontSize ?? 16) // respect base font size for thumbnails
+            : 24
         let title = makeTitle(initialFontSize)
         const originalLineCount = title.lines.length
         // decrease the initial font size by no more than 2px using 0.5px steps

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -223,11 +223,15 @@ export class StaticHeader extends Header<StaticHeaderProps> {
             ? (24 / 16) * (manager.fontSize ?? 16) // respect base font size for thumbnails
             : 24
         let title = makeTitle(initialFontSize)
+
+        // if the title is already a single line, no need to decrease font size
+        if (title.lines.length <= 1) return title
+
         const originalLineCount = title.lines.length
-        // decrease the initial font size by no more than 2px using 0.5px steps
+        // decrease the initial font size by no more than 20% using 0.5px steps
         const potentialFontSizes = range(
             initialFontSize,
-            initialFontSize - 2.5,
+            initialFontSize * 0.8,
             -0.5
         )
         for (const fontSize of potentialFontSizes) {
@@ -236,12 +240,8 @@ export class StaticHeader extends Header<StaticHeaderProps> {
             if (currentLineCount <= 1 || currentLineCount < originalLineCount)
                 break
         }
-
-        // if decreasing the font size didn't make a difference, use the initial font size
-        if (title.lines.length === originalLineCount) {
-            return makeTitle(initialFontSize)
-        }
-
+        // return the title at the new font size: either it now fits into a single line, or
+        // its size has been reduced so the multi-line title doesn't take up quite that much space
         return title
     }
 

--- a/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
+++ b/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
@@ -18,4 +18,6 @@ export interface HeaderManager {
     framePaddingVertical?: number
     isOnCanonicalUrl?: boolean
     isInIFrame?: boolean
+    isGeneratingThumbnail?: boolean
+    fontSize?: number
 }


### PR DESCRIPTION
@sophiamersmann, if you could take a look at 0a312618ad9df3f802b74246580e2caec9e084da for a moment that would be great.

Basically, the rationale is that if a title spans two or more lines, then we benefit from the font size reduction even if that doesn't reduce the number of lines.
I also changed the font size reduction to a maximum of 20% rather than cap it at 2px. It's just another arbitrary number, so feel free to change.

In theory we could also make this behavior dependent on the `isGeneratingThumbnail` flag, so let me know what you think.


Here are some thumbnails rendered using the worker. The last three have a reduced title font size.
![image](https://github.com/owid/owid-grapher/assets/2641501/581afdd8-553c-4cbc-b7dc-e1a0b2d5181c)
![image](https://github.com/owid/owid-grapher/assets/2641501/9cdeccd2-4bb9-4886-944c-ce33d7b48b14)
![image](https://github.com/owid/owid-grapher/assets/2641501/1e79898a-c10c-4507-868e-fddbc3f6da96)
![image](https://github.com/owid/owid-grapher/assets/2641501/820a9140-4bee-4ab5-910a-d7b9e340c149)
