### PR TITLE
fix(gdocs): article published today

### DIFF
--- a/packages/@ourworldindata/utils/src/Util.test.ts
+++ b/packages/@ourworldindata/utils/src/Util.test.ts
@@ -29,6 +29,7 @@ import {
     findGreatestCommonDivisorOfArray,
     traverseEnrichedBlocks,
     cartesian,
+    getNextDayMidnightDate,
 } from "./Util.js"
 import {
     BlockImageSize,
@@ -790,5 +791,20 @@ describe(cartesian, () => {
             ["b", "y", "+"],
             ["b", "y", "-"],
         ])
+    })
+})
+
+describe(getNextDayMidnightDate, () => {
+    it("returns the next day at midnight", () => {
+        const date = new Date("2024-01-01T01:20:30Z")
+        expect(getNextDayMidnightDate(date)).toEqual(
+            new Date("2024-01-02T00:00:00Z")
+        )
+    })
+    it("returns the next day at midnight across months", () => {
+        const date = new Date("2024-01-31T01:20:30Z")
+        expect(getNextDayMidnightDate(date)).toEqual(
+            new Date("2024-02-01T00:00:00Z")
+        )
     })
 })

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1819,3 +1819,10 @@ export function cartesian<T>(matrix: T[][]): T[][] {
         [[]]
     )
 }
+
+export function getNextDayMidnightDate(currentDay: Date): Date {
+    const nextDay = new Date(currentDay)
+    nextDay.setDate(nextDay.getDate() + 1)
+    nextDay.setHours(0, 0, 0, 0)
+    return nextDay
+}

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -202,6 +202,7 @@ export {
     lowercaseObjectKeys,
     detailOnDemandRegex,
     extractDetailsFromSyntax,
+    getNextDayMidnightDate,
 } from "./Util.js"
 
 export { isPresent } from "./isPresent.js"


### PR DESCRIPTION
> The time part of the timestamp gets set upon publishing, but the date picker only allows you to change the date part of it. This means that trying to publish now an article that was published at 21:34 on Jan 15 (then later unpublished), will result in the article being only published today at 21:34 at the earliest (which is several hours into the future as I speak now)

see [slack](https://owid.slack.com/archives/C46U9LXRR/p1708536644027349) 