### PR TITLE
Linear topic page all charts improvements

### DIFF
--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -128,6 +128,30 @@ const migrate = async (): Promise<void> => {
             adjustHeadingLevels(archieMlBodyElements)
 
             if (relatedCharts.length) {
+                const indexOfFirstHeading = archieMlBodyElements.findIndex(
+                    (block) => block.type === "heading"
+                )
+                archieMlBodyElements.splice(indexOfFirstHeading, 0, {
+                    type: "text",
+                    value: [
+                        {
+                            spanType: "span-bold",
+                            children: [
+                                {
+                                    spanType: "span-link",
+                                    url: `#all-charts`,
+                                    children: [
+                                        {
+                                            spanType: "span-simple-text",
+                                            text: `See all interactive charts on ${post.title} ↓`,
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                    parseErrors: [],
+                })
                 const allChartsBlock: EnrichedBlockAllCharts = {
                     type: "all-charts",
                     parseErrors: [],

--- a/site/gdocs/utils.tsx
+++ b/site/gdocs/utils.tsx
@@ -118,13 +118,12 @@ const LinkedA = ({ span }: { span: SpanLink }): JSX.Element => {
     const { linkedChart } = useLinkedChart(span.url)
 
     if (linkType === "url") {
+        // Don't open in new tab if it's an anchor link
+        const linkProps = !span.url.startsWith("#")
+            ? { target: "_blank", rel: "noopener noreferrer" }
+            : {}
         return (
-            <a
-                href={span.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="span-link"
-            >
+            <a href={span.url} className="span-link" {...linkProps}>
                 {renderSpans(span.children)}
             </a>
         )


### PR DESCRIPTION
Adds an anchor link to the all charts block for linear topic pages, and also updated the `LinkedA` component to not open in a new tab if it's an anchor link.

<img width="737" alt="image" src="https://github.com/owid/owid-grapher/assets/11844404/995e245f-889e-48b9-8440-96a2ff981707">
