### PR TITLE
:sparkles: add displayOrder column to posts_gdocs_variables_faqs table

### DIFF
--- a/db/migration/1697464705200-PostsGdocsLinksDisplayOrder.ts
+++ b/db/migration/1697464705200-PostsGdocsLinksDisplayOrder.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class PostsGdocsLinksDisplayOrder1697464705200
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(
+            `ALTER TABLE posts_gdocs_variables_faqs
+            ADD COLUMN displayOrder SMALLINT NOT NULL DEFAULT 0;`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(
+            `ALTER TABLE posts_gdocs_variables_faqs
+            DROP COLUMN display_order;`
+        )
+    }
+}


### PR DESCRIPTION
Needed by https://github.com/owid/etl/pull/1797