### PR TITLE
:hammer: (db) migrate Dataset and Source to knex

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -50,15 +50,20 @@ import {
     OwidGdoc,
 } from "@ourworldindata/utils"
 import {
+    DbPlainDatasetTag,
     GrapherInterface,
     OwidGdocType,
+    DbPlainTag,
     grapherKeysToSerialize,
+    DbRawVariable,
+    DbRawOrigin,
+    parseOriginsRow,
 } from "@ourworldindata/types"
 import {
     getVariableDataRoute,
     getVariableMetadataRoute,
 } from "@ourworldindata/grapher"
-import { Dataset } from "../db/model/Dataset.js"
+import { getDatasetById, setTagsForDataset } from "../db/model/Dataset.js"
 import { User } from "../db/model/User.js"
 import { GdocPost } from "../db/model/Gdoc/GdocPost.js"
 import { GdocBase, Tag as TagEntity } from "../db/model/Gdoc/GdocBase.js"
@@ -1589,7 +1594,10 @@ apiRouter.get(
 )
 
 apiRouter.get("/datasets.json", async (req) => {
-    const datasets = await db.queryMysql(`
+    await db.knexInstance().transaction(
+        async (trx) => {
+            const datasets = await db.knexRaw<Record<string, any>>(
+                `
         WITH variable_counts AS (
             SELECT
                 v.datasetId,
@@ -1618,29 +1626,42 @@ apiRouter.get("/datasets.json", async (req) => {
         JOIN users mu ON mu.id=ad.metadataEditedByUserId
         JOIN datasets d ON d.id=ad.id
         ORDER BY ad.dataEditedAt DESC
-    `)
+    `,
+                trx
+            )
 
-    const tags = await db.queryMysql(`
+            const tags = await db.knexRaw<
+                Pick<DbPlainTag, "id" | "name"> &
+                    Pick<DbPlainDatasetTag, "datasetId">
+            >(
+                `
         SELECT dt.datasetId, t.id, t.name FROM dataset_tags dt
         JOIN tags t ON dt.tagId = t.id
-    `)
-    const tagsByDatasetId = lodash.groupBy(tags, (t) => t.datasetId)
-    for (const dataset of datasets) {
-        dataset.tags = (tagsByDatasetId[dataset.id] || []).map((t) =>
-            lodash.omit(t, "datasetId")
-        )
-    }
-    /*LEFT JOIN variables AS v ON v.datasetId=d.id
+    `,
+                trx
+            )
+            const tagsByDatasetId = lodash.groupBy(tags, (t) => t.datasetId)
+            for (const dataset of datasets) {
+                dataset.tags = (tagsByDatasetId[dataset.id] || []).map((t) =>
+                    lodash.omit(t, "datasetId")
+                )
+            }
+            /*LEFT JOIN variables AS v ON v.datasetId=d.id
     GROUP BY d.id*/
 
-    return { datasets: datasets }
+            return { datasets: datasets }
+        },
+        { readOnly: true }
+    )
 })
 
 apiRouter.get("/datasets/:datasetId.json", async (req: Request) => {
     const datasetId = expectInt(req.params.datasetId)
 
-    const dataset = await db.mysqlFirst(
-        `
+    await db.knexInstance().transaction(
+        async (trx) => {
+            const dataset = await db.knexRawFirst<Record<string, any>>(
+                `
         SELECT d.id,
             d.namespace,
             d.name,
@@ -1663,35 +1684,42 @@ apiRouter.get("/datasets/:datasetId.json", async (req: Request) => {
         JOIN users mu ON mu.id=d.metadataEditedByUserId
         WHERE d.id = ?
     `,
-        [datasetId]
-    )
+                trx,
+                [datasetId]
+            )
 
-    if (!dataset) throw new JsonError(`No dataset by id '${datasetId}'`, 404)
+            if (!dataset)
+                throw new JsonError(`No dataset by id '${datasetId}'`, 404)
 
-    const zipFile = await db.mysqlFirst(
-        `SELECT filename FROM dataset_files WHERE datasetId=?`,
-        [datasetId]
-    )
-    if (zipFile) dataset.zipFile = zipFile
+            const zipFile = await db.knexRawFirst(
+                `SELECT filename FROM dataset_files WHERE datasetId=?`,
+                trx,
+                [datasetId]
+            )
+            if (zipFile) dataset.zipFile = zipFile
 
-    const variables = await db.queryMysql(
-        `
+            const variables: Pick<
+                DbRawVariable,
+                "id" | "name" | "description" | "display" | "catalogPath"
+            >[] = await db.knexRaw(
+                `
         SELECT v.id, v.name, v.description, v.display, v.catalogPath
         FROM variables AS v
         WHERE v.datasetId = ?
     `,
-        [datasetId]
-    )
+                trx,
+                [datasetId]
+            )
 
-    for (const v of variables) {
-        v.display = JSON.parse(v.display)
-    }
+            for (const v of variables) {
+                v.display = JSON.parse(v.display)
+            }
 
-    dataset.variables = variables
+            dataset.variables = variables
 
-    // add all origins
-    const origins = await db.queryMysql(
-        `
+            // add all origins
+            const origins: DbRawOrigin[] = await db.knexRaw(
+                `
         select distinct
             o.*
         from origins_variables as ov
@@ -1699,36 +1727,36 @@ apiRouter.get("/datasets/:datasetId.json", async (req: Request) => {
         join variables as v on ov.variableId = v.id
         where v.datasetId = ?
     `,
-        [datasetId]
-    )
+                trx,
+                [datasetId]
+            )
 
-    for (const o of origins) {
-        o.license = JSON.parse(o.license)
-    }
+            const parsedOrigins = origins.map(parseOriginsRow)
 
-    dataset.origins = origins
+            dataset.origins = parsedOrigins
 
-    const sources = await db.queryMysql(
-        `
+            const sources = await db.knexRaw(
+                `
         SELECT s.id, s.name, s.description
         FROM sources AS s
         WHERE s.datasetId = ?
         ORDER BY s.id ASC
     `,
-        [datasetId]
-    )
+                trx,
+                [datasetId]
+            )
 
-    // expand description of sources and add to dataset as variableSources
-    dataset.variableSources = sources.map((s: any) => {
-        return {
-            id: s.id,
-            name: s.name,
-            ...JSON.parse(s.description),
-        }
-    })
+            // expand description of sources and add to dataset as variableSources
+            dataset.variableSources = sources.map((s: any) => {
+                return {
+                    id: s.id,
+                    name: s.name,
+                    ...JSON.parse(s.description),
+                }
+            })
 
-    const charts = await db.queryMysql(
-        `
+            const charts = await db.knexRaw(
+                `
         SELECT ${OldChart.listFields}
         FROM charts
         JOIN chart_dimensions AS cd ON cd.chartId = charts.id
@@ -1738,45 +1766,54 @@ apiRouter.get("/datasets/:datasetId.json", async (req: Request) => {
         WHERE v.datasetId = ?
         GROUP BY charts.id
     `,
-        [datasetId]
-    )
+                trx,
+                [datasetId]
+            )
 
-    dataset.charts = charts
+            dataset.charts = charts
 
-    await Chart.assignTagsForCharts(charts)
+            await Chart.assignTagsForCharts(charts as any)
 
-    const tags = await db.queryMysql(
-        `
+            const tags = await db.knexRaw(
+                `
         SELECT t.id, t.name
         FROM tags t
         JOIN dataset_tags dt ON dt.tagId = t.id
         WHERE dt.datasetId = ?
     `,
-        [datasetId]
-    )
-    dataset.tags = tags
+                trx,
+                [datasetId]
+            )
+            dataset.tags = tags
 
-    const availableTags = await db.queryMysql(`
+            const availableTags = await db.knexRaw(
+                `
         SELECT t.id, t.name, p.name AS parentName
         FROM tags AS t
         JOIN tags AS p ON t.parentId=p.id
         WHERE p.isBulkImport IS FALSE
-    `)
-    dataset.availableTags = availableTags
+    `,
+                trx
+            )
+            dataset.availableTags = availableTags
 
-    return { dataset: dataset }
+            return { dataset: dataset }
+        },
+        { readOnly: true }
+    )
 })
 
 apiRouter.put("/datasets/:datasetId", async (req: Request, res: Response) => {
     // Only updates `nonRedistributable` and `tags`, other fields come from ETL
     // and are not editable
     const datasetId = expectInt(req.params.datasetId)
-    const dataset = await Dataset.findOneBy({ id: datasetId })
+    const knex = db.knexInstance()
+    const dataset = await getDatasetById(knex, datasetId)
     if (!dataset) throw new JsonError(`No dataset by id ${datasetId}`, 404)
 
-    await db.transaction(async (t) => {
+    await knex.transaction(async (t) => {
         const newDataset = (req.body as { dataset: any }).dataset
-        await t.execute(
+        await t.raw(
             `
             UPDATE datasets
             SET
@@ -1794,27 +1831,24 @@ apiRouter.put("/datasets/:datasetId", async (req: Request, res: Response) => {
         )
 
         const tagRows = newDataset.tags.map((tag: any) => [tag.id, datasetId])
-        await t.execute(`DELETE FROM dataset_tags WHERE datasetId=?`, [
-            datasetId,
-        ])
+        await t.raw(`DELETE FROM dataset_tags WHERE datasetId=?`, [datasetId])
         if (tagRows.length)
-            await t.execute(
+            await t.raw(
                 `INSERT INTO dataset_tags (tagId, datasetId) VALUES ?`,
                 [tagRows]
             )
-    })
 
-    // Note: not currently in transaction
-    try {
-        await syncDatasetToGitRepo(datasetId, {
-            oldDatasetName: dataset.name,
-            commitName: res.locals.user.fullName,
-            commitEmail: res.locals.user.email,
-        })
-    } catch (err) {
-        logErrorAndMaybeSendToBugsnag(err, req)
-        // Continue
-    }
+        try {
+            await syncDatasetToGitRepo(t, datasetId, {
+                oldDatasetName: dataset.name!,
+                commitName: res.locals.user.fullName,
+                commitEmail: res.locals.user.email,
+            })
+        } catch (err) {
+            logErrorAndMaybeSendToBugsnag(err, req)
+            // Continue
+        }
+    })
 
     return { success: true }
 })
@@ -1823,10 +1857,11 @@ apiRouter.post(
     "/datasets/:datasetId/setArchived",
     async (req: Request, res: Response) => {
         const datasetId = expectInt(req.params.datasetId)
-        const dataset = await Dataset.findOneBy({ id: datasetId })
+        const knex = db.knexInstance()
+        const dataset = await getDatasetById(knex, datasetId)
         if (!dataset) throw new JsonError(`No dataset by id ${datasetId}`, 404)
-        await db.transaction(async (t) => {
-            await t.execute(`UPDATE datasets SET isArchived = 1 WHERE id=?`, [
+        await knex.transaction(async (t) => {
+            await t.raw(`UPDATE datasets SET isArchived = 1 WHERE id=?`, [
                 datasetId,
             ])
         })
@@ -1839,7 +1874,7 @@ apiRouter.post(
     async (req: Request, res: Response) => {
         const datasetId = expectInt(req.params.datasetId)
 
-        await Dataset.setTags(datasetId, req.body.tagIds)
+        await setTagsForDataset(db.knexInstance(), datasetId, req.body.tagIds)
 
         return { success: true }
     }
@@ -1850,28 +1885,25 @@ apiRouter.delete(
     async (req: Request, res: Response) => {
         const datasetId = expectInt(req.params.datasetId)
 
-        const dataset = await Dataset.findOneBy({ id: datasetId })
+        const knex = db.knexInstance()
+        const dataset = await getDatasetById(knex, datasetId)
         if (!dataset) throw new JsonError(`No dataset by id ${datasetId}`, 404)
 
-        await db.transaction(async (t) => {
-            await t.execute(
+        await knex.transaction(async (t) => {
+            await t.raw(
                 `DELETE d FROM country_latest_data AS d JOIN variables AS v ON d.variable_id=v.id WHERE v.datasetId=?`,
                 [datasetId]
             )
-            await t.execute(`DELETE FROM dataset_files WHERE datasetId=?`, [
+            await t.raw(`DELETE FROM dataset_files WHERE datasetId=?`, [
                 datasetId,
             ])
-            await t.execute(`DELETE FROM variables WHERE datasetId=?`, [
-                datasetId,
-            ])
-            await t.execute(`DELETE FROM sources WHERE datasetId=?`, [
-                datasetId,
-            ])
-            await t.execute(`DELETE FROM datasets WHERE id=?`, [datasetId])
+            await t.raw(`DELETE FROM variables WHERE datasetId=?`, [datasetId])
+            await t.raw(`DELETE FROM sources WHERE datasetId=?`, [datasetId])
+            await t.raw(`DELETE FROM datasets WHERE id=?`, [datasetId])
         })
 
         try {
-            await removeDatasetFromGitRepo(dataset.name, dataset.namespace, {
+            await removeDatasetFromGitRepo(dataset.name!, dataset.namespace, {
                 commitName: res.locals.user.fullName,
                 commitEmail: res.locals.user.email,
             })
@@ -1889,12 +1921,13 @@ apiRouter.post(
     async (req: Request, res: Response) => {
         const datasetId = expectInt(req.params.datasetId)
 
-        const dataset = await Dataset.findOneBy({ id: datasetId })
+        const knex = db.knexInstance()
+        const dataset = await getDatasetById(knex, datasetId)
         if (!dataset) throw new JsonError(`No dataset by id ${datasetId}`, 404)
 
         if (req.body.republish) {
-            await db.transaction(async (t) => {
-                await t.execute(
+            await knex.transaction(async (t) => {
+                await t.raw(
                     `
             UPDATE charts
             SET config = JSON_SET(config, "$.version", config->"$.version" + 1)
@@ -2296,21 +2329,29 @@ apiRouter.post("/posts/:postId/unlinkGdoc", async (req: Request) => {
 
 apiRouter.get("/sources/:sourceId.json", async (req: Request) => {
     const sourceId = expectInt(req.params.sourceId)
-    const source = await db.mysqlFirst(
-        `
+    db.knexInstance().transaction(
+        async (trx) => {
+            const source = await db.knexRawFirst<Record<string, any>>(
+                `
         SELECT s.id, s.name, s.description, s.createdAt, s.updatedAt, d.namespace
         FROM sources AS s
         JOIN active_datasets AS d ON d.id=s.datasetId
         WHERE s.id=?`,
-        [sourceId]
-    )
-    source.description = JSON.parse(source.description)
-    source.variables = await db.queryMysql(
-        `SELECT id, name, updatedAt FROM variables WHERE variables.sourceId=?`,
-        [sourceId]
-    )
+                trx,
+                [sourceId]
+            )
+            if (!source)
+                throw new JsonError(`No source by id '${sourceId}'`, 404)
+            source.variables = await db.knexRaw(
+                `SELECT id, name, updatedAt FROM variables WHERE variables.sourceId=?`,
+                trx,
+                [sourceId]
+            )
 
-    return { source: source }
+            return { source: source }
+        },
+        { readOnly: true }
+    )
 })
 
 apiRouter.get("/deploys.json", async () => ({

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -1844,7 +1844,7 @@ apiRouter.put("/datasets/:datasetId", async (req: Request, res: Response) => {
 
         try {
             await syncDatasetToGitRepo(trx, datasetId, {
-                oldDatasetName: dataset.name!,
+                oldDatasetName: dataset.name,
                 commitName: res.locals.user.fullName,
                 commitEmail: res.locals.user.email,
             })
@@ -1918,7 +1918,7 @@ apiRouter.delete(
         })
 
         try {
-            await removeDatasetFromGitRepo(dataset.name!, dataset.namespace, {
+            await removeDatasetFromGitRepo(dataset.name, dataset.namespace, {
                 commitName: res.locals.user.fullName,
                 commitEmail: res.locals.user.email,
             })

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -1594,7 +1594,7 @@ apiRouter.get(
 )
 
 apiRouter.get("/datasets.json", async (req) => {
-    await db.knexInstance().transaction(
+    return db.knexInstance().transaction(
         async (trx) => {
             const datasets = await db.knexRaw<Record<string, any>>(
                 `
@@ -1658,7 +1658,7 @@ apiRouter.get("/datasets.json", async (req) => {
 apiRouter.get("/datasets/:datasetId.json", async (req: Request) => {
     const datasetId = expectInt(req.params.datasetId)
 
-    await db.knexInstance().transaction(
+    return db.knexInstance().transaction(
         async (trx) => {
             const dataset = await db.knexRawFirst<Record<string, any>>(
                 `
@@ -2329,7 +2329,7 @@ apiRouter.post("/posts/:postId/unlinkGdoc", async (req: Request) => {
 
 apiRouter.get("/sources/:sourceId.json", async (req: Request) => {
     const sourceId = expectInt(req.params.sourceId)
-    db.knexInstance().transaction(
+    return db.knexInstance().transaction(
         async (trx) => {
             const source = await db.knexRawFirst<Record<string, any>>(
                 `

--- a/adminSiteServer/exportGitData.ts
+++ b/adminSiteServer/exportGitData.ts
@@ -1,14 +1,16 @@
 import * as db from "../db/db.js"
 import { syncDatasetToGitRepo } from "./gitDataExport.js"
-import { Dataset } from "../db/model/Dataset.js"
+import { DbPlainDataset, DatasetsTableName } from "@ourworldindata/types"
 
 const main = async () => {
-    await db.getConnection()
-    for (const dataset of await Dataset.findBy({ namespace: "owid" })) {
+    const knex = db.knexInstance()
+    const datasets = await knex<DbPlainDataset>(DatasetsTableName).where({
+        namespace: "owid",
+    })
+    for (const dataset of datasets) {
         if (!dataset.isPrivate && !dataset.nonRedistributable)
-            await syncDatasetToGitRepo(dataset.id, { commitOnly: true })
+            await syncDatasetToGitRepo(knex, dataset.id, { commitOnly: true })
     }
-    await db.closeTypeOrmAndKnexConnections()
 }
 
 main()

--- a/adminSiteServer/exportGitData.ts
+++ b/adminSiteServer/exportGitData.ts
@@ -11,6 +11,7 @@ const main = async () => {
         if (!dataset.isPrivate && !dataset.nonRedistributable)
             await syncDatasetToGitRepo(knex, dataset.id, { commitOnly: true })
     }
+    await db.closeTypeOrmAndKnexConnections()
 }
 
 main()

--- a/adminSiteServer/gitDataExport.ts
+++ b/adminSiteServer/gitDataExport.ts
@@ -4,7 +4,6 @@ import {
     datasetToCSV,
     datasetToDatapackage,
     getDatasetById,
-    isDatasetWithName,
 } from "../db/model/Dataset.js"
 import {
     GIT_DATASETS_DIR,
@@ -82,9 +81,6 @@ export async function syncDatasetToGitRepo(
     const dataset = await getDatasetById(knex, datasetId)
 
     if (!dataset) throw new JsonError(`No such dataset ${datasetId}`, 404)
-
-    if (!isDatasetWithName(dataset))
-        throw new JsonError(`Dataset ${datasetId} has no name`, 500)
 
     const datasetFilename = filenamify(dataset.name)
 

--- a/adminSiteServer/gitDataExport.ts
+++ b/adminSiteServer/gitDataExport.ts
@@ -1,7 +1,11 @@
 import path from "path"
 import fs from "fs-extra"
-import { Dataset } from "../db/model/Dataset.js"
-import { Source } from "../db/model/Source.js"
+import {
+    datasetToCSV,
+    datasetToDatapackage,
+    getDatasetById,
+    isDatasetWithName,
+} from "../db/model/Dataset.js"
 import {
     GIT_DATASETS_DIR,
     TMP_DIR,
@@ -12,10 +16,16 @@ import * as db from "../db/db.js"
 import filenamify from "filenamify"
 import { execFormatted } from "../db/execWrapper.js"
 import { JsonError } from "@ourworldindata/utils"
+import { DbPlainDataset } from "@ourworldindata/types"
+import { Knex } from "knex"
+import { getSourcesForDataset } from "../db/model/Source.js"
 
-const datasetToReadme = async (dataset: Dataset): Promise<string> => {
+const datasetToReadme = async (
+    knex: Knex<any, any[]>,
+    dataset: DbPlainDataset
+): Promise<string> => {
     // TODO: add origins here
-    const source = await Source.findOneBy({ datasetId: dataset.id })
+    const source = (await getSourcesForDataset(knex, dataset.id))[0]
     return `# ${dataset.name}\n\n${
         (source && source.description && source.description.additionalInfo) ||
         ""
@@ -53,6 +63,7 @@ export async function removeDatasetFromGitRepo(
 }
 
 export async function syncDatasetToGitRepo(
+    knex: Knex<any, any[]>,
     datasetId: number,
     options: {
         transaction?: db.TransactionContext
@@ -68,12 +79,14 @@ export async function syncDatasetToGitRepo(
         ? filenamify(oldDatasetName)
         : undefined
 
-    const datasetRepo = options.transaction
-        ? options.transaction.manager.getRepository(Dataset)
-        : Dataset.getRepository()
+    const dataset = await getDatasetById(knex, datasetId)
 
-    const dataset = await datasetRepo.findOneBy({ id: datasetId })
     if (!dataset) throw new JsonError(`No such dataset ${datasetId}`, 404)
+
+    if (!isDatasetWithName(dataset))
+        throw new JsonError(`Dataset ${datasetId} has no name`, 500)
+
+    const datasetFilename = filenamify(dataset.name)
 
     if (dataset.isPrivate || dataset.nonRedistributable)
         // Private dataset doesn't go in git repo
@@ -98,28 +111,32 @@ export async function syncDatasetToGitRepo(
     }
 
     // Output dataset to temporary directory
-    const tmpDatasetDir = path.join(TMP_DIR, dataset.filename)
+    const tmpDatasetDir = path.join(TMP_DIR, datasetFilename)
     await fs.mkdirp(tmpDatasetDir)
 
     await Promise.all([
         fs.writeFile(
-            path.join(tmpDatasetDir, `${dataset.filename}.csv`),
-            await dataset.toCSV()
+            path.join(tmpDatasetDir, `${datasetFilename}.csv`),
+            await datasetToCSV(knex, dataset.id)
         ),
         fs.writeFile(
             path.join(tmpDatasetDir, `datapackage.json`),
-            JSON.stringify(await dataset.toDatapackage(), null, 2)
+            JSON.stringify(
+                await datasetToDatapackage(knex, dataset.id),
+                null,
+                2
+            )
         ),
         fs.writeFile(
             path.join(tmpDatasetDir, `README.md`),
-            await datasetToReadme(dataset)
+            await datasetToReadme(knex, dataset)
         ),
     ])
 
     const datasetsDir = path.join(repoDir, "datasets")
     await fs.mkdirp(datasetsDir)
 
-    const finalDatasetDir = path.join(datasetsDir, dataset.filename)
+    const finalDatasetDir = path.join(datasetsDir, datasetFilename || "")
     const isNew = !fs.existsSync(finalDatasetDir)
     await execFormatted(`cd %s && rm -rf %s && mv %s %s && git add -A %s`, [
         repoDir,
@@ -129,7 +146,7 @@ export async function syncDatasetToGitRepo(
         finalDatasetDir,
     ])
 
-    if (oldDatasetFilename && oldDatasetFilename !== dataset.filename) {
+    if (oldDatasetFilename && oldDatasetFilename !== datasetFilename) {
         const oldDatasetDir = path.join(datasetsDir, oldDatasetFilename)
         await execFormatted(`cd %s && rm -rf %s && git add -A %s`, [
             repoDir,
@@ -139,8 +156,8 @@ export async function syncDatasetToGitRepo(
     }
 
     const commitMsg = isNew
-        ? `Adding ${dataset.filename}`
-        : `Updating ${dataset.filename}`
+        ? `Adding ${datasetFilename}`
+        : `Updating ${datasetFilename}`
     await execFormatted(
         `cd %s && (git diff-index --quiet HEAD || (git commit -m %s --quiet --author="${
             commitName || GIT_DEFAULT_USERNAME

--- a/db/model/Dataset.ts
+++ b/db/model/Dataset.ts
@@ -10,13 +10,17 @@ import {
 import { Writable } from "stream"
 
 import { User } from "./User.js"
-import { Source } from "./Source.js"
+import { getSourcesForDataset, sourceToDatapackage } from "./Source.js"
 
 import * as db from "../db.js"
-import { slugify } from "@ourworldindata/utils"
-import filenamify from "filenamify"
 import { VariableRow, variableTable, writeVariableCSV } from "./Variable.js"
 import _ from "lodash"
+import {
+    DbPlainDataset,
+    DatasetsTableName,
+    DbPlainTag,
+} from "@ourworldindata/types"
+import { Knex } from "knex"
 
 @Entity("datasets")
 @Unique(["name", "namespace"])
@@ -36,100 +40,126 @@ export class Dataset extends BaseEntity {
 
     @ManyToOne(() => User, (user) => user.createdDatasets)
     createdByUser!: Relation<User>
+}
 
-    // Export dataset variables to CSV (not including metadata)
-    static async writeCSV(datasetId: number, stream: Writable): Promise<void> {
-        // get variables of a dataset
-        const variableIds = (
-            await db.queryMysql(
-                `
-            SELECT
-                id as variableId
+export async function getDatasetById(
+    knex: Knex<any, any[]>,
+    datasetId: number
+): Promise<DbPlainDataset | undefined> {
+    const dataset = await knex<DbPlainDataset>(DatasetsTableName)
+        .where({ id: datasetId })
+        .first()
+    if (!dataset) return undefined
+    return {
+        ...dataset,
+        // for backwards compatibility
+        namespace: dataset.namespace ?? "owid",
+        description: dataset.description ?? "",
+    }
+}
+
+// Export dataset variables to CSV (not including metadata)
+export async function writeDatasetCSV(
+    knex: Knex<any, any[]>,
+    datasetId: number,
+    stream: Writable
+): Promise<void> {
+    // get variables of a dataset
+    const variableIds = (
+        await db.knexRaw<{ variableId: number }>(
+            `SELECT id as variableId
             FROM variables v
             WHERE datasetId=?`,
-                [datasetId]
-            )
-        ).map((row: any) => row.variableId)
-
-        await writeVariableCSV(variableIds, stream)
-    }
-
-    static async setTags(datasetId: number, tagIds: number[]): Promise<void> {
-        await db.transaction(async (t) => {
-            const tagRows = tagIds.map((tagId) => [tagId, datasetId])
-            await t.execute(`DELETE FROM dataset_tags WHERE datasetId=?`, [
-                datasetId,
-            ])
-            if (tagRows.length)
-                await t.execute(
-                    `INSERT INTO dataset_tags (tagId, datasetId) VALUES ?`,
-                    [tagRows]
-                )
-        })
-    }
-
-    async toCSV(): Promise<string> {
-        let csv = ""
-        await Dataset.writeCSV(this.id, {
-            write: (s: string) => (csv += s),
-            end: () => null,
-        } as any)
-        return csv
-    }
-
-    get filename(): string {
-        return filenamify(this.name)
-    }
-
-    get slug(): string {
-        return slugify(this.name)
-    }
-
-    // Return object representing datapackage.json for this dataset
-    async toDatapackage(): Promise<any> {
-        // XXX
-        const sources = await Source.findBy({ datasetId: this.id })
-        const variables = (await db
-            .knexTable(variableTable)
-            .where({ datasetId: this.id })) as VariableRow[]
-        const tags = await db.queryMysql(
-            `SELECT t.id, t.name FROM dataset_tags dt JOIN tags t ON t.id=dt.tagId WHERE dt.datasetId=?`,
-            [this.id]
+            knex,
+            [datasetId]
         )
+    ).map((row) => row.variableId)
 
-        const initialFields = [
-            { name: "Entity", type: "string" },
-            { name: "Year", type: "year" },
-        ]
+    await writeVariableCSV(variableIds, stream)
+}
 
-        const dataPackage = {
-            name: this.name,
-            title: this.name,
-            id: this.id,
-            description:
-                (sources[0] &&
-                    sources[0].description &&
-                    sources[0].description.additionalInfo) ||
-                "",
-            sources: sources.map((s) => s.toDatapackage()),
-            owidTags: tags.map((t: any) => t.name),
-            resources: [
-                {
-                    path: `${this.name}.csv`,
-                    schema: {
-                        fields: initialFields.concat(
-                            variables.map((v) => ({
-                                name: v.name,
-                                type: "any",
-                                description: v.description,
-                                owidDisplaySettings: v.display,
-                            }))
-                        ),
-                    },
+export async function datasetToCSV(
+    knex: Knex<any, any[]>,
+    datasetId: number
+): Promise<string> {
+    let csv = ""
+    await writeDatasetCSV(knex, datasetId, {
+        write: (s: string) => (csv += s),
+        end: () => null,
+    } as any)
+    return csv
+}
+
+export async function setTagsForDataset(
+    knex: Knex<any, any[]>,
+    datasetId: number,
+    tagIds: number[]
+): Promise<void> {
+    await knex.transaction(async (t: Knex<any, any[]>) => {
+        const tagRows = tagIds.map((tagId) => [tagId, datasetId])
+        await t.raw(`DELETE FROM dataset_tags WHERE datasetId=?`, [datasetId])
+        if (tagRows.length)
+            await t.raw(
+                `INSERT INTO dataset_tags (tagId, datasetId) VALUES ?`,
+                [tagRows]
+            )
+    })
+}
+
+// Return object representing datapackage.json for this dataset
+export async function datasetToDatapackage(
+    knex: Knex<any, any[]>,
+    datasetId: number
+): Promise<any> {
+    const datasetName = (await getDatasetById(knex, datasetId))?.name
+    const sources = await getSourcesForDataset(knex, datasetId)
+    const variables = (await db
+        .knexTable(variableTable)
+        .where({ datasetId })) as VariableRow[]
+    const tags = await db.knexRaw<Pick<DbPlainTag, "id" | "name">>(
+        `SELECT t.id, t.name FROM dataset_tags dt JOIN tags t ON t.id=dt.tagId WHERE dt.datasetId=?`,
+        knex,
+        [datasetId]
+    )
+
+    const initialFields = [
+        { name: "Entity", type: "string" },
+        { name: "Year", type: "year" },
+    ]
+
+    const dataPackage = {
+        name: datasetName,
+        title: datasetName,
+        id: datasetId,
+        description:
+            (sources[0] &&
+                sources[0].description &&
+                sources[0].description.additionalInfo) ||
+            "",
+        sources: sources.map((s) => sourceToDatapackage(s)),
+        owidTags: tags.map((t: any) => t.name),
+        resources: [
+            {
+                path: `${datasetName}.csv`,
+                schema: {
+                    fields: initialFields.concat(
+                        variables.map((v) => ({
+                            name: v.name,
+                            type: "any",
+                            description: v.description,
+                            owidDisplaySettings: v.display,
+                        }))
+                    ),
                 },
-            ],
-        }
-
-        return dataPackage
+            },
+        ],
     }
+
+    return dataPackage
+}
+
+export function isDatasetWithName(
+    dataset: DbPlainDataset
+): dataset is DbPlainDataset & { name: NonNullable<DbPlainDataset["name"]> } {
+    return dataset.name !== undefined && dataset.name !== null
 }

--- a/db/model/Dataset.ts
+++ b/db/model/Dataset.ts
@@ -95,12 +95,15 @@ export async function setTagsForDataset(
     datasetId: number,
     tagIds: number[]
 ): Promise<void> {
-    await knex.transaction(async (t: Knex<any, any[]>) => {
+    await knex.transaction(async (trx: Knex<any, any[]>) => {
         const tagRows = tagIds.map((tagId) => [tagId, datasetId])
-        await t.raw(`DELETE FROM dataset_tags WHERE datasetId=?`, [datasetId])
+        await db.knexRaw(`DELETE FROM dataset_tags WHERE datasetId=?`, trx, [
+            datasetId,
+        ])
         if (tagRows.length)
-            await t.raw(
+            await db.knexRaw(
                 `INSERT INTO dataset_tags (tagId, datasetId) VALUES ?`,
+                trx,
                 [tagRows]
             )
     })

--- a/db/model/Dataset.ts
+++ b/db/model/Dataset.ts
@@ -160,9 +160,3 @@ export async function datasetToDatapackage(
 
     return dataPackage
 }
-
-export function isDatasetWithName(
-    dataset: DbPlainDataset
-): dataset is DbPlainDataset & { name: NonNullable<DbPlainDataset["name"]> } {
-    return dataset.name !== undefined && dataset.name !== null
-}

--- a/db/model/Source.ts
+++ b/db/model/Source.ts
@@ -1,4 +1,11 @@
 import { Entity, PrimaryGeneratedColumn, Column, BaseEntity } from "typeorm"
+import { Knex } from "knex"
+import {
+    DbEnrichedSource,
+    DbRawSource,
+    SourcesTableName,
+    parseSourcesRow,
+} from "@ourworldindata/types"
 
 @Entity("sources")
 export class Source extends BaseEntity {
@@ -6,9 +13,47 @@ export class Source extends BaseEntity {
     @Column() datasetId!: number
     @Column() name!: string
     @Column({ default: "{}", type: "json" }) description!: any
+}
 
-    // To datapackage json format
-    toDatapackage(): any {
-        return Object.assign({}, { name: this.name }, this.description)
-    }
+export async function getSourceById(
+    knex: Knex<any, any[]>,
+    sourceId: number
+): Promise<DbEnrichedSource | undefined> {
+    const rawSource: DbRawSource | undefined = await knex<DbRawSource>(
+        SourcesTableName
+    )
+        .where({ id: sourceId })
+        .first()
+    if (!rawSource) return undefined
+    const source = parseSourcesRow({
+        ...rawSource,
+        // for backwards compatibility
+        description: rawSource.description ?? "{}",
+    })
+    return source
+}
+
+export async function getSourcesForDataset(
+    knex: Knex<any, any[]>,
+    datasetId: number
+): Promise<DbEnrichedSource[]> {
+    const rawSources: DbRawSource[] = await knex<DbRawSource>(
+        SourcesTableName
+    ).where({
+        datasetId,
+    })
+    const sources = rawSources.map((rawSource) =>
+        parseSourcesRow({
+            ...rawSource,
+            // for backwards compatibility
+            description: rawSource.description ?? "{}",
+        })
+    )
+    return sources
+}
+
+export async function sourceToDatapackage(
+    source: DbEnrichedSource
+): Promise<any> {
+    return Object.assign({}, { name: source.name }, source.description)
 }

--- a/db/model/Source.ts
+++ b/db/model/Source.ts
@@ -52,8 +52,8 @@ export async function getSourcesForDataset(
     return sources
 }
 
-export async function sourceToDatapackage(
+export function sourceToDatapackage(
     source: DbEnrichedSource
-): Promise<any> {
+): Record<string, any> {
     return Object.assign({}, { name: source.name }, source.description)
 }


### PR DESCRIPTION
- Makes the `Dataset` and `Source` TypeORM classes obsolete by switching db access to knex
- This PR does not do any clean-up, e.g. SQL queries in the router files are not moved, although they ultimately should live in the `db` folder

- I added two helper functions that can be used as drop-in replacements for `queryMysql` and `mysqlFirst` that are often used in our codebase, `knexRaw` and `knexRawFirst` (both live in `db.ts`)

- Routes that I could easily test are tested, but not all of the code is!

@danyx23 let me know if this is how you imagined it, or if I should do anything differently.

@coderabbitai ignore