### PR TITLE
:bug: Use baked URL for explorer thumbnails

### DIFF
--- a/site/ExplorerPage.tsx
+++ b/site/ExplorerPage.tsx
@@ -98,7 +98,7 @@ window.Explorer.renderSingleExplorerOnExplorerPage(explorerProgram, grapherConfi
 
     // Replace thumnails with admin links to baked images
     let resolvedThumbnail
-    if (thumbnail && thumbnail.includes("https://owid.cloud")) {
+    if (thumbnail && thumbnail.startsWith("https://owid.cloud")) {
         resolvedThumbnail = thumbnail.replace("https://owid.cloud", baseUrl)
     } else {
         resolvedThumbnail = thumbnail

--- a/site/ExplorerPage.tsx
+++ b/site/ExplorerPage.tsx
@@ -96,6 +96,14 @@ const urlMigrationSpec = ${
     };
 window.Explorer.renderSingleExplorerOnExplorerPage(explorerProgram, grapherConfigs, partialGrapherConfigs, urlMigrationSpec);`
 
+    // Replace thumnails with admin links to baked images
+    let resolvedThumbnail
+    if (thumbnail && thumbnail.includes("https://owid.cloud")) {
+        resolvedThumbnail = thumbnail.replace("https://owid.cloud", baseUrl)
+    } else {
+        resolvedThumbnail = thumbnail
+    }
+
     return (
         <html>
             <Head
@@ -103,7 +111,7 @@ window.Explorer.renderSingleExplorerOnExplorerPage(explorerProgram, grapherConfi
                 hideCanonicalUrl // explorers set their canonical url dynamically
                 pageTitle={`${explorerTitle} Data Explorer`}
                 pageDesc={explorerSubtitle}
-                imageUrl={thumbnail}
+                imageUrl={resolvedThumbnail}
                 baseUrl={baseUrl}
             >
                 <IFrameDetector />


### PR DESCRIPTION
Fixes #3319

Explorer thumbnails currently point to internal admin URLs at `owid.cloud`, we want to replace them at bake time with a production URL.

Staging site: http://staging-site-explorer-thumb-3319/
