### PR TITLE
🐛 use absolute URLs for image assets in homepage components

### DIFF
--- a/site/gdocs/components/ExplorerTiles.scss
+++ b/site/gdocs/components/ExplorerTiles.scss
@@ -41,7 +41,7 @@
         }
     }
     .explorer-tile {
-        background-image: url("/explorer-thumbnail.webp");
+        background-image: url("https://ourworldindata.org/explorer-thumbnail.webp");
         background-size: cover;
         background-position: center;
         padding: 16px;

--- a/site/gdocs/components/ExplorerTiles.tsx
+++ b/site/gdocs/components/ExplorerTiles.tsx
@@ -4,6 +4,7 @@ import { useLinkedChart } from "../utils.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faArrowRight } from "@fortawesome/free-solid-svg-icons"
 import { DocumentContext } from "../OwidGdoc.js"
+import { BAKED_BASE_URL } from "../../../settings/clientSettings.js"
 
 function ExplorerTile({ url }: { url: string }) {
     const { linkedChart, errorMessage } = useLinkedChart(url)
@@ -18,7 +19,7 @@ function ExplorerTile({ url }: { url: string }) {
         <img
             height={40}
             width={40}
-            src={`/images/tag-icons/${linkedChart.tags[0].name}.svg`}
+            src={`${BAKED_BASE_URL}/images/tag-icons/${linkedChart.tags[0].name}.svg`}
             className="explorer-tile__icon"
         />
     ) : null

--- a/site/gdocs/components/centered-article.scss
+++ b/site/gdocs/components/centered-article.scss
@@ -1027,7 +1027,7 @@ div.raw-html-table__container {
 }
 
 .article-block__homepage-search {
-    background-image: url("/images/world.svg");
+    background-image: url("https://ourworldindata.org/images/world.svg");
     background-color: $blue-100;
     background-repeat: no-repeat;
     background-position: center;


### PR DESCRIPTION
Make sure these assets load correctly on owid.cloud when the dev server is disabled.