### PR TITLE
:sparkles: (data-page) allow About this data section to use full width

### DIFF
--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -257,6 +257,10 @@
         margin-bottom: 8px;
     }
 
+    .wrapper-about-this-data {
+        width: 100%;
+    }
+
     .about-this-data__title {
         @include datapage-section-title;
         @include md-up {

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -312,7 +312,7 @@ export const DataPageV2Content = ({
                             className="wrapper"
                             id="explore-the-data"
                         />
-                        <div className="wrapper grid grid-cols-12">
+                        <div className="wrapper wrapper-about-this-data grid grid-cols-12">
                             {hasDescriptionKey ||
                             datapageData.descriptionFromProducer ||
                             datapageData.source?.additionalInfo ? (


### PR DESCRIPTION
The "About this data" Section should use the full width:

![Screenshot 2023-11-28 at 16 48 25](https://github.com/owid/owid-grapher/assets/12461810/4183f51a-223a-430f-a0d9-23dc50478d0d)
