### PR TITLE
Entry Emulator - hide sticky nav on linear topic pages

### DIFF
--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -171,6 +171,9 @@ const migrate = async (): Promise<void> => {
                     type: isEntry
                         ? OwidGdocType.TopicPage
                         : OwidGdocType.Article,
+                    // Provide an empty array to prevent the sticky nav from rendering at all
+                    // Because if it isn't defined, it tries to automatically populate itself
+                    "sticky-nav": isEntry ? [] : undefined,
                 },
                 relatedCharts,
                 published: false,

--- a/db/model/Gdoc/archieToEnriched.ts
+++ b/db/model/Gdoc/archieToEnriched.ts
@@ -39,6 +39,8 @@ function generateStickyNav(
 ): OwidGdocStickyNavItem[] | undefined {
     if (content.type !== OwidGdocType.TopicPage) return
     // If a sticky nav has been explicitly defined, use that.
+    // We are using this for linear topic pages, as a way to have a document using the topic page template
+    // but without a sticky nav
     if (content["sticky-nav"]) return content["sticky-nav"]
     // These are the default headings that we'll try to find and create sticky nav headings for
     // Even if the id for the heading is "key-insights-on-poverty", we can just do substring matches

--- a/db/model/Gdoc/archieToGdoc.ts
+++ b/db/model/Gdoc/archieToGdoc.ts
@@ -41,6 +41,14 @@ function* owidArticleToArchieMLStringGenerator(
     yield* propertyToArchieMLString("dateline", article)
     yield* propertyToArchieMLString("excerpt", article)
     yield* propertyToArchieMLString("type", article)
+    if (article["sticky-nav"]) {
+        yield "[.sticky-nav]"
+        for (const item of article["sticky-nav"]) {
+            yield* propertyToArchieMLString("target", item)
+            yield* propertyToArchieMLString("text", item)
+        }
+        yield "[]"
+    }
     // TODO: inline refs
     yieldMultiBlockPropertyIfDefined("summary", article, article.summary)
     yield* propertyToArchieMLString("hide-citation", article)

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1343,7 +1343,7 @@ export interface OwidGdocContent {
         | "sdg-color-16"
         | "sdg-color-17"
         | "amber"
-    "sticky-nav"?: []
+    "sticky-nav"?: OwidGdocStickyNavItem[]
     details?: DetailDictionary
     // TODO: having both the unparsed and parsed variant on the same type is pretty crude
     // Consider moving faqs into body or splitting the types and creating

--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -118,7 +118,7 @@ export function OwidGdoc({
                         publishedAt={publishedAt}
                         breadcrumbs={breadcrumbs ?? undefined}
                     />
-                    {content.type === "topic-page" && stickyNavLinks ? (
+                    {content.type === "topic-page" && stickyNavLinks?.length ? (
                         <nav className="sticky-nav sticky-nav--dark span-cols-14 grid grid-cols-12-full-width">
                             <StickyNav
                                 links={stickyNavLinks}


### PR DESCRIPTION
Is it a hack if you use the code as was intended? 😁 

This adds an empty array to the gdoc content object's `sticky-nav` property, which causes the sticky nav to not render.

It was either this, or some sort of flag to hide the sticky nav. This seemed like the less intrusive way to handle it.

### example:
<img width="1496" alt="image" src="https://github.com/owid/owid-grapher/assets/11844404/b65ffcf5-38ce-4c71-93c8-c10e3c967f3e">

### archie excerpt:
<img width="624" alt="image" src="https://github.com/owid/owid-grapher/assets/11844404/d6723fdc-9ac1-40bc-a203-2dcd07b98eb6">
