### PR TITLE
:bug: retry 500 errors when fetching data / metadata

### DIFF
--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -61,6 +61,7 @@ import { parseFaqs } from "../db/model/Gdoc/rawToEnriched.js"
 import { GdocPost } from "../db/model/Gdoc/GdocPost.js"
 import { getShortPageCitation } from "../site/gdocs/utils.js"
 import { getSlugForTopicTag, getTagToSlugMap } from "./GrapherBakingUtils.js"
+import pMap from "p-map"
 
 const renderDatapageIfApplicable = async (
     grapher: GrapherInterface,
@@ -491,11 +492,13 @@ export const bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers =
             }
         )
 
-        await Promise.all(
-            jobs.map(async (job) => {
+        await pMap(
+            jobs,
+            async (job) => {
                 await bakeSingleGrapherChart(job)
                 progressBar.tick({ name: `slug ${job.slug}` })
-            })
+            },
+            { concurrency: 10 }
         )
 
         await deleteOldGraphers(bakedSiteDir, excludeUndefined(newSlugs))

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -415,10 +415,10 @@ export const fetchS3DataValuesByPath = async (
     const resp = await retryPromise(
         () =>
             fetch(dataPath, { keepalive: true }).then((response) => {
-                if (!resp.ok) {
+                if (!response.ok) {
                     // Trigger retry
                     throw new Error(
-                        `Error fetching data from S3 for ${dataPath}: ${resp.status} ${resp.statusText}`
+                        `Error fetching data from S3 for ${dataPath}: ${response.status} ${response.statusText}`
                     )
                 }
                 return response
@@ -448,10 +448,10 @@ export const fetchS3MetadataByPath = async (
     const resp = await retryPromise(
         () =>
             fetch(metadataPath, { keepalive: true }).then((response) => {
-                if (!resp.ok) {
+                if (!response.ok) {
                     // Trigger retry
                     throw new Error(
-                        `Error fetching metadata from S3 for ${metadataPath}: ${resp.status} ${resp.statusText}`
+                        `Error fetching metadata from S3 for ${metadataPath}: ${response.status} ${response.statusText}`
                     )
                 }
                 return response

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -413,20 +413,22 @@ export const fetchS3DataValuesByPath = async (
     dataPath: string
 ): Promise<OwidVariableMixedData> => {
     const resp = await retryPromise(
-        () => fetch(dataPath, { keepalive: true }),
+        () =>
+            fetch(dataPath, { keepalive: true }).then((response) => {
+                if (!resp.ok) {
+                    // Trigger retry
+                    throw new Error(
+                        `Error fetching data from S3 for ${dataPath}: ${resp.status} ${resp.statusText}`
+                    )
+                }
+                return response
+            }),
         {
             maxRetries: 7,
             exponentialBackoff: true,
             initialDelay: 1000,
         }
     )
-    if (!resp.ok) {
-        throw new Error(
-            `Error fetching data from S3 for ${dataPath}: ${resp.status} ${
-                resp.statusText
-            } ${await resp.text()}`
-        )
-    }
     try {
         return await resp.json()
     } catch (error: any) {
@@ -444,20 +446,22 @@ export const fetchS3MetadataByPath = async (
     metadataPath: string
 ): Promise<OwidVariableWithSourceAndDimension> => {
     const resp = await retryPromise(
-        () => fetch(metadataPath, { keepalive: true }),
+        () =>
+            fetch(metadataPath, { keepalive: true }).then((response) => {
+                if (!resp.ok) {
+                    // Trigger retry
+                    throw new Error(
+                        `Error fetching metadata from S3 for ${metadataPath}: ${resp.status} ${resp.statusText}`
+                    )
+                }
+                return response
+            }),
         {
             maxRetries: 7,
             exponentialBackoff: true,
             initialDelay: 1000,
         }
     )
-    if (!resp.ok) {
-        throw new Error(
-            `Error fetching metadata from S3 for ${metadataPath}: ${
-                resp.status
-            } ${resp.statusText} ${await resp.text()}`
-        )
-    }
     try {
         return await resp.json()
     } catch (error: any) {


### PR DESCRIPTION
Retry didn't apply to 500 errors, and these errors failed right away. Move `resp.ok` check to `retryPromise` to trigger retry.

Possible fix for https://github.com/owid/owid-grapher/issues/3212.