### PR TITLE
Miscellaneous bug fixes for the site

### DIFF
--- a/adminSiteClient/TagEditPage.tsx
+++ b/adminSiteClient/TagEditPage.tsx
@@ -152,7 +152,7 @@ class TagEditor extends React.Component<{ tag: TagPageData }> {
                                     field="slug"
                                     store={newtag}
                                     label="Slug"
-                                    helpText="The slug for the topic page that this tag corresponds to e.g. trade-and-globalization"
+                                    helpText="The slug for this tag's topic page, e.g. trade-and-globalization. If specified, we assume this tag is a topic."
                                 />
                                 <FieldsRow>
                                     <NumericSelectField

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -209,7 +209,7 @@ const migrate = async (): Promise<void> => {
                     // Provide an empty array to prevent the sticky nav from rendering at all
                     // Because if it isn't defined, it tries to automatically populate itself
                     "sticky-nav": isEntry ? [] : undefined,
-                    "sidebar-toc": `${isEntry}`,
+                    "sidebar-toc": isEntry,
                 },
                 relatedCharts,
                 published: false,

--- a/db/migration/1701803220442-GdocFrontMatterBooleans.ts
+++ b/db/migration/1701803220442-GdocFrontMatterBooleans.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class GdocFrontMatterBooleans1701803220442
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const gdocs: { id: string; content: string }[] =
+            await queryRunner.query(
+                `SELECT id, content FROM posts_gdocs WHERE published = TRUE AND (content LIKE '%"true"%' OR content LIKE '%"false"%')`
+            )
+
+        for (const gdoc of gdocs) {
+            const content = JSON.parse(gdoc.content)
+            for (const [key, value] of Object.entries(content)) {
+                if (typeof value === "string") {
+                    if (value === "true") {
+                        content[key] = true
+                    } else if (value === "false") {
+                        content[key] = false
+                    }
+                }
+            }
+            await queryRunner.query(
+                `UPDATE posts_gdocs SET content = ? WHERE id = ?`,
+                [JSON.stringify(content), gdoc.id]
+            )
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const gdocs: { id: string; content: string }[] =
+            await queryRunner.query(
+                `SELECT id, content FROM posts_gdocs WHERE published = TRUE AND (content LIKE '%: true%' OR content LIKE '%: false%')`
+            )
+        for (const gdoc of gdocs) {
+            const content = JSON.parse(gdoc.content)
+            for (const [key, value] of Object.entries(content)) {
+                if (typeof value === "boolean") {
+                    content[key] = value ? "true" : "false"
+                }
+            }
+            await queryRunner.query(
+                `UPDATE posts_gdocs SET content = ? WHERE id = ?`,
+                [JSON.stringify(content), gdoc.id]
+            )
+        }
+    }
+}

--- a/db/model/Gdoc/GdocPost.ts
+++ b/db/model/Gdoc/GdocPost.ts
@@ -127,12 +127,22 @@ export class GdocPost extends GdocBase implements OwidGdocInterface {
     _validateSubclass = async (): Promise<OwidGdocErrorMessage[]> => {
         const errors: OwidGdocErrorMessage[] = []
 
-        if (this.hasAllChartsBlock && !this.tags.length) {
-            errors.push({
-                property: "content",
-                message: "No tags set on document for all-charts block to use",
-                type: OwidGdocErrorMessageType.Error,
-            })
+        if (!this.tags.length) {
+            if (this.content.type !== OwidGdocType.Fragment) {
+                errors.push({
+                    property: "content",
+                    message:
+                        "Article has no tags set. We won't be able to connect this article to datapages.",
+                    type: OwidGdocErrorMessageType.Warning,
+                })
+            }
+            if (this.hasAllChartsBlock) {
+                errors.push({
+                    property: "content",
+                    message: "Tags must be set for all-charts block",
+                    type: OwidGdocErrorMessageType.Error,
+                })
+            }
         }
 
         const faqs = this.content.faqs

--- a/db/model/Gdoc/GdocPost.ts
+++ b/db/model/Gdoc/GdocPost.ts
@@ -105,7 +105,7 @@ export class GdocPost extends GdocBase implements OwidGdocInterface {
     }
 
     _enrichSubclassContent = (content: Record<string, any>): void => {
-        const isTocForSidebar = content["sidebar-toc"] === "true"
+        const isTocForSidebar = content["sidebar-toc"]
         content.toc = generateToc(content.body, isTocForSidebar)
 
         if (content.summary) {

--- a/db/model/Gdoc/archieToEnriched.ts
+++ b/db/model/Gdoc/archieToEnriched.ts
@@ -292,6 +292,12 @@ export const archieToEnriched = (
     const parsed_unsanitized = load(noLeadingWSLinks)
     const parsed: any = lowercaseObjectKeys(parsed_unsanitized)
 
+    // Convert "true" and "false" strings in the front matter to booleans
+    for (const key of Object.keys(parsed)) {
+        if (parsed[key] === "true") parsed[key] = true
+        if (parsed[key] === "false") parsed[key] = false
+    }
+
     // Parse elements of the ArchieML into enrichedBlocks
     parsed.body = compact(parsed.body.map(parseRawBlocksToEnrichedBlocks))
 

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -1437,7 +1437,7 @@ export interface OwidGdocContent {
     "featured-image"?: string
     "atom-title"?: string
     "atom-excerpt"?: string
-    "sidebar-toc"?: "true" | "false"
+    "sidebar-toc"?: boolean
     "cover-color"?:
         | "sdg-color-1"
         | "sdg-color-2"

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -8,9 +8,14 @@
     .header__wrapper {
         padding-top: 24px;
         padding-bottom: 24px;
-
         @include sm-up {
             padding-top: 48px;
+            padding-bottom: 0;
+        }
+    }
+
+    .header__left {
+        @include sm-up {
             padding-bottom: 40px;
         }
     }

--- a/site/gdocs/ProminentLink.tsx
+++ b/site/gdocs/ProminentLink.tsx
@@ -57,9 +57,10 @@ export const ProminentLink = (props: {
         description =
             // Adding extra context for graphers by default
             // Not needed for Explorers as their titles are self-explanatory
-            description ?? linkType === "grapher"
+            description ??
+            (linkType === "grapher"
                 ? "See the data in our interactive visualization"
-                : ""
+                : "")
     }
 
     const Thumbnail = ({ thumbnail }: { thumbnail: string }) => {


### PR DESCRIPTION
Fixes #2981 - preview: [after (many tags)](https://github.com/owid/owid-grapher/assets/11844404/2a8616a9-2df2-4128-be3f-6816fc12d76d) | [after (few tags)](https://github.com/owid/owid-grapher/assets/11844404/903ae1c0-779f-45f2-a095-93cd1443ad14) | [after (many tags mobile)](https://github.com/owid/owid-grapher/assets/11844404/0ff14ef5-6434-4da5-a265-cdabd3fd7e1c)

Changes gdocs to use proper booleans instead of `"true"` and `"false"` strings for front matter. This is obviously how it should have always been but I was a bit rushed 😇 The migration is overkill seeing as this only affects LTPs and none of them have `"sidebar-toc": "false"` (which would be [treated as truthy](https://github.com/owid/owid-grapher/blob/master/site/gdocs/OwidGdoc.tsx#L126) until the article was republished) but better safe than sorry!

Improves the messaging for how the tag slug field works and what it means

Fixes a random prominent link bug I stumbled upon while testing something else

Adds a warning if you're publishing a non-Fragment gdoc if you don't have any tags set.