### PR TITLE
fix broken slope charts

### DIFF
--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -423,6 +423,9 @@ export class SlopeChart
                     })
                 })
 
+                // sort values by time
+                const sortedValues = sortBy(values, (v) => v.x)
+
                 const color =
                     table.getColorForEntityName(seriesName) ??
                     colorBySeriesName.get(seriesName) ??
@@ -432,7 +435,7 @@ export class SlopeChart
                     seriesName,
                     color,
                     size: sizeByEntity.get(seriesName) || 1,
-                    values,
+                    values: sortedValues,
                 } as SlopeChartSeries
             })
             .filter((series) => series.values.length >= 2)


### PR DESCRIPTION
### Problem

<img width="782" alt="Screenshot 2023-11-24 at 14 43 54" src="https://github.com/owid/owid-grapher/assets/12461810/a19ed9cb-701d-4551-904c-85c6871f0d47">

To reproduce:
- Go to https://owid.cloud/admin/charts/2562/edit
- Change chart to slope chart
- Drag the start time handle to > 1950

### Solution

The order of data points to be plotted was swapped for some data points. These should be ordered by time. If not, bad things happen (see screenshot).