### PR TITLE
hotfix(grapher): remove missing data strategy for (stacked) discrete bar charts

### DIFF
--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -108,13 +108,9 @@ export class EditorFeatures {
             return true
         }
 
-        // for line charts and discrete bar charts, specifying a missing
-        // data strategy only makes sense if there are multiple entities
-        if (
-            this.grapher.isLineChart ||
-            this.grapher.isDiscreteBar ||
-            this.grapher.isStackedDiscreteBar
-        ) {
+        // for line charts, specifying a missing data strategy only makes sense
+        // if there are multiple entities
+        if (this.grapher.isLineChart) {
             return (
                 this.grapher.canChangeEntity ||
                 this.grapher.canSelectMultipleEntities

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -25,7 +25,6 @@ import {
     BASE_FONT_SIZE,
     SeriesStrategy,
     FacetStrategy,
-    MissingDataStrategy,
 } from "../core/GrapherConstants"
 import {
     HorizontalAxisComponent,
@@ -126,15 +125,6 @@ export class DiscreteBarChart
                 .interpolateColumnWithTolerance(this.colorColumnSlug)
         }
 
-        // drop all data when the author chose to hide entities with missing data and
-        // at least one of the variables has no data for the current entity
-        if (
-            this.missingDataStrategy === MissingDataStrategy.hide &&
-            table.hasAnyColumnNoValidValue(this.yColumnSlugs)
-        ) {
-            table = table.dropAllRows()
-        }
-
         return table
     }
 
@@ -151,10 +141,6 @@ export class DiscreteBarChart
 
     @computed private get manager(): DiscreteBarChartManager {
         return this.props.manager
-    }
-
-    @computed private get missingDataStrategy(): MissingDataStrategy {
-        return this.manager.missingDataStrategy || MissingDataStrategy.auto
     }
 
     @computed private get targetTime(): Time | undefined {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -24,7 +24,6 @@ import { observer } from "mobx-react"
 import {
     BASE_FONT_SIZE,
     FacetStrategy,
-    MissingDataStrategy,
     SeriesName,
 } from "../core/GrapherConstants"
 import {
@@ -130,15 +129,6 @@ export class StackedDiscreteBarChart
             )
         }
 
-        // drop all data when the author chose to hide entities with missing data and
-        // at least one of the variables has no data for the current entity
-        if (
-            this.missingDataStrategy === MissingDataStrategy.hide &&
-            table.hasAnyColumnNoValidValue(this.yColumnSlugs)
-        ) {
-            table = table.dropAllRows()
-        }
-
         return table
     }
 
@@ -166,10 +156,6 @@ export class StackedDiscreteBarChart
     @computed private get bounds(): Bounds {
         // bottom padding avoids axis labels to be cut off at some resolutions
         return (this.props.bounds ?? DEFAULT_BOUNDS).padRight(10).padBottom(2)
-    }
-
-    @computed private get missingDataStrategy(): MissingDataStrategy {
-        return this.manager.missingDataStrategy || MissingDataStrategy.auto
     }
 
     @computed private get baseFontSize(): number {


### PR DESCRIPTION
- The transforms functions that apply the missing data strategy to DiscreteBar charts and StackedDiscreteBar charts are buggy
- Luckily, none of our DiscreteBar/StackedDiscreteBar charts in the live db currently use the missing data strategy option (maybe a sign?!)
- As a hot fix, I simply remove the data missing strategy option for these chart types
- We might add them back in the future (or maybe not, cause apparently no-one has used these options for months)
- But we might want to make Grapher a bit smarter when it comes to missing data (I'll elaborate elsewhere)