### PR TITLE
:sparkles: add `analytics_charts` table

### DIFF
--- a/db/migration/1701446901429-create-analytics-charts.ts
+++ b/db/migration/1701446901429-create-analytics-charts.ts
@@ -7,11 +7,13 @@ export class CreateAnalyticsCharts1701446901429 implements MigrationInterface {
             CREATE TABLE analytics_charts (
                 chart_id INT NOT NULL,
                 slug VARCHAR(180) NOT NULL,
+                is_data_page TINYINT NOT NULL,
                 views_7d INT NOT NULL,
                 views_14d INT NOT NULL,
                 views_365d INT NOT NULL,
                 url VARCHAR(255) NOT NULL,
-                updated_at DATETIME NOT NULL,
+                views_updated_at DATETIME NOT NULL,
+                chart_updated_at DATETIME NOT NULL,
                 PRIMARY KEY (chart_id)
             );
         `)

--- a/db/migration/1701446901429-create-analytics-charts.ts
+++ b/db/migration/1701446901429-create-analytics-charts.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CreateAnalyticsCharts1701446901429 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // index on slug
+        await queryRunner.query(`
+            CREATE TABLE analytics_charts (
+                chart_id INT NOT NULL,
+                slug VARCHAR(180) NOT NULL,
+                views_7d INT NOT NULL,
+                views_14d INT NOT NULL,
+                views_365d INT NOT NULL,
+                url VARCHAR(255) NOT NULL,
+                updated_at DATETIME NOT NULL,
+                PRIMARY KEY (chart_id)
+            );
+        `)
+        await queryRunner.query(`
+            CREATE INDEX analytics_charts_slug ON analytics_charts (slug);
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP INDEX IF EXISTS analytics_charts_slug;
+        `)
+        await queryRunner.query(`
+            DROP TABLE IF EXISTS analytics_charts;
+        `)
+    }
+}


### PR DESCRIPTION
The table is intended to have one row for every published chart. It will be published using data from `analytics_pageviews` and republished whenever `analytics_pageviews` gets updated.

## Materialised table vs view

The approach taken here is to materialise the table nightly in code, in the `analytics` repo. This has the advantage that queries on it are faster, which is desirable since this too might just be a building block for some other piece of analytics (e.g. indicators).

The downside of not using a view is that it will show charts that have since been renamed or deleted, and new charts may have been added since the last nightly update. This seems a reasonable tradeoff for now.

## Todo

- [ ] Add `is_data_page` field