### PR TITLE
✨ unify transaction creation and close db connection in same call for scripts

### DIFF
--- a/adminSiteServer/exportGitData.ts
+++ b/adminSiteServer/exportGitData.ts
@@ -13,9 +13,7 @@ const main = async () => {
                     commitOnly: true,
                 })
         }
-    })
-
-    await db.closeTypeOrmAndKnexConnections()
+    }, db.TransactionCloseMode.Close)
 }
 
 void main()

--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -132,10 +132,11 @@ const indexChartsToAlgolia = async () => {
 
     const index = client.initIndex(getIndexName(SearchIndexName.Charts))
 
-    const records = await db.knexReadonlyTransaction(getChartsRecords)
+    const records = await db.knexReadonlyTransaction(
+        getChartsRecords,
+        db.TransactionCloseMode.Close
+    )
     await index.replaceAllObjects(records)
-
-    await db.closeTypeOrmAndKnexConnections()
 }
 
 process.on("unhandledRejection", (e) => {

--- a/baker/algolia/indexExplorersToAlgolia.ts
+++ b/baker/algolia/indexExplorersToAlgolia.ts
@@ -196,10 +196,11 @@ const indexExplorersToAlgolia = async () => {
     try {
         const index = client.initIndex(getIndexName(SearchIndexName.Explorers))
 
-        const records = await db.knexReadonlyTransaction(getExplorerRecords)
+        const records = await db.knexReadonlyTransaction(
+            getExplorerRecords,
+            db.TransactionCloseMode.Close
+        )
         await index.replaceAllObjects(records)
-
-        await db.closeTypeOrmAndKnexConnections()
     } catch (e) {
         console.log("Error indexing explorers to Algolia: ", e)
     }

--- a/baker/algolia/indexToAlgolia.tsx
+++ b/baker/algolia/indexToAlgolia.tsx
@@ -234,12 +234,14 @@ const indexToAlgolia = async () => {
     }
     const index = client.initIndex(getIndexName(SearchIndexName.Pages))
 
-    const records = await db.knexReadonlyTransaction(getPagesRecords)
+    const records = await db.knexReadonlyTransaction(
+        getPagesRecords,
+        db.TransactionCloseMode.Close
+    )
 
     await index.replaceAllObjects(records)
 
     await wpdb.singleton.end()
-    await db.closeTypeOrmAndKnexConnections()
 }
 
 process.on("unhandledRejection", (e) => {

--- a/baker/bakeGdocPost.ts
+++ b/baker/bakeGdocPost.ts
@@ -19,8 +19,9 @@ void yargs(hideBin(process.argv))
         async ({ slug }) => {
             const baker = new SiteBaker(BAKED_SITE_DIR, BAKED_BASE_URL)
 
-            await db.knexReadonlyTransaction((trx) =>
-                baker.bakeGDocPosts(trx, [slug])
+            await db.knexReadonlyTransaction(
+                (trx) => baker.bakeGDocPosts(trx, [slug]),
+                db.TransactionCloseMode.Close
             )
             process.exit(0)
         }

--- a/baker/bakeGdocPosts.ts
+++ b/baker/bakeGdocPosts.ts
@@ -24,8 +24,9 @@ void yargs(hideBin(process.argv))
         async ({ slugs }) => {
             const baker = new SiteBaker(BAKED_SITE_DIR, BAKED_BASE_URL)
 
-            await db.knexReadonlyTransaction((trx) =>
-                baker.bakeGDocPosts(trx, slugs)
+            await db.knexReadonlyTransaction(
+                (trx) => baker.bakeGDocPosts(trx, slugs),
+                db.TransactionCloseMode.Close
             )
             process.exit(0)
         }

--- a/baker/batchTagWithGpt.ts
+++ b/baker/batchTagWithGpt.ts
@@ -82,11 +82,11 @@ if (require.main === module) {
             },
             async (argv) => {
                 try {
-                    await db.knexReadonlyTransaction((trx) =>
-                        batchTagChartsWithGpt(trx, argv)
+                    await db.knexReadonlyTransaction(
+                        (trx) => batchTagChartsWithGpt(trx, argv),
+                        db.TransactionCloseMode.Close
                     )
                 } finally {
-                    await db.closeTypeOrmAndKnexConnections()
                 }
             }
         )

--- a/baker/buildLocalBake.ts
+++ b/baker/buildLocalBake.ts
@@ -17,7 +17,10 @@ const bakeDomainToFolder = async (
     await fs.mkdirp(dir)
     const baker = new SiteBaker(dir, baseUrl, bakeSteps)
     console.log(`Baking site locally with baseUrl '${baseUrl}' to dir '${dir}'`)
-    await db.knexReadonlyTransaction((trx) => baker.bakeAll(trx))
+    await db.knexReadonlyTransaction(
+        (trx) => baker.bakeAll(trx),
+        db.TransactionCloseMode.Close
+    )
 }
 
 void yargs(hideBin(process.argv))

--- a/baker/postUpdatedHook.ts
+++ b/baker/postUpdatedHook.ts
@@ -200,8 +200,9 @@ const main = async (
 ) => {
     console.log(email, name, postId)
     try {
-        const slug = db.knexReadWriteTransaction((trx) =>
-            syncPostToGrapher(trx, postId)
+        const slug = db.knexReadWriteTransaction(
+            (trx) => syncPostToGrapher(trx, postId),
+            db.TransactionCloseMode.Close
         )
 
         if (BAKE_ON_CHANGE)

--- a/baker/recalcLatestCountryData.ts
+++ b/baker/recalcLatestCountryData.ts
@@ -5,8 +5,10 @@ import * as db from "../db/db.js"
 import { denormalizeLatestCountryData } from "../baker/countryProfiles.js"
 
 const main = async () => {
-    await db.knexReadWriteTransaction(denormalizeLatestCountryData)
-    await db.closeTypeOrmAndKnexConnections()
+    await db.knexReadWriteTransaction(
+        denormalizeLatestCountryData,
+        db.TransactionCloseMode.Close
+    )
 }
 
 if (require.main === module) void main()

--- a/baker/runBakeGraphers.ts
+++ b/baker/runBakeGraphers.ts
@@ -9,11 +9,13 @@ import * as db from "../db/db.js"
  */
 
 const main = async (folder: string) => {
-    return db.knexReadonlyTransaction((trx) =>
-        bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers(
-            folder,
-            trx
-        )
+    return db.knexReadonlyTransaction(
+        (trx) =>
+            bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers(
+                folder,
+                trx
+            ),
+        db.TransactionCloseMode.Close
     )
 }
 

--- a/baker/startDeployQueueServer.ts
+++ b/baker/startDeployQueueServer.ts
@@ -33,7 +33,10 @@ const main = async () => {
         setTimeout(deployIfQueueIsNotEmpty, 10 * 1000)
     })
 
-    await db.knexReadonlyTransaction(deployIfQueueIsNotEmpty)
+    await db.knexReadonlyTransaction(
+        deployIfQueueIsNotEmpty,
+        db.TransactionCloseMode.Close
+    )
 }
 
 void main()

--- a/baker/syncRedirectsToGrapher.ts
+++ b/baker/syncRedirectsToGrapher.ts
@@ -67,10 +67,12 @@ export const syncRedirectsToGrapher = async (
 
 const main = async (): Promise<void> => {
     try {
-        await db.knexReadWriteTransaction((trx) => syncRedirectsToGrapher(trx))
+        await db.knexReadWriteTransaction(
+            (trx) => syncRedirectsToGrapher(trx),
+            db.TransactionCloseMode.Close
+        )
     } finally {
         await wpdb.singleton.end()
-        await db.closeTypeOrmAndKnexConnections()
     }
 }
 

--- a/db/analyzeWpPosts.ts
+++ b/db/analyzeWpPosts.ts
@@ -65,9 +65,7 @@ const analyze = async (): Promise<void> => {
         for (const [tag, count] of sortedTagCount) {
             console.log(`${tag}: ${count}`)
         }
-    })
-
-    await db.closeTypeOrmAndKnexConnections()
+    }, db.TransactionCloseMode.Close)
 }
 
 void analyze()

--- a/db/migrateWpPostsToArchieMl.ts
+++ b/db/migrateWpPostsToArchieMl.ts
@@ -276,7 +276,7 @@ const migrate = async (trx: db.KnexReadWriteTransaction): Promise<void> => {
             await db.knexRaw(trx, insertQuery, [
                 JSON.stringify(archieMlFieldContent, null, 2),
                 JSON.stringify(archieMlStatsContent, null, 2),
-                markdown,
+                markdown ?? null,
                 post.id,
             ])
             console.log("inserted", post.id)
@@ -315,8 +315,7 @@ const migrate = async (trx: db.KnexReadWriteTransaction): Promise<void> => {
 }
 
 async function runMigrate(): Promise<void> {
-    await db.knexReadWriteTransaction(migrate)
-    await db.closeTypeOrmAndKnexConnections()
+    await db.knexReadWriteTransaction(migrate, db.TransactionCloseMode.Close)
 }
 
 void runMigrate()

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -740,13 +740,9 @@ export class GdocBase implements OwidGdocBaseInterface {
             []
         )
 
-        const { chartIdsBySlug, publishedExplorersBySlug } =
-            await db.knexReadonlyTransaction(async (trx) => {
-                const chartIdsBySlug = await mapSlugsToIds(trx)
-                const publishedExplorersBySlug =
-                    await db.getPublishedExplorersBySlug(trx)
-                return { chartIdsBySlug, publishedExplorersBySlug }
-            })
+        const chartIdsBySlug = await mapSlugsToIds(knex)
+        const publishedExplorersBySlug =
+            await db.getPublishedExplorersBySlug(knex)
 
         const linkErrors: OwidGdocErrorMessage[] = this.links.reduce(
             (errors: OwidGdocErrorMessage[], link): OwidGdocErrorMessage[] => {

--- a/db/refreshPageviewsFromDatasette.ts
+++ b/db/refreshPageviewsFromDatasette.ts
@@ -70,11 +70,13 @@ async function downloadAndInsertCSV(
 
 const main = async (): Promise<void> => {
     try {
-        await db.knexReadWriteTransaction((trx) => downloadAndInsertCSV(trx))
+        await db.knexReadWriteTransaction(
+            (trx) => downloadAndInsertCSV(trx),
+            db.TransactionCloseMode.Close
+        )
     } catch (e) {
         console.error(e)
     } finally {
-        await db.closeTypeOrmAndKnexConnections()
     }
 }
 

--- a/db/syncPostsToGrapher.ts
+++ b/db/syncPostsToGrapher.ts
@@ -435,10 +435,12 @@ const syncPostsToGrapher = async (
 
 const main = async (): Promise<void> => {
     try {
-        await db.knexReadWriteTransaction((trx) => syncPostsToGrapher(trx))
+        await db.knexReadWriteTransaction(
+            (trx) => syncPostsToGrapher(trx),
+            db.TransactionCloseMode.Close
+        )
     } finally {
         await wpdb.singleton.end()
-        await db.closeTypeOrmAndKnexConnections()
     }
 }
 

--- a/db/tests/basic.test.ts
+++ b/db/tests/basic.test.ts
@@ -9,6 +9,7 @@ import {
     KnexReadWriteTransaction,
     knexRawFirst,
     knexReadonlyTransaction,
+    TransactionCloseMode,
 } from "../db.js"
 import { deleteUser, insertUser, updateUser } from "../model/User.js"
 import {
@@ -65,115 +66,128 @@ function sleep(time: number, value: any): Promise<any> {
 }
 
 test("timestamps are automatically created and updated", async () => {
-    await knexReadWriteTransaction(async (trx) => {
-        const chart: DbInsertChart = {
-            config: "{}",
-            lastEditedAt: new Date(),
-            lastEditedByUserId: 1,
-            is_indexable: 0,
-        }
-        await trx.table(ChartsTableName).insert(chart)
-        const created = await knexRawFirst<DbRawChart>(
-            trx,
-            "select * from charts where id = 1",
-            []
-        )
-        expect(created).not.toBeNull()
-        if (created) {
-            expect(created.createdAt).not.toBeNull()
-            expect(created.updatedAt).toBeNull()
-            await sleep(1000, undefined)
-            await trx
-                .table(ChartsTableName)
-                .where({ id: 1 })
-                .update({ is_indexable: 1 })
-            const updated = await knexRawFirst<DbRawChart>(
+    await knexReadWriteTransaction(
+        async (trx) => {
+            const chart: DbInsertChart = {
+                config: "{}",
+                lastEditedAt: new Date(),
+                lastEditedByUserId: 1,
+                is_indexable: 0,
+            }
+            await trx.table(ChartsTableName).insert(chart)
+            const created = await knexRawFirst<DbRawChart>(
                 trx,
                 "select * from charts where id = 1",
                 []
             )
-            expect(updated).not.toBeNull()
-            if (updated) {
-                expect(updated.createdAt).not.toBeNull()
-                expect(updated.updatedAt).not.toBeNull()
-                expect(
-                    updated.updatedAt!.getTime() - updated.createdAt.getTime()
-                ).toBeGreaterThan(800)
-                expect(
-                    updated.updatedAt!.getTime() - updated.createdAt.getTime()
-                ).toBeLessThanOrEqual(2000)
+            expect(created).not.toBeNull()
+            if (created) {
+                expect(created.createdAt).not.toBeNull()
+                expect(created.updatedAt).toBeNull()
+                await sleep(1000, undefined)
+                await trx
+                    .table(ChartsTableName)
+                    .where({ id: 1 })
+                    .update({ is_indexable: 1 })
+                const updated = await knexRawFirst<DbRawChart>(
+                    trx,
+                    "select * from charts where id = 1",
+                    []
+                )
+                expect(updated).not.toBeNull()
+                if (updated) {
+                    expect(updated.createdAt).not.toBeNull()
+                    expect(updated.updatedAt).not.toBeNull()
+                    expect(
+                        updated.updatedAt!.getTime() -
+                            updated.createdAt.getTime()
+                    ).toBeGreaterThan(800)
+                    expect(
+                        updated.updatedAt!.getTime() -
+                            updated.createdAt.getTime()
+                    ).toBeLessThanOrEqual(2000)
+                }
             }
-        }
-    }, knexInstance)
+        },
+        TransactionCloseMode.KeepOpen,
+        knexInstance
+    )
 })
 
 test("knex interface", async () => {
     if (!knexInstance) throw new Error("Knex connection not initialized")
 
     // Create a transaction and run all tests inside it
-    await knexReadWriteTransaction(async (trx) => {
-        // Fetch all users into memory
-        const users = await trx
-            .from<DbPlainUser>(UsersTableName)
-            .select("isSuperuser", "email")
-        expect(users.length).toBe(1)
+    await knexReadWriteTransaction(
+        async (trx) => {
+            // Fetch all users into memory
+            const users = await trx
+                .from<DbPlainUser>(UsersTableName)
+                .select("isSuperuser", "email")
+            expect(users.length).toBe(1)
 
-        // Fetch all users in a streaming fashion, iterate over them async to avoid having to load everything into memory
-        const usersStream = trx
-            .from<DbPlainUser>(UsersTableName)
-            .select("isSuperuser", "email")
-            .stream()
+            // Fetch all users in a streaming fashion, iterate over them async to avoid having to load everything into memory
+            const usersStream = trx
+                .from<DbPlainUser>(UsersTableName)
+                .select("isSuperuser", "email")
+                .stream()
 
-        for await (const user of usersStream) {
-            expect(user.isSuperuser).toBe(0)
-            expect(user.email).toBe("admin@example.com")
-        }
+            for await (const user of usersStream) {
+                expect(user.isSuperuser).toBe(0)
+                expect(user.email).toBe("admin@example.com")
+            }
 
-        // Use the insert helper method
-        await insertUser(trx, {
-            email: "test@example.com",
-            fullName: "Test User",
-        })
-
-        // Use the update helper method
-        await updateUser(trx, 2, { isSuperuser: 1 })
-
-        // Check results after update and insert
-        const afterUpdate = await trx
-            .from<DbPlainUser>(UsersTableName)
-            .select("isSuperuser", "email")
-            .orderBy("id")
-        expect(afterUpdate.length).toBe(2)
-        expect(afterUpdate[1].isSuperuser).toBe(1)
-
-        // The pick type is used to type the result row
-        const usersFromRawQuery: Pick<DbPlainUser, "email">[] = await knexRaw(
-            trx,
-            "select email from users",
-            []
-        )
-        expect(usersFromRawQuery.length).toBe(2)
-
-        // Check if in queries work as expected
-        const usersFromRawQueryWithInClauseAsObj: Pick<DbPlainUser, "email">[] =
-            await knexRaw(trx, "select * from users where email in (:emails)", {
-                emails: [
-                    usersFromRawQuery[0].email,
-                    usersFromRawQuery[1].email,
-                ],
+            // Use the insert helper method
+            await insertUser(trx, {
+                email: "test@example.com",
+                fullName: "Test User",
             })
-        expect(usersFromRawQueryWithInClauseAsObj.length).toBe(2)
 
-        const usersFromRawQueryWithInClauseAsArray: Pick<
-            DbPlainUser,
-            "email"
-        >[] = await knexRaw(trx, "select * from users where email in (?)", [
-            [usersFromRawQuery[0].email, usersFromRawQuery[1].email],
-        ])
-        expect(usersFromRawQueryWithInClauseAsArray.length).toBe(2)
+            // Use the update helper method
+            await updateUser(trx, 2, { isSuperuser: 1 })
 
-        await deleteUser(trx, 2)
-    }, knexInstance)
+            // Check results after update and insert
+            const afterUpdate = await trx
+                .from<DbPlainUser>(UsersTableName)
+                .select("isSuperuser", "email")
+                .orderBy("id")
+            expect(afterUpdate.length).toBe(2)
+            expect(afterUpdate[1].isSuperuser).toBe(1)
+
+            // The pick type is used to type the result row
+            const usersFromRawQuery: Pick<DbPlainUser, "email">[] =
+                await knexRaw(trx, "select email from users", [])
+            expect(usersFromRawQuery.length).toBe(2)
+
+            // Check if in queries work as expected
+            const usersFromRawQueryWithInClauseAsObj: Pick<
+                DbPlainUser,
+                "email"
+            >[] = await knexRaw(
+                trx,
+                "select * from users where email in (:emails)",
+                {
+                    emails: [
+                        usersFromRawQuery[0].email,
+                        usersFromRawQuery[1].email,
+                    ],
+                }
+            )
+            expect(usersFromRawQueryWithInClauseAsObj.length).toBe(2)
+
+            const usersFromRawQueryWithInClauseAsArray: Pick<
+                DbPlainUser,
+                "email"
+            >[] = await knexRaw(trx, "select * from users where email in (?)", [
+                [usersFromRawQuery[0].email, usersFromRawQuery[1].email],
+            ])
+            expect(usersFromRawQueryWithInClauseAsArray.length).toBe(2)
+
+            await deleteUser(trx, 2)
+        },
+        TransactionCloseMode.KeepOpen,
+        knexInstance
+    )
 })
 
 export async function testRo(
@@ -198,21 +212,29 @@ export async function testRw(trx: KnexReadWriteTransaction): Promise<void> {
     ])
 }
 test("Transaction setup", async () => {
-    const result = await knexReadWriteTransaction(async (trx) => {
-        const result = await testRo(trx)
-        expect(result.length).toBe(1)
-        expect(result[0].result).toBe(2)
-        await testRw(trx)
-        return await testGetNumUsers(trx)
-    }, knexInstance)
+    const result = await knexReadWriteTransaction(
+        async (trx) => {
+            const result = await testRo(trx)
+            expect(result.length).toBe(1)
+            expect(result[0].result).toBe(2)
+            await testRw(trx)
+            return await testGetNumUsers(trx)
+        },
+        TransactionCloseMode.KeepOpen,
+        knexInstance
+    )
     expect(result.length).toBe(1)
     expect(result[0].userCount).toBe(2)
 })
 
 test("Write actions in read-only transactions fail", async () => {
     await expect(async () => {
-        return knexReadonlyTransaction(async (trx) => {
-            await testRw(trx as KnexReadWriteTransaction) // The cast is necessary to not make TypeScript complain and catch this error :)
-        }, knexInstance)
+        return knexReadonlyTransaction(
+            async (trx) => {
+                await testRw(trx as KnexReadWriteTransaction) // The cast is necessary to not make TypeScript complain and catch this error :)
+            },
+            TransactionCloseMode.KeepOpen,
+            knexInstance
+        )
     }).rejects.toThrow()
 })

--- a/devTools/markdownTest/markdown.ts
+++ b/devTools/markdownTest/markdown.ts
@@ -1,7 +1,4 @@
-import {
-    closeTypeOrmAndKnexConnections,
-    knexReadonlyTransaction,
-} from "../../db/db.js"
+import { TransactionCloseMode, knexReadonlyTransaction } from "../../db/db.js"
 import { getPostRawBySlug } from "../../db/model/Post.js"
 import { enrichedBlocksToMarkdown } from "../../db/model/Gdoc/enrichedToMarkdown.js"
 
@@ -47,10 +44,8 @@ async function main(parsedArgs: parseArgs.ParsedArgs) {
                 process.exit(-1)
             }
             console.log(markdown)
-        })
-        await closeTypeOrmAndKnexConnections()
+        }, TransactionCloseMode.Close)
     } catch (error) {
-        await closeTypeOrmAndKnexConnections()
         console.error("Encountered an error: ", error)
         // This call to exit is necessary for some unknown reason to make sure that the process terminates. It
         // was not required before introducing the multiprocessing library.

--- a/devTools/svgTester/dump-chart-ids.ts
+++ b/devTools/svgTester/dump-chart-ids.ts
@@ -3,10 +3,7 @@
 import fs from "fs-extra"
 import parseArgs from "minimist"
 
-import {
-    closeTypeOrmAndKnexConnections,
-    knexReadonlyTransaction,
-} from "../../db/db.js"
+import { TransactionCloseMode, knexReadonlyTransaction } from "../../db/db.js"
 import { getMostViewedGrapherIdsByChartType } from "../../db/model/Chart.js"
 import { CHART_TYPES } from "./utils.js"
 
@@ -27,16 +24,14 @@ async function main(parsedArgs: parseArgs.ParsedArgs) {
             )
             const chartIds = (await Promise.all(promises)).flatMap((ids) => ids)
             return chartIds
-        })
+        }, TransactionCloseMode.Close)
 
         console.log(`Writing ${chartIds.length} chart ids to ${outFile}`)
 
         fs.writeFileSync(outFile, chartIds.join("\n"))
 
-        await closeTypeOrmAndKnexConnections()
         process.exit(0)
     } catch (error) {
-        await closeTypeOrmAndKnexConnections()
         console.error("Encountered an error: ", error)
         process.exit(-1)
     }


### PR DESCRIPTION
This PR adds a new parameter for the transaction creation functions that closes the database connection. This is useful for scripts which usually want to run stuff in one transaction and would then like to have the DB connection closes. For the api router the option is not used of course as it is a long running process.