### PR TITLE
Remove Gdoc Preview autoupdating, fix lightning publishing

### DIFF
--- a/adminSiteClient/Admin.tsx
+++ b/adminSiteClient/Admin.tsx
@@ -46,12 +46,6 @@ export class Admin {
     }
 
     @observable currentRequests: Promise<Response>[] = []
-    // A way to cancel fetch requests
-    // e.g. currentRequestAbortControllers.get(request).abort()
-    @observable currentRequestAbortControllers: Map<
-        Promise<Response>,
-        AbortController
-    > = new Map()
 
     @computed get showLoadingIndicator(): boolean {
         return this.loadingIndicatorSetting === "default"
@@ -132,7 +126,6 @@ export class Admin {
                 abortController
             )
             this.addRequest(request)
-            this.currentRequestAbortControllers.set(request, abortController)
 
             response = await request
             text = await response.text()
@@ -154,7 +147,6 @@ export class Admin {
         } finally {
             if (request) {
                 this.removeRequest(request)
-                this.currentRequestAbortControllers.delete(request)
             }
         }
 

--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -2,7 +2,6 @@ import React, {
     useCallback,
     useContext,
     useEffect,
-    useMemo,
     useRef,
     useState,
 } from "react"

--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -21,12 +21,7 @@ import {
 } from "@ourworldindata/utils"
 import { Button, Col, Drawer, Row, Space, Tag, Typography } from "antd"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
-import {
-    faGear,
-    faArrowsRotate,
-    faExclamationTriangle,
-    faAngleLeft,
-} from "@fortawesome/free-solid-svg-icons"
+import { faGear, faAngleLeft } from "@fortawesome/free-solid-svg-icons"
 
 import { getErrors } from "./gdocsValidation.js"
 import { GdocsSaveButtons } from "./GdocsSaveButtons.js"
@@ -59,7 +54,6 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
     }
     const hasChanges = useGdocsChanged(originalGdoc, currentGdoc)
     const [isSettingsOpen, setSettingsOpen] = useState(false)
-    const [hasSyncingError, setHasSyncingError] = useState(false)
     const [criticalErrorMessage, setCriticalErrorMessage] = useState<
         undefined | string
     >()
@@ -87,9 +81,6 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
         if (checkIsPlainObjectWithGuard(error) && error.status === 500) {
             console.log("Critical error", error)
             setCriticalErrorMessage(error.message as string)
-        } else {
-            console.log("Syncing error", error)
-            setHasSyncingError(true)
         }
     }, [])
 
@@ -229,29 +220,6 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                             <div>
                                 {!currentGdoc.published && (
                                     <Tag color="default">Draft</Tag>
-                                )}
-                                {hasSyncingError ? (
-                                    <Tag
-                                        icon={
-                                            <FontAwesomeIcon
-                                                icon={faExclamationTriangle}
-                                            />
-                                        }
-                                        color="warning"
-                                    >
-                                        Syncing error, retrying...
-                                    </Tag>
-                                ) : (
-                                    <Tag
-                                        icon={
-                                            <FontAwesomeIcon
-                                                icon={faArrowsRotate}
-                                            />
-                                        }
-                                        color="success"
-                                    >
-                                        preview
-                                    </Tag>
                                 )}
                             </div>
                         </Space>

--- a/adminSiteClient/GdocsStore.tsx
+++ b/adminSiteClient/GdocsStore.tsx
@@ -2,6 +2,7 @@ import React, { useContext, createContext, useState } from "react"
 import { action, observable } from "mobx"
 import {
     getOwidGdocFromJSON,
+    omit,
     OwidGdocInterface,
     OwidGdocJSON,
     Tag,
@@ -33,7 +34,14 @@ export class GdocsStore {
     @action
     async update(gdoc: OwidGdocInterface): Promise<OwidGdocInterface> {
         return this.admin
-            .requestJSON<OwidGdocJSON>(`/api/gdocs/${gdoc.id}`, gdoc, "PUT")
+            .requestJSON<OwidGdocJSON>(
+                `/api/gdocs/${gdoc.id}`,
+                // omitting tags because they get saved via the /api/gdocs/:id/setTags route, not this /api/gdocs/:id route
+                // If we were to save them here, it could lead to updates from this request
+                // overwriting tags that had been set by someone else after the preview page was loaded
+                omit(gdoc, "tags"),
+                "PUT"
+            )
             .then(getOwidGdocFromJSON)
     }
 

--- a/adminSiteClient/gdocsDeploy.ts
+++ b/adminSiteClient/gdocsDeploy.ts
@@ -26,29 +26,70 @@ export const checkIsLightningUpdate = (
     nextGdoc: OwidGdocInterface,
     hasChanges: boolean
 ) => {
-    const lightningArticleProps: Array<keyof OwidGdocInterface> = [
-        "updatedAt",
-        "linkedDocuments",
-        "imageMetadata",
-        "linkedCharts",
-        "errors",
-        "revisionId",
-    ]
+    // lightning props are props that do not require a full rebake of the site if changed, because
+    // their impact is limited to just this article. They are marked as "true" in these two config maps.
+    // The props that *do* require a full rebake if changed are marked "false".
+    const lightningPropConfigMap: Record<
+        Exclude<keyof OwidGdocInterface, "content">,
+        boolean
+    > = {
+        breadcrumbs: true,
+        errors: true,
+        imageMetadata: true,
+        linkedCharts: true,
+        linkedDocuments: true,
+        relatedCharts: true,
+        revisionId: true,
+        updatedAt: true,
+        createdAt: false,
+        id: false, // weird case - can't be updated
+        publicationContext: false, // requires an update of the blog roll
+        published: false, // requires an update of the blog roll
+        publishedAt: false, // could require an update of the blog roll
+        slug: false, // requires updating any articles that link to it
+        tags: false, // requires updating related articles on grapher pages
+    }
 
-    const lightningContentProps: Array<keyof OwidGdocContent> = [
-        "body",
-        "subtitle",
-        "toc",
-        "supertitle",
-        "refs",
-        "summary",
-        "cover-image",
-        "cover-color",
-    ]
+    const lightningPropContentConfigMap: Record<
+        keyof OwidGdocContent,
+        boolean
+    > = {
+        "cover-color": true,
+        "cover-image": true,
+        "hide-citation": true,
+        body: true,
+        dateline: true,
+        details: true,
+        refs: true,
+        subtitle: true,
+        summary: true,
+        "sticky-nav": true,
+        supertitle: true,
+        toc: true,
+        "atom-excerpt": false, // requires updating the atom feed / blog roll
+        "atom-title": false, // requires updating the atom feed / blog roll
+        "featured-image": false, // requires updating references to this article
+        authors: false, // requires updating references to this article
+        excerpt: false, // requires updating references to this article
+        faqs: false, // requires updating datapages
+        parsedFaqs: false, // requires updating datapages
+        title: false, // requires updating references to this article
+        type: false, // could require updating other content if switching type to fragment
+    }
 
-    const lightningProps = [
-        ...lightningArticleProps,
-        ...lightningContentProps.map((prop) => `content.${prop}`),
+    const getLightningPropKeys = (configMap: Record<string, boolean>) =>
+        Object.entries(configMap)
+            .filter(([_, isLightningProp]) => isLightningProp)
+            .map(([key]) => key)
+
+    const lightningPropKeys = getLightningPropKeys(lightningPropConfigMap)
+    const lightningPropContentKeys = getLightningPropKeys(
+        lightningPropContentConfigMap
+    )
+
+    const keysToOmit = [
+        ...lightningPropKeys,
+        ...lightningPropContentKeys.map((key) => `content.${key}`),
     ]
 
     // When this function is called from server-side code and a Gdoc object
@@ -59,11 +100,11 @@ export const checkIsLightningUpdate = (
     // issue with Dates and date strings.
     const prevOmitted = omit(
         { ...prevGdoc, tags: nextGdoc.tags?.map((tag) => JSON.stringify(tag)) },
-        lightningProps
+        keysToOmit
     )
     const nextOmitted = omit(
         { ...nextGdoc, tags: prevGdoc.tags?.map((tag) => JSON.stringify(tag)) },
-        lightningProps
+        keysToOmit
     )
 
     return (

--- a/adminSiteClient/gdocsDeploy.ts
+++ b/adminSiteClient/gdocsDeploy.ts
@@ -40,6 +40,9 @@ export const checkIsLightningUpdate = (
         linkedDocuments: true,
         relatedCharts: true,
         revisionId: true,
+        // "tags" is not actually a lightning prop, as it requires rebaking other parts of the site,
+        // but they're set via the /setTags route and so should be ignored here
+        tags: true,
         updatedAt: true,
         createdAt: false,
         id: false, // weird case - can't be updated
@@ -47,7 +50,6 @@ export const checkIsLightningUpdate = (
         published: false, // requires an update of the blog roll
         publishedAt: false, // could require an update of the blog roll
         slug: false, // requires updating any articles that link to it
-        tags: false, // requires updating related articles on grapher pages
     }
 
     const lightningPropContentConfigMap: Record<
@@ -96,16 +98,9 @@ export const checkIsLightningUpdate = (
     // is passed in, the omit() call will surface Gdoc class members. The
     // comparison will then fail if the other operand in the comparison is
     // an OwidGdocInterface object. To avoid this, we spread into new objects
-    // in order to compare the same types. Tags are stringified to avoid a similar
-    // issue with Dates and date strings.
-    const prevOmitted = omit(
-        { ...prevGdoc, tags: nextGdoc.tags?.map((tag) => JSON.stringify(tag)) },
-        keysToOmit
-    )
-    const nextOmitted = omit(
-        { ...nextGdoc, tags: prevGdoc.tags?.map((tag) => JSON.stringify(tag)) },
-        keysToOmit
-    )
+    // in order to compare the same types.
+    const prevOmitted = omit({ ...prevGdoc }, keysToOmit)
+    const nextOmitted = omit({ ...nextGdoc }, keysToOmit)
 
     return (
         hasChanges &&

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -2490,7 +2490,12 @@ apiRouter.put("/gdocs/:id", async (req, res) => {
         return updated
     }
 
-    const prevGdoc = await Gdoc.findOneBy({ id })
+    const prevGdoc = await Gdoc.findOne({
+        where: {
+            id: id,
+        },
+        relations: ["tags"],
+    })
     if (!prevGdoc) throw new JsonError(`No Google Doc with id ${id} found`)
 
     const nextGdoc = dataSource

--- a/site/hooks.ts
+++ b/site/hooks.ts
@@ -67,28 +67,6 @@ export const useEmbedChart = (
     }, [activeChartIdx, refChartContainer])
 }
 
-// Adapted from https://overreacted.io/making-setinterval-declarative-with-react-hooks/
-export const useInterval = (callback: VoidFunction, delay: number | null) => {
-    const savedCallback = useRef(callback)
-
-    // Remember the latest callback.
-    useEffect(() => {
-        savedCallback.current = callback
-    }, [callback])
-
-    // Set up the interval.
-    useEffect(() => {
-        function tick() {
-            savedCallback.current()
-        }
-        if (delay !== null) {
-            const id = setInterval(tick, delay)
-            return () => clearInterval(id)
-        }
-        return
-    }, [delay])
-}
-
 export const useDebounceCallback = (callback: any, delay: number) => {
     return useRef(debounce(callback, delay)).current
 }


### PR DESCRIPTION
Autoupdating was causing lots of headaches when multiple clients were previewing the same document. The effort in fixing that class of issue seems to outweigh the marginal benefit of autoupdating, so I'm removing the autoupdating functionality altogether.

I also noticed that lightning updates hadn't been working properly for ages, so I've updated that code to fix the thing that was breaking it (Date comparisons) and made the declaration of light props more explicit and tied to our type validation so that it'll be harder to miss in the future.