### PR TITLE
:hammer: fix posts_links FK constraint, add reusable block tombstones

### DIFF
--- a/db/migration/1701280181658-FixPostLinksForeingKeyDeleteClause.ts
+++ b/db/migration/1701280181658-FixPostLinksForeingKeyDeleteClause.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class FixPostLinksForeingKeyDeleteClause1701280181658
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE posts_links
+            DROP FOREIGN KEY posts_links_ibfk_1;
+        `)
+        await queryRunner.query(`
+            ALTER TABLE posts_links
+            ADD CONSTRAINT posts_links_ibfk_1
+            FOREIGN KEY (sourceId)
+            REFERENCES posts(id)
+            ON UPDATE CASCADE
+            ON DELETE CASCADE;
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/db/migration/1701280181658-FixPostLinksForeingKeyDeleteClause.ts
+++ b/db/migration/1701280181658-FixPostLinksForeingKeyDeleteClause.ts
@@ -18,5 +18,7 @@ export class FixPostLinksForeingKeyDeleteClause1701280181658
         `)
     }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {}
+    public async down(_queryRunner: QueryRunner): Promise<void> {
+        return
+    }
 }

--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -53,7 +53,10 @@ function buildReplacerFunction(
         matches: Record<string, string>
     ) => {
         const block = blocks[matches["id"].toString()]
-        return block ? block.post_content : ""
+        return block
+            ? `<!-- wp-block-tombstone ${matches["id"]} -->` +
+                  block.post_content
+            : ""
     }
 }
 


### PR DESCRIPTION
This PR fixes the FK constraint from posts_gdocs to posts that was missing an ON DELETE CASCADE clause. 

It also adds reusable block tombstone comments - this is useful because we currently inline WP reusable blocks into the posts when we sync them from WP into the grapher DB. At the moment this does not leave any trace, but for planning some content migration work it would be useful to be able to query for these tombstones.