### PR TITLE
🐛 (sources) fix css for lists and headings

### DIFF
--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.scss
@@ -33,11 +33,24 @@
             }
         }
 
-        .description-below-title p {
+        .description-below-title {
             @include body-3-medium;
-            margin-top: 8px;
-            margin-bottom: 16px;
             color: $dark-text;
+
+            p {
+                margin-top: 8px;
+                margin-bottom: 16px;
+            }
+
+            ul,
+            ol {
+                padding-left: 1em;
+                margin: 1em 0;
+
+                li + li {
+                    margin-top: 0.5em;
+                }
+            }
         }
 
         .title-fragments {

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.scss
@@ -132,6 +132,21 @@
             --non-expandable-border: #{$border};
         }
 
+        .ExpandableToggle__content {
+            h1,
+            h2,
+            h3,
+            h4,
+            h5,
+            h6 {
+                color: $dark-text;
+                font-family: $sans-serif-font-stack;
+                font-size: 1em !important;
+                margin-top: 14px;
+                margin-bottom: 6px;
+            }
+        }
+
         .Tabs__tab {
             font-size: $tab-font-size;
             padding: 8px $tab-padding;

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -174,11 +174,12 @@
             margin: 0;
         }
 
-        ul {
+        ul,
+        ol {
             padding-left: 1em;
+            margin: 1em 0;
 
             li {
-                @include body-2-regular;
                 margin-bottom: 1em;
 
                 &:last-child {


### PR DESCRIPTION
- Fixes a number of CSS issues for datapages and Grapher's sources modal (see screenshots below)
- Examples:
    - https://ourworldindata.org/grapher/same-sex-sexual-acts-illegal
    - https://ourworldindata.org/grapher/median-income-after-tax-lis

| Before  | After  |
| ------- | ------ |
| <img width="677" alt="Screenshot 2024-02-27 at 17 20 58" src="https://github.com/owid/owid-grapher/assets/12461810/63583c8e-14f7-4bb6-bb5d-61a72cd0416e"> | <img width="677" alt="Screenshot 2024-02-27 at 17 20 35" src="https://github.com/owid/owid-grapher/assets/12461810/540662b8-8301-4bd7-89db-e19cf4c44532"> |
| <img width="677" alt="Screenshot 2024-02-27 at 17 12 47" src="https://github.com/owid/owid-grapher/assets/12461810/40124fb6-dfd7-4171-98e0-87c0c95a3774"> | <img width="677" alt="Screenshot 2024-02-27 at 17 16 24" src="https://github.com/owid/owid-grapher/assets/12461810/0a929ecf-0ede-4f82-9560-6b6edcb91c44"> |
| <img width="609" src="https://github.com/owid/owid-grapher/assets/12461810/a149cefd-f15c-4e4c-924b-ee45c39cf7c6"> | <img width="609" alt="Screenshot 2024-02-27 at 16 54 51" src="https://github.com/owid/owid-grapher/assets/12461810/cb986dd0-4822-4bf1-858e-ac27ae8ee239"> | 


