### PR TITLE
:tada: Vastly improved search over variables in the variable admin

### DIFF
--- a/adminSiteClient/AdminLayout.tsx
+++ b/adminSiteClient/AdminLayout.tsx
@@ -122,7 +122,9 @@ export class AdminLayout extends React.Component<{
                     </ul>
                 </nav>
                 {showSidebar && <AdminSidebar />}
-                {this.props.children}
+                <div style={{ marginBottom: "3rem" }}>
+                    {this.props.children}
+                </div>
             </div>
         )
     }

--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -199,10 +199,11 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
     }
 
     @computed get gitHistoryUrl() {
-        return `https://github.com/${this.context.admin.settings.GITHUB_USERNAME
-            }/owid-datasets/tree/master/datasets/${encodeURIComponent(
-                filenamify(this.props.dataset.name)
-            )}`
+        return `https://github.com/${
+            this.context.admin.settings.GITHUB_USERNAME
+        }/owid-datasets/tree/master/datasets/${encodeURIComponent(
+            filenamify(this.props.dataset.name)
+        )}`
     }
 
     render() {

--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -199,11 +199,10 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
     }
 
     @computed get gitHistoryUrl() {
-        return `https://github.com/${
-            this.context.admin.settings.GITHUB_USERNAME
-        }/owid-datasets/tree/master/datasets/${encodeURIComponent(
-            filenamify(this.props.dataset.name)
-        )}`
+        return `https://github.com/${this.context.admin.settings.GITHUB_USERNAME
+            }/owid-datasets/tree/master/datasets/${encodeURIComponent(
+                filenamify(this.props.dataset.name)
+            )}`
     }
 
     render() {
@@ -350,7 +349,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                     )}
                 <section>
                     <h3>Indicators</h3>
-                    <VariableList variables={dataset.variables} />
+                    <VariableList variables={dataset.variables} fields={[]} />
                 </section>
                 <section>
                     <button

--- a/adminSiteClient/SourceEditPage.tsx
+++ b/adminSiteClient/SourceEditPage.tsx
@@ -154,7 +154,7 @@ class SourceEditor extends React.Component<{ source: SourcePageData }> {
                 </section>
                 <section>
                     <h3>Indicators</h3>
-                    <VariableList variables={source.variables} />
+                    <VariableList variables={source.variables} fields={[]} />
                 </section>
             </main>
         )

--- a/adminSiteClient/VariableList.tsx
+++ b/adminSiteClient/VariableList.tsx
@@ -67,7 +67,7 @@ class VariableRow extends React.Component<{
                         {
                             // Some "short names" are very long, so truncate them
                             variable.shortName &&
-                                variable.shortName!.length > 20
+                            variable.shortName!.length > 20
                                 ? variable.shortName!.substring(0, 20) + "..."
                                 : variable.shortName
                         }

--- a/adminSiteClient/VariableList.tsx
+++ b/adminSiteClient/VariableList.tsx
@@ -49,42 +49,30 @@ class VariableRow extends React.Component<{
                             : variable.name}
                     </Link>
                 </td>
-                {fields.includes("namespace") && (
-                    <td>
-                        {variable.namespace}
-                    </td>
-                )
-                }
-                {fields.includes("version") && (
-                    <td>
-                        {variable.version}
-                    </td>
-                )
-                }
-                {fields.includes("dataset") && (
-                    <td>
-                        {variable.dataset}
-                    </td>
-                )
-                }
+                {fields.includes("namespace") && <td>{variable.namespace}</td>}
+                {fields.includes("version") && <td>{variable.version}</td>}
+                {fields.includes("dataset") && <td>{variable.dataset}</td>}
                 {fields.includes("table") && (
                     <td>
                         {
                             // Some table are very long, truncate them
-                            (variable.table && variable.table!.length > 20) ? variable.table!.substring(0, 20) + "..." : variable.table
+                            variable.table && variable.table!.length > 20
+                                ? variable.table!.substring(0, 20) + "..."
+                                : variable.table
                         }
                     </td>
-                )
-                }
+                )}
                 {fields.includes("shortName") && (
                     <td>
                         {
                             // Some "short names" are very long, so truncate them
-                            (variable.shortName && variable.shortName!.length > 20) ? variable.shortName!.substring(0, 20) + "..." : variable.shortName
+                            variable.shortName &&
+                            variable.shortName!.length > 20
+                                ? variable.shortName!.substring(0, 20) + "..."
+                                : variable.shortName
                         }
                     </td>
-                )
-                }
+                )}
                 {fields.includes("uploadedAt") && (
                     <td>
                         <Timeago
@@ -117,20 +105,15 @@ export class VariableList extends React.Component<{
                         {props.fields.includes("namespace") && (
                             <th>Namespace</th>
                         )}
-                        {props.fields.includes("version") && (
-                            <th>Version</th>
-                        )}
-                        {props.fields.includes("dataset") && (
-                            <th>Dataset</th>
-                        )}
-                        {props.fields.includes("table") && (
-                            <th>Table</th>
-                        )}
+                        {props.fields.includes("version") && <th>Version</th>}
+                        {props.fields.includes("dataset") && <th>Dataset</th>}
+                        {props.fields.includes("table") && <th>Table</th>}
                         {props.fields.includes("shortName") && (
                             <th>Short name</th>
                         )}
                         {props.fields.includes("uploadedAt") && (
-                            <th>Uploaded</th>)}
+                            <th>Uploaded</th>
+                        )}
                     </tr>
                 </thead>
                 <tbody>

--- a/adminSiteClient/VariableList.tsx
+++ b/adminSiteClient/VariableList.tsx
@@ -67,7 +67,7 @@ class VariableRow extends React.Component<{
                         {
                             // Some "short names" are very long, so truncate them
                             variable.shortName &&
-                            variable.shortName!.length > 20
+                                variable.shortName!.length > 20
                                 ? variable.shortName!.substring(0, 20) + "..."
                                 : variable.shortName
                         }
@@ -101,7 +101,7 @@ export class VariableList extends React.Component<{
             <table className="table table-bordered">
                 <thead>
                     <tr>
-                        <th>Indicator</th>
+                        <th>Name</th>
                         {props.fields.includes("namespace") && (
                             <th>Namespace</th>
                         )}

--- a/adminSiteClient/VariableList.tsx
+++ b/adminSiteClient/VariableList.tsx
@@ -8,6 +8,11 @@ import { Timeago } from "./Forms.js"
 export interface VariableListItem {
     id: number
     name: string
+    namespace?: string
+    version?: string
+    dataset?: string
+    table?: string
+    shortName?: string
     uploadedAt?: Date
     uploadedBy?: string
     isPrivate?: boolean
@@ -17,13 +22,14 @@ export interface VariableListItem {
 @observer
 class VariableRow extends React.Component<{
     variable: VariableListItem
+    fields: string[]
     searchHighlight?: (text: string) => string | JSX.Element
 }> {
     static contextType = AdminAppContext
     context!: AdminAppContextType
 
     render() {
-        const { variable, searchHighlight } = this.props
+        const { variable, fields, searchHighlight } = this.props
 
         return (
             <tr>
@@ -43,7 +49,43 @@ class VariableRow extends React.Component<{
                             : variable.name}
                     </Link>
                 </td>
-                {variable.uploadedAt && (
+                {fields.includes("namespace") && (
+                    <td>
+                        {variable.namespace}
+                    </td>
+                )
+                }
+                {fields.includes("version") && (
+                    <td>
+                        {variable.version}
+                    </td>
+                )
+                }
+                {fields.includes("dataset") && (
+                    <td>
+                        {variable.dataset}
+                    </td>
+                )
+                }
+                {fields.includes("table") && (
+                    <td>
+                        {
+                            // Some table are very long, truncate them
+                            (variable.table && variable.table!.length > 20) ? variable.table!.substring(0, 20) + "..." : variable.table
+                        }
+                    </td>
+                )
+                }
+                {fields.includes("shortName") && (
+                    <td>
+                        {
+                            // Some "short names" are very long, so truncate them
+                            (variable.shortName && variable.shortName!.length > 20) ? variable.shortName!.substring(0, 20) + "..." : variable.shortName
+                        }
+                    </td>
+                )
+                }
+                {fields.includes("uploadedAt") && (
                     <td>
                         <Timeago
                             time={variable.uploadedAt}
@@ -59,6 +101,7 @@ class VariableRow extends React.Component<{
 @observer
 export class VariableList extends React.Component<{
     variables: VariableListItem[]
+    fields: string[]
     searchHighlight?: (text: string) => string | JSX.Element
 }> {
     static contextType = AdminAppContext
@@ -71,15 +114,30 @@ export class VariableList extends React.Component<{
                 <thead>
                     <tr>
                         <th>Indicator</th>
-                        {props.variables.some(
-                            (v) => v.uploadedAt !== undefined
-                        ) && <th>Uploaded</th>}
+                        {props.fields.includes("namespace") && (
+                            <th>Namespace</th>
+                        )}
+                        {props.fields.includes("version") && (
+                            <th>Version</th>
+                        )}
+                        {props.fields.includes("dataset") && (
+                            <th>Dataset</th>
+                        )}
+                        {props.fields.includes("table") && (
+                            <th>Table</th>
+                        )}
+                        {props.fields.includes("shortName") && (
+                            <th>Short name</th>
+                        )}
+                        {props.fields.includes("uploadedAt") && (
+                            <th>Uploaded</th>)}
                     </tr>
                 </thead>
                 <tbody>
                     {props.variables.map((variable) => (
                         <VariableRow
                             key={variable.id}
+                            fields={this.props.fields}
                             variable={variable}
                             searchHighlight={props.searchHighlight}
                         />

--- a/adminSiteClient/VariablesIndexPage.tsx
+++ b/adminSiteClient/VariablesIndexPage.tsx
@@ -72,6 +72,7 @@ export class VariablesIndexPage extends React.Component {
                     </FieldsRow>
                     <VariableList
                         variables={variablesToShow}
+                        fields={["namespace", "version", "dataset", "table", "shortName", "uploadedAt"]}
                         searchHighlight={highlight}
                     />
                     {!searchInput && (

--- a/adminSiteClient/VariablesIndexPage.tsx
+++ b/adminSiteClient/VariablesIndexPage.tsx
@@ -106,6 +106,7 @@ export class VariablesIndexPage extends React.Component {
                 // Make sure this response is current
                 this.variables = json.variables
                 this.numTotalRows = json.numTotalRows
+                // NOTE: search highlighting is less relevant with fielded and regex search
                 this.highlightSearch = searchInput
             }
         })

--- a/adminSiteClient/VariablesIndexPage.tsx
+++ b/adminSiteClient/VariablesIndexPage.tsx
@@ -72,7 +72,14 @@ export class VariablesIndexPage extends React.Component {
                     </FieldsRow>
                     <VariableList
                         variables={variablesToShow}
-                        fields={["namespace", "version", "dataset", "table", "shortName", "uploadedAt"]}
+                        fields={[
+                            "namespace",
+                            "version",
+                            "dataset",
+                            "table",
+                            "shortName",
+                            "uploadedAt",
+                        ]}
                         searchHighlight={highlight}
                     />
                     {!searchInput && (

--- a/adminSiteClient/VariablesIndexPage.tsx
+++ b/adminSiteClient/VariablesIndexPage.tsx
@@ -62,7 +62,7 @@ export class VariablesIndexPage extends React.Component {
                             indicators
                         </span>
                         <SearchField
-                            placeholder="Search all indicators..."
+                            placeholder="e.g. ^population before:2023"
                             value={searchInput}
                             onValue={action(
                                 (v: string) => (this.searchInput = v)
@@ -70,6 +70,7 @@ export class VariablesIndexPage extends React.Component {
                             autofocus
                         />
                     </FieldsRow>
+                    <p><em>You can use regular expressions and the following fields:</em> <code>name:</code>, <code>namespace:</code>, <code>version:</code>, <code>dataset:</code>, <code>table:</code>, <code>short:</code>, <code>before:</code>, <code>after:</code></p>
                     <VariableList
                         variables={variablesToShow}
                         fields={[

--- a/adminSiteClient/VariablesIndexPage.tsx
+++ b/adminSiteClient/VariablesIndexPage.tsx
@@ -70,7 +70,16 @@ export class VariablesIndexPage extends React.Component {
                             autofocus
                         />
                     </FieldsRow>
-                    <p><em>You can use regular expressions and the following fields:</em> <code>name:</code>, <code>namespace:</code>, <code>version:</code>, <code>dataset:</code>, <code>table:</code>, <code>short:</code>, <code>before:</code>, <code>after:</code></p>
+                    <p>
+                        <em>
+                            You can use regular expressions and the following
+                            fields:
+                        </em>{" "}
+                        <code>name:</code>, <code>namespace:</code>,{" "}
+                        <code>version:</code>, <code>dataset:</code>,{" "}
+                        <code>table:</code>, <code>short:</code>,{" "}
+                        <code>before:</code>, <code>after:</code>
+                    </p>
                     <VariableList
                         variables={variablesToShow}
                         fields={[

--- a/adminSiteClient/VariablesIndexPage.tsx
+++ b/adminSiteClient/VariablesIndexPage.tsx
@@ -62,7 +62,7 @@ export class VariablesIndexPage extends React.Component {
                             indicators
                         </span>
                         <SearchField
-                            placeholder="e.g. ^population before:2023"
+                            placeholder="e.g. ^population before:2023 -wdi"
                             value={searchInput}
                             onValue={action(
                                 (v: string) => (this.searchInput = v)
@@ -75,10 +75,11 @@ export class VariablesIndexPage extends React.Component {
                             You can use regular expressions and the following
                             fields:
                         </em>{" "}
-                        <code>name:</code>, <code>namespace:</code>,{" "}
-                        <code>version:</code>, <code>dataset:</code>,{" "}
-                        <code>table:</code>, <code>short:</code>,{" "}
-                        <code>before:</code>, <code>after:</code>
+                        <code>name:</code>, <code>path:</code>,{" "}
+                        <code>namespace:</code>, <code>version:</code>,{" "}
+                        <code>dataset:</code>, <code>table:</code>,{" "}
+                        <code>short:</code>, <code>before:</code>,{" "}
+                        <code>after:</code>
                     </p>
                     <VariableList
                         variables={variablesToShow}

--- a/adminSiteClient/VariablesIndexPage.tsx
+++ b/adminSiteClient/VariablesIndexPage.tsx
@@ -79,7 +79,8 @@ export class VariablesIndexPage extends React.Component {
                         <code>namespace:</code>, <code>version:</code>,{" "}
                         <code>dataset:</code>, <code>table:</code>,{" "}
                         <code>short:</code>, <code>before:</code>,{" "}
-                        <code>after:</code>
+                        <code>after:</code>, <code>is:public</code>,{" "}
+                        <code>is:private</code>
                     </p>
                     <VariableList
                         variables={variablesToShow}

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -170,11 +170,11 @@ const getPostsForSlugs = async (
                     AND post_status='publish'
                     AND (
                         ${slugs
-                .map(
-                    () =>
-                        `post_content REGEXP CONCAT('grapher/', ?, '[^a-zA-Z_\-]')`
-                )
-                .join(" OR ")}
+                            .map(
+                                () =>
+                                    `post_content REGEXP CONCAT('grapher/', ?, '[^a-zA-Z_\-]')`
+                            )
+                            .join(" OR ")}
                     )
             `,
             slugs.map(lodash.escapeRegExp)
@@ -659,14 +659,14 @@ apiRouter.get(
 
         let dataset:
             | {
-                id: number
-                name: string
-                version: string
-                namespace: string
-                isPrivate: boolean
-                nonRedistributable: boolean
-                variables: { id: number; name: string }[]
-            }
+                  id: number
+                  name: string
+                  version: string
+                  namespace: string
+                  isPrivate: boolean
+                  nonRedistributable: boolean
+                  variables: { id: number; name: string }[]
+              }
             | undefined
         for (const row of rows) {
             if (!dataset || row.datasetName !== dataset.name) {
@@ -979,9 +979,9 @@ apiRouter.post(
                 ) {
                     throw new JsonError(
                         `Expected all "${obj.key}" values to be non-null and of ` +
-                        `type "${obj.expectedType}", but one or more chart ` +
-                        `configs contains a "${obj.key}" value that does ` +
-                        `not meet this criteria.`
+                            `type "${obj.expectedType}", but one or more chart ` +
+                            `configs contains a "${obj.key}" value that does ` +
+                            `not meet this criteria.`
                     )
                 }
             })
@@ -1140,9 +1140,9 @@ apiRouter.post(
                     if (!config.hasOwnProperty(k)) {
                         throw new JsonError(
                             `The "${k}" field is required, but one or more ` +
-                            `chart configs in the database does not ` +
-                            `contain it. Please report this issue to a ` +
-                            `developer.`
+                                `chart configs in the database does not ` +
+                                `contain it. Please report this issue to a ` +
+                                `developer.`
                         )
                     }
                 })
@@ -1212,8 +1212,9 @@ apiRouter.post(
             if (suggestedConfigs.length - result.affectedRows > 0) {
                 messages.push({
                     type: "warning",
-                    text: `${suggestedConfigs.length - result.affectedRows
-                        } chart revisions have not been queued for approval (e.g. because the chart revision does not contain any changes).`,
+                    text: `${
+                        suggestedConfigs.length - result.affectedRows
+                    } chart revisions have not been queued for approval (e.g. because the chart revision does not contain any changes).`,
                 })
             }
         })
@@ -1340,7 +1341,7 @@ apiRouter.post(
             if (!canUpdate) {
                 throw new JsonError(
                     `Suggest chart revision ${suggestedChartRevisionId} cannot be ` +
-                    `updated with status="${status}".`,
+                        `updated with status="${status}".`,
                     404
                 )
             }
@@ -1493,45 +1494,83 @@ apiRouter.get("/variables.json", async (req) => {
     if (searchStr) {
         for (let part of searchStr.split(" ")) {
             part = part.trim()
-            let not = ' '
+            let not = " "
             if (part.startsWith("-")) {
                 part = part.substr(1)
-                not = 'NOT '
+                not = "NOT "
             }
             if (part.startsWith("name:")) {
                 const q = part.substr("name:".length)
                 // force a case insensitive regex search
-                q && whereClauses.push(`v.name COLLATE utf8mb4_general_ci ${not} REGEXP ${escape(q)}`)
+                q &&
+                    whereClauses.push(
+                        `v.name COLLATE utf8mb4_general_ci ${not} REGEXP ${escape(
+                            q
+                        )}`
+                    )
             } else if (part.startsWith("path:")) {
                 const q = part.substr("path:".length)
-                q && whereClauses.push(`v.catalogPath ${not} REGEXP ${escape(q)}`)
+                q &&
+                    whereClauses.push(
+                        `v.catalogPath ${not} REGEXP ${escape(q)}`
+                    )
             } else if (part.startsWith("namespace:")) {
                 const q = part.substr("namespace:".length)
-                q && whereClauses.push(`v.catalogPath ${not} LIKE "grapher/${q}/%/%/%#%"`)
+                q &&
+                    whereClauses.push(
+                        `v.catalogPath ${not} LIKE "grapher/${q}/%/%/%#%"`
+                    )
             } else if (part.startsWith("version:")) {
                 const q = part.substr("version:".length)
-                q && whereClauses.push(`v.catalogPath ${not} LIKE "grapher/%/${q}/%/%#%"`)
+                q &&
+                    whereClauses.push(
+                        `v.catalogPath ${not} LIKE "grapher/%/${q}/%/%#%"`
+                    )
             } else if (part.startsWith("dataset:")) {
                 const q = part.substr("dataset:".length)
-                q && whereClauses.push(`v.catalogPath ${not} LIKE "grapher/%/%/${q}/%#%"`)
+                q &&
+                    whereClauses.push(
+                        `v.catalogPath ${not} LIKE "grapher/%/%/${q}/%#%"`
+                    )
             } else if (part.startsWith("table:")) {
                 const q = part.substr("table:".length)
-                q && whereClauses.push(`v.catalogPath ${not} LIKE "grapher/%/%/%/${q}#%"`)
+                q &&
+                    whereClauses.push(
+                        `v.catalogPath ${not} LIKE "grapher/%/%/%/${q}#%"`
+                    )
             } else if (part.startsWith("short:")) {
                 const q = part.substr("short:".length)
-                q && whereClauses.push(`v.catalogPath ${not} LIKE "grapher/%/%/%/%#${q}"`)
+                q &&
+                    whereClauses.push(
+                        `v.catalogPath ${not} LIKE "grapher/%/%/%/%#${q}"`
+                    )
             } else if (part.startsWith("before:")) {
                 const q = part.substr("before:".length)
-                q && whereClauses.push(`${not} IF(d.version is not null, d.version < ${escape(q)}, cast(date(d.createdAt) as char) < ${escape(q)})`)
+                q &&
+                    whereClauses.push(
+                        `${not} IF(d.version is not null, d.version < ${escape(
+                            q
+                        )}, cast(date(d.createdAt) as char) < ${escape(q)})`
+                    )
             } else if (part.startsWith("after:")) {
                 const q = part.substr("after:".length)
-                q && whereClauses.push(`${not} (IF (d.version is not null, d.version = "latest" OR d.version > ${escape(q)}, cast(date(d.createdAt) as char) > ${escape(q)}))`)
+                q &&
+                    whereClauses.push(
+                        `${not} (IF (d.version is not null, d.version = "latest" OR d.version > ${escape(
+                            q
+                        )}, cast(date(d.createdAt) as char) > ${escape(q)}))`
+                    )
             } else if (part === "is:published") {
                 whereClauses.push(`${not} (NOT d.isPrivate)`)
             } else if (part === "is:private") {
                 whereClauses.push(`${not} d.isPrivate`)
             } else {
-                part && whereClauses.push(`${not} (v.name REGEXP ${escape(part)} OR v.catalogPath REGEXP ${escape(part)})`)
+                part &&
+                    whereClauses.push(
+                        `${not} (v.name REGEXP ${escape(
+                            part
+                        )} OR v.catalogPath REGEXP ${escape(part)})`
+                    )
             }
         }
     }
@@ -1550,16 +1589,13 @@ apiRouter.get("/variables.json", async (req) => {
         FROM variables AS v
         JOIN active_datasets d ON d.id=v.datasetId
         JOIN users u ON u.id=d.dataEditedByUserId
-        ${(whereClauses.length ? "WHERE " + whereClauses.join(" AND ") : "")}
+        ${whereClauses.length ? "WHERE " + whereClauses.join(" AND ") : ""}
         ORDER BY d.dataEditedAt DESC
         LIMIT ?
     `
     console.log(query)
 
-    const rows = await db.queryMysql(
-        query,
-        [limit]
-    )
+    const rows = await db.queryMysql(query, [limit])
 
     const numTotalRows = (
         await db.queryMysql(`SELECT COUNT(*) as count FROM variables`)
@@ -1568,7 +1604,9 @@ apiRouter.get("/variables.json", async (req) => {
     rows.forEach((row: any) => {
         if (row.catalogPath) {
             const [path, shortName] = row.catalogPath.split("#")
-            const [namespace, version, dataset, table] = path.substr('grapher/'.length).split('/')
+            const [namespace, version, dataset, table] = path
+                .substr("grapher/".length)
+                .split("/")
 
             row.namespace = namespace
             row.version = version
@@ -2714,8 +2752,8 @@ apiRouter.put("/gdocs/:id", async (req, res) => {
             prevGdoc.published && nextGdoc.published
                 ? "Updating"
                 : !prevGdoc.published && nextGdoc.published
-                    ? "Publishing"
-                    : "Unpublishing"
+                ? "Publishing"
+                : "Unpublishing"
         await triggerStaticBuild(res.locals.user, `${action} ${nextGdoc.slug}`)
     }
 

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -170,11 +170,11 @@ const getPostsForSlugs = async (
                     AND post_status='publish'
                     AND (
                         ${slugs
-                            .map(
-                                () =>
-                                    `post_content REGEXP CONCAT('grapher/', ?, '[^a-zA-Z_\-]')`
-                            )
-                            .join(" OR ")}
+                .map(
+                    () =>
+                        `post_content REGEXP CONCAT('grapher/', ?, '[^a-zA-Z_\-]')`
+                )
+                .join(" OR ")}
                     )
             `,
             slugs.map(lodash.escapeRegExp)
@@ -659,14 +659,14 @@ apiRouter.get(
 
         let dataset:
             | {
-                  id: number
-                  name: string
-                  version: string
-                  namespace: string
-                  isPrivate: boolean
-                  nonRedistributable: boolean
-                  variables: { id: number; name: string }[]
-              }
+                id: number
+                name: string
+                version: string
+                namespace: string
+                isPrivate: boolean
+                nonRedistributable: boolean
+                variables: { id: number; name: string }[]
+            }
             | undefined
         for (const row of rows) {
             if (!dataset || row.datasetName !== dataset.name) {
@@ -979,9 +979,9 @@ apiRouter.post(
                 ) {
                     throw new JsonError(
                         `Expected all "${obj.key}" values to be non-null and of ` +
-                            `type "${obj.expectedType}", but one or more chart ` +
-                            `configs contains a "${obj.key}" value that does ` +
-                            `not meet this criteria.`
+                        `type "${obj.expectedType}", but one or more chart ` +
+                        `configs contains a "${obj.key}" value that does ` +
+                        `not meet this criteria.`
                     )
                 }
             })
@@ -1140,9 +1140,9 @@ apiRouter.post(
                     if (!config.hasOwnProperty(k)) {
                         throw new JsonError(
                             `The "${k}" field is required, but one or more ` +
-                                `chart configs in the database does not ` +
-                                `contain it. Please report this issue to a ` +
-                                `developer.`
+                            `chart configs in the database does not ` +
+                            `contain it. Please report this issue to a ` +
+                            `developer.`
                         )
                     }
                 })
@@ -1212,9 +1212,8 @@ apiRouter.post(
             if (suggestedConfigs.length - result.affectedRows > 0) {
                 messages.push({
                     type: "warning",
-                    text: `${
-                        suggestedConfigs.length - result.affectedRows
-                    } chart revisions have not been queued for approval (e.g. because the chart revision does not contain any changes).`,
+                    text: `${suggestedConfigs.length - result.affectedRows
+                        } chart revisions have not been queued for approval (e.g. because the chart revision does not contain any changes).`,
                 })
             }
         })
@@ -1341,7 +1340,7 @@ apiRouter.post(
             if (!canUpdate) {
                 throw new JsonError(
                     `Suggest chart revision ${suggestedChartRevisionId} cannot be ` +
-                        `updated with status="${status}".`,
+                    `updated with status="${status}".`,
                     404
                 )
             }
@@ -1488,12 +1487,60 @@ apiRouter.post("/users/add", async (req: Request, res: Response) => {
 
 apiRouter.get("/variables.json", async (req) => {
     const limit = parseIntOrUndefined(req.query.limit as string) ?? 50
-    const searchStr = req.query.search
+    const searchStr = req.query.search as string
+
+    const whereClauses = []
+    if (searchStr) {
+        for (let part of searchStr.split(" ")) {
+            part = part.trim()
+            let not = ' '
+            if (part.startsWith("-")) {
+                part = part.substr(1)
+                not = 'NOT '
+            }
+            if (part.startsWith("name:")) {
+                const q = part.substr("name:".length)
+                // force a case insensitive regex search
+                q && whereClauses.push(`v.name COLLATE utf8mb4_general_ci ${not} REGEXP ${escape(q)}`)
+            } else if (part.startsWith("path:")) {
+                const q = part.substr("path:".length)
+                q && whereClauses.push(`v.catalogPath ${not} REGEXP ${escape(q)}`)
+            } else if (part.startsWith("namespace:")) {
+                const q = part.substr("namespace:".length)
+                q && whereClauses.push(`v.catalogPath ${not} LIKE "grapher/${q}/%/%/%#%"`)
+            } else if (part.startsWith("version:")) {
+                const q = part.substr("version:".length)
+                q && whereClauses.push(`v.catalogPath ${not} LIKE "grapher/%/${q}/%/%#%"`)
+            } else if (part.startsWith("dataset:")) {
+                const q = part.substr("dataset:".length)
+                q && whereClauses.push(`v.catalogPath ${not} LIKE "grapher/%/%/${q}/%#%"`)
+            } else if (part.startsWith("table:")) {
+                const q = part.substr("table:".length)
+                q && whereClauses.push(`v.catalogPath ${not} LIKE "grapher/%/%/%/${q}#%"`)
+            } else if (part.startsWith("short:")) {
+                const q = part.substr("short:".length)
+                q && whereClauses.push(`v.catalogPath ${not} LIKE "grapher/%/%/%/%#${q}"`)
+            } else if (part.startsWith("before:")) {
+                const q = part.substr("before:".length)
+                q && whereClauses.push(`${not} IF(d.version is not null, d.version < ${escape(q)}, cast(date(d.createdAt) as char) < ${escape(q)})`)
+            } else if (part.startsWith("after:")) {
+                const q = part.substr("after:".length)
+                q && whereClauses.push(`${not} (IF (d.version is not null, d.version = "latest" OR d.version > ${escape(q)}, cast(date(d.createdAt) as char) > ${escape(q)}))`)
+            } else if (part === "is:published") {
+                whereClauses.push(`${not} (NOT d.isPrivate)`)
+            } else if (part === "is:private") {
+                whereClauses.push(`${not} d.isPrivate`)
+            } else {
+                part && whereClauses.push(`${not} (v.name REGEXP ${escape(part)} OR v.catalogPath REGEXP ${escape(part)})`)
+            }
+        }
+    }
 
     const query = `
         SELECT
             v.id,
             v.name,
+            catalogPath,
             d.id AS datasetId,
             d.name AS datasetName,
             d.isPrivate AS isPrivate,
@@ -1503,19 +1550,33 @@ apiRouter.get("/variables.json", async (req) => {
         FROM variables AS v
         JOIN active_datasets d ON d.id=v.datasetId
         JOIN users u ON u.id=d.dataEditedByUserId
-        ${searchStr ? "WHERE v.name LIKE ?" : ""}
+        ${(whereClauses.length ? "WHERE " + whereClauses.join(" AND ") : "")}
         ORDER BY d.dataEditedAt DESC
         LIMIT ?
     `
+    console.log(query)
 
     const rows = await db.queryMysql(
         query,
-        searchStr ? [`%${searchStr}%`, limit] : [limit]
+        [limit]
     )
 
     const numTotalRows = (
         await db.queryMysql(`SELECT COUNT(*) as count FROM variables`)
     )[0].count
+
+    rows.forEach((row: any) => {
+        if (row.catalogPath) {
+            const [path, shortName] = row.catalogPath.split("#")
+            const [namespace, version, dataset, table] = path.substr('grapher/'.length).split('/')
+
+            row.namespace = namespace
+            row.version = version
+            row.dataset = dataset
+            row.table = table
+            row.shortName = shortName
+        }
+    })
 
     return { variables: rows, numTotalRows: numTotalRows }
 })
@@ -1847,7 +1908,7 @@ apiRouter.get("/datasets/:datasetId.json", async (req: Request) => {
 
     const variables = await db.queryMysql(
         `
-        SELECT v.id, v.name, v.description, v.display
+        SELECT v.id, v.name, v.description, v.display, v.catalogPath
         FROM variables AS v
         WHERE v.datasetId = ?
     `,
@@ -2653,8 +2714,8 @@ apiRouter.put("/gdocs/:id", async (req, res) => {
             prevGdoc.published && nextGdoc.published
                 ? "Updating"
                 : !prevGdoc.published && nextGdoc.published
-                ? "Publishing"
-                : "Unpublishing"
+                    ? "Publishing"
+                    : "Unpublishing"
         await triggerStaticBuild(res.locals.user, `${action} ${nextGdoc.slug}`)
     }
 

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -171,11 +171,11 @@ const getPostsForSlugs = async (
                     AND post_status='publish'
                     AND (
                         ${slugs
-                .map(
-                    () =>
-                        `post_content REGEXP CONCAT('grapher/', ?, '[^a-zA-Z_\-]')`
-                )
-                .join(" OR ")}
+                            .map(
+                                () =>
+                                    `post_content REGEXP CONCAT('grapher/', ?, '[^a-zA-Z_\-]')`
+                            )
+                            .join(" OR ")}
                     )
             `,
             slugs.map(lodash.escapeRegExp)
@@ -660,14 +660,14 @@ apiRouter.get(
 
         let dataset:
             | {
-                id: number
-                name: string
-                version: string
-                namespace: string
-                isPrivate: boolean
-                nonRedistributable: boolean
-                variables: { id: number; name: string }[]
-            }
+                  id: number
+                  name: string
+                  version: string
+                  namespace: string
+                  isPrivate: boolean
+                  nonRedistributable: boolean
+                  variables: { id: number; name: string }[]
+              }
             | undefined
         for (const row of rows) {
             if (!dataset || row.datasetName !== dataset.name) {
@@ -980,9 +980,9 @@ apiRouter.post(
                 ) {
                     throw new JsonError(
                         `Expected all "${obj.key}" values to be non-null and of ` +
-                        `type "${obj.expectedType}", but one or more chart ` +
-                        `configs contains a "${obj.key}" value that does ` +
-                        `not meet this criteria.`
+                            `type "${obj.expectedType}", but one or more chart ` +
+                            `configs contains a "${obj.key}" value that does ` +
+                            `not meet this criteria.`
                     )
                 }
             })
@@ -1141,9 +1141,9 @@ apiRouter.post(
                     if (!config.hasOwnProperty(k)) {
                         throw new JsonError(
                             `The "${k}" field is required, but one or more ` +
-                            `chart configs in the database does not ` +
-                            `contain it. Please report this issue to a ` +
-                            `developer.`
+                                `chart configs in the database does not ` +
+                                `contain it. Please report this issue to a ` +
+                                `developer.`
                         )
                     }
                 })
@@ -1213,8 +1213,9 @@ apiRouter.post(
             if (suggestedConfigs.length - result.affectedRows > 0) {
                 messages.push({
                     type: "warning",
-                    text: `${suggestedConfigs.length - result.affectedRows
-                        } chart revisions have not been queued for approval (e.g. because the chart revision does not contain any changes).`,
+                    text: `${
+                        suggestedConfigs.length - result.affectedRows
+                    } chart revisions have not been queued for approval (e.g. because the chart revision does not contain any changes).`,
                 })
             }
         })
@@ -1341,7 +1342,7 @@ apiRouter.post(
             if (!canUpdate) {
                 throw new JsonError(
                     `Suggest chart revision ${suggestedChartRevisionId} cannot be ` +
-                    `updated with status="${status}".`,
+                        `updated with status="${status}".`,
                     404
                 )
             }
@@ -2625,8 +2626,8 @@ apiRouter.put("/gdocs/:id", async (req, res) => {
             prevGdoc.published && nextGdoc.published
                 ? "Updating"
                 : !prevGdoc.published && nextGdoc.published
-                    ? "Publishing"
-                    : "Unpublishing"
+                ? "Publishing"
+                : "Unpublishing"
         await triggerStaticBuild(res.locals.user, `${action} ${nextGdoc.slug}`)
     }
 

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -1496,56 +1496,54 @@ apiRouter.get("/variables.json", async (req) => {
             part = part.trim()
             let not = " "
             if (part.startsWith("-")) {
-                part = part.substr(1)
+                part = part.substring(1)
                 not = "NOT "
             }
             if (part.startsWith("name:")) {
-                const q = part.substr("name:".length)
+                const q = part.substring("name:".length)
                 // force a case insensitive regex search
                 q &&
                     whereClauses.push(
-                        `v.name COLLATE utf8mb4_general_ci ${not} REGEXP ${escape(
-                            q
-                        )}`
+                        `${not} REGEXP_LIKE(v.name, ${escape(q)}, 'i')`
                     )
             } else if (part.startsWith("path:")) {
-                const q = part.substr("path:".length)
+                const q = part.substring("path:".length)
                 q &&
                     whereClauses.push(
-                        `v.catalogPath ${not} REGEXP ${escape(q)}`
+                        `${not} REGEXP_LIKE(v.catalogPath, ${escape(q)}, 'i')`
                     )
             } else if (part.startsWith("namespace:")) {
-                const q = part.substr("namespace:".length)
+                const q = part.substring("namespace:".length)
                 q &&
                     whereClauses.push(
                         `v.catalogPath ${not} LIKE "grapher/${q}/%/%/%#%"`
                     )
             } else if (part.startsWith("version:")) {
-                const q = part.substr("version:".length)
+                const q = part.substring("version:".length)
                 q &&
                     whereClauses.push(
                         `v.catalogPath ${not} LIKE "grapher/%/${q}/%/%#%"`
                     )
             } else if (part.startsWith("dataset:")) {
-                const q = part.substr("dataset:".length)
+                const q = part.substring("dataset:".length)
                 q &&
                     whereClauses.push(
                         `v.catalogPath ${not} LIKE "grapher/%/%/${q}/%#%"`
                     )
             } else if (part.startsWith("table:")) {
-                const q = part.substr("table:".length)
+                const q = part.substring("table:".length)
                 q &&
                     whereClauses.push(
                         `v.catalogPath ${not} LIKE "grapher/%/%/%/${q}#%"`
                     )
             } else if (part.startsWith("short:")) {
-                const q = part.substr("short:".length)
+                const q = part.substring("short:".length)
                 q &&
                     whereClauses.push(
                         `v.catalogPath ${not} LIKE "grapher/%/%/%/%#${q}"`
                     )
             } else if (part.startsWith("before:")) {
-                const q = part.substr("before:".length)
+                const q = part.substring("before:".length)
                 q &&
                     whereClauses.push(
                         `${not} IF(d.version is not null, d.version < ${escape(
@@ -1553,7 +1551,7 @@ apiRouter.get("/variables.json", async (req) => {
                         )}, cast(date(d.createdAt) as char) < ${escape(q)})`
                     )
             } else if (part.startsWith("after:")) {
-                const q = part.substr("after:".length)
+                const q = part.substring("after:".length)
                 q &&
                     whereClauses.push(
                         `${not} (IF (d.version is not null, d.version = "latest" OR d.version > ${escape(
@@ -1567,9 +1565,7 @@ apiRouter.get("/variables.json", async (req) => {
             } else {
                 part &&
                     whereClauses.push(
-                        `${not} (v.name REGEXP ${escape(
-                            part
-                        )} OR v.catalogPath REGEXP ${escape(part)})`
+                        `${not} (REGEXP_LIKE(v.name, ${escape(part)}, 'i') OR REGEXP_LIKE(v.catalogPath, ${escape(part)}, 'i'))`
                     )
             }
         }
@@ -1605,7 +1601,7 @@ apiRouter.get("/variables.json", async (req) => {
         if (row.catalogPath) {
             const [path, shortName] = row.catalogPath.split("#")
             const [namespace, version, dataset, table] = path
-                .substr("grapher/".length)
+                .substring("grapher/".length)
                 .split("/")
 
             row.namespace = namespace

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -1565,7 +1565,11 @@ apiRouter.get("/variables.json", async (req) => {
             } else {
                 part &&
                     whereClauses.push(
-                        `${not} (REGEXP_LIKE(v.name, ${escape(part)}, 'i') OR REGEXP_LIKE(v.catalogPath, ${escape(part)}, 'i'))`
+                        `${not} (REGEXP_LIKE(v.name, ${escape(
+                            part
+                        )}, 'i') OR REGEXP_LIKE(v.catalogPath, ${escape(
+                            part
+                        )}, 'i'))`
                     )
             }
         }

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -419,7 +419,8 @@ export const fetchS3DataValuesByPath = async (
     )
     if (!resp.ok) {
         throw new Error(
-            `Error fetching data from S3 for ${dataPath}: ${resp.status} ${resp.statusText
+            `Error fetching data from S3 for ${dataPath}: ${resp.status} ${
+                resp.statusText
             } ${await resp.text()}`
         )
     }
@@ -438,7 +439,8 @@ export const fetchS3MetadataByPath = async (
     )
     if (!resp.ok) {
         throw new Error(
-            `Error fetching metadata from S3 for ${metadataPath}: ${resp.status
+            `Error fetching metadata from S3 for ${metadataPath}: ${
+                resp.status
             } ${resp.statusText} ${await resp.text()}`
         )
     }
@@ -469,7 +471,10 @@ export const readSQLasDF = async (
 /**
  * Perform regex search over the variables table.
  */
-export const searchVariables = async (query: string, limit: number): Promise<VariablesSearchResult> => {
+export const searchVariables = async (
+    query: string,
+    limit: number
+): Promise<VariablesSearchResult> => {
     const whereClauses = buildWhereClauses(query)
 
     const fromWhere = `
@@ -569,7 +574,9 @@ const buildWhereClauses = (query: string): string[] => {
             // NOTE: we don't have the table name in any db field, it's horrible to query
             q &&
                 whereClauses.push(
-                    `${not} REGEXP_LIKE(SUBSTRING_INDEX(SUBSTRING_INDEX(v.catalogPath, '/', 5), '/', -1), ${escape(q)}, 'i')`
+                    `${not} REGEXP_LIKE(SUBSTRING_INDEX(SUBSTRING_INDEX(v.catalogPath, '/', 5), '/', -1), ${escape(
+                        q
+                    )}, 'i')`
                 )
         } else if (part.startsWith("short:")) {
             const q = part.substring("short:".length)
@@ -600,7 +607,11 @@ const buildWhereClauses = (query: string): string[] => {
         } else {
             part &&
                 whereClauses.push(
-                    `${not} (REGEXP_LIKE(v.name, ${escape(part)}, 'i') OR REGEXP_LIKE(v.catalogPath, ${escape(part)}, 'i'))`
+                    `${not} (REGEXP_LIKE(v.name, ${escape(
+                        part
+                    )}, 'i') OR REGEXP_LIKE(v.catalogPath, ${escape(
+                        part
+                    )}, 'i'))`
                 )
         }
     }
@@ -609,8 +620,8 @@ const buildWhereClauses = (query: string): string[] => {
 
 /**
  * Run a MySQL query that's robust to regular expression failures, simply
- * returning an empty result if the query fails. 
- * 
+ * returning an empty result if the query fails.
+ *
  * This is useful if the regex is user-supplied and we want them to be able
  * to construct it incrementally.
  */


### PR DESCRIPTION
Improve search through our indicators in the admin with more expansive search and search verbs, Google style.

- `(no prefix)` searches name or path (regex)
- `name:` search the name only (regex)
- `path:` search the catalog path only (regex)
- Search part of the catalog path (like)
    - `namespace:`
    - `version:`
    - `dataset:`
    - `table:`
    - `short:`
- Search in time with `before:` and `after:`
- Negate a search term with `-` before it
- Search for private or public with `is:private` and `is:public`

## Todo

- [x] Draft search logic
- [x] Move search logic to its own module
- [x] Verify other locations where variables are listed still render nicely