### PR TITLE
Migrate Wordpress post rendering

### DIFF
--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -42,7 +42,6 @@ import { getVariableData, getVariableMetadata } from "../db/model/Variable.js"
 import { MultiEmbedderTestPage } from "../site/multiembedder/MultiEmbedderTestPage.js"
 import { JsonError } from "@ourworldindata/utils"
 import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants.js"
-import { isWordpressAPIEnabled } from "../db/wpdb.js"
 import { EXPLORERS_ROUTE_FOLDER } from "../explorer/ExplorerConstants.js"
 import { getExplorerRedirectForPath } from "../explorerAdminServer/ExplorerRedirects.js"
 import { explorerUrlMigrationsById } from "../explorer/urlMigrations/ExplorerUrlMigrations.js"
@@ -259,10 +258,6 @@ mockSiteRouter.get("/latest/page/:pageno", async (req, res) => {
 })
 
 mockSiteRouter.get("/headerMenu.json", async (req, res) => {
-    if (!isWordpressAPIEnabled) {
-        res.status(404).send(await renderNotFoundPage())
-        return
-    }
     res.contentType("application/json")
     res.send(await renderMenuJson())
 })

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -385,6 +385,9 @@ export class SiteBaker {
 
     private async removeDeletedPosts() {
         if (!this.bakeSteps.has("removeDeletedPosts")) return
+
+        await db.getConnection()
+
         const postsApi = await getPosts()
 
         const postSlugs = []

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -71,7 +71,7 @@ import {
     bakeAllPublishedExplorers,
 } from "./ExplorerBaker.js"
 import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer.js"
-import { postsTable } from "../db/model/Post.js"
+import { getPosts, postsTable } from "../db/model/Post.js"
 import { GdocPost } from "../db/model/Gdoc/GdocPost.js"
 import { Image } from "../db/model/Image.js"
 import { generateEmbedSnippet } from "../site/viteUtils.js"
@@ -385,7 +385,7 @@ export class SiteBaker {
 
     private async removeDeletedPosts() {
         if (!this.bakeSteps.has("removeDeletedPosts")) return
-        const postsApi = await wpdb.getPosts()
+        const postsApi = await getPosts()
 
         const postSlugs = []
         for (const postApi of postsApi) {
@@ -415,7 +415,7 @@ export class SiteBaker {
         const alreadyPublishedViaGdocsSlugsSet =
             await db.getSlugsWithPublishedGdocsSuccessors(db.knexInstance())
 
-        const postsApi = await wpdb.getPosts(
+        const postsApi = await getPosts(
             undefined,
             (postrow) => !alreadyPublishedViaGdocsSlugsSet.has(postrow.slug)
         )

--- a/baker/pageOverrides.test.ts
+++ b/baker/pageOverrides.test.ts
@@ -1,24 +1,43 @@
 import {
-    FullPost,
+    DbEnrichedPost,
     WP_PostType,
     extractFormattingOptions,
 } from "@ourworldindata/utils"
+import * as Post from "../db/model/Post.js"
 import * as pageOverrides from "./pageOverrides.js"
 
-const mockCreatePost = (slug: string): FullPost => {
+import { jest } from "@jest/globals"
+
+const mockCreatePost = (slug: string): DbEnrichedPost => {
     return {
         id: 123,
         type: WP_PostType.Post,
         slug: slug,
         title: "",
-        date: new Date(0),
-        modifiedDate: new Date(0),
         authors: [],
         content: "",
+        status: "",
+        isListed: false,
+        published_at: new Date(0),
+        updated_at: new Date(0),
+        updated_at_in_wordpress: new Date(0),
+        gdocSuccessorId: "",
+        excerpt: "",
+        created_at_in_wordpress: new Date(0),
+        featured_image: "",
+        formattingOptions: null,
+        archieml: null,
+        archieml_update_statistics: null,
+        markdown: "",
     }
 }
 
 const forestLandingSlug = "forests-and-deforestation"
+
+const getPostEnrichedBySlug = jest.spyOn(Post, "getPostEnrichedBySlug")
+getPostEnrichedBySlug.mockImplementation((landingSlug) =>
+    Promise.resolve(mockCreatePost(landingSlug))
+)
 
 it("gets parent landing", async () => {
     const formattingOptions = extractFormattingOptions(
@@ -26,10 +45,7 @@ it("gets parent landing", async () => {
     )
 
     await expect(
-        pageOverrides.getLandingOnlyIfParent(
-            mockCreatePost("forest-area"),
-            formattingOptions
-        )
+        pageOverrides.getLandingOnlyIfParent("forest-area", formattingOptions)
     ).resolves.toEqual(mockCreatePost(forestLandingSlug))
 })
 
@@ -39,10 +55,7 @@ it("does not get parent landing (subnavId invalid)", async () => {
     )
 
     await expect(
-        pageOverrides.getLandingOnlyIfParent(
-            mockCreatePost("forest-area"),
-            formattingOptions
-        )
+        pageOverrides.getLandingOnlyIfParent("forest-area", formattingOptions)
     ).resolves.toEqual(undefined)
 })
 
@@ -53,7 +66,7 @@ it("does not get parent landing (post is already a landing)", async () => {
 
     await expect(
         pageOverrides.getLandingOnlyIfParent(
-            mockCreatePost(forestLandingSlug),
+            forestLandingSlug,
             formattingOptions
         )
     ).resolves.toEqual(undefined)
@@ -64,10 +77,11 @@ it("does not get parent landing and logs (landing post not found)", async () => 
         "<!-- formatting-options subnavId:forests subnavCurrentId:forest-area -->"
     )
 
+    getPostEnrichedBySlug.mockImplementationOnce(() =>
+        Promise.resolve(undefined)
+    )
+
     await expect(
-        pageOverrides.getLandingOnlyIfParent(
-            mockCreatePost("forest-area"),
-            formattingOptions
-        )
+        pageOverrides.getLandingOnlyIfParent("forest-area", formattingOptions)
     ).resolves.toEqual(undefined)
 })

--- a/baker/pageOverrides.test.ts
+++ b/baker/pageOverrides.test.ts
@@ -12,7 +12,6 @@ const mockCreatePost = (slug: string): FullPost => {
         id: 123,
         type: WP_PostType.Post,
         slug: slug,
-        path: "",
         title: "",
         date: new Date(0),
         modifiedDate: new Date(0),

--- a/baker/pageOverrides.test.ts
+++ b/baker/pageOverrides.test.ts
@@ -5,8 +5,6 @@ import {
 } from "@ourworldindata/utils"
 import * as pageOverrides from "./pageOverrides.js"
 
-import { jest } from "@jest/globals"
-
 const mockCreatePost = (slug: string): FullPost => {
     return {
         id: 123,
@@ -21,14 +19,6 @@ const mockCreatePost = (slug: string): FullPost => {
 }
 
 const forestLandingSlug = "forests-and-deforestation"
-
-const getPostBySlugLogToSlackNoThrow = jest.spyOn(
-    pageOverrides,
-    "getPostBySlugLogToSlackNoThrow"
-)
-getPostBySlugLogToSlackNoThrow.mockImplementation((landingSlug) =>
-    Promise.resolve(mockCreatePost(landingSlug))
-)
 
 it("gets parent landing", async () => {
     const formattingOptions = extractFormattingOptions(
@@ -72,10 +62,6 @@ it("does not get parent landing (post is already a landing)", async () => {
 it("does not get parent landing and logs (landing post not found)", async () => {
     const formattingOptions = extractFormattingOptions(
         "<!-- formatting-options subnavId:forests subnavCurrentId:forest-area -->"
-    )
-
-    getPostBySlugLogToSlackNoThrow.mockImplementationOnce(() =>
-        Promise.resolve(undefined)
     )
 
     await expect(

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -238,7 +238,7 @@ export const renderPost = async (
 
     const formatted = await formatPost(post, formattingOptions, grapherExports)
 
-    const pageOverrides = await getPageOverrides(post, formattingOptions)
+    const pageOverrides = await getPageOverrides(post.slug, formattingOptions)
     const citationStatus =
         (await isPostCitable(post)) || isPageOverridesCitable(pageOverrides)
 

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -62,7 +62,6 @@ import { CountryProfileSpec } from "../site/countryProfileProjects.js"
 import { formatPost } from "./formatWordpressPost.js"
 import {
     getBlogIndex,
-    getLatestPostRevision,
     isPostCitable,
     getBlockContent,
     getFullPost,
@@ -87,7 +86,11 @@ import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer.
 import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants.js"
 import { ExplorerFullQueryParams } from "../explorer/ExplorerConstants.js"
 import { resolveInternalRedirect } from "./redirects.js"
-import { getPostEnrichedBySlug, postsTable } from "../db/model/Post.js"
+import {
+    getPostEnrichedById,
+    getPostEnrichedBySlug,
+    postsTable,
+} from "../db/model/Post.js"
 import { GdocPost } from "../db/model/Gdoc/GdocPost.js"
 import { logErrorAndMaybeSendToBugsnag } from "../serverUtils/errorLog.js"
 import { GdocFactory } from "../db/model/Gdoc/GdocFactory.js"
@@ -201,8 +204,10 @@ export const renderPageBySlug = async (slug: string) => {
 }
 
 export const renderPreview = async (postId: number): Promise<string> => {
-    const postApi = await getLatestPostRevision(postId)
-    return renderPost(postApi)
+    const post = await getPostEnrichedById(postId)
+    if (!post) throw new JsonError(`No such post: ${postId}`, 404)
+
+    return renderPost(await getFullPost(post))
 }
 
 export const renderMenuJson = async () => {

--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -6,13 +6,13 @@ import {
 } from "../settings/serverSettings.js"
 import { dayjs, countries, queryParamsToStr } from "@ourworldindata/utils"
 import * as db from "../db/db.js"
-import * as wpdb from "../db/wpdb.js"
 import urljoin from "url-join"
 import { countryProfileSpecs } from "../site/countryProfileProjects.js"
 import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer.js"
 import { EXPLORERS_ROUTE_FOLDER } from "../explorer/ExplorerConstants.js"
 import { ExplorerProgram } from "../explorer/ExplorerProgram.js"
 import { GdocPost } from "../db/model/Gdoc/GdocPost.js"
+import { getPosts } from "../db/model/Post.js"
 
 interface SitemapUrl {
     loc: string
@@ -62,7 +62,7 @@ export const makeSitemap = async (explorerAdminServer: ExplorerAdminServer) => {
     const knex = db.knexInstance()
     const alreadyPublishedViaGdocsSlugsSet =
         await db.getSlugsWithPublishedGdocsSuccessors(knex)
-    const postsApi = await wpdb.getPosts(
+    const postsApi = await getPosts(
         undefined,
         (postrow) => !alreadyPublishedViaGdocsSlugsSet.has(postrow.slug)
     )
@@ -92,7 +92,7 @@ export const makeSitemap = async (explorerAdminServer: ExplorerAdminServer) => {
         .concat(
             postsApi.map((p) => ({
                 loc: urljoin(BAKED_BASE_URL, p.slug),
-                lastmod: dayjs(p.modified_gmt).format("YYYY-MM-DD"),
+                lastmod: dayjs(p.updated_at).format("YYYY-MM-DD"),
             }))
         )
         .concat(

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -70,6 +70,16 @@ export const setTagsForPost = async (
 export const getPostRawBySlug = async (
     slug: string
 ): Promise<DbRawPost | undefined> =>
+    // Slugs are not guaranteed to be unique across post types so we are
+    // grabbing the first match in case of duplicates. Here is a query to
+    // get a list of offending slugs:
+
+    // SELECT dup_slugs.slug,
+    // GROUP_CONCAT(p.id ORDER BY p.id) AS post_ids,
+    // GROUP_CONCAT(p.type ORDER BY p.id) AS post_types
+    // FROM ( SELECT slug FROM posts GROUP BY slug HAVING COUNT(*) > 1) AS dup_slugs
+    // JOIN posts p ON dup_slugs.slug = p.slug
+    // GROUP BY dup_slugs.slug;
     (await db.knexTable("posts").where({ slug: slug }))[0]
 
 export const getPostEnrichedBySlug = async (

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -67,6 +67,14 @@ export const setTagsForPost = async (
             )
     })
 
+export const getPostEnrichedById = async (
+    id: number
+): Promise<DbEnrichedPost | undefined> => {
+    const post: DbRawPost = await db.knexTable("posts").where({ id }).first()
+    if (!post) return undefined
+    return parsePostRow(post)
+}
+
 export const getPostRawBySlug = async (
     slug: string
 ): Promise<DbRawPost | undefined> =>

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -106,7 +106,7 @@ export const getPosts = async (
 ): Promise<DbEnrichedPost[]> => {
     const posts: DbRawPost[] = await db
         .knexTable(postsTable)
-        .where("type", "in", [postTypes.join(",")])
+        .where("type", "in", postTypes)
         .andWhere("status", "publish")
 
     // Published pages excluded from public views

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -386,27 +386,6 @@ export const getPostIdAndTypeBySlug = async (
     return { id: rows[0].id, type: rows[0].type }
 }
 
-export const getPostBySlug = async (slug: string): Promise<FullPost> => {
-    // Slugs are not guaranteed to be unique across post types so we are
-    // grabbing the first match in case of duplicates. Here is a query to
-    // get a list of offending slugs:
-
-    // SELECT dup_slugs.slug,
-    // GROUP_CONCAT(p.id ORDER BY p.id) AS post_ids,
-    // GROUP_CONCAT(p.type ORDER BY p.id) AS post_types
-    // FROM ( SELECT slug FROM posts GROUP BY slug HAVING COUNT(*) > 1) AS dup_slugs
-    // JOIN posts p ON dup_slugs.slug = p.slug
-    // GROUP BY dup_slugs.slug;
-
-    const post = await db.mysqlFirst("SELECT * from posts WHERE `slug` = ?", [
-        slug,
-    ])
-
-    if (!post) throw new JsonError(`No page found by slug ${slug}`, 404)
-
-    return getFullPost(post)
-}
-
 // the /revisions endpoint does not send back all the metadata required for
 // the proper rendering of the post (e.g. authors), hence the double request.
 export const getLatestPostRevision = async (id: number): Promise<FullPost> => {

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -649,7 +649,7 @@ export const getFullPost = async (
 ): Promise<FullPost> => {
     const {
         published_at,
-        updated_at,
+        updated_at_in_wordpress,
         authors,
         excerpt,
         type,
@@ -657,12 +657,16 @@ export const getFullPost = async (
         id,
         featured_image,
     } = postApi
-    if (!updated_at) throw new Error("Missing required fields in postApi")
+
+    if (!updated_at_in_wordpress)
+        throw new Error(
+            "Missing required updated_at_in_wordpress field in postApi"
+        )
 
     return {
         ...postApi,
-        date: published_at || updated_at,
-        modifiedDate: updated_at,
+        date: published_at || updated_at_in_wordpress,
+        modifiedDate: updated_at_in_wordpress,
         authors: authors ?? [],
         excerpt: excerpt ?? undefined,
         imageUrl: featured_image ?? `${BAKED_BASE_URL}/default-thumbnail.jpg`,

--- a/packages/@ourworldindata/types/src/domainTypes/Posts.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Posts.ts
@@ -29,7 +29,6 @@ export interface IndexPost {
 
 export interface FullPost extends IndexPost {
     id: number
-    path: string
     content: string
     thumbnailUrl?: string
     imageId?: number

--- a/packages/@ourworldindata/types/src/wordpressTypes/WordpressTypes.ts
+++ b/packages/@ourworldindata/types/src/wordpressTypes/WordpressTypes.ts
@@ -1,3 +1,5 @@
+import { DbRawPost } from "../dbTypes/Posts.js"
+
 export enum WP_PostType {
     Post = "post",
     Page = "page",
@@ -51,7 +53,7 @@ export interface PostRestApi {
     }
 }
 
-export type FilterFnPostRestApi = (post: PostRestApi) => boolean
+export type FilterFnPostRestApi = (post: DbRawPost) => boolean
 
 export enum WP_ColumnStyle {
     StickyRight = "sticky-right",


### PR DESCRIPTION
⚠️ This PR should not be merged as-is, but is a foundational step towards baking from the grapher DB.

This PR swaps the data source for the rendering of Wordpress posts from the Wordpress API to the synced grapher DB.

This change aims to be as surgical as possible, but still touches a lot of rendering code, including the
sitemap, algolia, blog index, country profiles, post previews and post rendering.

The next steps will be centered around the render functions in `formatWordpressPost()`, e.g. `renderProminentLinks()`, which relied on PHP code that is not part of the rendering pipeline anymore (e.g. `prominent-link.php`)

Note: I kept `getFullPost` and `getPostRowEnriched` separate but we could imagine merging them. I didn't want to propagate getFullPost edge cases to the parts of the codebase already relying on getPostRowEnriched. If this overall approach seems promising, we might decide to spend more time on refactoring for clarity, although the   opportunity cost needs to be carefully weighed given the expected temporary and frozen nature of this part of the codebase.

- [x] update owid-staging WP DB (used by staging-site servers)
- [x] [blog index](https://ourworldindata.org/latest): manually compare pages 1, 10 and 19
- [x] sitemap: live and staging sitemaps are identical
- [x] country profile: all render fine (with the caveat mentioned above about PHP rendering)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced post retrieval and rendering processes for better performance and accuracy.
- **Bug Fixes**
	- Fixed issues related to post data handling and rendering, ensuring more reliable content display.
- **Refactor**
	- Updated post data model and types for improved clarity and consistency across the application.
	- Streamlined post fetching and enrichment logic to enhance system efficiency.
- **Chores**
	- Removed outdated code and dependencies to maintain a clean and efficient codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->