### PR TITLE
Fix misplaced indicator's `description` field

### DIFF
--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
@@ -400,9 +400,11 @@ export class Source extends React.Component<{
         return (
             <div className="source">
                 {this.renderTitle()}
-                {this.def.descriptionShort && (
+                {this.def.descriptionShort ? (
                     <SimpleMarkdownText text={this.def.descriptionShort} />
-                )}
+                ) : this.def.description ? (
+                    <SimpleMarkdownText text={this.def.description} />
+                ) : null}
                 <SourcesKeyDataTable
                     attribution={this.attributions}
                     owidProcessingLevel={this.def.owidProcessingLevel}

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -173,7 +173,6 @@ export const prepareSourcesForDisplay = (
     ) {
         sourcesForDisplay.push({
             label: source?.name,
-            description,
             dataPublishedBy: source?.dataPublishedBy,
             retrievedOn: source?.retrievedDate,
             retrievedFrom: source?.link,

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -158,18 +158,15 @@ const prepareOriginForDisplay = (origin: OwidOrigin): DisplaySource => {
 }
 
 export const prepareSourcesForDisplay = (
-    variable: Pick<OwidVariableWithSource, "origins" | "source" | "description">
+    variable: Pick<OwidVariableWithSource, "origins" | "source">
 ): DisplaySource[] => {
-    const { origins, source, description } = variable
+    const { origins, source } = variable
 
     const sourcesForDisplay: DisplaySource[] = []
 
     if (
         source?.name &&
-        (description ||
-            source?.dataPublishedBy ||
-            source?.retrievedDate ||
-            source?.link)
+        (source?.dataPublishedBy || source?.retrievedDate || source?.link)
     ) {
         sourcesForDisplay.push({
             label: source?.name,


### PR DESCRIPTION
Fixes https://github.com/owid/owid-grapher/issues/3052

NOTE: I am not very familiar with this code and have not looked deeply into it, so there may be cases I haven't considered.

This PR:
* Shows `description` next to the indicator's title, when `descriptionShort` does not exist but `description` does exist.
* Removes indicator's `description` from the sources.
