### PR TITLE
fix(grapher): fix chart icon on first load for line charts

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
@@ -13,6 +13,7 @@ export interface ContentSwitchersManager {
     isNarrow?: boolean
     type?: ChartTypeName
     isLineChartThatTurnedIntoDiscreteBar?: boolean
+    isAuthoredAsLineChartThatTurnedIntoDiscreteBar?: boolean
 }
 
 @observer
@@ -45,20 +46,28 @@ export class ContentSwitchers extends React.Component<{
             case GrapherTabOption.map:
                 return <FontAwesomeIcon icon={faEarthAmericas} />
             case GrapherTabOption.chart:
-                const chartIcon = manager.isLineChartThatTurnedIntoDiscreteBar
+                let chartIcon = manager.isLineChartThatTurnedIntoDiscreteBar
                     ? chartIcons[ChartTypeName.DiscreteBar]
                     : chartIcons[this.chartType]
                 // If we're switching from a line chart to the map, then the timeline
                 // is automatically set to a single year, and the underlying chart switches to
                 // a discrete bar chart, which makes the line chart icon change into a bar chart icon.
                 // To prevent that, we hold onto the previous chart icon if we're not currently on the chart tab.
-                const newChartIcon =
-                    this.previousChartIcon &&
-                    manager.tab !== GrapherTabOption.chart
-                        ? this.previousChartIcon
-                        : chartIcon
-                this.previousChartIcon = newChartIcon
-                return newChartIcon
+                if (manager.tab !== GrapherTabOption.chart) {
+                    // make sure we're showing the line chart icon on first load
+                    // if the chart is configured to be a line chart initially
+                    if (
+                        !this.previousChartIcon &&
+                        this.chartType === ChartTypeName.LineChart &&
+                        !manager.isAuthoredAsLineChartThatTurnedIntoDiscreteBar
+                    ) {
+                        chartIcon = chartIcons[ChartTypeName.LineChart]
+                    } else if (this.previousChartIcon) {
+                        chartIcon = this.previousChartIcon
+                    }
+                }
+                this.previousChartIcon = chartIcon
+                return chartIcon
         }
     }
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2676,6 +2676,16 @@ export class Grapher
         })
     }
 
+    @computed
+    get isAuthoredAsLineChartThatTurnedIntoDiscreteBar(): boolean {
+        const {
+            type = ChartTypeName.LineChart,
+            minTime,
+            maxTime,
+        } = this.legacyConfigAsAuthored
+        return type === ChartTypeName.LineChart && minTime === maxTime
+    }
+
     @computed get queryStr(): string {
         return queryParamsToStr(this.changedParams)
     }


### PR DESCRIPTION
Fixes an issue where the chart icon changes unexpectedly.

This is what happens (see video below):
- On first load, the user lands on the map
- Since we're on the map, a single year is selected
- With a single year selected, the line chart turns into a discrete bar chart
- That's why we show the bar chart icon in the content switchers
- If the user clicks on the chart tab, the time is reset and a start and an end year is now selected
- The chart icon changes from a bar chart icon to a line chart icon (unexpected!)

We would rather show a line chart icon from the beginning.

https://github.com/owid/owid-grapher/assets/12461810/17f56f73-3d66-453b-95d2-a03a276a920d

Examples:
- Line chart by default: https://ourworldindata.org/grapher/co-emissions-per-capita
- Discrete bar chart by default (but actually a line chart): https://ourworldindata.org/grapher/fish-and-seafood-consumption-per-capita