### PR TITLE
✨ add click event analytics for autosuggest

### DIFF
--- a/site/search/Autocomplete.tsx
+++ b/site/search/Autocomplete.tsx
@@ -26,6 +26,10 @@ import {
     parseIndexName,
 } from "./searchClient.js"
 import { queryParamsToStr } from "@ourworldindata/utils"
+import {
+    PreferenceType,
+    getPreferenceValue,
+} from "../CookiePreferencesManager.js"
 
 type BaseItem = Record<string, unknown>
 
@@ -264,6 +268,7 @@ export function Autocomplete({
                 return sources
             },
             plugins: [recentSearchesPlugin],
+            insights: getPreferenceValue(PreferenceType.Analytics),
         })
 
         const container = document.querySelector(AUTOCOMPLETE_CONTAINER_ID)


### PR DESCRIPTION
Adds "click" and "view" events for autosuggest results. They are automatically generated by algolia's analytics client

These can be seen in the debugger: https://dashboard.algolia.com/apps/ASCB5XMYF2/events/debugger

e.g.

![image](https://github.com/owid/owid-grapher/assets/11844404/6681ee7a-8465-432e-b8fa-e0de86e4d84b)

I'm not yet sure if these will be understood by Algolia as clicks for searches, because it doesn't use the event in analytics if the host is localhost it seems. We'll have to merge and find out 🙂