### PR TITLE
:tada: (gdocs) add key-indicator component

### DIFF
--- a/adminSiteClient/gdocsDeploy.ts
+++ b/adminSiteClient/gdocsDeploy.ts
@@ -1,12 +1,11 @@
+import { isEqual, omit } from "@ourworldindata/utils"
 import {
     OwidGdoc,
     OwidGdocBaseInterface,
     OwidGdocPostContent,
-    isEqual,
-    omit,
     OwidGdocDataInsightContent,
     OwidGdocType,
-} from "@ourworldindata/utils"
+} from "@ourworldindata/types"
 import { GDOC_DIFF_OMITTABLE_PROPERTIES } from "./GdocsDiff.js"
 import { GDOCS_DETAILS_ON_DEMAND_ID } from "../settings/clientSettings.js"
 
@@ -52,6 +51,7 @@ export const checkIsLightningUpdate = (
         breadcrumbs: true,
         errors: true,
         linkedCharts: true,
+        linkedIndicators: true,
         linkedDocuments: true,
         relatedCharts: true,
         revisionId: true,

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -7,22 +7,12 @@ import {
     urlToSlug,
     without,
     deserializeJSONFromHTML,
-    OwidVariableDataMetadataDimensions,
     uniq,
-    JsonError,
     keyBy,
-    DimensionProperty,
-    OwidVariableWithSource,
     mergePartialGrapherConfigs,
-    OwidChartDimensionInterface,
     compact,
-    OwidGdocPostInterface,
     merge,
-    EnrichedFaq,
-    FaqEntryData,
-    FaqDictionary,
     partition,
-    ImageMetadata,
 } from "@ourworldindata/utils"
 import {
     getRelatedArticles,
@@ -45,13 +35,25 @@ import * as db from "../db/db.js"
 import { glob } from "glob"
 import { isPathRedirectedToExplorer } from "../explorerAdminServer/ExplorerRedirects.js"
 import { getPostEnrichedBySlug } from "../db/model/Post.js"
-import { ChartTypeName, GrapherInterface } from "@ourworldindata/types"
+import {
+    JsonError,
+    GrapherInterface,
+    OwidVariableDataMetadataDimensions,
+    DimensionProperty,
+    OwidVariableWithSource,
+    OwidChartDimensionInterface,
+    OwidGdocPostInterface,
+    EnrichedFaq,
+    FaqEntryData,
+    FaqDictionary,
+    ImageMetadata,
+} from "@ourworldindata/types"
 import workerpool from "workerpool"
 import ProgressBar from "progress"
 import {
     getVariableData,
-    getVariableMetadata,
     getMergedGrapherConfigForVariable,
+    getVariableOfDatapageIfApplicable,
 } from "../db/model/Variable.js"
 import { getDatapageDataV2, getDatapageGdoc } from "../datapage/Datapage.js"
 import { ExplorerProgram } from "../explorer/ExplorerProgram.js"
@@ -61,7 +63,6 @@ import { logErrorAndMaybeSendToBugsnag } from "../serverUtils/errorLog.js"
 import { parseFaqs } from "../db/model/Gdoc/rawToEnriched.js"
 import { GdocPost } from "../db/model/Gdoc/GdocPost.js"
 import { getShortPageCitation } from "../site/gdocs/utils.js"
-import { isEmpty } from "lodash"
 import { getSlugForTopicTag, getTagToSlugMap } from "./GrapherBakingUtils.js"
 
 const renderDatapageIfApplicable = async (
@@ -70,50 +71,19 @@ const renderDatapageIfApplicable = async (
     publishedExplorersBySlug?: Record<string, ExplorerProgram>,
     imageMetadataDictionary?: Record<string, Image>
 ) => {
-    // If we have a single Y variable and that one has a schema version >= 2,
-    // meaning it has the metadata to render a datapage, AND if the metadata includes
-    // text for at least one of the description* fields or titlePublic, then we show the datapage
-    // based on this information.
-    const yVariableIds = grapher
-        .dimensions!.filter((d) => d.property === DimensionProperty.y)
-        .map((d) => d.variableId)
-    const xVariableIds = grapher
-        .dimensions!.filter((d) => d.property === DimensionProperty.x)
-        .map((d) => d.variableId)
-    // Make a data page for single indicator indicator charts.
-    // For scatter plots we want to only show a data page if it has no X variable mapped, which
-    // is a special case where time is the X axis. Marimekko charts are the other chart that uses
-    // the X dimension but there we usually map population on X which should not prevent us from
-    // showing a data page.
-    if (
-        yVariableIds.length === 1 &&
-        (grapher.type !== ChartTypeName.ScatterPlot ||
-            xVariableIds.length === 0)
-    ) {
-        const variableId = yVariableIds[0]
-        const variableMetadata = await getVariableMetadata(variableId)
+    const variable = await getVariableOfDatapageIfApplicable(grapher)
 
-        if (
-            variableMetadata.schemaVersion !== undefined &&
-            variableMetadata.schemaVersion >= 2 &&
-            (!isEmpty(variableMetadata.descriptionShort) ||
-                !isEmpty(variableMetadata.descriptionProcessing) ||
-                !isEmpty(variableMetadata.descriptionKey) ||
-                !isEmpty(variableMetadata.descriptionFromProducer) ||
-                !isEmpty(variableMetadata.presentation?.titlePublic))
-        ) {
-            return await renderDataPageV2({
-                variableId,
-                variableMetadata,
-                isPreviewing: isPreviewing,
-                useIndicatorGrapherConfigs: false,
-                pageGrapher: grapher,
-                publishedExplorersBySlug,
-                imageMetadataDictionary,
-            })
-        }
-    }
-    return undefined
+    if (!variable) return undefined
+
+    return await renderDataPageV2({
+        variableId: variable.id,
+        variableMetadata: variable.metadata,
+        isPreviewing: isPreviewing,
+        useIndicatorGrapherConfigs: false,
+        pageGrapher: grapher,
+        publishedExplorersBySlug,
+        imageMetadataDictionary,
+    })
 }
 
 /**

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -56,6 +56,7 @@ import {
     DATA_INSIGHTS_INDEX_PAGE_SIZE,
     OwidGdocMinimalPostInterface,
     excludeUndefined,
+    grabMetadataForGdocLinkedIndicator,
 } from "@ourworldindata/utils"
 
 import { execWrapper } from "../db/execWrapper.js"
@@ -345,7 +346,7 @@ export class SiteBaker {
                     const metadata = await getVariableMetadata(indicatorId)
                     return {
                         id: indicatorId,
-                        titlePublic: metadata.presentation?.titlePublic,
+                        ...grabMetadataForGdocLinkedIndicator(metadata),
                     }
                 })
             )

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -504,6 +504,15 @@ export class GdocBase extends BaseEntity implements OwidGdocBaseInterface {
                     }),
                 ]
             })
+            .with({ type: "key-indicator" }, (block) => {
+                return [
+                    Link.createFromUrl({
+                        url: block.datapageUrl,
+                        source: this,
+                        componentType: block.type,
+                    }),
+                ]
+            })
             .with(
                 {
                     // no urls directly on any of these blocks
@@ -521,7 +530,6 @@ export class GdocBase extends BaseEntity implements OwidGdocBaseInterface {
                         "horizontal-rule",
                         "html",
                         "image",
-                        "key-indicator",
                         "list",
                         "missing-data",
                         "numbered-list",

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -34,8 +34,6 @@ import {
     BreadcrumbItem,
     MinimalDataInsightInterface,
     OwidGdocMinimalPostInterface,
-    getFeaturedImageFilename,
-    OwidGdoc,
     urlToSlug,
 } from "@ourworldindata/utils"
 import { BAKED_GRAPHER_URL } from "../../../settings/serverSettings.js"

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -35,6 +35,7 @@ import {
     MinimalDataInsightInterface,
     OwidGdocMinimalPostInterface,
     urlToSlug,
+    grabMetadataForGdocLinkedIndicator,
 } from "@ourworldindata/utils"
 import { BAKED_GRAPHER_URL } from "../../../settings/serverSettings.js"
 import { google } from "googleapis"
@@ -618,7 +619,7 @@ export class GdocBase extends BaseEntity implements OwidGdocBaseInterface {
                 )
                 const linkedIndicator: LinkedIndicator = {
                     id: linkedChart.indicatorId,
-                    titlePublic: metadata.presentation?.titlePublic,
+                    ...grabMetadataForGdocLinkedIndicator(metadata),
                 }
                 return linkedIndicator
             })

--- a/db/model/Gdoc/GdocPost.ts
+++ b/db/model/Gdoc/GdocPost.ts
@@ -12,8 +12,7 @@ import {
     RawBlockText,
     RelatedChart,
     OwidGdocMinimalPostInterface,
-} from "@ourworldindata/types"
-import { traverseEnrichedBlocks, urlToSlug } from "@ourworldindata/utils"
+} from "@ourworldindata/utils"
 import { GDOCS_DETAILS_ON_DEMAND_ID } from "../../../settings/serverSettings.js"
 import {
     formatCitation,
@@ -143,25 +142,6 @@ export class GdocPost extends GdocBase implements OwidGdocPostInterface {
                     type: OwidGdocErrorMessageType.Error,
                 })
             }
-        }
-
-        // Validate that charts referenced in key-indicator blocks render a datapage
-        for (const enrichedBlockSource of this.enrichedBlockSources) {
-            enrichedBlockSource.forEach((block) =>
-                traverseEnrichedBlocks(block, (block) => {
-                    if (block.type === "key-indicator" && block.datapageUrl) {
-                        const slug = urlToSlug(block.datapageUrl)
-                        const linkedChart = this.linkedCharts?.[slug]
-                        if (!linkedChart?.indicatorId) {
-                            errors.push({
-                                property: "body",
-                                type: OwidGdocErrorMessageType.Error,
-                                message: `Grapher chart with slug ${slug} is not a datapage`,
-                            })
-                        }
-                    }
-                })
-            )
         }
 
         return errors

--- a/db/model/Gdoc/enrichedToMarkdown.ts
+++ b/db/model/Gdoc/enrichedToMarkdown.ts
@@ -271,5 +271,16 @@ ${links}`
             ).join("\n\n> ")
             return `> ${text}` + b.citation ? `\n-- ${b.citation}` : ""
         })
+        .with({ type: "key-indicator" }, (b): string | undefined =>
+            markdownComponent(
+                "KeyIndicator",
+                {
+                    datapageUrl: b.datapageUrl,
+                    title: b.title,
+                    // blurb ignored
+                },
+                exportComponents
+            )
+        )
         .exhaustive()
 }

--- a/db/model/Gdoc/enrichedToMarkdown.ts
+++ b/db/model/Gdoc/enrichedToMarkdown.ts
@@ -277,6 +277,7 @@ ${links}`
                 {
                     datapageUrl: b.datapageUrl,
                     title: b.title,
+                    source: b.source,
                     // blurb ignored
                 },
                 exportComponents

--- a/db/model/Gdoc/enrichedToMarkdown.ts
+++ b/db/model/Gdoc/enrichedToMarkdown.ts
@@ -279,7 +279,7 @@ ${links}`
                     datapageUrl: b.datapageUrl,
                     title: b.title,
                     source: b.source,
-                    // blurb ignored
+                    // text ignored
                 },
                 exportComponents
             )

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -440,12 +440,10 @@ export function enrichedBlockToRawBlock(
                 value: {
                     datapageUrl: b.datapageUrl,
                     title: b.title,
-                    blurb: b.blurb
-                        ? b.blurb.map((enriched) => ({
-                              type: "text",
-                              value: spansToHtmlText(enriched.value),
-                          }))
-                        : undefined,
+                    blurb: b.blurb.map((enriched) => ({
+                        type: "text",
+                        value: spansToHtmlText(enriched.value),
+                    })),
                     source: b.source,
                 },
             }

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -446,6 +446,7 @@ export function enrichedBlockToRawBlock(
                               value: spansToHtmlText(enriched.value),
                           }))
                         : undefined,
+                    source: b.source,
                 },
             }
         })

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -439,11 +439,13 @@ export function enrichedBlockToRawBlock(
                 type: "key-indicator",
                 value: {
                     datapageUrl: b.datapageUrl,
-                    blurb: b.blurb.map((enriched) => ({
-                        type: "text",
-                        value: spansToHtmlText(enriched.value),
-                    })),
                     title: b.title,
+                    blurb: b.blurb
+                        ? b.blurb.map((enriched) => ({
+                              type: "text",
+                              value: spansToHtmlText(enriched.value),
+                          }))
+                        : undefined,
                 },
             }
         })

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -441,7 +441,7 @@ export function enrichedBlockToRawBlock(
                 value: {
                     datapageUrl: b.datapageUrl,
                     title: b.title,
-                    blurb: b.blurb.map((enriched) => ({
+                    text: b.text.map((enriched) => ({
                         type: "text",
                         value: spansToHtmlText(enriched.value),
                     })),

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -36,7 +36,8 @@ import {
     RawBlockVideo,
     RawBlockTable,
     RawBlockBlockquote,
-} from "@ourworldindata/utils"
+    RawBlockKeyIndicator,
+} from "@ourworldindata/types"
 import { spanToHtmlString } from "./gdocUtils.js"
 import { match, P } from "ts-pattern"
 
@@ -430,6 +431,19 @@ export function enrichedBlockToRawBlock(
                         value: spansToHtmlText(enriched.value),
                     })),
                     citation: b.citation,
+                },
+            }
+        })
+        .with({ type: "key-indicator" }, (b): RawBlockKeyIndicator => {
+            return {
+                type: "key-indicator",
+                value: {
+                    datapageUrl: b.datapageUrl,
+                    blurb: b.blurb.map((enriched) => ({
+                        type: "text",
+                        value: spansToHtmlText(enriched.value),
+                    })),
+                    title: b.title,
                 },
             }
         })

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -538,7 +538,6 @@ export const enrichedBlockExamples: Record<
     "key-indicator": {
         type: "key-indicator",
         datapageUrl: "https://ourworldindata.org/grapher/life-expectancy",
-        blurb: [enrichedBlockText],
         parseErrors: [],
     },
 }

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -535,4 +535,10 @@ export const enrichedBlockExamples: Record<
         citation: "Max Roser",
         parseErrors: [],
     },
+    "key-indicator": {
+        type: "key-indicator",
+        datapageUrl: "https://ourworldindata.org/grapher/life-expectancy",
+        blurb: [enrichedBlockText],
+        parseErrors: [],
+    },
 }

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -539,7 +539,7 @@ export const enrichedBlockExamples: Record<
         type: "key-indicator",
         datapageUrl: "https://ourworldindata.org/grapher/life-expectancy",
         title: "How did people's life expectancy change over time?",
-        blurb: [enrichedBlockText],
+        text: [enrichedBlockText],
         parseErrors: [],
     },
     "key-indicator-collection": {
@@ -550,7 +550,7 @@ export const enrichedBlockExamples: Record<
                 datapageUrl:
                     "https://ourworldindata.org/grapher/life-expectancy",
                 title: "How did people's life expectancy change over time?",
-                blurb: [enrichedBlockText],
+                text: [enrichedBlockText],
                 parseErrors: [],
             },
             {
@@ -558,7 +558,7 @@ export const enrichedBlockExamples: Record<
                 datapageUrl:
                     "https://ourworldindata.org/grapher/share-of-population-in-extreme-poverty",
                 title: "What share of the population is living in extreme poverty?",
-                blurb: [enrichedBlockText],
+                text: [enrichedBlockText],
                 parseErrors: [],
             },
         ],

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -538,6 +538,8 @@ export const enrichedBlockExamples: Record<
     "key-indicator": {
         type: "key-indicator",
         datapageUrl: "https://ourworldindata.org/grapher/life-expectancy",
+        title: "How did people's life expectancy change over time?",
+        blurb: [enrichedBlockText],
         parseErrors: [],
     },
 }

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -630,9 +630,9 @@ function* rawBlockKeyIndicatorToArchieMLString(
         yield* propertyToArchieMLString("datapageUrl", block.value)
         yield* propertyToArchieMLString("title", block.value)
         yield* propertyToArchieMLString("source", block.value)
-        if (block.value.blurb) {
-            yield "[.+blurb]"
-            for (const textBlock of block.value.blurb) {
+        if (block.value.text) {
+            yield "[.+text]"
+            for (const textBlock of block.value.text) {
                 yield* OwidRawGdocBlockToArchieMLStringGenerator(textBlock)
             }
             yield "[]"

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -32,11 +32,12 @@ import {
     RawBlockExpandableParagraph,
     RawBlockAlign,
     RawBlockEntrySummary,
-    isArray,
     RawBlockTable,
     RawBlockTableRow,
     RawBlockBlockquote,
-} from "@ourworldindata/utils"
+    RawBlockKeyIndicator,
+} from "@ourworldindata/types"
+import { isArray } from "@ourworldindata/utils"
 import { match } from "ts-pattern"
 
 export function appendDotEndIfMultiline(
@@ -620,6 +621,24 @@ function* rawBlockTableToArchieMLString(
     yield "{}"
 }
 
+function* rawBlockKeyIndicatorToArchieMLString(
+    block: RawBlockKeyIndicator
+): Generator<string, void, undefined> {
+    yield "{.key-indicator}"
+    if (typeof block.value !== "string") {
+        yield* propertyToArchieMLString("datapageUrl", block.value)
+        yield* propertyToArchieMLString("title", block.value)
+        if (block.value.blurb) {
+            yield "[.+blurb]"
+            for (const textBlock of block.value.blurb) {
+                yield* OwidRawGdocBlockToArchieMLStringGenerator(textBlock)
+            }
+            yield "[]"
+        }
+    }
+    yield "{}"
+}
+
 export function* OwidRawGdocBlockToArchieMLStringGenerator(
     block: OwidRawGdocBlock | RawBlockTableRow
 ): Generator<string, void, undefined> {
@@ -684,6 +703,7 @@ export function* OwidRawGdocBlockToArchieMLStringGenerator(
         .with({ type: "table" }, rawBlockTableToArchieMLString)
         .with({ type: "table-row" }, rawBlockRowToArchieMLString)
         .with({ type: "blockquote" }, rawBlockBlockquoteToArchieMLString)
+        .with({ type: "key-indicator" }, rawBlockKeyIndicatorToArchieMLString)
         .exhaustive()
     yield* content
 }

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -628,6 +628,7 @@ function* rawBlockKeyIndicatorToArchieMLString(
     if (typeof block.value !== "string") {
         yield* propertyToArchieMLString("datapageUrl", block.value)
         yield* propertyToArchieMLString("title", block.value)
+        yield* propertyToArchieMLString("source", block.value)
         if (block.value.blurb) {
             yield "[.+blurb]"
             for (const textBlock of block.value.blurb) {

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -1933,6 +1933,7 @@ const parseKeyIndicator = (
         datapageUrl: url,
         blurb: parsedBlurb.length > 0 ? parsedBlurb : undefined,
         title: val.title,
+        source: val.source,
         parseErrors: parsedBlurbErrors,
     }) as EnrichedBlockKeyIndicator
 }

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -1903,7 +1903,7 @@ const parseKeyIndicator = (
 
     if (typeof val === "string")
         return createError({
-            message: "Value is a string, not an object with properties",
+            message: `key-indicator block must be written as "{.key-indicator}"`,
         })
 
     if (!val.datapageUrl)

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -1894,6 +1894,8 @@ const parseKeyIndicator = (
     ): EnrichedBlockKeyIndicator => ({
         type: "key-indicator",
         datapageUrl,
+        title: "",
+        blurb: [],
         parseErrors: [error],
     })
 
@@ -1915,7 +1917,13 @@ const parseKeyIndicator = (
 
     const url = extractUrl(val.datapageUrl)
 
-    if (val.blurb && !isArray(val.blurb))
+    if (!val.title)
+        return createError(
+            { message: "title property is missing or empty" },
+            url
+        )
+
+    if (!isArray(val.blurb))
         return createError(
             {
                 message:
@@ -1924,14 +1932,13 @@ const parseKeyIndicator = (
             url
         )
 
-    const blurb = val.blurb ?? []
-    const parsedBlurb = blurb.map(parseText)
+    const parsedBlurb = val.blurb.map(parseText)
     const parsedBlurbErrors = parsedBlurb.flatMap((block) => block.parseErrors)
 
     return omitUndefinedValues({
         type: "key-indicator",
         datapageUrl: url,
-        blurb: parsedBlurb.length > 0 ? parsedBlurb : undefined,
+        blurb: parsedBlurb,
         title: val.title,
         source: val.source,
         parseErrors: parsedBlurbErrors,

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -1894,7 +1894,6 @@ const parseKeyIndicator = (
     ): EnrichedBlockKeyIndicator => ({
         type: "key-indicator",
         datapageUrl,
-        blurb: [],
         parseErrors: [error],
     })
 
@@ -1916,7 +1915,7 @@ const parseKeyIndicator = (
 
     const url = extractUrl(val.datapageUrl)
 
-    if (!isArray(val.blurb))
+    if (val.blurb && !isArray(val.blurb))
         return createError(
             {
                 message:
@@ -1925,13 +1924,14 @@ const parseKeyIndicator = (
             url
         )
 
-    const parsedBlurb = val.blurb.map(parseText)
+    const blurb = val.blurb ?? []
+    const parsedBlurb = blurb.map(parseText)
     const parsedBlurbErrors = parsedBlurb.flatMap((block) => block.parseErrors)
 
     return omitUndefinedValues({
         type: "key-indicator",
         datapageUrl: url,
-        blurb: parsedBlurb,
+        blurb: parsedBlurb.length > 0 ? parsedBlurb : undefined,
         title: val.title,
         parseErrors: parsedBlurbErrors,
     }) as EnrichedBlockKeyIndicator

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -1890,7 +1890,7 @@ const parseKeyIndicator = (
 ): EnrichedBlockKeyIndicator => {
     const createError = (
         error: ParseError,
-        datapageUrl: string
+        datapageUrl = ""
     ): EnrichedBlockKeyIndicator => ({
         type: "key-indicator",
         datapageUrl,
@@ -1902,18 +1902,14 @@ const parseKeyIndicator = (
     const val = raw.value
 
     if (typeof val === "string")
-        return createError(
-            {
-                message: "Value is a string, not an object with properties",
-            },
-            ""
-        )
+        return createError({
+            message: "Value is a string, not an object with properties",
+        })
 
     if (!val.datapageUrl)
-        return createError(
-            { message: "datapageUrl property is missing or empty" },
-            ""
-        )
+        return createError({
+            message: "datapageUrl property is missing or empty",
+        })
 
     const url = extractUrl(val.datapageUrl)
 
@@ -1922,6 +1918,8 @@ const parseKeyIndicator = (
             { message: "title property is missing or empty" },
             url
         )
+
+    if (!val.blurb) return createError({ message: "blurb is missing" }, url)
 
     if (!isArray(val.blurb))
         return createError(

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -1898,7 +1898,7 @@ const parseKeyIndicator = (
         type: "key-indicator",
         datapageUrl,
         title: "",
-        blurb: [],
+        text: [],
         parseErrors: [error],
     })
 
@@ -1922,24 +1922,24 @@ const parseKeyIndicator = (
             url
         )
 
-    if (!val.blurb) return createError({ message: "blurb is missing" }, url)
+    if (!val.text) return createError({ message: "text is missing" }, url)
 
-    if (!isArray(val.blurb))
+    if (!isArray(val.text))
         return createError(
             {
                 message:
-                    "Blurb is not a freeform array. Make sure you've written [.+blurb]",
+                    "Blurb is not a freeform array. Make sure you've written [.+text]",
             },
             url
         )
 
-    const parsedBlurb = val.blurb.map(parseText)
+    const parsedBlurb = val.text.map(parseText)
     const parsedBlurbErrors = parsedBlurb.flatMap((block) => block.parseErrors)
 
     return omitUndefinedValues({
         type: "key-indicator",
         datapageUrl: url,
-        blurb: parsedBlurb,
+        text: parsedBlurb,
         title: val.title,
         source: val.source,
         parseErrors: parsedBlurbErrors,

--- a/packages/@ourworldindata/components/src/IndicatorKeyData/IndicatorKeyData.tsx
+++ b/packages/@ourworldindata/components/src/IndicatorKeyData/IndicatorKeyData.tsx
@@ -12,23 +12,21 @@ export const makeSource = ({
     attribution,
     owidProcessingLevel,
     isEmbeddedInADataPage,
-    hideProcessingLevel = false,
 }: {
     attribution?: string
     owidProcessingLevel?: OwidProcessingLevel
     isEmbeddedInADataPage?: boolean
-    hideProcessingLevel?: boolean
 }): React.ReactNode => {
     if (!attribution) return null
     const isEmbedded = isEmbeddedInADataPage ?? true
     const processingLevelPhrase =
         getPhraseForProcessingLevel(owidProcessingLevel)
-    const hideProcessingPhrase =
-        hideProcessingLevel || attribution.toLowerCase() === "our world in data"
+    const hideProcessingPhase =
+        attribution.toLowerCase() === "our world in data"
     return (
         <>
             <SimpleMarkdownText text={attribution} useParagraphs={false} />
-            {!hideProcessingPhrase && (
+            {!hideProcessingPhase && (
                 <>
                     {" – "}
                     {isEmbedded ? (

--- a/packages/@ourworldindata/components/src/IndicatorKeyData/IndicatorKeyData.tsx
+++ b/packages/@ourworldindata/components/src/IndicatorKeyData/IndicatorKeyData.tsx
@@ -23,8 +23,8 @@ export const makeSource = ({
     const isEmbedded = isEmbeddedInADataPage ?? true
     const processingLevelPhrase =
         getPhraseForProcessingLevel(owidProcessingLevel)
-    const hideProcessingPhrase = hideProcessingLevel ||
-        attribution.toLowerCase() === "our world in data"
+    const hideProcessingPhrase =
+        hideProcessingLevel || attribution.toLowerCase() === "our world in data"
     return (
         <>
             <SimpleMarkdownText text={attribution} useParagraphs={false} />

--- a/packages/@ourworldindata/components/src/IndicatorKeyData/IndicatorKeyData.tsx
+++ b/packages/@ourworldindata/components/src/IndicatorKeyData/IndicatorKeyData.tsx
@@ -12,21 +12,23 @@ export const makeSource = ({
     attribution,
     owidProcessingLevel,
     isEmbeddedInADataPage,
+    hideProcessingLevel = false,
 }: {
     attribution?: string
     owidProcessingLevel?: OwidProcessingLevel
     isEmbeddedInADataPage?: boolean
+    hideProcessingLevel?: boolean
 }): React.ReactNode => {
     if (!attribution) return null
     const isEmbedded = isEmbeddedInADataPage ?? true
     const processingLevelPhrase =
         getPhraseForProcessingLevel(owidProcessingLevel)
-    const hideProcessingPhase =
+    const hideProcessingPhrase = hideProcessingLevel ||
         attribution.toLowerCase() === "our world in data"
     return (
         <>
             <SimpleMarkdownText text={attribution} useParagraphs={false} />
-            {!hideProcessingPhase && (
+            {!hideProcessingPhrase && (
                 <>
                     {" – "}
                     {isEmbedded ? (

--- a/packages/@ourworldindata/components/src/styles/typography.scss
+++ b/packages/@ourworldindata/components/src/styles/typography.scss
@@ -260,6 +260,15 @@ body {
     @include subtitle-2;
 }
 
+@mixin subtitle-2-bold {
+    @include subtitle-2;
+    font-weight: 700;
+}
+
+.subtitle-2-bold {
+    @include subtitle-2-bold;
+}
+
 @mixin overline-black-caps {
     font-family: $sans-serif-font-stack;
     font-size: 0.75rem;

--- a/packages/@ourworldindata/components/src/styles/typography.scss
+++ b/packages/@ourworldindata/components/src/styles/typography.scss
@@ -260,15 +260,6 @@ body {
     @include subtitle-2;
 }
 
-@mixin subtitle-2-bold {
-    @include subtitle-2;
-    font-weight: 700;
-}
-
-.subtitle-2-bold {
-    @include subtitle-2-bold;
-}
-
 @mixin overline-black-caps {
     font-family: $sans-serif-font-stack;
     font-size: 0.75rem;

--- a/packages/@ourworldindata/types/src/OwidVariable.ts
+++ b/packages/@ourworldindata/types/src/OwidVariable.ts
@@ -1,6 +1,7 @@
 import { OwidOrigin } from "./OwidOrigin.js"
 import { OwidSource } from "./OwidSource.js"
 import { OwidVariableDisplayConfigInterface } from "./OwidVariableDisplayConfigInterface.js"
+import { GrapherInterface } from "./grapherTypes/GrapherTypes.js"
 
 export interface OwidVariableWithSource {
     id: number
@@ -71,7 +72,7 @@ export interface OwidVariablePresentation {
     attribution?: string
     topicTagsLinks?: string[]
     faqs?: FaqLink[]
-    grapherConfigETL?: string
+    grapherConfigETL?: GrapherInterface
 }
 
 export type OwidProcessingLevel = "minor" | "major"

--- a/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
@@ -86,6 +86,24 @@ export type EnrichedBlockChart = {
     tabs?: ChartTabKeyword[]
 } & EnrichedBlockWithParseErrors
 
+export type RawBlockKeyIndicatorValue = {
+    datapageUrl?: string
+    title?: string
+    blurb?: RawBlockText[]
+}
+
+export type RawBlockKeyIndicator = {
+    type: "key-indicator"
+    value: RawBlockKeyIndicatorValue | ArchieMLUnexpectedNonObjectValue
+}
+
+export type EnrichedBlockKeyIndicator = {
+    type: "key-indicator"
+    datapageUrl: string
+    blurb: EnrichedBlockText[]
+    title?: string
+} & EnrichedBlockWithParseErrors
+
 export type RawBlockScroller = {
     type: "scroller"
     value: OwidRawGdocBlock[] | ArchieMLUnexpectedNonObjectValue
@@ -723,6 +741,7 @@ export type OwidRawGdocBlock =
     | RawBlockEntrySummary
     | RawBlockTable
     | RawBlockBlockquote
+    | RawBlockKeyIndicator
 
 export type OwidEnrichedGdocBlock =
     | EnrichedBlockAllCharts
@@ -760,3 +779,4 @@ export type OwidEnrichedGdocBlock =
     | EnrichedBlockEntrySummary
     | EnrichedBlockTable
     | EnrichedBlockBlockquote
+    | EnrichedBlockKeyIndicator

--- a/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
@@ -100,8 +100,8 @@ export type RawBlockKeyIndicator = {
 export type EnrichedBlockKeyIndicator = {
     type: "key-indicator"
     datapageUrl: string
-    blurb: EnrichedBlockText[]
     title?: string
+    blurb?: EnrichedBlockText[]
 } & EnrichedBlockWithParseErrors
 
 export type RawBlockScroller = {

--- a/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
@@ -89,7 +89,7 @@ export type EnrichedBlockChart = {
 export type RawBlockKeyIndicatorValue = {
     datapageUrl?: string
     title?: string
-    blurb?: RawBlockText[]
+    text?: RawBlockText[]
     source?: string
 }
 
@@ -102,7 +102,7 @@ export type EnrichedBlockKeyIndicator = {
     type: "key-indicator"
     datapageUrl: string
     title: string
-    blurb: EnrichedBlockText[]
+    text: EnrichedBlockText[]
     source?: string
 } & EnrichedBlockWithParseErrors
 

--- a/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
@@ -90,6 +90,7 @@ export type RawBlockKeyIndicatorValue = {
     datapageUrl?: string
     title?: string
     blurb?: RawBlockText[]
+    source?: string
 }
 
 export type RawBlockKeyIndicator = {
@@ -102,6 +103,7 @@ export type EnrichedBlockKeyIndicator = {
     datapageUrl: string
     title?: string
     blurb?: EnrichedBlockText[]
+    source?: string
 } & EnrichedBlockWithParseErrors
 
 export type RawBlockScroller = {

--- a/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
@@ -101,8 +101,8 @@ export type RawBlockKeyIndicator = {
 export type EnrichedBlockKeyIndicator = {
     type: "key-indicator"
     datapageUrl: string
-    title?: string
-    blurb?: EnrichedBlockText[]
+    title: string
+    blurb: EnrichedBlockText[]
     source?: string
 } & EnrichedBlockWithParseErrors
 

--- a/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
@@ -146,7 +146,11 @@ export type DataPageParseError = { message: string; path?: string }
 
 export type FaqEntryData = Pick<
     OwidGdocPostInterface,
-    "linkedCharts" | "linkedDocuments" | "relatedCharts" | "imageMetadata"
+    | "linkedCharts"
+    | "linkedIndicators"
+    | "linkedDocuments"
+    | "relatedCharts"
+    | "imageMetadata"
 > & {
     faqs: OwidEnrichedGdocBlock[]
 }

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -29,7 +29,7 @@ export interface LinkedChart {
 export interface LinkedIndicator {
     id: number
     title: string
-    source?: string
+    attributionShort?: string
 }
 
 export enum OwidGdocType {

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -28,7 +28,10 @@ export interface LinkedChart {
 
 export interface LinkedIndicator {
     id: number
-    titlePublic?: string
+    title: string
+    dateRange?: string
+    lastUpdated?: string
+    attributionUnshortened?: string
 }
 
 export enum OwidGdocType {

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -32,6 +32,7 @@ export interface LinkedIndicator {
     dateRange?: string
     lastUpdated?: string
     attributionUnshortened?: string
+    descriptionShort?: string
 }
 
 export enum OwidGdocType {

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -29,9 +29,10 @@ export interface LinkedChart {
 export interface LinkedIndicator {
     id: number
     title: string
+    titleVariant?: string
+    attributionShort?: string
     dateRange?: string
     lastUpdated?: string
-    attributionUnshortened?: string
     descriptionShort?: string
 }
 

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -23,6 +23,12 @@ export interface LinkedChart {
     resolvedUrl: string
     title: string
     thumbnail?: string
+    indicatorId?: number // in case of a datapage
+}
+
+export interface LinkedIndicator {
+    id: number
+    titlePublic?: string
 }
 
 export enum OwidGdocType {
@@ -46,6 +52,7 @@ export interface OwidGdocBaseInterface {
     breadcrumbs?: BreadcrumbItem[] | null
     linkedDocuments?: Record<string, OwidGdocMinimalPostInterface>
     linkedCharts?: Record<string, LinkedChart>
+    linkedIndicators?: Record<number, LinkedIndicator>
     imageMetadata?: Record<string, ImageMetadata>
     relatedCharts?: RelatedChart[]
     tags?: Tag[]

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -29,11 +29,7 @@ export interface LinkedChart {
 export interface LinkedIndicator {
     id: number
     title: string
-    titleVariant?: string
-    attributionShort?: string
-    dateRange?: string
-    lastUpdated?: string
-    descriptionShort?: string
+    source?: string
 }
 
 export enum OwidGdocType {

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -26,6 +26,12 @@ export interface LinkedChart {
     indicatorId?: number // in case of a datapage
 }
 
+/**
+ * A linked indicator is derived from a linked grapher's config (see: getVariableOfDatapageIfApplicable)
+ * e.g. https://ourworldindata.org/grapher/tomato-production -> config for grapher with { slug: "tomato-production" } -> indicator metadata
+ * currently we only attach a small amount of metadata that we need for key-indicator blocks.
+ * In the future we might want to attach more metadata, e.g. the indicator's description, source, etc
+ */
 export interface LinkedIndicator {
     id: number
     title: string

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -191,6 +191,7 @@ export {
     type RawBlockText,
     type RawBlockTopicPageIntro,
     type RawBlockUrl,
+    type RawBlockKeyIndicator,
     tableTemplates,
     type TableTemplate,
     tableSizes,
@@ -248,6 +249,7 @@ export {
     type EnrichedBlockTable,
     type EnrichedBlockTableRow,
     type EnrichedBlockTableCell,
+    type EnrichedBlockKeyIndicator,
     type RawBlockResearchAndWritingRow,
 } from "./gdocTypes/ArchieMlComponents.js"
 export {
@@ -277,6 +279,7 @@ export {
     type OwidArticleBackportingStatistics,
     type LinkedChart,
     OwidGdocLinkType,
+    type LinkedIndicator,
     DYNAMIC_COLLECTION_PAGE_CONTAINER_ID,
 } from "./gdocTypes/Gdoc.js"
 

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1626,6 +1626,17 @@ export function traverseEnrichedBlocks(
         })
         .with(
             {
+                type: "key-indicator",
+            },
+            (keyIndicator) => {
+                callback(keyIndicator)
+                keyIndicator.blurb.forEach((node) => {
+                    traverseEnrichedBlocks(node, callback, spanCallback)
+                })
+            }
+        )
+        .with(
+            {
                 type: P.union(
                     "chart-story",
                     "chart",
@@ -1643,8 +1654,7 @@ export function traverseEnrichedBlocks(
                     "sdg-toc",
                     "topic-page-intro",
                     "all-charts",
-                    "entry-summary",
-                    "key-indicator"
+                    "entry-summary"
                 ),
             },
             callback

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1643,7 +1643,8 @@ export function traverseEnrichedBlocks(
                     "sdg-toc",
                     "topic-page-intro",
                     "all-charts",
-                    "entry-summary"
+                    "entry-summary",
+                    "key-indicator"
                 ),
             },
             callback

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1630,7 +1630,7 @@ export function traverseEnrichedBlocks(
             },
             (keyIndicator) => {
                 callback(keyIndicator)
-                keyIndicator.blurb.forEach((node) => {
+                keyIndicator.text.forEach((node) => {
                     traverseEnrichedBlocks(node, callback, spanCallback)
                 })
             }

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -133,7 +133,6 @@ export {
     getCitationLong,
     getCitationShort,
     grabMetadataForGdocLinkedIndicator,
-    getAttributionUnshortened,
 } from "./metadataHelpers.js"
 
 export {

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -132,6 +132,8 @@ export {
     formatSourceDate,
     getCitationLong,
     getCitationShort,
+    grabMetadataForGdocLinkedIndicator,
+    getAttributionUnshortened,
 } from "./metadataHelpers.js"
 
 export {

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -304,5 +304,6 @@ export function grabMetadataForGdocLinkedIndicator(
             attributions: getAttributionFragmentsFromVariable(metadata),
             origins: metadata.origins ?? [],
         }),
+        descriptionShort: metadata.descriptionShort,
     }
 }

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -7,6 +7,7 @@ import {
     OwidSource,
     OwidVariableWithSourceAndDimension,
     LinkedIndicator,
+    joinTitleFragments,
 } from "@ourworldindata/types"
 import { compact, uniq, last, excludeUndefined } from "./Util"
 import dayjs from "./dayjs.js"
@@ -293,15 +294,14 @@ export function grabMetadataForGdocLinkedIndicator(
 ): Omit<LinkedIndicator, "id"> {
     return {
         title:
-            metadata.presentation?.titlePublic ??
-            metadata.presentation?.grapherConfigETL?.title ??
-            metadata.display?.name ??
-            metadata.name ??
+            metadata.presentation?.titlePublic ||
+            metadata.presentation?.grapherConfigETL?.title ||
+            metadata.display?.name ||
+            metadata.name ||
             "",
-        titleVariant: metadata.presentation?.titleVariant,
-        attributionShort: metadata.presentation?.attributionShort,
-        dateRange: metadata.timespan,
-        lastUpdated: getLastUpdatedFromVariable(metadata),
-        descriptionShort: metadata.descriptionShort,
+        source: joinTitleFragments(
+            metadata.presentation?.attributionShort,
+            metadata.presentation?.titleVariant
+        ),
     }
 }

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -298,12 +298,10 @@ export function grabMetadataForGdocLinkedIndicator(
             metadata.display?.name ??
             metadata.name ??
             "",
+        titleVariant: metadata.presentation?.titleVariant,
+        attributionShort: metadata.presentation?.attributionShort,
         dateRange: metadata.timespan,
         lastUpdated: getLastUpdatedFromVariable(metadata),
-        attributionUnshortened: getAttributionUnshortened({
-            attributions: getAttributionFragmentsFromVariable(metadata),
-            origins: metadata.origins ?? [],
-        }),
         descriptionShort: metadata.descriptionShort,
     }
 }

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -275,20 +275,6 @@ export const formatSourceDate = (
     return parsedDate.format(format)
 }
 
-export function getAttributionUnshortened({
-    origins,
-    attributions,
-}: {
-    origins: OwidOrigin[]
-    attributions: string[]
-}): string {
-    const producersWithYear = uniq(
-        origins.map((o) => `${o.producer}${getYearSuffixFromOrigin(o)}`)
-    )
-    const attributionFragments = attributions ?? producersWithYear
-    return attributionFragments.join("; ")
-}
-
 export function grabMetadataForGdocLinkedIndicator(
     metadata: OwidVariableWithSourceAndDimension
 ): Omit<LinkedIndicator, "id"> {
@@ -299,7 +285,7 @@ export function grabMetadataForGdocLinkedIndicator(
             metadata.display?.name ||
             metadata.name ||
             "",
-        source: joinTitleFragments(
+        attributionShort: joinTitleFragments(
             metadata.presentation?.attributionShort,
             metadata.presentation?.titleVariant
         ),

--- a/site/DataInsightsIndexPageContent.tsx
+++ b/site/DataInsightsIndexPageContent.tsx
@@ -106,6 +106,7 @@ export const DataInsightsIndexPageContent = (
                     imageMetadata,
                     linkedCharts,
                     linkedDocuments,
+                    linkedIndicators: {}, // not needed for data insights
                     relatedCharts: [], // not needed for the index page
                     latestDataInsights: [], // not needed for the index page
                 }}

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -34,12 +34,12 @@ import {
     DataPageRelatedResearch,
     isEmpty,
     excludeUndefined,
-    OwidOrigin,
     DataPageDataV2,
     getCitationShort,
     GrapherInterface,
     getCitationLong,
     joinTitleFragments,
+    getAttributionUnshortened,
 } from "@ourworldindata/utils"
 import { AttachmentsContext, DocumentContext } from "./gdocs/OwidGdoc.js"
 import StickyNav from "./blocks/StickyNav.js"
@@ -126,24 +126,12 @@ export const DataPageV2Content = ({
         datapageData.descriptionKey && datapageData.descriptionKey.length > 0
 
     const sourcesForDisplay = prepareSourcesForDisplay(datapageData)
-    const getYearSuffixFromOrigin = (o: OwidOrigin) => {
-        const year = o.dateAccessed
-            ? dayjs(o.dateAccessed, ["YYYY-MM-DD", "YYYY"]).year()
-            : o.datePublished
-            ? dayjs(o.datePublished, ["YYYY-MM-DD", "YYYY"]).year()
-            : undefined
-        if (year) return ` (${year})`
-        else return ""
-    }
     const producers = uniq(datapageData.origins.map((o) => `${o.producer}`))
-    const producersWithYear = uniq(
-        datapageData.origins.map(
-            (o) => `${o.producer}${getYearSuffixFromOrigin(o)}`
-        )
-    )
 
-    const attributionFragments = datapageData.attributions ?? producersWithYear
-    const attributionUnshortened = attributionFragments.join("; ")
+    const attributionUnshortened = getAttributionUnshortened({
+        attributions: datapageData.attributions,
+        origins: datapageData.origins,
+    })
     const citationShort = getCitationShort(
         datapageData.origins,
         datapageData.attributions,
@@ -751,7 +739,7 @@ const KeyDataTable = (props: {
     const links = makeLinks({ link: datapageData.source?.link })
 
     return (
-        <div className="key-data-block grid grid-cols-4 grid-sm-cols-12 ">
+        <div className="key-data-block grid grid-cols-4 grid-sm-cols-12">
             {datapageData.descriptionShort && (
                 <div className="key-data span-cols-4 span-sm-cols-12">
                     <div className="key-data__title key-data-description-short__title">

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -165,6 +165,7 @@ export const DataPageV2Content = ({
         linkedDocuments = {},
         imageMetadata = {},
         linkedCharts = {},
+        linkedIndicators = {},
         relatedCharts = [],
     } = faqEntries ?? {}
 
@@ -237,6 +238,7 @@ export const DataPageV2Content = ({
                 linkedDocuments,
                 imageMetadata,
                 linkedCharts,
+                linkedIndicators,
                 relatedCharts,
             }}
         >

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -34,12 +34,12 @@ import {
     DataPageRelatedResearch,
     isEmpty,
     excludeUndefined,
+    OwidOrigin,
     DataPageDataV2,
     getCitationShort,
     GrapherInterface,
     getCitationLong,
     joinTitleFragments,
-    getAttributionUnshortened,
 } from "@ourworldindata/utils"
 import { AttachmentsContext, DocumentContext } from "./gdocs/OwidGdoc.js"
 import StickyNav from "./blocks/StickyNav.js"
@@ -126,12 +126,24 @@ export const DataPageV2Content = ({
         datapageData.descriptionKey && datapageData.descriptionKey.length > 0
 
     const sourcesForDisplay = prepareSourcesForDisplay(datapageData)
+    const getYearSuffixFromOrigin = (o: OwidOrigin) => {
+        const year = o.dateAccessed
+            ? dayjs(o.dateAccessed, ["YYYY-MM-DD", "YYYY"]).year()
+            : o.datePublished
+            ? dayjs(o.datePublished, ["YYYY-MM-DD", "YYYY"]).year()
+            : undefined
+        if (year) return ` (${year})`
+        else return ""
+    }
     const producers = uniq(datapageData.origins.map((o) => `${o.producer}`))
+    const producersWithYear = uniq(
+        datapageData.origins.map(
+            (o) => `${o.producer}${getYearSuffixFromOrigin(o)}`
+        )
+    )
 
-    const attributionUnshortened = getAttributionUnshortened({
-        attributions: datapageData.attributions,
-        origins: datapageData.origins,
-    })
+    const attributionFragments = datapageData.attributions ?? producersWithYear
+    const attributionUnshortened = attributionFragments.join("; ")
     const citationShort = getCitationShort(
         datapageData.origins,
         datapageData.attributions,

--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -2,9 +2,7 @@ import React, { createContext } from "react"
 import ReactDOM from "react-dom"
 import {
     LinkedChart,
-    getOwidGdocFromJSON,
     LinkedIndicator,
-    OwidGdocPostInterface,
     ImageMetadata,
     RelatedChart,
     OwidGdocType,

--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -3,14 +3,16 @@ import ReactDOM from "react-dom"
 import {
     LinkedChart,
     getOwidGdocFromJSON,
+    LinkedIndicator,
+    OwidGdocPostInterface,
     ImageMetadata,
     RelatedChart,
-    get,
     OwidGdocType,
     OwidGdoc as OwidGdocInterface,
     MinimalDataInsightInterface,
     OwidGdocMinimalPostInterface,
-} from "@ourworldindata/utils"
+} from "@ourworldindata/types"
+import { get, getOwidGdocFromJSON } from "@ourworldindata/utils"
 import { DebugProvider } from "./DebugContext.js"
 import { match, P } from "ts-pattern"
 import { GdocPost } from "./pages/GdocPost.js"
@@ -19,6 +21,7 @@ import { Fragment } from "./pages/Fragment.js"
 
 export const AttachmentsContext = createContext<{
     linkedCharts: Record<string, LinkedChart>
+    linkedIndicators: Record<number, LinkedIndicator>
     linkedDocuments: Record<string, OwidGdocMinimalPostInterface>
     imageMetadata: Record<string, ImageMetadata>
     relatedCharts: RelatedChart[]
@@ -27,6 +30,7 @@ export const AttachmentsContext = createContext<{
     linkedDocuments: {},
     imageMetadata: {},
     linkedCharts: {},
+    linkedIndicators: {},
     relatedCharts: [],
     latestDataInsights: [],
 })
@@ -97,6 +101,7 @@ export function OwidGdoc({
                 linkedDocuments: get(props, "linkedDocuments", {}),
                 imageMetadata: get(props, "imageMetadata", {}),
                 linkedCharts: get(props, "linkedCharts", {}),
+                linkedIndicators: get(props, "linkedIndicators", {}),
                 relatedCharts: get(props, "relatedCharts", []),
                 latestDataInsights: get(props, "latestDataInsights", []),
             }}

--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -34,6 +34,7 @@ import { ResearchAndWriting } from "./ResearchAndWriting.js"
 import { AllCharts } from "./AllCharts.js"
 import Video from "./Video.js"
 import { Table } from "./Table.js"
+import KeyIndicator from "./KeyIndicator.js"
 
 export type Container =
     | "default"
@@ -69,6 +70,7 @@ const layouts: { [key in Container]: Layouts} = {
         ["image--narrow"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12",
         ["image--wide"]: "col-start-4 span-cols-8 col-md-start-2 span-md-cols-12",
         ["image-caption"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
+        ["key-indicator"]: "col-start-5 span-cols-6",
         ["key-insights"]: "col-start-2 span-cols-12",
         ["list"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["numbered-list"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
@@ -623,6 +625,9 @@ export default function ArticleBlock({
                 </blockquote>
             )
         })
+        .with({ type: "key-indicator" }, (block) => (
+            <KeyIndicator className={getLayout("key-indicator")} d={block} />
+        ))
         .exhaustive()
 
     return (

--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -70,7 +70,7 @@ const layouts: { [key in Container]: Layouts} = {
         ["image--narrow"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12",
         ["image--wide"]: "col-start-4 span-cols-8 col-md-start-2 span-md-cols-12",
         ["image-caption"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
-        ["key-indicator"]: "col-start-5 span-cols-6",
+        ["key-indicator"]: "col-start-2 span-cols-12",
         ["key-insights"]: "col-start-2 span-cols-12",
         ["list"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["numbered-list"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",

--- a/site/gdocs/components/Chart.scss
+++ b/site/gdocs/components/Chart.scss
@@ -5,3 +5,7 @@ figure.chart {
 figure.explorer {
     height: 700px;
 }
+
+div.margin-0 figure {
+    margin: 0;
+}

--- a/site/gdocs/components/Chart.tsx
+++ b/site/gdocs/components/Chart.tsx
@@ -20,9 +20,11 @@ import { ExplorerProps } from "../../../explorer/Explorer.js"
 export default function Chart({
     d,
     className,
+    shouldOptimizeForHorizontalSpace = true,
 }: {
     d: EnrichedBlockChart
     className?: string
+    shouldOptimizeForHorizontalSpace?: boolean
 }) {
     const refChartContainer = useRef<HTMLDivElement>(null)
     useEmbedChart(0, refChartContainer)
@@ -42,11 +44,8 @@ export default function Chart({
 
     // applies to both charts and explorers
     const common = {
-        // On mobile, we optimize for horizontal space by having Grapher bleed onto the edges horizontally.
-        // We want to do this for all stand-alone charts and charts in a Key Insights block, but not for charts
-        // listed in an All Charts block. The <Chart /> component is not used to render charts in an All Charts block,
-        // so we can just set this to true here.
-        shouldOptimizeForHorizontalSpace: true,
+        // On mobile, we optimize for horizontal space by having Grapher bleed onto the edges horizontally
+        shouldOptimizeForHorizontalSpace,
     }
 
     // props passed to explorers

--- a/site/gdocs/components/KeyIndicator.scss
+++ b/site/gdocs/components/KeyIndicator.scss
@@ -1,13 +1,10 @@
 .key-indicator {
+    --padding: var(--grid-gap, 24px);
+
     background-color: $blue-5;
 
-    margin: 24px -24px;
-    padding: 24px;
-
-    @include sm-only {
-        margin: 0 -16px 16px;
-        padding: 16px;
-    }
+    margin: 24px calc(-1 * var(--padding));
+    padding: var(--padding);
 
     .left {
         @include sm-only {

--- a/site/gdocs/components/KeyIndicator.scss
+++ b/site/gdocs/components/KeyIndicator.scss
@@ -93,5 +93,10 @@
         @include sm-up {
             display: none;
         }
+
+        svg {
+            font-size: 0.75rem;
+            margin-left: 8px;
+        }
     }
 }

--- a/site/gdocs/components/KeyIndicator.scss
+++ b/site/gdocs/components/KeyIndicator.scss
@@ -40,7 +40,8 @@
         @include owid-link-90;
     }
 
-    .metadata {
+    .metadata,
+    .description {
         @include sm-only {
             display: none;
         }

--- a/site/gdocs/components/KeyIndicator.scss
+++ b/site/gdocs/components/KeyIndicator.scss
@@ -15,16 +15,19 @@
         }
     }
 
+    .indicator-metadata {
+        margin-bottom: 16px;
+    }
+
     .indicator-title {
         @include body-2-semibold;
         color: $blue-90;
-        margin-bottom: 16px;
+        margin-right: 8px;
     }
 
     .indicator-source {
         @include body-3-medium;
         display: inline-block;
-        margin-left: 8px;
         color: $blue-50;
     }
 
@@ -35,6 +38,10 @@
         color: $blue-90;
         margin-top: 0;
         margin-bottom: 16px;
+
+        @include sm-only {
+            font-size: 1.25rem;
+        }
     }
 
     .blurb {

--- a/site/gdocs/components/KeyIndicator.scss
+++ b/site/gdocs/components/KeyIndicator.scss
@@ -64,6 +64,13 @@
         color: $blue-90;
     }
 
+    .description {
+        @include body-3-medium;
+        color: $blue-60;
+        margin-top: 0;
+        margin-bottom: 16px;
+    }
+
     .datapage-link {
         @include body-3-medium;
 

--- a/site/gdocs/components/KeyIndicator.scss
+++ b/site/gdocs/components/KeyIndicator.scss
@@ -1,31 +1,43 @@
 .key-indicator {
-    background-color: $blue-10;
+    background-color: $blue-5;
 
     margin: 0 -24px 24px;
-    padding: 16px 24px;
+    padding: 24px;
 
     @include sm-only {
         margin: 0 -16px 16px;
         padding: 16px;
     }
 
+    .left {
+        @include sm-only {
+            margin-bottom: 16px;
+        }
+    }
+
     .indicator-title {
         @include body-2-semibold;
-        color: $blue-60;
-        margin-bottom: 14px;
+        color: $blue-90;
+        margin-bottom: 16px;
+    }
+
+    .indicator-source {
+        @include body-3-medium;
+        display: inline-block;
+        margin-left: 8px;
+        color: $blue-50;
     }
 
     .narrative-title {
-        @include h3-bold;
+        @include subtitle-2-bold;
         color: $blue-90;
         margin-top: 0;
-        margin-bottom: 8px;
+        margin-bottom: 16px;
     }
 
     .blurb {
         @include body-2-regular;
         color: $blue-90;
-        margin-bottom: 16px;
 
         p:first-of-type {
             margin-top: 0;
@@ -40,21 +52,8 @@
         @include owid-link-90;
     }
 
-    .metadata,
-    .description {
-        @include sm-only {
-            display: none;
-        }
-    }
-
-    .metadata--border-top {
-        border-top: solid rgba(164, 182, 202, 0.5);
-        padding-top: 16px;
-    }
-
     .metadata-entry {
         @include body-3-medium;
-        margin-bottom: 16px;
     }
 
     .metadata-entry__title {
@@ -87,10 +86,20 @@
         background-color: $blue-60;
         cursor: pointer;
         border: none;
+
+        &:hover {
+            background-color: $blue-90;
+        }
+
+        svg {
+            font-size: 0.75rem;
+            margin-left: 8px;
+        }
     }
 
+    // TODO: should this be at the bottom of the section?
     .datapage-link-desktop {
-        margin-top: 8px;
+        margin-top: 24px;
         @include sm-only {
             display: none;
         }
@@ -100,11 +109,6 @@
         margin-top: 16px;
         @include sm-up {
             display: none;
-        }
-
-        svg {
-            font-size: 0.75rem;
-            margin-left: 8px;
         }
     }
 }

--- a/site/gdocs/components/KeyIndicator.scss
+++ b/site/gdocs/components/KeyIndicator.scss
@@ -1,7 +1,7 @@
 .key-indicator {
     background-color: $blue-5;
 
-    margin: 0 -24px 24px;
+    margin: 24px -24px;
     padding: 24px;
 
     @include sm-only {
@@ -78,16 +78,21 @@
 
         display: block;
         @include sm-up {
-            display: inline-block;
+            display: inline-flex;
+            align-items: center;
         }
 
         min-height: 40px;
         padding: 8px 24px;
+        margin-top: 16px;
         text-align: center;
         color: $white;
         background-color: $blue-60;
         cursor: pointer;
         border: none;
+        display: flex;
+        align-items: center;
+        justify-content: center;
 
         &:hover {
             background-color: $blue-90;
@@ -99,16 +104,13 @@
         }
     }
 
-    // TODO: should this be at the bottom of the section?
     .datapage-link-desktop {
-        margin-top: 24px;
         @include sm-only {
             display: none;
         }
     }
 
     .datapage-link-mobile {
-        margin-top: 16px;
         @include sm-up {
             display: none;
         }

--- a/site/gdocs/components/KeyIndicator.scss
+++ b/site/gdocs/components/KeyIndicator.scss
@@ -1,0 +1,68 @@
+.key-indicator {
+    $frame-padding: 24px;
+    $padding: 16px;
+
+    background-color: $blue-10;
+    padding: $frame-padding;
+    margin-bottom: $frame-padding;
+
+    .indicator-title {
+        @include body-2-semibold;
+        color: $blue-60;
+        margin-bottom: 14px;
+    }
+
+    .narrative-title {
+        @include h3-bold;
+        color: $blue-90;
+        margin-top: 0;
+        margin-bottom: 8px;
+    }
+
+    .blurb {
+        @include body-2-regular;
+        color: $blue-90;
+        margin-bottom: $padding;
+    }
+
+    .blurb a {
+        @include owid-link-90;
+    }
+
+    .metadata--border-top {
+        border-top: solid rgba(164, 182, 202, 0.5);
+        padding-top: $padding;
+    }
+
+    .metadata-entry {
+        @include body-3-medium;
+        margin-bottom: $padding;
+    }
+
+    .metadata-entry__title {
+        color: $blue-50;
+    }
+
+    .metadata-entry__value {
+        color: $blue-90;
+    }
+
+    .datapage-link {
+        @include body-3-medium;
+
+        display: block;
+        @include sm-up {
+            display: inline-block;
+        }
+
+        height: 40px;
+        padding: 8px 24px;
+        text-align: center;
+        color: $white;
+        background-color: $blue-60;
+        cursor: pointer;
+        border: none;
+
+        margin-top: $padding;
+    }
+}

--- a/site/gdocs/components/KeyIndicator.scss
+++ b/site/gdocs/components/KeyIndicator.scss
@@ -29,7 +29,9 @@
     }
 
     .narrative-title {
-        @include subtitle-2-bold;
+        font-size: 1.5rem;
+        font-weight: 700;
+        line-height: calc(28 / 22);
         color: $blue-90;
         margin-top: 0;
         margin-bottom: 16px;

--- a/site/gdocs/components/KeyIndicator.scss
+++ b/site/gdocs/components/KeyIndicator.scss
@@ -4,6 +4,7 @@
 
     background-color: $blue-10;
     padding: $frame-padding;
+    margin: 0 (-$frame-padding);
     margin-bottom: $frame-padding;
 
     .indicator-title {
@@ -55,7 +56,7 @@
             display: inline-block;
         }
 
-        height: 40px;
+        min-height: 40px;
         padding: 8px 24px;
         text-align: center;
         color: $white;

--- a/site/gdocs/components/KeyIndicator.scss
+++ b/site/gdocs/components/KeyIndicator.scss
@@ -1,11 +1,13 @@
 .key-indicator {
-    $frame-padding: 24px;
-    $padding: 16px;
-
     background-color: $blue-10;
-    padding: $frame-padding;
-    margin: 0 (-$frame-padding);
-    margin-bottom: $frame-padding;
+
+    margin: 0 -24px 24px;
+    padding: 16px 24px;
+
+    @include sm-only {
+        margin: 0 -16px 16px;
+        padding: 16px;
+    }
 
     .indicator-title {
         @include body-2-semibold;
@@ -23,21 +25,35 @@
     .blurb {
         @include body-2-regular;
         color: $blue-90;
-        margin-bottom: $padding;
+        margin-bottom: 16px;
+
+        p:first-of-type {
+            margin-top: 0;
+        }
+
+        p:last-of-type {
+            margin-bottom: 0;
+        }
     }
 
     .blurb a {
         @include owid-link-90;
     }
 
+    .metadata {
+        @include sm-only {
+            display: none;
+        }
+    }
+
     .metadata--border-top {
         border-top: solid rgba(164, 182, 202, 0.5);
-        padding-top: $padding;
+        padding-top: 16px;
     }
 
     .metadata-entry {
         @include body-3-medium;
-        margin-bottom: $padding;
+        margin-bottom: 16px;
     }
 
     .metadata-entry__title {
@@ -63,7 +79,19 @@
         background-color: $blue-60;
         cursor: pointer;
         border: none;
+    }
 
-        margin-top: $padding;
+    .datapage-link-desktop {
+        margin-top: 8px;
+        @include sm-only {
+            display: none;
+        }
+    }
+
+    .datapage-link-mobile {
+        margin-top: 16px;
+        @include sm-up {
+            display: none;
+        }
     }
 }

--- a/site/gdocs/components/KeyIndicator.scss
+++ b/site/gdocs/components/KeyIndicator.scss
@@ -44,7 +44,7 @@
         }
     }
 
-    .blurb {
+    .text {
         @include body-2-regular;
         color: $blue-90;
 
@@ -57,7 +57,7 @@
         }
     }
 
-    .blurb a {
+    .text a {
         @include owid-link-90;
     }
 

--- a/site/gdocs/components/KeyIndicator.tsx
+++ b/site/gdocs/components/KeyIndicator.tsx
@@ -6,14 +6,8 @@ import { faArrowRight } from "@fortawesome/free-solid-svg-icons"
 import {
     EnrichedBlockKeyIndicator,
     EnrichedBlockText,
-    LinkedIndicator,
 } from "@ourworldindata/types"
-import {
-    makeDateRange,
-    makeLastUpdated,
-    SimpleMarkdownText,
-} from "@ourworldindata/components"
-import { capitalize, joinTitleFragments } from "@ourworldindata/utils"
+import { capitalize } from "@ourworldindata/utils"
 
 import Chart from "./Chart.js"
 import Paragraph from "./Paragraph.js"
@@ -34,14 +28,7 @@ export default function KeyIndicator({
     if (!linkedChart) return null
     if (!linkedIndicator) return null
 
-    const source =
-        d.source ||
-        capitalize(
-            joinTitleFragments(
-                linkedIndicator.attributionShort,
-                linkedIndicator.titleVariant
-            )
-        )
+    const source = capitalize(d.source || linkedIndicator.source)
 
     return (
         <div className={cx("key-indicator grid grid-cols-12", className)}>
@@ -50,11 +37,12 @@ export default function KeyIndicator({
                     {linkedIndicator.title}{" "}
                     <span className="indicator-source">{source}</span>
                 </div>
-                {d.title || d.blurb ? (
-                    <IndicatorNarrative block={d} />
-                ) : (
-                    <IndicatorMetadata linkedIndicator={linkedIndicator} />
-                )}
+                <h4 className="narrative-title">{d.title}</h4>
+                <div className="blurb">
+                    {d.blurb.map((textBlock: EnrichedBlockText, i: number) => (
+                        <Paragraph d={textBlock} key={i} />
+                    ))}
+                </div>
                 <a
                     className="datapage-link datapage-link-desktop"
                     href={linkedChart.resolvedUrl}
@@ -79,74 +67,5 @@ export default function KeyIndicator({
                 Explore and learn more about this data
             </a>
         </div>
-    )
-}
-
-function IndicatorNarrative({
-    block,
-}: {
-    block: EnrichedBlockKeyIndicator
-}): JSX.Element {
-    return (
-        <>
-            {block.title && <h4 className="narrative-title">{block.title}</h4>}
-            {block.blurb && (
-                <div className="blurb">
-                    {block.blurb.map(
-                        (textBlock: EnrichedBlockText, i: number) => (
-                            <Paragraph d={textBlock} key={i} />
-                        )
-                    )}
-                </div>
-            )}
-        </>
-    )
-}
-
-function IndicatorMetadata({
-    linkedIndicator,
-}: {
-    linkedIndicator: LinkedIndicator
-}): JSX.Element {
-    const dateRange = makeDateRange({
-        dateRange: linkedIndicator.dateRange,
-    })
-    const lastUpdated = makeLastUpdated({
-        lastUpdated: linkedIndicator.lastUpdated,
-    })
-
-    return (
-        <>
-            {linkedIndicator.descriptionShort && (
-                <div className="description">
-                    <SimpleMarkdownText
-                        text={linkedIndicator.descriptionShort}
-                    />
-                </div>
-            )}
-            <div className="metadata grid grid-cols-4">
-                {dateRange && (
-                    <div className="metadata-entry col-start-1 span-cols-2">
-                        <div className="metadata-entry__title">Date range</div>
-                        <div className="metadata-entry__value">{dateRange}</div>
-                    </div>
-                )}
-                {lastUpdated && (
-                    <div
-                        className={cx("metadata-entry", {
-                            "col-start-3 span-cols-2": !!dateRange,
-                            "col-start-1 span-cols-4": !dateRange,
-                        })}
-                    >
-                        <div className="metadata-entry__title">
-                            Last updated
-                        </div>
-                        <div className="metadata-entry__value">
-                            {lastUpdated}
-                        </div>
-                    </div>
-                )}
-            </div>
-        </>
     )
 }

--- a/site/gdocs/components/KeyIndicator.tsx
+++ b/site/gdocs/components/KeyIndicator.tsx
@@ -33,12 +33,14 @@ export default function KeyIndicator({
     if (!linkedChart) return null
     if (!linkedIndicator) return null
 
-    const source = capitalize(
-        joinTitleFragments(
-            linkedIndicator.attributionShort,
-            linkedIndicator.titleVariant
+    const source =
+        d.source ||
+        capitalize(
+            joinTitleFragments(
+                linkedIndicator.attributionShort,
+                linkedIndicator.titleVariant
+            )
         )
-    )
     const dateRange = makeDateRange({
         dateRange: linkedIndicator.dateRange,
     })

--- a/site/gdocs/components/KeyIndicator.tsx
+++ b/site/gdocs/components/KeyIndicator.tsx
@@ -1,5 +1,7 @@
 import React from "react"
 import cx from "classnames"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
+import { faArrowRight } from "@fortawesome/free-solid-svg-icons"
 
 import {
     EnrichedBlockKeyIndicator,
@@ -111,6 +113,7 @@ export default function KeyIndicator({
                 href={d.datapageUrl}
             >
                 Explore and learn more about this data
+                <FontAwesomeIcon icon={faArrowRight} />
             </a>
         </div>
     )

--- a/site/gdocs/components/KeyIndicator.tsx
+++ b/site/gdocs/components/KeyIndicator.tsx
@@ -96,6 +96,11 @@ export default function KeyIndicator({
                         </div>
                     )}
                 </div>
+                {linkedIndicator.descriptionShort && (
+                    <p className="description">
+                        {linkedIndicator.descriptionShort}
+                    </p>
+                )}
                 <a
                     className="datapage-link datapage-link-desktop"
                     href={d.datapageUrl}

--- a/site/gdocs/components/KeyIndicator.tsx
+++ b/site/gdocs/components/KeyIndicator.tsx
@@ -33,8 +33,10 @@ export default function KeyIndicator({
     return (
         <div className={cx("key-indicator grid grid-cols-12", className)}>
             <div className="left col-start-1 span-cols-4 span-sm-cols-12">
-                <div className="indicator-title">
-                    {linkedIndicator.title}{" "}
+                <div className="indicator-metadata">
+                    <span className="indicator-title">
+                        {linkedIndicator.title}
+                    </span>{" "}
                     <span className="indicator-source">{source}</span>
                 </div>
                 <h4 className="narrative-title">{d.title}</h4>

--- a/site/gdocs/components/KeyIndicator.tsx
+++ b/site/gdocs/components/KeyIndicator.tsx
@@ -6,6 +6,7 @@ import { faArrowRight } from "@fortawesome/free-solid-svg-icons"
 import {
     EnrichedBlockKeyIndicator,
     EnrichedBlockText,
+    LinkedIndicator,
 } from "@ourworldindata/types"
 import {
     makeDateRange,
@@ -41,78 +42,25 @@ export default function KeyIndicator({
                 linkedIndicator.titleVariant
             )
         )
-    const dateRange = makeDateRange({
-        dateRange: linkedIndicator.dateRange,
-    })
-    const lastUpdated = makeLastUpdated({
-        lastUpdated: linkedIndicator.lastUpdated,
-    })
 
     return (
         <div className={cx("key-indicator grid grid-cols-12", className)}>
-            <div className="col-start-1 span-cols-4 span-sm-cols-12">
-                <div className="indicator-title">{linkedIndicator.title}</div>
-                {d.title && <h4 className="narrative-title">{d.title}</h4>}
-                {d.blurb && (
-                    <div className="blurb">
-                        {d.blurb.map(
-                            (textBlock: EnrichedBlockText, i: number) => (
-                                <Paragraph d={textBlock} key={i} />
-                            )
-                        )}
-                    </div>
-                )}
-                <div
-                    className={cx("metadata grid grid-cols-4", {
-                        "metadata--border-top": d.title || d.blurb,
-                    })}
-                >
-                    {source && (
-                        <div className="metadata-entry col-start-1 span-cols-4">
-                            <div className="metadata-entry__title">Source</div>
-                            <div className="metadata-entry__value">
-                                {source}
-                            </div>
-                        </div>
-                    )}
-                    {dateRange && (
-                        <div className="metadata-entry col-start-1 span-cols-2">
-                            <div className="metadata-entry__title">
-                                Date range
-                            </div>
-                            <div className="metadata-entry__value">
-                                {dateRange}
-                            </div>
-                        </div>
-                    )}
-                    {lastUpdated && (
-                        <div
-                            className={cx("metadata-entry", {
-                                "col-start-3 span-cols-2": !!dateRange,
-                                "col-start-1 span-cols-4": !dateRange,
-                            })}
-                        >
-                            <div className="metadata-entry__title">
-                                Last updated
-                            </div>
-                            <div className="metadata-entry__value">
-                                {lastUpdated}
-                            </div>
-                        </div>
-                    )}
+            <div className="left col-start-1 span-cols-4 span-sm-cols-12">
+                <div className="indicator-title">
+                    {linkedIndicator.title}{" "}
+                    <span className="indicator-source">{source}</span>
                 </div>
-                {linkedIndicator.descriptionShort && (
-                    <div className="description">
-                        <SimpleMarkdownText
-                            text={linkedIndicator.descriptionShort}
-                        />
-                    </div>
+                {d.title || d.blurb ? (
+                    <IndicatorNarrative block={d} />
+                ) : (
+                    <IndicatorMetadata linkedIndicator={linkedIndicator} />
                 )}
                 <a
                     className="datapage-link datapage-link-desktop"
                     href={d.datapageUrl}
                 >
                     Explore and learn more about this data
+                    <FontAwesomeIcon icon={faArrowRight} />
                 </a>
             </div>
             <Chart
@@ -125,8 +73,76 @@ export default function KeyIndicator({
                 href={d.datapageUrl}
             >
                 Explore and learn more about this data
-                <FontAwesomeIcon icon={faArrowRight} />
             </a>
         </div>
+    )
+}
+
+function IndicatorNarrative({
+    block,
+}: {
+    block: EnrichedBlockKeyIndicator
+}): JSX.Element {
+    return (
+        <>
+            {block.title && <h4 className="narrative-title">{block.title}</h4>}
+            {block.blurb && (
+                <div className="blurb">
+                    {block.blurb.map(
+                        (textBlock: EnrichedBlockText, i: number) => (
+                            <Paragraph d={textBlock} key={i} />
+                        )
+                    )}
+                </div>
+            )}
+        </>
+    )
+}
+
+function IndicatorMetadata({
+    linkedIndicator,
+}: {
+    linkedIndicator: LinkedIndicator
+}): JSX.Element {
+    const dateRange = makeDateRange({
+        dateRange: linkedIndicator.dateRange,
+    })
+    const lastUpdated = makeLastUpdated({
+        lastUpdated: linkedIndicator.lastUpdated,
+    })
+
+    return (
+        <>
+            {linkedIndicator.descriptionShort && (
+                <div className="description">
+                    <SimpleMarkdownText
+                        text={linkedIndicator.descriptionShort}
+                    />
+                </div>
+            )}
+            <div className="metadata grid grid-cols-4">
+                {dateRange && (
+                    <div className="metadata-entry col-start-1 span-cols-2">
+                        <div className="metadata-entry__title">Date range</div>
+                        <div className="metadata-entry__value">{dateRange}</div>
+                    </div>
+                )}
+                {lastUpdated && (
+                    <div
+                        className={cx("metadata-entry", {
+                            "col-start-3 span-cols-2": !!dateRange,
+                            "col-start-1 span-cols-4": !dateRange,
+                        })}
+                    >
+                        <div className="metadata-entry__title">
+                            Last updated
+                        </div>
+                        <div className="metadata-entry__value">
+                            {lastUpdated}
+                        </div>
+                    </div>
+                )}
+            </div>
+        </>
     )
 }

--- a/site/gdocs/components/KeyIndicator.tsx
+++ b/site/gdocs/components/KeyIndicator.tsx
@@ -28,7 +28,7 @@ export default function KeyIndicator({
     if (!linkedChart) return null
     if (!linkedIndicator) return null
 
-    const source = capitalize(d.source || linkedIndicator.source)
+    const source = capitalize(d.source || linkedIndicator.attributionShort)
 
     return (
         <div className={cx("key-indicator grid grid-cols-12", className)}>

--- a/site/gdocs/components/KeyIndicator.tsx
+++ b/site/gdocs/components/KeyIndicator.tsx
@@ -43,7 +43,7 @@ export default function KeyIndicator({
 
     return (
         <div className={cx("key-indicator grid grid-cols-12", className)}>
-            <div className="col-start-1 span-cols-4">
+            <div className="col-start-1 span-cols-4 span-sm-cols-12">
                 <div className="indicator-title">{linkedIndicator.title}</div>
                 {d.title && <h3 className="narrative-title">{d.title}</h3>}
                 {d.blurb && (
@@ -94,14 +94,24 @@ export default function KeyIndicator({
                         </div>
                     )}
                 </div>
-                <a className="datapage-link" href={d.datapageUrl}>
+                <a
+                    className="datapage-link datapage-link-desktop"
+                    href={d.datapageUrl}
+                >
                     Explore and learn more about this data
                 </a>
             </div>
             <Chart
-                className="col-start-5 span-cols-8 margin-0"
+                className="col-start-5 span-cols-8 span-sm-cols-12 margin-0"
                 d={{ url: d.datapageUrl, type: "chart", parseErrors: [] }}
+                shouldOptimizeForHorizontalSpace={false}
             />
+            <a
+                className="datapage-link datapage-link-mobile col-start-1 span-cols-12"
+                href={d.datapageUrl}
+            >
+                Explore and learn more about this data
+            </a>
         </div>
     )
 }

--- a/site/gdocs/components/KeyIndicator.tsx
+++ b/site/gdocs/components/KeyIndicator.tsx
@@ -57,7 +57,7 @@ export default function KeyIndicator({
                 )}
                 <a
                     className="datapage-link datapage-link-desktop"
-                    href={d.datapageUrl}
+                    href={linkedChart.resolvedUrl}
                 >
                     Explore and learn more about this data
                     <FontAwesomeIcon icon={faArrowRight} />
@@ -65,12 +65,16 @@ export default function KeyIndicator({
             </div>
             <Chart
                 className="col-start-5 span-cols-8 span-sm-cols-12 margin-0"
-                d={{ url: d.datapageUrl, type: "chart", parseErrors: [] }}
+                d={{
+                    url: linkedChart.resolvedUrl,
+                    type: "chart",
+                    parseErrors: [],
+                }}
                 shouldOptimizeForHorizontalSpace={false}
             />
             <a
                 className="datapage-link datapage-link-mobile col-start-1 span-cols-12"
-                href={d.datapageUrl}
+                href={linkedChart.resolvedUrl}
             >
                 Explore and learn more about this data
             </a>

--- a/site/gdocs/components/KeyIndicator.tsx
+++ b/site/gdocs/components/KeyIndicator.tsx
@@ -7,11 +7,8 @@ import {
     EnrichedBlockKeyIndicator,
     EnrichedBlockText,
 } from "@ourworldindata/types"
-import {
-    makeSource,
-    makeDateRange,
-    makeLastUpdated,
-} from "@ourworldindata/components"
+import { makeDateRange, makeLastUpdated } from "@ourworldindata/components"
+import { capitalize, joinTitleFragments } from "@ourworldindata/utils"
 
 import Chart from "./Chart.js"
 import Paragraph from "./Paragraph.js"
@@ -32,10 +29,12 @@ export default function KeyIndicator({
     if (!linkedChart) return null
     if (!linkedIndicator) return null
 
-    const source = makeSource({
-        attribution: linkedIndicator.attributionUnshortened,
-        hideProcessingLevel: true,
-    })
+    const source = capitalize(
+        joinTitleFragments(
+            linkedIndicator.attributionShort,
+            linkedIndicator.titleVariant
+        )
+    )
     const dateRange = makeDateRange({
         dateRange: linkedIndicator.dateRange,
     })

--- a/site/gdocs/components/KeyIndicator.tsx
+++ b/site/gdocs/components/KeyIndicator.tsx
@@ -40,8 +40,8 @@ export default function KeyIndicator({
                     <span className="indicator-source">{source}</span>
                 </div>
                 <h4 className="narrative-title">{d.title}</h4>
-                <div className="blurb">
-                    {d.blurb.map((textBlock: EnrichedBlockText, i: number) => (
+                <div className="text">
+                    {d.text.map((textBlock: EnrichedBlockText, i: number) => (
                         <Paragraph d={textBlock} key={i} />
                     ))}
                 </div>

--- a/site/gdocs/components/KeyIndicator.tsx
+++ b/site/gdocs/components/KeyIndicator.tsx
@@ -27,12 +27,14 @@ export default function KeyIndicator({
             <div>
                 <b>Default title:</b> {linkedChart?.title}
             </div>
-            <div>
-                <b>Blurb:</b>
-                {d.blurb.map((textBlock, i) => (
-                    <Paragraph d={textBlock} key={i} />
-                ))}
-            </div>
+            {d.blurb && (
+                <div>
+                    <b>Blurb:</b>
+                    {d.blurb.map((textBlock, i) => (
+                        <Paragraph d={textBlock} key={i} />
+                    ))}
+                </div>
+            )}
             <Chart
                 className="margin-0"
                 d={{ url: d.datapageUrl, type: "chart", parseErrors: [] }}

--- a/site/gdocs/components/KeyIndicator.tsx
+++ b/site/gdocs/components/KeyIndicator.tsx
@@ -1,0 +1,46 @@
+import React from "react"
+import { EnrichedBlockKeyIndicator } from "@ourworldindata/types"
+import Chart from "./Chart.js"
+import Paragraph from "./Paragraph.js"
+import { useLinkedChart, useLinkedIndicator } from "../utils.js"
+
+export default function KeyIndicator({
+    d,
+    className,
+}: {
+    d: EnrichedBlockKeyIndicator
+    className?: string
+}) {
+    const { linkedChart } = useLinkedChart(d.datapageUrl)
+    const { linkedIndicator } = useLinkedIndicator(
+        linkedChart?.indicatorId ?? 0
+    )
+
+    if (!linkedChart) return null
+    if (!linkedIndicator) return null
+
+    return (
+        <div className={className} style={{ border: "solid gray" }}>
+            <div>
+                <b>Custom title:</b> {d.title}
+            </div>
+            <div>
+                <b>Default title:</b> {linkedChart?.title}
+            </div>
+            <div>
+                <b>Blurb:</b>
+                {d.blurb.map((textBlock, i) => (
+                    <Paragraph d={textBlock} key={i} />
+                ))}
+            </div>
+            <Chart
+                className="margin-0"
+                d={{ url: d.datapageUrl, type: "chart", parseErrors: [] }}
+            />
+            <div>
+                <b>Linked indicator with metadata:</b>
+                <code>{JSON.stringify(linkedIndicator, null, 2)}</code>
+            </div>
+        </div>
+    )
+}

--- a/site/gdocs/components/KeyIndicator.tsx
+++ b/site/gdocs/components/KeyIndicator.tsx
@@ -7,7 +7,11 @@ import {
     EnrichedBlockKeyIndicator,
     EnrichedBlockText,
 } from "@ourworldindata/types"
-import { makeDateRange, makeLastUpdated } from "@ourworldindata/components"
+import {
+    makeDateRange,
+    makeLastUpdated,
+    SimpleMarkdownText,
+} from "@ourworldindata/components"
 import { capitalize, joinTitleFragments } from "@ourworldindata/utils"
 
 import Chart from "./Chart.js"
@@ -96,9 +100,11 @@ export default function KeyIndicator({
                     )}
                 </div>
                 {linkedIndicator.descriptionShort && (
-                    <p className="description">
-                        {linkedIndicator.descriptionShort}
-                    </p>
+                    <div className="description">
+                        <SimpleMarkdownText
+                            text={linkedIndicator.descriptionShort}
+                        />
+                    </div>
                 )}
                 <a
                     className="datapage-link datapage-link-desktop"

--- a/site/gdocs/components/KeyIndicator.tsx
+++ b/site/gdocs/components/KeyIndicator.tsx
@@ -50,7 +50,7 @@ export default function KeyIndicator({
         <div className={cx("key-indicator grid grid-cols-12", className)}>
             <div className="col-start-1 span-cols-4 span-sm-cols-12">
                 <div className="indicator-title">{linkedIndicator.title}</div>
-                {d.title && <h3 className="narrative-title">{d.title}</h3>}
+                {d.title && <h4 className="narrative-title">{d.title}</h4>}
                 {d.blurb && (
                     <div className="blurb">
                         {d.blurb.map(

--- a/site/gdocs/components/KeyIndicator.tsx
+++ b/site/gdocs/components/KeyIndicator.tsx
@@ -1,5 +1,16 @@
 import React from "react"
-import { EnrichedBlockKeyIndicator } from "@ourworldindata/types"
+import cx from "classnames"
+
+import {
+    EnrichedBlockKeyIndicator,
+    EnrichedBlockText,
+} from "@ourworldindata/types"
+import {
+    makeSource,
+    makeDateRange,
+    makeLastUpdated,
+} from "@ourworldindata/components"
+
 import Chart from "./Chart.js"
 import Paragraph from "./Paragraph.js"
 import { useLinkedChart, useLinkedIndicator } from "../utils.js"
@@ -19,30 +30,78 @@ export default function KeyIndicator({
     if (!linkedChart) return null
     if (!linkedIndicator) return null
 
+    const source = makeSource({
+        attribution: linkedIndicator.attributionUnshortened,
+        hideProcessingLevel: true,
+    })
+    const dateRange = makeDateRange({
+        dateRange: linkedIndicator.dateRange,
+    })
+    const lastUpdated = makeLastUpdated({
+        lastUpdated: linkedIndicator.lastUpdated,
+    })
+
     return (
-        <div className={className} style={{ border: "solid gray" }}>
-            <div>
-                <b>Custom title:</b> {d.title}
-            </div>
-            <div>
-                <b>Default title:</b> {linkedChart?.title}
-            </div>
-            {d.blurb && (
-                <div>
-                    <b>Blurb:</b>
-                    {d.blurb.map((textBlock, i) => (
-                        <Paragraph d={textBlock} key={i} />
-                    ))}
+        <div className={cx("key-indicator grid grid-cols-12", className)}>
+            <div className="col-start-1 span-cols-4">
+                <div className="indicator-title">{linkedIndicator.title}</div>
+                {d.title && <h3 className="narrative-title">{d.title}</h3>}
+                {d.blurb && (
+                    <div className="blurb">
+                        {d.blurb.map(
+                            (textBlock: EnrichedBlockText, i: number) => (
+                                <Paragraph d={textBlock} key={i} />
+                            )
+                        )}
+                    </div>
+                )}
+                <div
+                    className={cx("metadata grid grid-cols-4", {
+                        "metadata--border-top": d.title || d.blurb,
+                    })}
+                >
+                    {source && (
+                        <div className="metadata-entry col-start-1 span-cols-4">
+                            <div className="metadata-entry__title">Source</div>
+                            <div className="metadata-entry__value">
+                                {source}
+                            </div>
+                        </div>
+                    )}
+                    {dateRange && (
+                        <div className="metadata-entry col-start-1 span-cols-2">
+                            <div className="metadata-entry__title">
+                                Date range
+                            </div>
+                            <div className="metadata-entry__value">
+                                {dateRange}
+                            </div>
+                        </div>
+                    )}
+                    {lastUpdated && (
+                        <div
+                            className={cx("metadata-entry", {
+                                "col-start-3 span-cols-2": !!dateRange,
+                                "col-start-1 span-cols-4": !dateRange,
+                            })}
+                        >
+                            <div className="metadata-entry__title">
+                                Last updated
+                            </div>
+                            <div className="metadata-entry__value">
+                                {lastUpdated}
+                            </div>
+                        </div>
+                    )}
                 </div>
-            )}
+                <a className="datapage-link" href={d.datapageUrl}>
+                    Explore and learn more about this data
+                </a>
+            </div>
             <Chart
-                className="margin-0"
+                className="col-start-5 span-cols-8 margin-0"
                 d={{ url: d.datapageUrl, type: "chart", parseErrors: [] }}
             />
-            <div>
-                <b>Linked indicator with metadata:</b>
-                <code>{JSON.stringify(linkedIndicator, null, 2)}</code>
-            </div>
         </div>
     )
 }

--- a/site/gdocs/utils.tsx
+++ b/site/gdocs/utils.tsx
@@ -6,12 +6,12 @@ import {
     SpanLink,
     ImageMetadata,
     LinkedChart,
-    Url,
     OwidGdocPostContent,
-    formatAuthors,
     OwidGdocMinimalPostInterface,
     OwidGdocType,
-} from "@ourworldindata/utils"
+    LinkedIndicator,
+} from "@ourworldindata/types"
+import { formatAuthors, Url } from "@ourworldindata/utils"
 import { match } from "ts-pattern"
 import { AttachmentsContext } from "./OwidGdoc.js"
 
@@ -104,6 +104,22 @@ export const useLinkedChart = (
             resolvedUrl: `${linkedChart.resolvedUrl}${queryString}`,
         },
     }
+}
+
+export const useLinkedIndicator = (
+    id: number
+): { linkedIndicator?: LinkedIndicator; errorMessage?: string } => {
+    const { linkedIndicators } = useContext(AttachmentsContext)
+
+    const linkedIndicator = linkedIndicators?.[id]
+
+    if (!linkedIndicator) {
+        return {
+            errorMessage: `Indicator with id ${id} not found`,
+        }
+    }
+
+    return { linkedIndicator }
 }
 
 export const useImage = (

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -94,6 +94,7 @@
 @import "./gdocs/components/AdditionalCharts.scss";
 @import "./gdocs/components/ResearchAndWriting.scss";
 @import "./gdocs/components/Chart.scss";
+@import "./gdocs/components/KeyIndicator.scss";
 @import "./DataPage.scss";
 @import "./DataPageContent.scss";
 @import "./detailsOnDemand.scss";


### PR DESCRIPTION
Adds a new GDoc component, `key-indicator`, that showcases a given indicator by rendering an interactive Grapher chart, a title and motivational text, and some metadata.

Note that the `key-indicator` component is used as a building block of a higher-order component, `key-indicator-collection` (added in #3108), but can also be used as a stand-alone component.

## Examples

Working example: [Gdoc](https://docs.google.com/document/d/16RPW3OD0GqKJS6iLDfLtpS8dAZ-jKGFcGecGjhpGREU/edit) / [Admin](http://staging-site-gdoc-key-indicator-block/admin/gdocs/16RPW3OD0GqKJS6iLDfLtpS8dAZ-jKGFcGecGjhpGREU/preview) / [Staging](http://staging-site-gdoc-key-indicator-block/test-key-indicator-component)
Example with error states: [Gdoc](https://docs.google.com/document/d/1vvl6MubA6X3eFt-3OzG9piAXboY555ThWQ5YHSNBMvY/edit) / [Admin](http://staging-site-gdoc-key-indicator-block/admin/gdocs/1vvl6MubA6X3eFt-3OzG9piAXboY555ThWQ5YHSNBMvY/preview)

```
{.key-indicator}
    datapageUrl: https://ourworldindata.org/grapher/life-expectancy
    title: My title
    source: Optional source overwrite

    [.+blurb]
        Required Intro text.

        Allowing for multiple paragraphs.
    []
{}
```

<img width="1340" alt="Screenshot 2024-02-05 at 14 04 21" src="https://github.com/owid/owid-grapher/assets/12461810/b1e02331-b859-44c6-918a-7fae8c9ea046">

## Spec

- `datapageUrl` (required)
    - Non-datapage grapher links are not supported
- `title` (required)
- `blurb` (required): multi-paragraph motivational text
- `source` (optional): optional source overwrite
    - the indicator's source is inferred from metadata, but the responsible metadata fields are not guaranteed to be given or be well curated
    - ideally, we'd fix the metadata and wouldn't need the overwrite
    - but for now, Joe has decided that an Archie overwrite is the practical thing to do

Metadata defaults: the indicator title and source are inferred from metadata; both show the exact same string that is shown on a datapage (see screenshots below)
- Indicator title: equals the title of a datapage
- Indicator source (next to the title): equals the short attribution shown next to the title on a datapage

<details><summary>Datapage</summary>
<img width="1340" alt="Screenshot 2024-02-05 at 14 16 35" src="https://github.com/owid/owid-grapher/assets/12461810/085a9385-9976-494a-9de3-fc6dd66998a1">
</details> 

<details><summary>Key indicator block</summary>
<img width="1340" alt="Screenshot 2024-02-05 at 14 04 21" src="https://github.com/owid/owid-grapher/assets/12461810/0e04a558-db4c-4710-9363-aea12070a468">
</details> 

## Technical details

- The key indicator component (i) renders a chart and (ii) displays indicator metadata
    - To make (i) work, the key indicator chart is added to the `linkedCharts` attachment
    - To make (ii) work, a new attachment is added, `linkedIndicators` that stores a subset of metadata for a given indicator
- How linked charts and linked indicators interact:
    - If a linked chart renders as a datapage, we grab the relevant indicator ID and store it with the linked chart (note that we're doing this for all linked charts)
    - For each linked chart that has an indicator ID (and is referenced in a key indicator block), we add an entry in `linkedIndicators` that stores a subset of metadata properties
- To figure out whether a grapher page renders as datapage, I extracted code that lived in the `GrapherBaker` and refactored it into a separate function (`getVariableOfDatapageIfApplicable(grapher)`) that can be used elsewhere


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for "Linked Indicators" across the site, allowing for richer, data-driven narratives.
	- Introduced a new component for displaying key indicators dynamically, enhancing data presentation and user engagement.
- **Enhancements**
	- Improved data page rendering logic for clarity and efficiency, ensuring a smoother user experience.
	- Updated styling for charts and key indicators, optimizing visual presentation across various screen sizes.
- **Refactor**
	- Consolidated and reorganized imports across multiple files for better maintainability.
	- Refined handling and prefetching of linked indicators and documents, improving site performance.
- **Documentation**
	- Expanded type definitions to include new entities related to "Linked Indicators," facilitating development and integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->