### PR TITLE
:bug: (discrete-bar) fix charts with projected data

### DIFF
--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -592,6 +592,13 @@ export class DiscreteBarChart
         ) {
             return SeriesStrategy.entity
         }
+        if (
+            autoStrategy === SeriesStrategy.entity &&
+            this.selectionArray.numSelectedEntities === 1 &&
+            this.yColumns.length > 1
+        ) {
+            return SeriesStrategy.column
+        }
         return autoStrategy
     }
 


### PR DESCRIPTION
- fixes #3069 

- there are two ways of fixing this:
    - setting the series strategy to `column` instead of `entity` such that – for a single country – both y-variables are plotted (they don't show up at the same time because they have no time overlap)
    - setting the facetting strategy to facet by metric (with series strategy `entity`). that way, we would get two distinct bar charts – one for each y-column, i.e. one for historical and one for future data – where both bar charts display a single entity

The first solution produces the better result I think.

Example: [live](https://ourworldindata.org/grapher/number-of-deaths-per-year?time=latest) / [staging](http://staging-site-fix-broken-bar-chart-with-projected-data/grapher/number-of-deaths-per-year?time=latest)
