### PR TITLE
🐛 fix insert statement array return value

### DIFF
--- a/db/db.ts
+++ b/db/db.ts
@@ -135,7 +135,7 @@ export const knexRawInsert = async (
     knex: KnexReadWriteTransaction,
     str: string,
     params?: any[]
-): Promise<{ insertId: number }> => await knex.raw(str, params ?? [])
+): Promise<{ insertId: number }> => (await knex.raw(str, params ?? []))[0]
 
 /**
  *  In the backporting workflow, the users create gdoc posts for posts. As long as these are not yet published,


### PR DESCRIPTION
The knexRaw function returns an array of objects. For insert statemements the first row then contains information like the insertId. The insert helper function forgot to reach into the array and return the first result but the type signature made it look like that is what happened.