### PR TITLE
🎉 add `grapherLoaded` event

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2739,6 +2739,22 @@ export class Grapher
         this.setUpIntersectionObserver()
         this.setUpWindowResizeEventHandler()
         exposeInstanceOnWindow(this, "grapher")
+        // Emit a custom event when the grapher is ready
+        // We can use this in global scripts that depend on the grapher e.g. the site-screenshots tool
+        this.disposers.push(
+            reaction(
+                () => this.isReady,
+                () => {
+                    if (this.isReady) {
+                        document.dispatchEvent(
+                            new CustomEvent("grapherLoaded", {
+                                detail: { grapher: this },
+                            })
+                        )
+                    }
+                }
+            )
+        )
         if (this.props.bindUrlToWindow) this.bindToWindow()
         if (this.props.enableKeyboardShortcuts) this.bindKeyboardShortcuts()
     }


### PR DESCRIPTION
Adds a reaction to each Grapher so that when `isReady` is set to true, a `"grapherLoaded"` event is emitted. This enables us to do things once we know the Graphers on the page have fully loaded.

This isn't working correctly for datapages, however, because for some reason data page Graphers are mounting 3 times (so three separate events are getting emitted)

Here's a demo of me creating an event listener for the event, which I attach to the document immediately after refreshing the page so that it fires when the Grapher on the page finishes loading. Navigating around the grapher doesn't cause the event to fire again.
https://github.com/owid/owid-grapher/assets/11844404/04adab9e-6b7a-4e8d-aa92-4a97cb2329a2

