### PR TITLE
Add better search for posts

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -2266,6 +2266,7 @@ apiRouter.get("/posts.json", async (req) => {
         "id",
         "title",
         "type",
+        "slug",
         "status",
         "updated_at_in_wordpress",
         "gdocSuccessorId"


### PR DESCRIPTION
This PR replaces the search for posts. We used to have fuzzy search here like for filenames in sublime text but I think this is unsuited for finding posts. We now use the same search that we have for charts and gdocs posts. The fields to be searched are:
- title
- slug
- authors
- id

I also changed the behaviour a bit for how loading more works.