### PR TITLE
🐛 (grapher) adjust medium breakpoint

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2681,7 +2681,7 @@ export class Grapher
     // (e.g. stand-alone charts in the main text of an article)
     @computed get isMedium(): boolean {
         if (this.isStatic) return false
-        return this.renderWidth <= 840
+        return this.renderWidth <= 845
     }
 
     @computed get isStaticAndSmall(): boolean {


### PR DESCRIPTION
- The medium breakpoint is supposed to be true when Grapher is rendered into 8 columns
- It was off by a few pixels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted the condition for determining medium-sized graphs to enhance display responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->