### PR TITLE
chore(algolia): change sort ranking order

### DIFF
--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -38,7 +38,7 @@ export const configureAlgolia = async () => {
     const baseSettings: Settings = {
         queryLanguages: ["en"],
         indexLanguages: ["en"],
-        ranking: ["exact", "typo", "attribute", "words", "proximity", "custom"],
+        ranking: ["exact", "typo", "words", "proximity", "attribute", "custom"],
         alternativesAsExact: [
             "ignorePlurals",
             "singleWordSynonym",


### PR DESCRIPTION
I am pretty sure this rejiggle can lead to some improvement in our search results.

See https://www.algolia.com/doc/guides/managing-results/relevance-overview/in-depth/ranking-criteria/ as a reference document.

Several notes:
- The default ranking in Algolia is `["typo","geo","words","filters","proximity","attribute","exact","custom"]`, and aligning our criteria closer to theirs is probably a good thing (they know what they are doing; we don't!)
- The distinction between [Attribute and proximity](https://www.algolia.com/doc/guides/managing-results/relevance-overview/in-depth/ranking-criteria/#attribute-and-proximity-combinations) is very interesting; and Algolia writes:
	> This ordering is a subtle distinction. You should keep the default ranking [with proximity before attribute] since Proximity usually leads to better identification of the best-matched attribute.
- `words` doesn't make a difference for us, since we're not using `optionalWords` - but doesn't hurt to keep it in

In particular, I stumbled across this when trying to find the "Modal age at death" chart by searching for "age at death".

With the old ranking, the chart was not returned at all within the first 40, since the word "death" appears in the title often, and the word "age" appears _in some other attribute_.

With the new ranking, the relevant chart is returned as the first result.