### PR TITLE
🐛 add type="button" to all Grapher buttons

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
@@ -348,6 +348,7 @@ export function ActionButton(props: {
                     setShowTooltip(false)
                 }}
                 aria-label={props.label}
+                type="button"
             >
                 <FontAwesomeIcon icon={props.icon} />
                 {props.showLabel && (

--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
@@ -90,6 +90,7 @@ function Tab(props: {
                 onClick={props.onClick}
                 data-track-note={"chart_click_" + props.tab}
                 aria-label={props.tab}
+                type="button"
             >
                 {props.icon}
                 {props.showLabel && <span className="label">{props.tab}</span>}

--- a/packages/@ourworldindata/grapher/src/controls/EntitySelectionToggle.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/EntitySelectionToggle.tsx
@@ -81,6 +81,7 @@ export class EntitySelectionToggle extends React.Component<{
                         this.props.manager.isSelectingData = !active
                         e.stopPropagation()
                     }}
+                    type="button"
                     data-track-note="chart_add_entity"
                     aria-label={`${label.action} ${label.entity}`}
                 >

--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
@@ -421,6 +421,7 @@ export class SettingsMenu extends React.Component<{
                     onClick={this.toggleVisibility}
                     data-track-note="chart_settings_menu_toggle"
                     title="Chart settings"
+                    type="button"
                     aria-label="Chart settings"
                 >
                     <FontAwesomeIcon icon={faGear} />

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
@@ -260,6 +260,7 @@ export class TimelineComponent extends React.Component<{
         return (
             <button
                 className="date clickable"
+                type="button"
                 onClick={(): void =>
                     markerType === "start"
                         ? controller.resetStartToMin()


### PR DESCRIPTION
When inside the Variable Edit form, the `type="submit"` default behaviour of the HTML `<button>` element was messing things up. Explicitly setting all Grapher buttons to `type="button"` to fix this and any potential future issues like this.