### PR TITLE
✨ (data table filter) hide "Show selection only" toggle if appropriate

### DIFF
--- a/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
@@ -77,7 +77,9 @@ export const makeClipPath = (
     }
 }
 
-export const makeSelectionArray = (manager: ChartManager): SelectionArray =>
+export const makeSelectionArray = (
+    manager: Pick<ChartManager, "selection">
+): SelectionArray =>
     manager.selection instanceof SelectionArray
         ? manager.selection
         : new SelectionArray(manager.selection ?? [])

--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
@@ -123,18 +123,12 @@ export class SettingsMenu extends React.Component<{
     }
 
     @computed get showZoomToggle(): boolean {
-        // TODO:
-        // grapher passes a SelectionArray instance but programmatically defined
-        // managers treat `selection` as a string[] of entity names. do we need both?
-        const { selection, type, hideZoomToggle } = this.manager,
-            entities =
-                selection instanceof SelectionArray
-                    ? selection.selectedEntityNames
-                    : Array.isArray(selection)
-                    ? selection
-                    : []
-
-        return !hideZoomToggle && type === ScatterPlot && entities.length > 0
+        const { type, hideZoomToggle } = this.manager
+        return (
+            !hideZoomToggle &&
+            type === ScatterPlot &&
+            this.selectionArray.hasSelection
+        )
     }
 
     @computed get showNoDataAreaToggle(): boolean {
@@ -199,9 +193,8 @@ export class SettingsMenu extends React.Component<{
     @computed get showTableFilterToggle(): boolean {
         const { hideTableFilterToggle, showEntitySelectionToggle } =
             this.manager
-        const selectionArray = makeSelectionArray(this.manager)
         return (
-            selectionArray.hasSelection &&
+            this.selectionArray.hasSelection &&
             !!showEntitySelectionToggle &&
             !hideTableFilterToggle
         )
@@ -221,7 +214,7 @@ export class SettingsMenu extends React.Component<{
             this.showAbsRelToggle
         )
 
-        // TODO: add a showCompareEndPointsOnlyTogggle to complement compareEndPointsOnly
+        // TODO: add a showCompareEndPointsOnlyToggle to complement compareEndPointsOnly
     }
 
     componentDidMount(): void {
@@ -269,6 +262,10 @@ export class SettingsMenu extends React.Component<{
     @computed get chartType(): string {
         const { type } = this.manager
         return type.replace(/([A-Z])/g, " $1")
+    }
+
+    @computed get selectionArray(): SelectionArray {
+        return makeSelectionArray(this.manager)
     }
 
     @computed get drawer(): Element | null {

--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
@@ -67,7 +67,7 @@ export interface SettingsMenuManager
     type: ChartTypeName
     isRelativeMode?: boolean
     selection?: SelectionArray | EntityName[]
-    shouldShowEntitySelectionToggle?: boolean
+    hasEntitySelectionToggle?: boolean
     filledDimensions: ChartDimension[]
     xColumnSlug?: string
     xOverrideTime?: number
@@ -191,11 +191,10 @@ export class SettingsMenu extends React.Component<{
     }
 
     @computed get showTableFilterToggle(): boolean {
-        const { hideTableFilterToggle, shouldShowEntitySelectionToggle } =
-            this.manager
+        const { hideTableFilterToggle, hasEntitySelectionToggle } = this.manager
         return (
             this.selectionArray.hasSelection &&
-            !!shouldShowEntitySelectionToggle &&
+            !!hasEntitySelectionToggle &&
             !hideTableFilterToggle
         )
     }

--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
@@ -67,7 +67,7 @@ export interface SettingsMenuManager
     type: ChartTypeName
     isRelativeMode?: boolean
     selection?: SelectionArray | EntityName[]
-    showEntitySelectionToggle?: boolean
+    shouldShowEntitySelectionToggle?: boolean
     filledDimensions: ChartDimension[]
     xColumnSlug?: string
     xOverrideTime?: number
@@ -191,11 +191,11 @@ export class SettingsMenu extends React.Component<{
     }
 
     @computed get showTableFilterToggle(): boolean {
-        const { hideTableFilterToggle, showEntitySelectionToggle } =
+        const { hideTableFilterToggle, shouldShowEntitySelectionToggle } =
             this.manager
         return (
             this.selectionArray.hasSelection &&
-            !!showEntitySelectionToggle &&
+            !!shouldShowEntitySelectionToggle &&
             !hideTableFilterToggle
         )
     }

--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
@@ -8,6 +8,7 @@ import { faXmark, faGear } from "@fortawesome/free-solid-svg-icons"
 import { EntityName, ChartTypeName, FacetStrategy } from "@ourworldindata/types"
 import { SelectionArray } from "../selection/SelectionArray"
 import { ChartDimension } from "../chart/ChartDimension"
+import { makeSelectionArray } from "../chart/ChartUtils.js"
 import { AxisConfig } from "../axis/AxisConfig"
 import { GRAPHER_SETTINGS_DRAWER_ID } from "../core/GrapherConstants"
 
@@ -66,6 +67,7 @@ export interface SettingsMenuManager
     type: ChartTypeName
     isRelativeMode?: boolean
     selection?: SelectionArray | EntityName[]
+    showEntityButton?: boolean
     filledDimensions: ChartDimension[]
     xColumnSlug?: string
     xOverrideTime?: number
@@ -195,13 +197,13 @@ export class SettingsMenu extends React.Component<{
     }
 
     @computed get showTableFilterToggle(): boolean {
-        const { hideTableFilterToggle, selection } = this.manager
-        const hasSelection =
-            selection instanceof SelectionArray
-                ? selection.hasSelection
-                : (selection?.length ?? 0) > 0
-
-        return hasSelection && !hideTableFilterToggle
+        const { hideTableFilterToggle, showEntityButton } = this.manager
+        const selectionArray = makeSelectionArray(this.manager)
+        return (
+            selectionArray.hasSelection &&
+            !!showEntityButton &&
+            !hideTableFilterToggle
+        )
     }
 
     @computed get showSettingsMenuToggle(): boolean {

--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
@@ -67,7 +67,7 @@ export interface SettingsMenuManager
     type: ChartTypeName
     isRelativeMode?: boolean
     selection?: SelectionArray | EntityName[]
-    showEntityButton?: boolean
+    showEntitySelectionToggle?: boolean
     filledDimensions: ChartDimension[]
     xColumnSlug?: string
     xOverrideTime?: number
@@ -197,11 +197,12 @@ export class SettingsMenu extends React.Component<{
     }
 
     @computed get showTableFilterToggle(): boolean {
-        const { hideTableFilterToggle, showEntityButton } = this.manager
+        const { hideTableFilterToggle, showEntitySelectionToggle } =
+            this.manager
         const selectionArray = makeSelectionArray(this.manager)
         return (
             selectionArray.hasSelection &&
-            !!showEntityButton &&
+            !!showEntitySelectionToggle &&
             !hideTableFilterToggle
         )
     }

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -3069,9 +3069,10 @@ export class Grapher
 
     @computed get showEntityButton(): boolean {
         return (
-            this.showChangeEntityButton ||
-            this.showAddEntityButton ||
-            this.showSelectEntitiesButton
+            this.hasChartTab &&
+            (this.showChangeEntityButton ||
+                this.showAddEntityButton ||
+                this.showSelectEntitiesButton)
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -194,6 +194,7 @@ import {
     StaticChartRasterizer,
     type GrapherExport,
 } from "../captionedChart/StaticChartRasterizer.js"
+import { EntitySelectionToggle } from "../controls/EntitySelectionToggle.js"
 
 declare const window: any
 
@@ -3067,13 +3068,8 @@ export class Grapher
         )
     }
 
-    @computed get showEntityButton(): boolean {
-        return (
-            this.hasChartTab &&
-            (this.showChangeEntityButton ||
-                this.showAddEntityButton ||
-                this.showSelectEntitiesButton)
-        )
+    @computed get showEntitySelectionToggle(): boolean {
+        return EntitySelectionToggle.shouldShow(this)
     }
 
     @computed get canSelectMultipleEntities(): boolean {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -3067,6 +3067,14 @@ export class Grapher
         )
     }
 
+    @computed get showEntityButton(): boolean {
+        return (
+            this.showChangeEntityButton ||
+            this.showAddEntityButton ||
+            this.showSelectEntitiesButton
+        )
+    }
+
     @computed get canSelectMultipleEntities(): boolean {
         if (this.numSelectableEntityNames < 2) return false
         if (this.addCountryMode === EntitySelectionMode.MultipleEntities)

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -3069,7 +3069,12 @@ export class Grapher
     }
 
     @computed get showEntitySelectionToggle(): boolean {
-        return EntitySelectionToggle.shouldShow(this)
+        return (
+            this.hasChartTab &&
+            (this.showChangeEntityButton ||
+                this.showAddEntityButton ||
+                this.showSelectEntitiesButton)
+        )
     }
 
     @computed get canSelectMultipleEntities(): boolean {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -194,7 +194,6 @@ import {
     StaticChartRasterizer,
     type GrapherExport,
 } from "../captionedChart/StaticChartRasterizer.js"
-import { EntitySelectionToggle } from "../controls/EntitySelectionToggle.js"
 
 declare const window: any
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -3042,15 +3042,15 @@ export class Grapher
             : timeColumn.formatValue(value)
     }
 
-    @computed get shouldShowChangeEntityButton(): boolean {
+    @computed get hasChangeEntityButton(): boolean {
         return this.canChangeEntity
     }
 
     @computed get showChangeEntityButton(): boolean {
-        return !this.hideEntityControls && this.shouldShowChangeEntityButton
+        return !this.hideEntityControls && this.hasChangeEntityButton
     }
 
-    @computed get shouldShowAddEntityButton(): boolean {
+    @computed get hasAddEntityButton(): boolean {
         return (
             this.canSelectMultipleEntities &&
             (this.isLineChart ||
@@ -3061,10 +3061,10 @@ export class Grapher
     }
 
     @computed get showAddEntityButton(): boolean {
-        return !this.hideEntityControls && this.shouldShowAddEntityButton
+        return !this.hideEntityControls && this.hasAddEntityButton
     }
 
-    @computed get shouldShowSelectEntitiesButton(): boolean {
+    @computed get hasSelectEntitiesButton(): boolean {
         return (
             this.addCountryMode !== EntitySelectionMode.Disabled &&
             this.numSelectableEntityNames > 1 &&
@@ -3074,18 +3074,15 @@ export class Grapher
     }
 
     @computed get showSelectEntitiesButton(): boolean {
-        return (
-            !this.hideEntityControls &&
-            this.shouldShowSelectEntitiesButton
-        )
+        return !this.hideEntityControls && this.hasSelectEntitiesButton
     }
 
-    @computed get shouldShowEntitySelectionToggle(): boolean {
+    @computed get hasEntitySelectionToggle(): boolean {
         return (
             this.hasChartTab &&
-            (this.shouldShowChangeEntityButton ||
-                this.shouldShowAddEntityButton ||
-                this.shouldShowSelectEntitiesButton)
+            (this.hasChangeEntityButton ||
+                this.hasAddEntityButton ||
+                this.hasSelectEntitiesButton)
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -3042,13 +3042,16 @@ export class Grapher
             : timeColumn.formatValue(value)
     }
 
-    @computed get showChangeEntityButton(): boolean {
-        return !this.hideEntityControls && this.canChangeEntity
+    @computed get shouldShowChangeEntityButton(): boolean {
+        return this.canChangeEntity
     }
 
-    @computed get showAddEntityButton(): boolean {
+    @computed get showChangeEntityButton(): boolean {
+        return !this.hideEntityControls && this.shouldShowChangeEntityButton
+    }
+
+    @computed get shouldShowAddEntityButton(): boolean {
         return (
-            !this.hideEntityControls &&
             this.canSelectMultipleEntities &&
             (this.isLineChart ||
                 this.isStackedArea ||
@@ -3057,9 +3060,12 @@ export class Grapher
         )
     }
 
-    @computed get showSelectEntitiesButton(): boolean {
+    @computed get showAddEntityButton(): boolean {
+        return !this.hideEntityControls && this.shouldShowAddEntityButton
+    }
+
+    @computed get shouldShowSelectEntitiesButton(): boolean {
         return (
-            !this.hideEntityControls &&
             this.addCountryMode !== EntitySelectionMode.Disabled &&
             this.numSelectableEntityNames > 1 &&
             !this.showAddEntityButton &&
@@ -3067,12 +3073,19 @@ export class Grapher
         )
     }
 
-    @computed get showEntitySelectionToggle(): boolean {
+    @computed get showSelectEntitiesButton(): boolean {
+        return (
+            !this.hideEntityControls &&
+            this.shouldShowSelectEntitiesButton
+        )
+    }
+
+    @computed get shouldShowEntitySelectionToggle(): boolean {
         return (
             this.hasChartTab &&
-            (this.showChangeEntityButton ||
-                this.showAddEntityButton ||
-                this.showSelectEntitiesButton)
+            (this.shouldShowChangeEntityButton ||
+                this.shouldShowAddEntityButton ||
+                this.shouldShowSelectEntitiesButton)
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.sample.ts
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.sample.ts
@@ -69,6 +69,7 @@ export const IncompleteDataTable = (
     props: Partial<GrapherInterface> = {}
 ): Grapher =>
     new Grapher({
+        hasMapTab: true,
         tab: GrapherTabOption.table,
         dimensions: [
             {
@@ -145,6 +146,7 @@ export const DataTableWithAggregates = (
     props: Partial<GrapherInterface> = {}
 ): Grapher =>
     new Grapher({
+        hasMapTab: true,
         tab: GrapherTabOption.table,
         dimensions: [
             {
@@ -216,6 +218,7 @@ export const DataTableWithMultipleVariablesAndMultipleYears = (
     props: Partial<GrapherInterface> = {}
 ): Grapher =>
     new Grapher({
+        hasMapTab: true,
         tab: GrapherTabOption.table,
         dimensions: [
             {

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -91,6 +91,8 @@ export interface DataTableManager {
     isMedium?: boolean
     isNarrow?: boolean
     selection?: SelectionArray | EntityName[]
+    showEntitySelectionToggle?: boolean
+    hasMapTab?: boolean
 }
 
 @observer
@@ -134,9 +136,23 @@ export class DataTable extends React.Component<{
         }
     }
 
+    @computed get showSelectionOnlyInDataTable(): boolean {
+        const {
+            showSelectionOnlyInDataTable,
+            showEntitySelectionToggle,
+            hasMapTab,
+        } = this.manager
+
+        // filter the table if the "Show selection only" toggle is hidden
+        // (unless we have a map tab, in which case we want to show all entities)
+        if (!showEntitySelectionToggle && !hasMapTab) return true
+
+        return !!showSelectionOnlyInDataTable
+    }
+
     @computed get table(): OwidTable {
         let table = this.manager.tableForDisplay
-        if (this.manager.showSelectionOnlyInDataTable) {
+        if (this.showSelectionOnlyInDataTable) {
             table = table.filterByEntityNames(
                 this.selectionArray.selectedEntityNames
             )

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -91,7 +91,7 @@ export interface DataTableManager {
     isMedium?: boolean
     isNarrow?: boolean
     selection?: SelectionArray | EntityName[]
-    shouldShowEntitySelectionToggle?: boolean
+    hasEntitySelectionToggle?: boolean
     hasMapTab?: boolean
     hasChartTab?: boolean
 }
@@ -140,7 +140,7 @@ export class DataTable extends React.Component<{
     @computed get showSelectionOnlyInDataTable(): boolean {
         const {
             showSelectionOnlyInDataTable,
-            shouldShowEntitySelectionToggle,
+            hasEntitySelectionToggle,
             hasChartTab,
             hasMapTab,
         } = this.manager
@@ -148,7 +148,7 @@ export class DataTable extends React.Component<{
 
         // filter the table if the "Show selection only" toggle is hidden
         if (
-            !shouldShowEntitySelectionToggle &&
+            !hasEntitySelectionToggle &&
             selectionArray.hasSelection &&
             hasChartTab &&
             // if we have a map tab, we want to show all entities

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -93,6 +93,7 @@ export interface DataTableManager {
     selection?: SelectionArray | EntityName[]
     showEntitySelectionToggle?: boolean
     hasMapTab?: boolean
+    hasChartTab?: boolean
 }
 
 @observer
@@ -140,12 +141,20 @@ export class DataTable extends React.Component<{
         const {
             showSelectionOnlyInDataTable,
             showEntitySelectionToggle,
+            hasChartTab,
             hasMapTab,
         } = this.manager
+        const { selectionArray } = this
 
         // filter the table if the "Show selection only" toggle is hidden
-        // (unless we have a map tab, in which case we want to show all entities)
-        if (!showEntitySelectionToggle && !hasMapTab) return true
+        if (
+            !showEntitySelectionToggle &&
+            selectionArray.hasSelection &&
+            hasChartTab &&
+            // if we have a map tab, we want to show all entities
+            !hasMapTab
+        )
+            return true
 
         return !!showSelectionOnlyInDataTable
     }

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -90,6 +90,7 @@ export interface DataTableManager {
     isSmall?: boolean
     isMedium?: boolean
     isNarrow?: boolean
+    selection?: SelectionArray | EntityName[]
 }
 
 @observer

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -91,7 +91,7 @@ export interface DataTableManager {
     isMedium?: boolean
     isNarrow?: boolean
     selection?: SelectionArray | EntityName[]
-    showEntitySelectionToggle?: boolean
+    shouldShowEntitySelectionToggle?: boolean
     hasMapTab?: boolean
     hasChartTab?: boolean
 }
@@ -140,7 +140,7 @@ export class DataTable extends React.Component<{
     @computed get showSelectionOnlyInDataTable(): boolean {
         const {
             showSelectionOnlyInDataTable,
-            showEntitySelectionToggle,
+            shouldShowEntitySelectionToggle,
             hasChartTab,
             hasMapTab,
         } = this.manager
@@ -148,7 +148,7 @@ export class DataTable extends React.Component<{
 
         // filter the table if the "Show selection only" toggle is hidden
         if (
-            !showEntitySelectionToggle &&
+            !shouldShowEntitySelectionToggle &&
             selectionArray.hasSelection &&
             hasChartTab &&
             // if we have a map tab, we want to show all entities


### PR DESCRIPTION
### Summary

- The "Show selection only" toggle only makes sense in concert with the entity selector
- If entity selection is disabled, the "Show selection only" toggle is hidden
- If entity selection is disabled, the data table shows the current selection only
     - Unless Grapher has a map tab, in which case the table shows all entities
     - Unless Grapher has no chart tab
     - Unless the selection is empty

### Example charts

- http://staging-site-improve-show-selection-only-toggle/grapher/out-of-school-girls-of-primary-school-age-by-world-region?tab=table
    - Grapher doesn't have an entity selector -> "Show selection only" toggle is hidden and the current selection is applied
- http://staging-site-improve-show-selection-only-toggle/grapher/population-census-world-bank?tab=table
    - Grapher doesn't have a chart tab, thus doesn't have an entity selector -> "Show selection only" toggle is hidden (but the current selection is not applied since we want to show all entities for maps)
- http://staging-site-improve-show-selection-only-toggle/grapher/sources-population-dataset
    - Grapher only has a table tab -> "Show selection only" toggle is hidden (but the table is not filtered by default)

### References

- fixes #2821 
- fixes #2790 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced SVG comparison tool with HTML report generation for visual differences.
  - Improved accessibility across the site by adding `aria-label` attributes to interactive elements.
  - Added "View live" link on document preview pages based on publication status.
  - Implemented new query parameter combinations for chart configurations in testing tools.
  - Introduced a new `cartesian` utility function for computing the cartesian product of arrays.

- **Bug Fixes**
  - Fixed an issue with Google Docs parsing by adjusting character replacements in API router.
  - Corrected image URL handling by using `encodeURIComponent` for better consistency.

- **Documentation**
  - Updated documentation to reflect changes in SVG comparison and testing tools.

- **Refactor**
  - Refactored several components in the admin site client for better maintainability.
  - Improved the modularity and readability of the `export-graphs.js` script.
  - Refined computed properties in `Grapher.tsx` for clearer entity selection logic.

- **Style**
  - Adjusted icon margin in `GdocsEditLink.tsx` for better visual layout.

- **Chores**
  - Updated the environment variable format in SVG comparison workflow.
  - Cleaned untracked files in SVG repository during testing.

- **Revert**
  - Removed "View changed SVGs" link from the admin site test index page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->