### PR TITLE
💄 (grapher) don't use viewport height for grapher on mobile

### DIFF
--- a/site/blocks/KeyInsights.scss
+++ b/site/blocks/KeyInsights.scss
@@ -1,14 +1,8 @@
+$slide-content-height: $grapher-height;
+
 @import "react-horizontal-scrolling-menu/styles.css";
 
 .wp-block-owid-key-insights {
-    --slide-content-height: 575px; // keep in sync with $grapher-height
-
-    @include sm-only {
-        // 50px is the height of the header on mobile
-        // 1rem is additional padding
-        --slide-content-height: calc(100vh - 50px - 1rem);
-    }
-
     .react-horizontal-scrolling-menu--wrapper {
         position: relative;
     }
@@ -95,7 +89,7 @@
 
     .slides {
         figure.chart:not(.grapherPreview) {
-            height: var(--slide-content-height, $grapher-height);
+            height: $slide-content-height;
         }
 
         @include sm-only {
@@ -109,7 +103,7 @@
         @include lg-up {
             .wp-block-columns.is-style-sticky-right .wp-block-column {
                 &:first-child {
-                    height: var(--slide-content-height, $grapher-height);
+                    height: $slide-content-height;
                     overflow-y: auto;
                     -webkit-mask-image: linear-gradient(
                         180deg,

--- a/site/collections/CollectionsPage.scss
+++ b/site/collections/CollectionsPage.scss
@@ -22,9 +22,5 @@
         height: $grapher-height;
         margin: 0;
         margin-bottom: 48px;
-
-        @include sm-only {
-            height: 95vh;
-        }
     }
 }

--- a/site/gdocs/components/AllCharts.scss
+++ b/site/gdocs/components/AllCharts.scss
@@ -5,13 +5,5 @@
 
     figure[data-grapher-src] {
         height: $grapher-height;
-
-        @include sm-only {
-            // 50px is the height of the header on mobile
-            // 40px is the height of the gallery navigation
-            // 1rem is the margin between the figure and the gallery navigation
-            // 1rem is additional padding
-            height: calc(100vh - 90px - 2rem);
-        }
     }
 }

--- a/site/gdocs/components/Chart.scss
+++ b/site/gdocs/components/Chart.scss
@@ -1,11 +1,5 @@
 figure.chart {
     height: $grapher-height;
-
-    @include sm-only {
-        // 50px is the height of the header on mobile
-        // 1rem is additional padding
-        height: calc(100vh - 50px - 1rem);
-    }
 }
 
 figure.explorer {

--- a/site/gdocs/components/centered-article.scss
+++ b/site/gdocs/components/centered-article.scss
@@ -778,13 +778,6 @@ div.article-block__table--wide {
             width: 100%;
             > figure {
                 margin: 0;
-
-                @include sm-only {
-                    // 50px is the height of the header on mobile
-                    // 65px is the height of the navigation
-                    // 1rem is additional padding
-                    height: calc(100vh - 115px - 1rem);
-                }
             }
         }
     }


### PR DESCRIPTION
- Reverts https://github.com/owid/owid-grapher/pull/2605
- https://github.com/owid/owid-grapher/pull/2605 was an attempt to give Grapher a bit more vertical space if possible
- but in the case of maps, it only adds whitespace
- and in the case of charts, it does give more space to that chart but also yields a suboptimal aspect ratio
- in the case of tables, the extra space is valuable, but I value maps & charts higher
- all in all, I think https://github.com/owid/owid-grapher/pull/2605 was net negative, so I'm reverting it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Standardized and simplified the height properties for charts and figures across the site.
	- Removed responsive styling specific to small screens for a more consistent viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->