### PR TITLE
(wp) dereference tablespress tables

### DIFF
--- a/baker/formatWordpressPost.tsx
+++ b/baker/formatWordpressPost.tsx
@@ -3,8 +3,6 @@ import urlSlug from "url-slug"
 import React from "react"
 import ReactDOMServer from "react-dom/server.js"
 import { BAKED_BASE_URL, HTTPS_ONLY } from "../settings/serverSettings.js"
-import { getTables } from "../db/wpdb.js"
-import Tablepress from "../site/Tablepress.js"
 import { GrapherExports } from "../baker/GrapherBakingUtils.js"
 import { AllCharts, renderAllCharts } from "../site/blocks/AllCharts.js"
 import { FormattingOptions } from "@ourworldindata/types"
@@ -248,17 +246,6 @@ export const formatWordpressPost = async (
             )
         }
     )
-
-    // Insert [table id=foo] tablepress tables
-    const tables = await getTables()
-    html = html.replace(/\[table\s+id=(\d+)\s*\/\]/g, (match, tableId) => {
-        const table = tables.get(tableId)
-        if (table)
-            return ReactDOMServer.renderToStaticMarkup(
-                <Tablepress data={table.data} />
-            )
-        return "UNKNOWN TABLE"
-    })
 
     // Give "Add country" text (and variations) the appearance of "+ Add Country" chart control
     html = html.replace(

--- a/baker/postUpdatedHook.ts
+++ b/baker/postUpdatedHook.ts
@@ -14,6 +14,7 @@ import * as wpdb from "../db/wpdb.js"
 import * as db from "../db/db.js"
 import {
     buildReusableBlocksResolver,
+    buildTablePressResolver,
     getLinksToAddAndRemoveForPost,
 } from "../db/syncPostsToGrapher.js"
 import { postsTable, select } from "../db/model/Post.js"
@@ -94,6 +95,7 @@ const syncPostToGrapher = async (
         [postId, postId, postId, postId]
     )
     const dereferenceReusableBlocksFn = await buildReusableBlocksResolver()
+    const dereferenceTablePressFn = await buildTablePressResolver()
 
     const matchingRows = await db.knexTable(postsTable).where({ id: postId })
     const existsInGrapher = !!matchingRows.length
@@ -137,8 +139,8 @@ const syncPostToGrapher = async (
             // Delete from grapher
             await transaction.table(postsTable).where({ id: postId }).delete()
         else if (postRow) {
-            const contentWithBlocksInlined = dereferenceReusableBlocksFn(
-                postRow.content
+            const contentWithBlocksInlined = dereferenceTablePressFn(
+                dereferenceReusableBlocksFn(postRow.content)
             )
             postRow.content = contentWithBlocksInlined
 

--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -1338,7 +1338,24 @@ function cheerioToArchieML(
                 }
             )
             .with(
-                { tagName: P.union("svg", "table", "video") },
+                { tagName: "table" },
+                (): BlockParseResult<EnrichedBlockHtml> => {
+                    return {
+                        errors: [],
+                        content: [
+                            {
+                                type: "html",
+                                value: `<div class="raw-html-table__container">${
+                                    context.$.html(element) ?? ""
+                                }</div>`,
+                                parseErrors: [],
+                            },
+                        ],
+                    }
+                }
+            )
+            .with(
+                { tagName: P.union("svg", "video") },
                 (): BlockParseResult<EnrichedBlockHtml> => {
                     return {
                         errors: [],

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -850,7 +850,7 @@ export const getTopics = async (cursor: string = ""): Promise<Topic[]> => {
     }
 }
 
-interface TablepressTable {
+export interface TablepressTable {
     tableId: string
     data: string[][]
 }

--- a/site/Tablepress.tsx
+++ b/site/Tablepress.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import ReactDOMServer from "react-dom/server.js"
 
 interface Cell {
     data: string
@@ -38,6 +39,10 @@ function parseTable(table: string[][]): Cell[][] {
         resultTable.push(resultRow)
     })
     return resultTable
+}
+
+export const renderTablePress = (table: string[][]) => {
+    return ReactDOMServer.renderToStaticMarkup(<Tablepress data={table} />)
 }
 
 export default function Tablepress(props: { data: string[][] }) {

--- a/site/Tablepress.tsx
+++ b/site/Tablepress.tsx
@@ -16,6 +16,7 @@ function cell(data?: string) {
 }
 
 const ROWSPAN_TOKEN = "#rowspan#"
+const COLSPAN_TOKEN = "#colspan#"
 
 function parseTable(table: string[][]): Cell[][] {
     const resultTable: Cell[][] = []
@@ -29,6 +30,16 @@ function parseTable(table: string[][]): Cell[][] {
                 }
                 if (i >= 0) {
                     resultTable[i][c].rowspan++
+                } else {
+                    resultRow.push(cell())
+                }
+            } else if (data === COLSPAN_TOKEN) {
+                let j = c - 1
+                while (j >= 0 && row[j] === COLSPAN_TOKEN) {
+                    j--
+                }
+                if (j >= 0) {
+                    resultRow[j].colspan++
                 } else {
                     resultRow.push(cell())
                 }
@@ -56,6 +67,7 @@ export default function Tablepress(props: { data: string[][] }) {
                     {headerRow.map((cell, i) => (
                         <th
                             key={i}
+                            colSpan={cell.colspan}
                             dangerouslySetInnerHTML={{ __html: cell.data }}
                         />
                     ))}
@@ -69,7 +81,9 @@ export default function Tablepress(props: { data: string[][] }) {
                                 key={j}
                                 colSpan={cell.colspan}
                                 rowSpan={cell.rowspan}
-                                dangerouslySetInnerHTML={{ __html: cell.data }}
+                                dangerouslySetInnerHTML={{
+                                    __html: cell.data,
+                                }}
                             />
                         ))}
                     </tr>

--- a/site/Tablepress.tsx
+++ b/site/Tablepress.tsx
@@ -61,19 +61,20 @@ export default function Tablepress(props: { data: string[][] }) {
     const table = parseTable(data)
     const [headerRow, ...body] = table
     return (
-        <table className="tablepress">
+        <table>
             <thead>
                 <tr>
                     {headerRow.map((cell, i) => (
                         <th
                             key={i}
+                            scope="col"
                             colSpan={cell.colspan}
                             dangerouslySetInnerHTML={{ __html: cell.data }}
                         />
                     ))}
                 </tr>
             </thead>
-            <tbody className="row-hover">
+            <tbody>
                 {body.map((row, i) => (
                     <tr key={i}>
                         {row.map((cell, j) => (

--- a/site/gdocs/components/centered-article.scss
+++ b/site/gdocs/components/centered-article.scss
@@ -612,7 +612,8 @@ h3.article-block__heading.has-supertitle {
 }
 
 div.article-block__table--narrow,
-div.article-block__table--wide {
+div.article-block__table--wide,
+div.raw-html-table__container {
     overflow-x: auto;
     table {
         min-width: 100%;
@@ -649,6 +650,10 @@ div.article-block__table--wide {
             }
         }
     }
+}
+
+div.raw-html-table__container {
+    @include body-3-medium;
 }
 
 .article-block__pull-quote {


### PR DESCRIPTION
This PR dereferences TablePress tables during the `syncPostsToGrapher.ts` call, similar to the dereferencing of reusable blocks. During the migration to ArchieML, it wraps the table in an `row-html-table__container` div to allow horizontal scrolling via `overflow-x: auto` on mobile.

```mermaid
sequenceDiagram
    Author ->> Admin: saves WP post
    Admin ->> wp_posts.post_content: syncPostToGrapher() from...
    wp_posts.post_content ->> posts.content: to...
    loop live.owid.io crontab
        posts.content ->> posts.archieml: migrateWpPostsToArchieMl()
    end
    Author ->> Admin: clicks "Create GDoc" button
    note right of Admin: This starts the creation of a<br>Google Doc from the<br>ArchieML content saved in <br>posts.archieml
    Admin ->> posts.archieml: create Google Doc from...
    Author ->> Admin: clicks "♻️"
    Admin ->> posts.archieml: recreate and overwrite Google Doc from...
    
```

## Testing
- `SELECT * from posts where content like "%[table%"` -> should return a few rows
- run `node itsJustJavascript/db/syncPostsToGrapher.js`
- `SELECT * from posts where content like "%[table%"` -> the result set should now be empty, meaning all tables were dereferenced (provided no errors have been logged). 

### With preview comparison
- `node itsJustJavascript/db/syncPostsToGrapher.js && node itsJustJavascript/db/migrateWpPostsToArchieMl.js`
- http://localhost:3030/admin/posts/compare/3604
<img width="1440" alt="Screenshot 2024-01-25 at 10 46 07" src="https://github.com/owid/owid-grapher/assets/13406362/599e4c22-8699-4880-ac2c-c2cfa9ae1309">

### With colspan and rowspan

Tablepress supports `colspan` and `rowspan` attributes by adding #colspan# and #rowspan# tokens into the relevant cells. Both attributes are now fully supported in the `<TablePress>` custom component used to render table during the `syncPostsToGrapher` call.

<img width="1440" alt="Screenshot 2024-01-25 at 11 06 48" src="https://github.com/owid/owid-grapher/assets/13406362/288a3b83-660a-4656-9f65-a7bdf57ff519">

[compare](http://localhost:3030/admin/posts/compare/3604), [edit table](http://localhost:8080/wp/wp-admin/admin.php?page=tablepress&action=edit&table_id=59)

## Background

Tablepress rendering was initially being done with the custom `<TablePress>` component, before being handled by Wordpress (see [Shifting rendering to Wordpress](https://www.notion.so/owid/Shifting-rendering-to-wordpress-47522264959542169186445aa0d36528#282622d424024d48b49ae0135acb128c)).

This can be checked on any post containing a `[table id=xxx]` shortcode. In the absence of the custom TablePress rendering code, the tables are still rendered properly. E.g. http://localhost:8080/wp-json/wp/v2/pages/1588/revisions?per_page=1 shows rendered HTML tables, before any node code has had a chance to run.

With this migration, tables are rendered:
- when Wordpress posts are rendered via Wordpress: through the Tablepress plugin pipeline
- when Wordpress posts are prepared for ArchieML migration: we're now returning to rendering tables in node, and can again rely on the `<TablePress>` component.

## Tasks

- [x] handle/fix table shortcode in post 1588 (`[table id=4 responsive="all" /]` --> `[table id=4 /]`)
- [x] handle/fix table 108 not found  ([slack](https://owid.slack.com/archives/C03NV9Z3YSV/p1706102398383419))
- [x] dereference in single postUpdatedHook
- [x] dereference in batch syncPostsToGrapher
- [ ] after deploy: run syncPostsToGrapher
- [ ] after deploy: run migrateWpPostsToArchieMl.js

## Caveat
See https://github.com/owid/owid-grapher/issues/3133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced table handling in WordPress post formatting.
  - Improved parsing of `table` tags in documents, wrapping them in a new classed `div`.
  - Support for the `colspan` attribute in tables.

- **Refactor**
  - Updated block and link handling logic in content synchronization.

- **Style**
  - Introduced new styling for tables within centered articles.

- **Documentation**
  - Made the `TablepressTable` interface publicly accessible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->