### PR TITLE
refactor: pass knex as parameter

### DIFF
--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -445,7 +445,7 @@ export interface BakeSingleGrapherChartArguments {
 
 export const bakeSingleGrapherChart = async (
     args: BakeSingleGrapherChartArguments,
-    knex: Knex<any, any[]>
+    knex: Knex<any, any[]> = db.knexInstance()
 ) => {
     const grapher: GrapherInterface = JSON.parse(args.config)
     grapher.id = args.id

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -61,6 +61,7 @@ import { getShortPageCitation } from "../site/gdocs/utils.js"
 import { getSlugForTopicTag, getTagToSlugMap } from "./GrapherBakingUtils.js"
 import pMap from "p-map"
 import { getRelatedChartsForVariable } from "../db/model/Chart.js"
+import { Knex } from "knex"
 
 const renderDatapageIfApplicable = async (
     grapher: GrapherInterface,
@@ -87,6 +88,7 @@ const renderDatapageIfApplicable = async (
  */
 export const renderDataPageOrGrapherPage = async (
     grapher: GrapherInterface,
+    knex: Knex<any, any[]>,
     imageMetadataDictionary?: Record<string, Image>
 ): Promise<string> => {
     const datapage = await renderDatapageIfApplicable(
@@ -95,7 +97,7 @@ export const renderDataPageOrGrapherPage = async (
         imageMetadataDictionary
     )
     if (datapage) return datapage
-    return renderGrapherPage(grapher)
+    return renderGrapherPage(grapher, knex)
 }
 
 type EnrichedFaqLookupError = {
@@ -305,15 +307,19 @@ export async function renderDataPageV2({
  * Similar to renderDataPageOrGrapherPage(), but for admin previews
  */
 export const renderPreviewDataPageOrGrapherPage = async (
-    grapher: GrapherInterface
+    grapher: GrapherInterface,
+    knex: Knex<any, any[]>
 ) => {
     const datapage = await renderDatapageIfApplicable(grapher, true)
     if (datapage) return datapage
 
-    return renderGrapherPage(grapher)
+    return renderGrapherPage(grapher, knex)
 }
 
-const renderGrapherPage = async (grapher: GrapherInterface) => {
+const renderGrapherPage = async (
+    grapher: GrapherInterface,
+    knex: Knex<any, any[]>
+) => {
     const postSlug = urlToSlug(grapher.originUrl || "")
     const post = postSlug ? await getPostEnrichedBySlug(postSlug) : undefined
     const relatedCharts =
@@ -322,7 +328,7 @@ const renderGrapherPage = async (grapher: GrapherInterface) => {
             : undefined
     const relatedArticles =
         grapher.id && isWordpressAPIEnabled
-            ? await getRelatedArticles(grapher.id)
+            ? await getRelatedArticles(grapher.id, knex)
             : undefined
 
     return renderToHtmlPage(
@@ -354,7 +360,8 @@ const chartIsSameVersion = async (
 const bakeGrapherPageAndVariablesPngAndSVGIfChanged = async (
     bakedSiteDir: string,
     imageMetadataDictionary: Record<string, Image>,
-    grapher: GrapherInterface
+    grapher: GrapherInterface,
+    knex: Knex<any, any[]>
 ) => {
     const htmlPath = `${bakedSiteDir}/grapher/${grapher.slug}.html`
     const isSameVersion = await chartIsSameVersion(htmlPath, grapher.version)
@@ -371,7 +378,11 @@ const bakeGrapherPageAndVariablesPngAndSVGIfChanged = async (
     const outPath = `${bakedSiteDir}/grapher/${grapher.slug}.html`
     await fs.writeFile(
         outPath,
-        await renderDataPageOrGrapherPage(grapher, imageMetadataDictionary)
+        await renderDataPageOrGrapherPage(
+            grapher,
+            knex,
+            imageMetadataDictionary
+        )
     )
     console.log(outPath)
 
@@ -433,7 +444,8 @@ export interface BakeSingleGrapherChartArguments {
 }
 
 export const bakeSingleGrapherChart = async (
-    args: BakeSingleGrapherChartArguments
+    args: BakeSingleGrapherChartArguments,
+    knex: Knex<any, any[]>
 ) => {
     const grapher: GrapherInterface = JSON.parse(args.config)
     grapher.id = args.id
@@ -448,13 +460,14 @@ export const bakeSingleGrapherChart = async (
     await bakeGrapherPageAndVariablesPngAndSVGIfChanged(
         args.bakedSiteDir,
         args.imageMetadataDictionary,
-        grapher
+        grapher,
+        knex
     )
     return args
 }
 
 export const bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers =
-    async (bakedSiteDir: string) => {
+    async (bakedSiteDir: string, knex: Knex<any, any[]>) => {
         const chartsToBake: { id: number; config: string; slug: string }[] =
             await db.queryMysql(`
                 SELECT
@@ -494,7 +507,7 @@ export const bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers =
         await pMap(
             jobs,
             async (job) => {
-                await bakeSingleGrapherChart(job)
+                await bakeSingleGrapherChart(job, knex)
                 progressBar.tick({ name: `slug ${job.slug}` })
             },
             { concurrency: 10 }

--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -8,13 +8,16 @@ import { MarkdownTextWrap } from "@ourworldindata/components"
 import { Pageview } from "../../db/model/Pageview.js"
 import { Link } from "../../db/model/Link.js"
 import { getRelatedArticles } from "../../db/model/Post.js"
+import { Knex } from "knex"
 
 const computeScore = (record: Omit<ChartRecord, "score">): number => {
     const { numRelatedArticles, views_7d } = record
     return numRelatedArticles * 500 + views_7d
 }
 
-const getChartsRecords = async (): Promise<ChartRecord[]> => {
+const getChartsRecords = async (
+    knex: Knex<any, any[]>
+): Promise<ChartRecord[]> => {
     const chartsToIndex = await db.queryMysql(`
     SELECT c.id,
         config ->> "$.slug"                   AS slug,
@@ -64,7 +67,7 @@ const getChartsRecords = async (): Promise<ChartRecord[]> => {
         // otherwise they will fail when rendered in the search results
         if (isPathRedirectedToExplorer(`/grapher/${c.slug}`)) continue
 
-        const relatedArticles = (await getRelatedArticles(c.id)) ?? []
+        const relatedArticles = (await getRelatedArticles(c.id, knex)) ?? []
         const linksFromGdocs = await Link.getPublishedLinksTo(
             c.slug,
             OwidGdocLinkType.Grapher
@@ -114,7 +117,7 @@ const indexChartsToAlgolia = async () => {
     const index = client.initIndex(SearchIndexName.Charts)
 
     await db.getConnection()
-    const records = await getChartsRecords()
+    const records = await getChartsRecords(db.knexInstance())
     await index.replaceAllObjects(records)
 
     await db.closeTypeOrmAndKnexConnections()

--- a/baker/buildLocalBake.ts
+++ b/baker/buildLocalBake.ts
@@ -5,6 +5,7 @@ import { hideBin } from "yargs/helpers"
 import { BakeStep, BakeStepConfig, bakeSteps, SiteBaker } from "./SiteBaker.js"
 import fs from "fs-extra"
 import { normalize } from "path"
+import * as db from "../db/db.js"
 
 const bakeDomainToFolder = async (
     baseUrl = "http://localhost:3000/",
@@ -15,7 +16,7 @@ const bakeDomainToFolder = async (
     fs.mkdirp(dir)
     const baker = new SiteBaker(dir, baseUrl, bakeSteps)
     console.log(`Baking site locally with baseUrl '${baseUrl}' to dir '${dir}'`)
-    await baker.bakeAll()
+    await baker.bakeAll(db.knexInstance())
 }
 
 yargs(hideBin(process.argv))

--- a/baker/formatWordpressPost.tsx
+++ b/baker/formatWordpressPost.tsx
@@ -59,6 +59,7 @@ import { renderKeyInsights, renderProminentLinks } from "./siteRenderers.js"
 import { KEY_INSIGHTS_CLASS_NAME } from "../site/blocks/KeyInsights.js"
 import { RELATED_CHARTS_CLASS_NAME } from "../site/blocks/RelatedCharts.js"
 import { logErrorAndMaybeSendToBugsnag } from "../serverUtils/errorLog.js"
+import { Knex } from "knex"
 
 const initMathJax = () => {
     const adaptor = liteAdaptor()
@@ -128,6 +129,7 @@ const formatLatex = async (
 export const formatWordpressPost = async (
     post: FullPost,
     formattingOptions: FormattingOptions,
+    knex: Knex<any, any[]>,
     grapherExports?: GrapherExports
 ): Promise<FormattedPost> => {
     let html = post.content
@@ -310,7 +312,7 @@ export const formatWordpressPost = async (
     renderCodeSnippets(cheerioEl)
     renderHelp(cheerioEl)
     renderAllCharts(cheerioEl, post)
-    await renderProminentLinks(cheerioEl, post.id)
+    await renderProminentLinks(cheerioEl, post.id, knex)
 
     // Extract inline styling
     let style
@@ -593,6 +595,7 @@ export const formatWordpressPost = async (
 export const formatPost = async (
     post: FullPost,
     formattingOptions: FormattingOptions,
+    knex: Knex<any, any[]>,
     grapherExports?: GrapherExports
 ): Promise<FormattedPost> => {
     // No formatting applied, plain source HTML returned
@@ -612,5 +615,5 @@ export const formatPost = async (
         ...formattingOptions,
     }
 
-    return formatWordpressPost(post, options, grapherExports)
+    return formatWordpressPost(post, options, knex, grapherExports)
 }

--- a/baker/redirects.test.ts
+++ b/baker/redirects.test.ts
@@ -4,6 +4,7 @@ import * as redirects from "./redirects.js"
 import { resolveInternalRedirect } from "./redirects.js"
 
 import { jest } from "@jest/globals"
+import { Knex } from "knex"
 
 type ArrayForMap = [string, string][]
 
@@ -15,6 +16,8 @@ const getGrapherAndWordpressRedirectsMap = jest.spyOn(
 const getFormattedUrl = (url: string): Url => {
     return Url.fromURL(formatUrls(url))
 }
+
+const knex: Knex = {} as Knex
 
 it("resolves pathnames", async () => {
     const src = "/hello"
@@ -28,7 +31,9 @@ it("resolves pathnames", async () => {
         Promise.resolve(new Map(redirectsArr))
     )
 
-    expect(await resolveInternalRedirect(urlToResolve)).toEqual(resolvedUrl)
+    expect(await resolveInternalRedirect(urlToResolve, knex)).toEqual(
+        resolvedUrl
+    )
 })
 
 it("does not support query string in redirects map", async () => {
@@ -42,7 +47,9 @@ it("does not support query string in redirects map", async () => {
         Promise.resolve(new Map(redirectsArr))
     )
 
-    expect(await resolveInternalRedirect(urlToResolve)).toEqual(urlToResolve)
+    expect(await resolveInternalRedirect(urlToResolve, knex)).toEqual(
+        urlToResolve
+    )
 })
 
 it("passes query string params when resolving", async () => {
@@ -62,7 +69,9 @@ it("passes query string params when resolving", async () => {
         Promise.resolve(new Map(redirectsArr))
     )
 
-    expect(await resolveInternalRedirect(urlToResolve)).toEqual(resolvedUrl)
+    expect(await resolveInternalRedirect(urlToResolve, knex)).toEqual(
+        resolvedUrl
+    )
 })
 
 it("does not pass query string params when some present on the target", async () => {
@@ -79,7 +88,9 @@ it("does not pass query string params when some present on the target", async ()
         Promise.resolve(new Map(redirectsArr))
     )
 
-    expect(await resolveInternalRedirect(urlToResolve)).toEqual(resolvedUrl)
+    expect(await resolveInternalRedirect(urlToResolve, knex)).toEqual(
+        resolvedUrl
+    )
 })
 
 it("resolves self-redirects", async () => {
@@ -93,7 +104,9 @@ it("resolves self-redirects", async () => {
         Promise.resolve(new Map(redirectsArr))
     )
 
-    expect(await resolveInternalRedirect(urlToResolve)).toEqual(urlToResolve)
+    expect(await resolveInternalRedirect(urlToResolve, knex)).toEqual(
+        urlToResolve
+    )
 })
 
 it("does not support query params in self-redirects", async () => {
@@ -110,10 +123,12 @@ it("does not support query params in self-redirects", async () => {
         Promise.resolve(new Map(redirectsArr))
     )
 
-    expect(await resolveInternalRedirect(urlToResolve)).toEqual(urlToResolve)
-    expect(await resolveInternalRedirect(urlToResolveWithQueryParam)).toEqual(
-        urlToResolveWithQueryParam
+    expect(await resolveInternalRedirect(urlToResolve, knex)).toEqual(
+        urlToResolve
     )
+    expect(
+        await resolveInternalRedirect(urlToResolveWithQueryParam, knex)
+    ).toEqual(urlToResolveWithQueryParam)
 })
 
 it("resolves circular redirects", async () => {
@@ -132,5 +147,7 @@ it("resolves circular redirects", async () => {
         Promise.resolve(new Map(redirectsArr))
     )
 
-    expect(await resolveInternalRedirect(urlToResolve)).toEqual(urlToResolve)
+    expect(await resolveInternalRedirect(urlToResolve, knex)).toEqual(
+        urlToResolve
+    )
 })

--- a/baker/runBakeGraphers.ts
+++ b/baker/runBakeGraphers.ts
@@ -1,5 +1,6 @@
 #! /usr/bin/env node
 import { bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers } from "./GrapherBaker.js"
+import * as db from "../db/db"
 
 /**
  * This bakes all the Graphers to a folder on your computer, running the same baking code as the SiteBaker.
@@ -9,7 +10,8 @@ import { bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers } fro
 
 const main = async (folder: string) => {
     await bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers(
-        folder
+        folder,
+        db.knexInstance()
     )
 }
 

--- a/baker/siteRenderers.test.ts
+++ b/baker/siteRenderers.test.ts
@@ -3,13 +3,17 @@
 import {} from "../site/blocks/ProminentLink.js"
 import { renderExplorerPage } from "./siteRenderers.js"
 import { ExplorerProgram } from "../explorer/ExplorerProgram.js"
+import { Knex } from "knex"
 
 // Note: renderProminentLinks() tests are now e2e (see kitchenSink.js)
 
 it("renders an explorer page with title", async () => {
+    const knex: Knex = {} as Knex
+
     expect(
         await renderExplorerPage(
-            new ExplorerProgram("foo", "explorerTitle helloWorld")
+            new ExplorerProgram("foo", "explorerTitle helloWorld"),
+            knex
         )
     ).toContain("helloWorld")
 })

--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -13,6 +13,7 @@ import { EXPLORERS_ROUTE_FOLDER } from "../explorer/ExplorerConstants.js"
 import { ExplorerProgram } from "../explorer/ExplorerProgram.js"
 import { GdocPost } from "../db/model/Gdoc/GdocPost.js"
 import { getPostsFromSnapshots } from "../db/model/Post.js"
+import { Knex } from "knex"
 
 interface SitemapUrl {
     loc: string
@@ -57,12 +58,14 @@ const explorerToSitemapUrl = (program: ExplorerProgram): SitemapUrl[] => {
     }
 }
 
-export const makeSitemap = async (explorerAdminServer: ExplorerAdminServer) => {
-    // TODO: the knex instance should be handed down as a parameter
-    const knex = db.knexInstance()
+export const makeSitemap = async (
+    explorerAdminServer: ExplorerAdminServer,
+    knex: Knex<any, any[]>
+) => {
     const alreadyPublishedViaGdocsSlugsSet =
         await db.getSlugsWithPublishedGdocsSuccessors(knex)
     const postsApi = await getPostsFromSnapshots(
+        knex,
         undefined,
         (postrow) => !alreadyPublishedViaGdocsSlugsSet.has(postrow.slug)
     )

--- a/baker/startDeployQueueServer.ts
+++ b/baker/startDeployQueueServer.ts
@@ -35,7 +35,7 @@ const main = async () => {
         setTimeout(deployIfQueueIsNotEmpty, 10 * 1000)
     })
 
-    deployIfQueueIsNotEmpty()
+    deployIfQueueIsNotEmpty(db.knexInstance())
 }
 
 main()

--- a/baker/syncRedirectsToGrapher.ts
+++ b/baker/syncRedirectsToGrapher.ts
@@ -60,8 +60,9 @@ export const syncRedirectsToGrapher = async (): Promise<void> => {
             console.log(
                 `Adding redirect: ${source} -> ${resolvedTarget} (${code})`
             )
-            await knex.raw(
+            await db.knexRaw(
                 `INSERT INTO redirects (source, target, code) VALUES (?, ?, ?)`,
+                knex,
                 [source, resolvedTarget, code]
             )
         }

--- a/baker/syncRedirectsToGrapher.ts
+++ b/baker/syncRedirectsToGrapher.ts
@@ -2,12 +2,12 @@ import * as db from "../db/db"
 import * as wpdb from "../db/wpdb"
 import { getRedirectsFromDb } from "../db/model/Redirect.js"
 import { resolveRedirectFromMap } from "./redirects.js"
-import { Redirect, Url } from "@ourworldindata/utils"
+import { DbPlainRedirect, Url } from "@ourworldindata/utils"
 
 // A close cousing of the getWordpressRedirectsMap() function from
 // redirects.ts.
 const getWordpressRedirectsMapFromRedirects = (
-    redirects: Redirect[]
+    redirects: DbPlainRedirect[]
 ): Map<string, string> => {
     return new Map(redirects.map((r) => [r.source, r.target]))
 }
@@ -27,9 +27,9 @@ export const syncRedirectsToGrapher = async (): Promise<void> => {
         target: stripTrailingSlash(r.target),
     }))
 
-    const existingRedirectsFromDb = await getRedirectsFromDb()
+    await db.knexInstance().transaction(async (knex) => {
+        const existingRedirectsFromDb = await getRedirectsFromDb(knex)
 
-    await db.knexInstance().transaction(async (t) => {
         for (const { source, code } of allWordpressRedirects) {
             // We only want to insert redirects for which we don't have a redirected source yet
             if (existingRedirectsFromDb.some((r) => r.source === source)) {
@@ -60,7 +60,7 @@ export const syncRedirectsToGrapher = async (): Promise<void> => {
             console.log(
                 `Adding redirect: ${source} -> ${resolvedTarget} (${code})`
             )
-            await t.raw(
+            await knex.raw(
                 `INSERT INTO redirects (source, target, code) VALUES (?, ?, ?)`,
                 [source, resolvedTarget, code]
             )

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -391,9 +391,8 @@ export const getChartEmbedUrlsInPublishedWordpressPosts = async (
     const chartSlugQueryString: Pick<
         DbPlainPostLink,
         "target" | "queryString"
-    >[] = (
-        await knex.raw(
-            `
+    >[] = await db.knexRaw(
+        `
             SELECT
                 pl.target,
                 pl.queryString
@@ -430,9 +429,9 @@ export const getChartEmbedUrlsInPublishedWordpressPosts = async (
         --      AND pgl.componentType = "chart"
         --      AND pg.content ->> '$.type' <> 'fragment'
         --      AND pg.published = 1
-    `
-        )
-    )[0]
+    `,
+        knex
+    )
 
     return chartSlugQueryString.map((row) => {
         return `${BAKED_BASE_URL}/${row.target}${row.queryString}`

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -23,12 +23,14 @@ import {
     GrapherInterface,
     ChartTypeName,
     RelatedChart,
+    DbPlainPostLink,
 } from "@ourworldindata/types"
 import { OpenAI } from "openai"
 import {
     BAKED_BASE_URL,
     OPENAI_API_KEY,
 } from "../../settings/serverSettings.js"
+import { Knex } from "knex"
 
 // XXX hardcoded filtering to public parent tags
 export const PUBLIC_TAG_PARENT_IDS = [
@@ -383,11 +385,14 @@ export const getRelatedChartsForVariable = async (
             `)
 }
 
-export const getChartEmbedUrlsInPublishedWordpressPosts = async (): Promise<
-    string[]
-> => {
-    const chartSlugQueryString: { target: string; queryString: string }[] = (
-        await db.knexInstance().raw(
+export const getChartEmbedUrlsInPublishedWordpressPosts = async (
+    knex: Knex<any, any[]>
+): Promise<string[]> => {
+    const chartSlugQueryString: Pick<
+        DbPlainPostLink,
+        "target" | "queryString"
+    >[] = (
+        await knex.raw(
             `
             SELECT
                 pl.target,

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -157,11 +157,12 @@ export const isPostSlugCitable = (slug: string): boolean => {
 }
 
 export const getPostsFromSnapshots = async (
+    knex: Knex<any, any[]>,
     postTypes: string[] = [WP_PostType.Post, WP_PostType.Page],
     filterFunc?: FilterFnPostRestApi
 ): Promise<PostRestApi[]> => {
     const rawPosts: Pick<DbRawPost, "wpApiSnapshot">[] = (
-        await db.knexInstance().raw(
+        await knex.raw(
             `
                 SELECT wpApiSnapshot FROM ${postsTable}
                 WHERE wpApiSnapshot IS NOT NULL
@@ -237,29 +238,32 @@ export const getFullPost = async (
 const selectHomepagePosts: FilterFnPostRestApi = (post) =>
     post.meta?.owid_publication_context_meta_field?.homepage === true
 
-export const getBlogIndex = memoize(async (): Promise<IndexPost[]> => {
-    await db.getConnection() // side effect: ensure connection is established
-    const gdocPosts = await GdocPost.getListedGdocs()
-    const wpPosts = await Promise.all(
-        await getPostsFromSnapshots(
-            [WP_PostType.Post],
-            selectHomepagePosts
-        ).then((posts) => posts.map((post) => getFullPost(post, true)))
-    )
+export const getBlogIndex = memoize(
+    async (knex: Knex<any, any[]>): Promise<IndexPost[]> => {
+        await db.getConnection() // side effect: ensure connection is established
+        const gdocPosts = await GdocPost.getListedGdocs()
+        const wpPosts = await Promise.all(
+            await getPostsFromSnapshots(
+                knex,
+                [WP_PostType.Post],
+                selectHomepagePosts
+            ).then((posts) => posts.map((post) => getFullPost(post, true)))
+        )
 
-    const gdocSlugs = new Set(gdocPosts.map(({ slug }) => slug))
-    const posts = [...mapGdocsToWordpressPosts(gdocPosts)]
+        const gdocSlugs = new Set(gdocPosts.map(({ slug }) => slug))
+        const posts = [...mapGdocsToWordpressPosts(gdocPosts)]
 
-    // Only adding each wpPost if there isn't already a gdoc with the same slug,
-    // to make sure we use the most up-to-date metadata
-    for (const wpPost of wpPosts) {
-        if (!gdocSlugs.has(wpPost.slug)) {
-            posts.push(wpPost)
+        // Only adding each wpPost if there isn't already a gdoc with the same slug,
+        // to make sure we use the most up-to-date metadata
+        for (const wpPost of wpPosts) {
+            if (!gdocSlugs.has(wpPost.slug)) {
+                posts.push(wpPost)
+            }
         }
-    }
 
-    return orderBy(posts, (post) => post.date.getTime(), ["desc"])
-})
+        return orderBy(posts, (post) => post.date.getTime(), ["desc"])
+    }
+)
 
 export const mapGdocsToWordpressPosts = (
     gdocs: OwidGdocPostInterface[]
@@ -296,10 +300,11 @@ export const getBlockContentFromSnapshot = async (
 }
 
 export const getWordpressPostReferencesByChartId = async (
-    chartId: number
+    chartId: number,
+    knex: Knex<any, any[]>
 ): Promise<PostReference[]> => {
     const relatedWordpressPosts: PostReference[] = (
-        await db.knexInstance().raw(
+        await knex.raw(
             `
             SELECT DISTINCT
                 p.title,
@@ -344,10 +349,11 @@ export const getWordpressPostReferencesByChartId = async (
 }
 
 export const getGdocsPostReferencesByChartId = async (
-    chartId: number
+    chartId: number,
+    knex: Knex<any, any[]>
 ): Promise<PostReference[]> => {
     const relatedGdocsPosts: PostReference[] = (
-        await db.knexInstance().raw(
+        await knex.raw(
             `
             SELECT DISTINCT
                 pg.content ->> '$.title' AS title,
@@ -387,10 +393,14 @@ export const getGdocsPostReferencesByChartId = async (
  * Get all the gdocs and Wordpress posts mentioning a chart
  */
 export const getRelatedArticles = async (
-    chartId: number
+    chartId: number,
+    knex: Knex<any, any[]>
 ): Promise<PostReference[] | undefined> => {
-    const wordpressPosts = await getWordpressPostReferencesByChartId(chartId)
-    const gdocsPosts = await getGdocsPostReferencesByChartId(chartId)
+    const wordpressPosts = await getWordpressPostReferencesByChartId(
+        chartId,
+        knex
+    )
+    const gdocsPosts = await getGdocsPostReferencesByChartId(chartId, knex)
 
     return [...wordpressPosts, ...gdocsPosts].sort(
         // Alphabetise

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -161,18 +161,17 @@ export const getPostsFromSnapshots = async (
     postTypes: string[] = [WP_PostType.Post, WP_PostType.Page],
     filterFunc?: FilterFnPostRestApi
 ): Promise<PostRestApi[]> => {
-    const rawPosts: Pick<DbRawPost, "wpApiSnapshot">[] = (
-        await knex.raw(
-            `
+    const rawPosts: Pick<DbRawPost, "wpApiSnapshot">[] = await db.knexRaw(
+        `
                 SELECT wpApiSnapshot FROM ${postsTable}
                 WHERE wpApiSnapshot IS NOT NULL
                 AND status = "publish"
                 AND type IN (?)
                 ORDER BY wpApiSnapshot->>'$.date' DESC;
             `,
-            [postTypes]
-        )
-    )[0]
+        knex,
+        [postTypes]
+    )
 
     const posts = rawPosts
         .map((p) => p.wpApiSnapshot)
@@ -303,9 +302,8 @@ export const getWordpressPostReferencesByChartId = async (
     chartId: number,
     knex: Knex<any, any[]>
 ): Promise<PostReference[]> => {
-    const relatedWordpressPosts: PostReference[] = (
-        await knex.raw(
-            `
+    const relatedWordpressPosts: PostReference[] = await db.knexRaw(
+        `
             SELECT DISTINCT
                 p.title,
                 p.slug,
@@ -341,9 +339,9 @@ export const getWordpressPostReferencesByChartId = async (
             ORDER BY
                 p.title ASC
         `,
-            [chartId]
-        )
-    )[0]
+        knex,
+        [chartId]
+    )
 
     return relatedWordpressPosts
 }
@@ -352,9 +350,8 @@ export const getGdocsPostReferencesByChartId = async (
     chartId: number,
     knex: Knex<any, any[]>
 ): Promise<PostReference[]> => {
-    const relatedGdocsPosts: PostReference[] = (
-        await knex.raw(
-            `
+    const relatedGdocsPosts: PostReference[] = await db.knexRaw(
+        `
             SELECT DISTINCT
                 pg.content ->> '$.title' AS title,
                 pg.slug AS slug,
@@ -382,9 +379,9 @@ export const getGdocsPostReferencesByChartId = async (
             ORDER BY
                 pg.content ->> '$.title' ASC
         `,
-            [chartId]
-        )
-    )[0]
+        knex,
+        [chartId]
+    )
 
     return relatedGdocsPosts
 }

--- a/db/model/Redirect.ts
+++ b/db/model/Redirect.ts
@@ -1,9 +1,11 @@
-import * as db from "../db"
+import { Knex } from "knex"
 import { DbPlainRedirect } from "@ourworldindata/types"
 
-export const getRedirectsFromDb = async (): Promise<DbPlainRedirect[]> => {
-    const redirectsFromDb = (
-        await db.knexInstance().raw(`
+export const getRedirectsFromDb = async (
+    knex: Knex<any, any[]>
+): Promise<DbPlainRedirect[]> => {
+    const redirectsFromDb: DbPlainRedirect[] = (
+        await knex.raw(`
         SELECT source, target, code FROM redirects
         `)
     )[0]

--- a/db/model/Redirect.ts
+++ b/db/model/Redirect.ts
@@ -1,14 +1,16 @@
 import { Knex } from "knex"
 import { DbPlainRedirect } from "@ourworldindata/types"
+import * as db from "../db"
 
 export const getRedirectsFromDb = async (
     knex: Knex<any, any[]>
 ): Promise<DbPlainRedirect[]> => {
-    const redirectsFromDb: DbPlainRedirect[] = (
-        await knex.raw(`
+    const redirectsFromDb: DbPlainRedirect[] = await db.knexRaw(
+        `
         SELECT source, target, code FROM redirects
-        `)
-    )[0]
+        `,
+        knex
+    )
 
     return redirectsFromDb
 }

--- a/db/model/Redirect.ts
+++ b/db/model/Redirect.ts
@@ -1,7 +1,7 @@
 import * as db from "../db"
-import { Redirect } from "@ourworldindata/types"
+import { DbPlainRedirect } from "@ourworldindata/types"
 
-export const getRedirectsFromDb = async (): Promise<Redirect[]> => {
+export const getRedirectsFromDb = async (): Promise<DbPlainRedirect[]> => {
     const redirectsFromDb = (
         await db.knexInstance().raw(`
         SELECT source, target, code FROM redirects

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -13,7 +13,7 @@ import { Knex, knex } from "knex"
 import { Base64 } from "js-base64"
 import { registerExitHandler } from "./cleanup.js"
 import { WP_PostType, JsonError, PostRestApi } from "@ourworldindata/utils"
-import { Redirect } from "@ourworldindata/types"
+import { DbPlainRedirect } from "@ourworldindata/types"
 
 let _knexInstance: Knex
 
@@ -268,7 +268,9 @@ export const FOR_SYNC_ONLY_getTables = async (): Promise<
     return tables
 }
 
-export const FOR_SYNC_ONLY_getRedirects = async (): Promise<Redirect[]> => {
+export const FOR_SYNC_ONLY_getRedirects = async (): Promise<
+    DbPlainRedirect[]
+> => {
     return singleton.query(`
         SELECT url AS source, action_data AS target, action_code AS code
         FROM wp_redirection_items WHERE status = 'enabled'

--- a/packages/@ourworldindata/types/src/dbTypes/Redirects.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Redirects.ts
@@ -3,7 +3,7 @@ export enum RedirectCode {
     FOUND = 302,
 }
 
-export interface Redirect {
+export interface DbPlainRedirect {
     source: string
     target: string
     code: RedirectCode

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -608,4 +608,4 @@ export {
     type License,
 } from "./dbTypes/Variables.js"
 
-export { RedirectCode, type Redirect } from "./dbTypes/Redirects.js"
+export { RedirectCode, type DbPlainRedirect } from "./dbTypes/Redirects.js"


### PR DESCRIPTION
- pass knex as a parameter to downstream functions
- wrap top API calls in a transaction
- replace knex.raw() with knexRaw()
- this PR doesn't add [{readOnly: true}](https://www.notion.so/owid/Database-access-in-Grapher-d9db343c2bfb4ae0b14b3dec72f686c6?pvs=4#fdb6c225d4134e47a78fe3436a19f72c).

@danyx23 [as you know](https://github.com/owid/owid-grapher/pull/3145), these refactors tend to start with a small surface area but end up requiring extensive surgery across the codebase.

This is partly why I hadn't dived into it as part of this project, and continued using the `db.knexInstance().raw()` paradigm in downstream functions. (Another reason had to do with the value of doing this refactor on partly obsolete code).

So in case this ends up needing more work and blocks the delivery of the core wordpress sunsetting project, I'll revert it to draft for later.

How does that sound?

Context: https://github.com/owid/owid-grapher/pull/3166#issuecomment-1942426303