### PR TITLE
🐛 Don't trigger lightning updates if dod document is updated

### DIFF
--- a/adminSiteClient/gdocsDeploy.ts
+++ b/adminSiteClient/gdocsDeploy.ts
@@ -5,6 +5,7 @@ import {
     omit,
 } from "@ourworldindata/utils"
 import { GDOC_DIFF_OMITTABLE_PROPERTIES } from "./GdocsDiff.js"
+import { GDOCS_DETAILS_ON_DEMAND_ID } from "../settings/clientSettings.js"
 
 export const checkFullDeployFallback = (
     prevGdoc: OwidGdocInterface,
@@ -103,6 +104,7 @@ export const checkIsLightningUpdate = (
     const nextOmitted = omit({ ...nextGdoc }, keysToOmit)
 
     return (
+        prevGdoc.id !== GDOCS_DETAILS_ON_DEMAND_ID &&
         hasChanges &&
         prevGdoc.published &&
         nextGdoc.published &&

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -78,3 +78,6 @@ export const IMAGE_HOSTING_BUCKET_SUBFOLDER_PATH: string =
 // Fast-track settings, by default points to staging version. You need Tailscale to access it.
 export const FASTTRACK_URL: string =
     process.env.FASTTRACK_URL ?? "http://owid-analytics:8083/"
+
+export const GDOCS_DETAILS_ON_DEMAND_ID: string =
+    process.env.GDOCS_DETAILS_ON_DEMAND_ID ?? ""


### PR DESCRIPTION
The DoD document requires we rebake dods.json and grapher embeds that reference them. 

So this PR disqualifies it from ever being a lightning update candidate.