### PR TITLE
:tada: (data-table) allow to hide change columns

### DIFF
--- a/adminSiteClient/DimensionCard.tsx
+++ b/adminSiteClient/DimensionCard.tsx
@@ -49,8 +49,7 @@ export class DimensionCard extends React.Component<{
     }
 
     private get tableDisplaySettings() {
-        const { tableDisplay } = this.props.dimension.display
-        if (!tableDisplay) return
+        const { tableDisplay = {} } = this.props.dimension.display
         return (
             <React.Fragment>
                 <hr className="ui divider" />
@@ -59,6 +58,9 @@ export class DimensionCard extends React.Component<{
                     label="Hide absolute change column"
                     value={!!tableDisplay.hideAbsoluteChange}
                     onValue={(value) => {
+                        if (!this.props.dimension.display.tableDisplay) {
+                            this.props.dimension.display.tableDisplay = {}
+                        }
                         tableDisplay.hideAbsoluteChange = value
                         this.onChange()
                     }}
@@ -67,6 +69,9 @@ export class DimensionCard extends React.Component<{
                     label="Hide relative change column"
                     value={!!tableDisplay.hideRelativeChange}
                     onValue={(value) => {
+                        if (!this.props.dimension.display.tableDisplay) {
+                            this.props.dimension.display.tableDisplay = {}
+                        }
                         tableDisplay.hideRelativeChange = value
                         this.onChange()
                     }}

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -727,21 +727,22 @@ export class DataTable extends React.Component<{
                     ? TargetTimeMode.point
                     : TargetTimeMode.range
 
-            const prelimValuesByEntity = this.preliminaryDimensionValues(
+            const prelimValuesByEntity = this.preliminaryDimensionValues({
                 sourceColumn,
-                targetTimes
-            )
-
-            const valueByEntity = this.dataValuesFromPreliminaryValues(
-                prelimValuesByEntity,
-                targetTimeMode,
-                sourceColumn
-            )
-
-            const columns: DimensionColumn[] = this.dimensionColumns(
                 targetTimes,
-                targetTimeMode
-            )
+            })
+
+            const valueByEntity = this.dataValuesFromPreliminaryValues({
+                prelimValuesByEntity,
+                sourceColumn,
+                targetTimeMode,
+            })
+
+            const columns: DimensionColumn[] = this.dimensionColumns({
+                sourceColumn,
+                targetTimes,
+                targetTimeMode,
+            })
 
             return {
                 columns,
@@ -751,18 +752,23 @@ export class DataTable extends React.Component<{
         })
     }
 
-    private dimensionColumns(
-        targetTimes: number[],
+    private dimensionColumns({
+        sourceColumn,
+        targetTimes,
+        targetTimeMode,
+    }: {
+        sourceColumn: CoreColumn
+        targetTimes: number[]
         targetTimeMode: TargetTimeMode
-    ): DimensionColumn[] {
+    }): DimensionColumn[] {
         // Inject delta columns if we have start & end values to compare in the table.
         // One column for absolute difference, another for % difference.
         const deltaColumns: DimensionColumn[] = []
         if (targetTimeMode === TargetTimeMode.range) {
-            const tableDisplay = {} as any
-            if (!tableDisplay?.hideAbsoluteChange)
+            const { tableDisplay = {} } = sourceColumn.display ?? {}
+            if (!tableDisplay.hideAbsoluteChange)
                 deltaColumns.push({ key: RangeValueKey.delta })
-            if (!tableDisplay?.hideRelativeChange)
+            if (!tableDisplay.hideRelativeChange)
                 deltaColumns.push({ key: RangeValueKey.deltaRatio })
         }
 
@@ -779,10 +785,13 @@ export class DataTable extends React.Component<{
         return [...valueColumns, ...deltaColumns]
     }
 
-    private preliminaryDimensionValues(
-        sourceColumn: CoreColumn,
+    private preliminaryDimensionValues({
+        sourceColumn,
+        targetTimes,
+    }: {
+        sourceColumn: CoreColumn
         targetTimes: number[]
-    ): Map<string, (DataValue | undefined)[]> {
+    }): Map<string, (DataValue | undefined)[]> {
         return valuesByEntityAtTimes(
             sourceColumn.valueByEntityNameAndOriginalTime,
             targetTimes,
@@ -790,11 +799,15 @@ export class DataTable extends React.Component<{
         )
     }
 
-    private dataValuesFromPreliminaryValues(
-        prelimValuesByEntity: Map<string, (DataValue | undefined)[]>,
-        targetTimeMode: TargetTimeMode,
+    private dataValuesFromPreliminaryValues({
+        prelimValuesByEntity,
+        targetTimeMode,
+        sourceColumn,
+    }: {
+        prelimValuesByEntity: Map<string, (DataValue | undefined)[]>
+        targetTimeMode: TargetTimeMode
         sourceColumn: CoreColumn
-    ): Map<string, DimensionValue> {
+    }): Map<string, DimensionValue> {
         return es6mapValues(prelimValuesByEntity, (dvs) => {
             // There is always a column, but not always a data value (in the delta column the
             // value needs to be calculated)


### PR DESCRIPTION
- fixes #2787 

### Background

- Our config defines a `tableDisplay` field on the `display` property of a dimension
- `tableDisplay`  holds two properties, `hideAbsoluteChange` and `hideRelativeChange`, that hide change columns in the data table if set to true
- But these fields are currently ignored by Grapher (I don't know why)
- Both fields can be edited via the admin, but the UI is currently only exposed if `tableDisplay` already exists in the config

### Summary

- This PR makes it so that `hideAbsoluteChange` and `hideRelativeChange` are respected
- Toggles to edit both fields are always exposed in the admin

### Migration

- We don't have any indicators that set one of the fields to true ([Datasette](https://datasette-public.owid.io/owid?sql=select%0D%0A++id,%0D%0A++name,%0D%0A++display%0D%0Afrom%0D%0A++variables%0D%0Awhere%0D%0A++display+like+%22%25hideAbsoluteChange%25%22%0D%0A++or+display+like+%22%25hideRelativeChange%25%22%0D%0Alimit%0D%0A++10))
- A single chart currently sets one of the fields to true ([Datasette](https://datasette-public.owid.io/owid?sql=select%0D%0A++*%0D%0Afrom%0D%0A++charts%0D%0Awhere%0D%0A++config+like+'%25%22hideAbsoluteChange%22:+true%25'%0D%0A++or+config+like+'%25%22hideRelativeChange%22:+true%25'%0D%0Alimit%0D%0A++10))
    - I would update the chart manually

### Screenshots

Admin

<img width="515" alt="Screenshot 2024-01-11 at 17 53 48" src="https://github.com/owid/owid-grapher/assets/12461810/1f374b71-434f-4d73-8fca-4bae95e7f46e">
