### PR TITLE
:bug: Try resolving #3116 by pinning MySQL to 8.0

### DIFF
--- a/devTools/docker/mysql-init-docker/Dockerfile
+++ b/devTools/docker/mysql-init-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql/mysql-server:latest
+FROM mysql/mysql-server:8.0
 
 RUN microdnf -y update \
  && microdnf install -y \

--- a/docker-compose.dbtests.yml
+++ b/docker-compose.dbtests.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
     # Stock mysql database. Root password is hardcoded for now
     db:
-        image: mysql/mysql-server:latest
+        image: mysql/mysql-server:8.0
         command: --default-authentication-plugin=mysql_native_password --log-bin-trust-function-creators=ON
         restart: always
         volumes:

--- a/docker-compose.devcontainer.yml
+++ b/docker-compose.devcontainer.yml
@@ -44,7 +44,7 @@ services:
 
     # Stock mysql database. Used for both grapher and wordpress databases. Root password is hardcoded for now
     db:
-        image: mysql/mysql-server:latest
+        image: mysql/mysql-server:8.0
         command: --default-authentication-plugin=mysql_native_password
         restart: always
         volumes:

--- a/docker-compose.grapher.yml
+++ b/docker-compose.grapher.yml
@@ -29,7 +29,7 @@ version: "3.7"
 services:
     # Stock mysql database. Root password is hardcoded for now
     db:
-        image: mysql/mysql-server:latest
+        image: mysql/mysql-server:8.0
         command: --default-authentication-plugin=mysql_native_password
         restart: always
         volumes:
@@ -49,7 +49,7 @@ services:
     db-load-data:
         build:
             context: ./devTools/docker/mysql-init-docker
-        # image: mysql/mysql-server:latest
+        # image: mysql/mysql-server:8.0
         command: "/app/grapher-mysql-init.sh"
         volumes:
             - ./devTools/docker:/app


### PR DESCRIPTION
Since everything was working until recently, it seems likely that the upstream MySQL docker image on `:latest`, which is currently `8.3`, is broken.

This PR tries to fix the issue by pinning to `8.0` to see if that works.
