### PR TITLE
🐛 (stacked bar) hide y-axis labels when shared

### DIFF
--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -446,12 +446,14 @@ export class StackedBarChart
                     opacity={0}
                     fill="rgba(255,255,255,0)"
                 />
-                <VerticalAxisComponent
-                    bounds={bounds}
-                    verticalAxis={verticalAxis}
-                    labelColor={manager.secondaryColorInStaticCharts}
-                    detailsMarker={manager.detailsMarkerInSvg}
-                />
+                {!verticalAxis.hideAxis && (
+                    <VerticalAxisComponent
+                        bounds={bounds}
+                        verticalAxis={verticalAxis}
+                        labelColor={manager.secondaryColorInStaticCharts}
+                        detailsMarker={manager.detailsMarkerInSvg}
+                    />
+                )}
                 <VerticalAxisGridLines
                     verticalAxis={verticalAxis}
                     bounds={innerBounds}


### PR DESCRIPTION
- Came up on [Slack](https://owid.slack.com/archives/C46U9LXRR/p1710173527593069)
- `StackedBar` y-axis labels are currently overlapping with other charts in faceted mode
- We should only show the y-axis labels for charts in the left row, and hide labels for all other charts