### PR TITLE
Add redirects table and migration script

### DIFF
--- a/baker/syncRedirectsToGrapher.ts
+++ b/baker/syncRedirectsToGrapher.ts
@@ -1,29 +1,30 @@
 import * as db from "../db/db"
 import * as wpdb from "../db/wpdb"
 import { getRedirectsFromDb } from "../db/model/Redirect.js"
+import { formatWpUrl, resolveRedirectFromMap } from "./redirects.js"
+import { Redirect, Url } from "@ourworldindata/utils"
 
-const removeTrailingSlashIfNotRoot = (str: string): string => {
-    return str.replace(/\/$/, "") || "/"
+// A close cousing of the getWordpressRedirectsMap() function from
+// redirects.ts.
+const getWordpressRedirectsMap = (
+    redirects: Redirect[]
+): Map<string, string> => {
+    return new Map(redirects.map((r) => [r.source, r.target]))
 }
 
 export const syncRedirectsToGrapher = async (): Promise<void> => {
     const allWordpressRedirectsRaw = await wpdb.FOR_SYNC_ONLY_getRedirects()
-    const allWordpressRedirects = allWordpressRedirectsRaw.map((r) => {
-        return {
-            // In absolute terms, redirecting the "/" path is unlikely but there
-            // could be rare temporary use cases for it. In the context of this
-            // short-lived script, this doesn't really matter either way given
-            // none of the redirects this script will parse are from the root
-            // path, but we keep it here for completeness.
-            source: removeTrailingSlashIfNotRoot(r.source),
-            target: removeTrailingSlashIfNotRoot(r.target),
-            code: r.code,
-        }
-    })
+
+    const allWordpressRedirects = allWordpressRedirectsRaw.map((r) => ({
+        ...r,
+        source: formatWpUrl(r.source),
+        target: formatWpUrl(r.target),
+    }))
+
     const existingRedirectsFromDb = await getRedirectsFromDb()
 
     await db.knexInstance().transaction(async (t) => {
-        for (const { source, target, code } of allWordpressRedirects) {
+        for (const { source, code } of allWordpressRedirects) {
             // We only want to insert redirects for which we don't have a redirected source yet
             if (existingRedirectsFromDb.some((r) => r.source === source)) {
                 console.log(
@@ -31,10 +32,31 @@ export const syncRedirectsToGrapher = async (): Promise<void> => {
                 )
                 continue
             }
-            console.log(`Adding redirect: ${source} -> ${target} (${code})`)
+
+            // Resolve the target of the redirect, recursively following any
+            // Wordpress redirects until we reach a final target
+            const resolvedUrl = await resolveRedirectFromMap(
+                Url.fromURL(source),
+                getWordpressRedirectsMap(allWordpressRedirects)
+            )
+
+            // Use the no-trailing slash version of the resolved target URL.
+            // This is to handle the case where parsing a URL with no pathname
+            // (e.g. https://africaindata.org) still results in a trailing slash
+            // being added by url-parse when creating a new Url object. This
+            // solves the issue at hand, although it's debatable whether the
+            // issue needed fixing for the one case this script will ever come
+            // across (https://africaindata.org). It might just make more sense
+            // to fix this edge case manually and avoid polluting the Url class
+            // with code that won't be used after the migration.
+            const resolvedTarget = resolvedUrl.fullUrlNoTrailingSlash
+
+            console.log(
+                `Adding redirect: ${source} -> ${resolvedTarget} (${code})`
+            )
             await t.raw(
                 `INSERT INTO redirects (source, target, code) VALUES (?, ?, ?)`,
-                [source, target, code]
+                [source, resolvedTarget, code]
             )
         }
     })

--- a/baker/syncRedirectsToGrapher.ts
+++ b/baker/syncRedirectsToGrapher.ts
@@ -6,7 +6,7 @@ import { Redirect, Url } from "@ourworldindata/utils"
 
 // A close cousing of the getWordpressRedirectsMap() function from
 // redirects.ts.
-const getWordpressRedirectsMap = (
+const getWordpressRedirectsMapFromRedirects = (
     redirects: Redirect[]
 ): Map<string, string> => {
     return new Map(redirects.map((r) => [r.source, r.target]))
@@ -37,7 +37,7 @@ export const syncRedirectsToGrapher = async (): Promise<void> => {
             // Wordpress redirects until we reach a final target
             const resolvedUrl = await resolveRedirectFromMap(
                 Url.fromURL(source),
-                getWordpressRedirectsMap(allWordpressRedirects)
+                getWordpressRedirectsMapFromRedirects(allWordpressRedirects)
             )
 
             // Use the no-trailing slash version of the resolved target URL.

--- a/baker/syncRedirectsToGrapher.ts
+++ b/baker/syncRedirectsToGrapher.ts
@@ -1,6 +1,6 @@
-import * as db from "./db"
-import * as wpdb from "./wpdb"
-import { getRedirectsFromDb } from "./model/Redirect.js"
+import * as db from "../db/db"
+import * as wpdb from "../db/wpdb"
+import { getRedirectsFromDb } from "../db/model/Redirect.js"
 
 const removeTrailingSlashIfNotRoot = (str: string): string => {
     return str.replace(/\/$/, "") || "/"

--- a/db/migration/1707467006420-AddRedirectsTable.ts
+++ b/db/migration/1707467006420-AddRedirectsTable.ts
@@ -7,7 +7,7 @@ export class AddRedirectsTable1707467006420 implements MigrationInterface {
                 id INT AUTO_INCREMENT PRIMARY KEY,
                 source TEXT NOT NULL,
                 target TEXT NOT NULL,
-                code ENUM('301', '302') DEFAULT '301',
+                code INT DEFAULT 301,
                 createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
             );

--- a/db/migration/1707467006420-AddRedirectsTable.ts
+++ b/db/migration/1707467006420-AddRedirectsTable.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddRedirectsTable1707467006420 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE TABLE redirects (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                source TEXT NOT NULL,
+                target TEXT NOT NULL,
+                code ENUM('301', '302') DEFAULT '301',
+                createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+            );
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE redirects`)
+    }
+}

--- a/db/model/Redirect.ts
+++ b/db/model/Redirect.ts
@@ -1,0 +1,12 @@
+import * as db from "../db"
+import { Redirect } from "@ourworldindata/types"
+
+export const getRedirectsFromDb = async (): Promise<Redirect[]> => {
+    const redirectsFromDb = (
+        await db.knexInstance().raw(`
+        SELECT source, target, code FROM redirects
+        `)
+    )[0]
+
+    return redirectsFromDb
+}

--- a/db/syncRedirectsToGrapher.ts
+++ b/db/syncRedirectsToGrapher.ts
@@ -1,0 +1,37 @@
+import * as db from "./db"
+import * as wpdb from "./wpdb"
+import { getRedirectsFromDb } from "./model/Redirect.js"
+
+export const syncRedirectsToGrapher = async (): Promise<void> => {
+    const allWordpressRedirects = await wpdb.FOR_SYNC_ONLY_getRedirects()
+    const existingRedirectsFromDb = await getRedirectsFromDb()
+
+    await db.knexInstance().transaction(async (t) => {
+        for (const { source, target, code } of allWordpressRedirects) {
+            // We only want to insert redirects for which we don't have a redirected source yet
+            if (existingRedirectsFromDb.some((r) => r.source === source)) {
+                console.log(
+                    `Skipping, a redirect already exists for "${source}"`
+                )
+                continue
+            }
+            console.log(`Adding redirect: ${source} -> ${target} (${code})`)
+            await t.raw(
+                `INSERT INTO redirects (source, target, code) VALUES (?, ?, ?)`,
+                [source, target, code]
+            )
+        }
+    })
+}
+
+const main = async (): Promise<void> => {
+    try {
+        await db.getConnection()
+        await syncRedirectsToGrapher()
+    } finally {
+        await wpdb.singleton.end()
+        await db.closeTypeOrmAndKnexConnections()
+    }
+}
+
+main()

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -13,6 +13,7 @@ import { Knex, knex } from "knex"
 import { Base64 } from "js-base64"
 import { registerExitHandler } from "./cleanup.js"
 import { WP_PostType, JsonError, PostRestApi } from "@ourworldindata/utils"
+import { Redirect } from "@ourworldindata/types"
 
 let _knexInstance: Knex
 
@@ -265,4 +266,11 @@ export const FOR_SYNC_ONLY_getTables = async (): Promise<
     }
 
     return tables
+}
+
+export const FOR_SYNC_ONLY_getRedirects = async (): Promise<Redirect[]> => {
+    return singleton.query(`
+        SELECT url AS source, action_data AS target, action_code AS code
+        FROM wp_redirection_items WHERE status = 'enabled'
+    `)
 }

--- a/packages/@ourworldindata/types/src/dbTypes/Redirects.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Redirects.ts
@@ -1,0 +1,10 @@
+export enum RedirectCode {
+    MOVED_PERMANENTLY = 301,
+    FOUND = 302,
+}
+
+export interface Redirect {
+    source: string
+    target: string
+    code: RedirectCode
+}

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -607,3 +607,5 @@ export {
     serializeVariableProcessingLog,
     type License,
 } from "./dbTypes/Variables.js"
+
+export { RedirectCode, type Redirect } from "./dbTypes/Redirects.js"

--- a/packages/@ourworldindata/utils/src/urls/Url.test.ts
+++ b/packages/@ourworldindata/utils/src/urls/Url.test.ts
@@ -108,4 +108,27 @@ describe(Url, () => {
             ).isUpload
         ).toBe(false)
     })
+
+    it("prints URL with no trailing slash", () => {
+        const urlSlash = Url.fromURL("https://ourworldindata.org/")
+        expect(urlSlash.fullUrlNoTrailingSlash).toEqual(
+            "https://ourworldindata.org"
+        )
+        const urlNoSlash = Url.fromURL("https://ourworldindata.org")
+        expect(urlNoSlash.fullUrlNoTrailingSlash).toEqual(
+            "https://ourworldindata.org"
+        )
+    })
+
+    it("prints path with no trailing slash", () => {
+        const urlSlash = Url.fromURL("/grapher/abc/")
+        expect(urlSlash.fullUrlNoTrailingSlash).toEqual("/grapher/abc")
+        const urlNoSlash = Url.fromURL("/grapher/abc")
+        expect(urlNoSlash.fullUrlNoTrailingSlash).toEqual("/grapher/abc")
+    })
+
+    it("prints URL with only trailing slash when no origin", () => {
+        const url = Url.fromURL("/")
+        expect(url.fullUrlNoTrailingSlash).toEqual("/")
+    })
 })

--- a/packages/@ourworldindata/utils/src/urls/Url.ts
+++ b/packages/@ourworldindata/utils/src/urls/Url.ts
@@ -113,6 +113,10 @@ export class Url {
         ]).join("")
     }
 
+    get fullUrlNoTrailingSlash(): string {
+        return this.fullUrl.replace(/\/$/, "") || "/"
+    }
+
     get queryParams(): QueryParams {
         return strToQueryParams(this.queryStr)
     }


### PR DESCRIPTION
This PR adds a new `redirects` table to hold redirects currently stored in the Wordpress database.

It also adds a migration script to import Wordpress redirects: `syncRedirectsToGrapher`:

```
[...]
Skipping, a redirect already exists for "/what-makes-a-disease-eradicable"
Skipping, a redirect already exists for "/sources-for-eradication-of-diseases"
Skipping, a redirect already exists for "/can-the-world-eradicate-another-disease"
Adding redirect: /full-stack-engineer-q4-2023 -> /jobs
```

- [ ] when going live: `node itsJustJavascript/baker/syncRedirectsToGrapher.js`

### Testing
The number of enabled redirected in the Wordpress table is identical to the number of redirects in the new table after running the migration script. 