### PR TITLE
✨ (static chart) remove link underlines

### DIFF
--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -675,10 +675,7 @@ export class StaticFooter extends Footer<StaticFooterProps> {
     @computed protected get licenseAndOriginUrlText(): string {
         const { finalUrl, finalUrlText, licenseText, licenseUrl, textColor } =
             this
-        const textDecoration = this.manager.isStaticAndSmall
-            ? "none"
-            : "underline"
-        const linkStyle = `fill: ${textColor};  text-decoration: ${textDecoration};`
+        const linkStyle = `fill: ${textColor};`
         const licenseSvg = `<a target="_blank" style="${linkStyle}" href="${licenseUrl}">${licenseText}</a>`
         if (!finalUrlText) return licenseSvg
         const originUrlSvg = `<a target="_blank" style="${linkStyle}" href="${finalUrl}">${finalUrlText}</a>`


### PR DESCRIPTION
Resolves #3295 

I decided to remove link underlines for all static charts, including SVGs.

- Clicking on links within a static chart SVG on our website is not possible since we usually include the SVG via an `<img />` tag (aside, we also often wrap the static chart image itself in a link, which means the whole image is clickable)
- Thus, link underlines for static charts used on our website are never relevant
- They're only relevant when someone downloads the SVG version of a chart and then looks at it in their browser
    - But if they do anything else with the chart, e.g. include it in a doc or presentation slides, share it on social media, etc., again, the link underlines would be misleading since they're not clickable in most environments

All in all, I don't think it's worth the complication of having a PNG-specific version. So, I decided to remove them from all static charts.