### PR TITLE
refactor: move `embedCharts.js` to the `/assets` route

### DIFF
--- a/_routes.json
+++ b/_routes.json
@@ -1,5 +1,5 @@
 {
     "version": 1,
     "include": ["/grapher/*", "/donation/*"],
-    "exclude": ["/grapher/embedCharts.js", "/grapher/_grapherRedirects.json"]
+    "exclude": ["/grapher/_grapherRedirects.json"]
 }

--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -114,7 +114,7 @@ mockSiteRouter.get(
     }
 )
 
-mockSiteRouter.get("/grapher/embedCharts.js", async (req, res) => {
+mockSiteRouter.get("/assets/embedCharts.js", async (req, res) => {
     res.contentType("text/javascript").send(generateEmbedSnippet())
 })
 

--- a/adminSiteServer/testPageRouter.tsx
+++ b/adminSiteServer/testPageRouter.tsx
@@ -396,7 +396,7 @@ function EmbedTestPage(props: EmbedTestPageProps) {
                         <a href={props.nextPageUrl}>Next &gt;&gt;</a>
                     )}
                 </nav>
-                <script src={`${BAKED_GRAPHER_URL}/embedCharts.js`} />
+                <script src={`${BAKED_BASE_URL}/assets/embedCharts.js`} />
             </body>
         </html>
     )
@@ -572,7 +572,7 @@ function EmbedVariantsTestPage(
                         <a href={props.nextPageUrl}>Next &gt;&gt;</a>
                     )}
                 </nav>
-                <script src={`${BAKED_GRAPHER_URL}/embedCharts.js`} />
+                <script src={`${BAKED_BASE_URL}/assets/embedCharts.js`} />
             </body>
         </html>
     )

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -873,12 +873,13 @@ export class SiteBaker {
             `rsync -hav --delete ${BASE_DIR}/public/* ${this.bakedSiteDir}/ ${excludes}`
         )
 
-        await fs.ensureDir(`${this.bakedSiteDir}/grapher`)
         await fs.writeFile(
-            `${this.bakedSiteDir}/grapher/embedCharts.js`,
+            `${this.bakedSiteDir}/assets/embedCharts.js`,
             generateEmbedSnippet()
         )
-        this.stage(`${this.bakedSiteDir}/grapher/embedCharts.js`)
+        this.stage(`${this.bakedSiteDir}/assets/embedCharts.js`)
+
+        await fs.ensureDir(`${this.bakedSiteDir}/grapher`)
         this.progressBar.tick({ name: "✅ baked assets" })
     }
 


### PR DESCRIPTION
See [Slack](https://owid.slack.com/archives/CQQUA2C2U/p1709027956213309) for context.