### PR TITLE
🔨 sync not just wp pages and posts but also wp_blocks

### DIFF
--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -568,6 +568,7 @@ export class SiteBaker {
         const rows = (await db
             .knexTable(postsTable)
             .where({ status: "publish" })
+            .whereNot({ type: "wp_block" })
             .join("post_tags", { "post_tags.post_id": "posts.id" })
             .join("tags", { "tags.id": "post_tags.tag_id" })
             .where({ "tags.name": "Entries" })

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -430,6 +430,7 @@ ${posts
 export const entriesByYearPage = async (year?: number) => {
     const entries = (await knexTable(postsTable)
         .where({ status: "publish" })
+        .whereNot({ type: "wp_block" })
         .join("post_tags", { "post_tags.post_id": "posts.id" })
         .join("tags", { "tags.id": "post_tags.tag_id" })
         .where({ "tags.name": "Entries" })

--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -268,7 +268,7 @@ const syncPostsToGrapher = async (): Promise<void> => {
 		left join post_ids_with_authors pwa   on p.ID = pwa.ID
         left join first_revision fr on fr.post_id = pwa.ID
         left join post_featured_image fi on fi.ID = p.id
-        where p.post_type in ('post', 'page') AND post_status != 'trash'
+        where p.post_type in ('post', 'page', 'wp_block') AND post_status != 'trash'
         `
     )
 

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -731,6 +731,7 @@ export const getRelatedResearchAndWritingForVariable = async (
                 and cd.variableId = ?
                 and cd.property in ('x', 'y') -- ignore cases where the indicator is size, color etc
                 and p.status = 'publish' -- only use published wp posts
+                and p.type != 'wp_block'
                 and coalesce(pg.published, 0) = 0 -- ignore posts if the wp post has a published gdoc successor. The
                                                   -- coalesce makes sure that if there is no gdoc successor then
                                                   -- the filter keeps the post


### PR DESCRIPTION
This is mostly to unify the behaviour of syncPostsToGrapher
and postUpdateHook