### PR TITLE
✨ (slope) remove size dimension

### DIFF
--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -310,27 +310,29 @@ export class EditorBasicTab extends React.Component<{ editor: ChartEditor }> {
             grapher.stackMode = StackMode.relative
         }
 
-        if (!grapher.isScatter && !grapher.isSlopeChart) return
+        // Give scatterplots and slope charts a default color dimension if they don't have one
+        if (grapher.isScatter || grapher.isSlopeChart) {
+            const hasColor = grapher.dimensions.find(
+                (d) => d.property === DimensionProperty.color
+            )
+            if (!hasColor)
+                grapher.addDimension({
+                    variableId: 123, // "Countries Continents"
+                    property: DimensionProperty.color,
+                })
+        }
 
-        // Give scatterplots and slope charts a default color and size dimension if they don't have one
-        const hasColor = grapher.dimensions.find(
-            (d) => d.property === DimensionProperty.color
-        )
-        const hasSize = grapher.dimensions.find(
-            (d) => d.property === DimensionProperty.size
-        )
-
-        if (!hasColor)
-            grapher.addDimension({
-                variableId: 123, // "Countries Continents"
-                property: DimensionProperty.color,
-            })
-
-        if (!hasSize)
-            grapher.addDimension({
-                variableId: 597929, // "Population (various sources, 2023.1)"
-                property: DimensionProperty.size,
-            })
+        // Give scatterplots a default size dimension if they don't have one
+        if (grapher.isScatter) {
+            const hasSize = grapher.dimensions.find(
+                (d) => d.property === DimensionProperty.size
+            )
+            if (!hasSize)
+                grapher.addDimension({
+                    variableId: 597929, // "Population (various sources, 2023.1)"
+                    property: DimensionProperty.size,
+                })
+        }
     }
 
     render() {

--- a/db/migration/1709735276047-RemoveSizeDimensionFromSlopeCharts.ts
+++ b/db/migration/1709735276047-RemoveSizeDimensionFromSlopeCharts.ts
@@ -1,0 +1,54 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class RemoveSizeDimensionFromSlopeCharts1709735276047
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const configColumns = [
+            { table: "charts", column: "config" },
+            { table: "chart_revisions", column: "config" },
+            { table: "suggested_chart_revisions", column: "suggestedConfig" },
+            { table: "variables", column: "grapherConfigAdmin" },
+            { table: "variables", column: "grapherConfigETL" },
+        ]
+
+        // remove the size dimension from all configs in the database
+        for (const { table, column } of configColumns) {
+            const slopeCharts = await queryRunner.query(
+                `SELECT id, ?? FROM ?? WHERE ?? ->> "$.type" = 'SlopeChart'`,
+                [column, table, column]
+            )
+
+            // update all slope charts that currently have a size dimension
+            for (const chart of slopeCharts) {
+                const config = JSON.parse(chart[column])
+                if (!config.dimensions) continue
+
+                const index = config.dimensions.findIndex(
+                    (dimension: any) => dimension.property === "size"
+                )
+                if (index >= 0) {
+                    config.dimensions.splice(index, 1)
+                    await queryRunner.query(
+                        `UPDATE ?? SET ?? = ? WHERE id = ?`,
+                        [table, column, JSON.stringify(config), chart.id]
+                    )
+                }
+            }
+        }
+
+        // drop rows from the chart dimensions table
+        await queryRunner.query(
+            `-- sql
+            DELETE cd
+            FROM chart_dimensions cd
+            JOIN charts c ON c.id = cd.chartId
+            WHERE
+                c.type = "SlopeChart"
+                AND property = "size"`
+        )
+    }
+
+    // eslint-disable-next-line
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1204,7 +1204,7 @@ export class Grapher
         if (this.isLineChart || this.isDiscreteBar) return [yAxis, color]
         else if (this.isScatter) return [yAxis, xAxis, size, color]
         else if (this.isMarimekko) return [yAxis, xAxis, color]
-        else if (this.isSlopeChart) return [yAxis, size, color]
+        else if (this.isSlopeChart) return [yAxis, color]
         return [yAxis]
     }
 

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartConstants.ts
@@ -24,7 +24,6 @@ export interface SlopeEntryProps extends ChartSeries {
     y1: number
     x2: number
     y2: number
-    size: number
 
     hasLeftLabel: boolean
     leftEntityLabel: TextWrap


### PR DESCRIPTION
Removes the size dimension for slope charts.

### Summary

- The size dimension currently maps to the stroke width of the slopes (we don't communicate that to the user though)
- We realised that it doesn't add to the understanding of the chart:
    - In the case of slope charts with many slopes, slope thickness is hardly visible since slopes are overlapping ([example](https://ourworldindata.org/grapher/children-per-woman))
    - In the case of slope charts with few slopes, different slope widths add noise since it isn't clear why some slopes are thicker than others ([example](https://ourworldindata.org/grapher/participation-time-in-personal-care-per-day))