### PR TITLE
:bug: disable topic fetching in the chart admin

### DIFF
--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -304,7 +304,10 @@ export class ChartEditorPage
         this.fetchRefs()
         this.fetchRedirects()
         this.fetchPageviews()
-        this.fetchTopics()
+
+        // (2024-02-15) Disabled due to slow query performance
+        // https://github.com/owid/owid-grapher/issues/3198
+        // this.fetchTopics()
     }
 
     disposers: IReactionDisposer[] = []


### PR DESCRIPTION
Since moving the DB further from the admin geographically, this call has had very bad performance impacts, and the results from it are not used.

Aims to improve: https://github.com/owid/owid-grapher/issues/3198
