### PR TITLE
Add support for changing the entity when faceted by metric

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2870,7 +2870,7 @@ export class Grapher
             return true
         if (
             this.addCountryMode === EntitySelectionMode.SingleEntity &&
-            this.facetStrategy !== FacetStrategy.none
+            this.facetStrategy === FacetStrategy.entity
         )
             return true
 


### PR DESCRIPTION
- If a faceting strategy is specified, we force the "add-entity" button, regardless of the author's settings
- That makes sense if the chart is faceted by entity (because in that case, a single entity chart doesn't make sense)
- But if faceted by metric, it should be possible to use the "change-entity" button

I'm worried what this does to charts where the faceting toggle is not hidden:
- If the config specifies the "change-entity" button, then it might happen that:
   - If the user switches from splitting by entity to splitting by metric:  "add-entity" button changes to "change-entity" button
   - If the user switches from splitting by metric to splitting by entity: "change-entity" button changes to "add-entity" button

A feasible solution might be to only support the "change-entity" button for charts split by metric _if the faceting toggle is hidden_. Will look at examples next week when I have some more time!