### PR TITLE
cleanup: remove <Text> component and use dominant-baseline instead

### DIFF
--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -9,8 +9,6 @@ import {
     sum,
     getRelativeMouse,
     colorScaleConfigDefaults,
-    omit,
-    FontFamily,
 } from "@ourworldindata/utils"
 import {
     VerticalAxisComponent,
@@ -473,7 +471,7 @@ export class StackedBarChart
                 <g>
                     {ticks.map((tick, i) => {
                         return (
-                            <Text
+                            <text
                                 key={i}
                                 x={tick.bounds.x}
                                 y={tick.bounds.y}
@@ -483,9 +481,10 @@ export class StackedBarChart
                                     this.onLabelMouseOver(tick)
                                 }}
                                 onMouseLeave={this.onLabelMouseLeave}
+                                dominantBaseline="text-before-edge"
                             >
                                 {tick.text}
-                            </Text>
+                            </text>
                         )
                     })}
                 </g>
@@ -576,30 +575,6 @@ export class StackedBarChart
             withMissingValuesAsZeroes(this.unstackedSeries, {
                 enforceUniformSpacing,
             })
-        )
-    }
-}
-
-interface TextProps extends React.SVGProps<SVGTextElement> {
-    x: number
-    y: number
-    fontSize: number
-    fontFamily?: FontFamily
-    children: string
-}
-
-class Text extends React.Component<TextProps> {
-    render(): JSX.Element {
-        const bounds = Bounds.forText(this.props.children, {
-            fontSize: this.props.fontSize,
-            fontFamily: this.props.fontFamily,
-        })
-        const y = this.props.y + bounds.height - bounds.height * 0.2
-
-        return (
-            <text {...omit(this.props, ["children"])} y={y}>
-                {this.props.children}
-            </text>
         )
     }
 }

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -9,6 +9,7 @@ import {
     sum,
     getRelativeMouse,
     colorScaleConfigDefaults,
+    dyFromAlign,
 } from "@ourworldindata/utils"
 import {
     VerticalAxisComponent,
@@ -37,7 +38,7 @@ import {
 } from "./AbstractStackedChart"
 import { StackedPoint, StackedSeries } from "./StackedConstants"
 import { VerticalAxis } from "../axis/Axis"
-import { ColorSchemeName } from "@ourworldindata/types"
+import { ColorSchemeName, VerticalAlign } from "@ourworldindata/types"
 import { stackSeries, withMissingValuesAsZeroes } from "./StackedUtils"
 import { makeClipPath } from "../chart/ChartUtils"
 import { ColorScaleConfigDefaults } from "../color/ColorScaleConfig"
@@ -474,14 +475,14 @@ export class StackedBarChart
                             <text
                                 key={i}
                                 x={tick.bounds.x}
-                                y={tick.bounds.y}
+                                y={tick.bounds.y + 1}
                                 fill={GRAPHER_DARK_TEXT}
                                 fontSize={this.tickFontSize}
                                 onMouseOver={(): void => {
                                     this.onLabelMouseOver(tick)
                                 }}
                                 onMouseLeave={this.onLabelMouseLeave}
-                                dominantBaseline="text-before-edge"
+                                dy={dyFromAlign(VerticalAlign.bottom)}
                             >
                                 {tick.text}
                             </text>


### PR DESCRIPTION
In #3288, Sophia gets rid of the `<Text>` component uses in slope charts.

The only other remaining use is in stacked bar charts, but there it is only used in one (simple) place: The tick labels as seen below.
![CleanShot 2024-03-11 at 09 23 32](https://github.com/owid/owid-grapher/assets/2641501/fc0862ff-e8ca-4e22-92a9-797de8607c7e)


We can instead just use `dy` to achieve (almost) the same effect.