### PR TITLE
:honeybee: (admin) remove WorldMap from chart type list

### DIFF
--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -326,7 +326,9 @@ export class EditorBasicTab extends React.Component<{ editor: ChartEditor }> {
     render() {
         const { editor } = this.props
         const { grapher } = editor
-        const chartTypes = Object.keys(ChartTypeName)
+        const chartTypes = Object.keys(ChartTypeName).filter(
+            (chartType) => chartType !== ChartTypeName.WorldMap
+        )
 
         return (
             <div className="EditorBasicTab">

--- a/devTools/schemaProcessor/columns.json
+++ b/devTools/schemaProcessor/columns.json
@@ -644,7 +644,6 @@
             "StackedDiscreteBar",
             "SlopeChart",
             "StackedBar",
-            "WorldMap",
             "Marimekko"
         ]
     },

--- a/packages/@ourworldindata/grapher/src/controls/ChartIcons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ChartIcons.tsx
@@ -17,9 +17,6 @@ export const chartIcons: Record<ChartTypeName, JSX.Element> = {
     [ChartTypeName.StackedBar]: <FontAwesomeIcon icon={faChartColumn} />,
     [ChartTypeName.StackedDiscreteBar]: <FontAwesomeIcon icon={faChartBar} />,
 
-    // world map
-    [ChartTypeName.WorldMap]: <FontAwesomeIcon icon={faEarthAmericas} />,
-
     // scatter
     [ChartTypeName.ScatterPlot]: (
         <svg
@@ -110,4 +107,7 @@ export const chartIcons: Record<ChartTypeName, JSX.Element> = {
             </g>
         </svg>
     ),
+
+    // world map (will never be invoked but included for completeness)
+    [ChartTypeName.WorldMap]: <FontAwesomeIcon icon={faEarthAmericas} />,
 }

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -10,8 +10,10 @@ export enum ChartTypeName {
     StackedDiscreteBar = "StackedDiscreteBar",
     SlopeChart = "SlopeChart",
     StackedBar = "StackedBar",
-    WorldMap = "WorldMap",
     Marimekko = "Marimekko",
+
+    // special map type that can't be selected by authors
+    WorldMap = "WorldMap",
 }
 
 export const GRAPHER_EMBEDDED_FIGURE_ATTR = "data-grapher-src"

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
@@ -548,7 +548,6 @@ properties:
             - StackedDiscreteBar
             - SlopeChart
             - StackedBar
-            - WorldMap
             - Marimekko
     hasMapTab:
         type: boolean


### PR DESCRIPTION
- `WorldMap` is removed from the admin's chart type list but continues to be used as chart type internally
- None of our charts are of type `WorldMap` currently, so no migration necessary
- Technically, this is a breaking change for our schema, but I don't think there is a need to increase the schema version etc since there is no code change