### PR TITLE
✨ (a11y) make time slider keyboard accessible

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
@@ -347,6 +347,7 @@ export function ActionButton(props: {
                 onMouseLeave={(): void => {
                     setShowTooltip(false)
                 }}
+                aria-label={props.label}
             >
                 <FontAwesomeIcon icon={props.icon} />
                 {props.showLabel && (

--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
@@ -24,7 +24,7 @@
         position: relative;
     }
 
-    li > a {
+    li > button {
         $height: $controlRowHeight - 2 * $visual-gap;
 
         display: block;
@@ -69,7 +69,7 @@
         }
     }
 
-    li.active > a {
+    li.active > button {
         color: $active-text;
         background-color: $active-fill;
 
@@ -105,7 +105,7 @@
 }
 
 &.GrapherComponentMedium {
-    .ContentSwitchers:not(.iconOnly) li > a {
+    .ContentSwitchers:not(.iconOnly) li > button {
         padding: 0 8px;
     }
 }

--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
@@ -80,19 +80,20 @@ function Tab(props: {
     tab: GrapherTabOption
     icon: JSX.Element
     isActive?: boolean
-    onClick?: React.MouseEventHandler<HTMLAnchorElement>
+    onClick?: React.MouseEventHandler<HTMLButtonElement>
     showLabel?: boolean
 }): JSX.Element {
     const className = "tab clickable" + (props.isActive ? " active" : "")
     return (
         <li key={props.tab} className={className}>
-            <a
+            <button
                 onClick={props.onClick}
                 data-track-note={"chart_click_" + props.tab}
+                aria-label={props.tab}
             >
                 {props.icon}
                 {props.showLabel && <span className="label">{props.tab}</span>}
-            </a>
+            </button>
         </li>
     )
 }

--- a/packages/@ourworldindata/grapher/src/controls/EntitySelectionToggle.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/EntitySelectionToggle.tsx
@@ -82,6 +82,7 @@ export class EntitySelectionToggle extends React.Component<{
                         e.stopPropagation()
                     }}
                     data-track-note="chart_add_entity"
+                    aria-label={`${label.action} ${label.entity}`}
                 >
                     {label.icon}
                     <label>

--- a/packages/@ourworldindata/grapher/src/controls/LabeledSwitch.scss
+++ b/packages/@ourworldindata/grapher/src/controls/LabeledSwitch.scss
@@ -80,6 +80,10 @@ $lato: $sans-serif-font-stack;
                 }
             }
 
+            input:focus-visible + .outer {
+                outline: 2px solid $controls-color;
+            }
+
             input:checked + .outer {
                 background: $active-fill;
                 .inner {

--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
@@ -421,6 +421,7 @@ export class SettingsMenu extends React.Component<{
                     onClick={this.toggleVisibility}
                     data-track-note="chart_settings_menu_toggle"
                     title="Chart settings"
+                    aria-label="Chart settings"
                 >
                     <FontAwesomeIcon icon={faGear} />
                     <span className="label"> Settings</span>

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
@@ -455,7 +455,8 @@ const TimelineHandle = ({
     onBlur?: React.FocusEventHandler<HTMLDivElement>
 }): JSX.Element => {
     return (
-        // @ts-expect-error aria-value* fields expect a number, but we're passing a string
+        // @ts-expect-error aria-value* fields expect a number, but if we're dealing with daily data,
+        // the numeric representation of a date is meaningless, so we pass the formatted date string instead.
         <div
             className={classNames("handle", type)}
             style={{
@@ -463,9 +464,9 @@ const TimelineHandle = ({
             }}
             role="slider"
             tabIndex={0}
-            aria-valuemin={formattedMinTime}
-            aria-valuenow={formattedCurrTime}
-            aria-valuemax={formattedMaxTime}
+            aria-valuemin={castToNumberIfPossible(formattedMinTime)}
+            aria-valuenow={castToNumberIfPossible(formattedCurrTime)}
+            aria-valuemax={castToNumberIfPossible(formattedMaxTime)}
             aria-label={label}
             onFocus={onFocus}
             onBlur={onBlur}
@@ -488,4 +489,12 @@ const TimelineHandle = ({
             )}
         </div>
     )
+}
+
+function castToNumberIfPossible(s: string): string | number {
+    return isNumber(s) ? +s : s
+}
+
+function isNumber(s: string): boolean {
+    return /^\d+$/.test(s)
 }

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
@@ -285,9 +285,9 @@ export class TimelineComponent extends React.Component<{
             controller.resetStartToMin()
         } else if (key === "End") {
             controller.setStartToMax()
-        } else if (key === "ArrowLeft") {
+        } else if (key === "ArrowLeft" || key === "ArrowDown") {
             controller.decreaseStartTime()
-        } else if (key === "ArrowRight") {
+        } else if (key === "ArrowRight" || key === "ArrowUp") {
             controller.increaseStartTime()
         }
     }
@@ -298,9 +298,9 @@ export class TimelineComponent extends React.Component<{
             controller.setEndToMin()
         } else if (key === "End") {
             controller.resetEndToMax()
-        } else if (key === "ArrowLeft") {
+        } else if (key === "ArrowLeft" || key === "ArrowDown") {
             controller.decreaseEndTime()
-        } else if (key === "ArrowRight") {
+        } else if (key === "ArrowRight" || key === "ArrowUp") {
             controller.increaseEndTime()
         }
     }

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
@@ -258,7 +258,7 @@ export class TimelineComponent extends React.Component<{
         const time =
             markerType === "start" ? controller.minTime : controller.maxTime
         return (
-            <div
+            <button
                 className="date clickable"
                 onClick={(): void =>
                     markerType === "start"
@@ -267,7 +267,7 @@ export class TimelineComponent extends React.Component<{
                 }
             >
                 {this.formatTime(time)}
-            </div>
+            </button>
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineController.ts
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineController.ts
@@ -65,6 +65,10 @@ export class TimelineController {
         return this.timesAsc[this.timesAsc.indexOf(time) + 1] ?? this.maxTime
     }
 
+    getPrevTime(time: number): number {
+        return this.timesAsc[this.timesAsc.indexOf(time) - 1] ?? this.minTime
+    }
+
     // By default, play means extend the endTime to the right. Toggle this to play one time unit at a time.
     private rangeMode = true
     toggleRangeMode(): this {
@@ -109,6 +113,26 @@ export class TimelineController {
         }
 
         return tickCount
+    }
+
+    increaseStartTime(): void {
+        const nextTime = this.getNextTime(this.startTime)
+        this.updateStartTime(nextTime)
+    }
+
+    decreaseStartTime(): void {
+        const prevTime = this.getPrevTime(this.startTime)
+        this.updateStartTime(prevTime)
+    }
+
+    increaseEndTime(): void {
+        const nextTime = this.getNextTime(this.endTime)
+        this.updateEndTime(nextTime)
+    }
+
+    decreaseEndTime(): void {
+        const prevTime = this.getPrevTime(this.endTime)
+        this.updateEndTime(prevTime)
     }
 
     private stop(): void {
@@ -214,5 +238,13 @@ export class TimelineController {
 
     resetEndToMax(): void {
         this.updateEndTime(TimeBoundValue.positiveInfinity)
+    }
+
+    setStartToMax(): void {
+        this.updateStartTime(TimeBoundValue.positiveInfinity)
+    }
+
+    setEndToMin(): void {
+        this.updateEndTime(TimeBoundValue.negativeInfinity)
     }
 }


### PR DESCRIPTION
### Summary

- Grapher's time slider is inaccessible to keyboard users and screen readers (as described in #3137)
- This PR doesn't change fundamentals but improves the status quo by implementing the Slider pattern defined [here](https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb/examples/slider-multithumb/):
    - Adds the start and end thumbs to the tab sequence
    - Adds aria information that is accessible to screen readers
    - Adds support for keyboard navigation via arrow keys

Important limitation:
- Keyboard navigation only allows updating both sliders separately. It is currently impossible – by keyboard navigation only – to enter "single-year" mode if a chart has range mode

### Other a11y improvements
- Use a `<button />` when appropriate (instead of links or divs)
- Add aria labels for buttons that may not contain a textual label
- Add focus state to the LabelledSwitch component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced accessibility across various components with the addition of `aria-label` attributes.
	- Improved keyboard navigation for the timeline component with new keyboard event handling methods.
- **Refactor**
	- Changed tab elements from anchor (`<a>`) tags to button (`<button>`) tags in the `ContentSwitchers` component for better semantic HTML and accessibility.
	- Updated the `ActionButton` component to hide tooltips on mouse leave.
- **Style**
	- Adjusted CSS selectors in `ContentSwitchers` to apply styles to button elements instead of anchor tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->