### PR TITLE
refactor(wp): remove unnecessary checks

### DIFF
--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -42,7 +42,6 @@ import { getVariableData, getVariableMetadata } from "../db/model/Variable.js"
 import { MultiEmbedderTestPage } from "../site/multiembedder/MultiEmbedderTestPage.js"
 import { JsonError } from "@ourworldindata/utils"
 import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants.js"
-import { isWordpressAPIEnabled } from "../db/wpdb.js"
 import { EXPLORERS_ROUTE_FOLDER } from "../explorer/ExplorerConstants.js"
 import { getExplorerRedirectForPath } from "../explorerAdminServer/ExplorerRedirects.js"
 import { explorerUrlMigrationsById } from "../explorer/urlMigrations/ExplorerUrlMigrations.js"
@@ -289,10 +288,6 @@ mockSiteRouter.get("/latest/page/:pageno", async (req, res) => {
 })
 
 mockSiteRouter.get("/headerMenu.json", async (req, res) => {
-    if (!isWordpressAPIEnabled) {
-        res.status(404).send(await renderNotFoundPage())
-        return
-    }
     res.contentType("application/json")
     res.send(await renderMenuJson())
 })

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -14,7 +14,6 @@ import {
     merge,
     partition,
 } from "@ourworldindata/utils"
-import { isWordpressAPIEnabled, isWordpressDBEnabled } from "../db/wpdb.js"
 import fs from "fs-extra"
 import * as lodash from "lodash"
 import { bakeGraphersToPngs } from "./GrapherImageBaker.js"
@@ -333,14 +332,10 @@ const renderGrapherPage = async (
 ) => {
     const postSlug = urlToSlug(grapher.originUrl || "")
     const post = postSlug ? await getPostEnrichedBySlug(postSlug) : undefined
-    const relatedCharts =
-        post && isWordpressDBEnabled
-            ? await getPostRelatedCharts(post.id)
-            : undefined
-    const relatedArticles =
-        grapher.id && isWordpressAPIEnabled
-            ? await getRelatedArticles(grapher.id, knex)
-            : undefined
+    const relatedCharts = post ? await getPostRelatedCharts(post.id) : undefined
+    const relatedArticles = grapher.id
+        ? await getRelatedArticles(grapher.id, knex)
+        : undefined
 
     return renderToHtmlPage(
         <GrapherPage


### PR DESCRIPTION
Remove WP API and DB checks. 

These checks are now unnecessary following the previous refactors whereby the underlying features were migrated to using the grapher DB.

When we disable the WP API and DB, these checks will disable  those same features that we actually want to keep.