### PR TITLE
:sparkles: increase retries when fetching data & metadata from Data API

### DIFF
--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -413,7 +413,7 @@ export const fetchS3DataValuesByPath = async (
     const resp = await retryPromise(
         () => fetch(dataPath, { keepalive: true }),
         {
-            maxRetries: 5,
+            maxRetries: 7,
             exponentialBackoff: true,
             initialDelay: 1000,
         }
@@ -444,7 +444,7 @@ export const fetchS3MetadataByPath = async (
     const resp = await retryPromise(
         () => fetch(metadataPath, { keepalive: true }),
         {
-            maxRetries: 5,
+            maxRetries: 7,
             exponentialBackoff: true,
             initialDelay: 1000,
         }


### PR DESCRIPTION
Still getting 500 errors from Cloudflare Worker after 5 retries. Try increasing it even more (the latest retry waits 32s).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved reliability of data fetching from S3 by increasing retries to 7 and using exponential backoff strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->