### PR TITLE
Better automatic links to topic pages

### DIFF
--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -73,6 +73,19 @@ const getDateRange = (dateRange: string): string | null => {
     return null
 }
 
+const slugify_topic = (topic: string) => {
+    // This is a heuristic to map from free form tag texts to topic page URLs. We'll
+    // have to switch to explicitly stored URLs or explicit links between tags and topic pages
+    // soon but for the time being this makes sure that "CO2 & Greenhouse Gas Emissions" can be automatically
+    // linked to /co2-and-greenhouse-gas-emissions
+    // Note that the heuristic fails for a few cases like "HIV/AIDS" or "Mpox (Monkeypox)"
+    const replaced = topic
+        .replace("&", "-and-")
+        .replace("'", "")
+        .replace("+", "")
+    return slugify(replaced)
+}
+
 export const DataPageV2Content = ({
     datapageData,
     grapherConfig,
@@ -228,7 +241,9 @@ export const DataPageV2Content = ({
                                         {datapageData.topicTagsLinks?.map(
                                             (topic: any) => (
                                                 <a
-                                                    href={`/${slugify(topic)}`}
+                                                    href={`/${slugify_topic(
+                                                        topic
+                                                    )}`}
                                                     key={topic}
                                                 >
                                                     {topic}


### PR DESCRIPTION
At the right top of topic pages we show tags if they are given in the ETL. The tags are rendered as little pills and should link to the topic page that we have for this tag. Unfortunately, at this point we don't have the "authoritative links" stored with the tags and no association between tags and their topic pages so we slugify the text and 🤞. 

This PR improves the slugify function for this particular use case. It's not bullet proof but it makes sure that the system works for a few more of the important tags. Some remain broken until we store the links properly.