### PR TITLE
:sparkles: (discrete-bar) add striped pattern for projected data

### DIFF
--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -444,6 +444,7 @@ export class DiscreteBarChart
                 {series.map((series) => {
                     // Todo: add a "placedSeries" getter to get the transformed series, then just loop over the placedSeries and render a bar for each
                     const isNegative = series.value < 0
+                    const isProjection = series.yColumn.isProjection
                     const barX = isNegative
                         ? yAxis.place(series.value)
                         : yAxis.place(this.x0)
@@ -465,6 +466,28 @@ export class DiscreteBarChart
                             className="bar"
                             transform={`translate(0, ${yOffset})`}
                         >
+                            <defs>
+                                {/* Ids should be unique per document (!) Including the color
+                                in the id makes sure that – even if a pattern gets resolved
+                                to a definition from a different chart instance –
+                                the correct color will be used. */}
+                                <pattern
+                                    id={`DiscreteBarChart_striped_${barColor}`}
+                                    patternUnits="userSpaceOnUse"
+                                    width="16"
+                                    height="16"
+                                    patternTransform="rotate(45)"
+                                >
+                                    <line
+                                        x1="0"
+                                        y="0"
+                                        x2="0"
+                                        y2="16"
+                                        stroke={barColor}
+                                        stroke-width="28"
+                                    />
+                                </pattern>
+                            </defs>
                             <text
                                 x={0}
                                 y={0}
@@ -484,7 +507,11 @@ export class DiscreteBarChart
                                 })`}
                                 width={barWidth}
                                 height={barHeight}
-                                fill={barColor}
+                                fill={
+                                    isProjection
+                                        ? `url(#DiscreteBarChart_striped_${barColor})`
+                                        : barColor
+                                }
                                 opacity={GRAPHER_AREA_OPACITY_DEFAULT}
                                 style={{ transition: "height 200ms ease" }}
                             />


### PR DESCRIPTION
- Adds a striped pattern to bars in discrete bar charts when they show projected data
- I had to recreate Christian's `repeating-linear-gradient` CSS code as SVG pattern, so it might not be _excactly_ the same

Examples:
- http://staging-site-discrete-bar-striped-pattern/grapher/number-of-deaths-per-year?time=latest
- http://staging-site-discrete-bar-striped-pattern/grapher/median-age?time=2094&facet=entity&country=LBY~LBR
- http://staging-site-discrete-bar-striped-pattern/grapher/comparison-of-world-population-projections?time=2099&country=~AND

Screenshots:

<img width="738" alt="Screenshot 2024-01-10 at 11 38 45" src="https://github.com/owid/owid-grapher/assets/12461810/3d09add1-d8b1-42df-903c-c8bf9a734506">
<img width="738" alt="Screenshot 2024-01-10 at 11 38 51" src="https://github.com/owid/owid-grapher/assets/12461810/30d1c7e9-d869-400e-8040-ee6bb8495866">
<img width="738" alt="Screenshot 2024-01-10 at 11 38 57" src="https://github.com/owid/owid-grapher/assets/12461810/f2ed5c7a-2705-4d02-a7e3-186faea15ecd">


