### PR TITLE
🐛 (grapher) guard against undefined

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -384,7 +384,12 @@ abstract class AbstractAxis {
                     return (this.range[0] + this.range[1]) / 2
             }
         }
-        return parseFloat(this.d3_scale(value).toFixed(1))
+        const placedValue = this.d3_scale(value)
+        if (placedValue === undefined) {
+            console.error(`Placed value is undefined for ${value}`)
+            return value
+        }
+        return parseFloat(placedValue.toFixed(1))
     }
 
     /** This function returns the inverse of place - i.e. given a screen space


### PR DESCRIPTION
Baking fails for chart `sources-population-dataset` with the following error message:

```
TypeError: Cannot read properties of undefined (reading 'toFixed')
_HorizontalAxis.place (/home/owid/owid-grapher/packages/@ourworldindata/grapher/src/axis/Axis.ts:387:46)
<anonymous> (/home/owid/owid-grapher/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx:471:33)
Array.map (<anonymous>)
DiscreteBarChart.render (/home/owid/owid-grapher/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx:462:25)
Object.allowStateChanges [as _allowStateChanges] (/home/owid/owid-grapher/node_modules/mobx/lib/mobx.js:991:15)
/home/owid/owid-grapher/node_modules/mobx-react/index.js:851:28
trackDerivedFunction (/home/owid/owid-grapher/node_modules/mobx/lib/mobx.js:776:24)
Reaction.track (/home/owid/owid-grapher/node_modules/mobx/lib/mobx.js:1806:22)
DiscreteBarChart.reactiveRender [as render] (/home/owid/owid-grapher/node_modules/mobx-react/index.js:845:16)
DiscreteBarChart.makeComponentReactive (/home/owid/owid-grapher/node_modules/mobx-react/index.js:915:27)
```

Guarding against undefined when placing the value on the axis "fixes" this, but it's not clear to me why DiscreteBar chart is even rendered for the chart in question. https://ourworldindata.org/grapher/sources-population-dataset doesn't have a chart tab and is, in theory, a line chart