### PR TITLE
:hammer: (db) migrate Pageview to knex

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -58,6 +58,7 @@ import {
     DbRawVariable,
     DbRawOrigin,
     parseOriginsRow,
+    AnalyticsPageviewsTableName,
 } from "@ourworldindata/types"
 import {
     getVariableDataRoute,
@@ -67,7 +68,6 @@ import { getDatasetById, setTagsForDataset } from "../db/model/Dataset.js"
 import { User } from "../db/model/User.js"
 import { GdocPost } from "../db/model/Gdoc/GdocPost.js"
 import { GdocBase, Tag as TagEntity } from "../db/model/Gdoc/GdocBase.js"
-import { Pageview } from "../db/model/Pageview.js"
 import {
     syncDatasetToGitRepo,
     removeDatasetFromGitRepo,
@@ -480,9 +480,14 @@ apiRouter.get(
         ).then((chart) => chart?.config?.slug)
         if (!slug) return {}
 
-        const pageviewsByUrl = await Pageview.findOneBy({
-            url: `https://ourworldindata.org/grapher/${slug}`,
-        })
+        const pageviewsByUrl = await db.knexRawFirst(
+            "select * from ?? where url = ?",
+            db.knexInstance(),
+            [
+                AnalyticsPageviewsTableName,
+                `https://ourworldindata.org/grapher/${slug}`,
+            ]
+        )
 
         return {
             pageviews: pageviewsByUrl ?? undefined,

--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -5,7 +5,7 @@ import { isPathRedirectedToExplorer } from "../../explorerAdminServer/ExplorerRe
 import { ChartRecord, SearchIndexName } from "../../site/search/searchTypes.js"
 import { KeyChartLevel, OwidGdocLinkType, isNil } from "@ourworldindata/utils"
 import { MarkdownTextWrap } from "@ourworldindata/components"
-import { Pageview } from "../../db/model/Pageview.js"
+import { getAnalyticsPageviewsByUrlObj } from "../../db/model/Pageview.js"
 import { Link } from "../../db/model/Link.js"
 import { getRelatedArticles } from "../../db/model/Post.js"
 import { Knex } from "knex"
@@ -59,7 +59,7 @@ const getChartsRecords = async (
         )
     }
 
-    const pageviews = await Pageview.getViewsByUrlObj()
+    const pageviews = await getAnalyticsPageviewsByUrlObj(knex)
 
     const records: ChartRecord[] = []
     for (const c of chartsToIndex) {

--- a/baker/algolia/indexExplorersToAlgolia.ts
+++ b/baker/algolia/indexExplorersToAlgolia.ts
@@ -9,7 +9,7 @@ import {
 import { getAlgoliaClient } from "./configureAlgolia.js"
 import * as db from "../../db/db.js"
 import { ALGOLIA_INDEXING } from "../../settings/serverSettings.js"
-import { Pageview } from "../../db/model/Pageview.js"
+import { getAnalyticsPageviewsByUrlObj } from "../../db/model/Pageview.js"
 import { chunkParagraphs } from "../chunk.js"
 import { SearchIndexName } from "../../site/search/searchTypes.js"
 import { Chart } from "../../db/model/Chart.js"
@@ -112,7 +112,7 @@ function getNullishJSONValueAsPlaintext(value: string): string {
 }
 
 const getExplorerRecords = async (): Promise<ExplorerRecord[]> => {
-    const pageviews = await Pageview.getViewsByUrlObj()
+    const pageviews = await getAnalyticsPageviewsByUrlObj(db.knexInstance())
 
     // Fetch info about all charts used in explorers, as linked by the explorer_charts table
     const graphersUsedInExplorers = await db

--- a/baker/algolia/indexExplorersToAlgolia.ts
+++ b/baker/algolia/indexExplorersToAlgolia.ts
@@ -13,6 +13,7 @@ import { getAnalyticsPageviewsByUrlObj } from "../../db/model/Pageview.js"
 import { chunkParagraphs } from "../chunk.js"
 import { SearchIndexName } from "../../site/search/searchTypes.js"
 import { Chart } from "../../db/model/Chart.js"
+import { Knex } from "knex"
 
 type ExplorerBlockColumns = {
     type: "columns"
@@ -111,16 +112,19 @@ function getNullishJSONValueAsPlaintext(value: string): string {
     return value !== "null" ? cheerio.load(value)("body").text() : ""
 }
 
-const getExplorerRecords = async (): Promise<ExplorerRecord[]> => {
-    const pageviews = await getAnalyticsPageviewsByUrlObj(db.knexInstance())
+const getExplorerRecords = async (
+    knex: Knex<any, any[]>
+): Promise<ExplorerRecord[]> => {
+    const pageviews = await getAnalyticsPageviewsByUrlObj(knex)
 
     // Fetch info about all charts used in explorers, as linked by the explorer_charts table
     const graphersUsedInExplorers = await db
-        .queryMysql(
+        .knexRaw<{ chartId: number }>(
             `
         SELECT DISTINCT chartId
         FROM explorer_charts
-        `
+        `,
+            knex
         )
         .then((results: { chartId: number }[]) =>
             results.map(({ chartId }) => chartId)
@@ -129,7 +133,7 @@ const getExplorerRecords = async (): Promise<ExplorerRecord[]> => {
         .then((charts) => keyBy(charts, "id"))
 
     const explorerRecords = await db
-        .queryMysql(
+        .knexRaw<Omit<ExplorerEntry, "views_7d">>(
             `
     SELECT slug,
         COALESCE(config->>"$.explorerSubtitle", "null")     AS subtitle,
@@ -137,9 +141,10 @@ const getExplorerRecords = async (): Promise<ExplorerRecord[]> => {
         COALESCE(config->>"$.blocks", "null")               AS blocks
     FROM explorers
     WHERE isPublished = true
-    `
+    `,
+            knex
         )
-        .then((results: ExplorerEntry[]) =>
+        .then((results) =>
             results.flatMap(({ slug, title, subtitle, blocks }) => {
                 const textFromExplorer = extractTextFromExplorer(
                     blocks,
@@ -190,8 +195,8 @@ const indexExplorersToAlgolia = async () => {
     try {
         const index = client.initIndex(SearchIndexName.Explorers)
 
-        await db.getConnection()
-        const records = await getExplorerRecords()
+        const knex = db.knexInstance()
+        const records = await getExplorerRecords(knex)
         await index.replaceAllObjects(records)
 
         await db.closeTypeOrmAndKnexConnections()

--- a/baker/algolia/indexToAlgolia.tsx
+++ b/baker/algolia/indexToAlgolia.tsx
@@ -22,7 +22,7 @@ import {
     PageType,
     SearchIndexName,
 } from "../../site/search/searchTypes.js"
-import { Pageview } from "../../db/model/Pageview.js"
+import { getAnalyticsPageviewsByUrlObj } from "../../db/model/Pageview.js"
 import { GdocPost } from "../../db/model/Gdoc/GdocPost.js"
 import { ArticleBlocks } from "../../site/gdocs/components/ArticleBlocks.js"
 import React from "react"
@@ -196,7 +196,7 @@ function generateGdocRecords(
 
 // Generate records for countries, WP posts (not including posts that have been succeeded by Gdocs equivalents), and Gdocs
 const getPagesRecords = async (knex: Knex<any, any[]>) => {
-    const pageviews = await Pageview.getViewsByUrlObj()
+    const pageviews = await getAnalyticsPageviewsByUrlObj(db.knexInstance())
     const gdocs = await GdocPost.getPublishedGdocs()
     const publishedGdocsBySlug = keyBy(gdocs, "slug")
     // TODO: the knex instance should be handed down as a parameter

--- a/baker/algolia/indexToAlgolia.tsx
+++ b/baker/algolia/indexToAlgolia.tsx
@@ -196,12 +196,12 @@ function generateGdocRecords(
 
 // Generate records for countries, WP posts (not including posts that have been succeeded by Gdocs equivalents), and Gdocs
 const getPagesRecords = async (knex: Knex<any, any[]>) => {
-    const pageviews = await getAnalyticsPageviewsByUrlObj(db.knexInstance())
+    const pageviews = await getAnalyticsPageviewsByUrlObj(knex)
     const gdocs = await GdocPost.getPublishedGdocs()
     const publishedGdocsBySlug = keyBy(gdocs, "slug")
     // TODO: the knex instance should be handed down as a parameter
     const slugsWithPublishedGdocsSuccessors =
-        await db.getSlugsWithPublishedGdocsSuccessors(db.knexInstance())
+        await db.getSlugsWithPublishedGdocsSuccessors(knex)
     const postsApi = await getPostsFromSnapshots(knex, undefined, (post) => {
         // Two things can happen here:
         // 1. There's a published Gdoc with the same slug

--- a/db/model/Pageview.ts
+++ b/db/model/Pageview.ts
@@ -1,6 +1,12 @@
 import { keyBy } from "lodash"
 import { Entity, Column, BaseEntity } from "typeorm"
 import { RawPageview } from "@ourworldindata/utils"
+import * as db from "../db.js"
+import { Knex } from "knex"
+import {
+    DbPlainAnalyticsPageview,
+    AnalyticsPageviewsTableName,
+} from "@ourworldindata/types"
 
 @Entity("analytics_pageviews")
 export class Pageview extends BaseEntity implements RawPageview {
@@ -18,13 +24,23 @@ export class Pageview extends BaseEntity implements RawPageview {
     @Column() views_14d!: number
     /** Sum of pageviews over the last 365 days. */
     @Column() views_365d!: number
+}
 
-    static async getViewsByUrlObj(): Promise<{ [url: string]: RawPageview }> {
-        const pageviews = await Pageview.find()
+export async function getAnalyticsPageviewsByUrlObj(
+    knex: Knex<any, any[]>
+): Promise<{
+    [url: string]: DbPlainAnalyticsPageview
+}> {
+    const pageviews = await db.knexRaw<DbPlainAnalyticsPageview>(
+        "SELECT * FROM ??",
+        knex,
+        [AnalyticsPageviewsTableName]
+    )
 
-        // Normalize URLs to be relative to the root of the site.
-        // This also filters out any URLs that don't start with ourworldindata.org.
-        const pageviewsNormalized: RawPageview[] = pageviews.flatMap((p) => {
+    // Normalize URLs to be relative to the root of the site.
+    // This also filters out any URLs that don't start with ourworldindata.org.
+    const pageviewsNormalized = pageviews.flatMap(
+        (p: DbPlainAnalyticsPageview) => {
             if (p.url.startsWith("https://ourworldindata.org/"))
                 return [
                     {
@@ -36,8 +52,8 @@ export class Pageview extends BaseEntity implements RawPageview {
                     },
                 ]
             else return []
-        })
+        }
+    )
 
-        return keyBy(pageviewsNormalized, (p) => p.url)
-    }
+    return keyBy(pageviewsNormalized, (p) => p.url)
 }


### PR DESCRIPTION
- Makes the `Pageview` TypeORM class obsolete by switching db access to knex
- This PR does not do any clean-up, e.g. SQL queries in the router files are not moved, although they ultimately should live in the `db` folder


@coderabbitai ignore