### PR TITLE
:sparkles: log fetched gdrive images

### DIFF
--- a/baker/GDriveImagesBaker.tsx
+++ b/baker/GDriveImagesBaker.tsx
@@ -57,6 +57,11 @@ export const bakeDriveImages = async (bakedSiteDir: string) => {
             // Image has not been modified, skip
             if (response.status === 304) {
                 return
+            } else {
+                // Log fetched images, this should be pretty rare as most images should return 304
+                console.log(
+                    `Fetching image ${image.filename} from ${remoteFilePath} using etag ${existingEtag}...`
+                )
             }
 
             if (!response.ok) {


### PR DESCRIPTION
We're getting 404s on staging-site-master, one hypothesis is that we're not handling etags properly.