### PR TITLE
:hammer: log errors from Data API

### DIFF
--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -425,7 +425,16 @@ export const fetchS3DataValuesByPath = async (
             } ${await resp.text()}`
         )
     }
-    return resp.json()
+    try {
+        return await resp.json()
+    } catch (error: any) {
+        // Handle the case where the response is not valid JSON
+        throw new Error(
+            `Error parsing JSON from response for ${dataPath}: ${
+                error.message
+            }\nResponse Body: ${await resp.text()}`
+        )
+    }
 }
 
 export const fetchS3MetadataByPath = async (

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -428,10 +428,11 @@ export const fetchS3DataValuesByPath = async (
     try {
         return await resp.json()
     } catch (error: any) {
-        // Handle the case where the response is not valid JSON
         throw new Error(
             `Error parsing JSON from response for ${dataPath}: ${
                 error.message
+            }\nStatus Code: ${resp.status} ${
+                resp.statusText
             }\nResponse Body: ${await resp.text()}`
         )
     }
@@ -455,7 +456,17 @@ export const fetchS3MetadataByPath = async (
             } ${resp.statusText} ${await resp.text()}`
         )
     }
-    return resp.json()
+    try {
+        return await resp.json()
+    } catch (error: any) {
+        throw new Error(
+            `Error parsing JSON from response for ${metadataPath}: ${
+                error.message
+            }\nStatus Code: ${resp.status} ${
+                resp.statusText
+            }\nResponse Body: ${await resp.text()}`
+        )
+    }
 }
 
 export const createDataFrame = (data: unknown): pl.DataFrame => {


### PR DESCRIPTION
We get these kinds of errors in baking
```
bake grapher page [] 5/4467 0.3s 14/s 308.8s Baked chart absolute-change-co2
  | 2024-01-29 09:10:34 CEST |  
  | 2024-01-29 09:10:34 CEST | SyntaxError: Unexpected token < in JSON at position 0
  | 2024-01-29 09:10:34 CEST | at JSON.parse (<anonymous>)
  | 2024-01-29 09:10:34 CEST | at parseJSONFromBytes (node:internal/deps/undici/undici:6571:19)
  | 2024-01-29 09:10:34 CEST | at successSteps (node:internal/deps/undici/undici:6545:27)
  | 2024-01-29 09:10:34 CEST | at node:internal/deps/undici/undici:1211:60
  | 2024-01-29 09:10:34 CEST | at node:internal/process/task_queues:140:7
  | 2024-01-29 09:10:34 CEST | at AsyncResource.runInAsyncScope (node:async_hooks:203:9)
  | 2024-01-29 09:10:34 CEST | at AsyncResource.runMicrotask (node:internal/process/task_queues:137:8)
  | 2024-01-29 09:10:34 CEST | at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
  | 2024-01-29 09:10:35 CEST | 🚨 Error: The command exited with status 1
```
This PR makes it more informative. If we find it's expected, we can add it to the retry logic to make baking more stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in data fetching to gracefully manage non-JSON responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->