### PR TITLE
🎉 Entry Emulator - sidebar table of contents

### DIFF
--- a/adminSiteClient/gdocsDeploy.ts
+++ b/adminSiteClient/gdocsDeploy.ts
@@ -59,6 +59,7 @@ export const checkIsLightningUpdate = (
         "cover-color": true,
         "cover-image": true,
         "hide-citation": true,
+        "sidebar-toc": true,
         body: true,
         dateline: true,
         details: true,

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -168,6 +168,7 @@ const migrate = async (): Promise<void> => {
                     // Provide an empty array to prevent the sticky nav from rendering at all
                     // Because if it isn't defined, it tries to automatically populate itself
                     "sticky-nav": isEntry ? [] : undefined,
+                    "sidebar-toc": true,
                 },
                 relatedCharts,
                 published: false,

--- a/db/model/Gdoc/archieToEnriched.ts
+++ b/db/model/Gdoc/archieToEnriched.ts
@@ -131,8 +131,9 @@ function generateToc(
             if (child.type === "heading") {
                 const { level, text, supertitle } = child
                 const titleString = spansToSimpleString(text)
-                const supertitleString =
-                    supertitle && spansToSimpleString(supertitle)
+                const supertitleString = supertitle
+                    ? spansToSimpleString(supertitle)
+                    : ""
                 if (titleString && (level === 2 || level === 3)) {
                     toc.push({
                         title: titleString,

--- a/db/model/Gdoc/archieToGdoc.ts
+++ b/db/model/Gdoc/archieToGdoc.ts
@@ -49,6 +49,7 @@ function* owidArticleToArchieMLStringGenerator(
         }
         yield "[]"
     }
+    yield* propertyToArchieMLString("sidebar-toc", article)
     // TODO: inline refs
     yieldMultiBlockPropertyIfDefined("summary", article, article.summary)
     yield* propertyToArchieMLString("hide-citation", article)

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -37,8 +37,9 @@ import {
 import { match } from "ts-pattern"
 
 export function appendDotEndIfMultiline(
-    line: string | null | undefined
+    line: string | boolean | null | undefined
 ): string {
+    if (typeof line === "boolean") return line ? "true" : "false"
     if (line && line.includes("\n")) return line + "\n:end"
     return line ?? ""
 }

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1324,6 +1324,7 @@ export interface OwidGdocContent {
     "featured-image"?: string
     "atom-title"?: string
     "atom-excerpt"?: string
+    "sidebar-toc"?: boolean
     "cover-color"?:
         | "sdg-color-1"
         | "sdg-color-2"

--- a/site/TableOfContents.tsx
+++ b/site/TableOfContents.tsx
@@ -115,7 +115,10 @@ export const TableOfContents = ({
             contentHeadings.forEach((contentHeading) => {
                 observer.observe(contentHeading)
             })
+
+            return () => observer.disconnect()
         }
+        return
     }, [headings, hideSubheadings])
 
     return (

--- a/site/css/grid.scss
+++ b/site/css/grid.scss
@@ -56,7 +56,6 @@ $grid-responsive: (lg, md, sm);
     gap: 0 var(--grid-gap);
     grid-template-columns: repeat(12, 1fr);
     grid-auto-rows: min-content;
-    align-items: start;
 }
 
 // Use this when you want a full-page-width grid container

--- a/site/css/grid.scss
+++ b/site/css/grid.scss
@@ -56,6 +56,7 @@ $grid-responsive: (lg, md, sm);
     gap: 0 var(--grid-gap);
     grid-template-columns: repeat(12, 1fr);
     grid-auto-rows: min-content;
+    align-items: start;
 }
 
 // Use this when you want a full-page-width grid container

--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -21,6 +21,7 @@ import { DebugProvider } from "./DebugContext.js"
 import { OwidGdocHeader } from "./OwidGdocHeader.js"
 import StickyNav from "../blocks/StickyNav.js"
 import { getShortPageCitation } from "./utils.js"
+import { TableOfContents } from "../TableOfContents.js"
 export const AttachmentsContext = createContext<{
     linkedCharts: Record<string, LinkedChart>
     linkedDocuments: Record<string, OwidGdocInterface>
@@ -70,6 +71,7 @@ export function OwidGdoc({
         publishedAt
     )
     const citationText = `${shortPageCitation} Published online at OurWorldInData.org. Retrieved from: '${`${BAKED_BASE_URL}/${slug}`}' [Online Resource]`
+    const hasSidebarToc = content["sidebar-toc"]
 
     const bibtex = `@article{owid-${slug.replace(/\//g, "-")},
     author = {${formatAuthors({
@@ -119,6 +121,12 @@ export function OwidGdoc({
                         publishedAt={publishedAt}
                         breadcrumbs={breadcrumbs ?? undefined}
                     />
+                    {hasSidebarToc && content.toc ? (
+                        <TableOfContents
+                            headings={content.toc}
+                            pageTitle={content.title || ""}
+                        />
+                    ) : null}
                     {content.type === "topic-page" && stickyNavLinks?.length ? (
                         <nav className="sticky-nav sticky-nav--dark span-cols-14 grid grid-cols-12-full-width">
                             <StickyNav

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -35,6 +35,10 @@
             transition: margin 300ms ease;
             width: 400px;
             margin-left: -400px;
+            @include sm-only {
+                width: 100vw;
+                margin-left: -100vw;
+            }
             .toggle-toc {
                 margin-left: 0;
                 transform: translateX(calc(100% + 16px));

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -33,8 +33,8 @@
             height: 100vh;
             position: absolute;
             transition: margin 300ms ease;
-            width: calc(50vw - 330px);
-            margin-left: calc(-50vw + 330px);
+            width: 400px;
+            margin-left: -400px;
             .toggle-toc {
                 margin-left: 0;
                 transform: translateX(calc(100% + 16px));

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -35,9 +35,46 @@
             transition: margin 300ms ease;
             width: 400px;
             margin-left: -400px;
+            box-shadow: none;
             @include sm-only {
                 width: 100vw;
                 margin-left: -100vw;
+            }
+            @include sm-up {
+                ul {
+                    margin-left: 32px;
+                }
+            }
+
+            li {
+                &.section {
+                    margin-top: 24px;
+                }
+                a {
+                    padding-left: 16px;
+                }
+            }
+            li.section a,
+            li.subsection a {
+                border-width: 6px;
+                padding-right: 32px;
+                margin-left: 0;
+                color: $blue-90;
+
+                &:hover {
+                    background: none;
+                    text-decoration: underline;
+                }
+            }
+
+            li.subsection a {
+                color: $blue-60;
+                margin-left: 16px;
+            }
+
+            li.active a {
+                border-left-color: $vermillion;
+                background: unset;
             }
             .toggle-toc {
                 margin-left: 0;
@@ -57,12 +94,43 @@
                     top: 16px;
                     pointer-events: auto;
                     white-space: nowrap;
+                    box-shadow: none;
+                    background: #fff;
+                    border: 1px solid $blue-20;
+                    line-height: 1.25;
+                    padding: 6px;
+                    border-radius: 4px;
+
+                    &:hover {
+                        background: #fff;
+                        svg {
+                            color: $blue-100;
+                        }
+                    }
+                    svg {
+                        margin-right: 0;
+                        color: $blue-90;
+                        height: 12px;
+                    }
+
+                    span {
+                        color: $blue-90;
+                        margin-left: 5px;
+                        position: relative;
+                        top: 1px;
+                    }
                 }
             }
             &.entry-sidebar--is-open {
                 margin-left: 0;
                 .toggle-toc {
                     transform: translateX(-16px);
+                    button {
+                        border: none;
+                        span {
+                            display: none;
+                        }
+                    }
                 }
             }
         }

--- a/site/gdocs/centered-article.scss
+++ b/site/gdocs/centered-article.scss
@@ -23,6 +23,46 @@
             color: $vermillion !important;
         }
     }
+
+    .toc-wrapper {
+        position: sticky;
+        top: 0;
+        z-index: 2;
+        margin-top: -48px;
+        .entry-sidebar {
+            height: 100vh;
+            position: absolute;
+            transition: margin 300ms ease;
+            width: calc(50vw - 330px);
+            margin-left: calc(-50vw + 330px);
+            .toggle-toc {
+                margin-left: 0;
+                transform: translateX(calc(100% + 16px));
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                right: 0;
+                padding: 16px 0;
+                pointer-events: none;
+                display: unset;
+                transition: transform 300ms ease;
+                button {
+                    @include popover-box-button;
+                    z-index: 20;
+                    position: sticky;
+                    top: 16px;
+                    pointer-events: auto;
+                    white-space: nowrap;
+                }
+            }
+            &.entry-sidebar--is-open {
+                margin-left: 0;
+                .toggle-toc {
+                    transform: translateX(-16px);
+                }
+            }
+        }
+    }
 }
 
 $banner-height: 200px;


### PR DESCRIPTION
Adds support for sidebars in Gdocs articles. Luckily, because the sdg-toc was already an extension of the original site `TableOfContents`, required changes were minimal 🙌 

Marwa had [given the component a refresh on figma](https://www.figma.com/file/9bQW46okOjxeJtismQQdPu/%5BDesktop%5D-Screens-1.0?type=design&node-id=788-825&mode=design&t=GE9VzQ4gQVgGxely-0), but when I began working on this I realized it wouldn't really work. It _has_ to be an overlay because we have textual and graphic content that goes full width.

Thus, an overlay it is (and one that isn't exactly integrated with our grid system either 🙈.)

![image](https://github.com/owid/owid-grapher/assets/11844404/abd5444a-d069-4776-976d-fe877ab4a780)

There's an issue where scrolling doesn't always correctly update the highlighted heading in the sidebar. I'll check with Matthieu if he has any ideas, but first wanted to validate this overall solution with the team before working on it further.