### PR TITLE
🔨 Replace `polyfill.io` in the docs and the site

### DIFF
--- a/docs/browser-support.md
+++ b/docs/browser-support.md
@@ -23,7 +23,7 @@ As of **2023-07-27**, we support the following browsers:
 
 ### Polyfills
 
-We use polyfill.io (see `site/SiteConstants.ts`), so using modern methods like `str.replaceAll()` is fine as long as it's included in the list of polyfilled functions.
+We use cdnjs.cloudflare.com/polyfill (see `site/SiteConstants.ts`), so using modern methods like `str.replaceAll()` is fine as long as it's included in the list of polyfilled functions.
 
 ### Setting the Vite `target`
 

--- a/site/SiteConstants.ts
+++ b/site/SiteConstants.ts
@@ -1,4 +1,4 @@
-// See https://polyfill.io/v3/url-builder/ for a list of all supported features
+// See https://cdnjs.cloudflare.com/polyfill/v3/url-builder/ for a list of all supported features
 const polyfillFeatures = [
     "es2019", // Array.flat, Array.flatMap, Object.fromEntries, ...
     "es2020", // String.matchAll, Promise.allSettled, ...
@@ -9,6 +9,6 @@ const polyfillFeatures = [
     "ResizeObserver",
     "globalThis", // some dependencies use this
 ]
-export const POLYFILL_URL: string = `https://polyfill.io/v3/polyfill.min.js?features=${polyfillFeatures.join(
+export const POLYFILL_URL: string = `https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=${polyfillFeatures.join(
     ","
 )}`


### PR DESCRIPTION
The PR replaces the `polyfill.io` inside the docs and the site to `cdnjs.cloudflare.com/polyfill`.

----

`polyfill.io` was acquired by **a China-based CDN company** "Funnull", see [the announcement from the `polyfill.io` domain owner's Twitter](https://x.com/JakeDChampion/status/1761315227008643367) and https://github.com/polyfillpolyfill/polyfill-service/issues/2834. Despite Funnull's claims of operating in the United States, the predominance of Simplified Chinese on its website suggests otherwise, and it turns out that **"Funnull" is notorious for providing service for the betting and pornography industries**.

[The original creator of the `polyfill.io` has voiced his concern on Twitter](https://twitter.com/triblondon/status/1761852117579427975). And since the acquisition, numerous issues have emerged (https://github.com/polyfillpolyfill/polyfill-service/issues/2835, https://github.com/polyfillpolyfill/polyfill-service/issues/2838, https://github.com/alist-org/alist/issues/6100), rendering the `polyfill.io` service **extremely unstable**. Since then, Fastly ([Announcement](https://community.fastly.com/t/new-options-for-polyfill-io-users/2540)) and Cloudflare ([Announcement](https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk)) has hosted their own instances of `polyfill.io` service.
