### PR TITLE
🐛 filter non-editorial content out of sitemap

### DIFF
--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -288,16 +288,8 @@ export class SiteBaker {
 
     private async bakePosts() {
         if (!this.bakeSteps.has("wordpressPosts")) return
-        // In the backporting workflow, the users create gdoc posts for posts. As long as these are not yet published,
-        // we still want to bake them from the WP posts. Once the users presses publish there though, we want to stop
-        // baking them from the wordpress post. Here we fetch all the slugs of posts that have been published via gdocs
-        // and exclude them from the baking process.
-        const alreadyPublishedViaGdocsSlugs = await db.knexRaw(`-- sql
-            select slug from posts_with_gdoc_publish_status
-            where isGdocPublished = TRUE`)
-        const alreadyPublishedViaGdocsSlugsSet = new Set(
-            alreadyPublishedViaGdocsSlugs.map((row: any) => row.slug)
-        )
+        const alreadyPublishedViaGdocsSlugsSet =
+            await db.getSlugsWithPublishedGdocsSuccessors()
 
         const postsApi = await wpdb.getPosts(
             undefined,

--- a/baker/algolia/indexToAlgolia.tsx
+++ b/baker/algolia/indexToAlgolia.tsx
@@ -11,6 +11,7 @@ import {
     OwidGdocType,
     type RawPageview,
     Tag,
+    PostRestApi,
 } from "@ourworldindata/utils"
 import { formatPost } from "../formatWordpressPost.js"
 import ReactDOMServer from "react-dom/server.js"
@@ -71,7 +72,7 @@ function generateChunksFromHtmlText(htmlString: string) {
 }
 
 async function generateWordpressRecords(
-    postsApi: wpdb.PostAPI[],
+    postsApi: PostRestApi[],
     pageviews: Record<string, RawPageview>
 ): Promise<PageRecord[]> {
     const getPostTypeAndImportance = (
@@ -187,11 +188,10 @@ const getPagesRecords = async () => {
     const pageviews = await Pageview.getViewsByUrlObj()
     const gdocs = await Gdoc.getPublishedGdocs()
     const publishedGdocsBySlug = keyBy(gdocs, "slug")
-    const postsApi = await wpdb
-        .getPosts()
-        .then((posts) =>
-            posts.filter((post) => !publishedGdocsBySlug[`/${post.slug}`])
-        )
+    const postsApi = await wpdb.getPosts(
+        undefined,
+        (post) => !publishedGdocsBySlug[`/${post.slug}`]
+    )
 
     const countryRecords = generateCountryRecords(countries, pageviews)
     const wordpressRecords = await generateWordpressRecords(postsApi, pageviews)

--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -58,12 +58,8 @@ const explorerToSitemapUrl = (program: ExplorerProgram): SitemapUrl[] => {
 }
 
 export const makeSitemap = async (explorerAdminServer: ExplorerAdminServer) => {
-    const alreadyPublishedViaGdocsSlugs = await db.knexRaw(`-- sql
-            select slug from posts_with_gdoc_publish_status
-            where isGdocPublished = TRUE`)
-    const alreadyPublishedViaGdocsSlugsSet = new Set(
-        alreadyPublishedViaGdocsSlugs.map((row: any) => row.slug)
-    )
+    const alreadyPublishedViaGdocsSlugsSet =
+        await db.getSlugsWithPublishedGdocsSuccessors()
     const postsApi = await wpdb.getPosts(
         undefined,
         (postrow) => !alreadyPublishedViaGdocsSlugsSet.has(postrow.slug)

--- a/db/db.ts
+++ b/db/db.ts
@@ -109,3 +109,21 @@ export const knexTable = (table: string): Knex.QueryBuilder =>
     knexInstance().table(table)
 
 export const knexRaw = (str: string): Knex.Raw => knexInstance().raw(str)
+
+/**
+ *  In the backporting workflow, the users create gdoc posts for posts. As long as these are not yet published,
+ *  we still want to bake them from the WP posts. Once the users presses publish there though, we want to stop
+ *  baking them from the wordpress post. This funciton fetches all the slugs of posts that have been published via gdocs,
+ *  to help us exclude them from the baking process.
+ */
+export const getSlugsWithPublishedGdocsSuccessors = async (): Promise<
+    Set<string>
+> => {
+    return knexRaw(
+        `-- sql
+            select slug from posts_with_gdoc_publish_status
+            where isGdocPublished = TRUE`
+    )
+        .then((res) => res[0])
+        .then((rows) => new Set(rows.map((row: any) => row.slug)))
+}

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -476,7 +476,7 @@ export const getPosts = async (
     postTypes: string[] = [WP_PostType.Post, WP_PostType.Page],
     filterFunc?: FilterFnPostRestApi,
     limit?: number
-): Promise<any[]> => {
+): Promise<PostRestApi[]> => {
     if (!isWordpressAPIEnabled) return []
 
     const perPage = 20
@@ -720,27 +720,9 @@ export const getBlockContent = async (
 
     return post.data?.wpBlock?.content ?? undefined
 }
-export interface PostAPI {
-    id: number
-    type: WP_PostType
-    slug: string
-    title: {
-        rendered: string
-    }
-    date_gmt: string
-    modified_gmt: string
-    authors_name?: string[]
-    content: { rendered: string }
-    excerpt: { rendered: string }
-    featured_media_paths: {
-        medium_large: string
-        thumbnail: string
-    }
-    featured_media: number
-}
 
 export const getFullPost = async (
-    postApi: PostAPI,
+    postApi: PostRestApi,
     excludeContent?: boolean
 ): Promise<FullPost> => ({
     id: postApi.id,

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -324,6 +324,43 @@ export interface PostRestApi {
             latest?: boolean
         }
     }
+    id: number
+    date: string
+    date_gmt: string
+    guid: {
+        rendered: string
+    }
+    modified: string
+    modified_gmt: string
+
+    status: string
+    type: WP_PostType
+    link: string
+    title: {
+        rendered: string
+    }
+    content: {
+        rendered: string
+        protected: boolean
+    }
+    excerpt: {
+        rendered: string
+        protected: boolean
+    }
+    author: number
+    featured_media: number
+    comment_status: string
+    ping_status: string
+    sticky: boolean
+    template: string
+    format: string
+    categories: number[]
+    tags: any[]
+    authors_name: string[]
+    featured_media_paths: {
+        thumbnail: string
+        medium_large: string
+    }
 }
 
 export interface KeyInsight {


### PR DESCRIPTION
Fixes https://github.com/owid/owid-grapher/issues/2726

Uses the `wbdb.getPosts()` method (and fixes up / simplifies some incorrect typing) which correctly filters out reusable blocks. There's a default filter for posts that end in `-country-profile` in this method, but AFAICT that's to filter out the templates, not the pages themselves - those still get added:

<img width="340" alt="image" src="https://github.com/owid/owid-grapher/assets/11844404/a0a7285c-f785-4a05-b49f-a8ae8621d930">

As well as default country pages:

<img width="299" alt="image" src="https://github.com/owid/owid-grapher/assets/11844404/e1b216a7-4cbd-4a8c-8c4d-5edae2ce1ad1">


Also uses the `Gdoc.getPublishedGdocs()` method which filters out fragments and unpublished documents.

On my local environment:
`sitemap.xml` length before: 6056
`sitemap.xml` length after: 6043

The filtered pages:
```
http://localhost:3030/co2-country-profile
http://localhost:3030/coronavirus-country-profile
http://localhost:3030/energy-country-profile
http://localhost:3030/untitled-reusable-block-128
http://localhost:3030/untitled-reusable-block-129
http://localhost:3030/untitled-reusable-block-130
http://localhost:3030/untitled-reusable-block-131
http://localhost:3030/untitled-reusable-block-145
http://localhost:3030/untitled-reusable-block-171
http://localhost:3030/untitled-reusable-block-180
http://localhost:3030/untitled-reusable-block-266
http://localhost:3030/untitled-reusable-block-275
http://localhost:3030/untitled-reusable-block-277
http://localhost:3030/untitled-reusable-block-295
http://localhost:3030/untitled-reusable-block-7
http://localhost:3030/untitled-reusable-block-77
```