### PR TITLE
cleanup: remove old, unused css

### DIFF
--- a/site/owid.scss
+++ b/site/owid.scss
@@ -256,70 +256,72 @@ h6:hover .deep-link {
 /* Teaching Page
 --------------------------------------------- */
 
-.teaching-hub .columns {
-    margin-bottom: 1.5rem;
-}
+.teaching-hub {
+    .columns {
+        margin-bottom: 1.5rem;
 
-.teaching-hub .columns .column {
-    display: inline-block;
-    margin: 0 0.6rem 0.6rem 0;
-}
+        .column {
+            display: inline-block;
+            margin: 0 0.6rem 0.6rem 0;
+        }
 
-@media screen and (max-width: 640px) {
-    .teaching-hub .columns .column {
-        display: block;
+        @media screen and (max-width: 640px) {
+            .column {
+                display: block;
+            }
+        }
     }
-}
 
-.teaching-hub .button {
-    background-color: #3a4c71;
-    color: white;
-    padding: 0.75rem 1.4rem;
-    text-align: center;
-    line-height: 1.2;
-    display: block;
-}
+    .button {
+        background-color: #3a4c71;
+        color: white;
+        padding: 0.75rem 1.4rem;
+        text-align: center;
+        line-height: 1.2;
+        display: block;
 
-.teaching-hub .button:hover {
-    text-decoration: none;
-    background-color: #4b5c7e;
-    color: white;
-}
+        &:hover {
+            text-decoration: none;
+            background-color: #4b5c7e;
+            color: white;
+        }
 
-.teaching-hub a.button:visited {
-    color: white;
-}
+        &:visited {
+            color: white;
+        }
 
-.teaching-hub .primary-button {
-    background-color: #b62300;
-}
+        &.primary-button {
+            background-color: #b62300;
 
-.teaching-hub .primary-button:hover {
-    background-color: #bb4122;
-}
+            &:hover {
+                background-color: #bb4122;
+            }
+        }
 
-.teaching-hub .button .label {
-    font-weight: bold;
-    margin-bottom: 0.3rem;
-}
+        .label {
+            font-weight: bold;
+            margin-bottom: 0.3rem;
+        }
 
-.teaching-hub .button .note {
-    font-size: 68.75%;
-    text-transform: uppercase;
-    letter-spacing: 0.04rem;
-    opacity: 0.6;
-}
+        .note {
+            font-size: 68.75%;
+            text-transform: uppercase;
+            letter-spacing: 0.04rem;
+            opacity: 0.6;
+        }
 
-.teaching-hub .button span {
-    display: block;
-}
+        span {
+            display: block;
+        }
 
-.teaching-hub .authors-byline {
-    display: none;
-}
+        &::selection {
+            background: transparent;
+        }
+    }
 
-.teaching-hub .button::selection {
-    background: transparent;
+    .authors-byline {
+        display: none;
+    }
 }
 
 /* Blog post updates listing on front page */

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -192,13 +192,6 @@ main {
     min-height: 500px;
 }
 
-#fancybox-frame {
-    width: 100% !important;
-}
-#fancybox-wrap .chart-wrapper-inner {
-    box-sizing: border-box !important;
-}
-
 .deep-link {
     display: inline-block;
     width: 28px;
@@ -227,12 +220,6 @@ h6:hover .deep-link {
     opacity: 1;
 }
 
-#un-button.un-bottom.css3 {
-    left: 0 !important;
-    margin-left: 20px !important;
-    font-size: 16px;
-}
-
 .heading-latest {
     font-family: $serif-font-stack;
     font-size: 1.75rem;
@@ -252,12 +239,6 @@ h6:hover .deep-link {
     }
 }
 
-/* search */
-.archive-pagination {
-    margin: 40px auto;
-    text-align: center;
-}
-
 .article-footer a {
     @include owid-link-90;
 }
@@ -272,63 +253,8 @@ h6:hover .deep-link {
     z-index: $zindex-site-header;
 }
 
-/* Homepage
---------------------------------------------- */
-
-.social a {
-    font-size: 24px;
-    background-color: #c0023e;
-    color: white;
-    width: 36px;
-    height: 36px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 4px;
-    margin-right: 5px;
-
-    svg {
-        width: 24px;
-        height: 24px;
-    }
-}
-
-.social a:hover {
-    color: white;
-    background-color: #5b011d;
-}
-
-@include lg-up {
-    .owid-data .link-container {
-        display: flex;
-        flex-flow: row wrap;
-        display: -webkit-flex;
-        -webkit-flex-flow: row wrap;
-        display: -ms-flexbox;
-        -ms-flex-flow: row wrap;
-    }
-
-    .owid-data li a {
-        width: 33.3333%;
-        display: inline-block;
-    }
-}
-
 /* Teaching Page
 --------------------------------------------- */
-
-.teaching-hub #category-nav,
-.teaching-hub #entries-nav {
-    display: none;
-}
-
-.teaching-hub .article-content h2 {
-    font-family: inherit;
-    font-size: 36px;
-    font-weight: 700;
-    text-align: left;
-    margin: 1rem 0 2rem;
-}
 
 .teaching-hub .columns {
     margin-bottom: 1.5rem;
@@ -394,109 +320,6 @@ h6:hover .deep-link {
 
 .teaching-hub .button::selection {
     background: transparent;
-}
-
-/* OWID Data Entries Table
---------------------------------------------- */
-
-.owid-data h1 {
-    margin: 0;
-    text-align: center;
-    z-index: 1;
-    position: relative;
-}
-
-.owid-data h1 > span {
-    background: white;
-    text-transform: uppercase;
-    font-size: 24px;
-    color: #002147;
-    padding: 0 15px;
-}
-
-.owid-data .separator {
-    position: relative;
-    opacity: 0.8;
-}
-
-.owid-data hr {
-    position: relative;
-    margin: 0;
-    top: -1.2em;
-
-    background: #002147;
-    border: 0;
-    clear: both;
-    color: #002147;
-    display: block;
-    height: 1px;
-    padding: 0;
-    margin-left: 20px;
-    margin-right: 20px;
-}
-
-.owid-data ul {
-    margin: 0 !important;
-}
-
-.owid-data li {
-    list-style-type: none !important;
-    margin-top: 5px;
-    margin-bottom: 5px;
-}
-
-.owid-data h4 {
-    font-family: $serif-font-stack;
-    font-weight: 400;
-    margin-top: 25px;
-    margin-bottom: 0;
-    font-size: 16px;
-    color: #002147;
-    text-align: center;
-    position: relative;
-}
-
-.owid-data li a {
-    display: block;
-    box-sizing: border-box;
-    border-bottom: 1px solid #ddd !important;
-    border-right: 1px solid #ddd;
-    padding: 5px 10px;
-    background: none !important;
-    font-size: 16px;
-    color: #002147 !important;
-}
-
-.owid-data li a:hover {
-    color: white !important;
-    /*padding-bottom: 2px;*/
-}
-
-.owid-data a.starred:hover:after {
-    color: white;
-}
-
-/* MISPY: Front page mobile-default responsiveness and data entry listing */
-
-body.home .mobile.subheading {
-    font-family: $serif-font-stack;
-    color: rgb(255, 203, 31);
-    font-size: 22px;
-}
-
-.owid-presentations li:nth-of-type(1) .link-container {
-    border-top: 2px solid #333;
-}
-
-div.owid-presentations li:nth-of-type(1) h4 {
-    color: #333;
-}
-div.owid-presentations li:nth-of-type(1) a:hover {
-    background: #333 !important;
-}
-
-.footer-widgets .widget-title {
-    color: #fff;
 }
 
 /* Blog post updates listing on front page */
@@ -761,11 +584,6 @@ hr {
     max-width: $content-max-width;
 }
 
-.article-content .twitter-tweet {
-    margin-left: auto;
-    margin-right: auto;
-}
-
 /* HACK (Mispy): Solve an issue with inconsistent WP markup.
    Sometimes iframes are inside the same <p> element as their preceding text,
    sometimes not. */
@@ -782,32 +600,6 @@ iframe:not(:first-child) {
         width: 12px;
         height: 12px;
     }
-}
-
-article.page .authors-byline .citation-note {
-    opacity: 0.9;
-    color: #0645ad;
-    cursor: pointer;
-    user-select: none;
-    -webkit-user-select: none; /* Chrome/Safari/Opera */
-    -moz-user-select: none; /* Firefox */
-    -ms-user-select: none; /* IE/Edge */
-    -webkit-touch-callout: none; /* iOS Safari */
-}
-
-article.page .authors-byline .citation-note:hover {
-    color: #0645ad;
-}
-
-.citation-guideline {
-    display: none;
-    text-align: center;
-    max-width: 900px;
-    margin: auto;
-    border: 1px solid #ccc;
-    padding: 1em;
-    font-size: 18px;
-    margin-top: 1.2rem;
 }
 
 /* Customizations to tooltip */
@@ -911,14 +703,6 @@ a.ref sup {
     font-size: 120%; // emphasize footnote markers a bit
 }
 
-/* Hide feedback button on mobile */
-
-@media only screen and (max-width: 1060px) {
-    #un-button {
-        display: none !important;
-    }
-}
-
 /* Printing
 --------------------------------------------- */
 
@@ -937,7 +721,6 @@ html:not(.js) {
     .alert-banner,
     .offset-subnavigation,
     footer.SiteFooter,
-    #un-button,
     .citation-note,
     .entry-sidebar,
     address,


### PR DESCRIPTION
I went through `owid.scss` a bit and removed some rules that are obviously not in use anymore.
For all of these, I ran ripgrep through `live-data/bakedSite` to see that they are actually not in use anymore.
The removed styles are certainly not an exhaustive list of the unused css rules, but it's a start.

## Rules that I could identify:
- `.owid-data` used to be an "All our articles" block on the old homepage, circa 2018

	<details>
	<summary>Details</summary>
	
	![CleanShot 2024-03-05 at 10 00 35@2x](https://github.com/owid/owid-grapher/assets/2641501/42942870-c01e-4506-b898-db35a0b9fb17)
	
	
	</details>
- [Fancybox](http://fancybox.net/) used to be a jQuery-based image viewing tool that we certainly don't use any more.
- The `.social` component was this old one here, circa 2018

	<details>
	<summary>Details</summary>
	
	![CleanShot 2024-03-05 at 10 07 41@2x](https://github.com/owid/owid-grapher/assets/2641501/d40db46c-617c-4c0f-913e-534cc3494a24)
	
	
	</details>
- `#un-button` I couldn't really find anywhere.
- `.citation-note` is the `[cite]` in the screenshot below, and `.citation-guideline` is the highlighted component here:

	<details>
	<summary>Details</summary>
	
	![CleanShot 2024-03-05 at 10 11 12@2x](https://github.com/owid/owid-grapher/assets/2641501/1f8d6839-214c-4511-837a-09a7b1321f52)
	
	
	</details>
- `.twitter-tweet` is presumably an embedded tweet, of which we don't have any.
- `.archive-pagination` I cannot find anywhere 🤷🏻 
- The [teaching hub](https://ourworldindata.org/teaching) page neither contains `#category-nav` nor `#entries-nav`.
- The teaching hub `h2` rules are completely overwritten by other, more specific rules.
- `.mobile.subheading` and `.owid-presentations` used to be features on the frontpage, the latter one being similar to `.owid-data`.
- Couldn't find `.footer-widgets`.