### PR TITLE
Topic tag slug resolver

### DIFF
--- a/adminSiteClient/TagEditPage.tsx
+++ b/adminSiteClient/TagEditPage.tsx
@@ -4,13 +4,7 @@ import { observable, computed, action, runInAction } from "mobx"
 import { Prompt, Redirect } from "react-router-dom"
 import { ChartTagJoin } from "@ourworldindata/utils"
 import { AdminLayout } from "./AdminLayout.js"
-import {
-    BindString,
-    NumericSelectField,
-    FieldsRow,
-    Timeago,
-    Toggle,
-} from "./Forms.js"
+import { BindString, NumericSelectField, FieldsRow, Timeago } from "./Forms.js"
 import { DatasetList, DatasetListItem } from "./DatasetList.js"
 import { ChartList, ChartListItem } from "./ChartList.js"
 import { TagBadge } from "./TagBadge.js"

--- a/adminSiteClient/TagEditPage.tsx
+++ b/adminSiteClient/TagEditPage.tsx
@@ -75,6 +75,9 @@ class TagEditor extends React.Component<{ tag: TagPageData }> {
                 this.props.tag.updatedAt = new Date().toString()
             })
         }
+        if (json.tagUpdateWarning) {
+            window.alert(json.tagUpdateWarning)
+        }
     }
 
     async deleteTag() {

--- a/adminSiteClient/TagEditPage.tsx
+++ b/adminSiteClient/TagEditPage.tsx
@@ -27,13 +27,13 @@ interface TagPageData {
     children: ChartTagJoin[]
     possibleParents: ChartTagJoin[]
     isBulkImport: boolean
-    isTopic: boolean
+    slug: string | null
 }
 
 class TagEditable {
     @observable name: string = ""
     @observable parentId?: number
-    @observable isTopic: boolean = false
+    @observable slug: string | null = null
 
     constructor(json: TagPageData) {
         for (const key in this) {
@@ -68,9 +68,10 @@ class TagEditor extends React.Component<{ tag: TagPageData }> {
 
     async save() {
         const { tag } = this.props
+        const slug = this.newtag.slug || null
         const json = await this.context.admin.requestJSON(
             `/api/tags/${tag.id}`,
-            { tag: this.newtag },
+            { tag: { ...this.newtag, slug } },
             "PUT"
         )
 
@@ -150,15 +151,12 @@ class TagEditor extends React.Component<{ tag: TagPageData }> {
                         />
                         {!tag.isBulkImport && (
                             <>
-                                <FieldsRow>
-                                    <Toggle
-                                        value={!!newtag.isTopic}
-                                        onValue={(value) => {
-                                            newtag.isTopic = value
-                                        }}
-                                        label="Tag is a topic"
-                                    />
-                                </FieldsRow>
+                                <BindString
+                                    field="slug"
+                                    store={newtag}
+                                    label="Slug"
+                                    helpText="The slug for the topic page that this tag corresponds to e.g. trade-and-globalization"
+                                />
                                 <FieldsRow>
                                     <NumericSelectField
                                         label="Parent Category"

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -2191,6 +2191,28 @@ apiRouter.put("/tags/:tagId", async (req: Request) => {
         `UPDATE tags SET name=?, updatedAt=?, parentId=?, slug=? WHERE id=?`,
         [tag.name, new Date(), tag.parentId, tag.slug, tagId]
     )
+    if (tag.slug) {
+        // See if there's a published gdoc with a matching slug.
+        // We're not enforcing that the gdoc be a topic page, as there are cases like /human-development-index,
+        // where the page for the topic is just an article.
+        const gdoc: OwidGdocInterface[] = await db.execute(
+            `SELECT slug FROM posts_gdocs pg
+             WHERE EXISTS (
+                    SELECT 1
+                    FROM posts_gdocs_x_tags gt
+                    WHERE pg.id = gt.gdocId AND gt.tagId = ?
+            ) AND pg.published = TRUE`,
+            [tag.id]
+        )
+        if (!gdoc.length) {
+            return {
+                success: true,
+                tagUpdateWarning: `The tag's slug has been updated, but there isn't a published Gdoc page with the same slug. 
+                    
+Are you sure you haven't made a typo?`,
+            }
+        }
+    }
     return { success: true }
 })
 

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -2089,7 +2089,7 @@ apiRouter.get("/tags/:tagId.json", async (req: Request, res: Response) => {
 
     const tag = await db.mysqlFirst(
         `
-        SELECT t.id, t.name, t.specialType, t.updatedAt, t.parentId, t.isTopic, p.isBulkImport
+        SELECT t.id, t.name, t.specialType, t.updatedAt, t.parentId, t.slug, p.isBulkImport
         FROM tags t LEFT JOIN tags p ON t.parentId=p.id
         WHERE t.id = ?
     `,
@@ -2188,8 +2188,8 @@ apiRouter.put("/tags/:tagId", async (req: Request) => {
     const tagId = expectInt(req.params.tagId)
     const tag = (req.body as { tag: any }).tag
     await db.execute(
-        `UPDATE tags SET name=?, updatedAt=?, parentId=?, isTopic=? WHERE id=?`,
-        [tag.name, new Date(), tag.parentId, tag.isTopic, tagId]
+        `UPDATE tags SET name=?, updatedAt=?, parentId=?, slug=? WHERE id=?`,
+        [tag.name, new Date(), tag.parentId, tag.slug, tagId]
     )
     return { success: true }
 })

--- a/baker/GrapherBakingUtils.ts
+++ b/baker/GrapherBakingUtils.ts
@@ -128,24 +128,21 @@ export const getGrapherExportsByUrl = async (): Promise<GrapherExports> => {
  *   "Women's Rights" -> "womens-rights"
  *   123 -> "womens-rights"
  */
-let _tagsByIdAndName: Record<string | number, string> | undefined = undefined
 export async function getTagToSlugMap(): Promise<
     Record<string | number, string>
 > {
-    if (!_tagsByIdAndName) {
-        const tags = (await db.queryMysql(
-            `SELECT slug, name, id FROM tags WHERE slug IS NOT NULL`
-        )) as Pick<Tag, "name" | "id" | "slug">[]
-        _tagsByIdAndName = {}
-        for (const tag of tags) {
-            if (tag.slug) {
-                _tagsByIdAndName[tag.name] = tag.slug
-                _tagsByIdAndName[tag.id] = tag.slug
-            }
+    const tags = (await db.queryMysql(
+        `SELECT slug, name, id FROM tags WHERE slug IS NOT NULL`
+    )) as Pick<Tag, "name" | "id" | "slug">[]
+    const tagsByIdAndName: Record<string | number, string> = {}
+    for (const tag of tags) {
+        if (tag.slug) {
+            tagsByIdAndName[tag.name] = tag.slug
+            tagsByIdAndName[tag.id] = tag.slug
         }
     }
 
-    return _tagsByIdAndName
+    return tagsByIdAndName
 }
 
 /**

--- a/baker/batchTagWithGpt.ts
+++ b/baker/batchTagWithGpt.ts
@@ -40,7 +40,7 @@ const batchTagChartsWithGpt = async ({
         SELECT chartId
         FROM chart_tags
         JOIN tags ON chart_tags.tagId = tags.id
-        WHERE tags.isTopic = 1 OR tags.name = 'Unlisted'
+        WHERE tags.slug IS NOT NULL OR tags.name = 'Unlisted'
     )
     GROUP BY id
     ${limit ? `LIMIT ${limit}` : ""}

--- a/db/migration/1701450183524-TagTopicSlug.ts
+++ b/db/migration/1701450183524-TagTopicSlug.ts
@@ -182,6 +182,7 @@ async function writeToSlugMap(path: string, slug: string): Promise<void> {
     return
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function resolveSlugs(): Promise<void> {
     console.log("Resolving slugs 🚀")
     const slugMap = await readSlugMap()
@@ -229,6 +230,7 @@ const manualSlugMap: Record<string, string> = {
     "Suicides": "suicide",
     "Meat & Dairy Production": "meat-production",
     "Water Use & Stress": "water-use-stress",
+    "Human Development Index (HDI)": "human-development-index",
     "Space Exploration & Satellites": "space-exploration-satellites",
     "Violence Against Children & Children's Rights": "violence-against-rights-for-children",
     "Education Spending": "financing-education",
@@ -303,7 +305,6 @@ const tagNameSlugResolutions = {
   "Economic Inequality": "economic-inequality",
   "Economic Inequality by Gender": "economic-inequality-by-gender",
   "Happiness & Life Satisfaction": "happiness-and-life-satisfaction",
-  "Human Development Index (HDI)": "human-development-index-hdi",
   "Working Hours": "working-hours",
   "Urbanization": "urbanization",
   "Homelessness": "homelessness",

--- a/db/migration/1701450183524-TagTopicSlug.ts
+++ b/db/migration/1701450183524-TagTopicSlug.ts
@@ -1,0 +1,395 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+import fs from "fs/promises"
+import { get, set } from "lodash"
+
+/**
+ * This file includes the code I used to generate the data we're inserting into the new column
+ */
+
+// SELECT name FROM tags WHERE isTopic = TRUE
+const topicTagNames = [
+    "Population Growth",
+    "Fertility Rate",
+    "Age Structure",
+    "Child & Infant Mortality",
+    "Life Expectancy",
+    "Gender Ratio",
+    "Eradication of Diseases",
+    "HIV/AIDS",
+    "Malaria",
+    "Maternal Mortality",
+    "Smoking",
+    "Suicides",
+    "Vaccination",
+    "Cancer",
+    "Financing Healthcare",
+    "Causes of Death",
+    "Burden of Disease",
+    "Cardiovascular Diseases",
+    "Tuberculosis",
+    "Mental Health",
+    "Food Supply",
+    "Hunger & Undernourishment",
+    "Famines",
+    "Human Height",
+    "Employment in Agriculture",
+    "Fertilizers",
+    "Food Prices",
+    "Agricultural Production",
+    "Diet Compositions",
+    "Obesity",
+    "Meat & Dairy Production",
+    "CO2 & Greenhouse Gas Emissions",
+    "Energy",
+    "Nuclear Energy",
+    "Renewable Energy",
+    "Fossil Fuels",
+    "Forests & Deforestation",
+    "Indoor Air Pollution",
+    "Land Use",
+    "Natural Disasters",
+    "Oil Spills",
+    "Climate Change",
+    "Biodiversity",
+    "Water Use & Stress",
+    "Ozone Layer",
+    "Air Pollution",
+    "Waste Management",
+    "Research & Development",
+    "Technological Change",
+    "Space Exploration & Satellites",
+    "Economic Growth",
+    "Economic Inequality",
+    "Economic Inequality by Gender",
+    "Happiness & Life Satisfaction",
+    "Human Development Index (HDI)",
+    "Light at Night",
+    "Working Hours",
+    "Urbanization",
+    "Homelessness",
+    "Child Labor",
+    "Government Spending",
+    "Trade & Globalization",
+    "Tourism",
+    "Migration",
+    "Nuclear Weapons",
+    "Terrorism",
+    "War & Peace",
+    "Democracy",
+    "Homicides",
+    "Women's Rights",
+    "Human Rights",
+    "Violence Against Children & Children's Rights",
+    "LGBT+ Rights",
+    "Animal Welfare",
+    "Education Spending",
+    "Global Education",
+    "Tertiary Education",
+    "Quality of Education",
+    "Literacy",
+    "Pre-Primary Education",
+    "Teachers & Schools",
+    "Books",
+    "Internet",
+    "Trust",
+    "Marriages & Divorces",
+    "Smallpox",
+    "Diarrheal Diseases",
+    "Polio",
+    "Neurodevelopmental Disorders",
+    "Alcohol Consumption",
+    "Pesticides",
+    "Plastic Pollution",
+    "Sanitation",
+    "Transport",
+    "Taxation",
+    "Corruption",
+    "Women's Employment",
+    "Poverty",
+    "Micronutrient Deficiency",
+    "Tetanus",
+    "Access to Energy",
+    "Crop Yields",
+    "COVID-19",
+    "Fish & Overfishing",
+    "Environmental Impacts of Food Production",
+    "Lead Pollution",
+    "Biological & Chemical Weapons",
+    "Artificial Intelligence",
+    "Farm Size",
+    "Influenza",
+    "Rights of Marginalized Ethnic Groups",
+    "Pandemics",
+    "Alzheimer's & Dementia",
+    "Clean Water & Sanitation",
+    "Electricity Mix",
+    "Energy Mix",
+    "Global Health",
+    "Labor Supply & Employment",
+    "Loneliness & Social Connections",
+    "Mpox (monkeypox)",
+    "Outdoor Air Pollution",
+    "Pneumonia",
+    "Primary & Secondary Education",
+    "State Capacity",
+    "Time Use",
+    "Illicit Drug Use",
+    "Military Personnel & Spending",
+    "Clean Water",
+]
+
+function slugify(text: string): string {
+    return text
+        .toLowerCase()
+        .replace(/ /g, "-")
+        .replace(/&/g, "and")
+        .replace(/'/g, "")
+        .replace(/[^\w-]+/g, "")
+}
+
+const TS_DIR = "./db/migration"
+
+const SLUGMAP_FILENAME = "1701450183524-TagTopicSlug.json"
+
+const SLUGMAP_PATH = `${TS_DIR}/${SLUGMAP_FILENAME}`
+
+async function readSlugMap(): Promise<Record<string, string>> {
+    return fs
+        .readFile(SLUGMAP_PATH, "utf8")
+        .then(JSON.parse)
+        .catch(async (e) => {
+            if (e.code === "ENOENT") {
+                console.log("slugMap.json doesn't exist. Creating it.")
+                await fs.writeFile(SLUGMAP_PATH, "{}")
+                return {}
+            } else {
+                throw e
+            }
+        })
+}
+
+async function writeToSlugMap(path: string, slug: string): Promise<void> {
+    let slugMap = await readSlugMap()
+    const value = get(slugMap, path)
+    if (value) {
+        console.log(`${path} → ${slug} already exists in slugMap.json`)
+        return
+    }
+
+    slugMap = set(slugMap, path, slug)
+
+    await fs.writeFile(SLUGMAP_PATH, JSON.stringify(slugMap, null, 2))
+    return
+}
+
+async function resolveSlugs(): Promise<void> {
+    console.log("Resolving slugs 🚀")
+    const slugMap = await readSlugMap()
+    for (const topicTagName of topicTagNames) {
+        // Skip if already in slugMap
+        if (
+            get(slugMap, topicTagName) ||
+            get(slugMap, ["unresolved", topicTagName])
+        )
+            continue
+
+        const slugCandidate = slugify(topicTagName)
+        console.log("Trying: ", slugCandidate)
+        const attempt = await fetch(
+            `https://ourworldindata.org/${slugCandidate}`
+        )
+
+        if (attempt.status === 200) {
+            console.log(
+                `${topicTagName} successfully resolved to ${slugCandidate}`
+            )
+            await writeToSlugMap(topicTagName, slugCandidate)
+        }
+        if (attempt.status === 404) {
+            console.log(
+                `${topicTagName} could not be resolved to ${slugCandidate}`
+            )
+            await writeToSlugMap(`unresolved.${topicTagName}`, slugCandidate)
+            continue
+        }
+    }
+}
+
+// According to @edomt, these topics have been deprecated
+const topicsThatAreNoLongerTopics = [
+    "Teachers & Schools",
+    "Rights of Marginalized Ethnic Groups",
+    "Alzheimer's & Dementia",
+    "Labor Supply & Employment",
+].map((topic) => topic.replace(/'/g, "''"))
+
+// prettier-ignore
+const manualSlugMap: Record<string, string> = {
+    "HIV/AIDS": "hiv-aids",
+    "Suicides": "suicide",
+    "Meat & Dairy Production": "meat-production",
+    "Water Use & Stress": "water-use-stress",
+    "Space Exploration & Satellites": "space-exploration-satellites",
+    "Violence Against Children & Children's Rights": "violence-against-rights-for-children",
+    "Education Spending": "financing-education",
+    "Women's Employment": "female-labor-supply",
+    "Access to Energy": "energy-access",
+    "COVID-19": "coronavirus",
+    "Environmental Impacts of Food Production": "environmental-impacts-of-food",
+    "Clean Water & Sanitation": "clean-water-sanitation",
+    "Global Health": "health-meta",
+    "Loneliness & Social Connections": "social-connections-and-loneliness",
+    "Mpox (monkeypox)": "monkeypox",
+    "Military Personnel & Spending": "military-personnel-spending",
+    // These three don't yet have published pages, but will in the next month
+    "Cardiovascular Diseases": "cardiovascular-diseases",
+    "Tuberculosis": "tuberculosis",
+    "Pandemics": "pandemics",
+}
+
+// The result of running resolveSlugs() on 2023-12-01
+// Plus manualSlugMap resolutions
+// Minus topicsThatAreNoLongerTopics
+// prettier-ignore
+const tagNameSlugResolutions = {
+   ...manualSlugMap,
+  "Child & Infant Mortality": "child-and-infant-mortality",
+  "Child Labor": "child-labor",
+  "Women's Rights": "womens-rights",
+  "Light at Night": "light-at-night",
+  "Population Growth": "population-growth",
+  "Fertility Rate": "fertility-rate",
+  "Age Structure": "age-structure",
+  "Life Expectancy": "life-expectancy",
+  "Gender Ratio": "gender-ratio",
+  "Eradication of Diseases": "eradication-of-diseases",
+  "Malaria": "malaria",
+  "Maternal Mortality": "maternal-mortality",
+  "Smoking": "smoking",
+  "Vaccination": "vaccination",
+  "Cancer": "cancer",
+  "Financing Healthcare": "financing-healthcare",
+  "Causes of Death": "causes-of-death",
+  "Burden of Disease": "burden-of-disease",
+  "Mental Health": "mental-health",
+  "Food Supply": "food-supply",
+  "Hunger & Undernourishment": "hunger-and-undernourishment",
+  "Famines": "famines",
+  "Human Height": "human-height",
+  "Employment in Agriculture": "employment-in-agriculture",
+  "Fertilizers": "fertilizers",
+  "Food Prices": "food-prices",
+  "Agricultural Production": "agricultural-production",
+  "Diet Compositions": "diet-compositions",
+  "Obesity": "obesity",
+  "CO2 & Greenhouse Gas Emissions": "co2-and-greenhouse-gas-emissions",
+  "Energy": "energy",
+  "Nuclear Energy": "nuclear-energy",
+  "Renewable Energy": "renewable-energy",
+  "Fossil Fuels": "fossil-fuels",
+  "Forests & Deforestation": "forests-and-deforestation",
+  "Indoor Air Pollution": "indoor-air-pollution",
+  "Land Use": "land-use",
+  "Natural Disasters": "natural-disasters",
+  "Oil Spills": "oil-spills",
+  "Climate Change": "climate-change",
+  "Biodiversity": "biodiversity",
+  "Ozone Layer": "ozone-layer",
+  "Air Pollution": "air-pollution",
+  "Waste Management": "waste-management",
+  "Research & Development": "research-and-development",
+  "Technological Change": "technological-change",
+  "Economic Growth": "economic-growth",
+  "Economic Inequality": "economic-inequality",
+  "Economic Inequality by Gender": "economic-inequality-by-gender",
+  "Happiness & Life Satisfaction": "happiness-and-life-satisfaction",
+  "Human Development Index (HDI)": "human-development-index-hdi",
+  "Working Hours": "working-hours",
+  "Urbanization": "urbanization",
+  "Homelessness": "homelessness",
+  "Government Spending": "government-spending",
+  "Trade & Globalization": "trade-and-globalization",
+  "Tourism": "tourism",
+  "Migration": "migration",
+  "Nuclear Weapons": "nuclear-weapons",
+  "Terrorism": "terrorism",
+  "War & Peace": "war-and-peace",
+  "Democracy": "democracy",
+  "Homicides": "homicides",
+  "Human Rights": "human-rights",
+  "LGBT+ Rights": "lgbt-rights",
+  "Animal Welfare": "animal-welfare",
+  "Global Education": "global-education",
+  "Tertiary Education": "tertiary-education",
+  "Quality of Education": "quality-of-education",
+  "Literacy": "literacy",
+  "Pre-Primary Education": "pre-primary-education",
+  "Books": "books",
+  "Internet": "internet",
+  "Trust": "trust",
+  "Marriages & Divorces": "marriages-and-divorces",
+  "Smallpox": "smallpox",
+  "Diarrheal Diseases": "diarrheal-diseases",
+  "Polio": "polio",
+  "Neurodevelopmental Disorders": "neurodevelopmental-disorders",
+  "Alcohol Consumption": "alcohol-consumption",
+  "Pesticides": "pesticides",
+  "Plastic Pollution": "plastic-pollution",
+  "Sanitation": "sanitation",
+  "Transport": "transport",
+  "Taxation": "taxation",
+  "Corruption": "corruption",
+  "Poverty": "poverty",
+  "Micronutrient Deficiency": "micronutrient-deficiency",
+  "Tetanus": "tetanus",
+  "Crop Yields": "crop-yields",
+  "Fish & Overfishing": "fish-and-overfishing",
+  "Lead Pollution": "lead-pollution",
+  "Biological & Chemical Weapons": "biological-and-chemical-weapons",
+  "Artificial Intelligence": "artificial-intelligence",
+  "Farm Size": "farm-size",
+  "Influenza": "influenza",
+  "Electricity Mix": "electricity-mix",
+  "Energy Mix": "energy-mix",
+  "Outdoor Air Pollution": "outdoor-air-pollution",
+  "Pneumonia": "pneumonia",
+  "Primary & Secondary Education": "primary-and-secondary-education",
+  "State Capacity": "state-capacity",
+  "Time Use": "time-use",
+  "Illicit Drug Use": "illicit-drug-use",
+  "Clean Water": "clean-water"
+}
+
+export class TagTopicSlug1701450183524 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // change isTopic to FALSE for topics that are no longer topics
+        await queryRunner.query(`
+            UPDATE tags
+            SET isTopic = FALSE
+            WHERE name IN ('${topicsThatAreNoLongerTopics.join("','")}')
+        `)
+
+        await queryRunner.query(`
+            ALTER TABLE tags
+            ADD COLUMN slug VARCHAR(512) DEFAULT NULL UNIQUE
+        `)
+
+        for (const [tagName, slug] of Object.entries(tagNameSlugResolutions)) {
+            await queryRunner.query(`
+                UPDATE tags
+                SET slug = '${slug}'
+                WHERE name = '${tagName.replaceAll("'", "''")}'
+                AND isTopic = TRUE
+            `)
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // There is no need to revert isTopic changes
+
+        queryRunner.query(`
+            ALTER TABLE tags
+            DROP COLUMN slug
+        `)
+    }
+}

--- a/db/migration/1701459310622-RemoveIsTopic.ts
+++ b/db/migration/1701459310622-RemoveIsTopic.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class RemoveIsTopic1701459310622 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE tags
+            DROP COLUMN isTopic;
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // SELECT id FROM tags WHERE isTopic = TRUE
+        // live_grapher 2023-12-01
+        const IDS_OF_TOPIC_TAGS = [
+            1, 3, 4, 5, 7, 8, 11, 13, 14, 15, 16, 17, 18, 19, 22, 24, 25, 28,
+            30, 35, 36, 37, 38, 39, 40, 43, 44, 46, 58, 62, 67, 71, 72, 80, 81,
+            82, 88, 89, 90, 91, 92, 93, 99, 102, 105, 106, 107, 110, 111, 114,
+            134, 135, 147, 159, 160, 161, 163, 175, 180, 186, 206, 217, 231,
+            233, 242, 244, 246, 255, 279, 282, 285, 289, 290, 291, 293, 294,
+            295, 300, 302, 305, 307, 313, 314, 324, 325, 1557, 1560, 1563, 1568,
+            1572, 1573, 1575, 1576, 1578, 1582, 1584, 1589, 1602, 1603, 1639,
+            1791, 1792, 1793, 1795, 1796, 1797, 1798, 1800, 1801, 1804, 1806,
+            1807, 1809, 1810, 1811, 1812, 1815, 1816, 1817, 1818, 1819, 1821,
+            1822, 1823, 1824, 1825, 1826, 1827,
+        ]
+        await queryRunner.query(`
+            ALTER TABLE tags
+            ADD COLUMN isTopic TINYINT(1) NOT NULL DEFAULT 0;
+        `)
+
+        for (const id of IDS_OF_TOPIC_TAGS) {
+            await queryRunner.query(`
+                UPDATE tags
+                SET isTopic = 1
+                WHERE id = ${id};
+            `)
+        }
+    }
+}

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -192,7 +192,7 @@ WHERE c.config -> "$.isPublished" = true
         const topics: Pick<Tag, "id" | "name">[] = await db.queryMysql(`
         SELECT t.id, t.name
             FROM tags t
-            WHERE t.isTopic IS TRUE
+            WHERE t.slug IS NOT NULL
             AND t.parentId IN (${PUBLIC_TAG_PARENT_IDS.join(",")})
         `)
 

--- a/db/model/Gdoc/GdocPost.ts
+++ b/db/model/Gdoc/GdocPost.ts
@@ -46,7 +46,7 @@ export class Tag extends BaseEntity implements TagInterface {
     @Column({ nullable: true }) updatedAt!: Date
     @Column({ nullable: true }) parentId!: number
     @Column() isBulkImport!: boolean
-    @Column() isTopic!: boolean
+    @Column() slug!: string
     @Column() specialType!: string
     @ManyToMany(() => GdocPost, (gdoc) => gdoc.tags)
     gdocs!: GdocPost[]

--- a/db/model/Gdoc/GdocPost.ts
+++ b/db/model/Gdoc/GdocPost.ts
@@ -46,7 +46,7 @@ export class Tag extends BaseEntity implements TagInterface {
     @Column({ nullable: true }) updatedAt!: Date
     @Column({ nullable: true }) parentId!: number
     @Column() isBulkImport!: boolean
-    @Column() slug!: string
+    @Column({ type: "varchar", nullable: true }) slug!: string | null
     @Column() specialType!: string
     @ManyToMany(() => GdocPost, (gdoc) => gdoc.tags)
     gdocs!: GdocPost[]

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -205,7 +205,7 @@ export interface Tag {
     parentId: number
     isBulkImport: boolean
     specialType: string
-    slug: string
+    slug: string | null
 }
 
 /** the entity in the `chart_tags` table */
@@ -1726,6 +1726,7 @@ export interface DataPageV2ContentFields {
     // TODO: add gdocs for FAQs
     isPreviewing?: boolean
     canonicalUrl: string
+    tagToSlugMap: Record<string, string>
 }
 
 export interface UserCountryInformation {

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -205,7 +205,7 @@ export interface Tag {
     parentId: number
     isBulkImport: boolean
     specialType: string
-    isTopic: boolean
+    slug: string
 }
 
 /** the entity in the `chart_tags` table */

--- a/site/DataPageV2.tsx
+++ b/site/DataPageV2.tsx
@@ -13,6 +13,7 @@ import {
     mergePartialGrapherConfigs,
     compact,
     FaqEntryData,
+    pick,
 } from "@ourworldindata/utils"
 import { MarkdownTextWrap } from "@ourworldindata/components"
 import React from "react"
@@ -98,14 +99,9 @@ export const DataPageV2 = (props: {
     }
 
     // Only embed the tags that are actually used by the datapage, instead of the complete JSON object with ~240 properties
-    const minimalTagToSlugMap = Object.entries(tagToSlugMap).reduce(
-        (acc, [key, value]) => {
-            if (datapageData.topicTagsLinks?.includes(key)) {
-                acc[key] = value
-            }
-            return acc
-        },
-        {} as Record<string, string>
+    const minimalTagToSlugMap = pick(
+        tagToSlugMap,
+        datapageData.topicTagsLinks || []
     )
 
     return (

--- a/site/DataPageV2.tsx
+++ b/site/DataPageV2.tsx
@@ -39,6 +39,7 @@ export const DataPageV2 = (props: {
     baseGrapherUrl: string
     isPreviewing: boolean
     faqEntries?: FaqEntryData
+    tagToSlugMap: Record<string | number, string>
 }) => {
     const {
         grapher,
@@ -47,6 +48,7 @@ export const DataPageV2 = (props: {
         baseUrl,
         isPreviewing,
         faqEntries,
+        tagToSlugMap,
     } = props
     const pageTitle = grapher?.title ?? datapageData.title
     const canonicalUrl = grapher?.slug
@@ -95,6 +97,17 @@ export const DataPageV2 = (props: {
         dataApiUrl: DATA_API_URL,
     }
 
+    // Only embed the tags that are actually used by the datapage, instead of the complete JSON object with ~240 properties
+    const minimalTagToSlugMap = Object.entries(tagToSlugMap).reduce(
+        (acc, [key, value]) => {
+            if (datapageData.topicTagsLinks?.includes(key)) {
+                acc[key] = value
+            }
+            return acc
+        },
+        {} as Record<string, string>
+    )
+
     return (
         <html>
             <Head
@@ -139,6 +152,7 @@ export const DataPageV2 = (props: {
                                         datapageData,
                                         faqEntries,
                                         canonicalUrl,
+                                        tagToSlugMap: minimalTagToSlugMap,
                                     }
                                 )}`,
                             }}
@@ -151,6 +165,7 @@ export const DataPageV2 = (props: {
                                     isPreviewing={isPreviewing}
                                     faqEntries={faqEntries}
                                     canonicalUrl={canonicalUrl}
+                                    tagToSlugMap={tagToSlugMap}
                                 />
                             </DebugProvider>
                         </div>

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -30,7 +30,6 @@ import { ArticleBlocks } from "./gdocs/ArticleBlocks.js"
 import { RelatedCharts } from "./blocks/RelatedCharts.js"
 import {
     DataPageV2ContentFields,
-    slugify,
     uniq,
     formatAuthors,
     intersection,
@@ -59,22 +58,13 @@ declare global {
 }
 export const OWID_DATAPAGE_CONTENT_ROOT_ID = "owid-datapageJson-root"
 
-export const slugify_topic = (topic: string) => {
-    // This is a heuristic to map from free form tag texts to topic page URLs. We'll
-    // have to switch to explicitly stored URLs or explicit links between tags and topic pages
-    // soon but for the time being this makes sure that "CO2 & Greenhouse Gas Emissions" can be automatically
-    // linked to /co2-and-greenhouse-gas-emissions
-    // Note that the heuristic fails for a few cases like "HIV/AIDS" or "Mpox (Monkeypox)"
-    const replaced = topic.replace("&", "and").replace("'", "").replace("+", "")
-    return slugify(replaced)
-}
-
 export const DataPageV2Content = ({
     datapageData,
     grapherConfig,
     isPreviewing = false,
     faqEntries,
     canonicalUrl = "{URL}", // when we bake pages to their proper url this will be set correctly but on preview pages we leave this undefined
+    tagToSlugMap,
 }: DataPageV2ContentFields & {
     grapherConfig: GrapherInterface
 }) => {
@@ -247,6 +237,15 @@ export const DataPageV2Content = ({
     }
     // TODO: mark topic pages
 
+    const topicTags = datapageData.topicTagsLinks
+        ?.map((name) => ({ name, slug: tagToSlugMap[name] }))
+        .filter((tag): tag is { name: string; slug: string } => !!tag.slug)
+        .map((tag) => (
+            <a href={`/${tag.slug}`} key={tag.slug}>
+                {tag.name}
+            </a>
+        ))
+
     return (
         <AttachmentsContext.Provider
             value={{
@@ -281,18 +280,7 @@ export const DataPageV2Content = ({
                                         See all data and research on:
                                     </div>
                                     <div className="topic-tags">
-                                        {datapageData.topicTagsLinks?.map(
-                                            (topic: any) => (
-                                                <a
-                                                    href={`/${slugify_topic(
-                                                        topic
-                                                    )}`}
-                                                    key={topic}
-                                                >
-                                                    {topic}
-                                                </a>
-                                            )
-                                        )}
+                                        {topicTags}
                                     </div>
                                 </div>
                             )}


### PR DESCRIPTION
This PR replaces the `isTopic` boolean on Tags with a `slug` column and adds UI in the admin to set a Tag's slug.

This allows us to resolve datapage's `topicTagsLinks` ( `Tag["name"][]` ) into actual slugs instead of the good-enough heuristic we launched with. And it will allow us to do the same for data insights

I added some util functions that the site renderer uses to supply the correct mapping to datapages. There's a small & regrettable amount of prop drilling to get them in the right place so they can hydrate correctly.