### PR TITLE
enhance(search): show placeholder panels for chart thumbnails

### DIFF
--- a/packages/@ourworldindata/components/src/styles/variables.scss
+++ b/packages/@ourworldindata/components/src/styles/variables.scss
@@ -48,6 +48,12 @@ $article-cover-height: 224px;
 $article-page-top-offset: 88px;
 
 $search-cta-height: 40px;
+
+// Grapher sizing
+// Keep in sync with DEFAULT_GRAPHER_WIDTH, and the (dynamic/static) thumbnail generation code
+$grapher-thumbnail-width: 850px;
+$grapher-thumbnail-height: 600px;
+
 /*******************************************************************************
 * Breakpoints
 */

--- a/site/search/Search.scss
+++ b/site/search/Search.scss
@@ -271,12 +271,23 @@
     font-size: 0.9em;
 }
 
+@keyframes chartErrorFadeIn {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
 .search-results__chart-hit-img-container {
     margin-bottom: 8px;
+    aspect-ratio: 850 / 600;
+    width: 100%;
+    background-color: $gray-10;
+
     img {
         display: block; // remove the space below the image
-        width: 100%;
-        background-color: $gray-10;
         transition: box-shadow 0.1s;
 
         &.loaded {
@@ -285,6 +296,27 @@
                 0px 6px 13px 0px rgba(49, 37, 2, 0.03),
                 0px 93px 37px 0px rgba(49, 37, 2, 0.01),
                 0px 145px 41px 0px rgba(49, 37, 2, 0);
+        }
+
+        &.error {
+            display: none;
+        }
+    }
+
+    .search-results__chart-hit-img-error {
+        display: flex;
+        height: 100%;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+
+        color: $grey-text-color;
+        animation: chartErrorFadeIn 0.3s;
+
+        gap: 0.5em;
+
+        svg {
+            font-size: 1.75em;
         }
     }
 }

--- a/site/search/Search.scss
+++ b/site/search/Search.scss
@@ -255,7 +255,7 @@
         .search-results__chart-hit-highlight {
             text-decoration: underline;
         }
-        img {
+        .search-results__chart-hit-img-container img {
             box-shadow: none;
         }
     }
@@ -275,12 +275,17 @@
     margin-bottom: 8px;
     img {
         display: block; // remove the space below the image
-        box-shadow:
-            0px 0px 0px 0px rgba(49, 37, 2, 0.03),
-            0px 6px 13px 0px rgba(49, 37, 2, 0.03),
-            0px 93px 37px 0px rgba(49, 37, 2, 0.01),
-            0px 145px 41px 0px rgba(49, 37, 2, 0);
+        width: 100%;
+        background-color: $gray-10;
         transition: box-shadow 0.1s;
+
+        &.loaded {
+            box-shadow:
+                0px 0px 0px 0px rgba(49, 37, 2, 0.03),
+                0px 6px 13px 0px rgba(49, 37, 2, 0.03),
+                0px 93px 37px 0px rgba(49, 37, 2, 0.01),
+                0px 145px 41px 0px rgba(49, 37, 2, 0);
+        }
     }
 }
 

--- a/site/search/Search.scss
+++ b/site/search/Search.scss
@@ -282,7 +282,7 @@
 
 .search-results__chart-hit-img-container {
     margin-bottom: 8px;
-    aspect-ratio: 850 / 600;
+    aspect-ratio: calc($grapher-thumbnail-width / $grapher-thumbnail-height);
     width: 100%;
     background-color: $gray-10;
 

--- a/site/search/SearchPanel.tsx
+++ b/site/search/SearchPanel.tsx
@@ -48,6 +48,10 @@ import {
     PreferenceType,
     getPreferenceValue,
 } from "../CookiePreferencesManager.js"
+import {
+    DEFAULT_GRAPHER_HEIGHT,
+    DEFAULT_GRAPHER_WIDTH,
+} from "@ourworldindata/grapher"
 
 function PagesHit({ hit }: { hit: IPageHit }) {
     return (
@@ -97,8 +101,8 @@ function ChartHit({ hit }: { hit: IChartHit }) {
                 <img
                     className={cx({ loaded: imgLoaded, error: imgError })}
                     loading="lazy"
-                    width={850}
-                    height={600}
+                    width={DEFAULT_GRAPHER_WIDTH}
+                    height={DEFAULT_GRAPHER_HEIGHT}
                     src={`${BAKED_GRAPHER_URL}/exports/${hit.slug}.svg`}
                     onLoad={() => setImgLoaded(true)}
                     onError={() => setImgError(true)}

--- a/site/search/SearchPanel.tsx
+++ b/site/search/SearchPanel.tsx
@@ -1,5 +1,5 @@
 import ReactDOM from "react-dom"
-import React, { useCallback, useEffect } from "react"
+import React, { useCallback, useEffect, useState } from "react"
 import cx from "classnames"
 import {
     keyBy,
@@ -77,6 +77,8 @@ function PagesHit({ hit }: { hit: IPageHit }) {
 }
 
 function ChartHit({ hit }: { hit: IChartHit }) {
+    const [imgLoaded, setImgLoaded] = useState(false)
+
     return (
         <a
             href={`${BAKED_GRAPHER_URL}/${hit.slug}`}
@@ -86,8 +88,12 @@ function ChartHit({ hit }: { hit: IChartHit }) {
         >
             <div className="search-results__chart-hit-img-container">
                 <img
+                    className={cx({ loaded: imgLoaded })}
                     loading="lazy"
+                    width={850}
+                    height={600}
                     src={`${BAKED_GRAPHER_URL}/exports/${hit.slug}.svg`}
+                    onLoad={() => setImgLoaded(true)}
                 />
             </div>
             <Highlight

--- a/site/search/SearchPanel.tsx
+++ b/site/search/SearchPanel.tsx
@@ -38,7 +38,7 @@ import {
 } from "./searchTypes.js"
 import { EXPLORERS_ROUTE_FOLDER } from "../../explorer/ExplorerConstants.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
-import { faSearch } from "@fortawesome/free-solid-svg-icons"
+import { faHeartBroken, faSearch } from "@fortawesome/free-solid-svg-icons"
 import {
     DEFAULT_SEARCH_PLACEHOLDER,
     getIndexName,
@@ -78,6 +78,7 @@ function PagesHit({ hit }: { hit: IPageHit }) {
 
 function ChartHit({ hit }: { hit: IChartHit }) {
     const [imgLoaded, setImgLoaded] = useState(false)
+    const [imgError, setImgError] = useState(false)
 
     return (
         <a
@@ -87,13 +88,20 @@ function ChartHit({ hit }: { hit: IChartHit }) {
             data-algolia-position={hit.__position}
         >
             <div className="search-results__chart-hit-img-container">
+                {imgError && (
+                    <div className="search-results__chart-hit-img-error">
+                        <FontAwesomeIcon icon={faHeartBroken} />
+                        <span>Chart preview not available</span>
+                    </div>
+                )}
                 <img
-                    className={cx({ loaded: imgLoaded })}
+                    className={cx({ loaded: imgLoaded, error: imgError })}
                     loading="lazy"
                     width={850}
                     height={600}
                     src={`${BAKED_GRAPHER_URL}/exports/${hit.slug}.svg`}
                     onLoad={() => setImgLoaded(true)}
+                    onError={() => setImgError(true)}
                 />
             </div>
             <Highlight


### PR DESCRIPTION
Currently, we have loads of layout jumps in the search UI while the chart previews load.
This is not much of an issue on fast networks, but is very noticeable on slow networks.

In the future, when we want to use dynamic thumbnails sometimes, we need to also think about
- that these take longer to load, and
- that they can also fail to load in rare cases.

That's why I've worked on a jump-less placeholder UI, and also a small error tile that we can show instead.

<table>
<tr>
<th>Before
<th>After
<tr>
 <td>

![CleanShot 2024-03-20 at 09 45 10](https://github.com/owid/owid-grapher/assets/2641501/f65a9d78-78b6-40aa-9ad8-d33d52010c25)

 <td>

![CleanShot 2024-03-20 at 09 47 05](https://github.com/owid/owid-grapher/assets/2641501/8c5df879-7f4c-44f6-8d86-e033bfa10bfb)

<tr>
<td>Many layout jumps during loading
<td>No layout jumps; error tile for when errors occur

</table>

## Testing

For testing this:
- It's best to use DevTools' network throttling, for example "Fast 3G".
- To test the error behavior, manually clear out the `src` field of an `img` element in DevTools.