### PR TITLE
:bug: don't leave buildkite handing for skipped builds

### DIFF
--- a/baker/BuildkiteTrigger.ts
+++ b/baker/BuildkiteTrigger.ts
@@ -94,6 +94,7 @@ export class BuildkiteTrigger {
         }
 
         if (!["passed", "skipped", "canceled", "finished"].includes(state)) {
+            // failing states: failed, blocked, not_run
             throw new Error(
                 `Build ${buildNumber} failed with state "${state}". See Buildkite for details.`
             )

--- a/baker/BuildkiteTrigger.ts
+++ b/baker/BuildkiteTrigger.ts
@@ -93,9 +93,7 @@ export class BuildkiteTrigger {
             state = buildData.state
         }
 
-        if (["passed", "skipped", "canceled", "finished"].includes(state)) {
-            return
-        } else {
+        if (!["passed", "skipped", "canceled", "finished"].includes(state)) {
             throw new Error(
                 `Build ${buildNumber} failed with state "${state}". See Buildkite for details.`
             )


### PR DESCRIPTION
Skipped builds (that happen when there's more than one build in the queue) were in an infinite loop, which eventually led to connection timeouts for those old builds. This PR adds all build states and handles them appropriately.

Additionally:
* await buildkite builds
* put back local bake when not baking on buildkite (enables baking on staging servers and local)