### PR TITLE
🎉 add reusable Button component

### DIFF
--- a/packages/@ourworldindata/components/src/Button/Button.scss
+++ b/packages/@ourworldindata/components/src/Button/Button.scss
@@ -5,6 +5,7 @@
     border-radius: 0;
     text-align: center;
     display: block;
+    cursor: pointer;
 
     svg {
         font-size: 0.75rem;
@@ -27,5 +28,14 @@
     &:hover {
         border-color: $accent-vermillion;
         color: $accent-vermillion;
+    }
+}
+
+.owid-btn--solid-blue {
+    background-color: $blue-60;
+    color: #fff;
+
+    &:hover {
+        background-color: $blue-90;
     }
 }

--- a/packages/@ourworldindata/components/src/Button/Button.scss
+++ b/packages/@ourworldindata/components/src/Button/Button.scss
@@ -1,0 +1,31 @@
+.owid-btn {
+    @include body-3-medium;
+    padding: 8.5px 24px;
+    border: 1px solid transparent;
+    border-radius: 0;
+    text-align: center;
+    display: block;
+
+    svg {
+        font-size: 0.75rem;
+    }
+}
+
+.owid-btn--solid-vermillion {
+    background-color: $vermillion;
+    color: #fff;
+
+    &:hover {
+        background-color: $accent-vermillion;
+    }
+}
+
+.owid-btn--outline-vermillion {
+    border-color: $vermillion;
+    color: $vermillion;
+
+    &:hover {
+        border-color: $accent-vermillion;
+        color: $accent-vermillion;
+    }
+}

--- a/packages/@ourworldindata/components/src/Button/Button.tsx
+++ b/packages/@ourworldindata/components/src/Button/Button.tsx
@@ -1,0 +1,56 @@
+import React from "react"
+import cx from "classnames"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
+import { IconDefinition, faArrowRight } from "@fortawesome/free-solid-svg-icons"
+
+type ButtonCommonProps = {
+    text: string
+    className?: string
+    theme: "solid-vermillion" | "outline-vermillion"
+    /** Set to null to hide the icon */
+    icon?: IconDefinition | null
+}
+
+type WithHrefProps = {
+    href: string
+    onClick?: never
+}
+
+type WithOnClickProps = {
+    onClick: () => void
+    href?: never
+}
+
+export type ButtonProps =
+    | (ButtonCommonProps & WithHrefProps)
+    | (ButtonCommonProps & WithOnClickProps)
+
+export const Button = ({
+    theme = "solid-vermillion",
+    className,
+    href,
+    onClick,
+    text,
+    icon = faArrowRight,
+}: ButtonProps) => {
+    const classes = cx("owid-btn", `owid-btn--${theme}`, className)
+
+    if (href) {
+        return (
+            <a
+                className={classes}
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                {text} {icon && <FontAwesomeIcon icon={icon} />}
+            </a>
+        )
+    }
+
+    return (
+        <button className={classes} onClick={onClick}>
+            {text} {icon && <FontAwesomeIcon icon={icon} />}
+        </button>
+    )
+}

--- a/packages/@ourworldindata/components/src/Button/Button.tsx
+++ b/packages/@ourworldindata/components/src/Button/Button.tsx
@@ -6,7 +6,7 @@ import { IconDefinition, faArrowRight } from "@fortawesome/free-solid-svg-icons"
 type ButtonCommonProps = {
     text: string
     className?: string
-    theme: "solid-vermillion" | "outline-vermillion"
+    theme: "solid-vermillion" | "outline-vermillion" | "solid-blue"
     /** Set to null to hide the icon */
     icon?: IconDefinition | null
 }

--- a/packages/@ourworldindata/components/src/index.ts
+++ b/packages/@ourworldindata/components/src/index.ts
@@ -45,3 +45,5 @@ export {
     DATAPAGE_SOURCES_AND_PROCESSING_SECTION_ID,
     REUSE_THIS_WORK_SECTION_ID,
 } from "./SharedDataPageConstants.js"
+
+export { Button } from "./Button/Button.js"

--- a/site/gdocs/components/ExplorerTiles.scss
+++ b/site/gdocs/components/ExplorerTiles.scss
@@ -8,23 +8,11 @@
         margin: 0 0 16px 0;
     }
     .explorer-tiles__cta {
-        display: block;
-        padding: 8.5px 16px;
-        color: $vermillion;
-        border: 1px solid $vermillion;
-        border-radius: 0;
         width: fit-content;
         justify-self: end;
         grid-row: span 2;
         align-self: center;
-        height: 40px;
-        &:hover {
-            color: $accent-vermillion;
-            border-color: $accent-vermillion;
-        }
-        svg {
-            font-size: 0.75rem;
-        }
+
         @include sm-only {
             justify-self: start;
             margin-top: 16px;

--- a/site/gdocs/components/ExplorerTiles.tsx
+++ b/site/gdocs/components/ExplorerTiles.tsx
@@ -1,8 +1,7 @@
 import { EnrichedBlockExplorerTiles } from "@ourworldindata/types"
+import { Button } from "@ourworldindata/components"
 import React, { useContext } from "react"
 import { useLinkedChart } from "../utils.js"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
-import { faArrowRight } from "@fortawesome/free-solid-svg-icons"
 import { DocumentContext } from "../OwidGdoc.js"
 import { BAKED_BASE_URL } from "../../../settings/clientSettings.js"
 
@@ -55,13 +54,13 @@ export function ExplorerTiles({
             <h2 className="h2-bold span-cols-6 span-md-12 explorer-tiles__title">
                 {title}
             </h2>
-            <a
+            <Button
                 className="span-cols-4 col-start-9 span-md-cols-5 col-md-start-8 col-sm-start-1 span-sm-cols-12 body-3-medium explorer-tiles__cta"
                 href="/charts"
-            >
-                See all our Data Explorers{" "}
-                <FontAwesomeIcon icon={faArrowRight} />
-            </a>
+                text="See all our Data Explorers"
+                theme="outline-vermillion"
+            />
+
             <p className="body-2-regular explorer-tiles__subtitle span-cols-8 span-md-cols-7 span-sm-cols-12">
                 {subtitle}
             </p>

--- a/site/gdocs/components/HomepageIntro.scss
+++ b/site/gdocs/components/HomepageIntro.scss
@@ -129,22 +129,6 @@
     margin-top: 0;
 }
 
-.homepage-intro__subscribe-button,
-.homepage-intro__see-all-work-button,
-.homepage-intro__donate-button {
-    display: block;
-    width: 100%;
-    border: 1px solid $vermillion;
-    color: $vermillion;
-    text-align: center;
-    padding: 8.5px 0;
-
-    &:hover {
-        border-color: $accent-vermillion;
-        color: $accent-vermillion;
-    }
-}
-
 .homepage-intro__see-all-work-button-container {
     display: flex;
     margin-top: 32px;
@@ -161,11 +145,6 @@
 .homepage-intro__see-all-work-button {
     align-self: flex-end;
     width: auto;
-    padding: 8.5px 24px;
-    display: inline-block;
-    svg {
-        margin-left: 8px;
-    }
 
     @include sm-only {
         display: none;
@@ -178,17 +157,6 @@
         display: block;
         margin-top: 24px;
         width: 100%;
-    }
-}
-
-.homepage-intro__donate-button {
-    background-color: $vermillion;
-    color: #fff;
-    border-color: none;
-
-    &:hover {
-        background-color: $accent-vermillion;
-        color: #fff;
     }
 }
 

--- a/site/gdocs/components/HomepageIntro.tsx
+++ b/site/gdocs/components/HomepageIntro.tsx
@@ -202,13 +202,12 @@ export function HomepageIntro({ className, featuredWork }: HomepageIntroProps) {
                     </div>
                 </div>
                 <div className="span-cols-6 span-sm-cols-12">
-                    <a
+                    <Button
                         href="/latest"
                         className="body-3-medium homepage-intro__see-all-work-button homepage-intro__see-all-work-button--mobile"
-                    >
-                        See all our latest work
-                        <FontAwesomeIcon icon={faArrowRight} />
-                    </a>
+                        text="See all our latest work"
+                        theme="outline-vermillion"
+                    />
                 </div>
             </section>
         </section>

--- a/site/gdocs/components/HomepageIntro.tsx
+++ b/site/gdocs/components/HomepageIntro.tsx
@@ -5,6 +5,7 @@ import {
     EnrichedBlockHomepageIntroPost,
 } from "@ourworldindata/types"
 import { formatAuthors, groupBy } from "@ourworldindata/utils"
+import { Button } from "@ourworldindata/components"
 import { useLinkedDocument } from "../utils.js"
 import { DocumentContext } from "../OwidGdoc.js"
 import Image from "./Image.js"
@@ -131,12 +132,13 @@ export function HomepageIntro({ className, featuredWork }: HomepageIntroProps) {
                         Read about our mission{" "}
                         <FontAwesomeIcon icon={faArrowRight} />
                     </a>
-                    <a
+                    <Button
                         href="#subscribe"
                         className="homepage-intro__subscribe-button body-3-medium"
-                    >
-                        Subscribe to our newsletter
-                    </a>
+                        text="Subscribe to our newsletter"
+                        theme="outline-vermillion"
+                        icon={null}
+                    />
                 </div>
                 <div className="homepage-intro__mission-wrapper body-3-medium">
                     <p>
@@ -148,9 +150,13 @@ export function HomepageIntro({ className, featuredWork }: HomepageIntroProps) {
                         accessible to everyone. Consider supporting us if you
                         find our work valuable.
                     </p>
-                    <a className="homepage-intro__donate-button" href="/donate">
-                        Donate to support us
-                    </a>
+                    <Button
+                        className="homepage-intro__donate-button"
+                        href="/donate"
+                        text="Donate to support us"
+                        theme="solid-vermillion"
+                        icon={null}
+                    />
                 </div>
                 <div className="h6-black-caps">As seen on</div>
                 <img
@@ -187,13 +193,12 @@ export function HomepageIntro({ className, featuredWork }: HomepageIntroProps) {
                         ))}
                     </div>
                     <div className="span-cols-6 homepage-intro__see-all-work-button-container">
-                        <a
+                        <Button
                             href="/latest"
                             className="body-3-medium homepage-intro__see-all-work-button"
-                        >
-                            See all our latest work
-                            <FontAwesomeIcon icon={faArrowRight} />
-                        </a>
+                            text="See all our latest work"
+                            theme="outline-vermillion"
+                        />
                     </div>
                 </div>
                 <div className="span-cols-6 span-sm-cols-12">

--- a/site/gdocs/components/KeyIndicator.scss
+++ b/site/gdocs/components/KeyIndicator.scss
@@ -81,34 +81,8 @@
     }
 
     .datapage-link {
-        @include body-3-medium;
-
-        display: block;
-        @include sm-up {
-            display: inline-flex;
-            align-items: center;
-        }
-
-        min-height: 40px;
-        padding: 8px 24px;
         margin-top: 16px;
-        text-align: center;
-        color: $white;
-        background-color: $blue-60;
-        cursor: pointer;
-        border: none;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-
-        &:hover {
-            background-color: $blue-90;
-        }
-
-        svg {
-            font-size: 0.75rem;
-            margin-left: 8px;
-        }
+        display: inline-block;
     }
 
     .datapage-link-desktop {

--- a/site/gdocs/components/KeyIndicator.tsx
+++ b/site/gdocs/components/KeyIndicator.tsx
@@ -12,6 +12,7 @@ import { capitalize } from "@ourworldindata/utils"
 import Chart from "./Chart.js"
 import Paragraph from "./Paragraph.js"
 import { useLinkedChart, useLinkedIndicator } from "../utils.js"
+import { Button } from "@ourworldindata/components"
 
 export default function KeyIndicator({
     d,
@@ -45,13 +46,12 @@ export default function KeyIndicator({
                         <Paragraph d={textBlock} key={i} />
                     ))}
                 </div>
-                <a
+                <Button
                     className="datapage-link datapage-link-desktop"
                     href={linkedChart.resolvedUrl}
-                >
-                    Explore and learn more about this data
-                    <FontAwesomeIcon icon={faArrowRight} />
-                </a>
+                    text="Explore and learn more about this data"
+                    theme="solid-blue"
+                />
             </div>
             <Chart
                 className="key-indicator-chart col-start-5 span-cols-8 span-sm-cols-12 margin-0"
@@ -62,12 +62,12 @@ export default function KeyIndicator({
                 }}
                 shouldOptimizeForHorizontalSpace={false}
             />
-            <a
+            <Button
                 className="datapage-link datapage-link-mobile col-start-1 span-cols-12"
                 href={linkedChart.resolvedUrl}
-            >
-                Explore and learn more about this data
-            </a>
+                text="Explore and learn more about this data"
+                theme="solid-blue"
+            />
         </div>
     )
 }

--- a/site/gdocs/components/KeyIndicator.tsx
+++ b/site/gdocs/components/KeyIndicator.tsx
@@ -1,18 +1,16 @@
 import React from "react"
 import cx from "classnames"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
-import { faArrowRight } from "@fortawesome/free-solid-svg-icons"
 
 import {
     EnrichedBlockKeyIndicator,
     EnrichedBlockText,
 } from "@ourworldindata/types"
 import { capitalize } from "@ourworldindata/utils"
+import { Button } from "@ourworldindata/components"
 
 import Chart from "./Chart.js"
 import Paragraph from "./Paragraph.js"
 import { useLinkedChart, useLinkedIndicator } from "../utils.js"
-import { Button } from "@ourworldindata/components"
 
 export default function KeyIndicator({
     d,

--- a/site/gdocs/components/KeyIndicatorCollection.scss
+++ b/site/gdocs/components/KeyIndicatorCollection.scss
@@ -96,17 +96,10 @@
     }
 
     .key-indicator-collection__all-charts-button {
-        color: $vermillion;
-        border: 1px solid $vermillion;
-        padding: 8.5px 24px;
         // needed to align the button with the header
         margin-top: -16px;
         align-self: center;
         justify-self: end;
-
-        svg {
-            font-size: 0.75rem;
-        }
 
         @include sm-only {
             margin: 24px 16px;

--- a/site/gdocs/components/KeyIndicatorCollection.tsx
+++ b/site/gdocs/components/KeyIndicatorCollection.tsx
@@ -20,6 +20,7 @@ import { Url, urlToSlug } from "@ourworldindata/utils"
 import { useLinkedChart, useLinkedIndicator } from "../utils.js"
 import KeyIndicator from "./KeyIndicator.js"
 import { AttachmentsContext } from "../OwidGdoc.js"
+import { Button } from "@ourworldindata/components"
 
 // keep in sync with $duration in KeyIndicatorCollection.scss
 const HEIGHT_ANIMATION_DURATION_IN_SECONDS = 0.4
@@ -63,12 +64,12 @@ export default function KeyIndicatorCollection({
                     </p>
                 )}
             </header>
-            <a
+            <Button
                 href="/charts"
                 className="key-indicator-collection__all-charts-button body-3-medium span-cols-4 col-start-9 col-sm-start-1 span-sm-cols-12"
-            >
-                See all our data <FontAwesomeIcon icon={faArrowRight} />
-            </a>
+                text="See all our data"
+                theme="outline-vermillion"
+            />
             <div className="span-cols-12">
                 {blocks.map(
                     (block: EnrichedBlockKeyIndicator, blockIndex: number) => {

--- a/site/gdocs/components/LatestDataInsights.scss
+++ b/site/gdocs/components/LatestDataInsights.scss
@@ -54,21 +54,10 @@
 }
 
 .latest-data-insights-block__see-all-data-insights-button {
-    color: $vermillion;
-    border: 1px solid $vermillion;
-    padding: 8.5px 24px;
     justify-self: end;
     align-self: center;
     // necessary to be centered with heading
     margin-bottom: 16px;
-    &:hover {
-        border-color: $accent-vermillion;
-        color: $accent-vermillion;
-    }
-
-    svg {
-        font-size: 0.75rem;
-    }
 
     @include sm-only {
         margin-top: 16px;

--- a/site/gdocs/components/LatestDataInsights.tsx
+++ b/site/gdocs/components/LatestDataInsights.tsx
@@ -1,10 +1,9 @@
 import React, { useContext } from "react"
 import cx from "classnames"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { AttachmentsContext } from "../OwidGdoc.js"
-import { faArrowRight } from "@fortawesome/free-solid-svg-icons"
 import { dataInsightIndexToIdMap } from "../pages/DataInsight.js"
 import { formatDate } from "@ourworldindata/utils"
+import { Button } from "@ourworldindata/components"
 
 export const LatestDataInsightsBlock = ({
     className,
@@ -22,12 +21,12 @@ export const LatestDataInsightsBlock = ({
                     Bite-sized insights on how the world is changing.
                 </p>
             </header>
-            <a
+            <Button
                 href="/data-insights"
                 className="latest-data-insights-block__see-all-data-insights-button body-3-medium span-cols-4 col-start-10 span-sm-cols-12 col-sm-start-2"
-            >
-                See all Data Insights <FontAwesomeIcon icon={faArrowRight} />
-            </a>
+                text="See all Data Insights"
+                theme="outline-vermillion"
+            />
             <div className="latest-data-insights-block__card-container span-cols-12 col-start-2">
                 {latestDataInsights.map((dataInsight, index) => (
                     <a

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -29,6 +29,7 @@
 @import "../packages/@ourworldindata/components/src/ExpandableToggle/ExpandableToggle.scss";
 @import "../packages/@ourworldindata/components/src/IndicatorSources/IndicatorSources.scss";
 @import "../packages/@ourworldindata/components/src/IndicatorProcessing/IndicatorProcessing.scss";
+@import "../packages/@ourworldindata/components/src/Button/Button.scss";
 
 @import "css/grid.scss";
 @import "css/layout.scss";


### PR DESCRIPTION
Makes a new component for the `~~Button~~` that we're using everywhere

Contemplated hiding the icon when `onClick` is defined but decided to cross that bridge when we come to it.

## Mobile
[red-button-mobile](https://github.com/owid/owid-grapher/assets/11844404/8a8b7e15-3910-488d-bc39-3f8e5b0165e3)
[master-mobile](https://github.com/owid/owid-grapher/assets/11844404/0fa75c75-bde9-40f4-905d-0e00fe460375)

## Desktop
[master-desktop](https://github.com/owid/owid-grapher/assets/11844404/5ea8cfb8-cd6e-4c79-8e60-dfab12b4fd02)
[red-button-desktop](https://github.com/owid/owid-grapher/assets/11844404/104f3933-12f2-4b93-b6fa-897c1fe73fc2)
