### PR TITLE
fix(modal): don't dismiss when clicking on an interactive element

### DIFF
--- a/packages/@ourworldindata/grapher/src/modal/Modal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/Modal.tsx
@@ -33,10 +33,14 @@ export class Modal extends React.Component<{
     }
 
     @action.bound onDocumentClick(e: MouseEvent): void {
-        // check if the click was outside of the modal
+        const tagName = (e.target as HTMLElement).tagName
+        const isTargetInteractive = ["A", "BUTTON", "INPUT"].includes(tagName)
         if (
             this.contentRef?.current &&
             !this.contentRef.current.contains(e.target as Node) &&
+            // clicking on an interactive element should not dismiss the modal
+            // (this is especially important for the suggested chart review tool)
+            !isTargetInteractive &&
             // check that the target is still mounted to the document; we also get click events on nodes that have since been removed by React
             document.contains(e.target as Node)
         )


### PR DESCRIPTION
- In the chart revision tool, authors look at two charts side by side
- If one chart has a modal open, then clicking on the second chart closes the modal of the first one
- This makes it impossible to have both modals open at the same time
- This happens because any outside click is registered and dismisses the modal
- As a fix, I put in an additional check that checks whether the target that is clicked on is interactive
- If it is interactive, we assume the user didn't intend to dismiss the modal, so we keep it open

Is this a sensible solution?

<details>
<summary>Video of the bug:</summary>
https://github.com/owid/owid-grapher/assets/12461810/547a1ae8-4edc-4291-b6a6-36f5d33d5607
</details>