### PR TITLE
GDoc migration: normalize headings

### DIFF
--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -8,7 +8,6 @@ import {
     OwidGdocType,
     RelatedChart,
     EnrichedBlockAllCharts,
-    OwidEnrichedGdocBlock,
 } from "@ourworldindata/utils"
 import * as Post from "./model/Post.js"
 import fs from "fs"
@@ -17,6 +16,7 @@ import {
     withoutEmptyOrWhitespaceOnlyTextBlocks,
     convertAllWpComponentsToArchieMLBlocks,
     adjustHeadingLevels,
+    findMinimumHeadingLevel,
 } from "./model/Gdoc/htmlToEnriched.js"
 import { getRelatedCharts, isPostCitable } from "./wpdb.js"
 import { parsePostAuthors } from "./model/Post.js"
@@ -286,23 +286,6 @@ const migrate = async (): Promise<void> => {
         console.error("Errors", errors)
         throw new Error(`${errors.length} items had errors`)
     }
-}
-
-function findMinimumHeadingLevel(blocks: OwidEnrichedGdocBlock[]): number {
-    let minBlockLevel = 6
-    for (const block of blocks) {
-        if (block.type === "heading") {
-            minBlockLevel = Math.min(block.level, minBlockLevel)
-        } else if ("children" in block) {
-            minBlockLevel = Math.min(
-                findMinimumHeadingLevel(
-                    block.children as OwidEnrichedGdocBlock[]
-                ),
-                minBlockLevel
-            )
-        }
-    }
-    return minBlockLevel
 }
 
 migrate()

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -93,7 +93,7 @@ const migrate = async (): Promise<void> => {
         "created_at_in_wordpress",
         "updated_at",
         "featured_image"
-    ).from(db.knexTable(Post.postsTable)) //.where("id", "=", "24808"))
+    ).from(db.knexTable(Post.postsTable)) //.where("id", "=", "54759"))
 
     for (const post of posts) {
         try {
@@ -139,7 +139,8 @@ const migrate = async (): Promise<void> => {
 
             // Heading levels used to start at 2, in the new layout system they start at 1
             // This function iterates all blocks recursively and adjusts the heading levels inline
-            // If the article is an entry, we also put an <hr /> above and below h1's
+            // If the article is an entry, we also put an <hr /> above and below h1's. The adjustment
+            // pulls heading levels up so that entries end up with h1s and others with h2s at the top.
             const minHeadingLevel =
                 findMinimumHeadingLevel(archieMlBodyElements)
             adjustHeadingLevels(archieMlBodyElements, minHeadingLevel, isEntry)

--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -395,6 +395,25 @@ export function convertAllWpComponentsToArchieMLBlocks(
     })
 }
 
+export function findMinimumHeadingLevel(
+    blocks: OwidEnrichedGdocBlock[]
+): number {
+    let minBlockLevel = 6
+    for (const block of blocks) {
+        if (block.type === "heading") {
+            minBlockLevel = Math.min(block.level, minBlockLevel)
+        } else if ("children" in block) {
+            minBlockLevel = Math.min(
+                findMinimumHeadingLevel(
+                    block.children as OwidEnrichedGdocBlock[]
+                ),
+                minBlockLevel
+            )
+        }
+    }
+    return minBlockLevel
+}
+
 export function adjustHeadingLevels(
     blocks: OwidEnrichedGdocBlock[],
     minHeadingLevel: number,

--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -397,6 +397,7 @@ export function convertAllWpComponentsToArchieMLBlocks(
 
 export function adjustHeadingLevels(
     blocks: OwidEnrichedGdocBlock[],
+    minHeadingLevel: number,
     isEntry: boolean
 ): void {
     for (let i = 0; i < blocks.length; i++) {
@@ -411,10 +412,11 @@ export function adjustHeadingLevels(
                 blocks.splice(i + 2, 0, { ...hr })
                 i += 2
             }
-            block.level = Math.max(1, block.level - 1)
+            block.level = block.level - (minHeadingLevel - 1)
         } else if ("children" in block) {
             adjustHeadingLevels(
                 block.children as OwidEnrichedGdocBlock[],
+                minHeadingLevel,
                 isEntry
             )
         }

--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -412,7 +412,10 @@ export function adjustHeadingLevels(
                 blocks.splice(i + 2, 0, { ...hr })
                 i += 2
             }
-            block.level = block.level - (minHeadingLevel - 1)
+            const correction = isEntry
+                ? minHeadingLevel - 1
+                : Math.max(0, minHeadingLevel - 2)
+            block.level = block.level - correction
         } else if ("children" in block) {
             adjustHeadingLevels(
                 block.children as OwidEnrichedGdocBlock[],


### PR DESCRIPTION
This PR normalizes the heading levels so that the relative distance between headings is kept as before but the biggest heading used is h1 for entries/linear topic pages and h2 for others.