### PR TITLE
fix(url-parser): allow ':' in urls

### DIFF
--- a/packages/@ourworldindata/utils/src/MarkdownTextWrap/parser.ts
+++ b/packages/@ourworldindata/utils/src/MarkdownTextWrap/parser.ts
@@ -249,7 +249,7 @@ const plainUrlParser = (): P.Parser<PlainUrl> =>
 
 // https://urlregex.com
 const urlRegex =
-    /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@~\.\w_]*)#?(?:[\.\!\/\\\w\-]*))?)/
+    /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~:%\/\.\w\-_]*)?\??(?:[\-\+=&;%@~:\.\w_]*)#?(?:[\.\!\/\\\w\-]*))?)/
 
 const nonBracketWordParser: (r: MdParser) => P.Parser<NonBracketWord> = () =>
     P.regex(/[^\[\]\s]+/).map((val) => ({ type: "text", value: val })) //  no brackets, no WS


### PR DESCRIPTION
- fixes https://github.com/owid/owid-grapher/issues/2661

- Allows ':' in the hostname to detect URLs like: http://web.archive.org/web/20230906141841/http://196.40.56.11/scij/Busqueda/Normativa/Normas/nrmtextocompleto.aspx?nValor1=1&nValor2=11967
- Allows ':' in the query string to detect URLs like: https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:legge:2022-08-04;127