### PR TITLE
🎉 (test page) add explorer test pages

### DIFF
--- a/adminSiteClient/TestIndexPage.tsx
+++ b/adminSiteClient/TestIndexPage.tsx
@@ -172,6 +172,42 @@ export class TestIndexPage extends React.Component {
                             </Link>
                         </li>
                     </ul>
+
+                    <h2>Test Explorer Embeds</h2>
+                    <ul>
+                        <li>
+                            <Link native target="_blank" to="/test/explorers">
+                                All explorers
+                            </Link>
+                        </li>
+                        <li>
+                            <Link
+                                native
+                                target="_blank"
+                                to="/test/explorers?type=grapher-ids"
+                            >
+                                Grapher ID-based explorers
+                            </Link>
+                        </li>
+                        <li>
+                            <Link
+                                native
+                                target="_blank"
+                                to="/test/explorers?type=csv-files"
+                            >
+                                CSV file-based explorers
+                            </Link>
+                        </li>
+                        <li>
+                            <Link
+                                native
+                                target="_blank"
+                                to="/test/explorers?type=indicators"
+                            >
+                                Indicator-based explorers
+                            </Link>
+                        </li>
+                    </ul>
                 </main>
             </AdminLayout>
         )


### PR DESCRIPTION
### Background

- It would be great if we had some testing in place for explorers
    - In recent months, two explorer bugs happened that we should have caught before they went live:
        1. The source line disappeared for charts in an explorer 
        2. The entity selector disappeared for an explorer 
     - Both of these bugs weren't a result of work that was done on explorers, they were the result of code changes that were made far away from explorers
     - Additionally, these bugs only surfaced for one (or few) explorers, not all of them
     - (What I'm trying to say is that, without any testing in place, it is quite difficult at the moment to catch these bugs before shipping because, in theory, we would need to manually check all explorers for every grapher code change...)
 - In the long term, I'd love for the site screenshotting tool to include a few carefully selected explorers (ideal would be all of them, but I realise that that is probably not feasible...)
- For now, I figured that a relatively simple thing to do that would help me check explorers before shipping is to add explorer test pages in the admin that allow me to quickly scroll through before/after views of all explorers

### Summary

Adds:
- explorer test page that lists before/after views of all published explorers
- three more test pages that split explorer by chart creation mode, i.e.
    - Grapher id based explorers
    - CSV based explorers
    - Indicator based explorers

### Notes

- I didn't add pagination because I prefer scrolling and I think lazy loading should be enough to make the page performant
- Test pages don't currently work on staging sites because the [embed script](https://ourworldindata.org/grapher/embedCharts.js) isn't correctly served on staging. It's something that Marcel will look into once he's back
