### PR TITLE
Data insights RSS feed

### DIFF
--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -20,6 +20,7 @@ import {
     renderTopChartsCollectionPage,
     renderDataInsightsIndexPage,
     renderThankYouPage,
+    makeDataInsightsAtomFeed,
 } from "../baker/siteRenderers.js"
 import {
     BAKED_BASE_URL,
@@ -74,17 +75,6 @@ mockSiteRouter.use(express.json())
 // TODO: this transaction is only RW because somewhere inside it we fetch images
 getPlainRouteNonIdempotentWithRWTransaction(
     mockSiteRouter,
-    "/sitemap.xml",
-    async (req, res, trx) => {
-        res.set("Content-Type", "application/xml")
-        const sitemap = await makeSitemap(explorerAdminServer, trx)
-        res.send(sitemap)
-    }
-)
-
-// TODO: this transaction is only RW because somewhere inside it we fetch images
-getPlainRouteNonIdempotentWithRWTransaction(
-    mockSiteRouter,
     "/atom.xml",
     async (req, res, trx) => {
         res.set("Content-Type", "application/xml")
@@ -101,6 +91,17 @@ getPlainRouteNonIdempotentWithRWTransaction(
         res.set("Content-Type", "application/xml")
         const atomFeedNoTopicPages = await makeAtomFeedNoTopicPages(trx)
         res.send(atomFeedNoTopicPages)
+    }
+)
+
+// TODO: this transaction is only RW because somewhere inside it we fetch images
+getPlainRouteNonIdempotentWithRWTransaction(
+    mockSiteRouter,
+    "/sitemap.xml",
+    async (req, res, trx) => {
+        res.set("Content-Type", "application/xml")
+        const sitemap = await makeSitemap(explorerAdminServer, trx)
+        res.send(sitemap)
     }
 )
 

--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -63,6 +63,7 @@ import {
     getPlainRouteWithROTransaction,
 } from "./plainRouterHelpers.js"
 import { DEFAULT_LOCAL_BAKE_DIR } from "../site/SiteConstants.js"
+import { DATA_INSIGHTS_ATOM_FEED_NAME } from "../site/gdocs/utils.js"
 
 require("express-async-errors")
 
@@ -91,6 +92,19 @@ getPlainRouteNonIdempotentWithRWTransaction(
         res.set("Content-Type", "application/xml")
         const atomFeedNoTopicPages = await makeAtomFeedNoTopicPages(trx)
         res.send(atomFeedNoTopicPages)
+    }
+)
+
+// TODO: this transaction is only RW because somewhere inside it we fetch images
+getPlainRouteNonIdempotentWithRWTransaction(
+    mockSiteRouter,
+    `/${DATA_INSIGHTS_ATOM_FEED_NAME}`,
+    async (_, res) => {
+        res.set("Content-Type", "application/xml")
+        const atomFeedDataInsights = await db.knexReadonlyTransaction((knex) =>
+            makeDataInsightsAtomFeed(knex)
+        )
+        res.send(atomFeedDataInsights)
     }
 )
 

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -33,6 +33,7 @@ import {
     renderTopChartsCollectionPage,
     renderDataInsightsIndexPage,
     renderThankYouPage,
+    makeDataInsightsAtomFeed,
 } from "../baker/siteRenderers.js"
 import {
     bakeGrapherUrls,
@@ -888,6 +889,10 @@ export class SiteBaker {
         await this.stageWrite(
             `${this.bakedSiteDir}/atom-no-topic-pages.xml`,
             await makeAtomFeedNoTopicPages(knex)
+        )
+        await this.stageWrite(
+            `${this.bakedSiteDir}/atom-data-insights.xml`,
+            await makeDataInsightsAtomFeed(knex)
         )
         this.progressBar.tick({ name: "✅ baked rss" })
     }

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -103,6 +103,7 @@ import {
 import { getAllMinimalGdocBaseObjects } from "../db/model/Gdoc/GdocFactory.js"
 import { getBakePath } from "@ourworldindata/components"
 import { GdocAuthor } from "../db/model/Gdoc/GdocAuthor.js"
+import { DATA_INSIGHTS_ATOM_FEED_NAME } from "../site/gdocs/utils.js"
 
 type PrefetchedAttachments = {
     linkedDocuments: Record<string, OwidGdocMinimalPostInterface>
@@ -891,7 +892,7 @@ export class SiteBaker {
             await makeAtomFeedNoTopicPages(knex)
         )
         await this.stageWrite(
-            `${this.bakedSiteDir}/atom-data-insights.xml`,
+            `${this.bakedSiteDir}/${DATA_INSIGHTS_ATOM_FEED_NAME}`,
             await makeDataInsightsAtomFeed(knex)
         )
         this.progressBar.tick({ name: "✅ baked rss" })

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -630,17 +630,21 @@ export const renderProminentLinks = async (
                     (!isCanonicalInternalUrl(resolvedUrl)
                         ? null // attempt fallback for internal urls only
                         : resolvedUrl.isExplorer
-                        ? await getExplorerTitleByUrl(knex, resolvedUrl)
-                        : resolvedUrl.isGrapher && resolvedUrl.slug
-                        ? (await getChartConfigBySlug(knex, resolvedUrl.slug))
-                              ?.config?.title // optim?
-                        : resolvedUrl.slug &&
-                          (
-                              await getFullPostBySlugFromSnapshot(
-                                  knex,
-                                  resolvedUrl.slug
-                              )
-                          ).title)
+                          ? await getExplorerTitleByUrl(knex, resolvedUrl)
+                          : resolvedUrl.isGrapher && resolvedUrl.slug
+                            ? (
+                                  await getChartConfigBySlug(
+                                      knex,
+                                      resolvedUrl.slug
+                                  )
+                              )?.config?.title // optim?
+                            : resolvedUrl.slug &&
+                              (
+                                  await getFullPostBySlugFromSnapshot(
+                                      knex,
+                                      resolvedUrl.slug
+                                  )
+                              ).title)
             } finally {
                 if (!title) {
                     void logErrorAndMaybeSendToBugsnag(
@@ -660,12 +664,15 @@ export const renderProminentLinks = async (
                 (!isCanonicalInternalUrl(resolvedUrl)
                     ? null
                     : resolvedUrl.isExplorer
-                    ? renderExplorerDefaultThumbnail()
-                    : resolvedUrl.isGrapher && resolvedUrl.slug
-                    ? renderGrapherThumbnailByResolvedChartSlug(
-                          resolvedUrl.slug
-                      )
-                    : await renderPostThumbnailBySlug(knex, resolvedUrl.slug))
+                      ? renderExplorerDefaultThumbnail()
+                      : resolvedUrl.isGrapher && resolvedUrl.slug
+                        ? renderGrapherThumbnailByResolvedChartSlug(
+                              resolvedUrl.slug
+                          )
+                        : await renderPostThumbnailBySlug(
+                              knex,
+                              resolvedUrl.slug
+                          ))
 
             const rendered = ReactDOMServer.renderToStaticMarkup(
                 <div className="block-wrapper">

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -377,7 +377,7 @@ export async function makeAtomFeed(knex: KnexReadWriteTransaction) {
 
 export async function makeDataInsightsAtomFeed(knex: KnexReadonlyTransaction) {
     const dataInsights = await getPublishedDataInsights(knex).then((results) =>
-        results.map((di) => ({
+        results.slice(0, 10).map((di) => ({
             authors: di.authors,
             title: di.title,
             date: new Date(di.publishedAt),

--- a/db/db.ts
+++ b/db/db.ts
@@ -229,6 +229,7 @@ export const getPublishedDataInsights = (
         `-- sql
         SELECT
             content->>'$.title' AS title,
+            content->>'$.authors' AS authors,
             publishedAt,
             updatedAt,
             slug,
@@ -244,6 +245,7 @@ export const getPublishedDataInsights = (
         results.map((record: any) => ({
             ...record,
             index: Number(record.index),
+            authors: JSON.parse(record.authors),
         }))
     ) as Promise<MinimalDataInsightInterface[]>
 }

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -139,6 +139,7 @@ export type MinimalDataInsightInterface = Pick<
     publishedAt: string
     updatedAt: string
     slug: string
+    // Not used in any UI, only needed for the data insights atom feed
     authors: string[]
     // We select the 5 most recently published insights
     // We only display 4, but if you're on the DI page for one of them we hide it and show the next most recent

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -139,6 +139,7 @@ export type MinimalDataInsightInterface = Pick<
     publishedAt: string
     updatedAt: string
     slug: string
+    authors: string[]
     // We select the 5 most recently published insights
     // We only display 4, but if you're on the DI page for one of them we hide it and show the next most recent
     index: 0 | 1 | 2 | 3 | 4

--- a/site/DataInsightsIndexPage.tsx
+++ b/site/DataInsightsIndexPage.tsx
@@ -11,6 +11,7 @@ import {
     DataInsightsIndexPageContent,
     _OWID_DATA_INSIGHTS_INDEX_PAGE_DATA,
 } from "./DataInsightsIndexPageContent.js"
+import { DATA_INSIGHT_ATOM_FEED_PROPS } from "./gdocs/utils.js"
 
 export interface DataInsightsIndexPageProps {
     dataInsights: OwidGdocDataInsightInterface[]
@@ -30,6 +31,7 @@ export const DataInsightsIndexPage = (props: DataInsightsIndexPageProps) => {
                 baseUrl={baseUrl}
                 pageDesc="Bite-sized insights on how the world is changing, written by our team"
                 imageUrl={`${baseUrl}/data-insights-thumbnail.png`}
+                atom={DATA_INSIGHT_ATOM_FEED_PROPS}
             ></Head>
             <body>
                 <SiteHeader baseUrl={baseUrl} />

--- a/site/Head.tsx
+++ b/site/Head.tsx
@@ -40,6 +40,10 @@ export const Head = (props: {
     imageUrl?: string
     children?: any
     baseUrl: string
+    atom?: {
+        title: string
+        href: string
+    }
 }) => {
     const { canonicalUrl, hideCanonicalUrl, baseUrl } = props
     const pageTitle = props.pageTitle || `Our World in Data`
@@ -50,6 +54,10 @@ export const Head = (props: {
         props.pageDesc ||
         "Research and data to make progress against the world’s largest problems"
     const imageUrl = props.imageUrl || `${baseUrl}/default-thumbnail.jpg`
+    const atom = props.atom ?? {
+        title: "Atom feed for Our World in Data",
+        href: "/atom.xml",
+    }
 
     const stylesheets = viteAssets(VITE_ASSET_SITE_ENTRY).forHeader
 
@@ -65,7 +73,8 @@ export const Head = (props: {
             <link
                 rel="alternate"
                 type="application/atom+xml"
-                href="/atom.xml"
+                href={atom.href}
+                title={atom.title}
             />
             <link
                 rel="apple-touch-icon"

--- a/site/SiteFooter.tsx
+++ b/site/SiteFooter.tsx
@@ -175,10 +175,18 @@ export const SiteFooter = (props: SiteFooterProps) => (
                             </li>
                             <li>
                                 <a
-                                    href="/feed"
+                                    href="/atom.xml"
                                     data-track-note="footer_navigation"
                                 >
-                                    RSS Feed
+                                    Articles & Topic Pages RSS Feed
+                                </a>
+                            </li>
+                            <li>
+                                <a
+                                    href="/atom-data-insights.xml"
+                                    data-track-note="footer_navigation"
+                                >
+                                    Data Insights RSS Feed
                                 </a>
                             </li>
                         </ul>

--- a/site/SiteFooter.tsx
+++ b/site/SiteFooter.tsx
@@ -178,7 +178,7 @@ export const SiteFooter = (props: SiteFooterProps) => (
                                     href="/atom.xml"
                                     data-track-note="footer_navigation"
                                 >
-                                    Articles & Topic Pages RSS Feed
+                                    Research & Writing RSS Feed
                                 </a>
                             </li>
                             <li>

--- a/site/gdocs/OwidGdocPage.tsx
+++ b/site/gdocs/OwidGdocPage.tsx
@@ -15,6 +15,7 @@ import { getCanonicalUrl, getPageTitle } from "@ourworldindata/components"
 import { DebugProvider } from "./DebugContext.js"
 import { match, P } from "ts-pattern"
 import { IMAGES_DIRECTORY } from "@ourworldindata/types"
+import { DATA_INSIGHT_ATOM_FEED_PROPS } from "./utils.js"
 
 declare global {
     interface Window {
@@ -79,6 +80,7 @@ export default function OwidGdocPage({
     const featuredImageFilename = getFeaturedImageFilename(gdoc)
     const canonicalUrl = getCanonicalUrl(baseUrl, gdoc)
     const pageTitle = getPageTitle(gdoc)
+    const isDataInsight = gdoc.content.type === OwidGdocType.DataInsight
 
     return (
         <html>
@@ -92,6 +94,7 @@ export default function OwidGdocPage({
                         ? `${baseUrl}${IMAGES_DIRECTORY}${featuredImageFilename}`
                         : undefined
                 }
+                atom={isDataInsight ? DATA_INSIGHT_ATOM_FEED_PROPS : undefined}
                 baseUrl={baseUrl}
             >
                 <CitationMeta

--- a/site/gdocs/pages/Homepage.tsx
+++ b/site/gdocs/pages/Homepage.tsx
@@ -102,9 +102,6 @@ const SocialSection = () => {
                             <span className="label">Threads</span>
                         </a>
                     </li>
-                </ul>
-                <h2 className="h2-semibold">RSS</h2>
-                <ul className="homepage-social-ribbon__social-list">
                     <li>
                         <a
                             href="/atom.xml"
@@ -117,7 +114,7 @@ const SocialSection = () => {
                                 <FontAwesomeIcon icon={faRss} />
                             </span>
                             <span className="label">
-                                Articles & Topic Pages
+                                Articles & Topic Pages RSS Feed
                             </span>
                         </a>
                     </li>
@@ -133,7 +130,9 @@ const SocialSection = () => {
                             <span className="icon">
                                 <FontAwesomeIcon icon={faRss} />
                             </span>
-                            <span className="label">Data Insights</span>
+                            <span className="label">
+                                Data Insights RSS Feed
+                            </span>
                         </a>
                     </li>
                 </ul>

--- a/site/gdocs/pages/Homepage.tsx
+++ b/site/gdocs/pages/Homepage.tsx
@@ -114,7 +114,7 @@ const SocialSection = () => {
                                 <FontAwesomeIcon icon={faRss} />
                             </span>
                             <span className="label">
-                                Articles & Topic Pages RSS Feed
+                                Research & Writing RSS Feed
                             </span>
                         </a>
                     </li>

--- a/site/gdocs/pages/Homepage.tsx
+++ b/site/gdocs/pages/Homepage.tsx
@@ -102,6 +102,9 @@ const SocialSection = () => {
                             <span className="label">Threads</span>
                         </a>
                     </li>
+                </ul>
+                <h2 className="h2-semibold">RSS</h2>
+                <ul className="homepage-social-ribbon__social-list">
                     <li>
                         <a
                             href="/atom.xml"
@@ -113,7 +116,9 @@ const SocialSection = () => {
                             <span className="icon">
                                 <FontAwesomeIcon icon={faRss} />
                             </span>
-                            <span className="label">Articles RSS Feed</span>
+                            <span className="label">
+                                Articles & Topic Pages
+                            </span>
                         </a>
                     </li>
                     <li>
@@ -128,9 +133,7 @@ const SocialSection = () => {
                             <span className="icon">
                                 <FontAwesomeIcon icon={faRss} />
                             </span>
-                            <span className="label">
-                                Data Insights RSS Feed
-                            </span>
+                            <span className="label">Data Insights</span>
                         </a>
                     </li>
                 </ul>

--- a/site/gdocs/pages/Homepage.tsx
+++ b/site/gdocs/pages/Homepage.tsx
@@ -18,6 +18,7 @@ import {
     OwidGdocHomepageContent,
 } from "@ourworldindata/types"
 import { SiteNavigationStatic } from "../../SiteNavigation.js"
+import { DATA_INSIGHTS_ATOM_FEED_NAME } from "../utils.js"
 
 export interface HomepageProps {
     content: OwidGdocHomepageContent
@@ -103,7 +104,7 @@ const SocialSection = () => {
                     </li>
                     <li>
                         <a
-                            href="/feed"
+                            href="/atom.xml"
                             className="list-item"
                             title="RSS"
                             target="_blank"
@@ -112,7 +113,24 @@ const SocialSection = () => {
                             <span className="icon">
                                 <FontAwesomeIcon icon={faRss} />
                             </span>
-                            <span className="label">RSS Feed</span>
+                            <span className="label">Articles RSS Feed</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a
+                            href={`/${DATA_INSIGHTS_ATOM_FEED_NAME}`}
+                            className="list-item"
+                            title="Data Insights RSS"
+                            target="_blank"
+                            data-track-note="homepage_follow_us"
+                            rel="noopener"
+                        >
+                            <span className="icon">
+                                <FontAwesomeIcon icon={faRss} />
+                            </span>
+                            <span className="label">
+                                Data Insights RSS Feed
+                            </span>
                         </a>
                     </li>
                 </ul>

--- a/site/gdocs/utils.tsx
+++ b/site/gdocs/utils.tsx
@@ -227,3 +227,10 @@ export function getShortPageCitation(
         authors: authors,
     })} (${publishedAt?.getFullYear()}) - “${title}”`
 }
+
+export const DATA_INSIGHTS_ATOM_FEED_NAME = "atom-data-insights.xml"
+
+export const DATA_INSIGHT_ATOM_FEED_PROPS = {
+    title: "Atom feed for Data Insights",
+    href: `https://ourworldindata.org/${DATA_INSIGHTS_ATOM_FEED_NAME}`,
+}


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/3365

Changes:
- Adds a new data insight feed page at `/atom-data-insights.xml`
- Adds logic to link to this page in the `<head>` if on `/data-insights` or a child thereof
- Updates UI to link to the new atom feed

To test:
1. Have some data insights published
2. Go to http://localhost:3030/atom-data-insights.xml and confirm it looks good
3. Check for regressions in http://localhost:3030/atom.xml
4. View source on http://localhost:3030/data-insights and http://localhost:3030/data-insights/your-data-insight-slug and check that the atom feed link is updated
5. Check for regressions on 2 other pages
6. Run `node itsJustJavascript/baker/buildLocalBake.js --steps rss` and confirm the output looks good 

