### PR TITLE
fix(dev): serve gdoc images on local dev

### DIFF
--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -54,6 +54,7 @@ import { GdocPost } from "../db/model/Gdoc/GdocPost.js"
 import { GdocDataInsight } from "../db/model/Gdoc/GdocDataInsight.js"
 import * as db from "../db/db.js"
 import { calculateDataInsightIndexPageCount } from "../db/model/Gdoc/gdocUtils.js"
+import { DEFAULT_LOCAL_BAKE_DIR } from "../site/SiteConstants.js"
 
 require("express-async-errors")
 
@@ -303,6 +304,13 @@ mockSiteRouter.use(
     // on front page.
     ["/uploads", "/app/uploads"],
     express.static(path.join(WORDPRESS_DIR, "web/app/uploads"), {
+        fallthrough: false,
+    })
+)
+
+mockSiteRouter.use(
+    "/images/published",
+    express.static(path.join(DEFAULT_LOCAL_BAKE_DIR, "images/published"), {
         fallthrough: false,
     })
 )

--- a/baker/buildLocalBake.ts
+++ b/baker/buildLocalBake.ts
@@ -6,10 +6,11 @@ import { BakeStep, BakeStepConfig, bakeSteps, SiteBaker } from "./SiteBaker.js"
 import fs from "fs-extra"
 import { normalize } from "path"
 import * as db from "../db/db.js"
+import { DEFAULT_LOCAL_BAKE_DIR } from "../site/SiteConstants.js"
 
 const bakeDomainToFolder = async (
     baseUrl = "http://localhost:3000/",
-    dir = "localBake",
+    dir = DEFAULT_LOCAL_BAKE_DIR,
     bakeSteps?: BakeStepConfig
 ) => {
     dir = normalize(dir)

--- a/site/SiteConstants.ts
+++ b/site/SiteConstants.ts
@@ -12,3 +12,5 @@ const polyfillFeatures = [
 export const POLYFILL_URL: string = `https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=${polyfillFeatures.join(
     ","
 )}`
+
+export const DEFAULT_LOCAL_BAKE_DIR = "localBake"


### PR DESCRIPTION
Serves images from the default local bake folder (`localBake`) on local dev environments.

At the very least, it avoids trying to load pages for image routes and fails straightaway.

`yarn buildLocalBake (--steps gdriveImages)` should have run at least once for image to resolve locally.