### PR TITLE
🐛 fix undefined URLs in homepage featured posts

### DIFF
--- a/site/gdocs/components/HomepageIntro.tsx
+++ b/site/gdocs/components/HomepageIntro.tsx
@@ -32,7 +32,7 @@ function FeaturedWorkTile({
     const { isPreviewing } = useContext(DocumentContext)
     const linkedDocumentFeaturedImage = linkedDocument?.["featured-image"]
     const thumbnailFilename = filename ?? linkedDocumentFeaturedImage
-    const href = `/${linkedDocument?.slug}` || url
+    const href = linkedDocument ? `/${linkedDocument.slug}` : url
 
     if (isPreviewing) {
         if (errorMessage) {


### PR DESCRIPTION
Fixes 

![image](https://github.com/owid/owid-grapher/assets/11844404/f877fcb5-cf56-4488-82d6-d85694581c57)

which was occurring due to a nonsensical usage of the nullish coalescing operator