### PR TITLE
🎉 Entry Emulator - support dateline in topic page header

### DIFF
--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -846,23 +846,7 @@ function cheerioToArchieML(
             .with({ tagName: "details" }, unwrapElementWithContext)
             .with({ tagName: "div" }, (div) => {
                 const className = div.attribs.class || ""
-                // Special handling for a div that we use to mark the "First published on..." notice
-                if (className.includes("blog-info")) {
-                    const children = unwrapElementWithContext(div)
-                    const textChildren = children.content.filter(
-                        (c) => "type" in c && c.type === "text"
-                    ) as EnrichedBlockText[]
-                    const callout: EnrichedBlockCallout = {
-                        type: "callout",
-                        title: "",
-                        text: textChildren,
-                        parseErrors: [],
-                    }
-                    return {
-                        errors: [],
-                        content: [callout],
-                    }
-                } else if (className.includes("pcrm")) {
+                if (className.includes("pcrm")) {
                     // pcrm stands for "preliminary collection of relevant material" which was used to designate entries
                     // that weren't fully polished, but then became a way to create a general-purpose "warning box".
                     const unwrapped = unwrapElementWithContext(element)

--- a/site/gdocs/OwidGdocHeader.tsx
+++ b/site/gdocs/OwidGdocHeader.tsx
@@ -139,6 +139,9 @@ function OwidTopicPageHeader({
                     })}
                 </a>
             </p>
+            <p className="topic-page-header__dateline body-3-medium-italic col-start-2 span-cols-8">
+                {content.dateline}
+            </p>
         </header>
     )
 }

--- a/site/gdocs/topic-page.scss
+++ b/site/gdocs/topic-page.scss
@@ -22,10 +22,17 @@
     p.topic-page-header__byline,
     .topic-page-header__byline a {
         color: $blue-60;
+        margin-bottom: 0;
+        @include sm-only {
+            font-size: 0.875rem;
+        }
+    }
+
+    // Applies to either .topic-page-header__byline or .topic-page-header__dateline, if specified
+    p:last-child {
         margin-bottom: 34px;
         @include sm-only {
             margin-bottom: 16px;
-            font-size: 0.875rem;
         }
     }
 


### PR DESCRIPTION
Adds support for rendering a string dateline in topic page headers, which we'll use for linear topic pages.

Thus I've removed the code that extracted this text and turned it into a callout.

About 30 out of 50 of the entries we wish to migrate feature this text, so instead of writing a weird path that allows us to return metadata out of the `cheerioToArchieML` function, I figure I'll just manually copy-paste it 30 times.

![image](https://github.com/owid/owid-grapher/assets/11844404/35b84527-ed80-4d13-92c0-6b126f13fa30)
