### PR TITLE
feat: add about page template

### DIFF
--- a/adminSiteClient/GdocsIndexPage.tsx
+++ b/adminSiteClient/GdocsIndexPage.tsx
@@ -10,6 +10,7 @@ import {
     faPuzzlePiece,
     faQuestion,
     faThList,
+    faBuildingNgo,
 } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import {
@@ -37,6 +38,7 @@ const iconGdocTypeMap = {
     [OwidGdocType.TopicPage]: <FontAwesomeIcon icon={faLightbulb} />,
     [OwidGdocType.LinearTopicPage]: <FontAwesomeIcon icon={faLightbulb} />,
     [OwidGdocType.DataInsight]: <FontAwesomeIcon icon={faThList} />,
+    [OwidGdocType.AboutPage]: <FontAwesomeIcon icon={faBuildingNgo} />,
 }
 
 @observer
@@ -55,6 +57,7 @@ class GdocsIndexPageSearch extends React.Component<{
             OwidGdocType.TopicPage,
             OwidGdocType.LinearTopicPage,
             OwidGdocType.DataInsight,
+            OwidGdocType.AboutPage,
         ]
         return (
             <div className="d-flex flex-grow-1 flex-wrap">
@@ -113,6 +116,7 @@ export class GdocsIndexPage extends React.Component<GdocsMatchProps> {
         [OwidGdocType.TopicPage]: false,
         [OwidGdocType.LinearTopicPage]: false,
         [OwidGdocType.DataInsight]: false,
+        [OwidGdocType.AboutPage]: false,
     }
 
     @observable search = { value: "" }

--- a/adminSiteClient/GdocsIndexPage.tsx
+++ b/adminSiteClient/GdocsIndexPage.tsx
@@ -253,8 +253,12 @@ export class GdocsIndexPage extends React.Component<GdocsMatchProps> {
                                     {gdoc.content.authors?.join(", ")}
                                 </p>
                                 <span className="gdoc-index-item__tags">
-                                    {gdoc.content.type !==
-                                        OwidGdocType.Fragment && gdoc.tags ? (
+                                    {gdoc.content.type &&
+                                    ![
+                                        OwidGdocType.Fragment,
+                                        OwidGdocType.AboutPage,
+                                    ].includes(gdoc.content.type) &&
+                                    gdoc.tags ? (
                                         <EditableTags
                                             tags={gdoc.tags}
                                             onSave={(tags) =>

--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -296,7 +296,8 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                                         OwidGdocType.Article,
                                         OwidGdocType.TopicPage,
                                         OwidGdocType.LinearTopicPage,
-                                        OwidGdocType.Fragment
+                                        OwidGdocType.Fragment,
+                                        OwidGdocType.AboutPage
                                     ),
                                 },
                             },

--- a/adminSiteClient/gdocsDeploy.ts
+++ b/adminSiteClient/gdocsDeploy.ts
@@ -112,6 +112,7 @@ export const checkIsLightningUpdate = (
         [OwidGdocType.LinearTopicPage]: postlightningPropContentConfigMap,
         [OwidGdocType.TopicPage]: postlightningPropContentConfigMap,
         [OwidGdocType.DataInsight]: dataInsightLightningPropContentConfigMap,
+        [OwidGdocType.AboutPage]: postlightningPropContentConfigMap,
     }
 
     const getLightningPropKeys = (configMap: Record<string, boolean>) =>

--- a/baker/algolia/indexToAlgolia.tsx
+++ b/baker/algolia/indexToAlgolia.tsx
@@ -148,6 +148,8 @@ function generateGdocRecords(
             case OwidGdocType.Fragment:
                 // this should not happen because we filter out fragments; but we want to have an exhaustive switch/case so we include it
                 return { type: "other", importance: 0 }
+            case OwidGdocType.AboutPage:
+                return { type: "about", importance: 0 }
             case OwidGdocType.Article:
             case undefined:
                 return { type: "article", importance: 0 }

--- a/db/model/Gdoc/GdocFactory.ts
+++ b/db/model/Gdoc/GdocFactory.ts
@@ -41,7 +41,8 @@ export class GdocFactory {
                     OwidGdocType.Article,
                     OwidGdocType.LinearTopicPage,
                     OwidGdocType.TopicPage,
-                    OwidGdocType.Fragment
+                    OwidGdocType.Fragment,
+                    OwidGdocType.AboutPage
                 ),
                 // TODO: better validation here?
                 () => GdocPost.create({ ...(json as any) })
@@ -116,7 +117,8 @@ export class GdocFactory {
                     OwidGdocType.Article,
                     OwidGdocType.LinearTopicPage,
                     OwidGdocType.TopicPage,
-                    OwidGdocType.Fragment
+                    OwidGdocType.Fragment,
+                    OwidGdocType.AboutPage
                 ),
                 () => GdocPost.create(base)
             )

--- a/db/model/Gdoc/GdocPost.ts
+++ b/db/model/Gdoc/GdocPost.ts
@@ -85,7 +85,12 @@ export class GdocPost extends GdocBase implements OwidGdocPostInterface {
         const errors: OwidGdocErrorMessage[] = []
 
         if (!this.tags?.length) {
-            if (this.content.type !== OwidGdocType.Fragment) {
+            if (
+                this.content.type &&
+                ![OwidGdocType.Fragment, OwidGdocType.AboutPage].includes(
+                    this.content.type
+                )
+            ) {
                 errors.push({
                     property: "content",
                     message:
@@ -232,6 +237,7 @@ export class GdocPost extends GdocBase implements OwidGdocPostInterface {
                         OwidGdocType.Article,
                         OwidGdocType.TopicPage,
                         OwidGdocType.LinearTopicPage,
+                        OwidGdocType.AboutPage,
                     ].includes(type)
             )
         )

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -19,6 +19,7 @@ import {
     PostReference,
     Tag,
     DataPageRelatedResearch,
+    OwidGdocType,
 } from "@ourworldindata/types"
 import { uniqBy, sortBy, memoize, orderBy } from "@ourworldindata/utils"
 import { Knex } from "knex"
@@ -367,7 +368,10 @@ export const getGdocsPostReferencesByChartId = async (
                 )
             WHERE
                 c.id = ?
-                AND pg.content ->> '$.type' <> 'fragment'
+                AND pg.content ->> '$.type' NOT IN (
+                    '${OwidGdocType.Fragment}',
+                    '${OwidGdocType.AboutPage}'
+                )
                 AND pg.published = 1
             ORDER BY
                 pg.content ->> '$.title' ASC

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -48,6 +48,7 @@ export enum OwidGdocType {
     Fragment = "fragment",
     LinearTopicPage = "linear-topic-page",
     DataInsight = "data-insight",
+    AboutPage = "about-page",
 }
 
 export interface OwidGdocBaseInterface {
@@ -177,6 +178,7 @@ export interface OwidGdocPostContent {
         | OwidGdocType.Article
         | OwidGdocType.TopicPage
         | OwidGdocType.LinearTopicPage
+        | OwidGdocType.AboutPage
         // TODO: Fragments need their own OwidGdocFragment interface and flow in the UI
         // Historically they were treated the same as GdocPosts but not baked
         // In reality, they have multiple possible data structures in their content (details, faqs, frontPageConfig, etc)

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1795,6 +1795,7 @@ export function checkIsGdocPost(x: unknown): x is OwidGdocPostInterface {
         OwidGdocType.TopicPage,
         OwidGdocType.LinearTopicPage,
         OwidGdocType.Fragment,
+        OwidGdocType.AboutPage,
     ].includes(type)
 }
 

--- a/packages/@ourworldindata/utils/src/image.ts
+++ b/packages/@ourworldindata/utils/src/image.ts
@@ -85,7 +85,8 @@ export function getFeaturedImageFilename(gdoc: OwidGdoc): string | undefined {
                     type: P.union(
                         OwidGdocType.Article,
                         OwidGdocType.TopicPage,
-                        OwidGdocType.LinearTopicPage
+                        OwidGdocType.LinearTopicPage,
+                        OwidGdocType.AboutPage
                     ),
                 },
             },

--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -66,7 +66,8 @@ export function OwidGdoc({
                     type: P.union(
                         OwidGdocType.Article,
                         OwidGdocType.TopicPage,
-                        OwidGdocType.LinearTopicPage
+                        OwidGdocType.LinearTopicPage,
+                        OwidGdocType.AboutPage
                     ),
                 },
             },

--- a/site/gdocs/OwidGdocPage.tsx
+++ b/site/gdocs/OwidGdocPage.tsx
@@ -28,7 +28,8 @@ function getPageDesc(gdoc: OwidGdocUnionType): string | undefined {
                     type: P.union(
                         OwidGdocType.Article,
                         OwidGdocType.TopicPage,
-                        OwidGdocType.LinearTopicPage
+                        OwidGdocType.LinearTopicPage,
+                        OwidGdocType.AboutPage
                     ),
                 },
             },

--- a/site/gdocs/components/OwidGdocHeader.tsx
+++ b/site/gdocs/components/OwidGdocHeader.tsx
@@ -183,7 +183,10 @@ export function OwidGdocHeader(props: {
         return <OwidArticleHeader {...props} />
     if (props.content.type === OwidGdocType.TopicPage)
         return <OwidTopicPageHeader {...props} />
-    if (props.content.type === OwidGdocType.LinearTopicPage)
+    if (
+        props.content.type === OwidGdocType.LinearTopicPage ||
+        props.content.type === OwidGdocType.AboutPage
+    )
         return <OwidLinearTopicPageHeader {...props} />
     // Defaulting to ArticleHeader, but will require the value to be set for all docs going forward
     return <OwidArticleHeader {...props} />

--- a/site/gdocs/pages/GdocPost.tsx
+++ b/site/gdocs/pages/GdocPost.tsx
@@ -21,7 +21,8 @@ const citationDescriptionsByArticleType: Record<
     | OwidGdocType.Article
     | OwidGdocType.TopicPage
     | OwidGdocType.LinearTopicPage
-    | OwidGdocType.Fragment,
+    | OwidGdocType.Fragment
+    | OwidGdocType.AboutPage,
     string
 > = {
     [OwidGdocType.TopicPage]:
@@ -33,6 +34,9 @@ const citationDescriptionsByArticleType: Record<
     // This case should never occur as Fragments aren't baked and can't be viewed by themselves.
     [OwidGdocType.Fragment]:
         "Our articles and data visualizations rely on work from many different people and organizations. When citing this text, please also cite the underlying data sources. This text can be cited as:",
+    // It is unlikely that we would want to cite an about page, but there might be a use case for it.
+    [OwidGdocType.AboutPage]:
+        "Our articles and data visualizations rely on work from many different people and organizations. When citing this page, please also cite the underlying data sources. This page can be cited as:",
 }
 
 export function GdocPost({


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2024-02-13 at 16 15 05" src="https://github.com/owid/owid-grapher/assets/13406362/596c7882-3571-48fe-972e-280e071d6882">

- Example gdoc: https://docs.google.com/document/d/1gdVS23tMmqH1ABXp0hlvy7L-VPUv_CtowGvyujNXtg4/edit
- Preview: http://staging-site-about-page-tpl/admin/gdocs/1gdVS23tMmqH1ABXp0hlvy7L-VPUv_CtowGvyujNXtg4/preview
- Baked: http://staging-site-about-page-tpl/test-about-page

This PR adds a new template for about pages:
- these pages are visually similar to linear topic pages (headers are identical), although citations are discouraged.
- about pages are excluded from content graph queries as the charts they contain are usually used as examples and not for their semantic value (e.g. https://ourworldindata.org/owid-grapher)
- indexed by Algolia, but with a low importance

## Testing

- create a new gdoc
- use the `template: about-page` frontmatter property to set the template