### PR TITLE
:bug: (gdocs) encode ',' in image paths

### DIFF
--- a/packages/@ourworldindata/utils/src/image.ts
+++ b/packages/@ourworldindata/utils/src/image.ts
@@ -36,7 +36,7 @@ export function generateSrcSet(
             const path = `/images/published/${getFilenameWithoutExtension(
                 filename
             )}_${size}.webp`
-            return `${encodeURI(path)} ${size}w`
+            return `${encodeURIComponent(path)} ${size}w`
         })
         .join(", ")
 }

--- a/site/gdocs/components/Image.tsx
+++ b/site/gdocs/components/Image.tsx
@@ -92,9 +92,9 @@ export default function Image(props: {
 
     if (isPreviewing) {
         const makePreviewUrl = (f: string) =>
-            encodeURI(
-                `${IMAGE_HOSTING_CDN_URL}/${IMAGE_HOSTING_BUCKET_SUBFOLDER_PATH}/${f}`
-            )
+            `${IMAGE_HOSTING_CDN_URL}/${IMAGE_HOSTING_BUCKET_SUBFOLDER_PATH}/${encodeURIComponent(
+                f
+            )}`
 
         const PreviewSource = (props: { i?: ImageMetadata; sm?: boolean }) => {
             const { i, sm } = props
@@ -130,7 +130,7 @@ export default function Image(props: {
         return (
             <div className={className}>
                 <img
-                    src={encodeURI(imgSrc)}
+                    src={encodeURIComponent(imgSrc)}
                     alt={alt}
                     className={maybeLightboxClassName}
                 />
@@ -163,7 +163,7 @@ export default function Image(props: {
                 />
             ))}
             <img
-                src={encodeURI(imageSrc)}
+                src={encodeURIComponent(imageSrc)}
                 alt={alt}
                 className={maybeLightboxClassName}
                 loading="lazy"


### PR DESCRIPTION
- fixes #3127 
- The screen is blank because the lightbox image can't be found
- Why this happens:
    - Commas in image filenames aren't escaped properly
    - When extracting the path for the lightbox image, we split the `srcset` attribute by `,` which then results in a partial/broken URL
- Using `encodeURIComponent` instead of `encodeURI` fixes this since `encodeURIComponent` escapes commas, `encodeURI` does not
- I'm wondering if we should use `encodeURIComponent` instead of `encodeURI` elsewhere?

Example: [Live](https://ourworldindata.org/limits-personal-experience) / [Staging](http://staging-site-fix-gdocs-blank-lightbox-image/limits-personal-experience)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved image path and URL encoding to handle special characters correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->