### PR TITLE
:honeybee: set the dev tools to use a profile for s3 credentials

### DIFF
--- a/devTools/docker/sync-s3-images.sh
+++ b/devTools/docker/sync-s3-images.sh
@@ -13,4 +13,12 @@ fi
 # for local development, it should be owid-image-upload/local-yourname
 # at least until we decide to instead host images locally, if ever
 
+if ! grep -q 'profile owid-spaces' ~/.aws/config; then
+  echo 'Please configure your S3 credentials for profile owid-spaces:'
+  echo
+  echo '  aws configure --profile=owid-spaces'
+  echo
+  exit 1
+fi
+
 aws --profile=owid-spaces --endpoint=https://nyc3.digitaloceanspaces.com s3 sync s3://owid-image-upload/production/ s3://$IMAGE_HOSTING_BUCKET_PATH/ --acl public-read

--- a/devTools/docker/sync-s3-images.sh
+++ b/devTools/docker/sync-s3-images.sh
@@ -13,4 +13,4 @@ fi
 # for local development, it should be owid-image-upload/local-yourname
 # at least until we decide to instead host images locally, if ever
 
-aws --endpoint=https://nyc3.digitaloceanspaces.com s3 sync s3://owid-image-upload/production/ s3://$IMAGE_HOSTING_BUCKET_PATH/ --acl public-read
+aws --profile=owid-spaces --endpoint=https://nyc3.digitaloceanspaces.com s3 sync s3://owid-image-upload/production/ s3://$IMAGE_HOSTING_BUCKET_PATH/ --acl public-read


### PR DESCRIPTION
## Motivation

Previously, our dev tool used the default s3 credentials when syncing to DigitalOcean Spaces. This is a little problematic, since we are now using multiple object stores.

This change suggests setting up a profile for OWID and explicitly using that. In this way, it's compatible with using multiple object stores, and in fact having multiple sets of S3 credentials on your machine.

## Setting up a profile

`aws configure --profile=owid-spaces`