### PR TITLE
enhance: _OWID_HAVE_ALL_GRAPHERS_LOADED flag respects charts' parent …

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -122,6 +122,7 @@ import {
     GRAPHER_DARK_TEXT,
     STATIC_EXPORT_DETAIL_SPACING,
     GRAPHER_LIGHT_TEXT,
+    GRAPHER_LOADED_EVENT_NAME,
 } from "../core/GrapherConstants"
 import Cookies from "js-cookie"
 import {
@@ -2730,7 +2731,7 @@ export class Grapher
                 () => {
                     if (this.isReady) {
                         document.dispatchEvent(
-                            new CustomEvent("grapherLoaded", {
+                            new CustomEvent(GRAPHER_LOADED_EVENT_NAME, {
                                 detail: { grapher: this },
                             })
                         )

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -13,6 +13,7 @@ export const DEFAULT_GRAPHER_CONFIG_SCHEMA =
 
 export const DEFAULT_GRAPHER_ENTITY_TYPE = "country or region"
 export const DEFAULT_GRAPHER_ENTITY_TYPE_PLURAL = "countries and regions"
+export const GRAPHER_MOUNTED_EVENT_NAME = "grapherMounted"
 export const GRAPHER_LOADED_EVENT_NAME = "grapherLoaded"
 
 export const DEFAULT_GRAPHER_WIDTH = 850

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -54,8 +54,6 @@ declare global {
     interface Window {
         _OWID_DATAPAGEV2_PROPS: DataPageV2ContentFields
         _OWID_GRAPHER_CONFIG: GrapherInterface
-        // Set in runAllGraphersLoadedListener; used in site-screenshots tool
-        _OWID_HAVE_ALL_GRAPHERS_LOADED?: boolean
     }
 }
 export const OWID_DATAPAGE_CONTENT_ROOT_ID = "owid-datapageJson-root"

--- a/site/runAllGraphersLoadedListener.ts
+++ b/site/runAllGraphersLoadedListener.ts
@@ -7,6 +7,12 @@ import {
     ExplorerContainerId,
 } from "../explorer/ExplorerConstants.js"
 
+declare global {
+    interface Window {
+        _OWID_HAVE_ALL_GRAPHERS_LOADED?: boolean
+    }
+}
+
 /**
  * Counts the number of visible chart embeds in the page and sets a boolean on the window once all of them have loaded
  * We set a boolean instead of dispatching a second event, because grapher pages can sometimes finish loading faster than others scripts can execute
@@ -14,7 +20,7 @@ import {
  */
 export function runAllGraphersLoadedListener() {
     const grapherEmbeds = [
-        ...document.querySelectorAll(
+        ...document.querySelectorAll<HTMLElement>(
             [
                 // embedded graphers
                 `[${GRAPHER_EMBEDDED_FIGURE_ATTR}]`,
@@ -28,7 +34,17 @@ export function runAllGraphersLoadedListener() {
     ].filter((el) => {
         let parent = el.parentElement
         while (parent) {
-            if (window.getComputedStyle(parent).display === "none") return false
+            const computedStyle = window.getComputedStyle(parent)
+            if (
+                computedStyle.display === "none" ||
+                computedStyle.visibility === "hidden"
+            )
+                return false
+
+            // Parent height is so small that the child is not visible, e.g. inside expandable paragraph
+            if (parent.offsetTop + parent.offsetHeight < el.offsetTop)
+                return false
+
             parent = parent.parentElement
         }
         return true


### PR DESCRIPTION
Problem:
In https://ourworldindata.org/from-1-90-to-2-15-a-day-the-updated-international-poverty-line, there's a grapher nested inside an expandable paragraph.
That paragraph is not `display: none`, but rather simply `height: 100px`, and for this reason the `_OWID_HAVE_ALL_GRAPHERS_LOADED` flag never got set to true, annoying @Marigold to no end.

This additional check covers this case also, and should hopefully make the flag more reliable.