### PR TITLE
🔨 disable nx cache for buildkite production builds

### DIFF
--- a/ops/buildkite/build-code
+++ b/ops/buildkite/build-code
@@ -93,7 +93,7 @@ build_grapher() {
         yarn cleanTsc
         git rev-parse HEAD > /home/owid/live-data/bakedSite/head.txt
         yarn install
-        yarn buildLerna
+        yarn buildLerna --skip-nx-cache
         yarn buildTsc
         yarn buildVite
         yarn runDbMigrations


### PR DESCRIPTION
Recently we had a production code deploy die - the lerna build reported no action needed and the cache to be used but then the typescript build complained about some things not existing in the lerna built packages. This PR disables lerna caching for production buildkite builds