### PR TITLE
Better search on GDocs index page

### DIFF
--- a/adminSiteClient/GdocsIndexPage.scss
+++ b/adminSiteClient/GdocsIndexPage.scss
@@ -61,6 +61,10 @@
     width: 100%;
 }
 
+.gdoc-index__help-link {
+    margin-right: 8px;
+}
+
 .gdoc-index-filter-checkbox {
     cursor: pointer;
     margin-right: 16px;

--- a/adminSiteClient/GdocsIndexPage.tsx
+++ b/adminSiteClient/GdocsIndexPage.tsx
@@ -8,6 +8,7 @@ import {
     faLightbulb,
     faNewspaper,
     faPuzzlePiece,
+    faQuestion,
 } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import {
@@ -196,6 +197,15 @@ export class GdocsIndexPage extends React.Component<GdocsMatchProps> {
                             search={this.search}
                         />
                         <div>
+                            <a
+                                className="btn btn-secondary gdoc-index__help-link"
+                                target="_blank"
+                                href="https://docs.google.com/document/d/1OLoTWloy4VecOjKTjB1wLV6tEphHJIMXfexrf1ZYJzU/edit"
+                                rel="noopener"
+                            >
+                                <FontAwesomeIcon icon={faQuestion} /> Open
+                                documentation
+                            </a>
                             <button
                                 className="btn btn-primary"
                                 onClick={() =>

--- a/adminSiteClient/GdocsIndexPage.tsx
+++ b/adminSiteClient/GdocsIndexPage.tsx
@@ -35,11 +35,6 @@ const iconGdocTypeMap = {
     [OwidGdocType.TopicPage]: <FontAwesomeIcon icon={faLightbulb} />,
 }
 
-interface Searchable {
-    gdoc: OwidGdocInterface
-    term?: Fuzzysort.Prepared
-}
-
 @observer
 class GdocsIndexPageSearch extends React.Component<{
     filters: Record<OwidGdocType, boolean>

--- a/adminSiteClient/GdocsIndexPage.tsx
+++ b/adminSiteClient/GdocsIndexPage.tsx
@@ -170,23 +170,6 @@ export class GdocsIndexPage extends React.Component<GdocsMatchProps> {
         }
     }
 
-    // @computed get searchIndex(): Searchable[] {
-    //     if (!this.context) return []
-    //     const searchIndex: Searchable[] = []
-    //     for (const gdoc of this.context.gdocs) {
-    //         searchIndex.push({
-    //             gdoc,
-    //             term: fuzzysort.prepare(
-    //                 `${gdoc.content.title} ${gdoc.content.authors?.join(
-    //                     " "
-    //                 )} ${gdoc.tags?.map(({ name }) => name).join(" ")}`
-    //             ),
-    //         })
-    //     }
-
-    //     return searchIndex
-    // }
-
     render() {
         return (
             <AdminLayout title="Google Docs">


### PR DESCRIPTION
This PR changes the search in the GDocs index pages to work like the one on charts and indicators. 

This means it only matches continuous word fragments, not fuzzy filename like search where the characters can come up in any part of a long string as long as they are in order. Also, -term style queries work that exclude term.

The PR also adds a button stlye link to the documentation next to the add button.