### PR TITLE
🐛 GdocPost.tags is supposed to always exist but doesn't when accessing the featured content gdoc

### DIFF
--- a/db/model/Gdoc/GdocPost.ts
+++ b/db/model/Gdoc/GdocPost.ts
@@ -83,7 +83,7 @@ export class GdocPost extends GdocBase implements OwidGdocPostInterface {
     _validateSubclass = async (): Promise<OwidGdocErrorMessage[]> => {
         const errors: OwidGdocErrorMessage[] = []
 
-        if (!this.tags.length) {
+        if (!this.tags?.length) {
             if (this.content.type !== OwidGdocType.Fragment) {
                 errors.push({
                     property: "content",
@@ -151,7 +151,7 @@ export class GdocPost extends GdocBase implements OwidGdocPostInterface {
     }
 
     async loadRelatedCharts(): Promise<void> {
-        if (!this.tags.length || !this.hasAllChartsBlock) return
+        if (!this.tags?.length || !this.hasAllChartsBlock) return
 
         const connection = await getConnection()
         const relatedCharts = await connection.query(


### PR DESCRIPTION
This PR fixes this by guarding access to the tags property