### PR TITLE
fix(axis): center axis labels

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -179,6 +179,10 @@ abstract class AbstractAxis {
         return Math.min(this.range[1], this.range[0])
     }
 
+    @computed get rangeCenter(): number {
+        return this.rangeMin + this.rangeSize / 2
+    }
+
     /** The number of ticks we should _aim_ to show, not necessarily a strict target. */
     @computed private get totalTicksTarget(): number {
         // Chose 1.8 here by trying a bunch of different faceted charts and figuring out what

--- a/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
+++ b/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
@@ -210,9 +210,11 @@ export class VerticalAxisComponent extends React.Component<{
             <g className="VerticalAxis">
                 {labelTextWrap &&
                     labelTextWrap.render(
-                        -bounds.centerY - labelTextWrap.width / 2,
+                        -verticalAxis.rangeCenter - labelTextWrap.width / 2,
                         bounds.left,
-                        { transform: "rotate(-90)" }
+                        {
+                            transform: "rotate(-90)",
+                        }
                     )}
                 {tickLabels.map((label, i) => {
                     const { y, xAlign, yAlign, formattedValue } = label
@@ -294,7 +296,7 @@ export class HorizontalAxisComponent extends React.Component<{
             <g className="HorizontalAxis">
                 {label &&
                     label.render(
-                        bounds.centerX - label.width / 2,
+                        axis.rangeCenter - label.width / 2,
                         labelYPosition
                     )}
                 {tickMarks}


### PR DESCRIPTION
Fixes #2850.

The issue here is that `bounds` are the bounds of the whole charting area, but the vertical axis has some extra bottom padding and the horizontal axis has some extra left padding:

```
V         |
e         |
r         |
t         |
i         |
c         |
a         |
l         |
          |
a         |
x         |
i         |
s         |
          |
-------------------------------------------------------------
PADDING   |                   Horizontal axis
```

By relying on `axis.range`, and in particular on the new `axis.rangeCenter` property, we can circumvent this issue.