### PR TITLE
fix(static-chart): don't render chart on table tab

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -608,7 +608,13 @@ export class StaticCaptionedChart extends CaptionedChart {
                     targetX={paddedBounds.x}
                     targetY={paddedBounds.y}
                 />
-                <g style={{ pointerEvents: "none" }}>{this.renderChart()}</g>
+                <g style={{ pointerEvents: "none" }}>
+                    {/*
+                     We cannot render a table to svg, but would rather display nothing at all to avoid issues.
+                     See https://github.com/owid/owid-grapher/issues/3283
+                    */}
+                    {this.manager.isOnTableTab ? undefined : this.renderChart()}
+                </g>
                 <StaticFooter
                     manager={manager}
                     maxWidth={maxWidth}


### PR DESCRIPTION
Fixes #3283 at the source, and aligns `StaticCaptionedChart` and `CaptionedChart` a bit here.