### PR TITLE
Data insights in sitemap and site nav

### DIFF
--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -95,7 +95,10 @@ import {
 } from "../settings/clientSettings.js"
 import pMap from "p-map"
 import { GdocDataInsight } from "../db/model/Gdoc/GdocDataInsight.js"
-import { fullGdocToMinimalGdoc } from "../db/model/Gdoc/gdocUtils.js"
+import {
+    calculateDataInsightIndexPageCount,
+    fullGdocToMinimalGdoc,
+} from "../db/model/Gdoc/gdocUtils.js"
 import {
     getVariableMetadata,
     getVariableOfDatapageIfApplicable,
@@ -698,7 +701,10 @@ export class SiteBaker {
 
     private async bakeDataInsights() {
         if (!this.bakeSteps.has("dataInsights")) return
-        const latestDataInsights = await db.getLatestDataInsights()
+        const latestDataInsights = await db.getPublishedDataInsights(
+            db.knexInstance(),
+            5
+        )
         const publishedDataInsights =
             await GdocDataInsight.getPublishedDataInsights()
 
@@ -740,7 +746,10 @@ export class SiteBaker {
             }
         }
 
-        const totalPageCount = await GdocDataInsight.getTotalPageCount()
+        const totalPageCount = calculateDataInsightIndexPageCount(
+            publishedDataInsights.length
+        )
+
         for (let pageNumber = 0; pageNumber < totalPageCount; pageNumber++) {
             const html = renderDataInsightsIndexPage(
                 publishedDataInsights.slice(

--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -4,7 +4,12 @@ import {
     BAKED_BASE_URL,
     BAKED_GRAPHER_URL,
 } from "../settings/serverSettings.js"
-import { dayjs, countries, queryParamsToStr } from "@ourworldindata/utils"
+import {
+    dayjs,
+    countries,
+    queryParamsToStr,
+    DATA_INSIGHTS_INDEX_PAGE_SIZE,
+} from "@ourworldindata/utils"
 import * as db from "../db/db.js"
 import urljoin from "url-join"
 import { countryProfileSpecs } from "../site/countryProfileProjects.js"
@@ -14,6 +19,7 @@ import { ExplorerProgram } from "../explorer/ExplorerProgram.js"
 import { GdocPost } from "../db/model/Gdoc/GdocPost.js"
 import { getPostsFromSnapshots } from "../db/model/Post.js"
 import { Knex } from "knex"
+import { calculateDataInsightIndexPageCount } from "../db/model/Gdoc/gdocUtils.js"
 
 interface SitemapUrl {
     loc: string
@@ -70,6 +76,12 @@ export const makeSitemap = async (
         (postrow) => !alreadyPublishedViaGdocsSlugsSet.has(postrow.slug)
     )
     const gdocPosts = await GdocPost.getPublishedGdocs()
+
+    const publishedDataInsights = await db.getPublishedDataInsights(knex)
+    const dataInsightFeedPageCount = calculateDataInsightIndexPageCount(
+        publishedDataInsights.length
+    )
+
     const charts = (await db
         .knexTable(Chart.table)
         .select(knex.raw(`updatedAt, config->>"$.slug" AS slug`))
@@ -102,6 +114,25 @@ export const makeSitemap = async (
             gdocPosts.map((p) => ({
                 loc: urljoin(BAKED_BASE_URL, p.slug),
                 lastmod: dayjs(p.updatedAt).format("YYYY-MM-DD"),
+            }))
+        )
+        .concat(
+            publishedDataInsights.map((d) => ({
+                loc: urljoin(BAKED_BASE_URL, "data-insights", d.slug),
+                lastmod: dayjs(d.updatedAt).format("YYYY-MM-DD"),
+            }))
+        )
+        .concat(
+            // Data insight index pages: /data-insights, /data-insights/2, /data-insights/3, etc.
+            Array.from({ length: dataInsightFeedPageCount }, (_, i) => ({
+                loc: urljoin(
+                    BAKED_BASE_URL,
+                    "data-insights",
+                    i === 0 ? "" : `/${i + 1}`
+                ),
+                lastmod: dayjs(publishedDataInsights[0].updatedAt).format(
+                    "YYYY-MM-DD"
+                ),
             }))
         )
         .concat(

--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -4,12 +4,7 @@ import {
     BAKED_BASE_URL,
     BAKED_GRAPHER_URL,
 } from "../settings/serverSettings.js"
-import {
-    dayjs,
-    countries,
-    queryParamsToStr,
-    DATA_INSIGHTS_INDEX_PAGE_SIZE,
-} from "@ourworldindata/utils"
+import { dayjs, countries, queryParamsToStr } from "@ourworldindata/utils"
 import * as db from "../db/db.js"
 import urljoin from "url-join"
 import { countryProfileSpecs } from "../site/countryProfileProjects.js"

--- a/db/model/Gdoc/GdocDataInsight.ts
+++ b/db/model/Gdoc/GdocDataInsight.ts
@@ -45,7 +45,11 @@ export class GdocDataInsight
     }
 
     _loadSubclassAttachments = async (): Promise<void> => {
-        this.latestDataInsights = await db.getLatestDataInsights()
+        // TODO: refactor these classes to properly use knex - not going to start it now
+        this.latestDataInsights = await db.getPublishedDataInsights(
+            db.knexInstance(),
+            5
+        )
     }
 
     static async getPublishedDataInsights(
@@ -68,14 +72,5 @@ export class GdocDataInsight
             skip: isPaging ? page * DATA_INSIGHTS_INDEX_PAGE_SIZE : undefined,
             relations: ["tags"],
         })
-    }
-
-    /**
-     * Returns the number of pages that will exist on the data insights index page
-     * based on the number of published data insights and DATA_INSIGHTS_INDEX_PAGE_SIZE
-     */
-    static async getTotalPageCount(): Promise<number> {
-        const count = await db.getPublishedDataInsightCount()
-        return Math.ceil(count / DATA_INSIGHTS_INDEX_PAGE_SIZE)
     }
 }

--- a/db/model/Gdoc/GdocHomepage.ts
+++ b/db/model/Gdoc/GdocHomepage.ts
@@ -60,6 +60,10 @@ export class GdocHomepage
             topicCount: UNIQUE_TOPIC_COUNT,
         }
 
-        this.latestDataInsights = await db.getLatestDataInsights(4)
+        // TODO: refactor these classes to properly use knex - not going to start it now
+        this.latestDataInsights = await db.getPublishedDataInsights(
+            db.knexInstance(),
+            4
+        )
     }
 }

--- a/db/model/Gdoc/gdocUtils.ts
+++ b/db/model/Gdoc/gdocUtils.ts
@@ -7,6 +7,7 @@ import {
     OwidGdocType,
     formatDate,
     OwidGdocBaseInterface,
+    DATA_INSIGHTS_INDEX_PAGE_SIZE,
 } from "@ourworldindata/utils"
 import { match, P } from "ts-pattern"
 import cheerio from "cheerio"
@@ -171,4 +172,14 @@ export function fullGdocToMinimalGdoc(
         type: gdoc.content.type || OwidGdocType.Article,
         "featured-image": gdoc.content["featured-image"],
     }
+}
+
+/**
+ * Calculate the number of pages needed to display all data insights
+ * e.g. if there are 61 data insights and we want to display 20 per page, we need 4 pages
+ */
+export function calculateDataInsightIndexPageCount(
+    publishedDataInsightCount: number
+): number {
+    return Math.ceil(publishedDataInsightCount / DATA_INSIGHTS_INDEX_PAGE_SIZE)
 }

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -99,7 +99,7 @@ export interface OwidGdocDataInsightContent {
     type: OwidGdocType.DataInsight
 }
 
-export const DATA_INSIGHTS_INDEX_PAGE_SIZE = 2
+export const DATA_INSIGHTS_INDEX_PAGE_SIZE = 20
 
 export interface OwidGdocDataInsightInterface extends OwidGdocBaseInterface {
     content: OwidGdocDataInsightContent

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -99,7 +99,7 @@ export interface OwidGdocDataInsightContent {
     type: OwidGdocType.DataInsight
 }
 
-export const DATA_INSIGHTS_INDEX_PAGE_SIZE = 20
+export const DATA_INSIGHTS_INDEX_PAGE_SIZE = 2
 
 export interface OwidGdocDataInsightInterface extends OwidGdocBaseInterface {
     content: OwidGdocDataInsightContent
@@ -112,6 +112,8 @@ export type MinimalDataInsightInterface = Pick<
     "title"
 > & {
     publishedAt: string
+    updatedAt: string
+    slug: string
     // We select the 5 most recently published insights
     // We only display 4, but if you're on the DI page for one of them we hide it and show the next most recent
     index: 0 | 1 | 2 | 3 | 4

--- a/site/SiteResources.tsx
+++ b/site/SiteResources.tsx
@@ -7,6 +7,9 @@ export const SiteResources = () => {
                 <a href="/charts">Charts and Explorers</a>
             </li>
             <li>
+                <a href="/data-insights">Data Insights</a>
+            </li>
+            <li>
                 <a href="/sdgs">Sustainable Development Goals Tracker</a>
             </li>
             <li>


### PR DESCRIPTION
This PR adds data insights to the sitemap and nav, and half-heartedly updates some data insight DB code to use Knex, before stopping arbitrarily to avoid spilling out into having to refactor the entire Gdocs codebase.

**Local sitemap with `DATA_INSIGHTS_INDEX_PAGE_SIZE` temporarily set to `2`:**

![data insights sitemap](https://github.com/owid/owid-grapher/assets/11844404/726914c4-cff5-476d-8618-301ce4fb6791)

**The site nav Resources menu:**
![image](https://github.com/owid/owid-grapher/assets/11844404/9b09854a-e973-4437-a809-fd0f2d644b0d)