### PR TITLE
:hammer: enable metadata edits, add loading

### DIFF
--- a/adminSiteClient/Admin.tsx
+++ b/adminSiteClient/Admin.tsx
@@ -76,7 +76,8 @@ export class Admin {
         path: string,
         data: string | File | undefined,
         method: HTTPMethod,
-        abortController?: AbortController
+        abortController?: AbortController,
+        credentials: RequestCredentials = "same-origin"
     ): Promise<Response> {
         const headers: HeadersInit = {}
         const isFile = data instanceof File
@@ -89,7 +90,7 @@ export class Admin {
 
         return fetch(fetchUrl, {
             method: method,
-            credentials: "same-origin",
+            credentials: credentials,
             headers: headers,
             body: method !== "GET" ? data : undefined,
             signal: abortController?.signal,

--- a/adminSiteClient/AdminLayout.tsx
+++ b/adminSiteClient/AdminLayout.tsx
@@ -54,7 +54,11 @@ export class AdminLayout extends React.Component<{
         const { admin } = this.context
         if (admin.settings.ENV === "development") {
             return <span className="dev">dev</span>
-        } else if (window.location.origin === "https://owid.cloud") {
+        } else if (
+            ["https://owid.cloud", "https://admin.owid.io"].includes(
+                window.location.origin
+            )
+        ) {
             return <span className="live">live</span>
         } else {
             return <span className="test">test</span>

--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -212,7 +212,6 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
         const { dataset } = this.props
         const { newDataset } = this
         const isBulkImport = dataset.namespace !== "owid"
-        const isDisabled = true
 
         return (
             <main className="DatasetEditPage">
@@ -282,7 +281,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                                     store={newDataset}
                                     label="Name"
                                     secondaryLabel="DB field: datasets.name"
-                                    disabled={isDisabled}
+                                    disabled
                                     helpText="Short name for this dataset, followed by the source and year. Example: Government Revenue Data – ICTD (2016)"
                                 />
                                 <DatasetTagEditor
@@ -296,10 +295,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                                         onValue={(v) =>
                                             (newDataset.isPrivate = !v)
                                         }
-                                        disabled={
-                                            isDisabled ||
-                                            newDataset.nonRedistributable
-                                        }
+                                        disabled={newDataset.nonRedistributable}
                                     />
                                 </FieldsRow>
                                 <FieldsRow>
@@ -309,7 +305,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                                         onValue={(v) => {
                                             newDataset.nonRedistributable = v
                                         }}
-                                        disabled={isDisabled}
+                                        disabled
                                     />
                                 </FieldsRow>
                             </div>
@@ -318,7 +314,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                                     label="Number of days between OWID updates"
                                     field="updatePeriodDays"
                                     store={newDataset}
-                                    disabled={isDisabled}
+                                    disabled
                                     helpText="Date when this data was obtained by us. Date format should always be YYYY-MM-DD."
                                 />
                                 <BindString
@@ -327,7 +323,7 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                                     label="Internal notes"
                                     secondaryLabel="DB field: datasets.description"
                                     textarea
-                                    disabled={isDisabled}
+                                    disabled
                                 />
                             </div>
                         </div>

--- a/adminSiteClient/OriginList.tsx
+++ b/adminSiteClient/OriginList.tsx
@@ -13,7 +13,6 @@ export class OriginList extends React.Component<{
 
     render() {
         const { origins } = this.props
-        const isDisabled = true
 
         return (
             <div>
@@ -25,25 +24,25 @@ export class OriginList extends React.Component<{
                                 label="Title"
                                 field="title"
                                 store={origin}
-                                disabled={isDisabled}
+                                disabled
                             />
                             <BindString
                                 label="Title Snapshot"
                                 field="titleSnapshot"
                                 store={origin}
-                                disabled={isDisabled}
+                                disabled
                             />
                             <BindString
                                 label="Attribution"
                                 field="attribution"
                                 store={origin}
-                                disabled={isDisabled}
+                                disabled
                             />
                             <BindString
                                 label="Attribution Short"
                                 field="attributionShort"
                                 store={origin}
-                                disabled={isDisabled}
+                                disabled
                             />
                         </FieldsRow>
                         <FieldsRow>
@@ -51,28 +50,28 @@ export class OriginList extends React.Component<{
                                 label="Description"
                                 field="description"
                                 store={origin}
-                                disabled={isDisabled}
+                                disabled
                                 textarea
                             />
                             <BindString
                                 label="Description Snapshot"
                                 field="descriptionSnapshot"
                                 store={origin}
-                                disabled={isDisabled}
+                                disabled
                                 textarea
                             />
                             <BindString
                                 label="Citation Full"
                                 field="citationFull"
                                 store={origin}
-                                disabled={isDisabled}
+                                disabled
                                 textarea
                             />
                             <BindString
                                 label="Producer"
                                 field="producer"
                                 store={origin}
-                                disabled={isDisabled}
+                                disabled
                             />
                         </FieldsRow>
                         <FieldsRow>
@@ -80,25 +79,25 @@ export class OriginList extends React.Component<{
                                 label="URL Main"
                                 field="urlMain"
                                 store={origin}
-                                disabled={isDisabled}
+                                disabled
                             />
                             <BindString
                                 label="URL Download"
                                 field="urlDownload"
                                 store={origin}
-                                disabled={isDisabled}
+                                disabled
                             />
                             <BindString
                                 label="Date Accessed"
                                 field="dateAccessed"
                                 store={origin}
-                                disabled={isDisabled}
+                                disabled
                             />
                             <BindString
                                 label="Date Published"
                                 field="datePublished"
                                 store={origin}
-                                disabled={isDisabled}
+                                disabled
                             />
                             {/* Missing origin license... is it worth adding it? */}
                         </FieldsRow>

--- a/adminSiteClient/SourceList.tsx
+++ b/adminSiteClient/SourceList.tsx
@@ -15,7 +15,6 @@ export class SourceList extends React.Component<{
 
     render() {
         const { sources } = this.props
-        const isDisabled = true
 
         // Use slice to create a new array with at most MAX_SOURCES items
         const limitedSources =
@@ -41,7 +40,7 @@ export class SourceList extends React.Component<{
                                     store={source}
                                     label="Source name"
                                     secondaryLabel="DB field: sources.description ->> '$.name'"
-                                    disabled={isDisabled}
+                                    disabled
                                     // helpText={`Short citation of the main sources, to be displayed on the charts. Additional sources (e.g. population denominator) should not be included. Use semi-colons to separate multiple sources e.g. "UN (2022); World Bank (2022)". For institutional datasets or reports, use "Institution, Project (year or vintage)" e.g. "IHME, Global Burden of Disease (2019)". For data we have modified extensively, use "Our World in Data based on X (year)" e.g. "Our World in Data based on Pew Research Center (2022)". For academic papers, use "Authors (year)" e.g. "Arroyo-Abad and Lindert (2016)".`}
                                 />
                                 <BindString
@@ -49,7 +48,7 @@ export class SourceList extends React.Component<{
                                     store={source}
                                     label="Data published by"
                                     secondaryLabel="DB field: sources.description ->> '$.dataPublishedBy'"
-                                    disabled={isDisabled}
+                                    disabled
                                     // helpText={`Full citation of main and additional sources. For academic papers, institutional datasets, and reports, use the complete citation recommended by the publisher. For data we have modified extensively, use "Our World in Data based on X (year) and Y (year)" e.g. "Our World in Data based on Pew Research Center (2022) and UN (2022)".`}
                                 />
                                 <BindString
@@ -57,7 +56,7 @@ export class SourceList extends React.Component<{
                                     store={source}
                                     label="Data publisher's source"
                                     secondaryLabel="DB field: sources.description ->> '$.dataPublisherSource'"
-                                    disabled={isDisabled}
+                                    disabled
                                     // helpText={`Optional field. Basic indication of how the publisher collected this data e.g. "Survey data". Anything longer than a line should go in the dataset description.`}
                                 />
                                 <BindString
@@ -65,7 +64,7 @@ export class SourceList extends React.Component<{
                                     store={source}
                                     label="Link"
                                     secondaryLabel="DB field: sources.description ->> '$.link'"
-                                    disabled={isDisabled}
+                                    disabled
                                     // helpText="Link to the publication from which we retrieved this data"
                                 />
                                 <BindString
@@ -73,7 +72,7 @@ export class SourceList extends React.Component<{
                                     store={source}
                                     label="Retrieved"
                                     secondaryLabel="DB field: sources.description ->> '$.retrievedDate'"
-                                    disabled={isDisabled}
+                                    disabled
                                     // helpText="Date when this data was obtained by us. Date format should always be YYYY-MM-DD."
                                 />
                             </div>
@@ -85,7 +84,7 @@ export class SourceList extends React.Component<{
                                     label="Additional info"
                                     secondaryLabel="DB field: sources.description ->> '$.additionalInfo'"
                                     textarea
-                                    disabled={isDisabled}
+                                    disabled
                                     // helpText="Describe the dataset and the methodology used in its construction. This can be as long and detailed as you like."
                                     rows={15}
                                 />

--- a/adminSiteClient/VariableEditPage.tsx
+++ b/adminSiteClient/VariableEditPage.tsx
@@ -172,7 +172,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                 <form
                     onSubmit={(e) => {
                         e.preventDefault()
-                        // this.save()
+                        this.save()
                     }}
                 >
                     <div className="row">
@@ -226,7 +226,6 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                     field="name"
                                     store={newVariable}
                                     label="Indicator Name"
-                                    disabled={isDisabled}
                                 />
                                 <BindString
                                     field="catalogPath"
@@ -238,7 +237,6 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                     label="Display name"
                                     field="name"
                                     store={newVariable.display}
-                                    disabled={isDisabled}
                                 />
                                 <FieldsRow>
                                     <BindString
@@ -246,14 +244,12 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                         field="unit"
                                         store={newVariable.display}
                                         placeholder={newVariable.unit}
-                                        disabled={isDisabled}
                                     />
                                     <BindString
                                         label="Short (axis) unit"
                                         field="shortUnit"
                                         store={newVariable.display}
                                         placeholder={newVariable.shortUnit}
-                                        disabled={isDisabled}
                                     />
                                 </FieldsRow>
                                 <FieldsRow>
@@ -262,14 +258,12 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                         field="numDecimalPlaces"
                                         store={newVariable.display}
                                         helpText={`A negative number here will round integers`}
-                                        disabled={isDisabled}
                                     />
                                     <BindFloat
                                         label="Unit conversion factor"
                                         field="conversionFactor"
                                         store={newVariable.display}
                                         helpText={`Multiply all values by this amount`}
-                                        disabled={isDisabled}
                                     />
                                 </FieldsRow>
                                 <FieldsRow>
@@ -339,25 +333,21 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                         label="Title public"
                                         field="titlePublic"
                                         store={newVariable.presentation}
-                                        disabled={isDisabled}
                                     />
                                     <BindString
                                         label="Title variant"
                                         field="titleVariant"
                                         store={newVariable.presentation}
-                                        disabled={isDisabled}
                                     />
                                     <BindString
                                         label="Attribution"
                                         field="attribution"
                                         store={newVariable.presentation}
-                                        disabled={isDisabled}
                                     />
                                     <BindString
                                         label="Attribution short"
                                         field="attributionShort"
                                         store={newVariable.presentation}
-                                        disabled={isDisabled}
                                     />
                                 </FieldsRow>
                                 <FieldsRow>
@@ -366,14 +356,12 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                         field="descriptionShort"
                                         store={newVariable}
                                         textarea
-                                        disabled={isDisabled}
                                     />
                                     <BindString
                                         label="Description from producer"
                                         field="descriptionFromProducer"
                                         store={newVariable}
                                         textarea
-                                        disabled={isDisabled}
                                     />
                                 </FieldsRow>
                                 <FieldsRow>
@@ -395,7 +383,6 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                         field="descriptionKey"
                                         store={newVariable}
                                         rows={8}
-                                        disabled={isDisabled}
                                     />
                                 </FieldsRow>
                                 <FieldsRow>
@@ -406,7 +393,6 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                             store={newVariable}
                                             textarea
                                             rows={8}
-                                            disabled={isDisabled}
                                         />
                                     </div>
                                     <div className="col">
@@ -424,13 +410,11 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                                     label: "Major",
                                                 },
                                             ]}
-                                            disabled={isDisabled}
                                         />
                                         <BindString
                                             label="Number of days between OWID updates"
                                             field="updatePeriodDays"
                                             store={newVariable}
-                                            disabled={isDisabled}
                                         />
                                     </div>
                                 </FieldsRow>
@@ -473,7 +457,6 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                 type="submit"
                                 className="btn btn-success"
                                 value="Update indicator"
-                                disabled={isDisabled}
                             />
                         </div>
                     </div>

--- a/adminSiteClient/VariableEditPage.tsx
+++ b/adminSiteClient/VariableEditPage.tsx
@@ -510,7 +510,9 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
             await this.context.admin.rawRequest(
                 healthcheckUrl,
                 undefined,
-                "GET"
+                "GET",
+                undefined,
+                "include"
             )
             return true
         } catch (err) {
@@ -538,7 +540,9 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
         const request = this.context.admin.rawRequest(
             url,
             JSON.stringify(data),
-            "PUT"
+            "PUT",
+            undefined,
+            "include"
         )
         let response: Response
         try {

--- a/adminSiteClient/VariableEditPage.tsx
+++ b/adminSiteClient/VariableEditPage.tsx
@@ -523,6 +523,8 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
     async save() {
         const { variable } = this.props
 
+        this.context.admin.loadingIndicatorSetting = "loading"
+
         const url = `${ETL_API_URL}/indicators`
 
         const indicatorDiff = getDifference(
@@ -547,6 +549,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
         let response: Response
         try {
             response = await request
+            this.context.admin.loadingIndicatorSetting = "off"
         } catch (err) {
             const title = (await this.etlApiIsRunning())
                 ? `Internal error`
@@ -565,6 +568,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                 ),
                 isFatal: true,
             })
+            this.context.admin.loadingIndicatorSetting = "off"
             throw err
         }
 

--- a/adminSiteClient/VariableEditPage.tsx
+++ b/adminSiteClient/VariableEditPage.tsx
@@ -143,7 +143,6 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
     render() {
         const { variable } = this.props
         const { newVariable, isV2MetadataVariable } = this
-        const isDisabled = true
 
         const pathFragments = variable.catalogPath
             ? getETLPathComponents(variable.catalogPath)
@@ -277,7 +276,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                                 value)
                                         }
                                         label="Treat year column as day series"
-                                        disabled={isDisabled}
+                                        disabled
                                     />
                                     <BindString
                                         label="Zero Day as YYYY-MM-DD"
@@ -286,7 +285,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                         // disabled={
                                         //     !newVariable.display.yearIsDay
                                         // }
-                                        disabled={isDisabled}
+                                        disabled
                                         placeholder={
                                             newVariable.display.yearIsDay
                                                 ? EPOCH_DATE
@@ -374,7 +373,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                                     .grapherConfigETL
                                             ),
                                         }}
-                                        disabled={isDisabled}
+                                        disabled
                                         textarea
                                         rows={8}
                                     />
@@ -431,7 +430,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                                 value)
                                         }
                                         label="Include in table"
-                                        disabled={isDisabled}
+                                        disabled
                                     />
                                 </FieldsRow>
                                 <FieldsRow>
@@ -440,7 +439,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                         store={newVariable}
                                         label="Description"
                                         textarea
-                                        disabled={isDisabled}
+                                        disabled
                                     />
                                     <BindString
                                         field="entityAnnotationsMap"
@@ -448,7 +447,7 @@ class VariableEditor extends React.Component<{ variable: VariablePageData }> {
                                         store={newVariable.display}
                                         label="Entity annotations"
                                         textarea
-                                        disabled={isDisabled}
+                                        disabled
                                         helpText="Additional text to show next to entity labels. Each note should be in a separate line."
                                     />
                                 </FieldsRow>


### PR DESCRIPTION
ETL API now runs on HTTPS behind Cloudflare Access (e.g. https://etl.owid.io/api/v1/health). Hence, the browser doesn't complain anymore about making requests to http, and we can enable metadata editing again.

We have to call ETL API with `credentials: "include"` to pass CF cookies needed for auth. I've also turned on "loading indicator" in case the update takes longer (it should take a couple of seconds max).

## How to test

Go to [dummy indicator](http://staging-site-enable-metadata-edits/admin/variables/553199) and edit its name or any other editable field. Then click on `Update indicator` and wait for loading to complete. You should see your change after refresh. (In prod, it would also make a commit to ETL)