### PR TITLE
🐛 (discrete bar) remove extra space on top

### DIFF
--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -165,7 +165,7 @@ export class DiscreteBarChart
 
     @computed private get boundsWithoutColorLegend(): Bounds {
         return this.bounds.padTop(
-            this.hasColorLegend ? this.legendHeight + LEGEND_PADDING : 0
+            this.showColorLegend ? this.legendHeight + LEGEND_PADDING : 0
         )
     }
 


### PR DESCRIPTION
### Summary

- Sometimes, there was a bit too much padding on top of a discrete bar chart (see screenshot below)
- The reason is that Grapher incorrectly thinks that we need space for a legend

### Screenshots

| Before  | After  |
| ------- | ------ |
| <img width="733" alt="Screenshot 2024-02-26 at 15 02 37" src="https://github.com/owid/owid-grapher/assets/12461810/b83b5342-2793-460b-a6ba-01854655f7b5">  | <img width="733" alt="Screenshot 2024-02-26 at 15 02 23" src="https://github.com/owid/owid-grapher/assets/12461810/59318376-fd39-4652-966f-e40bf920c284"> |