### PR TITLE
🎉 Homepage Gdoc type

### DIFF
--- a/adminSiteClient/GdocsIndexPage.tsx
+++ b/adminSiteClient/GdocsIndexPage.tsx
@@ -5,6 +5,7 @@ import { Modal, SearchField } from "./Forms.js"
 import { EditableTags } from "./EditableTags.js"
 import {
     faCirclePlus,
+    faHouse,
     faLightbulb,
     faNewspaper,
     faPuzzlePiece,
@@ -37,6 +38,7 @@ const iconGdocTypeMap = {
     [OwidGdocType.TopicPage]: <FontAwesomeIcon icon={faLightbulb} />,
     [OwidGdocType.LinearTopicPage]: <FontAwesomeIcon icon={faLightbulb} />,
     [OwidGdocType.DataInsight]: <FontAwesomeIcon icon={faThList} />,
+    [OwidGdocType.Homepage]: <FontAwesomeIcon icon={faHouse} />,
 }
 
 @observer
@@ -113,6 +115,7 @@ export class GdocsIndexPage extends React.Component<GdocsMatchProps> {
         [OwidGdocType.TopicPage]: false,
         [OwidGdocType.LinearTopicPage]: false,
         [OwidGdocType.DataInsight]: false,
+        [OwidGdocType.Homepage]: false,
     }
 
     @observable search = { value: "" }

--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -7,7 +7,11 @@ import React, {
 } from "react"
 import { AdminLayout } from "./AdminLayout.js"
 import { GdocsMatchProps } from "./GdocsIndexPage.js"
-import { GdocPostSettings, GdocInsightSettings } from "./GdocsSettingsForms.js"
+import {
+    GdocPostSettings,
+    GdocInsightSettings,
+    GdocHomepageSettings,
+} from "./GdocsSettingsForms.js"
 import { AdminAppContext } from "./AdminAppContext.js"
 import {
     checkIsPlainObjectWithGuard,
@@ -322,6 +326,19 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                                     setCurrentGdoc={(updatedGdoc) =>
                                         setCurrentGdoc(() => updatedGdoc)
                                     }
+                                    errors={errors}
+                                />
+                            )
+                        )
+                        .with(
+                            {
+                                content: {
+                                    type: OwidGdocType.Homepage,
+                                },
+                            },
+                            (gdoc) => (
+                                <GdocHomepageSettings
+                                    gdoc={gdoc}
                                     errors={errors}
                                 />
                             )

--- a/adminSiteClient/GdocsSettingsContentField.tsx
+++ b/adminSiteClient/GdocsSettingsContentField.tsx
@@ -7,6 +7,7 @@ import {
     OwidGdocDataInsightInterface,
     OwidGdocErrorMessageProperty,
     get,
+    OwidGdocHomepageInterface,
 } from "@ourworldindata/utils"
 import { GdocsEditLink } from "./GdocsEditLink.js"
 import { GdocsErrorHelp } from "./GdocsErrorHelp.js"
@@ -21,7 +22,10 @@ export const GdocsSettingsContentField = ({
     errors,
     description,
 }: {
-    gdoc: OwidGdocPostInterface | OwidGdocDataInsightInterface
+    gdoc:
+        | OwidGdocPostInterface
+        | OwidGdocDataInsightInterface
+        | OwidGdocHomepageInterface
     property: OwidGdocErrorMessageProperty
     render?: (props: {
         name: string

--- a/adminSiteClient/GdocsSettingsForms.tsx
+++ b/adminSiteClient/GdocsSettingsForms.tsx
@@ -4,6 +4,7 @@ import {
     OwidGdocErrorMessage,
     OwidGdocDataInsightInterface,
     OwidGdoc,
+    OwidGdocHomepageInterface,
 } from "@ourworldindata/utils"
 import { EXCERPT_MAX_LENGTH } from "./gdocsValidation.js"
 import { GdocsSlug } from "./GdocsSlug.js"
@@ -200,5 +201,25 @@ export const GdocInsightSettings = ({
                 />
             </div>
         </form>
+    )
+}
+
+export const GdocHomepageSettings = ({
+    gdoc,
+    errors,
+}: {
+    gdoc: OwidGdocHomepageInterface
+    errors?: OwidGdocErrorMessage[]
+}) => {
+    if (!gdoc || !errors) return null
+    return (
+        <div className="GdocsSettingsForm">
+            <GdocCommonErrors errors={errors} errorsToFilter={[]} />
+            <div className="form-group">
+                <h3 className="form-section-heading">Homepage settings</h3>
+                <p>The homepage has no custom authors, slug, title, etc.</p>
+                <p>Just hit publish when you'd like to update the page!</p>
+            </div>
+        </div>
     )
 }

--- a/adminSiteClient/gdocsDeploy.ts
+++ b/adminSiteClient/gdocsDeploy.ts
@@ -5,6 +5,7 @@ import {
     OwidGdocPostContent,
     OwidGdocDataInsightContent,
     OwidGdocType,
+    OwidGdocHomepageContent,
 } from "@ourworldindata/types"
 import { GDOC_DIFF_OMITTABLE_PROPERTIES } from "./GdocsDiff.js"
 import { GDOCS_DETAILS_ON_DEMAND_ID } from "../settings/clientSettings.js"
@@ -105,6 +106,15 @@ export const checkIsLightningUpdate = (
         body: false, // requires rebaking the feed
         type: false, // shouldn't be changed, but would require rebaking the feed if it was
     }
+    const homepageLightningPropContentConfigMap: Record<
+        keyof OwidGdocHomepageContent,
+        boolean
+    > = {
+        body: true,
+        title: false, // shouldn't be changed, but won't be used in the baked page anyway
+        authors: false, // shouldn't be set, but defaults to "Our World in Data" because it's assumed to exist in the DB
+        type: false, // should never be changed
+    }
 
     const contentPropsMap: Record<OwidGdocType, Record<string, boolean>> = {
         [OwidGdocType.Article]: postlightningPropContentConfigMap,
@@ -112,6 +122,7 @@ export const checkIsLightningUpdate = (
         [OwidGdocType.LinearTopicPage]: postlightningPropContentConfigMap,
         [OwidGdocType.TopicPage]: postlightningPropContentConfigMap,
         [OwidGdocType.DataInsight]: dataInsightLightningPropContentConfigMap,
+        [OwidGdocType.Homepage]: homepageLightningPropContentConfigMap,
     }
 
     const getLightningPropKeys = (configMap: Record<string, boolean>) =>

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -76,6 +76,7 @@ import {
     KEY_INSIGHTS_CLASS_NAME,
 } from "../site/blocks/KeyInsights.js"
 import { formatUrls, KEY_INSIGHTS_H2_CLASSNAME } from "../site/formatting.js"
+import * as db from "../db/db.js"
 
 import { GrapherProgrammaticInterface } from "@ourworldindata/grapher"
 import { ExplorerProgram } from "../explorer/ExplorerProgram.js"
@@ -242,7 +243,23 @@ export const renderPost = async (
     )
 }
 
+// This function is temporarily forked until we have fully transitioned to a gdocs homepage,
+// whereupon we'll strip out the old front page code.
 export const renderFrontPage = async () => {
+    // Annoying, MySQL+TypeORM doesn't support JSONB, so I'm using raw SQL to confirm if there's a published homepage
+    const gdocHomepageResult = await db.knexRawFirst<{ id: string }>(
+        `SELECT id FROM posts_gdocs WHERE content->>"$.type" = "${OwidGdocType.Homepage}" AND published = TRUE`,
+        db.knexInstance()
+    )
+
+    if (gdocHomepageResult) {
+        const gdocHomepage = await GdocFactory.load(gdocHomepageResult.id)
+        if (gdocHomepage) {
+            await gdocHomepage.loadState()
+            return renderGdoc(gdocHomepage)
+        }
+    }
+
     const posts = await getBlogIndex()
 
     const NUM_FEATURED_POSTS = 6

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -528,6 +528,16 @@ export class GdocBase extends BaseEntity implements OwidGdocBaseInterface {
                     }),
                 ]
             })
+            .with({ type: "pill-row" }, (pillRow) => {
+                return pillRow.pills.map((pill) =>
+                    Link.createFromUrl({
+                        url: pill.url,
+                        source: this,
+                        componentType: pillRow.type,
+                        text: pill.text,
+                    })
+                )
+            })
             .with(
                 {
                     // no urls directly on any of these blocks

--- a/db/model/Gdoc/GdocFactory.ts
+++ b/db/model/Gdoc/GdocFactory.ts
@@ -10,6 +10,7 @@ import {
 import { GdocBase, Tag } from "./GdocBase.js"
 import { GdocPost } from "./GdocPost.js"
 import { GdocDataInsight } from "./GdocDataInsight.js"
+import { GdocHomepage } from "./GdocHomepage.js"
 
 // Handles the registration and loading of Gdocs
 // Couldn't put this in GdocBase because of circular dependency issues
@@ -51,6 +52,11 @@ export class GdocFactory {
                 // TODO: better validation here?
                 () => GdocDataInsight.create({ ...(json as any) })
             )
+            .with(
+                OwidGdocType.Homepage,
+                // TODO: better validation here?
+                () => GdocHomepage.create({ ...(json as any) })
+            )
             .exhaustive()
     }
 
@@ -70,7 +76,9 @@ export class GdocFactory {
         return gdoc
     }
 
-    static async loadBySlug(slug: string): Promise<GdocPost | GdocDataInsight> {
+    static async loadBySlug(
+        slug: string
+    ): Promise<GdocPost | GdocDataInsight | GdocHomepage> {
         const base = await GdocBase.findOne({
             where: { slug, published: true },
         })
@@ -87,7 +95,7 @@ export class GdocFactory {
     static async load(
         id: string,
         contentSource?: GdocsContentSource
-    ): Promise<GdocPost | GdocDataInsight> {
+    ): Promise<GdocPost | GdocDataInsight | GdocHomepage> {
         const base = await GdocBase.findOne({
             where: {
                 id,
@@ -121,6 +129,7 @@ export class GdocFactory {
                 () => GdocPost.create(base)
             )
             .with(OwidGdocType.DataInsight, () => GdocDataInsight.create(base))
+            .with(OwidGdocType.Homepage, () => GdocHomepage.create(base))
             .exhaustive()
 
         if (contentSource === GdocsContentSource.Gdocs) {

--- a/db/model/Gdoc/GdocHomepage.ts
+++ b/db/model/Gdoc/GdocHomepage.ts
@@ -1,0 +1,34 @@
+import { Entity, Column } from "typeorm"
+import {
+    OwidGdocErrorMessage,
+    OwidGdocHomepageContent,
+    OwidGdocHomepageInterface,
+    OwidGdocMinimalPostInterface,
+} from "@ourworldindata/utils"
+import { GdocBase } from "./GdocBase.js"
+
+@Entity("posts_gdocs")
+export class GdocHomepage
+    extends GdocBase
+    implements OwidGdocHomepageInterface
+{
+    @Column({ default: "{}", type: "json" })
+    content!: OwidGdocHomepageContent
+
+    constructor(id?: string) {
+        super()
+        if (id) {
+            this.id = id
+        }
+    }
+
+    linkedDocuments: Record<string, OwidGdocMinimalPostInterface> = {}
+    _urlProperties: string[] = []
+
+    _validateSubclass = async (): Promise<OwidGdocErrorMessage[]> => {
+        const errors: OwidGdocErrorMessage[] = []
+        return errors
+    }
+
+    _loadSubclassAttachments = async (): Promise<void> => {}
+}

--- a/db/model/Gdoc/enrichedToMarkdown.ts
+++ b/db/model/Gdoc/enrichedToMarkdown.ts
@@ -293,5 +293,12 @@ ${links}`
                 .join("\n")
             return `<KeyIndicatorCollection>\n${keyIndicators}\n</KeyIndicatorCollection>`
         })
+        .with({ type: "pill-row" }, (b): string | undefined => {
+            const title = b.title ? `### ${b.title}` : ""
+            const pills = b.pills
+                .map((pill) => `* [${pill.text}](${pill.url})`)
+                .join("\n")
+            return [title, pills].join("\n")
+        })
         .exhaustive()
 }

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -39,6 +39,7 @@ import {
     RawBlockExplorerTiles,
     RawBlockKeyIndicator,
     RawBlockKeyIndicatorCollection,
+    RawBlockPillRow,
 } from "@ourworldindata/types"
 import { spanToHtmlString } from "./gdocUtils.js"
 import { match, P } from "ts-pattern"
@@ -469,5 +470,14 @@ export function enrichedBlockToRawBlock(
                 }
             }
         )
+        .with({ type: "pill-row" }, (b): RawBlockPillRow => {
+            return {
+                type: "pill-row",
+                value: {
+                    title: b.title,
+                    pills: b.pills,
+                },
+            }
+        })
         .exhaustive()
 }

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -6,7 +6,7 @@ import {
     OwidEnrichedGdocBlock,
     Span,
     SpanSimpleText,
-} from "@ourworldindata/utils"
+} from "@ourworldindata/types"
 
 const spanSimpleText: SpanSimpleText = {
     spanType: "span-simple-text",
@@ -572,6 +572,15 @@ export const enrichedBlockExamples: Record<
                 text: [enrichedBlockText],
                 parseErrors: [],
             },
+        ],
+        parseErrors: [],
+    },
+    "pill-row": {
+        type: "pill-row",
+        title: "Recently updated",
+        pills: [
+            { text: "Energy", url: "https://ourworldindata.org/energy" },
+            { text: "Poverty", url: "https://ourworldindata.org/poverty" },
         ],
         parseErrors: [],
     },

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -38,6 +38,7 @@ import {
     RawBlockKeyIndicator,
     RawBlockKeyIndicatorCollection,
     RawBlockExplorerTiles,
+    RawBlockPillRow,
 } from "@ourworldindata/types"
 import { isArray } from "@ourworldindata/utils"
 import { match } from "ts-pattern"
@@ -655,6 +656,22 @@ function* rawBlockKeyIndicatorToArchieMLString(
             yield "[]"
         }
     }
+}
+
+function* rawBlockPillRowToArchieMLString(
+    block: RawBlockPillRow
+): Generator<string, void, undefined> {
+    yield "{.pill-row}"
+    yield* propertyToArchieMLString("title", block.value)
+    const pills = block?.value?.pills
+    if (pills) {
+        yield "[.pills]"
+        for (const pill of pills) {
+            yield* propertyToArchieMLString("text", pill)
+            yield* propertyToArchieMLString("url", pill)
+        }
+        yield "[]"
+    }
     yield "{}"
 }
 
@@ -739,6 +756,7 @@ export function* OwidRawGdocBlockToArchieMLStringGenerator(
             { type: "key-indicator-collection" },
             rawBlockKeyIndicatorCollectionToArchieMLString
         )
+        .with({ type: "pill-row" }, rawBlockPillRowToArchieMLString)
         .exhaustive()
     yield* content
 }

--- a/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
@@ -733,6 +733,27 @@ export type RefDictionary = {
     [refId: string]: Ref
 }
 
+export type RawBlockPillRow = {
+    type: "pill-row"
+    value: {
+        title?: string
+        pills?: {
+            text?: string
+            url?: string
+        }[]
+    }
+}
+
+export type EnrichedBlockPillRow = {
+    type: "pill-row"
+    title: string
+    pills: {
+        // optional because when linking to a gdoc we can use that title
+        text?: string
+        url: string
+    }[]
+} & EnrichedBlockWithParseErrors
+
 export type OwidRawGdocBlock =
     | RawBlockAllCharts
     | RawBlockAside
@@ -772,6 +793,7 @@ export type OwidRawGdocBlock =
     | RawBlockBlockquote
     | RawBlockKeyIndicator
     | RawBlockKeyIndicatorCollection
+    | RawBlockPillRow
 
 export type OwidEnrichedGdocBlock =
     | EnrichedBlockAllCharts
@@ -812,3 +834,4 @@ export type OwidEnrichedGdocBlock =
     | EnrichedBlockBlockquote
     | EnrichedBlockKeyIndicator
     | EnrichedBlockKeyIndicatorCollection
+    | EnrichedBlockPillRow

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -48,6 +48,7 @@ export enum OwidGdocType {
     Fragment = "fragment",
     LinearTopicPage = "linear-topic-page",
     DataInsight = "data-insight",
+    Homepage = "homepage",
 }
 
 export interface OwidGdocBaseInterface {
@@ -115,8 +116,28 @@ export type MinimalDataInsightInterface = Pick<
     index: 0 | 1 | 2 | 3 | 4
 }
 
-export type OwidGdoc = OwidGdocPostInterface | OwidGdocDataInsightInterface
-export type OwidGdocContent = OwidGdocPostContent | OwidGdocDataInsightContent
+export interface OwidGdocHomepageContent {
+    type: OwidGdocType.Homepage
+    title?: string
+    authors: string[]
+    body: OwidEnrichedGdocBlock[]
+}
+
+export interface OwidGdocHomepageInterface extends OwidGdocBaseInterface {
+    content: OwidGdocHomepageContent
+    linkedDocuments?: Record<string, OwidGdocMinimalPostInterface>
+    tags?: Tag[] // won't be used, but necessary in various validation steps
+}
+
+export type OwidGdocContent =
+    | OwidGdocPostContent
+    | OwidGdocDataInsightContent
+    | OwidGdocHomepageContent
+
+export type OwidGdoc =
+    | OwidGdocPostInterface
+    | OwidGdocDataInsightInterface
+    | OwidGdocHomepageInterface
 
 export enum OwidGdocErrorMessageType {
     Error = "error",

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -255,6 +255,8 @@ export {
     type EnrichedBlockKeyIndicator,
     type EnrichedBlockKeyIndicatorCollection,
     type RawBlockResearchAndWritingRow,
+    type RawBlockPillRow,
+    type EnrichedBlockPillRow,
 } from "./gdocTypes/ArchieMlComponents.js"
 export {
     OwidGdocPublicationContext,

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -269,6 +269,8 @@ export {
     type OwidGdocDataInsightContent,
     type OwidGdocDataInsightInterface,
     type MinimalDataInsightInterface,
+    type OwidGdocHomepageContent,
+    type OwidGdocHomepageInterface,
     DATA_INSIGHTS_INDEX_PAGE_SIZE,
     type OwidGdoc,
     type RawDetail,

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1664,7 +1664,8 @@ export function traverseEnrichedBlocks(
                     "topic-page-intro",
                     "all-charts",
                     "entry-summary",
-                    "explorer-tiles"
+                    "explorer-tiles",
+                    "pill-row"
                 ),
             },
             callback

--- a/packages/@ourworldindata/utils/src/image.ts
+++ b/packages/@ourworldindata/utils/src/image.ts
@@ -111,7 +111,16 @@ export function getFeaturedImageFilename(gdoc: OwidGdoc): string | undefined {
             return filename
         })
         .with(
-            { content: { type: P.union(OwidGdocType.Fragment, undefined) } },
+            {
+                content: {
+                    type: P.union(
+                        OwidGdocType.Fragment,
+                        // undefined so that we use default-thumbnail.jpg as defined in Head.tsx
+                        OwidGdocType.Homepage,
+                        undefined
+                    ),
+                },
+            },
             () => {
                 return undefined
             }

--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -16,6 +16,7 @@ import { match, P } from "ts-pattern"
 import { GdocPost } from "./pages/GdocPost.js"
 import { DataInsightPage } from "./pages/DataInsight.js"
 import { Fragment } from "./pages/Fragment.js"
+import { Homepage } from "./pages/Homepage.js"
 
 export const AttachmentsContext = createContext<{
     linkedCharts: Record<string, LinkedChart>
@@ -74,6 +75,9 @@ export function OwidGdoc({
         )
         .with({ content: { type: OwidGdocType.DataInsight } }, (props) => (
             <DataInsightPage {...props} />
+        ))
+        .with({ content: { type: OwidGdocType.Homepage } }, (props) => (
+            <Homepage {...props} totalCharts={1000} totalTopics={100} />
         ))
         .with({ content: { type: OwidGdocType.Fragment } }, (props) => (
             <Fragment {...props} />

--- a/site/gdocs/OwidGdocPage.tsx
+++ b/site/gdocs/OwidGdocPage.tsx
@@ -40,6 +40,9 @@ function getPageDesc(gdoc: OwidGdocUnionType): string | undefined {
             // TODO: what do we put here?
             return undefined
         })
+        .with({ content: { type: OwidGdocType.Homepage } }, () => {
+            return "Research and data to make progress against the world’s largest problems"
+        })
         .with(
             { content: { type: P.union(OwidGdocType.Fragment, undefined) } },
             () => {

--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -37,6 +37,7 @@ import { Table } from "./Table.js"
 import { ExplorerTiles } from "./ExplorerTiles.js"
 import KeyIndicator from "./KeyIndicator.js"
 import KeyIndicatorCollection from "./KeyIndicatorCollection.js"
+import { PillRow } from "./PillRow.js"
 
 export type Container =
     | "default"
@@ -79,6 +80,7 @@ const layouts: { [key in Container]: Layouts} = {
         ["list"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["numbered-list"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["prominent-link"]: "grid grid-cols-6 span-cols-6 col-start-5 span-md-cols-10 col-md-start-3 grid-md-cols-10 span-sm-cols-12 col-sm-start-2 grid-sm-cols-12",
+        ["pill-row"]: "grid span-cols-14 grid-cols-12-full-width",
         ["pull-quote"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["recirc"]: "col-start-11 span-cols-3 span-rows-3 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["research-and-writing"]: "col-start-2 span-cols-12",
@@ -644,6 +646,14 @@ export default function ArticleBlock({
                 d={block}
             />
         ))
+        .with({ type: "pill-row" }, (block) => {
+            return (
+                <PillRow
+                    {...block}
+                    className={getLayout("pill-row", containerType)}
+                />
+            )
+        })
         .exhaustive()
 
     return (

--- a/site/gdocs/components/PillRow.tsx
+++ b/site/gdocs/components/PillRow.tsx
@@ -1,0 +1,47 @@
+import { EnrichedBlockPillRow } from "@ourworldindata/types"
+import React, { useContext } from "react"
+import { useLinkedDocument } from "../utils.js"
+import { DocumentContext } from "../OwidGdoc.js"
+
+function Pill(props: { text?: string; url: string }) {
+    const { linkedDocument, errorMessage } = useLinkedDocument(props.url)
+    const { isPreviewing } = useContext(DocumentContext)
+    const url = linkedDocument ? `/${linkedDocument.slug}` : props.url
+    const text = linkedDocument ? linkedDocument.title : props.text
+
+    if (isPreviewing) {
+        if (errorMessage || !text || !url) {
+            return (
+                <li className="article-block__pill article-block__pill--error">
+                    Something is wrong with a document you're linking to in this
+                    pill. This message won't appear on the live site.
+                </li>
+            )
+        }
+    }
+
+    if (!text || !url) return null
+
+    return (
+        <li className="article-block__pill">
+            <a className="body-3-medium" href={url}>
+                {text}
+            </a>
+        </li>
+    )
+}
+
+export function PillRow(props: EnrichedBlockPillRow & { className?: string }) {
+    return (
+        <div className={props.className}>
+            <div className="article-block__pill-row-interior span-cols-12 col-start-2">
+                <p className="h5-black-caps">{props.title}</p>
+                <ul>
+                    {props.pills.map((pill, i) => (
+                        <Pill key={i} {...pill} />
+                    ))}
+                </ul>
+            </div>
+        </div>
+    )
+}

--- a/site/gdocs/components/centered-article.scss
+++ b/site/gdocs/components/centered-article.scss
@@ -989,17 +989,19 @@ div.raw-html-table__container {
 
 .article-block__pill-row {
     background-color: $blue-20;
+    scrollbar-width: thin;
+    overflow-x: auto;
     .article-block__pill-row-interior {
         display: flex;
         padding: 8px 0;
     }
     p {
         color: $blue-60;
-        margin-right: 9px;
+        margin: 0 9px 0 0;
+        line-height: 32px;
+        white-space: nowrap;
     }
     ul {
-        scrollbar-width: thin;
-        overflow-x: auto;
         list-style: none;
         display: flex;
         flex-wrap: nowrap;
@@ -1012,7 +1014,7 @@ div.raw-html-table__container {
             color: $blue-100;
             background-color: #fff;
             line-height: 2rem;
-            padding: 5.5px 16px;
+            padding: 0 16px;
             display: inline-block;
             transition: background-color 250ms;
             border-radius: 32px;

--- a/site/gdocs/components/centered-article.scss
+++ b/site/gdocs/components/centered-article.scss
@@ -986,3 +986,40 @@ div.raw-html-table__container {
         padding: 6px;
     }
 }
+
+.article-block__pill-row {
+    background-color: $blue-20;
+    .article-block__pill-row-interior {
+        display: flex;
+        padding: 8px 0;
+    }
+    p {
+        color: $blue-60;
+        margin-right: 9px;
+    }
+    ul {
+        scrollbar-width: thin;
+        overflow-x: auto;
+        list-style: none;
+        display: flex;
+        flex-wrap: nowrap;
+    }
+    .article-block__pill {
+        &:not(:last-child) {
+            margin-right: 8px;
+        }
+        a {
+            color: $blue-100;
+            background-color: #fff;
+            line-height: 2rem;
+            padding: 5.5px 16px;
+            display: inline-block;
+            transition: background-color 250ms;
+            border-radius: 32px;
+            white-space: nowrap;
+            &:hover {
+                background-color: $gray-10;
+            }
+        }
+    }
+}

--- a/site/gdocs/pages/Homepage.tsx
+++ b/site/gdocs/pages/Homepage.tsx
@@ -1,0 +1,282 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faRss, faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons"
+import {
+    faTwitter,
+    faFacebookSquare,
+    faInstagram,
+    faThreads,
+} from "@fortawesome/free-brands-svg-icons"
+import React from "react"
+import {
+    NewsletterSubscriptionContext,
+    NewsletterSubscriptionForm,
+} from "../../NewsletterSubscription.js"
+import { BAKED_BASE_URL } from "../../../settings/clientSettings.js"
+
+export interface HomepageProps {
+    totalCharts: number
+    totalTopics: number
+}
+
+export const Homepage = (props: HomepageProps): JSX.Element => {
+    const baseUrl = BAKED_BASE_URL
+    const { totalCharts, totalTopics } = props
+
+    return (
+        <div>
+            <section className="homepage-masthead">
+                <div className="wrapper">
+                    <h1>
+                        Research and data to make progress against the world’s
+                        largest problems
+                    </h1>
+                    <p>
+                        {totalCharts} charts across {totalTopics} topics
+                    </p>
+                    <p>All free: open access and open source</p>
+                </div>
+            </section>
+
+            <section className="homepage-coverage">
+                <div className="wrapper">
+                    <div className="inner-wrapper">
+                        <div className="owid-row owid-spacing--4">
+                            <div className="owid-col owid-col--lg-2">
+                                <section>
+                                    <h3 className="align-center">
+                                        Trusted in{" "}
+                                        <strong>research and media</strong>
+                                    </h3>
+                                    <a
+                                        href="/about/coverage#coverage"
+                                        className="coverage-link"
+                                        data-track-note="homepage_trust"
+                                    >
+                                        <img
+                                            src={`${baseUrl}/media-logos-wide.png`}
+                                            alt="Two rows of logos from the publications that have used Our World In Data's content: Science, Nature, PNAS, Royal Statistics Society, BBC, The New York Times, CNN, Financial Times, The Guardian, The Wall Street Journal, CNBC, The Washington Post, and Vox"
+                                            width={1200}
+                                            height={109}
+                                        />
+                                        <div className="hover-note">
+                                            <p>
+                                                Find out how our work is used by
+                                                journalists and researchers
+                                            </p>
+                                        </div>
+                                    </a>
+                                </section>
+                                <section>
+                                    <h3 className="align-center">
+                                        Used in <strong>teaching</strong>
+                                    </h3>
+                                    <a
+                                        href="/about/coverage#teaching"
+                                        className="coverage-link"
+                                        data-track-note="homepage_trust"
+                                    >
+                                        <picture>
+                                            <source
+                                                type="image/avif"
+                                                srcSet={`${baseUrl}/university-logos-wide.avif`}
+                                            />
+                                            <img
+                                                src={`${baseUrl}/university-logos-wide.png`}
+                                                alt="A row of logos for universites that have used Our World In Data's content: Harvard, Stanford, Berkeley, Cambridge, Oxford, and MIT"
+                                                width={1200}
+                                                height={57}
+                                            />
+                                        </picture>
+                                        <div className="hover-note">
+                                            <p>
+                                                Find out how our work is used in
+                                                teaching
+                                            </p>
+                                        </div>
+                                    </a>
+                                </section>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section className="homepage-posts">
+                <div className="wrapper">
+                    <div className="owid-row">
+                        <div className="owid-col flex-row"></div>
+                    </div>
+                </div>
+            </section>
+
+            <section className="homepage-subscribe" id="subscribe">
+                <div className="wrapper">
+                    <div className="owid-row">
+                        <div className="owid-col owid-col--lg-2 flex-row">
+                            <div className="newsletter-subscription">
+                                <div className="box">
+                                    <h2>Subscribe to our newsletter</h2>
+                                    <div className="root">
+                                        {/* Hydrated in runSiteTools() */}
+                                        <NewsletterSubscriptionForm
+                                            context={
+                                                NewsletterSubscriptionContext.Homepage
+                                            }
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div className="owid-col owid-col--lg-1">
+                            <div className="homepage-subscribe--social-media">
+                                <div className="shaded-box">
+                                    <h2>Follow us</h2>
+                                    <div className="list">
+                                        <a
+                                            href="https://twitter.com/ourworldindata"
+                                            className="list-item"
+                                            title="Twitter"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            data-track-note="homepage_follow_us"
+                                        >
+                                            <div className="icon">
+                                                <FontAwesomeIcon
+                                                    icon={faTwitter}
+                                                />
+                                            </div>
+                                            <div className="label">Twitter</div>
+                                        </a>
+                                        <a
+                                            href="https://facebook.com/ourworldindata"
+                                            className="list-item"
+                                            title="Facebook"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            data-track-note="homepage_follow_us"
+                                        >
+                                            <div className="icon">
+                                                <FontAwesomeIcon
+                                                    icon={faFacebookSquare}
+                                                />
+                                            </div>
+                                            <div className="label">
+                                                Facebook
+                                            </div>
+                                        </a>
+                                        <a
+                                            href="https://www.instagram.com/ourworldindata/"
+                                            className="list-item"
+                                            title="Instagram"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            data-track-note="homepage_follow_us"
+                                        >
+                                            <div className="icon">
+                                                <FontAwesomeIcon
+                                                    icon={faInstagram}
+                                                />
+                                            </div>
+                                            <div className="label">
+                                                Instagram
+                                            </div>
+                                        </a>
+                                        <a
+                                            href="https://www.threads.net/@ourworldindata"
+                                            className="list-item"
+                                            title="Threads"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            data-track-note="homepage_follow_us"
+                                        >
+                                            <div className="icon">
+                                                <FontAwesomeIcon
+                                                    icon={faThreads}
+                                                />
+                                            </div>
+                                            <div className="label">Threads</div>
+                                        </a>
+                                        <a
+                                            href="/feed"
+                                            className="list-item"
+                                            title="RSS"
+                                            target="_blank"
+                                            data-track-note="homepage_follow_us"
+                                        >
+                                            <div className="icon">
+                                                <FontAwesomeIcon icon={faRss} />
+                                            </div>
+                                            <div className="label">
+                                                RSS Feed
+                                            </div>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section className="homepage-projects">
+                <div className="wrapper">
+                    <div className="list">
+                        <a
+                            href="/sdgs"
+                            className="list-item"
+                            data-track-note="homepage_projects"
+                        >
+                            <div className="icon-left">
+                                <picture>
+                                    <source
+                                        srcSet={`${baseUrl}/sdg-wheel.avif`}
+                                        type="image/avif"
+                                    />
+                                    <img
+                                        src={`${baseUrl}/sdg-wheel.png`}
+                                        alt="SDG Tracker logo"
+                                        loading="lazy"
+                                    />
+                                </picture>
+                            </div>
+                            <div className="content">
+                                <h3>Sustainable Development Goals Tracker</h3>
+                                <p>
+                                    Is the world on track to reach the
+                                    Sustainable Development Goals?
+                                </p>
+                            </div>
+                            <div className="icon-right">
+                                <FontAwesomeIcon icon={faExternalLinkAlt} />
+                            </div>
+                        </a>
+                        <a
+                            href="/teaching"
+                            className="list-item"
+                            data-track-note="homepage_projects"
+                        >
+                            <div className="icon-left">
+                                <img
+                                    src={`${baseUrl}/teaching-hub.svg`}
+                                    alt="Teaching Hub logo"
+                                    loading="lazy"
+                                />
+                            </div>
+                            <div className="content">
+                                <h3>Teaching Hub</h3>
+                                <p>
+                                    Slides, research, and visualizations for
+                                    teaching and learning about global
+                                    development
+                                </p>
+                            </div>
+                            <div className="icon-right">
+                                <FontAwesomeIcon icon={faExternalLinkAlt} />
+                            </div>
+                        </a>
+                    </div>
+                </div>
+            </section>
+        </div>
+    )
+}

--- a/site/gdocs/pages/Homepage.tsx
+++ b/site/gdocs/pages/Homepage.tsx
@@ -12,19 +12,28 @@ import {
     NewsletterSubscriptionForm,
 } from "../../NewsletterSubscription.js"
 import { BAKED_BASE_URL } from "../../../settings/clientSettings.js"
+import { ArticleBlocks } from "../components/ArticleBlocks.js"
+import { OwidGdocHomepageContent } from "@ourworldindata/types"
 
 export interface HomepageProps {
     totalCharts: number
     totalTopics: number
+    content: OwidGdocHomepageContent
 }
 
 export const Homepage = (props: HomepageProps): JSX.Element => {
     const baseUrl = BAKED_BASE_URL
-    const { totalCharts, totalTopics } = props
+    const { totalCharts, totalTopics, content } = props
 
     return (
-        <div>
-            <section className="homepage-masthead">
+        <div className="grid grid-cols-12-full-width">
+            <ArticleBlocks blocks={content.body} />
+        </div>
+    )
+}
+
+/*
+<section className="homepage-masthead">
                 <div className="wrapper">
                     <h1>
                         Research and data to make progress against the world’s
@@ -117,7 +126,6 @@ export const Homepage = (props: HomepageProps): JSX.Element => {
                                 <div className="box">
                                     <h2>Subscribe to our newsletter</h2>
                                     <div className="root">
-                                        {/* Hydrated in runSiteTools() */}
                                         <NewsletterSubscriptionForm
                                             context={
                                                 NewsletterSubscriptionContext.Homepage
@@ -277,6 +285,4 @@ export const Homepage = (props: HomepageProps): JSX.Element => {
                     </div>
                 </div>
             </section>
-        </div>
-    )
-}
+*/

--- a/site/search/SearchPage.tsx
+++ b/site/search/SearchPage.tsx
@@ -13,6 +13,21 @@ export const SearchPage = (props: { baseUrl: string }) => {
                 pageDesc="Search articles and charts on Our World in Data."
                 baseUrl={baseUrl}
             />
+            <script
+                dangerouslySetInnerHTML={{
+                    // Structured data for google
+                    __html: JSON.stringify({
+                        "@context": "https://schema.org",
+                        "@type": "WebSite",
+                        url: baseUrl,
+                        potentialAction: {
+                            "@type": "SearchAction",
+                            target: `${baseUrl}/search?q={search_term_string}`,
+                            "query-input": "required name=search_term_string",
+                        },
+                    }),
+                }}
+            />
             <body>
                 <SiteHeader baseUrl={baseUrl} />
                 <main className="search-page-container" />


### PR DESCRIPTION
A new page type so that we can preview changes to the homepage in the admin before publishing (avoiding issues where featured posts aren't rendered correctly, etc)

It's basically a port of `Frontpage.tsx` and some extra boilerplate around the gdocs admin side of things.

Also adds a `pill-row` component

![image](https://github.com/owid/owid-grapher/assets/11844404/3f2a2c87-1fc9-49a7-bfef-eaca7e33dab9)

```
title: Test homepage with pill-row
excerpt: ignore me
type: homepage
authors: You


[+body]
{.pill-row}
title: Popular pages
[.pills]
text: Hello
url: https://en.wikipedia.org/

text: World
url: https://fr.wikipedia.org/

text:
url: https://docs.google.com/document/d/1Lo3CtGGESA3iQVrlhlQZbtG15ecUNt1Qfk2X3iBlwIk/edit

[]
{}

[]
```

The linting and comments are fixed in subsequent branches.