### PR TITLE
🐛 (a11y) add focus state to checkboxes

### DIFF
--- a/packages/@ourworldindata/components/src/Checkbox.scss
+++ b/packages/@ourworldindata/components/src/Checkbox.scss
@@ -39,6 +39,10 @@
         }
     }
 
+    input:focus-visible + .custom {
+        outline: 2px solid $controls-color;
+    }
+
     input:active + .custom {
         background: $active-fill;
     }


### PR DESCRIPTION
- fixes #2912 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated the custom checkbox to display an outline when focused for improved accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->