### PR TITLE
🐛 Fix mistaken HTML character encoding grapher urls

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -2378,7 +2378,11 @@ apiRouter.post("/posts/:postId/createGdoc", async (req: Request) => {
     const tags =
         tagsByPostId.get(postId)?.map(({ id }) => TagEntity.create({ id })) ||
         []
-    const archieMl = JSON.parse(post.archieml) as OwidGdocPostInterface
+    const archieMl = JSON.parse(
+        // Google Docs interprets &region in grapher URLS as ®ion
+        // So we escape them here
+        post.archieml.replaceAll("&", "&amp;")
+    ) as OwidGdocPostInterface
     const gdocId = await createGdocAndInsertOwidGdocPostContent(
         archieMl.content,
         post.gdocSuccessorId

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -216,8 +216,12 @@ const migrate = async (): Promise<void> => {
                     body: archieMlBodyElements,
                     toc: [],
                     title: post.title,
-                    subtitle: post.excerpt ?? "",
-                    excerpt: post.excerpt ?? "",
+                    // Falling back to undefined instead of an empty string
+                    // because an empty string gets turned into "subtitle: \n" in the gdoc
+                    // which doesn't parse and breaks validation, whereas undefined means the field is omitted entirely.
+                    // It's better to omit it and warn that it's missing.
+                    subtitle: post.excerpt || undefined,
+                    excerpt: post.excerpt || undefined,
                     authors: post.authors ?? [],
                     "featured-image": post.featured_image.split("/").at(-1),
                     dateline: dateline,


### PR DESCRIPTION
Given the following (subselection o) archieML JSON in the posts table:
```
"body": [
      {
        "type": "text",
        "value": [
          {
            "text": "I am some text with an ampersand &",
            "spanType": "span-simple-text"
          }
        ],
        "parseErrors": []
      },
      {
        "url": "https://ourworldindata.org/grapher/annual-deforestation?stackMode=absolute&region=World",
        "type": "chart",
        "parseErrors": []
      }
    ]
```

Here's how it was getting inserted into Gdocs:

Before:
![image](https://github.com/owid/owid-grapher/assets/11844404/cc119220-7e42-4dbe-b54f-72a7b576c296)


After:
<img width="676" alt="image" src="https://github.com/owid/owid-grapher/assets/11844404/94f2fd2a-33b8-45dd-a6ab-2cd94fd91b00">

I opted to make the fix inline just before the gdoc creation, because an arbitrary HTML code escape done earlier in the pipeline would then cascade into a bunch of other places that we'd need to make sure was handled correctly.