### PR TITLE
Better date displays - processing level display

### DIFF
--- a/datapage/Datapage.ts
+++ b/datapage/Datapage.ts
@@ -36,9 +36,14 @@ export const getDatapageDataV2 = async (
         let nextUpdate = undefined
         if (variableMetadata.updatePeriodDays) {
             const date = dayjs(version)
-            nextUpdate = date
-                .add(variableMetadata.updatePeriodDays, "day")
-                .format("MMMM YYYY")
+            const nextUpdateDate = date.add(
+                variableMetadata.updatePeriodDays,
+                "day"
+            )
+            // If the next update date is in the past, we set it to the next month
+            if (nextUpdateDate.isBefore(dayjs()))
+                nextUpdate = dayjs().add(1, "month").format("MMMM YYYY")
+            else nextUpdate = nextUpdateDate.format("MMMM YYYY")
         }
         const datapageJson: DataPageDataV2 = {
             status: "draft",


### PR DESCRIPTION
This PR improves the rendering of some dates and time ranges, updates the processing level (minor/major) text and fixes some minor wording issues.

This is related to #2755 and fixes these points:
* [x] Instead of mentioning Twitter (in "How to cite this data"), we should say "social media".
* [x] We should not say "OWID" anywhere (as it happens in "How to cite this data").
* [x] We should show the date of next expected update. This should be based on `dataset.update_period_days` and the current date (if it's passed, increase it by a month).
* [x] Change the wording of "processed" or "adapated" by under the chart to "with minor/major processing by Our World In Data"
* [x] If the time range for an indicator includes negative years (like our long run population data does), then show `10000 BC to 2020 AD` instead of `-10000-2020`
* [x] Last updated date should render as a formatted date instead of a raw date string