### PR TITLE
:sparkles: Add link/unlink button for the subtitle in the chart admin

### DIFF
--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -238,7 +238,7 @@ export class ChartEditorPage
     // these may point to non-existent details e.g. ["not_a_real_term", "pvotery"]
     @computed get currentDetailReferences() {
         return {
-            subtitle: extractDetailsFromSyntax(this.grapher.subtitle),
+            subtitle: extractDetailsFromSyntax(this.grapher.currentSubtitle),
             note: extractDetailsFromSyntax(this.grapher.note),
         }
     }

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -17,6 +17,7 @@ import { ChartEditor } from "./ChartEditor.js"
 import {
     AutoTextField,
     BindAutoString,
+    BindAutoStringExt,
     BindString,
     Button,
     RadioGroup,
@@ -155,8 +156,11 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
                         }
                         helpText="Human-friendly URL for this chart"
                     />
-                    <BindString
-                        field="subtitle"
+                    <BindAutoStringExt
+                        label={"Subtitle"}
+                        readFn={(g) => g.currentSubtitle}
+                        writeFn={(g, newVal) => (g.subtitle = newVal)}
+                        isAuto={grapher.subtitle === undefined}
                         store={grapher}
                         placeholder="Briefly describe the context of the data. It's best to avoid duplicating any information which can be easily inferred from other visual elements of the chart."
                         textarea

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -194,7 +194,7 @@ export class TextAreaField extends React.Component<TextFieldProps> {
                 )}
                 <div className="input-group">
                     <textarea
-                        className="form-control custom-control"
+                        className="form-control"
                         value={props.value}
                         onChange={this.onChange}
                         onBlur={this.onBlur}

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -318,7 +318,7 @@ export class Grapher
     @observable.ref version = 1
     @observable.ref slug?: string = undefined
     @observable.ref title?: string = undefined
-    @observable.ref subtitle = ""
+    @observable.ref subtitle: string | undefined = undefined
     @observable.ref sourceDesc?: string = undefined
     @observable.ref note = ""
     @observable hideAnnotationFieldsInTitle?: AnnotationFieldsInTitle =
@@ -1185,7 +1185,7 @@ export class Grapher
 
     // Used for superscript numbers in static exports
     @computed get detailsOrderedByReference(): Set<string> {
-        const textInOrderOfAppearance = this.subtitle + this.note
+        const textInOrderOfAppearance = this.currentSubtitle + this.note
         const details = textInOrderOfAppearance.matchAll(
             new RegExp(detailOnDemandRegex, "g")
         )
@@ -1235,7 +1235,7 @@ export class Grapher
 
     @computed get currentSubtitle(): string {
         const subtitle = this.subtitle
-        if (subtitle) return subtitle
+        if (subtitle !== undefined) return subtitle
         const yColumns = this.yColumnsFromDimensions
         if (yColumns.length === 1) return yColumns[0].def.descriptionShort ?? ""
         return ""


### PR DESCRIPTION
With descriptionShort being used as a fallback for the subtitle in a chart we now have seen some unfortunate cases that made it necessary to be able to control if the fallback should be used or not.

The reason why this is necessary is that some old charts do not have a subtitle. If we now update the indicator to have a descriptionShort then all of a sudden this desriptionShort would be used as subtitle which is maybe not what we want.

To fix this, the PR adds a link button to the subtitle text field in the chart admin. If a custom text is set then the button shows as "unlinked". If you click it the button links and you get whatever default the fallback chain provides (i.e. descriptionShort or no subtitle). 

For cases where there is currently no subtitle and you want to makes sure it stays this way, set the subtitle to linked but the subtitle text to empty.

An easy way to test this is by [looking at this chart](http://staging-site-grapher-admin-allow-subtitle-link-unlink/admin/charts/7264/edit) that uses the Dummy indicator (which has descriptionShort). 

@pabloarosado can you test this and see if it behaves the way you would expect?