### PR TITLE
fix(country-profiles): only include published charts

### DIFF
--- a/baker/countryProfiles.tsx
+++ b/baker/countryProfiles.tsx
@@ -46,7 +46,9 @@ const countryIndicatorGraphers = async (): Promise<GrapherInterface[]> =>
         const graphers = (
             await db
                 .knexTable("charts")
-                .whereRaw("publishedAt is not null and is_indexable is true")
+                .whereRaw(
+                    "publishedAt is not null and config->>'$.isPublished' = 'true' and is_indexable is true"
+                )
         ).map((c: any) => JSON.parse(c.config)) as GrapherInterface[]
 
         return graphers.filter(checkShouldShowIndicator)


### PR DESCRIPTION
I noticed that right now, on e.g. https://ourworldindata.org/country/germany, we are including some charts that are not currently published, e.g. `acute-care-beds-per-1000`.

The reason for this is that `publishedAt` (because the chart used to be published) is set, but `config.isPublished` is missing.