### PR TITLE
Revert "🔨 switch mysql docker images to debian to work around microdnf issues"

### DIFF
--- a/devTools/docker/mysql-init-docker/Dockerfile
+++ b/devTools/docker/mysql-init-docker/Dockerfile
@@ -1,7 +1,8 @@
-FROM mysql:8.0-debian
+FROM mysql/mysql-server:latest
 
-RUN apt-get -y update \
- && apt-get install -y \
+RUN microdnf -y update \
+ && microdnf install -y \
+    libpwquality \
     curl \
     rsync \
     unzip \

--- a/docker-compose.dbtests.yml
+++ b/docker-compose.dbtests.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
     # Stock mysql database. Root password is hardcoded for now
     db:
-        image: mysql:8.0-debian
+        image: mysql/mysql-server:latest
         command: --default-authentication-plugin=mysql_native_password --log-bin-trust-function-creators=ON
         restart: always
         volumes:

--- a/docker-compose.devcontainer.yml
+++ b/docker-compose.devcontainer.yml
@@ -44,7 +44,7 @@ services:
 
     # Stock mysql database. Used for both grapher and wordpress databases. Root password is hardcoded for now
     db:
-        image: mysql:8.0-debian
+        image: mysql/mysql-server:latest
         command: --default-authentication-plugin=mysql_native_password
         restart: always
         volumes:

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -33,7 +33,7 @@ version: "3.7"
 services:
     # Stock mysql database. Used for both grapher and wordpress databases. Root password is hardcoded for now
     db:
-        image: mysql:8.0-debian
+        image: mysql/mysql-server:latest
         command: --default-authentication-plugin=mysql_native_password
         restart: always
         volumes:

--- a/docker-compose.grapher.yml
+++ b/docker-compose.grapher.yml
@@ -29,7 +29,7 @@ version: "3.7"
 services:
     # Stock mysql database. Root password is hardcoded for now
     db:
-        image: mysql:8.0-debian
+        image: mysql/mysql-server:latest
         command: --default-authentication-plugin=mysql_native_password
         restart: always
         volumes:


### PR DESCRIPTION
This reverts commit 9d5e7310e0dfaf57e6b30b583530bbefe194c149.

The reason for the revert is that the debian based mysql image is not available for M1/M2 based Macs :(