### PR TITLE
Simplify authors fields in posts table, introduce better DB interaction for Posts

### DIFF
--- a/adminSiteClient/PostsIndexPage.tsx
+++ b/adminSiteClient/PostsIndexPage.tsx
@@ -34,9 +34,9 @@ interface PostIndexMeta {
     title: string
     type: string
     status: string
-    authors: string[]
+    authors: string[] | null
     slug: string
-    updatedAtInWordpress: string
+    updatedAtInWordpress: string | null
     tags: ChartTagJoin[] | null
     gdocSuccessorId: string | undefined
     gdocSuccessorPublished: boolean
@@ -209,7 +209,7 @@ class PostRow extends React.Component<PostRowProps> {
         return (
             <tr>
                 <td>{post.title || "(no title)"}</td>
-                <td>{post.authors.join(", ")}</td>
+                <td>{post.authors?.join(", ")}</td>
                 <td>{post.type}</td>
                 <td>{post.status}</td>
                 <td>{post.slug}</td>
@@ -273,7 +273,7 @@ export class PostsIndexPage extends React.Component {
                     post.title,
                     post.slug,
                     `${post.id}`,
-                    post.authors.join(" "),
+                    post.authors?.join(" "),
                 ]
             )
             return posts.filter(filterFn)

--- a/adminSiteServer/adminRouter.tsx
+++ b/adminSiteServer/adminRouter.tsx
@@ -178,6 +178,14 @@ adminRouter.get("/posts/compare/:postId", async (req, res) => {
         "archieml",
         "archieml_update_statistics"
     ).from(db.knexTable(Post.postsTable).where({ id: postId }))
+    if (
+        archieMlText.length === 0 ||
+        archieMlText[0].archieml === null ||
+        archieMlText[0].archieml_update_statistics === null
+    )
+        throw new Error(
+            `Could not compare posts because archieml was not present in the database for ${postId}`
+        )
     const archieMlJson = JSON.parse(archieMlText[0].archieml) as OwidGdocJSON
     const updateStatsJson = JSON.parse(
         archieMlText[0].archieml_update_statistics

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -37,7 +37,7 @@ import {
     OwidGdocInterface,
     parseIntOrUndefined,
     parseToOperation,
-    PostRow,
+    PostRowEnriched,
     PostRowWithGdocPublishStatus,
     SuggestedChartRevisionStatus,
     variableAnnotationAllowedColumnNamesAndTypes,
@@ -2370,7 +2370,7 @@ apiRouter.get("/posts/:postId.json", async (req: Request, res: Response) => {
         .knexTable(postsTable)
         .where({ id: postId })
         .select("*")
-        .first()) as PostRow | undefined
+        .first()) as PostRowEnriched | undefined
     return camelCaseProperties({ ...post })
 })
 

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -2323,7 +2323,7 @@ apiRouter.get("/posts.json", async (req) => {
              posts.slug as slug,
              status,
              updated_at_in_wordpress,
-             posts.authors, -- authors is a json array of objects with name and order
+             posts.authors,
              posts_tags_aggregated.tags as tags,
              gdocSuccessorId,
              gdocSuccessor.published as isGdocSuccessorPublished,
@@ -2343,11 +2343,7 @@ apiRouter.get("/posts.json", async (req) => {
         tags: JSON.parse(row.tags),
         isGdocSuccessorPublished: !!row.isGdocSuccessorPublished,
         gdocSlugSuccessors: JSON.parse(row.gdocSlugSuccessors),
-        authors: row.authors
-            ? sortBy(JSON.parse(row.authors), "order").map(
-                  (author) => author.author
-              )
-            : [],
+        authors: JSON.parse(row.authors),
     }))
 
     return { posts: rows }
@@ -2393,6 +2389,11 @@ apiRouter.post("/posts/:postId/createGdoc", async (req: Request) => {
             400
         )
     }
+    if (post.archieml === null)
+        throw new JsonError(
+            `ArchieML was not present for post with id ${postId}`,
+            500
+        )
     const tagsByPostId = await getTagsByPostId()
     const tags =
         tagsByPostId.get(postId)?.map(({ id }) => TagEntity.create({ id })) ||

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -48,7 +48,6 @@ import {
     DimensionProperty,
     TaggableType,
     ChartTagJoin,
-    sortBy,
 } from "@ourworldindata/utils"
 import {
     GrapherInterface,

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -44,7 +44,7 @@ import {
 import * as db from "../db/db.js"
 import { glob } from "glob"
 import { isPathRedirectedToExplorer } from "../explorerAdminServer/ExplorerRedirects.js"
-import { bySlug, getPostBySlug, parsePostAuthors } from "../db/model/Post.js"
+import { getPostEnrichedBySlug } from "../db/model/Post.js"
 import { ChartTypeName, GrapherInterface } from "@ourworldindata/grapher"
 import workerpool from "workerpool"
 import ProgressBar from "progress"
@@ -298,9 +298,9 @@ export async function renderDataPageV2({
                 citation,
             }
         } else {
-            const post = await bySlug(slug)
+            const post = await getPostEnrichedBySlug(slug)
             if (post) {
-                const authors = parsePostAuthors(post.authors)
+                const authors = post.authors
                 const citation = getShortPageCitation(
                     authors,
                     post.title,
@@ -359,7 +359,7 @@ export const renderPreviewDataPageOrGrapherPage = async (
 
 const renderGrapherPage = async (grapher: GrapherInterface) => {
     const postSlug = urlToSlug(grapher.originUrl || "")
-    const post = postSlug ? await getPostBySlug(postSlug) : undefined
+    const post = postSlug ? await getPostEnrichedBySlug(postSlug) : undefined
     const relatedCharts =
         post && isWordpressDBEnabled
             ? await getRelatedCharts(post.id)

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -302,7 +302,7 @@ export async function renderDataPageV2({
             if (post) {
                 const authors = post.authors
                 const citation = getShortPageCitation(
-                    authors,
+                    authors ?? [],
                     post.title,
                     post.published_at
                 )

--- a/baker/postUpdatedHook.ts
+++ b/baker/postUpdatedHook.ts
@@ -4,7 +4,11 @@ import parseArgs from "minimist"
 import { BAKE_ON_CHANGE } from "../settings/serverSettings.js"
 import { DeployQueueServer } from "./DeployQueueServer.js"
 import { exit } from "../db/cleanup.js"
-import { PostRow, extractFormattingOptions } from "@ourworldindata/utils"
+import {
+    PostRow,
+    extractFormattingOptions,
+    sortBy,
+} from "@ourworldindata/utils"
 import * as wpdb from "../db/wpdb.js"
 import * as db from "../db/db.js"
 import {
@@ -96,7 +100,10 @@ const syncPostToGrapher = async (
     const wpPost = rows[0]
 
     const formattingOptions = extractFormattingOptions(wpPost.post_content)
-
+    const authors: string[] = sortBy(
+        JSON.parse(wpPost.authors),
+        (item: { author: string; order: number }) => item.order
+    ).map((author: { author: string; order: number }) => author.author)
     const postRow = wpPost
         ? ({
               id: wpPost.ID,
@@ -114,7 +121,7 @@ const syncPostToGrapher = async (
                   wpPost.post_modified_gmt === zeroDateString
                       ? "1970-01-01 00:00:00"
                       : wpPost.post_modified_gmt,
-              authors: wpPost.authors,
+              authors: JSON.stringify(authors),
               excerpt: wpPost.post_excerpt,
               created_at_in_wordpress:
                   wpPost.created_at === zeroDateString

--- a/baker/postUpdatedHook.ts
+++ b/baker/postUpdatedHook.ts
@@ -5,9 +5,10 @@ import { BAKE_ON_CHANGE } from "../settings/serverSettings.js"
 import { DeployQueueServer } from "./DeployQueueServer.js"
 import { exit } from "../db/cleanup.js"
 import {
-    PostRow,
+    PostRowEnriched,
     extractFormattingOptions,
     sortBy,
+    serializePostRow,
 } from "@ourworldindata/utils"
 import * as wpdb from "../db/wpdb.js"
 import * as db from "../db/db.js"
@@ -121,14 +122,14 @@ const syncPostToGrapher = async (
                   wpPost.post_modified_gmt === zeroDateString
                       ? "1970-01-01 00:00:00"
                       : wpPost.post_modified_gmt,
-              authors: JSON.stringify(authors),
+              authors: authors,
               excerpt: wpPost.post_excerpt,
               created_at_in_wordpress:
                   wpPost.created_at === zeroDateString
                       ? "1970-01-01 00:00:00"
                       : wpPost.created_at,
               formattingOptions: formattingOptions,
-          } as PostRow)
+          } as PostRowEnriched)
         : undefined
 
     await db.knexInstance().transaction(async (transaction) => {
@@ -141,11 +142,7 @@ const syncPostToGrapher = async (
             )
             postRow.content = contentWithBlocksInlined
 
-            const rowForDb = {
-                ...postRow,
-                // TODO: it's not nice that we have to stringify this here
-                formattingOptions: JSON.stringify(postRow.formattingOptions),
-            }
+            const rowForDb = serializePostRow(postRow)
 
             if (!existsInGrapher)
                 await transaction.table(postsTable).insert(rowForDb)

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -50,12 +50,12 @@ import {
     JsonError,
     KeyInsight,
     OwidGdocInterface,
-    PostRowEnriched,
     Url,
     IndexPost,
     mergePartialGrapherConfigs,
     OwidGdocType,
     extractFormattingOptions,
+    PostRowRaw,
 } from "@ourworldindata/utils"
 import { CountryProfileSpec } from "../site/countryProfileProjects.js"
 import { formatPost } from "./formatWordpressPost.js"
@@ -435,7 +435,7 @@ export const entriesByYearPage = async (year?: number) => {
         .join("tags", { "tags.id": "post_tags.tag_id" })
         .where({ "tags.name": "Entries" })
         .select("title", "posts.slug", "published_at")) as Pick<
-        PostRowEnriched,
+        PostRowRaw,
         "title" | "slug" | "published_at"
     >[]
 

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -50,7 +50,7 @@ import {
     JsonError,
     KeyInsight,
     OwidGdocInterface,
-    PostRow,
+    PostRowEnriched,
     Url,
     IndexPost,
     mergePartialGrapherConfigs,
@@ -435,7 +435,7 @@ export const entriesByYearPage = async (year?: number) => {
         .join("tags", { "tags.id": "post_tags.tag_id" })
         .where({ "tags.name": "Entries" })
         .select("title", "posts.slug", "published_at")) as Pick<
-        PostRow,
+        PostRowEnriched,
         "title" | "slug" | "published_at"
     >[]
 

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -98,7 +98,9 @@ const migrate = async (): Promise<void> => {
         try {
             const post = {
                 ...postRaw,
-                authors: parsePostAuthors(postRaw.authors),
+                authors: postRaw.authors
+                    ? parsePostAuthors(postRaw.authors)
+                    : null,
             }
             const isEntry = entries.has(post.slug)
             const text = post.content
@@ -113,6 +115,7 @@ const migrate = async (): Promise<void> => {
             )
             if (
                 shouldIncludeMaxAsAuthor &&
+                post.authors &&
                 !post.authors.includes("Max Roser")
             ) {
                 post.authors.push("Max Roser")
@@ -198,9 +201,9 @@ const migrate = async (): Promise<void> => {
                     body: archieMlBodyElements,
                     toc: [],
                     title: post.title,
-                    subtitle: post.excerpt,
-                    excerpt: post.excerpt,
-                    authors: post.authors,
+                    subtitle: post.excerpt ?? "",
+                    excerpt: post.excerpt ?? "",
+                    authors: post.authors ?? [],
                     "featured-image": post.featured_image.split("/").at(-1),
                     dateline: dateline,
                     // TODO: this discards block level elements - those might be needed?

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -1,6 +1,11 @@
 import * as db from "../db.js"
 import { Knex } from "knex"
-import { PostRowRaw, sortBy } from "@ourworldindata/utils"
+import {
+    PostRowEnriched,
+    PostRowRaw,
+    parsePostRow,
+    sortBy,
+} from "@ourworldindata/utils"
 
 export const postsTable = "posts"
 
@@ -46,9 +51,6 @@ export const setTags = async (
             )
     })
 
-export const bySlug = async (slug: string): Promise<PostRowRaw | undefined> =>
-    (await db.knexTable("posts").where({ slug: slug }))[0]
-
 export const setTagsForPost = async (
     postId: number,
     tagIds: number[]
@@ -63,7 +65,15 @@ export const setTagsForPost = async (
             )
     })
 
-export const getPostBySlug = async (
+export const getPostRawBySlug = async (
     slug: string
 ): Promise<PostRowRaw | undefined> =>
     (await db.knexTable("posts").where({ slug: slug }))[0]
+
+export const getPostEnrichedBySlug = async (
+    slug: string
+): Promise<PostRowEnriched | undefined> => {
+    const post = await getPostRawBySlug(slug)
+    if (!post) return undefined
+    return parsePostRow(post)
+}

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -4,7 +4,6 @@ import {
     PostRowEnriched,
     PostRowRaw,
     parsePostRow,
-    sortBy,
 } from "@ourworldindata/utils"
 
 export const postsTable = "posts"

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -1,14 +1,14 @@
 import * as db from "../db.js"
 import { Knex } from "knex"
-import { PostRow, sortBy } from "@ourworldindata/utils"
+import { PostRowRaw, sortBy } from "@ourworldindata/utils"
 
 export const postsTable = "posts"
 
-export const table = "posts"
-
-export const select = <K extends keyof PostRow>(
+export const select = <K extends keyof PostRowRaw>(
     ...args: K[]
-): { from: (query: Knex.QueryBuilder) => Promise<Pick<PostRow, K>[]> } => ({
+): {
+    from: (query: Knex.QueryBuilder) => Promise<Pick<PostRowRaw, K>[]>
+} => ({
     from: (query) => query.select(...args) as any,
 })
 
@@ -46,16 +46,8 @@ export const setTags = async (
             )
     })
 
-export const bySlug = async (slug: string): Promise<PostRow | undefined> =>
+export const bySlug = async (slug: string): Promise<PostRowRaw | undefined> =>
     (await db.knexTable("posts").where({ slug: slug }))[0]
-
-/** The authors field in the posts table is a json column that contains an array of
-    { order: 1, authors: "Max Mustermann" } like records. This function parses the
-    string and returns a simple string array of author names in the correct order  */
-export const parsePostAuthors = (authorsJson: string): string[] => {
-    const authors = JSON.parse(authorsJson)
-    return sortBy(authors, ["order"]).map((author) => author.author)
-}
 
 export const setTagsForPost = async (
     postId: number,
@@ -73,5 +65,5 @@ export const setTagsForPost = async (
 
 export const getPostBySlug = async (
     slug: string
-): Promise<PostRow | undefined> =>
+): Promise<PostRowRaw | undefined> =>
     (await db.knexTable("posts").where({ slug: slug }))[0]

--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -9,6 +9,7 @@ import {
     groupBy,
     keyBy,
     PostRow,
+    sortBy,
 } from "@ourworldindata/utils"
 import { postsTable, select } from "./model/Post.js"
 import { PostLink } from "./model/PostLink.js"
@@ -285,6 +286,10 @@ const syncPostsToGrapher = async (): Promise<void> => {
     const toInsert = rows.map((post: any) => {
         const content = post.post_content as string
         const formattingOptions = extractFormattingOptions(content)
+        const authors: string[] = sortBy(
+            JSON.parse(post.authors),
+            (item: { author: string; order: number }) => item.order
+        ).map((author: { author: string; order: number }) => author.author)
 
         return {
             id: post.ID,
@@ -302,7 +307,7 @@ const syncPostsToGrapher = async (): Promise<void> => {
                 post.post_modified_gmt === zeroDateString
                     ? "1970-01-01 00:00:00"
                     : post.post_modified_gmt,
-            authors: post.authors,
+            authors: JSON.stringify(authors),
             excerpt: post.post_excerpt,
             created_at_in_wordpress:
                 post.created_at === zeroDateString ? null : post.created_at,

--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -62,7 +62,7 @@ function buildReplacerFunction(
     ) => {
         const block = blocks[matches["id"].toString()]
         return block
-            ? `<!-- wp-block-tombstone ${matches["id"]} -->` +
+            ? `<!-- wp-block-tombstone ${matches["id"]} -->\n` +
                   block.post_content
             : ""
     }

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -794,22 +794,13 @@ export const getRelatedResearchAndWritingForVariable = async (
 
     const allSortedRelatedResearch = sorted.map((post) => {
         const parsedAuthors = JSON.parse(post.authors)
-        // The authors in the gdocs table are just a list of strings, but in the wp_posts table
-        // they are a list of objects with an "author" key and an "order" key. We want to normalize this so that
-        // we can just use the same code to display the authors in both cases.
-        let authors
-        if (parsedAuthors.length > 0 && !isString(parsedAuthors[0])) {
-            authors = sortBy(parsedAuthors, (author) => author.order).map(
-                (author: any) => author.author
-            )
-        } else authors = parsedAuthors
         const parsedTags = post.tags !== "" ? JSON.parse(post.tags) : []
 
         return {
             title: post.title,
             url: `/${post.postSlug}`,
             variantName: "",
-            authors,
+            authors: parsedAuthors,
             imageUrl: post.thumbnail,
             tags: parsedTags,
         }

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -38,7 +38,6 @@ import {
     uniqBy,
     sortBy,
     DataPageRelatedResearch,
-    isString,
     OwidGdocType,
     Tag,
 } from "@ourworldindata/utils"

--- a/packages/@ourworldindata/utils/src/dbTypes/Posts.ts
+++ b/packages/@ourworldindata/utils/src/dbTypes/Posts.ts
@@ -1,0 +1,31 @@
+import { FormattingOptions, WP_PostType } from "../owidTypes.js"
+
+export interface PostRowPlainFields {
+    id: number
+    title: string
+    slug: string
+    type: WP_PostType
+    status: string
+    content: string
+    published_at: Date | null
+    updated_at: Date | null
+    updated_at_in_wordpress: Date | null
+    archieml: string
+    archieml_update_statistics: string
+    gdocSuccessorId: string | null
+    excerpt: string
+    created_at_in_wordpress: Date | null
+    featured_image: string
+}
+
+export interface PostRowUnparsedFields {
+    authors: string
+    formattingOptions: string
+}
+
+export interface PostRowParsedFields {
+    authors: string[]
+    formattingOptions: FormattingOptions
+}
+export type PostRowRaw = PostRowPlainFields & PostRowUnparsedFields
+export type PostRowEnriched = PostRowPlainFields & PostRowParsedFields

--- a/packages/@ourworldindata/utils/src/dbTypes/Posts.ts
+++ b/packages/@ourworldindata/utils/src/dbTypes/Posts.ts
@@ -1,4 +1,9 @@
-import { FormattingOptions, WP_PostType } from "../owidTypes.js"
+import {
+    FormattingOptions,
+    OwidArticleBackportingStatistics,
+    OwidGdocInterface,
+    WP_PostType,
+} from "../owidTypes.js"
 
 export interface PostRowPlainFields {
     id: number
@@ -10,22 +15,24 @@ export interface PostRowPlainFields {
     published_at: Date | null
     updated_at: Date | null
     updated_at_in_wordpress: Date | null
-    archieml: string
-    archieml_update_statistics: string
     gdocSuccessorId: string | null
-    excerpt: string
+    excerpt: string | null
     created_at_in_wordpress: Date | null
     featured_image: string
 }
 
 export interface PostRowUnparsedFields {
-    authors: string
-    formattingOptions: string
+    authors: string | null
+    formattingOptions: string | null
+    archieml: string | null
+    archieml_update_statistics: string | null
 }
 
 export interface PostRowParsedFields {
-    authors: string[]
-    formattingOptions: FormattingOptions
+    authors: string[] | null
+    formattingOptions: FormattingOptions | null
+    archieml: OwidGdocInterface | null
+    archieml_update_statistics: OwidArticleBackportingStatistics | null
 }
 export type PostRowRaw = PostRowPlainFields & PostRowUnparsedFields
 export type PostRowEnriched = PostRowPlainFields & PostRowParsedFields

--- a/packages/@ourworldindata/utils/src/dbTypes/PostsUtilities.ts
+++ b/packages/@ourworldindata/utils/src/dbTypes/PostsUtilities.ts
@@ -12,13 +12,22 @@ export function parsePostAuthors(authors: string): string[] {
     return authorsJson
 }
 
+export function parsePostArchieml(archieml: string): any {
+    // TODO: validation would be nice here
+    return JSON.parse(archieml)
+}
+
 export function parsePostRow(postRow: PostRowRaw): PostRowEnriched {
     return {
         ...postRow,
-        authors: parsePostAuthors(postRow.authors),
-        formattingOptions: parsePostFormattingOptions(
-            postRow.formattingOptions
-        ),
+        authors: postRow.authors ? parsePostAuthors(postRow.authors) : null,
+        formattingOptions: postRow.formattingOptions
+            ? parsePostFormattingOptions(postRow.formattingOptions)
+            : null,
+        archieml: postRow.archieml ? parsePostArchieml(postRow.archieml) : null,
+        archieml_update_statistics: postRow.archieml_update_statistics
+            ? JSON.parse(postRow.archieml_update_statistics)
+            : null,
     }
 }
 
@@ -27,5 +36,9 @@ export function serializePostRow(postRow: PostRowEnriched): PostRowRaw {
         ...postRow,
         authors: JSON.stringify(postRow.authors),
         formattingOptions: JSON.stringify(postRow.formattingOptions),
+        archieml: JSON.stringify(postRow.archieml),
+        archieml_update_statistics: JSON.stringify(
+            postRow.archieml_update_statistics
+        ),
     }
 }

--- a/packages/@ourworldindata/utils/src/dbTypes/PostsUtilities.ts
+++ b/packages/@ourworldindata/utils/src/dbTypes/PostsUtilities.ts
@@ -1,0 +1,31 @@
+import { FormattingOptions } from "../owidTypes.js"
+import { PostRowEnriched, PostRowRaw } from "./Posts.js"
+
+export function parsePostFormattingOptions(
+    formattingOptions: string
+): FormattingOptions {
+    return JSON.parse(formattingOptions)
+}
+
+export function parsePostAuthors(authors: string): string[] {
+    const authorsJson = JSON.parse(authors)
+    return authorsJson
+}
+
+export function parsePostRow(postRow: PostRowRaw): PostRowEnriched {
+    return {
+        ...postRow,
+        authors: parsePostAuthors(postRow.authors),
+        formattingOptions: parsePostFormattingOptions(
+            postRow.formattingOptions
+        ),
+    }
+}
+
+export function serializePostRow(postRow: PostRowEnriched): PostRowRaw {
+    return {
+        ...postRow,
+        authors: JSON.stringify(postRow.authors),
+        formattingOptions: JSON.stringify(postRow.formattingOptions),
+    }
+}

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -123,7 +123,7 @@ export {
     type PositionMap,
     type PostReference,
     type PostRestApi,
-    type PostRow,
+    type PostRowEnriched,
     type PostRowRaw,
     type PrimitiveType,
     type RawBlockAllCharts,
@@ -238,6 +238,13 @@ export {
     type RawBlockAlign,
     type BreadcrumbItem,
     type DisplaySource,
+    type PostParsedFields,
+    type PostPlainFields,
+    type PostUnparsedFields,
+    parsePostFormattingOptions,
+    parsePostAuthors,
+    parsePostRow,
+    serializePostRow,
 } from "./owidTypes.js"
 
 export {

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -123,8 +123,6 @@ export {
     type PositionMap,
     type PostReference,
     type PostRestApi,
-    type PostRowEnriched,
-    type PostRowRaw,
     type PrimitiveType,
     type RawBlockAllCharts,
     type RawBlockAdditionalCharts,
@@ -238,14 +236,22 @@ export {
     type RawBlockAlign,
     type BreadcrumbItem,
     type DisplaySource,
-    type PostParsedFields,
-    type PostPlainFields,
-    type PostUnparsedFields,
+} from "./owidTypes.js"
+
+export {
     parsePostFormattingOptions,
     parsePostAuthors,
     parsePostRow,
     serializePostRow,
-} from "./owidTypes.js"
+} from "./dbTypes/PostsUtilities.js"
+
+export {
+    type PostRowParsedFields,
+    type PostRowPlainFields,
+    type PostRowUnparsedFields,
+    type PostRowEnriched,
+    type PostRowRaw,
+} from "./dbTypes/Posts.js"
 
 export {
     pairs,

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -124,6 +124,7 @@ export {
     type PostReference,
     type PostRestApi,
     type PostRow,
+    type PostRowRaw,
     type PrimitiveType,
     type RawBlockAllCharts,
     type RawBlockAdditionalCharts,

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -183,17 +183,17 @@ export interface PostPlainFields {
     featured_image: string
 }
 
-interface PostUnparsedFields {
+export interface PostUnparsedFields {
     authors: string
     formattingOptions: string
 }
 
-interface PostParsedFields {
+export interface PostParsedFields {
     authors: string[]
     formattingOptions: FormattingOptions
 }
 export type PostRowRaw = PostPlainFields & PostUnparsedFields
-export type PostRow = PostPlainFields & PostParsedFields
+export type PostRowEnriched = PostPlainFields & PostParsedFields
 
 export function parsePostFormattingOptions(
     formattingOptions: string
@@ -206,7 +206,7 @@ export function parsePostAuthors(authors: string): string[] {
     return authorsJson
 }
 
-export function parsePostRow(postRow: PostRowRaw): PostRow {
+export function parsePostRow(postRow: PostRowRaw): PostRowEnriched {
     return {
         ...postRow,
         authors: parsePostAuthors(postRow.authors),
@@ -216,7 +216,7 @@ export function parsePostRow(postRow: PostRowRaw): PostRow {
     }
 }
 
-export function serializePostRow(postRow: PostRow): PostRowRaw {
+export function serializePostRow(postRow: PostRowEnriched): PostRowRaw {
     return {
         ...postRow,
         authors: JSON.stringify(postRow.authors),
@@ -224,7 +224,7 @@ export function serializePostRow(postRow: PostRow): PostRowRaw {
     }
 }
 
-export interface PostRowWithGdocPublishStatus extends PostRow {
+export interface PostRowWithGdocPublishStatus extends PostRowEnriched {
     isGdocPublished: boolean
 }
 

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -165,8 +165,7 @@ export interface TocHeadingWithTitleSupertitle extends TocHeading {
     supertitle?: string
 }
 
-// todo; remove
-export interface PostRow {
+export interface PostPlainFields {
     id: number
     title: string
     slug: string
@@ -179,11 +178,50 @@ export interface PostRow {
     archieml: string
     archieml_update_statistics: string
     gdocSuccessorId: string | null
-    authors: string
     excerpt: string
     created_at_in_wordpress: Date | null
     featured_image: string
+}
+
+interface PostUnparsedFields {
+    authors: string
+    formattingOptions: string
+}
+
+interface PostParsedFields {
+    authors: string[]
     formattingOptions: FormattingOptions
+}
+export type PostRowRaw = PostPlainFields & PostUnparsedFields
+export type PostRow = PostPlainFields & PostParsedFields
+
+export function parsePostFormattingOptions(
+    formattingOptions: string
+): FormattingOptions {
+    return JSON.parse(formattingOptions)
+}
+
+export function parsePostAuthors(authors: string): string[] {
+    const authorsJson = JSON.parse(authors)
+    return authorsJson
+}
+
+export function parsePostRow(postRow: PostRowRaw): PostRow {
+    return {
+        ...postRow,
+        authors: parsePostAuthors(postRow.authors),
+        formattingOptions: parsePostFormattingOptions(
+            postRow.formattingOptions
+        ),
+    }
+}
+
+export function serializePostRow(postRow: PostRow): PostRowRaw {
+    return {
+        ...postRow,
+        authors: JSON.stringify(postRow.authors),
+        formattingOptions: JSON.stringify(postRow.formattingOptions),
+    }
 }
 
 export interface PostRowWithGdocPublishStatus extends PostRow {

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -4,7 +4,7 @@ import { gdocUrlRegex } from "./GdocsConstants.js"
 import { OwidOrigin } from "./OwidOrigin.js"
 import { OwidSource } from "./OwidSource.js"
 import { OwidProcessingLevel } from "./OwidVariable.js"
-import { PostRowEnriched } from "./dbTypes/Posts.js"
+import { PostRowRaw } from "./dbTypes/Posts.js"
 
 // todo: remove when we ditch Year and YearIsDay
 export const EPOCH_DATE = "2020-01-21"
@@ -166,7 +166,7 @@ export interface TocHeadingWithTitleSupertitle extends TocHeading {
     supertitle?: string
 }
 
-export interface PostRowWithGdocPublishStatus extends PostRowEnriched {
+export interface PostRowWithGdocPublishStatus extends PostRowRaw {
     isGdocPublished: boolean
 }
 

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -4,6 +4,7 @@ import { gdocUrlRegex } from "./GdocsConstants.js"
 import { OwidOrigin } from "./OwidOrigin.js"
 import { OwidSource } from "./OwidSource.js"
 import { OwidProcessingLevel } from "./OwidVariable.js"
+import { PostRowEnriched } from "./dbTypes/Posts.js"
 
 // todo: remove when we ditch Year and YearIsDay
 export const EPOCH_DATE = "2020-01-21"
@@ -163,65 +164,6 @@ export interface TocHeading {
 export interface TocHeadingWithTitleSupertitle extends TocHeading {
     title: string
     supertitle?: string
-}
-
-export interface PostPlainFields {
-    id: number
-    title: string
-    slug: string
-    type: WP_PostType
-    status: string
-    content: string
-    published_at: Date | null
-    updated_at: Date | null
-    updated_at_in_wordpress: Date | null
-    archieml: string
-    archieml_update_statistics: string
-    gdocSuccessorId: string | null
-    excerpt: string
-    created_at_in_wordpress: Date | null
-    featured_image: string
-}
-
-export interface PostUnparsedFields {
-    authors: string
-    formattingOptions: string
-}
-
-export interface PostParsedFields {
-    authors: string[]
-    formattingOptions: FormattingOptions
-}
-export type PostRowRaw = PostPlainFields & PostUnparsedFields
-export type PostRowEnriched = PostPlainFields & PostParsedFields
-
-export function parsePostFormattingOptions(
-    formattingOptions: string
-): FormattingOptions {
-    return JSON.parse(formattingOptions)
-}
-
-export function parsePostAuthors(authors: string): string[] {
-    const authorsJson = JSON.parse(authors)
-    return authorsJson
-}
-
-export function parsePostRow(postRow: PostRowRaw): PostRowEnriched {
-    return {
-        ...postRow,
-        authors: parsePostAuthors(postRow.authors),
-        formattingOptions: parsePostFormattingOptions(
-            postRow.formattingOptions
-        ),
-    }
-}
-
-export function serializePostRow(postRow: PostRowEnriched): PostRowRaw {
-    return {
-        ...postRow,
-        authors: JSON.stringify(postRow.authors),
-        formattingOptions: JSON.stringify(postRow.formattingOptions),
-    }
 }
 
 export interface PostRowWithGdocPublishStatus extends PostRowEnriched {

--- a/site/EntriesByYearPage.tsx
+++ b/site/EntriesByYearPage.tsx
@@ -1,11 +1,11 @@
 import React from "react"
-import { dayjs, groupBy, PostRow } from "@ourworldindata/utils"
+import { dayjs, groupBy, PostRowEnriched } from "@ourworldindata/utils"
 import { Head } from "./Head.js"
 import { SiteHeader } from "./SiteHeader.js"
 import { SiteFooter } from "./SiteFooter.js"
 import { TableOfContents } from "../site/TableOfContents.js"
 
-type Entry = Pick<PostRow, "title" | "slug" | "published_at">
+type Entry = Pick<PostRowEnriched, "title" | "slug" | "published_at">
 
 export const EntriesByYearPage = (props: {
     entries: Entry[]

--- a/site/GrapherPage.jsdom.test.tsx
+++ b/site/GrapherPage.jsdom.test.tsx
@@ -4,7 +4,7 @@ import { GrapherInterface } from "@ourworldindata/grapher"
 import {
     DimensionProperty,
     KeyChartLevel,
-    PostRow,
+    PostRowEnriched,
     RelatedChart,
 } from "@ourworldindata/utils"
 import React from "react"
@@ -30,7 +30,7 @@ const mockGrapher: GrapherInterface = {
 }
 
 let grapher: GrapherInterface
-let post: PostRow
+let post: PostRowEnriched
 let relatedCharts: RelatedChart[]
 
 beforeAll(() => {

--- a/site/GrapherPage.tsx
+++ b/site/GrapherPage.tsx
@@ -9,7 +9,7 @@ import {
 import {
     flatten,
     PostReference,
-    PostRow,
+    PostRowEnriched,
     RelatedChart,
     serializeJSONForHTML,
     uniq,
@@ -34,7 +34,7 @@ import { SiteHeader } from "./SiteHeader.js"
 
 export const GrapherPage = (props: {
     grapher: GrapherInterface
-    post?: PostRow
+    post?: PostRowEnriched
     relatedCharts?: RelatedChart[]
     relatedArticles?: PostReference[]
     baseUrl: string


### PR DESCRIPTION
This PR does two things:
- it changes the `authors` field in the `posts` table to contain simply an ordered list of authors (instead of an unordered list of json objects with `{author: string, order: number}` type)
- it splits the `PostRow` type that represents a result for of the posts table into two, one `PostRowRaw` where authors and formattingOptions are still string fields and one `PostRowEnriched` where the json fields are parsed and the typed accordingly.