### PR TITLE
🐛 fix explorer and r&w algolia hit clicks not being tracked correctly

### DIFF
--- a/site/search/SearchPanel.tsx
+++ b/site/search/SearchPanel.tsx
@@ -284,9 +284,10 @@ const SearchResults = (props: SearchResultsProps) => {
                     const position = target.getAttribute(
                         "data-algolia-position"
                     )
-                    if (objectId && position) {
+                    const index = target.getAttribute("data-algolia-index")
+                    if (objectId && position && index) {
                         logSiteSearchClick({
-                            index: getIndexName(SearchIndexName.Charts),
+                            index,
                             queryID,
                             objectIDs: [objectId],
                             positions: [parseInt(position)],
@@ -429,11 +430,7 @@ export class InstantSearchContainer extends React.Component {
 
     constructor(props: Record<string, never>) {
         super(props)
-        this.searchClient = algoliasearch(ALGOLIA_ID, ALGOLIA_SEARCH_KEY, {
-            queryParameters: {
-                clickAnalytics: "true",
-            },
-        })
+        this.searchClient = algoliasearch(ALGOLIA_ID, ALGOLIA_SEARCH_KEY)
         this.categoryFilterContainerRef = React.createRef<HTMLUListElement>()
         this.handleCategoryFilterClick =
             this.handleCategoryFilterClick.bind(this)


### PR DESCRIPTION
Resolves #2932

It was a simple hardcoded value that was causing the hit clicks not to be tracked.

Before, all events were being sent as:

```json
{
    "events": [
        {
            "eventType": "click",
            "index": "charts",
            "queryID": "blah",
            "objectIDs": ["global-food-2"],
            "positions": [1],
            "eventName": "click",
            "userToken": "blah",
        },
    ],
}
```

which meant Algolia wasn't able to resolve them to any actual results in the index.

I'm waiting for the analytics data to update in our owid-staging application to confirm this has fixed it and then we should be good to go.
