### PR TITLE
✨ allow publishing without excerpt

### DIFF
--- a/adminSiteClient/gdocsValidation.ts
+++ b/adminSiteClient/gdocsValidation.ts
@@ -111,7 +111,11 @@ function validateExcerpt(
     errors: OwidGdocErrorMessage[]
 ) {
     if (!gdoc.content.excerpt) {
-        errors.push(getMissingContentPropertyError("excerpt"))
+        errors.push({
+            property: "excerpt",
+            type: OwidGdocErrorMessageType.Warning,
+            message: `It is advised to add an excerpt before publishing.`,
+        })
     } else if (gdoc.content.excerpt.length > EXCERPT_MAX_LENGTH) {
         errors.push({
             property: "excerpt",


### PR DESCRIPTION
Natasha and Charlie are working on migrating all our old articles to GDocs. For this, having to write an excerpt is a substantial effort (as it needs checking back with authors etc).

This PR makes excerpts optional. If things go well we should be able to make it mandatory at some point later in the year when authors had some time to go though the content but excpert is not strictly speaking necessary today anyway.