### PR TITLE
Local env for cloudflare functions with makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,8 @@ up.full: require create-if-missing.env.full wordpress/.env tmp-downloads/owid_me
 			set remain-on-exit on \; \
 		new-window -n lerna 'yarn startLernaWatcher' \; \
 			set remain-on-exit on \; \
+		new-window -n functions 'yarn startLocalCloudflareFunctions' \; \
+			set remain-on-exit on \; \
 		new-window -n welcome 'devTools/docker/banner.sh; exec $(LOGIN_SHELL)' \; \
 		bind R respawn-pane -k \; \
 		bind X kill-pane \; \

--- a/devTools/docker/banner.sh
+++ b/devTools/docker/banner.sh
@@ -29,6 +29,7 @@ Try these URLs to see if your environment is working:
     http://localhost:3030/admin/test  <-- a list of all charts in the db
     http://localhost:8080/wp/wp-admin/  <-- the WordPress admin interface
     http://localhost:8090/  <-- the vite dev server
+    http://localhost:8788/  <-- the cloudflare functions dev server
 
 Happy hacking!
 EOF

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "revertLastDbMigration": "yarn typeorm migration:revert -d itsJustJavascript/db/dataSource.js",
         "runPostUpdateHook": "node --enable-source-maps ./itsJustJavascript/baker/postUpdatedHook.js",
         "startAdminServer": "node --enable-source-maps ./itsJustJavascript/adminSiteServer/app.js",
+        "startLocalCloudflareFunctions": "wrangler pages dev localBake --compatibility-date 2023-10-09",
         "startDeployQueueServer": "node --enable-source-maps ./itsJustJavascript/baker/startDeployQueueServer.js",
         "startLernaWatcher": "lerna watch --scope '@ourworldindata/*' -- lerna run build --scope=\\$LERNA_PACKAGE_NAME --include-dependents",
         "startTmuxServer": "node_modules/tmex/tmex dev \"yarn startTscServer\" \"yarn startLernaWatcher\" \"yarn startAdminServer\" \"yarn startViteServer\"",


### PR DESCRIPTION
This PR adds local development support for Cloudflare Pages functions.

It integrates the wrangler dev server to the `make up.full` command.