### PR TITLE
:honeybee: Dev tooling: log all MySQL queries in dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ up: require create-if-missing.env ../owid-content tmp-downloads/owid_metadata.sq
 	yarn run tsc -b
 
 	@echo '==> Starting dev environment'
+	@mkdir -p logs
 	tmux new-session -s grapher \
 		-n docker 'docker-compose -f docker-compose.grapher.yml up' \; \
 			set remain-on-exit on \; \
@@ -83,6 +84,7 @@ up.devcontainer: create-if-missing.env.devcontainer tmp-downloads/owid_metadata.
 	yarn run tsc -b
 
 	@echo '==> Starting dev environment'
+	@mkdir -p logs
 	tmux new-session -s grapher \
 		-n admin \
 			'devTools/docker/wait-for-mysql.sh && yarn run tsc-watch -b --onSuccess "yarn startAdminServer"' \; \

--- a/devTools/docker/my.cnf
+++ b/devTools/docker/my.cnf
@@ -11,3 +11,6 @@ pid-file=/var/run/mysqld/mysqld.pid
 # owid-specific
 general_log = 1
 general_log_file = /var/log/mysql/queries.log
+slow_query_log = 1
+slow_query_log_file = /var/log/mysql/slow-queries.log
+long_query_time = 2

--- a/devTools/docker/my.cnf
+++ b/devTools/docker/my.cnf
@@ -1,0 +1,13 @@
+[mysqld]
+# defaults
+skip-host-cache
+skip-name-resolve
+datadir=/var/lib/mysql
+socket=/var/lib/mysql/mysql.sock
+secure-file-priv=/var/lib/mysql-files
+user=mysql
+pid-file=/var/run/mysqld/mysqld.pid
+
+# owid-specific
+general_log = 1
+general_log_file = /var/log/mysql/queries.log

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -37,7 +37,9 @@ services:
         command: --default-authentication-plugin=mysql_native_password
         restart: always
         volumes:
+            - ./devTools/docker/my.cnf:/etc/my.cnf:ro
             - mysql_data:/var/lib/mysql
+            - ./logs:/var/log/mysql
         ports:
             # Exposing via the port specified for Grapher
             # Should always be the same as the WordPress port, because we store both DBs on the same server

--- a/docker-compose.grapher.yml
+++ b/docker-compose.grapher.yml
@@ -33,7 +33,9 @@ services:
         command: --default-authentication-plugin=mysql_native_password
         restart: always
         volumes:
+            - ./devTools/my.cnf:/etc/my.cnf:ro
             - mysql_data_public:/var/lib/mysql
+            - ./logs:/var/log/mysql
         ports:
             # Exposing via the port specified for Grapher
             # Should always be the same as the WordPress port, because we store both DBs on the same server


### PR DESCRIPTION
Sometimes it's helpful to understand what queries are actually hitting the database as you work.

This change mounts the .gitignored `logs/` folder into the Docker MySQL container, and writes queries to `logs/queries.log` as they happen. This means you can `tail -f logs/queries.log` in your local environment and see queries happen live.
