### PR TITLE
🐛 (key-indicator) make sure title matches the datapage title

### DIFF
--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -346,15 +346,19 @@ export class SiteBaker {
             )
             const publishedChartsBySlug = keyBy(publishedCharts, "originalSlug")
 
-            const datapageIndicatorIds = excludeUndefined(
-                publishedCharts.map((chart) => chart.indicatorId)
+            const publishedChartsWithIndicatorIds = publishedCharts.filter(
+                (chart) => chart.indicatorId
             )
+
             const datapageIndicators: LinkedIndicator[] = await Promise.all(
-                datapageIndicatorIds.map(async (indicatorId: number) => {
+                publishedChartsWithIndicatorIds.map(async (linkedChart) => {
+                    const indicatorId = linkedChart.indicatorId as number
                     const metadata = await getVariableMetadata(indicatorId)
                     return {
                         id: indicatorId,
-                        ...grabMetadataForGdocLinkedIndicator(metadata),
+                        ...grabMetadataForGdocLinkedIndicator(metadata, {
+                            chartConfigTitle: linkedChart.title,
+                        }),
                     }
                 })
             )

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -650,7 +650,9 @@ export class GdocBase extends BaseEntity implements OwidGdocBaseInterface {
                 )
                 const linkedIndicator: LinkedIndicator = {
                     id: linkedChart.indicatorId,
-                    ...grabMetadataForGdocLinkedIndicator(metadata),
+                    ...grabMetadataForGdocLinkedIndicator(metadata, {
+                        chartConfigTitle: linkedChart.title,
+                    }),
                 }
                 return linkedIndicator
             })

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -276,11 +276,13 @@ export const formatSourceDate = (
 }
 
 export function grabMetadataForGdocLinkedIndicator(
-    metadata: OwidVariableWithSourceAndDimension
+    metadata: OwidVariableWithSourceAndDimension,
+    { chartConfigTitle }: { chartConfigTitle: string }
 ): Omit<LinkedIndicator, "id"> {
     return {
         title:
             metadata.presentation?.titlePublic ||
+            chartConfigTitle ||
             metadata.presentation?.grapherConfigETL?.title ||
             metadata.display?.name ||
             metadata.name ||


### PR DESCRIPTION
- In the key indicator block, the key indicator title (pulled from the metadata) didn't always match the datapage title
- The datapage title uses a chain of metadata properties to resolve the correct title
    - The key indicator block should use the same chain, but I forgot to include the chart config title

Example:

<img width="1293" alt="Screenshot 2024-02-22 at 14 37 43" src="https://github.com/owid/owid-grapher/assets/12461810/870d70ec-3966-4e9a-a9e0-49dcf6eb66a0">