### PR TITLE
🐛 only include endnotes in sticky nav if endnotes exist

### DIFF
--- a/db/model/Gdoc/archieToEnriched.ts
+++ b/db/model/Gdoc/archieToEnriched.ts
@@ -21,6 +21,7 @@ import {
     RESEARCH_AND_WRITING_ID,
     checkIsPlainObjectWithGuard,
     identity,
+    isEmpty,
 } from "@ourworldindata/utils"
 import { convertHeadingTextToId } from "@ourworldindata/components"
 import { parseRawBlocksToEnrichedBlocks, parseRefs } from "./rawToEnriched.js"
@@ -100,12 +101,15 @@ export function generateStickyNav(
         })
     )
 
+    if (!isEmpty(content.refs?.definitions)) {
+        stickyNavItems.push({
+            text: "Endnotes",
+            target: `#${ENDNOTES_ID}`,
+        })
+    }
+
     stickyNavItems.push(
         ...[
-            {
-                text: "Endnotes",
-                target: `#${ENDNOTES_ID}`,
-            },
             {
                 text: "Cite This Work",
                 target: `#${CITATION_ID}`,


### PR DESCRIPTION
https://github.com/owid/owid-grapher/assets/11844404/061996d7-dcd5-4cc7-a1b3-a100c380aa30

I noticed a small bug in the sticky nav where Endnotes was being unconditionally added as an item, resulting in a flash of content once the hydration logic that confirms the specified IDs exist kicks in.

This PR fixes that by making sure that at least one ref is defined before adding the Endnotes item.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Dynamically added an "Endnotes" section to the sticky navigation menu in documents, visible when definitions are present in the content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->