### PR TITLE
✨automatically refresh deploy status page

### DIFF
--- a/adminSiteClient/DeployStatusPage.tsx
+++ b/adminSiteClient/DeployStatusPage.tsx
@@ -22,6 +22,18 @@ export class DeployStatusPage extends React.Component {
 
     @observable deploys: Deploy[] = []
     @observable canManuallyDeploy = true
+    refreshIntervalId?: number
+
+    componentDidMount() {
+        this.getData()
+        this.refreshIntervalId = window.setInterval(() => this.getData(), 30000)
+    }
+
+    componentWillUnmount() {
+        if (this.refreshIntervalId) {
+            window.clearInterval(this.refreshIntervalId)
+        }
+    }
 
     render() {
         return (
@@ -118,9 +130,5 @@ export class DeployStatusPage extends React.Component {
         runInAction(() => {
             this.deploys = json.deploys
         })
-    }
-
-    componentDidMount() {
-        this.getData()
     }
 }

--- a/adminSiteClient/DeployStatusPage.tsx
+++ b/adminSiteClient/DeployStatusPage.tsx
@@ -26,13 +26,17 @@ export class DeployStatusPage extends React.Component {
 
     componentDidMount() {
         this.getData()
-        this.refreshIntervalId = window.setInterval(() => this.getData(), 30000)
+        document.addEventListener(
+            "visibilitychange",
+            this.handleVisibilityChange
+        )
     }
 
     componentWillUnmount() {
-        if (this.refreshIntervalId) {
-            window.clearInterval(this.refreshIntervalId)
-        }
+        document.removeEventListener(
+            "visibilitychange",
+            this.handleVisibilityChange
+        )
     }
 
     render() {
@@ -113,6 +117,10 @@ export class DeployStatusPage extends React.Component {
                 </main>
             </AdminLayout>
         )
+    }
+
+    @action.bound handleVisibilityChange = () => {
+        if (document.visibilityState === "visible") this.getData()
     }
 
     @action.bound async triggerDeploy() {


### PR DESCRIPTION
Automatically refresh /admin/deploys ~~every 30 seconds.~~ when tab becomes active again (e.g. after visiting another tab)

Context: [slack](https://owid.slack.com/archives/C0149NKLZAM/p1703091958890729)
