### PR TITLE
✨ add formatting options column to wp posts table

### DIFF
--- a/baker/formatWordpressPost.tsx
+++ b/baker/formatWordpressPost.tsx
@@ -16,6 +16,7 @@ import {
     JsonError,
     TocHeading,
     WP_BlockType,
+    parseKeyValueArgs,
 } from "@ourworldindata/utils"
 import { Footnote } from "../site/Footnote.js"
 import { LoadingIndicator } from "@ourworldindata/grapher"
@@ -28,7 +29,6 @@ import {
     extractDataValuesConfiguration,
     formatDataValue,
     formatImages,
-    parseKeyValueArgs,
 } from "./formatting.js"
 import { mathjax } from "mathjax-full/js/mathjax.js"
 import { TeX } from "mathjax-full/js/input/tex.js"

--- a/baker/formatting.test.ts
+++ b/baker/formatting.test.ts
@@ -1,10 +1,11 @@
 #! /usr/bin/env jest
 
+import { extractDataValuesConfiguration } from "./formatting.js"
+
 import {
-    extractDataValuesConfiguration,
     parseFormattingOptions,
     parseKeyValueArgs,
-} from "./formatting.js"
+} from "@ourworldindata/utils"
 
 it("parses formatting options", () => {
     const formattingOptions =

--- a/baker/formatting.tsx
+++ b/baker/formatting.tsx
@@ -3,8 +3,6 @@ import {
     DataValueConfiguration,
     DataValueQueryArgs,
     FormattedPost,
-    FormattingOptions,
-    KeyValueProps,
     OwidVariableId,
     Country,
     OwidVariableDataMetadataDimensions,
@@ -12,8 +10,6 @@ import {
     OwidVariableDisplayConfigInterface,
     capitalize,
     Url,
-    extractFormattingOptions,
-    parseFormattingOptions,
     parseKeyValueArgs,
 } from "@ourworldindata/utils"
 import { countryProfileDefaultCountryPlaceholder } from "../site/countryProfileProjects.js"

--- a/baker/formatting.tsx
+++ b/baker/formatting.tsx
@@ -12,6 +12,9 @@ import {
     OwidVariableDisplayConfigInterface,
     capitalize,
     Url,
+    extractFormattingOptions,
+    parseFormattingOptions,
+    parseKeyValueArgs,
 } from "@ourworldindata/utils"
 import { countryProfileDefaultCountryPlaceholder } from "../site/countryProfileProjects.js"
 import { BAKED_BASE_URL } from "../settings/serverSettings.js"
@@ -21,21 +24,6 @@ import { getBodyHtml } from "../site/formatting.js"
 import path from "path"
 
 export const DEEP_LINK_CLASS = "deep-link"
-
-export const extractFormattingOptions = (html: string): FormattingOptions => {
-    const formattingOptionsMatch = html.match(
-        /<!--\s*formatting-options\s+(.*)\s*-->/
-    )
-    return formattingOptionsMatch
-        ? parseFormattingOptions(formattingOptionsMatch[1])
-        : {}
-}
-
-// Converts "toc:false raw somekey:somevalue" to { toc: false, raw: true, somekey: "somevalue" }
-// If only the key is specified, the value is assumed to be true (e.g. "raw" above)
-export const parseFormattingOptions = (text: string): FormattingOptions => {
-    return parseKeyValueArgs(text)
-}
 
 export const dataValueRegex = new RegExp(
     `{{\\s*${DATA_VALUE}\\s*(.+?)\\s*}}`,
@@ -72,29 +60,6 @@ export const parseDataValueArgs = (
             Number(v),
         ])
     )
-}
-
-export const parseKeyValueArgs = (text: string): KeyValueProps => {
-    const options: { [key: string]: string | boolean } = {}
-    text.split(/\s+/)
-        // filter out empty strings
-        .filter((s) => s && s.length > 0)
-        .forEach((option: string) => {
-            // using regex instead of split(":") to handle ":" in value
-            // e.g. {{LastUpdated timestampUrl:https://...}}
-            const optionRegex = /([^:]+):?(.*)/
-            const [, name, value] = option.match(optionRegex) as [
-                any,
-                string,
-                string,
-            ]
-            let parsedValue
-            if (value === "" || value === "true") parsedValue = true
-            else if (value === "false") parsedValue = false
-            else parsedValue = value
-            options[name] = parsedValue
-        })
-    return options
 }
 
 export const formatDataValue = (

--- a/baker/pageOverrides.test.ts
+++ b/baker/pageOverrides.test.ts
@@ -1,5 +1,8 @@
-import { FullPost, WP_PostType } from "@ourworldindata/utils"
-import { extractFormattingOptions } from "./formatting.js"
+import {
+    FullPost,
+    WP_PostType,
+    extractFormattingOptions,
+} from "@ourworldindata/utils"
 import * as pageOverrides from "./pageOverrides.js"
 
 import { jest } from "@jest/globals"

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -16,11 +16,7 @@ import OwidGdocPage from "../site/gdocs/OwidGdocPage.js"
 import React from "react"
 import ReactDOMServer from "react-dom/server.js"
 import * as lodash from "lodash"
-import {
-    extractFormattingOptions,
-    formatCountryProfile,
-    isCanonicalInternalUrl,
-} from "./formatting.js"
+import { formatCountryProfile, isCanonicalInternalUrl } from "./formatting.js"
 import {
     bakeGrapherUrls,
     getGrapherExportsByUrl,
@@ -59,6 +55,7 @@ import {
     IndexPost,
     mergePartialGrapherConfigs,
     OwidGdocType,
+    extractFormattingOptions,
 } from "@ourworldindata/utils"
 import { CountryProfileSpec } from "../site/countryProfileProjects.js"
 import { formatPost } from "./formatWordpressPost.js"

--- a/db/migration/1702473994107-PostsAddFormattingOptions.ts
+++ b/db/migration/1702473994107-PostsAddFormattingOptions.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class PostsAddFormattingOptions1702473994107
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // add json column formattingOptions to posts mysql table
+        await queryRunner.query(
+            "ALTER TABLE posts ADD COLUMN formattingOptions JSON"
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // remove json column formattingOptions from posts mysql table
+        await queryRunner.query(
+            "ALTER TABLE posts DROP COLUMN formattingOptions"
+        )
+    }
+}

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -641,3 +641,9 @@ export {
     gdocUrlRegex,
     gdocIdRegex,
 } from "./GdocsConstants.js"
+
+export {
+    extractFormattingOptions,
+    parseFormattingOptions,
+    parseKeyValueArgs,
+} from "./wordpressUtils.js"

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -183,6 +183,7 @@ export interface PostRow {
     excerpt: string
     created_at_in_wordpress: Date | null
     featured_image: string
+    formattingOptions: FormattingOptions
 }
 
 export interface PostRowWithGdocPublishStatus extends PostRow {

--- a/packages/@ourworldindata/utils/src/wordpressUtils.ts
+++ b/packages/@ourworldindata/utils/src/wordpressUtils.ts
@@ -1,0 +1,39 @@
+import { FormattingOptions, KeyValueProps } from "./owidTypes.js"
+
+export const extractFormattingOptions = (html: string): FormattingOptions => {
+    const formattingOptionsMatch = html.match(
+        /<!--\s*formatting-options\s+(.*)\s*-->/
+    )
+    return formattingOptionsMatch
+        ? parseFormattingOptions(formattingOptionsMatch[1])
+        : {}
+}
+
+// Converts "toc:false raw somekey:somevalue" to { toc: false, raw: true, somekey: "somevalue" }
+// If only the key is specified, the value is assumed to be true (e.g. "raw" above)
+export const parseFormattingOptions = (text: string): FormattingOptions => {
+    return parseKeyValueArgs(text)
+}
+
+export const parseKeyValueArgs = (text: string): KeyValueProps => {
+    const options: { [key: string]: string | boolean } = {}
+    text.split(/\s+/)
+        // filter out empty strings
+        .filter((s) => s && s.length > 0)
+        .forEach((option: string) => {
+            // using regex instead of split(":") to handle ":" in value
+            // e.g. {{LastUpdated timestampUrl:https://...}}
+            const optionRegex = /([^:]+):?(.*)/
+            const [, name, value] = option.match(optionRegex) as [
+                any,
+                string,
+                string,
+            ]
+            let parsedValue
+            if (value === "" || value === "true") parsedValue = true
+            else if (value === "false") parsedValue = false
+            else parsedValue = value
+            options[name] = parsedValue
+        })
+    return options
+}

--- a/packages/@ourworldindata/utils/src/wordpressUtils.ts
+++ b/packages/@ourworldindata/utils/src/wordpressUtils.ts
@@ -2,10 +2,13 @@ import { FormattingOptions, KeyValueProps } from "./owidTypes.js"
 
 export const extractFormattingOptions = (html: string): FormattingOptions => {
     const formattingOptionsMatch = html.match(
-        /<!--\s*formatting-options\s+(.*)\s*-->/
+        /<!--\s*formatting-options(.*)-->/
     )
+    const innerFormattingOptions = formattingOptionsMatch
+        ? formattingOptionsMatch[1].trim()
+        : ""
     return formattingOptionsMatch
-        ? parseFormattingOptions(formattingOptionsMatch[1])
+        ? parseFormattingOptions(innerFormattingOptions)
         : {}
 }
 


### PR DESCRIPTION
This PR adds formattingOptions as a json column on the posts table. This is useful e.g. for identifying modular topic pages ($.bodyClassName = 'topic-page') or for identifying admin pages ($.subnavId = 'about')