### PR TITLE
🎉 use ts-pattern for OwidGdocPage attributes

### DIFF
--- a/packages/@ourworldindata/components/src/GdocsUtils.ts
+++ b/packages/@ourworldindata/components/src/GdocsUtils.ts
@@ -1,4 +1,4 @@
-import { OwidGdocLinkType } from "@ourworldindata/types"
+import { OwidGdoc, OwidGdocLinkType, OwidGdocType } from "@ourworldindata/types"
 import {
     spansToUnformattedPlainText,
     gdocUrlRegex,
@@ -6,6 +6,7 @@ import {
     Url,
 } from "@ourworldindata/utils"
 import urlSlug from "url-slug"
+import { P, match } from "ts-pattern"
 
 export function getLinkType(urlString: string): OwidGdocLinkType {
     const url = Url.fromURL(urlString)
@@ -42,4 +43,77 @@ export function getUrlTarget(urlString: string): string {
 
 export function convertHeadingTextToId(headingText: Span[]): string {
     return urlSlug(spansToUnformattedPlainText(headingText))
+}
+
+export function getCanonicalUrl(baseUrl: string, gdoc: OwidGdoc): string {
+    return match(gdoc)
+        .with(
+            {
+                content: { type: OwidGdocType.Homepage },
+            },
+            () => baseUrl
+        )
+        .with(
+            {
+                content: {
+                    type: P.union(
+                        OwidGdocType.Article,
+                        OwidGdocType.TopicPage,
+                        OwidGdocType.LinearTopicPage,
+                        OwidGdocType.AboutPage
+                    ),
+                },
+            },
+            () => `${baseUrl}/${gdoc.slug}`
+        )
+        .with(
+            {
+                content: { type: OwidGdocType.DataInsight },
+            },
+            () => `${baseUrl}/data-insights/${gdoc.slug}`
+        )
+        .with(
+            {
+                content: { type: P.union(OwidGdocType.Fragment, undefined) },
+            },
+            () => ""
+        )
+        .exhaustive()
+}
+
+export function getPageTitle(gdoc: OwidGdoc) {
+    return match(gdoc)
+        .with(
+            {
+                content: {
+                    type: OwidGdocType.Homepage,
+                },
+            },
+            // <Head> uses the default title of "Our World in Data" when pageTitle is undefined
+            // Otherwise we'd get " - Our World in Data" appended to whatever title we return here
+            () => undefined
+        )
+        .with(
+            {
+                content: {
+                    type: P.union(
+                        OwidGdocType.Article,
+                        OwidGdocType.TopicPage,
+                        OwidGdocType.LinearTopicPage,
+                        OwidGdocType.AboutPage,
+                        OwidGdocType.DataInsight
+                    ),
+                },
+            },
+            (match) => match.content.title
+        )
+        .with(
+            {
+                content: {
+                    type: P.union(OwidGdocType.Fragment, undefined),
+                },
+            },
+            () => undefined
+        )
+        .exhaustive()
 }

--- a/packages/@ourworldindata/components/src/index.ts
+++ b/packages/@ourworldindata/components/src/index.ts
@@ -14,6 +14,8 @@ export {
     getUrlTarget,
     checkIsInternalLink,
     convertHeadingTextToId,
+    getCanonicalUrl,
+    getPageTitle,
 } from "./GdocsUtils.js"
 
 export { ExpandableToggle } from "./ExpandableToggle/ExpandableToggle.js"

--- a/site/gdocs/OwidGdocPage.tsx
+++ b/site/gdocs/OwidGdocPage.tsx
@@ -10,6 +10,7 @@ import {
     SiteFooterContext,
     OwidGdocType,
 } from "@ourworldindata/utils"
+import { getCanonicalUrl, getPageTitle } from "@ourworldindata/components"
 import { DebugProvider } from "./DebugContext.js"
 import { match, P } from "ts-pattern"
 import { IMAGES_DIRECTORY } from "@ourworldindata/types"
@@ -64,14 +65,12 @@ export default function OwidGdocPage({
     debug?: boolean
     isPreviewing?: boolean
 }) {
-    const { content, slug, createdAt, updatedAt } = gdoc
+    const { content, createdAt, updatedAt } = gdoc
 
     const pageDesc = getPageDesc(gdoc)
     const featuredImageFilename = getFeaturedImageFilename(gdoc)
-    const canonicalUrl = `${baseUrl}/${slug}`
-    const pageTitle =
-        // <Head> uses the default title of "Our World in Data" when pageTitle is undefined
-        content.type === OwidGdocType.Homepage ? undefined : content.title
+    const canonicalUrl = getCanonicalUrl(baseUrl, gdoc)
+    const pageTitle = getPageTitle(gdoc)
 
     return (
         <html>


### PR DESCRIPTION
Fixes prod's homepage's canonical URL being https://ourworldindata.org/owid-homepage at the moment.

I think `ts-pattern` saves us from overlooking lots of things and that in general we should use it for most Gdoc attributes so that we don't miss anything whenever we add additional gdoc templates.