### PR TITLE
:bug: Fix #3038 issue loading Grapher tables

### DIFF
--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -547,7 +547,7 @@ export class DataTable extends React.Component<{
     }
 
     @computed private get tableCaption(): JSX.Element | null {
-        if (this.hasDimensionHeaders) return null
+        if (!this.hasDimensionHeaders) return null
         const singleDimension = this.displayDimensions[0]
         const titleFragments = (singleDimension.display.columnName
             .attributionShort ||


### PR DESCRIPTION
The issue is that loading a Grapher chart with `tab=table` in the URL fails, though navigating to the table does not.

It appears to be due to a typo in the guard when creating a table caption, fixed in this change.
