### PR TITLE
:hammer: update /coronavirus-data-explorer redirect

### DIFF
--- a/explorer/urlMigrations/LegacyCovidUrlMigration.ts
+++ b/explorer/urlMigrations/LegacyCovidUrlMigration.ts
@@ -85,19 +85,33 @@ const legacyToCurrentCovidQueryParams = (
 
     const urlContainsMetric = !!covidMetricFromLegacyQueryParams(queryParams)
 
+    // For the following params, use the modern query param if it exists, otherwise
+    // fall back to trying to convert the legacy one.
     const explorerQueryParams: QueryParams = {
         Metric:
+            queryParams.Metric ??
+            baseQueryParams.Metric ??
             covidMetricFromLegacyQueryParams(queryParams) ??
             covidMetricFromLegacyQueryParams(baseQueryParams),
         Interval:
+            queryParams.Interval ??
+            baseQueryParams.Interval ??
             covidIntervalFromLegacyQueryParams(queryParams) ??
             covidIntervalFromLegacyQueryParams(baseQueryParams),
-        "Align outbreaks": urlContainsMetric
-            ? boolParamToString(queryParams.aligned)
-            : boolParamToString(baseQueryParams.aligned),
-        "Relative to Population": urlContainsMetric
-            ? boolParamToString(queryParams.perCapita)
-            : boolParamToString(baseQueryParams.perCapita),
+        "Align outbreaks": boolParamToString(
+            queryParams["Align outbreaks"] ??
+                baseQueryParams["Align outbreaks"] ??
+                urlContainsMetric
+                ? queryParams.aligned
+                : baseQueryParams.aligned
+        ),
+        "Relative to Population": boolParamToString(
+            queryParams["Relative to Population"] ??
+                baseQueryParams["Relative to Population"] ??
+                urlContainsMetric
+                ? queryParams.perCapita
+                : baseQueryParams.perCapita
+        ),
     }
 
     return {

--- a/explorerAdminServer/ExplorerRedirects.ts
+++ b/explorerAdminServer/ExplorerRedirects.ts
@@ -196,7 +196,7 @@ const explorerRedirectTableMatrix = [
     [
         "legacyToGridCovidExplorer",
         "/coronavirus-data-explorer",
-        "zoomToSelection=true&time=2020-03-01..latest&country=USA~GBR~CAN~DEU~ITA~IND&region=World&casesMetric=true&interval=smoothed&perCapita=true&smoothing=7&pickerMetric=location&pickerSort=asc",
+        "zoomToSelection=true&country=USA~GBR~CAN~DEU~ITA~IND&pickerSort=asc&pickerMetric=location&Metric=Excess+mortality+(estimates)&Interval=Cumulative&Relative+to+Population=true&Color+by+test+positivity=false",
     ],
 ]
 


### PR DESCRIPTION
The old COVID explorer redirect used to only take old legacy query params into account and discarded new query params - this PR fixes this

This only came into play if you went to the covid explorer via certain links, e.g. if you go to /coronavirus-data-explorer which then redirects to /explorers/coronavirus-data-explorer with a bunch of special logic. This logic needed updating as the old logic only took legacy query params into account.