### PR TITLE
:honeybee: (grapher) revert title font weight: semibold -> medium

### DIFF
--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -210,7 +210,7 @@ export class StaticHeader extends Header<StaticHeaderProps> {
                 text: titleText,
                 maxWidth: this.maxWidth - logoWidth - 24,
                 fontSize,
-                fontWeight: 600,
+                fontWeight: 500,
                 lineHeight: 1.2,
             })
 


### PR DESCRIPTION
Revert #2970 

PNGs didn't pick up the right font (I think), and displayed the title as `bold` which was too overpowering