### PR TITLE
fix(bake): lightning deploys populate gdoc metadata

### DIFF
--- a/adminSiteClient/GdocsDiff.tsx
+++ b/adminSiteClient/GdocsDiff.tsx
@@ -7,6 +7,9 @@ import { omit, OwidGdocInterface } from "@ourworldindata/utils"
 // Errors are already shown in the settings drawer, so we don't show those either
 export const GDOC_DIFF_OMITTABLE_PROPERTIES = [
     "errors",
+    // imageMetadata *does* count as something that meaningfully contributes to whether a Gdoc is different,
+    // And it's checked in the checkIsLightningUpdate function,
+    // but for the preview, it's already captured by changes to the body text, so we don't need to show these objects in the diff also
     "imageMetadata",
     "linkedCharts",
     "linkedDocuments",

--- a/adminSiteClient/gdocsDeploy.ts
+++ b/adminSiteClient/gdocsDeploy.ts
@@ -36,7 +36,6 @@ export const checkIsLightningUpdate = (
     > = {
         breadcrumbs: true,
         errors: true,
-        imageMetadata: true,
         linkedCharts: true,
         linkedDocuments: true,
         relatedCharts: true,
@@ -47,6 +46,7 @@ export const checkIsLightningUpdate = (
         updatedAt: true,
         createdAt: false,
         id: false, // weird case - can't be updated
+        imageMetadata: false, // could require baking new images
         publicationContext: false, // requires an update of the blog roll
         published: false, // requires an update of the blog roll
         publishedAt: false, // could require an update of the blog roll

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -2502,6 +2502,10 @@ apiRouter.put("/gdocs/:id", async (req, res) => {
         .getRepository(Gdoc)
         .create(getOwidGdocFromJSON(nextGdocJSON))
 
+    // Need to load these to compare them for lightning update candidacy
+    await prevGdoc.loadImageMetadata()
+    await nextGdoc.loadImageMetadata()
+
     // Deleting and recreating these is simpler than tracking orphans over the next code block
     await GdocXImage.delete({ gdocId: id })
     const filenames = nextGdoc.filenames

--- a/baker/DeployUtils.ts
+++ b/baker/DeployUtils.ts
@@ -55,11 +55,10 @@ const triggerBakeAndDeploy = async (
         // otherwise, bake locally. This is used for local development or staging servers
         const baker = new SiteBaker(BAKED_SITE_DIR, BAKED_BASE_URL)
         if (lightningQueue?.length) {
-            for (const change of lightningQueue) {
-                if (!change.slug)
-                    throw new Error("Lightning deploy has missing slug")
-                await baker.bakeGDocPosts(lightningQueue.map((c) => c.slug!))
-            }
+            if (!lightningQueue.every((change) => change.slug))
+                throw new Error("Lightning deploy is missing a slug")
+
+            await baker.bakeGDocPosts(lightningQueue.map((c) => c.slug!))
         } else {
             await baker.bakeAll()
         }

--- a/baker/DeployUtils.ts
+++ b/baker/DeployUtils.ts
@@ -58,7 +58,7 @@ const triggerBakeAndDeploy = async (
             for (const change of lightningQueue) {
                 if (!change.slug)
                     throw new Error("Lightning deploy has missing slug")
-                await baker.bakeGDocPosts([change.slug])
+                await baker.bakeGDocPosts(lightningQueue.map((c) => c.slug!))
             }
         } else {
             await baker.bakeAll()

--- a/baker/DeployUtils.ts
+++ b/baker/DeployUtils.ts
@@ -7,8 +7,7 @@ import {
     BAKED_BASE_URL,
     BUILDKITE_API_ACCESS_TOKEN,
 } from "../settings/serverSettings.js"
-import { DeployChange, OwidGdocPublished } from "@ourworldindata/utils"
-import { Gdoc } from "../db/model/Gdoc/Gdoc.js"
+import { DeployChange } from "@ourworldindata/utils"
 import { SiteBaker } from "../baker/SiteBaker.js"
 
 const deployQueueServer = new DeployQueueServer()
@@ -57,11 +56,9 @@ const triggerBakeAndDeploy = async (
         const baker = new SiteBaker(BAKED_SITE_DIR, BAKED_BASE_URL)
         if (lightningQueue?.length) {
             for (const change of lightningQueue) {
-                const gdoc = (await Gdoc.findOneByOrFail({
-                    published: true,
-                    slug: change.slug,
-                })) as OwidGdocPublished
-                await baker.bakeGDocPost(gdoc)
+                if (!change.slug)
+                    throw new Error("Lightning deploy has missing slug")
+                await baker.bakeGDocPosts([change.slug])
             }
         } else {
             await baker.bakeAll()

--- a/baker/bakeGdocPost.ts
+++ b/baker/bakeGdocPost.ts
@@ -4,8 +4,6 @@ import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
 import { SiteBaker } from "./SiteBaker.js"
 import { BAKED_SITE_DIR, BAKED_BASE_URL } from "../settings/serverSettings.js"
-import { Gdoc } from "../db/model/Gdoc/Gdoc.js"
-import { OwidGdocPublished } from "@ourworldindata/utils"
 import * as db from "../db/db.js"
 
 yargs(hideBin(process.argv))
@@ -22,11 +20,7 @@ yargs(hideBin(process.argv))
             const baker = new SiteBaker(BAKED_SITE_DIR, BAKED_BASE_URL)
 
             await db.getConnection()
-            const gdoc = (await Gdoc.findOneByOrFail({
-                published: true,
-                slug: slug,
-            })) as OwidGdocPublished
-            await baker.bakeGDocPost(gdoc)
+            await baker.bakeGDocPosts([slug])
             process.exit(0)
         }
     )

--- a/baker/bakeGdocPosts.ts
+++ b/baker/bakeGdocPosts.ts
@@ -4,8 +4,6 @@ import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
 import { SiteBaker } from "./SiteBaker.js"
 import { BAKED_SITE_DIR, BAKED_BASE_URL } from "../settings/serverSettings.js"
-import { Gdoc } from "../db/model/Gdoc/Gdoc.js"
-import { OwidGdocPublished } from "@ourworldindata/utils"
 import * as db from "../db/db.js"
 
 yargs(hideBin(process.argv))
@@ -27,15 +25,7 @@ yargs(hideBin(process.argv))
             const baker = new SiteBaker(BAKED_SITE_DIR, BAKED_BASE_URL)
 
             await db.getConnection()
-            await Promise.all(
-                slugs.map(async (slug) => {
-                    const gdoc = (await Gdoc.findOneByOrFail({
-                        published: true,
-                        slug: slug,
-                    })) as OwidGdocPublished
-                    await baker.bakeGDocPost(gdoc)
-                })
-            )
+            await baker.bakeGDocPosts(slugs)
             process.exit(0)
         }
     )

--- a/ops/buildkite/deploy-content
+++ b/ops/buildkite/deploy-content
@@ -30,7 +30,6 @@ deploy_content () {
     # NOTE: in theory we could run lightning bake in parallel to regular bake and only lock `deploy_to_cloudflare`
     # right now lightning bake has to wait if there's a regular bake
     if [ -n "${LIGHTNING_GDOC_SLUGS:-}" ]; then
-        # TODO: do we need to trigger `yarn buildLocalBake --steps gdriveImages` to get up to date images for the lightning post?
         bake_gdoc_posts "$LIGHTNING_GDOC_SLUGS"
     else
         update_owid_content_repo

--- a/ops/buildkite/deploy-content
+++ b/ops/buildkite/deploy-content
@@ -27,20 +27,17 @@ deploy_content () {
         exit 1
     fi
 
-    # Lightning deploys ARE CURRENTLY DISABLED because they're screwing up the site
     # NOTE: in theory we could run lightning bake in parallel to regular bake and only lock `deploy_to_cloudflare`
     # right now lightning bake has to wait if there's a regular bake
-    # if [ -n "${LIGHTNING_GDOC_SLUGS:-}" ]; then
-    #     # TODO: do we need to trigger `yarn buildLocalBake --steps gdriveImages` to get up to date images for the lightning post?
-    #     bake_gdoc_posts "$LIGHTNING_GDOC_SLUGS"
-    # else
-
-    update_owid_content_repo
-    sync_wordpress_uploads
-    bake_site
-    sync_baked_data_to_r2
-
-    # fi
+    if [ -n "${LIGHTNING_GDOC_SLUGS:-}" ]; then
+        # TODO: do we need to trigger `yarn buildLocalBake --steps gdriveImages` to get up to date images for the lightning post?
+        bake_gdoc_posts "$LIGHTNING_GDOC_SLUGS"
+    else
+        update_owid_content_repo
+        sync_wordpress_uploads
+        bake_site
+        sync_baked_data_to_r2
+    fi
 
     create_dist
     deploy_to_cloudflare


### PR DESCRIPTION
Fixes #2906.

❗ I didn't test this in any way yet!

The underlying issue here was that gdoc properties like `linkedDocuments` and `imageMetadata` didn't get populated in the lightning deploy code path (`bakeGDocPost`).

I instead extended `bakeGDocPosts` to optionally take an array of slugs that it should bake, and bake every published gdoc otherwise.


✅ In order to reenable lightning deploys, we will also have to revert https://github.com/owid/owid-grapher/commit/ab2b183b166d808f034d245ff8bb3061ed0aa583.