### PR TITLE
fix(gdocs): prominent links in side-by-side blocks

### DIFF
--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -128,6 +128,7 @@ const layouts: { [key in Container]: Layouts} = {
     },
     ["side-by-side"]: {
         ["default"]: "span-cols-6 span-sm-cols-12",
+        ["prominent-link"]: "grid grid-cols-6 span-cols-6 grid-sm-cols-12 span-sm-cols-12 ",
     },
     ["summary"]: {
         ["default"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",


### PR DESCRIPTION
## Before

![image](https://github.com/owid/owid-grapher/assets/13406362/a72706f5-41ca-4582-8272-9c7b1a159fdd)

## After

<img width="1440" alt="Screenshot 2024-02-22 at 15 58 23" src="https://github.com/owid/owid-grapher/assets/13406362/3d4a5d68-0823-4617-9ec2-95405c1df9da">

(minus de repetition in the left column added for testing)

## Context
see [slack](https://owid.slack.com/archives/C05UE1V6E6M/p1708601580764439)