### PR TITLE
:sparkles: speed up image sync by replacing s3cmd with awscli

### DIFF
--- a/devTools/docker/sync-s3-images.sh
+++ b/devTools/docker/sync-s3-images.sh
@@ -13,4 +13,4 @@ fi
 # for local development, it should be owid-image-upload/local-yourname
 # at least until we decide to instead host images locally, if ever
 
-aws --endpoint=https://nyc3.digitaloceanspaces.com s3 sync s3://owid-image-upload/production/ s3://$IMAGE_HOSTING_BUCKET_PATH/
+aws --endpoint=https://nyc3.digitaloceanspaces.com s3 sync s3://owid-image-upload/production/ s3://$IMAGE_HOSTING_BUCKET_PATH/ --acl public-read

--- a/devTools/docker/sync-s3-images.sh
+++ b/devTools/docker/sync-s3-images.sh
@@ -13,4 +13,4 @@ fi
 # for local development, it should be owid-image-upload/local-yourname
 # at least until we decide to instead host images locally, if ever
 
-s3cmd sync s3://owid-image-upload/production/ s3://$IMAGE_HOSTING_BUCKET_PATH/
+aws --endpoint=https://nyc3.digitaloceanspaces.com s3 sync s3://owid-image-upload/production/ s3://$IMAGE_HOSTING_BUCKET_PATH/

--- a/site/README.md
+++ b/site/README.md
@@ -59,4 +59,11 @@ This means that any other documents that reference the image will use the update
 
 If you are refreshing your environment's database by importing a database dump from prod, the prod `images` table may make claims about the existence of files in your environment's S3 folder that aren't true, which will lead to 403 errors when trying to bake.
 
-In this project's root Makefile, we have a make command (`make sync-images`) that runs `s3cmd sync` from prod to your environment to solve this problem. Make sure your [s3cmd is configured correctly](https://docs.digitalocean.com/products/spaces/reference/s3cmd/) before running it.
+In this project's root Makefile, we have a make command (`make sync-images`) that runs `aws s3 sync` from prod to your environment to solve this problem. Make sure your `~/.aws/config` is configured correctly and contains
+
+```
+[owid]
+aws_access_key_id = xxx
+aws_secret_access_key = xxx
+region = nyc3
+```


### PR DESCRIPTION
`s3cmd` is really slow. Syncing images takes more than 3 minutes now, which is considerable time for our staging servers. Switching to `awscli` reduces the time to about 15s. (I'm not sure why is it so much faster, parallel sync perhaps?)

Moreover, using `.aws/config` is more intuitive than `~/.s3cfg`