### PR TITLE
:bug: (explorer) respect global selection when embedded

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -186,9 +186,9 @@ export class Explorer
     // only used for the checkbox at the bottom of the embed dialog
     @observable embedDialogHideControls = true
 
-    selection =
-        this.props.selection ??
-        new SelectionArray(this.explorerProgram.selection)
+    selection = this.props.selection?.hasSelection
+        ? this.props.selection
+        : new SelectionArray(this.explorerProgram.selection)
 
     entityType = this.explorerProgram.entityType ?? DEFAULT_GRAPHER_ENTITY_TYPE
 
@@ -485,6 +485,11 @@ export class Explorer
             manuallyProvideData: false,
         }
 
+        // if not empty, respect the explorer's selection
+        if (this.selection.hasSelection) {
+            config.selectedEntityNames = this.selection.selectedEntityNames
+        }
+
         grapher.setAuthoredVersion(config)
         grapher.reset()
         this.updateGrapherFromExplorerCommon()
@@ -522,6 +527,11 @@ export class Explorer
             dataApiUrl: DATA_API_URL,
             hideEntityControls: this.showExplorerControls,
             manuallyProvideData: false,
+        }
+
+        // if not empty, respect the explorer's selection
+        if (this.selection.hasSelection) {
+            config.selectedEntityNames = this.selection.selectedEntityNames
         }
 
         // set given variable IDs as dimensions to make Grapher
@@ -656,6 +666,11 @@ export class Explorer
             dataApiUrl: DATA_API_URL,
             hideEntityControls: this.showExplorerControls,
             manuallyProvideData: true,
+        }
+
+        // if not empty, respect the explorer's selection
+        if (this.selection.hasSelection) {
+            config.selectedEntityNames = this.selection.selectedEntityNames
         }
 
         grapher.setAuthoredVersion(config)


### PR DESCRIPTION
### Bug

- The entity selection of this [explorer embedded in a topic page](https://ourworldindata.org/war-and-peace#explore-data-on-armed-conflict-and-war) is empty, although a global Explorer selection is given and respected on the [explorer page](https://ourworldindata.org/explorers/countries-in-conflict-data?facet=none&Measure=Deaths&Conflict+type=All+armed+conflicts&Conflict+sub-type=all)

### Why this happened

- Explorers handle these two cases differently:
    - If the entity selection passed to the Explorer is undefined, then the Explorer's global selection is used
    - If the entity selection passed to the Explorer is defined but empty, then the chart's selected entities are used (unexpected!)
- The bug:
    - If no global entity selector exists on the page, the MultiEmbedder passes an empty entity selection array to the Explorer
    - Thus, the Explorer uses the chart's selected entities
        - For Grapher-ID-based Explorers, the chart's selected entities array is often some sensible choice, authored in the chart admin
        - For indicator-based Explorers, the chart's selected entities array is often empty (it could be defined by a partial Grapher config, but at the time of writing partial Grapher configs are rarely used)
    - Hence, this [embedded indicator-based explorer](https://ourworldindata.org/war-and-peace#explore-data-on-armed-conflict-and-war) has an empty selection 

### What now

- If the entity selection passed to the Explorer is defined but empty, the Explorer should use its global selection if there is one
- If the global selection is empty as well, only then we want to use the chart's selection