### PR TITLE
🐛 fix script that refreshes pageviews

### DIFF
--- a/db/refreshPageviewsFromDatasette.ts
+++ b/db/refreshPageviewsFromDatasette.ts
@@ -60,9 +60,8 @@ async function downloadAndInsertCSV(knex: Knex<any, any[]>): Promise<void> {
     console.log("Parsed CSV data:", onlyValidRows.length, "rows")
     console.log("Columns:", analyticsPageviewsColumnNames.join(", "))
 
+    await db.knexRaw("TRUNCATE TABLE analytics_pageviews", knex)
     await knex.transaction(async (trx) => {
-        await db.knexRaw("TRUNCATE TABLE analytics_pageviews", trx)
-
         await trx.batchInsert("analytics_pageviews", onlyValidRows)
     })
     console.log("CSV data inserted successfully!")

--- a/db/refreshPageviewsFromDatasette.ts
+++ b/db/refreshPageviewsFromDatasette.ts
@@ -4,6 +4,7 @@ import Papa from "papaparse"
 import * as db from "./db.js"
 import { DbPlainAnalyticsPageview } from "@ourworldindata/types"
 import { omitUndefinedValues } from "@ourworldindata/utils"
+import { Knex } from "knex"
 
 const analyticsPageviewsColumnNames: Array<keyof DbPlainAnalyticsPageview> = [
     "day",
@@ -16,7 +17,7 @@ const analyticsPageviewsColumnNames: Array<keyof DbPlainAnalyticsPageview> = [
 const emojiRegex =
     /[\u{1f300}-\u{1f5ff}\u{1f900}-\u{1f9ff}\u{1f600}-\u{1f64f}\u{1f680}-\u{1f6ff}\u{2600}-\u{26ff}\u{2700}-\u{27bf}\u{1f1e6}-\u{1f1ff}\u{1f191}-\u{1f251}\u{1f004}\u{1f0cf}\u{1f170}-\u{1f171}\u{1f17e}-\u{1f17f}\u{1f18e}\u{3030}\u{2b50}\u{2b55}\u{2934}-\u{2935}\u{2b05}-\u{2b07}\u{2b1b}-\u{2b1c}\u{3297}\u{3299}\u{303d}\u{00a9}\u{00ae}\u{2122}\u{23f3}\u{24c2}\u{23e9}-\u{23ef}\u{25b6}\u{23f8}-\u{23fa}]/gu
 
-async function downloadAndInsertCSV(): Promise<void> {
+async function downloadAndInsertCSV(knex: Knex<any, any[]>): Promise<void> {
     // Fetch CSV from private Datasette and insert it to a local MySQL. This function
     // exists because `make refresh` uses MySQL dump that excludes analytics_pageviews
     // table. That's why it's necessary to call `make refresh.pageviews` separately.
@@ -59,9 +60,6 @@ async function downloadAndInsertCSV(): Promise<void> {
     console.log("Parsed CSV data:", onlyValidRows.length, "rows")
     console.log("Columns:", analyticsPageviewsColumnNames.join(", "))
 
-    // TODO: this instance should be handed down as a parameter
-    const knex = db.knexInstance()
-
     await knex.transaction(async (trx) => {
         await db.knexRaw("TRUNCATE TABLE analytics_pageviews", trx)
 
@@ -72,7 +70,8 @@ async function downloadAndInsertCSV(): Promise<void> {
 
 const main = async (): Promise<void> => {
     try {
-        await downloadAndInsertCSV()
+        const knex = db.knexInstance()
+        await downloadAndInsertCSV(knex)
     } catch (e) {
         console.error(e)
     } finally {


### PR DESCRIPTION
- The script that runs on `make refresh.pageviews` currently doesn't work. It incorrectly filters out all rows, and then inserts 0 rows into the database.
- This statement threw out all entries (maybe because additional columns were recently added to the Datsette table?): https://github.com/owid/owid-grapher/blob/8fbf4ab92c74a79542aa88e04fca59338beec740/db/refreshPageviewsFromDatasette.ts#L30-L32
- To make this a bit more robust, I grab all valid pageview fields from each row of the downloaded data. A row is then declared "valid" if it has a day and a URL
    - Note that we're also removing rows where the URL contains an emoji since MySQL couldn't insert those. We currently have one single entry where the URL contains an emoji ([Datasette](http://datasette-private/owid?sql=select%0D%0A++*%0D%0Afrom%0D%0A++analytics_pageviews%0D%0Awhere%0D%0A++url+%3D+'https://ourworldindata.org/time-use-living-conditions+%F0%9F%91%88%F0%9F%8F%BB'%0D%0Alimit%0D%0A++101)) 

----

Also, knex gives me the following warning when running this script:

<img width="581" alt="Screenshot 2024-02-22 at 16 44 42" src="https://github.com/owid/owid-grapher/assets/12461810/8b7a603b-a525-41f4-9406-bde09bba8570">

Is this something we should care about?