### PR TITLE
🐛 fix undefined in source display in grapher

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1546,7 +1546,7 @@ export class Grapher
         const uniqueAttributions = uniq(compact(attributions))
 
         if (uniqueAttributions.length > 3)
-            return `${attributions[0]} and other sources`
+            return `${uniqueAttributions[0]} and other sources`
 
         return uniqueAttributions.join("; ")
     }


### PR DESCRIPTION
Fixes a bug where if there are more than 3 sources, grapher would sometimes say "undefined and other sources"