### PR TITLE
fix(grapher): open sources modal when embedded

### DIFF
--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -415,6 +415,16 @@ export class Footer<
                     data-track-note="chart_click_sources"
                     onClick={action((e) => {
                         e.stopPropagation()
+
+                        // if embbedded, open the sources modal
+                        if (
+                            this.manager.isEmbeddedInAnOwidPage ||
+                            this.manager.isInIFrame
+                        ) {
+                            this.manager.isSourcesModalOpen = true
+                            return
+                        }
+
                         // on data pages, scroll to the "Sources and Processing" section
                         const sourcesIdOnDataPage =
                             DATAPAGE_SOURCES_AND_PROCESSING_SECTION_ID

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -415,27 +415,25 @@ export class Footer<
                     data-track-note="chart_click_sources"
                     onClick={action((e) => {
                         e.stopPropagation()
-                        // if embbedded, open the sources modal
-                        if (this.manager.isEmbeddedInAnOwidPage) {
-                            this.manager.isSourcesModalOpen = true
-                            return
-                        }
-
                         // on data pages, scroll to the "Sources and Processing" section
-                        // on grapher pages, open the sources modal
                         const sourcesIdOnDataPage =
                             DATAPAGE_SOURCES_AND_PROCESSING_SECTION_ID
                         const sourcesElement =
                             document.getElementById(sourcesIdOnDataPage)
-                        if (sourcesElement && sourcesElement.scrollIntoView) {
-                            sourcesElement.scrollIntoView({
-                                behavior: "smooth",
-                            })
-                            this.manager.isInFullScreenMode = false
-                        } else if (sourcesElement) {
-                            window.location.hash = "#" + sourcesIdOnDataPage
+                        if (
+                            this.manager.isEmbeddedInADataPage &&
+                            sourcesElement
+                        ) {
+                            if (sourcesElement.scrollIntoView) {
+                                sourcesElement.scrollIntoView({
+                                    behavior: "smooth",
+                                })
+                            } else {
+                                window.location.hash = "#" + sourcesIdOnDataPage
+                            }
                             this.manager.isInFullScreenMode = false
                         } else {
+                            // on grapher pages, open the sources modal
                             this.manager.isSourcesModalOpen = true
                         }
                     })}

--- a/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
+++ b/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
@@ -18,4 +18,5 @@ export interface FooterManager extends TooltipManager, ActionButtonsManager {
     fontSize?: number
     isInFullScreenMode?: boolean
     isEmbeddedInAnOwidPage?: boolean
+    isEmbeddedInADataPage?: boolean
 }


### PR DESCRIPTION
Clicking on "Learn more about this data" should scroll to the "Sources & Processing" Section on data pages, otherwise the sources modal should open.

There were a couple of problems here:
- We were relying on the the existence of the sources and processing section only, but that means that _any_ chart (including charts in the All Charts block) would scroll to the Sources & Processing Section
- We didn't handle the iframe case properly (should always open in a modal)