### PR TITLE
:sparkles: graceful retries of JSON files fetching

### DIFF
--- a/baker/GDriveImagesBaker.tsx
+++ b/baker/GDriveImagesBaker.tsx
@@ -46,12 +46,14 @@ export const bakeDriveImages = async (bakedSiteDir: string) => {
                 localImageEtagPath
             )
 
-            const response = await retryPromise(() =>
-                fetch(remoteFilePath, {
-                    headers: {
-                        "If-None-Match": existingEtag,
-                    },
-                })
+            const response = await retryPromise(
+                () =>
+                    fetch(remoteFilePath, {
+                        headers: {
+                            "If-None-Match": existingEtag,
+                        },
+                    }),
+                { maxRetries: 5, exponentialBackoff: true, initialDelay: 1000 }
             )
 
             // Image has not been modified, skip

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -413,8 +413,9 @@ export const fetchS3DataValuesByPath = async (
     const resp = await retryPromise(
         () => fetch(dataPath, { keepalive: true }),
         {
-            maxRetries: 3,
+            maxRetries: 5,
             exponentialBackoff: true,
+            initialDelay: 1000,
         }
     )
     if (!resp.ok) {

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -434,8 +434,9 @@ export const fetchS3MetadataByPath = async (
     const resp = await retryPromise(
         () => fetch(metadataPath, { keepalive: true }),
         {
-            maxRetries: 3,
+            maxRetries: 5,
             exponentialBackoff: true,
+            initialDelay: 1000,
         }
     )
     if (!resp.ok) {


### PR DESCRIPTION
We're running into 500 errors when building staging servers / production quite often. Currently, we make 3 requests with delays 200ms and 400ms, which is pretty hard on Cloudflare.

This PR changes it to 5 requests with delays 1s, 2s, 4s, 8s. It does the same when fetching images from DigitalOcean Spaces (where we experience errors too).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced the data retrieval stability with increased retry attempts and added delay for exponential backoff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->