### PR TITLE
✨ (slope) move legend to the top on mobile

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -2,7 +2,7 @@
     "files": [
         {
             "path": "./dist/assets/common.mjs",
-            "maxSize": "2.18MB"
+            "maxSize": "2.2MB"
         },
         {
             "path": "./dist/assets/owid.mjs",

--- a/packages/@ourworldindata/grapher/src/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/packages/@ourworldindata/grapher/src/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -89,6 +89,9 @@ export interface HorizontalColorLegendManager {
     equalSizeBins?: boolean
     onLegendMouseLeave?: () => void
     onLegendMouseOver?: (d: ColorScaleBin) => void
+    onLegendClick?: (d: ColorScaleBin) => void
+    activeColors?: string[]
+    focusColors?: string[]
 }
 
 const DEFAULT_NUMERIC_BIN_SIZE = 10
@@ -780,11 +783,19 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
 
     render(): JSX.Element {
         const { manager, marks } = this
+        const { activeColors, focusColors } = manager
 
         return (
             <g>
                 <g className="categoricalColorLegend">
                     {marks.map((mark, index) => {
+                        const isActive = activeColors?.includes(mark.bin.color)
+                        const isFocus = focusColors?.includes(mark.bin.color)
+
+                        const fill = mark.bin.patternRef
+                            ? `url(#${mark.bin.patternRef})`
+                            : mark.bin.color
+
                         return (
                             <g
                                 key={index}
@@ -796,6 +807,11 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
                                 onMouseLeave={(): void =>
                                     manager.onLegendMouseLeave
                                         ? manager.onLegendMouseLeave()
+                                        : undefined
+                                }
+                                onClick={(): void =>
+                                    manager.onLegendClick
+                                        ? manager.onLegendClick(mark.bin)
                                         : undefined
                                 }
                                 style={{ cursor: "default" }}
@@ -819,9 +835,9 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
                                     width={mark.rectSize}
                                     height={mark.rectSize}
                                     fill={
-                                        mark.bin.patternRef
-                                            ? `url(#${mark.bin.patternRef})`
-                                            : mark.bin.color
+                                        isActive || activeColors === undefined
+                                            ? fill
+                                            : "#ccc"
                                     }
                                     stroke={manager.categoricalBinStroke}
                                     strokeWidth={0.4}
@@ -838,6 +854,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
                                     // do with some rough positioning.
                                     dy={dyFromAlign(VerticalAlign.middle)}
                                     fontSize={mark.label.fontSize}
+                                    fontWeight={isFocus ? "bold" : undefined}
                                 >
                                     {mark.label.text}
                                 </text>

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -16,6 +16,7 @@ import {
     exposeInstanceOnWindow,
     PointVector,
     clamp,
+    HorizontalAlign,
 } from "@ourworldindata/utils"
 import { TextWrap } from "@ourworldindata/components"
 import { observable, computed, action } from "mobx"
@@ -56,9 +57,15 @@ import { autoDetectYColumnSlugs, makeSelectionArray } from "../chart/ChartUtils"
 import { AxisConfig, AxisManager } from "../axis/AxisConfig"
 import { VerticalAxis } from "../axis/Axis"
 import { VerticalAxisComponent } from "../axis/AxisViews"
+import {
+    HorizontalCategoricalColorLegend,
+    HorizontalColorLegendManager,
+} from "../horizontalColorLegend/HorizontalColorLegends"
+import { CategoricalBin, ColorScaleBin } from "../color/ColorScaleBin"
 
 export interface SlopeChartManager extends ChartManager {
     isModalOpen?: boolean
+    isSemiNarrow?: boolean
 }
 
 const LABEL_SLOPE_PADDING = 8
@@ -73,7 +80,11 @@ export class SlopeChart
         bounds?: Bounds
         manager: SlopeChartManager
     }>
-    implements ChartInterface, VerticalColorLegendManager, ColorScaleManager
+    implements
+        ChartInterface,
+        VerticalColorLegendManager,
+        HorizontalColorLegendManager,
+        ColorScaleManager
 {
     // currently hovered individual series key
     @observable hoverKey?: string
@@ -103,6 +114,15 @@ export class SlopeChart
         return this.manager.fontSize ?? BASE_FONT_SIZE
     }
 
+    @computed private get isPortrait(): boolean {
+        return !!(this.manager.isNarrow || this.manager.isStaticAndSmall)
+    }
+
+    @computed private get showHorizontalLegend(): boolean {
+        return !!(this.manager.isSemiNarrow || this.manager.isStaticAndSmall)
+    }
+
+    // used by the <VerticalColorLegend /> component
     @computed get legendItems() {
         return this.colorScale.legendBins
             .filter((bin) => this.colorsInUse.includes(bin.color))
@@ -113,6 +133,18 @@ export class SlopeChart
                     color: bin.color,
                 }
             })
+    }
+
+    // used by the <HorizontalCategoricalColorLegend /> component
+    @computed get categoricalLegendData(): CategoricalBin[] {
+        return this.legendItems.map(
+            (legendItem, index) =>
+                new CategoricalBin({
+                    ...legendItem,
+                    index,
+                    value: legendItem.label,
+                })
+        )
     }
 
     @action.bound onSlopeMouseOver(slopeProps: SlopeEntryProps) {
@@ -132,8 +164,12 @@ export class SlopeChart
         this.selectionArray.toggleSelection(hoverKey)
     }
 
-    @action.bound onLegendMouseOver(color: string) {
-        this.hoverColor = color
+    // Both legend managers accept a `onLegendMouseOver` property, but define different signatures.
+    // The <HorizontalCategoricalColorLegend /> component expects a string,
+    // the <VerticalColorLegend /> component expects a ColorScaleBin.
+    @action.bound onLegendMouseOver(binOrColor: string | ColorScaleBin) {
+        this.hoverColor =
+            typeof binOrColor === "string" ? binOrColor : binOrColor.color
     }
 
     @action.bound onLegendMouseLeave() {
@@ -234,12 +270,34 @@ export class SlopeChart
         return uniq(this.series.map((series) => series.color))
     }
 
-    @computed private get legendWidth(): number {
-        return new VerticalColorLegend({ manager: this }).width
+    @computed get legendAlign(): HorizontalAlign {
+        return HorizontalAlign.left
+    }
+
+    @computed get verticalColorLegend(): VerticalColorLegend {
+        return new VerticalColorLegend({ manager: this })
+    }
+
+    @computed get horizontalColorLegend(): HorizontalCategoricalColorLegend {
+        return new HorizontalCategoricalColorLegend({ manager: this })
+    }
+
+    @computed get legendHeight(): number {
+        return this.showHorizontalLegend
+            ? this.horizontalColorLegend.height
+            : this.verticalColorLegend.height
+    }
+
+    @computed get legendWidth(): number {
+        return this.showHorizontalLegend
+            ? this.bounds.width
+            : this.verticalColorLegend.width
     }
 
     @computed get maxLegendWidth(): number {
-        return this.bounds.width * 0.5
+        return this.showHorizontalLegend
+            ? this.bounds.width
+            : this.bounds.width * 0.5
     }
 
     @computed.struct private get sidebarWidth() {
@@ -248,11 +306,14 @@ export class SlopeChart
 
     // correction is to account for the space taken by the legend
     @computed private get innerBounds() {
-        const { sidebarWidth, showLegend } = this
-
-        return showLegend
-            ? this.bounds.padRight(sidebarWidth + 16)
-            : this.bounds
+        const { sidebarWidth, showLegend, legendHeight } = this
+        let bounds = this.bounds
+        if (showLegend) {
+            bounds = this.showHorizontalLegend
+                ? bounds.padTop(legendHeight + 8)
+                : bounds.padRight(sidebarWidth + 16)
+        }
+        return bounds
     }
 
     // verify the validity of data used to show legend
@@ -275,12 +336,19 @@ export class SlopeChart
             )
 
         const { manager } = this.props
-        const { series, focusKeys, hoverKeys, innerBounds, showLegend } = this
+        const {
+            series,
+            focusKeys,
+            hoverKeys,
+            innerBounds,
+            showLegend,
+            showHorizontalLegend,
+        } = this
 
-        const legend = showLegend ? (
-            <VerticalColorLegend manager={this} />
+        const legend = showHorizontalLegend ? (
+            <HorizontalCategoricalColorLegend manager={this} />
         ) : (
-            <div></div>
+            <VerticalColorLegend manager={this} />
         )
 
         return (
@@ -295,8 +363,9 @@ export class SlopeChart
                     onMouseOver={this.onSlopeMouseOver}
                     onMouseLeave={this.onSlopeMouseLeave}
                     onClick={this.onSlopeClick}
+                    isPortrait={this.isPortrait}
                 />
-                {legend}
+                {showLegend && legend}
             </g>
         )
     }
@@ -306,7 +375,9 @@ export class SlopeChart
     }
 
     @computed get legendX(): number {
-        return this.bounds.right - this.sidebarWidth
+        return this.showHorizontalLegend
+            ? this.bounds.left
+            : this.bounds.right - this.sidebarWidth
     }
 
     @computed get failMessage() {
@@ -685,8 +756,8 @@ class LabelledSlopes
         return this.hoveredSeriesNames.length > 1
     }
 
-    @computed private get isPortrait() {
-        return this.manager.isNarrow || this.manager.isStaticAndSmall
+    @computed get isPortrait(): boolean {
+        return this.props.isPortrait
     }
 
     @computed private get allValues() {

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartConstants.ts
@@ -50,6 +50,7 @@ export interface LabelledSlopesProps {
     onMouseOver: (slopeProps: SlopeEntryProps) => void
     onMouseLeave: () => void
     onClick: () => void
+    isPortrait: boolean
 }
 
 export interface SlopeAxisProps {


### PR DESCRIPTION
Moves the colour legend to the top on mobile. In other words, renders a vertical colour legend on larger screens and a horizontal colour legend on smaller screens.

### Summary

| Before  | After  |
| ------- | ------ |
| <img width="367" alt="Screenshot 2024-03-08 at 14 42 21" src="https://github.com/owid/owid-grapher/assets/12461810/e7d3496f-6e38-4225-8898-5cbc89503205"> | <img width="367" alt="Screenshot 2024-03-08 at 14 42 11" src="https://github.com/owid/owid-grapher/assets/12461810/ccad7e3b-0ff9-4c65-ba52-d6306babb1b6"> |

- It looks like we're not making use of the full width, but we need the space on the left to be reserved for entity labels in case the user select a slope