### PR TITLE
Bake posts, pages and blocks from API snapshot

### DIFF
--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -26,7 +26,6 @@ import {
 } from "@ourworldindata/utils"
 import {
     getRelatedArticles,
-    getRelatedCharts,
     getRelatedChartsForVariable,
     getRelatedResearchAndWritingForVariable,
     isWordpressAPIEnabled,
@@ -44,7 +43,10 @@ import {
 import * as db from "../db/db.js"
 import { glob } from "glob"
 import { isPathRedirectedToExplorer } from "../explorerAdminServer/ExplorerRedirects.js"
-import { getPostEnrichedBySlug } from "../db/model/Post.js"
+import {
+    getPostEnrichedBySlug,
+    getPostRelatedCharts,
+} from "../db/model/Post.js"
 import { ChartTypeName, GrapherInterface } from "@ourworldindata/types"
 import workerpool from "workerpool"
 import ProgressBar from "progress"
@@ -362,7 +364,7 @@ const renderGrapherPage = async (grapher: GrapherInterface) => {
     const post = postSlug ? await getPostEnrichedBySlug(postSlug) : undefined
     const relatedCharts =
         post && isWordpressDBEnabled
-            ? await getRelatedCharts(post.id)
+            ? await getPostRelatedCharts(post.id)
             : undefined
     const relatedArticles =
         grapher.id && isWordpressAPIEnabled

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -71,7 +71,7 @@ import {
     bakeAllPublishedExplorers,
 } from "./ExplorerBaker.js"
 import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer.js"
-import { postsTable } from "../db/model/Post.js"
+import { getPostsFromSnapshots, postsTable } from "../db/model/Post.js"
 import { GdocPost } from "../db/model/Gdoc/GdocPost.js"
 import { Image } from "../db/model/Image.js"
 import { generateEmbedSnippet } from "../site/viteUtils.js"
@@ -385,7 +385,7 @@ export class SiteBaker {
 
     private async removeDeletedPosts() {
         if (!this.bakeSteps.has("removeDeletedPosts")) return
-        const postsApi = await wpdb.getPosts()
+        const postsApi = await getPostsFromSnapshots()
 
         const postSlugs = []
         for (const postApi of postsApi) {
@@ -415,7 +415,7 @@ export class SiteBaker {
         const alreadyPublishedViaGdocsSlugsSet =
             await db.getSlugsWithPublishedGdocsSuccessors(db.knexInstance())
 
-        const postsApi = await wpdb.getPosts(
+        const postsApi = await getPostsFromSnapshots(
             undefined,
             (postrow) => !alreadyPublishedViaGdocsSlugsSet.has(postrow.slug)
         )

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -71,7 +71,12 @@ import {
     bakeAllPublishedExplorers,
 } from "./ExplorerBaker.js"
 import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer.js"
-import { getPostsFromSnapshots, postsTable } from "../db/model/Post.js"
+import {
+    getBlogIndex,
+    getFullPost,
+    getPostsFromSnapshots,
+    postsTable,
+} from "../db/model/Post.js"
 import { GdocPost } from "../db/model/Gdoc/GdocPost.js"
 import { Image } from "../db/model/Image.js"
 import { generateEmbedSnippet } from "../site/viteUtils.js"
@@ -389,7 +394,7 @@ export class SiteBaker {
 
         const postSlugs = []
         for (const postApi of postsApi) {
-            const post = await wpdb.getFullPost(postApi)
+            const post = await getFullPost(postApi)
             postSlugs.push(post.slug)
         }
 
@@ -423,7 +428,7 @@ export class SiteBaker {
         await pMap(
             postsApi,
             async (postApi) =>
-                wpdb.getFullPost(postApi).then((post) => this.bakePost(post)),
+                getFullPost(postApi).then((post) => this.bakePost(post)),
             { concurrency: 10 }
         )
 
@@ -747,7 +752,7 @@ export class SiteBaker {
     // Bake the blog index
     private async bakeBlogIndex() {
         if (!this.bakeSteps.has("blogIndex")) return
-        const allPosts = await wpdb.getBlogIndex()
+        const allPosts = await getBlogIndex()
         const numPages = Math.ceil(allPosts.length / BLOG_POSTS_PER_PAGE)
 
         for (let i = 1; i <= numPages; i++) {

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -75,6 +75,7 @@ import {
     getBlogIndex,
     getFullPost,
     getPostsFromSnapshots,
+    postsFlushCache,
     postsTable,
 } from "../db/model/Post.js"
 import { GdocPost } from "../db/model/Gdoc/GdocPost.js"
@@ -912,7 +913,7 @@ export class SiteBaker {
 
     private flushCache() {
         // Clear caches to allow garbage collection while waiting for next run
-        wpdb.flushCache()
+        postsFlushCache()
         siteBakingFlushCache()
         redirectsFlushCache()
         this.progressBar.tick({ name: "✅ cache flushed" })

--- a/baker/algolia/indexToAlgolia.tsx
+++ b/baker/algolia/indexToAlgolia.tsx
@@ -26,7 +26,7 @@ import { Pageview } from "../../db/model/Pageview.js"
 import { GdocPost } from "../../db/model/Gdoc/GdocPost.js"
 import { ArticleBlocks } from "../../site/gdocs/components/ArticleBlocks.js"
 import React from "react"
-import { getPostsFromSnapshots } from "../../db/model/Post.js"
+import { getFullPost, getPostsFromSnapshots } from "../../db/model/Post.js"
 
 interface TypeAndImportance {
     type: PageType
@@ -93,7 +93,7 @@ async function generateWordpressRecords(
     const records: PageRecord[] = []
 
     for (const postApi of postsApi) {
-        const rawPost = await wpdb.getFullPost(postApi)
+        const rawPost = await getFullPost(postApi)
         if (isEmpty(rawPost.content)) {
             // we have some posts that are only placeholders (e.g. for a redirect); don't index these
             console.log(

--- a/baker/algolia/indexToAlgolia.tsx
+++ b/baker/algolia/indexToAlgolia.tsx
@@ -26,6 +26,7 @@ import { Pageview } from "../../db/model/Pageview.js"
 import { GdocPost } from "../../db/model/Gdoc/GdocPost.js"
 import { ArticleBlocks } from "../../site/gdocs/components/ArticleBlocks.js"
 import React from "react"
+import { getPostsFromSnapshots } from "../../db/model/Post.js"
 
 interface TypeAndImportance {
     type: PageType
@@ -193,7 +194,7 @@ const getPagesRecords = async () => {
     // TODO: the knex instance should be handed down as a parameter
     const slugsWithPublishedGdocsSuccessors =
         await db.getSlugsWithPublishedGdocsSuccessors(db.knexInstance())
-    const postsApi = await wpdb.getPosts(undefined, (post) => {
+    const postsApi = await getPostsFromSnapshots(undefined, (post) => {
         // Two things can happen here:
         // 1. There's a published Gdoc with the same slug
         // 2. This post has a Gdoc successor (which might have a different slug)

--- a/baker/formatWordpressPost.tsx
+++ b/baker/formatWordpressPost.tsx
@@ -3,8 +3,6 @@ import urlSlug from "url-slug"
 import React from "react"
 import ReactDOMServer from "react-dom/server.js"
 import { BAKED_BASE_URL, HTTPS_ONLY } from "../settings/serverSettings.js"
-import { getTables } from "../db/wpdb.js"
-import Tablepress from "../site/Tablepress.js"
 import { GrapherExports } from "../baker/GrapherBakingUtils.js"
 import { AllCharts, renderAllCharts } from "../site/blocks/AllCharts.js"
 import { FormattingOptions } from "@ourworldindata/types"
@@ -250,15 +248,16 @@ export const formatWordpressPost = async (
     )
 
     // Insert [table id=foo] tablepress tables
-    const tables = await getTables()
-    html = html.replace(/\[table\s+id=(\d+)\s*\/\]/g, (match, tableId) => {
-        const table = tables.get(tableId)
-        if (table)
-            return ReactDOMServer.renderToStaticMarkup(
-                <Tablepress data={table.data} />
-            )
-        return "UNKNOWN TABLE"
-    })
+    // No-op since tablepress tables are already rendered when requesting a post through the API
+    // const tables = await getTables()
+    // html = html.replace(/\[table\s+id=(\d+)\s*\/\]/g, (match, tableId) => {
+    //     const table = tables.get(tableId)
+    //     if (table)
+    //         return ReactDOMServer.renderToStaticMarkup(
+    //             <Tablepress data={table.data} />
+    //         )
+    //     return "UNKNOWN TABLE"
+    // })
 
     // Give "Add country" text (and variations) the appearance of "+ Add Country" chart control
     html = html.replace(

--- a/baker/pageOverrides.tsx
+++ b/baker/pageOverrides.tsx
@@ -2,14 +2,15 @@ import { PageOverrides } from "../site/LongFormPage.js"
 import { BAKED_BASE_URL } from "../settings/serverSettings.js"
 import { urlToSlug, FullPost, JsonError } from "@ourworldindata/utils"
 import { FormattingOptions } from "@ourworldindata/types"
-import { getPostBySlugFromSnapshot, isPostCitable } from "../db/wpdb.js"
+import { isPostCitable } from "../db/wpdb.js"
 import { getTopSubnavigationParentItem } from "../site/SiteSubnavigation.js"
 import { logErrorAndMaybeSendToBugsnag } from "../serverUtils/errorLog.js"
+import { getFullPostBySlugFromSnapshot } from "../db/model/Post.js"
 
 export const getPostBySlugLogToSlackNoThrow = async (slug: string) => {
     let post
     try {
-        post = await getPostBySlugFromSnapshot(slug)
+        post = await getFullPostBySlugFromSnapshot(slug)
     } catch (err) {
         logErrorAndMaybeSendToBugsnag(err)
     } finally {

--- a/baker/pageOverrides.tsx
+++ b/baker/pageOverrides.tsx
@@ -2,10 +2,12 @@ import { PageOverrides } from "../site/LongFormPage.js"
 import { BAKED_BASE_URL } from "../settings/serverSettings.js"
 import { urlToSlug, FullPost, JsonError } from "@ourworldindata/utils"
 import { FormattingOptions } from "@ourworldindata/types"
-import { isPostCitable } from "../db/wpdb.js"
 import { getTopSubnavigationParentItem } from "../site/SiteSubnavigation.js"
 import { logErrorAndMaybeSendToBugsnag } from "../serverUtils/errorLog.js"
-import { getFullPostBySlugFromSnapshot } from "../db/model/Post.js"
+import {
+    getFullPostBySlugFromSnapshot,
+    isPostSlugCitable,
+} from "../db/model/Post.js"
 
 export const getPostBySlugLogToSlackNoThrow = async (slug: string) => {
     let post
@@ -62,7 +64,7 @@ export const getPageOverrides = async (
     const landing = await getLandingOnlyIfParent(post, formattingOptions)
     if (!landing) return
 
-    const isParentLandingCitable = await isPostCitable(landing)
+    const isParentLandingCitable = await isPostSlugCitable(landing.slug)
     if (!isParentLandingCitable) return
 
     return {

--- a/baker/pageOverrides.tsx
+++ b/baker/pageOverrides.tsx
@@ -2,14 +2,14 @@ import { PageOverrides } from "../site/LongFormPage.js"
 import { BAKED_BASE_URL } from "../settings/serverSettings.js"
 import { urlToSlug, FullPost, JsonError } from "@ourworldindata/utils"
 import { FormattingOptions } from "@ourworldindata/types"
-import { getPostBySlug, isPostCitable } from "../db/wpdb.js"
+import { getPostBySlugFromSnapshot, isPostCitable } from "../db/wpdb.js"
 import { getTopSubnavigationParentItem } from "../site/SiteSubnavigation.js"
 import { logErrorAndMaybeSendToBugsnag } from "../serverUtils/errorLog.js"
 
 export const getPostBySlugLogToSlackNoThrow = async (slug: string) => {
     let post
     try {
-        post = await getPostBySlug(slug)
+        post = await getPostBySlugFromSnapshot(slug)
     } catch (err) {
         logErrorAndMaybeSendToBugsnag(err)
     } finally {

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -63,9 +63,9 @@ import { formatPost } from "./formatWordpressPost.js"
 import {
     getBlogIndex,
     getLatestPostRevision,
-    getPostBySlug,
     isPostCitable,
     getBlockContent,
+    getPostBySlugFromSnapshot,
 } from "../db/wpdb.js"
 import { queryMysql, knexTable } from "../db/db.js"
 import { getPageOverrides, isPageOverridesCitable } from "./pageOverrides.js"
@@ -194,7 +194,7 @@ export const renderGdoc = (gdoc: OwidGdoc, isPreviewing: boolean = false) => {
 }
 
 export const renderPageBySlug = async (slug: string) => {
-    const post = await getPostBySlug(slug)
+    const post = await getPostBySlugFromSnapshot(slug)
     return renderPost(post)
 }
 
@@ -485,7 +485,7 @@ const getCountryProfilePost = memoize(
         grapherExports?: GrapherExports
     ): Promise<[FormattedPost, FormattingOptions]> => {
         // Get formatted content from generic covid country profile page.
-        const genericCountryProfilePost = await getPostBySlug(
+        const genericCountryProfilePost = await getPostBySlugFromSnapshot(
             profileSpec.genericProfileSlug
         )
 
@@ -505,7 +505,7 @@ const getCountryProfilePost = memoize(
 // todo: we used to flush cache of this thing.
 const getCountryProfileLandingPost = memoize(
     async (profileSpec: CountryProfileSpec) => {
-        return getPostBySlug(profileSpec.landingPageSlug)
+        return getPostBySlugFromSnapshot(profileSpec.landingPageSlug)
     }
 )
 
@@ -564,7 +564,7 @@ const renderPostThumbnailBySlug = async (
 
     let post
     try {
-        post = await getPostBySlug(slug)
+        post = await getPostBySlugFromSnapshot(slug)
     } catch (err) {
         // if no post is found, then we return early instead of throwing
     }
@@ -604,7 +604,8 @@ export const renderProminentLinks = async (
                         ? (await Chart.getBySlug(resolvedUrl.slug))?.config
                               ?.title // optim?
                         : resolvedUrl.slug &&
-                          (await getPostBySlug(resolvedUrl.slug)).title)
+                          (await getPostBySlugFromSnapshot(resolvedUrl.slug))
+                              .title)
             } finally {
                 if (!title) {
                     logErrorAndMaybeSendToBugsnag(

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -60,7 +60,7 @@ import {
 import { FormattingOptions, GrapherInterface } from "@ourworldindata/types"
 import { CountryProfileSpec } from "../site/countryProfileProjects.js"
 import { formatPost } from "./formatWordpressPost.js"
-import { getBlogIndex, isPostCitable, getBlockContent } from "../db/wpdb.js"
+import { getBlogIndex, getBlockContent } from "../db/wpdb.js"
 import { queryMysql, knexTable } from "../db/db.js"
 import { getPageOverrides, isPageOverridesCitable } from "./pageOverrides.js"
 import { ProminentLink } from "../site/blocks/ProminentLink.js"
@@ -84,6 +84,7 @@ import { resolveInternalRedirect } from "./redirects.js"
 import {
     getFullPostByIdFromSnapshot,
     getFullPostBySlugFromSnapshot,
+    isPostSlugCitable,
     postsTable,
 } from "../db/model/Post.js"
 import { GdocPost } from "../db/model/Gdoc/GdocPost.js"
@@ -231,7 +232,8 @@ export const renderPost = async (
 
     const pageOverrides = await getPageOverrides(post, formattingOptions)
     const citationStatus =
-        (await isPostCitable(post)) || isPageOverridesCitable(pageOverrides)
+        (await isPostSlugCitable(post.slug)) ||
+        isPageOverridesCitable(pageOverrides)
 
     return renderToHtmlPage(
         <LongFormPage

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -62,10 +62,10 @@ import { CountryProfileSpec } from "../site/countryProfileProjects.js"
 import { formatPost } from "./formatWordpressPost.js"
 import {
     getBlogIndex,
-    getLatestPostRevision,
     isPostCitable,
     getBlockContent,
     getPostBySlugFromSnapshot,
+    getPostByIdFromSnapshot,
 } from "../db/wpdb.js"
 import { queryMysql, knexTable } from "../db/db.js"
 import { getPageOverrides, isPageOverridesCitable } from "./pageOverrides.js"
@@ -199,7 +199,7 @@ export const renderPageBySlug = async (slug: string) => {
 }
 
 export const renderPreview = async (postId: number): Promise<string> => {
-    const postApi = await getLatestPostRevision(postId)
+    const postApi = await getPostByIdFromSnapshot(postId)
     return renderPost(postApi)
 }
 

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -60,13 +60,7 @@ import {
 import { FormattingOptions, GrapherInterface } from "@ourworldindata/types"
 import { CountryProfileSpec } from "../site/countryProfileProjects.js"
 import { formatPost } from "./formatWordpressPost.js"
-import {
-    getBlogIndex,
-    isPostCitable,
-    getBlockContent,
-    getPostBySlugFromSnapshot,
-    getPostByIdFromSnapshot,
-} from "../db/wpdb.js"
+import { getBlogIndex, isPostCitable, getBlockContent } from "../db/wpdb.js"
 import { queryMysql, knexTable } from "../db/db.js"
 import { getPageOverrides, isPageOverridesCitable } from "./pageOverrides.js"
 import { ProminentLink } from "../site/blocks/ProminentLink.js"
@@ -87,7 +81,11 @@ import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer.
 import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants.js"
 import { ExplorerFullQueryParams } from "../explorer/ExplorerConstants.js"
 import { resolveInternalRedirect } from "./redirects.js"
-import { postsTable } from "../db/model/Post.js"
+import {
+    getFullPostByIdFromSnapshot,
+    getFullPostBySlugFromSnapshot,
+    postsTable,
+} from "../db/model/Post.js"
 import { GdocPost } from "../db/model/Gdoc/GdocPost.js"
 import { logErrorAndMaybeSendToBugsnag } from "../serverUtils/errorLog.js"
 import { GdocFactory } from "../db/model/Gdoc/GdocFactory.js"
@@ -194,12 +192,12 @@ export const renderGdoc = (gdoc: OwidGdoc, isPreviewing: boolean = false) => {
 }
 
 export const renderPageBySlug = async (slug: string) => {
-    const post = await getPostBySlugFromSnapshot(slug)
+    const post = await getFullPostBySlugFromSnapshot(slug)
     return renderPost(post)
 }
 
 export const renderPreview = async (postId: number): Promise<string> => {
-    const postApi = await getPostByIdFromSnapshot(postId)
+    const postApi = await getFullPostByIdFromSnapshot(postId)
     return renderPost(postApi)
 }
 
@@ -485,7 +483,7 @@ const getCountryProfilePost = memoize(
         grapherExports?: GrapherExports
     ): Promise<[FormattedPost, FormattingOptions]> => {
         // Get formatted content from generic covid country profile page.
-        const genericCountryProfilePost = await getPostBySlugFromSnapshot(
+        const genericCountryProfilePost = await getFullPostBySlugFromSnapshot(
             profileSpec.genericProfileSlug
         )
 
@@ -505,7 +503,7 @@ const getCountryProfilePost = memoize(
 // todo: we used to flush cache of this thing.
 const getCountryProfileLandingPost = memoize(
     async (profileSpec: CountryProfileSpec) => {
-        return getPostBySlugFromSnapshot(profileSpec.landingPageSlug)
+        return getFullPostBySlugFromSnapshot(profileSpec.landingPageSlug)
     }
 )
 
@@ -564,7 +562,7 @@ const renderPostThumbnailBySlug = async (
 
     let post
     try {
-        post = await getPostBySlugFromSnapshot(slug)
+        post = await getFullPostBySlugFromSnapshot(slug)
     } catch (err) {
         // if no post is found, then we return early instead of throwing
     }
@@ -604,8 +602,11 @@ export const renderProminentLinks = async (
                         ? (await Chart.getBySlug(resolvedUrl.slug))?.config
                               ?.title // optim?
                         : resolvedUrl.slug &&
-                          (await getPostBySlugFromSnapshot(resolvedUrl.slug))
-                              .title)
+                          (
+                              await getFullPostBySlugFromSnapshot(
+                                  resolvedUrl.slug
+                              )
+                          ).title)
             } finally {
                 if (!title) {
                     logErrorAndMaybeSendToBugsnag(

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -60,7 +60,7 @@ import {
 import { FormattingOptions, GrapherInterface } from "@ourworldindata/types"
 import { CountryProfileSpec } from "../site/countryProfileProjects.js"
 import { formatPost } from "./formatWordpressPost.js"
-import { getBlockContent } from "../db/wpdb.js"
+import { getBlockContentFromApi } from "../db/wpdb.js"
 import { queryMysql, knexTable } from "../db/db.js"
 import { getPageOverrides, isPageOverridesCitable } from "./pageOverrides.js"
 import { ProminentLink } from "../site/blocks/ProminentLink.js"
@@ -719,7 +719,7 @@ export const renderExplorerPage = async (
 
     const wpContent = program.wpBlockId
         ? await renderReusableBlock(
-              await getBlockContent(program.wpBlockId),
+              await getBlockContentFromApi(program.wpBlockId),
               program.wpBlockId
           )
         : undefined

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -60,7 +60,7 @@ import {
 import { FormattingOptions, GrapherInterface } from "@ourworldindata/types"
 import { CountryProfileSpec } from "../site/countryProfileProjects.js"
 import { formatPost } from "./formatWordpressPost.js"
-import { getBlogIndex, getBlockContent } from "../db/wpdb.js"
+import { getBlockContent } from "../db/wpdb.js"
 import { queryMysql, knexTable } from "../db/db.js"
 import { getPageOverrides, isPageOverridesCitable } from "./pageOverrides.js"
 import { ProminentLink } from "../site/blocks/ProminentLink.js"
@@ -82,6 +82,7 @@ import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants.js"
 import { ExplorerFullQueryParams } from "../explorer/ExplorerConstants.js"
 import { resolveInternalRedirect } from "./redirects.js"
 import {
+    getBlogIndex,
     getFullPostByIdFromSnapshot,
     getFullPostBySlugFromSnapshot,
     isPostSlugCitable,

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -60,7 +60,6 @@ import {
 import { FormattingOptions, GrapherInterface } from "@ourworldindata/types"
 import { CountryProfileSpec } from "../site/countryProfileProjects.js"
 import { formatPost } from "./formatWordpressPost.js"
-import { getBlockContentFromApi } from "../db/wpdb.js"
 import { queryMysql, knexTable } from "../db/db.js"
 import { getPageOverrides, isPageOverridesCitable } from "./pageOverrides.js"
 import { ProminentLink } from "../site/blocks/ProminentLink.js"
@@ -82,6 +81,7 @@ import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants.js"
 import { ExplorerFullQueryParams } from "../explorer/ExplorerConstants.js"
 import { resolveInternalRedirect } from "./redirects.js"
 import {
+    getBlockContentFromSnapshot,
     getBlogIndex,
     getFullPostByIdFromSnapshot,
     getFullPostBySlugFromSnapshot,
@@ -719,7 +719,7 @@ export const renderExplorerPage = async (
 
     const wpContent = program.wpBlockId
         ? await renderReusableBlock(
-              await getBlockContentFromApi(program.wpBlockId),
+              await getBlockContentFromSnapshot(program.wpBlockId),
               program.wpBlockId
           )
         : undefined

--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -6,13 +6,13 @@ import {
 } from "../settings/serverSettings.js"
 import { dayjs, countries, queryParamsToStr } from "@ourworldindata/utils"
 import * as db from "../db/db.js"
-import * as wpdb from "../db/wpdb.js"
 import urljoin from "url-join"
 import { countryProfileSpecs } from "../site/countryProfileProjects.js"
 import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer.js"
 import { EXPLORERS_ROUTE_FOLDER } from "../explorer/ExplorerConstants.js"
 import { ExplorerProgram } from "../explorer/ExplorerProgram.js"
 import { GdocPost } from "../db/model/Gdoc/GdocPost.js"
+import { getPostsFromSnapshots } from "../db/model/Post.js"
 
 interface SitemapUrl {
     loc: string
@@ -62,7 +62,7 @@ export const makeSitemap = async (explorerAdminServer: ExplorerAdminServer) => {
     const knex = db.knexInstance()
     const alreadyPublishedViaGdocsSlugsSet =
         await db.getSlugsWithPublishedGdocsSuccessors(knex)
-    const postsApi = await wpdb.getPosts(
+    const postsApi = await getPostsFromSnapshots(
         undefined,
         (postrow) => !alreadyPublishedViaGdocsSlugsSet.has(postrow.slug)
     )

--- a/db/DEPRECATEDwpdb.ts
+++ b/db/DEPRECATEDwpdb.ts
@@ -192,7 +192,9 @@ export const DEPRECATEDgetPostType = async (
 }
 
 let cachedFeaturedImages: Map<number, string> | undefined
-export const getFeaturedImages = async (): Promise<Map<number, string>> => {
+export const DEPRECATEDgetFeaturedImages = async (): Promise<
+    Map<number, string>
+> => {
     if (cachedFeaturedImages) return cachedFeaturedImages
 
     const rows = await singleton.query(
@@ -206,4 +208,42 @@ export const getFeaturedImages = async (): Promise<Map<number, string>> => {
 
     cachedFeaturedImages = featuredImages
     return featuredImages
+}
+interface TablepressTable {
+    tableId: string
+    data: string[][]
+}
+export let cachedTables: Map<string, TablepressTable> | undefined
+export const DEPRECATEDgetTables = async (): Promise<
+    Map<string, TablepressTable>
+> => {
+    if (cachedTables) return cachedTables
+
+    const optRows = await singleton.query(`
+        SELECT option_value AS json FROM wp_options WHERE option_name='tablepress_tables'
+    `)
+
+    const tableToPostIds = JSON.parse(optRows[0].json).table_post
+
+    const rows = await singleton.query(`
+        SELECT ID, post_content FROM wp_posts WHERE post_type='tablepress_table'
+    `)
+
+    const tableContents = new Map<string, string>()
+    for (const row of rows) {
+        tableContents.set(row.ID, row.post_content)
+    }
+
+    cachedTables = new Map()
+    for (const tableId in tableToPostIds) {
+        const data = JSON.parse(
+            tableContents.get(tableToPostIds[tableId]) || "[]"
+        )
+        cachedTables.set(tableId, {
+            tableId: tableId,
+            data: data,
+        })
+    }
+
+    return cachedTables
 }

--- a/db/DEPRECATEDwpdb.ts
+++ b/db/DEPRECATEDwpdb.ts
@@ -23,6 +23,7 @@ import {
     singleton,
     OWID_API_ENDPOINT,
     getEndpointSlugFromType,
+    getBlockApiFromApi,
 } from "./wpdb.js"
 import { getFullPost } from "./model/Post.js"
 
@@ -246,4 +247,14 @@ export const DEPRECATEDgetTables = async (): Promise<
     }
 
     return cachedTables
+}
+
+export const DEPRECATEDgetBlockContentFromApi = async (
+    id: number
+): Promise<string | undefined> => {
+    if (!isWordpressAPIEnabled) return undefined
+
+    const post = await getBlockApiFromApi(id)
+
+    return post.data?.wpBlock?.content ?? undefined
 }

--- a/db/DEPRECATEDwpdb.ts
+++ b/db/DEPRECATEDwpdb.ts
@@ -1,0 +1,93 @@
+/**
+ *
+ * DO NOT USE - DEPRECATED - FOR DOCUMENTATION PURPOSES ONLY
+ *
+ * Note: This file contains now deprecated functions that were querying the Wordpress
+ * tables or APIs. It is kept around for easier reference during the transition period
+ * but should not be used for new code.
+ */
+
+import {
+    WP_PostType,
+    FilterFnPostRestApi,
+    PostRestApi,
+    FullPost,
+    JsonError,
+} from "@ourworldindata/types"
+import { BLOG_SLUG } from "../settings/serverSettings.js"
+import {
+    WP_API_ENDPOINT,
+    apiQuery,
+    getEndpointSlugFromType,
+    getFullPost,
+    getPostApiBySlugFromApi,
+    isWordpressAPIEnabled,
+} from "./wpdb.js"
+
+// Limit not supported with multiple post types: When passing multiple post
+// types, the limit is applied to the resulting array of sequentially sorted
+// posts (all blog posts, then all pages, ...), so there will be a predominance
+// of a certain post type.
+export const DEPRECATEDgetPosts = async (
+    postTypes: string[] = [WP_PostType.Post, WP_PostType.Page],
+    filterFunc?: FilterFnPostRestApi,
+    limit?: number
+): Promise<PostRestApi[]> => {
+    if (!isWordpressAPIEnabled) return []
+
+    const perPage = 20
+    const posts: PostRestApi[] = []
+
+    for (const postType of postTypes) {
+        const endpoint = `${WP_API_ENDPOINT}/${getEndpointSlugFromType(
+            postType
+        )}`
+
+        // Get number of items to retrieve
+        const headers = await apiQuery(endpoint, {
+            searchParams: [["per_page", 1]],
+            returnResponseHeadersOnly: true,
+        })
+        const maxAvailable = headers.get("X-WP-TotalPages")
+        const count = limit && limit < maxAvailable ? limit : maxAvailable
+
+        for (let page = 1; page <= Math.ceil(count / perPage); page++) {
+            const postsCurrentPage = await apiQuery(endpoint, {
+                searchParams: [
+                    ["per_page", perPage],
+                    ["page", page],
+                ],
+            })
+            posts.push(...postsCurrentPage)
+        }
+    }
+
+    // Published pages excluded from public views
+    const excludedSlugs = [BLOG_SLUG]
+
+    const filterConditions: Array<FilterFnPostRestApi> = [
+        (post): boolean => !excludedSlugs.includes(post.slug),
+        (post): boolean => !post.slug.endsWith("-country-profile"),
+    ]
+    if (filterFunc) filterConditions.push(filterFunc)
+
+    const filteredPosts = posts.filter((post) =>
+        filterConditions.every((c) => c(post))
+    )
+
+    return limit ? filteredPosts.slice(0, limit) : filteredPosts
+}
+
+// We might want to cache this as the network of prominent links densifies and
+// multiple requests to the same posts are happening.
+export const DEPRECATEDgetPostBySlugFromApi = async (
+    slug: string
+): Promise<FullPost> => {
+    if (!isWordpressAPIEnabled) {
+        throw new JsonError(`Need wordpress API to match slug ${slug}`, 404)
+    }
+
+    const postApi = await getPostApiBySlugFromApi(slug)
+
+    return getFullPost(postApi)
+}

--- a/db/DEPRECATEDwpdb.ts
+++ b/db/DEPRECATEDwpdb.ts
@@ -23,6 +23,7 @@ import {
     getPostApiBySlugFromApi,
     getPostType,
     isWordpressAPIEnabled,
+    singleton,
 } from "./wpdb.js"
 
 // Limit not supported with multiple post types: When passing multiple post
@@ -122,4 +123,60 @@ export const DEPRECATEDgetLatestPostRevision = async (
         content: revision.content,
         title: revision.title,
     })
+}
+
+export const DEPRECATEDgetTagsByPostId = async (): Promise<
+    Map<number, string[]>
+> => {
+    const tagsByPostId = new Map<number, string[]>()
+    const rows = await singleton.query(`
+        SELECT p.id, t.name
+        FROM wp_posts p
+        JOIN wp_term_relationships tr
+            on (p.id=tr.object_id)
+        JOIN wp_term_taxonomy tt
+            on (tt.term_taxonomy_id=tr.term_taxonomy_id
+            and tt.taxonomy='post_tag')
+        JOIN wp_terms t
+            on (tt.term_id=t.term_id)
+    `)
+
+    for (const row of rows) {
+        let cats = tagsByPostId.get(row.id)
+        if (!cats) {
+            cats = []
+            tagsByPostId.set(row.id, cats)
+        }
+        cats.push(row.name)
+    }
+
+    return tagsByPostId
+}
+
+// Retrieve a map of post ids to authors
+export let cachedAuthorship: Map<number, string[]> | undefined
+export const DEPRECATEDgetAuthorship = async (): Promise<
+    Map<number, string[]>
+> => {
+    if (cachedAuthorship) return cachedAuthorship
+
+    const authorRows = await singleton.query(`
+        SELECT object_id, terms.description FROM wp_term_relationships AS rels
+        LEFT JOIN wp_term_taxonomy AS terms ON terms.term_taxonomy_id=rels.term_taxonomy_id
+        WHERE terms.taxonomy='author'
+        ORDER BY rels.term_order ASC
+    `)
+
+    const authorship = new Map<number, string[]>()
+    for (const row of authorRows) {
+        let authors = authorship.get(row.object_id)
+        if (!authors) {
+            authors = []
+            authorship.set(row.object_id, authors)
+        }
+        authors.push(row.description.split(" ").slice(0, 2).join(" "))
+    }
+
+    cachedAuthorship = authorship
+    return authorship
 }

--- a/db/DEPRECATEDwpdb.ts
+++ b/db/DEPRECATEDwpdb.ts
@@ -18,13 +18,13 @@ import { BLOG_SLUG } from "../settings/serverSettings.js"
 import {
     WP_API_ENDPOINT,
     apiQuery,
-    getFullPost,
     getPostApiBySlugFromApi,
     isWordpressAPIEnabled,
     singleton,
     OWID_API_ENDPOINT,
     getEndpointSlugFromType,
 } from "./wpdb.js"
+import { getFullPost } from "./model/Post.js"
 
 // Limit not supported with multiple post types: When passing multiple post
 // types, the limit is applied to the resulting array of sequentially sorted

--- a/db/DEPRECATEDwpdb.ts
+++ b/db/DEPRECATEDwpdb.ts
@@ -21,6 +21,7 @@ import {
     getEndpointSlugFromType,
     getFullPost,
     getPostApiBySlugFromApi,
+    getPostType,
     isWordpressAPIEnabled,
 } from "./wpdb.js"
 
@@ -90,4 +91,35 @@ export const DEPRECATEDgetPostBySlugFromApi = async (
     const postApi = await getPostApiBySlugFromApi(slug)
 
     return getFullPost(postApi)
+}
+
+// the /revisions endpoint does not send back all the metadata required for
+// the proper rendering of the post (e.g. authors), hence the double request.
+export const DEPRECATEDgetLatestPostRevision = async (
+    id: number
+): Promise<FullPost> => {
+    const type = await getPostType(id)
+    const endpointSlug = getEndpointSlugFromType(type)
+
+    const postApi = await apiQuery(`${WP_API_ENDPOINT}/${endpointSlug}/${id}`)
+
+    const revision = (
+        await apiQuery(
+            `${WP_API_ENDPOINT}/${endpointSlug}/${id}/revisions?per_page=1`
+        )
+    )[0]
+
+    // Since WP does not store metadata for revisions, some elements of a
+    // previewed page will not reflect the latest edits:
+    // - published date (will show the correct one - that is the one in the
+    //   sidebar - for unpublished posts though. For published posts, the
+    //   current published date is displayed, regardless of what is shown
+    //   and could have been modified in the sidebar.)
+    // - authors
+    // ...
+    return getFullPost({
+        ...postApi,
+        content: revision.content,
+        title: revision.title,
+    })
 }

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -19,8 +19,7 @@ import {
     adjustHeadingLevels,
     findMinimumHeadingLevel,
 } from "./model/Gdoc/htmlToEnriched.js"
-import { getRelatedCharts } from "./wpdb.js"
-import { isPostSlugCitable } from "./model/Post.js"
+import { getPostRelatedCharts, isPostSlugCitable } from "./model/Post.js"
 import { enrichedBlocksToMarkdown } from "./model/Gdoc/enrichedToMarkdown.js"
 
 // slugs from all the linear entries we want to migrate from @edomt
@@ -109,7 +108,7 @@ const migrate = async (): Promise<void> => {
             const text = post.content
             let relatedCharts: RelatedChart[] = []
             if (isEntry) {
-                relatedCharts = await getRelatedCharts(post.id)
+                relatedCharts = await getPostRelatedCharts(post.id)
             }
 
             const shouldIncludeMaxAsAuthor = await isPostSlugCitable(post.slug)

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -19,7 +19,8 @@ import {
     adjustHeadingLevels,
     findMinimumHeadingLevel,
 } from "./model/Gdoc/htmlToEnriched.js"
-import { getRelatedCharts, isPostCitable } from "./wpdb.js"
+import { getRelatedCharts } from "./wpdb.js"
+import { isPostSlugCitable } from "./model/Post.js"
 import { enrichedBlocksToMarkdown } from "./model/Gdoc/enrichedToMarkdown.js"
 
 // slugs from all the linear entries we want to migrate from @edomt
@@ -111,10 +112,7 @@ const migrate = async (): Promise<void> => {
                 relatedCharts = await getRelatedCharts(post.id)
             }
 
-            const shouldIncludeMaxAsAuthor = await isPostCitable(
-                // Only needs post.slug
-                post as any
-            )
+            const shouldIncludeMaxAsAuthor = await isPostSlugCitable(post.slug)
             if (
                 shouldIncludeMaxAsAuthor &&
                 post.authors &&

--- a/db/migration/1706711579844-AddWordpressApiSnapshotToPosts.ts
+++ b/db/migration/1706711579844-AddWordpressApiSnapshotToPosts.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddWordpressApiSnapshotToPosts1706711579844
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE posts ADD wpApiSnapshot JSON DEFAULT NULL`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE posts DROP COLUMN wpApiSnapshot`)
+    }
+}

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -14,6 +14,7 @@ import {
     OwidGdocPostInterface,
     IMAGES_DIRECTORY,
     snapshotIsPostRestApi,
+    snapshotIsBlockGraphQlApi,
 } from "@ourworldindata/types"
 import { Knex } from "knex"
 import { memoize, orderBy } from "lodash"
@@ -111,7 +112,10 @@ export const getFullPostBySlugFromSnapshot = async (
     slug: string
 ): Promise<FullPost> => {
     const postEnriched = await getPostEnrichedBySlug(slug)
-    if (!snapshotIsPostRestApi(postEnriched?.wpApiSnapshot))
+    if (
+        !postEnriched?.wpApiSnapshot ||
+        !snapshotIsPostRestApi(postEnriched.wpApiSnapshot)
+    )
         throw new JsonError(`No page snapshot found by slug ${slug}`, 404)
 
     return getFullPost(postEnriched.wpApiSnapshot)
@@ -121,7 +125,10 @@ export const getFullPostByIdFromSnapshot = async (
     id: number
 ): Promise<FullPost> => {
     const postEnriched = await getPostEnrichedById(id)
-    if (!snapshotIsPostRestApi(postEnriched?.wpApiSnapshot))
+    if (
+        !postEnriched?.wpApiSnapshot ||
+        !snapshotIsPostRestApi(postEnriched.wpApiSnapshot)
+    )
         throw new JsonError(`No page snapshot found by id ${id}`, 404)
 
     return getFullPost(postEnriched.wpApiSnapshot)
@@ -266,4 +273,17 @@ export const mapGdocsToWordpressPosts = (
 
 export const postsFlushCache = (): void => {
     getBlogIndex.cache.clear?.()
+}
+
+export const getBlockContentFromSnapshot = async (
+    id: number
+): Promise<string | undefined> => {
+    const enrichedBlock = await getPostEnrichedById(id)
+    if (
+        !enrichedBlock?.wpApiSnapshot ||
+        !snapshotIsBlockGraphQlApi(enrichedBlock.wpApiSnapshot)
+    )
+        return
+
+    return enrichedBlock?.wpApiSnapshot.data?.wpBlock?.content
 }

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -63,12 +63,25 @@ export const setTagsForPost = async (
 export const getPostRawBySlug = async (
     slug: string
 ): Promise<DbRawPost | undefined> =>
-    (await db.knexTable("posts").where({ slug: slug }))[0]
+    (await db.knexTable(postsTable).where({ slug }))[0]
+
+export const getPostRawById = async (
+    id: number
+): Promise<DbRawPost | undefined> =>
+    (await db.knexTable(postsTable).where({ id }))[0]
 
 export const getPostEnrichedBySlug = async (
     slug: string
 ): Promise<DbEnrichedPost | undefined> => {
     const post = await getPostRawBySlug(slug)
+    if (!post) return undefined
+    return parsePostRow(post)
+}
+
+export const getPostEnrichedById = async (
+    id: number
+): Promise<DbEnrichedPost | undefined> => {
+    const post = await getPostRawById(id)
     if (!post) return undefined
     return parsePostRow(post)
 }

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -1,6 +1,13 @@
 import * as db from "../db.js"
 import { Knex } from "knex"
-import { DbEnrichedPost, DbRawPost, parsePostRow } from "@ourworldindata/utils"
+import {
+    DbEnrichedPost,
+    DbRawPost,
+    FullPost,
+    JsonError,
+    parsePostRow,
+} from "@ourworldindata/utils"
+import { getFullPost } from "../wpdb.js"
 
 export const postsTable = "posts"
 
@@ -84,4 +91,24 @@ export const getPostEnrichedById = async (
     const post = await getPostRawById(id)
     if (!post) return undefined
     return parsePostRow(post)
+}
+
+export const getFullPostBySlugFromSnapshot = async (
+    slug: string
+): Promise<FullPost> => {
+    const postEnriched = await getPostEnrichedBySlug(slug)
+    if (!postEnriched?.wpApiSnapshot)
+        throw new JsonError(`No page snapshot found by slug ${slug}`, 404)
+
+    return getFullPost(postEnriched.wpApiSnapshot)
+}
+
+export const getFullPostByIdFromSnapshot = async (
+    id: number
+): Promise<FullPost> => {
+    const postEnriched = await getPostEnrichedById(id)
+    if (!postEnriched?.wpApiSnapshot)
+        throw new JsonError(`No page snapshot found by id ${id}`, 404)
+
+    return getFullPost(postEnriched.wpApiSnapshot)
 }

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -18,7 +18,6 @@ import { Knex } from "knex"
 import { memoize, orderBy } from "lodash"
 import { BAKED_BASE_URL } from "../../settings/clientSettings.js"
 import { BLOG_SLUG } from "../../settings/serverSettings.js"
-import { selectHomepagePosts } from "../wpdb.js"
 import { GdocPost } from "./Gdoc/GdocPost.js"
 import { SiteNavigationStatic } from "../../site/SiteNavigation.js"
 import { decodeHTML } from "entities"
@@ -219,6 +218,9 @@ export const getFullPost = async (
             ? await getPostRelatedCharts(postApi.id)
             : undefined,
 })
+
+const selectHomepagePosts: FilterFnPostRestApi = (post) =>
+    post.meta?.owid_publication_context_meta_field?.homepage === true
 
 export const getBlogIndex = memoize(async (): Promise<IndexPost[]> => {
     await db.getConnection() // side effect: ensure connection is established

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -260,3 +260,7 @@ export const mapGdocsToWordpressPosts = (
             : `${BAKED_BASE_URL}/default-thumbnail.jpg`,
     }))
 }
+
+export const postsFlushCache = (): void => {
+    getBlogIndex.cache.clear?.()
+}

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -13,6 +13,7 @@ import {
     IndexPost,
     OwidGdocPostInterface,
     IMAGES_DIRECTORY,
+    snapshotIsPostRestApi,
 } from "@ourworldindata/types"
 import { Knex } from "knex"
 import { memoize, orderBy } from "lodash"
@@ -110,7 +111,7 @@ export const getFullPostBySlugFromSnapshot = async (
     slug: string
 ): Promise<FullPost> => {
     const postEnriched = await getPostEnrichedBySlug(slug)
-    if (!postEnriched?.wpApiSnapshot)
+    if (!snapshotIsPostRestApi(postEnriched?.wpApiSnapshot))
         throw new JsonError(`No page snapshot found by slug ${slug}`, 404)
 
     return getFullPost(postEnriched.wpApiSnapshot)
@@ -120,7 +121,7 @@ export const getFullPostByIdFromSnapshot = async (
     id: number
 ): Promise<FullPost> => {
     const postEnriched = await getPostEnrichedById(id)
-    if (!postEnriched?.wpApiSnapshot)
+    if (!snapshotIsPostRestApi(postEnriched?.wpApiSnapshot))
         throw new JsonError(`No page snapshot found by id ${id}`, 404)
 
     return getFullPost(postEnriched.wpApiSnapshot)

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -1,6 +1,7 @@
 import * as db from "../db.js"
 import { Knex } from "knex"
 import {
+    CategoryWithEntries,
     DbEnrichedPost,
     DbRawPost,
     FullPost,
@@ -8,6 +9,7 @@ import {
     parsePostRow,
 } from "@ourworldindata/utils"
 import { getFullPost } from "../wpdb.js"
+import { SiteNavigationStatic } from "../../site/SiteNavigation.js"
 
 export const postsTable = "posts"
 
@@ -111,4 +113,20 @@ export const getFullPostByIdFromSnapshot = async (
         throw new JsonError(`No page snapshot found by id ${id}`, 404)
 
     return getFullPost(postEnriched.wpApiSnapshot)
+}
+
+export const isPostSlugCitable = async (slug: string): Promise<boolean> => {
+    const entries = SiteNavigationStatic.categories
+    return entries.some((category) => {
+        return (
+            category.entries.some((entry) => entry.slug === slug) ||
+            (category.subcategories ?? []).some(
+                (subcategory: CategoryWithEntries) => {
+                    return subcategory.entries.some(
+                        (subCategoryEntry) => subCategoryEntry.slug === slug
+                    )
+                }
+            )
+        )
+    })
 }

--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -305,7 +305,7 @@ const syncPostsToGrapher = async (): Promise<void> => {
                 content: dereferenceReusableBlocksFn(content),
                 wpApiSnapshot:
                     post.post_type === "wp_block"
-                        ? await wpdb.getBlockApi(post.ID)
+                        ? await wpdb.getBlockApiFromApi(post.ID)
                         : await wpdb.getPostApiBySlugFromApi(post.post_name),
                 featured_image: post.featured_image || "",
                 published_at:

--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -14,6 +14,7 @@ import {
 } from "@ourworldindata/utils"
 import { postsTable, select } from "./model/Post.js"
 import { PostLink } from "./model/PostLink.js"
+import pMap from "p-map"
 
 const zeroDateString = "0000-00-00 00:00:00"
 
@@ -284,37 +285,46 @@ const syncPostsToGrapher = async (): Promise<void> => {
         .filter((p) => !doesExistInWordpress[p.id])
         .map((p) => p.id)
 
-    const toInsert = rows.map((post: any) => {
-        const content = post.post_content as string
-        const formattingOptions = extractFormattingOptions(content)
-        const authors: string[] = sortBy(
-            JSON.parse(post.authors),
-            (item: { author: string; order: number }) => item.order
-        ).map((author: { author: string; order: number }) => author.author)
+    const toInsert = (await pMap(
+        rows,
+        async (post: any) => {
+            console.log("Processing post", post.ID, post.post_title)
+            const content = post.post_content as string
+            const formattingOptions = extractFormattingOptions(content)
+            const authors: string[] = sortBy(
+                JSON.parse(post.authors),
+                (item: { author: string; order: number }) => item.order
+            ).map((author: { author: string; order: number }) => author.author)
 
-        return {
-            id: post.ID,
-            title: post.post_title,
-            slug: post.post_name.replace(/__/g, "/"),
-            type: post.post_type,
-            status: post.post_status,
-            content: dereferenceReusableBlocksFn(content),
-            featured_image: post.featured_image || "",
-            published_at:
-                post.post_date_gmt === zeroDateString
-                    ? null
-                    : post.post_date_gmt,
-            updated_at_in_wordpress:
-                post.post_modified_gmt === zeroDateString
-                    ? "1970-01-01 00:00:00"
-                    : post.post_modified_gmt,
-            authors: authors,
-            excerpt: post.post_excerpt,
-            created_at_in_wordpress:
-                post.created_at === zeroDateString ? null : post.created_at,
-            formattingOptions: formattingOptions,
-        }
-    }) as DbEnrichedPost[]
+            return {
+                id: post.ID,
+                title: post.post_title,
+                slug: post.post_name.replace(/__/g, "/"),
+                type: post.post_type,
+                status: post.post_status,
+                content: dereferenceReusableBlocksFn(content),
+                wpApiSnapshot:
+                    post.post_type === "wp_block"
+                        ? await wpdb.getBlockApi(post.ID)
+                        : await wpdb.getPostApiBySlug(post.post_name),
+                featured_image: post.featured_image || "",
+                published_at:
+                    post.post_date_gmt === zeroDateString
+                        ? null
+                        : post.post_date_gmt,
+                updated_at_in_wordpress:
+                    post.post_modified_gmt === zeroDateString
+                        ? "1970-01-01 00:00:00"
+                        : post.post_modified_gmt,
+                authors: authors,
+                excerpt: post.post_excerpt,
+                created_at_in_wordpress:
+                    post.created_at === zeroDateString ? null : post.created_at,
+                formattingOptions: formattingOptions,
+            }
+        },
+        { concurrency: 20 }
+    )) as DbEnrichedPost[]
     const postLinks = await PostLink.find()
     const postLinksById = groupBy(postLinks, (link: PostLink) => link.sourceId)
 

--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -306,7 +306,7 @@ const syncPostsToGrapher = async (): Promise<void> => {
                 wpApiSnapshot:
                     post.post_type === "wp_block"
                         ? await wpdb.getBlockApi(post.ID)
-                        : await wpdb.getPostApiBySlug(post.post_name),
+                        : await wpdb.getPostApiBySlugFromApi(post.post_name),
                 featured_image: post.featured_image || "",
                 published_at:
                     post.post_date_gmt === zeroDateString

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -18,7 +18,6 @@ import { Base64 } from "js-base64"
 import { registerExitHandler } from "./cleanup.js"
 import {
     RelatedChart,
-    CategoryWithEntries,
     FullPost,
     WP_PostType,
     DocumentNode,
@@ -52,7 +51,6 @@ import {
 import { TOPICS_CONTENT_GRAPH } from "../settings/clientSettings.js"
 import { GdocPost } from "./model/Gdoc/GdocPost.js"
 import { Link } from "./model/Link.js"
-import { SiteNavigationStatic } from "../site/SiteNavigation.js"
 import { postsTable } from "./model/Post.js"
 
 let _knexInstance: Knex
@@ -258,23 +256,6 @@ export const getDocumentsInfo = async (
     } else {
         return documents
     }
-}
-
-export const isPostCitable = async (post: FullPost): Promise<boolean> => {
-    const entries = SiteNavigationStatic.categories
-    return entries.some((category) => {
-        return (
-            category.entries.some((entry) => entry.slug === post.slug) ||
-            (category.subcategories ?? []).some(
-                (subcategory: CategoryWithEntries) => {
-                    return subcategory.entries.some(
-                        (subCategoryEntry) =>
-                            subCategoryEntry.slug === post.slug
-                    )
-                }
-            )
-        )
-    })
 }
 
 export const getPermalinks = async (): Promise<{

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -53,11 +53,7 @@ import { TOPICS_CONTENT_GRAPH } from "../settings/clientSettings.js"
 import { GdocPost } from "./model/Gdoc/GdocPost.js"
 import { Link } from "./model/Link.js"
 import { SiteNavigationStatic } from "../site/SiteNavigation.js"
-import {
-    getPostEnrichedById,
-    getPostEnrichedBySlug,
-    postsTable,
-} from "./model/Post.js"
+import { postsTable } from "./model/Post.js"
 
 let _knexInstance: Knex
 
@@ -449,26 +445,6 @@ export const getPostApiBySlugFromApi = async (
     const { id, type } = postIdAndType
 
     return apiQuery(`${WP_API_ENDPOINT}/${getEndpointSlugFromType(type)}/${id}`)
-}
-
-export const getPostBySlugFromSnapshot = async (
-    slug: string
-): Promise<FullPost> => {
-    const postEnriched = await getPostEnrichedBySlug(slug)
-    if (!postEnriched?.wpApiSnapshot)
-        throw new JsonError(`No page snapshot found by slug ${slug}`, 404)
-
-    return getFullPost(postEnriched.wpApiSnapshot)
-}
-
-export const getPostByIdFromSnapshot = async (
-    id: number
-): Promise<FullPost> => {
-    const postEnriched = await getPostEnrichedById(id)
-    if (!postEnriched?.wpApiSnapshot)
-        throw new JsonError(`No page snapshot found by id ${id}`, 404)
-
-    return getFullPost(postEnriched.wpApiSnapshot)
 }
 
 export const getRelatedCharts = async (

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -19,7 +19,6 @@ import {
     DocumentNode,
     PostReference,
     JsonError,
-    FilterFnPostRestApi,
     PostRestApi,
     TopicId,
     GraphType,
@@ -253,9 +252,6 @@ export const getPermalinks = async (): Promise<{
 
 // page => pages, post => posts
 export const getEndpointSlugFromType = (type: string): string => `${type}s`
-
-export const selectHomepagePosts: FilterFnPostRestApi = (post) =>
-    post.meta?.owid_publication_context_meta_field?.homepage === true
 
 // The API query in getPostType is cleaner but slower, which becomes more of an
 // issue with prominent links requesting posts by slugs (getPostBySlug) to

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -267,23 +267,6 @@ export const getPermalinks = async (): Promise<{
         postName.replace(/\/+$/g, "").replace(/--/g, "/").replace(/__/g, "/"),
 })
 
-let cachedFeaturedImages: Map<number, string> | undefined
-export const getFeaturedImages = async (): Promise<Map<number, string>> => {
-    if (cachedFeaturedImages) return cachedFeaturedImages
-
-    const rows = await singleton.query(
-        `SELECT wp_postmeta.post_id, wp_posts.guid FROM wp_postmeta INNER JOIN wp_posts ON wp_posts.ID=wp_postmeta.meta_value WHERE wp_postmeta.meta_key='_thumbnail_id'`
-    )
-
-    const featuredImages = new Map<number, string>()
-    for (const row of rows) {
-        featuredImages.set(row.post_id, row.guid)
-    }
-
-    cachedFeaturedImages = featuredImages
-    return featuredImages
-}
-
 // page => pages, post => posts
 export const getEndpointSlugFromType = (type: string): string => `${type}s`
 
@@ -321,14 +304,6 @@ export const getPosts = async (
     if (filterFunc) filterConditions.push(filterFunc)
 
     return posts.filter((post) => filterConditions.every((c) => c(post)))
-}
-
-// todo / refactor : narrow down scope to getPostTypeById?
-export const getPostType = async (search: number | string): Promise<string> => {
-    const paramName = typeof search === "number" ? "id" : "slug"
-    return apiQuery(`${OWID_API_ENDPOINT}/type`, {
-        searchParams: [[paramName, search]],
-    })
 }
 
 // The API query in getPostType is cleaner but slower, which becomes more of an
@@ -776,7 +751,6 @@ export const getTables = async (): Promise<Map<string, TablepressTable>> => {
 }
 
 export const flushCache = (): void => {
-    cachedFeaturedImages = undefined
     getBlogIndex.cache.clear?.()
     cachedTables = undefined
 }

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -525,7 +525,7 @@ export const getRelatedArticles = async (
     )
 }
 
-export const getBlockApi = async (id: number): Promise<any> => {
+export const getBlockApiFromApi = async (id: number): Promise<any> => {
     if (!isWordpressAPIEnabled) return undefined
 
     const query = `
@@ -538,12 +538,12 @@ export const getBlockApi = async (id: number): Promise<any> => {
     return graphqlQuery(query, { id })
 }
 
-export const getBlockContent = async (
+export const getBlockContentFromApi = async (
     id: number
 ): Promise<string | undefined> => {
     if (!isWordpressAPIEnabled) return undefined
 
-    const post = await getBlockApi(id)
+    const post = await getBlockApiFromApi(id)
 
     return post.data?.wpBlock?.content ?? undefined
 }

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -712,45 +712,6 @@ export const getTopics = async (cursor: string = ""): Promise<Topic[]> => {
     }
 }
 
-interface TablepressTable {
-    tableId: string
-    data: string[][]
-}
-
-let cachedTables: Map<string, TablepressTable> | undefined
-export const getTables = async (): Promise<Map<string, TablepressTable>> => {
-    if (cachedTables) return cachedTables
-
-    const optRows = await singleton.query(`
-        SELECT option_value AS json FROM wp_options WHERE option_name='tablepress_tables'
-    `)
-
-    const tableToPostIds = JSON.parse(optRows[0].json).table_post
-
-    const rows = await singleton.query(`
-        SELECT ID, post_content FROM wp_posts WHERE post_type='tablepress_table'
-    `)
-
-    const tableContents = new Map<string, string>()
-    for (const row of rows) {
-        tableContents.set(row.ID, row.post_content)
-    }
-
-    cachedTables = new Map()
-    for (const tableId in tableToPostIds) {
-        const data = JSON.parse(
-            tableContents.get(tableToPostIds[tableId]) || "[]"
-        )
-        cachedTables.set(tableId, {
-            tableId: tableId,
-            data: data,
-        })
-    }
-
-    return cachedTables
-}
-
 export const flushCache = (): void => {
     getBlogIndex.cache.clear?.()
-    cachedTables = undefined
 }

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -538,16 +538,6 @@ export const getBlockApiFromApi = async (id: number): Promise<any> => {
     return graphqlQuery(query, { id })
 }
 
-export const getBlockContentFromApi = async (
-    id: number
-): Promise<string | undefined> => {
-    if (!isWordpressAPIEnabled) return undefined
-
-    const post = await getBlockApiFromApi(id)
-
-    return post.data?.wpBlock?.content ?? undefined
-}
-
 export const getTopics = async (cursor: string = ""): Promise<Topic[]> => {
     if (!isWordpressAPIEnabled) return []
     const query = `query {

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -36,7 +36,6 @@ import {
 } from "./contentGraph.js"
 import { TOPICS_CONTENT_GRAPH } from "../settings/clientSettings.js"
 import { Link } from "./model/Link.js"
-import { getBlogIndex } from "./model/Post.js"
 
 let _knexInstance: Knex
 
@@ -578,8 +577,4 @@ export const getTopics = async (cursor: string = ""): Promise<Topic[]> => {
     } else {
         return topics
     }
-}
-
-export const flushCache = (): void => {
-    getBlogIndex.cache.clear?.()
 }

--- a/packages/@ourworldindata/types/src/dbTypes/Posts.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Posts.ts
@@ -2,6 +2,7 @@ import {
     WP_PostType,
     FormattingOptions,
     PostRestApi,
+    BlockGraphQlApi,
 } from "../wordpressTypes/WordpressTypes.js"
 import {
     OwidArticleBackportingStatistics,
@@ -43,7 +44,7 @@ export type DbEnrichedPost = Omit<
     formattingOptions: FormattingOptions | null
     archieml: OwidGdocPostInterface | null
     archieml_update_statistics: OwidArticleBackportingStatistics | null
-    wpApiSnapshot: PostRestApi | null
+    wpApiSnapshot: PostRestApi | BlockGraphQlApi | null
 }
 export interface DbRawPostWithGdocPublishStatus extends DbRawPost {
     isGdocPublished: boolean
@@ -93,4 +94,14 @@ export function serializePostRow(postRow: DbEnrichedPost): DbRawPost {
         ),
         wpApiSnapshot: JSON.stringify(postRow.wpApiSnapshot),
     }
+}
+
+export const snapshotIsPostRestApi = (
+    snapshot: PostRestApi | BlockGraphQlApi | undefined | null
+): snapshot is PostRestApi => {
+    if (!snapshot) return false
+
+    return [WP_PostType.Page, WP_PostType.Post].includes(
+        (snapshot as PostRestApi).type
+    )
 }

--- a/packages/@ourworldindata/types/src/dbTypes/Posts.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Posts.ts
@@ -97,11 +97,15 @@ export function serializePostRow(postRow: DbEnrichedPost): DbRawPost {
 }
 
 export const snapshotIsPostRestApi = (
-    snapshot: PostRestApi | BlockGraphQlApi | undefined | null
+    snapshot: PostRestApi | BlockGraphQlApi
 ): snapshot is PostRestApi => {
-    if (!snapshot) return false
-
     return [WP_PostType.Page, WP_PostType.Post].includes(
         (snapshot as PostRestApi).type
     )
+}
+
+export const snapshotIsBlockGraphQlApi = (
+    snapshot: PostRestApi | BlockGraphQlApi
+): snapshot is BlockGraphQlApi => {
+    return (snapshot as BlockGraphQlApi).data?.wpBlock?.content !== undefined
 }

--- a/packages/@ourworldindata/types/src/dbTypes/Posts.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Posts.ts
@@ -1,6 +1,7 @@
 import {
     WP_PostType,
     FormattingOptions,
+    PostRestApi,
 } from "../wordpressTypes/WordpressTypes.js"
 import {
     OwidArticleBackportingStatistics,
@@ -27,16 +28,22 @@ export interface DbInsertPost {
     formattingOptions?: string | null
     archieml?: string | null
     archieml_update_statistics?: string | null
+    wpApiSnapshot?: string | null
 }
 export type DbRawPost = Required<DbInsertPost>
 export type DbEnrichedPost = Omit<
     DbRawPost,
-    "authors" | "formattingOptions" | "archieml" | "archieml_update_statistics"
+    | "authors"
+    | "formattingOptions"
+    | "archieml"
+    | "archieml_update_statistics"
+    | "wpApiSnapshot"
 > & {
     authors: string[] | null
     formattingOptions: FormattingOptions | null
     archieml: OwidGdocPostInterface | null
     archieml_update_statistics: OwidArticleBackportingStatistics | null
+    wpApiSnapshot: PostRestApi | null
 }
 export interface DbRawPostWithGdocPublishStatus extends DbRawPost {
     isGdocPublished: boolean
@@ -69,6 +76,9 @@ export function parsePostRow(postRow: DbRawPost): DbEnrichedPost {
         archieml_update_statistics: postRow.archieml_update_statistics
             ? JSON.parse(postRow.archieml_update_statistics)
             : null,
+        wpApiSnapshot: postRow.wpApiSnapshot
+            ? JSON.parse(postRow.wpApiSnapshot)
+            : null,
     }
 }
 
@@ -81,5 +91,6 @@ export function serializePostRow(postRow: DbEnrichedPost): DbRawPost {
         archieml_update_statistics: JSON.stringify(
             postRow.archieml_update_statistics
         ),
+        wpApiSnapshot: JSON.stringify(postRow.wpApiSnapshot),
     }
 }

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -495,6 +495,7 @@ export {
     serializePostRow,
     parsePostArchieml,
     snapshotIsPostRestApi,
+    snapshotIsBlockGraphQlApi,
 } from "./dbTypes/Posts.js"
 export {
     type DbInsertPostGdoc,

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -494,6 +494,7 @@ export {
     parsePostRow,
     serializePostRow,
     parsePostArchieml,
+    snapshotIsPostRestApi,
 } from "./dbTypes/Posts.js"
 export {
     type DbInsertPostGdoc,

--- a/packages/@ourworldindata/types/src/wordpressTypes/WordpressTypes.ts
+++ b/packages/@ourworldindata/types/src/wordpressTypes/WordpressTypes.ts
@@ -51,6 +51,14 @@ export interface PostRestApi {
     }
 }
 
+export interface BlockGraphQlApi {
+    data?: {
+        wpBlock?: {
+            content: string
+        }
+    }
+}
+
 export type FilterFnPostRestApi = (post: PostRestApi) => boolean
 
 export enum WP_ColumnStyle {


### PR DESCRIPTION
feat(wp): add wp api snapshot migration

feat(wp): add wp api snapshot to syncPostsToGrapher

feat: use snapshot version of getPostBySlug

refactor(wp): replace getPosts with snapshot version

refactor(wp): move deprecated code to own file for clarity

refactor(wp): replace getLatestPostRevision with snapshot version

refactor(wp): move snapshot functions to Post model

refactor(wp): move unused code to deprecated file

refactor(wp): isPostSlugCitable only need slug

refactor(wp): move more unused code to deprecated file

refactor(wp): move no-op tables code to deprecated file

refactor(wp): move getPosts to Post model

refactor(wp): move more non wp db functions into Post

refactor(wp): move flush cache to Post

refactor(wp): move listed filter fn to Post

refactor(wp): rename getBlockContent

feat(wp): type check snapshot

feat(wp): get block content from snapshot

refactor(wp): deprecate getBlockContentFromApi