### PR TITLE
Small gdocs index page enhancements

### DIFF
--- a/adminSiteClient/GdocsAdd.tsx
+++ b/adminSiteClient/GdocsAdd.tsx
@@ -67,6 +67,10 @@ export const GdocsAdd = ({ onAdd }: { onAdd: (id: string) => void }) => {
                         placeholder="https://docs.google.com/document/d/****/edit"
                         pattern={gdocUrlRegex.toString().slice(1, -1)}
                     />
+                    <span className="validation-notice">
+                        Invalid URL - it should look like this:{" "}
+                        <pre>https://docs.google.com/document/d/****/edit</pre>
+                    </span>
                 </div>
             </div>
             <div className="modal-footer">

--- a/adminSiteClient/GdocsIndexPage.tsx
+++ b/adminSiteClient/GdocsIndexPage.tsx
@@ -158,6 +158,7 @@ export class GdocsIndexPage extends React.Component<GdocsMatchProps> {
                           )
                         : undefined,
                     gdoc.slug,
+                    gdoc.id,
                     gdoc.content.authors?.join(" "),
                     gdoc.tags?.map(({ name }) => name).join(" "),
                 ]

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -1243,6 +1243,22 @@ main:not(.ChartEditorPage):not(.GdocsEditPage) {
             margin-bottom: 1rem;
         }
     }
+    .validation-notice {
+        display: none;
+    }
+    input:invalid + .validation-notice {
+        display: block;
+        margin-top: 4px;
+        color: red;
+        padding-left: 5px;
+        pre {
+            color: red;
+        }
+    }
+    // don't show the validation notice when the input is blank (because that counts as "invalid")
+    input:placeholder-shown + .validation-notice {
+        display: none;
+    }
 }
 
 .GdocsEditPage,

--- a/packages/@ourworldindata/utils/src/GdocsConstants.ts
+++ b/packages/@ourworldindata/utils/src/GdocsConstants.ts
@@ -20,6 +20,6 @@ export const IMAGES_DIRECTORY = "/images/published/"
  * https://docs.google.com/spreadsheets/d/abcd1234
  */
 export const gdocUrlRegex =
-    /https:\/\/docs\.google\.com\/document(?:\/u\/\d)?\/d\/([-\w]+)\/?(edit)?#?/
+    /https:\/\/docs\.google\.com\/document(?:\/u\/\d)?\/d\/([\-\w]+)\/?(edit)?#?/
 
 export const gdocIdRegex = /^[0-9A-Za-z\-_]{44}$/


### PR DESCRIPTION
Changes:
- Stops the server from throwing an error if attempting to register an already-registered article*
- Allows searching by gdoc ID
- Fixes the validation for the gdoc URL input (which hadn't been working correctly for the last few months)
- Adds some hints if validation fails


https://github.com/owid/owid-grapher/assets/11844404/48ce7a8c-e897-4bbf-911b-e37bbbe88cd1



\* I was doing this semi-frequently on prod when debugging things and it seemed a bit overkill to get a notification in slack because of it