### PR TITLE
:bug: (explorer) fix empty entity picker

### DIFF
--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -119,6 +119,13 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         )
     }
 
+    @imemo get entityNameColumn(): CoreColumn {
+        return (
+            this.getFirstColumnWithType(ColumnTypeNames.EntityName) ??
+            this.get(OwidTableSlugs.entityName)
+        )
+    }
+
     @imemo get minTime(): Time {
         return this.allTimes[0]
     }

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -312,7 +312,7 @@ export class LineChart
             )
 
             const groupedByEntity = table
-                .groupBy("entityName")
+                .groupBy(table.entityNameColumn.slug)
                 .filter((t) => !t.hasAnyColumnNoValidValue(this.yColumnSlugs))
 
             if (groupedByEntity.length === 0) return BlankOwidTable()

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -104,7 +104,7 @@ export class AbstractStackedChart
             }
 
             const groupedByEntity = table
-                .groupBy("entityName")
+                .groupBy(table.entityNameColumn.slug)
                 .map((t: OwidTable) =>
                     t.dropRowsWithErrorValuesForAnyColumn(this.yColumnSlugs)
                 )


### PR DESCRIPTION
- Fixes a bug where the explorer's entity picker was empty (see screenshot)
- In explorers, the entity name column has slug "country", not "entityName"
- That's why the `tableForSelection` came back empty

<img width="1238" alt="Screenshot 2024-01-09 at 18 00 42" src="https://github.com/owid/owid-grapher/assets/12461810/d6755f75-7c06-4f53-b924-4755ba47a77c">
