### PR TITLE
:sparkles: (data-table) hide change columns for non-numerical data

### DIFF
--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -550,7 +550,7 @@ export class MissingColumn extends AbstractCoreColumn<any> {
     }
 }
 
-class StringColumn extends AbstractCoreColumn<string> {
+export class StringColumn extends AbstractCoreColumn<string> {
     jsType = JsTypes.string
 
     formatValue(value: unknown): string {

--- a/packages/@ourworldindata/core-table/src/index.ts
+++ b/packages/@ourworldindata/core-table/src/index.ts
@@ -51,6 +51,7 @@ export {
     ColumnTypeMap,
     AbstractCoreColumn,
     TimeColumn,
+    StringColumn,
 } from "./CoreTableColumns.js"
 
 export {

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -16,6 +16,7 @@ import {
     BlankOwidTable,
     OwidTable,
     CoreColumn,
+    StringColumn,
 } from "@ourworldindata/core-table"
 import {
     capitalize,
@@ -764,9 +765,10 @@ export class DataTable extends React.Component<{
         const deltaColumns: DimensionColumn[] = []
         if (targetTimeMode === TargetTimeMode.range) {
             const { tableDisplay = {} } = sourceColumn.display ?? {}
-            if (!tableDisplay.hideAbsoluteChange)
+            const isStringColumn = sourceColumn instanceof StringColumn
+            if (!isStringColumn && !tableDisplay.hideAbsoluteChange)
                 deltaColumns.push({ key: RangeValueKey.delta })
-            if (!tableDisplay.hideRelativeChange)
+            if (!isStringColumn && !tableDisplay.hideRelativeChange)
                 deltaColumns.push({ key: RangeValueKey.deltaRatio })
         }
 


### PR DESCRIPTION
- relates to #2787 
- hides change columns for non-numerical data
- note that Grapher currently doesn't have data type and models all table columns as `NumberOrStringColumn`, i.e these changes don't have any effect on grapher charts!
- however, this change will have an effect on charts in explorers as explorers use columns of different data types
- once we have data types in grapher (which we want to do), this will be useful for grapher as well