### PR TITLE
🐛 change entries-by-year baked filepath to fix ERR_TOO_MANY_REDIRECTS

### DIFF
--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -828,7 +828,7 @@ export class SiteBaker {
     private async bakeGoogleScholar() {
         if (!this.bakeSteps.has("googleScholar")) return
         await this.stageWrite(
-            `${this.bakedSiteDir}/entries-by-year/index.html`,
+            `${this.bakedSiteDir}/entries-by-year.html`,
             await entriesByYearPage()
         )
 

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -405,6 +405,8 @@ export const entriesByYearPage = async (year?: number) => {
         "title" | "slug" | "published_at"
     >[]
 
+    // TODO: include topic pages here once knex refactor is done
+
     if (year !== undefined)
         return renderToHtmlPage(
             <EntriesForYearPage


### PR DESCRIPTION
Resolves #2936

@marcelgerber you suggested adding a redirect but this should also work, right?

Or is it still preferable to keep it at index.html for server best practice reasons? (My only reason for doing it this way instead is that it seems simpler)