### PR TITLE
🐛 fix double uriEncoding of gdocs og:image URLs

### DIFF
--- a/packages/@ourworldindata/utils/src/image.ts
+++ b/packages/@ourworldindata/utils/src/image.ts
@@ -3,12 +3,7 @@ Common utlities for deriving properties from image metadata.
 */
 
 import { traverseEnrichedBlocks } from "./Util.js"
-import {
-    OwidGdoc,
-    OwidGdocType,
-    IMAGES_DIRECTORY,
-    ImageMetadata,
-} from "@ourworldindata/types"
+import { OwidGdoc, OwidGdocType, ImageMetadata } from "@ourworldindata/types"
 import { match, P } from "ts-pattern"
 
 export function getSizes(
@@ -50,12 +45,6 @@ export function getFilenameWithoutExtension(
 export function getFilenameAsPng(filename: ImageMetadata["filename"]): string {
     return `${getFilenameWithoutExtension(filename)}.png`
 }
-
-/**
- * example-image.png -> https://ourworldindata.org/uploads/published/example-image.png
- */
-export const filenameToUrl = (filename: string, baseUrl: string): string =>
-    new URL(`${IMAGES_DIRECTORY}${getFilenameAsPng(filename)}`, baseUrl).href
 
 export type SourceProps = {
     media: string | undefined

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -365,7 +365,6 @@ export {
     type SourceProps,
     generateSourceProps,
     getFeaturedImageFilename,
-    filenameToUrl,
 } from "./image.js"
 
 export { Tippy, TippyIfInteractive } from "./Tippy.js"

--- a/site/gdocs/OwidGdocPage.tsx
+++ b/site/gdocs/OwidGdocPage.tsx
@@ -9,10 +9,10 @@ import {
     OwidGdoc as OwidGdocUnionType,
     SiteFooterContext,
     OwidGdocType,
-    filenameToUrl,
 } from "@ourworldindata/utils"
 import { DebugProvider } from "./DebugContext.js"
 import { match, P } from "ts-pattern"
+import { IMAGES_DIRECTORY } from "@ourworldindata/types"
 
 declare global {
     interface Window {
@@ -75,7 +75,7 @@ export default function OwidGdocPage({
                 imageUrl={
                     // uriEncoding is taken care of inside the Head component
                     featuredImageFilename
-                        ? filenameToUrl(featuredImageFilename, baseUrl)
+                        ? `${baseUrl}${IMAGES_DIRECTORY}${featuredImageFilename}`
                         : undefined
                 }
                 baseUrl={baseUrl}


### PR DESCRIPTION
![image](https://github.com/owid/owid-grapher/assets/11844404/1c88a189-2033-4212-bda1-d6b523010b26)

The culprit was the `new URL('blah').href` which also URI encodes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified code structure by removing unused code and optimizing image URL construction in the `OwidGdocPage` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->