### PR TITLE
:hammer: disable metadata edits

### DIFF
--- a/adminSiteClient/VariableEditPage.tsx
+++ b/adminSiteClient/VariableEditPage.tsx
@@ -172,7 +172,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                 <form
                     onSubmit={(e) => {
                         e.preventDefault()
-                        this.save()
+                        // this.save()
                     }}
                 >
                     <div className="row">
@@ -226,6 +226,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                     field="name"
                                     store={newVariable}
                                     label="Indicator Name"
+                                    disabled={isDisabled}
                                 />
                                 <BindString
                                     field="catalogPath"
@@ -237,6 +238,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                     label="Display name"
                                     field="name"
                                     store={newVariable.display}
+                                    disabled={isDisabled}
                                 />
                                 <FieldsRow>
                                     <BindString
@@ -244,12 +246,14 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                         field="unit"
                                         store={newVariable.display}
                                         placeholder={newVariable.unit}
+                                        disabled={isDisabled}
                                     />
                                     <BindString
                                         label="Short (axis) unit"
                                         field="shortUnit"
                                         store={newVariable.display}
                                         placeholder={newVariable.shortUnit}
+                                        disabled={isDisabled}
                                     />
                                 </FieldsRow>
                                 <FieldsRow>
@@ -258,12 +262,14 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                         field="numDecimalPlaces"
                                         store={newVariable.display}
                                         helpText={`A negative number here will round integers`}
+                                        disabled={isDisabled}
                                     />
                                     <BindFloat
                                         label="Unit conversion factor"
                                         field="conversionFactor"
                                         store={newVariable.display}
                                         helpText={`Multiply all values by this amount`}
+                                        disabled={isDisabled}
                                     />
                                 </FieldsRow>
                                 <FieldsRow>
@@ -333,21 +339,25 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                         label="Title public"
                                         field="titlePublic"
                                         store={newVariable.presentation}
+                                        disabled={isDisabled}
                                     />
                                     <BindString
                                         label="Title variant"
                                         field="titleVariant"
                                         store={newVariable.presentation}
+                                        disabled={isDisabled}
                                     />
                                     <BindString
                                         label="Attribution"
                                         field="attribution"
                                         store={newVariable.presentation}
+                                        disabled={isDisabled}
                                     />
                                     <BindString
                                         label="Attribution short"
                                         field="attributionShort"
                                         store={newVariable.presentation}
+                                        disabled={isDisabled}
                                     />
                                 </FieldsRow>
                                 <FieldsRow>
@@ -356,12 +366,14 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                         field="descriptionShort"
                                         store={newVariable}
                                         textarea
+                                        disabled={isDisabled}
                                     />
                                     <BindString
                                         label="Description from producer"
                                         field="descriptionFromProducer"
                                         store={newVariable}
                                         textarea
+                                        disabled={isDisabled}
                                     />
                                 </FieldsRow>
                                 <FieldsRow>
@@ -383,6 +395,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                         field="descriptionKey"
                                         store={newVariable}
                                         rows={8}
+                                        disabled={isDisabled}
                                     />
                                 </FieldsRow>
                                 <FieldsRow>
@@ -393,6 +406,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                             store={newVariable}
                                             textarea
                                             rows={8}
+                                            disabled={isDisabled}
                                         />
                                     </div>
                                     <div className="col">
@@ -410,11 +424,13 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                                     label: "Major",
                                                 },
                                             ]}
+                                            disabled={isDisabled}
                                         />
                                         <BindString
                                             label="Number of days between OWID updates"
                                             field="updatePeriodDays"
                                             store={newVariable}
+                                            disabled={isDisabled}
                                         />
                                     </div>
                                 </FieldsRow>
@@ -457,6 +473,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                 type="submit"
                                 className="btn btn-success"
                                 value="Update indicator"
+                                disabled={isDisabled}
                             />
                         </div>
                     </div>


### PR DESCRIPTION
Browser doesn't allow fetching from **http**://etl.owid.io/api/v1 to make edits to metadata. It has to be `https` to make it work.

We need to put ETL API behind Cloudflare auth and make it available on `https`. A weird thing is that switching to a bar chart triggers a form save. Only Enter or Update button should trigger that (maybe we should only allow the button).

This PR disables metadata editing.