### PR TITLE
🐛 use absolute URL instead of relative for allExplorers.json fetch

### DIFF
--- a/explorerAdminClient/ExplorersListPage.tsx
+++ b/explorerAdminClient/ExplorersListPage.tsx
@@ -283,7 +283,7 @@ export class ExplorersIndexPage extends React.Component<{
     private async fetchAllExplorers() {
         const { searchInput } = this
 
-        const response = await fetch(GetAllExplorersRoute)
+        const response = await fetch(`/admin/${GetAllExplorersRoute}`)
         const json = (await response.json()) as ExplorersRouteResponse
         if (!json.success) alert(JSON.stringify(json.errorMessage))
         this.needsPull = json.needsPull


### PR DESCRIPTION
I'm not sure why this suddenly broke, but I think this will fix it?

Might hold off on merging until we can work out what changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the fetch URL for retrieving all explorers to enhance administrative access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->