### PR TITLE
🎉 Add support for small filename in gdocs images

### DIFF
--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -96,6 +96,9 @@ export class GdocBase extends BaseEntity implements OwidGdocBaseInterface {
                         if ("filename" in item && item.filename) {
                             filenames.add(item.filename)
                         }
+                        if (item.type === "image" && item.smallFilename) {
+                            filenames.add(item.smallFilename)
+                        }
                         if (item.type === "prominent-link" && item.thumbnail) {
                             filenames.add(item.thumbnail)
                         }

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -601,6 +601,7 @@ const parseImage = (image: RawBlockImage): EnrichedBlockImage => {
     return {
         type: "image",
         filename,
+        smallFilename: image.value.smallFilename,
         alt: image.value.alt,
         caption,
         size,

--- a/packages/@ourworldindata/components/src/styles/variables.scss
+++ b/packages/@ourworldindata/components/src/styles/variables.scss
@@ -9,7 +9,7 @@ $vertical-spacing: 16px;
 :root {
     --grid-gap: 24px;
 
-    @media (max-width: 798px) {
+    @media (max-width: 768px) {
         --grid-gap: 16px;
     }
 }

--- a/packages/@ourworldindata/components/src/styles/variables.scss
+++ b/packages/@ourworldindata/components/src/styles/variables.scss
@@ -52,7 +52,7 @@ $search-cta-height: 40px;
 * Breakpoints
 */
 
-// Calculations in Image.tsx rely on these variables. Please change them there if you change them here.
+// Calculations in Image.tsx and image.ts rely on these variables. Please change them there if you change them here.
 $sm: 768px;
 $md: 960px;
 $lg: 1280px;

--- a/packages/@ourworldindata/utils/src/image.ts
+++ b/packages/@ourworldindata/utils/src/image.ts
@@ -68,7 +68,12 @@ export type SourceProps = {
     srcSet: string
 }
 
-// When we have a small and large image, we want to generate two <source> elements, one of which will only be used on mobile
+/**
+ * When we have a small and large image, we want to generate two <source> elements.
+ * The first will only be active at small screen sizes, due to its `media` property.
+ * The second will be active at all screen sizes.
+ * These props work in conjuction with a `sizes` attribute on the <source> element.
+ */
 export function generateSourceProps(
     smallImage: ImageMetadata | undefined,
     regularImage: ImageMetadata

--- a/packages/@ourworldindata/utils/src/image.ts
+++ b/packages/@ourworldindata/utils/src/image.ts
@@ -62,3 +62,29 @@ export function getFilenameWithoutExtension(
 export function getFilenameAsPng(filename: ImageMetadata["filename"]): string {
     return `${getFilenameWithoutExtension(filename)}.png`
 }
+
+export type SourceProps = {
+    media: string | undefined
+    srcSet: string
+}
+
+// When we have a small and large image, we want to generate two <source> elements, one of which will only be used on mobile
+export function generateSourceProps(
+    smallImage: ImageMetadata | undefined,
+    regularImage: ImageMetadata
+): SourceProps[] {
+    const props: SourceProps[] = []
+    if (smallImage) {
+        const smallSizes = getSizes(smallImage.originalWidth)
+        props.push({
+            media: "(max-width: 768px)",
+            srcSet: generateSrcSet(smallSizes, smallImage.filename),
+        })
+    }
+    const regularSizes = getSizes(regularImage.originalWidth)
+    props.push({
+        media: undefined,
+        srcSet: generateSrcSet(regularSizes, regularImage.filename),
+    })
+    return props
+}

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -624,6 +624,8 @@ export {
     getFilenameAsPng,
     type GDriveImageMetadata,
     type ImageMetadata,
+    type SourceProps,
+    generateSourceProps,
 } from "./image.js"
 
 export { Tippy, TippyIfInteractive } from "./Tippy.js"

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -706,6 +706,7 @@ export type RawBlockImage = {
     type: "image"
     value: {
         filename?: string
+        smallFilename?: string
         alt?: string
         caption?: string
         size?: BlockImageSize
@@ -715,6 +716,7 @@ export type RawBlockImage = {
 export type EnrichedBlockImage = {
     type: "image"
     filename: string
+    smallFilename?: string
     alt?: string // optional as we can use the default alt from the file
     caption?: Span[]
     originalWidth?: number

--- a/site/gdocs/ArticleBlock.tsx
+++ b/site/gdocs/ArticleBlock.tsx
@@ -228,6 +228,7 @@ export default function ArticleBlock({
             >
                 <Image
                     filename={block.filename}
+                    smallFilename={block.smallFilename}
                     alt={block.alt}
                     containerType={containerType}
                 />

--- a/site/gdocs/Image.tsx
+++ b/site/gdocs/Image.tsx
@@ -1,10 +1,8 @@
 import React, { useContext } from "react"
 import {
-    getSizes,
-    generateSrcSet,
     getFilenameWithoutExtension,
     IMAGES_DIRECTORY,
-    identity,
+    generateSourceProps,
     ImageMetadata,
 } from "@ourworldindata/utils"
 import { LIGHTBOX_IMAGE_CLASS } from "../Lightbox.js"
@@ -142,32 +140,21 @@ export default function Image(props: {
         )
     }
 
-    let sizes = getSizes(image.originalWidth)
-    let smallSrcSet = ""
-    if (smallImage) {
-        /**
-         * If we have a small image
-         * 1. generate its srcSet
-         * 2. remove sizes that are smaller than it from the sizes of the larger image
-         * 3. generate the srcSet for the larger image
-         * 4. combine the two srcSets
-         * e.g. small_100.png 100px, small_350.png 350px, large_600.png 600px, large_850.png 850px
-         */
-        const smallSizes = getSizes(smallImage.originalWidth)
-        smallSrcSet = generateSrcSet(smallSizes, smallImage.filename)
-        sizes = sizes.filter((size) => size > smallImage.originalWidth!)
-    }
-    const srcSet = generateSrcSet(sizes, filename)
     const imageSrc = `${IMAGES_DIRECTORY}${filename}`
-    const finalSrcSet = [smallSrcSet, srcSet].filter(identity).join(", ")
+    const sourceProps = generateSourceProps(smallImage, image)
 
     return (
         <picture className={className}>
-            <source
-                srcSet={finalSrcSet}
-                type="image/webp"
-                sizes={containerSizes[containerType] ?? containerSizes.default}
-            />
+            {sourceProps.map((props, i) => (
+                <source
+                    key={i}
+                    {...props}
+                    type="image/webp"
+                    sizes={
+                        containerSizes[containerType] ?? containerSizes.default
+                    }
+                />
+            ))}
             <img
                 src={encodeURI(imageSrc)}
                 alt={alt}

--- a/site/gdocs/Image.tsx
+++ b/site/gdocs/Image.tsx
@@ -94,20 +94,25 @@ export default function Image(props: {
         const makePreviewUrl = (f: string) =>
             `${IMAGE_HOSTING_CDN_URL}/${IMAGE_HOSTING_BUCKET_SUBFOLDER_PATH}/${f}`
 
-        const previewSrcset = [smallImage, image]
-            .filter((i): i is ImageMetadata => !!i)
-            .map((i) => `${makePreviewUrl(i.filename)} ${i.originalWidth}w`)
-            .join(", ")
+        const PreviewSource = (props: { i?: ImageMetadata; sm?: boolean }) => {
+            const { i, sm } = props
+            if (!i) return null
 
-        return (
-            <picture className={className}>
+            return (
                 <source
-                    srcSet={previewSrcset}
+                    srcSet={`${makePreviewUrl(i.filename)} ${i.originalWidth}w`}
+                    media={sm ? "(max-width: 798px)" : undefined}
                     type="image/webp"
                     sizes={
                         containerSizes[containerType] ?? containerSizes.default
                     }
                 />
+            )
+        }
+        return (
+            <picture className={className}>
+                <PreviewSource i={smallImage} sm />
+                <PreviewSource i={image} />
                 <img
                     src={makePreviewUrl(image.filename)}
                     alt={alt}

--- a/site/gdocs/Image.tsx
+++ b/site/gdocs/Image.tsx
@@ -92,7 +92,9 @@ export default function Image(props: {
 
     if (isPreviewing) {
         const makePreviewUrl = (f: string) =>
-            `${IMAGE_HOSTING_CDN_URL}/${IMAGE_HOSTING_BUCKET_SUBFOLDER_PATH}/${f}`
+            encodeURI(
+                `${IMAGE_HOSTING_CDN_URL}/${IMAGE_HOSTING_BUCKET_SUBFOLDER_PATH}/${f}`
+            )
 
         const PreviewSource = (props: { i?: ImageMetadata; sm?: boolean }) => {
             const { i, sm } = props
@@ -101,7 +103,7 @@ export default function Image(props: {
             return (
                 <source
                     srcSet={`${makePreviewUrl(i.filename)} ${i.originalWidth}w`}
-                    media={sm ? "(max-width: 798px)" : undefined}
+                    media={sm ? "(max-width: 768px)" : undefined}
                     type="image/webp"
                     sizes={
                         containerSizes[containerType] ?? containerSizes.default


### PR DESCRIPTION
Adds an optional `smallFilename` property to the `{.image}` component in archie.

This small image is assumed to be smaller than the regular image, and will show when the `Image` component's `img` tag has a width that is less than or equal to the width of the small image.

e.g.

```
{.image}
filename: large.png
smallFilename: small.png
{}
```

This will generate two `<source>` elements for the Image's `<picture>` to consider. The first one will only be active when the viewport width is less than 768px, the second source will always be active.

When previewing, it only uses the Digital Ocean CDN to load the original versions of the images (i.e. a srcset with only one URL specified.)

When baking, it makes multiple resizes of each image and includes all of those in the srcset.


https://github.com/owid/owid-grapher/assets/11844404/9c56435e-9f27-463e-bd35-7fb9e25ad8c5



## Testing guidelines:
You can use the following archie to test it:
```
{.image}
filename: ike-test-life-expectancy-large.png
smallFilename: ike-test-life-expectancy-small.png
{}

{.image}
filename: ike-test-life-expectancy-large.png
{}
```
It should work as expected in the preview, with DPR 2.0 and DPR 1.0

And then if you publish it and run `node itsJustJavascript/baker/buildLocalBake.js --steps gdocPosts gdriveImages` and then `yarn startLocalBakeServer`

it should work with all the resized versions of those two images as expected  http://127.0.0.1:3000/your-article-slug-here.html