### PR TITLE
🎉 (dod) support dods in axis labels

### DIFF
--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -11,6 +11,7 @@ import {
     type RawPageview,
     Topic,
     PostReference,
+    DimensionProperty,
 } from "@ourworldindata/utils"
 import { computed, observable, runInAction, when } from "mobx"
 import { BAKED_GRAPHER_URL } from "../settings/clientSettings.js"
@@ -92,6 +93,10 @@ export type FieldWithDetailReferences =
 
 export type DetailReferences = Record<FieldWithDetailReferences, string[]>
 
+export interface DimensionErrorMessages {
+    displayName?: string
+}
+
 export interface ChartEditorManager {
     admin: Admin
     grapher: Grapher
@@ -104,6 +109,10 @@ export interface ChartEditorManager {
     details: DetailDictionary
     invalidDetailReferences: DetailReferences
     errorMessages: Partial<Record<FieldWithDetailReferences, string>>
+    errorMessagesForDimensions: Record<
+        DimensionProperty,
+        DimensionErrorMessages[]
+    >
 }
 
 interface VariableIdUsageRecord {

--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -84,6 +84,14 @@ export class EditorDatabase {
     }
 }
 
+export type FieldWithDetailReferences =
+    | "subtitle"
+    | "note"
+    | "axisLabelX"
+    | "axisLabelY"
+
+export type DetailReferences = Record<FieldWithDetailReferences, string[]>
+
 export interface ChartEditorManager {
     admin: Admin
     grapher: Grapher
@@ -94,7 +102,8 @@ export interface ChartEditorManager {
     pageviews?: RawPageview
     allTopics: Topic[]
     details: DetailDictionary
-    invalidDetailReferences: Record<"subtitle" | "note", string[]>
+    invalidDetailReferences: DetailReferences
+    errorMessages: Partial<Record<FieldWithDetailReferences, string>>
 }
 
 interface VariableIdUsageRecord {

--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -93,7 +93,7 @@ export type FieldWithDetailReferences =
 
 export type DetailReferences = Record<FieldWithDetailReferences, string[]>
 
-export interface DimensionErrorMessages {
+export interface DimensionErrorMessage {
     displayName?: string
 }
 
@@ -111,7 +111,7 @@ export interface ChartEditorManager {
     errorMessages: Partial<Record<FieldWithDetailReferences, string>>
     errorMessagesForDimensions: Record<
         DimensionProperty,
-        DimensionErrorMessages[]
+        DimensionErrorMessage[]
     >
 }
 

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -291,19 +291,14 @@ export class ChartEditorPage
 
     @computed
     get invalidDetailReferences(): ChartEditorManager["invalidDetailReferences"] {
-        const { currentDetailReferences } = this
-        const keys = getIndexableKeys(currentDetailReferences)
-
-        const invalidDetailReferences = Object.fromEntries(
-            keys.map((key: FieldWithDetailReferences) => [
-                key,
-                currentDetailReferences[key].filter(
-                    (term: string) => !this.details[term]
-                ),
-            ])
-        ) as DetailReferences
-
-        return invalidDetailReferences
+        const { subtitle, note, axisLabelX, axisLabelY } =
+            this.currentDetailReferences
+        return {
+            subtitle: subtitle.filter((term) => !this.details[term]),
+            note: note.filter((term) => !this.details[term]),
+            axisLabelX: axisLabelX.filter((term) => !this.details[term]),
+            axisLabelY: axisLabelY.filter((term) => !this.details[term]),
+        }
     }
 
     @computed get errorMessages(): ChartEditorManager["errorMessages"] {

--- a/adminSiteClient/DimensionCard.tsx
+++ b/adminSiteClient/DimensionCard.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { observable, computed, action } from "mobx"
 import { observer } from "mobx-react"
 import { ChartDimension } from "@ourworldindata/grapher"
-import { ChartEditor, DimensionErrorMessages } from "./ChartEditor.js"
+import { ChartEditor, DimensionErrorMessage } from "./ChartEditor.js"
 import { Toggle, BindAutoString, BindAutoFloat, ColorBox } from "./Forms.js"
 import { Link } from "./Link.js"
 import {
@@ -23,7 +23,7 @@ export class DimensionCard extends React.Component<{
     onChange: (dimension: ChartDimension) => void
     onEdit?: () => void
     onRemove?: () => void
-    errorMessages?: DimensionErrorMessages
+    errorMessage?: DimensionErrorMessage
 }> {
     @observable.ref isExpanded: boolean = false
 
@@ -150,7 +150,7 @@ export class DimensionCard extends React.Component<{
                             store={dimension.display}
                             auto={column.displayName}
                             onBlur={this.onChange}
-                            errorMessage={this.props.errorMessages?.displayName}
+                            errorMessage={this.props.errorMessage?.displayName}
                         />
                         <BindAutoString
                             label="Unit of measurement"

--- a/adminSiteClient/DimensionCard.tsx
+++ b/adminSiteClient/DimensionCard.tsx
@@ -14,7 +14,6 @@ import {
 } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { OwidTable } from "@ourworldindata/core-table"
-import { makeDetailIdFromText } from "@ourworldindata/utils"
 
 @observer
 export class DimensionCard extends React.Component<{
@@ -151,12 +150,6 @@ export class DimensionCard extends React.Component<{
                             store={dimension.display}
                             auto={column.displayName}
                             onBlur={this.onChange}
-                            helpText={`Detail: ${makeDetailIdFromText({
-                                text:
-                                    dimension.display.name ??
-                                    column.displayName,
-                                type: "indicator",
-                            })}`}
                             errorMessage={this.props.errorMessages?.displayName}
                         />
                         <BindAutoString

--- a/adminSiteClient/DimensionCard.tsx
+++ b/adminSiteClient/DimensionCard.tsx
@@ -14,6 +14,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { OwidTable } from "@ourworldindata/core-table"
+import { makeDetailIdFromText } from "@ourworldindata/utils"
 
 @observer
 export class DimensionCard extends React.Component<{
@@ -149,6 +150,12 @@ export class DimensionCard extends React.Component<{
                             store={dimension.display}
                             auto={column.displayName}
                             onBlur={this.onChange}
+                            helpText={`Detail: ${makeDetailIdFromText({
+                                text:
+                                    dimension.display.name ??
+                                    column.displayName,
+                                type: "indicator",
+                            })}`}
                         />
                         <BindAutoString
                             label="Unit of measurement"

--- a/adminSiteClient/DimensionCard.tsx
+++ b/adminSiteClient/DimensionCard.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { observable, computed, action } from "mobx"
 import { observer } from "mobx-react"
 import { ChartDimension } from "@ourworldindata/grapher"
-import { ChartEditor } from "./ChartEditor.js"
+import { ChartEditor, DimensionErrorMessages } from "./ChartEditor.js"
 import { Toggle, BindAutoString, BindAutoFloat, ColorBox } from "./Forms.js"
 import { Link } from "./Link.js"
 import {
@@ -24,6 +24,7 @@ export class DimensionCard extends React.Component<{
     onChange: (dimension: ChartDimension) => void
     onEdit?: () => void
     onRemove?: () => void
+    errorMessages?: DimensionErrorMessages
 }> {
     @observable.ref isExpanded: boolean = false
 
@@ -156,6 +157,7 @@ export class DimensionCard extends React.Component<{
                                     column.displayName,
                                 type: "indicator",
                             })}`}
+                            errorMessage={this.props.errorMessages?.displayName}
                         />
                         <BindAutoString
                             label="Unit of measurement"

--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -25,7 +25,7 @@ import {
 } from "@ourworldindata/utils"
 import { FieldsRow, Section, SelectField, Toggle } from "./Forms.js"
 import { VariableSelector } from "./VariableSelector.js"
-import { ChartEditor } from "./ChartEditor.js"
+import { ChartEditor, ChartEditorManager } from "./ChartEditor.js"
 import { DimensionCard } from "./DimensionCard.js"
 import {
     DragDropContext,
@@ -45,6 +45,11 @@ class DimensionSlotView extends React.Component<{
 
     private get grapher() {
         return this.props.editor.grapher
+    }
+
+    @computed
+    get errorMessages(): ChartEditorManager["errorMessagesForDimensions"] {
+        return this.props.editor.manager.errorMessagesForDimensions
     }
 
     @action.bound private onAddVariables(variableIds: OwidVariableId[]) {
@@ -228,6 +233,11 @@ class DimensionSlotView extends React.Component<{
                                                     }
                                                     isDndEnabled={
                                                         this.isDndEnabled
+                                                    }
+                                                    errorMessages={
+                                                        this.errorMessages[
+                                                            slot.property
+                                                        ][index]
                                                     }
                                                 />
                                             </div>

--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -234,7 +234,7 @@ class DimensionSlotView extends React.Component<{
                                                     isDndEnabled={
                                                         this.isDndEnabled
                                                     }
-                                                    errorMessages={
+                                                    errorMessage={
                                                         this.errorMessages[
                                                             slot.property
                                                         ][index]

--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -448,6 +448,10 @@ class ComparisonLineSection extends React.Component<{ editor: ChartEditor }> {
 export class EditorCustomizeTab extends React.Component<{
     editor: ChartEditor
 }> {
+    @computed get errorMessages() {
+        return this.props.editor.manager.errorMessages
+    }
+
     render() {
         const xAxisConfig = this.props.editor.grapher.xAxis
         const yAxisConfig = this.props.editor.grapher.yAxis
@@ -516,6 +520,7 @@ export class EditorCustomizeTab extends React.Component<{
                                 label="Label"
                                 field="label"
                                 store={yAxisConfig}
+                                errorMessage={this.errorMessages.axisLabelY}
                             />
                         )}
                     </Section>
@@ -579,6 +584,7 @@ export class EditorCustomizeTab extends React.Component<{
                                 label="Label"
                                 field="label"
                                 store={xAxisConfig}
+                                errorMessage={this.errorMessages.axisLabelX}
                             />
                         )}
                     </Section>

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -291,7 +291,7 @@ export class EditorExportTab extends React.Component<EditorExportTabProps> {
                             }
                         />
                     )}
-                    {this.originalGrapher.detailsOrderedByReference.size >
+                    {this.originalGrapher.detailsOrderedByReference.length >
                         0 && (
                         <Toggle
                             label="Details on demand"

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -15,7 +15,7 @@ import { observer } from "mobx-react"
 import React from "react"
 import Select from "react-select"
 import { TOPICS_CONTENT_GRAPH } from "../settings/clientSettings.js"
-import { ChartEditor } from "./ChartEditor.js"
+import { ChartEditor, ChartEditorManager } from "./ChartEditor.js"
 import {
     AutoTextField,
     BindAutoString,
@@ -74,7 +74,7 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
         grapher.hideAnnotationFieldsInTitle.changeInPrefix = value || undefined
     }
 
-    @computed get errorMessages() {
+    @computed get errorMessages(): ChartEditorManager["errorMessages"] {
         return this.props.editor.manager.errorMessages
     }
 

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -9,7 +9,7 @@ import {
     Grapher,
     getErrorMessageRelatedQuestionUrl,
 } from "@ourworldindata/grapher"
-import { getIndexableKeys, slugify } from "@ourworldindata/utils"
+import { slugify } from "@ourworldindata/utils"
 import { action, computed, runInAction } from "mobx"
 import { observer } from "mobx-react"
 import React from "react"
@@ -75,20 +75,7 @@ export class EditorTextTab extends React.Component<{ editor: ChartEditor }> {
     }
 
     @computed get errorMessages() {
-        const { invalidDetailReferences } = this.props.editor.manager
-        const keys = getIndexableKeys(invalidDetailReferences)
-
-        const errorMessages: Partial<Record<(typeof keys)[number], string>> = {}
-
-        keys.forEach((key) => {
-            const references = invalidDetailReferences[key]
-            if (references.length) {
-                errorMessages[
-                    key
-                ] = `Invalid detail(s) specified: ${references.join(", ")}`
-            }
-        })
-        return errorMessages
+        return this.props.editor.manager.errorMessages
     }
 
     @computed get showAnyAnnotationFieldInTitleToggle() {

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -781,6 +781,7 @@ export class BindAutoString<
     auto: string
     label?: string
     helpText?: string
+    errorMessage?: string
     softCharacterLimit?: number
     onBlur?: () => void
 }> {

--- a/adminSiteClient/SaveButtons.tsx
+++ b/adminSiteClient/SaveButtons.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { ChartEditor } from "./ChartEditor.js"
 import { action, computed } from "mobx"
 import { observer } from "mobx-react"
+import { isEmpty } from "@ourworldindata/utils"
 
 @observer
 export class SaveButtons extends React.Component<{ editor: ChartEditor }> {
@@ -23,21 +24,12 @@ export class SaveButtons extends React.Component<{ editor: ChartEditor }> {
         const { editor } = this.props
         const { errorMessages, errorMessagesForDimensions } = editor.manager
 
-        for (const message of Object.values(errorMessages)) {
-            if (message) return true
-        }
+        if (!isEmpty(errorMessages)) return true
 
-        for (const slot of Object.values(errorMessagesForDimensions)) {
-            for (const dimension of slot) {
-                if (!dimension) continue
-                const messages = Object.values(dimension).filter(
-                    (message) => message
-                )
-                if (messages.length > 0) return true
-            }
-        }
-
-        return false
+        const allErrorMessagesForDimensions = Object.values(
+            errorMessagesForDimensions
+        ).flat()
+        return allErrorMessagesForDimensions.some((error) => error)
     }
 
     render() {

--- a/adminSiteClient/SaveButtons.tsx
+++ b/adminSiteClient/SaveButtons.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { ChartEditor } from "./ChartEditor.js"
-import { action } from "mobx"
+import { action, computed } from "mobx"
 import { observer } from "mobx-react"
 
 @observer
@@ -19,15 +19,33 @@ export class SaveButtons extends React.Component<{ editor: ChartEditor }> {
         else this.props.editor.publishGrapher()
     }
 
+    @computed get hasEditingErrors(): boolean {
+        const { editor } = this.props
+        const { errorMessages, errorMessagesForDimensions } = editor.manager
+
+        for (const message of Object.values(errorMessages)) {
+            if (message) return true
+        }
+
+        for (const slot of Object.values(errorMessagesForDimensions)) {
+            for (const dimension of slot) {
+                if (!dimension) continue
+                const messages = Object.values(dimension).filter(
+                    (message) => message
+                )
+                if (messages.length > 0) return true
+            }
+        }
+
+        return false
+    }
+
     render() {
+        const { hasEditingErrors } = this
         const { editor } = this.props
         const { grapher } = editor
-        const detailErrorsCount = Object.values(
-            editor.manager.invalidDetailReferences
-        ).reduce((acc, curr) => acc + curr.length, 0)
-        const hasDetailErrors = detailErrorsCount > 0
 
-        const isSavingDisabled = grapher.hasFatalErrors || hasDetailErrors
+        const isSavingDisabled = grapher.hasFatalErrors || hasEditingErrors
 
         return (
             <div className="SaveButtons">

--- a/adminSiteClient/SaveButtons.tsx
+++ b/adminSiteClient/SaveButtons.tsx
@@ -22,10 +22,10 @@ export class SaveButtons extends React.Component<{ editor: ChartEditor }> {
     render() {
         const { editor } = this.props
         const { grapher } = editor
-        const hasDetailErrors = Boolean(
-            editor.manager.invalidDetailReferences.subtitle.length ||
-                editor.manager.invalidDetailReferences.note.length
-        )
+        const detailErrorsCount = Object.values(
+            editor.manager.invalidDetailReferences
+        ).reduce((acc, curr) => acc + curr.length, 0)
+        const hasDetailErrors = detailErrorsCount > 0
 
         const isSavingDisabled = grapher.hasFatalErrors || hasDetailErrors
 

--- a/functions/_common/grapherRenderer.ts
+++ b/functions/_common/grapherRenderer.ts
@@ -168,7 +168,7 @@ async function fetchAndRenderGrapherToSvg({
     const promises = []
     promises.push(grapher.downloadLegacyDataFromOwidVariableIds())
 
-    if (options.details && grapher.detailsOrderedByReference.size) {
+    if (options.details && grapher.detailsOrderedByReference.length) {
         promises.push(
             await fetch("https://ourworldindata.org/dods.json")
                 .then((r) => r.json())

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
@@ -516,7 +516,7 @@ type MarkdownTextWrapProps = {
     lineHeight?: number
     maxWidth?: number
     style?: CSSProperties
-    detailsOrderedByReference?: Set<string>
+    detailsOrderedByReference?: string[]
 }
 
 export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
@@ -558,8 +558,8 @@ export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
         text = text.replaceAll("@@LINEBREAK@@", "  \n")
         return text
     }
-    @computed get detailsOrderedByReference(): Set<string> {
-        return this.props.detailsOrderedByReference || new Set()
+    @computed get detailsOrderedByReference(): string[] {
+        return this.props.detailsOrderedByReference || []
     }
 
     @computed get plaintext(): string {
@@ -1060,7 +1060,7 @@ function convertMarkdownNodeToIRTokens(
 
 function appendReferenceNumbers(
     tokens: IRToken[],
-    references: Set<string>
+    references: string[]
 ): IRToken[] {
     function traverse(token: IRToken, callback: (token: IRToken) => any): any {
         if (token instanceof IRElement) {
@@ -1073,7 +1073,7 @@ function appendReferenceNumbers(
         traverse(token, (token: IRToken) => {
             if (token instanceof IRDetailOnDemand) {
                 const referenceIndex =
-                    [...references].findIndex((term) => term === token.term) + 1
+                    references.findIndex((term) => term === token.term) + 1
                 if (referenceIndex === 0) return token
                 token.children.push(
                     new IRSuperscript(String(referenceIndex), token.fontParams)

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
@@ -14,7 +14,7 @@ import {
     dropRightWhile,
     cloneDeep,
 } from "@ourworldindata/utils"
-import { DodMarker } from "@ourworldindata/types"
+import { DetailsMarker } from "@ourworldindata/types"
 import { TextWrap } from "../TextWrap/TextWrap.js"
 import fromMarkdown from "mdast-util-from-markdown"
 import type { Root, Content } from "mdast"
@@ -640,8 +640,13 @@ export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
     renderSVG(
         x: number,
         y: number,
-        options?: React.SVGProps<SVGTextElement>,
-        dodMarker: DodMarker = "superscript"
+        {
+            textProps,
+            dodMarker = "superscript",
+        }: {
+            textProps?: React.SVGProps<SVGTextElement>
+            dodMarker?: DetailsMarker
+        } = {}
     ): JSX.Element | null {
         const { fontSize, lineHeight } = this
         const lines =
@@ -670,7 +675,7 @@ export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
                     x={x.toFixed(1)}
                     y={yOffset.toFixed(1)}
                     style={this.style}
-                    {...options}
+                    {...textProps}
                 >
                     {lines.map((line, lineIndex) => (
                         <tspan
@@ -702,7 +707,7 @@ export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
                                         strokeWidth={1}
                                         strokeDasharray={1}
                                         // important for rotated text
-                                        transform={options?.transform}
+                                        transform={textProps?.transform}
                                     />
                                 ) : null
                             currWidth += token.width

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
@@ -642,15 +642,15 @@ export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
         y: number,
         {
             textProps,
-            dodMarker = "superscript",
+            detailsMarker = "superscript",
         }: {
             textProps?: React.SVGProps<SVGTextElement>
-            dodMarker?: DetailsMarker
+            detailsMarker?: DetailsMarker
         } = {}
     ): JSX.Element | null {
         const { fontSize, lineHeight } = this
         const lines =
-            dodMarker === "superscript"
+            detailsMarker === "superscript"
                 ? this.svgLinesWithDodReferenceNumbers
                 : this.svgLines
         if (lines.length === 0) return null
@@ -690,7 +690,7 @@ export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
                     ))}
                 </text>
                 {/* SVG doesn't support dotted underlines, so we draw them manually */}
-                {dodMarker === "underline" &&
+                {detailsMarker === "underline" &&
                     lines.map((line, lineIndex) => {
                         const y = (getLineY(lineIndex) + 2).toFixed(1)
                         let currWidth = 0

--- a/packages/@ourworldindata/components/src/TextWrap/TextWrap.tsx
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrap.tsx
@@ -240,9 +240,8 @@ export class TextWrap {
     render(
         x: number,
         y: number,
-        options?: React.SVGProps<SVGTextElement>
+        { textProps }: { textProps?: React.SVGProps<SVGTextElement> } = {}
     ): JSX.Element | null {
-        //React.SVGAttributes<SVGTextElement>) {
         const { props, lines, fontSize, fontWeight, lineHeight } = this
 
         if (lines.length === 0) return null
@@ -263,7 +262,7 @@ export class TextWrap {
                 fontWeight={fontWeight}
                 x={x.toFixed(1)}
                 y={yOffset.toFixed(1)}
-                {...options}
+                {...textProps}
             >
                 {lines.map((line, i) => {
                     if (props.rawHtml)

--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -21,8 +21,8 @@ import {
     ValueRange,
     cloneDeep,
 } from "@ourworldindata/utils"
-import { AxisConfig } from "./AxisConfig"
-import { TextWrap } from "@ourworldindata/components"
+import { AxisConfig, AxisManager } from "./AxisConfig"
+import { MarkdownTextWrap } from "@ourworldindata/components"
 import { ColumnTypeMap, CoreColumn } from "@ourworldindata/core-table"
 import { GRAPHER_FONT_SCALE_12 } from "../core/GrapherConstants.js"
 
@@ -61,6 +61,7 @@ const boundsFromLabelPlacement = (label: TickLabelPlacement): Bounds => {
 
 abstract class AbstractAxis {
     config: AxisConfig
+    axisManager?: AxisManager
 
     @observable.ref domain: ValueRange
     @observable formatColumn?: CoreColumn // Pass the column purely for formatting reasons. Might be a better way to do this.
@@ -69,9 +70,10 @@ abstract class AbstractAxis {
     @observable private _scaleType?: ScaleType
     @observable private _label?: string
 
-    constructor(config: AxisConfig) {
+    constructor(config: AxisConfig, axisManager?: AxisManager) {
         this.config = config
         this.domain = [config.domain[0], config.domain[1]]
+        this.axisManager = axisManager
     }
 
     /**
@@ -426,14 +428,16 @@ abstract class AbstractAxis {
         return GRAPHER_FONT_SCALE_12 * this.fontSize
     }
 
-    @computed get labelTextWrap(): TextWrap | undefined {
+    @computed get labelTextWrap(): MarkdownTextWrap | undefined {
         const text = this.label
         return text
-            ? new TextWrap({
+            ? new MarkdownTextWrap({
                   maxWidth: this.labelWidth,
                   fontSize: this.labelFontSize,
                   text,
                   lineHeight: 1,
+                  detailsOrderedByReference:
+                      this.axisManager?.detailsOrderedByReference,
               })
             : undefined
     }
@@ -441,7 +445,7 @@ abstract class AbstractAxis {
 
 export class HorizontalAxis extends AbstractAxis {
     clone(): HorizontalAxis {
-        return new HorizontalAxis(this.config)._update(this)
+        return new HorizontalAxis(this.config, this.axisManager)._update(this)
     }
 
     @computed get orient(): Position {
@@ -558,7 +562,7 @@ export class HorizontalAxis extends AbstractAxis {
 
 export class VerticalAxis extends AbstractAxis {
     clone(): VerticalAxis {
-        return new VerticalAxis(this.config)._update(this)
+        return new VerticalAxis(this.config, this.axisManager)._update(this)
     }
 
     @computed get orient(): Position {

--- a/packages/@ourworldindata/grapher/src/axis/AxisConfig.ts
+++ b/packages/@ourworldindata/grapher/src/axis/AxisConfig.ts
@@ -17,8 +17,9 @@ import {
     Tickmark,
 } from "@ourworldindata/types"
 
-export interface FontSizeManager {
+export interface AxisManager {
     fontSize: number
+    detailsOrderedByReference?: Set<string>
 }
 
 class AxisConfigDefaults implements AxisConfigInterface {
@@ -45,16 +46,13 @@ export class AxisConfig
     extends AxisConfigDefaults
     implements AxisConfigInterface, Persistable
 {
-    constructor(
-        props?: AxisConfigInterface,
-        fontSizeManager?: FontSizeManager
-    ) {
+    constructor(props?: AxisConfigInterface, axisManager?: AxisManager) {
         super()
         this.updateFromObject(props)
-        this.fontSizeManager = fontSizeManager
+        this.axisManager = axisManager
     }
 
-    fontSizeManager?: FontSizeManager
+    axisManager?: AxisManager
 
     // todo: test/refactor
     updateFromObject(props?: AxisConfigInterface): void {
@@ -88,7 +86,7 @@ export class AxisConfig
     }
 
     @computed get fontSize(): number {
-        return this.fontSizeManager?.fontSize || BASE_FONT_SIZE
+        return this.axisManager?.fontSize || BASE_FONT_SIZE
     }
 
     // A log scale domain cannot have values <= 0, so we double check here
@@ -119,10 +117,10 @@ export class AxisConfig
     // Convert axis configuration to a finalized axis spec by supplying
     // any needed information calculated from the data
     toHorizontalAxis(): HorizontalAxis {
-        return new HorizontalAxis(this)
+        return new HorizontalAxis(this, this.axisManager)
     }
 
     toVerticalAxis(): VerticalAxis {
-        return new VerticalAxis(this)
+        return new VerticalAxis(this, this.axisManager)
     }
 }

--- a/packages/@ourworldindata/grapher/src/axis/AxisConfig.ts
+++ b/packages/@ourworldindata/grapher/src/axis/AxisConfig.ts
@@ -19,7 +19,7 @@ import {
 
 export interface AxisManager {
     fontSize: number
-    detailsOrderedByReference?: Set<string>
+    detailsOrderedByReference?: string[]
 }
 
 class AxisConfigDefaults implements AxisConfigInterface {

--- a/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
+++ b/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
@@ -157,7 +157,7 @@ interface DualAxisViewProps {
     labelColor?: string
     tickColor?: string
     lineWidth?: number
-    dodMarker?: DetailsMarker
+    detailsMarker?: DetailsMarker
 }
 
 @observer
@@ -169,7 +169,7 @@ export class DualAxisComponent extends React.Component<DualAxisViewProps> {
             labelColor,
             tickColor,
             lineWidth,
-            dodMarker,
+            detailsMarker,
         } = this.props
         const { bounds, horizontalAxis, verticalAxis, innerBounds } = dualAxis
 
@@ -195,7 +195,7 @@ export class DualAxisComponent extends React.Component<DualAxisViewProps> {
                 verticalAxis={verticalAxis}
                 labelColor={labelColor}
                 tickColor={tickColor}
-                dodMarker={dodMarker}
+                detailsMarker={detailsMarker}
             />
         )
 
@@ -208,7 +208,7 @@ export class DualAxisComponent extends React.Component<DualAxisViewProps> {
                 labelColor={labelColor}
                 tickColor={tickColor}
                 tickMarkWidth={lineWidth}
-                dodMarker={dodMarker}
+                detailsMarker={detailsMarker}
             />
         )
 
@@ -229,10 +229,10 @@ export class VerticalAxisComponent extends React.Component<{
     verticalAxis: VerticalAxis
     labelColor?: string
     tickColor?: string
-    dodMarker?: DetailsMarker
+    detailsMarker?: DetailsMarker
 }> {
     render(): JSX.Element {
-        const { bounds, verticalAxis, labelColor, tickColor, dodMarker } =
+        const { bounds, verticalAxis, labelColor, tickColor, detailsMarker } =
             this.props
         const { tickLabels, labelTextWrap } = verticalAxis
 
@@ -247,7 +247,7 @@ export class VerticalAxisComponent extends React.Component<{
                                 transform: "rotate(-90)",
                                 fill: labelColor || GRAPHER_DARK_TEXT,
                             },
-                            dodMarker,
+                            detailsMarker,
                         }
                     )}
                 {tickLabels.map((label, i) => {
@@ -285,7 +285,7 @@ export class HorizontalAxisComponent extends React.Component<{
     labelColor?: string
     tickColor?: string
     tickMarkWidth?: number
-    dodMarker?: DetailsMarker
+    detailsMarker?: DetailsMarker
 }> {
     @computed get scaleType(): ScaleType {
         return this.props.axis.scaleType
@@ -312,7 +312,7 @@ export class HorizontalAxisComponent extends React.Component<{
             labelColor,
             tickColor,
             tickMarkWidth,
-            dodMarker,
+            detailsMarker,
         } = this.props
         const { tickLabels, labelTextWrap: label, labelOffset, orient } = axis
         const horizontalAxisLabelsOnTop = orient === Position.top
@@ -348,7 +348,7 @@ export class HorizontalAxisComponent extends React.Component<{
                             textProps: {
                                 fill: labelColor || GRAPHER_DARK_TEXT,
                             },
-                            dodMarker,
+                            detailsMarker,
                         }
                     )}
                 {tickMarks}

--- a/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
+++ b/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
@@ -13,7 +13,7 @@ import {
 import { VerticalAxis, HorizontalAxis, DualAxis } from "./Axis"
 import classNames from "classnames"
 import { GRAPHER_DARK_TEXT } from "../core/GrapherConstants"
-import { ScaleType, DodMarker } from "@ourworldindata/types"
+import { ScaleType, DetailsMarker } from "@ourworldindata/types"
 
 const dasharrayFromFontSize = (fontSize: number): string => {
     const dashLength = Math.round((fontSize / 16) * 3)
@@ -157,7 +157,7 @@ interface DualAxisViewProps {
     labelColor?: string
     tickColor?: string
     lineWidth?: number
-    dodMarker?: DodMarker
+    dodMarker?: DetailsMarker
 }
 
 @observer
@@ -229,7 +229,7 @@ export class VerticalAxisComponent extends React.Component<{
     verticalAxis: VerticalAxis
     labelColor?: string
     tickColor?: string
-    dodMarker?: DodMarker
+    dodMarker?: DetailsMarker
 }> {
     render(): JSX.Element {
         const { bounds, verticalAxis, labelColor, tickColor, dodMarker } =
@@ -243,10 +243,12 @@ export class VerticalAxisComponent extends React.Component<{
                         -verticalAxis.rangeCenter - labelTextWrap.width / 2,
                         bounds.left,
                         {
-                            transform: "rotate(-90)",
-                            fill: labelColor || GRAPHER_DARK_TEXT,
-                        },
-                        dodMarker
+                            textProps: {
+                                transform: "rotate(-90)",
+                                fill: labelColor || GRAPHER_DARK_TEXT,
+                            },
+                            dodMarker,
+                        }
                     )}
                 {tickLabels.map((label, i) => {
                     const { y, xAlign, yAlign, formattedValue } = label
@@ -283,7 +285,7 @@ export class HorizontalAxisComponent extends React.Component<{
     labelColor?: string
     tickColor?: string
     tickMarkWidth?: number
-    dodMarker?: DodMarker
+    dodMarker?: DetailsMarker
 }> {
     @computed get scaleType(): ScaleType {
         return this.props.axis.scaleType
@@ -342,8 +344,12 @@ export class HorizontalAxisComponent extends React.Component<{
                     label.renderSVG(
                         axis.rangeCenter - label.width / 2,
                         labelYPosition,
-                        { fill: labelColor || GRAPHER_DARK_TEXT },
-                        dodMarker
+                        {
+                            textProps: {
+                                fill: labelColor || GRAPHER_DARK_TEXT,
+                            },
+                            dodMarker,
+                        }
                     )}
                 {tickMarks}
                 {tickLabels.map((label, i) => {

--- a/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
+++ b/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
@@ -13,7 +13,7 @@ import {
 import { VerticalAxis, HorizontalAxis, DualAxis } from "./Axis"
 import classNames from "classnames"
 import { GRAPHER_DARK_TEXT } from "../core/GrapherConstants"
-import { ScaleType } from "@ourworldindata/types"
+import { ScaleType, DodMarker } from "@ourworldindata/types"
 
 const dasharrayFromFontSize = (fontSize: number): string => {
     const dashLength = Math.round((fontSize / 16) * 3)
@@ -157,13 +157,20 @@ interface DualAxisViewProps {
     labelColor?: string
     tickColor?: string
     lineWidth?: number
+    dodMarker?: DodMarker
 }
 
 @observer
 export class DualAxisComponent extends React.Component<DualAxisViewProps> {
     render(): JSX.Element {
-        const { dualAxis, showTickMarks, labelColor, tickColor, lineWidth } =
-            this.props
+        const {
+            dualAxis,
+            showTickMarks,
+            labelColor,
+            tickColor,
+            lineWidth,
+            dodMarker,
+        } = this.props
         const { bounds, horizontalAxis, verticalAxis, innerBounds } = dualAxis
 
         const verticalGridlines = verticalAxis.hideGridlines ? null : (
@@ -188,6 +195,7 @@ export class DualAxisComponent extends React.Component<DualAxisViewProps> {
                 verticalAxis={verticalAxis}
                 labelColor={labelColor}
                 tickColor={tickColor}
+                dodMarker={dodMarker}
             />
         )
 
@@ -200,6 +208,7 @@ export class DualAxisComponent extends React.Component<DualAxisViewProps> {
                 labelColor={labelColor}
                 tickColor={tickColor}
                 tickMarkWidth={lineWidth}
+                dodMarker={dodMarker}
             />
         )
 
@@ -220,21 +229,24 @@ export class VerticalAxisComponent extends React.Component<{
     verticalAxis: VerticalAxis
     labelColor?: string
     tickColor?: string
+    dodMarker?: DodMarker
 }> {
     render(): JSX.Element {
-        const { bounds, verticalAxis, labelColor, tickColor } = this.props
+        const { bounds, verticalAxis, labelColor, tickColor, dodMarker } =
+            this.props
         const { tickLabels, labelTextWrap } = verticalAxis
 
         return (
             <g className="VerticalAxis">
                 {labelTextWrap &&
-                    labelTextWrap.render(
+                    labelTextWrap.renderSVG(
                         -verticalAxis.rangeCenter - labelTextWrap.width / 2,
                         bounds.left,
                         {
                             transform: "rotate(-90)",
                             fill: labelColor || GRAPHER_DARK_TEXT,
-                        }
+                        },
+                        dodMarker
                     )}
                 {tickLabels.map((label, i) => {
                     const { y, xAlign, yAlign, formattedValue } = label
@@ -271,6 +283,7 @@ export class HorizontalAxisComponent extends React.Component<{
     labelColor?: string
     tickColor?: string
     tickMarkWidth?: number
+    dodMarker?: DodMarker
 }> {
     @computed get scaleType(): ScaleType {
         return this.props.axis.scaleType
@@ -297,6 +310,7 @@ export class HorizontalAxisComponent extends React.Component<{
             labelColor,
             tickColor,
             tickMarkWidth,
+            dodMarker,
         } = this.props
         const { tickLabels, labelTextWrap: label, labelOffset, orient } = axis
         const horizontalAxisLabelsOnTop = orient === Position.top
@@ -325,10 +339,11 @@ export class HorizontalAxisComponent extends React.Component<{
         return (
             <g className="HorizontalAxis">
                 {label &&
-                    label.render(
+                    label.renderSVG(
                         axis.rangeCenter - label.width / 2,
                         labelYPosition,
-                        { fill: labelColor || GRAPHER_DARK_TEXT }
+                        { fill: labelColor || GRAPHER_DARK_TEXT },
+                        dodMarker
                     )}
                 {tickMarks}
                 {tickLabels.map((label, i) => {

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -43,7 +43,7 @@ import {
     HorizontalAxisZeroLine,
 } from "../axis/AxisViews"
 import { NoDataModal } from "../noDataModal/NoDataModal"
-import { AxisConfig, FontSizeManager } from "../axis/AxisConfig"
+import { AxisConfig, AxisManager } from "../axis/AxisConfig"
 import { ColorSchemes } from "../color/ColorSchemes"
 import { ChartInterface } from "../chart/ChartInterface"
 import {
@@ -102,7 +102,7 @@ export class DiscreteBarChart
         bounds?: Bounds
         manager: DiscreteBarChartManager
     }>
-    implements ChartInterface, FontSizeManager, ColorScaleManager
+    implements ChartInterface, AxisManager, ColorScaleManager
 {
     base: React.RefObject<SVGGElement> = React.createRef()
 

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -556,7 +556,9 @@ export class StaticCaptionedChart extends CaptionedChart {
                     {this.manager.detailRenderers.map((detail, i) => {
                         previousOffset = yOffset
                         yOffset += detail.height + STATIC_EXPORT_DETAIL_SPACING
-                        return detail.renderSVG(0, previousOffset, { key: i })
+                        return detail.renderSVG(0, previousOffset, {
+                            textProps: { key: i },
+                        })
                     })}
                 </g>
             </>

--- a/packages/@ourworldindata/grapher/src/chart/ChartInterface.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartInterface.ts
@@ -49,4 +49,7 @@ export interface ChartInterface {
      * Does not necessarily contain FacetStrategy.None -- there are situations where an unfaceted chart doesn't make sense.
      */
     availableFacetStrategies?: FacetStrategy[]
+
+    currentVerticalAxisLabel?: string
+    currentHorizontalAxisLabel?: string
 }

--- a/packages/@ourworldindata/grapher/src/chart/ChartInterface.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartInterface.ts
@@ -50,6 +50,6 @@ export interface ChartInterface {
      */
     availableFacetStrategies?: FacetStrategy[]
 
-    currentVerticalAxisLabel?: string
-    currentHorizontalAxisLabel?: string
+    defaultYAxisLabel?: string
+    defaultXAxisLabel?: string
 }

--- a/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
@@ -96,6 +96,6 @@ export interface ChartManager {
     isStaticAndSmall?: boolean
     secondaryColorInStaticCharts?: string
 
-    detailsOrderedByReference?: Set<string>
+    detailsOrderedByReference?: string[]
     detailsMarkerInSvg?: DetailsMarker
 }

--- a/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
@@ -10,7 +10,7 @@ import {
     AxisConfigInterface,
     ColorSchemeName,
     EntityName,
-    DodMarker,
+    DetailsMarker,
 } from "@ourworldindata/types"
 import { TooltipManager } from "../tooltip/TooltipProps"
 import { OwidTable, CoreColumn } from "@ourworldindata/core-table"
@@ -97,5 +97,5 @@ export interface ChartManager {
     secondaryColorInStaticCharts?: string
 
     detailsOrderedByReference?: Set<string>
-    detailsMarkerInSvg?: DodMarker
+    detailsMarkerInSvg?: DetailsMarker
 }

--- a/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
@@ -10,6 +10,7 @@ import {
     AxisConfigInterface,
     ColorSchemeName,
     EntityName,
+    DodMarker,
 } from "@ourworldindata/types"
 import { TooltipManager } from "../tooltip/TooltipProps"
 import { OwidTable, CoreColumn } from "@ourworldindata/core-table"
@@ -94,4 +95,7 @@ export interface ChartManager {
     isNarrow?: boolean
     isStaticAndSmall?: boolean
     secondaryColorInStaticCharts?: string
+
+    detailsOrderedByReference?: Set<string>
+    detailsMarkerInSvg?: DodMarker
 }

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -65,7 +65,6 @@ import {
     compact,
     getOriginAttributionFragments,
     sortBy,
-    makeDetailIdFromText,
     extractDetailsFromSyntax,
 } from "@ourworldindata/utils"
 import {
@@ -1262,24 +1261,38 @@ export class Grapher
     @computed get detailsOrderedByReference(): string[] {
         if (typeof window === "undefined") return []
 
-        // if a custom axis label is given, extract details from it;
-        // otherwise, check if a detail exists for the default axis label
-        function extractDetailsFromAxisLabel(
-            configLabel?: string,
-            defaultLabel?: string
-        ): string[] {
-            if (configLabel) {
-                return extractDetailsFromSyntax(configLabel)
-            } else if (defaultLabel) {
-                return [
-                    makeDetailIdFromText({
-                        text: defaultLabel,
-                        type: "indicator",
-                    }),
-                ]
-            }
-            return []
-        }
+        // We are toying with the idea of automatically looking for a detail with a specific prefix
+        // (e.g. grapher_indicator_per-capita-emissions) when an indicator name is used as the default axis label.
+        // This feature is disabled for now, but we might want to enable it in the future.
+        //
+        // // if a custom axis label is given, extract details from it;
+        // // otherwise, check if a detail exists for the default axis label
+        // function extractDetailsFromAxisLabel(
+        //     configLabel?: string,
+        //     defaultLabel?: string
+        // ): string[] {
+        //     if (configLabel) {
+        //         return extractDetailsFromSyntax(configLabel)
+        //     } else if (defaultLabel) {
+        //         return [
+        //             makeDetailIdFromText({
+        //                 text: defaultLabel,
+        //                 type: "indicator",
+        //             }),
+        //         ]
+        //     }
+        //     return []
+        // }
+        //
+        // // extract details from axis labels
+        // const yAxisDetails = extractDetailsFromAxisLabel(
+        //     this.yAxisConfig.label,
+        //     this.defaultYAxisLabel
+        // )
+        // const xAxisDetails = extractDetailsFromAxisLabel(
+        //     this.xAxisConfig.label,
+        //     this.defaultXAxisLabel
+        // )
 
         // extract details from supporting text
         const subtitleDetails = !this.hideSubtitle
@@ -1290,13 +1303,11 @@ export class Grapher
             : []
 
         // extract details from axis labels
-        const yAxisDetails = extractDetailsFromAxisLabel(
-            this.yAxisConfig.label,
-            this.defaultYAxisLabel
+        const yAxisDetails = extractDetailsFromSyntax(
+            this.yAxisConfig.label || ""
         )
-        const xAxisDetails = extractDetailsFromAxisLabel(
-            this.xAxisConfig.label,
-            this.defaultXAxisLabel
+        const xAxisDetails = extractDetailsFromSyntax(
+            this.xAxisConfig.label || ""
         )
 
         // text fragments are ordered by appearance

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -66,7 +66,7 @@ import {
     compact,
     getOriginAttributionFragments,
     sortBy,
-    excludeNull,
+    excludeNullish,
 } from "@ourworldindata/utils"
 import {
     MarkdownTextWrap,
@@ -1254,11 +1254,11 @@ export class Grapher
 
     // Used for superscript numbers in static exports
     @computed get detailsOrderedByReference(): Set<string> {
-        const textInOrderOfAppearance = excludeNull([
-            this.currentSubtitle,
+        const textInOrderOfAppearance = excludeNullish([
+            !this.hideSubtitle ? this.currentSubtitle : null,
             this.currentVerticalAxisLabel,
             this.currentHorizontalAxisLabel,
-            this.note,
+            !this.hideNote ? this.note : null,
         ]).join()
         const details = textInOrderOfAppearance.matchAll(
             new RegExp(detailOnDemandRegex, "g")

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1262,22 +1262,14 @@ export class Grapher
     @computed get detailsOrderedByReference(): string[] {
         if (typeof window === "undefined") return []
 
-        function extractDetailIdsFromText(
-            text: string,
-            isHidden = false
-        ): string[] {
-            if (isHidden) return []
-            return extractDetailsFromSyntax(text)
-        }
-
-        // if a custom axis label is given, extract details from text.
+        // if a custom axis label is given, extract details from it;
         // otherwise, check if a detail exists for the default axis label
-        function extractDetailIdsFromAxisLabel(
+        function extractDetailsFromAxisLabel(
             configLabel?: string,
             defaultLabel?: string
         ): string[] {
             if (configLabel) {
-                return extractDetailIdsFromText(configLabel)
+                return extractDetailsFromSyntax(configLabel)
             } else if (defaultLabel) {
                 return [
                     makeDetailIdFromText({
@@ -1289,37 +1281,38 @@ export class Grapher
             return []
         }
 
-        // extract detail from supporting text
-        const subtitleDetailIds = extractDetailIdsFromText(
-            this.currentSubtitle,
-            this.hideSubtitle
-        )
-        const noteDetailIds = extractDetailIdsFromText(this.note, this.hideNote)
+        // extract details from supporting text
+        const subtitleDetails = !this.hideSubtitle
+            ? extractDetailsFromSyntax(this.currentSubtitle)
+            : []
+        const noteDetails = !this.hideNote
+            ? extractDetailsFromSyntax(this.note)
+            : []
 
         // extract details from axis labels
-        const yAxisDetailIds = extractDetailIdsFromAxisLabel(
+        const yAxisDetails = extractDetailsFromAxisLabel(
             this.yAxisConfig.label,
             this.defaultYAxisLabel
         )
-        const xAxisDetailIds = extractDetailIdsFromAxisLabel(
+        const xAxisDetails = extractDetailsFromAxisLabel(
             this.xAxisConfig.label,
             this.defaultXAxisLabel
         )
 
-        // should be ordered by appearance
-        const uniqueDetailIds = uniq([
-            ...subtitleDetailIds,
-            ...yAxisDetailIds,
-            ...xAxisDetailIds,
-            ...noteDetailIds,
+        // text fragments are ordered by appearance
+        const uniqueDetails = uniq([
+            ...subtitleDetails,
+            ...yAxisDetails,
+            ...xAxisDetails,
+            ...noteDetails,
         ])
 
-        const validDetailIds = uniqueDetailIds.filter((detailId: string) => {
+        const validDetails = uniqueDetails.filter((detailId: string) => {
             const detail = window.details?.[detailId]
             return detail !== undefined
         })
 
-        return validDetailIds
+        return validDetails
     }
 
     @computed get detailsMarkerInSvg(): DetailsMarker {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -101,7 +101,7 @@ import {
     ColorSchemeName,
     AxisConfigInterface,
     GrapherStaticFormat,
-    DodMarker,
+    DetailsMarker,
 } from "@ourworldindata/types"
 import {
     BlankOwidTable,
@@ -1270,7 +1270,7 @@ export class Grapher
         return uniqueDetails
     }
 
-    @computed get detailsMarkerInSvg(): DodMarker {
+    @computed get detailsMarkerInSvg(): DetailsMarker {
         const { isStatic, shouldIncludeDetailsInStaticExport } = this
         return !isStatic
             ? "underline"

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -292,10 +292,7 @@ export class Footer<
             maxWidth: this.noteMaxWidth,
             fontSize,
             lineHeight,
-            detailsOrderedByReference:
-                manager.shouldIncludeDetailsInStaticExport
-                    ? manager.detailsOrderedByReference
-                    : new Set(),
+            detailsOrderedByReference: manager.detailsOrderedByReference,
         })
     }
 
@@ -773,7 +770,8 @@ export class StaticFooter extends Footer<StaticFooterProps> {
                 {this.showNote &&
                     note.renderSVG(
                         targetX,
-                        targetY + sources.height + this.verticalPadding
+                        targetY + sources.height + this.verticalPadding,
+                        { dodMarker: this.manager.detailsMarkerInSvg }
                     )}
                 {showLicenseNextToSources
                     ? licenseAndOriginUrl.render(

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -771,7 +771,7 @@ export class StaticFooter extends Footer<StaticFooterProps> {
                     note.renderSVG(
                         targetX,
                         targetY + sources.height + this.verticalPadding,
-                        { dodMarker: this.manager.detailsMarkerInSvg }
+                        { detailsMarker: this.manager.detailsMarkerInSvg }
                     )}
                 {showLicenseNextToSources
                     ? licenseAndOriginUrl.render(

--- a/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
+++ b/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
@@ -1,5 +1,5 @@
 import { TooltipManager } from "../tooltip/TooltipProps"
-import { GrapherInterface } from "@ourworldindata/types"
+import { GrapherInterface, DetailsMarker } from "@ourworldindata/types"
 import { ActionButtonsManager } from "../controls/ActionButtons"
 
 export interface FooterManager extends TooltipManager, ActionButtonsManager {
@@ -23,4 +23,5 @@ export interface FooterManager extends TooltipManager, ActionButtonsManager {
     hideOriginUrl?: boolean
     secondaryColorInStaticCharts?: string
     isStaticAndSmall?: boolean
+    detailsMarkerInSvg?: DetailsMarker
 }

--- a/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
+++ b/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
@@ -1,5 +1,5 @@
 import { TooltipManager } from "../tooltip/TooltipProps"
-import { GrapherInterface, DetailsMarker } from "@ourworldindata/types"
+import { DetailsMarker } from "@ourworldindata/types"
 import { ActionButtonsManager } from "../controls/ActionButtons"
 
 export interface FooterManager extends TooltipManager, ActionButtonsManager {
@@ -7,8 +7,7 @@ export interface FooterManager extends TooltipManager, ActionButtonsManager {
     note?: string
     hasOWIDLogo?: boolean
     originUrlWithProtocol?: string
-    details?: GrapherInterface["details"]
-    detailsOrderedByReference?: Set<string>
+    detailsOrderedByReference?: string[]
     shouldIncludeDetailsInStaticExport?: boolean
     isSourcesModalOpen?: boolean
     isSmall?: boolean

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -164,10 +164,7 @@ export class Header<
             fontSize: this.subtitleFontSize,
             text: this.subtitleText,
             lineHeight: this.subtitleLineHeight,
-            detailsOrderedByReference: this.manager
-                .shouldIncludeDetailsInStaticExport
-                ? this.manager.detailsOrderedByReference
-                : new Set(),
+            detailsOrderedByReference: this.manager.detailsOrderedByReference,
         })
     }
 
@@ -293,7 +290,7 @@ export class StaticHeader extends Header<StaticHeaderProps> {
                         rel="noopener"
                     >
                         {title.render(x, y, {
-                            fill: GRAPHER_DARK_TEXT,
+                            textProps: { fill: GRAPHER_DARK_TEXT },
                         })}
                     </a>
                 )}
@@ -305,7 +302,10 @@ export class StaticHeader extends Header<StaticHeaderProps> {
                                 ? title.height + this.subtitleMarginTop
                                 : 0),
                         {
-                            fill: manager.secondaryColorInStaticCharts,
+                            textProps: {
+                                fill: manager.secondaryColorInStaticCharts,
+                            },
+                            dodMarker: this.manager.detailsMarkerInSvg,
                         }
                     )}
             </g>

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -305,7 +305,7 @@ export class StaticHeader extends Header<StaticHeaderProps> {
                             textProps: {
                                 fill: manager.secondaryColorInStaticCharts,
                             },
-                            dodMarker: this.manager.detailsMarkerInSvg,
+                            detailsMarker: this.manager.detailsMarkerInSvg,
                         }
                     )}
             </g>

--- a/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
+++ b/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
@@ -9,7 +9,7 @@ export interface HeaderManager {
     logo?: string
     canonicalUrl?: string
     tabBounds?: Bounds
-    detailsOrderedByReference?: Set<string>
+    detailsOrderedByReference?: string[]
     shouldIncludeDetailsInStaticExport?: boolean
     isExportingToSvgOrPng?: boolean
     isNarrow?: boolean

--- a/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
+++ b/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
@@ -1,4 +1,5 @@
 import { Bounds } from "@ourworldindata/utils"
+import { DetailsMarker } from "@ourworldindata/types"
 
 export interface HeaderManager {
     currentTitle?: string
@@ -24,4 +25,5 @@ export interface HeaderManager {
     hideSubtitle?: boolean
     secondaryColorInStaticCharts?: string
     isStaticAndSmall?: boolean
+    detailsMarkerInSvg?: DetailsMarker
 }

--- a/packages/@ourworldindata/grapher/src/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/packages/@ourworldindata/grapher/src/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -626,7 +626,7 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                         height -
                         this.legendTitle.height +
                         this.legendTitleFontSize * 0.2,
-                    { fill: this.legendTextColor }
+                    { textProps: { fill: this.legendTextColor } }
                 )}
             </g>
         )

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -58,7 +58,7 @@ import {
     BASE_FONT_SIZE,
 } from "../core/GrapherConstants"
 import { ColorSchemes } from "../color/ColorSchemes"
-import { AxisConfig, FontSizeManager } from "../axis/AxisConfig"
+import { AxisConfig, AxisManager } from "../axis/AxisConfig"
 import { ChartInterface } from "../chart/ChartInterface"
 import {
     LinesProps,
@@ -266,7 +266,7 @@ export class LineChart
     implements
         ChartInterface,
         LineLegendManager,
-        FontSizeManager,
+        AxisManager,
         ColorScaleManager,
         HorizontalColorLegendManager
 {
@@ -690,6 +690,10 @@ export class LineChart
         return guid()
     }
 
+    @computed get detailsOrderedByReference(): Set<string> {
+        return this.manager.detailsOrderedByReference ?? new Set()
+    }
+
     @computed get fontSize(): number {
         return this.manager.fontSize ?? BASE_FONT_SIZE
     }
@@ -792,6 +796,7 @@ export class LineChart
                             ? GRAPHER_AXIS_LINE_WIDTH_THICK
                             : GRAPHER_AXIS_LINE_WIDTH_DEFAULT
                     }
+                    dodMarker={manager.detailsMarkerInSvg}
                 />
                 <g clipPath={clipPath.id}>
                     {comparisonLines.map((line, index) => (

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -690,8 +690,8 @@ export class LineChart
         return guid()
     }
 
-    @computed get detailsOrderedByReference(): Set<string> {
-        return this.manager.detailsOrderedByReference ?? new Set()
+    @computed get detailsOrderedByReference(): string[] {
+        return this.manager.detailsOrderedByReference ?? []
     }
 
     @computed get fontSize(): number {

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -796,7 +796,7 @@ export class LineChart
                             ? GRAPHER_AXIS_LINE_WIDTH_THICK
                             : GRAPHER_AXIS_LINE_WIDTH_DEFAULT
                     }
-                    dodMarker={manager.detailsMarkerInSvg}
+                    detailsMarker={manager.detailsMarkerInSvg}
                 />
                 <g clipPath={clipPath.id}>
                     {comparisonLines.map((line, index) => (

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -126,16 +126,18 @@ class Label extends React.Component<{
                 {series.textWrap.render(
                     needsLines ? markerX2 + MARKER_MARGIN : markerX1,
                     series.bounds.y,
-                    { fill: textColor }
+                    { textProps: { fill: textColor } }
                 )}
                 {series.annotationTextWrap &&
                     series.annotationTextWrap.render(
                         needsLines ? markerX2 + MARKER_MARGIN : markerX1,
                         series.bounds.y + series.textWrap.height,
                         {
-                            fill: annotationColor,
-                            className: "textAnnotation",
-                            style: { fontWeight: 300 },
+                            textProps: {
+                                fill: annotationColor,
+                                className: "textAnnotation",
+                                style: { fontWeight: 300 },
+                            },
                         }
                     )}
             </g>

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.test.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.test.tsx
@@ -38,7 +38,6 @@ it("correctly passes non-redistributable flag", () => {
             rasterize: () => new Promise(() => {}),
             displaySlug: "",
             table: tableFalse,
-            detailRenderers: [],
         },
     })
     expect(viewFalse["nonRedistributable"]).toBeFalsy()
@@ -50,7 +49,6 @@ it("correctly passes non-redistributable flag", () => {
             rasterize: () => new Promise(() => {}),
             displaySlug: "",
             table: tableTrue,
-            detailRenderers: [],
         },
     })
     expect(viewTrue["nonRedistributable"]).toBeTruthy()

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -4,6 +4,7 @@ import { observer } from "mobx-react"
 import {
     Bounds,
     DEFAULT_BOUNDS,
+    isEmpty,
     triggerDownloadFromBlob,
     triggerDownloadFromUrl,
 } from "@ourworldindata/utils"
@@ -204,7 +205,7 @@ export class DownloadModal extends React.Component<DownloadModalProps> {
     }
 
     @computed private get hasDetails(): boolean {
-        return (this.manager.detailsOrderedByReference ?? []).length > 0
+        return !isEmpty(this.manager.detailsOrderedByReference)
     }
 
     @computed private get showExportControls(): boolean {

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -4,11 +4,10 @@ import { observer } from "mobx-react"
 import {
     Bounds,
     DEFAULT_BOUNDS,
-    isEmpty,
     triggerDownloadFromBlob,
     triggerDownloadFromUrl,
 } from "@ourworldindata/utils"
-import { MarkdownTextWrap, Checkbox } from "@ourworldindata/components"
+import { Checkbox } from "@ourworldindata/components"
 import { LoadingIndicator } from "../loadingIndicator/LoadingIndicator"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faDownload, faInfoCircle } from "@fortawesome/free-solid-svg-icons"
@@ -32,7 +31,7 @@ export interface DownloadModalManager {
     table?: OwidTable
     externalCsvLink?: string // Todo: we can ditch this once rootTable === externalCsv (currently not quite the case for Covid Explorer)
     shouldIncludeDetailsInStaticExport?: boolean
-    detailRenderers: MarkdownTextWrap[]
+    detailsOrderedByReference?: string[]
     isDownloadModalOpen?: boolean
     tabBounds?: Bounds
     isOnChartOrMapTab?: boolean
@@ -204,11 +203,12 @@ export class DownloadModal extends React.Component<DownloadModalProps> {
             !this.manager.shouldIncludeDetailsInStaticExport
     }
 
+    @computed private get hasDetails(): boolean {
+        return (this.manager.detailsOrderedByReference ?? []).length > 0
+    }
+
     @computed private get showExportControls(): boolean {
-        return (
-            !isEmpty(this.manager.detailRenderers) ||
-            !!this.manager.showAdminControls
-        )
+        return this.hasDetails || !!this.manager.showAdminControls
     }
 
     private renderReady(): JSX.Element {
@@ -260,7 +260,7 @@ export class DownloadModal extends React.Component<DownloadModalProps> {
                         </div>
                         {this.showExportControls && (
                             <div className="static-exports-options">
-                                {!isEmpty(this.manager.detailRenderers) && (
+                                {this.hasDetails && (
                                     <Checkbox
                                         checked={this.shouldIncludeDetails}
                                         label="Include terminology definitions at bottom of chart"

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ConnectedScatterLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ConnectedScatterLegend.tsx
@@ -77,11 +77,13 @@ export class ConnectedScatterLegend {
                     fill="#fff"
                     opacity={0}
                 />
-                {startLabel.render(targetX, targetY, { fill: fontColor })}
+                {startLabel.render(targetX, targetY, {
+                    textProps: { fill: fontColor },
+                })}
                 {endLabel.render(
                     targetX + manager.sidebarWidth - endLabel.width,
                     targetY,
-                    { fill: fontColor }
+                    { textProps: { fill: fontColor } }
                 )}
                 <line
                     x1={lineLeft}

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -791,7 +791,7 @@ export class ScatterPlotChart
                             ? GRAPHER_AXIS_LINE_WIDTH_THICK
                             : GRAPHER_AXIS_LINE_WIDTH_DEFAULT
                     }
-                    dodMarker={manager.detailsMarkerInSvg}
+                    detailsMarker={manager.detailsMarkerInSvg}
                 />
                 {comparisonLines &&
                     comparisonLines.map((line, i) => (

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -41,6 +41,7 @@ import {
     PointVector,
     Bounds,
     DEFAULT_BOUNDS,
+    maybeMakeMarkdownDetail,
 } from "@ourworldindata/utils"
 import { observer } from "mobx-react"
 import { NoDataModal } from "../noDataModal/NoDataModal"
@@ -1132,10 +1133,26 @@ export class ScatterPlotChart
         return this.domainDefault("y")
     }
 
-    @computed get currentVerticalAxisLabel(): string {
-        const { manager, yAxisConfig, yColumn } = this
+    @computed get defaultYAxisLabel(): string | undefined {
+        return this.yColumn?.displayName
+    }
 
-        let label = yAxisConfig.label || yColumn?.displayName || ""
+    @computed get currentVerticalAxisLabel(): string {
+        const {
+            manager,
+            yAxisConfig,
+            defaultYAxisLabel,
+            detailsOrderedByReference,
+        } = this
+
+        let label =
+            yAxisConfig.label ||
+            maybeMakeMarkdownDetail({
+                text: defaultYAxisLabel,
+                details: detailsOrderedByReference,
+                type: "indicator",
+            }) ||
+            ""
 
         if (manager.isRelativeMode && label && label.length > 1) {
             label = `Average annual change in ${lowerCaseFirstLetterUnlessAbbreviation(
@@ -1181,8 +1198,17 @@ export class ScatterPlotChart
             : this.xAxisConfig.scaleType ?? ScaleType.linear
     }
 
+    @computed get defaultXAxisLabel(): string | undefined {
+        return this.xColumn?.displayName
+    }
+
     @computed private get xAxisLabelBase(): string {
-        const xDimName = this.xColumn?.displayName
+        const xDimName =
+            maybeMakeMarkdownDetail({
+                text: this.defaultXAxisLabel,
+                type: "indicator",
+                details: this.detailsOrderedByReference,
+            }) ?? ""
         if (this.xOverrideTime !== undefined)
             return `${xDimName} in ${this.xOverrideTime}`
         return xDimName

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -377,8 +377,8 @@ export class ScatterPlotChart
         )
     }
 
-    @computed get detailsOrderedByReference(): Set<string> {
-        return this.manager.detailsOrderedByReference ?? new Set()
+    @computed get detailsOrderedByReference(): string[] {
+        return this.manager.detailsOrderedByReference ?? []
     }
 
     @computed get fontSize(): number {

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterSizeLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterSizeLegend.tsx
@@ -223,10 +223,10 @@ export class ScatterSizeLegend {
                 {this.label.render(
                     centerX,
                     targetY + this.legendSize + LEGEND_PADDING,
-                    {
-                        fill: LABEL_COLOR,
-                        textAnchor: "middle",
-                    }
+                   {textProps:  {
+                       fill: LABEL_COLOR,
+                       textAnchor: "middle",
+                   }}
                 )}
                 {this.title.render(
                     centerX,
@@ -236,8 +236,10 @@ export class ScatterSizeLegend {
                         this.label.height +
                         LABEL_PADDING,
                     {
-                        fill: TITLE_COLOR,
-                        textAnchor: "middle",
+                      textProps: {
+                          fill: TITLE_COLOR,
+                          textAnchor: "middle",
+                      }
                     }
                 )}
             </g>

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterSizeLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterSizeLegend.tsx
@@ -223,10 +223,12 @@ export class ScatterSizeLegend {
                 {this.label.render(
                     centerX,
                     targetY + this.legendSize + LEGEND_PADDING,
-                   {textProps:  {
-                       fill: LABEL_COLOR,
-                       textAnchor: "middle",
-                   }}
+                    {
+                        textProps: {
+                            fill: LABEL_COLOR,
+                            textAnchor: "middle",
+                        },
+                    }
                 )}
                 {this.title.render(
                     centerX,
@@ -236,10 +238,10 @@ export class ScatterSizeLegend {
                         this.label.height +
                         LABEL_PADDING,
                     {
-                      textProps: {
-                          fill: TITLE_COLOR,
-                          textAnchor: "middle",
-                      }
+                        textProps: {
+                            fill: TITLE_COLOR,
+                            textAnchor: "middle",
+                        },
                     }
                 )}
             </g>

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -56,7 +56,7 @@ import {
 } from "./SlopeChartConstants"
 import { CoreColumn, OwidTable } from "@ourworldindata/core-table"
 import { autoDetectYColumnSlugs, makeSelectionArray } from "../chart/ChartUtils"
-import { AxisConfig, FontSizeManager } from "../axis/AxisConfig"
+import { AxisConfig, AxisManager } from "../axis/AxisConfig"
 
 @observer
 export class SlopeChart
@@ -88,6 +88,10 @@ export class SlopeChart
 
     @computed.struct get bounds() {
         return this.props.bounds ?? DEFAULT_BOUNDS
+    }
+
+    @computed get detailsOrderedByReference(): Set<string> {
+        return this.manager.detailsOrderedByReference ?? new Set()
     }
 
     @computed get fontSize() {
@@ -651,7 +655,7 @@ class Slope extends React.Component<SlopeProps> {
 @observer
 class LabelledSlopes
     extends React.Component<LabelledSlopesProps>
-    implements FontSizeManager
+    implements AxisManager
 {
     base: React.RefObject<SVGGElement> = React.createRef()
 

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -641,10 +641,13 @@ class Slope extends React.Component<SlopeProps> {
                     </Text>
                 )}
                 {hasRightLabel &&
-                    rightLabel.render(rightLabelBounds.x, rightLabelBounds.y, {textProps: {
-                        fill: labelColor,
-                        fontWeight: isFocused || isHovered ? "bold" : undefined,
-                    }})}
+                    rightLabel.render(rightLabelBounds.x, rightLabelBounds.y, {
+                        textProps: {
+                            fill: labelColor,
+                            fontWeight:
+                                isFocused || isHovered ? "bold" : undefined,
+                        },
+                    })}
             </g>
         )
     }

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -585,10 +585,12 @@ class Slope extends React.Component<SlopeProps> {
                         leftLabelBounds.x + leftLabelBounds.width,
                         leftLabelBounds.y,
                         {
-                            textAnchor: "end",
-                            fill: labelColor,
-                            fontWeight:
-                                isFocused || isHovered ? "bold" : undefined,
+                            textProps: {
+                                textAnchor: "end",
+                                fill: labelColor,
+                                fontWeight:
+                                    isFocused || isHovered ? "bold" : undefined,
+                            },
                         }
                     )}
                 {hasLeftLabel && (
@@ -639,10 +641,10 @@ class Slope extends React.Component<SlopeProps> {
                     </Text>
                 )}
                 {hasRightLabel &&
-                    rightLabel.render(rightLabelBounds.x, rightLabelBounds.y, {
+                    rightLabel.render(rightLabelBounds.x, rightLabelBounds.y, {textProps: {
                         fill: labelColor,
                         fontWeight: isFocused || isHovered ? "bold" : undefined,
-                    })}
+                    }})}
             </g>
         )
     }

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -90,10 +90,6 @@ export class SlopeChart
         return this.props.bounds ?? DEFAULT_BOUNDS
     }
 
-    @computed get detailsOrderedByReference(): Set<string> {
-        return this.manager.detailsOrderedByReference ?? new Set()
-    }
-
     @computed get fontSize() {
         return this.manager.fontSize ?? BASE_FONT_SIZE
     }

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -1,5 +1,5 @@
 import { DualAxis, HorizontalAxis, VerticalAxis } from "../axis/Axis"
-import { AxisConfig, FontSizeManager } from "../axis/AxisConfig"
+import { AxisConfig, AxisManager } from "../axis/AxisConfig"
 import { ChartInterface } from "../chart/ChartInterface"
 import { ChartManager } from "../chart/ChartManager"
 import {
@@ -52,7 +52,7 @@ export interface AbstractStackedChartProps {
 @observer
 export class AbstractStackedChart
     extends React.Component<AbstractStackedChartProps>
-    implements ChartInterface, FontSizeManager
+    implements ChartInterface, AxisManager
 {
     transformTable(table: OwidTable): OwidTable {
         table = table.filterByEntityNames(
@@ -146,6 +146,10 @@ export class AbstractStackedChart
 
     @computed get fontSize(): number {
         return this.manager.fontSize ?? BASE_FONT_SIZE
+    }
+
+    @computed get detailsOrderedByReference(): Set<string> {
+        return this.manager.detailsOrderedByReference ?? new Set()
     }
 
     protected get paddingForLegend(): number {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -148,8 +148,8 @@ export class AbstractStackedChart
         return this.manager.fontSize ?? BASE_FONT_SIZE
     }
 
-    @computed get detailsOrderedByReference(): Set<string> {
-        return this.manager.detailsOrderedByReference ?? new Set()
+    @computed get detailsOrderedByReference(): string[] {
+        return this.manager.detailsOrderedByReference ?? []
     }
 
     protected get paddingForLegend(): number {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -21,6 +21,7 @@ import {
     getRelativeMouse,
     ColorSchemeName,
     EntitySelectionMode,
+    maybeMakeMarkdownDetail,
 } from "@ourworldindata/utils"
 import { action, computed, observable } from "mobx"
 import { observer } from "mobx-react"
@@ -599,10 +600,20 @@ export class MarimekkoChart
         )
     }
 
+    @computed get defaultYAxisLabel(): string | undefined {
+        return this.yColumns.length > 0
+            ? this.yColumns[0].displayName
+            : undefined
+    }
+
     @computed get currentVerticalAxisLabel(): string {
         const config = this.yAxisConfig
         const fallbackLabel =
-            this.yColumns.length > 0 ? this.yColumns[0].displayName : ""
+            maybeMakeMarkdownDetail({
+                text: this.defaultYAxisLabel,
+                type: "indicator",
+                details: this.detailsOrderedByReference,
+            }) ?? ""
         return this.isNarrow ? "" : config.label || fallbackLabel
     }
 
@@ -622,10 +633,18 @@ export class MarimekkoChart
     }
 
     @computed private get xAxisLabelBase(): string {
-        const xDimName = this.xColumn?.displayName
+        const xDimName = maybeMakeMarkdownDetail({
+            text: this.defaultXAxisLabel,
+            type: "indicator",
+            details: this.detailsOrderedByReference,
+        })
         if (this.manager.xOverrideTime !== undefined)
             return `${xDimName} in ${this.manager.xOverrideTime}`
         return xDimName ?? "" // This sets the axis label to emtpy if we don't have an x column - not entirely sure this is what we want
+    }
+
+    @computed get defaultXAxisLabel(): string | undefined {
+        return this.xColumn?.displayName
     }
 
     @computed get currentHorizontalAxisLabel(): string {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -861,8 +861,8 @@ export class MarimekkoChart
         return this.baseFontSize
     }
 
-    @computed get detailsOrderedByReference(): Set<string> {
-        return this.manager.detailsOrderedByReference ?? new Set()
+    @computed get detailsOrderedByReference(): string[] {
+        return this.manager.detailsOrderedByReference ?? []
     }
 
     @computed get categoricalLegendData(): CategoricalBin[] {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -598,15 +598,21 @@ export class MarimekkoChart
             this
         )
     }
+
+    @computed get currentVerticalAxisLabel(): string {
+        const config = this.yAxisConfig
+        const fallbackLabel =
+            this.yColumns.length > 0 ? this.yColumns[0].displayName : ""
+        return this.isNarrow ? "" : config.label || fallbackLabel
+    }
+
     @computed private get verticalAxisPart(): VerticalAxis {
         const config = this.yAxisConfig
         const axis = config.toVerticalAxis()
         axis.updateDomainPreservingUserSettings(this.yDomainDefault)
 
         axis.formatColumn = this.yColumns[0]
-        const fallbackLabel =
-            this.yColumns.length > 0 ? this.yColumns[0].displayName : ""
-        axis.label = this.isNarrow ? "" : config.label || fallbackLabel
+        axis.label = this.currentVerticalAxisLabel
 
         return axis
     }
@@ -614,6 +620,7 @@ export class MarimekkoChart
         // TODO: this should probably come from grapher?
         return this.bounds.width < 650 // innerBounds would lead to dependency cycle
     }
+
     @computed private get xAxisLabelBase(): string {
         const xDimName = this.xColumn?.displayName
         if (this.manager.xOverrideTime !== undefined)
@@ -621,8 +628,14 @@ export class MarimekkoChart
         return xDimName ?? "" // This sets the axis label to emtpy if we don't have an x column - not entirely sure this is what we want
     }
 
+    @computed get currentHorizontalAxisLabel(): string {
+        const { xAxisLabelBase } = this
+        const config = this.xAxisConfig
+        return config.label || xAxisLabelBase
+    }
+
     @computed private get horizontalAxisPart(): HorizontalAxis {
-        const { manager, xAxisLabelBase, xDomainDefault, xColumn } = this
+        const { manager, xDomainDefault, xColumn } = this
         const config = this.xAxisConfig
         let axis = config.toHorizontalAxis()
         if (manager.isRelativeMode && xColumn) {
@@ -632,16 +645,16 @@ export class MarimekkoChart
             axis = new HorizontalAxis(
                 new AxisConfig(
                     { ...config.toObject(), maxTicks: 10 },
-                    config.fontSizeManager
-                )
+                    config.axisManager
+                ),
+                config.axisManager
             )
             axis.domain = [0, 100]
         } else axis.updateDomainPreservingUserSettings(xDomainDefault)
 
         axis.formatColumn = xColumn
 
-        const label = config.label || xAxisLabelBase
-        axis.label = label
+        axis.label = this.currentHorizontalAxisLabel
         return axis
     }
 
@@ -829,6 +842,10 @@ export class MarimekkoChart
         return this.baseFontSize
     }
 
+    @computed get detailsOrderedByReference(): Set<string> {
+        return this.manager.detailsOrderedByReference ?? new Set()
+    }
+
     @computed get categoricalLegendData(): CategoricalBin[] {
         const { colorColumnSlug, colorScale, series } = this
         const customHiddenCategories =
@@ -972,6 +989,7 @@ export class MarimekkoChart
                             ? GRAPHER_AXIS_LINE_WIDTH_THICK
                             : GRAPHER_AXIS_LINE_WIDTH_DEFAULT
                     }
+                    dodMarker={manager.detailsMarkerInSvg}
                 />
                 <HorizontalCategoricalColorLegend manager={this} />
                 {this.renderBars()}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -1008,7 +1008,7 @@ export class MarimekkoChart
                             ? GRAPHER_AXIS_LINE_WIDTH_THICK
                             : GRAPHER_AXIS_LINE_WIDTH_DEFAULT
                     }
-                    dodMarker={manager.detailsMarkerInSvg}
+                    detailsMarker={manager.detailsMarkerInSvg}
                 />
                 <HorizontalCategoricalColorLegend manager={this} />
                 {this.renderBars()}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -542,6 +542,7 @@ export class StackedAreaChart
                             ? GRAPHER_AXIS_LINE_WIDTH_THICK
                             : GRAPHER_AXIS_LINE_WIDTH_DEFAULT
                     }
+                    dodMarker={manager.detailsMarkerInSvg}
                 />
                 <g clipPath={clipPath.id}>
                     {showLegend && <LineLegend manager={this} />}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -542,7 +542,7 @@ export class StackedAreaChart
                             ? GRAPHER_AXIS_LINE_WIDTH_THICK
                             : GRAPHER_AXIS_LINE_WIDTH_DEFAULT
                     }
-                    dodMarker={manager.detailsMarkerInSvg}
+                    detailsMarker={manager.detailsMarkerInSvg}
                 />
                 <g clipPath={clipPath.id}>
                     {showLegend && <LineLegend manager={this} />}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -450,6 +450,7 @@ export class StackedBarChart
                     bounds={bounds}
                     verticalAxis={verticalAxis}
                     labelColor={manager.secondaryColorInStaticCharts}
+                    dodMarker={manager.detailsMarkerInSvg}
                 />
                 <VerticalAxisGridLines
                     verticalAxis={verticalAxis}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -450,7 +450,7 @@ export class StackedBarChart
                     bounds={bounds}
                     verticalAxis={verticalAxis}
                     labelColor={manager.secondaryColorInStaticCharts}
-                    dodMarker={manager.detailsMarkerInSvg}
+                    detailsMarker={manager.detailsMarkerInSvg}
                 />
                 <VerticalAxisGridLines
                     verticalAxis={verticalAxis}

--- a/packages/@ourworldindata/grapher/src/verticalColorLegend/VerticalColorLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/verticalColorLegend/VerticalColorLegend.tsx
@@ -142,7 +142,8 @@ export class VerticalColorLegend extends React.Component<{
 
         return (
             <>
-                {title && title.render(x, y, { fontWeight: 700 })}
+                {title &&
+                    title.render(x, y, { textProps: { fontWeight: 700 } })}
                 <g
                     className="ScatterColorLegend clickable"
                     style={{ cursor: "pointer" }}
@@ -191,7 +192,11 @@ export class VerticalColorLegend extends React.Component<{
                                     x + rectSize + rectPadding,
                                     y + markOffset,
                                     isFocus
-                                        ? { style: { fontWeight: "bold" } }
+                                        ? {
+                                              textProps: {
+                                                  style: { fontWeight: "bold" },
+                                              },
+                                          }
                                         : undefined
                                 )}
                             </g>

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -61,7 +61,11 @@ export enum KeyChartLevel {
     Top = 3, // chart will show at the top of the all charts block
 }
 
-export type DodMarker = "superscript" | "underline" | "none"
+// How to mark a detail on demand
+// - superscript: add a superscript reference number
+// - underline: underline the text
+// - none: don't mark it
+export type DetailsMarker = "superscript" | "underline" | "none"
 
 export interface BasicChartInformation {
     title: string

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -61,10 +61,12 @@ export enum KeyChartLevel {
     Top = 3, // chart will show at the top of the all charts block
 }
 
-// How to mark a detail on demand
-// - superscript: add a superscript reference number
-// - underline: underline the text
-// - none: don't mark it
+/**
+ * How to mark a detail on demand:
+ * - superscript: add a superscript reference number
+ * - underline: underline the text
+ * - none: don't mark it
+ */
 export type DetailsMarker = "superscript" | "underline" | "none"
 
 export interface BasicChartInformation {

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -53,12 +53,15 @@ export interface Annotation {
     entityName?: string
     year?: number
 }
+
 export enum KeyChartLevel {
     None = 0, // not a key chart, will not show in the all charts block of the related topic page
     Bottom = 1, // chart will show at the bottom of the all charts block
     Middle = 2, // chart will show in the middle of the all charts block
     Top = 3, // chart will show at the top of the all charts block
 }
+
+export type DodMarker = "superscript" | "underline" | "none"
 
 export interface BasicChartInformation {
     title: string

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -109,7 +109,7 @@ export {
     type SeriesName,
     type LegacyGrapherQueryParams,
     GrapherStaticFormat,
-    type DodMarker,
+    type DetailsMarker,
 } from "./grapherTypes/GrapherTypes.js"
 
 export {

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -109,6 +109,7 @@ export {
     type SeriesName,
     type LegacyGrapherQueryParams,
     GrapherStaticFormat,
+    type DodMarker,
 } from "./grapherTypes/GrapherTypes.js"
 
 export {

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1825,3 +1825,40 @@ export function cartesian<T>(matrix: T[][]): T[][] {
         [[]]
     )
 }
+
+export function makeDetailIdFromText({
+    text,
+    type,
+}: {
+    text: string
+    type: "indicator"
+}): string {
+    return `grapher_${type}_${slugify(text)}`
+}
+
+export function makeMarkdownDetail({
+    text,
+    id,
+}: {
+    text: string
+    id: string
+}): string {
+    return `[${text}](#dod:${id})`
+}
+
+export function maybeMakeMarkdownDetail({
+    text,
+    type,
+    details,
+}: {
+    text?: string
+    type: "indicator"
+    details: Set<string>
+}): string | undefined {
+    if (!text) return text
+    const maybeDetailId = makeDetailIdFromText({ text, type })
+    if (details.has(maybeDetailId)) {
+        return makeMarkdownDetail({ id: maybeDetailId, text })
+    }
+    return text
+}

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1853,11 +1853,11 @@ export function maybeMakeMarkdownDetail({
 }: {
     text?: string
     type: "indicator"
-    details: Set<string>
+    details: string[]
 }): string | undefined {
     if (!text) return text
     const maybeDetailId = makeDetailIdFromText({ text, type })
-    if (details.has(maybeDetailId)) {
+    if (details.includes(maybeDetailId)) {
         return makeMarkdownDetail({ id: maybeDetailId, text })
     }
     return text

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -203,6 +203,9 @@ export {
     lowercaseObjectKeys,
     detailOnDemandRegex,
     extractDetailsFromSyntax,
+    makeDetailIdFromText,
+    makeMarkdownDetail,
+    maybeMakeMarkdownDetail,
 } from "./Util.js"
 
 export { isPresent } from "./isPresent.js"

--- a/site/Head.tsx
+++ b/site/Head.tsx
@@ -1,6 +1,9 @@
 import React from "react"
 import { VITE_ASSET_SITE_ENTRY, viteAssets } from "./viteUtils.js"
-import { GOOGLE_TAG_MANAGER_ID } from "../settings/clientSettings.js"
+import {
+    GOOGLE_TAG_MANAGER_ID,
+    BAKED_BASE_URL,
+} from "../settings/clientSettings.js"
 
 export const GTMScriptTags = ({ gtmId }: { gtmId: string }) => {
     if (!gtmId || /["']/.test(gtmId)) return null
@@ -89,8 +92,29 @@ export const Head = (props: {
             <meta name="twitter:description" content={pageDesc} />
             <meta name="twitter:image" content={encodeURI(imageUrl)} />
             {stylesheets}
+            <ScriptTagLoadingDetails />
             {props.children}
             <GTMScriptTags gtmId={GOOGLE_TAG_MANAGER_ID} />
         </head>
+    )
+}
+
+function ScriptTagLoadingDetails() {
+    return (
+        <script
+            dangerouslySetInnerHTML={{
+                __html: `fetch("${BAKED_BASE_URL}/dods.json", {
+                    method: "GET",
+                    credentials: "same-origin",
+                    headers: {
+                        Accept: "application/json",
+                    },
+                })
+                    .then((res) => res.json())
+                    .then((details) => {
+                        window.details = details
+                    })`,
+            }}
+        />
     )
 }

--- a/site/detailsOnDemand.tsx
+++ b/site/detailsOnDemand.tsx
@@ -17,18 +17,20 @@ declare global {
 }
 
 export async function runDetailsOnDemand() {
-    const details: DetailDictionary = await fetch(
-        `${BAKED_BASE_URL}/dods.json`,
-        {
-            method: "GET",
-            credentials: "same-origin",
-            headers: {
-                Accept: "application/json",
-            },
-        }
-    ).then((res) => res.json())
+    if (!window.details) {
+        const details: DetailDictionary = await fetch(
+            `${BAKED_BASE_URL}/dods.json`,
+            {
+                method: "GET",
+                credentials: "same-origin",
+                headers: {
+                    Accept: "application/json",
+                },
+            }
+        ).then((res) => res.json())
 
-    window.details = details
+        window.details = details
+    }
 
     document.addEventListener("mouseover", handleEvent, { passive: true })
     document.addEventListener("touchstart", handleEvent, { passive: true })


### PR DESCRIPTION
**tldr** Adds support for details on demand in x- and y-axis labels.

This PR allows authors to use DoD syntax in the admin's x- and y-label fields. Some chart types (Scatter, Marimekko) use the indicator's display name as default if no custom axis label is given. We toyed with the idea of automatically checking for details with a specific prefix (e.g. `grapher_indicator_per-capita-emissions`) when the metadata default is used but decided against it for now. The automatic approach for default labels is implemented though but temporarily disabled (see the [last commit](https://github.com/owid/owid-grapher/pull/3150/commits/e9da915dc47d78984433b24fe46497440fccafbe)), so that we can quickly enable it when the time is right.

### Summary

- This PR adds support for details on demand in axis labels by:
    - allowing authors to use Dod syntax in the admin's x- and y-axis label fields
    - (disabled feature) automatically checking for an existing detail with a specific prefix when a default label is used
- Details are validated in the admin
    - If invalid details are specified in the x- and y-axis label fields, an error message is displayed, and the chart cannot be saved
    - If details are specified in the dimension's display name field, an error message is displayed, and the chart cannot be saved

### Example

On staging: http://staging-site-dod-in-axis-labels/admin/charts/937/edit (the deploy queue seems to stuck for some reason, so you won't see DoDs on the grapher page)

### Details

- How does Grapher know which label is currently in use?
    - Scatter plots and Marimekko charts define `defaultYAxisLabel` and `defaultXAxisLabel`
    - If no custom overwrite is provided and `default{X,Y}AxisLabel` is given, Grapher knows that a default label is in use
- How does Grapher connect a given indicator name to an existing detail?
    - If the indicator name is used as default label, Grapher checks if a detail with id `grapher_indicator_my-slugified-display-name` exists (e.g. `grapher_indicator_biofuels`)
    - If it does exist, it replaces the indicator name with Dod syntax just before rendering, i.e. the display name "Biofuels" is turned into `[Biofuels](#dod:grapher_indicator_biofuels)`
- How does Grapher decide how to highlight a given Dod?
    - The logic used to be:
        - If rendered as HTML, we're in an interactive environment, so underline the detail
        - If rendered as SVG, we're exporting to a static chart, so show a reference number (or don't show anything if details shouldn't be included in the export)
    - That doesn't work for text that is always rendered to SVG (like axis labels); we need to be more explicit here (see Grapher's `detailsMarkerInSvg` property)

### Notes

- Details used to be fetched late (in the footer). That was okay since we only needed details after an interaction had taken place (e.g. the user hovers over a detail or clicks the download button). With these changes, details need to be validated early, which means that the details object must exist when Grapher loads. To guarantee that it does, details are now loaded in the `<Head />` component
- SVG text doesn't support dotted underlines, so MarkdownTextWrap manually draws dotted lines that act as underlines for details
- Since I updated the interface of `renderSVG` of the MarkdownTextWrap class to account for `dodMarker`, I did the same for the TextWrap class (it makes the interface a bit more involved, but I value consistency higher)

### Caveats

- Technically, axis labels now support any Markdown syntax, although we wouldn't want authors to use bold or italic text in axis labels for consistency. We could solve this on a technical level by adding a new `DetailsTextWrap` class or maybe by allowing/blocking specific Markdown syntax. I haven't done that though – I hope that a convention of not using Markdown syntax for axis labels is enough. But I went back and forth on this – what do you think, Ike?

### Related issues

- Closes #2484.
- Also fixes #3009 (to place the underline correctly below the DoD, I fixed some bugs in `MarkdownTextWrap`; apparently, that has also fixed alignment issues for thumbnails 🙏🏻 )

The SVG tester flags many charts since axis labels are now wrapped in a group element.

The code scanner complains about running `slugify` on invalidated input (since it uses a regex), I guess because we're running it on an indicator's display name. But indicator metadata either comes from the ETL or from our internal admin, so it should be fine? Don't know how to let the code scanner know, though.