### PR TITLE
Add author header

### DIFF
--- a/adminSiteClient/GdocsIndexPage.tsx
+++ b/adminSiteClient/GdocsIndexPage.tsx
@@ -12,6 +12,7 @@ import {
     faQuestion,
     faThList,
     faBuildingNgo,
+    faUserPen,
 } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import {
@@ -41,6 +42,7 @@ const iconGdocTypeMap = {
     [OwidGdocType.DataInsight]: <FontAwesomeIcon icon={faThList} />,
     [OwidGdocType.Homepage]: <FontAwesomeIcon icon={faHouse} />,
     [OwidGdocType.AboutPage]: <FontAwesomeIcon icon={faBuildingNgo} />,
+    [OwidGdocType.Author]: <FontAwesomeIcon icon={faUserPen} />,
 }
 
 @observer
@@ -60,6 +62,7 @@ class GdocsIndexPageSearch extends React.Component<{
             OwidGdocType.LinearTopicPage,
             OwidGdocType.DataInsight,
             OwidGdocType.AboutPage,
+            OwidGdocType.Author,
         ]
         return (
             <div className="d-flex flex-grow-1 flex-wrap">
@@ -120,6 +123,7 @@ export class GdocsIndexPage extends React.Component<GdocsMatchProps> {
         [OwidGdocType.DataInsight]: false,
         [OwidGdocType.Homepage]: false,
         [OwidGdocType.AboutPage]: false,
+        [OwidGdocType.Author]: false,
     }
 
     @observable search = { value: "" }

--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -11,6 +11,7 @@ import {
     GdocPostSettings,
     GdocInsightSettings,
     GdocHomepageSettings,
+    GdocAuthorSettings,
 } from "./GdocsSettingsForms.js"
 import { AdminAppContext } from "./AdminAppContext.js"
 import {
@@ -340,6 +341,22 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                             (gdoc) => (
                                 <GdocHomepageSettings
                                     gdoc={gdoc}
+                                    errors={errors}
+                                />
+                            )
+                        )
+                        .with(
+                            {
+                                content: {
+                                    type: OwidGdocType.Author,
+                                },
+                            },
+                            (gdoc) => (
+                                <GdocAuthorSettings
+                                    gdoc={gdoc}
+                                    setCurrentGdoc={(updatedGdoc) =>
+                                        setCurrentGdoc(() => updatedGdoc)
+                                    }
                                     errors={errors}
                                 />
                             )

--- a/adminSiteClient/GdocsSettingsContentField.tsx
+++ b/adminSiteClient/GdocsSettingsContentField.tsx
@@ -8,6 +8,7 @@ import {
     OwidGdocErrorMessageProperty,
     get,
     OwidGdocHomepageInterface,
+    OwidGdocAuthorInterface,
 } from "@ourworldindata/utils"
 import { GdocsEditLink } from "./GdocsEditLink.js"
 import { GdocsErrorHelp } from "./GdocsErrorHelp.js"
@@ -26,6 +27,7 @@ export const GdocsSettingsContentField = ({
         | OwidGdocPostInterface
         | OwidGdocDataInsightInterface
         | OwidGdocHomepageInterface
+        | OwidGdocAuthorInterface
     property: OwidGdocErrorMessageProperty
     render?: (props: {
         name: string

--- a/adminSiteClient/GdocsSettingsForms.tsx
+++ b/adminSiteClient/GdocsSettingsForms.tsx
@@ -5,6 +5,7 @@ import {
     OwidGdocDataInsightInterface,
     OwidGdoc,
     OwidGdocHomepageInterface,
+    OwidGdocAuthorInterface,
 } from "@ourworldindata/utils"
 import { EXCERPT_MAX_LENGTH } from "./gdocsValidation.js"
 import { GdocsSlug } from "./GdocsSlug.js"
@@ -219,6 +220,44 @@ export const GdocHomepageSettings = ({
                 <h3 className="form-section-heading">Homepage settings</h3>
                 <p>The homepage has no custom authors, slug, title, etc.</p>
                 <p>Just hit publish when you'd like to update the page!</p>
+            </div>
+        </div>
+    )
+}
+
+export const GdocAuthorSettings = ({
+    gdoc,
+    setCurrentGdoc,
+    errors,
+}: {
+    gdoc: OwidGdocAuthorInterface
+    setCurrentGdoc: (gdoc: OwidGdocAuthorInterface) => void
+    errors?: OwidGdocErrorMessage[]
+}) => {
+    if (!gdoc || !errors) return null
+    return (
+        <div className="GdocsSettingsForm">
+            <GdocCommonErrors errors={errors} errorsToFilter={[]} />
+            <div className="form-group">
+                <h3 className="form-section-heading">Common settings</h3>
+                <GdocsSettingsContentField
+                    property="title"
+                    gdoc={gdoc}
+                    errors={errors}
+                />
+                <GdocsSlug
+                    gdoc={gdoc}
+                    setCurrentGdoc={setCurrentGdoc}
+                    errors={errors}
+                />
+            </div>
+            <div className="form-group">
+                <h3 className="form-section-heading">Author settings</h3>
+                <GdocsSettingsContentField
+                    property="role"
+                    gdoc={gdoc}
+                    errors={errors}
+                />
             </div>
         </div>
     )

--- a/adminSiteClient/gdocsDeploy.ts
+++ b/adminSiteClient/gdocsDeploy.ts
@@ -6,6 +6,7 @@ import {
     OwidGdocDataInsightContent,
     OwidGdocType,
     OwidGdocHomepageContent,
+    OwidGdocAuthorContent,
 } from "@ourworldindata/types"
 import { GDOC_DIFF_OMITTABLE_PROPERTIES } from "./GdocsDiff.js"
 import { GDOCS_DETAILS_ON_DEMAND_ID } from "../settings/clientSettings.js"
@@ -116,6 +117,20 @@ export const checkIsLightningUpdate = (
         type: false, // should never be changed
     }
 
+    const authorLightningPropContentConfigMap: Record<
+        keyof OwidGdocAuthorContent,
+        boolean
+    > = {
+        type: false, // shouldn't change
+        title: false, // assumed to be used in "author cards" throughout the site
+        role: false, // assumed to be used in "author cards" throughout the site
+        bio: false, // assumed to be used in "author cards" throughout the site
+        "featured-image": false, // assumed to be used in "author cards" throughout the site
+        authors: true, // not used
+        socials: false, // assumed to be used in "author cards" throughout the site
+        body: true, // probably not used outside of the author page, if at all
+    }
+
     const contentPropsMap: Record<OwidGdocType, Record<string, boolean>> = {
         [OwidGdocType.Article]: postlightningPropContentConfigMap,
         [OwidGdocType.Fragment]: postlightningPropContentConfigMap,
@@ -124,6 +139,7 @@ export const checkIsLightningUpdate = (
         [OwidGdocType.DataInsight]: dataInsightLightningPropContentConfigMap,
         [OwidGdocType.Homepage]: homepageLightningPropContentConfigMap,
         [OwidGdocType.AboutPage]: postlightningPropContentConfigMap,
+        [OwidGdocType.Author]: authorLightningPropContentConfigMap,
     }
 
     const getLightningPropKeys = (configMap: Record<string, boolean>) =>

--- a/adminSiteClient/gdocsValidation.ts
+++ b/adminSiteClient/gdocsValidation.ts
@@ -11,6 +11,8 @@ import {
     checkIsGdocPost,
     checkIsDataInsight,
     OwidGdocDataInsightInterface,
+    checkIsAuthor,
+    OwidGdocAuthorInterface,
 } from "@ourworldindata/utils"
 
 function validateTitle(gdoc: OwidGdoc, errors: OwidGdocErrorMessage[]) {
@@ -208,6 +210,25 @@ function validateAtomFields(
     }
 }
 
+function validateSocials(
+    gdoc: OwidGdocAuthorInterface,
+    errors: OwidGdocErrorMessage[]
+) {
+    const { socials } = gdoc.content
+
+    if (!socials?.parseErrors) return
+
+    errors.push(
+        ...socials.parseErrors.map((parseError) => ({
+            message: parseError.message,
+            type: parseError.isWarning
+                ? OwidGdocErrorMessageType.Warning
+                : OwidGdocErrorMessageType.Error,
+            property: "socials" as const,
+        }))
+    )
+}
+
 export const getErrors = (gdoc: OwidGdoc): OwidGdocErrorMessage[] => {
     const errors: OwidGdocErrorMessage[] = []
 
@@ -225,11 +246,11 @@ export const getErrors = (gdoc: OwidGdoc): OwidGdocErrorMessage[] => {
         validateExcerpt(gdoc, errors)
         validateBreadcrumbs(gdoc, errors)
         validateAtomFields(gdoc, errors)
-    }
-
-    if (checkIsDataInsight(gdoc)) {
+    } else if (checkIsDataInsight(gdoc)) {
         validateApprovedBy(gdoc, errors)
         validateGrapherUrl(gdoc, errors)
+    } else if (checkIsAuthor(gdoc)) {
+        validateSocials(gdoc, errors)
     }
 
     return errors

--- a/db/model/Gdoc/GdocAuthor.ts
+++ b/db/model/Gdoc/GdocAuthor.ts
@@ -22,7 +22,12 @@ export class GdocAuthor extends GdocBase implements OwidGdocAuthorInterface {
     _filenameProperties: string[] = ["featured-image"]
 
     _getSubclassEnrichedBlocks = (gdoc: this): OwidEnrichedGdocBlock[] => {
-        return gdoc.content.bio ?? []
+        const blocks: OwidEnrichedGdocBlock[] = []
+
+        if (gdoc.content.socials) blocks.push(gdoc.content.socials)
+        if (gdoc.content.bio) blocks.push(...gdoc.content.bio)
+
+        return blocks
     }
 
     _enrichSubclassContent = (content: Record<string, any>): void => {

--- a/db/model/Gdoc/GdocAuthor.ts
+++ b/db/model/Gdoc/GdocAuthor.ts
@@ -1,0 +1,71 @@
+import { Entity, Column } from "typeorm"
+import {
+    OwidGdocErrorMessage,
+    OwidGdocAuthorInterface,
+    OwidGdocAuthorContent,
+    RawBlockText,
+    OwidEnrichedGdocBlock,
+    OwidGdocErrorMessageType,
+} from "@ourworldindata/utils"
+import { GdocBase } from "./GdocBase.js"
+import { htmlToEnrichedTextBlock } from "./htmlToEnriched.js"
+import { parseSocials } from "./rawToEnriched.js"
+
+@Entity("posts_gdocs")
+export class GdocAuthor extends GdocBase implements OwidGdocAuthorInterface {
+    @Column({ default: "{}", type: "json" })
+    content!: OwidGdocAuthorContent
+
+    constructor(id?: string) {
+        super(id)
+    }
+    _filenameProperties: string[] = ["featured-image"]
+
+    _getSubclassEnrichedBlocks = (gdoc: this): OwidEnrichedGdocBlock[] => {
+        return gdoc.content.bio ?? []
+    }
+
+    _enrichSubclassContent = (content: Record<string, any>): void => {
+        if (content.bio) {
+            content.bio = content.bio.map((html: RawBlockText) =>
+                htmlToEnrichedTextBlock(html.value)
+            )
+        }
+        if (content.socials) {
+            // We're parsing here an ArchieML array of objects outside of the
+            // usual freeform array [+body]. This means we need to manually
+            // reconstruct the {type, value} object created by freeform arrays
+            // that parseSocials expects. Technically, we could just parse the
+            // [socials] array without all the parseRawBlocksToEnrichedBlocks
+            // machinery (like we dit above for the [bio] block), but this way
+            // we benefit from features and the predictability of the regular
+            // parsing pipeline. In particular, this gives us round trip testing
+            // and the documenting of blocks in a consistent way, wihch is more
+            // justifiable here compared to the bio block given the wider array
+            // of edge cases for this block.
+            content.socials = parseSocials({
+                type: "socials",
+                value: content.socials,
+            })
+        }
+    }
+
+    _validateSubclass = async (): Promise<OwidGdocErrorMessage[]> => {
+        const errors: OwidGdocErrorMessage[] = []
+        if (!this.content.bio) {
+            errors.push({
+                type: OwidGdocErrorMessageType.Warning,
+                property: "bio",
+                message: "You might want to add a bio for this author.",
+            })
+        }
+        if (!this.content.socials) {
+            errors.push({
+                type: OwidGdocErrorMessageType.Warning,
+                property: "socials",
+                message: "You might want to add socials for this author.",
+            })
+        }
+        return errors
+    }
+}

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -589,7 +589,8 @@ export class GdocBase extends BaseEntity implements OwidGdocBaseInterface {
                         "table",
                         "text",
                         "homepage-search",
-                        "latest-data-insights"
+                        "latest-data-insights",
+                        "socials" // only external links
                     ),
                 },
                 () => []

--- a/db/model/Gdoc/GdocFactory.ts
+++ b/db/model/Gdoc/GdocFactory.ts
@@ -18,7 +18,7 @@ import { GdocAuthor } from "./GdocAuthor.js"
 export class GdocFactory {
     static fromJSON(
         json: Record<string, any>
-    ): GdocPost | GdocDataInsight | GdocAuthor {
+    ): GdocPost | GdocDataInsight | GdocHomepage | GdocAuthor {
         if (typeof json.content === "string") {
             json.content = JSON.parse(json.content)
         }

--- a/db/model/Gdoc/GdocFactory.ts
+++ b/db/model/Gdoc/GdocFactory.ts
@@ -11,11 +11,14 @@ import { GdocBase, Tag } from "./GdocBase.js"
 import { GdocPost } from "./GdocPost.js"
 import { GdocDataInsight } from "./GdocDataInsight.js"
 import { GdocHomepage } from "./GdocHomepage.js"
+import { GdocAuthor } from "./GdocAuthor.js"
 
 // Handles the registration and loading of Gdocs
 // Couldn't put this in GdocBase because of circular dependency issues
 export class GdocFactory {
-    static fromJSON(json: Record<string, any>): GdocPost | GdocDataInsight {
+    static fromJSON(
+        json: Record<string, any>
+    ): GdocPost | GdocDataInsight | GdocAuthor {
         if (typeof json.content === "string") {
             json.content = JSON.parse(json.content)
         }
@@ -58,6 +61,11 @@ export class GdocFactory {
                 // TODO: better validation here?
                 () => GdocHomepage.create({ ...(json as any) })
             )
+            .with(
+                OwidGdocType.Author,
+                // TODO: better validation here?
+                () => GdocAuthor.create({ ...(json as any) })
+            )
             .exhaustive()
     }
 
@@ -79,7 +87,7 @@ export class GdocFactory {
 
     static async loadBySlug(
         slug: string
-    ): Promise<GdocPost | GdocDataInsight | GdocHomepage> {
+    ): Promise<GdocPost | GdocDataInsight | GdocHomepage | GdocAuthor> {
         const base = await GdocBase.findOne({
             where: { slug, published: true },
         })
@@ -96,7 +104,7 @@ export class GdocFactory {
     static async load(
         id: string,
         contentSource?: GdocsContentSource
-    ): Promise<GdocPost | GdocDataInsight | GdocHomepage> {
+    ): Promise<GdocPost | GdocDataInsight | GdocHomepage | GdocAuthor> {
         const base = await GdocBase.findOne({
             where: {
                 id,
@@ -132,6 +140,7 @@ export class GdocFactory {
             )
             .with(OwidGdocType.DataInsight, () => GdocDataInsight.create(base))
             .with(OwidGdocType.Homepage, () => GdocHomepage.create(base))
+            .with(OwidGdocType.Author, () => GdocAuthor.create(base))
             .exhaustive()
 
         if (contentSource === GdocsContentSource.Gdocs) {

--- a/db/model/Gdoc/enrichedToMarkdown.ts
+++ b/db/model/Gdoc/enrichedToMarkdown.ts
@@ -315,5 +315,10 @@ ${links}`
                 .filter((item) => item !== "")
                 .join("\n")
         })
+        .with({ type: "socials" }, (b): string | undefined => {
+            return b.links
+                .map((link) => `* [${link.text}](${link.url})`)
+                .join("\n")
+        })
         .exhaustive()
 }

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -43,6 +43,7 @@ import {
     RawBlockHomepageSearch,
     RawBlockHomepageIntro,
     RawBlockLatestDataInsights,
+    RawBlockSocials,
 } from "@ourworldindata/types"
 import { spanToHtmlString } from "./gdocUtils.js"
 import { match, P } from "ts-pattern"
@@ -511,6 +512,12 @@ export function enrichedBlockToRawBlock(
                         })
                     ),
                 },
+            }
+        })
+        .with({ type: "socials" }, (b): RawBlockSocials => {
+            return {
+                type: "socials",
+                value: b.links,
             }
         })
         .exhaustive()

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -4,6 +4,7 @@ import {
     EnrichedBlockText,
     HorizontalAlign,
     OwidEnrichedGdocBlock,
+    SocialLinkType,
     Span,
     SpanSimpleText,
 } from "@ourworldindata/types"
@@ -639,6 +640,27 @@ export const enrichedBlockExamples: Record<
     },
     "latest-data-insights": {
         type: "latest-data-insights",
+        parseErrors: [],
+    },
+    socials: {
+        type: "socials",
+        links: [
+            {
+                url: "https://twitter.com/OurWorldInData",
+                text: "@OurWorldInData",
+                type: SocialLinkType.X,
+            },
+            {
+                url: "https://facebook.com/OurWorldInData",
+                text: "OurWorldInData",
+                type: SocialLinkType.Facebook,
+            },
+            {
+                url: "https://ourworldindata.org",
+                text: "ourworldindata.org",
+            },
+        ],
+
         parseErrors: [],
     },
 }

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -42,6 +42,7 @@ import {
     RawBlockPillRow,
     RawBlockHomepageSearch,
     RawBlockLatestDataInsights,
+    RawBlockSocials,
 } from "@ourworldindata/types"
 import { isArray } from "@ourworldindata/utils"
 import { match } from "ts-pattern"
@@ -729,6 +730,20 @@ function* rawBlockHomepageIntroToArchieMLString(
     yield "{}"
 }
 
+function* rawBlockSocialsToArchieMLString(
+    block: RawBlockSocials
+): Generator<string, void, undefined> {
+    yield "[.socials]"
+    if (typeof block.value !== "string") {
+        for (const link of block.value) {
+            yield* propertyToArchieMLString("text", link)
+            yield* propertyToArchieMLString("url", link)
+            yield* propertyToArchieMLString("type", link)
+        }
+    }
+    yield "[]"
+}
+
 export function* OwidRawGdocBlockToArchieMLStringGenerator(
     block: OwidRawGdocBlock | RawBlockTableRow
 ): Generator<string, void, undefined> {
@@ -809,6 +824,7 @@ export function* OwidRawGdocBlockToArchieMLStringGenerator(
             rawBlockHomepageSearchToArchieMLString
         )
         .with({ type: "homepage-intro" }, rawBlockHomepageIntroToArchieMLString)
+        .with({ type: "socials" }, rawBlockSocialsToArchieMLString)
         .exhaustive()
     yield* content
 }

--- a/packages/@ourworldindata/components/src/GdocsUtils.ts
+++ b/packages/@ourworldindata/components/src/GdocsUtils.ts
@@ -74,6 +74,12 @@ function _getPrefixedPath(prefix: string, gdoc: OwidGdoc): string {
         )
         .with(
             {
+                content: { type: OwidGdocType.Author },
+            },
+            () => `${prefix}/team/${gdoc.slug}`
+        )
+        .with(
+            {
                 content: { type: P.union(OwidGdocType.Fragment, undefined) },
             },
             () => ""
@@ -109,7 +115,8 @@ export function getPageTitle(gdoc: OwidGdoc) {
                         OwidGdocType.TopicPage,
                         OwidGdocType.LinearTopicPage,
                         OwidGdocType.AboutPage,
-                        OwidGdocType.DataInsight
+                        OwidGdocType.DataInsight,
+                        OwidGdocType.Author
                     ),
                 },
             },

--- a/packages/@ourworldindata/components/src/styles/colors.scss
+++ b/packages/@ourworldindata/components/src/styles/colors.scss
@@ -9,6 +9,7 @@ $amber: #f7c020;
 
 // Blue shades
 $blue-100: #002147;
+$blue-95: #112e4f;
 $blue-90: #1d3d63;
 $blue-60: #577291;
 $blue-65: #46688f;

--- a/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
@@ -821,6 +821,32 @@ export type EnrichedBlockLatestDataInsights = {
     type: "latest-data-insights"
 } & EnrichedBlockWithParseErrors
 
+export enum SocialLinkType {
+    X = "x",
+    Facebook = "facebook",
+    Instagram = "instagram",
+    Youtube = "youtube",
+    Linkedin = "linkedin",
+}
+
+export type RawSocialLink = {
+    text: string
+    url: string
+    type?: SocialLinkType
+}
+
+export type RawBlockSocials = {
+    type: "socials"
+    value: RawSocialLink[] | ArchieMLUnexpectedNonObjectValue
+}
+
+export type EnrichedSocialLink = RawSocialLink
+
+export type EnrichedBlockSocials = {
+    type: "socials"
+    links: EnrichedSocialLink[]
+} & EnrichedBlockWithParseErrors
+
 export type OwidRawGdocBlock =
     | RawBlockAllCharts
     | RawBlockAside
@@ -864,6 +890,7 @@ export type OwidRawGdocBlock =
     | RawBlockHomepageSearch
     | RawBlockHomepageIntro
     | RawBlockLatestDataInsights
+    | RawBlockSocials
 
 export type OwidEnrichedGdocBlock =
     | EnrichedBlockAllCharts
@@ -908,3 +935,4 @@ export type OwidEnrichedGdocBlock =
     | EnrichedBlockHomepageSearch
     | EnrichedBlockHomepageIntro
     | EnrichedBlockLatestDataInsights
+    | EnrichedBlockSocials

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -4,6 +4,7 @@ import { BreadcrumbItem } from "../domainTypes/Site.js"
 import { TocHeadingWithTitleSupertitle } from "../domainTypes/Toc.js"
 import { ImageMetadata } from "./Image.js"
 import {
+    EnrichedBlockSocials,
     EnrichedBlockText,
     EnrichedBlockWithParseErrors,
     OwidEnrichedGdocBlock,
@@ -50,6 +51,7 @@ export enum OwidGdocType {
     DataInsight = "data-insight",
     Homepage = "homepage",
     AboutPage = "about-page",
+    Author = "author",
 }
 
 export interface OwidGdocBaseInterface {
@@ -138,15 +140,32 @@ export interface OwidGdocHomepageInterface extends OwidGdocBaseInterface {
     tags?: Tag[] // won't be used, but necessary in various validation steps
 }
 
+export interface OwidGdocAuthorContent {
+    type: OwidGdocType.Author
+    title?: string
+    role: string
+    bio?: EnrichedBlockText[]
+    socials?: EnrichedBlockSocials
+    "featured-image"?: string
+    authors: string[]
+    body: OwidEnrichedGdocBlock[]
+}
+
+export interface OwidGdocAuthorInterface extends OwidGdocBaseInterface {
+    content: OwidGdocAuthorContent
+}
+
 export type OwidGdocContent =
     | OwidGdocPostContent
     | OwidGdocDataInsightContent
     | OwidGdocHomepageContent
+    | OwidGdocAuthorContent
 
 export type OwidGdoc =
     | OwidGdocPostInterface
     | OwidGdocDataInsightInterface
     | OwidGdocHomepageInterface
+    | OwidGdocAuthorInterface
 
 export enum OwidGdocErrorMessageType {
     Error = "error",
@@ -158,6 +177,9 @@ export type OwidGdocProperty =
     | keyof OwidGdocPostContent
     | keyof OwidGdocDataInsightInterface
     | keyof OwidGdocDataInsightContent
+    | keyof OwidGdocAuthorInterface
+    | keyof OwidGdocAuthorContent
+
 export type OwidGdocErrorMessageProperty =
     | OwidGdocProperty
     | `${OwidGdocProperty}${string}` // also allows for nesting, like `breadcrumbs[0].label`

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -260,6 +260,11 @@ export {
     type EnrichedBlockPillRow,
     type RawBlockHomepageSearch,
     type EnrichedBlockHomepageSearch,
+    type RawBlockSocials,
+    type EnrichedBlockSocials,
+    SocialLinkType,
+    type RawSocialLink,
+    type EnrichedSocialLink,
 } from "./gdocTypes/ArchieMlComponents.js"
 export {
     OwidGdocPublicationContext,
@@ -267,6 +272,8 @@ export {
     type OwidGdocErrorMessage,
     OwidGdocErrorMessageType,
     type OwidGdocLinkJSON,
+    type OwidGdocAuthorContent,
+    type OwidGdocAuthorInterface,
     type OwidGdocBaseInterface,
     type OwidGdocPostContent,
     type OwidGdocPostInterface,

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -161,6 +161,7 @@ import {
     type EnrichedScrollerItem,
     type OwidGdocPostInterface,
     type OwidGdocDataInsightInterface,
+    type OwidGdocAuthorInterface,
     type OwidGdoc,
     OwidGdocType,
     type OwidGdocJSON,
@@ -1670,7 +1671,8 @@ export function traverseEnrichedBlocks(
                     "pill-row",
                     "homepage-search",
                     "homepage-intro",
-                    "latest-data-insights"
+                    "latest-data-insights",
+                    "socials"
                 ),
             },
             callback
@@ -1812,6 +1814,10 @@ export function checkIsDataInsight(
     return type === OwidGdocType.DataInsight
 }
 
+export function checkIsAuthor(x: unknown): x is OwidGdocAuthorInterface {
+    const type = get(x, "content.type")
+    return type === OwidGdocType.Author
+}
 /**
  * Returns the cartesian product of the given arrays.
  *

--- a/packages/@ourworldindata/utils/src/image.ts
+++ b/packages/@ourworldindata/utils/src/image.ts
@@ -105,7 +105,8 @@ export function getFeaturedImageFilename(gdoc: OwidGdoc): string | undefined {
                         OwidGdocType.Article,
                         OwidGdocType.TopicPage,
                         OwidGdocType.LinearTopicPage,
-                        OwidGdocType.AboutPage
+                        OwidGdocType.AboutPage,
+                        OwidGdocType.Author
                     ),
                 },
             },

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -116,6 +116,7 @@ export {
     copyToClipboard,
     checkIsGdocPost,
     checkIsDataInsight,
+    checkIsAuthor,
     cartesian,
 } from "./Util.js"
 

--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -18,6 +18,7 @@ import { GdocPost } from "./pages/GdocPost.js"
 import { DataInsightPage } from "./pages/DataInsight.js"
 import { Fragment } from "./pages/Fragment.js"
 import { Homepage } from "./pages/Homepage.js"
+import { Author } from "./pages/Author.js"
 
 export const AttachmentsContext = createContext<{
     linkedCharts: Record<string, LinkedChart>
@@ -82,6 +83,9 @@ export function OwidGdoc({
         ))
         .with({ content: { type: OwidGdocType.Homepage } }, (props) => (
             <Homepage {...props} />
+        ))
+        .with({ content: { type: OwidGdocType.Author } }, (props) => (
+            <Author {...props} />
         ))
         .with({ content: { type: OwidGdocType.Fragment } }, (props) => (
             <Fragment {...props} />

--- a/site/gdocs/OwidGdocPage.tsx
+++ b/site/gdocs/OwidGdocPage.tsx
@@ -9,6 +9,7 @@ import {
     OwidGdoc as OwidGdocUnionType,
     SiteFooterContext,
     OwidGdocType,
+    spansToUnformattedPlainText,
 } from "@ourworldindata/utils"
 import { getCanonicalUrl, getPageTitle } from "@ourworldindata/components"
 import { DebugProvider } from "./DebugContext.js"
@@ -44,6 +45,13 @@ function getPageDesc(gdoc: OwidGdocUnionType): string | undefined {
         })
         .with({ content: { type: OwidGdocType.Homepage } }, () => {
             return "Research and data to make progress against the world’s largest problems"
+        })
+        .with({ content: { type: OwidGdocType.Author } }, (gdoc) => {
+            return gdoc.content.bio
+                ? spansToUnformattedPlainText(
+                      gdoc.content.bio.flatMap((block) => block.value)
+                  )
+                : undefined
         })
         .with(
             { content: { type: P.union(OwidGdocType.Fragment, undefined) } },

--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -41,6 +41,7 @@ import { PillRow } from "./PillRow.js"
 import { HomepageIntro } from "./HomepageIntro.js"
 import { HomepageSearch } from "./HomepageSearch.js"
 import { LatestDataInsightsBlock } from "./LatestDataInsights.js"
+import { Socials } from "./Socials.js"
 
 export type Container =
     | "default"
@@ -52,6 +53,7 @@ export type Container =
     | "summary"
     | "datapage"
     | "key-insight"
+    | "author-header"
 
 // Each container must have a default layout, usually just full-width
 type Layouts = { default: string; [key: string]: string }
@@ -109,6 +111,11 @@ const layouts: { [key in Container]: Layouts} = {
     ["datapage"]: {
         ["default"]: "col-start-2 span-cols-6 col-lg-start-2 span-lg-cols-7 col-md-start-2 span-md-cols-10 col-sm-start-1 span-sm-cols-12",
         ["chart"]: "span-cols-8 span-lg-cols-9 span-md-cols-12",
+    },
+    ["author-header"]: {
+        ["default"]: "span-cols-8",
+        ["image"]: "span-cols-2",
+        ["socials"]: "span-cols-3",
     },
     ["sticky-right-left-column"]: {
         ["chart"]: "span-cols-5 col-start-1 span-md-cols-10 col-md-start-2 span-sm-cols-12 col-sm-start-1",
@@ -682,6 +689,12 @@ export default function ArticleBlock({
                 />
             )
         })
+        .with({ type: "socials" }, (block) => (
+            <Socials
+                className={getLayout("socials", containerType)}
+                {...block}
+            />
+        ))
         .exhaustive()
 
     return (

--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -113,9 +113,10 @@ const layouts: { [key in Container]: Layouts} = {
         ["chart"]: "span-cols-8 span-lg-cols-9 span-md-cols-12",
     },
     ["author-header"]: {
-        ["default"]: "span-cols-6",
-        ["image"]: "span-cols-2",
-        ["socials"]: "span-cols-3",
+        ["default"]: "span-cols-8",
+        ["image"]: "span-cols-2 span-md-cols-3",
+        ["text"]: "span-cols-6 span-md-cols-8 col-sm-start-2 span-sm-cols-12",
+        ["socials"]: "span-cols-3 col-sm-start-2 span-sm-cols-12",
     },
     ["sticky-right-left-column"]: {
         ["chart"]: "span-cols-5 col-start-1 span-md-cols-10 col-md-start-2 span-sm-cols-12 col-sm-start-1",

--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -113,7 +113,7 @@ const layouts: { [key in Container]: Layouts} = {
         ["chart"]: "span-cols-8 span-lg-cols-9 span-md-cols-12",
     },
     ["author-header"]: {
-        ["default"]: "span-cols-8",
+        ["default"]: "span-cols-6",
         ["image"]: "span-cols-2",
         ["socials"]: "span-cols-3",
     },

--- a/site/gdocs/components/Image.tsx
+++ b/site/gdocs/components/Image.tsx
@@ -24,6 +24,7 @@ const generateResponsiveSizes = (numberOfColumns: number): string =>
         1280 * (numberOfColumns / 12)
     )}px`
 
+const gridSpan2 = generateResponsiveSizes(2)
 const gridSpan5 = generateResponsiveSizes(5)
 const gridSpan6 = generateResponsiveSizes(6)
 const gridSpan7 = generateResponsiveSizes(7)
@@ -43,6 +44,7 @@ const containerSizes: Record<ImageParentContainer, string> = {
     ["datapage"]: gridSpan6,
     ["full-width"]: "100vw",
     ["key-insight"]: gridSpan5,
+    ["author-header"]: gridSpan2,
 }
 
 export default function Image(props: {

--- a/site/gdocs/components/Socials.tsx
+++ b/site/gdocs/components/Socials.tsx
@@ -1,0 +1,47 @@
+import {
+    EnrichedBlockSocials,
+    EnrichedSocialLink,
+    SocialLinkType,
+} from "@ourworldindata/types"
+import React from "react"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
+import {
+    IconDefinition,
+    faFacebook,
+    faInstagram,
+    faLinkedin,
+    faXTwitter,
+    faYoutube,
+} from "@fortawesome/free-brands-svg-icons"
+import { faGlobe } from "@fortawesome/free-solid-svg-icons"
+
+function SocialLink({ url, text, type }: EnrichedSocialLink) {
+    const typeToIcon: Record<SocialLinkType, IconDefinition> = {
+        x: faXTwitter,
+        facebook: faFacebook,
+        instagram: faInstagram,
+        linkedin: faLinkedin,
+        youtube: faYoutube,
+    }
+
+    return (
+        <li className="article-block__social-link">
+            <FontAwesomeIcon icon={type ? typeToIcon[type] : faGlobe} />
+            <a key={url} href={url} target="_blank" rel="noopener noreferrer">
+                {text}
+            </a>
+        </li>
+    )
+}
+
+export function Socials(props: EnrichedBlockSocials & { className?: string }) {
+    return (
+        <div className={props.className}>
+            <ul>
+                {props.links.map((link) => (
+                    <SocialLink {...link} key={link.url} />
+                ))}
+            </ul>
+        </div>
+    )
+}

--- a/site/gdocs/pages/Author.scss
+++ b/site/gdocs/pages/Author.scss
@@ -1,15 +1,24 @@
 .author-header {
-    margin: 56px 0;
+    padding-bottom: 24px;
+    padding-top: 16px;
+    @include sm-up {
+        padding-top: 40px;
+    }
+    background-color: $blue-95;
+
+    .article-block__text {
+        @include body-2-regular;
+        color: $white;
+    }
+}
+
+.author-header__name {
+    color: $amber;
 }
 
 .author-header__role {
     @include body-2-regular;
-    color: $blue-60;
-}
-
-.article-block__text {
-    @include body-2-regular;
-    color: $blue-90;
+    color: $blue-40;
 }
 
 .author-header__portrait {
@@ -21,7 +30,6 @@
 }
 
 .article-block__socials {
-    color: $blue-60;
     @include body-3-medium;
 
     ul {
@@ -30,14 +38,19 @@
     }
 
     a {
-        @include owid-link-60;
+        color: $blue-20;
+        &:hover {
+            text-decoration: underline;
+            text-underline-offset: 4px;
+        }
     }
     svg {
         margin-right: 8px;
+        color: $blue-50;
     }
 }
 
-.author-header--sm {
+.author-header__sm {
     @include sm-up {
         display: none;
     }
@@ -66,7 +79,7 @@
     }
 }
 
-.author-header--md {
+.author-header__md {
     display: none;
     @include sm-up {
         display: grid;

--- a/site/gdocs/pages/Author.scss
+++ b/site/gdocs/pages/Author.scss
@@ -2,26 +2,19 @@
     margin: 56px 0;
 }
 
-.author-header__name {
-    @include display-1-semibold;
-    margin-top: 0;
-    margin-bottom: 8px;
-}
-
 .author-header__role {
-    @include body-1-regular;
+    @include body-2-regular;
     color: $blue-60;
 }
 
-.author-header__bio {
-    @include body-1-regular;
-    margin-top: 8px;
+.article-block__text {
+    @include body-2-regular;
     color: $blue-90;
 }
 
 .author-header__portrait {
     margin-top: 0;
-    margin-bottom: 24px;
+    margin-bottom: 0;
     img {
         border-radius: 50%;
     }
@@ -32,16 +25,8 @@
     @include body-3-medium;
 
     ul {
-        margin-left: 24px;
         list-style-type: none;
         list-style-position: inside;
-    }
-
-    li {
-        margin-bottom: 16px;
-        &:last-child {
-            margin-bottom: 0;
-        }
     }
 
     a {
@@ -49,5 +34,78 @@
     }
     svg {
         margin-right: 8px;
+    }
+}
+
+.author-header--sm {
+    @include sm-up {
+        display: none;
+    }
+
+    .author-header__name {
+        @include h2-bold;
+        margin-top: 8px;
+        margin-bottom: 4px;
+    }
+
+    .author-header__role {
+        margin-bottom: 24px;
+    }
+
+    .article-block__socials {
+        margin-bottom: 32px;
+        ul {
+            display: flex;
+            li {
+                margin-right: 16px;
+                &:last-child {
+                    margin-right: 0;
+                }
+            }
+        }
+    }
+}
+
+.author-header--md {
+    display: none;
+    @include sm-up {
+        display: grid;
+    }
+
+    .author-header__name {
+        @include display-2-semibold;
+        margin-top: 0;
+        margin-bottom: 4px;
+
+        @include md-up {
+            @include display-1-semibold;
+            margin-top: 0;
+            margin-bottom: 8px;
+        }
+    }
+
+    .article-block__text {
+        margin-top: 8px;
+        @include md-up {
+            @include body-1-regular;
+        }
+    }
+
+    .author-header__role {
+        @include md-up {
+            @include body-1-regular;
+        }
+    }
+
+    .article-block__socials {
+        margin-top: 24px;
+        margin-left: 24px;
+
+        li {
+            margin-bottom: 16px;
+            &:last-child {
+                margin-bottom: 0;
+            }
+        }
     }
 }

--- a/site/gdocs/pages/Author.scss
+++ b/site/gdocs/pages/Author.scss
@@ -1,0 +1,53 @@
+.author-header {
+    margin: 56px 0;
+}
+
+.author-header__name {
+    @include display-1-semibold;
+    margin-top: 0;
+    margin-bottom: 8px;
+}
+
+.author-header__role {
+    @include body-1-regular;
+    color: $blue-60;
+}
+
+.author-header__bio {
+    @include body-1-regular;
+    margin-top: 8px;
+    color: $blue-90;
+}
+
+.author-header__portrait {
+    margin-top: 0;
+    margin-bottom: 24px;
+    img {
+        border-radius: 50%;
+    }
+}
+
+.article-block__socials {
+    color: $blue-60;
+    @include body-3-medium;
+
+    ul {
+        margin-left: 24px;
+        list-style-type: none;
+        list-style-position: inside;
+    }
+
+    li {
+        margin-bottom: 16px;
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+
+    a {
+        @include owid-link-60;
+    }
+    svg {
+        margin-right: 8px;
+    }
+}

--- a/site/gdocs/pages/Author.tsx
+++ b/site/gdocs/pages/Author.tsx
@@ -1,0 +1,60 @@
+import React from "react"
+import {
+    OwidGdocAuthorContent,
+    OwidGdocAuthorInterface,
+} from "@ourworldindata/types"
+import { ArticleBlocks } from "../components/ArticleBlocks.js"
+import Image from "../components/Image.js"
+import ArticleBlock, { getLayout } from "../components/ArticleBlock.js"
+
+export interface AuthorProps {
+    content: OwidGdocAuthorContent
+}
+
+const AuthorHeader = (gdoc: OwidGdocAuthorInterface) => {
+    const {
+        title,
+        role,
+        bio,
+        "featured-image": featuredImage,
+        socials,
+    } = gdoc.content
+
+    return (
+        <section className="author-header grid grid-cols-12-full-width span-cols-14">
+            <div className="author-header__content span-cols-8 col-start-2">
+                <h1 className="author-header__name h1-bold">{title}</h1>
+                <div className="author-header__role body-2-regular">{role}</div>
+                {bio?.length && (
+                    <div className="author-header__bio grid grid-cols-8 span-cols-8 body-2-regular">
+                        <ArticleBlocks
+                            blocks={bio}
+                            containerType="author-header"
+                        />
+                    </div>
+                )}
+            </div>
+            <div className="grid grid-cols-3 span-cols-3 col-start-10">
+                {featuredImage && (
+                    <Image
+                        filename={featuredImage}
+                        alt={`Portrait of ${title}`}
+                        className={getLayout("image", "author-header")}
+                        containerType="author-header"
+                    />
+                )}
+                {socials && (
+                    <ArticleBlock b={socials} containerType="author-header" />
+                )}
+            </div>
+        </section>
+    )
+}
+
+export const Author = (gdoc: OwidGdocAuthorInterface): JSX.Element => {
+    return (
+        <div className="grid grid-cols-12-full-width">
+            <AuthorHeader {...gdoc} />
+        </div>
+    )
+}

--- a/site/gdocs/pages/Author.tsx
+++ b/site/gdocs/pages/Author.tsx
@@ -6,6 +6,7 @@ import {
 import { ArticleBlocks } from "../components/ArticleBlocks.js"
 import Image from "../components/Image.js"
 import ArticleBlock, { getLayout } from "../components/ArticleBlock.js"
+import cx from "classnames"
 
 export interface AuthorProps {
     content: OwidGdocAuthorContent
@@ -22,11 +23,11 @@ const AuthorHeader = (gdoc: OwidGdocAuthorInterface) => {
 
     return (
         <section className="author-header grid grid-cols-12-full-width span-cols-14">
-            <div className="author-header__content span-cols-8 col-start-2">
-                <h1 className="author-header__name h1-bold">{title}</h1>
-                <div className="author-header__role body-2-regular">{role}</div>
+            <div className="grid grid-cols-8 span-cols-8 col-start-2">
+                <h1 className="author-header__name span-cols-7">{title}</h1>
+                <div className="author-header__role span-cols-7">{role}</div>
                 {bio?.length && (
-                    <div className="author-header__bio grid grid-cols-8 span-cols-8 body-2-regular">
+                    <div className="author-header__bio grid grid-cols-8 span-cols-8">
                         <ArticleBlocks
                             blocks={bio}
                             containerType="author-header"
@@ -39,7 +40,10 @@ const AuthorHeader = (gdoc: OwidGdocAuthorInterface) => {
                     <Image
                         filename={featuredImage}
                         alt={`Portrait of ${title}`}
-                        className={getLayout("image", "author-header")}
+                        className={cx(
+                            "author-header__portrait",
+                            getLayout("image", "author-header")
+                        )}
                         containerType="author-header"
                     />
                 )}

--- a/site/gdocs/pages/Author.tsx
+++ b/site/gdocs/pages/Author.tsx
@@ -22,8 +22,8 @@ const AuthorHeader = (gdoc: OwidGdocAuthorInterface) => {
     } = gdoc.content
 
     return (
-        <>
-            <section className="author-header author-header--sm grid grid-cols-12-full-width span-cols-14">
+        <div className="author-header grid grid-cols-12-full-width span-cols-14">
+            <section className="author-header__sm grid grid-cols-12-full-width span-cols-14">
                 <div className="col-start-2 span-cols-8">
                     <h1 className="author-header__name">{title}</h1>
                     <div className="author-header__role">{role}</div>
@@ -48,7 +48,7 @@ const AuthorHeader = (gdoc: OwidGdocAuthorInterface) => {
                     <ArticleBlocks blocks={bio} containerType="author-header" />
                 )}
             </section>
-            <section className="author-header author-header--md grid grid-cols-12-full-width span-cols-14">
+            <section className="author-header__md grid grid-cols-12-full-width span-cols-14">
                 <div className="grid grid-cols-8 span-cols-8 col-start-2">
                     <h1 className="author-header__name span-cols-8">{title}</h1>
                     <div className="author-header__role span-cols-8">
@@ -81,14 +81,10 @@ const AuthorHeader = (gdoc: OwidGdocAuthorInterface) => {
                     )}
                 </div>
             </section>
-        </>
+        </div>
     )
 }
 
 export const Author = (gdoc: OwidGdocAuthorInterface): JSX.Element => {
-    return (
-        <div className="grid grid-cols-12-full-width">
-            <AuthorHeader {...gdoc} />
-        </div>
-    )
+    return <AuthorHeader {...gdoc} />
 }

--- a/site/gdocs/pages/Author.tsx
+++ b/site/gdocs/pages/Author.tsx
@@ -22,36 +22,66 @@ const AuthorHeader = (gdoc: OwidGdocAuthorInterface) => {
     } = gdoc.content
 
     return (
-        <section className="author-header grid grid-cols-12-full-width span-cols-14">
-            <div className="grid grid-cols-8 span-cols-8 col-start-2">
-                <h1 className="author-header__name span-cols-7">{title}</h1>
-                <div className="author-header__role span-cols-7">{role}</div>
-                {bio?.length && (
-                    <div className="author-header__bio grid grid-cols-8 span-cols-8">
-                        <ArticleBlocks
-                            blocks={bio}
+        <>
+            <section className="author-header author-header--sm grid grid-cols-12-full-width span-cols-14">
+                <div className="col-start-2 span-cols-8">
+                    <h1 className="author-header__name">{title}</h1>
+                    <div className="author-header__role">{role}</div>
+                </div>
+                {featuredImage && (
+                    <div className="grid grid-cols-3 col-start-11 span-cols-3">
+                        <Image
+                            filename={featuredImage}
+                            alt={`Portrait of ${title}`}
+                            className={cx(
+                                "author-header__portrait",
+                                getLayout("image", "author-header")
+                            )}
                             containerType="author-header"
                         />
                     </div>
                 )}
-            </div>
-            <div className="grid grid-cols-3 span-cols-3 col-start-10">
-                {featuredImage && (
-                    <Image
-                        filename={featuredImage}
-                        alt={`Portrait of ${title}`}
-                        className={cx(
-                            "author-header__portrait",
-                            getLayout("image", "author-header")
-                        )}
-                        containerType="author-header"
-                    />
-                )}
                 {socials && (
                     <ArticleBlock b={socials} containerType="author-header" />
                 )}
-            </div>
-        </section>
+                {bio?.length && (
+                    <ArticleBlocks blocks={bio} containerType="author-header" />
+                )}
+            </section>
+            <section className="author-header author-header--md grid grid-cols-12-full-width span-cols-14">
+                <div className="grid grid-cols-8 span-cols-8 col-start-2">
+                    <h1 className="author-header__name span-cols-8">{title}</h1>
+                    <div className="author-header__role span-cols-8">
+                        {role}
+                    </div>
+                    {bio?.length && (
+                        <ArticleBlocks
+                            blocks={bio}
+                            containerType="author-header"
+                        />
+                    )}
+                </div>
+                <div className="grid grid-cols-3 col-start-11 span-cols-3">
+                    {featuredImage && (
+                        <Image
+                            filename={featuredImage}
+                            alt={`Portrait of ${title}`}
+                            className={cx(
+                                "author-header__portrait",
+                                getLayout("image", "author-header")
+                            )}
+                            containerType="author-header"
+                        />
+                    )}
+                    {socials && (
+                        <ArticleBlock
+                            b={socials}
+                            containerType="author-header"
+                        />
+                    )}
+                </div>
+            </section>
+        </>
     )
 }
 

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -105,6 +105,7 @@
 
 @import "./gdocs/pages/DataInsight.scss";
 @import "./gdocs/pages/Homepage.scss";
+@import "./gdocs/pages/Author.scss";
 
 @import "css/donate.scss";
 @import "./ThankYouPage.scss";


### PR DESCRIPTION
![Screenshot 2024-03-06 at 18.44.34.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0SFFiIjKuUK6UPYHVe6u/ba11db02-39d5-4589-ba40-a199e2b4925e.png)

This PR adds a new "Author" OwidGdocType and associated template.

👉 See [this comment](https://github.com/owid/owid-grapher/pull/3256#discussion_r1506571552) for some of the more structural decisions I made.

- [x] responsive styles

[staging preview](http://staging-site-author-header/admin/gdocs/1VDcqVRkbi7dYI0xI9m3AQmp14xCEy9UukJoD6n3rHtE/preview), [gdoc](https://docs.google.com/document/d/1VDcqVRkbi7dYI0xI9m3AQmp14xCEy9UukJoD6n3rHtE/edit)

Only consider the "🌑 Dark launch" scope from the [tracking issue](https://github.com/owid/owid-grapher/issues/3224)