### PR TITLE
✨ (admin) persist entities for stacked charts more often

### DIFF
--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -90,7 +90,8 @@ class DimensionSlotView extends React.Component<{
         } else if (
             grapher.yColumnsFromDimensions.length > 1 &&
             !grapher.isStackedArea &&
-            !grapher.isStackedBar
+            !grapher.isStackedBar &&
+            !grapher.isStackedDiscreteBar
         ) {
             // non-stacked charts with multiple y-dimensions should select a single entity by default.
             // if possible, the currently selected entity is persisted, otherwise "World" is preferred

--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -105,7 +105,7 @@ class DimensionSlotView extends React.Component<{
         } else {
             // stacked charts or charts with a single y-dimension should select multiple entities by default.
             // if possible, the currently selected entities are persisted, otherwise a random sample is selected
-            if (selection.numSelectedEntities <= 1) {
+            if (selection.numSelectedEntities === 0) {
                 selection.setSelectedEntities(
                     availableEntityNames.length > 10
                         ? sampleSize(availableEntityNames, 4)


### PR DESCRIPTION
- When creating a new chart, we want to sample a random set of entities
- But when editing a chart, we usually want to persist entities (unless it doesn't make sense)
- For stacked charts (StackedBar, StackedArea, StackedDiscreteBar), we were throwing away entities more often than necessary
- This PR implements two improvements:
    - Stacked charts persist a single entity and only sample new entities when the current selection is empty
    - StackedDiscreteBar charts are treated like other stacked charts – see above