### PR TITLE
refactor: bake redirects from db

### DIFF
--- a/baker/redirects.ts
+++ b/baker/redirects.ts
@@ -58,11 +58,9 @@ export const getRedirects = async () => {
     ]
 
     // Get redirects from the database (exported from the Wordpress DB)
+    // Redirects are assumed to be trailing-slash-free (see syncRedirectsToGrapher.ts)
     const redirectsFromDb = (await getRedirectsFromDb()).map(
-        (row) =>
-            `${stripTrailingSlash(row.source)} ${stripTrailingSlash(
-                row.target
-            )} ${row.code}`
+        (row) => `${row.source} ${row.target} ${row.code}`
     )
 
     // Add newlines in between so we get some more overview
@@ -102,12 +100,7 @@ export const stripTrailingSlash = (url: string) => {
 export const getWordpressRedirectsMap = async () => {
     const redirectsFromDb = await getRedirectsFromDb()
 
-    return new Map(
-        redirectsFromDb.map((row) => [
-            stripTrailingSlash(row.source),
-            stripTrailingSlash(row.target),
-        ])
-    )
+    return new Map(redirectsFromDb.map((row) => [row.source, row.target]))
 }
 
 export const getGrapherAndWordpressRedirectsMap = memoize(

--- a/baker/redirects.ts
+++ b/baker/redirects.ts
@@ -91,12 +91,6 @@ export const getGrapherRedirectsMap = async (
     )
 }
 
-export const stripTrailingSlash = (url: string) => {
-    if (url === "/") return url
-
-    return url.replace(/\/$/, "") // remove trailing slash: /abc/ -> /abc
-}
-
 export const getWordpressRedirectsMap = async () => {
     const redirectsFromDb = await getRedirectsFromDb()
 

--- a/baker/redirects.ts
+++ b/baker/redirects.ts
@@ -1,5 +1,4 @@
 import * as db from "../db/db.js"
-import * as wpdb from "../db/wpdb.js"
 import { memoize, JsonError, Url } from "@ourworldindata/utils"
 import { isCanonicalInternalUrl } from "./formatting.js"
 import { resolveExplorerRedirect } from "./replaceExplorerRedirects.js"
@@ -101,14 +100,12 @@ export const stripTrailingSlash = (url: string) => {
 }
 
 export const getWordpressRedirectsMap = async () => {
-    const wordpressRedirectRows = (await wpdb.singleton.query(
-        `SELECT url, action_data FROM wp_redirection_items WHERE status = 'enabled'`
-    )) as Array<{ url: string; action_data: string }>
+    const redirectsFromDb = await getRedirectsFromDb()
 
     return new Map(
-        wordpressRedirectRows.map((row) => [
-            stripTrailingSlash(row.url),
-            stripTrailingSlash(row.action_data),
+        redirectsFromDb.map((row) => [
+            stripTrailingSlash(row.source),
+            stripTrailingSlash(row.target),
         ])
     )
 }

--- a/baker/syncRedirectsToGrapher.ts
+++ b/baker/syncRedirectsToGrapher.ts
@@ -1,7 +1,7 @@
 import * as db from "../db/db"
 import * as wpdb from "../db/wpdb"
 import { getRedirectsFromDb } from "../db/model/Redirect.js"
-import { stripTrailingSlash, resolveRedirectFromMap } from "./redirects.js"
+import { resolveRedirectFromMap } from "./redirects.js"
 import { Redirect, Url } from "@ourworldindata/utils"
 
 // A close cousing of the getWordpressRedirectsMap() function from
@@ -10,6 +10,12 @@ const getWordpressRedirectsMapFromRedirects = (
     redirects: Redirect[]
 ): Map<string, string> => {
     return new Map(redirects.map((r) => [r.source, r.target]))
+}
+
+const stripTrailingSlash = (url: string) => {
+    if (url === "/") return url
+
+    return url.replace(/\/$/, "") // remove trailing slash: /abc/ -> /abc
 }
 
 export const syncRedirectsToGrapher = async (): Promise<void> => {

--- a/baker/syncRedirectsToGrapher.ts
+++ b/baker/syncRedirectsToGrapher.ts
@@ -1,7 +1,7 @@
 import * as db from "../db/db"
 import * as wpdb from "../db/wpdb"
 import { getRedirectsFromDb } from "../db/model/Redirect.js"
-import { formatWpUrl, resolveRedirectFromMap } from "./redirects.js"
+import { stripTrailingSlash, resolveRedirectFromMap } from "./redirects.js"
 import { Redirect, Url } from "@ourworldindata/utils"
 
 // A close cousing of the getWordpressRedirectsMap() function from
@@ -17,8 +17,8 @@ export const syncRedirectsToGrapher = async (): Promise<void> => {
 
     const allWordpressRedirects = allWordpressRedirectsRaw.map((r) => ({
         ...r,
-        source: formatWpUrl(r.source),
-        target: formatWpUrl(r.target),
+        source: stripTrailingSlash(r.source),
+        target: stripTrailingSlash(r.target),
     }))
 
     const existingRedirectsFromDb = await getRedirectsFromDb()


### PR DESCRIPTION
- refactor: bake redirects from db
- refactor: resolve internal redirects from db

### Internal redirect resolver

The internal resolver is currently only used for prominent links. The following query reveals some examples of where it might be used:

```
select
    *
from
    posts_links pl
    join posts p on pl.sourceId = p.id
where
    pl.linkType = 'grapher'
    and componentType = 'prominent-link'
    and p.status = 'publish'
    and p.gdocSuccessorId is NULL
    and pl.target in (
        select
            slug
        from
            chart_slug_redirects csr
    )
```

For instance, in https://ourworldindata.org/ukraine-war 

![Screenshot 2024-02-10 at 09.10.18.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0SFFiIjKuUK6UPYHVe6u/f120f2fc-5e01-4eb2-9990-050ddd0827f8.png)


### formatWpUrl refactor

This PR also simplifies the formatWpUrl function since none of the paths in redirects contain the "__" string:

```
SELECT url, action_data, action_code FROM wp_redirection_items WHERE (url like "%\_\_%" OR action_data like "%\_\_%")  and status = "enabled"
```
--> 0 results

