### PR TITLE
🐛 (grapher) show a minimum of two tick labels if possible

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -8,6 +8,7 @@ import {
     max,
     numberMagnitude,
     sortedUniqBy,
+    clamp,
     Bounds,
     DEFAULT_BOUNDS,
     AxisAlign,
@@ -18,6 +19,7 @@ import {
     TickFormattingOptions,
     Tickmark,
     ValueRange,
+    cloneDeep,
 } from "@ourworldindata/utils"
 import { AxisConfig } from "./AxisConfig"
 import { TextWrap } from "@ourworldindata/components"
@@ -82,6 +84,7 @@ abstract class AbstractAxis {
     abstract get labelWidth(): number
 
     abstract placeTickLabel(value: number): TickLabelPlacement
+    abstract get tickLabels(): TickLabelPlacement[]
 
     @computed get hideAxis(): boolean {
         return this.config.hideAxis ?? false
@@ -101,6 +104,10 @@ abstract class AbstractAxis {
 
     @computed get fontSize(): number {
         return this.config.fontSize
+    }
+
+    @computed protected get minTicks(): number {
+        return 2
     }
 
     @computed private get maxTicks(): number {
@@ -188,7 +195,11 @@ abstract class AbstractAxis {
         // NOTE: This setting is used between both log & linear axes, check both when tweaking.
         // -@danielgavrilov, 2021-06-15
         return Math.round(
-            Math.min(this.maxTicks, this.rangeSize / (this.fontSize * 1.8))
+            clamp(
+                this.rangeSize / (this.fontSize * 1.8),
+                this.minTicks,
+                this.maxTicks
+            )
         )
     }
 
@@ -392,31 +403,6 @@ abstract class AbstractAxis {
         return this.getTickValues().filter((tick) => !tick.gridLineOnly)
     }
 
-    @computed get tickLabels(): TickLabelPlacement[] {
-        // Get ticks with coordinates, sorted by priority
-        const tickLabels = sortBy(this.baseTicks, (tick) => tick.priority).map(
-            (tick) => this.placeTickLabel(tick.value)
-        )
-        // Hide overlapping ticks
-        for (let i = 0; i < tickLabels.length; i++) {
-            for (let j = i + 1; j < tickLabels.length; j++) {
-                const t1 = tickLabels[i],
-                    t2 = tickLabels[j]
-                if (t1 === t2 || t1.isHidden || t2.isHidden) continue
-                if (
-                    doIntersect(
-                        // Expand bounds slightly so that labels aren't
-                        // too close together.
-                        boundsFromLabelPlacement(t1).expand(3),
-                        boundsFromLabelPlacement(t2).expand(3)
-                    )
-                )
-                    t2.isHidden = true
-            }
-        }
-        return tickLabels.filter((t) => !t.isHidden)
-    }
-
     formatTick(
         tick: number,
         formattingOptionsOverride?: TickFormattingOptions
@@ -519,6 +505,17 @@ export class HorizontalAxis extends AbstractAxis {
         return sortedUniqBy(sortedTicks, (t) => t.value)
     }
 
+    @computed get tickLabels(): TickLabelPlacement[] {
+        // Get ticks with coordinates, sorted by priority
+        const tickLabels = sortBy(this.baseTicks, (tick) => tick.priority).map(
+            (tick) => this.placeTickLabel(tick.value)
+        )
+        const visibleTickLabels = hideOverlappingTickLabels(tickLabels, {
+            padding: 3,
+        })
+        return visibleTickLabels
+    }
+
     placeTickLabel(value: number): TickLabelPlacement {
         const formattedValue = this.formatTick(value)
         const { width, height } = Bounds.forText(formattedValue, {
@@ -590,6 +587,47 @@ export class VerticalAxis extends AbstractAxis {
 
     @computed get size(): number {
         return this.width
+    }
+
+    @computed get tickLabels(): TickLabelPlacement[] {
+        const { domain } = this
+
+        const tickLabels = sortBy(this.baseTicks, (tick) => tick.priority).map(
+            (tick) => this.placeTickLabel(tick.value)
+        )
+
+        // hide overlapping ticks, and allow for some padding
+        let visibleTicks = hideOverlappingTickLabels(tickLabels, { padding: 3 })
+
+        // if we end up with too few ticks, try again with less padding
+        if (visibleTicks.length < this.minTicks) {
+            visibleTicks = hideOverlappingTickLabels(tickLabels, { padding: 1 })
+        }
+
+        // if we still have too few ticks, de-prioritize the zero tick
+        // if it's a start or end value and drawn as a solid line
+        if (visibleTicks.length < this.minTicks) {
+            const updatedBaseTicks = cloneDeep(this.baseTicks)
+            if (domain[0] === 0 || domain[1] === 0) {
+                const zeroIndex = updatedBaseTicks
+                    .map((tick) => tick.value)
+                    .indexOf(0)
+                if (zeroIndex >= 0 && updatedBaseTicks[zeroIndex].solid) {
+                    updatedBaseTicks[zeroIndex] = {
+                        value: 0,
+                        priority: 3,
+                    }
+                }
+            }
+
+            const tickLabels = sortBy(
+                updatedBaseTicks,
+                (tick) => tick.priority
+            ).map((tick) => this.placeTickLabel(tick.value))
+            visibleTicks = hideOverlappingTickLabels(tickLabels, { padding: 1 })
+        }
+
+        return visibleTicks
     }
 
     placeTickLabel(value: number): TickLabelPlacement {
@@ -665,4 +703,26 @@ export class DualAxis {
     @computed get bounds(): Bounds {
         return this.props.bounds ?? DEFAULT_BOUNDS
     }
+}
+
+function hideOverlappingTickLabels(
+    tickLabels: TickLabelPlacement[],
+    { padding = 0 }: { padding?: number } = {}
+): TickLabelPlacement[] {
+    for (let i = 0; i < tickLabels.length; i++) {
+        for (let j = i + 1; j < tickLabels.length; j++) {
+            const t1 = tickLabels[i],
+                t2 = tickLabels[j]
+            if (t1 === t2 || t1.isHidden || t2.isHidden) continue
+            if (
+                doIntersect(
+                    // Expand bounds so that labels aren't too close together.
+                    boundsFromLabelPlacement(t1).expand(padding),
+                    boundsFromLabelPlacement(t2).expand(padding)
+                )
+            )
+                t2.isHidden = true
+        }
+    }
+    return tickLabels.filter((tick) => !tick.isHidden)
 }

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1,6 +1,7 @@
 import {
     capitalize,
     chunk,
+    clamp,
     clone,
     cloneDeep,
     compact,
@@ -71,6 +72,7 @@ import {
 export {
     capitalize,
     chunk,
+    clamp,
     clone,
     cloneDeep,
     compact,

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -138,6 +138,7 @@ export {
 export {
     capitalize,
     chunk,
+    clamp,
     clone,
     cloneDeep,
     compact,


### PR DESCRIPTION
- Fixes https://github.com/owid/owid-grapher/issues/3007

### Problem

- On smaller screens, Grapher sometimes displays a single tick label due to space constraints, which makes it impossible to read the chart
- Example: https://ourworldindata.org/grapher/death-rate-by-cause-who-mdb?facet=metric (on a smaller screen)

### Solution

- Given a number of base ticks, we want to find a subset of ticks whose labels are not overlapping:
    - The original strategy figured out which tick labels to hide so that we don't end up with overlapping tick labels
    - The updated strategy does the same but retries if we end up with a single visible tick label:
        1. Hide overlapping ticks, allowing for some padding (3px) between tick labels (this is the original strategy)
        2. If we end up with a single tick label, try again but reduce the allowed padding between tick labels (1px) – note that for vertical axes, padding between tick labels is not essential
        3. If we still end up with a single tick label, then there really isn't enough space to show a second label – in such cases, try to show a "useful" tick label; in other words, if the zero tick is visually marked by a solid line, deprioritise it, such that a non-zero tick label is chosen to be displayed

### Example (from the original issue)

Before             |  After
:-------------------------:|:-------------------------:
<img width="732" alt="Screenshot 2024-02-26 at 10 20 17" src="https://github.com/owid/owid-grapher/assets/12461810/a7b2b401-ffed-484a-bad3-52230f4611e7">  |  <img width="732" alt="Screenshot 2024-02-26 at 10 20 22" src="https://github.com/owid/owid-grapher/assets/12461810/def93b22-932b-409a-bf84-791690e0988e">
Only zero ticks are shown, which makes it impossible to read the chart | We don't have space for a second tick, but we choose to show a non-zero tick, which gives useful information

### SVG tester

<img width="849" alt="Screenshot 2024-02-26 at 10 12 10" src="https://github.com/owid/owid-grapher/assets/12461810/4703a336-f204-4cfe-a6a4-69eb36e5a4ee">

Adds an additional grid line (makes no difference really). (The second chart in the top row is broken in another way, which is fixed in [this PR](https://github.com/owid/owid-grapher/pull/3244))

<img width="849" alt="Screenshot 2024-02-26 at 10 11 17" src="https://github.com/owid/owid-grapher/assets/12461810/bac091a7-de7a-46de-b555-f007b6171e64">

Displays some more tick labels (which is a good thing)