### PR TITLE
🐛 Fix missing featured images

### DIFF
--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -343,14 +343,21 @@ export class SiteBaker {
                 linkedGrapherSlugs,
                 linkedExplorerSlugs,
             ] = picks
+            const linkedDocuments = pick(
+                this._prefetchedAttachmentsCache.linkedDocuments,
+                linkedDocumentIds
+            )
+            // Gdoc.linkedImageFilenames normally gets featuredImages, but it relies on linkedDocuments already being populated,
+            // which is isn't when we're prefetching attachments. So we have to do it manually here.
+            const featuredImages = Object.values(linkedDocuments)
+                .map((gdoc) => gdoc.content["featured-image"])
+                .filter((filename): filename is string => !!filename)
+
             return {
-                linkedDocuments: pick(
-                    this._prefetchedAttachmentsCache.linkedDocuments,
-                    linkedDocumentIds
-                ),
+                linkedDocuments,
                 imageMetadata: pick(
                     this._prefetchedAttachmentsCache.imageMetadata,
-                    imageFilenames
+                    [...imageFilenames, ...featuredImages]
                 ),
                 linkedCharts: {
                     graphers: {


### PR DESCRIPTION
`getPrefetchedGdocAttachments` is a function that queries the DB a couple of times to get all possible attachment data and caches it, so that we can pick the attachments from memory instead of querying the DB for each gdoc bake.

There was a bug in my implementation where linked documents' featured images weren't getting picked, because `linkedDocuments` is a dependency of `linkedImageFilenames`, but both are undefined when we call the function.

This PR fixes the bug by appending the featured images of any linked documents to the list of linkedImageFilenames when we're doing the picking.

**Before:**
![image](https://github.com/owid/owid-grapher/assets/11844404/3e930598-c7b2-480e-89de-279a870eb0af)


**After:**
![image](https://github.com/owid/owid-grapher/assets/11844404/70e3bc06-3a1a-4899-b8cf-9eab456e8126)
