### PR TITLE
fix(homepage): url-encode tag name for icon

### DIFF
--- a/site/gdocs/components/ExplorerTiles.tsx
+++ b/site/gdocs/components/ExplorerTiles.tsx
@@ -18,7 +18,9 @@ function ExplorerTile({ url }: { url: string }) {
         <img
             height={40}
             width={40}
-            src={`${BAKED_BASE_URL}/images/tag-icons/${linkedChart.tags[0].name}.svg`}
+            src={`${BAKED_BASE_URL}/images/tag-icons/${encodeURIComponent(
+                linkedChart.tags[0].name
+            )}.svg`}
             className="explorer-tile__icon"
         />
     ) : null

--- a/site/gdocs/components/ExplorerTiles.tsx
+++ b/site/gdocs/components/ExplorerTiles.tsx
@@ -22,6 +22,8 @@ function ExplorerTile({ url }: { url: string }) {
                 linkedChart.tags[0].name
             )}.svg`}
             className="explorer-tile__icon"
+            alt={`Icon for topic ${linkedChart.tags[0].name}`}
+            loading="lazy"
         />
     ) : null
 

--- a/site/gdocs/components/HomepageIntro.tsx
+++ b/site/gdocs/components/HomepageIntro.tsx
@@ -165,6 +165,7 @@ export function HomepageIntro({ className, featuredWork }: HomepageIntroProps) {
                     alt="Logos of the publications that have used our content. From left to right: Science, Nature, PNAS, BBC, Financial Times, The New York Times, The Guardian, The Atlantic, and The Washington Post"
                     width={230}
                     height={75}
+                    loading="lazy"
                 />
             </section>
             <section className="grid grid-cols-9 span-cols-9 col-start-5 span-md-cols-12 col-md-start-2 homepage-intro__right-section">


### PR DESCRIPTION
Just two small fixes for the new homepage that I encountered:
- URI-encode the tag name for the explorer tag icon. Currently, we're using `<img src="https://ourworldindata.org/images/tag-icons/Population and Demographic Change.svg">`, which works but is not technically valid.
- Lazy-load images, especially these explorer tags since they're pretty far down the page
- Add an alt tag while we're at it