### PR TITLE
Static Grapher exports: Make title semibold

### DIFF
--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -210,7 +210,7 @@ export class StaticHeader extends Header<StaticHeaderProps> {
                 text: titleText,
                 maxWidth: this.maxWidth - logoWidth - 24,
                 fontSize,
-                fontWeight: 500,
+                fontWeight: 600,
                 lineHeight: 1.2,
             })
 


### PR DESCRIPTION
- The title of interactive and static charts should be semibold
- But for some reason, if the title is semibold, sometimes the title text overflows with the logo (only for static charts, not for interactive one, which is quite weird)
- As a quick "fix" I had the set the font weight for static exports to Medium

Before this can be merged, I need to do another investigation of why the title sometimes overflow for static charts.

---

This happened only locally LOL