### PR TITLE
:hammer: Rename `pageviews` to `analytics_pageviews`

### DIFF
--- a/db/migration/1701443655214-rename-analytics-pageviews.ts
+++ b/db/migration/1701443655214-rename-analytics-pageviews.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class RenameAnalyticsPageviews1701443655214 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('ALTER TABLE `pageviews` RENAME TO `analytics_pageviews`')
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('ALTER TABLE `analytics_pageviews` RENAME TO `pageviews`')
+    }
+
+}

--- a/db/model/Pageview.ts
+++ b/db/model/Pageview.ts
@@ -2,7 +2,7 @@ import { keyBy } from "lodash"
 import { Entity, Column, BaseEntity } from "typeorm"
 import { RawPageview } from "@ourworldindata/utils"
 
-@Entity("pageviews")
+@Entity("analytics_pageviews")
 export class Pageview extends BaseEntity implements RawPageview {
     /** The last day with pageview data that is included in the sum */
     @Column({ primary: true }) day!: Date

--- a/db/refreshPageviewsFromDatasette.ts
+++ b/db/refreshPageviewsFromDatasette.ts
@@ -30,9 +30,9 @@ async function downloadAndInsertCSV(): Promise<void> {
     console.log("Parsed CSV data:", onlyValidRows.length, "rows")
     console.log("Columns:", parsedData.meta.fields)
 
-    await db.knexRaw("TRUNCATE TABLE pageviews")
+    await db.knexRaw("TRUNCATE TABLE analytics_pageviews")
 
-    await db.knexInstance().batchInsert("pageviews", onlyValidRows)
+    await db.knexInstance().batchInsert("analytics_pageviews", onlyValidRows)
     console.log("CSV data inserted successfully!")
 }
 

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -715,7 +715,7 @@ export const getRelatedResearchAndWritingForVariable = async (
                 charts_via_redirects.id = csr.chart_id
             left join chart_dimensions cd on
                 cd.chartId = coalesce(csr.chart_id, c.id)
-            left join pageviews pv on
+            left join analytics_pageviews pv on
                 pv.url = concat('https://ourworldindata.org/', p.slug )
             left join posts_gdocs pg on
             	pg.id = p.gdocSuccessorId
@@ -773,7 +773,7 @@ export const getRelatedResearchAndWritingForVariable = async (
                 pl.target = csr.slug
             join chart_dimensions cd on
                 cd.chartId = c.id
-            left join pageviews pv on
+            left join analytics_pageviews pv on
                 pv.url = concat('https://ourworldindata.org/', p.slug )
             left join posts_gdocs_x_tags pt on
                 pt.gdocId = p.id


### PR DESCRIPTION
We have decided that tables managed by the `analytics` codebase should be prefixed with `analytics_`. In that spirit, this change renames the `pageviews` table to `analytics_pageviews`.

Immediately after merge, we need to update the `owid-analytics` codebase and hotfix the new table name.
