### PR TITLE
Align post update hook and sync script

### DIFF
--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -293,6 +293,7 @@ const syncPostsToGrapher = async (): Promise<void> => {
             type: post.post_type,
             status: post.post_status,
             content: dereferenceReusableBlocksFn(content),
+            featured_image: post.featured_image || "",
             published_at:
                 post.post_date_gmt === zeroDateString
                     ? null
@@ -305,12 +306,11 @@ const syncPostsToGrapher = async (): Promise<void> => {
             excerpt: post.post_excerpt,
             created_at_in_wordpress:
                 post.created_at === zeroDateString ? null : post.created_at,
-            featured_image: post.featured_image || "",
             formattingOptions: formattingOptions,
         }
     }) as PostRow[]
     const postLinks = await PostLink.find()
-    const postLinksById = groupBy(postLinks, (link) => link.sourceId)
+    const postLinksById = groupBy(postLinks, (link: PostLink) => link.sourceId)
 
     const linksToAdd: PostLink[] = []
     const linksToDelete: PostLink[] = []


### PR DESCRIPTION
The wordpress posts sync script (`syncPostsToGrapher.ts`) and the update hook (`postUpdatedHook.ts`) are supposed to do pretty much the same thing, the former in batch mode and the latter for a single post. 

The two got a bit our of sync though as of late. One issues was that the treatment of reusable blocks (`wp_block`) was different - the sync script ignored them but they still came in via the hook. These can be useful (e.g. to migrate the reuseable blocks that store the content below explorers). 

Another issue was that the formattingOptions were not yet extracted in the update hook.