### PR TITLE
:bug: (sparkline) fix visual glitch

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -1209,7 +1209,7 @@ export class LineChart
         return axis
     }
 
-    @computed private get dualAxis(): DualAxis {
+    @computed get dualAxis(): DualAxis {
         return new DualAxis({
             bounds: this.boundsWithoutColorLegend
                 .padRight(

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.scss
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.scss
@@ -1,6 +1,3 @@
-$inset: 15px; // space between the sparkline and tooltip frame
-$nudge: 3px; // step away from the axis
-
 .sparkline {
     padding-bottom: 4px;
 
@@ -35,17 +32,6 @@ $nudge: 3px; // step away from the axis
     }
 
     .axis-label {
-        &.max {
-            transform: translate(calc(100% - $inset - $nudge), $inset - $nudge);
-        }
-
-        &.min {
-            transform: translate(
-                calc(100% - $inset - $nudge),
-                calc(100% - $inset - 2 * $nudge)
-            );
-        }
-
         text {
             font: 400 10px Lato;
             letter-spacing: 0.01em;

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
@@ -240,6 +240,10 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
         const notice =
             datum && datum.time !== targetTime ? displayTime : undefined
 
+        const labelX = axisBounds.right - SPARKLINE_NUDGE
+        const labelTop = axisBounds.top - SPARKLINE_NUDGE
+        const labelBottom = axisBounds.bottom - SPARKLINE_NUDGE
+
         return (
             <Tooltip
                 id="mapTooltip"
@@ -287,10 +291,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                             />
                             {maxLabel !== minLabel && (
                                 <g className="max axis-label">
-                                    <text
-                                        x={axisBounds.right}
-                                        y={axisBounds.top - SPARKLINE_NUDGE}
-                                    >
+                                    <text x={labelX} y={labelTop}>
                                         {maxLabel}
                                     </text>
                                 </g>
@@ -298,15 +299,12 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                             <g className="min axis-label">
                                 <text
                                     className="outline"
-                                    x={axisBounds.right}
-                                    y={axisBounds.bottom - SPARKLINE_NUDGE}
+                                    x={labelX}
+                                    y={labelBottom}
                                 >
                                     {minLabel}
                                 </text>
-                                <text
-                                    x={axisBounds.right}
-                                    y={axisBounds.bottom - SPARKLINE_NUDGE}
-                                >
+                                <text x={labelX} y={labelBottom}>
                                     {minLabel}
                                 </text>
                             </g>


### PR DESCRIPTION
- fixes https://github.com/owid/owid-grapher/issues/2960

### Why this bug happened

- Sparkline uses Grapher's LineChart to render
- The horizontal min and max lines and their labels are defined outside of the LineChart
- At some point, the LineChart added some more top and bottom padding to its bounds, but the sparkline chart wasn't updated accordingly

### Solution

- To make sure the code doesn't go out of sync again, the LineChart's axis object is used to figure out the position of the extra lines and labels that live outside of the line chart

### Before / after

<img width="683" alt="Screenshot 2024-01-12 at 18 27 02" src="https://github.com/owid/owid-grapher/assets/12461810/17c4287b-518b-4e9d-bf3e-f9ca17534c30">
<img width="683" alt="Screenshot 2024-01-12 at 18 27 21" src="https://github.com/owid/owid-grapher/assets/12461810/4a42d84a-406a-427c-b2d9-e9eceb4e3ad3">
