### PR TITLE
Grapher redesign updates (vii)

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
@@ -226,13 +226,20 @@ export class SettingsMenu extends React.Component<{
     }
 
     componentDidMount(): void {
+        document.addEventListener("keydown", this.onDocumentKeyDown)
         document.addEventListener("click", this.onDocumentClick, {
             capture: true,
         })
     }
 
     componentWillUnmount(): void {
+        document.removeEventListener("keydown", this.onDocumentKeyDown)
         document.removeEventListener("click", this.onDocumentClick)
+    }
+
+    @action.bound onDocumentKeyDown(e: KeyboardEvent): void {
+        // dismiss menu on esc
+        if (this.active && e.key === "Escape") this.toggleVisibility()
     }
 
     @action.bound onDocumentClick(e: MouseEvent): void {

--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
@@ -51,9 +51,9 @@ export interface SettingsMenuManager
         ZoomToggleManager,
         TableFilterToggleManager,
         FacetStrategySelectionManager {
-    base?: React.RefObject<SVGGElement | HTMLDivElement> // the root grapher element
     showConfigurationDrawer?: boolean
     isInIFrame?: boolean
+    isEmbeddedInAnOwidPage?: boolean
 
     // ArchieML directives
     hideFacetControl?: boolean
@@ -273,12 +273,12 @@ export class SettingsMenu extends React.Component<{
     }
 
     @computed get drawer(): Element | null {
-        const { isInIFrame, base } = this.manager,
-            isInRelatedCharts = !!base?.current?.closest(".related-charts")
-        // use the drawer `<nav>` element if it exists unless this is an embed or
-        // a related-charts entry, otherwise render into a drop-down menu
-        return isInIFrame || isInRelatedCharts
-            ? null // also use a drop-down menu within the Related Charts section
+        const { isInIFrame, isEmbeddedInAnOwidPage } = this.manager
+        // Use the drawer `<nav>` element if it exists in the page markup (as it does on grapher and data pages)
+        // unless this is an external embed or an internal one (e.g., in the data page's Related Charts block).
+        // Otherwise, render into a drop-down menu.
+        return isInIFrame || isEmbeddedInAnOwidPage
+            ? null
             : document.querySelector(`nav#${GRAPHER_SETTINGS_DRAWER_ID}`)
     }
 

--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
@@ -53,6 +53,7 @@ export interface SettingsMenuManager
         FacetStrategySelectionManager {
     base?: React.RefObject<SVGGElement | HTMLDivElement> // the root grapher element
     showConfigurationDrawer?: boolean
+    isInIFrame?: boolean
 
     // ArchieML directives
     hideFacetControl?: boolean
@@ -265,8 +266,11 @@ export class SettingsMenu extends React.Component<{
     }
 
     @computed get drawer(): Element | null {
-        // use the drawer `<nav>` element if it exists, otherwise render into a drop-down menu
-        return this.manager.base?.current?.closest(".related-charts")
+        const { isInIFrame, base } = this.manager,
+            isInRelatedCharts = !!base?.current?.closest(".related-charts")
+        // use the drawer `<nav>` element if it exists unless this is an embed or
+        // a related-charts entry, otherwise render into a drop-down menu
+        return isInIFrame || isInRelatedCharts
             ? null // also use a drop-down menu within the Related Charts section
             : document.querySelector(`nav#${GRAPHER_SETTINGS_DRAWER_ID}`)
     }


### PR DESCRIPTION
Some final(?) tweaks:
- detect when the page is an embed rendering inside an iframe and use the pop-up settings menu
   - use the `isEmbeddedInAnOwidPage` flag to detect entries in Related Charts blocks rather than walking the DOM
- add a shortcut to dismiss an open menu/drawer with the escape key