### PR TITLE
:honeybee: install missing GPG keys for mysql in dbtest

### DIFF
--- a/devTools/docker/mysql-init-docker/Dockerfile
+++ b/devTools/docker/mysql-init-docker/Dockerfile
@@ -1,6 +1,7 @@
 FROM mysql/mysql-server:latest
 
-RUN microdnf -y update \
+RUN rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2023 \
+ && microdnf -y update \
  && microdnf install -y \
     libpwquality \
     curl \


### PR DESCRIPTION
Fixes #3116
