### PR TITLE
feat(search): index explorer views to Algolia

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -358,6 +358,7 @@ reindex: itsJustJavascript
 	node --enable-source-maps itsJustJavascript/baker/algolia/indexToAlgolia.js
 	node --enable-source-maps itsJustJavascript/baker/algolia/indexChartsToAlgolia.js
 	node --enable-source-maps itsJustJavascript/baker/algolia/indexExplorersToAlgolia.js
+	node --enable-source-maps itsJustJavascript/baker/algolia/indexExplorerViewsToAlgolia.js
 
 clean:
 	rm -rf node_modules itsJustJavascript

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -131,6 +131,22 @@ export const configureAlgolia = async () => {
         disableTypoToleranceOnAttributes: ["text"],
     })
 
+    const explorerViewsIndex = client.initIndex(
+        getIndexName(SearchIndexName.ExplorerViews)
+    )
+
+    await explorerViewsIndex.setSettings({
+        ...baseSettings,
+        searchableAttributes: [
+            "unordered(viewTitle)",
+            "unordered(viewSettings)",
+        ],
+        customRanking: ["desc(score)", "asc(viewIndexWithinExplorer)"],
+        attributeForDistinct: "viewTitleAndExplorerSlug",
+        distinct: true,
+        minWordSizefor1Typo: 6,
+    })
+
     const synonyms = [
         ["kids", "children"],
         ["pork", "pigmeat"],

--- a/baker/algolia/indexExplorerViewsToAlgolia.ts
+++ b/baker/algolia/indexExplorerViewsToAlgolia.ts
@@ -1,0 +1,199 @@
+import * as db from "../../db/db.js"
+import { ExplorerBlockGraphers } from "./indexExplorersToAlgolia.js"
+import { DecisionMatrix } from "../../explorer/ExplorerDecisionMatrix.js"
+import { tsvFormat } from "d3-dsv"
+import {
+    ExplorerChoiceParams,
+    ExplorerControlType,
+} from "../../explorer/ExplorerConstants.js"
+import { GridBoolean } from "../../gridLang/GridLangConstants.js"
+import { getAnalyticsPageviewsByUrlObj } from "../../db/model/Pageview.js"
+import { ALGOLIA_INDEXING } from "../../settings/serverSettings.js"
+import { getAlgoliaClient } from "./configureAlgolia.js"
+import { getIndexName } from "../../site/search/searchClient.js"
+import { SearchIndexName } from "../../site/search/searchTypes.js"
+
+interface ExplorerViewEntry {
+    viewTitle: string
+    viewSubtitle: string
+    viewSettings: string[]
+    viewQueryParams: string
+
+    viewGrapherId?: number
+
+    // Potential ranking criteria
+    viewIndexWithinExplorer: number
+    titleLength: number
+    numNonDefaultSettings: number
+    // viewViews_7d: number
+}
+
+interface ExplorerViewEntryWithExplorerInfo extends ExplorerViewEntry {
+    explorerSlug: string
+    explorerTitle: string
+    explorerViews_7d: number
+    viewTitleAndExplorerSlug: string // used for deduplication: `viewTitle | explorerSlug`
+
+    score: number
+
+    objectID?: string
+}
+
+const explorerChoiceToViewSettings = (
+    choices: ExplorerChoiceParams,
+    decisionMatrix: DecisionMatrix
+): string[] => {
+    return Object.entries(choices).map(([choiceName, choiceValue]) => {
+        const choiceControlType =
+            decisionMatrix.choiceNameToControlTypeMap.get(choiceName)
+        if (choiceControlType === ExplorerControlType.Checkbox)
+            return choiceValue === GridBoolean.true ? choiceName : ""
+        else return choiceValue
+    })
+}
+
+const getExplorerViewRecordsForExplorerSlug = async (
+    trx: db.KnexReadonlyTransaction,
+    slug: string
+): Promise<ExplorerViewEntry[]> => {
+    const explorerConfig = await trx
+        .table("explorers")
+        .select("config")
+        .where({ slug })
+        .first()
+        .then((row) => JSON.parse(row.config) as any)
+
+    const explorerGrapherBlock: ExplorerBlockGraphers =
+        explorerConfig.blocks.filter(
+            (block: any) => block.type === "graphers"
+        )[0] as ExplorerBlockGraphers
+
+    if (explorerGrapherBlock === undefined)
+        throw new Error(`Explorer ${slug} has no grapher block`)
+
+    // TODO: Maybe make DecisionMatrix accept JSON directly
+    const tsv = tsvFormat(explorerGrapherBlock.block)
+    const explorerDecisionMatrix = new DecisionMatrix(tsv)
+
+    console.log(
+        `Processing explorer ${slug} (${explorerDecisionMatrix.numRows} rows)`
+    )
+
+    const defaultSettings = explorerDecisionMatrix.defaultSettings
+
+    const records = explorerDecisionMatrix
+        .allDecisionsAsQueryParams()
+        .map((choice, i) => {
+            explorerDecisionMatrix.setValuesFromChoiceParams(choice)
+
+            // Check which choices are non-default, i.e. are not the first available option in a dropdown/radio
+            const nonDefaultSettings = Object.entries(
+                explorerDecisionMatrix.availableChoiceOptions
+            ).filter(([choiceName, choiceOptions]) => {
+                // Keep only choices which are not the default, which is:
+                // - either the options marked as `default` in the decision matrix
+                // - or the first available option in the decision matrix
+                return (
+                    choiceOptions.length > 1 &&
+                    !(defaultSettings[choiceName] !== undefined
+                        ? defaultSettings[choiceName] === choice[choiceName]
+                        : choice[choiceName] === choiceOptions[0])
+                )
+            })
+
+            // TODO: Handle grapherId and fetch title/subtitle
+            // TODO: Handle indicator-based explorers
+
+            const record: ExplorerViewEntry = {
+                viewTitle: explorerDecisionMatrix.selectedRow.title,
+                viewSubtitle: explorerDecisionMatrix.selectedRow.subtitle,
+                viewSettings: explorerChoiceToViewSettings(
+                    choice,
+                    explorerDecisionMatrix
+                ),
+                viewGrapherId: explorerDecisionMatrix.selectedRow.grapherId,
+                viewQueryParams: explorerDecisionMatrix.toString(),
+
+                viewIndexWithinExplorer: i,
+                titleLength: explorerDecisionMatrix.selectedRow.title?.length,
+                numNonDefaultSettings: nonDefaultSettings.length,
+            }
+            return record
+        })
+
+    return records
+}
+
+const getExplorerViewRecords = async (
+    trx: db.KnexReadonlyTransaction
+): Promise<ExplorerViewEntryWithExplorerInfo[]> => {
+    const publishedExplorers = Object.values(
+        await db.getPublishedExplorersBySlug(trx)
+    )
+
+    const pageviews = await getAnalyticsPageviewsByUrlObj(trx)
+
+    let records = [] as ExplorerViewEntryWithExplorerInfo[]
+    for (const explorerInfo of publishedExplorers) {
+        const explorerViewRecords = await getExplorerViewRecordsForExplorerSlug(
+            trx,
+            explorerInfo.slug
+        )
+
+        const explorerPageviews =
+            pageviews[`/explorers/${explorerInfo.slug}`]?.views_7d ?? 0
+        records = records.concat(
+            explorerViewRecords.map(
+                (record, i): ExplorerViewEntryWithExplorerInfo => ({
+                    ...record,
+                    explorerSlug: explorerInfo.slug,
+                    explorerTitle: explorerInfo.title,
+                    explorerViews_7d: explorerPageviews,
+                    viewTitleAndExplorerSlug: `${record.viewTitle} | ${explorerInfo.slug}`,
+                    // Scoring function
+                    score:
+                        explorerPageviews * 10 -
+                        record.numNonDefaultSettings * 50 -
+                        record.titleLength,
+
+                    objectID: `${explorerInfo.slug}-${i}`,
+                })
+            )
+        )
+    }
+
+    return records
+}
+
+const indexExplorerViewsToAlgolia = async () => {
+    if (!ALGOLIA_INDEXING) return
+
+    const client = getAlgoliaClient()
+    if (!client) {
+        console.error(
+            `Failed indexing explorer views (Algolia client not initialized)`
+        )
+        return
+    }
+
+    try {
+        const index = client.initIndex(
+            getIndexName(SearchIndexName.ExplorerViews)
+        )
+
+        const records = await db.knexReadonlyTransaction(
+            getExplorerViewRecords,
+            db.TransactionCloseMode.Close
+        )
+        await index.replaceAllObjects(records)
+    } catch (e) {
+        console.log("Error indexing explorer views to Algolia:", e)
+    }
+}
+
+process.on("unhandledRejection", (e) => {
+    console.error(e)
+    process.exit(1)
+})
+
+void indexExplorerViewsToAlgolia()

--- a/baker/algolia/indexExplorersToAlgolia.ts
+++ b/baker/algolia/indexExplorersToAlgolia.ts
@@ -22,7 +22,7 @@ type ExplorerBlockColumns = {
     block: { name: string; additionalInfo?: string }[]
 }
 
-type ExplorerBlockGraphers = {
+export type ExplorerBlockGraphers = {
     type: "graphers"
     block: {
         title?: string

--- a/explorer/ExplorerDecisionMatrix.ts
+++ b/explorer/ExplorerDecisionMatrix.ts
@@ -86,7 +86,7 @@ export class DecisionMatrix {
     table: CoreTable
     @observable currentParams: ExplorerChoiceParams = {}
     constructor(delimited: string, hash = "") {
-        this.choices = makeChoicesMap(delimited)
+        this.choiceNameToControlTypeMap = makeChoicesMap(delimited)
         this.table = new CoreTable(parseDelimited(dropColumnTypes(delimited)), [
             // todo: remove col def?
             {
@@ -141,7 +141,7 @@ export class DecisionMatrix {
         )
     }
 
-    private choices: Map<ChoiceName, ExplorerControlType>
+    choiceNameToControlTypeMap: Map<ChoiceName, ExplorerControlType>
     hash: string
 
     toConstrainedOptions(): ExplorerChoiceParams {
@@ -243,7 +243,7 @@ export class DecisionMatrix {
     }
 
     @computed private get choiceNames(): ChoiceName[] {
-        return Array.from(this.choices.keys())
+        return Array.from(this.choiceNameToControlTypeMap.keys())
     }
 
     @computed private get allChoiceOptions(): ChoiceMap {
@@ -256,7 +256,7 @@ export class DecisionMatrix {
         return choiceMap
     }
 
-    @computed private get availableChoiceOptions(): ChoiceMap {
+    @computed get availableChoiceOptions(): ChoiceMap {
         const result: ChoiceMap = {}
         this.choiceNames.forEach((choiceName) => {
             result[choiceName] = this.allChoiceOptions[choiceName].filter(
@@ -317,7 +317,7 @@ export class DecisionMatrix {
     }
 
     // The first row with defaultView column value of "true" determines the default view to use
-    private get defaultSettings() {
+    get defaultSettings() {
         const hits = this.rowsWith({
             [GrapherGrammar.defaultView.keyword]: "true",
         })
@@ -373,7 +373,7 @@ export class DecisionMatrix {
                     constrainedOptions
                 )
             )
-            const type = this.choices.get(title)!
+            const type = this.choiceNameToControlTypeMap.get(title)!
 
             return {
                 title,

--- a/site/search/Autocomplete.tsx
+++ b/site/search/Autocomplete.tsx
@@ -73,7 +73,12 @@ const getItemUrl: AutocompleteSource<BaseItem>["getItemUrl"] = ({ item }) =>
 const prependSubdirectoryToAlgoliaItemUrl = (item: BaseItem): string => {
     const indexName = parseIndexName(item.__autocomplete_indexName as string)
     const subdirectory = indexNameToSubdirectoryMap[indexName]
-    return `${subdirectory}/${item.slug}`
+    switch (indexName) {
+        case SearchIndexName.ExplorerViews:
+            return `${subdirectory}/${item.explorerSlug}${item.viewQueryParams}`
+        default:
+            return `${subdirectory}/${item.slug}`
+    }
 }
 
 const FeaturedSearchesSource: AutocompleteSource<BaseItem> = {
@@ -134,6 +139,14 @@ const AlgoliaSource: AutocompleteSource<BaseItem> = {
                     },
                 },
                 {
+                    indexName: getIndexName(SearchIndexName.ExplorerViews),
+                    query,
+                    params: {
+                        hitsPerPage: 1,
+                        distinct: true,
+                    },
+                },
+                {
                     indexName: getIndexName(SearchIndexName.Explorers),
                     query,
                     params: {
@@ -152,11 +165,20 @@ const AlgoliaSource: AutocompleteSource<BaseItem> = {
                 item.__autocomplete_indexName as string
             )
             const indexLabel =
-                index === SearchIndexName.Charts
-                    ? "Chart"
-                    : index === SearchIndexName.Explorers
-                      ? "Explorer"
-                      : pageTypeDisplayNames[item.type as PageType]
+                index === SearchIndexName.Charts ? (
+                    "Chart"
+                ) : index === SearchIndexName.Explorers ? (
+                    "Explorer"
+                ) : index === SearchIndexName.ExplorerViews ? (
+                    <>
+                        in <em>{item.explorerTitle} Data Explorer</em>
+                    </>
+                ) : (
+                    pageTypeDisplayNames[item.type as PageType]
+                )
+
+            const mainAttribute =
+                index === SearchIndexName.ExplorerViews ? "viewTitle" : "title"
 
             return (
                 <div
@@ -167,7 +189,7 @@ const AlgoliaSource: AutocompleteSource<BaseItem> = {
                     <span>
                         <components.Highlight
                             hit={item}
-                            attribute="title"
+                            attribute={mainAttribute}
                             tagName="strong"
                         />
                     </span>

--- a/site/search/Search.scss
+++ b/site/search/Search.scss
@@ -193,6 +193,7 @@
 
 .search-results__pages-list,
 .search-results__explorers-list,
+.search-results__explorer-views-list,
 .search-results__charts-list {
     gap: var(--grid-gap);
     @include sm-only {
@@ -227,7 +228,8 @@
     display: block;
 }
 
-.search-results__explorer-hit a {
+.search-results__explorer-hit a,
+.search-results__explorer-view-hit a {
     background-color: $blue-10;
     height: 100%;
     padding: 24px;
@@ -326,6 +328,7 @@
 
 .search-results__pages,
 .search-results__explorers,
+.search-results__explorer-views,
 .search-results__charts {
     display: none;
 }
@@ -333,6 +336,7 @@
 .search-results[data-active-filter="all"] {
     .search-results__pages,
     .search-results__explorers,
+    .search-results__explorer-views,
     .search-results__charts {
         // both needed for .search-results__show-more-container absolute-positioning
         display: inline-block;
@@ -377,10 +381,21 @@
     }
 }
 
-.search-results[data-active-filter="explorers"] .search-results__explorers {
+.search-results__explorer-view-hit {
+    display: none;
+
+    &:nth-child(-n + 4) {
+        display: inline;
+    }
+}
+
+.search-results[data-active-filter="explorers"] .search-results__explorers,
+.search-results[data-active-filter="explorers"]
+    .search-results__explorer-views {
     display: inline;
 
-    .search-results__explorer-hit {
+    .search-results__explorer-hit,
+    .search-results__explorer-view-hit {
         display: inline;
     }
 }

--- a/site/search/SearchPanel.tsx
+++ b/site/search/SearchPanel.tsx
@@ -35,6 +35,7 @@ import {
     searchCategoryFilters,
     IPageHit,
     pageTypeDisplayNames,
+    IExplorerViewHit,
 } from "./searchTypes.js"
 import { EXPLORERS_ROUTE_FOLDER } from "../../explorer/ExplorerConstants.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
@@ -121,6 +122,23 @@ function ChartHit({ hit }: { hit: IChartHit }) {
     )
 }
 
+function ExplorerViewHit({ hit }: { hit: IExplorerViewHit }) {
+    return (
+        <a
+            data-algolia-index={getIndexName(SearchIndexName.ExplorerViews)}
+            data-algolia-object-id={hit.objectID}
+            data-algolia-position={hit.__position}
+            href={`${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${hit.explorerSlug}${hit.viewQueryParams}`}
+        >
+            <h4 className="h3-bold">{hit.viewTitle}</h4>
+            <span>
+                in <em>{hit.explorerTitle} Data Explorer</em>
+            </span>
+            {/* Explorer subtitles are mostly useless at the moment, so we're only showing titles */}
+        </a>
+    )
+}
+
 function ExplorerHit({ hit }: { hit: IExplorerHit }) {
     return (
         <a
@@ -194,9 +212,14 @@ function Filters({
     const hitsLengthByIndexName = mapValues(resultsByIndexName, (results) =>
         get(results, ["results", "hits", "length"], 0)
     )
+
     hitsLengthByIndexName[getIndexName("all")] = Object.values(
         hitsLengthByIndexName
     ).reduce((a: number, b: number) => a + b, 0)
+
+    hitsLengthByIndexName[getIndexName(SearchIndexName.Explorers)] =
+        hitsLengthByIndexName[getIndexName(SearchIndexName.Explorers)] +
+        hitsLengthByIndexName[getIndexName(SearchIndexName.ExplorerViews)]
 
     return (
         <div className="search-filters">
@@ -371,6 +394,38 @@ const SearchResults = (props: SearchResultsProps) => {
                                 item: "search-results__explorer-hit",
                             }}
                             hitComponent={ExplorerHit}
+                        />
+                    </section>
+                </NoResultsBoundary>
+            </Index>
+            <Index indexName={getIndexName(SearchIndexName.ExplorerViews)}>
+                <Configure
+                    hitsPerPage={10}
+                    distinct
+                    clickAnalytics={hasClickAnalyticsConsent}
+                />
+                <NoResultsBoundary>
+                    <section className="search-results__explorer-views">
+                        <header className="search-results__header">
+                            <h2 className="h2-bold search-results__section-title">
+                                Data Explorer views
+                            </h2>
+                            <ShowMore
+                                category={SearchIndexName.ExplorerViews}
+                                cutoffNumber={4}
+                                activeCategoryFilter={activeCategoryFilter}
+                                handleCategoryFilterClick={
+                                    handleCategoryFilterClick
+                                }
+                            />
+                        </header>
+                        <Hits
+                            classNames={{
+                                root: "search-results__list-container",
+                                list: "search-results__explorer-views-list grid grid-cols-2 grid-sm-cols-1",
+                                item: "search-results__explorer-view-hit",
+                            }}
+                            hitComponent={ExplorerViewHit}
                         />
                     </section>
                 </NoResultsBoundary>

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -68,6 +68,7 @@ export type IChartHit = Hit<BaseHit> & ChartRecord
 
 export enum SearchIndexName {
     Explorers = "explorers",
+    ExplorerViews = "explorer-views",
     Charts = "charts",
     Pages = "pages",
 }
@@ -85,4 +86,5 @@ export const indexNameToSubdirectoryMap: Record<SearchIndexName, string> = {
     [SearchIndexName.Pages]: "",
     [SearchIndexName.Charts]: "/grapher",
     [SearchIndexName.Explorers]: "/explorers",
+    [SearchIndexName.ExplorerViews]: "/explorers",
 }

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -36,6 +36,14 @@ export interface PageRecord {
 
 export type IPageHit = PageRecord & Hit<BaseHit>
 
+export type IExplorerViewHit = Hit<BaseHit> & {
+    objectID: string
+    explorerSlug: string
+    viewTitle: string
+    explorerTitle: string
+    viewQueryParams: string
+}
+
 export type IExplorerHit = Hit<BaseHit> & {
     objectID: string
     slug: string


### PR DESCRIPTION
> [!Warning]
> Very much a work in progress.

Resolves #3332.

## Ranking

Ranking criteria being used:
- 7-day pageviews of the _whole_ explorer
- Number of explorer settings that differ from the default
- Length of title

These are then combined into the rather-arbitrary-but-seemingly-working-quite well
```
score = explorerPageviews * 10 - numNonDefaultSettings * 50 - titleLength
```

Note that `explorerPageviews` doesn't change between different views of the same explorers; so it's only used to discriminate results from different explorers.