### PR TITLE
refactor: use `<CodeSnippet>` in embed modal

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -153,6 +153,16 @@ $zindex-controls-drawer: 140;
     .DataTableContainer {
         z-index: $zindex-table;
     }
+
+    // customize css of the <CodeSnippet> component
+    .wp-code-snippet {
+        --code-snippet-border: #e7e7e7;
+        --code-snippet-background-light: #f7f7f7;
+        --code-snippet-text: #{$light-text};
+        --code-snippet-button: #{$dark-text};
+        --code-snippet-button-hover: #{$light-text};
+        --code-snippet-button-active: #{$light-text};
+    }
 }
 
 .GrapherComponent.isExportingToSvgOrPng {

--- a/packages/@ourworldindata/grapher/src/modal/EmbedModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/EmbedModal.scss
@@ -9,32 +9,4 @@
         font-size: 0.875em;
         font-weight: 500;
     }
-
-    .embedCode {
-        width: 100%;
-        padding: 1em 1.5em;
-        border: 1px solid #e7e7e7;
-        background: #f7f7f7;
-        display: flex;
-        align-items: flex-start;
-    }
-
-    code {
-        width: 100%;
-        border: none;
-        background: none;
-        color: $light-text;
-        font-size: 0.75em;
-        line-height: 1.33;
-        word-break: break-word;
-    }
-
-    button {
-        flex: 0 0 64px;
-        cursor: pointer;
-        color: $dark-text;
-        padding: 0;
-        text-align: right;
-        font-size: 0.875em;
-    }
 }

--- a/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
@@ -1,14 +1,9 @@
 import { observer } from "mobx-react"
 import React from "react"
 import { computed, action } from "mobx"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
-import { faCopy } from "@fortawesome/free-solid-svg-icons"
-import {
-    Bounds,
-    canWriteToClipboard,
-    DEFAULT_BOUNDS,
-} from "@ourworldindata/utils"
+import { Bounds, DEFAULT_BOUNDS } from "@ourworldindata/utils"
 import { Modal } from "./Modal"
+import { CodeSnippet } from "@ourworldindata/components"
 
 export interface EmbedModalManager {
     canonicalUrl?: string
@@ -22,27 +17,8 @@ interface EmbedModalProps {
     manager: EmbedModalManager
 }
 
-interface EmbedModalState {
-    canWriteToClipboard: boolean
-    copied: boolean
-}
-
 @observer
-export class EmbedModal extends React.Component<
-    EmbedModalProps,
-    EmbedModalState
-> {
-    textAreaRef: React.RefObject<HTMLTextAreaElement> = React.createRef()
-
-    constructor(props: EmbedModalProps) {
-        super(props)
-
-        this.state = {
-            canWriteToClipboard: false,
-            copied: false,
-        }
-    }
-
+export class EmbedModal extends React.Component<EmbedModalProps> {
     @computed private get tabBounds(): Bounds {
         return this.manager.tabBounds ?? DEFAULT_BOUNDS
     }
@@ -62,25 +38,6 @@ export class EmbedModal extends React.Component<
         return this.props.manager
     }
 
-    componentDidMount(): void {
-        canWriteToClipboard().then((canWriteToClipboard) =>
-            this.setState({ canWriteToClipboard })
-        )
-    }
-
-    @action.bound async copyCodeSnippet(): Promise<void> {
-        try {
-            await navigator.clipboard.writeText(this.codeSnippet)
-            this.setState({ copied: true })
-            setTimeout(() => this.setState({ copied: false }), 2000)
-        } catch (err) {
-            console.error(
-                "couldn't copy to clipboard using navigator.clipboard",
-                err
-            )
-        }
-    }
-
     render(): JSX.Element {
         return (
             <Modal
@@ -93,18 +50,7 @@ export class EmbedModal extends React.Component<
             >
                 <div className="embedMenu">
                     <p>Paste this into any HTML page:</p>
-                    <div className="embedCode">
-                        <code>{this.codeSnippet}</code>
-                        {this.state.canWriteToClipboard && (
-                            <button onClick={this.copyCodeSnippet}>
-                                {this.state.copied ? (
-                                    "Copied!"
-                                ) : (
-                                    <FontAwesomeIcon icon={faCopy} />
-                                )}
-                            </button>
-                        )}
-                    </div>
+                    <CodeSnippet code={this.codeSnippet} />
                     {this.manager.embedDialogAdditionalElements}
                 </div>
             </Modal>

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.scss
@@ -109,15 +109,6 @@
             --non-expandable-border: #{$border};
         }
 
-        .wp-code-snippet {
-            --code-snippet-border: #{$border};
-            --code-snippet-background-light: #f7f7f7;
-            --code-snippet-text: #{$light-text};
-            --code-snippet-button: #{$dark-text};
-            --code-snippet-button-hover: #{$light-text};
-            --code-snippet-button-active: #{$light-text};
-        }
-
         .Tabs__tab {
             font-size: $tab-font-size;
             padding: 8px $tab-padding;


### PR DESCRIPTION
Just getting rid of some code that used to be duplicated.

They look a bit different, but not by all that much. Left is what's currently live, right is the new one:
![CleanShot 2023-11-06 at 13 37 58](https://github.com/owid/owid-grapher/assets/2641501/d3980592-94b4-4d73-826c-cecfc764de00)
