### PR TITLE
Fixed the line seperator bug between colorLegend and SizeLegend in scatterplot charts

### DIFF
--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -759,13 +759,16 @@ export class ScatterPlotChart
                 <VerticalColorLegend manager={this} />
                 {sizeLegend && (
                     <>
-                        <line
-                            x1={bounds.right - sidebarWidth}
-                            y1={sizeLegendY - 14}
-                            x2={bounds.right - 5}
-                            y2={sizeLegendY - 14}
-                            stroke="#ccc"
-                        />
+                    {(this.activeColors.length > 1) && (
+                            <line
+                                x1={bounds.right - sidebarWidth}
+                                y1={sizeLegendY - 14}
+                                x2={bounds.right - 5}
+                                y2={sizeLegendY - 14}
+                                stroke="#ccc"
+                            />
+                            )
+                    }
                         {sizeLegend.render(this.legendX, sizeLegendY)}
                     </>
                 )}


### PR DESCRIPTION
Issue it fixes: #2735 

What kind of change does this PR introduce:
It fixes the line seperator bug between ColorLegend and SizeLegend in the scatterplot charts. 