### PR TITLE
🔨 Data pages: ignore indicator level grapher configs on /grapher/ pages for now

### DIFF
--- a/adminSiteServer/adminRouter.tsx
+++ b/adminSiteServer/adminRouter.tsx
@@ -275,6 +275,7 @@ adminRouter.get("/datapage-preview/:id", async (req, res) => {
             variableId,
             variableMetadata,
             isPreviewing: true,
+            useIndicatorGrapherConfigs: true,
             publishedExplorersBySlug,
         })
     )

--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -176,6 +176,7 @@ mockSiteRouter.get("/datapage-preview/:id", async (req, res) => {
             variableId,
             variableMetadata,
             isPreviewing: true,
+            useIndicatorGrapherConfigs: true,
             publishedExplorersBySlug,
         })
     )

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -64,12 +64,9 @@ import { Gdoc } from "../db/model/Gdoc/Gdoc.js"
 import { getShortPageCitation } from "../site/gdocs/utils.js"
 import { isEmpty } from "lodash"
 
-/**
- *
- * Render a datapage if available, otherwise render a grapher page.
- */
-export const renderDataPageOrGrapherPage = async (
+const renderDatapageIfApplicable = async (
     grapher: GrapherInterface,
+    isPreviewing: boolean,
     publishedExplorersBySlug?: Record<string, ExplorerProgram>,
     imageMetadataDictionary?: Record<string, Image>
 ) => {
@@ -108,13 +105,33 @@ export const renderDataPageOrGrapherPage = async (
             return await renderDataPageV2({
                 variableId,
                 variableMetadata,
-                isPreviewing: true,
+                isPreviewing: false,
+                useIndicatorGrapherConfigs: false,
                 pageGrapher: grapher,
                 publishedExplorersBySlug,
                 imageMetadataDictionary,
             })
         }
     }
+    return undefined
+}
+
+/**
+ *
+ * Render a datapage if available, otherwise render a grapher page.
+ */
+export const renderDataPageOrGrapherPage = async (
+    grapher: GrapherInterface,
+    publishedExplorersBySlug?: Record<string, ExplorerProgram>,
+    imageMetadataDictionary?: Record<string, Image>
+): Promise<string> => {
+    const datapage = await renderDatapageIfApplicable(
+        grapher,
+        false,
+        publishedExplorersBySlug,
+        imageMetadataDictionary
+    )
+    if (datapage) return datapage
     return renderGrapherPage(grapher)
 }
 
@@ -134,6 +151,7 @@ export async function renderDataPageV2({
     variableId,
     variableMetadata,
     isPreviewing,
+    useIndicatorGrapherConfigs,
     pageGrapher,
     publishedExplorersBySlug,
     imageMetadataDictionary = {},
@@ -141,16 +159,20 @@ export async function renderDataPageV2({
     variableId: number
     variableMetadata: OwidVariableWithSource
     isPreviewing: boolean
+    useIndicatorGrapherConfigs: boolean
     pageGrapher?: GrapherInterface
     publishedExplorersBySlug?: Record<string, ExplorerProgram>
     imageMetadataDictionary?: Record<string, ImageMetadata>
 }) {
     const grapherConfigForVariable =
         await getMergedGrapherConfigForVariable(variableId)
-    const grapher = mergePartialGrapherConfigs(
-        grapherConfigForVariable,
-        pageGrapher
-    )
+    // Only merge the grapher config on the indicator if the caller tells us to do so -
+    // this is true for preview pages for datapages on the indicator level but false
+    // if we are on Grapher pages. Once we have a good way in the grapher admin for how
+    // to use indicator level defaults, we should reconsider how this works here.
+    const grapher = useIndicatorGrapherConfigs
+        ? mergePartialGrapherConfigs(grapherConfigForVariable, pageGrapher)
+        : pageGrapher ?? {}
 
     const faqDocs = compact(
         uniq(variableMetadata.presentation?.faqs?.map((faq) => faq.gdocId))
@@ -311,30 +333,12 @@ export const renderPreviewDataPageOrGrapherPage = async (
     grapher: GrapherInterface,
     publishedExplorersBySlug?: Record<string, ExplorerProgram>
 ) => {
-    // If we have a single Y variable and that one has a schema version >= 2,
-    // meaning it has the metadata to render a datapage, then we show the datapage
-    // based on this information. Otherwise we see if there is a legacy datapage.json
-    // available and if all else fails we render a classic Grapher page.
-    const yVariableIds = grapher
-        .dimensions!.filter((d) => d.property === DimensionProperty.y)
-        .map((d) => d.variableId)
-    if (yVariableIds.length === 1) {
-        const variableId = yVariableIds[0]
-        const variableMetadata = await getVariableMetadata(variableId)
-
-        if (
-            variableMetadata.schemaVersion !== undefined &&
-            variableMetadata.schemaVersion >= 2
-        ) {
-            return await renderDataPageV2({
-                variableId,
-                variableMetadata,
-                isPreviewing: true,
-                pageGrapher: grapher,
-                publishedExplorersBySlug,
-            })
-        }
-    }
+    const datapage = await renderDatapageIfApplicable(
+        grapher,
+        true,
+        publishedExplorersBySlug
+    )
+    if (datapage) return datapage
 
     return renderGrapherPage(grapher)
 }

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -105,7 +105,7 @@ const renderDatapageIfApplicable = async (
             return await renderDataPageV2({
                 variableId,
                 variableMetadata,
-                isPreviewing: false,
+                isPreviewing: isPreviewing,
                 useIndicatorGrapherConfigs: false,
                 pageGrapher: grapher,
                 publishedExplorersBySlug,


### PR DESCRIPTION
This PR changes how grapher configs are treated in data pages. Grapher configs coming from the ETL level grapher config are no longer taken into account on /grapher/ pages, only in pure datapage previews.

The PR also streamlines the code between previews and baking a bit.

Once our grapher admin can deal with defaults in a better way (i.e. show the user where defaults are used and given them an option to disable the default value) we should change this again.