### PR TITLE
Smaller chromeless explorer embeds in articles & a fix for native tables crashing

### DIFF
--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -61,7 +61,7 @@ const layouts: { [key in Container]: Layouts} = {
         ["chart"]: "col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["default"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["divider"]: "col-start-2 span-cols-12",
-        ["explorer"]: "col-start-2 span-cols-12 span-md-cols-12 col-md-start-2",
+        ["explorer"]: "col-start-2 span-cols-12",
         ["gray-section"]: "span-cols-14 grid grid-cols-12-full-width",
         ["heading"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["horizontal-rule"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
@@ -186,8 +186,10 @@ export default function ArticleBlock({
             />
         ))
         .with({ type: "chart" }, (block) => {
-            const { isExplorer } = Url.fromURL(block.url)
-            const layoutSubtype = isExplorer ? "explorer" : "chart"
+            const { isExplorer, queryStr } = Url.fromURL(block.url)
+            const areControlsHidden = queryStr.includes("hideControls=true")
+            const layoutSubtype =
+                isExplorer && !areControlsHidden ? "explorer" : "chart"
             return (
                 <Chart
                     className={getLayout(layoutSubtype, containerType)}


### PR DESCRIPTION
Just two small improvements:

1. Renders explorers at 8 columns if `hideControls=true` is present in the query string.
2. Skips parsing native tables if we're not inside a `{.table}` block.
    1. The alternative was turning `{.table-rows}` into its own component which was a lot of new code and would require a migration for any tables that had already been created.