### PR TITLE
🎉 add debounce to tooltip

### DIFF
--- a/site/Footnote.tsx
+++ b/site/Footnote.tsx
@@ -30,6 +30,7 @@ export const Footnote = ({
                 )
             }
             interactive
+            interactiveDebounce={50}
             placement="bottom"
             theme="owid-footnote"
             trigger="mouseenter focus click"


### PR DESCRIPTION
Adds a [debounce](https://atomiks.github.io/tippyjs/v6/all-props/#interactivedebounce) to our gdoc tooltips

Before:

https://github.com/owid/owid-grapher/assets/11844404/2bc89aab-10b6-436d-8c0b-f05aeced0889

After:

https://github.com/owid/owid-grapher/assets/11844404/9e09e930-fc33-4df8-a7e9-f64e401bc10b

