### PR TITLE
:sparkles: improve data page fallback chains

### DIFF
--- a/datapage/Datapage.ts
+++ b/datapage/Datapage.ts
@@ -50,11 +50,10 @@ export const getDatapageDataV2 = async (
             title:
                 variableMetadata.presentation?.titlePublic ??
                 partialGrapherConfig.title ??
+                variableMetadata.display?.name ??
                 variableMetadata.name ??
                 "",
-            descriptionShort:
-                variableMetadata.descriptionShort ??
-                partialGrapherConfig.subtitle,
+            descriptionShort: variableMetadata.descriptionShort,
             descriptionFromProducer: variableMetadata.descriptionFromProducer,
             attributionShort: variableMetadata.presentation?.attributionShort,
             titleVariant: variableMetadata.presentation?.titleVariant,

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
@@ -82,10 +82,7 @@ export class SourcesModal extends React.Component<{
                 maxTime
             )}`
 
-        const title =
-            column.def.titlePublic && column.def.titlePublic !== ""
-                ? column.def.titlePublic
-                : column.name
+        const title = column.displayName
 
         const retrievedDate =
             source.retrievedDate ??


### PR DESCRIPTION
This implements better fallback chains for the title of an indciator on both data pages and in the sources tab:

1. sources tab to: `display.name > indicator.title`
1. data page title to: `presentation.title_public > presentation.grapher_config.title > display.name > indicator.title`