### PR TITLE
✨ (admin) hide x-axis label field if it has no effect

### DIFF
--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -26,7 +26,12 @@ export class EditorFeatures {
     }
 
     @computed get canCustomizeXAxisLabel() {
-        return true
+        return (
+            this.grapher.isLineChart ||
+            this.grapher.isScatter ||
+            this.grapher.isMarimekko ||
+            this.grapher.isStackedArea
+        )
     }
 
     @computed get canCustomizeYAxis() {


### PR DESCRIPTION
- We show a field to customize the x-axis label for all chart types
- But for some chart types, editing the x-axis label has no effect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved logic for customizing X-axis labels in the editor for various chart types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->