### PR TITLE
Show only important sources in summaries

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1450,7 +1450,7 @@ export class Grapher
         const { yColumnSlugs, xColumnSlug, sizeColumnSlug, colorColumnSlug } =
             this
 
-        const columnSlugs = excludeUndefined( [
+        const columnSlugs = excludeUndefined([
             ...yColumnSlugs,
             xColumnSlug,
             sizeColumnSlug,

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.stories.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.stories.tsx
@@ -9,9 +9,11 @@ export default {
 
 export const WithSources = (): JSX.Element => (
     <SourcesModal
-        manager={{ columnsWithSources: SynthesizeGDPTable().columnsAsArray }}
+        manager={{
+            columnsWithSourcesExtensive: SynthesizeGDPTable().columnsAsArray,
+        }}
     />
 )
 export const NoSources = (): JSX.Element => (
-    <SourcesModal manager={{ columnsWithSources: [] }} />
+    <SourcesModal manager={{ columnsWithSourcesExtensive: [] }} />
 )

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
@@ -16,7 +16,7 @@ import { Modal } from "./Modal"
 
 export interface SourcesModalManager {
     adminBaseUrl?: string
-    columnsWithSources: CoreColumn[]
+    columnsWithSourcesExtensive: CoreColumn[]
     showAdminControls?: boolean
     isSourcesModalOpen?: boolean
     tabBounds?: Bounds
@@ -268,7 +268,7 @@ export class SourcesModal extends React.Component<{
     }
 
     render(): JSX.Element {
-        const cols = this.manager.columnsWithSources
+        const cols = this.manager.columnsWithSourcesExtensive
         return (
             <Modal
                 title="Sources"


### PR DESCRIPTION
This PR introduces two different ways to iterate over the sources of a chart - a `columnsWithSourcesExtensive` and `columnsWithSourcesCondensed`. When rendering the sources at the bottom of the chart we want to only show the most relevant ones (i.e. hide stuff like population used for sizing a scatter) - for this we use the `Condensed` version. When showing the sources tab we use the Extensive so that all our sources are rendered there.

This is related to #2755 and fixes these points:
* [x] Following [Ed's suggested](https://owid.slack.com/archives/C0193RW5E2J/p1695720931545929?thread_ts=1695717004.876169&cid=C0193RW5E2J) (it seems we already decided about it at some other time in the past) scatter plots should not show population in the footer of the chart, but they should show population in the sources tab (in "Data published by").
