### PR TITLE
fix(r&w): font sizes and row gap

### DIFF
--- a/site/gdocs/components/ResearchAndWriting.scss
+++ b/site/gdocs/components/ResearchAndWriting.scss
@@ -20,19 +20,18 @@ $rw-margin-bottom-grid-cell: 4px;
     color: $blue-50;
 }
 
-.research-and-writing-link__title {
-    margin-top: 0;
-    margin-bottom: $rw-margin-bottom-grid-cell;
-}
-
 .research-and-writing-row__links {
-    row-gap: 32px - $rw-margin-bottom-grid-cell;
+    row-gap: 40px - $rw-margin-bottom-grid-cell;
 
     @include sm-only {
         display: flex;
         overflow-x: auto;
         scrollbar-width: thin;
     }
+}
+
+.research-and-writing-row__links--condensed {
+    row-gap: 32px - $rw-margin-bottom-grid-cell;
 }
 
 .research-and-writing-link {
@@ -66,6 +65,11 @@ $rw-margin-bottom-grid-cell: 4px;
         left: 0;
         top: 0;
     }
+}
+
+.research-and-writing-link__title {
+    margin-top: 0;
+    margin-bottom: $rw-margin-bottom-grid-cell;
 }
 
 .research-and-writing-link__description {

--- a/site/gdocs/components/ResearchAndWriting.tsx
+++ b/site/gdocs/components/ResearchAndWriting.tsx
@@ -149,7 +149,7 @@ export function ResearchAndWriting(props: ResearchAndWritingProps) {
                     <h2 className="h2-bold research-and-writing-row__heading">
                         {more.heading}
                     </h2>
-                    <div className="grid grid-cols-4 grid-lg-cols-3 grid-md-cols-2 research-and-writing-row__links">
+                    <div className="grid grid-cols-4 grid-lg-cols-3 grid-md-cols-2 research-and-writing-row__links research-and-writing-row__links--condensed">
                         {more.articles.map((link, i) => (
                             <ResearchAndWritingLink
                                 shouldHideThumbnail


### PR DESCRIPTION
closes #3265, #3264 

Small design fixes to the research and writing block used on topic pages, and soon on author pages (#3224)

Testing page: http://staging-site-fix-style-research-writing/co2-and-greenhouse-gas-emissions#research-writing

see [figma](https://www.figma.com/file/Tm4bd2QXmrAR4m7UfWKAle/%5BProject%5D-Author-Pages?type=design&node-id=153-1701&mode=design&t=9eSHnR0VM8SBgAVD-0)