### PR TITLE
🐛 (svg tester) fix all-views action for the master branch

### DIFF
--- a/.github/workflows/svg-compare-all-views.yml
+++ b/.github/workflows/svg-compare-all-views.yml
@@ -16,14 +16,16 @@ jobs:
               if: ${{ github.repository_owner == 'owid' }}
               shell: bash
               run: |
-                  echo "PUSH_BRANCH_NAME=${{ github.ref_name }}__all-views" >> $GITHUB_ENV
+                  [[ ${{ github.ref_name }} = 'master' ]] && suffix="" || suffix="__all-views"
+                  echo "PUSH_BRANCH_NAME=${{ github.ref_name }}$suffix" >> $GITHUB_ENV
                   echo "TOKEN=${{ secrets.GITHUBPAT }}" >> $GITHUB_ENV
 
             - name: Set branch name and token for runs from a fork
               if: ${{ github.repository_owner != 'owid' }}
               shell: bash
               run: |
-                  echo "PUSH_BRANCH_NAME=${{ github.repository_owner }}/${{ github.ref_name }}__all-views" >> $GITHUB_ENV
+                  [[ ${{ github.ref_name }} = 'master' ]] && suffix="" || suffix="__all-views"
+                  echo "PUSH_BRANCH_NAME=${{ github.repository_owner }}/${{ github.ref_name }}$suffix" >> $GITHUB_ENV
                   echo "TOKEN=${{ github.token }}" >> $GITHUB_ENV
 
             # Checkout the owid-grapher-svgs repo into a subfolder. Use a Personal Access Token for checkout so the


### PR DESCRIPTION
- The all-views SVG tester pushes its changes to a branch named `<my-branch>__all-views`
- If run from the master branch, we want to push to the `owid-grapher-svgs` repo's master branch, but the action pushes to `master__all-views`. It also fails with differences on master, because we have some `branch-name = 'master'` checks (which don't work if the current branch name is `master__all-views`)
- This is fixed by using the `master` branch if on master, i.e.:
    - If on master, keep the branch name `master`
    - If not on master, use `<my-branch>__all-views`

Note that the SVG tester fails because one of my recent merges into master was supposed to update the owid-grapher-svgs repo but didn't (because the action failed early)