### PR TITLE
🔨 make name on datasets mandatory

### DIFF
--- a/db/migration/1706317870929-DatasetsFieldNameMandatory.ts
+++ b/db/migration/1706317870929-DatasetsFieldNameMandatory.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class DatasetsFieldNameMandatory1706317870929
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // The name field is nullable in the DB schema but null is never used in the values in the DB,
+        // so it's better to make it mandatory in the DB schema.
+        await queryRunner.query(
+            `ALTER TABLE datasets MODIFY COLUMN name VARCHAR(512) NOT NULL`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE datasets MODIFY COLUMN name VARCHAR(512)`
+        )
+    }
+}

--- a/packages/@ourworldindata/types/src/dbTypes/Datasets.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Datasets.ts
@@ -10,7 +10,7 @@ export interface DbInsertDataset {
     isPrivate?: number
     metadataEditedAt: Date
     metadataEditedByUserId: number
-    name?: string | null
+    name: string
     namespace: string
     nonRedistributable?: number
     shortName?: string | null


### PR DESCRIPTION
This PR changes the `datasets` table so that the `name` column is no longer nullable. Null values were never used in this column and it's nicer if the column types match the content exactly.