### PR TITLE
📝(donate) document Stripe CLI login

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -5,7 +5,7 @@ ENV=development
 
 # https://dashboard.stripe.com/test/apikeys
 # required by /donation/donate
-STRIPE_SECRET_KEY=
+STRIPE_API_KEY=
 
 # https://www.google.com/recaptcha/admin/site/345413385
 # required by /donation/donate

--- a/functions/README.md
+++ b/functions/README.md
@@ -136,10 +136,11 @@ In order to test the webhook function locally, you can use the Stripe CLI to lis
 2. Register a temporary webhook using the Stripe CLI (runs in test mode by default):
 
 ```sh
-stripe listen --latest --forward-to localhost:8788/donation/thank-you
+STRIPE_API_KEY=xxx stripe listen --latest --forward-to localhost:8788/donation/thank-you
 ```
 
-Note: `--latest` is required when development code uses a more recent API version than the one set in the Stripe dashboard (which `stripe listen` will default to).
+-   replace `xxx` with the value of `STRIPE_API_KEY (dev)` in 1password. Alternatively, if you have access to the Stripe dashboard, you can forgo the `STRIPE_API_KEY=xxx` part and let `stripe listen ...` guide you through a one-time login process.
+-   `--latest` is required when development code uses a more recent API version than the one set in the Stripe dashboard (which `stripe listen` will default to).
 
 3. Copy the webhook secret into `STRIPE_WEBHOOK_SECRET` variable in your `.dev.vars` and then restart the development server. This secret is shown when you ran `stripe listen`, and is stable across restarts.
 

--- a/functions/donation/donate.ts
+++ b/functions/donation/donate.ts
@@ -11,12 +11,12 @@ import { Value } from "@sinclair/typebox/value"
 import { DEFAULT_HEADERS, CORS_HEADERS } from "./_utils/constants.js"
 
 interface DonateEnvVars {
-    STRIPE_SECRET_KEY: string
+    STRIPE_API_KEY: string
     RECAPTCHA_SECRET_KEY: string
 }
 
 const hasDonateEnvVars = (env: any): env is DonateEnvVars => {
-    return !!env.STRIPE_SECRET_KEY && !!env.RECAPTCHA_SECRET_KEY
+    return !!env.STRIPE_API_KEY && !!env.RECAPTCHA_SECRET_KEY
 }
 
 // This function is called when the request is a preflight request ("OPTIONS").
@@ -37,7 +37,7 @@ export const onRequestPost: PagesFunction = async ({
     if (!hasDonateEnvVars(env))
         // This error is not being caught and surfaced to the client voluntarily.
         throw new Error(
-            "Missing environment variables. Please check that both STRIPE_SECRET_KEY and RECAPTCHA_SECRET_KEY are set."
+            "Missing environment variables. Please check that both STRIPE_API_KEY and RECAPTCHA_SECRET_KEY are set."
         )
 
     // Parse the body of the request as JSON
@@ -69,7 +69,7 @@ export const onRequestPost: PagesFunction = async ({
 
         const session = await createCheckoutSession(
             donation,
-            env.STRIPE_SECRET_KEY
+            env.STRIPE_API_KEY
         )
         const sessionResponse: DonateSessionResponse = { url: session.url }
 

--- a/functions/donation/thank-you.ts
+++ b/functions/donation/thank-you.ts
@@ -14,16 +14,16 @@ interface MessageData {
 
 type ThankYouEnvVars = {
     STRIPE_WEBHOOK_SECRET: string
-    STRIPE_SECRET_KEY: string
+    STRIPE_API_KEY: string
 } & MailgunEnvVars
 
 const hasThankYouEnvVars = (env: unknown): env is ThankYouEnvVars => {
     return (
         typeof env === "object" &&
         "STRIPE_WEBHOOK_SECRET" in env &&
-        "STRIPE_SECRET_KEY" in env &&
+        "STRIPE_API_KEY" in env &&
         !!env.STRIPE_WEBHOOK_SECRET &&
-        !!env.STRIPE_SECRET_KEY
+        !!env.STRIPE_API_KEY
     )
 }
 
@@ -75,11 +75,11 @@ export const onRequestPost: PagesFunction = async ({
     try {
         if (!hasThankYouEnvVars(env))
             throw new JsonError(
-                "Missing environment variables. Please check that both STRIPE_WEBHOOK_SECRET and STRIPE_SECRET_KEY are set.",
+                "Missing environment variables. Please check that both STRIPE_WEBHOOK_SECRET and STRIPE_API_KEY are set.",
                 500
             )
 
-        const stripe = new Stripe(env.STRIPE_SECRET_KEY, {
+        const stripe = new Stripe(env.STRIPE_API_KEY, {
             apiVersion: STRIPE_API_VERSION,
             maxNetworkRetries: 2,
         })


### PR DESCRIPTION
Add instructions to log into the Stripe CLI with the same `STRIPE_API_KEY` env variable defined in .dev.vars. This allows testers without access to the stripe dashboard to register a local webhook and test the donation/thank-you route.

Clouflare env variables (production and preview) updated accordingly.

Preview on https://donate.owid.pages.dev updated.