### PR TITLE
🐝 (svg tester) add GitHub action to test all possible chart views

### DIFF
--- a/.github/workflows/svg-compare-all-views.yml
+++ b/.github/workflows/svg-compare-all-views.yml
@@ -35,16 +35,20 @@ jobs:
                   path: owid-grapher-svgs
                   token: ${{ env.TOKEN }}
 
-            # Switch to or create a branch on that repo that matches the branch name we are on in the owid-grapher repo
+            # Create a branch on that repo that matches the branch name we are on in the owid-grapher repo
             # but only do this if we are not on master in owid-graphers (in this case we want to commit and push on master
             # in owid-grapher-svgs as well)
             - name: create owid-grapher-svgs local branch
               if: ${{ env.PUSH_BRANCH_NAME != 'master'}}
               working-directory: owid-grapher-svgs
               continue-on-error: true
-              run: |
-                  git branch ${{ env.PUSH_BRANCH_NAME }} || echo "Branch ${{ env.PUSH_BRANCH_NAME }} already exists"
-                  git checkout ${{ env.PUSH_BRANCH_NAME }}
+              run: git branch ${{ env.PUSH_BRANCH_NAME }} || echo "Branch ${{ env.PUSH_BRANCH_NAME }} already exists"
+
+            # Checkout the branch we just created (but not if we are on master in owid-grapher)
+            - name: checkout owid-grapher-svgs local branch
+              if: ${{ env.PUSH_BRANCH_NAME != 'master'}}
+              working-directory: owid-grapher-svgs
+              run: git checkout ${{ env.PUSH_BRANCH_NAME }}
 
             # Run the verify tool overwriting any svgs. Stdout is piped to compare-result which will be a 0 byte file if everything works or contain failed grapher ids otherwise
             - name: Generate SVGs and compare to reference

--- a/.github/workflows/svg-compare-all-views.yml
+++ b/.github/workflows/svg-compare-all-views.yml
@@ -1,0 +1,83 @@
+name: SVG diff (all views)
+on: workflow_dispatch
+
+jobs:
+    svgTester:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Clone repository
+              uses: actions/checkout@v3
+
+            - uses: ./.github/actions/setup-node-yarn-deps
+            - uses: ./.github/actions/build-tsc
+
+            - name: Set branch name and token for OWID runs
+              if: ${{ github.repository_owner == 'owid' }}
+              shell: bash
+              run: |
+                  echo "PUSH_BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
+                  echo "SVG_TESTER_BRANCH_NAME=${{ github.ref_name }}-all-views" >> $GITHUB_ENV
+                  echo "TOKEN=${{ secrets.GITHUBPAT }}" >> $GITHUB_ENV
+
+            - name: Set branch name and token for runs from a fork
+              if: ${{ github.repository_owner != 'owid' }}
+              shell: bash
+              run: |
+                  echo "PUSH_BRANCH_NAME=${{ github.repository_owner }}/${{ github.ref_name }}" >> $GITHUB_ENV
+                  echo "SVG_TESTER_BRANCH_NAME=${{ github.repository_owner }}/${{ github.ref_name }}-all-views" >> $GITHUB_ENV
+                  echo "TOKEN=${{ github.token }}" >> $GITHUB_ENV
+
+            # Checkout the owid-grapher-svgs repo into a subfolder. Use a Personal Access Token for checkout so the
+            # action will have permission to push later on if required.
+            - name: Clone svg tester repo
+              uses: actions/checkout@v3
+              with:
+                  repository: "owid/owid-grapher-svgs"
+                  path: owid-grapher-svgs
+                  token: ${{ env.TOKEN }}
+
+            # Switch to or create a branch on that repo that matches the branch name we are on in the owid-grapher repo
+            # but only do this if we are not on master in owid-graphers (in this case we want to commit and push on master
+            # in owid-grapher-svgs as well)
+            - name: create owid-grapher-svgs local branch
+              if: ${{ env.PUSH_BRANCH_NAME != 'master'}}
+              working-directory: owid-grapher-svgs
+              run: git branch ${{ env.SVG_TESTER_BRANCH_NAME }} && git checkout ${{ env.SVG_TESTER_BRANCH_NAME }}
+
+            # Run the verify tool overwriting any svgs. Stdout is piped to compare-result which will be a 0 byte file if everything works or contain failed grapher ids otherwise
+            - name: Generate SVGs and compare to reference
+              id: run-verify-graphs
+              continue-on-error: true
+              env:
+                  # using "ternary operator" from https://github.com/actions/runner/issues/409#issuecomment-752775072
+                  RM_ON_ERROR: ${{ env.PUSH_BRANCH_NAME == 'master' && '' || '--rm-on-error' }}
+              run: node --enable-source-maps itsJustJavascript/devTools/svgTester/verify-graphs.js -i owid-grapher-svgs/configs -o owid-grapher-svgs/svg-all-views -r owid-grapher-svgs/svg-all-views $RM_ON_ERROR > compare-result
+
+            # If the last step failed we want to commit all changed svgs and push them to the new branch on the owid-grapher-svgs repo
+            - uses: stefanzweifel/git-auto-commit-action@v4
+              if: ${{ steps.run-verify-graphs.outcome == 'failure' }}
+              with:
+                  repository: ./owid-grapher-svgs/
+                  branch: ${{ env.PUSH_BRANCH_NAME }}
+                  push_options: "--force"
+                  commit_message: Automated commit with svg differences triggered by commit https://github.com/owid/owid-grapher/commit/${{github.sha}}
+
+            # The action fails if there were any errors.
+            - name: Fail with error message if we had errors
+              if: ${{ steps.run-verify-graphs.outputs.num_errors > 0 }}
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      core.setFailed('Errors were thrown during checking! Please check diffs at https://github.com/owid/owid-grapher-svgs/commits/${{ env.PUSH_BRANCH_NAME }}')
+
+            # We make the action fail if there were any differences and if we are on a branch other than master. On master
+            # we do not want to fail because the differences on master are intended to be authorative and thus there is no
+            # reason to mark this action as failed.
+            - name: Fail with error message if we had differences
+              if: ${{ steps.run-verify-graphs.outputs.num_differences > 0 }}
+              continue-on-error: ${{ env.PUSH_BRANCH_NAME == 'master' }}
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      core.setFailed('SVGs were different from reference! Please check diffs at https://github.com/owid/owid-grapher-svgs/commits/${{ env.PUSH_BRANCH_NAME }}')

--- a/.github/workflows/svg-compare-all-views.yml
+++ b/.github/workflows/svg-compare-all-views.yml
@@ -66,7 +66,7 @@ jobs:
                   repository: ./owid-grapher-svgs/
                   branch: ${{ env.PUSH_BRANCH_NAME }}
                   push_options: "--force"
-                  commit_message: Automated commit with svg differences triggered by commit https://github.com/owid/owid-grapher/commit/${{github.sha}}
+                  commit_message: Automated commit with svg differences of all views triggered by commit https://github.com/owid/owid-grapher/commit/${{github.sha}}
 
             # The action fails if there were any errors.
             - name: Fail with error message if we had errors

--- a/.github/workflows/svg-compare-all-views.yml
+++ b/.github/workflows/svg-compare-all-views.yml
@@ -17,7 +17,6 @@ jobs:
               shell: bash
               run: |
                   echo "PUSH_BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
-                  echo "SVG_TESTER_BRANCH_NAME=${{ github.ref_name }}-all-views" >> $GITHUB_ENV
                   echo "TOKEN=${{ secrets.GITHUBPAT }}" >> $GITHUB_ENV
 
             - name: Set branch name and token for runs from a fork
@@ -25,7 +24,6 @@ jobs:
               shell: bash
               run: |
                   echo "PUSH_BRANCH_NAME=${{ github.repository_owner }}/${{ github.ref_name }}" >> $GITHUB_ENV
-                  echo "SVG_TESTER_BRANCH_NAME=${{ github.repository_owner }}/${{ github.ref_name }}-all-views" >> $GITHUB_ENV
                   echo "TOKEN=${{ github.token }}" >> $GITHUB_ENV
 
             # Checkout the owid-grapher-svgs repo into a subfolder. Use a Personal Access Token for checkout so the
@@ -43,7 +41,9 @@ jobs:
             - name: create owid-grapher-svgs local branch
               if: ${{ env.PUSH_BRANCH_NAME != 'master'}}
               working-directory: owid-grapher-svgs
-              run: git branch ${{ env.SVG_TESTER_BRANCH_NAME }} && git checkout ${{ env.SVG_TESTER_BRANCH_NAME }}
+              run: |
+                  git branch ${{ env.PUSH_BRANCH_NAME }} || echo "Branch ${{ env.PUSH_BRANCH_NAME }} already exists"
+                  git checkout ${{ env.PUSH_BRANCH_NAME }}
 
             # Run the verify tool overwriting any svgs. Stdout is piped to compare-result which will be a 0 byte file if everything works or contain failed grapher ids otherwise
             - name: Generate SVGs and compare to reference

--- a/.github/workflows/svg-compare-all-views.yml
+++ b/.github/workflows/svg-compare-all-views.yml
@@ -52,7 +52,7 @@ jobs:
               env:
                   # using "ternary operator" from https://github.com/actions/runner/issues/409#issuecomment-752775072
                   RM_ON_ERROR: ${{ env.PUSH_BRANCH_NAME == 'master' && '' || '--rm-on-error' }}
-              run: node --enable-source-maps itsJustJavascript/devTools/svgTester/verify-graphs.js -i owid-grapher-svgs/configs -o owid-grapher-svgs/svg-all-views -r owid-grapher-svgs/svg-all-views --ids-from-file owid-grapher-svgs/most-viewed-charts.txt --all-views $RM_ON_ERROR > compare-result
+              run: node --enable-source-maps itsJustJavascript/devTools/svgTester/verify-graphs.js -i owid-grapher-svgs/configs -o owid-grapher-svgs/all-views/svg -r owid-grapher-svgs/all-views/svg --ids-from-file owid-grapher-svgs/most-viewed-charts.txt --all-views $RM_ON_ERROR > compare-result
 
             # If the last step failed we want to commit all changed svgs and push them to the new branch on the owid-grapher-svgs repo
             - uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/svg-compare-all-views.yml
+++ b/.github/workflows/svg-compare-all-views.yml
@@ -52,7 +52,7 @@ jobs:
               env:
                   # using "ternary operator" from https://github.com/actions/runner/issues/409#issuecomment-752775072
                   RM_ON_ERROR: ${{ env.PUSH_BRANCH_NAME == 'master' && '' || '--rm-on-error' }}
-              run: node --enable-source-maps itsJustJavascript/devTools/svgTester/verify-graphs.js -i owid-grapher-svgs/configs -o owid-grapher-svgs/svg-all-views -r owid-grapher-svgs/svg-all-views --ids-from-file owid-grapher-svgs/most-viewed-charts.txt $RM_ON_ERROR > compare-result
+              run: node --enable-source-maps itsJustJavascript/devTools/svgTester/verify-graphs.js -i owid-grapher-svgs/configs -o owid-grapher-svgs/svg-all-views -r owid-grapher-svgs/svg-all-views --ids-from-file owid-grapher-svgs/most-viewed-charts.txt --all-views $RM_ON_ERROR > compare-result
 
             # If the last step failed we want to commit all changed svgs and push them to the new branch on the owid-grapher-svgs repo
             - uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/svg-compare-all-views.yml
+++ b/.github/workflows/svg-compare-all-views.yml
@@ -52,7 +52,7 @@ jobs:
               env:
                   # using "ternary operator" from https://github.com/actions/runner/issues/409#issuecomment-752775072
                   RM_ON_ERROR: ${{ env.PUSH_BRANCH_NAME == 'master' && '' || '--rm-on-error' }}
-              run: node --enable-source-maps itsJustJavascript/devTools/svgTester/verify-graphs.js -i owid-grapher-svgs/configs -o owid-grapher-svgs/svg-all-views -r owid-grapher-svgs/svg-all-views $RM_ON_ERROR > compare-result
+              run: node --enable-source-maps itsJustJavascript/devTools/svgTester/verify-graphs.js -i owid-grapher-svgs/configs -o owid-grapher-svgs/svg-all-views -r owid-grapher-svgs/svg-all-views --ids-from-file owid-grapher-svgs/most-viewed-charts.txt $RM_ON_ERROR > compare-result
 
             # If the last step failed we want to commit all changed svgs and push them to the new branch on the owid-grapher-svgs repo
             - uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/svg-compare-all-views.yml
+++ b/.github/workflows/svg-compare-all-views.yml
@@ -41,6 +41,7 @@ jobs:
             - name: create owid-grapher-svgs local branch
               if: ${{ env.PUSH_BRANCH_NAME != 'master'}}
               working-directory: owid-grapher-svgs
+              continue-on-error: true
               run: |
                   git branch ${{ env.PUSH_BRANCH_NAME }} || echo "Branch ${{ env.PUSH_BRANCH_NAME }} already exists"
                   git checkout ${{ env.PUSH_BRANCH_NAME }}

--- a/.github/workflows/svg-compare.yml
+++ b/.github/workflows/svg-compare.yml
@@ -35,16 +35,20 @@ jobs:
                   path: owid-grapher-svgs
                   token: ${{ env.TOKEN }}
 
-            # Switch to or create a branch on that repo that matches the branch name we are on in the owid-grapher repo
+            # Create a branch on that repo that matches the branch name we are on in the owid-grapher repo
             # but only do this if we are not on master in owid-graphers (in this case we want to commit and push on master
             # in owid-grapher-svgs as well)
             - name: create owid-grapher-svgs local branch
               if: ${{ env.PUSH_BRANCH_NAME != 'master'}}
               working-directory: owid-grapher-svgs
               continue-on-error: true
-              run: |
-                  git branch ${{ env.PUSH_BRANCH_NAME }} || echo "Branch ${{ env.PUSH_BRANCH_NAME }} already exists"
-                  git checkout ${{ env.PUSH_BRANCH_NAME }}
+              run: git branch ${{ env.PUSH_BRANCH_NAME }} || echo "Branch ${{ env.PUSH_BRANCH_NAME }} already exists"
+
+            # Checkout the branch we just created (but not if we are on master in owid-grapher)
+            - name: checkout owid-grapher-svgs local branch
+              if: ${{ env.PUSH_BRANCH_NAME != 'master'}}
+              working-directory: owid-grapher-svgs
+              run: git checkout ${{ env.PUSH_BRANCH_NAME }}
 
             # Run the verify tool overwriting any svgs. Stdout is piped to compare-result which will be a 0 byte file if everything works or contain failed grapher ids otherwise
             - name: Generate SVGs and compare to reference

--- a/.github/workflows/svg-compare.yml
+++ b/.github/workflows/svg-compare.yml
@@ -41,7 +41,9 @@ jobs:
             - name: create owid-grapher-svgs local branch
               if: ${{ env.PUSH_BRANCH_NAME != 'master'}}
               working-directory: owid-grapher-svgs
-              run: git branch ${{ env.PUSH_BRANCH_NAME }} && git checkout ${{ env.PUSH_BRANCH_NAME }}
+              run: |
+                  git branch ${{ env.PUSH_BRANCH_NAME }} || echo "Branch ${{ env.PUSH_BRANCH_NAME }} already exists"
+                  git checkout ${{ env.PUSH_BRANCH_NAME }}
 
             # Run the verify tool overwriting any svgs. Stdout is piped to compare-result which will be a 0 byte file if everything works or contain failed grapher ids otherwise
             - name: Generate SVGs and compare to reference

--- a/.github/workflows/svg-compare.yml
+++ b/.github/workflows/svg-compare.yml
@@ -41,6 +41,7 @@ jobs:
             - name: create owid-grapher-svgs local branch
               if: ${{ env.PUSH_BRANCH_NAME != 'master'}}
               working-directory: owid-grapher-svgs
+              continue-on-error: true
               run: |
                   git branch ${{ env.PUSH_BRANCH_NAME }} || echo "Branch ${{ env.PUSH_BRANCH_NAME }} already exists"
                   git checkout ${{ env.PUSH_BRANCH_NAME }}


### PR DESCRIPTION
- Adds a GitHub action to test all possible views of a subset of charts
- The action works exactly like the other action works
    - To review, it's probably easiest to look at the diff between `svg-compare.yml` and `svg-compare-all-views.yml`
- Both actions commit to the same branch in `owid-grapher-svgs`
    - Having all SVGs for one change on the same branch is convenient since I often pull from the repo to look at the SVG differences locally (if there are many differences, GitHub often fails too to load the page) 
    - Accidental content overwrites are impossible because both actions operate in different directories
- The verify step:
    - The verify script reads chart IDs to process from the `most-viewed-charts.txt` file in `owid-grapher-svgs`
    - The reference SVGs for all chart views are stored in `all-views/svg`
    - Reference SVGs and the `most-viewed-charts.txt` text file are added to the `owid-grapher-svgs` repo in https://github.com/owid/owid-grapher-svgs/pull/12

---

- I couldn't get `act` to run actions locally, so this GitHub action is not tested in any way
- That's why for now the action is configured to not run automatically. It can only be triggered by the click of a button on GitHub.
- Once it's properly tested, I'd configure it to run on push/pull.