### PR TITLE
🔨 use a minimal representation of gdocs to link to

### DIFF
--- a/db/model/Gdoc/GdocDataInsight.ts
+++ b/db/model/Gdoc/GdocDataInsight.ts
@@ -4,10 +4,10 @@ import {
     OwidGdocErrorMessageType,
     OwidGdocDataInsightContent,
     OwidGdocDataInsightInterface,
-    OwidGdocPostInterface,
     MinimalDataInsightInterface,
     OwidGdocType,
     DATA_INSIGHTS_INDEX_PAGE_SIZE,
+    OwidGdocMinimalPostInterface,
 } from "@ourworldindata/utils"
 import { GdocBase } from "./GdocBase.js"
 import { getConnection } from "../../../db/db.js"
@@ -27,7 +27,7 @@ export class GdocDataInsight
         }
     }
 
-    linkedDocuments: Record<string, OwidGdocPostInterface> = {}
+    linkedDocuments: Record<string, OwidGdocMinimalPostInterface> = {}
     latestDataInsights: MinimalDataInsightInterface[] = []
     // TODO: support query parameters in grapher urls so we can track country selections
     _urlProperties: string[] = ["grapher-url"]

--- a/db/model/Gdoc/GdocPost.ts
+++ b/db/model/Gdoc/GdocPost.ts
@@ -11,6 +11,7 @@ import {
     OwidEnrichedGdocBlock,
     RawBlockText,
     RelatedChart,
+    OwidGdocMinimalPostInterface,
 } from "@ourworldindata/utils"
 import { GDOCS_DETAILS_ON_DEMAND_ID } from "../../../settings/serverSettings.js"
 import {
@@ -35,7 +36,7 @@ export class GdocPost extends GdocBase implements OwidGdocPostInterface {
         }
     }
 
-    linkedDocuments: Record<string, OwidGdocPostInterface> = {}
+    linkedDocuments: Record<string, OwidGdocMinimalPostInterface> = {}
     relatedCharts: RelatedChart[] = []
     _filenameProperties = ["cover-image", "featured-image"]
 

--- a/db/model/Gdoc/gdocUtils.ts
+++ b/db/model/Gdoc/gdocUtils.ts
@@ -3,6 +3,10 @@ import {
     Span,
     excludeNullish,
     EnrichedBlockResearchAndWritingLink,
+    OwidGdocMinimalPostInterface,
+    OwidGdocType,
+    formatDate,
+    OwidGdocBaseInterface,
 } from "@ourworldindata/utils"
 import { match, P } from "ts-pattern"
 import cheerio from "cheerio"
@@ -150,4 +154,21 @@ export function parseAuthors(authors?: string): string[] {
     return (authors || "Our World in Data team")
         .split(",")
         .map((author: string) => author.trim())
+}
+
+export function fullGdocToMinimalGdoc(
+    gdoc: OwidGdocBaseInterface
+): OwidGdocMinimalPostInterface {
+    return {
+        id: gdoc.id,
+        title: gdoc.content.title || "",
+        slug: gdoc.slug,
+        authors: gdoc.content.authors,
+        publishedAt: gdoc.publishedAt ? formatDate(gdoc.publishedAt) : "",
+        published: gdoc.published,
+        subtitle: gdoc.content.subtitle || "",
+        excerpt: gdoc.content.excerpt || "",
+        type: gdoc.content.type || OwidGdocType.Article,
+        "featured-image": gdoc.content["featured-image"],
+    }
 }

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -54,21 +54,20 @@ export interface OwidGdocBaseInterface {
 
 export interface OwidGdocPostInterface extends OwidGdocBaseInterface {
     content: OwidGdocPostContent
-    linkedDocuments?: Record<string, OwidGdocMinimalPostInterface>
 }
 
 // Used for linkedDocuments attachments, instead of attaching the entire gdoc model
 export interface OwidGdocMinimalPostInterface {
     id: string
-    title: string
+    title: string // used in prominent links, topic-page-intro related topics, etc
     slug: string
-    authors: string[]
-    publishedAt: string
-    published: boolean
-    subtitle: string
-    excerpt: string
-    type: OwidGdocType
-    "featured-image"?: string
+    authors: string[] // used in research & writing block
+    publishedAt: string // used in research & writing block
+    published: boolean // used in preview to validate whether or not the post will display
+    subtitle: string // used in prominent links & research & writing block
+    excerpt: string // used in prominent links
+    type: OwidGdocType // used in useLinkedDocument to prepend /data-insights/ to the slug
+    "featured-image"?: string // used in prominent links and research & writing block
 }
 
 export interface OwidGdocDataInsightContent {
@@ -84,7 +83,6 @@ export const DATA_INSIGHTS_INDEX_PAGE_SIZE = 20
 
 export interface OwidGdocDataInsightInterface extends OwidGdocBaseInterface {
     content: OwidGdocDataInsightContent
-    linkedDocuments?: Record<string, OwidGdocMinimalPostInterface>
     latestDataInsights?: MinimalDataInsightInterface[]
     tags?: Tag[]
 }

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -44,7 +44,7 @@ export interface OwidGdocBaseInterface {
     revisionId: string | null
     publicationContext: OwidGdocPublicationContext
     breadcrumbs?: BreadcrumbItem[] | null
-    linkedDocuments?: Record<string, OwidGdocBaseInterface>
+    linkedDocuments?: Record<string, OwidGdocMinimalPostInterface>
     linkedCharts?: Record<string, LinkedChart>
     imageMetadata?: Record<string, ImageMetadata>
     relatedCharts?: RelatedChart[]
@@ -54,7 +54,21 @@ export interface OwidGdocBaseInterface {
 
 export interface OwidGdocPostInterface extends OwidGdocBaseInterface {
     content: OwidGdocPostContent
-    linkedDocuments?: Record<string, OwidGdocPostInterface>
+    linkedDocuments?: Record<string, OwidGdocMinimalPostInterface>
+}
+
+// Used for linkedDocuments attachments, instead of attaching the entire gdoc model
+export interface OwidGdocMinimalPostInterface {
+    id: string
+    title: string
+    slug: string
+    authors: string[]
+    publishedAt: string
+    published: boolean
+    subtitle: string
+    excerpt: string
+    type: OwidGdocType
+    "featured-image"?: string
 }
 
 export interface OwidGdocDataInsightContent {
@@ -70,7 +84,7 @@ export const DATA_INSIGHTS_INDEX_PAGE_SIZE = 20
 
 export interface OwidGdocDataInsightInterface extends OwidGdocBaseInterface {
     content: OwidGdocDataInsightContent
-    linkedDocuments?: Record<string, OwidGdocPostInterface>
+    linkedDocuments?: Record<string, OwidGdocMinimalPostInterface>
     latestDataInsights?: MinimalDataInsightInterface[]
     tags?: Tag[]
 }

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -261,6 +261,7 @@ export {
     type OwidGdocBaseInterface,
     type OwidGdocPostContent,
     type OwidGdocPostInterface,
+    type OwidGdocMinimalPostInterface,
     type OwidGdocDataInsightContent,
     type OwidGdocDataInsightInterface,
     type MinimalDataInsightInterface,

--- a/site/DataInsightsIndexPageContent.tsx
+++ b/site/DataInsightsIndexPageContent.tsx
@@ -4,7 +4,7 @@ import ReactDOM from "react-dom"
 import {
     ImageMetadata,
     LinkedChart,
-    OwidGdocPostInterface,
+    OwidGdocMinimalPostInterface,
     merge,
 } from "@ourworldindata/utils"
 import { DataInsightBody, indexToIdMap } from "./gdocs/pages/DataInsight.js"
@@ -93,7 +93,10 @@ export const DataInsightsIndexPageContent = (
             {
                 imageMetadata: {} as Record<string, ImageMetadata>,
                 linkedCharts: {} as Record<string, LinkedChart>,
-                linkedDocuments: {} as Record<string, OwidGdocPostInterface>,
+                linkedDocuments: {} as Record<
+                    string,
+                    OwidGdocMinimalPostInterface
+                >,
             }
         )
     return (

--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -2,7 +2,6 @@ import React, { createContext } from "react"
 import ReactDOM from "react-dom"
 import {
     LinkedChart,
-    OwidGdocPostInterface,
     getOwidGdocFromJSON,
     ImageMetadata,
     RelatedChart,
@@ -10,6 +9,7 @@ import {
     OwidGdocType,
     OwidGdoc as OwidGdocInterface,
     MinimalDataInsightInterface,
+    OwidGdocMinimalPostInterface,
 } from "@ourworldindata/utils"
 import { DebugProvider } from "./DebugContext.js"
 import { match, P } from "ts-pattern"
@@ -19,7 +19,7 @@ import { Fragment } from "./pages/Fragment.js"
 
 export const AttachmentsContext = createContext<{
     linkedCharts: Record<string, LinkedChart>
-    linkedDocuments: Record<string, OwidGdocPostInterface>
+    linkedDocuments: Record<string, OwidGdocMinimalPostInterface>
     imageMetadata: Record<string, ImageMetadata>
     relatedCharts: RelatedChart[]
     latestDataInsights?: MinimalDataInsightInterface[]

--- a/site/gdocs/components/ProminentLink.tsx
+++ b/site/gdocs/components/ProminentLink.tsx
@@ -47,9 +47,9 @@ export const ProminentLink = (props: {
     let thumbnail: string | undefined = props.thumbnail
     if (linkType === "gdoc") {
         href = `/${linkedDocument?.slug}`
-        title = title ?? linkedDocument?.content.title
-        description = description ?? linkedDocument?.content.excerpt
-        thumbnail = thumbnail ?? linkedDocument?.content["featured-image"]
+        title = title ?? linkedDocument?.title
+        description = description ?? linkedDocument?.excerpt
+        thumbnail = thumbnail ?? linkedDocument?.["featured-image"]
     } else if (linkType === "grapher" || linkType === "explorer") {
         href = `${linkedChart?.resolvedUrl}`
         title = title ?? linkedChart?.title

--- a/site/gdocs/components/Recirc.tsx
+++ b/site/gdocs/components/Recirc.tsx
@@ -10,14 +10,12 @@ function RecircItem({ url }: { url: string }) {
     return (
         <aside className="recirc-article-container">
             <h3 className="h3-bold">
-                <a href={`/${linkedDocument.slug}`}>
-                    {linkedDocument.content.title}
-                </a>
+                <a href={`/${linkedDocument.slug}`}>{linkedDocument.title}</a>
             </h3>
-            {linkedDocument.content.authors ? (
+            {linkedDocument.authors ? (
                 <div className="body-3-medium-italic">
                     {formatAuthors({
-                        authors: linkedDocument.content.authors,
+                        authors: linkedDocument.authors,
                     })}
                 </div>
             ) : null}

--- a/site/gdocs/components/ResearchAndWriting.tsx
+++ b/site/gdocs/components/ResearchAndWriting.tsx
@@ -43,10 +43,10 @@ function ResearchAndWritingLinkContainer(
 
     if (linkedDocument) {
         url = `/${linkedDocument.slug}`
-        title = linkedDocument.content.title || title
-        authors = linkedDocument.content.authors || authors
-        subtitle = linkedDocument.content.excerpt || subtitle
-        filename = linkedDocument.content["featured-image"] || filename
+        title = linkedDocument.title || title
+        authors = linkedDocument.authors || authors
+        subtitle = linkedDocument.excerpt || subtitle
+        filename = linkedDocument["featured-image"] || filename
     }
 
     const heading = React.createElement(

--- a/site/gdocs/components/TopicPageIntro.tsx
+++ b/site/gdocs/components/TopicPageIntro.tsx
@@ -20,7 +20,7 @@ function TopicPageRelatedTopic({
     if (errorMessage && isPreviewing) {
         return <li>{errorMessage}</li>
     }
-    const topicText = linkedDocument?.content.title || text
+    const topicText = linkedDocument?.title || text
     const topicUrl = linkedDocument?.slug ? `/${linkedDocument?.slug}` : url
     return (
         <li>

--- a/site/gdocs/utils.tsx
+++ b/site/gdocs/utils.tsx
@@ -4,12 +4,13 @@ import { getLinkType, getUrlTarget } from "@ourworldindata/components"
 import {
     Span,
     SpanLink,
-    OwidGdocPostInterface,
     ImageMetadata,
     LinkedChart,
     Url,
     OwidGdocPostContent,
     formatAuthors,
+    OwidGdocMinimalPostInterface,
+    OwidGdocType,
 } from "@ourworldindata/utils"
 import { match } from "ts-pattern"
 import { AttachmentsContext } from "./OwidGdoc.js"
@@ -45,10 +46,10 @@ export const breadcrumbColorForCoverColor = (
 
 export const useLinkedDocument = (
     url: string
-): { linkedDocument?: OwidGdocPostInterface; errorMessage?: string } => {
+): { linkedDocument?: OwidGdocMinimalPostInterface; errorMessage?: string } => {
     const { linkedDocuments } = useContext(AttachmentsContext)
     let errorMessage: string | undefined = undefined
-    let linkedDocument: OwidGdocPostInterface | undefined = undefined
+    let linkedDocument: OwidGdocMinimalPostInterface | undefined = undefined
     const linkType = getLinkType(url)
     if (linkType !== "gdoc") {
         return { linkedDocument }
@@ -59,7 +60,7 @@ export const useLinkedDocument = (
     const hash = urlObj.hash
     const urlTarget = getUrlTarget(url)
     linkedDocument = linkedDocuments?.[urlTarget] as
-        | OwidGdocPostInterface
+        | OwidGdocMinimalPostInterface
         | undefined
 
     if (!linkedDocument) {
@@ -68,10 +69,12 @@ export const useLinkedDocument = (
     } else if (!linkedDocument.published) {
         errorMessage = `Article with slug "${linkedDocument.slug}" isn't published.`
     }
+    const subdirectory =
+        linkedDocument.type === OwidGdocType.DataInsight ? "data-insights/" : ""
     return {
         linkedDocument: {
             ...linkedDocument,
-            slug: `${linkedDocument.slug}${queryString}${hash}`,
+            slug: `${subdirectory}${linkedDocument.slug}${queryString}${hash}`,
         },
         errorMessage,
     }


### PR DESCRIPTION
Currently if you link to another gdoc, we attach the entire gdoc as an attachment to the JSON that we send to the front-end

This is very inefficient seeing as we, at most, only use a couple of properties in the front-matter from the gdoc (title, subtitle, featured-image, etc)

This PR introduces a `OwidGdocMinimalPostInterface` type and uses that to pass to the FE instead.

On topic pages that link to a lot of other gdocs, e.g. [Energy](https://ourworldindata.org/energy) this offers huge savings.

Before: 1.2MB of linkedDocuments
After: 182.1kB



Here's a demo, with one of the minimal models highlighted in the console.
<img width="1350" alt="image" src="https://github.com/owid/owid-grapher/assets/11844404/623fb3a4-8175-42ea-a7b8-554d2d410cc8">
