### PR TITLE
Keep time axis constant while playing the timeline animation

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -182,6 +182,7 @@ import { MarimekkoChartManager } from "../stackedCharts/MarimekkoChartConstants"
 import { AxisConfigInterface } from "../axis/AxisConfigInterface"
 import Bugsnag from "@bugsnag/js"
 import { FacetChartManager } from "../facetChart/FacetChartConstants"
+import { AbtractStackedChartManager } from "../stackedCharts/AbstractStackedChart"
 
 declare const window: any
 
@@ -316,7 +317,8 @@ export class Grapher
         FacetChartManager,
         EntitySelectorModalManager,
         SettingsMenuManager,
-        MapChartManager
+        MapChartManager,
+        AbtractStackedChartManager
 {
     @observable.ref $schema = DEFAULT_GRAPHER_CONFIG_SCHEMA
     @observable.ref type = ChartTypeName.LineChart
@@ -763,7 +765,11 @@ export class Grapher
     @observable.ref isGeneratingThumbnail = false
 
     tooltips?: TooltipManager["tooltips"] = observable.map({}, { deep: false })
-    @observable isPlaying = false
+
+    @observable.ref isPlaying = false
+    @observable.ref isTimelineAnimationActive = false // true if the timeline animation is either playing or paused but not finished
+    @observable.ref animationStartTime: Time | undefined = undefined
+
     @observable.ref isSelectingData = false
 
     @observable.ref isSourcesModalOpen = false
@@ -2776,6 +2782,17 @@ export class Grapher
 
     @computed get disablePlay(): boolean {
         return this.isSlopeChart
+    }
+
+    @computed get animationEndTime(): Time {
+        const { timeColumn } = this.tableAfterAuthorTimelineFilter
+        if (this.timelineMaxTime) {
+            return (
+                findClosestTime(timeColumn.uniqValues, this.timelineMaxTime) ??
+                timeColumn.maxTime
+            )
+        }
+        return timeColumn.maxTime
     }
 
     formatTime(value: Time): string {

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -559,12 +559,7 @@ export class DataTable extends React.Component<{
     @computed get autoSelectedStartTime(): number | undefined {
         let autoSelectedStartTime: number | undefined = undefined
 
-        if (
-            // this.grapher.userHasSetTimeline ||
-            //this.initialTimelineStartTimeSpecified ||
-            !this.loadedWithData
-        )
-            return undefined
+        if (!this.loadedWithData) return undefined
 
         const numEntitiesInTable = this.entityNames.length
 

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -674,7 +674,9 @@ export class LineChart
     }
 
     @computed get lineLegendX(): number {
-        return this.bounds.right - (this.lineLegendDimensions?.width || 0)
+        return this.manager.isTimelineAnimationActive && this.manager.endTime
+            ? this.xAxis.place(this.manager.endTime)
+            : this.bounds.right - (this.lineLegendDimensions?.width || 0)
     }
 
     @computed get clipPathBounds(): Bounds {
@@ -1135,9 +1137,20 @@ export class LineChart
 
     @computed private get horizontalAxisPart(): HorizontalAxis {
         const axis = this.xAxisConfig.toHorizontalAxis()
-        axis.updateDomainPreservingUserSettings(
-            this.transformedTable.timeDomainFor(this.yColumnSlugs)
-        )
+        if (
+            this.manager.isTimelineAnimationActive &&
+            this.manager.animationStartTime !== undefined &&
+            this.manager.animationEndTime !== undefined
+        ) {
+            axis.domain = [
+                this.manager.animationStartTime,
+                this.manager.animationEndTime,
+            ]
+        } else {
+            axis.updateDomainPreservingUserSettings(
+                this.transformedTable.timeDomainFor(this.yColumnSlugs)
+            )
+        }
         axis.scaleType = ScaleType.linear
         axis.formatColumn = this.inputTable.timeColumn
         axis.hideFractionalTicks = true

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartConstants.ts
@@ -2,7 +2,7 @@ import { DualAxis } from "../axis/Axis"
 import { ChartManager } from "../chart/ChartManager"
 import { SeriesName } from "../core/GrapherConstants"
 import { ChartSeries } from "../chart/ChartInterface"
-import { CoreValueType } from "@ourworldindata/core-table"
+import { CoreValueType, Time } from "@ourworldindata/core-table"
 import { Color } from "@ourworldindata/utils"
 
 export interface LinePoint {
@@ -39,4 +39,8 @@ export interface LinesProps {
 export interface LineChartManager extends ChartManager {
     lineStrokeWidth?: number
     canSelectMultipleEntities?: boolean
+    isTimelineAnimationActive?: boolean
+    animationStartTime?: Time
+    animationEndTime?: Time
+    endTime?: Time
 }

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -547,6 +547,8 @@ export class StackedAreaChart
     }
 
     @computed get lineLegendX(): number {
+        if (this.manager.isTimelineAnimationActive && this.manager.endTime)
+            return this.xAxis.place(this.manager.endTime)
         return this.legendDimensions
             ? this.bounds.right - this.legendDimensions.width
             : 0

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.stories.tsx
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.stories.tsx
@@ -6,7 +6,6 @@ import { TimelineController, TimelineManager } from "./TimelineController"
 
 class TimelineManagerMock implements TimelineManager {
     @observable isPlaying = false
-    @observable userHasSetTimeline = true
     @observable times = range(1900, 2021)
 
     @observable protected _endTime = 2020

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
@@ -73,7 +73,7 @@ export class TimelineComponent extends React.Component<{
     }
 
     @action.bound private onDrag(inputTime: number): void {
-        if (!this.manager.isPlaying) this.manager.userHasSetTimeline = true
+        this.controller.onDrag()
         this.dragTarget = this.controller.dragHandleToTime(
             this.dragTarget!,
             inputTime

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineController.ts
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineController.ts
@@ -10,12 +10,13 @@ export interface TimelineManager {
     disablePlay?: boolean
     formatTimeFn?: (time: Time) => string
     isPlaying?: boolean
-    userHasSetTimeline?: boolean
     times: Time[]
     startHandleTimeBound: TimeBound
     endHandleTimeBound: TimeBound
     msPerTick?: number
     onPlay?: () => void
+    isTimelineAnimationActive?: boolean
+    animationStartTime?: Time
 }
 
 const delay = (ms: number): Promise<void> =>
@@ -89,6 +90,8 @@ export class TimelineController {
     async play(numberOfTicks?: number): Promise<number> {
         const { manager } = this
         manager.isPlaying = true
+        manager.isTimelineAnimationActive = true
+        manager.animationStartTime = this.startTime
 
         if (this.isAtEnd()) this.resetToBeginning()
 
@@ -113,10 +116,16 @@ export class TimelineController {
 
     private stop(): void {
         this.manager.isPlaying = false
+        this.manager.isTimelineAnimationActive = false
+        this.manager.animationStartTime = undefined
     }
 
     private pause(): void {
         this.manager.isPlaying = false
+    }
+
+    onDrag(): void {
+        this.stop()
     }
 
     async togglePlay(): Promise<void> {


### PR DESCRIPTION
Whoever reads this, feel free to pick it up :)

---

Keeps the horizontal time axis constant while playing the timeline animation

- Works for line charts and stacked area charts
- Stacked bar charts need more work because they don't use our `HorizontalAxis` component

Other changes:
- Removed the timeline's `userHasSetTimeline` property (it wasn't currently in use)
- Small UX win: when a user starts dragging while an animation is playing, the animation is stopped

To do:
- [ ] Make it work for StackedBar charts
- [ ] (optional): Keep y-axis domain constant for LineCharts, StackedArea and StackedBar charts