### PR TITLE
chore(ci): update github actions

### DIFF
--- a/.github/actions/setup-node-yarn-deps/action.yml
+++ b/.github/actions/setup-node-yarn-deps/action.yml
@@ -4,7 +4,7 @@ runs:
     using: composite
     steps:
         - name: Use Node.js (.nvmrc)
-          uses: actions/setup-node@v3
+          uses: actions/setup-node@v4
           with:
               node-version-file: ".nvmrc"
               cache: "yarn"

--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -11,4 +11,4 @@ jobs:
     assign-author:
         runs-on: ubuntu-latest
         steps:
-            - uses: toshimaru/auto-author-assign@v1.6.2
+            - uses: toshimaru/auto-author-assign@v2.1.0

--- a/.github/workflows/auto-deploy-gh-pages.yml
+++ b/.github/workflows/auto-deploy-gh-pages.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Clone repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - uses: ./.github/actions/setup-node-yarn-deps
             - uses: ./.github/actions/build-tsc

--- a/.github/workflows/buildkite.yml
+++ b/.github/workflows/buildkite.yml
@@ -10,10 +10,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Set up Python
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.x
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
         steps:
             - name: Clone repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - uses: ./.github/actions/setup-node-yarn-deps
 
@@ -25,7 +25,7 @@ jobs:
 
         steps:
             - name: Clone repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - uses: ./.github/actions/setup-node-yarn-deps
 
@@ -46,7 +46,7 @@ jobs:
 
         steps:
             - name: Clone repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - uses: ./.github/actions/setup-node-yarn-deps
 
@@ -60,7 +60,7 @@ jobs:
 
         steps:
             - name: Clone repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - uses: ./.github/actions/setup-node-yarn-deps
             - uses: ./.github/actions/build-tsc

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   # We must fetch at least the immediate parents so that if this is
                   # a pull request then we can checkout the head.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,69 +3,81 @@
 #
 # You may wish to alter this file to override the set of languages analyzed,
 # or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
 name: "CodeQL"
 
 on:
     push:
-        branches: [master]
+        branches: ["master"]
     pull_request:
-        # The branches below must be a subset of the branches above
-        branches: [master]
+        branches: ["master"]
     schedule:
-        - cron: "0 14 * * 2"
+        - cron: "36 6 * * 6"
 
 jobs:
     analyze:
         name: Analyze
-        runs-on: ubuntu-latest
+        # Runner size impacts CodeQL analysis time. To learn more, please see:
+        #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+        #   - https://gh.io/supported-runners-and-hardware-resources
+        #   - https://gh.io/using-larger-runners
+        # Consider using larger runners for possible analysis time improvements.
+        runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+        timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+        permissions:
+            # required for all workflows
+            security-events: write
+
+            # only required for workflows in private repositories
+            actions: read
+            contents: read
 
         strategy:
             fail-fast: false
             matrix:
-                # Override automatic language detection by changing the below list
-                # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
-                language: ["javascript"]
-                # Learn more...
-                # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
+                language: ["javascript-typescript", "python"]
+                # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
+                # Use only 'java-kotlin' to analyze code written in Java, Kotlin or both
+                # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+                # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
-              with:
-                  # We must fetch at least the immediate parents so that if this is
-                  # a pull request then we can checkout the head.
-                  fetch-depth: 2
-
-            # If this run was triggered by a pull request event, then checkout
-            # the head of the pull request instead of the merge commit.
-            - run: git checkout HEAD^2
-              if: ${{ github.event_name == 'pull_request' }}
 
             # Initializes the CodeQL tools for scanning.
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v2
+              uses: github/codeql-action/init@v3
               with:
                   languages: ${{ matrix.language }}
                   # If you wish to specify custom queries, you can do so here or in a config file.
                   # By default, queries listed here will override any specified in a config file.
                   # Prefix the list here with "+" to use these queries and those in the config file.
-                  # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-            # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+                  # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+                  # queries: security-extended,security-and-quality
+
+            # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
             # If this step fails, then you should remove it and run the build manually (see below)
             - name: Autobuild
-              uses: github/codeql-action/autobuild@v2
+              uses: github/codeql-action/autobuild@v3
 
             # ℹ️ Command-line programs to run using the OS shell.
-            # 📚 https://git.io/JvXDl
+            # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-            # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-            #    and modify them (or add more) to build your code if your project
-            #    uses a compiled language
+            #   If the Autobuild fails above, remove it and uncomment the following three lines.
+            #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-            #- run: |
-            #   make bootstrap
-            #   make release
+            # - run: |
+            #     echo "Run, Build Application using script"
+            #     ./location_of_script_within_repo/buildscript.sh
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v2
+              uses: github/codeql-action/analyze@v3
+              with:
+                  category: "/language:${{matrix.language}}"

--- a/.github/workflows/prettify.yml
+++ b/.github/workflows/prettify.yml
@@ -14,7 +14,7 @@ jobs:
 
         steps:
             - name: Clone repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   ref: ${{ github.head_ref }}
 
@@ -23,6 +23,6 @@ jobs:
             - name: Run prettier
               run: yarn fixPrettierAll
 
-            - uses: stefanzweifel/git-auto-commit-action@v4
+            - uses: stefanzweifel/git-auto-commit-action@v5
               with:
                   commit_message: "🤖 style: prettify code"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
             pull-requests: write
 
         steps:
-            - uses: actions/stale@v8
+            - uses: actions/stale@v9
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   stale-issue-message: "This issue has had no activity within 10 months. It is considered stale and will be closed in 7 days unless it is worked on or tagged as pinned."

--- a/.github/workflows/svg-compare-all-views.yml
+++ b/.github/workflows/svg-compare-all-views.yml
@@ -8,7 +8,7 @@ jobs:
 
         steps:
             - name: Clone repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - uses: ./.github/actions/setup-node-yarn-deps
             - uses: ./.github/actions/build-tsc
@@ -38,7 +38,7 @@ jobs:
             # Checkout the owid-grapher-svgs repo into a subfolder. Use a Personal Access Token for checkout so the
             # action will have permission to push later on if required.
             - name: Clone svg tester repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   repository: "owid/owid-grapher-svgs"
                   path: owid-grapher-svgs
@@ -62,7 +62,7 @@ jobs:
               run: node --enable-source-maps itsJustJavascript/devTools/svgTester/verify-graphs.js -i owid-grapher-svgs/configs -o owid-grapher-svgs/all-views/svg -r owid-grapher-svgs/all-views/svg --ids-from-file owid-grapher-svgs/most-viewed-charts.txt --all-views $RM_ON_ERROR > compare-result
 
             # If the last step failed we want to commit all changed svgs and push them to the new branch on the owid-grapher-svgs repo
-            - uses: stefanzweifel/git-auto-commit-action@v4
+            - uses: stefanzweifel/git-auto-commit-action@v5
               if: ${{ steps.run-verify-graphs.outcome == 'failure' }}
               with:
                   repository: ./owid-grapher-svgs/
@@ -85,7 +85,7 @@ jobs:
             # The action fails if there were any errors.
             - name: Fail with error message if we had errors
               if: ${{ steps.run-verify-graphs.outputs.num_errors > 0 }}
-              uses: actions/github-script@v6
+              uses: actions/github-script@v7
               with:
                   script: |
                       core.setFailed('Errors were thrown during checking! Please check diffs at https://github.com/owid/owid-grapher-svgs/commits/${{ env.PUSH_BRANCH_NAME }}')
@@ -96,7 +96,7 @@ jobs:
             - name: Fail with error message if we had differences
               if: ${{ steps.run-verify-graphs.outputs.num_differences > 0 }}
               continue-on-error: ${{ env.ORIGINAL_BRANCH_NAME == 'master' }}
-              uses: actions/github-script@v6
+              uses: actions/github-script@v7
               with:
                   script: |
                       core.setFailed('SVGs were different from reference! Please check diffs at https://github.com/owid/owid-grapher-svgs/commits/${{ env.PUSH_BRANCH_NAME }}')

--- a/.github/workflows/svg-compare.yml
+++ b/.github/workflows/svg-compare.yml
@@ -8,7 +8,7 @@ jobs:
 
         steps:
             - name: Clone repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - uses: ./.github/actions/setup-node-yarn-deps
             - uses: ./.github/actions/build-tsc
@@ -37,7 +37,7 @@ jobs:
             # Checkout the owid-grapher-svgs repo into a subfolder. Use a Personal Access Token for checkout so the
             # action will have permission to push later on if required.
             - name: Clone svg tester repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   repository: "owid/owid-grapher-svgs"
                   path: owid-grapher-svgs
@@ -84,7 +84,7 @@ jobs:
             # The action fails if there were any errors.
             - name: Fail with error message if we had errors
               if: ${{ steps.run-verify-graphs.outputs.num_errors > 0 }}
-              uses: actions/github-script@v6
+              uses: actions/github-script@v7
               with:
                   script: |
                       core.setFailed('Errors were thrown during checking! Please check diffs at https://github.com/owid/owid-grapher-svgs/commits/${{ env.PUSH_BRANCH_NAME }}')
@@ -95,7 +95,7 @@ jobs:
             - name: Fail with error message if we had differences
               if: ${{ steps.run-verify-graphs.outputs.num_differences > 0 }}
               continue-on-error: ${{ env.ORIGINAL_BRANCH_NAME == 'master' }}
-              uses: actions/github-script@v6
+              uses: actions/github-script@v7
               with:
                   script: |
                       core.setFailed('SVGs were different from reference! Please check diffs at https://github.com/owid/owid-grapher-svgs/commits/${{ env.PUSH_BRANCH_NAME }}')


### PR DESCRIPTION
(almost) all of them should now be using node20, which gets rid of a deprecation warning; see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/