### PR TITLE
🎉 (static charts) add Export tab to the chart admin

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -2,11 +2,11 @@
     "files": [
         {
             "path": "./dist/assets/common.mjs",
-            "maxSize": "1.83MB"
+            "maxSize": "2MB"
         },
         {
             "path": "./dist/assets/owid.mjs",
-            "maxSize": "565 KB"
+            "maxSize": "450KB"
         }
     ],
     "defaultCompression": "none"

--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -111,6 +111,7 @@ export class ChartEditor {
     @observable.ref tab: EditorTab = "basic"
     @observable.ref errorMessage?: { title: string; content: string }
     @observable.ref previewMode: "mobile" | "desktop"
+    @observable.ref showStaticPreview: boolean = false
     @observable.ref savedGrapherJson: string = ""
 
     // This gets set when we save a new chart for the first time
@@ -172,6 +173,7 @@ export class ChartEditor {
         if (this.grapher.isMarimekko) tabs.push("marimekko")
         tabs.push("revisions")
         tabs.push("refs")
+        tabs.push("export")
         return tabs
     }
 

--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -113,7 +113,7 @@ export class ChartEditor {
     @observable.ref previewMode: "mobile" | "desktop"
     @observable.ref showStaticPreview: boolean = false
     @observable.ref staticPreviewFormat: GrapherStaticFormat =
-        GrapherStaticFormat.portrait
+        GrapherStaticFormat.square
     @observable.ref savedGrapherJson: string = ""
 
     // This gets set when we save a new chart for the first time

--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -5,7 +5,7 @@
  *
  */
 
-import { Grapher, GrapherStaticFormat, Topic } from "@ourworldindata/grapher"
+import { Grapher, Topic } from "@ourworldindata/grapher"
 import { type DetailDictionary, type RawPageview } from "@ourworldindata/utils"
 import { computed, observable, runInAction, when } from "mobx"
 import { BAKED_GRAPHER_URL } from "../settings/clientSettings.js"
@@ -112,8 +112,6 @@ export class ChartEditor {
     @observable.ref errorMessage?: { title: string; content: string }
     @observable.ref previewMode: "mobile" | "desktop"
     @observable.ref showStaticPreview: boolean = false
-    @observable.ref mobileStaticPreviewFormat: GrapherStaticFormat =
-        GrapherStaticFormat.square
     @observable.ref savedGrapherJson: string = ""
 
     // This gets set when we save a new chart for the first time

--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -111,7 +111,7 @@ export class ChartEditor {
     @observable.ref tab: EditorTab = "basic"
     @observable.ref errorMessage?: { title: string; content: string }
     @observable.ref previewMode: "mobile" | "desktop"
-    @observable.ref showStaticPreview: boolean = false
+    @observable.ref showStaticPreview = false
     @observable.ref savedGrapherJson: string = ""
 
     // This gets set when we save a new chart for the first time

--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -5,7 +5,7 @@
  *
  */
 
-import { Grapher, Topic } from "@ourworldindata/grapher"
+import { Grapher, GrapherStaticFormat, Topic } from "@ourworldindata/grapher"
 import { type DetailDictionary, type RawPageview } from "@ourworldindata/utils"
 import { computed, observable, runInAction, when } from "mobx"
 import { BAKED_GRAPHER_URL } from "../settings/clientSettings.js"
@@ -112,6 +112,8 @@ export class ChartEditor {
     @observable.ref errorMessage?: { title: string; content: string }
     @observable.ref previewMode: "mobile" | "desktop"
     @observable.ref showStaticPreview: boolean = false
+    @observable.ref staticPreviewFormat: GrapherStaticFormat =
+        GrapherStaticFormat.portrait
     @observable.ref savedGrapherJson: string = ""
 
     // This gets set when we save a new chart for the first time

--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -112,7 +112,7 @@ export class ChartEditor {
     @observable.ref errorMessage?: { title: string; content: string }
     @observable.ref previewMode: "mobile" | "desktop"
     @observable.ref showStaticPreview: boolean = false
-    @observable.ref staticPreviewFormat: GrapherStaticFormat =
+    @observable.ref mobileStaticPreviewFormat: GrapherStaticFormat =
         GrapherStaticFormat.square
     @observable.ref savedGrapherJson: string = ""
 

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -434,7 +434,7 @@ export class ChartEditorPage
                         data-grapher-src
                         style={{
                             minHeight: this.editor?.showStaticPreview
-                                ? this.grapher.staticBoundsWithDetails().height
+                                ? this.grapher.staticBoundsWithDetails.height
                                 : undefined,
                             boxShadow: this.editor?.showStaticPreview
                                 ? "0px 4px 40px rgba(0, 0, 0, 0.2)"

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -58,8 +58,8 @@ import {
     VisionDeficiencyEntity,
 } from "./VisionDeficiencies.js"
 import { EditorMarimekkoTab } from "./EditorMarimekkoTab.js"
-import { BAKED_BASE_URL } from "../settings/clientSettings.js"
 import { EditorExportTab } from "./EditorExportTab.js"
+import { runDetailsOnDemand } from "../site/detailsOnDemand.js"
 
 @observer
 class TabBinder extends React.Component<{ editor: ChartEditor }> {
@@ -151,7 +151,6 @@ export class ChartEditorPage
             bounds: this.bounds,
             staticFormat: this.staticFormat,
         }
-        this.grapher.shouldIncludeDetailsInStaticExport = false
         this.grapher.renderToStatic = !!this.editor?.showStaticPreview
         this.grapherElement = <Grapher {...grapherConfig} />
         this._isGrapherSet = true
@@ -232,12 +231,10 @@ export class ChartEditorPage
     }
 
     async fetchDetails(): Promise<void> {
-        const details: DetailDictionary = await fetch(
-            `${BAKED_BASE_URL}/dods.json`
-        ).then((res) => res.json())
+        await runDetailsOnDemand()
 
         runInAction(() => {
-            this.details = details
+            if (window.details) this.details = window.details
         })
     }
 
@@ -450,6 +447,9 @@ export class ChartEditorPage
                     <figure
                         data-grapher-src
                         style={{
+                            minHeight: this.editor?.showStaticPreview
+                                ? this.grapher.staticBoundsWithDetails().height
+                                : undefined,
                             filter:
                                 this.simulateVisionDeficiency &&
                                 `url(#${this.simulateVisionDeficiency.id})`,

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -311,6 +311,7 @@ export class ChartEditorPage
                             this.editor.previewMode
                         )
                     }
+                    this.updateGrapher()
                 }
             )
         )
@@ -450,7 +451,6 @@ export class ChartEditorPage
                                     type="radio"
                                     onChange={action(() => {
                                         editor.previewMode = "mobile"
-                                        this.updateGrapher()
                                     })}
                                     name="previewSize"
                                     id="mobile"
@@ -468,7 +468,6 @@ export class ChartEditorPage
                                 <input
                                     onChange={action(() => {
                                         editor.previewMode = "desktop"
-                                        this.updateGrapher()
                                     })}
                                     type="radio"
                                     name="previewSize"

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -313,15 +313,6 @@ export class ChartEditorPage
                 }
             )
         )
-
-        this.disposers.push(
-            reaction(
-                () => this.editor && this.editor.showStaticPreview,
-                () => {
-                    this.updateGrapher()
-                }
-            )
-        )
     }
 
     // This funny construction allows the "new chart" link to work by forcing an update
@@ -373,7 +364,12 @@ export class ChartEditorPage
                                                 ? " active"
                                                 : "")
                                         }
-                                        onClick={() => (editor.tab = tab)}
+                                        onClick={() => {
+                                            editor.tab = tab
+                                            editor.showStaticPreview =
+                                                tab === "export"
+                                            this.updateGrapher()
+                                        }}
                                     >
                                         {capitalize(tab)}
                                         {tab === "refs" && this.references

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -143,6 +143,7 @@ export class ChartEditorPage
             // admin-specific settings
             dataApiUrlForAdmin:
                 this.context.admin.settings.DATA_API_FOR_ADMIN_UI, // passed this way because clientSettings are baked and need a recompile to be updated
+            shouldIncludeDetailsInStaticExport: false,
             // reactive settings
             bounds: this.bounds,
         }

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -249,10 +249,8 @@ export class ChartEditorPage
     }
 
     @computed private get staticFormat(): GrapherStaticFormat {
-        const mobileStaticPreviewFormat =
-            this.editor?.mobileStaticPreviewFormat ?? GrapherStaticFormat.square
         return this.isMobilePreview
-            ? mobileStaticPreviewFormat
+            ? GrapherStaticFormat.square
             : GrapherStaticFormat.landscape
     }
 
@@ -324,15 +322,6 @@ export class ChartEditorPage
                             this.editor.previewMode
                         )
                     }
-                    this.updateGrapher()
-                }
-            )
-        )
-
-        this.disposers.push(
-            reaction(
-                () => this.editor && this.editor.mobileStaticPreviewFormat,
-                () => {
                     this.updateGrapher()
                 }
             )

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -381,9 +381,6 @@ export class ChartEditorPage
                                             editor.tab = tab
                                             editor.showStaticPreview =
                                                 tab === "export"
-                                            if (tab === "export") {
-                                                editor.previewMode = "mobile"
-                                            }
                                             this.updateGrapher()
                                         }}
                                     >

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -141,14 +141,12 @@ export class ChartEditorPage
             getGrapherInstance: (grapher: Grapher) => {
                 this.grapher = grapher
             },
-            // admin-specific settings
             dataApiUrlForAdmin:
                 this.context.admin.settings.DATA_API_FOR_ADMIN_UI, // passed this way because clientSettings are baked and need a recompile to be updated
-            shouldIncludeDetailsInStaticExport: false,
-            // reactive settings
             bounds: this.bounds,
-            renderToStatic: !!this.editor?.showStaticPreview,
         }
+        this.grapher.shouldIncludeDetailsInStaticExport = false
+        this.grapher.renderToStatic = !!this.editor?.showStaticPreview
         this.grapherElement = <Grapher {...grapherConfig} />
         this._isGrapherSet = true
     }
@@ -320,8 +318,7 @@ export class ChartEditorPage
             reaction(
                 () => this.editor && this.editor.showStaticPreview,
                 () => {
-                    this.grapher.renderToStatic =
-                        !!this.editor?.showStaticPreview
+                    this.updateGrapher()
                 }
             )
         )

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -445,7 +445,7 @@ export class ChartEditorPage
                             <EditorExportTab editor={editor} />
                         )}
                     </div>
-                    <SaveButtons editor={editor} />
+                    {editor.tab !== "export" && <SaveButtons editor={editor} />}
                 </div>
                 <div className="chart-editor-view">
                     <figure

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -54,6 +54,7 @@ import {
 } from "./VisionDeficiencies.js"
 import { EditorMarimekkoTab } from "./EditorMarimekkoTab.js"
 import { BAKED_BASE_URL } from "../settings/clientSettings.js"
+import { EditorExportTab } from "./EditorExportTab.js"
 
 @observer
 class TabBinder extends React.Component<{ editor: ChartEditor }> {
@@ -326,6 +327,16 @@ export class ChartEditorPage
                 }
             )
         )
+
+        this.disposers.push(
+            reaction(
+                () => this.editor && this.editor.showStaticPreview,
+                () => {
+                    this.grapher.renderToStatic =
+                        !!this.editor?.showStaticPreview
+                }
+            )
+        )
     }
 
     // This funny construction allows the "new chart" link to work by forcing an update
@@ -417,6 +428,9 @@ export class ChartEditorPage
                         )}
                         {editor.tab === "refs" && (
                             <EditorReferencesTab editor={editor} />
+                        )}
+                        {editor.tab === "export" && (
+                            <EditorExportTab editor={editor} />
                         )}
                     </div>
                     <SaveButtons editor={editor} />

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -118,14 +118,13 @@ export class ChartEditorPage
     fetchedGrapherConfig?: any
 
     async fetchGrapher(): Promise<void> {
-        const { grapherId, grapherConfig } = this.props
+        const { grapherId } = this.props
         if (grapherId !== undefined) {
             this.fetchedGrapherConfig = await this.context.admin.getJSON(
                 `/api/charts/${grapherId}.config.json`
             )
         }
-        const config = this.fetchedGrapherConfig ?? grapherConfig
-        this.initGrapher(config)
+        this.updateGrapher()
     }
 
     @observable private _isDbSet = false
@@ -134,7 +133,8 @@ export class ChartEditorPage
         return this._isDbSet && this._isGrapherSet
     }
 
-    @action.bound private initGrapher(config: any): void {
+    @action.bound private updateGrapher(): void {
+        const config = this.fetchedGrapherConfig ?? this.props.grapherConfig
         const grapherConfig = {
             ...config,
             // binds the grapher instance to this.grapher
@@ -147,23 +147,10 @@ export class ChartEditorPage
             shouldIncludeDetailsInStaticExport: false,
             // reactive settings
             bounds: this.bounds,
+            renderToStatic: !!this.editor?.showStaticPreview,
         }
         this.grapherElement = <Grapher {...grapherConfig} />
         this._isGrapherSet = true
-    }
-
-    @action.bound private updateGrapher(): void {
-        const config = this.fetchedGrapherConfig ?? this.props.grapherConfig
-        const grapherConfig = {
-            ...config,
-            // binds the grapher instance to this.grapher
-            getGrapherInstance: (grapher: Grapher) => {
-                this.grapher = grapher
-            },
-            // reactive settings
-            bounds: this.bounds,
-        }
-        this.grapherElement = <Grapher {...grapherConfig} />
     }
 
     @action.bound private setDb(json: any): void {

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -450,6 +450,9 @@ export class ChartEditorPage
                             minHeight: this.editor?.showStaticPreview
                                 ? this.grapher.staticBoundsWithDetails().height
                                 : undefined,
+                            boxShadow: this.editor?.showStaticPreview
+                                ? "0px 4px 40px rgba(0, 0, 0, 0.2)"
+                                : undefined,
                             filter:
                                 this.simulateVisionDeficiency &&
                                 `url(#${this.simulateVisionDeficiency.id})`,

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -5,9 +5,15 @@ import { ChartEditor } from "./ChartEditor.js"
 import { Section, SelectField } from "./Forms.js"
 import { GrapherStaticFormat } from "@ourworldindata/grapher"
 
+const FORMAT_LABELS: Record<GrapherStaticFormat, string> = {
+    [GrapherStaticFormat.portrait]: "Data insight",
+    [GrapherStaticFormat.instagram]: "Instagram",
+    [GrapherStaticFormat.landscape]: "Landscape",
+}
+
 @observer
 export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
-    @action.bound onFormatChange(value: string) {
+    @action.bound onPresetChange(value: string) {
         this.props.editor.staticPreviewFormat = value as GrapherStaticFormat
     }
 
@@ -18,8 +24,9 @@ export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
             <div className="EditorTextTab">
                 <Section name="Mobile image size">
                     <SelectField
+                        label="Preset"
                         value={editor.staticPreviewFormat}
-                        onValue={this.onFormatChange}
+                        onValue={this.onPresetChange}
                         options={Object.keys(GrapherStaticFormat)
                             .filter(
                                 (format) =>
@@ -27,7 +34,9 @@ export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
                             )
                             .map((format) => ({
                                 value: format,
-                                label: format,
+                                label: FORMAT_LABELS[
+                                    format as GrapherStaticFormat
+                                ],
                             }))}
                     />
                 </Section>

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -1,9 +1,10 @@
-import { action } from "mobx"
+import { action, computed } from "mobx"
 import { observer } from "mobx-react"
 import React from "react"
 import { ChartEditor } from "./ChartEditor.js"
 import { Section, SelectField } from "./Forms.js"
-import { GrapherStaticFormat } from "@ourworldindata/grapher"
+import { Grapher, GrapherStaticFormat } from "@ourworldindata/grapher"
+import { Bounds, triggerDownloadFromBlob } from "@ourworldindata/utils"
 
 const FORMAT_LABELS: Record<GrapherStaticFormat, string> = {
     [GrapherStaticFormat.portrait]: "Data insight",
@@ -11,17 +12,69 @@ const FORMAT_LABELS: Record<GrapherStaticFormat, string> = {
     [GrapherStaticFormat.landscape]: "Landscape",
 }
 
+type Format = "png" | "svg"
+type ExportFilename = `${string}.${Format}`
+
 @observer
 export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
+    @computed private get grapher(): Grapher {
+        return this.props.editor.grapher
+    }
+
+    @computed private get baseFilename(): string {
+        return this.props.editor.grapher.displaySlug
+    }
+
     @action.bound onPresetChange(value: string) {
         this.props.editor.staticPreviewFormat = value as GrapherStaticFormat
     }
 
+    @action.bound async onDownloadDesktopSVG() {
+        this.download(
+            `${this.baseFilename}-desktop.svg`,
+            this.grapher.idealBounds
+        )
+    }
+
+    @action.bound async onDownloadDesktopPNG() {
+        this.download(
+            `${this.baseFilename}-desktop.png`,
+            this.grapher.idealBounds
+        )
+    }
+
+    @action.bound async onDownloadMobileSVG() {
+        this.download(
+            `${this.baseFilename}-mobile.svg`,
+            this.grapher.staticBounds
+        )
+    }
+
+    @action.bound onDownloadMobilePNG() {
+        this.download(
+            `${this.baseFilename}-mobile.png`,
+            this.grapher.staticBounds
+        )
+    }
+
+    async download(filename: ExportFilename, bounds: Bounds) {
+        try {
+            const { blob: pngBlob, svgBlob } =
+                await this.grapher.rasterize(bounds)
+            if (filename.endsWith("svg") && svgBlob) {
+                triggerDownloadFromBlob(filename, svgBlob)
+            } else if (filename.endsWith("png") && pngBlob) {
+                triggerDownloadFromBlob(filename, pngBlob)
+            }
+        } catch (err) {
+            console.error(err)
+        }
+    }
+
     render() {
         const { editor } = this.props
-
         return (
-            <div className="EditorTextTab">
+            <div className="EditorExportTab">
                 <Section name="Mobile image size">
                     <SelectField
                         label="Preset"
@@ -39,6 +92,34 @@ export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
                                 ],
                             }))}
                     />
+                </Section>
+                <Section name="Export static chart">
+                    <div className="DownloadButtons">
+                        <button
+                            className="btn btn-primary"
+                            onClick={this.onDownloadDesktopPNG}
+                        >
+                            Download Desktop PNG
+                        </button>
+                        <button
+                            className="btn btn-primary"
+                            onClick={this.onDownloadDesktopSVG}
+                        >
+                            Download Desktop SVG
+                        </button>
+                        <button
+                            className="btn btn-primary"
+                            onClick={this.onDownloadMobilePNG}
+                        >
+                            Download Mobile PNG
+                        </button>
+                        <button
+                            className="btn btn-primary"
+                            onClick={this.onDownloadMobileSVG}
+                        >
+                            Download Mobile SVG
+                        </button>
+                    </div>
                 </Section>
             </div>
         )

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -4,13 +4,11 @@ import React from "react"
 import { ChartEditor } from "./ChartEditor.js"
 import { Section, SelectField, Toggle } from "./Forms.js"
 import { Grapher, GrapherStaticFormat } from "@ourworldindata/grapher"
-import { Bounds, triggerDownloadFromBlob } from "@ourworldindata/utils"
-
-const FORMAT_LABELS: Record<GrapherStaticFormat, string> = {
-    [GrapherStaticFormat.portrait]: "Data insight",
-    [GrapherStaticFormat.instagram]: "Instagram",
-    [GrapherStaticFormat.landscape]: "Landscape",
-}
+import {
+    Bounds,
+    triggerDownloadFromBlob,
+    capitalize,
+} from "@ourworldindata/utils"
 
 type Format = "png" | "svg"
 type ExportFilename = `${string}.${Format}`
@@ -100,9 +98,7 @@ export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
                             )
                             .map((format) => ({
                                 value: format,
-                                label: FORMAT_LABELS[
-                                    format as GrapherStaticFormat
-                                ],
+                                label: capitalize(format),
                             }))}
                     />
                 </Section>

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -29,6 +29,7 @@ type OriginalGrapher = Pick<
     | "note"
     | "originUrl"
     | "shouldIncludeDetailsInStaticExport"
+    | "detailsOrderedByReference"
 >
 
 type ExportSettingsByChartId = Record<number, ExportSettings>
@@ -133,6 +134,7 @@ export class EditorExportTab extends React.Component<EditorExportTabProps> {
             originUrl: this.grapher.originUrl,
             shouldIncludeDetailsInStaticExport:
                 this.grapher.shouldIncludeDetailsInStaticExport,
+            detailsOrderedByReference: this.grapher.detailsOrderedByReference,
         }
     }
 
@@ -286,14 +288,19 @@ export class EditorExportTab extends React.Component<EditorExportTabProps> {
                             }
                         />
                     )}
-                    <Toggle
-                        label="Details on demand"
-                        value={this.settings.shouldIncludeDetailsInStaticExport}
-                        onValue={(value) =>
-                            (this.settings.shouldIncludeDetailsInStaticExport =
-                                value)
-                        }
-                    />
+                    {this.originalGrapher.detailsOrderedByReference.size >
+                        0 && (
+                        <Toggle
+                            label="Details on demand"
+                            value={
+                                this.settings.shouldIncludeDetailsInStaticExport
+                            }
+                            onValue={(value) =>
+                                (this.settings.shouldIncludeDetailsInStaticExport =
+                                    value)
+                            }
+                        />
+                    )}
                 </Section>
                 <Section name="Export static chart">
                     <div className="DownloadButtons">

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -2,7 +2,7 @@ import { action, computed } from "mobx"
 import { observer } from "mobx-react"
 import React from "react"
 import { ChartEditor } from "./ChartEditor.js"
-import { Section, SelectField } from "./Forms.js"
+import { Section, SelectField, Toggle } from "./Forms.js"
 import { Grapher, GrapherStaticFormat } from "@ourworldindata/grapher"
 import { Bounds, triggerDownloadFromBlob } from "@ourworldindata/utils"
 
@@ -57,6 +57,18 @@ export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
         )
     }
 
+    @action.bound onToggleTitleAnnotationEntity(value: boolean) {
+        const { grapher } = this.props.editor
+        grapher.forceHideAnnotationFieldsInTitle ??= {}
+        grapher.forceHideAnnotationFieldsInTitle.entity = !value || undefined
+    }
+
+    @action.bound onToggleTitleAnnotationTime(value: boolean) {
+        const { grapher } = this.props.editor
+        grapher.forceHideAnnotationFieldsInTitle ??= {}
+        grapher.forceHideAnnotationFieldsInTitle.time = !value || undefined
+    }
+
     async download(filename: ExportFilename, bounds: Bounds) {
         try {
             const { blob: pngBlob, svgBlob } =
@@ -73,6 +85,7 @@ export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
 
     render() {
         const { editor } = this.props
+        const { grapher } = editor
         return (
             <div className="EditorExportTab">
                 <Section name="Mobile image size">
@@ -91,6 +104,20 @@ export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
                                     format as GrapherStaticFormat
                                 ],
                             }))}
+                    />
+                </Section>
+                <Section name="Displayed elements">
+                    <Toggle
+                        label="Title suffix: automatic entity"
+                        value={
+                            !grapher.forceHideAnnotationFieldsInTitle?.entity
+                        }
+                        onValue={this.onToggleTitleAnnotationEntity}
+                    />
+                    <Toggle
+                        label="Title suffix: automatic time"
+                        value={!grapher.forceHideAnnotationFieldsInTitle?.time}
+                        onValue={this.onToggleTitleAnnotationTime}
                     />
                 </Section>
                 <Section name="Export static chart">

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -1,26 +1,10 @@
-import { action } from "mobx"
 import { observer } from "mobx-react"
 import React from "react"
 import { ChartEditor } from "./ChartEditor.js"
-import { Section, Toggle } from "./Forms.js"
 
 @observer
 export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
-    @action.bound onToggleShowStaticPreview(value: boolean) {
-        this.props.editor.showStaticPreview = value
-    }
-
     render() {
-        return (
-            <div className="EditorTextTab">
-                <Section name="Static mode">
-                    <Toggle
-                        label="Show static preview"
-                        value={this.props.editor.showStaticPreview}
-                        onValue={this.onToggleShowStaticPreview}
-                    />
-                </Section>
-            </div>
-        )
+        return <div className="EditorTextTab"></div>
     }
 }

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -1,10 +1,37 @@
+import { action } from "mobx"
 import { observer } from "mobx-react"
 import React from "react"
 import { ChartEditor } from "./ChartEditor.js"
+import { Section, SelectField } from "./Forms.js"
+import { GrapherStaticFormat } from "@ourworldindata/grapher"
 
 @observer
 export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
+    @action.bound onFormatChange(value: string) {
+        this.props.editor.staticPreviewFormat = value as GrapherStaticFormat
+    }
+
     render() {
-        return <div className="EditorTextTab"></div>
+        const { editor } = this.props
+
+        return (
+            <div className="EditorTextTab">
+                <Section name="Mobile image size">
+                    <SelectField
+                        value={editor.staticPreviewFormat}
+                        onValue={this.onFormatChange}
+                        options={Object.keys(GrapherStaticFormat)
+                            .filter(
+                                (format) =>
+                                    format !== GrapherStaticFormat.landscape
+                            )
+                            .map((format) => ({
+                                value: format,
+                                label: format,
+                            }))}
+                    />
+                </Section>
+            </div>
+        )
     }
 }

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -20,6 +20,17 @@ type ExportSettings = Pick<
     | "hideOriginUrl"
 >
 
+type OriginalGrapher = Pick<
+    Grapher,
+    | "currentTitle"
+    | "shouldAddEntitySuffixToTitle"
+    | "shouldAddTimeSuffixToTitle"
+    | "currentSubtitle"
+    | "hideLogo"
+    | "note"
+    | "originUrl"
+>
+
 type ExportSettingsByChartId = Record<number, ExportSettings>
 
 type Format = "png" | "svg"
@@ -29,7 +40,10 @@ const STORAGE_KEY = "chart-export-settings"
 
 const DEFAULT_SETTINGS: ExportSettings = {
     hideTitle: false,
-    forceHideAnnotationFieldsInTitle: { entity: false, time: false },
+    forceHideAnnotationFieldsInTitle: {
+        entity: false,
+        time: false,
+    },
     hideSubtitle: false,
     hideLogo: false,
     hideNote: false,
@@ -40,10 +54,12 @@ const DEFAULT_SETTINGS: ExportSettings = {
 export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
     @observable private settings = DEFAULT_SETTINGS
     private originalSettings = DEFAULT_SETTINGS
+    private originalGrapher: OriginalGrapher | undefined = undefined
     private disposers: IReactionDisposer[] = []
 
     componentDidMount(): void {
         this.saveOriginalSettings()
+        this.saveOriginalGrapher()
 
         if (sessionStorage) {
             this.loadSettingsFromSessionStorage()
@@ -87,6 +103,19 @@ export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
             hideLogo: this.grapher.hideLogo,
             hideNote: this.grapher.hideNote,
             hideOriginUrl: this.grapher.hideOriginUrl,
+        }
+    }
+
+    private saveOriginalGrapher() {
+        this.originalGrapher = {
+            currentTitle: this.grapher.currentTitle,
+            shouldAddEntitySuffixToTitle:
+                this.grapher.shouldAddEntitySuffixToTitle,
+            shouldAddTimeSuffixToTitle: this.grapher.shouldAddTimeSuffixToTitle,
+            currentSubtitle: this.grapher.currentSubtitle,
+            hideLogo: this.grapher.hideLogo,
+            note: this.grapher.note,
+            originUrl: this.grapher.originUrl,
         }
     }
 
@@ -179,57 +208,80 @@ export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
                     />
                 </Section>
                 <Section name="Displayed elements">
-                    <Toggle
-                        label="Title"
-                        value={!this.settings.hideTitle}
-                        onValue={(value) => (this.settings.hideTitle = !value)}
-                    />
-                    <Toggle
-                        label="Title suffix: automatic entity"
-                        value={
-                            !this.settings.forceHideAnnotationFieldsInTitle
-                                ?.entity
-                        }
-                        onValue={(value) =>
-                            (this.settings.forceHideAnnotationFieldsInTitle.entity =
-                                !value)
-                        }
-                    />
-                    <Toggle
-                        label="Title suffix: automatic time"
-                        value={
-                            !this.settings.forceHideAnnotationFieldsInTitle
-                                ?.time
-                        }
-                        onValue={(value) =>
-                            (this.settings.forceHideAnnotationFieldsInTitle.time =
-                                !value)
-                        }
-                    />
-                    <Toggle
-                        label="Subtitle"
-                        value={!this.settings.hideSubtitle}
-                        onValue={(value) =>
-                            (this.settings.hideSubtitle = !value)
-                        }
-                    />
-                    <Toggle
-                        label="Logo"
-                        value={!this.settings.hideLogo}
-                        onValue={(value) => (this.settings.hideLogo = !value)}
-                    />
-                    <Toggle
-                        label="Note"
-                        value={!this.settings.hideNote}
-                        onValue={(value) => (this.settings.hideNote = !value)}
-                    />
-                    <Toggle
-                        label="Origin URL"
-                        value={!this.settings.hideOriginUrl}
-                        onValue={(value) =>
-                            (this.settings.hideOriginUrl = !value)
-                        }
-                    />
+                    {this.originalGrapher?.currentTitle && (
+                        <Toggle
+                            label="Title"
+                            value={!this.settings.hideTitle}
+                            onValue={(value) =>
+                                (this.settings.hideTitle = !value)
+                            }
+                        />
+                    )}
+                    {this.originalGrapher?.currentTitle &&
+                        this.originalGrapher?.shouldAddEntitySuffixToTitle && (
+                            <Toggle
+                                label="Title suffix: automatic entity"
+                                value={
+                                    !this.settings
+                                        .forceHideAnnotationFieldsInTitle
+                                        ?.entity
+                                }
+                                onValue={(value) =>
+                                    (this.settings.forceHideAnnotationFieldsInTitle.entity =
+                                        !value)
+                                }
+                            />
+                        )}
+                    {this.originalGrapher?.currentTitle &&
+                        this.originalGrapher?.shouldAddTimeSuffixToTitle && (
+                            <Toggle
+                                label="Title suffix: automatic time"
+                                value={
+                                    !this.settings
+                                        .forceHideAnnotationFieldsInTitle?.time
+                                }
+                                onValue={(value) =>
+                                    (this.settings.forceHideAnnotationFieldsInTitle.time =
+                                        !value)
+                                }
+                            />
+                        )}
+                    {this.originalGrapher?.currentSubtitle && (
+                        <Toggle
+                            label="Subtitle"
+                            value={!this.settings.hideSubtitle}
+                            onValue={(value) =>
+                                (this.settings.hideSubtitle = !value)
+                            }
+                        />
+                    )}
+                    {!this.originalGrapher?.hideLogo && (
+                        <Toggle
+                            label="Logo"
+                            value={!this.settings.hideLogo}
+                            onValue={(value) =>
+                                (this.settings.hideLogo = !value)
+                            }
+                        />
+                    )}
+                    {this.originalGrapher?.note && (
+                        <Toggle
+                            label="Note"
+                            value={!this.settings.hideNote}
+                            onValue={(value) =>
+                                (this.settings.hideNote = !value)
+                            }
+                        />
+                    )}
+                    {this.originalGrapher?.originUrl && (
+                        <Toggle
+                            label="Origin URL"
+                            value={!this.settings.hideOriginUrl}
+                            onValue={(value) =>
+                                (this.settings.hideOriginUrl = !value)
+                            }
+                        />
+                    )}
                 </Section>
                 <Section name="Export static chart">
                     <div className="DownloadButtons">

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -112,7 +112,8 @@ export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
     }
 
     @action.bound private onPresetChange(value: string) {
-        this.props.editor.staticPreviewFormat = value as GrapherStaticFormat
+        this.props.editor.mobileStaticPreviewFormat =
+            value as GrapherStaticFormat
     }
 
     @action.bound private onDownloadDesktopSVG() {
@@ -164,7 +165,7 @@ export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
                 <Section name="Mobile image size">
                     <SelectField
                         label="Preset"
-                        value={editor.staticPreviewFormat}
+                        value={editor.mobileStaticPreviewFormat}
                         onValue={this.onPresetChange}
                         options={Object.keys(GrapherStaticFormat)
                             .filter(

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -119,6 +119,16 @@ export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
                         value={!grapher.forceHideAnnotationFieldsInTitle?.time}
                         onValue={this.onToggleTitleAnnotationTime}
                     />
+                    <Toggle
+                        label="Note"
+                        value={!grapher.hideNote}
+                        onValue={(value) => (grapher.hideNote = !value)}
+                    />
+                    <Toggle
+                        label="Origin URL"
+                        value={!grapher.hideOriginUrl}
+                        onValue={(value) => (grapher.hideOriginUrl = !value)}
+                    />
                 </Section>
                 <Section name="Export static chart">
                     <div className="DownloadButtons">

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -1,0 +1,26 @@
+import { action } from "mobx"
+import { observer } from "mobx-react"
+import React from "react"
+import { ChartEditor } from "./ChartEditor.js"
+import { Section, Toggle } from "./Forms.js"
+
+@observer
+export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
+    @action.bound onToggleShowStaticPreview(value: boolean) {
+        this.props.editor.showStaticPreview = value
+    }
+
+    render() {
+        return (
+            <div className="EditorTextTab">
+                <Section name="Static mode">
+                    <Toggle
+                        label="Show static preview"
+                        value={this.props.editor.showStaticPreview}
+                        onValue={this.onToggleShowStaticPreview}
+                    />
+                </Section>
+            </div>
+        )
+    }
+}

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -185,7 +185,7 @@ export class EditorExportTab extends React.Component<EditorExportTabProps> {
         )
     }
 
-    async download(filename: ExportFilename, bounds: Bounds) {
+    private async download(filename: ExportFilename, bounds: Bounds) {
         try {
             const { blob: pngBlob, svgBlob } =
                 await this.grapher.rasterize(bounds)

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -108,6 +108,11 @@ export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
                 </Section>
                 <Section name="Displayed elements">
                     <Toggle
+                        label="Title"
+                        value={!grapher.hideTitle}
+                        onValue={(value) => (grapher.hideTitle = !value)}
+                    />
+                    <Toggle
                         label="Title suffix: automatic entity"
                         value={
                             !grapher.forceHideAnnotationFieldsInTitle?.entity
@@ -118,6 +123,16 @@ export class EditorExportTab extends React.Component<{ editor: ChartEditor }> {
                         label="Title suffix: automatic time"
                         value={!grapher.forceHideAnnotationFieldsInTitle?.time}
                         onValue={this.onToggleTitleAnnotationTime}
+                    />
+                    <Toggle
+                        label="Subtitle"
+                        value={!grapher.hideSubtitle}
+                        onValue={(value) => (grapher.hideSubtitle = !value)}
+                    />
+                    <Toggle
+                        label="Logo"
+                        value={!grapher.hideLogo}
+                        onValue={(value) => (grapher.hideLogo = !value)}
                     />
                     <Toggle
                         label="Note"

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -3,7 +3,7 @@ import { observer } from "mobx-react"
 import React from "react"
 import { ChartEditor } from "./ChartEditor.js"
 import { Section, Toggle } from "./Forms.js"
-import { Grapher } from "@ourworldindata/grapher"
+import { Grapher, GrapherStaticFormat } from "@ourworldindata/grapher"
 import { Bounds, triggerDownloadFromBlob } from "@ourworldindata/utils"
 
 type ExportSettings = Required<
@@ -157,32 +157,28 @@ export class EditorExportTab extends React.Component<EditorExportTabProps> {
         return this.props.editor.grapher.displaySlug
     }
 
+    @computed private get landscapeBounds(): Bounds {
+        return this.grapher.getStaticBounds(GrapherStaticFormat.landscape)
+    }
+
+    @computed private get squareBounds(): Bounds {
+        return this.grapher.getStaticBounds(GrapherStaticFormat.square)
+    }
+
     @action.bound private onDownloadDesktopSVG() {
-        this.download(
-            `${this.baseFilename}-desktop.svg`,
-            this.grapher.idealBounds
-        )
+        this.download(`${this.baseFilename}-desktop.svg`, this.landscapeBounds)
     }
 
     @action.bound private onDownloadDesktopPNG() {
-        this.download(
-            `${this.baseFilename}-desktop.png`,
-            this.grapher.idealBounds
-        )
+        this.download(`${this.baseFilename}-desktop.png`, this.landscapeBounds)
     }
 
     @action.bound private onDownloadMobileSVG() {
-        this.download(
-            `${this.baseFilename}-mobile.svg`,
-            this.grapher.staticBounds
-        )
+        this.download(`${this.baseFilename}-mobile.svg`, this.squareBounds)
     }
 
     @action.bound private onDownloadMobilePNG() {
-        this.download(
-            `${this.baseFilename}-mobile.png`,
-            this.grapher.staticBounds
-        )
+        this.download(`${this.baseFilename}-mobile.png`, this.squareBounds)
     }
 
     private async download(filename: ExportFilename, bounds: Bounds) {

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -2,13 +2,9 @@ import { IReactionDisposer, action, autorun, computed, observable } from "mobx"
 import { observer } from "mobx-react"
 import React from "react"
 import { ChartEditor } from "./ChartEditor.js"
-import { Section, SelectField, Toggle } from "./Forms.js"
-import { Grapher, GrapherStaticFormat } from "@ourworldindata/grapher"
-import {
-    Bounds,
-    triggerDownloadFromBlob,
-    capitalize,
-} from "@ourworldindata/utils"
+import { Section, Toggle } from "./Forms.js"
+import { Grapher } from "@ourworldindata/grapher"
+import { Bounds, triggerDownloadFromBlob } from "@ourworldindata/utils"
 
 type ExportSettings = Required<
     Pick<
@@ -161,11 +157,6 @@ export class EditorExportTab extends React.Component<EditorExportTabProps> {
         return this.props.editor.grapher.displaySlug
     }
 
-    @action.bound private onPresetChange(value: string) {
-        this.props.editor.mobileStaticPreviewFormat =
-            value as GrapherStaticFormat
-    }
-
     @action.bound private onDownloadDesktopSVG() {
         this.download(
             `${this.baseFilename}-desktop.svg`,
@@ -209,25 +200,8 @@ export class EditorExportTab extends React.Component<EditorExportTabProps> {
     }
 
     render() {
-        const { editor } = this.props
         return (
             <div className="EditorExportTab">
-                <Section name="Mobile image size">
-                    <SelectField
-                        label="Preset"
-                        value={editor.mobileStaticPreviewFormat}
-                        onValue={this.onPresetChange}
-                        options={Object.keys(GrapherStaticFormat)
-                            .filter(
-                                (format) =>
-                                    format !== GrapherStaticFormat.landscape
-                            )
-                            .map((format) => ({
-                                value: format,
-                                label: capitalize(format),
-                            }))}
-                    />
-                </Section>
                 <Section name="Displayed elements">
                     {this.originalGrapher.currentTitle && (
                         <Toggle

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -299,8 +299,8 @@ $nav-height: 45px;
     }
 
     > .chart-editor-settings {
-        min-width: 500px;
-        width: 500px;
+        min-width: 550px;
+        width: 550px;
         min-height: 100%;
         display: flex;
         flex-direction: column;
@@ -388,6 +388,15 @@ $nav-height: 45px;
         display: flex;
         flex-direction: column;
         gap: 1em;
+    }
+}
+
+.EditorExportTab {
+    .DownloadButtons {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        align-items: flex-start;
     }
 }
 

--- a/functions/_common/grapherRenderer.ts
+++ b/functions/_common/grapherRenderer.ts
@@ -181,7 +181,7 @@ async function fetchAndRenderGrapherToSvg({
     await Promise.all(promises) // Run these (potentially) two fetches in parallel
     grapherLogger.log("fetchDataAndDods")
 
-    const svg = grapher.generateStaticSvg(bounds)
+    const svg = grapher.generateStaticSvg()
     grapherLogger.log("generateStaticSvg")
     return svg
 }

--- a/functions/_common/grapherRenderer.ts
+++ b/functions/_common/grapherRenderer.ts
@@ -159,7 +159,7 @@ async function fetchAndRenderGrapherToSvg({
         bakedGrapherURL: grapherBaseUrl,
         queryStr: "?" + searchParams.toString(),
         bounds,
-        boundsForExport: bounds,
+        staticBounds: bounds,
         baseFontSize: options.fontSize,
     })
     grapher.shouldIncludeDetailsInStaticExport = options.details

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -181,8 +181,8 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
     @computed protected get bounds(): Bounds {
         return (
             this.props.bounds ??
-            // right padding prevents grapher's frame to be obscured by the chart/map
-            this.manager.tabBounds?.padRight(2) ??
+            // the padding ensures grapher's frame is not cut off
+            this.manager.tabBounds?.padRight(2).padBottom(2) ??
             DEFAULT_BOUNDS
         )
     }

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -68,7 +68,7 @@ export interface CaptionedChartManager
     containerElement?: HTMLDivElement
     tabBounds?: Bounds
     staticBounds?: Bounds
-    staticBoundsWithDetails?: (bounds?: Bounds) => Bounds
+    staticBoundsWithDetails?: Bounds
     fontSize?: number
     bakedGrapherURL?: string
     tab?: GrapherTabOption
@@ -81,7 +81,7 @@ export interface CaptionedChartManager
     entityType?: string
     entityTypePlural?: string
     shouldIncludeDetailsInStaticExport?: boolean
-    detailRenderers: (bounds?: Bounds) => MarkdownTextWrap[]
+    detailRenderers: MarkdownTextWrap[]
     isOnMapTab?: boolean
     isOnTableTab?: boolean
     hasTimeline?: boolean
@@ -530,10 +530,6 @@ export class StaticCaptionedChart extends CaptionedChart {
             .padTop(this.manager.isOnMapTab ? 0 : this.verticalPadding)
     }
 
-    @computed private get detailRenderers(): MarkdownTextWrap[] {
-        return this.manager.detailRenderers(this.bounds)
-    }
-
     renderSVGDetails(): JSX.Element {
         let yOffset = 0
         let previousOffset = 0
@@ -555,7 +551,7 @@ export class StaticCaptionedChart extends CaptionedChart {
                         this.bounds.height + this.framePaddingVertical
                     })`}
                 >
-                    {this.detailRenderers.map((detail, i) => {
+                    {this.manager.detailRenderers.map((detail, i) => {
                         previousOffset = yOffset
                         yOffset += detail.height + STATIC_EXPORT_DETAIL_SPACING
                         return detail.renderSVG(0, previousOffset, { key: i })
@@ -581,14 +577,13 @@ export class StaticCaptionedChart extends CaptionedChart {
     render(): JSX.Element {
         const { paddedBounds, manager, maxWidth } = this
 
-        const bounds =
-            this.manager.staticBoundsWithDetails?.(this.bounds) ?? this.bounds
+        const bounds = this.manager.staticBoundsWithDetails ?? this.bounds
         const width = bounds.width
         const height = bounds.height
 
         const includeDetailsInStaticExport =
             manager.shouldIncludeDetailsInStaticExport &&
-            !isEmpty(this.detailRenderers)
+            !isEmpty(this.manager.detailRenderers)
 
         return (
             <svg

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -611,7 +611,7 @@ export class StaticCaptionedChart extends CaptionedChart {
                     targetX={paddedBounds.x}
                     targetY={paddedBounds.y}
                 />
-                {this.renderChart()}
+                <g style={{ pointerEvents: "none" }}>{this.renderChart()}</g>
                 <StaticFooter
                     manager={manager}
                     maxWidth={maxWidth}

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -7,10 +7,7 @@ import {
     exposeInstanceOnWindow,
     isEmpty,
 } from "@ourworldindata/utils"
-import {
-    MarkdownTextWrap,
-    sumTextWrapHeights,
-} from "@ourworldindata/components"
+import { MarkdownTextWrap } from "@ourworldindata/components"
 import { Header, StaticHeader } from "../header/Header"
 import { Footer, StaticFooter } from "../footer/Footer"
 import {
@@ -94,6 +91,8 @@ export interface CaptionedChartManager
     isMedium?: boolean
     framePaddingHorizontal?: number
     framePaddingVertical?: number
+    exportWidth?: (bounds?: Bounds) => number
+    exportHeight?: (bounds?: Bounds) => number
 }
 
 interface CaptionedChartProps {
@@ -575,20 +574,13 @@ export class StaticCaptionedChart extends CaptionedChart {
 
     render(): JSX.Element {
         const { bounds, paddedBounds, manager, maxWidth } = this
-        let { width, height } = bounds
+
+        const width = this.manager.exportWidth?.(bounds) ?? bounds.width
+        const height = this.manager.exportHeight?.(bounds) ?? bounds.height
 
         const includeDetailsInStaticExport =
             manager.shouldIncludeDetailsInStaticExport &&
             !isEmpty(this.manager.detailRenderers)
-
-        if (includeDetailsInStaticExport) {
-            height +=
-                2 * this.framePaddingVertical +
-                sumTextWrapHeights(
-                    this.manager.detailRenderers,
-                    STATIC_EXPORT_DETAIL_SPACING
-                )
-        }
 
         return (
             <svg

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -81,7 +81,7 @@ export interface CaptionedChartManager
     entityType?: string
     entityTypePlural?: string
     shouldIncludeDetailsInStaticExport?: boolean
-    detailRenderers: MarkdownTextWrap[]
+    detailRenderers: (bounds?: Bounds) => MarkdownTextWrap[]
     isOnMapTab?: boolean
     isOnTableTab?: boolean
     hasTimeline?: boolean
@@ -534,6 +534,10 @@ export class StaticCaptionedChart extends CaptionedChart {
             .padTop(this.manager.isOnMapTab ? 0 : this.verticalPadding)
     }
 
+    @computed private get detailRenderers(): MarkdownTextWrap[] {
+        return this.manager.detailRenderers(this.bounds)
+    }
+
     renderSVGDetails(): JSX.Element {
         let yOffset = 0
         let previousOffset = 0
@@ -555,7 +559,7 @@ export class StaticCaptionedChart extends CaptionedChart {
                         this.bounds.height + this.framePaddingVertical
                     })`}
                 >
-                    {this.manager.detailRenderers.map((detail, i) => {
+                    {this.detailRenderers.map((detail, i) => {
                         previousOffset = yOffset
                         yOffset += detail.height + STATIC_EXPORT_DETAIL_SPACING
                         return detail.renderSVG(0, previousOffset, { key: i })
@@ -588,7 +592,7 @@ export class StaticCaptionedChart extends CaptionedChart {
 
         const includeDetailsInStaticExport =
             manager.shouldIncludeDetailsInStaticExport &&
-            !isEmpty(this.manager.detailRenderers)
+            !isEmpty(this.detailRenderers)
 
         return (
             <svg

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -486,11 +486,7 @@ export class StaticCaptionedChart extends CaptionedChart {
     }
 
     @computed protected get bounds(): Bounds {
-        const bounds =
-            this.props.bounds ?? this.manager.staticBounds ?? DEFAULT_BOUNDS
-        // the padding ensures grapher's frame is not cut off
-        const padding = this.manager.isExportingToSvgOrPng ? 0 : 2
-        return bounds.padRight(padding).padBottom(padding)
+        return this.props.bounds ?? this.manager.staticBounds ?? DEFAULT_BOUNDS
     }
 
     @computed protected get staticFooter(): Footer {

--- a/packages/@ourworldindata/grapher/src/captionedChart/StaticChartRasterizer.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/StaticChartRasterizer.tsx
@@ -1,6 +1,13 @@
 export const EMBEDDED_FONTS_CSS = "/fonts/embedded.css"
 export const IMPORT_FONTS_REGEX = /@import url\([^\)]*?fonts\.css\)/
 
+export interface GrapherExport {
+    url: string
+    blob: Blob
+    svgUrl: string
+    svgBlob: Blob
+}
+
 export class StaticChartRasterizer {
     svg: string
     width: number
@@ -97,12 +104,7 @@ export class StaticChartRasterizer {
         this.embeddedFonts = ""
     }
 
-    async render(): Promise<{
-        url: string
-        blob: Blob
-        svgUrl: string
-        svgBlob: Blob
-    }> {
+    async render(): Promise<GrapherExport> {
         // await the canvas before doing anything else to make sure .preloadFonts() has completed
         const canvas = await this.canvas,
             ctx = canvas.getContext("2d", { alpha: false })!

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1751,10 +1751,8 @@ export class Grapher
         switch (this.staticFormat) {
             case GrapherStaticFormat.landscape:
                 return this.idealBounds
-            case GrapherStaticFormat.portrait:
-                return new Bounds(0, 0, 600, 600)
-            case GrapherStaticFormat.instagram:
-                return new Bounds(0, 0, 1080, 1080)
+            case GrapherStaticFormat.square:
+                return new Bounds(0, 0, 540, 540)
             default:
                 return this.idealBounds
         }

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1270,6 +1270,7 @@ export class Grapher
     // Used for static exports. Defined at this level because they need to
     // be accessed by CaptionedChart and DownloadModal
     detailRenderers(bounds: Bounds = this.staticBounds): MarkdownTextWrap[] {
+        if (typeof window === "undefined") return []
         return [...this.detailsOrderedByReference].map((term, i) => {
             let text = `**${i + 1}.** `
             const detail: EnrichedDetail = window.details?.[term]

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1270,9 +1270,6 @@ export class Grapher
     // Used for static exports. Defined at this level because they need to
     // be accessed by CaptionedChart and DownloadModal
     @computed get detailRenderers(): MarkdownTextWrap[] {
-        const activeBounds = this.isExportingToSvgOrPng
-            ? this.staticBounds
-            : this.tabBounds
         return [...this.detailsOrderedByReference].map((term, i) => {
             let text = `**${i + 1}.** `
             const detail: EnrichedDetail = window.details?.[term]
@@ -1288,7 +1285,8 @@ export class Grapher
                 text,
                 fontSize: 12,
                 // leave room for padding on the left and right
-                maxWidth: activeBounds.width - 2 * this.framePaddingHorizontal,
+                maxWidth:
+                    this.staticBounds.width - 2 * this.framePaddingHorizontal,
                 lineHeight: 1.2,
                 style: {
                     fill: GRAPHER_DARK_TEXT,
@@ -1758,7 +1756,7 @@ export class Grapher
         }
     }
 
-    generateStaticSvg(bounds: Bounds = this.idealBounds): string {
+    generateStaticSvg(bounds: Bounds = this.staticBounds): string {
         const _isExportingToSvgOrPng = this.isExportingToSvgOrPng
         this.isExportingToSvgOrPng = true
         const staticSvg = ReactDOMServer.renderToStaticMarkup(
@@ -1769,40 +1767,33 @@ export class Grapher
     }
 
     get staticSVG(): string {
-        return this.generateStaticSvg()
+        return this.generateStaticSvg(this.idealBounds)
     }
 
-    exportWidth(bounds: Bounds = this.staticBounds): number {
-        return bounds.width
-    }
-
-    exportHeight(bounds: Bounds = this.staticBounds): number {
-        if (
+    staticBoundsWithDetails(bounds: Bounds = this.staticBounds): Bounds {
+        const includeDetails =
             this.shouldIncludeDetailsInStaticExport &&
             !isEmpty(this.detailRenderers)
-        ) {
-            return (
-                bounds.height +
-                2 * this.framePaddingVertical! +
+
+        let height = bounds.height
+        if (includeDetails) {
+            console.log("rendering details", this.detailRenderers)
+            height +=
+                2 * this.framePaddingVertical +
                 sumTextWrapHeights(
                     this.detailRenderers,
                     STATIC_EXPORT_DETAIL_SPACING
                 )
-            )
         }
-        return bounds.height
+
+        return new Bounds(0, 0, bounds.width, height)
     }
 
     rasterize(bounds: Bounds = this.staticBounds): Promise<GrapherExport> {
-        const targetWidth = this.exportWidth(bounds)
-        const targetHeight = this.exportHeight(bounds)
+        const { width, height } = this.staticBoundsWithDetails(bounds)
         const staticSVG = this.generateStaticSvg(bounds)
 
-        return new StaticChartRasterizer(
-            staticSVG,
-            targetWidth,
-            targetHeight
-        ).render()
+        return new StaticChartRasterizer(staticSVG, width, height).render()
     }
 
     @computed get disableIntroAnimation(): boolean {
@@ -2514,9 +2505,13 @@ export class Grapher
             GrapherComponentMedium: this.isMedium,
         })
 
+        const activeBounds = this.renderToStatic
+            ? this.staticBounds
+            : this.tabBounds
+
         const containerStyle = {
-            width: this.renderWidth,
-            height: this.renderHeight,
+            width: activeBounds.width,
+            height: activeBounds.height,
             fontSize: this.isExportingToSvgOrPng
                 ? 18
                 : Math.min(16, this.fontSize), // cap font size at 16px

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1757,8 +1757,8 @@ export class Grapher
         return this._staticFormat
     }
 
-    set staticFormat(preset: GrapherStaticFormat) {
-        this._staticFormat = preset
+    set staticFormat(format: GrapherStaticFormat) {
+        this._staticFormat = format
     }
 
     @computed get staticBounds(): Bounds {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1273,7 +1273,7 @@ export class Grapher
 
     // Used for static exports. Defined at this level because they need to
     // be accessed by CaptionedChart and DownloadModal
-    detailRenderers(bounds: Bounds = this.staticBounds): MarkdownTextWrap[] {
+    @computed get detailRenderers(): MarkdownTextWrap[] {
         if (typeof window === "undefined") return []
         return [...this.detailsOrderedByReference].map((term, i) => {
             let text = `**${i + 1}.** `
@@ -1290,7 +1290,8 @@ export class Grapher
                 text,
                 fontSize: 12,
                 // leave room for padding on the left and right
-                maxWidth: bounds.width - 2 * this.framePaddingHorizontal,
+                maxWidth:
+                    this.staticBounds.width - 2 * this.framePaddingHorizontal,
                 lineHeight: 1.2,
                 style: {
                     fill: GRAPHER_DARK_TEXT,
@@ -1777,41 +1778,41 @@ export class Grapher
         return this.getStaticBounds(this.staticFormat)
     }
 
-    generateStaticSvg(bounds: Bounds = this.staticBounds): string {
+    generateStaticSvg(): string {
         const _isExportingToSvgOrPng = this.isExportingToSvgOrPng
         this.isExportingToSvgOrPng = true
         const staticSvg = ReactDOMServer.renderToStaticMarkup(
-            <StaticCaptionedChart manager={this} bounds={bounds} />
+            <StaticCaptionedChart manager={this} />
         )
         this.isExportingToSvgOrPng = _isExportingToSvgOrPng
         return staticSvg
     }
 
     get staticSVG(): string {
-        return this.generateStaticSvg(this.idealBounds)
+        return this.generateStaticSvg()
     }
 
-    staticBoundsWithDetails(bounds: Bounds = this.staticBounds): Bounds {
-        const detailRenderers = this.detailRenderers(bounds)
+    @computed get staticBoundsWithDetails(): Bounds {
         const includeDetails =
-            this.shouldIncludeDetailsInStaticExport && !isEmpty(detailRenderers)
+            this.shouldIncludeDetailsInStaticExport &&
+            !isEmpty(this.detailRenderers)
 
-        let height = bounds.height
+        let height = this.staticBounds.height
         if (includeDetails) {
             height +=
                 2 * this.framePaddingVertical +
                 sumTextWrapHeights(
-                    detailRenderers,
+                    this.detailRenderers,
                     STATIC_EXPORT_DETAIL_SPACING
                 )
         }
 
-        return new Bounds(0, 0, bounds.width, height)
+        return new Bounds(0, 0, this.staticBounds.width, height)
     }
 
-    rasterize(bounds: Bounds = this.staticBounds): Promise<GrapherExport> {
-        const { width, height } = this.staticBoundsWithDetails(bounds)
-        const staticSVG = this.generateStaticSvg(bounds)
+    rasterize(): Promise<GrapherExport> {
+        const { width, height } = this.staticBoundsWithDetails
+        const staticSVG = this.generateStaticSvg()
 
         return new StaticChartRasterizer(staticSVG, width, height).render()
     }

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1761,10 +1761,8 @@ export class Grapher
         this._staticFormat = format
     }
 
-    @computed get staticBounds(): Bounds {
-        if (this.props.staticBounds) return this.props.staticBounds
-
-        switch (this.staticFormat) {
+    getStaticBounds(format: GrapherStaticFormat): Bounds {
+        switch (format) {
             case GrapherStaticFormat.landscape:
                 return this.idealBounds
             case GrapherStaticFormat.square:
@@ -1772,6 +1770,11 @@ export class Grapher
             default:
                 return this.idealBounds
         }
+    }
+
+    @computed get staticBounds(): Bounds {
+        if (this.props.staticBounds) return this.props.staticBounds
+        return this.getStaticBounds(this.staticFormat)
     }
 
     generateStaticSvg(bounds: Bounds = this.staticBounds): string {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -788,6 +788,8 @@ export class Grapher
         return this.tableAfterAllTransformsAndFilters
     }
 
+    @observable.ref renderToStatic = false
+
     @observable.ref isExportingToSvgOrPng = false
     @observable.ref exportFormat = GrapherExportFormat.landscape
 
@@ -1759,7 +1761,7 @@ export class Grapher
     }
 
     @computed get disableIntroAnimation(): boolean {
-        return this.isExportingToSvgOrPng
+        return this.isExportingToSvgOrPng || this.renderToStatic
     }
 
     @computed get mapConfig(): MapConfig {
@@ -2508,6 +2510,9 @@ export class Grapher
 
     private renderReady(): JSX.Element | null {
         if (!this.hasBeenVisible) return null
+        if (this.renderToStatic) {
+            return <StaticCaptionedChart manager={this} />
+        }
         return (
             <>
                 <CaptionedChart manager={this} />

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -275,6 +275,8 @@ export interface GrapherProgrammaticInterface extends GrapherInterface {
     staticBounds?: Bounds
     staticFormat?: GrapherStaticFormat
 
+    hideTitle?: boolean
+    hideSubtitle?: boolean
     hideNote?: boolean
     hideOriginUrl?: boolean
 
@@ -3041,6 +3043,8 @@ export class Grapher
         return this.showAddEntityButton && !this.isMobile
     }
 
+    @observable hideTitle = false
+    @observable hideSubtitle = false
     @observable hideNote = false
     @observable hideOriginUrl = false
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -813,6 +813,10 @@ export class Grapher
     @observable.ref isDownloadModalOpen = false
     @observable.ref isEmbedModalOpen = false
 
+    @computed private get isStatic(): boolean {
+        return this.renderToStatic || this.isExportingToSvgOrPng
+    }
+
     private get isStaging(): boolean {
         if (typeof location === undefined) return false
         return location.host.includes("staging")
@@ -1810,7 +1814,7 @@ export class Grapher
     }
 
     @computed get disableIntroAnimation(): boolean {
-        return this.isExportingToSvgOrPng || this.renderToStatic
+        return this.isStatic
     }
 
     @computed get mapConfig(): MapConfig {
@@ -2510,6 +2514,7 @@ export class Grapher
         const containerClasses = classnames({
             GrapherComponent: true,
             GrapherPortraitClass: this.isPortrait,
+            isStatic: this.isStatic,
             isExportingToSvgOrPng: this.isExportingToSvgOrPng,
             optimizeForHorizontalSpace: this.optimizeForHorizontalSpace,
             GrapherComponentNarrow: this.isNarrow,

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1269,7 +1269,7 @@ export class Grapher
 
     // Used for static exports. Defined at this level because they need to
     // be accessed by CaptionedChart and DownloadModal
-    @computed get detailRenderers(): MarkdownTextWrap[] {
+    detailRenderers(bounds: Bounds = this.staticBounds): MarkdownTextWrap[] {
         return [...this.detailsOrderedByReference].map((term, i) => {
             let text = `**${i + 1}.** `
             const detail: EnrichedDetail = window.details?.[term]
@@ -1285,8 +1285,7 @@ export class Grapher
                 text,
                 fontSize: 12,
                 // leave room for padding on the left and right
-                maxWidth:
-                    this.staticBounds.width - 2 * this.framePaddingHorizontal,
+                maxWidth: bounds.width - 2 * this.framePaddingHorizontal,
                 lineHeight: 1.2,
                 style: {
                     fill: GRAPHER_DARK_TEXT,
@@ -1785,17 +1784,16 @@ export class Grapher
     }
 
     staticBoundsWithDetails(bounds: Bounds = this.staticBounds): Bounds {
+        const detailRenderers = this.detailRenderers(bounds)
         const includeDetails =
-            this.shouldIncludeDetailsInStaticExport &&
-            !isEmpty(this.detailRenderers)
+            this.shouldIncludeDetailsInStaticExport && !isEmpty(detailRenderers)
 
         let height = bounds.height
         if (includeDetails) {
-            console.log("rendering details", this.detailRenderers)
             height +=
                 2 * this.framePaddingVertical +
                 sumTextWrapHeights(
-                    this.detailRenderers,
+                    detailRenderers,
                     STATIC_EXPORT_DETAIL_SPACING
                 )
         }

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -275,6 +275,9 @@ export interface GrapherProgrammaticInterface extends GrapherInterface {
     staticBounds?: Bounds
     staticFormat?: GrapherStaticFormat
 
+    hideNote?: boolean
+    hideOriginUrl?: boolean
+
     hideEntityControls?: boolean
     hideZoomToggle?: boolean
     hideNoDataAreaToggle?: boolean
@@ -3037,6 +3040,9 @@ export class Grapher
     @computed get startSelectingWhenLineClicked(): boolean {
         return this.showAddEntityButton && !this.isMobile
     }
+
+    @observable hideNote = false
+    @observable hideOriginUrl = false
 
     // For now I am only exposing this programmatically for the dashboard builder. Setting this to true
     // allows you to still use add country "modes" without showing the buttons in order to prioritize

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1739,6 +1739,8 @@ export class Grapher
             case GrapherStaticFormat.landscape:
                 return this.idealBounds
             case GrapherStaticFormat.portrait:
+                return new Bounds(0, 0, 600, 600)
+            case GrapherStaticFormat.instagram:
                 return new Bounds(0, 0, 1080, 1080)
             default:
                 return this.idealBounds

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -92,7 +92,7 @@ export enum GrapherTabOption {
     table = "table",
 }
 
-export enum GrapherExportFormat {
+export enum GrapherStaticFormat {
     landscape = "landscape",
     portrait = "portrait",
 }

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -95,6 +95,7 @@ export enum GrapherTabOption {
 export enum GrapherStaticFormat {
     landscape = "landscape",
     portrait = "portrait",
+    instagram = "instagram",
 }
 
 export enum ScaleType {

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -94,8 +94,7 @@ export enum GrapherTabOption {
 
 export enum GrapherStaticFormat {
     landscape = "landscape",
-    portrait = "portrait",
-    instagram = "instagram",
+    square = "square",
 }
 
 export enum ScaleType {

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -165,6 +165,10 @@ $zindex-controls-drawer: 140;
     }
 }
 
+.GrapherComponent.isStatic {
+    border: none;
+}
+
 .GrapherComponent.isExportingToSvgOrPng {
     padding: 0 !important;
 }

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -207,7 +207,7 @@ export class Footer<
         return this.manager.isSmall ? 12 : 13
     }
 
-    @computed protected get hasNote(): boolean {
+    @computed protected get showNote(): boolean {
         return !this.manager.hideNote && !!this.noteText
     }
 
@@ -220,13 +220,13 @@ export class Footer<
 
     @computed private get useFullWidthSources(): boolean {
         const {
-            hasNote,
+            showNote,
             sourcesFontSize,
             maxWidth,
             sourcesText,
             actionButtonsWidthWithIconsOnly,
         } = this
-        if (hasNote) return true
+        if (showNote) return true
         const sourcesWidth = Bounds.forText(sourcesText, {
             fontSize: sourcesFontSize,
         }).width
@@ -320,7 +320,7 @@ export class Footer<
             useFullWidthSources,
             sourcesText,
             noteText,
-            hasNote,
+            showNote,
             useFullWidthNote,
         } = this
 
@@ -332,7 +332,7 @@ export class Footer<
         // text next to the action buttons
         const leftTextWidth = !useFullWidthSources
             ? sourcesWidth
-            : hasNote && !useFullWidthNote
+            : showNote && !useFullWidthNote
             ? noteWidth
             : 0
         // text above the action buttons
@@ -491,7 +491,7 @@ export class Footer<
         const { sources, note } = this
 
         const renderSources = this.useFullWidthSources
-        const renderNote = this.hasNote && this.useFullWidthNote
+        const renderNote = this.showNote && this.useFullWidthNote
 
         if (!renderSources && !renderNote) return 0
 
@@ -507,7 +507,7 @@ export class Footer<
     // make sure to keep this.topContentHeight in sync if you edit this method
     private renderTopContent(): JSX.Element | null {
         const renderSources = this.useFullWidthSources
-        const renderNote = this.hasNote && this.useFullWidthNote
+        const renderNote = this.showNote && this.useFullWidthNote
         const renderLicense = this.showLicenseNextToSources
 
         if (!renderSources && !renderNote) return null
@@ -533,7 +533,7 @@ export class Footer<
         const { actionButtons, sources, note } = this
 
         const renderSources = !this.useFullWidthSources
-        const renderNote = this.hasNote && !this.useFullWidthNote
+        const renderNote = this.showNote && !this.useFullWidthNote
         const renderLicense = !this.showLicenseNextToSources
         const renderPadding = (renderSources || renderNote) && renderLicense
 
@@ -549,7 +549,7 @@ export class Footer<
     // make sure to keep this.bottomContentHeight in sync if you edit this method
     private renderBottomContent(): JSX.Element {
         const renderSources = !this.useFullWidthSources
-        const renderNote = this.hasNote && !this.useFullWidthNote
+        const renderNote = this.showNote && !this.useFullWidthNote
         const renderLicense = !this.showLicenseNextToSources
         const renderPadding = (renderSources || renderNote) && renderLicense
 
@@ -710,7 +710,7 @@ export class StaticFooter extends Footer<StaticFooterProps> {
     @computed get height(): number {
         return (
             this.sources.height +
-            (this.hasNote ? this.note.height + this.verticalPadding : 0) +
+            (this.showNote ? this.note.height + this.verticalPadding : 0) +
             (this.showLicenseNextToSources
                 ? 0
                 : this.licenseAndOriginUrl.height + this.verticalPadding)
@@ -730,7 +730,7 @@ export class StaticFooter extends Footer<StaticFooterProps> {
         return (
             <g className="SourcesFooter" style={{ fill: GRAPHER_DARK_TEXT }}>
                 {sources.renderSVG(targetX, targetY)}
-                {this.hasNote &&
+                {this.showNote &&
                     note.renderSVG(
                         targetX,
                         targetY + sources.height + this.verticalPadding
@@ -744,7 +744,7 @@ export class StaticFooter extends Footer<StaticFooterProps> {
                           targetX,
                           targetY +
                               sources.height +
-                              (this.hasNote
+                              (this.showNote
                                   ? note.height + this.verticalPadding
                                   : 0) +
                               this.verticalPadding

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -158,6 +158,8 @@ export class Footer<
             actionButtons,
         } = this
 
+        if (this.manager.hideOriginUrl) return undefined
+
         if (!correctedUrlText) return undefined
 
         const licenseAndOriginUrlText = Footer.constructLicenseAndOriginUrlText(
@@ -205,8 +207,8 @@ export class Footer<
         return this.manager.isSmall ? 12 : 13
     }
 
-    @computed private get hasNote(): boolean {
-        return !!this.noteText
+    @computed protected get hasNote(): boolean {
+        return !this.manager.hideNote && !!this.noteText
     }
 
     @computed private get actionButtonsWidthWithIconsOnly(): number {
@@ -650,6 +652,8 @@ export class StaticFooter extends Footer<StaticFooterProps> {
     @computed protected get finalUrlText(): string | undefined {
         const { correctedUrlText, licenseText, fontSize, maxWidth } = this
 
+        if (this.manager.hideOriginUrl) return undefined
+
         if (!correctedUrlText) return undefined
 
         const licenseAndOriginUrlText = Footer.constructLicenseAndOriginUrlText(
@@ -706,7 +710,7 @@ export class StaticFooter extends Footer<StaticFooterProps> {
     @computed get height(): number {
         return (
             this.sources.height +
-            (this.note.height ? this.note.height + this.verticalPadding : 0) +
+            (this.hasNote ? this.note.height + this.verticalPadding : 0) +
             (this.showLicenseNextToSources
                 ? 0
                 : this.licenseAndOriginUrl.height + this.verticalPadding)
@@ -726,10 +730,11 @@ export class StaticFooter extends Footer<StaticFooterProps> {
         return (
             <g className="SourcesFooter" style={{ fill: GRAPHER_DARK_TEXT }}>
                 {sources.renderSVG(targetX, targetY)}
-                {note.renderSVG(
-                    targetX,
-                    targetY + sources.height + this.verticalPadding
-                )}
+                {this.hasNote &&
+                    note.renderSVG(
+                        targetX,
+                        targetY + sources.height + this.verticalPadding
+                    )}
                 {showLicenseNextToSources
                     ? licenseAndOriginUrl.render(
                           targetX + maxWidth - licenseAndOriginUrl.width,
@@ -739,7 +744,7 @@ export class StaticFooter extends Footer<StaticFooterProps> {
                           targetX,
                           targetY +
                               sources.height +
-                              (note.height
+                              (this.hasNote
                                   ? note.height + this.verticalPadding
                                   : 0) +
                               this.verticalPadding

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -635,6 +635,11 @@ interface StaticFooterProps extends FooterProps {
 export class StaticFooter extends Footer<StaticFooterProps> {
     verticalPadding = 2
 
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    componentDidMount(): void {}
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    componentWillUnmount(): void {}
+
     @computed protected get showLicenseNextToSources(): boolean {
         return (
             this.maxWidth - this.sources.width - HORIZONTAL_PADDING >

--- a/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
+++ b/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
@@ -19,4 +19,6 @@ export interface FooterManager extends TooltipManager, ActionButtonsManager {
     isInFullScreenMode?: boolean
     isEmbeddedInAnOwidPage?: boolean
     isEmbeddedInADataPage?: boolean
+    hideNote?: boolean
+    hideOriginUrl?: boolean
 }

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -48,6 +48,14 @@ export class Header<
         return this.manager.fontSize ?? BASE_FONT_SIZE
     }
 
+    @computed protected get hasTitle(): boolean {
+        return !this.manager.hideTitle && !!this.titleText
+    }
+
+    @computed protected get hasSubtitle(): boolean {
+        return !this.manager.hideSubtitle && !!this.subtitleText
+    }
+
     @computed protected get titleText(): string {
         return this.manager.currentTitle?.trim() ?? ""
     }
@@ -127,11 +135,17 @@ export class Header<
     }
 
     @computed get height(): number {
-        const { title, subtitle, subtitleText, subtitleMarginTop, logoHeight } =
-            this
+        const {
+            title,
+            subtitle,
+            hasTitle,
+            hasSubtitle,
+            subtitleMarginTop,
+            logoHeight,
+        } = this
         return Math.max(
-            title.height +
-                (subtitleText ? subtitle.height + subtitleMarginTop : 0),
+            (hasTitle ? title.height : 0) +
+                (hasSubtitle ? subtitle.height + subtitleMarginTop : 0),
             logoHeight
         )
     }
@@ -197,10 +211,12 @@ export class Header<
                 }}
             >
                 {this.logo && this.logo.renderHTML()}
-                <div style={{ minHeight: this.height }}>
-                    {this.renderTitle()}
-                    {this.subtitleText && this.renderSubtitle()}
-                </div>
+                {(this.hasTitle || this.hasSubtitle) && (
+                    <div style={{ minHeight: this.height }}>
+                        {this.hasTitle && this.renderTitle()}
+                        {this.hasSubtitle && this.renderSubtitle()}
+                    </div>
+                )}
             </div>
         )
     }
@@ -260,26 +276,32 @@ export class StaticHeader extends Header<StaticHeaderProps> {
                 {logo &&
                     logo.height > 0 &&
                     logo.renderSVG(x + maxWidth - logo.width, y)}
-                <a
-                    href={manager.canonicalUrl}
-                    style={{
-                        fontFamily:
-                            "'Playfair Display', Georgia, 'Times New Roman', 'Liberation Serif', serif",
-                    }}
-                    target="_blank"
-                    rel="noopener"
-                >
-                    {title.render(x, y, {
-                        fill: GRAPHER_DARK_TEXT,
-                    })}
-                </a>
-                {subtitle.renderSVG(
-                    x,
-                    y + title.height + this.subtitleMarginTop,
-                    {
-                        fill: GRAPHER_DARK_TEXT,
-                    }
+                {this.hasTitle && (
+                    <a
+                        href={manager.canonicalUrl}
+                        style={{
+                            fontFamily:
+                                "'Playfair Display', Georgia, 'Times New Roman', 'Liberation Serif', serif",
+                        }}
+                        target="_blank"
+                        rel="noopener"
+                    >
+                        {title.render(x, y, {
+                            fill: GRAPHER_DARK_TEXT,
+                        })}
+                    </a>
                 )}
+                {this.hasSubtitle &&
+                    subtitle.renderSVG(
+                        x,
+                        y +
+                            (this.hasTitle
+                                ? title.height + this.subtitleMarginTop
+                                : 0),
+                        {
+                            fill: GRAPHER_DARK_TEXT,
+                        }
+                    )}
             </g>
         )
     }

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -48,11 +48,11 @@ export class Header<
         return this.manager.fontSize ?? BASE_FONT_SIZE
     }
 
-    @computed protected get hasTitle(): boolean {
+    @computed protected get showTitle(): boolean {
         return !this.manager.hideTitle && !!this.titleText
     }
 
-    @computed protected get hasSubtitle(): boolean {
+    @computed protected get showSubtitle(): boolean {
         return !this.manager.hideSubtitle && !!this.subtitleText
     }
 
@@ -138,14 +138,14 @@ export class Header<
         const {
             title,
             subtitle,
-            hasTitle,
-            hasSubtitle,
+            showTitle,
+            showSubtitle,
             subtitleMarginTop,
             logoHeight,
         } = this
         return Math.max(
-            (hasTitle ? title.height : 0) +
-                (hasSubtitle ? subtitle.height + subtitleMarginTop : 0),
+            (showTitle ? title.height : 0) +
+                (showSubtitle ? subtitle.height + subtitleMarginTop : 0),
             logoHeight
         )
     }
@@ -211,10 +211,10 @@ export class Header<
                 }}
             >
                 {this.logo && this.logo.renderHTML()}
-                {(this.hasTitle || this.hasSubtitle) && (
+                {(this.showTitle || this.showSubtitle) && (
                     <div style={{ minHeight: this.height }}>
-                        {this.hasTitle && this.renderTitle()}
-                        {this.hasSubtitle && this.renderSubtitle()}
+                        {this.showTitle && this.renderTitle()}
+                        {this.showSubtitle && this.renderSubtitle()}
                     </div>
                 )}
             </div>
@@ -276,7 +276,7 @@ export class StaticHeader extends Header<StaticHeaderProps> {
                 {logo &&
                     logo.height > 0 &&
                     logo.renderSVG(x + maxWidth - logo.width, y)}
-                {this.hasTitle && (
+                {this.showTitle && (
                     <a
                         href={manager.canonicalUrl}
                         style={{
@@ -291,11 +291,11 @@ export class StaticHeader extends Header<StaticHeaderProps> {
                         })}
                     </a>
                 )}
-                {this.hasSubtitle &&
+                {this.showSubtitle &&
                     subtitle.renderSVG(
                         x,
                         y +
-                            (this.hasTitle
+                            (this.showTitle
                                 ? title.height + this.subtitleMarginTop
                                 : 0),
                         {

--- a/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
+++ b/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
@@ -20,4 +20,6 @@ export interface HeaderManager {
     isInIFrame?: boolean
     useBaseFontSize?: boolean
     fontSize?: number
+    hideTitle?: boolean
+    hideSubtitle?: boolean
 }

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -41,7 +41,7 @@ export {
     Patterns,
     grapherInterfaceWithHiddenControlsOnly,
     grapherInterfaceWithHiddenTabsOnly,
-    GrapherExportFormat,
+    GrapherStaticFormat,
 } from "./core/GrapherConstants"
 export { ColorScale } from "./color/ColorScale"
 export { ColorScaleConfig } from "./color/ColorScaleConfig"

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.test.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.test.tsx
@@ -34,6 +34,10 @@ it("correctly passes non-redistributable flag", () => {
     const viewFalse = new DownloadModal({
         manager: {
             generateStaticSvg: () => "",
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            rasterize: () => new Promise(() => {}),
+            exportWidth: () => 0,
+            exportHeight: () => 0,
             displaySlug: "",
             table: tableFalse,
             detailRenderers: [],
@@ -45,6 +49,10 @@ it("correctly passes non-redistributable flag", () => {
     const viewTrue = new DownloadModal({
         manager: {
             generateStaticSvg: () => "",
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            rasterize: () => new Promise(() => {}),
+            exportWidth: () => 0,
+            exportHeight: () => 0,
             displaySlug: "",
             table: tableTrue,
             detailRenderers: [],

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.test.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.test.tsx
@@ -36,8 +36,6 @@ it("correctly passes non-redistributable flag", () => {
             generateStaticSvg: () => "",
             // eslint-disable-next-line @typescript-eslint/no-empty-function
             rasterize: () => new Promise(() => {}),
-            exportWidth: () => 0,
-            exportHeight: () => 0,
             displaySlug: "",
             table: tableFalse,
             detailRenderers: [],
@@ -51,8 +49,6 @@ it("correctly passes non-redistributable flag", () => {
             generateStaticSvg: () => "",
             // eslint-disable-next-line @typescript-eslint/no-empty-function
             rasterize: () => new Promise(() => {}),
-            exportWidth: () => 0,
-            exportHeight: () => 0,
             displaySlug: "",
             table: tableTrue,
             detailRenderers: [],

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.test.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.test.tsx
@@ -33,8 +33,7 @@ it("correctly passes non-redistributable flag", () => {
     const tableFalse = getTable({ nonRedistributable: false })
     const viewFalse = new DownloadModal({
         manager: {
-            staticSVGLandscape: "",
-            staticSVGPortrait: "",
+            generateStaticSvg: () => "",
             displaySlug: "",
             table: tableFalse,
             detailRenderers: [],
@@ -45,8 +44,7 @@ it("correctly passes non-redistributable flag", () => {
     const tableTrue = getTable({ nonRedistributable: true })
     const viewTrue = new DownloadModal({
         manager: {
-            staticSVGLandscape: "",
-            staticSVGPortrait: "",
+            generateStaticSvg: () => "",
             displaySlug: "",
             table: tableTrue,
             detailRenderers: [],

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.test.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.test.tsx
@@ -33,12 +33,11 @@ it("correctly passes non-redistributable flag", () => {
     const tableFalse = getTable({ nonRedistributable: false })
     const viewFalse = new DownloadModal({
         manager: {
-            generateStaticSvg: () => "",
             // eslint-disable-next-line @typescript-eslint/no-empty-function
             rasterize: () => new Promise(() => {}),
             displaySlug: "",
             table: tableFalse,
-            detailRenderers: () => [],
+            detailRenderers: [],
         },
     })
     expect(viewFalse["nonRedistributable"]).toBeFalsy()
@@ -46,12 +45,11 @@ it("correctly passes non-redistributable flag", () => {
     const tableTrue = getTable({ nonRedistributable: true })
     const viewTrue = new DownloadModal({
         manager: {
-            generateStaticSvg: () => "",
             // eslint-disable-next-line @typescript-eslint/no-empty-function
             rasterize: () => new Promise(() => {}),
             displaySlug: "",
             table: tableTrue,
-            detailRenderers: () => [],
+            detailRenderers: [],
         },
     })
     expect(viewTrue["nonRedistributable"]).toBeTruthy()

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.test.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.test.tsx
@@ -38,7 +38,7 @@ it("correctly passes non-redistributable flag", () => {
             rasterize: () => new Promise(() => {}),
             displaySlug: "",
             table: tableFalse,
-            detailRenderers: [],
+            detailRenderers: () => [],
         },
     })
     expect(viewFalse["nonRedistributable"]).toBeFalsy()
@@ -51,7 +51,7 @@ it("correctly passes non-redistributable flag", () => {
             rasterize: () => new Promise(() => {}),
             displaySlug: "",
             table: tableTrue,
-            detailRenderers: [],
+            detailRenderers: () => [],
         },
     })
     expect(viewTrue["nonRedistributable"]).toBeTruthy()

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -26,9 +26,8 @@ export interface DownloadModalManager {
     displaySlug: string
     generateStaticSvg: (bounds: Bounds) => string
     rasterize: (bounds?: Bounds) => Promise<GrapherExport>
-    exportWidth: (bounds?: Bounds) => number
-    exportHeight: (bounds?: Bounds) => number
     staticBounds?: Bounds
+    staticBoundsWithDetails?: (bounds?: Bounds) => Bounds
     staticFormat?: GrapherStaticFormat
     baseUrl?: string
     queryStr?: string
@@ -71,12 +70,19 @@ export class DownloadModal extends React.Component<DownloadModalProps> {
         return this.tabBounds.padHeight(16).padWidth(padWidth)
     }
 
+    @computed private get targetBounds(): Bounds {
+        return (
+            this.manager.staticBoundsWithDetails?.(this.staticBounds) ??
+            this.staticBounds
+        )
+    }
+
     @computed private get targetWidth(): number {
-        return this.manager.exportWidth(this.staticBounds)
+        return this.targetBounds.width
     }
 
     @computed private get targetHeight(): number {
-        return this.manager.exportHeight(this.staticBounds)
+        return this.targetBounds.height
     }
 
     @computed private get manager(): DownloadModalManager {

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -57,8 +57,8 @@ export class DownloadModal extends React.Component<DownloadModalProps> {
         return this.manager.tabBounds ?? DEFAULT_BOUNDS
     }
 
-    @computed private get isExportingPortrait(): boolean {
-        return this.manager.staticFormat === GrapherStaticFormat.portrait
+    @computed private get isExportingSquare(): boolean {
+        return this.manager.staticFormat === GrapherStaticFormat.square
     }
 
     @computed private get shouldIncludeDetails(): boolean {
@@ -195,9 +195,9 @@ export class DownloadModal extends React.Component<DownloadModalProps> {
     }
 
     @action.bound private toggleExportFormat(): void {
-        this.manager.staticFormat = this.isExportingPortrait
+        this.manager.staticFormat = this.isExportingSquare
             ? GrapherStaticFormat.landscape
-            : GrapherStaticFormat.portrait
+            : GrapherStaticFormat.square
     }
 
     @action.bound private toggleIncludeDetails(): void {
@@ -274,8 +274,8 @@ export class DownloadModal extends React.Component<DownloadModalProps> {
                                 )}
                                 {this.manager.showAdminControls && (
                                     <Checkbox
-                                        checked={this.isExportingPortrait}
-                                        label="Portrait format"
+                                        checked={this.isExportingSquare}
+                                        label="Square format"
                                         onChange={(): void => {
                                             this.reset()
                                             this.toggleExportFormat()

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -34,7 +34,7 @@ export interface DownloadModalManager {
     table?: OwidTable
     externalCsvLink?: string // Todo: we can ditch this once rootTable === externalCsv (currently not quite the case for Covid Explorer)
     shouldIncludeDetailsInStaticExport?: boolean
-    detailRenderers: MarkdownTextWrap[]
+    detailRenderers: (bounds?: Bounds) => MarkdownTextWrap[]
     isDownloadModalOpen?: boolean
     tabBounds?: Bounds
     isOnChartOrMapTab?: boolean
@@ -211,10 +211,13 @@ export class DownloadModal extends React.Component<DownloadModalProps> {
             !this.manager.shouldIncludeDetailsInStaticExport
     }
 
+    @computed private get detailRenderers(): MarkdownTextWrap[] {
+        return this.manager.detailRenderers(this.staticBounds)
+    }
+
     @computed private get showExportControls(): boolean {
         return (
-            !isEmpty(this.manager.detailRenderers) ||
-            !!this.manager.showAdminControls
+            !isEmpty(this.detailRenderers) || !!this.manager.showAdminControls
         )
     }
 
@@ -267,7 +270,7 @@ export class DownloadModal extends React.Component<DownloadModalProps> {
                         </div>
                         {this.showExportControls && (
                             <div className="static-exports-options">
-                                {!isEmpty(this.manager.detailRenderers) && (
+                                {!isEmpty(this.detailRenderers) && (
                                     <Checkbox
                                         checked={this.shouldIncludeDetails}
                                         label="Include terminology definitions at bottom of chart"


### PR DESCRIPTION
<details>
<summary><b>Christian's sketch</b></summary>
<img width="2070" alt="Artboard 1@2x" src="https://github.com/owid/owid-grapher/assets/12461810/36b807f7-c478-4ca5-9115-cbbf47496d7f">
</details>

### Summary

Adds an Export tab to the chart admin with the following features:

- Static previews in the browser (desktop & mobile)
- Show/hide individual elements (e.g. subtitle, note)
    - Data source and license can't be hidden
- Optionally include details at the bottom
- Export desktop/mobile PNG/SVG static charts with or without details included at the bottom

**Not implemented**

- Mobile Image Size Section
    - No need for a preset dropdown since, if possible, I'd like to have a single size preset for mobile images that works for data insights and Instagram
    - For now, we don't want authors to customise width/height individually
- Data Insights Section
    - Would be nice, but it’s not essential, and I’m pressed for time

### Details

- Export settings are not persisted (except for the current session)
- Export settings are isolated from the rest of the chart admin, i.e. hiding a static chart’s subtitle does not affect the interactive chart

**Grapher**

- Grapher gained the ability to render static charts into the browser
- Grapher thus has three output streams:
    - Interactive charts (using `tabBounds`; nothing changed here)
    - Static charts (using `staticBounds` that are either passed into Grapher or determined by the current `staticFormat`)
        - rendered into the browser (`renderToStatic` flag)
        - exported to SVG/PNG (`isExportingToSvgOrPng` flag)

### Follow up work

- Add static format (landscape or square) to query parameters of thumbnails
- DoDs in the admin look sad :( (see screenshot below)

<details>
<summary><b>DoD in the admin</b></summary>
<img width="676" alt="Screenshot 2023-12-12 at 19 13 35" src="https://github.com/owid/owid-grapher/assets/12461810/231851dc-2eff-46ee-b135-4a18cb7763c5">
</details>


