### PR TITLE
Track and use image height to prevent content jumping on slow connections

### DIFF
--- a/db/migration/1709135915963-ImageHeight.ts
+++ b/db/migration/1709135915963-ImageHeight.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class ImageHeight1709135915963 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE images ADD COLUMN originalHeight INT NULL`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE images DROP COLUMN originalHeight`)
+    }
+}

--- a/db/model/Image.ts
+++ b/db/model/Image.ts
@@ -161,6 +161,11 @@ export class Image extends BaseEntity implements ImageMetadata {
         nullable: true,
     })
     originalWidth?: number
+    @Column({
+        transformer: new ColumnNumericTransformer(),
+        nullable: true,
+    })
+    originalHeight?: number
 
     get isSvg(): boolean {
         return this.fileExtension === "svg"
@@ -200,6 +205,7 @@ export class Image extends BaseEntity implements ImageMetadata {
                     stored.updatedAt = fresh.updatedAt
                     stored.defaultAlt = fresh.defaultAlt
                     stored.originalWidth = fresh.originalWidth
+                    stored.originalHeight = fresh.originalHeight
                     await stored.save()
                 }
                 return stored

--- a/db/model/Image.ts
+++ b/db/model/Image.ts
@@ -35,9 +35,9 @@ class ImageStore {
 
     async fetchImageMetadata(filesnames: string[]): Promise<void> {
         console.log(
-            `Fetching image metadata from Google Drive for ${filesnames.join(
-                ", "
-            )}`
+            `Fetching image metadata from Google Drive ${
+                filesnames.length ? `for ${filesnames.join(", ")}` : ""
+            }`
         )
         const driveClient = google.drive({
             version: "v3",
@@ -96,6 +96,7 @@ class ImageStore {
                 defaultAlt: google.description ?? "",
                 updatedAt: new Date(google.modifiedTime).getTime(),
                 originalWidth: google.imageMediaMetadata?.width,
+                originalHeight: google.imageMediaMetadata?.height,
             }))
 
         const duplicateFilenames = findDuplicates(

--- a/devTools/updateImageHeights/tsconfig.json
+++ b/devTools/updateImageHeights/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../tsconfigs/tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "../../itsJustJavascript/devTools/updateImageHeights",
+        "rootDir": "."
+    },
+    "references": [{ "path": "../../settings" }, { "path": "../../db" }]
+}

--- a/devTools/updateImageHeights/update-image-heights.ts
+++ b/devTools/updateImageHeights/update-image-heights.ts
@@ -1,0 +1,83 @@
+import { imageStore } from "../../db/model/Image.js"
+import * as db from "../../db/db.js"
+import { exit } from "../../db/cleanup.js"
+
+async function updateImageHeights() {
+    const transaction = await db.knexInstance().transaction()
+    const filenames = await db
+        .knexRaw<{ filename: string }>(
+            `SELECT filename
+            FROM posts_gdocs_x_images pgxi
+            LEFT JOIN images i ON pgxi.imageId = i.id`,
+            transaction
+        )
+        .then((rows) => rows.map((row) => row.filename))
+
+    console.log("Fetching image metadata...")
+    await imageStore.fetchImageMetadata([])
+    console.log("Fetching image metadata...done")
+
+    if (!imageStore.images) {
+        throw new Error("No images found")
+    }
+
+    console.log("Batching image metadata...")
+    const batches = filenames.reduce<string[][]>(
+        (acc, filename) => {
+            const lastBatch = acc[acc.length - 1]
+            if (lastBatch.length === 20) {
+                acc.push([filename])
+            } else {
+                lastBatch.push(filename)
+            }
+            return acc
+        },
+        [[]]
+    )
+    console.log("Batching image metadata...done")
+
+    let imagesWithoutOriginalHeight = []
+    try {
+        let index = 0
+        for (const batch of batches) {
+            const promises = []
+            for (const filename of batch) {
+                const image = imageStore.images[filename]
+                if (image && image.originalHeight) {
+                    promises.push(
+                        db.knexRaw(
+                            `
+                            UPDATE images
+                            SET originalHeight = ?
+                            WHERE filename = ?
+                        `,
+                            transaction,
+                            [image.originalHeight, filename]
+                        )
+                    )
+                } else {
+                    console.error(`No original height found for ${filename}`)
+                    imagesWithoutOriginalHeight.push(filename)
+                }
+            }
+            console.log(`Updating image heights for batch ${index}...`)
+            await Promise.all(promises)
+            console.log(`Updating image heights for batch ${index}...done`)
+            index++
+        }
+        await transaction.commit()
+        console.log("All image heights updated successfully!")
+        // Most likely due to the original file being deleted but the DB not being updated, each of these will need to be manually checked
+        console.log(
+            "Images without original height:",
+            imagesWithoutOriginalHeight
+        )
+        await exit()
+    } catch (error) {
+        console.error(error)
+        await transaction.rollback()
+        await exit()
+    }
+}
+
+updateImageHeights()

--- a/packages/@ourworldindata/types/src/gdocTypes/Image.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Image.ts
@@ -6,6 +6,7 @@ export interface GDriveImageMetadata {
     description?: string // -> defaultAlt
     imageMediaMetadata?: {
         width?: number // -> originalWidth
+        height?: number // -> originalHeight
     }
 }
 
@@ -17,4 +18,5 @@ export interface ImageMetadata {
     // so we store as an epoch to avoid any conversion issues
     updatedAt: number
     originalWidth?: number
+    originalHeight?: number
 }

--- a/site/gdocs/components/Image.tsx
+++ b/site/gdocs/components/Image.tsx
@@ -120,6 +120,8 @@ export default function Image(props: {
                     src={makePreviewUrl(image.filename)}
                     alt={alt}
                     className={maybeLightboxClassName}
+                    width={image.originalWidth}
+                    height={image.originalHeight}
                 />
             </picture>
         )
@@ -134,6 +136,8 @@ export default function Image(props: {
                     src={imgSrc}
                     alt={alt}
                     className={maybeLightboxClassName}
+                    width={image.originalWidth}
+                    height={image.originalHeight}
                 />
                 {containerType !== "thumbnail" ? (
                     <a
@@ -168,6 +172,10 @@ export default function Image(props: {
                 alt={alt}
                 className={maybeLightboxClassName}
                 loading="lazy"
+                // There's no way of knowing in advance whether we'll be showing the image or smallImage - we just have to choose one
+                // I went with image, as we currently only use smallImage for data insights
+                width={image.originalWidth}
+                height={image.originalHeight}
             />
         </picture>
     )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,9 @@
             "path": "./adminSiteServer"
         },
         {
+            "path": "./devTools/updateImageHeights"
+        },
+        {
             "path": "./devTools/svgTester"
         },
         {


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/3091

Adds
- `originalHeight` to our images
- a script that we can run once on prod to populate the `originalHeight` column for all images. 
  - On my local I noticed 5 images that weren't resolved, because the original image had been deleted. These can be tended to manually.

![image](https://github.com/owid/owid-grapher/assets/11844404/2cff2281-0923-471d-a122-64dfd5e13829)


https://github.com/owid/owid-grapher/assets/11844404/ba0da179-bf03-49f1-bfad-f98f1ce6e46d

