### PR TITLE
refactor(baker): allow bake dirs for all gdoc types

### DIFF
--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -51,7 +51,6 @@ import {
     OwidGdocErrorMessageType,
     ImageMetadata,
     OwidGdoc,
-    OwidGdocType,
     DATA_INSIGHTS_INDEX_PAGE_SIZE,
     OwidGdocMinimalPostInterface,
     excludeUndefined,
@@ -104,6 +103,7 @@ import {
     getVariableOfDatapageIfApplicable,
 } from "../db/model/Variable.js"
 import { Knex } from "knex"
+import { getBakePath } from "@ourworldindata/components"
 
 type PrefetchedAttachments = {
     linkedDocuments: Record<string, OwidGdocMinimalPostInterface>
@@ -238,13 +238,9 @@ export class SiteBaker {
     }
 
     // Bake an individual post/page
-    private async bakeOwidGdoc(post: OwidGdoc) {
-        const html = renderGdoc(post)
-        const dir =
-            post.content.type === OwidGdocType.DataInsight
-                ? "data-insights/"
-                : ""
-        const outPath = path.join(this.bakedSiteDir, `${dir}${post.slug}.html`)
+    private async bakeOwidGdoc(gdoc: OwidGdoc) {
+        const html = renderGdoc(gdoc)
+        const outPath = `${getBakePath(this.bakedSiteDir, gdoc)}.html`
         await fs.mkdirp(path.dirname(outPath))
         await this.stageWrite(outPath, html)
     }

--- a/packages/@ourworldindata/components/src/GdocsUtils.ts
+++ b/packages/@ourworldindata/components/src/GdocsUtils.ts
@@ -45,13 +45,13 @@ export function convertHeadingTextToId(headingText: Span[]): string {
     return urlSlug(spansToUnformattedPlainText(headingText))
 }
 
-export function getCanonicalUrl(baseUrl: string, gdoc: OwidGdoc): string {
+function _getPrefixedPath(prefix: string, gdoc: OwidGdoc): string {
     return match(gdoc)
         .with(
             {
                 content: { type: OwidGdocType.Homepage },
             },
-            () => baseUrl
+            () => prefix
         )
         .with(
             {
@@ -64,13 +64,13 @@ export function getCanonicalUrl(baseUrl: string, gdoc: OwidGdoc): string {
                     ),
                 },
             },
-            () => `${baseUrl}/${gdoc.slug}`
+            () => `${prefix}/${gdoc.slug}`
         )
         .with(
             {
                 content: { type: OwidGdocType.DataInsight },
             },
-            () => `${baseUrl}/data-insights/${gdoc.slug}`
+            () => `${prefix}/data-insights/${gdoc.slug}`
         )
         .with(
             {
@@ -79,6 +79,14 @@ export function getCanonicalUrl(baseUrl: string, gdoc: OwidGdoc): string {
             () => ""
         )
         .exhaustive()
+}
+
+export const getBakePath = (bakedSiteDir: string, gdoc: OwidGdoc): string => {
+    return _getPrefixedPath(bakedSiteDir, gdoc)
+}
+
+export const getCanonicalUrl = (baseUrl: string, gdoc: OwidGdoc): string => {
+    return _getPrefixedPath(baseUrl, gdoc)
 }
 
 export function getPageTitle(gdoc: OwidGdoc) {

--- a/packages/@ourworldindata/components/src/index.ts
+++ b/packages/@ourworldindata/components/src/index.ts
@@ -14,6 +14,7 @@ export {
     getUrlTarget,
     checkIsInternalLink,
     convertHeadingTextToId,
+    getBakePath,
     getCanonicalUrl,
     getPageTitle,
 } from "./GdocsUtils.js"


### PR DESCRIPTION
This is in preparation of baking author pages under `/team`.

This PR reuses the `getCanonicalUrl` logic to build a bake path for all gdocs.

- test article: http://staging-site-generic-bake-dir/launching-data-insights
- test data insight: http://staging-site-generic-bake-dir/data-insights/extreme-poverty-in-china-has-been-almost-eliminated-first-in-rural-then-in-urban-regions