### PR TITLE
🐛 commit svg tester diffs to different branches

### DIFF
--- a/.github/workflows/svg-compare-all-views.yml
+++ b/.github/workflows/svg-compare-all-views.yml
@@ -16,14 +16,14 @@ jobs:
               if: ${{ github.repository_owner == 'owid' }}
               shell: bash
               run: |
-                  echo "PUSH_BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
+                  echo "PUSH_BRANCH_NAME=${{ github.ref_name }}__all-views" >> $GITHUB_ENV
                   echo "TOKEN=${{ secrets.GITHUBPAT }}" >> $GITHUB_ENV
 
             - name: Set branch name and token for runs from a fork
               if: ${{ github.repository_owner != 'owid' }}
               shell: bash
               run: |
-                  echo "PUSH_BRANCH_NAME=${{ github.repository_owner }}/${{ github.ref_name }}" >> $GITHUB_ENV
+                  echo "PUSH_BRANCH_NAME=${{ github.repository_owner }}/${{ github.ref_name }}__all-views" >> $GITHUB_ENV
                   echo "TOKEN=${{ github.token }}" >> $GITHUB_ENV
 
             # Checkout the owid-grapher-svgs repo into a subfolder. Use a Personal Access Token for checkout so the
@@ -35,20 +35,13 @@ jobs:
                   path: owid-grapher-svgs
                   token: ${{ env.TOKEN }}
 
-            # Create a branch on that repo that matches the branch name we are on in the owid-grapher repo
+            # Switch to or create a branch on that repo that matches the branch name we are on in the owid-grapher repo
             # but only do this if we are not on master in owid-graphers (in this case we want to commit and push on master
             # in owid-grapher-svgs as well)
             - name: create owid-grapher-svgs local branch
               if: ${{ env.PUSH_BRANCH_NAME != 'master'}}
               working-directory: owid-grapher-svgs
-              continue-on-error: true
-              run: git branch ${{ env.PUSH_BRANCH_NAME }} || echo "Branch ${{ env.PUSH_BRANCH_NAME }} already exists"
-
-            # Checkout the branch we just created (but not if we are on master in owid-grapher)
-            - name: checkout owid-grapher-svgs local branch
-              if: ${{ env.PUSH_BRANCH_NAME != 'master'}}
-              working-directory: owid-grapher-svgs
-              run: git checkout ${{ env.PUSH_BRANCH_NAME }}
+              run: git branch ${{ env.PUSH_BRANCH_NAME }} && git checkout ${{ env.PUSH_BRANCH_NAME }}
 
             # Run the verify tool overwriting any svgs. Stdout is piped to compare-result which will be a 0 byte file if everything works or contain failed grapher ids otherwise
             - name: Generate SVGs and compare to reference
@@ -66,7 +59,7 @@ jobs:
                   repository: ./owid-grapher-svgs/
                   branch: ${{ env.PUSH_BRANCH_NAME }}
                   push_options: "--force"
-                  commit_message: Automated commit with svg differences of all views triggered by commit https://github.com/owid/owid-grapher/commit/${{github.sha}}
+                  commit_message: Automated commit with svg differences (all views) triggered by commit https://github.com/owid/owid-grapher/commit/${{github.sha}}
 
             # The action fails if there were any errors.
             - name: Fail with error message if we had errors

--- a/.github/workflows/svg-compare.yml
+++ b/.github/workflows/svg-compare.yml
@@ -35,20 +35,13 @@ jobs:
                   path: owid-grapher-svgs
                   token: ${{ env.TOKEN }}
 
-            # Create a branch on that repo that matches the branch name we are on in the owid-grapher repo
+            # Switch to or create a branch on that repo that matches the branch name we are on in the owid-grapher repo
             # but only do this if we are not on master in owid-graphers (in this case we want to commit and push on master
             # in owid-grapher-svgs as well)
             - name: create owid-grapher-svgs local branch
               if: ${{ env.PUSH_BRANCH_NAME != 'master'}}
               working-directory: owid-grapher-svgs
-              continue-on-error: true
-              run: git branch ${{ env.PUSH_BRANCH_NAME }} || echo "Branch ${{ env.PUSH_BRANCH_NAME }} already exists"
-
-            # Checkout the branch we just created (but not if we are on master in owid-grapher)
-            - name: checkout owid-grapher-svgs local branch
-              if: ${{ env.PUSH_BRANCH_NAME != 'master'}}
-              working-directory: owid-grapher-svgs
-              run: git checkout ${{ env.PUSH_BRANCH_NAME }}
+              run: git branch ${{ env.PUSH_BRANCH_NAME }} && git checkout ${{ env.PUSH_BRANCH_NAME }}
 
             # Run the verify tool overwriting any svgs. Stdout is piped to compare-result which will be a 0 byte file if everything works or contain failed grapher ids otherwise
             - name: Generate SVGs and compare to reference


### PR DESCRIPTION
### Problem

- Both SVG tester actions commit to the same branch, but force-push their changes, which means that they overwrite changes on remote
- As a result, the last action that pushes wins and overwrites the commit of the other action

### Solution

- We could attempt to fix this, but I never felt strongly about having both actions commit to the same branch
- It's easier and less error-prone to just have both actions commit to different branches
    - If on branch `<my-branch>`, then the first action now commits to a branch of the same name, and the other action commits to `<my-branch>__all-views`

### Tests

[The follow-up PR](https://github.com/owid/owid-grapher/pull/3215) makes the SVG tester actions fail on purpose. Note that both actions commit to different branches:

SVG tester:

<img width="987" alt="Screenshot 2024-02-19 at 13 59 55" src="https://github.com/owid/owid-grapher/assets/12461810/601ed34a-df59-49d2-b55d-1ccf6b2c7bcc">
<img width="1073" alt="Screenshot 2024-02-19 at 14 00 24" src="https://github.com/owid/owid-grapher/assets/12461810/05cd0d60-8e96-4256-8bd3-52a9cb2a7b35">

SVG tester (all views):

<img width="1073" alt="Screenshot 2024-02-19 at 14 00 35" src="https://github.com/owid/owid-grapher/assets/12461810/69a47e32-8a88-4e9b-ab4b-1d1e8321783a">
<img width="1158" alt="Screenshot 2024-02-19 at 14 00 49" src="https://github.com/owid/owid-grapher/assets/12461810/6c9724d8-98eb-40d8-b6fc-3aa205e8b659">

