### PR TITLE
:tada: lightning chart deploys

### DIFF
--- a/baker/BuildkiteTrigger.ts
+++ b/baker/BuildkiteTrigger.ts
@@ -101,12 +101,28 @@ export class BuildkiteTrigger {
         }
     }
 
-    async runLightningBuild(
+    async runLightningGdocBuild(
         message: string,
         gdocSlugs: string[]
     ): Promise<void> {
+        if (!gdocSlugs.length) {
+            return
+        }
         const buildNumber = await this.triggerBuild(message, {
             LIGHTNING_GDOC_SLUGS: gdocSlugs.join(" "),
+        })
+        await this.waitForBuildToFinish(buildNumber)
+    }
+
+    async runLightningChartBuild(
+        message: string,
+        chartSlugs: string[]
+    ): Promise<void> {
+        if (!chartSlugs.length) {
+            return
+        }
+        const buildNumber = await this.triggerBuild(message, {
+            LIGHTNING_CHART_SLUGS: chartSlugs.join(" "),
         })
         await this.waitForBuildToFinish(buildNumber)
     }

--- a/baker/DeployQueueServer.test.ts
+++ b/baker/DeployQueueServer.test.ts
@@ -28,7 +28,7 @@ describe("parseQueueContent", () => {
         )
         expect(output[1].message).toEqual("something one")
         expect(output[2].message).toEqual("something two")
-        expect(output[3].slug).toEqual("article-lightning-deploy")
+        expect(output[3].gdocSlug).toEqual("article-lightning-deploy")
     })
 })
 

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -407,6 +407,17 @@ export class SiteBaker {
         this.progressBar.tick({ name: "✅ baked google doc posts" })
     }
 
+    async bakeCharts(slugsToBake: string[] = []) {
+        if (!this.bakeSteps.has("charts")) return
+        await bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers(
+            this.bakedSiteDir,
+            slugsToBake
+        )
+        this.progressBar.tick({
+            name: "✅ bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers",
+        })
+    }
+
     // Bake unique individual pages
     private async bakeSpecialPages() {
         if (!this.bakeSteps.has("specialPages")) return
@@ -678,14 +689,7 @@ export class SiteBaker {
         await this.bakeSpecialPages()
         await this.bakeCountryProfiles()
         await this.bakeExplorers()
-        if (this.bakeSteps.has("charts")) {
-            await bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers(
-                this.bakedSiteDir
-            )
-            this.progressBar.tick({
-                name: "✅ bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers",
-            })
-        }
+        await this.bakeCharts()
         await this.bakeDetailsOnDemand()
         await this.validateGrapherDodReferences()
         await this.bakeGDocPosts()

--- a/baker/bakeCharts.ts
+++ b/baker/bakeCharts.ts
@@ -1,0 +1,34 @@
+#! /usr/bin/env node
+
+import yargs from "yargs"
+import { hideBin } from "yargs/helpers"
+import { SiteBaker } from "./SiteBaker.js"
+import { BAKED_SITE_DIR, BAKED_BASE_URL } from "../settings/serverSettings.js"
+import * as db from "../db/db.js"
+
+yargs(hideBin(process.argv))
+    .command<{ slugs: string[] }>(
+        "$0 [slug]",
+        "Bake multiple Charts",
+        (yargs) => {
+            yargs
+                .option("slugs", {
+                    type: "array",
+                    describe: "Chart slugs",
+                })
+                .demandOption(
+                    ["slugs"],
+                    "Please provide slugs using --slugs slug1 slug2"
+                )
+        },
+        async ({ slugs }) => {
+            const baker = new SiteBaker(BAKED_SITE_DIR, BAKED_BASE_URL)
+
+            await db.getConnection()
+            await baker.bakeCharts(slugs)
+            process.exit(0)
+        }
+    )
+    .help()
+    .alias("help", "h")
+    .strict().argv

--- a/ops/buildkite/deploy-content
+++ b/ops/buildkite/deploy-content
@@ -31,6 +31,11 @@ deploy_content () {
     # right now lightning bake has to wait if there's a regular bake
     if [ -n "${LIGHTNING_GDOC_SLUGS:-}" ]; then
         bake_gdoc_posts "$LIGHTNING_GDOC_SLUGS"
+    # Lightning updates for charts
+    elif [ -n "${LIGHTNING_CHART_SLUGS:-}" ]; then
+        bake_charts "$LIGHTNING_CHART_SLUGS"
+        # We could only sync selected slugs, but syncing everything takes only 6s anyway
+        sync_to_r2_aws grapher/exports
     else
         update_owid_content_repo
         sync_wordpress_uploads
@@ -168,6 +173,15 @@ bake_gdoc_posts() {
     (
         cd owid-grapher
         yarn bakeGdocPosts --slugs ${slugs}
+    )
+}
+
+bake_charts() {
+    local slugs="$1"
+    echo "--- Baking Charts ${slugs}"
+    (
+        cd owid-grapher
+        yarn bakeCharts --slugs ${slugs}
     )
 }
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "buildVite": "vite build",
         "buildWordpressPlugin": "cd ./wordpress/web/app/plugins/owid && yarn && yarn build",
         "bakeGdocPosts": "node --enable-source-maps ./itsJustJavascript/baker/bakeGdocPosts.js",
+        "bakeCharts": "node --enable-source-maps ./itsJustJavascript/baker/bakeCharts.js",
         "cleanTsc": "rm -rf itsJustJavascript && tsc -b -clean",
         "deployWordpress": "./wordpress/scripts/deploy.sh",
         "fetchServerStatus": "node --enable-source-maps ./itsJustJavascript/baker/liveCommit.js",

--- a/packages/@ourworldindata/utils/src/owidTypes.ts
+++ b/packages/@ourworldindata/utils/src/owidTypes.ts
@@ -434,7 +434,8 @@ export interface DeployChange {
     authorName?: string
     authorEmail?: string
     message?: string
-    slug?: string
+    gdocSlug?: string
+    chartSlug?: string
 }
 
 export interface Deploy {


### PR DESCRIPTION
## Problem

Updating a chart enqueues a full deploy that can take >15min and is prone to errors (due to high load on external servers like R2 or Spaces). Deploying only a single chart could significantly speed up most deploys.

## Solution

* Add the `bakeCharts` command that is very similar to `bakeGDocs`, which takes care of GDocs lightning deploys
* Trigger a deployment after clicking on `Update chart` or `Publish` buttons
* Lightning build with `chartSlug` goes to deploy queue which triggers BuildkiteJob [OWID - deploy content](https://buildkite.com/our-world-in-data/owid-deploy-content-master) with env variable `LIGHTNING_CHART_SLUGS`
* Buildkite runs `bakeCharts --slugs LIGHTNING_CHART_SLUGS` on the server, syncs `grapher/exports` with generated png & svg to R2 and then deploys the site to Cloudflare

## Potential issues

What other things need to happen when we publish or update a chart? Perhaps updated redirects might require full rebuild or at least rebuilding of redirects file in Buildkite.

Things that could be affected by updated chart (need to check)
- explorer based indicators
- prominent links