### PR TITLE
🔨 set up eslint rule to error on dangling promises + fix 245 violations

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -51,8 +51,7 @@ module.exports = {
         "react/no-render-return-value": "warn",
         "react/no-unescaped-entities": ["warn", { forbid: [">", "}"] }],
         "react/prop-types": "warn",
-        // TODO: consider adding this and whitelisting all promises that don't need to be awaited with "void"
-        // "@typescript-eslint/no-floating-promises": "error",
+        "@typescript-eslint/no-floating-promises": "error",
     },
     settings: {
         "import/resolver": {

--- a/adminSiteClient/Admin.tsx
+++ b/adminSiteClient/Admin.tsx
@@ -163,6 +163,7 @@ export class Admin {
     }
 
     @action.bound private removeRequest(request: Promise<Response>): void {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.currentRequests = this.currentRequests.filter(
             (req) => req !== request
         )

--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -279,7 +279,7 @@ export class ChartEditor {
 
         if (window.confirm(`Publish chart at ${url}?`)) {
             this.grapher.isPublished = true
-            this.saveGrapher({
+            void this.saveGrapher({
                 onError: () => (this.grapher.isPublished = undefined),
             })
         }
@@ -292,7 +292,7 @@ export class ChartEditor {
                 : "Are you sure you want to unpublish this chart?"
         if (window.confirm(message)) {
             this.grapher.isPublished = undefined
-            this.saveGrapher({
+            void this.saveGrapher({
                 onError: () => (this.grapher.isPublished = true),
             })
         }

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -362,13 +362,13 @@ export class ChartEditorPage
     }
 
     @action.bound refresh(): void {
-        this.fetchGrapher()
-        this.fetchDetails()
-        this.fetchData()
-        this.fetchLogs()
-        this.fetchRefs()
-        this.fetchRedirects()
-        this.fetchPageviews()
+        void this.fetchGrapher()
+        void this.fetchDetails()
+        void this.fetchData()
+        void this.fetchLogs()
+        void this.fetchRefs()
+        void this.fetchRedirects()
+        void this.fetchPageviews()
 
         // (2024-02-15) Disabled due to slow query performance
         // https://github.com/owid/owid-grapher/issues/3198

--- a/adminSiteClient/ChartIndexPage.tsx
+++ b/adminSiteClient/ChartIndexPage.tsx
@@ -115,6 +115,6 @@ export class ChartIndexPage extends React.Component {
     }
 
     componentDidMount() {
-        this.getData()
+        void this.getData()
     }
 }

--- a/adminSiteClient/ChartList.tsx
+++ b/adminSiteClient/ChartList.tsx
@@ -95,7 +95,7 @@ export class ChartList extends React.Component<{
     }
 
     componentDidMount() {
-        this.getTags()
+        void this.getTags()
     }
 
     render() {

--- a/adminSiteClient/ChartRow.tsx
+++ b/adminSiteClient/ChartRow.tsx
@@ -36,7 +36,7 @@ export class ChartRow extends React.Component<{
     }
 
     @action.bound onSaveTags(tags: DbChartTagJoin[]) {
-        this.saveTags(tags)
+        void this.saveTags(tags)
     }
 
     render() {

--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -267,7 +267,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                     <form
                         onSubmit={(e) => {
                             e.preventDefault()
-                            this.save()
+                            void this.save()
                         }}
                     >
                         <p>
@@ -422,6 +422,6 @@ export class DatasetEditPage extends React.Component<{ datasetId: number }> {
         this.UNSAFE_componentWillReceiveProps()
     }
     UNSAFE_componentWillReceiveProps() {
-        this.getData()
+        void this.getData()
     }
 }

--- a/adminSiteClient/DatasetList.tsx
+++ b/adminSiteClient/DatasetList.tsx
@@ -49,7 +49,7 @@ class DatasetRow extends React.Component<{
     }
 
     @action.bound onSaveTags(tags: DbChartTagJoin[]) {
-        this.saveTags(tags)
+        void this.saveTags(tags)
     }
 
     render() {
@@ -113,7 +113,7 @@ export class DatasetList extends React.Component<{
     }
 
     componentDidMount() {
-        this.getTags()
+        void this.getTags()
     }
 
     render() {

--- a/adminSiteClient/DatasetsIndexPage.tsx
+++ b/adminSiteClient/DatasetsIndexPage.tsx
@@ -114,6 +114,6 @@ export class DatasetsIndexPage extends React.Component {
     }
 
     componentDidMount() {
-        this.getData()
+        void this.getData()
     }
 }

--- a/adminSiteClient/DeployStatusPage.tsx
+++ b/adminSiteClient/DeployStatusPage.tsx
@@ -25,7 +25,7 @@ export class DeployStatusPage extends React.Component {
     refreshIntervalId?: number
 
     componentDidMount() {
-        this.getData()
+        void this.getData()
         document.addEventListener(
             "visibilitychange",
             this.handleVisibilityChange
@@ -120,7 +120,7 @@ export class DeployStatusPage extends React.Component {
     }
 
     @action.bound handleVisibilityChange = () => {
-        if (document.visibilityState === "visible") this.getData()
+        if (document.visibilityState === "visible") void this.getData()
     }
 
     @action.bound async triggerDeploy() {

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -163,28 +163,28 @@ export class EditorExportTab extends React.Component<EditorExportTabProps> {
     }
 
     @action.bound private onDownloadDesktopSVG() {
-        this.download(
+        void this.download(
             `${this.baseFilename}-desktop.svg`,
             GrapherStaticFormat.landscape
         )
     }
 
     @action.bound private onDownloadDesktopPNG() {
-        this.download(
+        void this.download(
             `${this.baseFilename}-desktop.png`,
             GrapherStaticFormat.landscape
         )
     }
 
     @action.bound private onDownloadMobileSVG() {
-        this.download(
+        void this.download(
             `${this.baseFilename}-mobile.svg`,
             GrapherStaticFormat.square
         )
     }
 
     @action.bound private onDownloadMobilePNG() {
-        this.download(
+        void this.download(
             `${this.baseFilename}-mobile.png`,
             GrapherStaticFormat.square
         )

--- a/adminSiteClient/EditorHistoryTab.tsx
+++ b/adminSiteClient/EditorHistoryTab.tsx
@@ -73,7 +73,7 @@ export class EditorHistoryTab extends React.Component<{ editor: ChartEditor }> {
         delete chartConfigObject.version
         delete chartConfigObject.isPublished
         const chartConfigAsYaml = dump(chartConfigObject)
-        copyToClipboard(chartConfigAsYaml)
+        void copyToClipboard(chartConfigAsYaml)
         notification["success"]({
             message: "Copied YAML to clipboard",
             description: "You can now paste this into the ETL",

--- a/adminSiteClient/EditorReferencesTab.tsx
+++ b/adminSiteClient/EditorReferencesTab.tsx
@@ -262,7 +262,7 @@ class AddRedirectForm extends React.Component<{
             <form
                 onSubmit={(e) => {
                     e.preventDefault()
-                    this.onSubmit()
+                    void this.onSubmit()
                 }}
             >
                 <div className="input-group mb-3">

--- a/adminSiteClient/ExplorerTagsPage.tsx
+++ b/adminSiteClient/ExplorerTagsPage.tsx
@@ -29,7 +29,7 @@ export class ExplorerTagsPage extends React.Component {
     @observable newExplorerTags: DbChartTagJoin[] = []
 
     componentDidMount() {
-        this.getData()
+        void this.getData()
     }
 
     // Don't show explorers that already have tags
@@ -101,7 +101,7 @@ export class ExplorerTagsPage extends React.Component {
                                                 tags={explorer.tags}
                                                 suggestions={this.tags}
                                                 onSave={(tags) => {
-                                                    this.saveTags(
+                                                    void this.saveTags(
                                                         explorer.slug,
                                                         tags
                                                     )

--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -108,7 +108,7 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
             }
         }
         if (!originalGdoc) {
-            fetchGdocs()
+            void fetchGdocs()
         }
     }, [originalGdoc, fetchGdoc, handleError, admin])
 

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -298,7 +298,7 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
         // Add the disposer to the list of things we need to clean up on unmount
         this.disposers.push(disposer)
 
-        this.getFieldDefinitions()
+        void this.getFieldDefinitions()
     }
 
     @action.bound private resetViewStateAfterFetch(): void {
@@ -435,7 +435,7 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
                     currentColumnFieldDescription.default !== undefined &&
                     currentColumnFieldDescription.default === prevVal,
             }
-            this.doAction({ patches: [patch] })
+            void this.doAction({ patches: [patch] })
         } else {
             setValueRecursiveInplace(grapher, pointer, prevVal)
         }
@@ -942,7 +942,7 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
             }
         }
 
-        this.doAction({ patches })
+        void this.doAction({ patches })
     }
     validateCellChanges(
         changes: Handsontable.CellChange[] | null,
@@ -1084,7 +1084,7 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
         }
         // Perform a do operation that will add this to the undo stack and immediately
         // post this as a PATCH request to the server
-        this.doAction({ patches })
+        void this.doAction({ patches })
     }
 
     async getFieldDefinitions() {

--- a/adminSiteClient/PostEditorPage.tsx
+++ b/adminSiteClient/PostEditorPage.tsx
@@ -43,7 +43,7 @@ export class PostEditorPage extends React.Component<{ postId?: number }> {
     }
 
     componentDidMount() {
-        this.fetchPost()
+        void this.fetchPost()
     }
 
     render() {

--- a/adminSiteClient/PostsIndexPage.tsx
+++ b/adminSiteClient/PostsIndexPage.tsx
@@ -85,7 +85,7 @@ class PostRow extends React.Component<PostRowProps> {
     }
 
     @action.bound onSaveTags(tags: DbChartTagJoin[]) {
-        this.saveTags(tags)
+        void this.saveTags(tags)
     }
 
     @action.bound async onConvertGdoc(allowRecreate: boolean = false) {
@@ -106,7 +106,7 @@ class PostRow extends React.Component<PostRowProps> {
                 "This will overwrite the existing GDoc. Are you sure?"
             )
         ) {
-            this.onConvertGdoc(true)
+            void this.onConvertGdoc(true)
         }
     }
 
@@ -376,7 +376,7 @@ export class PostsIndexPage extends React.Component {
     }
 
     componentDidMount() {
-        this.getData()
-        this.getTags()
+        void this.getData()
+        void this.getTags()
     }
 }

--- a/adminSiteClient/RedirectsIndexPage.tsx
+++ b/adminSiteClient/RedirectsIndexPage.tsx
@@ -115,6 +115,6 @@ export class RedirectsIndexPage extends React.Component {
     }
 
     componentDidMount() {
-        this.getData()
+        void this.getData()
     }
 }

--- a/adminSiteClient/SaveButtons.tsx
+++ b/adminSiteClient/SaveButtons.tsx
@@ -7,11 +7,11 @@ import { isEmpty } from "@ourworldindata/utils"
 @observer
 export class SaveButtons extends React.Component<{ editor: ChartEditor }> {
     @action.bound onSaveChart() {
-        this.props.editor.saveGrapher()
+        void this.props.editor.saveGrapher()
     }
 
     @action.bound onSaveAsNew() {
-        this.props.editor.saveAsNewGrapher()
+        void this.props.editor.saveAsNewGrapher()
     }
 
     @action.bound onPublishToggle() {

--- a/adminSiteClient/SourceEditPage.tsx
+++ b/adminSiteClient/SourceEditPage.tsx
@@ -98,7 +98,7 @@ class SourceEditor extends React.Component<{ source: SourcePageData }> {
                     <form
                         onSubmit={(e) => {
                             e.preventDefault()
-                            this.save()
+                            void this.save()
                         }}
                     >
                         {isBulkImport && (
@@ -189,6 +189,6 @@ export class SourceEditPage extends React.Component<{ sourceId: number }> {
         this.UNSAFE_componentWillReceiveProps()
     }
     UNSAFE_componentWillReceiveProps() {
-        this.getData()
+        void this.getData()
     }
 }

--- a/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
+++ b/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
@@ -211,7 +211,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
         this.decisionReasonInput = this.currentSuggestedChartRevision
             ? this.currentSuggestedChartRevision.decisionReason ?? ""
             : ""
-        this.rerenderGraphers()
+        void this.rerenderGraphers()
         console.log("fetchGraphers 4")
     }
 
@@ -239,7 +239,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
 
     @action.bound onApproveSuggestedChartRevision() {
         console.log("WE GETTING CLOSER 0A")
-        this.updateSuggestedChartRevision(
+        void this.updateSuggestedChartRevision(
             SuggestedChartRevisionStatus.approved,
             this.decisionReasonInput
         )
@@ -247,7 +247,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
 
     @action.bound onRejectSuggestedChartRevision() {
         console.log("WE GETTING CLOSER 0R")
-        this.updateSuggestedChartRevision(
+        void this.updateSuggestedChartRevision(
             SuggestedChartRevisionStatus.rejected,
             this.decisionReasonInput
         )
@@ -255,7 +255,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
 
     @action.bound onFlagSuggestedChartRevision() {
         console.log("WE GETTING CLOSER 0F")
-        this.updateSuggestedChartRevision(
+        void this.updateSuggestedChartRevision(
             SuggestedChartRevisionStatus.flagged,
             this.decisionReasonInput
         )
@@ -282,7 +282,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
         //     this.numTotalRows -= 1
         // }
         this.disableChatGPT()
-        this.refresh()
+        void this.refresh()
     }
 
     @action.bound updateChartConfigWithGPT() {
@@ -305,7 +305,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                 this.usingGPT = true
             }
         }
-        this.rerenderGraphers()
+        void this.rerenderGraphers()
     }
 
     @action.bound getGPTModelNameUsed(): string | undefined {
@@ -329,7 +329,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
 
     @action.bound resetChartConfigWithGPT() {
         this.disableChatGPT()
-        this.refresh()
+        void this.refresh()
     }
 
     @action.bound disableChatGPT() {
@@ -342,7 +342,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
         if (!this.prevBtnIsDisabled) {
             this.disableChatGPT()
             this.rowNum = 1
-            this.refresh()
+            void this.refresh()
         }
     }
 
@@ -350,7 +350,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
         if (!this.prevBtnIsDisabled) {
             this.disableChatGPT()
             this.rowNum = this.rowNumValid - 1
-            this.refresh()
+            void this.refresh()
         }
     }
 
@@ -358,7 +358,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
         if (!this.nextBtnIsDisabled) {
             this.disableChatGPT()
             this.rowNum = this.rowNumValid + 1
-            this.refresh()
+            void this.refresh()
         }
     }
 
@@ -366,7 +366,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
         if (!this.nextBtnIsDisabled) {
             this.disableChatGPT()
             this.rowNum = this.numAvailableRowsForSelectedUser
-            this.refresh()
+            void this.refresh()
         }
     }
 
@@ -376,7 +376,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
             this.rowNum = Math.floor(
                 Math.random() * this.numAvailableRowsForSelectedUser + 1
             )
-            this.refresh()
+            void this.refresh()
         }
     }
 
@@ -394,35 +394,35 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
         }
         this.rowNum = input
         setTimeout(() => {
-            this.refresh()
+            void this.refresh()
         }, 100)
     }
 
     @action.bound onChangeDesktopPreviewSize(value: string) {
         console.log("onChangeDesktopPreviewSize")
         this.desktopPreviewSize = value
-        this.rerenderGraphers()
+        void this.rerenderGraphers()
     }
 
     @action.bound onChangePreviewSvgOrJson(value: string) {
         console.log("onChangePreviewSvgOrJson")
         this.previewSvgOrJson = value
-        this.rerenderGraphers()
+        void this.rerenderGraphers()
     }
 
     @action.bound onSortByChange(selected: any) {
         this.sortBy = selected.value
-        this.refresh()
+        void this.refresh()
     }
 
     @action.bound onSortOrderChange(value: SortOrder) {
         this.sortOrder = value
-        this.refresh()
+        void this.refresh()
     }
 
     @action.bound onToggleShowPendingOnly(value: boolean) {
         this.showPendingOnly = value
-        this.refresh()
+        void this.refresh()
     }
 
     @action.bound onToggleShowExistingChart(value: boolean) {
@@ -439,7 +439,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
     }
 
     componentDidMount() {
-        this.refresh().then(() => {
+        void this.refresh().then(() => {
             this.admin.loadingIndicatorSetting = "off"
         })
     }
@@ -582,7 +582,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
             this.rowNum = 1
         })
 
-        this.refresh()
+        void this.refresh()
     }
 
     renderUserMenu() {
@@ -1462,7 +1462,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                                     type="radio"
                                     onChange={action(() => {
                                         this.previewMode = "mobile"
-                                        this.rerenderGraphers()
+                                        void this.rerenderGraphers()
                                     })}
                                     name="previewSize"
                                     id="mobile"
@@ -1482,7 +1482,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                                 <input
                                     onChange={action(() => {
                                         this.previewMode = "desktop"
-                                        this.rerenderGraphers()
+                                        void this.rerenderGraphers()
                                     })}
                                     type="radio"
                                     name="previewSize"

--- a/adminSiteClient/SuggestedChartRevisionImportPage.tsx
+++ b/adminSiteClient/SuggestedChartRevisionImportPage.tsx
@@ -72,7 +72,7 @@ export class SuggestedChartRevisionImportPage extends React.Component {
             suggestedConfigs: this.suggestedConfigs,
             suggestedReason: this.suggestedReason,
         }
-        this.context.admin
+        void this.context.admin
             .requestJSON("/api/suggested-chart-revisions", requestData, "POST")
             .then((json: any) => {
                 runInAction(() => {

--- a/adminSiteClient/SuggestedChartRevisionListPage.tsx
+++ b/adminSiteClient/SuggestedChartRevisionListPage.tsx
@@ -96,16 +96,16 @@ export class SuggestedChartRevisionListPage extends React.Component {
 
     @action.bound onSortByChange(selected: any) {
         this.sortBy = selected.value
-        this.getData()
+        void this.getData()
     }
 
     @action.bound onSortOrderChange(value: SortOrder) {
         this.sortOrder = value
-        this.getData()
+        void this.getData()
     }
 
     componentDidMount() {
-        this.getData()
+        void this.getData()
     }
 
     render() {

--- a/adminSiteClient/TagEditPage.tsx
+++ b/adminSiteClient/TagEditPage.tsx
@@ -136,7 +136,7 @@ class TagEditor extends React.Component<{ tag: TagPageData }> {
                     <form
                         onSubmit={(e) => {
                             e.preventDefault()
-                            this.save()
+                            void this.save()
                         }}
                     >
                         <BindString
@@ -249,9 +249,9 @@ export class TagEditPage extends React.Component<{ tagId: number }> {
     }
 
     componentDidMount() {
-        this.getData(this.props.tagId)
+        void this.getData(this.props.tagId)
     }
     UNSAFE_componentWillReceiveProps(nextProps: any) {
-        this.getData(nextProps.tagId)
+        void this.getData(nextProps.tagId)
     }
 }

--- a/adminSiteClient/TagsIndexPage.tsx
+++ b/adminSiteClient/TagsIndexPage.tsx
@@ -59,7 +59,7 @@ class AddTagModal extends React.Component<{
                 <form
                     onSubmit={(e) => {
                         e.preventDefault()
-                        this.submit()
+                        void this.submit()
                     }}
                 >
                     <div className="modal-header">
@@ -199,6 +199,6 @@ export class TagsIndexPage extends React.Component {
     }
 
     componentDidMount() {
-        this.getData()
+        void this.getData()
     }
 }

--- a/adminSiteClient/UserEditPage.tsx
+++ b/adminSiteClient/UserEditPage.tsx
@@ -65,6 +65,6 @@ export class UserEditPage extends React.Component<{ userId: number }> {
     }
 
     componentDidMount() {
-        this.getData()
+        void this.getData()
     }
 }

--- a/adminSiteClient/UsersIndexPage.tsx
+++ b/adminSiteClient/UsersIndexPage.tsx
@@ -38,7 +38,7 @@ class InviteModal extends React.Component<{ onClose: () => void }> {
 
     @action.bound onSubmit(event: React.FormEvent) {
         event.preventDefault()
-        this.submit()
+        void this.submit()
     }
 
     render() {
@@ -212,6 +212,6 @@ export class UsersIndexPage extends React.Component {
     }
 
     componentDidMount() {
-        this.getData()
+        void this.getData()
     }
 }

--- a/adminSiteClient/VariableEditPage.tsx
+++ b/adminSiteClient/VariableEditPage.tsx
@@ -171,7 +171,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                 <form
                     onSubmit={(e) => {
                         e.preventDefault()
-                        this.save()
+                        void this.save()
                     }}
                 >
                     <div className="row">
@@ -662,6 +662,6 @@ export class VariableEditPage extends React.Component<{ variableId: number }> {
         this.UNSAFE_componentWillReceiveProps()
     }
     UNSAFE_componentWillReceiveProps() {
-        this.getData()
+        void this.getData()
     }
 }

--- a/adminSiteClient/VariableSelector.tsx
+++ b/adminSiteClient/VariableSelector.tsx
@@ -496,7 +496,7 @@ export class VariableSelector extends React.Component<VariableSelectorProps> {
     dispose!: IReactionDisposer
     base: React.RefObject<HTMLDivElement> = React.createRef()
     componentDidMount() {
-        this.props.editor.loadVariableUsageCounts()
+        void this.props.editor.loadVariableUsageCounts()
         this.initChosenVariablesAndNamespaces()
     }
 

--- a/adminSiteClient/VariablesIndexPage.tsx
+++ b/adminSiteClient/VariablesIndexPage.tsx
@@ -130,7 +130,7 @@ export class VariablesIndexPage extends React.Component {
             () => this.searchInput || this.maxVisibleRows,
             lodash.debounce(() => this.getData(), 200)
         )
-        this.getData()
+        void this.getData()
     }
 
     componentWillUnmount() {

--- a/adminSiteServer/adminRouter.tsx
+++ b/adminSiteServer/adminRouter.tsx
@@ -338,7 +338,7 @@ const gitCmsServer = new GitCmsServer({
     baseDir: GIT_CMS_DIR,
     shouldAutoPush: true,
 })
-gitCmsServer.createDirAndInitIfNeeded()
+void gitCmsServer.createDirAndInitIfNeeded()
 gitCmsServer.addToRouter(adminRouter)
 
 export { adminRouter }

--- a/adminSiteServer/app.test.tsx
+++ b/adminSiteServer/app.test.tsx
@@ -13,6 +13,6 @@ describe(OwidAdminApp, () => {
     it("should be able to start the app", async () => {
         await app.startListening(8765, "localhost")
         expect(app.server).toBeTruthy()
-        app.stopListening()
+        await app.stopListening()
     })
 })

--- a/adminSiteServer/app.tsx
+++ b/adminSiteServer/app.tsx
@@ -263,7 +263,7 @@ export class OwidAdminApp {
 }
 
 if (!module.parent)
-    new OwidAdminApp({
+    void new OwidAdminApp({
         gitCmsDir: GIT_CMS_DIR,
         isDev: ENV === "development",
     }).startListening(ADMIN_SERVER_PORT, ADMIN_SERVER_HOST)

--- a/adminSiteServer/exportGitData.ts
+++ b/adminSiteServer/exportGitData.ts
@@ -9,11 +9,13 @@ const main = async () => {
         })
         for (const dataset of datasets) {
             if (!dataset.isPrivate && !dataset.nonRedistributable)
-                syncDatasetToGitRepo(knex, dataset.id, { commitOnly: true })
+                await syncDatasetToGitRepo(knex, dataset.id, {
+                    commitOnly: true,
+                })
         }
     })
 
     await db.closeTypeOrmAndKnexConnections()
 }
 
-main()
+void main()

--- a/adminSiteServer/testPageRouter.tsx
+++ b/adminSiteServer/testPageRouter.tsx
@@ -243,7 +243,7 @@ async function propsFromQueryParams(
 
     if (datasetIds.length > 0) {
         const datasetIds = params.datasetIds
-        query.andWhere(
+        query = query.andWhere(
             `
             EXISTS(
                 SELECT *
@@ -258,7 +258,7 @@ async function propsFromQueryParams(
     }
 
     if (namespaces.length > 0) {
-        query.andWhere(
+        query = query.andWhere(
             `
             EXISTS(
                 SELECT *

--- a/baker/DeployUtils.ts
+++ b/baker/DeployUtils.ts
@@ -142,7 +142,7 @@ const getSlackMentionByEmail = async (
         const response = await slackClient.users.lookupByEmail({ email })
         return response.user?.id ? `<@${response.user.id}>` : undefined
     } catch (error) {
-        logErrorAndMaybeSendToBugsnag(error)
+        await logErrorAndMaybeSendToBugsnag(error)
     }
     return
 }

--- a/baker/ExplorerBaker.tsx
+++ b/baker/ExplorerBaker.tsx
@@ -13,8 +13,8 @@ export const bakeAllPublishedExplorers = async (
     knex: db.KnexReadonlyTransaction
 ) => {
     // remove all existing explorers, since we're re-baking every single one anyway
-    fs.remove(outputFolder)
-    fs.mkdirp(outputFolder)
+    await fs.remove(outputFolder)
+    await fs.mkdirp(outputFolder)
 
     const published = await explorerAdminServer.getAllPublishedExplorers()
     await bakeExplorersToDir(outputFolder, published, knex)

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -206,7 +206,7 @@ export async function renderDataPageV2(
 
     if (faqResolveErrors.length > 0) {
         for (const error of faqResolveErrors) {
-            logErrorAndMaybeSendToBugsnag(
+            await logErrorAndMaybeSendToBugsnag(
                 new JsonError(
                     `Data page error in finding FAQs for variable ${variableId}: ${error.error}`
                 )
@@ -250,7 +250,7 @@ export async function renderDataPageV2(
         try {
             slug = await getSlugForTopicTag(firstTopicTag)
         } catch (error) {
-            logErrorAndMaybeSendToBugsnag(
+            await logErrorAndMaybeSendToBugsnag(
                 `Datapage with variableId "${variableId}" and title "${datapageData.title.title}" is using "${firstTopicTag}" as its primary tag, which we are unable to resolve to a tag in the grapher DB`
             )
         }
@@ -519,7 +519,7 @@ export const bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers =
         await pMap(
             jobs,
             async (job) => {
-                db.knexReadonlyTransaction((trx) =>
+                await db.knexReadonlyTransaction((trx) =>
                     bakeSingleGrapherChart(job, trx)
                 )
                 progressBar.tick({ name: `slug ${job.slug}` })

--- a/baker/GrapherImageBaker.tsx
+++ b/baker/GrapherImageBaker.tsx
@@ -114,7 +114,7 @@ export async function bakeGrapherToSvg(
     let svgCode = grapher.staticSVG
     if (optimizeSvgs) svgCode = await optimizeSvg(svgCode)
 
-    fs.writeFile(outPath, svgCode)
+    await fs.writeFile(outPath, svgCode)
     return svgCode
 }
 

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -536,7 +536,7 @@ export class SiteBaker {
             try {
                 await this.bakeOwidGdoc(publishedGdoc)
             } catch (e) {
-                logErrorAndMaybeSendToBugsnag(
+                await logErrorAndMaybeSendToBugsnag(
                     `Error baking gdoc post with id "${publishedGdoc.id}" and slug "${publishedGdoc.slug}": ${e}`
                 )
             }
@@ -662,7 +662,7 @@ export class SiteBaker {
             )
             for (const detailId of detailIds) {
                 if (!details[detailId]) {
-                    logErrorAndMaybeSendToBugsnag(
+                    await logErrorAndMaybeSendToBugsnag(
                         `Grapher with slug ${chart.slug} references dod "${detailId}" which does not exist`
                     )
                 }
@@ -684,7 +684,7 @@ export class SiteBaker {
         const { details, parseErrors } =
             await GdocPost.getDetailsOnDemandGdoc(knex)
         if (parseErrors.length) {
-            logErrorAndMaybeSendToBugsnag(
+            await logErrorAndMaybeSendToBugsnag(
                 `Error(s) baking details: ${parseErrors
                     .map((e) => e.message)
                     .join(", ")}`
@@ -740,7 +740,7 @@ export class SiteBaker {
             try {
                 await this.bakeOwidGdoc(dataInsight)
             } catch (e) {
-                logErrorAndMaybeSendToBugsnag(
+                await logErrorAndMaybeSendToBugsnag(
                     `Error baking gdoc post with id "${dataInsight.id}" and slug "${dataInsight.slug}": ${e}`
                 )
             }
@@ -817,7 +817,7 @@ export class SiteBaker {
             try {
                 await this.bakeOwidGdoc(publishedAuthor)
             } catch (e) {
-                logErrorAndMaybeSendToBugsnag(
+                await logErrorAndMaybeSendToBugsnag(
                     `Error baking author with id "${publishedAuthor.id}" and slug "${publishedAuthor.slug}": ${e}`
                 )
             }
@@ -902,7 +902,7 @@ export class SiteBaker {
         for (const icon of tagIcons) {
             const iconName = icon.split(".")[0]
             if (!tagNames.has(iconName)) {
-                logErrorAndMaybeSendToBugsnag(
+                await logErrorAndMaybeSendToBugsnag(
                     `Tag icon "${icon}" does not have a corresponding tag in the database.`
                 )
             }
@@ -1034,9 +1034,9 @@ export class SiteBaker {
         console.log(msg || outPath)
     }
 
-    endDbConnections() {
-        wpdb.singleton.end()
-        db.closeTypeOrmAndKnexConnections()
+    async endDbConnections() {
+        await wpdb.singleton.end()
+        await db.closeTypeOrmAndKnexConnections()
     }
 
     private flushCache() {

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -286,4 +286,4 @@ export const configureAlgolia = async () => {
     }
 }
 
-if (require.main === module) configureAlgolia()
+if (require.main === module) void configureAlgolia()

--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -144,4 +144,4 @@ process.on("unhandledRejection", (e) => {
     process.exit(1)
 })
 
-indexChartsToAlgolia()
+void indexChartsToAlgolia()

--- a/baker/algolia/indexExplorersToAlgolia.ts
+++ b/baker/algolia/indexExplorersToAlgolia.ts
@@ -205,4 +205,4 @@ const indexExplorersToAlgolia = async () => {
     }
 }
 
-indexExplorersToAlgolia()
+void indexExplorersToAlgolia()

--- a/baker/algolia/indexToAlgolia.tsx
+++ b/baker/algolia/indexToAlgolia.tsx
@@ -237,7 +237,7 @@ const indexToAlgolia = async () => {
     await db.getConnection()
     const records = await db.knexReadonlyTransaction(getPagesRecords)
 
-    index.replaceAllObjects(records)
+    await index.replaceAllObjects(records)
 
     await wpdb.singleton.end()
     await db.closeTypeOrmAndKnexConnections()
@@ -248,4 +248,4 @@ process.on("unhandledRejection", (e) => {
     process.exit(1)
 })
 
-indexToAlgolia()
+void indexToAlgolia()

--- a/baker/bakeGdocPost.ts
+++ b/baker/bakeGdocPost.ts
@@ -6,7 +6,7 @@ import { SiteBaker } from "./SiteBaker.js"
 import { BAKED_SITE_DIR, BAKED_BASE_URL } from "../settings/serverSettings.js"
 import * as db from "../db/db.js"
 
-yargs(hideBin(process.argv))
+void yargs(hideBin(process.argv))
     .command<{ slug: string }>(
         "$0 [slug]",
         "Bake single GDoc post",

--- a/baker/bakeGdocPosts.ts
+++ b/baker/bakeGdocPosts.ts
@@ -6,7 +6,7 @@ import { SiteBaker } from "./SiteBaker.js"
 import { BAKED_SITE_DIR, BAKED_BASE_URL } from "../settings/serverSettings.js"
 import * as db from "../db/db.js"
 
-yargs(hideBin(process.argv))
+void yargs(hideBin(process.argv))
     .command<{ slugs: string[] }>(
         "$0 [slug]",
         "Bake multiple GDoc posts",

--- a/baker/batchTagWithGpt.ts
+++ b/baker/batchTagWithGpt.ts
@@ -22,7 +22,7 @@ export const batchTagWithGpt = async ({
     debug,
     limit,
 }: BatchTagWithGptArgs = {}) => {
-    db.knexReadonlyTransaction((trx) =>
+    await db.knexReadonlyTransaction((trx) =>
         batchTagChartsWithGpt(trx, { debug, limit })
     )
 }
@@ -72,7 +72,7 @@ const batchTagChartsWithGpt = async (
 }
 
 if (require.main === module) {
-    yargs(hideBin(process.argv))
+    void yargs(hideBin(process.argv))
         .command<BatchTagWithGptArgs>(
             "$0",
             "Batch tag charts with GPT topics",

--- a/baker/buildAndDeploySite.ts
+++ b/baker/buildAndDeploySite.ts
@@ -7,7 +7,7 @@ import os from "os"
 import path from "path"
 import { DeployTarget } from "./DeployTarget.js"
 
-yargs(hideBin(process.argv))
+void yargs(hideBin(process.argv))
     .command<{
         target: DeployTarget
         skipChecks: boolean

--- a/baker/buildLocalBake.ts
+++ b/baker/buildLocalBake.ts
@@ -14,13 +14,13 @@ const bakeDomainToFolder = async (
     bakeSteps?: BakeStepConfig
 ) => {
     dir = normalize(dir)
-    fs.mkdirp(dir)
+    await fs.mkdirp(dir)
     const baker = new SiteBaker(dir, baseUrl, bakeSteps)
     console.log(`Baking site locally with baseUrl '${baseUrl}' to dir '${dir}'`)
     await db.knexReadonlyTransaction((trx) => baker.bakeAll(trx))
 }
 
-yargs(hideBin(process.argv))
+void yargs(hideBin(process.argv))
     .command<{ baseUrl: string; dir: string; steps?: string[] }>(
         "$0 [baseUrl] [dir]",
         "Bake the site to a local folder",

--- a/baker/formatWordpressPost.tsx
+++ b/baker/formatWordpressPost.tsx
@@ -215,12 +215,14 @@ export const formatWordpressPost = async (
         })
     }
 
+    const jsonErrors: JsonError[] = []
+
     html = html.replace(dataValueRegex, (_, dataValueConfigurationString) => {
         const dataValueProps: DataValueProps | undefined = dataValues.get(
             dataValueConfigurationString
         )
         if (!dataValueProps) {
-            logErrorAndMaybeSendToBugsnag(
+            jsonErrors.push(
                 new JsonError(
                     `Missing data value for {{DataValue ${dataValueConfigurationString}}}" in ${BAKED_BASE_URL}/${post.slug}`
                 )
@@ -233,6 +235,8 @@ export const formatWordpressPost = async (
             </span>
         )
     })
+
+    await Promise.allSettled(jsonErrors.map(logErrorAndMaybeSendToBugsnag))
 
     // Needs to be happen after DataValue replacements, as the DataToken regex
     // would otherwise capture DataValue tags

--- a/baker/liveCommit.ts
+++ b/baker/liveCommit.ts
@@ -132,7 +132,7 @@ if (args._[0]) {
         )
 } else {
     // fetch information for _all_ servers
-    fetchAll().then((commitInformation) => {
+    void fetchAll().then((commitInformation) => {
         const data = mapValues(
             keyBy(
                 commitInformation,

--- a/baker/pageOverrides.tsx
+++ b/baker/pageOverrides.tsx
@@ -18,7 +18,7 @@ export const getPostBySlugLogToSlackNoThrow = async (
     try {
         post = await getFullPostBySlugFromSnapshot(knex, slug)
     } catch (err) {
-        logErrorAndMaybeSendToBugsnag(err)
+        void logErrorAndMaybeSendToBugsnag(err)
     } finally {
         return post
     }
@@ -47,7 +47,7 @@ export const getLandingOnlyIfParent = async (
         // todo: the concept of "citation overrides" does not belong to that
         // generic function. Logging this message should be the responsibility
         // of the caller function.
-        logErrorAndMaybeSendToBugsnag(
+        await logErrorAndMaybeSendToBugsnag(
             new JsonError(
                 // This error often shows up intermittently as a false-positive (DB unavailable when calling getPostBySlug()?)
                 // If it happens systematically, please check

--- a/baker/postUpdatedHook.ts
+++ b/baker/postUpdatedHook.ts
@@ -215,7 +215,7 @@ const main = async (
         console.error(err)
         throw err
     }
-    exit()
+    await exit()
 }
 
-main(argv._[0], argv._[1], parseInt(argv._[2]), argv._[3])
+void main(argv._[0], argv._[1], parseInt(argv._[2]), argv._[3])

--- a/baker/recalcLatestCountryData.ts
+++ b/baker/recalcLatestCountryData.ts
@@ -9,4 +9,4 @@ const main = async () => {
     await db.closeTypeOrmAndKnexConnections()
 }
 
-if (require.main === module) main()
+if (require.main === module) void main()

--- a/baker/redirects.ts
+++ b/baker/redirects.ts
@@ -125,7 +125,7 @@ export const resolveRedirectFromMap = async (
     const _resolveRedirectFromMap = async (url: Url): Promise<Url> => {
         ++recursionDepth
         if (recursionDepth > MAX_RECURSION_DEPTH) {
-            logErrorAndMaybeSendToBugsnag(
+            void logErrorAndMaybeSendToBugsnag(
                 new JsonError(
                     `A circular redirect (/a -> /b -> /a) has been detected for ${originalUrl.pathname} and is ignored.`
                 )
@@ -141,7 +141,7 @@ export const resolveRedirectFromMap = async (
         const targetUrl = Url.fromURL(target)
 
         if (targetUrl.pathname === url.pathname) {
-            logErrorAndMaybeSendToBugsnag(
+            void logErrorAndMaybeSendToBugsnag(
                 new JsonError(
                     `A self redirect (/a -> /a) has been detected for ${originalUrl.pathname} and is ignored.`
                 )

--- a/baker/runBakeGraphers.ts
+++ b/baker/runBakeGraphers.ts
@@ -9,7 +9,7 @@ import * as db from "../db/db.js"
  */
 
 const main = async (folder: string) => {
-    db.knexReadonlyTransaction((trx) =>
+    return db.knexReadonlyTransaction((trx) =>
         bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers(
             folder,
             trx
@@ -18,4 +18,4 @@ const main = async (folder: string) => {
 }
 
 const dir = process.argv.slice(2).join(" ")
-main(dir)
+void main(dir)

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -267,7 +267,7 @@ export const renderFrontPage = async (knex: KnexReadonlyTransaction) => {
         await gdocHomepage.loadState(knex)
         return renderGdoc(gdocHomepage)
     } else {
-        logErrorAndMaybeSendToBugsnag(
+        await logErrorAndMaybeSendToBugsnag(
             new JsonError(
                 `Failed to find homepage Gdoc with type "${OwidGdocType.Homepage}"`
             )
@@ -580,7 +580,7 @@ export const renderProminentLinks = async (
                           ).title)
             } finally {
                 if (!title) {
-                    logErrorAndMaybeSendToBugsnag(
+                    void logErrorAndMaybeSendToBugsnag(
                         new JsonError(
                             `No fallback title found for prominent link ${resolvedUrlString} in ${formatWordpressEditLink(
                                 containerPostId
@@ -769,7 +769,7 @@ export const renderKeyInsights = async (
         const title = $block.find("> title").text()
         const slug = $block.find("> slug").text()
         if (!title || !slug) {
-            logErrorAndMaybeSendToBugsnag(
+            void logErrorAndMaybeSendToBugsnag(
                 new JsonError(
                     `Title or anchor missing for key insights block, content removed in ${formatWordpressEditLink(
                         containerPostId
@@ -782,7 +782,7 @@ export const renderKeyInsights = async (
 
         const keyInsights = extractKeyInsights($, $block, containerPostId)
         if (!keyInsights.length) {
-            logErrorAndMaybeSendToBugsnag(
+            void logErrorAndMaybeSendToBugsnag(
                 new JsonError(
                     `No valid key insights found within block, content removed in ${formatWordpressEditLink(
                         containerPostId
@@ -838,7 +838,7 @@ export const extractKeyInsights = (
         // both as an unexpected behaviour or a feature, depending on the stage
         // of work (published or WIP).
         if (!title || !slug || !content) {
-            logErrorAndMaybeSendToBugsnag(
+            void logErrorAndMaybeSendToBugsnag(
                 new JsonError(
                     `Missing title, slug or content for key insight ${
                         title || slug

--- a/baker/startDeployQueueServer.ts
+++ b/baker/startDeployQueueServer.ts
@@ -38,4 +38,4 @@ const main = async () => {
     await db.knexReadonlyTransaction(deployIfQueueIsNotEmpty)
 }
 
-main()
+void main()

--- a/baker/syncRedirectsToGrapher.ts
+++ b/baker/syncRedirectsToGrapher.ts
@@ -75,4 +75,4 @@ const main = async (): Promise<void> => {
     }
 }
 
-main()
+void main()

--- a/db/analyzeWpPosts.ts
+++ b/db/analyzeWpPosts.ts
@@ -67,4 +67,4 @@ const analyze = async (): Promise<void> => {
     await db.closeTypeOrmAndKnexConnections()
 }
 
-analyze()
+void analyze()

--- a/db/exportMetadata.ts
+++ b/db/exportMetadata.ts
@@ -60,4 +60,4 @@ async function dataExport(): Promise<void> {
     await db.closeTypeOrmAndKnexConnections()
 }
 
-dataExport()
+void dataExport()

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -319,4 +319,4 @@ async function runMigrate(): Promise<void> {
     await db.closeTypeOrmAndKnexConnections()
 }
 
-runMigrate()
+void runMigrate()

--- a/db/migration/1642793082560-CleanupLegacyChartConfigs.ts
+++ b/db/migration/1642793082560-CleanupLegacyChartConfigs.ts
@@ -222,7 +222,7 @@ where JSON_CONTAINS_PATH(${column}, 'one', '$."yAxis"."numDecimalPlaces"') = 1;`
                 delete (dimension as any).chartId
                 delete (dimension as any).numDecimalPlaces
             }
-            queryRunner.query(
+            await queryRunner.query(
                 `update ${table} set ${column} = ? where id = ?`,
                 [JSON.stringify(json), id]
             )

--- a/db/migration/1647866984314-LineChartYMaxZero.ts
+++ b/db/migration/1647866984314-LineChartYMaxZero.ts
@@ -2,7 +2,7 @@ import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class LineChartYMaxZero1647866984314 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`
+        await queryRunner.query(`
             UPDATE charts
             SET config = JSON_SET(config, "$.yAxis.max", 0)
             WHERE (

--- a/db/migration/1652693645426-RemoveMinPopulationFilter.ts
+++ b/db/migration/1652693645426-RemoveMinPopulationFilter.ts
@@ -13,7 +13,7 @@ export class RemoveMinPopulationFilter1652693645426
         }
 
         for (const [tableName, columnName] of Object.entries(tables)) {
-            queryRunner.query(`UPDATE ${tableName}
+            await queryRunner.query(`UPDATE ${tableName}
         SET ${columnName} = JSON_REMOVE(${columnName}, '$.minPopulationFilter')
         WHERE JSON_CONTAINS_PATH(${columnName}, 'one', '$.minPopulationFilter') = 1;`)
         }

--- a/db/migration/1666871402674-AddWordpressPostArchieMlJsonColumn.ts
+++ b/db/migration/1666871402674-AddWordpressPostArchieMlJsonColumn.ts
@@ -4,7 +4,7 @@ export class AddWordpressPostArchieMlJsonColumn1666871402674
     implements MigrationInterface
 {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`-- sql
+        await queryRunner.query(`-- sql
             ALTER TABLE posts
             ADD COLUMN archieml json AFTER content,
             ADD COLUMN archieml_update_statistics json AFTER archieml
@@ -12,7 +12,7 @@ export class AddWordpressPostArchieMlJsonColumn1666871402674
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`-- sql
+        await queryRunner.query(`-- sql
             ALTER TABLE posts
             DROP COLUMN archieml,
             DROP COLUMN archieml_update_statistics

--- a/db/migration/1675374345914-ChartTagIsKeyChartNonNull.ts
+++ b/db/migration/1675374345914-ChartTagIsKeyChartNonNull.ts
@@ -4,26 +4,26 @@ export class ChartTagIsKeyChartNonNull1675374345914
     implements MigrationInterface
 {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`
+        await queryRunner.query(`
         UPDATE chart_tags
         SET isKey = 0
         WHERE isKey IS NULL`)
 
-        queryRunner.query(`
+        await queryRunner.query(`
         ALTER TABLE chart_tags
         MODIFY COLUMN isKey TINYINT UNSIGNED NOT NULL DEFAULT FALSE`)
 
-        queryRunner.query(`
+        await queryRunner.query(`
         ALTER TABLE chart_tags
         RENAME COLUMN isKey TO isKeyChart`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`
+        await queryRunner.query(`
         ALTER TABLE chart_tags
         RENAME COLUMN isKeyChart TO isKey`)
 
-        queryRunner.query(`
+        await queryRunner.query(`
         ALTER TABLE chart_tags
         MODIFY COLUMN isKey TINYINT UNSIGNED`)
     }

--- a/db/migration/1675942735841-DeleteObsoleteTables.ts
+++ b/db/migration/1675942735841-DeleteObsoleteTables.ts
@@ -2,9 +2,9 @@ import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class DeleteObsoleteTables1675942735841 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`DROP TABLE settings;`)
-        queryRunner.query(`DROP TABLE knex_migrations;`)
-        queryRunner.query(`DROP TABLE knex_migrations_lock;`)
+        await queryRunner.query(`DROP TABLE settings;`)
+        await queryRunner.query(`DROP TABLE knex_migrations;`)
+        await queryRunner.query(`DROP TABLE knex_migrations_lock;`)
     }
 
     public async down(): Promise<void> {} // eslint-disable-line

--- a/db/migration/1676376942081-PostsGdocsLinks.ts
+++ b/db/migration/1676376942081-PostsGdocsLinks.ts
@@ -2,7 +2,7 @@ import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class PostsGdocsLinks1676376942081 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`
+        await queryRunner.query(`
         CREATE TABLE posts_gdocs_links (
             id INT NOT NULL AUTO_INCREMENT,
             sourceId VARCHAR(255) COLLATE utf8mb4_0900_as_cs,
@@ -16,6 +16,6 @@ export class PostsGdocsLinks1676376942081 implements MigrationInterface {
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`DROP TABLE IF EXISTS posts_gdocs_links;`)
+        await queryRunner.query(`DROP TABLE IF EXISTS posts_gdocs_links;`)
     }
 }

--- a/db/migration/1678783599815-SplitHideTitleAnnotationIntoMultipleFlags.ts
+++ b/db/migration/1678783599815-SplitHideTitleAnnotationIntoMultipleFlags.ts
@@ -4,7 +4,7 @@ export class SplitHideTitleAnnotationIntoMultipleFlags1678783599815
     implements MigrationInterface
 {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`
+        await queryRunner.query(`
             UPDATE charts
             SET config = JSON_SET(config, "$.hideAnnotationFieldsInTitle", JSON_OBJECT("entity", TRUE, "time", TRUE, "changeInPrefix", TRUE)),
                 config = JSON_REMOVE(config, "$.hideTitleAnnotation")
@@ -13,7 +13,7 @@ export class SplitHideTitleAnnotationIntoMultipleFlags1678783599815
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`
+        await queryRunner.query(`
             UPDATE charts
             SET config = JSON_SET(config, "$.hideTitleAnnotation", TRUE),
                 config = JSON_REMOVE(config, "$.hideAnnotationFieldsInTitle")
@@ -21,7 +21,7 @@ export class SplitHideTitleAnnotationIntoMultipleFlags1678783599815
                 config->>"$.hideAnnotationFieldsInTitle.entity" = "true"
                 OR config->>"$.hideAnnotationFieldsInTitle.time" = "true"
                 OR config->>"$.hideAnnotationFieldsInTitle.changeInPrefix" = "true"
-            )    
+            )
         `)
     }
 }

--- a/db/migration/1679090531333-AddMoreLinkTypes.ts
+++ b/db/migration/1679090531333-AddMoreLinkTypes.ts
@@ -2,7 +2,7 @@ import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class AddMoreLinkTypes1679090531333 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(
+        await queryRunner.query(
             `ALTER TABLE posts_gdocs_links MODIFY linkType ENUM('gdoc', 'url', 'grapher', 'explorer');`
         )
     }

--- a/db/migration/1680210665372-PostsGdocsXTags.ts
+++ b/db/migration/1680210665372-PostsGdocsXTags.ts
@@ -2,7 +2,7 @@ import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class PostsGdocsXTags1680210665372 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`
+        await queryRunner.query(`
         CREATE TABLE posts_gdocs_x_tags (
             gdocId VARCHAR(255) NOT NULL,
             tagId INT NOT NULL,
@@ -14,7 +14,7 @@ export class PostsGdocsXTags1680210665372 implements MigrationInterface {
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`
+        await queryRunner.query(`
             DROP TABLE IF EXISTS posts_gdocs_x_tags;
         `)
     }

--- a/db/migration/1681862074619-RemoveDetails.ts
+++ b/db/migration/1681862074619-RemoveDetails.ts
@@ -2,7 +2,7 @@ import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class RemoveDetails1681862074619 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`
+        await queryRunner.query(`
             DROP TABLE IF EXISTS details
         `)
     }

--- a/db/migration/1682412341600-AddExplorerTables.ts
+++ b/db/migration/1682412341600-AddExplorerTables.ts
@@ -2,7 +2,7 @@ import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class AddExplorerTables1682412341600 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`
+        await queryRunner.query(`
         CREATE TABLE IF NOT EXISTS explorers (
                 slug VARCHAR(150) PRIMARY KEY,
                 isPublished BOOLEAN NOT NULL,
@@ -12,7 +12,7 @@ export class AddExplorerTables1682412341600 implements MigrationInterface {
             )
         `)
 
-        queryRunner.query(`
+        await queryRunner.query(`
         CREATE TABLE IF NOT EXISTS explorer_charts (
                 id INT AUTO_INCREMENT PRIMARY KEY,
                 explorerSlug VARCHAR(150) NOT NULL,
@@ -24,10 +24,10 @@ export class AddExplorerTables1682412341600 implements MigrationInterface {
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`
+        await queryRunner.query(`
             DROP TABLE IF EXISTS explorer_charts;
         `)
-        queryRunner.query(`
+        await queryRunner.query(`
             DROP TABLE IF EXISTS explorers;
         `)
     }

--- a/db/migration/1683577595565-ChartAddGeneratedColumns.ts
+++ b/db/migration/1683577595565-ChartAddGeneratedColumns.ts
@@ -4,20 +4,20 @@ export class ChartAddGeneratedColumns1683577595565
     implements MigrationInterface
 {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`-- sql
+        await queryRunner.query(`-- sql
         ALTER TABLE charts
         ADD COLUMN slug VARCHAR(255) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(config, '$.slug'))) VIRTUAL AFTER id,
         ADD COLUMN type VARCHAR(255) GENERATED ALWAYS AS (COALESCE(JSON_UNQUOTE(JSON_EXTRACT(config, '$.type')), 'LineChart')) VIRTUAL AFTER slug;`)
 
-        queryRunner.query(`-- sql
+        await queryRunner.query(`-- sql
         CREATE INDEX charts_slug ON charts (slug);`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`-- sql
+        await queryRunner.query(`-- sql
         DROP INDEX charts_slug ON charts;`)
 
-        queryRunner.query(`-- sql
+        await queryRunner.query(`-- sql
         ALTER TABLE charts
         DROP COLUMN slug,
         DROP COLUMN type;`)

--- a/db/migration/1685653967284-PostsFeaturedImage.ts
+++ b/db/migration/1685653967284-PostsFeaturedImage.ts
@@ -2,16 +2,16 @@ import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class PostsFeaturedImage1685653967284 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`
+        await queryRunner.query(`
         ALTER TABLE posts
-        ADD COLUMN featured_image VARCHAR(1024) NOT NULL DEFAULT "";    
+        ADD COLUMN featured_image VARCHAR(1024) NOT NULL DEFAULT "";
         `)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`
+        await queryRunner.query(`
         ALTER TABLE posts
-        DROP COLUMN featured_image;    
+        DROP COLUMN featured_image;
         `)
     }
 }

--- a/db/migration/1685706058408-AddLegacySdgChartReferences.ts
+++ b/db/migration/1685706058408-AddLegacySdgChartReferences.ts
@@ -41,7 +41,7 @@ export class AddLegacySdgChartReferences1685706058408
     }
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`-- sql
+        await queryRunner.query(`-- sql
         CREATE TABLE IF NOT EXISTS legacy_sdg_chart_references (
                 id INT AUTO_INCREMENT PRIMARY KEY,
                 slug VARCHAR(255),
@@ -61,7 +61,7 @@ export class AddLegacySdgChartReferences1685706058408
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`-- sql
+        await queryRunner.query(`-- sql
             DROP TABLE IF EXISTS legacy_sdg_chart_references;
         `)
     }

--- a/db/migration/1687851686136-GdocsAddBreadcrumbsColumn.ts
+++ b/db/migration/1687851686136-GdocsAddBreadcrumbsColumn.ts
@@ -4,12 +4,12 @@ export class GdocsAddBreadcrumbsColumn1687851686136
     implements MigrationInterface
 {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`-- sql
+        await queryRunner.query(`-- sql
             ALTER TABLE posts_gdocs ADD COLUMN breadcrumbs JSON`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`-- sql
+        await queryRunner.query(`-- sql
             ALTER TABLE posts_gdocs DROP COLUMN breadcrumbs`)
     }
 }

--- a/db/migration/1689327366854-AddExplorerVariablesTable.ts
+++ b/db/migration/1689327366854-AddExplorerVariablesTable.ts
@@ -4,7 +4,7 @@ export class AddExplorerVariablesTable1689327366854
     implements MigrationInterface
 {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`-- sql
+        await queryRunner.query(`-- sql
           CREATE TABLE \`explorer_variables\` (
             \`id\` int NOT NULL AUTO_INCREMENT,
             \`explorerSlug\` varchar(150) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NOT NULL,
@@ -18,6 +18,6 @@ export class AddExplorerVariablesTable1689327366854
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`DROP TABLE explorer_variables`)
+        await queryRunner.query(`DROP TABLE explorer_variables`)
     }
 }

--- a/db/migration/1689678362613-RemoveLegacySdgChartReferences.ts
+++ b/db/migration/1689678362613-RemoveLegacySdgChartReferences.ts
@@ -4,7 +4,7 @@ export class RemoveLegacySdgChartReferences1689678362613
     implements MigrationInterface
 {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`-- sql
+        await queryRunner.query(`-- sql
             DROP TABLE IF EXISTS legacy_sdg_chart_references;
         `)
     }

--- a/db/migration/1692042923850-AddPostsLinks.ts
+++ b/db/migration/1692042923850-AddPostsLinks.ts
@@ -2,7 +2,7 @@ import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class AddPostsLinks1692042923850 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`-- sql
+        await queryRunner.query(`-- sql
             CREATE TABLE posts_links (
                 id int NOT NULL AUTO_INCREMENT,
                 sourceId int NOT NULL,
@@ -19,7 +19,7 @@ export class AddPostsLinks1692042923850 implements MigrationInterface {
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`-- sql
+        await queryRunner.query(`-- sql
             DROP TABLE IF EXISTS posts_links;
         `)
     }

--- a/db/migration/1695651135934-IndexUpdatedAt.ts
+++ b/db/migration/1695651135934-IndexUpdatedAt.ts
@@ -2,13 +2,13 @@ import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class IndexUpdatedAt1695651135934 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(
+        await queryRunner.query(
             `ALTER TABLE posts_gdocs ADD INDEX idx_updatedAt (updatedAt);`
         )
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(
+        await queryRunner.query(
             `ALTER TABLE posts_gdocs DROP INDEX idx_updatedAt (updatedAt);`
         )
     }

--- a/db/migration/1696940352033-PostsGdocsLinksLongerTargetField.ts
+++ b/db/migration/1696940352033-PostsGdocsLinksLongerTargetField.ts
@@ -4,14 +4,14 @@ export class PostsGdocsLinksLongerTargetField1696940352033
     implements MigrationInterface
 {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(
+        await queryRunner.query(
             `ALTER TABLE posts_gdocs_links
             MODIFY target TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NOT NULL;`
         )
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(
+        await queryRunner.query(
             `ALTER TABLE posts_gdocs_links
             MODIFY target varchar(2047) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NOT NULL;`
         )

--- a/db/migration/1697464705200-PostsGdocsLinksDisplayOrder.ts
+++ b/db/migration/1697464705200-PostsGdocsLinksDisplayOrder.ts
@@ -4,14 +4,14 @@ export class PostsGdocsLinksDisplayOrder1697464705200
     implements MigrationInterface
 {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(
+        await queryRunner.query(
             `ALTER TABLE posts_gdocs_variables_faqs
             ADD COLUMN displayOrder SMALLINT NOT NULL DEFAULT 0;`
         )
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(
+        await queryRunner.query(
             `ALTER TABLE posts_gdocs_variables_faqs
             DROP COLUMN displayOrder;`
         )

--- a/db/migration/1698301390787-TopicTagsDisplayOrder.ts
+++ b/db/migration/1698301390787-TopicTagsDisplayOrder.ts
@@ -2,14 +2,14 @@ import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class TopicTagsDisplayOrder1698301390787 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(
+        await queryRunner.query(
             `ALTER TABLE tags_variables_topic_tags
             ADD COLUMN displayOrder SMALLINT NOT NULL DEFAULT 0;`
         )
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(
+        await queryRunner.query(
             `ALTER TABLE tags_variables_topic_tags
             DROP COLUMN displayOrder;`
         )

--- a/db/migration/1698655095475-OriginsVariablesDisplayOrder.ts
+++ b/db/migration/1698655095475-OriginsVariablesDisplayOrder.ts
@@ -4,14 +4,14 @@ export class OriginsVariablesDisplayOrder1698655095475
     implements MigrationInterface
 {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(
+        await queryRunner.query(
             `ALTER TABLE origins_variables
             ADD COLUMN displayOrder SMALLINT NOT NULL DEFAULT 0;`
         )
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(
+        await queryRunner.query(
             `ALTER TABLE origins_variables
             DROP COLUMN displayOrder;`
         )

--- a/db/migration/1701450183524-TagTopicSlug.ts
+++ b/db/migration/1701450183524-TagTopicSlug.ts
@@ -388,7 +388,7 @@ export class TagTopicSlug1701450183524 implements MigrationInterface {
     public async down(queryRunner: QueryRunner): Promise<void> {
         // There is no need to revert isTopic changes
 
-        queryRunner.query(`
+        await queryRunner.query(`
             ALTER TABLE tags
             DROP COLUMN slug
         `)

--- a/db/migration/1702059907881-AddMarkdownColumns.ts
+++ b/db/migration/1702059907881-AddMarkdownColumns.ts
@@ -33,15 +33,19 @@ export class AddMarkdownColumns1702059907881 implements MigrationInterface {
         //     from posts`
         // )
 
-        this.createAndStoreMarkdown("posts_gdocs", archieMlInGdocs, queryRunner)
+        await this.createAndStoreMarkdown(
+            "posts_gdocs",
+            archieMlInGdocs,
+            queryRunner
+        )
         // this.createAndStoreMarkdown("posts", archieMlInPosts, queryRunner)
     }
 
-    private createAndStoreMarkdown(
+    private async createAndStoreMarkdown(
         tableName: string,
         blocks: { id: string | number; content: string }[],
         queryRunner: QueryRunner
-    ): void {
+    ): Promise<void> {
         for (const row of blocks) {
             try {
                 const content: OwidGdocPostContent = JSON.parse(row.content)
@@ -68,7 +72,7 @@ export class AddMarkdownColumns1702059907881 implements MigrationInterface {
                 ]).flat()
 
                 const markdown = enrichedBlocksToMarkdown(blocks, true)
-                queryRunner.query(
+                await queryRunner.query(
                     `UPDATE ${tableName} SET markdown=? WHERE id=?`,
                     [markdown, row.id]
                 )

--- a/db/migration/1709913303952-RemoveIsExplorableColumnFromCharts.ts
+++ b/db/migration/1709913303952-RemoveIsExplorableColumnFromCharts.ts
@@ -4,11 +4,11 @@ export class RemoveIsExplorableColumnFromCharts1709913303952
     implements MigrationInterface
 {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(`ALTER TABLE charts DROP COLUMN isExplorable;`)
+        await queryRunner.query(`ALTER TABLE charts DROP COLUMN isExplorable;`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        queryRunner.query(
+        await queryRunner.query(
             `ALTER TABLE charts ADD COLUMN isExplorable tinyint(1) NOT NULL DEFAULT '0';`
         )
     }

--- a/db/model/Gdoc/GdocHomepage.ts
+++ b/db/model/Gdoc/GdocHomepage.ts
@@ -35,10 +35,12 @@ export class GdocHomepage
     linkedDocuments: Record<string, OwidGdocMinimalPostInterface> = {}
     homepageMetadata: OwidGdocHomepageMetadata = {}
 
-    _validateSubclass = async (): Promise<OwidGdocErrorMessage[]> => {
+    _validateSubclass = async (
+        knex: db.KnexReadonlyTransaction
+    ): Promise<OwidGdocErrorMessage[]> => {
         const errors: OwidGdocErrorMessage[] = []
         const otherPublishedHomepages = await db.knexRaw<{ id: string }>(
-            db.knexInstance(),
+            knex,
             `
             SELECT
                 id

--- a/db/refreshPageviewsFromDatasette.ts
+++ b/db/refreshPageviewsFromDatasette.ts
@@ -70,7 +70,7 @@ async function downloadAndInsertCSV(
 
 const main = async (): Promise<void> => {
     try {
-        db.knexReadWriteTransaction((trx) => downloadAndInsertCSV(trx))
+        await db.knexReadWriteTransaction((trx) => downloadAndInsertCSV(trx))
     } catch (e) {
         console.error(e)
     } finally {
@@ -78,4 +78,4 @@ const main = async (): Promise<void> => {
     }
 }
 
-main()
+void main()

--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -436,11 +436,11 @@ const syncPostsToGrapher = async (
 const main = async (): Promise<void> => {
     try {
         await db.getConnection()
-        db.knexReadWriteTransaction((trx) => syncPostsToGrapher(trx))
+        await db.knexReadWriteTransaction((trx) => syncPostsToGrapher(trx))
     } finally {
         await wpdb.singleton.end()
         await db.closeTypeOrmAndKnexConnections()
     }
 }
 
-main()
+void main()

--- a/db/tests/basic.test.ts
+++ b/db/tests/basic.test.ts
@@ -51,7 +51,7 @@ beforeAll(async () => {
 afterAll((done: any) => {
     // We leave the user in the database for other tests to use
     // For other cases it is good to drop any rows created in the test
-    Promise.allSettled([
+    void Promise.allSettled([
         typeOrmConnection?.destroy(),
         knexInstance?.destroy(),
     ]).then(() => done())
@@ -76,7 +76,7 @@ function sleep(time: number, value: any): Promise<any> {
 }
 
 test("timestamps are automatically created and updated", async () => {
-    knexReadWriteTransaction(async (trx) => {
+    await knexReadWriteTransaction(async (trx) => {
         const chart: DbInsertChart = {
             config: "{}",
             lastEditedAt: new Date(),
@@ -213,7 +213,7 @@ test("Transaction setup", async () => {
 })
 
 test("Write actions in read-only transactions fail", async () => {
-    expect(async () => {
+    await expect(async () => {
         return knexReadonlyTransaction(async (trx) => {
             await testRw(trx as KnexReadWriteTransaction) // The cast is necessary to not make TypeScript complain and catch this error :)
         }, knexInstance)

--- a/db/wpdb.ts
+++ b/db/wpdb.ts
@@ -65,7 +65,7 @@ class WPDB {
 
     async end(): Promise<void> {
         if (this.conn) this.conn.end()
-        this.destroyKnex()
+        await this.destroyKnex()
     }
 
     async query(queryStr: string, params?: any[]): Promise<any[]> {

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -374,7 +374,7 @@ export class Explorer
                 this.updateGrapherFromExplorerUsingGrapherId()
                 break
             case ExplorerChartCreationMode.FromVariableIds:
-                this.updateGrapherFromExplorerUsingVariableIds()
+                void this.updateGrapherFromExplorerUsingVariableIds()
                 break
             case ExplorerChartCreationMode.FromExplorerTableColumnSlugs:
                 this.updateGrapherFromExplorerUsingColumnSlugs()
@@ -672,7 +672,7 @@ export class Explorer
         this.setGrapherTable(
             BlankOwidTable(tableSlug, `Loading table '${tableSlug}'`)
         )
-        this.futureGrapherTable.set(this.tableLoader.get(tableSlug))
+        void this.futureGrapherTable.set(this.tableLoader.get(tableSlug))
 
         if (this.downloadDataLink)
             grapher.externalCsvLink = this.downloadDataLink
@@ -996,7 +996,9 @@ export class Explorer
             : this.explorerProgram.grapherConfig.tableSlug
 
         this.entityPickerTableIsLoading = true
-        this.futureEntityPickerTable.set(this.tableLoader.get(tableSlugToLoad))
+        void this.futureEntityPickerTable.set(
+            this.tableLoader.get(tableSlugToLoad)
+        )
     }
 
     setEntityPicker({

--- a/explorerAdminClient/ExplorerCreatePage.tsx
+++ b/explorerAdminClient/ExplorerCreatePage.tsx
@@ -71,7 +71,7 @@ export class ExplorerCreatePage extends React.Component<{
 
         if (this.props.doNotFetch) return
 
-        this.fetchExplorerProgramOnLoad()
+        void this.fetchExplorerProgramOnLoad()
         this.startPollingLocalStorageForPreviewChanges()
     }
 
@@ -208,8 +208,8 @@ export class ExplorerCreatePage extends React.Component<{
     @observable gitCmsBranchName = this.props.gitCmsBranchName
 
     @action.bound private onSave() {
-        if (this.program.isNewFile) this.saveAs()
-        else if (this.isModified) this.save()
+        if (this.program.isNewFile) void this.saveAs()
+        else if (this.isModified) void this.save()
     }
 
     render() {
@@ -472,7 +472,7 @@ class TemplatesComponent extends React.Component<{
     @observable.ref templates: GitCmsFile[] = []
 
     componentDidMount() {
-        if (this.props.isNewFile) this.fetchTemplatesOnLoad()
+        if (this.props.isNewFile) void this.fetchTemplatesOnLoad()
     }
 
     private gitCmsClient = new GitCmsClient(GIT_CMS_BASE_ROUTE)

--- a/explorerAdminClient/ExplorersListPage.tsx
+++ b/explorerAdminClient/ExplorersListPage.tsx
@@ -326,7 +326,7 @@ export class ExplorersIndexPage extends React.Component<{
             commitMessage: `Setting publish status of ${filename} to ${newVersion.isPublished}`,
         })
         this.resetLoadingModal()
-        this.fetchAllExplorers()
+        await this.fetchAllExplorers()
     }
 
     @action.bound async deleteFile(filename: string) {
@@ -337,7 +337,7 @@ export class ExplorersIndexPage extends React.Component<{
             filepath: `${EXPLORERS_GIT_CMS_FOLDER}/${filename}`,
         })
         this.resetLoadingModal()
-        this.fetchAllExplorers()
+        await this.fetchAllExplorers()
     }
 
     dispose!: IReactionDisposer
@@ -346,7 +346,7 @@ export class ExplorersIndexPage extends React.Component<{
             () => this.searchInput || this.maxVisibleRows,
             debounce(() => this.fetchAllExplorers(), 200)
         )
-        this.fetchAllExplorers()
+        void this.fetchAllExplorers()
     }
 
     componentWillUnmount() {

--- a/gitCms/GitCmsServer.ts
+++ b/gitCms/GitCmsServer.ts
@@ -90,7 +90,7 @@ export class GitCmsServer {
     }
 
     private async autopush() {
-        if (this.options.shouldAutoPush) this.git.push()
+        if (this.options.shouldAutoPush) void this.git.push()
     }
 
     private async pullCommand(verbose: boolean | undefined = undefined) {
@@ -203,7 +203,7 @@ export class GitCmsServer {
             return { success: true }
         } catch (error) {
             const err = error as Error
-            logErrorAndMaybeSendToBugsnag(err)
+            void logErrorAndMaybeSendToBugsnag(err)
             return { success: false, error: err.toString() }
         }
     }
@@ -247,7 +247,7 @@ export class GitCmsServer {
             return { success: true }
         } catch (error) {
             const err = error as Error
-            logErrorAndMaybeSendToBugsnag(err)
+            void logErrorAndMaybeSendToBugsnag(err)
             return { success: false, error: err.toString() }
         }
     }

--- a/packages/@ourworldindata/components/src/CodeSnippet/CodeSnippet.tsx
+++ b/packages/@ourworldindata/components/src/CodeSnippet/CodeSnippet.tsx
@@ -22,7 +22,7 @@ export const CodeSnippet = ({
     const [hasCopied, setHasCopied] = useState(false)
 
     useEffect(() => {
-        canWriteToClipboard().then(setCanCopy)
+        void canWriteToClipboard().then(setCanCopy)
     }, [])
 
     const copy = async () => {

--- a/packages/@ourworldindata/grapher/src/controls/ShareMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ShareMenu.tsx
@@ -70,7 +70,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
 
     componentDidMount(): void {
         document.addEventListener("click", this.onClickSomewhere)
-        canWriteToClipboard().then((canWriteToClipboard) =>
+        void canWriteToClipboard().then((canWriteToClipboard) =>
             this.setState({ canWriteToClipboard })
         )
     }

--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
@@ -435,7 +435,7 @@ export class EntityPicker extends React.Component<{
             () => this.focusOptionDirection(FocusDirection.first)
         )
 
-        this.populateLocalEntity()
+        void this.populateLocalEntity()
     }
 
     componentDidUpdate(): void {

--- a/packages/@ourworldindata/grapher/src/controls/globalEntitySelector/GlobalEntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/globalEntitySelector/GlobalEntitySelector.tsx
@@ -168,7 +168,7 @@ export class GlobalEntitySelector extends React.Component<{
                 () => this.prepareOptionGroups()
             )
         )
-        this.populateLocalEntity()
+        void this.populateLocalEntity()
     }
 
     componentWillUnmount(): void {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
@@ -431,7 +431,7 @@ describe("line chart to bar chart and bar chart race", () => {
     it("turns into a line chart race when playing a line chart that currently shows as a bar chart", () => {
         grapher.startHandleTimeBound = -Infinity
         grapher.endHandleTimeBound = -Infinity
-        grapher.timelineController.play(1)
+        void grapher.timelineController.play(1)
         expect(grapher.startHandleTimeBound).not.toEqual(
             grapher.endHandleTimeBound
         )

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -548,7 +548,7 @@ export class Grapher
         if (this.manuallyProvideData) {
         } else if (this.owidDataset) {
             this._receiveOwidDataAndApplySelection(this.owidDataset)
-        } else this.downloadLegacyDataFromOwidVariableIds()
+        } else void this.downloadLegacyDataFromOwidVariableIds()
     }
 
     @action.bound updateFromObject(obj?: GrapherProgrammaticInterface): void {
@@ -2181,7 +2181,7 @@ export class Grapher
     }
 
     @action.bound private togglePlayingCommand(): void {
-        this.timelineController.togglePlay()
+        void this.timelineController.togglePlay()
     }
 
     selection =

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
@@ -189,7 +189,7 @@ export class TimelineComponent extends React.Component<{
     @action.bound onPlayTouchEnd(evt: Event): void {
         evt.preventDefault()
         evt.stopPropagation()
-        this.controller.togglePlay()
+        void this.controller.togglePlay()
     }
 
     @computed private get isPlayingOrDragging(): boolean {
@@ -277,7 +277,7 @@ export class TimelineComponent extends React.Component<{
     @observable private lastUpdatedTooltip?: "startMarker" | "endMarker"
 
     @action.bound private togglePlay(): void {
-        this.controller.togglePlay()
+        void this.controller.togglePlay()
     }
 
     @action.bound updateStartTimeOnKeyDown(key: string): void {

--- a/packages/@ourworldindata/utils/src/PromiseSwitcher.test.ts
+++ b/packages/@ourworldindata/utils/src/PromiseSwitcher.test.ts
@@ -24,7 +24,7 @@ it("handles fulfilling single promise", async () => {
 it("selecting a new promise while one is pending discards the pending promise", async () => {
     const onResolve = jest.fn(() => undefined)
     const selector = new PromiseSwitcher({ onResolve })
-    selector.set(delayResolve("first"))
+    void selector.set(delayResolve("first"))
     await selector.set(Promise.resolve("second"))
     expect(onResolve).toHaveBeenCalledTimes(1)
     expect(onResolve).toHaveBeenCalledWith("second")
@@ -38,7 +38,7 @@ it("handles promise rejections", async () => {
     await selector.set(Promise.reject("error"))
     expect(onReject).toHaveBeenCalledWith("error")
 
-    selector.set(delayResolve("success"))
+    void selector.set(delayResolve("success"))
     await selector.set(Promise.reject("error 2"))
     expect(onResolve).not.toHaveBeenCalled()
     expect(onReject).toHaveBeenCalledTimes(2)
@@ -50,7 +50,7 @@ it("handles clearing pending promise", async () => {
     const selector = new PromiseSwitcher({ onResolve, onReject })
 
     const resolve = delayResolve("done")
-    selector.set(resolve)
+    void selector.set(resolve)
     selector.clear()
     await resolve
 
@@ -58,7 +58,7 @@ it("handles clearing pending promise", async () => {
     expect(onReject).not.toHaveBeenCalled()
 
     const reject = delayReject("error")
-    selector.set(reject)
+    void selector.set(reject)
     selector.clear()
     try {
         await reject

--- a/packages/@ourworldindata/utils/src/Util.test.ts
+++ b/packages/@ourworldindata/utils/src/Util.test.ts
@@ -213,21 +213,21 @@ describe(retryPromise, () => {
 
     it("resolves when promise succeeds first-time", async () => {
         const promiseGetter = resolveAfterNthRetry(0, "success")
-        expect(retryPromise(promiseGetter, { maxRetries: 1 })).resolves.toEqual(
-            "success"
-        )
+        return expect(
+            retryPromise(promiseGetter, { maxRetries: 1 })
+        ).resolves.toEqual("success")
     })
 
     it("resolves when promise succeeds before retry limit", async () => {
         const promiseGetter = resolveAfterNthRetry(2, "success")
-        expect(retryPromise(promiseGetter, { maxRetries: 3 })).resolves.toEqual(
-            "success"
-        )
+        return expect(
+            retryPromise(promiseGetter, { maxRetries: 3 })
+        ).resolves.toEqual("success")
     })
 
     it("rejects when promise doesn't succeed within retry limit", async () => {
         const promiseGetter = resolveAfterNthRetry(3, "success")
-        expect(
+        return expect(
             retryPromise(promiseGetter, { maxRetries: 3 })
         ).rejects.toBeUndefined()
     })

--- a/site/DonateForm.tsx
+++ b/site/DonateForm.tsx
@@ -482,7 +482,7 @@ export class DonateFormRunner {
     }
 }
 
-export function runDonateForm() {
+export async function runDonateForm() {
     const donateForm = new DonateFormRunner()
-    donateForm.run()
+    await donateForm.run()
 }

--- a/site/Feedback.tsx
+++ b/site/Feedback.tsx
@@ -143,7 +143,7 @@ export class FeedbackForm extends React.Component<{
         this.done = false
         this.error = undefined
         this.loading = true
-        this.submit()
+        void this.submit()
     }
 
     @action.bound onName(e: React.ChangeEvent<HTMLInputElement>) {

--- a/site/SiteNavigation.tsx
+++ b/site/SiteNavigation.tsx
@@ -118,7 +118,7 @@ export const SiteNavigation = ({
             const json = await response.json()
             setCategorizedTopics(json.categories)
         }
-        fetchCategorizedTopics()
+        void fetchCategorizedTopics()
     }, [])
 
     useTriggerOnEscape(closeOverlay)

--- a/site/covid/FullWidthRawHtml.tsx
+++ b/site/covid/FullWidthRawHtml.tsx
@@ -9,7 +9,7 @@ export const RawHtml = ({ url }: { url: string }) => {
             if (!response.ok) return
             setHtml(await response.text())
         }
-        fetchHtml()
+        void fetchHtml()
     }, [url])
 
     return html && <div dangerouslySetInnerHTML={{ __html: html }}></div>

--- a/site/covid/LastUpdated.tsx
+++ b/site/covid/LastUpdated.tsx
@@ -22,7 +22,7 @@ export const LastUpdated = ({ timestampUrl }: LastUpdatedTokenProps) => {
             if (!parsedDate.isValid()) return
             setDate(parsedDate)
         }
-        fetchTimeStamp()
+        void fetchTimeStamp()
     }, [timestampUrl])
 
     return (

--- a/site/gdocs/pages/DataInsight.tsx
+++ b/site/gdocs/pages/DataInsight.tsx
@@ -128,7 +128,7 @@ const DataInsightMeta = (props: {
                     id="copy-link-button"
                     className="data-insight-meta__copy-link-button body-3-medium"
                     onClick={() => {
-                        copyToClipboard(
+                        void copyToClipboard(
                             `${BAKED_BASE_URL}/data-insights/${props.slug}`
                         )
                         setHasCopied(true)

--- a/site/multiembedder/MultiEmbedder.tsx
+++ b/site/multiembedder/MultiEmbedder.tsx
@@ -121,7 +121,7 @@ class MultiEmbedder {
     async onIntersecting(entries: IntersectionObserverEntry[]) {
         entries.forEach((entry) => {
             if (entry.isIntersecting) {
-                this.renderInteractiveFigure(entry.target)
+                void this.renderInteractiveFigure(entry.target)
             }
         })
     }

--- a/site/runSiteFooterScripts.ts
+++ b/site/runSiteFooterScripts.ts
@@ -48,7 +48,7 @@ export const runSiteFooterScripts = (
             runSiteNavigation(BAKED_BASE_URL, hideDonationFlag)
             runSiteTools()
             runCookiePreferencesManager()
-            runDetailsOnDemand()
+            void runDetailsOnDemand()
             break
         case SiteFooterContext.grapherPage:
         case SiteFooterContext.explorerPage:
@@ -56,14 +56,14 @@ export const runSiteFooterScripts = (
             runAllGraphersLoadedListener()
             runSiteTools()
             runCookiePreferencesManager()
-            runDetailsOnDemand()
+            void runDetailsOnDemand()
             break
         case SiteFooterContext.gdocsDocument:
             hydrateOwidGdoc(debug, isPreviewing)
             runAllGraphersLoadedListener()
             runSiteNavigation(BAKED_BASE_URL, hideDonationFlag)
             runFootnotes()
-            runDetailsOnDemand()
+            void runDetailsOnDemand()
             runLightbox()
             runSiteTools()
             runCookiePreferencesManager()
@@ -97,7 +97,7 @@ export const runSiteFooterScripts = (
             runFootnotes()
             runSiteTools()
             runCookiePreferencesManager()
-            runDetailsOnDemand()
+            void runDetailsOnDemand()
             break
     }
 }


### PR DESCRIPTION
With the introduction of a more rigorous use of transactions, dangling promises have become more problematic. It used to the be the case that if a promise was not awaited in an api route handler, node would just wait for it to complete. But since we now open transaction scopes in the route handlers, it can happen that a the router handler finishes and closes a transaction and then the dangling promise continues and tries to access the db via that transaction which then leads to an error and crashes the admin.

This PR enables an ESLint rule that makes unhandled promises an error. You can either await the result, or, for cases where you genuinely do not need to await the promise, mark the promise as intentionally not awaited by prefixing it with the JS `void` operator.

This PR then fixes all the ~250 places that this eslint rule complained about