### PR TITLE
:sparkles: replace Fast-track tab by Wizard

### DIFF
--- a/adminSiteClient/AdminSidebar.tsx
+++ b/adminSiteClient/AdminSidebar.tsx
@@ -5,7 +5,6 @@ import {
     faChartBar,
     faFile,
     faTable,
-    faTruckFast,
     faSkullCrossbones,
     faPen,
     faDatabase,
@@ -19,9 +18,10 @@ import {
     faSatelliteDish,
     faCodeBranch,
     faDownload,
+    faHatWizard,
 } from "@fortawesome/free-solid-svg-icons"
 
-import { FASTTRACK_URL } from "../settings/clientSettings.js"
+import { ETL_WIZARD_URL } from "../settings/clientSettings.js"
 
 export const AdminSidebar = (): JSX.Element => (
     <aside className="AdminSidebar">
@@ -49,12 +49,12 @@ export const AdminSidebar = (): JSX.Element => (
 
             <li>
                 <a
-                    href={FASTTRACK_URL}
+                    href={ETL_WIZARD_URL}
                     target="_blank"
                     rel="noopener"
                     title="Tailscale required"
                 >
-                    <FontAwesomeIcon icon={faTruckFast} /> Fast-track
+                    <FontAwesomeIcon icon={faHatWizard} /> Wizard
                 </a>
             </li>
             <li>

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -73,9 +73,9 @@ export const IMAGE_HOSTING_BUCKET_PATH: string =
 export const IMAGE_HOSTING_BUCKET_SUBFOLDER_PATH: string =
     IMAGE_HOSTING_BUCKET_PATH.slice(IMAGE_HOSTING_BUCKET_PATH.indexOf("/") + 1)
 
-// Fast-track settings, by default points to staging version. You need Tailscale to access it.
-export const FASTTRACK_URL: string =
-    process.env.FASTTRACK_URL ?? "http://owid-analytics:8083/"
+// Link to production wizard.  You need Tailscale to access it in production.
+export const ETL_WIZARD_URL: string =
+    process.env.ETL_WIZARD_URL ?? "http://localhost:8053/"
 
 export const GDOCS_DETAILS_ON_DEMAND_ID: string =
     process.env.GDOCS_DETAILS_ON_DEMAND_ID ?? ""


### PR DESCRIPTION
## TODO
* [x] Set `ETL_WIZARD_URL=http://staging-site-[branch]/etl/wizard` on staging servers
* [x] Wait until https://github.com/owid/ops/pull/136 gets merged and recreate staging server
* [x] Test it on staging server for this branch
* [ ] Set `ETL_WIZARD_URL=http://etl.owid.io/wizard` in owid-live