### PR TITLE
🐛 fix missing type field in some posts_gdocs rows

### DIFF
--- a/db/migration/1703777475319-FixGdocPostsWithoutType.ts
+++ b/db/migration/1703777475319-FixGdocPostsWithoutType.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class FixGdocPostsWithoutType1703777475319
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // This migration makes sure that all posts_gdocs have the type field
+        // set in the content JSON blob. 'article' is not necessarily correct
+        // but the next time this article is opened it will be updated to the
+        // actual type in the gdoc. Because of the current code being too strict,
+        // the same does not happen when opening a gdoc in the admin if the type
+        // is missing, so this is a next-best workaround.
+        queryRunner.query(`-- sql
+            update posts_gdocs
+            set content = json_insert(content, '$.type', 'article')
+            where content->>'$.type' is null;`)
+    }
+
+    public async down(_queryRunner: QueryRunner): Promise<void> {
+        return
+    }
+}

--- a/db/migration/1703777475319-FixGdocPostsWithoutType.ts
+++ b/db/migration/1703777475319-FixGdocPostsWithoutType.ts
@@ -10,7 +10,7 @@ export class FixGdocPostsWithoutType1703777475319
         // actual type in the gdoc. Because of the current code being too strict,
         // the same does not happen when opening a gdoc in the admin if the type
         // is missing, so this is a next-best workaround.
-        queryRunner.query(`-- sql
+        await queryRunner.query(`-- sql
             update posts_gdocs
             set content = json_insert(content, '$.type', 'article')
             where content->>'$.type' is null;`)


### PR DESCRIPTION
With the introduction of data-insights, the `type` field of the content json blob became more important to the point where the admin refuses to show the content of a gdoc that does not have this field set. Most gdocs had it set in the db already but some only had it in the gdoc document. The admin now breaks if the type is missing which leads to a bind since if the DB does not already have the type set, there is no way for the user to get it set.

This PR just assigns the type `article` to all (12 or so) posts_gdocs that do not have the type set. Even if the page is actually a topic page, the next time it is opened in the admin, the correct type will overwrite the field in the db. I checked that none of the 12 documents that will be influenced by this are currently published AND are non-articles, so this should not break anything in baking either (i.e. there are no published topic-page entries or similar that would be wrongly baked as articles)