### PR TITLE
Revert perf optimization that breaks map charts

### DIFF
--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -1621,7 +1621,6 @@ class FilterMask {
         for (let i = 0; i < this.numRows; i++) {
             if (this.mask[i]) keepIndexes.push(i)
         }
-        if (keepIndexes.length === this.numRows) return columnStore
 
         Object.keys(columnStore).forEach((slug) => {
             const originalColumn = columnStore[slug]


### PR DESCRIPTION
❗ **Urgent, should be done by the 30th (Thursday)**

- fixes #2948

### Summary

- Pablo A wants to publish a set of map charts on the 30th
- Some map charts are broken; the data is available in the Table and Chart tab, but not in the Map tab (see #2948)
- I traced it down to the tolerance computation in the MapChart's transformTable function, and then did a `git bisect` to find the bad commit
- The commit introducing this bug is a perf optimization: https://github.com/owid/owid-grapher/pull/2620/commits/d58bef8cbe24185d3a7284f4ca23586def996ee6
- Since it's marked as a perf optimization only, I'm inclined to remove it, which fixes the bug

@danyx23 since you were the one reviewing [Marcel's PR](https://github.com/owid/owid-grapher/pull/2620), do you think it's safe to do so?