### PR TITLE
💄 render descriptionShort as markdown, fix DoD link display

### DIFF
--- a/packages/@ourworldindata/grapher/src/modal/SourcesKeyDataTable.scss
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesKeyDataTable.scss
@@ -30,6 +30,11 @@
         color: inherit;
         text-decoration: underline;
 
+        // DoD spans should be dotted via the border, not underlined
+        &.dod-span {
+            text-decoration: none;
+        }
+
         &:hover {
             text-decoration: none;
         }

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.scss
@@ -46,6 +46,11 @@
             &:hover {
                 text-decoration: none;
             }
+
+            // DoD spans should be dotted via the border, not underlined
+            &.dod-span {
+                text-decoration: none;
+            }
         }
 
         .heading {

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
@@ -16,6 +16,7 @@ import {
 import {
     IndicatorSources,
     IndicatorProcessing,
+    SimpleMarkdownText,
 } from "@ourworldindata/components"
 import React from "react"
 import { action, computed } from "mobx"
@@ -393,7 +394,7 @@ export class Source extends React.Component<{
             <div className="source">
                 {this.renderTitle()}
                 {this.def.descriptionShort && (
-                    <p>{this.def.descriptionShort}</p>
+                    <SimpleMarkdownText text={this.def.descriptionShort} />
                 )}
                 <SourcesKeyDataTable
                     attribution={this.attributions}

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -234,6 +234,11 @@
         a {
             @include owid-link-90;
             color: inherit;
+
+            // DoD spans should be dotted via the border, not underlined
+            &.dod-span {
+                text-decoration: none;
+            }
         }
     }
 

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -822,7 +822,11 @@ const KeyDataTable = (props: {
                     <div className="key-data__title key-data-description-short__title">
                         {datapageData.title}
                     </div>
-                    <div>{datapageData.descriptionShort}</div>
+                    <div>
+                        <SimpleMarkdownText
+                            text={datapageData.descriptionShort}
+                        />
+                    </div>
                 </div>
             )}
             {source && (

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -825,6 +825,7 @@ const KeyDataTable = (props: {
                     <div>
                         <SimpleMarkdownText
                             text={datapageData.descriptionShort}
+                            useParagraphs={false}
                         />
                     </div>
                 </div>


### PR DESCRIPTION
This PR renders descriptionShort as markdown and makes sure that DoD links are not underlined and instead retain the style they have site-wide.

I don't know if there is a better way to make sure that links that have the dod-span class are not underlined - @sophiamersmann if you would prefer another way of doing this in CSS then please let me know! 🙏 