### PR TITLE
🐝 (svg tester) minor improvements

### DIFF
--- a/baker/GrapherBakingUtils.ts
+++ b/baker/GrapherBakingUtils.ts
@@ -37,12 +37,15 @@ export const grapherUrlToSlugAndQueryStr = (grapherUrl: string) => {
 export const grapherSlugToExportFileKey = (
     slug: string,
     queryStr: string | undefined,
-    { shouldHashQueryStr = true }: { shouldHashQueryStr?: boolean } = {}
+    {
+        shouldHashQueryStr = true,
+        separator = "-",
+    }: { shouldHashQueryStr?: boolean; separator?: string } = {}
 ) => {
     const maybeHashedQueryStr = shouldHashQueryStr
         ? md5(queryStr ?? "")
         : queryStr
-    return `${slug}${queryStr ? `-${maybeHashedQueryStr}` : ""}`
+    return `${slug}${queryStr ? `${separator}${maybeHashedQueryStr}` : ""}`
 }
 
 export interface GrapherExports {

--- a/baker/GrapherImageBaker.tsx
+++ b/baker/GrapherImageBaker.tsx
@@ -134,11 +134,15 @@ export function initGrapherForSvgExport(
 
 export function buildSvgOutFilename(
     fragments: SvgFilenameFragments,
-    { shouldHashQueryStr = true }: { shouldHashQueryStr?: boolean } = {}
+    {
+        shouldHashQueryStr = true,
+        separator = "-",
+    }: { shouldHashQueryStr?: boolean; separator?: string } = {}
 ): string {
     const { slug, version, width, height, queryStr = "" } = fragments
     const fileKey = grapherSlugToExportFileKey(slug, queryStr, {
         shouldHashQueryStr,
+        separator,
     })
     const outFilename = `${fileKey}_v${version}_${width}x${height}.svg`
     return outFilename

--- a/devTools/svgTester/chart-configurations.ts
+++ b/devTools/svgTester/chart-configurations.ts
@@ -72,6 +72,7 @@ const VIEW_MATRIX_BY_CHART_TYPE: Record<ChartTypeName, ViewMatrix> = {
     [ChartTypeName.SlopeChart]: {
         tab: ["chart"],
         time: timeSpan,
+        yScale: scaleTypeOptions,
     },
     [ChartTypeName.StackedArea]: {
         tab: ["chart"],

--- a/devTools/svgTester/dump-chart-ids.ts
+++ b/devTools/svgTester/dump-chart-ids.ts
@@ -8,7 +8,7 @@ import { getMostViewedGrapherIdsByChartType } from "../../db/model/Chart.js"
 import { CHART_TYPES } from "./utils.js"
 
 const DEFAULT_OUT_FILE = "../owid-grapher-svgs/most-viewed-charts.txt"
-const CHART_COUNT_PER_TYPE = 30
+const CHART_COUNT_PER_TYPE = 25
 
 async function main(parsedArgs: parseArgs.ParsedArgs) {
     try {

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -414,7 +414,7 @@ export async function renderSvg(
             height,
             queryStr,
         },
-        { shouldHashQueryStr: false }
+        { shouldHashQueryStr: false, separator: "?" }
     )
 
     grapher.receiveOwidData(configAndData.variableData)


### PR DESCRIPTION
- use a `?` in the filename to separate the slug from the query params. it makes it easier to copy/paste a filename into the browser url bar
- add linear/log y-scales for slope charts
- reduce the number of charts per type to 25