### PR TITLE
(wp) add listed col for posts

### DIFF
--- a/db/migration/1706263030308-AddListedToPosts.ts
+++ b/db/migration/1706263030308-AddListedToPosts.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddListedToPosts1706263030308 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE posts ADD COLUMN isListed BOOLEAN NOT NULL DEFAULT FALSE;
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE posts DROP COLUMN isListed;
+        `)
+    }
+}

--- a/packages/@ourworldindata/types/src/dbTypes/Posts.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Posts.ts
@@ -14,6 +14,7 @@ export interface DbInsertPost {
     slug: string
     type: WP_PostType
     status: string
+    isListed: boolean
     content: string
     published_at?: Date | null
     updated_at?: Date | null


### PR DESCRIPTION
This PR adds a new field to the `posts` table - `isListed` - which is used to determine whether a post should be shown in the blog index, in the newsletter, and on the homepage. It is mirroring the `owid_publication_context_meta_field` meta field in the Wordpress database.

To get a list of all posts that are "listed" (and published), you can run the following query:

```
select * from wp_posts
where post_status="publish"
and id in (
    select post_id from wp_postmeta
    where meta_key = "owid_publication_context_meta_field"
    and meta_value = 'a:3:{s:20:"immediate_newsletter";b:1;s:8:"homepage";b:1;s:6:"latest";b:1;}'
)
```

Only posts should be returned, since the `owid_publication_context_meta_field` meta field is only available for posts.

This PR also adds support for `isListed` in both `syncPostsToGrapher` (run manually when necessary to sync all WP posts to the grapher DB) and `postUpdatedHook` (running the same sync for a single post automatically on post save)