### PR TITLE
:white_check_mark: (data table filter) add tests

### DIFF
--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
@@ -13,7 +13,7 @@ import {
 
 import Enzyme, { ReactWrapper } from "enzyme"
 import Adapter from "@wojtekmaj/enzyme-adapter-react-17"
-import { GrapherLifeExpectancy } from "../testData/OwidTestData.sample.js"
+import { Grapher_SingleYDim_MultipleEntities } from "../testData/OwidTestData.sample.js"
 Enzyme.configure({ adapter: new Adapter() })
 
 describe("when you render a table", () => {
@@ -155,7 +155,7 @@ describe("when the table has multiple variables and multiple years", () => {
 
 describe("when the table has no filter toggle", () => {
     it("does not filter by default if we have a map tab", () => {
-        const grapher = GrapherLifeExpectancy({
+        const grapher = Grapher_SingleYDim_MultipleEntities({
             hideEntityControls: true, // no filter toggle
             hasMapTab: true,
         })
@@ -165,7 +165,7 @@ describe("when the table has no filter toggle", () => {
     })
 
     it("does not filter by default if the selection is empty", () => {
-        const grapher = GrapherLifeExpectancy({
+        const grapher = Grapher_SingleYDim_MultipleEntities({
             hideEntityControls: true, // not filter toggle
             hasMapTab: false,
             selectedEntityNames: [],

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
@@ -13,7 +13,7 @@ import {
 
 import Enzyme, { ReactWrapper } from "enzyme"
 import Adapter from "@wojtekmaj/enzyme-adapter-react-17"
-import { Grapher_SingleYDim_MultipleEntities } from "../testData/OwidTestData.sample.js"
+import { LifeExpectancyGrapher } from "../testData/OwidTestData.sample.js"
 Enzyme.configure({ adapter: new Adapter() })
 
 describe("when you render a table", () => {
@@ -155,7 +155,8 @@ describe("when the table has multiple variables and multiple years", () => {
 
 describe("when the table has no filter toggle", () => {
     it("does not filter by default if we have a map tab", () => {
-        const grapher = Grapher_SingleYDim_MultipleEntities({
+        const grapher = LifeExpectancyGrapher({
+            selectedEntityNames: ["World"],
             hideEntityControls: true, // no filter toggle
             hasMapTab: true,
         })
@@ -165,10 +166,10 @@ describe("when the table has no filter toggle", () => {
     })
 
     it("does not filter by default if the selection is empty", () => {
-        const grapher = Grapher_SingleYDim_MultipleEntities({
-            hideEntityControls: true, // not filter toggle
-            hasMapTab: false,
+        const grapher = LifeExpectancyGrapher({
             selectedEntityNames: [],
+            hideEntityControls: true, // no filter toggle
+            hasMapTab: false,
         })
         const view = Enzyme.mount(<DataTable manager={grapher} />)
         const rows = view.find("tbody tr:not(.title)")

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
@@ -14,7 +14,6 @@ import {
 import Enzyme, { ReactWrapper } from "enzyme"
 import Adapter from "@wojtekmaj/enzyme-adapter-react-17"
 import { GrapherLifeExpectancy } from "../testData/OwidTestData.sample.js"
-import { faLeaf } from "@fortawesome/free-solid-svg-icons"
 Enzyme.configure({ adapter: new Adapter() })
 
 describe("when you render a table", () => {

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
@@ -13,6 +13,8 @@ import {
 
 import Enzyme, { ReactWrapper } from "enzyme"
 import Adapter from "@wojtekmaj/enzyme-adapter-react-17"
+import { GrapherLifeExpectancy } from "../testData/OwidTestData.sample.js"
+import { faLeaf } from "@fortawesome/free-solid-svg-icons"
 Enzyme.configure({ adapter: new Adapter() })
 
 describe("when you render a table", () => {
@@ -149,5 +151,28 @@ describe("when the table has multiple variables and multiple years", () => {
 
     it("header is split into two rows", () => {
         expect(view.find("thead tr")).toHaveLength(2)
+    })
+})
+
+describe("when the table has no filter toggle", () => {
+    it("does not filter by default if we have a map tab", () => {
+        const grapher = GrapherLifeExpectancy({
+            hideEntityControls: true, // no filter toggle
+            hasMapTab: true,
+        })
+        const view = Enzyme.mount(<DataTable manager={grapher} />)
+        const rows = view.find("tbody tr:not(.title)")
+        expect(rows).toHaveLength(grapher.availableEntities.length)
+    })
+
+    it("does not filter by default if the selection is empty", () => {
+        const grapher = GrapherLifeExpectancy({
+            hideEntityControls: true, // not filter toggle
+            hasMapTab: false,
+            selectedEntityNames: [],
+        })
+        const view = Enzyme.mount(<DataTable manager={grapher} />)
+        const rows = view.find("tbody tr:not(.title)")
+        expect(rows).toHaveLength(grapher.availableEntities.length)
     })
 })

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
@@ -6,9 +6,9 @@ import { DataTable } from "./DataTable"
 import { ChartTypeName, GrapherTabOption } from "@ourworldindata/types"
 import {
     childMortalityGrapher,
-    IncompleteDataTable,
-    DataTableWithAggregates,
-    DataTableWithMultipleVariablesAndMultipleYears,
+    GrapherWithIncompleteData,
+    GrapherWithAggregates,
+    GrapherWithMultipleVariablesAndMultipleYears,
 } from "./DataTable.sample"
 
 import Enzyme, { ReactWrapper } from "enzyme"
@@ -99,7 +99,7 @@ describe("when you select a range of years", () => {
 })
 
 describe("when the table doesn't have data for all rows", () => {
-    const grapher = IncompleteDataTable()
+    const grapher = GrapherWithIncompleteData()
     grapher.timelineHandleTimeBounds = [2000, 2000]
     const view = Enzyme.mount(<DataTable manager={grapher} />)
 
@@ -129,7 +129,7 @@ describe("when the table doesn't have data for all rows", () => {
 describe("when the table has aggregates", () => {
     let view: ReactWrapper
     beforeAll(() => {
-        const grapher = DataTableWithAggregates()
+        const grapher = GrapherWithAggregates()
         view = Enzyme.mount(<DataTable manager={grapher} />)
     })
 
@@ -143,7 +143,7 @@ describe("when the table has aggregates", () => {
 describe("when the table has multiple variables and multiple years", () => {
     let view: ReactWrapper
     beforeAll(() => {
-        const grapher = DataTableWithMultipleVariablesAndMultipleYears()
+        const grapher = GrapherWithMultipleVariablesAndMultipleYears()
         view = Enzyme.mount(<DataTable manager={grapher} />)
     })
 

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.sample.ts
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.sample.ts
@@ -1,310 +1,180 @@
 import { DimensionProperty } from "@ourworldindata/utils"
 import { Grapher } from "../core/Grapher"
 import { GrapherTabOption, GrapherInterface } from "@ourworldindata/types"
+import {
+    TestMetadata,
+    createOwidTestDataset,
+    fakeEntities,
+} from "../testData/OwidTestData"
 
 export const childMortalityGrapher = (
     props: Partial<GrapherInterface> = {}
-): Grapher =>
-    new Grapher({
+): Grapher => {
+    const childMortalityId = 104402
+    const childMortalityMetadata: TestMetadata = {
+        id: childMortalityId,
+        display: {
+            name: "Child mortality",
+            unit: "%",
+            shortUnit: "%",
+            conversionFactor: 0.1,
+        },
+    }
+    const childMortalityData = [
+        { year: 1950, entity: fakeEntities.Afghanistan, value: 224.45 },
+        { year: 1950, entity: fakeEntities.Iceland, value: 333.68 },
+
+        { year: 2005, entity: fakeEntities.Afghanistan, value: 295.59 },
+        { year: 2005, entity: fakeEntities.Iceland, value: 246.12 },
+
+        { year: 2019, entity: fakeEntities.Afghanistan, value: 215.59 },
+        { year: 2019, entity: fakeEntities.Iceland, value: 226.12 },
+    ]
+    const dimensions = [
+        {
+            variableId: childMortalityId,
+            property: DimensionProperty.y,
+        },
+    ]
+    return new Grapher({
         hasMapTab: true,
         tab: GrapherTabOption.map,
-        dimensions: [
-            {
-                variableId: 104402,
-                property: DimensionProperty.y,
-            },
-        ],
+        dimensions,
         ...props,
-        owidDataset: new Map([
-            [
-                104402,
-                {
-                    data: {
-                        years: [1950, 1950, 2005, 2005, 2019, 2019],
-                        entities: [15, 207, 15, 207, 15, 207],
-                        values: [
-                            224.45, 333.68, 295.59, 246.12, 215.59, 226.12,
-                        ],
-                    },
-                    metadata: {
-                        id: 104402,
-                        display: {
-                            name: "Child mortality",
-                            unit: "%",
-                            shortUnit: "%",
-                            conversionFactor: 0.1,
-                        },
-                        dimensions: {
-                            entities: {
-                                values: [
-                                    {
-                                        name: "Afghanistan",
-                                        id: 15,
-                                        code: "AFG",
-                                    },
-                                    { name: "Iceland", id: 207, code: "ICE" },
-                                ],
-                            },
-                            years: {
-                                values: [
-                                    {
-                                        id: 1950,
-                                    },
-                                    {
-                                        id: 2005,
-                                    },
-                                    {
-                                        id: 2019,
-                                    },
-                                ],
-                            },
-                        },
-                    },
-                },
-            ],
+        owidDataset: createOwidTestDataset([
+            {
+                metadata: childMortalityMetadata,
+                data: childMortalityData,
+            },
         ]),
     })
+}
 
-export const IncompleteDataTable = (
+export const GrapherWithIncompleteData = (
     props: Partial<GrapherInterface> = {}
-): Grapher =>
-    new Grapher({
-        hasMapTab: true,
+): Grapher => {
+    const indicatorId = 3512
+    const metadata = { id: indicatorId, shortUnit: "%" }
+    const data = [
+        { year: 2000, entity: fakeEntities.Iceland, value: 4 },
+        { year: 2001, entity: fakeEntities.France, value: 22 },
+        { year: 2010, entity: fakeEntities.Afghanistan, value: 20 },
+        { year: 2009, entity: fakeEntities.Iceland, value: 34 },
+    ]
+    const dimensions = [
+        {
+            variableId: indicatorId,
+            property: DimensionProperty.y,
+            display: {
+                name: "",
+                unit: "% of children under 5",
+                tolerance: 1,
+                isProjection: false,
+            },
+        },
+        {
+            variableId: indicatorId,
+            property: DimensionProperty.x,
+            targetYear: 2010,
+            display: {
+                name: "Children in 2010",
+                unit: "% of children under 5",
+                tolerance: 1,
+                isProjection: false,
+            },
+        },
+    ]
+    return new Grapher({
         tab: GrapherTabOption.table,
-        dimensions: [
-            {
-                variableId: 3512,
-                property: DimensionProperty.y,
-                display: {
-                    name: "",
-                    unit: "% of children under 5",
-                    tolerance: 1,
-                    isProjection: false,
-                },
-            },
-            {
-                variableId: 3512,
-                property: DimensionProperty.x,
-                targetYear: 2010,
-                display: {
-                    name: "Children in 2010",
-                    unit: "% of children under 5",
-                    tolerance: 1,
-                    isProjection: false,
-                },
-            },
-        ],
+        dimensions,
         ...props,
-        owidDataset: new Map([
-            [
-                3512,
-                {
-                    data: {
-                        years: [2000, 2001, 2010, 2009],
-                        entities: [207, 33, 15, 207],
-                        values: [4, 22, 20, 34],
-                    },
-                    metadata: {
-                        id: 3512,
-                        shortUnit: "%",
-                        dimensions: {
-                            entities: {
-                                values: [
-                                    {
-                                        name: "Afghanistan",
-                                        id: 15,
-                                        code: "AFG",
-                                    },
-                                    { name: "Iceland", id: 207, code: "ISL" },
-                                    { name: "France", id: 33, code: "FRA" },
-                                ],
-                            },
-                            years: {
-                                values: [
-                                    {
-                                        id: 2000,
-                                    },
-                                    {
-                                        id: 2001,
-                                    },
-                                    {
-                                        id: 2010,
-                                    },
-                                    {
-                                        id: 2009,
-                                    },
-                                ],
-                            },
-                        },
-                    },
-                },
-            ],
-        ]),
+        owidDataset: createOwidTestDataset([{ metadata, data }]),
     })
+}
 
-export const DataTableWithAggregates = (
+export const GrapherWithAggregates = (
     props: Partial<GrapherInterface> = {}
-): Grapher =>
-    new Grapher({
-        hasMapTab: true,
-        tab: GrapherTabOption.table,
-        dimensions: [
-            {
-                variableId: 104402,
-                property: DimensionProperty.y,
-            },
-        ],
-        ...props,
-        owidDataset: new Map([
-            [
-                104402,
-                {
-                    data: {
-                        years: [
-                            1950, 1950, 1950, 2005, 2005, 2005, 2019, 2019,
-                            2019,
-                        ],
-                        entities: [15, 207, 355, 15, 207, 355, 15, 207, 355],
-                        values: [
-                            224.45, 333.68, 456.33, 295.59, 246.12, 298.87,
-                            215.59, 226.12, 450.87,
-                        ],
-                    },
-                    metadata: {
-                        id: 104402,
-                        display: {
-                            name: "Child mortality",
-                            unit: "%",
-                            shortUnit: "%",
-                            conversionFactor: 0.1,
-                        },
-                        dimensions: {
-                            entities: {
-                                values: [
-                                    {
-                                        name: "Afghanistan",
-                                        id: 15,
-                                        code: "AFG",
-                                    },
-                                    { name: "Iceland", id: 207, code: "ICE" },
-                                    {
-                                        name: "World",
-                                        id: 355,
-                                        code: "OWID_WRL",
-                                    },
-                                ],
-                            },
-                            years: {
-                                values: [
-                                    {
-                                        id: 1950,
-                                    },
-                                    {
-                                        id: 2005,
-                                    },
-                                    {
-                                        id: 2019,
-                                    },
-                                ],
-                            },
-                        },
-                    },
-                },
-            ],
-        ]),
-    })
+): Grapher => {
+    const childMortalityId = 104402
+    const childMortalityMetadata: TestMetadata = {
+        id: childMortalityId,
+        display: {
+            name: "Child mortality",
+            unit: "%",
+            shortUnit: "%",
+            conversionFactor: 0.1,
+        },
+    }
+    const childMortalityData = [
+        { year: 1950, entity: fakeEntities.Afghanistan, value: 224.45 },
+        { year: 1950, entity: fakeEntities.Iceland, value: 333.68 },
+        { year: 1950, entity: fakeEntities.World, value: 456.33 },
 
-export const DataTableWithMultipleVariablesAndMultipleYears = (
-    props: Partial<GrapherInterface> = {}
-): Grapher =>
-    new Grapher({
-        hasMapTab: true,
+        { year: 2005, entity: fakeEntities.Afghanistan, value: 295.59 },
+        { year: 2005, entity: fakeEntities.Iceland, value: 246.12 },
+        { year: 2005, entity: fakeEntities.World, value: 298.87 },
+
+        { year: 2019, entity: fakeEntities.Afghanistan, value: 215.59 },
+        { year: 2019, entity: fakeEntities.Iceland, value: 226.12 },
+        { year: 2019, entity: fakeEntities.World, value: 450.87 },
+    ]
+    const dimensions = [
+        {
+            variableId: childMortalityId,
+            property: DimensionProperty.y,
+        },
+    ]
+    return new Grapher({
         tab: GrapherTabOption.table,
-        dimensions: [
-            {
-                variableId: 514050,
-                property: DimensionProperty.y,
-            },
-            {
-                variableId: 472265,
-                property: DimensionProperty.y,
-            },
-        ],
+        dimensions,
         ...props,
-        owidDataset: new Map([
-            [
-                514050,
-                {
-                    data: {
-                        years: [1950, 2005, 2019],
-                        entities: [355, 355, 355],
-                        values: [10, 20, 30],
-                    },
-                    metadata: {
-                        id: 514050,
-                        dimensions: {
-                            entities: {
-                                values: [
-                                    {
-                                        name: "World",
-                                        id: 355,
-                                        code: "OWID_WRL",
-                                    },
-                                ],
-                            },
-                            years: {
-                                values: [
-                                    {
-                                        id: 1950,
-                                    },
-                                    {
-                                        id: 2005,
-                                    },
-                                    {
-                                        id: 2019,
-                                    },
-                                ],
-                            },
-                        },
-                    },
-                },
-            ],
-            [
-                472265,
-                {
-                    data: {
-                        years: [1950, 2005, 2019],
-                        entities: [355, 355, 355],
-                        values: [5, 15, 10],
-                    },
-                    metadata: {
-                        id: 472265,
-                        dimensions: {
-                            entities: {
-                                values: [
-                                    {
-                                        name: "World",
-                                        id: 355,
-                                        code: "OWID_WRL",
-                                    },
-                                ],
-                            },
-                            years: {
-                                values: [
-                                    {
-                                        id: 1950,
-                                    },
-                                    {
-                                        id: 2005,
-                                    },
-                                    {
-                                        id: 2019,
-                                    },
-                                ],
-                            },
-                        },
-                    },
-                },
-            ],
+        owidDataset: createOwidTestDataset([
+            { metadata: childMortalityMetadata, data: childMortalityData },
         ]),
     })
+}
+
+export const GrapherWithMultipleVariablesAndMultipleYears = (
+    props: Partial<GrapherInterface> = {}
+): Grapher => {
+    const abovePovertyLineId = 514050
+    const belowPovertyLineId = 472265
+
+    const dimensions = [
+        {
+            variableId: abovePovertyLineId,
+            property: DimensionProperty.y,
+        },
+        {
+            variableId: belowPovertyLineId,
+            property: DimensionProperty.y,
+        },
+    ]
+
+    const abovePovertyLineDataset = {
+        metadata: { id: abovePovertyLineId },
+        data: [
+            { year: 1950, entity: fakeEntities.World, value: 10 },
+            { year: 2005, entity: fakeEntities.World, value: 20 },
+            { year: 2019, entity: fakeEntities.World, value: 30 },
+        ],
+    }
+    const belowPovertyLineDataset = {
+        metadata: { id: belowPovertyLineId },
+        data: [
+            { year: 1950, entity: fakeEntities.World, value: 5 },
+            { year: 2005, entity: fakeEntities.World, value: 15 },
+            { year: 2019, entity: fakeEntities.World, value: 10 },
+        ],
+    }
+
+    return new Grapher({
+        tab: GrapherTabOption.table,
+        dimensions,
+        ...props,
+        owidDataset: createOwidTestDataset([
+            abovePovertyLineDataset,
+            belowPovertyLineDataset,
+        ]),
+    })
+}

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.stories.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.stories.tsx
@@ -1,8 +1,11 @@
 import React from "react"
 import { DataTable, DataTableManager } from "./DataTable"
 import { SynthesizeGDPTable } from "@ourworldindata/core-table"
-import { childMortalityGrapher, IncompleteDataTable } from "./DataTable.sample"
 import { ChartTypeName, GrapherTabOption } from "@ourworldindata/types"
+import {
+    childMortalityGrapher,
+    GrapherWithIncompleteData,
+} from "./DataTable.sample"
 
 export default {
     title: "DataTable",
@@ -19,6 +22,7 @@ const entityType = "country"
 export const Default = (): JSX.Element => {
     const manager: DataTableManager = {
         table,
+        tableForDisplay: table,
         entityType,
     }
     return <DataTable manager={manager} />
@@ -27,6 +31,7 @@ export const Default = (): JSX.Element => {
 export const WithTimeRange = (): JSX.Element => {
     const manager: DataTableManager = {
         table,
+        tableForDisplay: table,
         entityType,
     }
     manager.startTime = 1950
@@ -53,6 +58,7 @@ export const WithTolerance = (): JSX.Element => {
             <DataTable
                 manager={{
                     table,
+                    tableForDisplay: table,
                     startTime: 2010,
                     endTime: 2010,
                     entityType,
@@ -67,6 +73,7 @@ export const WithTolerance = (): JSX.Element => {
                     startTime: 2010,
                     endTime: 2010,
                     table: filteredTable,
+                    tableForDisplay: filteredTable,
                     entityType,
                 }}
             />
@@ -90,7 +97,7 @@ export const FromLegacyWithTimeRange = (): JSX.Element => {
 }
 
 export const IncompleteDataTableComponent = (): JSX.Element => {
-    const grapher = IncompleteDataTable()
+    const grapher = GrapherWithIncompleteData()
     grapher.timelineHandleTimeBounds = [2000, 2000]
     return <DataTable manager={grapher} />
 }

--- a/packages/@ourworldindata/grapher/src/testData/OwidTestData.sample.ts
+++ b/packages/@ourworldindata/grapher/src/testData/OwidTestData.sample.ts
@@ -1,0 +1,70 @@
+import { DimensionProperty } from "@ourworldindata/utils"
+import { Grapher } from "../core/Grapher"
+import { GrapherInterface } from "../core/GrapherInterface"
+import {
+    TestMetadata,
+    createOwidTestDataset,
+    fakeEntities,
+} from "../testData/OwidTestData"
+
+/**
+Grapher properties:
+- LineChart
+- Single y-dimension
+- Multiple entities, including World, Continents, and Countries
+ */
+export const GrapherLifeExpectancy = (
+    props: Partial<GrapherInterface> = {}
+): Grapher => {
+    const lifeExpectancyId = 815383
+    const lifeExpectancyMetadata: TestMetadata = {
+        id: lifeExpectancyId,
+        display: {
+            name: "Life expectancy at birth",
+            unit: "years",
+            shortUnit: "years",
+            numDecimalPlaces: 1,
+        },
+    }
+    const lifeExpectancyData = [
+        { year: 1950, entity: fakeEntities.World, value: 46.5 },
+        { year: 1950, entity: fakeEntities.France, value: 66.4 },
+        { year: 1950, entity: fakeEntities.Europe, value: 62.8 },
+        { year: 1950, entity: fakeEntities.China, value: 43.7 },
+        { year: 1950, entity: fakeEntities.Asia, value: 42.0 },
+        { year: 1950, entity: fakeEntities.India, value: 41.7 },
+        { year: 1950, entity: fakeEntities.Africa, value: 37.6 },
+
+        { year: 2005, entity: fakeEntities.World, value: 74.1 },
+        { year: 2005, entity: fakeEntities.France, value: 80.3 },
+        { year: 2005, entity: fakeEntities.Europe, value: 74.5 },
+        { year: 2005, entity: fakeEntities.China, value: 69.6 },
+        { year: 2005, entity: fakeEntities.Asia, value: 68.2 },
+        { year: 2005, entity: fakeEntities.India, value: 65.0 },
+        { year: 2005, entity: fakeEntities.Africa, value: 55.5 },
+
+        { year: 2020, entity: fakeEntities.World, value: 77.7 },
+        { year: 2020, entity: fakeEntities.France, value: 82.2 },
+        { year: 2020, entity: fakeEntities.Europe, value: 78.1 },
+        { year: 2020, entity: fakeEntities.China, value: 73.7 },
+        { year: 2020, entity: fakeEntities.Asia, value: 72.0 },
+        { year: 2020, entity: fakeEntities.India, value: 70.1 },
+        { year: 2020, entity: fakeEntities.Africa, value: 62.2 },
+    ]
+    const dimensions = [
+        {
+            variableId: lifeExpectancyId,
+            property: DimensionProperty.y,
+        },
+    ]
+    return new Grapher({
+        ...props,
+        dimensions,
+        owidDataset: createOwidTestDataset([
+            {
+                metadata: lifeExpectancyMetadata,
+                data: lifeExpectancyData,
+            },
+        ]),
+    })
+}

--- a/packages/@ourworldindata/grapher/src/testData/OwidTestData.sample.ts
+++ b/packages/@ourworldindata/grapher/src/testData/OwidTestData.sample.ts
@@ -1,6 +1,5 @@
 import { DimensionProperty } from "@ourworldindata/utils"
-import { Grapher } from "../core/Grapher"
-import { GrapherInterface } from "../core/GrapherInterface"
+import { Grapher, GrapherProgrammaticInterface } from "../core/Grapher"
 import {
     TestMetadata,
     createOwidTestDataset,
@@ -14,7 +13,7 @@ Grapher properties:
 - Multiple entities, including World, Continents, and Countries
  */
 export const GrapherLifeExpectancy = (
-    props: Partial<GrapherInterface> = {}
+    props: Partial<GrapherProgrammaticInterface> = {}
 ): Grapher => {
     const lifeExpectancyId = 815383
     const lifeExpectancyMetadata: TestMetadata = {

--- a/packages/@ourworldindata/grapher/src/testData/OwidTestData.sample.ts
+++ b/packages/@ourworldindata/grapher/src/testData/OwidTestData.sample.ts
@@ -11,7 +11,7 @@ Grapher properties:
 - Single y-dimension
 - Multiple entities, including World, Continents, and Countries
  */
-export const Grapher_SingleYDim_MultipleEntities = (
+export const LifeExpectancyGrapher = (
     props: Partial<GrapherProgrammaticInterface> = {}
 ): Grapher => {
     const lifeExpectancyId = 815383

--- a/packages/@ourworldindata/grapher/src/testData/OwidTestData.sample.ts
+++ b/packages/@ourworldindata/grapher/src/testData/OwidTestData.sample.ts
@@ -8,11 +8,10 @@ import {
 
 /**
 Grapher properties:
-- LineChart
 - Single y-dimension
 - Multiple entities, including World, Continents, and Countries
  */
-export const GrapherLifeExpectancy = (
+export const Grapher_SingleYDim_MultipleEntities = (
     props: Partial<GrapherProgrammaticInterface> = {}
 ): Grapher => {
     const lifeExpectancyId = 815383

--- a/packages/@ourworldindata/grapher/src/testData/OwidTestData.ts
+++ b/packages/@ourworldindata/grapher/src/testData/OwidTestData.ts
@@ -1,0 +1,63 @@
+import {
+    MultipleOwidVariableDataDimensionsMap,
+    OwidVariableWithSource,
+    Region,
+    regions,
+    uniqBy,
+} from "@ourworldindata/utils"
+import { EntityCode, EntityId, EntityName } from "@ourworldindata/core-table"
+
+type Entity = { id: EntityId; code?: EntityCode; name?: EntityName }
+type TestDatum = { year: number; entity: Entity; value: string | number }
+
+export type TestData = TestDatum[]
+export type TestMetadata = OwidVariableWithSource
+
+const fakeRegions = regions.map((region: Region, index: number) => ({
+    ...region,
+    id: index + 1,
+}))
+
+export const fakeEntities = Object.fromEntries(
+    fakeRegions.map((entity: Region & { id: number }) => [
+        entity.name,
+        { id: entity.id, code: entity.code, name: entity.name },
+    ])
+)
+
+export function createOwidTestDataset(
+    indicators: {
+        data: TestData
+        metadata: TestMetadata
+    }[]
+): MultipleOwidVariableDataDimensionsMap {
+    return new Map(
+        indicators.map(({ data, metadata }) => [
+            metadata.id,
+            {
+                data: {
+                    years: data.map((d) => d.year),
+                    entities: data.map((d) => d.entity.id),
+                    values: data.map((d) => d.value),
+                },
+                metadata: {
+                    ...metadata,
+                    dimensions: {
+                        entities: {
+                            values: uniqBy(
+                                data.map((d) => d.entity),
+                                "id"
+                            ),
+                        },
+                        years: {
+                            values: uniqBy(
+                                data.map((d) => ({ id: d.year })),
+                                "id"
+                            ),
+                        },
+                    },
+                },
+            },
+        ])
+    )
+}

--- a/packages/@ourworldindata/grapher/src/testData/OwidTestData.ts
+++ b/packages/@ourworldindata/grapher/src/testData/OwidTestData.ts
@@ -1,11 +1,11 @@
+import { Region, regions, uniqBy } from "@ourworldindata/utils"
 import {
     MultipleOwidVariableDataDimensionsMap,
     OwidVariableWithSource,
-    Region,
-    regions,
-    uniqBy,
-} from "@ourworldindata/utils"
-import { EntityCode, EntityId, EntityName } from "@ourworldindata/core-table"
+    EntityCode,
+    EntityId,
+    EntityName,
+} from "@ourworldindata/types"
 
 type Entity = { id: EntityId; code?: EntityCode; name?: EntityName }
 type TestDatum = { year: number; entity: Entity; value: string | number }


### PR DESCRIPTION
- If the table filter toggle is missing, we filter the table by default in some instances
- This adds two tests to make sure the table is not filtered...
    - if the current selection is empty
    - if we have a map tab
- I also refactored the code a bit to make it easier to define test data in the future