### PR TITLE
🐛 (slope) fix chart state if entity without data is selected

### DIFF
--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -719,8 +719,12 @@ class LabelledSlopes
     // Then, a special "foreground" set of entities is rendered over the background
     @computed private get isLayerMode() {
         return (
+            this.hoveredSeriesNames.length > 0 ||
             this.focusedSeriesNames.length > 0 ||
-            this.hoveredSeriesNames.length > 0
+            // if the user has selected entities that are not in the chart,
+            // we want to move all entities into the background
+            (this.props.focusKeys?.length > 0 &&
+                this.focusedSeriesNames.length === 0)
         )
     }
 


### PR DESCRIPTION
- fixes #2878 
- Example chart: [Live](https://ourworldindata.org/grapher/child-mortality-1960-vs-latest-slope?country=~DEU) / [Staging](http://staging-site-slope-empty-focus-group/grapher/child-mortality-1960-vs-latest-slope?country=~DEU) (note that Germany is selected in both)
- Screenshots:

| Before  | After  |
| ------- | ------ |
| <img width="844" alt="Screenshot 2024-03-08 at 13 54 37" src="https://github.com/owid/owid-grapher/assets/12461810/db941bdf-249a-411c-a682-024c31843508"> | <img width="844" alt="Screenshot 2024-03-08 at 13 54 20" src="https://github.com/owid/owid-grapher/assets/12461810/14e7f610-217a-41d0-a339-9687256962e4"> |
| Note that the slope chart is in a weird state (all legend items are grayed out while slopes are displayed as usual) | If an entity is selected that is not currently displayed, we visually indicate that by moving all plotted entities into the background |