### PR TITLE
Merge content graph and chart references

### DIFF
--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -10,6 +10,7 @@ import {
     type DetailDictionary,
     type RawPageview,
     Topic,
+    PostReference,
 } from "@ourworldindata/utils"
 import { computed, observable, runInAction, when } from "mobx"
 import { BAKED_GRAPHER_URL } from "../settings/clientSettings.js"
@@ -52,13 +53,6 @@ export const getFullReferencesCount = (references: References): number => {
         references.postsGdocs.length +
         references.explorers.length
     )
-}
-
-export interface PostReference {
-    id: string
-    title: string
-    slug: string
-    url: string
 }
 
 export interface ChartRedirect {

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -149,33 +149,6 @@ async function getLogsByChartId(chartId: number): Promise<ChartRevision[]> {
 }
 
 const getReferencesByChartId = async (chartId: number): Promise<References> => {
-    const rows = await db.queryMysql(
-        `
-        SELECT config->"$.slug" AS slug
-        FROM charts
-        WHERE id = ?
-        UNION
-        SELECT slug AS slug
-        FROM chart_slug_redirects
-        WHERE chart_id = ?
-    `,
-        [chartId, chartId]
-    )
-
-    const slugs: string[] = rows
-        .map(
-            (row: { slug?: string }) =>
-                row.slug && row.slug.replace(/^"|"$/g, "")
-        )
-        .filter((slug: string | undefined) => !isUndefined(slug))
-
-    if (!slugs || slugs.length === 0)
-        return {
-            postsGdocs: [],
-            postsWordpress: [],
-            explorers: [],
-        }
-
     const postsWordpressPromise = getWordpressPostReferencesByChartId(chartId)
     const postGdocsPromise = getGdocsPostReferencesByChartId(chartId)
     const explorerSlugsPromise = db.queryMysql(

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -42,7 +42,6 @@ import {
     SuggestedChartRevisionStatus,
     variableAnnotationAllowedColumnNamesAndTypes,
     VariableAnnotationsResponseRow,
-    isUndefined,
     OwidVariableWithSource,
     OwidChartDimensionInterface,
     DimensionProperty,

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -71,11 +71,7 @@ import {
 import { ChartRevision } from "../db/model/ChartRevision.js"
 import { SuggestedChartRevision } from "../db/model/SuggestedChartRevision.js"
 import { denormalizeLatestCountryData } from "../baker/countryProfiles.js"
-import {
-    ChartRedirect,
-    PostReference,
-    References,
-} from "../adminSiteClient/ChartEditor.js"
+import { ChartRedirect, References } from "../adminSiteClient/ChartEditor.js"
 import { DeployQueueServer } from "../baker/DeployQueueServer.js"
 import { FunctionalRouter } from "./FunctionalRouter.js"
 import { escape } from "mysql"
@@ -84,6 +80,8 @@ import {
     postsTable,
     setTagsForPost,
     getTagsByPostId,
+    getWordpressPostReferencesByChartId,
+    getGdocsPostReferencesByChartId,
 } from "../db/model/Post.js"
 import {
     checkFullDeployFallback,
@@ -148,91 +146,6 @@ async function getLogsByChartId(chartId: number): Promise<ChartRevision[]> {
         [chartId]
     )
     return logs
-}
-
-export const getWordpressPostReferencesByChartId = async (
-    chartId: number
-): Promise<PostReference[]> => {
-    const relatedWordpressPosts: PostReference[] = (
-        await db.knexInstance().raw(
-            `
-            SELECT DISTINCT
-                p.title,
-                p.slug,
-                p.id,
-                CONCAT("${BAKED_BASE_URL}","/",p.slug) as url
-            FROM
-                posts p
-                JOIN posts_links pl ON p.id = pl.sourceId
-                JOIN charts c ON pl.target = c.slug
-                OR pl.target IN (
-                    SELECT
-                        cr.slug
-                    FROM
-                        chart_slug_redirects cr
-                    WHERE
-                        cr.chart_id = c.id
-                )
-            WHERE
-                c.id = ?
-                AND p.status = 'publish'
-                AND p.type != 'wp_block'
-                AND pl.linkType = 'grapher'
-                AND p.slug NOT IN (
-                    -- We want to exclude the slugs of published gdocs, since they override the Wordpress posts
-                    -- published under the same slugs.
-                    SELECT
-                        slug from posts_gdocs pg
-                    WHERE
-                        pg.slug = p.slug
-                        AND pg.content ->> '$.type' <> 'fragment'
-                        AND pg.published = 1
-                )
-            ORDER BY
-                p.title ASC
-        `,
-            [chartId]
-        )
-    )[0]
-
-    return relatedWordpressPosts
-}
-
-export const getGdocsPostReferencesByChartId = async (
-    chartId: number
-): Promise<PostReference[]> => {
-    const relatedGdocsPosts: PostReference[] = (
-        await db.knexInstance().raw(
-            `
-            SELECT DISTINCT
-                pg.content ->> '$.title' AS title,
-                pg.slug AS slug,
-                pg.id AS id,
-                CONCAT("${BAKED_BASE_URL}","/",pg.slug) as url
-            FROM
-                posts_gdocs pg
-                JOIN posts_gdocs_links pgl ON pg.id = pgl.sourceId
-                JOIN charts c ON pgl.target = c.slug
-                OR pgl.target IN (
-                    SELECT
-                        cr.slug
-                    FROM
-                        chart_slug_redirects cr
-                    WHERE
-                        cr.chart_id = c.id
-                )
-            WHERE
-                c.id = ?
-                AND pg.content ->> '$.type' <> 'fragment'
-                AND pg.published = 1
-            ORDER BY
-                pg.content ->> '$.title' ASC
-        `,
-            [chartId]
-        )
-    )[0]
-
-    return relatedGdocsPosts
 }
 
 const getReferencesByChartId = async (chartId: number): Promise<References> => {

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -360,15 +360,6 @@ export const getRelatedArticles = async (
     )
 }
 
-export const getPermalinks = async (): Promise<{
-    // Strip trailing slashes, and convert __ into / to allow custom subdirs like /about/media-coverage
-    get: (ID: number, postName: string) => string
-}> => ({
-    // Strip trailing slashes, and convert __ into / to allow custom subdirs like /about/media-coverage
-    get: (ID: number, postName: string): string =>
-        postName.replace(/\/+$/g, "").replace(/--/g, "/").replace(/__/g, "/"),
-})
-
 export const getPostTags = async (
     postId: number
 ): Promise<Pick<Tag, "id" | "name">[]> => {

--- a/packages/@ourworldindata/types/src/domainTypes/ContentGraph.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/ContentGraph.ts
@@ -11,7 +11,8 @@ export interface CategoryWithEntries {
 }
 
 export interface PostReference {
-    id: number | string
+    id: string
     title: string
     slug: string
+    url: string
 }

--- a/site/RelatedArticles/RelatedArticles.tsx
+++ b/site/RelatedArticles/RelatedArticles.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { PostReference } from "@ourworldindata/utils"
-import { BAKED_BASE_URL } from "../../settings/serverSettings.js"
 
 export const RelatedArticles = ({
     articles,
@@ -11,9 +10,7 @@ export const RelatedArticles = ({
         <ul className="research">
             {articles.map((article) => (
                 <li key={article.slug}>
-                    <a href={`${BAKED_BASE_URL}/${article.slug}`}>
-                        {article.title}
-                    </a>
+                    <a href={article.url}>{article.title}</a>
                 </li>
             ))}
         </ul>


### PR DESCRIPTION
This PR merges the content graph queries used in grapher pages (see #3176) and the references queries used in the chart admin to indicate where a chart is being used.

If fixes two issues on the tab page:
- Overridden Wordpress posts now ignored
- Remove duplicate posts

Reusable blocks are no longer surfaced. This is ok since reusable blocks are now dereferenced in the embedding article, which means a chart within a reusable block would show in the parent article. One exception is explorer content blocks, which are still standalone. A quick manual check on all explorers reveals that only one explorer references a chart: https://ourworldindata.org/explorers/plastic-pollution. Given these blocks' scope and limited lifetime, this caveat is acceptable.

_A future PR should use these references during the check performed before deleting a chart. Currently, [only gdocs are being checked](https://github.com/owid/owid-grapher/blob/e5acb212754bbba7d5d563fcd856adbb32ab8a36/adminSiteServer/apiRouter.ts#L603-L611)._

### Before
<img width="546" alt="Screenshot 2024-02-07 at 17 07 50" src="https://github.com/owid/owid-grapher/assets/13406362/1a4c25b8-3398-44b7-b14c-10c752d442d3">

### After
<img width="530" alt="Screenshot 2024-02-07 at 20 38 49" src="https://github.com/owid/owid-grapher/assets/13406362/1fad824e-8613-4825-9342-6d18a089d900">

### Testing links

Below are some testing links to grapher pages, backlinking to posts in different configurations.

- gdoc: [https://ourworldindata.org/grapher/agricultural-export-subsidies](https://ourworldindata.org/grapher/agricultural-export-subsidies)
    - [x]  [http://localhost:3030/grapher/agricultural-export-subsidies](http://localhost:3030/grapher/agricultural-export-subsidies)
    - [x]  [http://staging-site-content-graph-references/grapher/agricultural-export-subsidies](http://staging-site-content-graph-references/grapher/agricultural-export-subsidies)
- gdocs: [https://ourworldindata.org/grapher/pollution-deaths-from-fossil-fuels](https://ourworldindata.org/grapher/pollution-deaths-from-fossil-fuels)
    - [x]  [http://localhost:3030/grapher/pollution-deaths-from-fossil-fuels](http://localhost:3030/grapher/pollution-deaths-from-fossil-fuels)
    - [x]  [http://staging-site-content-graph-references/grapher/pollution-deaths-from-fossil-fuels](http://staging-site-content-graph-references/grapher/pollution-deaths-from-fossil-fuels)
- wp: [https://ourworldindata.org/grapher/dalys-rate-from-all-causes](https://ourworldindata.org/grapher/dalys-rate-from-all-causes)
    - [x]  [http://localhost:3030/grapher/dalys-rate-from-all-causes](http://localhost:3030/grapher/dalys-rate-from-all-causes)
    - [x]  [http://staging-site-content-graph-references/grapher/dalys-rate-from-all-causes](http://staging-site-content-graph-references/grapher/dalys-rate-from-all-causes)
- wp (with chart redirect): [https://ourworldindata.org/grapher/age-standardized-death-rate-from-pm25-pollution-per-100000-vs-gdp-per-capita-int-](https://ourworldindata.org/grapher/age-standardized-death-rate-from-pm25-pollution-per-100000-vs-gdp-per-capita-int-)
    - [x]  [http://localhost:3030/grapher/age-standardized-death-rate-from-pm25-pollution-per-100000-vs-gdp-per-capita-int-](http://localhost:3030/grapher/age-standardized-death-rate-from-pm25-pollution-per-100000-vs-gdp-per-capita-int-)
    - [x]  [http://staging-site-content-graph-references/grapher/age-standardized-death-rate-from-pm25-pollution-per-100000-vs-gdp-per-capita-int-](http://staging-site-content-graph-references/grapher/age-standardized-death-rate-from-pm25-pollution-per-100000-vs-gdp-per-capita-int-)
- gdoc (with chart redirect): [https://ourworldindata.org/grapher/population-long-run-with-projections?time=earliest..2100&country=~OWID_WRL](https://ourworldindata.org/grapher/population-long-run-with-projections?time=earliest..2100&country=~OWID_WRL)
    - [x]  [http://localhost:3030/grapher/population-long-run-with-projections?time=earliest..2100&country=~OWID_WRL](http://localhost:3030/grapher/population-long-run-with-projections?time=earliest..2100&country=~OWID_WRL)
    - [x]  [http://staging-site-content-graph-references/grapher/population-long-run-with-projections?time=earliest..2100&country=~OWID_WRL](http://staging-site-content-graph-references/grapher/population-long-run-with-projections?time=earliest..2100&country=~OWID_WRL)
- none: [https://ourworldindata.org/grapher/death-rates-alcohol-drug-overdoses-by-age-who](https://ourworldindata.org/grapher/death-rates-alcohol-drug-overdoses-by-age-who)
    - [x]  [http://localhost:3030/grapher/death-rates-alcohol-drug-overdoses-by-age-who](http://localhost:3030/grapher/death-rates-alcohol-drug-overdoses-by-age-who)
    - [x]  [http://staging-site-content-graph-references/grapher/death-rates-alcohol-drug-overdoses-by-age-who](http://staging-site-content-graph-references/grapher/death-rates-alcohol-drug-overdoses-by-age-who)