### PR TITLE
✨ (slope) improve hover interaction

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -197,6 +197,7 @@ import {
     StaticChartRasterizer,
     type GrapherExport,
 } from "../captionedChart/StaticChartRasterizer.js"
+import { SlopeChartManager } from "../slopeCharts/SlopeChart"
 
 declare global {
     interface Window {
@@ -344,7 +345,8 @@ export class Grapher
         FacetChartManager,
         EntitySelectorModalManager,
         SettingsMenuManager,
-        MapChartManager
+        MapChartManager,
+        SlopeChartManager
 {
     @observable.ref $schema = DEFAULT_GRAPHER_CONFIG_SCHEMA
     @observable.ref type = ChartTypeName.LineChart
@@ -2472,7 +2474,7 @@ export class Grapher
         }
     }
 
-    @computed private get isModalOpen(): boolean {
+    @computed get isModalOpen(): boolean {
         return (
             this.isSelectingData ||
             this.isSourcesModalOpen ||

--- a/packages/@ourworldindata/utils/src/PointVector.ts
+++ b/packages/@ourworldindata/utils/src/PointVector.ts
@@ -79,10 +79,10 @@ export class PointVector {
     }
 
     // From: http://stackoverflow.com/a/1501725/1983739
-    static distanceFromPointToLineSq(
+    static distanceFromPointToLineSegmentSq(
         p: PointVector,
-        v: PointVector,
-        w: PointVector
+        v: PointVector, // start of line segment
+        w: PointVector // end of line segment
     ): number {
         const l2 = PointVector.distanceSq(v, w)
         if (l2 === 0) return PointVector.distanceSq(p, v)


### PR DESCRIPTION
Improves hover interaction on slope charts.

### Summary

- Improves the "algorithm" to figure out which slope is currently closest to the mouse (see below for an explanation)
- Adds support for clicking anywhere inside the Grapher frame to dismiss the current selection
- Uses the "default" cursor for value and entity labels since they're clickable (default is the text selection cursor)

<details><summary>How do we figure out which slope is currently closest to the mouse?</summary>
<p>

| Before  | After  |
| ------- | ------ |
| ![Screenshot 2024-03-07 at 10 27 26](https://github.com/owid/owid-grapher/assets/12461810/f17d8117-804c-49a3-b1d6-2bed5e7f1ffe) | ![Screenshot 2024-03-07 at 10 27 34](https://github.com/owid/owid-grapher/assets/12461810/dd221a34-7396-4503-98d2-743b1b2adca3) |
| We used to measure the distance to the orange line that is defined by the start and end point of a slope but extends to both sides. | Now we measure the distance to the line _segment_ that is the slope or, if the mouse is outside of the chart area, we measure the distance to a label that is represented by a straight line |

</p>
</details> 

### Caveats

- If a Grapher chart has entities selected by default, then clicking anywhere inside the Grapher frame will dismiss the default selection ([Example](http://staging-site-slope-hover-interaction/grapher/change-in-female-height-slope))
    - I do believe that if it's possible to select entities by clicking on slopes or clicking the legend, then it should also be possible to dismiss a selection by clicking into dead space (it's almost expected behaviour, I think?)
    - But dismissing a default selection before a user has even interacted with a chart is not ideal
    - We have very few slope charts though that allow entity selection and have a set of entities selected by default
    - All in all, I think it's still net positive but can be convinced otherwise

### Videos

<details><summary>Before/After</summary>
<p>

https://github.com/owid/owid-grapher/assets/12461810/3e013eae-3981-492b-908d-a940411578db

https://github.com/owid/owid-grapher/assets/12461810/dbfcbcd3-66df-4dce-99a2-c2fe14cc6d7f

</p>
</details> 

### Context

Part of a larger body of work. See stack 👇🏻 

### SVG tester

All slope charts are updated because of the `cursor` change.