### PR TITLE
enhance: TextWrap opens and closes every HTML tag

### DIFF
--- a/packages/@ourworldindata/components/src/TextWrap/TextWrap.test.ts
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrap.test.ts
@@ -125,4 +125,23 @@ describe("lines()", () => {
             "an <strong>important</strong> <a href='https://youtu.be/dQw4w9WgXcQ'>line</a>",
         ])
     })
+
+    it("should properly close and re-open HTML tags that span multiple lines", () => {
+        // the HTML version of this string won't fit into a width of 150, but it will once the HTML tags are stripped
+        // - that's what the rawHtml mode is for.
+        const text = "a <strong><i>very important</i> message</strong> here"
+        const wrap = new TextWrap({
+            text,
+            maxWidth: 10,
+            fontSize: FONT_SIZE,
+            rawHtml: true,
+        })
+        expect(wrap.lines.map((l) => l.text)).toEqual([
+            "a",
+            "<strong><i>very</i></strong>",
+            "<strong><i>important</i></strong>",
+            "<strong>message</strong>",
+            "here",
+        ])
+    })
 })

--- a/packages/@ourworldindata/components/src/TextWrap/TextWrap.tsx
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrap.tsx
@@ -25,6 +25,9 @@ interface WrapLine {
     height: number
 }
 
+const HTML_OPENING_TAG_REGEX = /<(\w+)[^>]*>/
+const HTML_CLOSING_TAG_REGEX = /<\/(\w)+>/
+
 function startsWithNewline(text: string): boolean {
     return /^\n/.test(text)
 }
@@ -106,12 +109,14 @@ export class TextWrap {
                 startsWithNewline(word) ||
                 (nextBounds.width + 10 > maxWidth && line.length >= 1)
             ) {
-                const wordWithoutNewline = word.replace(/^\n/, "")
+                // Introduce a newline _before_ this word
                 lines.push({
                     text: line.join(" "),
                     width: lineBounds.width,
                     height: lineBounds.height,
                 })
+                // ... and start a new line with this word (with a potential leading newline stripped)
+                const wordWithoutNewline = word.replace(/^\n/, "")
                 line = [wordWithoutNewline]
                 lineBounds = Bounds.forText(wordWithoutNewline, {
                     fontSize,
@@ -122,6 +127,8 @@ export class TextWrap {
                 lineBounds = nextBounds
             }
         })
+
+        // Push the last line
         if (line.length > 0)
             lines.push({
                 text: line.join(" "),

--- a/packages/@ourworldindata/components/src/TextWrap/TextWrap.tsx
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrap.tsx
@@ -30,7 +30,7 @@ interface OpenHtmlTag {
     fullTag: string // e.g. "<a href='https://ourworldindata.org'>"
 }
 
-const HTML_OPENING_CLOSING_TAG_REGEX = /<(\/?)([A-Za-z]+)[^>]*>/g
+const HTML_OPENING_CLOSING_TAG_REGEX = /<(\/?)([A-Za-z]+)( [^<>]*)?>/g
 
 function startsWithNewline(text: string): boolean {
     return /^\n/.test(text)


### PR DESCRIPTION
Before, we were producing invalid HTML/SVG in the footer (`origin URL | CC BY`) in some very rare cases, [like this one here](https://ourworldindata.org/grapher/thumbnail/co-emissions-per-capita?imWidth=1000&imHeight=1000).