### PR TITLE
✨ add transaction types and api route helpers

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -51,6 +51,8 @@ module.exports = {
         "react/no-render-return-value": "warn",
         "react/no-unescaped-entities": ["warn", { forbid: [">", "}"] }],
         "react/prop-types": "warn",
+        // TODO: consider adding this and whitelisting all promises that don't need to be awaited with "void"
+        // "@typescript-eslint/no-floating-promises": "error",
     },
     settings: {
         "import/resolver": {

--- a/adminSiteServer/gitDataExport.ts
+++ b/adminSiteServer/gitDataExport.ts
@@ -16,11 +16,10 @@ import filenamify from "filenamify"
 import { execFormatted } from "../db/execWrapper.js"
 import { JsonError } from "@ourworldindata/utils"
 import { DbPlainDataset } from "@ourworldindata/types"
-import { Knex } from "knex"
 import { getSourcesForDataset } from "../db/model/Source.js"
 
 const datasetToReadme = async (
-    knex: Knex<any, any[]>,
+    knex: db.KnexReadonlyTransaction,
     dataset: DbPlainDataset
 ): Promise<string> => {
     // TODO: add origins here
@@ -62,7 +61,7 @@ export async function removeDatasetFromGitRepo(
 }
 
 export async function syncDatasetToGitRepo(
-    knex: Knex<any, any[]>,
+    knex: db.KnexReadonlyTransaction,
     datasetId: number,
     options: {
         transaction?: db.TransactionContext

--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -66,34 +66,38 @@ mockSiteRouter.use(express.json())
 
 mockSiteRouter.get("/sitemap.xml", async (req, res) => {
     res.set("Content-Type", "application/xml")
-    const sitemap = await db
-        .knexInstance()
-        .transaction(async (knex) => makeSitemap(explorerAdminServer, knex))
+    const sitemap = await db.knexReadonlyTransaction(async (knex) =>
+        makeSitemap(explorerAdminServer, knex)
+    )
     res.send(sitemap)
 })
 
 mockSiteRouter.get("/atom.xml", async (req, res) => {
     res.set("Content-Type", "application/xml")
-    const atomFeed = await db
-        .knexInstance()
-        .transaction(async (knex) => makeAtomFeed(knex))
+    const atomFeed = await db.knexReadonlyTransaction(async (knex) =>
+        makeAtomFeed(knex)
+    )
     res.send(atomFeed)
 })
 
 mockSiteRouter.get("/atom-no-topic-pages.xml", async (req, res) => {
     res.set("Content-Type", "application/xml")
-    const atomFeedNoTopicPages = await db
-        .knexInstance()
-        .transaction(async (knex) => makeAtomFeedNoTopicPages(knex))
+    const atomFeedNoTopicPages = await db.knexReadonlyTransaction(
+        async (knex) => makeAtomFeedNoTopicPages(knex)
+    )
     res.send(atomFeedNoTopicPages)
 })
 
 mockSiteRouter.get("/entries-by-year", async (req, res) =>
-    res.send(await entriesByYearPage())
+    res.send(await db.knexReadonlyTransaction((trx) => entriesByYearPage(trx)))
 )
 
 mockSiteRouter.get(`/entries-by-year/:year`, async (req, res) =>
-    res.send(await entriesByYearPage(parseInt(req.params.year)))
+    res.send(
+        await db.knexReadonlyTransaction((trx) =>
+            entriesByYearPage(trx, parseInt(req.params.year))
+        )
+    )
 )
 
 mockSiteRouter.get(
@@ -128,11 +132,9 @@ mockSiteRouter.get(`/${EXPLORERS_ROUTE_FOLDER}/:slug`, async (req, res) => {
         (program) => program.slug === req.params.slug
     )
     if (explorerProgram) {
-        const explorerPage = await db
-            .knexInstance()
-            .transaction(async (knex) => {
-                return renderExplorerPage(explorerProgram, knex)
-            })
+        const explorerPage = await db.knexReadonlyTransaction(async (knex) => {
+            return renderExplorerPage(explorerProgram, knex)
+        })
 
         res.send(explorerPage)
     } else
@@ -149,7 +151,7 @@ mockSiteRouter.get("/*", async (req, res, next) => {
     const { migrationId, baseQueryStr } = explorerRedirect
     const { explorerSlug } = explorerUrlMigrationsById[migrationId]
     const program = await explorerAdminServer.getExplorerFromSlug(explorerSlug)
-    const explorerPage = await db.knexInstance().transaction(async (knex) => {
+    const explorerPage = await db.knexReadonlyTransaction(async (knex) => {
         return renderExplorerPage(program, knex, {
             explorerUrlMigrationId: migrationId,
             baseQueryStr,
@@ -172,18 +174,16 @@ mockSiteRouter.get("/grapher/:slug", async (req, res) => {
 
     // XXX add dev-prod parity for this
     res.set("Access-Control-Allow-Origin", "*")
-    const previewDataPageOrGrapherPage = await db
-        .knexInstance()
-        .transaction(async (knex) =>
-            renderPreviewDataPageOrGrapherPage(entity.config, knex)
-        )
+    const previewDataPageOrGrapherPage = await db.knexReadonlyTransaction(
+        async (knex) => renderPreviewDataPageOrGrapherPage(entity.config, knex)
+    )
     res.send(previewDataPageOrGrapherPage)
 })
 
 mockSiteRouter.get("/", async (req, res) => {
-    const frontPage = await db
-        .knexInstance()
-        .transaction(async (knex) => renderFrontPage(knex))
+    const frontPage = await db.knexReadonlyTransaction(async (knex) =>
+        renderFrontPage(knex)
+    )
     res.send(frontPage)
 })
 
@@ -247,25 +247,25 @@ mockSiteRouter.get("/datapage-preview/:id", async (req, res) => {
     const variableMetadata = await getVariableMetadata(variableId)
 
     res.send(
-        await renderDataPageV2(
-            {
-                variableId,
-                variableMetadata,
-                isPreviewing: true,
-                useIndicatorGrapherConfigs: true,
-            },
-            db.knexInstance()
+        await db.knexReadonlyTransaction((trx) =>
+            renderDataPageV2(
+                {
+                    variableId,
+                    variableMetadata,
+                    isPreviewing: true,
+                    useIndicatorGrapherConfigs: true,
+                },
+                trx
+            )
         )
     )
 })
 
 countryProfileSpecs.forEach((spec) =>
     mockSiteRouter.get(`/${spec.rootPath}/:countrySlug`, async (req, res) => {
-        const countryPage = await db
-            .knexInstance()
-            .transaction(async (knex) =>
-                countryProfileCountryPage(spec, req.params.countrySlug, knex)
-            )
+        const countryPage = await db.knexReadonlyTransaction(async (knex) =>
+            countryProfileCountryPage(spec, req.params.countrySlug, knex)
+        )
         res.send(countryPage)
     })
 )
@@ -275,20 +275,18 @@ mockSiteRouter.get("/search", async (req, res) =>
 )
 
 mockSiteRouter.get("/latest", async (req, res) => {
-    const latest = await db
-        .knexInstance()
-        .transaction(async (knex) => renderBlogByPageNum(1, knex))
+    const latest = await db.knexReadonlyTransaction(async (knex) =>
+        renderBlogByPageNum(1, knex)
+    )
     res.send(latest)
 })
 
 mockSiteRouter.get("/latest/page/:pageno", async (req, res) => {
     const pagenum = parseInt(req.params.pageno, 10)
     if (!isNaN(pagenum)) {
-        const latestPageNum = await db
-            .knexInstance()
-            .transaction(async (knex) =>
-                renderBlogByPageNum(isNaN(pagenum) ? 1 : pagenum, knex)
-            )
+        const latestPageNum = await db.knexReadonlyTransaction(async (knex) =>
+            renderBlogByPageNum(isNaN(pagenum) ? 1 : pagenum, knex)
+        )
         res.send(latestPageNum)
     } else throw new Error("invalid page number")
 })
@@ -345,7 +343,11 @@ mockSiteRouter.get("/countries", async (req, res) =>
 )
 
 mockSiteRouter.get("/country/:countrySlug", async (req, res) =>
-    res.send(await countryProfilePage(req.params.countrySlug, BAKED_BASE_URL))
+    res.send(
+        await db.knexReadonlyTransaction((trx) =>
+            countryProfilePage(trx, req.params.countrySlug, BAKED_BASE_URL)
+        )
+    )
 )
 
 mockSiteRouter.get("/feedback", async (req, res) =>
@@ -383,9 +385,9 @@ mockSiteRouter.get("/*", async (req, res) => {
     }
 
     try {
-        const page = await db
-            .knexInstance()
-            .transaction(async (knex) => renderPageBySlug(slug, knex))
+        const page = await db.knexReadonlyTransaction(async (knex) =>
+            renderPageBySlug(slug, knex)
+        )
         res.send(page)
     } catch (e) {
         console.error(e)

--- a/adminSiteServer/routerHelpers.tsx
+++ b/adminSiteServer/routerHelpers.tsx
@@ -1,0 +1,98 @@
+import { FunctionalRouter } from "./FunctionalRouter.js"
+import { Request, Response } from "express"
+import * as db from "../db/db.js"
+export function getRouteWithROTransaction<T>(
+    router: FunctionalRouter,
+    targetPath: string,
+    handler: (
+        req: Request,
+        res: Response,
+        trx: db.KnexReadonlyTransaction
+    ) => Promise<T>
+) {
+    return router.get(targetPath, (req: Request, res: Response) => {
+        return db.knexReadonlyTransaction((transaction) =>
+            handler(req, res, transaction)
+        )
+    })
+}
+
+// Might be needed in the future if we have get requests that e.g. write analytics data or stats to the DB
+// function getRouteWithRWTransaction<T>(
+//     targetPath: string,
+//     handler: (
+//         req: Request,
+//         res: Response,
+//         trx: db.KnexReadWriteTransaction
+//     ) => Promise<T>
+// ) {
+//     return apiRouter.get(targetPath, (req: Request, res: Response) => {
+//         return db.knexReadWriteTransaction((transaction) =>
+//             handler(req, res, transaction)
+//         )
+//     })
+// }
+
+export function postRouteWithRWTransaction<T>(
+    router: FunctionalRouter,
+    targetPath: string,
+    handler: (
+        req: Request,
+        res: Response,
+        trx: db.KnexReadWriteTransaction
+    ) => Promise<T>
+) {
+    return router.post(targetPath, (req: Request, res: Response) => {
+        return db.knexReadWriteTransaction((transaction) =>
+            handler(req, res, transaction)
+        )
+    })
+}
+
+export function putRouteWithRWTransaction<T>(
+    router: FunctionalRouter,
+    targetPath: string,
+    handler: (
+        req: Request,
+        res: Response,
+        trx: db.KnexReadWriteTransaction
+    ) => Promise<T>
+) {
+    return router.put(targetPath, (req: Request, res: Response) => {
+        return db.knexReadWriteTransaction((transaction) =>
+            handler(req, res, transaction)
+        )
+    })
+}
+
+export function patchRouteWithRWTransaction<T>(
+    router: FunctionalRouter,
+    targetPath: string,
+    handler: (
+        req: Request,
+        res: Response,
+        trx: db.KnexReadWriteTransaction
+    ) => Promise<T>
+) {
+    return router.patch(targetPath, (req: Request, res: Response) => {
+        return db.knexReadWriteTransaction((transaction) =>
+            handler(req, res, transaction)
+        )
+    })
+}
+
+export function deleteRouteWithRWTransaction<T>(
+    router: FunctionalRouter,
+    targetPath: string,
+    handler: (
+        req: Request,
+        res: Response,
+        trx: db.KnexReadWriteTransaction
+    ) => Promise<T>
+) {
+    return router.delete(targetPath, (req: Request, res: Response) => {
+        return db.knexReadWriteTransaction((transaction) =>
+            handler(req, res, transaction)
+        )
+    })
+}

--- a/baker/DeployUtils.ts
+++ b/baker/DeployUtils.ts
@@ -11,7 +11,7 @@ import {
 import { SiteBaker } from "../baker/SiteBaker.js"
 import { WebClient } from "@slack/web-api"
 import { DeployChange, DeployMetadata } from "@ourworldindata/utils"
-import { Knex } from "knex"
+import { KnexReadonlyTransaction } from "../db/db.js"
 
 const deployQueueServer = new DeployQueueServer()
 
@@ -35,7 +35,7 @@ export const defaultCommitMessage = async (): Promise<string> => {
  */
 const triggerBakeAndDeploy = async (
     deployMetadata: DeployMetadata,
-    knex: Knex<any, any[]>,
+    knex: KnexReadonlyTransaction,
     lightningQueue?: DeployChange[]
 ) => {
     // deploy to Buildkite if we're on master and BUILDKITE_API_ACCESS_TOKEN is set
@@ -156,7 +156,9 @@ let deploying = false
  * the end of the current one, as long as there are changes in the queue.
  * If there are no changes in the queue, a deploy won't be initiated.
  */
-export const deployIfQueueIsNotEmpty = async (knex: Knex<any, any[]>) => {
+export const deployIfQueueIsNotEmpty = async (
+    knex: KnexReadonlyTransaction
+) => {
     if (deploying) return
     deploying = true
     let failures = 0

--- a/baker/ExplorerBaker.tsx
+++ b/baker/ExplorerBaker.tsx
@@ -5,12 +5,12 @@ import { explorerUrlMigrationsById } from "../explorer/urlMigrations/ExplorerUrl
 import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer.js"
 import { explorerRedirectTable } from "../explorerAdminServer/ExplorerRedirects.js"
 import { renderExplorerPage } from "./siteRenderers.js"
-import { Knex } from "knex"
+import * as db from "../db/db.js"
 
 export const bakeAllPublishedExplorers = async (
     outputFolder: string,
     explorerAdminServer: ExplorerAdminServer,
-    knex: Knex<any, any[]>
+    knex: db.KnexReadonlyTransaction
 ) => {
     // remove all existing explorers, since we're re-baking every single one anyway
     fs.remove(outputFolder)
@@ -23,7 +23,7 @@ export const bakeAllPublishedExplorers = async (
 const bakeExplorersToDir = async (
     directory: string,
     explorers: ExplorerProgram[] = [],
-    knex: Knex<any, any[]>
+    knex: db.KnexReadonlyTransaction
 ) => {
     for (const explorer of explorers) {
         await write(
@@ -36,7 +36,7 @@ const bakeExplorersToDir = async (
 export const bakeAllExplorerRedirects = async (
     outputFolder: string,
     explorerAdminServer: ExplorerAdminServer,
-    knex: Knex<any, any[]>
+    knex: db.KnexReadonlyTransaction
 ) => {
     const explorers = await explorerAdminServer.getAllExplorers()
     const redirects = explorerRedirectTable.rows

--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -8,7 +8,6 @@ import { MarkdownTextWrap } from "@ourworldindata/components"
 import { getAnalyticsPageviewsByUrlObj } from "../../db/model/Pageview.js"
 import { Link } from "../../db/model/Link.js"
 import { getRelatedArticles } from "../../db/model/Post.js"
-import { Knex } from "knex"
 import { getIndexName } from "../../site/search/searchClient.js"
 
 const computeScore = (record: Omit<ChartRecord, "score">): number => {
@@ -17,7 +16,7 @@ const computeScore = (record: Omit<ChartRecord, "score">): number => {
 }
 
 const getChartsRecords = async (
-    knex: Knex<any, any[]>
+    knex: db.KnexReadonlyTransaction
 ): Promise<ChartRecord[]> => {
     const chartsToIndex = await db.queryMysql(`
     SELECT c.id,
@@ -68,7 +67,7 @@ const getChartsRecords = async (
         // otherwise they will fail when rendered in the search results
         if (isPathRedirectedToExplorer(`/grapher/${c.slug}`)) continue
 
-        const relatedArticles = (await getRelatedArticles(c.id, knex)) ?? []
+        const relatedArticles = (await getRelatedArticles(knex, c.id)) ?? []
         const linksFromGdocs = await Link.getPublishedLinksTo(
             c.slug,
             OwidGdocLinkType.Grapher
@@ -118,7 +117,7 @@ const indexChartsToAlgolia = async () => {
     const index = client.initIndex(getIndexName(SearchIndexName.Charts))
 
     await db.getConnection()
-    const records = await getChartsRecords(db.knexInstance())
+    const records = await db.knexReadonlyTransaction(getChartsRecords)
     await index.replaceAllObjects(records)
 
     await db.closeTypeOrmAndKnexConnections()

--- a/baker/buildLocalBake.ts
+++ b/baker/buildLocalBake.ts
@@ -17,7 +17,7 @@ const bakeDomainToFolder = async (
     fs.mkdirp(dir)
     const baker = new SiteBaker(dir, baseUrl, bakeSteps)
     console.log(`Baking site locally with baseUrl '${baseUrl}' to dir '${dir}'`)
-    await baker.bakeAll(db.knexInstance())
+    await db.knexReadonlyTransaction((trx) => baker.bakeAll(trx))
 }
 
 yargs(hideBin(process.argv))

--- a/baker/countryProfiles.tsx
+++ b/baker/countryProfiles.tsx
@@ -41,11 +41,13 @@ const checkShouldShowIndicator = (grapher: GrapherInterface) =>
 
 // Find the charts that will be shown on the country profile page (if they have that country)
 // TODO: make this page per variable instead
-const countryIndicatorGraphers = async (): Promise<GrapherInterface[]> =>
+const countryIndicatorGraphers = async (
+    trx: db.KnexReadonlyTransaction
+): Promise<GrapherInterface[]> =>
     bakeCache(countryIndicatorGraphers, async () => {
         const graphers = (
-            await db
-                .knexTable("charts")
+            await trx
+                .table("charts")
                 .whereRaw(
                     "publishedAt is not null and config->>'$.isPublished' = 'true' and is_indexable is true"
                 )
@@ -54,22 +56,25 @@ const countryIndicatorGraphers = async (): Promise<GrapherInterface[]> =>
         return graphers.filter(checkShouldShowIndicator)
     })
 
-export const countryIndicatorVariables = async (): Promise<
-    DbEnrichedVariable[]
-> =>
+export const countryIndicatorVariables = async (
+    trx: db.KnexReadonlyTransaction
+): Promise<DbEnrichedVariable[]> =>
     bakeCache(countryIndicatorVariables, async () => {
-        const variableIds = (await countryIndicatorGraphers()).map(
+        const variableIds = (await countryIndicatorGraphers(trx)).map(
             (c) => c.dimensions![0]!.variableId
         )
-        const rows: DbRawVariable[] = await db
-            .knexTable(VariablesTableName)
+        const rows: DbRawVariable[] = await trx
+            .table(VariablesTableName)
             .whereIn("id", variableIds)
         return rows.map(parseVariablesRow)
     })
 
-export const denormalizeLatestCountryData = async (variableIds?: number[]) => {
-    const entities = (await db
-        .knexTable("entities")
+export const denormalizeLatestCountryData = async (
+    trx: db.KnexReadWriteTransaction,
+    variableIds?: number[]
+) => {
+    const entities = (await trx
+        .table("entities")
         .select("id", "code")
         .whereRaw("validated is true and code is not null")) as {
         id: number
@@ -80,7 +85,7 @@ export const denormalizeLatestCountryData = async (variableIds?: number[]) => {
     const entityIds = countries.map((c) => entitiesByCode[c.code].id)
 
     if (!variableIds) {
-        variableIds = (await countryIndicatorVariables()).map((v) => v.id)
+        variableIds = (await countryIndicatorVariables(trx)).map((v) => v.id)
 
         // exclude variables that are already in country_latest_data
         // NOTE: we always fetch all variables that don't have country entities because they never
@@ -88,17 +93,18 @@ export const denormalizeLatestCountryData = async (variableIds?: number[]) => {
         // entities used in variables there's no easy way. It's not as bad since this still takes
         // under a minute to run.
         const existingVariableIds = (
-            await db.queryMysql(
+            await db.knexRaw<{ variable_id: number }>(
+                trx,
                 `select variable_id from country_latest_data where variable_id in (?)`,
                 [variableIds]
             )
-        ).map((r: any) => r.variable_id)
+        ).map((r) => r.variable_id)
         variableIds = lodash.difference(variableIds, existingVariableIds)
     }
 
     const currentYear = new Date().getUTCFullYear()
 
-    const df = (await dataAsDF(variableIds, db.knexInstance()))
+    const df = (await dataAsDF(variableIds, trx))
         .filter(
             pl
                 .col("entityId")
@@ -113,26 +119,27 @@ export const denormalizeLatestCountryData = async (variableIds?: number[]) => {
         .select("variableId", "entityCode", "year", "value")
         .rename({ variableId: "variable_id", entityCode: "country_code" })
 
-    await db.knexInstance().transaction(async (t) => {
-        // Remove existing values
-        await t
-            .table("country_latest_data")
-            .whereIn("variable_id", variableIds as number[])
-            .delete()
+    // Remove existing values
+    await trx
+        .table("country_latest_data")
+        .whereIn("variable_id", variableIds as number[])
+        .delete()
 
-        // Insert new ones
-        if (df.height > 0) {
-            await t.table("country_latest_data").insert(df.toRecords())
-        }
-    })
+    // Insert new ones
+    if (df.height > 0) {
+        await trx.table("country_latest_data").insert(df.toRecords())
+    }
 }
 
-const countryIndicatorLatestData = async (countryCode: string) => {
+const countryIndicatorLatestData = async (
+    trx: db.KnexReadonlyTransaction,
+    countryCode: string
+) => {
     const dataValuesByEntityId = await bakeCache(
         countryIndicatorLatestData,
         async () => {
-            const dataValues = (await db
-                .knexTable("country_latest_data")
+            const dataValues = (await trx
+                .table("country_latest_data")
                 .select(
                     "variable_id AS variableId",
                     "country_code AS code",
@@ -153,14 +160,15 @@ const countryIndicatorLatestData = async (countryCode: string) => {
 }
 
 export const countryProfilePage = async (
+    trx: db.KnexReadonlyTransaction,
     countrySlug: string,
     baseUrl: string
 ) => {
     const country = getCountryBySlug(countrySlug)
     if (!country) throw new JsonError(`No such country ${countrySlug}`, 404)
 
-    const graphers = await countryIndicatorGraphers()
-    const dataValues = await countryIndicatorLatestData(country.code)
+    const graphers = await countryIndicatorGraphers(trx)
+    const dataValues = await countryIndicatorLatestData(trx, country.code)
 
     const valuesByVariableId = lodash.groupBy(dataValues, (v) => v.variableId)
 
@@ -193,14 +201,17 @@ export const countryProfilePage = async (
     )
 }
 
-export const bakeCountries = async (baker: SiteBaker) => {
+export const bakeCountries = async (
+    baker: SiteBaker,
+    trx: db.KnexReadonlyTransaction
+) => {
     const html = await countriesIndexPage(baker.baseUrl)
     await baker.writeFile("/countries.html", html)
 
     await baker.ensureDir("/country")
     for (const country of countries) {
         const path = `/country/${country.slug}.html`
-        const html = await countryProfilePage(country.slug, baker.baseUrl)
+        const html = await countryProfilePage(trx, country.slug, baker.baseUrl)
         await baker.writeFile(path, html)
     }
 

--- a/baker/formatWordpressPost.tsx
+++ b/baker/formatWordpressPost.tsx
@@ -59,7 +59,7 @@ import { renderKeyInsights, renderProminentLinks } from "./siteRenderers.js"
 import { KEY_INSIGHTS_CLASS_NAME } from "../site/blocks/KeyInsights.js"
 import { RELATED_CHARTS_CLASS_NAME } from "../site/blocks/RelatedCharts.js"
 import { logErrorAndMaybeSendToBugsnag } from "../serverUtils/errorLog.js"
-import { Knex } from "knex"
+import { KnexReadonlyTransaction } from "../db/db.js"
 
 const initMathJax = () => {
     const adaptor = liteAdaptor()
@@ -129,7 +129,7 @@ const formatLatex = async (
 export const formatWordpressPost = async (
     post: FullPost,
     formattingOptions: FormattingOptions,
-    knex: Knex<any, any[]>,
+    knex: KnexReadonlyTransaction,
     grapherExports?: GrapherExports
 ): Promise<FormattedPost> => {
     let html = post.content
@@ -596,7 +596,7 @@ export const formatWordpressPost = async (
 export const formatPost = async (
     post: FullPost,
     formattingOptions: FormattingOptions,
-    knex: Knex<any, any[]>,
+    knex: KnexReadonlyTransaction,
     grapherExports?: GrapherExports
 ): Promise<FormattedPost> => {
     // No formatting applied, plain source HTML returned

--- a/baker/pageOverrides.test.ts
+++ b/baker/pageOverrides.test.ts
@@ -6,6 +6,7 @@ import {
 import * as pageOverrides from "./pageOverrides.js"
 
 import { jest } from "@jest/globals"
+import { KnexReadonlyTransaction } from "../db/db.js"
 
 const mockCreatePost = (slug: string): FullPost => {
     return {
@@ -27,7 +28,7 @@ const getPostBySlugLogToSlackNoThrow = jest.spyOn(
     pageOverrides,
     "getPostBySlugLogToSlackNoThrow"
 )
-getPostBySlugLogToSlackNoThrow.mockImplementation((landingSlug) =>
+getPostBySlugLogToSlackNoThrow.mockImplementation((knex, landingSlug) =>
     Promise.resolve(mockCreatePost(landingSlug))
 )
 
@@ -38,6 +39,7 @@ it("gets parent landing", async () => {
 
     await expect(
         pageOverrides.getLandingOnlyIfParent(
+            {} as KnexReadonlyTransaction,
             mockCreatePost("forest-area"),
             formattingOptions
         )
@@ -51,6 +53,7 @@ it("does not get parent landing (subnavId invalid)", async () => {
 
     await expect(
         pageOverrides.getLandingOnlyIfParent(
+            {} as KnexReadonlyTransaction,
             mockCreatePost("forest-area"),
             formattingOptions
         )
@@ -64,6 +67,7 @@ it("does not get parent landing (post is already a landing)", async () => {
 
     await expect(
         pageOverrides.getLandingOnlyIfParent(
+            {} as KnexReadonlyTransaction,
             mockCreatePost(forestLandingSlug),
             formattingOptions
         )
@@ -81,6 +85,7 @@ it("does not get parent landing and logs (landing post not found)", async () => 
 
     await expect(
         pageOverrides.getLandingOnlyIfParent(
+            {} as KnexReadonlyTransaction,
             mockCreatePost("forest-area"),
             formattingOptions
         )

--- a/baker/recalcLatestCountryData.ts
+++ b/baker/recalcLatestCountryData.ts
@@ -5,7 +5,7 @@ import * as db from "../db/db.js"
 import { denormalizeLatestCountryData } from "../baker/countryProfiles.js"
 
 const main = async () => {
-    await denormalizeLatestCountryData()
+    await db.knexReadWriteTransaction(denormalizeLatestCountryData)
     await db.closeTypeOrmAndKnexConnections()
 }
 

--- a/baker/redirects.test.ts
+++ b/baker/redirects.test.ts
@@ -4,7 +4,7 @@ import * as redirects from "./redirects.js"
 import { resolveInternalRedirect } from "./redirects.js"
 
 import { jest } from "@jest/globals"
-import { Knex } from "knex"
+import { KnexReadonlyTransaction } from "../db/db.js"
 
 type ArrayForMap = [string, string][]
 
@@ -16,8 +16,6 @@ const getGrapherAndWordpressRedirectsMap = jest.spyOn(
 const getFormattedUrl = (url: string): Url => {
     return Url.fromURL(formatUrls(url))
 }
-
-const knex: Knex = {} as Knex
 
 it("resolves pathnames", async () => {
     const src = "/hello"
@@ -31,9 +29,12 @@ it("resolves pathnames", async () => {
         Promise.resolve(new Map(redirectsArr))
     )
 
-    expect(await resolveInternalRedirect(urlToResolve, knex)).toEqual(
-        resolvedUrl
-    )
+    expect(
+        await resolveInternalRedirect(
+            urlToResolve,
+            {} as KnexReadonlyTransaction
+        )
+    ).toEqual(resolvedUrl)
 })
 
 it("does not support query string in redirects map", async () => {
@@ -47,9 +48,12 @@ it("does not support query string in redirects map", async () => {
         Promise.resolve(new Map(redirectsArr))
     )
 
-    expect(await resolveInternalRedirect(urlToResolve, knex)).toEqual(
-        urlToResolve
-    )
+    expect(
+        await resolveInternalRedirect(
+            urlToResolve,
+            {} as KnexReadonlyTransaction
+        )
+    ).toEqual(urlToResolve)
 })
 
 it("passes query string params when resolving", async () => {
@@ -69,9 +73,12 @@ it("passes query string params when resolving", async () => {
         Promise.resolve(new Map(redirectsArr))
     )
 
-    expect(await resolveInternalRedirect(urlToResolve, knex)).toEqual(
-        resolvedUrl
-    )
+    expect(
+        await resolveInternalRedirect(
+            urlToResolve,
+            {} as KnexReadonlyTransaction
+        )
+    ).toEqual(resolvedUrl)
 })
 
 it("does not pass query string params when some present on the target", async () => {
@@ -88,9 +95,12 @@ it("does not pass query string params when some present on the target", async ()
         Promise.resolve(new Map(redirectsArr))
     )
 
-    expect(await resolveInternalRedirect(urlToResolve, knex)).toEqual(
-        resolvedUrl
-    )
+    expect(
+        await resolveInternalRedirect(
+            urlToResolve,
+            {} as KnexReadonlyTransaction
+        )
+    ).toEqual(resolvedUrl)
 })
 
 it("resolves self-redirects", async () => {
@@ -104,9 +114,12 @@ it("resolves self-redirects", async () => {
         Promise.resolve(new Map(redirectsArr))
     )
 
-    expect(await resolveInternalRedirect(urlToResolve, knex)).toEqual(
-        urlToResolve
-    )
+    expect(
+        await resolveInternalRedirect(
+            urlToResolve,
+            {} as KnexReadonlyTransaction
+        )
+    ).toEqual(urlToResolve)
 })
 
 it("does not support query params in self-redirects", async () => {
@@ -123,11 +136,17 @@ it("does not support query params in self-redirects", async () => {
         Promise.resolve(new Map(redirectsArr))
     )
 
-    expect(await resolveInternalRedirect(urlToResolve, knex)).toEqual(
-        urlToResolve
-    )
     expect(
-        await resolveInternalRedirect(urlToResolveWithQueryParam, knex)
+        await resolveInternalRedirect(
+            urlToResolve,
+            {} as KnexReadonlyTransaction
+        )
+    ).toEqual(urlToResolve)
+    expect(
+        await resolveInternalRedirect(
+            urlToResolveWithQueryParam,
+            {} as KnexReadonlyTransaction
+        )
     ).toEqual(urlToResolveWithQueryParam)
 })
 
@@ -147,7 +166,10 @@ it("resolves circular redirects", async () => {
         Promise.resolve(new Map(redirectsArr))
     )
 
-    expect(await resolveInternalRedirect(urlToResolve, knex)).toEqual(
-        urlToResolve
-    )
+    expect(
+        await resolveInternalRedirect(
+            urlToResolve,
+            {} as KnexReadonlyTransaction
+        )
+    ).toEqual(urlToResolve)
 })

--- a/baker/redirects.ts
+++ b/baker/redirects.ts
@@ -4,9 +4,8 @@ import { isCanonicalInternalUrl } from "./formatting.js"
 import { resolveExplorerRedirect } from "./replaceExplorerRedirects.js"
 import { logErrorAndMaybeSendToBugsnag } from "../serverUtils/errorLog.js"
 import { getRedirectsFromDb } from "../db/model/Redirect.js"
-import { Knex } from "knex"
 
-export const getRedirects = async (knex: Knex<any, any[]>) => {
+export const getRedirects = async (knex: db.KnexReadonlyTransaction) => {
     const staticRedirects = [
         // RSS feed
         "/feed /atom.xml 302",
@@ -92,14 +91,16 @@ export const getGrapherRedirectsMap = async (
     )
 }
 
-export const getWordpressRedirectsMap = async (knex: Knex<any, any[]>) => {
+export const getWordpressRedirectsMap = async (
+    knex: db.KnexReadonlyTransaction
+) => {
     const redirectsFromDb = await getRedirectsFromDb(knex)
 
     return new Map(redirectsFromDb.map((row) => [row.source, row.target]))
 }
 
 export const getGrapherAndWordpressRedirectsMap = memoize(
-    async (knex: Knex<any, any[]>): Promise<Map<string, string>> => {
+    async (knex: db.KnexReadonlyTransaction): Promise<Map<string, string>> => {
         // source: pathnames only (e.g. /transport)
         // target: pathnames with or without origins (e.g. /transport-new or https://ourworldindata.org/transport-new)
 
@@ -161,7 +162,7 @@ export const resolveRedirectFromMap = async (
 
 export const resolveInternalRedirect = async (
     url: Url,
-    knex: Knex<any, any[]>
+    knex: db.KnexReadonlyTransaction
 ): Promise<Url> => {
     if (!isCanonicalInternalUrl(url)) return url
 

--- a/baker/runBakeGraphers.ts
+++ b/baker/runBakeGraphers.ts
@@ -9,9 +9,11 @@ import * as db from "../db/db.js"
  */
 
 const main = async (folder: string) => {
-    await bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers(
-        folder,
-        db.knexInstance()
+    db.knexReadonlyTransaction((trx) =>
+        bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers(
+            folder,
+            trx
+        )
     )
 }
 

--- a/baker/siteRenderers.test.ts
+++ b/baker/siteRenderers.test.ts
@@ -3,12 +3,12 @@
 import {} from "../site/blocks/ProminentLink.js"
 import { renderExplorerPage } from "./siteRenderers.js"
 import { ExplorerProgram } from "../explorer/ExplorerProgram.js"
-import { Knex } from "knex"
+import { KnexReadonlyTransaction } from "../db/db.js"
 
 // Note: renderProminentLinks() tests are now e2e (see kitchenSink.js)
 
 it("renders an explorer page with title", async () => {
-    const knex: Knex = {} as Knex
+    const knex: KnexReadonlyTransaction = {} as KnexReadonlyTransaction
 
     expect(
         await renderExplorerPage(

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -58,7 +58,7 @@ import {
 import { FormattingOptions, GrapherInterface } from "@ourworldindata/types"
 import { CountryProfileSpec } from "../site/countryProfileProjects.js"
 import { formatPost } from "./formatWordpressPost.js"
-import { queryMysql, knexTable, getHomepageId } from "../db/db.js"
+import { queryMysql, getHomepageId, KnexReadonlyTransaction } from "../db/db.js"
 import { getPageOverrides, isPageOverridesCitable } from "./pageOverrides.js"
 import { ProminentLink } from "../site/blocks/ProminentLink.js"
 import {
@@ -90,7 +90,6 @@ import { GdocPost } from "../db/model/Gdoc/GdocPost.js"
 import { logErrorAndMaybeSendToBugsnag } from "../serverUtils/errorLog.js"
 import { GdocFactory } from "../db/model/Gdoc/GdocFactory.js"
 import { SiteNavigationStatic } from "../site/SiteNavigation.js"
-import { Knex } from "knex"
 
 export const renderToHtmlPage = (element: any) =>
     `<!doctype html>${ReactDOMServer.renderToStaticMarkup(element)}`
@@ -190,17 +189,17 @@ export const renderGdoc = (gdoc: OwidGdoc, isPreviewing: boolean = false) => {
 
 export const renderPageBySlug = async (
     slug: string,
-    knex: Knex<any, any[]>
+    knex: KnexReadonlyTransaction
 ) => {
-    const post = await getFullPostBySlugFromSnapshot(slug)
+    const post = await getFullPostBySlugFromSnapshot(knex, slug)
     return renderPost(post, knex)
 }
 
 export const renderPreview = async (
     postId: number,
-    knex: Knex<any, any[]>
+    knex: KnexReadonlyTransaction
 ): Promise<string> => {
-    const postApi = await getFullPostByIdFromSnapshot(postId)
+    const postApi = await getFullPostByIdFromSnapshot(knex, postId)
     return renderPost(postApi, knex)
 }
 
@@ -210,7 +209,7 @@ export const renderMenuJson = async () => {
 
 export const renderPost = async (
     post: FullPost,
-    knex: Knex<any, any[]>,
+    knex: KnexReadonlyTransaction,
     baseUrl: string = BAKED_BASE_URL,
     grapherExports?: GrapherExports
 ) => {
@@ -238,7 +237,7 @@ export const renderPost = async (
         grapherExports
     )
 
-    const pageOverrides = await getPageOverrides(post, formattingOptions)
+    const pageOverrides = await getPageOverrides(knex, post, formattingOptions)
     const citationStatus =
         isPostSlugCitable(post.slug) || isPageOverridesCitable(pageOverrides)
 
@@ -253,7 +252,7 @@ export const renderPost = async (
     )
 }
 
-export const renderFrontPage = async (knex: Knex<any, any[]>) => {
+export const renderFrontPage = async (knex: KnexReadonlyTransaction) => {
     const gdocHomepageId = await getHomepageId(knex)
 
     if (gdocHomepageId) {
@@ -311,7 +310,7 @@ export const renderDataInsightsIndexPage = (
 
 export const renderBlogByPageNum = async (
     pageNum: number,
-    knex: Knex<any, any[]>
+    knex: KnexReadonlyTransaction
 ) => {
     const allPosts = await getBlogIndex(knex)
 
@@ -337,7 +336,7 @@ export const renderSearchPage = () =>
 export const renderNotFoundPage = () =>
     renderToHtmlPage(<NotFoundPage baseUrl={BAKED_BASE_URL} />)
 
-export async function makeAtomFeed(knex: Knex<any, any[]>) {
+export async function makeAtomFeed(knex: KnexReadonlyTransaction) {
     const posts = (await getBlogIndex(knex)).slice(0, 10)
     return makeAtomFeedFromPosts(posts)
 }
@@ -345,7 +344,7 @@ export async function makeAtomFeed(knex: Knex<any, any[]>) {
 // We don't want to include topic pages in the atom feed that is being consumed
 // by Mailchimp for sending the "immediate update" newsletter. Instead topic
 // pages announcements are sent out manually.
-export async function makeAtomFeedNoTopicPages(knex: Knex<any, any[]>) {
+export async function makeAtomFeedNoTopicPages(knex: KnexReadonlyTransaction) {
     const posts = (await getBlogIndex(knex))
         .filter((post: IndexPost) => post.type !== OwidGdocType.TopicPage)
         .slice(0, 10)
@@ -393,8 +392,12 @@ ${posts
 }
 
 // These pages exist largely just for Google Scholar
-export const entriesByYearPage = async (year?: number) => {
-    const entries = (await knexTable(postsTable)
+export const entriesByYearPage = async (
+    trx: KnexReadonlyTransaction,
+    year?: number
+) => {
+    const entries = (await trx
+        .table(postsTable)
         .where({ status: "publish" })
         .whereNot({ type: "wp_block" })
         .join("post_tags", { "post_tags.post_id": "posts.id" })
@@ -427,11 +430,12 @@ export const feedbackPage = () =>
 const getCountryProfilePost = memoize(
     async (
         profileSpec: CountryProfileSpec,
-        knex: Knex<any, any[]>,
+        knex: KnexReadonlyTransaction,
         grapherExports?: GrapherExports
     ): Promise<[FormattedPost, FormattingOptions]> => {
         // Get formatted content from generic covid country profile page.
         const genericCountryProfilePost = await getFullPostBySlugFromSnapshot(
+            knex,
             profileSpec.genericProfileSlug
         )
 
@@ -451,15 +455,15 @@ const getCountryProfilePost = memoize(
 
 // todo: we used to flush cache of this thing.
 const getCountryProfileLandingPost = memoize(
-    async (profileSpec: CountryProfileSpec) => {
-        return getFullPostBySlugFromSnapshot(profileSpec.landingPageSlug)
+    async (knex: KnexReadonlyTransaction, profileSpec: CountryProfileSpec) => {
+        return getFullPostBySlugFromSnapshot(knex, profileSpec.landingPageSlug)
     }
 )
 
 export const renderCountryProfile = async (
     profileSpec: CountryProfileSpec,
     country: Country,
-    knex: Knex<any, any[]>,
+    knex: KnexReadonlyTransaction,
     grapherExports?: GrapherExports
 ) => {
     const [formatted, formattingOptions] = await getCountryProfilePost(
@@ -470,7 +474,7 @@ export const renderCountryProfile = async (
 
     const formattedCountryProfile = formatCountryProfile(formatted, country)
 
-    const landing = await getCountryProfileLandingPost(profileSpec)
+    const landing = await getCountryProfileLandingPost(knex, profileSpec)
 
     const overrides: PageOverrides = {
         pageTitle: `${country.name}: ${profileSpec.pageTitle} Country Profile`,
@@ -496,7 +500,7 @@ export const renderCountryProfile = async (
 export const countryProfileCountryPage = async (
     profileSpec: CountryProfileSpec,
     countrySlug: string,
-    knex: Knex<any, any[]>
+    knex: KnexReadonlyTransaction
 ) => {
     const country = getCountryBySlug(countrySlug)
     if (!country) throw new JsonError(`No such country ${countrySlug}`, 404)
@@ -508,13 +512,14 @@ export const countryProfileCountryPage = async (
 export const flushCache = () => getCountryProfilePost.cache.clear?.()
 
 const renderPostThumbnailBySlug = async (
+    knex: KnexReadonlyTransaction,
     slug: string | undefined
 ): Promise<string | undefined> => {
     if (!slug) return
 
     let post
     try {
-        post = await getFullPostBySlugFromSnapshot(slug)
+        post = await getFullPostBySlugFromSnapshot(knex, slug)
     } catch (err) {
         // if no post is found, then we return early instead of throwing
     }
@@ -528,7 +533,7 @@ const renderPostThumbnailBySlug = async (
 export const renderProminentLinks = async (
     $: CheerioStatic,
     containerPostId: number,
-    knex: Knex<any, any[]>
+    knex: KnexReadonlyTransaction
 ) => {
     const blocks = $("block[type='prominent-link']").toArray()
     await Promise.all(
@@ -560,6 +565,7 @@ export const renderProminentLinks = async (
                         : resolvedUrl.slug &&
                           (
                               await getFullPostBySlugFromSnapshot(
+                                  knex,
                                   resolvedUrl.slug
                               )
                           ).title)
@@ -587,7 +593,7 @@ export const renderProminentLinks = async (
                     ? renderGrapherThumbnailByResolvedChartSlug(
                           resolvedUrl.slug
                       )
-                    : await renderPostThumbnailBySlug(resolvedUrl.slug))
+                    : await renderPostThumbnailBySlug(knex, resolvedUrl.slug))
 
             const rendered = ReactDOMServer.renderToStaticMarkup(
                 <div className="block-wrapper">
@@ -609,7 +615,7 @@ export const renderProminentLinks = async (
 export const renderReusableBlock = async (
     html: string | undefined,
     containerPostId: number,
-    knex: Knex<any, any[]>
+    knex: KnexReadonlyTransaction
 ): Promise<string | undefined> => {
     if (!html) return
 
@@ -621,7 +627,7 @@ export const renderReusableBlock = async (
 
 export const renderExplorerPage = async (
     program: ExplorerProgram,
-    knex: Knex<any, any[]>,
+    knex: KnexReadonlyTransaction,
     urlMigrationSpec?: ExplorerPageUrlMigrationSpec
 ) => {
     const { requiredGrapherIds, requiredVariableIds } = program.decisionMatrix
@@ -674,7 +680,7 @@ export const renderExplorerPage = async (
 
     const wpContent = program.wpBlockId
         ? await renderReusableBlock(
-              await getBlockContentFromSnapshot(program.wpBlockId),
+              await getBlockContentFromSnapshot(knex, program.wpBlockId),
               program.wpBlockId,
               knex
           )

--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -13,7 +13,6 @@ import { EXPLORERS_ROUTE_FOLDER } from "../explorer/ExplorerConstants.js"
 import { ExplorerProgram } from "../explorer/ExplorerProgram.js"
 import { GdocPost } from "../db/model/Gdoc/GdocPost.js"
 import { getPostsFromSnapshots } from "../db/model/Post.js"
-import { Knex } from "knex"
 import { calculateDataInsightIndexPageCount } from "../db/model/Gdoc/gdocUtils.js"
 
 interface SitemapUrl {
@@ -61,7 +60,7 @@ const explorerToSitemapUrl = (program: ExplorerProgram): SitemapUrl[] => {
 
 export const makeSitemap = async (
     explorerAdminServer: ExplorerAdminServer,
-    knex: Knex<any, any[]>
+    knex: db.KnexReadonlyTransaction
 ) => {
     const alreadyPublishedViaGdocsSlugsSet =
         await db.getSlugsWithPublishedGdocsSuccessors(knex)
@@ -77,8 +76,8 @@ export const makeSitemap = async (
         publishedDataInsights.length
     )
 
-    const charts = (await db
-        .knexTable(Chart.table)
+    const charts = (await knex
+        .table(Chart.table)
         .select(knex.raw(`updatedAt, config->>"$.slug" AS slug`))
         .whereRaw('config->"$.isPublished" = true')) as {
         updatedAt: Date

--- a/baker/startDeployQueueServer.ts
+++ b/baker/startDeployQueueServer.ts
@@ -35,7 +35,7 @@ const main = async () => {
         setTimeout(deployIfQueueIsNotEmpty, 10 * 1000)
     })
 
-    deployIfQueueIsNotEmpty(db.knexInstance())
+    await db.knexReadonlyTransaction(deployIfQueueIsNotEmpty)
 }
 
 main()

--- a/db/DEPRECATEDwpdb.ts
+++ b/db/DEPRECATEDwpdb.ts
@@ -27,6 +27,7 @@ import {
     FOR_SYNC_ONLY_graphqlQuery,
 } from "./wpdb.js"
 import { getFullPost } from "./model/Post.js"
+import { KnexReadonlyTransaction } from "./db.js"
 
 const DEPRECATED_ENTRIES_CATEGORY_ID = 44
 const DEPRECATED_OWID_API_ENDPOINT = `${WORDPRESS_URL}/wp-json/owid/v1`
@@ -88,6 +89,7 @@ export const DEPRECATEDgetPosts = async (
 // We might want to cache this as the network of prominent links densifies and
 // multiple requests to the same posts are happening.
 export const DEPRECATEDgetPostBySlugFromApi = async (
+    knex: KnexReadonlyTransaction,
     slug: string
 ): Promise<FullPost> => {
     if (!isWordpressAPIEnabled) {
@@ -96,12 +98,13 @@ export const DEPRECATEDgetPostBySlugFromApi = async (
 
     const postApi = await FOR_SYNC_ONLY_getPostApiBySlugFromApi(slug)
 
-    return getFullPost(postApi)
+    return getFullPost(knex, postApi)
 }
 
 // the /revisions endpoint does not send back all the metadata required for
 // the proper rendering of the post (e.g. authors), hence the double request.
 export const DEPRECATEDgetLatestPostRevision = async (
+    knex: KnexReadonlyTransaction,
     id: number
 ): Promise<FullPost> => {
     const type = await DEPRECATEDgetPostType(id)
@@ -125,7 +128,7 @@ export const DEPRECATEDgetLatestPostRevision = async (
     //   and could have been modified in the sidebar.)
     // - authors
     // ...
-    return getFullPost({
+    return getFullPost(knex, {
         ...postApi,
         content: revision.content,
         title: revision.title,

--- a/db/Variable.test.ts
+++ b/db/Variable.test.ts
@@ -46,7 +46,13 @@ describe("writeVariableCSV", () => {
                 callback(null)
             },
         })
-        await writeVariableCSV(variableIds, writeStream, db.knexInstance())
+
+        await writeVariableCSV(
+            variableIds,
+            writeStream,
+            {} as db.KnexReadonlyTransaction
+        )
+
         return out
     }
 
@@ -165,7 +171,7 @@ describe("_dataAsDFfromS3", () => {
             },
         }
         mockS3data(s3data)
-        const df = await _dataAsDFfromS3([1], db.knexInstance())
+        const df = await _dataAsDFfromS3([1], {} as db.KnexReadonlyTransaction)
         expect(df.toObject()).toEqual({
             entityCode: ["code", "code"],
             entityId: [1, 1],

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -30,7 +30,6 @@ import {
     BAKED_BASE_URL,
     OPENAI_API_KEY,
 } from "../../settings/serverSettings.js"
-import { Knex } from "knex"
 
 // XXX hardcoded filtering to public parent tags
 export const PUBLIC_TAG_PARENT_IDS = [
@@ -258,21 +257,6 @@ WHERE c.config -> "$.isPublished" = true
             return []
         }
     }
-
-    static async all(): Promise<ChartRow[]> {
-        const rows = await db.knexTable(Chart.table)
-
-        for (const row of rows) {
-            row.config = JSON.parse(row.config)
-        }
-
-        return rows as ChartRow[] // This cast might be a lie?
-    }
-}
-
-interface ChartRow {
-    id: number
-    config: any
 }
 
 // TODO integrate this old logic with typeorm
@@ -384,7 +368,7 @@ export const getRelatedChartsForVariable = async (
 }
 
 export const getChartEmbedUrlsInPublishedWordpressPosts = async (
-    knex: Knex<any, any[]>
+    knex: db.KnexReadonlyTransaction
 ): Promise<string[]> => {
     const chartSlugQueryString: Pick<
         DbPlainPostLink,

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -646,8 +646,8 @@ export class GdocBase extends BaseEntity implements OwidGdocBaseInterface {
             )
         ).then(excludeNullish)
 
-        const publishedExplorersBySlug = await db.getPublishedExplorersBySlug(
-            db.knexInstance()
+        const publishedExplorersBySlug = await db.knexReadonlyTransaction(
+            (trx) => db.getPublishedExplorersBySlug(trx)
         )
 
         const linkedExplorerCharts = await Promise.all(
@@ -773,8 +773,8 @@ export class GdocBase extends BaseEntity implements OwidGdocBaseInterface {
         )
 
         const chartIdsBySlug = await Chart.mapSlugsToIds()
-        const publishedExplorersBySlug = await db.getPublishedExplorersBySlug(
-            db.knexInstance()
+        const publishedExplorersBySlug = await db.knexReadonlyTransaction(
+            (trx) => db.getPublishedExplorersBySlug(trx)
         )
 
         const linkErrors: OwidGdocErrorMessage[] = this.links.reduce(

--- a/db/model/Pageview.ts
+++ b/db/model/Pageview.ts
@@ -2,7 +2,6 @@ import { keyBy } from "lodash"
 import { Entity, Column, BaseEntity } from "typeorm"
 import { RawPageview } from "@ourworldindata/utils"
 import * as db from "../db.js"
-import { Knex } from "knex"
 import {
     DbPlainAnalyticsPageview,
     AnalyticsPageviewsTableName,
@@ -27,7 +26,7 @@ export class Pageview extends BaseEntity implements RawPageview {
 }
 
 export async function getAnalyticsPageviewsByUrlObj(
-    knex: Knex<any, any[]>
+    knex: db.KnexReadonlyTransaction
 ): Promise<{
     [url: string]: DbPlainAnalyticsPageview
 }> {

--- a/db/model/PostLink.ts
+++ b/db/model/PostLink.ts
@@ -6,7 +6,7 @@ import {
     Url,
 } from "@ourworldindata/utils"
 import { getLinkType, getUrlTarget } from "@ourworldindata/components"
-import { Knex } from "knex"
+import { KnexReadWriteTransaction, KnexReadonlyTransaction } from "../db.js"
 export function postLinkCreateFromUrl({
     url,
     sourceId,
@@ -36,41 +36,41 @@ export function postLinkCreateFromUrl({
 }
 
 export async function getPostLinkById(
-    knex: Knex<any, any[]>,
+    knex: KnexReadonlyTransaction,
     id: number
 ): Promise<DbPlainPostLink | undefined> {
     return knex<DbPlainPostLink>(PostsLinksTableName).where({ id }).first()
 }
 
 export async function getAllPostLinks(
-    knex: Knex<any, any[]>
+    knex: KnexReadonlyTransaction
 ): Promise<DbPlainPostLink[]> {
     return knex<DbPlainPostLink>(PostsLinksTableName)
 }
 
 export async function getPostLinksBySourceId(
-    knex: Knex<any, any[]>,
+    knex: KnexReadonlyTransaction,
     sourceId: number
 ): Promise<DbPlainPostLink[]> {
     return knex<DbPlainPostLink>(PostsLinksTableName).where({ sourceId })
 }
 
 export async function insertPostLink(
-    knex: Knex<any, any[]>,
+    knex: KnexReadWriteTransaction,
     postLink: DbInsertPostLink
 ): Promise<{ id: number }> {
     return knex(PostsLinksTableName).returning("id").insert(postLink)
 }
 
 export async function insertManyPostLinks(
-    knex: Knex<any, any[]>,
+    knex: KnexReadWriteTransaction,
     postLinks: DbInsertPostLink[]
 ): Promise<void> {
     return knex.batchInsert(PostsLinksTableName, postLinks)
 }
 
 export async function updatePostLink(
-    knex: Knex<any, any[]>,
+    knex: KnexReadWriteTransaction,
     id: number,
     postLink: DbInsertPostLink
 ): Promise<void> {
@@ -78,14 +78,14 @@ export async function updatePostLink(
 }
 
 export async function deletePostLink(
-    knex: Knex<any, any[]>,
+    knex: KnexReadWriteTransaction,
     id: number
 ): Promise<void> {
     return knex(PostsLinksTableName).where({ id }).delete()
 }
 
 export async function deleteManyPostLinks(
-    knex: Knex<any, any[]>,
+    knex: KnexReadWriteTransaction,
     ids: number[]
 ): Promise<void> {
     return knex(PostsLinksTableName).whereIn("id", ids).delete()

--- a/db/model/Redirect.ts
+++ b/db/model/Redirect.ts
@@ -1,9 +1,8 @@
-import { Knex } from "knex"
 import { DbPlainRedirect } from "@ourworldindata/types"
 import * as db from "../db"
 
 export const getRedirectsFromDb = async (
-    knex: Knex<any, any[]>
+    knex: db.KnexReadonlyTransaction
 ): Promise<DbPlainRedirect[]> => {
     const redirectsFromDb: DbPlainRedirect[] = await db.knexRaw(
         knex,

--- a/db/model/Source.ts
+++ b/db/model/Source.ts
@@ -1,11 +1,11 @@
 import { Entity, PrimaryGeneratedColumn, Column, BaseEntity } from "typeorm"
-import { Knex } from "knex"
 import {
     DbEnrichedSource,
     DbRawSource,
     SourcesTableName,
     parseSourcesRow,
 } from "@ourworldindata/types"
+import { KnexReadonlyTransaction } from "../db.js"
 
 @Entity("sources")
 export class Source extends BaseEntity {
@@ -16,7 +16,7 @@ export class Source extends BaseEntity {
 }
 
 export async function getSourceById(
-    knex: Knex<any, any[]>,
+    knex: KnexReadonlyTransaction,
     sourceId: number
 ): Promise<DbEnrichedSource | undefined> {
     const rawSource: DbRawSource | undefined = await knex<DbRawSource>(
@@ -34,7 +34,7 @@ export async function getSourceById(
 }
 
 export async function getSourcesForDataset(
-    knex: Knex<any, any[]>,
+    knex: KnexReadonlyTransaction,
     datasetId: number
 ): Promise<DbEnrichedSource[]> {
     const rawSources: DbRawSource[] = await knex<DbRawSource>(

--- a/db/model/User.ts
+++ b/db/model/User.ts
@@ -15,7 +15,7 @@ import {
     DbInsertUser,
     UsersTableName,
 } from "@ourworldindata/types"
-import { Knex } from "knex"
+import { KnexReadWriteTransaction, KnexReadonlyTransaction } from "../db.js"
 
 @Entity("users")
 export class User extends BaseEntity {
@@ -44,7 +44,7 @@ export class User extends BaseEntity {
 }
 
 export async function setPassword(
-    knex: Knex<any, any[]>,
+    knex: KnexReadWriteTransaction,
     id: number,
     password: string
 ): Promise<void> {
@@ -54,21 +54,21 @@ export async function setPassword(
 }
 
 export async function getUserById(
-    knex: Knex<any, any[]>,
+    knex: KnexReadonlyTransaction,
     id: number
 ): Promise<DbPlainUser | undefined> {
     return knex<DbPlainUser>(UsersTableName).where({ id }).first()
 }
 
 export async function insertUser(
-    knex: Knex<any, any[]>,
+    knex: KnexReadWriteTransaction,
     user: DbInsertUser
 ): Promise<{ id: number }> {
     return knex(UsersTableName).returning("id").insert(user)
 }
 
 export async function updateUser(
-    knex: Knex<any, any[]>,
+    knex: KnexReadWriteTransaction,
     id: number,
     user: Partial<DbInsertUser>
 ): Promise<void> {
@@ -76,7 +76,7 @@ export async function updateUser(
 }
 
 export async function deleteUser(
-    knex: Knex<any, any[]>,
+    knex: KnexReadWriteTransaction,
     id: number
 ): Promise<void> {
     return knex(UsersTableName).where({ id }).delete()

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -26,7 +26,6 @@ import {
     OwidProcessingLevel,
     DbRawVariable,
 } from "@ourworldindata/types"
-import { Knex } from "knex/types"
 import { knexRaw, knexRawFirst } from "../db.js"
 
 export interface VariableRow {
@@ -137,7 +136,7 @@ export function parseVariableRows(
 
 export async function getMergedGrapherConfigForVariable(
     variableId: number,
-    knex: Knex<any, any[]>
+    knex: db.KnexReadonlyTransaction
 ): Promise<GrapherInterface | undefined> {
     const rows: Pick<
         DbRawVariable,
@@ -200,7 +199,7 @@ export async function getDataForMultipleVariables(
 export async function writeVariableCSV(
     variableIds: number[],
     stream: Writable,
-    knex: Knex<any, any[]>
+    knex: db.KnexReadonlyTransaction
 ): Promise<void> {
     // get variables as dataframe
     const variablesDF = (
@@ -245,7 +244,7 @@ export async function writeVariableCSV(
 
 export const getDataValue = async (
     { variableId, entityId, year }: DataValueQueryArgs,
-    knex: Knex<any, any[]>
+    knex: db.KnexReadonlyTransaction
 ): Promise<DataValueResult | undefined> => {
     if (!variableId || !entityId) return
 
@@ -290,7 +289,7 @@ export const getDataValue = async (
 export const getOwidChartDimensionConfigForVariable = async (
     variableId: OwidVariableId,
     chartId: number,
-    knex: Knex<any, any[]>
+    knex: db.KnexReadonlyTransaction
 ): Promise<OwidChartDimensionInterface | undefined> => {
     const row = await db.knexRawFirst<{ dimensions: string }>(
         knex,
@@ -311,7 +310,7 @@ export const getOwidChartDimensionConfigForVariable = async (
 
 export const getOwidVariableDisplayConfig = async (
     variableId: OwidVariableId,
-    knex: Knex<any, any[]>
+    knex: db.KnexReadonlyTransaction
 ): Promise<OwidVariableDisplayConfigInterface | undefined> => {
     const row = await knexRawFirst<Pick<DbRawVariable, "display">>(
         knex,
@@ -324,7 +323,7 @@ export const getOwidVariableDisplayConfig = async (
 
 export const entitiesAsDF = async (
     entityIds: number[],
-    knex: Knex<any, any[]>
+    knex: db.KnexReadonlyTransaction
 ): Promise<pl.DataFrame> => {
     return (
         await readSQLasDF(
@@ -371,7 +370,7 @@ const emptyDataDF = (): pl.DataFrame => {
 
 export const _dataAsDFfromS3 = async (
     variableIds: OwidVariableId[],
-    knex: Knex<any, any[]>
+    knex: db.KnexReadonlyTransaction
 ): Promise<pl.DataFrame> => {
     if (variableIds.length === 0) {
         return emptyDataDF()
@@ -418,7 +417,7 @@ export const _dataAsDFfromS3 = async (
 
 export const dataAsDF = async (
     variableIds: OwidVariableId[],
-    knex: Knex<any, any[]>
+    knex: db.KnexReadonlyTransaction
 ): Promise<pl.DataFrame> => {
     return _dataAsDFfromS3(variableIds, knex)
 }
@@ -514,7 +513,7 @@ export const createDataFrame = (data: unknown): pl.DataFrame => {
 export const readSQLasDF = async (
     sql: string,
     params: any[],
-    knex: Knex<any, any[]>
+    knex: db.KnexReadonlyTransaction
 ): Promise<pl.DataFrame> => {
     return createDataFrame(await db.knexRaw(knex, sql, params))
 }
@@ -572,7 +571,7 @@ export async function getVariableOfDatapageIfApplicable(
 export const searchVariables = async (
     query: string,
     limit: number,
-    knex: Knex<any, any>
+    knex: db.KnexReadonlyTransaction
 ): Promise<VariablesSearchResult> => {
     const whereClauses = buildWhereClauses(query)
 
@@ -726,7 +725,7 @@ const buildWhereClauses = (query: string): string[] => {
  */
 const queryRegexSafe = async (
     query: string,
-    knex: Knex<any, any>
+    knex: db.KnexReadonlyTransaction
 ): Promise<any> => {
     // catch regular expression failures in MySQL and return empty result
     return await knexRaw(knex, query).catch((err) => {
@@ -739,7 +738,7 @@ const queryRegexSafe = async (
 
 const queryRegexCount = async (
     query: string,
-    knex: Knex<any, any>
+    knex: db.KnexReadonlyTransaction
 ): Promise<number> => {
     const results = await queryRegexSafe(query, knex)
     if (!results.length) {

--- a/db/refreshPageviewsFromDatasette.ts
+++ b/db/refreshPageviewsFromDatasette.ts
@@ -4,7 +4,6 @@ import Papa from "papaparse"
 import * as db from "./db.js"
 import { DbPlainAnalyticsPageview } from "@ourworldindata/types"
 import { omitUndefinedValues } from "@ourworldindata/utils"
-import { Knex } from "knex"
 
 const analyticsPageviewsColumnNames: Array<keyof DbPlainAnalyticsPageview> = [
     "day",
@@ -17,7 +16,9 @@ const analyticsPageviewsColumnNames: Array<keyof DbPlainAnalyticsPageview> = [
 const emojiRegex =
     /[\u{1f300}-\u{1f5ff}\u{1f900}-\u{1f9ff}\u{1f600}-\u{1f64f}\u{1f680}-\u{1f6ff}\u{2600}-\u{26ff}\u{2700}-\u{27bf}\u{1f1e6}-\u{1f1ff}\u{1f191}-\u{1f251}\u{1f004}\u{1f0cf}\u{1f170}-\u{1f171}\u{1f17e}-\u{1f17f}\u{1f18e}\u{3030}\u{2b50}\u{2b55}\u{2934}-\u{2935}\u{2b05}-\u{2b07}\u{2b1b}-\u{2b1c}\u{3297}\u{3299}\u{303d}\u{00a9}\u{00ae}\u{2122}\u{23f3}\u{24c2}\u{23e9}-\u{23ef}\u{25b6}\u{23f8}-\u{23fa}]/gu
 
-async function downloadAndInsertCSV(knex: Knex<any, any[]>): Promise<void> {
+async function downloadAndInsertCSV(
+    knex: db.KnexReadWriteTransaction
+): Promise<void> {
     // Fetch CSV from private Datasette and insert it to a local MySQL. This function
     // exists because `make refresh` uses MySQL dump that excludes analytics_pageviews
     // table. That's why it's necessary to call `make refresh.pageviews` separately.
@@ -69,8 +70,7 @@ async function downloadAndInsertCSV(knex: Knex<any, any[]>): Promise<void> {
 
 const main = async (): Promise<void> => {
     try {
-        const knex = db.knexInstance()
-        await downloadAndInsertCSV(knex)
+        db.knexReadWriteTransaction((trx) => downloadAndInsertCSV(trx))
     } catch (e) {
         console.error(e)
     } finally {

--- a/devTools/markdownTest/markdown.ts
+++ b/devTools/markdownTest/markdown.ts
@@ -1,4 +1,8 @@
-import { closeTypeOrmAndKnexConnections, getConnection } from "../../db/db.js"
+import {
+    closeTypeOrmAndKnexConnections,
+    getConnection,
+    knexReadonlyTransaction,
+} from "../../db/db.js"
 import { getPostRawBySlug } from "../../db/model/Post.js"
 import { enrichedBlocksToMarkdown } from "../../db/model/Gdoc/enrichedToMarkdown.js"
 import { GdocBase } from "../../db/model/Gdoc/GdocBase.js"
@@ -12,36 +16,40 @@ import { parsePostArchieml } from "@ourworldindata/utils"
 
 async function main(parsedArgs: parseArgs.ParsedArgs) {
     try {
-        const connection = await getConnection()
-        const gdoc = await GdocBase.findOneBy({ slug: parsedArgs._[0] })
-        let archieMlContent: OwidEnrichedGdocBlock[] | null
-        let contentToShowOnError: any
-        if (!gdoc) {
-            const post = await getPostRawBySlug(parsedArgs._[0])
-            if (!post) {
-                console.error("No post found")
+        await knexReadonlyTransaction(async (trx) => {
+            const gdoc = await GdocBase.findOneBy({ slug: parsedArgs._[0] })
+            let archieMlContent: OwidEnrichedGdocBlock[] | null
+            let contentToShowOnError: any
+            if (!gdoc) {
+                const post = await getPostRawBySlug(trx, parsedArgs._[0])
+                if (!post) {
+                    console.error("No post found")
+                    process.exit(-1)
+                }
+                archieMlContent = post?.archieml
+                    ? parsePostArchieml(post?.archieml)?.content?.body
+                    : null
+                contentToShowOnError = post?.archieml
+            } else {
+                archieMlContent = gdoc.enrichedBlockSources.flat()
+                contentToShowOnError = gdoc?.content
+            }
+
+            if (!archieMlContent) {
+                console.error("No archieMl found")
                 process.exit(-1)
             }
-            archieMlContent = post?.archieml
-                ? parsePostArchieml(post?.archieml)?.content?.body
-                : null
-            contentToShowOnError = post?.archieml
-        } else {
-            archieMlContent = gdoc.enrichedBlockSources.flat()
-            contentToShowOnError = gdoc?.content
-        }
-
-        if (!archieMlContent) {
-            console.error("No archieMl found")
-            process.exit(-1)
-        }
-        const markdown = enrichedBlocksToMarkdown(archieMlContent ?? [], true)
-        if (!markdown) {
-            console.error("No markdown found")
-            console.log(contentToShowOnError)
-            process.exit(-1)
-        }
-        console.log(markdown)
+            const markdown = enrichedBlocksToMarkdown(
+                archieMlContent ?? [],
+                true
+            )
+            if (!markdown) {
+                console.error("No markdown found")
+                console.log(contentToShowOnError)
+                process.exit(-1)
+            }
+            console.log(markdown)
+        })
         await closeTypeOrmAndKnexConnections()
     } catch (error) {
         await closeTypeOrmAndKnexConnections()

--- a/packages/@ourworldindata/types/src/NominalType.ts
+++ b/packages/@ourworldindata/types/src/NominalType.ts
@@ -1,0 +1,22 @@
+declare const __nominal__type: unique symbol
+/** Typescript is structurally typed, not nominally typed. This means that
+ * two types are considered equivalent if their members are equivalent.
+ * This is often useful but sometimes you want to distingish types based on their
+ * name alone - e.g. if you have an identifier that is just a string but you'd like
+ * some type safety when using it. This is where this nominal type comes in.
+ * @example
+ * type UserName = Nominal<string, "UserName">
+ * type UserId = Nominal<string, "UserId">
+ *
+ * function getUserName(name: UserName) {
+ *     return name
+ * }
+ *
+ * const name = getUserName("123" as UserName)   // OK
+ * const name2 = getUserName("123")              // Error
+ * const name3 = getUserName("123" as UserId)    // Error
+ * // of course the main benefit comes when the UserName and UserId types are used in a more complex call hierarchy
+ */
+export type Nominal<Type, Identifier> = Type & {
+    readonly [__nominal__type]: Identifier
+}

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -635,6 +635,8 @@ export {
 
 export { RedirectCode, type DbPlainRedirect } from "./dbTypes/Redirects.js"
 
+export type { Nominal } from "./NominalType.js"
+
 export {
     type DbRawLatestWork,
     type DbEnrichedLatestWork,


### PR DESCRIPTION
This PR adds custom types for read only transactions and read/write transactions. Through some typescript magic this is set up so that functions that need a read only transaction (because they only run `select` statements) can also be given read/write transactions but functions that need read/write transactions do not accept a readonly transaction. 

This PR also adds helper functions for API request handlers that also set up a transaction (which means that instead of writing a callback that takes a (request, response) tuple you write one that works with a (request, reqsponse, transaction) tuple).