### PR TITLE
feat(wp): add wp api snapshot migration

### DIFF
--- a/db/migration/1706711579844-AddWordpressApiSnapshotToPosts.ts
+++ b/db/migration/1706711579844-AddWordpressApiSnapshotToPosts.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddWordpressApiSnapshotToPosts1706711579844
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE posts ADD wpApiSnapshot JSON DEFAULT NULL`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE posts DROP COLUMN wpApiSnapshot`)
+    }
+}

--- a/packages/@ourworldindata/types/src/dbTypes/Posts.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Posts.ts
@@ -1,6 +1,7 @@
 import {
     WP_PostType,
     FormattingOptions,
+    PostRestApi,
 } from "../wordpressTypes/WordpressTypes.js"
 import {
     OwidArticleBackportingStatistics,
@@ -27,16 +28,22 @@ export interface DbInsertPost {
     formattingOptions?: string | null
     archieml?: string | null
     archieml_update_statistics?: string | null
+    wpApiSnapshot?: string | null
 }
 export type DbRawPost = Required<DbInsertPost>
 export type DbEnrichedPost = Omit<
     DbRawPost,
-    "authors" | "formattingOptions" | "archieml" | "archieml_update_statistics"
+    | "authors"
+    | "formattingOptions"
+    | "archieml"
+    | "archieml_update_statistics"
+    | "wpApiSnapshot"
 > & {
     authors: string[] | null
     formattingOptions: FormattingOptions | null
     archieml: OwidGdocPostInterface | null
     archieml_update_statistics: OwidArticleBackportingStatistics | null
+    wpApiSnapshot: PostRestApi | null
 }
 export interface DbRawPostWithGdocPublishStatus extends DbRawPost {
     isGdocPublished: boolean
@@ -69,6 +76,9 @@ export function parsePostRow(postRow: DbRawPost): DbEnrichedPost {
         archieml_update_statistics: postRow.archieml_update_statistics
             ? JSON.parse(postRow.archieml_update_statistics)
             : null,
+        wpApiSnapshot: postRow.wpApiSnapshot
+            ? JSON.parse(postRow.wpApiSnapshot)
+            : null,
     }
 }
 
@@ -81,5 +91,6 @@ export function serializePostRow(postRow: DbEnrichedPost): DbRawPost {
         archieml_update_statistics: JSON.stringify(
             postRow.archieml_update_statistics
         ),
+        wpApiSnapshot: JSON.stringify(postRow.wpApiSnapshot),
     }
 }


### PR DESCRIPTION
This PR adds a migration to hold the snapshot of the Wordpress API response, including the rendered HTML content.

It also updates the `syncPostsToGrapher` script to fill this additional column upon running.

- [ ] after deploy: run `syncPostsToGrapher`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new `wpApiSnapshot` field to posts for storing WordPress API data snapshots.
	- Enhanced post synchronization with parallel processing and fetching additional data based on post type.
- **Refactor**
	- Renamed and updated functions for better clarity and functionality in handling posts and block content.
	- Updated types and serialization methods to include `wpApiSnapshot`.
- **Accessibility**
	- Improved accessibility by adding `aria-label` attributes to various components for screen readers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->