### PR TITLE
enhance(grapher): disable action on line label click for mobile

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2846,7 +2846,7 @@ export class Grapher
     }
 
     @computed get startSelectingWhenLineClicked(): boolean {
-        return this.showAddEntityButton
+        return this.showAddEntityButton && !this.isMobile
     }
 
     // For now I am only exposing this programmatically for the dashboard builder. Setting this to true


### PR DESCRIPTION
- We had a report that the entity selector opened for no apparent reason when clicking on the year button in the timeline
- My guess is that the year button was close to a line label that opens the entity selector on click
- Since the chart area space and the label itself are so small on mobile, we decided to disable opening the entity selector from the line label