### PR TITLE
💄 (grapher) remove isExplorable option

### DIFF
--- a/adminSiteClient/ChartList.tsx
+++ b/adminSiteClient/ChartList.tsx
@@ -26,7 +26,6 @@ export interface ChartListItem {
     lastEditedBy: string
     publishedAt: string
     publishedBy: string
-    isExplorable: boolean
 
     tags: DbChartTagJoin[]
 }

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -273,16 +273,15 @@ const saveGrapher = async (
     const now = new Date()
     let chartId = existingConfig && existingConfig.id
     const newJsonConfig = JSON.stringify(newConfig)
-    // todo: drop "isExplorable"
     if (existingConfig)
         await transactionContext.query(
-            `UPDATE charts SET config=?, updatedAt=?, lastEditedAt=?, lastEditedByUserId=?, isExplorable=? WHERE id = ?`,
-            [newJsonConfig, now, now, user.id, false, chartId]
+            `UPDATE charts SET config=?, updatedAt=?, lastEditedAt=?, lastEditedByUserId=? WHERE id = ?`,
+            [newJsonConfig, now, now, user.id, chartId]
         )
     else {
         const result = await transactionContext.execute(
-            `INSERT INTO charts (config, createdAt, updatedAt, lastEditedAt, lastEditedByUserId, isExplorable) VALUES (?)`,
-            [[newJsonConfig, now, now, now, user.id, false]]
+            `INSERT INTO charts (config, createdAt, updatedAt, lastEditedAt, lastEditedByUserId) VALUES (?)`,
+            [[newJsonConfig, now, now, now, user.id]]
         )
         chartId = result.insertId
     }
@@ -391,8 +390,7 @@ apiRouter.get("/charts.csv", async (req: Request, res: Response) => {
             lastEditedByUser.fullName AS lastEditedBy,
             charts.publishedAt,
             charts.publishedByUserId,
-            publishedByUser.fullName AS publishedBy,
-            charts.isExplorable AS isExplorable
+            publishedByUser.fullName AS publishedBy
         FROM charts
         JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
         LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId

--- a/db/migration/1709913303952-RemoveIsExplorableColumnFromCharts.ts
+++ b/db/migration/1709913303952-RemoveIsExplorableColumnFromCharts.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class RemoveIsExplorableColumnFromCharts1709913303952
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`ALTER TABLE charts DROP COLUMN isExplorable;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(
+            `ALTER TABLE charts ADD COLUMN isExplorable tinyint(1) NOT NULL DEFAULT '0';`
+        )
+    }
+}

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -48,7 +48,6 @@ export class Chart extends BaseEntity {
     @Column({ nullable: true }) publishedByUserId!: number
     @Column() createdAt!: Date
     @Column() updatedAt!: Date
-    @Column() isExplorable!: boolean
 
     @ManyToOne(() => User, (user) => user.lastEditedCharts)
     lastEditedByUser!: Relation<User>
@@ -294,8 +293,7 @@ export class OldChart {
         lastEditedByUser.fullName AS lastEditedBy,
         charts.publishedAt,
         charts.publishedByUserId,
-        publishedByUser.fullName AS publishedBy,
-        charts.isExplorable AS isExplorable
+        publishedByUser.fullName AS publishedBy
     `
 
     static async getBySlug(slug: string): Promise<OldChart> {

--- a/db/tests/basic.test.ts
+++ b/db/tests/basic.test.ts
@@ -65,7 +65,6 @@ test("timestamps are automatically created and updated", async () => {
     chart.config = {}
     chart.lastEditedAt = new Date()
     chart.lastEditedByUserId = 1
-    chart.isExplorable = true
     await chart.save()
     const created: Chart | null = await Chart.findOne({ where: { id: 1 } })
     expect(created).not.toBeNull()
@@ -73,7 +72,7 @@ test("timestamps are automatically created and updated", async () => {
         expect(created.createdAt).not.toBeNull()
         expect(created.updatedAt).toBeNull()
         await sleep(1000, undefined)
-        created.isExplorable = false
+        chart.lastEditedByUserId = 2
         await created.save()
         const updated: Chart | null = await Chart.findOne({ where: { id: 1 } })
         expect(updated).not.toBeNull()

--- a/db/tests/basic.test.ts
+++ b/db/tests/basic.test.ts
@@ -72,7 +72,7 @@ test("timestamps are automatically created and updated", async () => {
         expect(created.createdAt).not.toBeNull()
         expect(created.updatedAt).toBeNull()
         await sleep(1000, undefined)
-        chart.lastEditedByUserId = 2
+        created.lastEditedAt = new Date()
         await created.save()
         const updated: Chart | null = await Chart.findOne({ where: { id: 1 } })
         expect(updated).not.toBeNull()

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.003.yaml
@@ -671,9 +671,4 @@ properties:
             - auto
             - hide
             - show
-    isExplorable:
-        type: boolean
-        default: false
-        description: Legacy flag, should be removed
-        $comment: Remove this flag once the codepaths that use it are deleted
 additionalProperties: false

--- a/packages/@ourworldindata/types/src/dbTypes/Charts.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Charts.ts
@@ -7,7 +7,6 @@ export interface DbInsertChart {
     createdAt?: Date
     id?: number
     is_indexable?: number
-    isExplorable?: number
     lastEditedAt: Date
     lastEditedByUserId: number
     publishedAt?: Date | null


### PR DESCRIPTION
> [!WARNING]  
> Db tests are failing.

Just a little bit of cleanup. Removes the `isExplorable` property from Grapher's config and the `isExplorable` column from the `charts` table.

The config schema states that the `isExplorable` property is not in use and should be removed. I then noticed that the `charts` table has a column called `isExplorable` that also isn't in use, so I decided to remove it too.

Technically, this is a breaking schema change, but there is no real code change, so I guess it's okay not to increase the schema version etc.
