### PR TITLE
StackedArea: Don't show interpolated values in tooltips

### DIFF
--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -30,7 +30,10 @@ import { Time, JsTypes, CoreValueType } from "./CoreTableConstants.js"
 import { ColumnTypeNames, CoreColumnDef } from "./CoreColumnDef.js"
 import { EntityName, OwidVariableRow } from "./OwidTableConstants.js" // todo: remove. Should not be on CoreTable
 import { ErrorValue, ErrorValueTypes, isNotErrorValue } from "./ErrorValues.js"
-import { getOriginalTimeColumnSlug } from "./OwidTableUtil.js"
+import {
+    getOriginalTimeColumnSlug,
+    getOriginalValueColumnSlug,
+} from "./OwidTableUtil.js"
 
 interface ColumnSummary {
     numErrorValues: number
@@ -394,6 +397,19 @@ export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
         ) as number[]
     }
 
+    @imemo get originalValueColumnSlug(): string | undefined {
+        return getOriginalValueColumnSlug(this.table, this.slug)
+    }
+
+    @imemo get originalValues(): JS_TYPE[] {
+        const { originalValueColumnSlug } = this
+        if (!originalValueColumnSlug) return []
+        return this.table.getValuesAtIndices(
+            originalValueColumnSlug,
+            this.validRowIndices
+        ) as JS_TYPE[]
+    }
+
     /**
      * True if the column has only 1 unique value. ErrorValues are counted as values, so
      * something like [DivideByZeroError, 2, 2] would not be constant.
@@ -476,15 +492,17 @@ export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
     // todo: remove? Should not be on CoreTable
     // assumes table is sorted by time
     @imemo get owidRows(): OwidVariableRow<JS_TYPE>[] {
+        const entities = this.allEntityNames
         const times = this.originalTimes
         const values = this.values
-        const entities = this.allEntityNames
+        const originalValues = this.originalValues
         return range(0, times.length).map((index) => {
-            return {
+            return omitUndefinedValues({
                 entityName: entities[index],
                 time: times[index],
                 value: values[index],
-            }
+                originalValue: originalValues[index],
+            })
         })
     }
 

--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -795,7 +795,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
                     ...timeColumn.def,
                 },
             ],
-            `Interpolated values in column ${columnSlug} linearly and and appended column ${originalColumnSlug} with the original values`,
+            `Interpolated values in column ${columnSlug} linearly and appended column ${originalColumnSlug} with the original values`,
             TransformType.UpdateColumnDefs
         )
     }

--- a/packages/@ourworldindata/core-table/src/OwidTableConstants.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTableConstants.ts
@@ -79,4 +79,5 @@ export interface OwidVariableRow<ValueType extends PrimitiveType> {
     entityName: EntityName
     time: Time
     value: ValueType
+    originalValue?: ValueType
 }

--- a/packages/@ourworldindata/core-table/src/OwidTableUtil.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTableUtil.ts
@@ -13,6 +13,10 @@ export function makeOriginalTimeSlugFromColumnSlug(slug: ColumnSlug): string {
     return `${slug}-originalTime`
 }
 
+export function makeOriginalValueSlugFromColumnSlug(slug: ColumnSlug): string {
+    return `${slug}-originalValue`
+}
+
 export function getOriginalTimeColumnSlug(
     table: CoreTable,
     slug: ColumnSlug
@@ -20,6 +24,15 @@ export function getOriginalTimeColumnSlug(
     const originalTimeSlug = makeOriginalTimeSlugFromColumnSlug(slug)
     if (table.has(originalTimeSlug)) return originalTimeSlug
     return table.timeColumn.slug
+}
+
+export function getOriginalValueColumnSlug(
+    table: CoreTable,
+    slug: ColumnSlug
+): ColumnSlug | undefined {
+    const originalValueSlug = makeOriginalValueSlugFromColumnSlug(slug)
+    if (table.has(originalValueSlug)) return originalValueSlug
+    return undefined
 }
 
 export function toPercentageColumnDef(

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -28,6 +28,7 @@ import {
     OwidTable,
     CoreColumn,
     BlankOwidTable,
+    isNotErrorValueOrEmptyCell,
 } from "@ourworldindata/core-table"
 import {
     autoDetectSeriesStrategy,
@@ -385,6 +386,10 @@ export class AbstractStackedChart
                         time: row.time,
                         value: row.value,
                         valueOffset: 0,
+                        interpolated:
+                            this.shouldRunLinearInterpolation &&
+                            isNotErrorValueOrEmptyCell(row.value) &&
+                            !isNotErrorValueOrEmptyCell(row.originalValue),
                     }
                 })
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.test.ts
@@ -159,6 +159,58 @@ it("should drop missing values at start or end", () => {
     expect(chart.series[1].points.length).toEqual(3)
 })
 
+it("should mark interpolated values as fake", () => {
+    const csv = `gdp,year,entityName
+    10,2000,france
+    0,2001,france
+    ,2002,france
+    ,2003,france
+    8,2005,france
+    ,2006,france
+    2,2000,uk
+    3,2004,uk`
+    const table = new OwidTable(csv, [
+        { slug: "gdp", type: ColumnTypeNames.Numeric },
+        { slug: "year", type: ColumnTypeNames.Year },
+    ])
+
+    const manager: ChartManager = {
+        table,
+        yColumnSlugs: ["gdp"],
+        selection: table.availableEntityNames,
+    }
+
+    const chart = new StackedAreaChart({ manager })
+
+    // indices are reversed because stacked charts reverse the stacking order
+    const pointsFrance = chart.series[1].points
+    const pointsUK = chart.series[0].points
+
+    // year 2000
+    expect(pointsFrance[0].interpolated).toBeFalsy()
+    expect(pointsFrance[0].fake).toBeFalsy()
+    expect(pointsUK[0].interpolated).toBeFalsy()
+    expect(pointsUK[0].fake).toBeFalsy()
+
+    // year = 2001
+    expect(pointsFrance[1].interpolated).toBeFalsy()
+    expect(pointsFrance[1].fake).toBeFalsy()
+    expect(pointsUK[1].interpolated).toBeTruthy()
+    expect(pointsUK[1].fake).toBeTruthy()
+
+    // year = 2004
+    expect(pointsFrance[2].interpolated).toBeTruthy()
+    expect(pointsFrance[2].fake).toBeTruthy()
+    expect(pointsUK[2].interpolated).toBeFalsy()
+    expect(pointsUK[2].fake).toBeFalsy()
+
+    // year = 2005
+    expect(pointsFrance[3].interpolated).toBeFalsy()
+    expect(pointsFrance[3].fake).toBeFalsy()
+    expect(pointsUK[3].interpolated).toBeFalsy()
+    expect(pointsUK[3].fake).toBeTruthy() // true since it's zero-filled
+})
+
 describe("externalLegendBins", () => {
     const table = SynthesizeFruitTable({
         timeRange: [2000, 2010],

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedConstants.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedConstants.ts
@@ -12,6 +12,7 @@ export interface StackedPoint<PositionType extends StackedPointPositionType> {
     value: number
     valueOffset: number
     time: number
+    interpolated?: boolean
     fake?: boolean
 }
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.ts
@@ -7,6 +7,7 @@ import {
     isArrayOfNumbers,
     findGreatestCommonDivisorOfArray,
     rollingMap,
+    omitUndefinedValues,
 } from "@ourworldindata/utils"
 import { StackedPointPositionType, StackedSeries } from "./StackedConstants"
 
@@ -64,13 +65,14 @@ export const withMissingValuesAsZeroes = <
                 const point = pointsByPosition[position]
                 const value = point?.value ?? 0
                 const time = point?.time ?? 0
-                return {
+                return omitUndefinedValues({
                     time,
                     position,
                     value,
                     valueOffset: 0,
-                    fake: !point,
-                }
+                    interpolated: point?.interpolated,
+                    fake: !point || !!point.interpolated,
+                })
             }),
         }
     })


### PR DESCRIPTION
- fixes #2866

### Problem

- StackedArea charts show interpolated (i.e. made-up) values in the tooltip
- I don't have a live example, but Pablo created a [buggy chart](http://staging-site-fix-tooltip-interpolated-values/grapher/energy-consumption-by-source-and-country?country=~BLR) for me on staging
    - You won't be able to see the bug since it's fixed on this branch now, but still:
    - Select Belarus and hover over any data point between 2000 and 2019
    - Now it shows "No data" for Nuclear (which is correct), but we used to show interpolated values here (I should have screenshotted it before pushing a fix 🤦‍♀️)

### Solution

- The fix is not trivial because linear interpolation overwrites the original column. We thus lose information on which values are real and which have been interpolated
- To keep track of this, the interpolation step appends a new column `<slug>-originalValue` to the table that stores the original values (`<slug>` stores the interpolated ones)
    - Alternatively, I could have created a new boolean column like `<slug>-interpolated`, but I went with the `<slug>-originalValue` approach because its application is less narrow, and it also aligns with the `<slug>-originalTime` pattern for tolerance
- A column's `owidRows` are then extended to optionally also hold the original value
- Given the (possible interpolated) value and the original value, the `AbstractStackedChart` then marks interpolated values as `fake`, which we don't show in the tooltip