### PR TITLE
fix(data-table): respect tolerance

### DIFF
--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -675,7 +675,6 @@ export class DataTable extends React.Component<{
                     : TargetTimeMode.range
 
             const prelimValuesByEntity = this.preliminaryDimensionValues(
-                targetTimeMode,
                 sourceColumn,
                 targetTimes
             )
@@ -728,27 +727,14 @@ export class DataTable extends React.Component<{
     }
 
     private preliminaryDimensionValues(
-        targetTimeMode: TargetTimeMode,
         sourceColumn: CoreColumn,
         targetTimes: number[]
     ): Map<string, (DataValue | undefined)[]> {
-        return targetTimeMode === TargetTimeMode.range
-            ? // In the "range" mode, we receive all data values within the range. But we
-
-              // only want to plot the start & end values in the table.
-              // getStartEndValues() extracts these two values.
-              es6mapValues(
-                  valuesByEntityWithinTimes(
-                      sourceColumn.valueByEntityNameAndOriginalTime,
-                      targetTimes
-                  ),
-                  getStartEndValues
-              )
-            : valuesByEntityAtTimes(
-                  sourceColumn.valueByEntityNameAndOriginalTime,
-                  targetTimes,
-                  sourceColumn.tolerance
-              )
+        return valuesByEntityAtTimes(
+            sourceColumn.valueByEntityNameAndOriginalTime,
+            targetTimes,
+            sourceColumn.tolerance
+        )
     }
 
     private dataValuesFromPreliminaryValues(

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -770,7 +770,8 @@ export class DataTable extends React.Component<{
                     start !== undefined &&
                     end !== undefined &&
                     typeof start.value === "number" &&
-                    typeof end.value === "number"
+                    typeof end.value === "number" &&
+                    start.time <= end.time
                 ) {
                     const deltaValue = end.value - start.value
                     const deltaRatioValue = deltaValue / Math.abs(start.value)

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -23,8 +23,6 @@ import {
     upperFirst,
     valuesByEntityAtTimes,
     es6mapValues,
-    valuesByEntityWithinTimes,
-    getStartEndValues,
     sortBy,
     countBy,
     union,

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -771,6 +771,9 @@ export class DataTable extends React.Component<{
                     end !== undefined &&
                     typeof start.value === "number" &&
                     typeof end.value === "number" &&
+                    // sanity check: start time should always be <= end time
+                    start.time !== undefined &&
+                    end.time !== undefined &&
                     start.time <= end.time
                 ) {
                     const deltaValue = end.value - start.value


### PR DESCRIPTION
- fixes https://github.com/owid/owid-grapher/issues/2831

- there are two code paths: "range" mode and "point" mode
  - in "range" mode, a start and end year are selected and we show four columns: Start year, end year, absolute change, relative change
  - in "point" mode, a single year is selected and we show a single column for that year
- in "point" mode, all is good
    - tolerance is appropriately applied and no hundreds-years-away data points are used to fill an empty cell
- the issue is with the "range" mode
  - here, we take the range of available data points within the current selection, and then apply min/max to get the values for the start and end point, i.e. if the user-selected time range is [1000, 2000] but we only have data for [1990, 2000], then we'll end up showing the 1990 value for the year 1000
  - the tolerance defined by the author is not taken into account, as far as I can see
- to fix the issue, we simply grab the closest available data point within tolerance for both the start and the end year

I can see that the special code path for "range" mode was a deliberate choice, but I'm not sure why (to show the delta columns as often as possible?). What am I missing?
