### PR TITLE
feat(redirects): handle grapher redirects in grapher worker

### DIFF
--- a/_routes.json
+++ b/_routes.json
@@ -1,5 +1,5 @@
 {
     "version": 1,
     "include": ["/grapher/*"],
-    "exclude": ["/grapher/embedCharts.js"]
+    "exclude": ["/grapher/embedCharts.js", "/grapher/_grapherRedirects.json"]
 }

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -636,7 +636,7 @@ export class SiteBaker {
         const grapherRedirects = await getGrapherRedirectsMap("")
         await this.stageWrite(
             path.join(this.bakedSiteDir, `grapher/_grapherRedirects.json`),
-            JSON.stringify(Object.fromEntries(grapherRedirects))
+            JSON.stringify(Object.fromEntries(grapherRedirects), null, 2)
         )
 
         this.progressBar.tick({ name: "✅ baked redirects" })

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -49,7 +49,11 @@ import {
 import { extractDetailsFromSyntax } from "@ourworldindata/components"
 import { execWrapper } from "../db/execWrapper.js"
 import { countryProfileSpecs } from "../site/countryProfileProjects.js"
-import { getRedirects, flushCache as redirectsFlushCache } from "./redirects.js"
+import {
+    getGrapherRedirectsMap,
+    getRedirects,
+    flushCache as redirectsFlushCache,
+} from "./redirects.js"
 import { bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers } from "./GrapherBaker.js"
 import { EXPLORERS_ROUTE_FOLDER } from "../explorer/ExplorerConstants.js"
 import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants.js"
@@ -628,6 +632,13 @@ export class SiteBaker {
             path.join(this.bakedSiteDir, `_redirects`),
             redirects.join("\n")
         )
+
+        const grapherRedirects = await getGrapherRedirectsMap("")
+        await this.stageWrite(
+            path.join(this.bakedSiteDir, `grapher/_grapherRedirects.json`),
+            JSON.stringify(Object.fromEntries(grapherRedirects))
+        )
+
         this.progressBar.tick({ name: "✅ baked redirects" })
     }
 

--- a/baker/redirects.ts
+++ b/baker/redirects.ts
@@ -68,19 +68,11 @@ export const getRedirects = async () => {
             }`
     )
 
-    // Redirect old slugs to new slugs
-    const grapherRedirectsMap = await getGrapherRedirectsMap()
-    const grapherRedirects = Array.from(grapherRedirectsMap).map(
-        ([oldSlug, newSlug]) => `${oldSlug} ${newSlug} 302`
-    )
-
     // Add newlines in between so we get some more overview
     return [
         ...staticRedirects,
         "",
         ...wpRedirects,
-        "",
-        ...grapherRedirects,
         "",
         ...dynamicRedirects, // Cloudflare requires all dynamic redirects to be at the very end of the _redirects file
     ]


### PR DESCRIPTION
Work around Cloudflare's 2000 static redirects limit by handling redirects directly in the worker.

This works by baking a `grapher/_grapherRedirects.json` file as part of the baking process, where all grapher redirects always go.
The original `_redirects` file will then only contain WP redirects, plus some hardcoded ones.
I checked and we're currently down to just 506 redirects in the file now, so quite some room to spare.

I tried out the following variations and they all work:
- `/grapher/life-expectancy` goes through
- `/grapher/life-EXPECTANCY` redirects to lowercase
- `/grapher/life-expectancy/` removes trailing slash
- `/grapher/life-expectancy-globally-since-1770` redirects
	- ^ this one also works with uppercase and a trailing slash mixed in
- `/grapher/number-affected-by-natural-disasters` redirects to an explorer using WP redirect

Caveats:
- The _thumbnails worker_ doesn't really take redirects into account, so if you went to `/grapher/thumbnail/life-expectancy-globally-since-1770` for example, it would just fail instead of resolving the redirect itself.
- In the very rare case where we have a grapher redirect and a WP redirect for the same URL, the grapher redirect now takes precedence. This is not a problem at all.

The `/grapher/_grapherRedirects.json` file looks like this:
```jsonc
{
  "correlation-between-child-mortality-and-mean-years-of-schooling-for-those-aged-15-and-older-2000": "correlation-between-child-mortality-and-mean-years-of-schooling-for-those-aged-15-and-older",
  "us-education-expenditure-as-share-of-gdp-public-and-private": "us-education-expenditure-as-share-of-gdp-public-and-private-institutions",
  "revenues-for-public-schools-by-source-us": "revenues-for-public-schools-by-source-gdp-us",
  // ...
}
```