### PR TITLE
🥅 (donate) notify front-end errors to bugsnag

### DIFF
--- a/site/stripe/DonateForm.tsx
+++ b/site/stripe/DonateForm.tsx
@@ -15,6 +15,7 @@ import { Tippy, stringifyUnknownError, titleCase } from "@ourworldindata/utils"
 import { Checkbox } from "@ourworldindata/components"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faArrowRight, faInfoCircle } from "@fortawesome/free-solid-svg-icons"
+import Bugsnag from "@bugsnag/js"
 
 type Interval = "once" | "monthly"
 
@@ -205,6 +206,19 @@ export class DonateForm extends React.Component {
 
             runInAction(() => {
                 const prefixedErrorMessage = stringifyUnknownError(error)
+                // Send all errors to Bugsnag. This will help surface issues
+                // with our aging reCAPTCHA setup, and pull the trigger on a
+                // (hook-based?) rewrite if it starts failing. This reporting
+                // also includes form validation errors, which are useful to
+                // identify possible UX improvements or validate UX experiments
+                // (such as the combination of the name field and the "include
+                // my name on the list" checkbox).
+                Bugsnag.notify(
+                    error instanceof Error
+                        ? error
+                        : new Error(prefixedErrorMessage)
+                )
+
                 if (!prefixedErrorMessage) {
                     this.errorMessage =
                         "Something went wrong. Please get in touch with us at donate@ourworldindata.org"


### PR DESCRIPTION
Updating reCAPTCHA on the donor form presents no ideal solutions so far: 

- (current) [react-recaptcha](https://www.npmjs.com/package/react-recaptcha): last update was 5 years ago
- [react-google-recaptcha](https://www.npmjs.com/package/react-google-recaptcha): quite a few issues on GH, current migration attempts are bumpy
- [react-hook-recaptcha](https://github.com/tomliangg/react-hook-recaptcha): would require migrating the whole form from a class to a functional component

In this context, the benefit of switching recaptcha libraries is unclear.

Instead, I suggest keeping the current working solution in place and making errors more prominent. This will help us react quicker to a possible failure of reCAPTCHA and act accordingly.

Given the high threshold for errors to be sent to slack (at least 50 / day) on the [default site bugsnag configuration](https://app.bugsnag.com/settings/our-world-in-data/projects/our-world-in-data-website/integrations/team-notification/60eecfe5fec132e6de9a2fc6), I added [a new configuration to send notifications on every error happening on /donate](https://app.bugsnag.com/settings/our-world-in-data/projects/our-world-in-data-website/integrations/team-notification/6565bd27ceaa0a4b41ed75fe).

To test this, the `BUGSNAG_API_KEY` env variable needs to be set.
