### PR TITLE
✨ homepage CSS fixes

### DIFF
--- a/site/gdocs/components/HomepageSearch.tsx
+++ b/site/gdocs/components/HomepageSearch.tsx
@@ -10,7 +10,12 @@ export function HomepageSearch(props: { className?: string }) {
         chartCount && topicCount ? (
             <>
                 <a href="/charts">{chartCount} charts</a> across{" "}
-                <a href="#all-topics">{topicCount} topics</a>
+                <a
+                    href="#all-topics"
+                    className="homepage-search__all-topics-link"
+                >
+                    {topicCount} topics
+                </a>
                 <span className="homepage-search__open-source-notice">
                     All free: open access and open source
                 </span>

--- a/site/gdocs/components/centered-article.scss
+++ b/site/gdocs/components/centered-article.scss
@@ -1059,6 +1059,14 @@ div.raw-html-table__container {
         }
     }
 
+    .homepage-search__all-topics-link {
+        // We hide the all topics section on mobile, so we don't want users to be able to click this
+        @include sm-only {
+            pointer-events: none;
+            text-decoration: none;
+        }
+    }
+
     .homepage-search__open-source-notice {
         &:before {
             content: " — ";
@@ -1070,6 +1078,11 @@ div.raw-html-table__container {
                 content: none;
             }
         }
+    }
+
+    #autocomplete {
+        height: 56px;
+        background-color: #fff;
     }
 
     .aa-DetachedSearchButton {


### PR DESCRIPTION
- Fixes the content jump from the search bar loading in
- Makes the all-topics link unclickable on mobile, because we hide the all topics section on mobile

https://github.com/owid/owid-grapher/assets/11844404/af9f6c4d-0772-4b1f-a836-f6e6ea5e8bd3

