### PR TITLE
Data insight `og:description`

### DIFF
--- a/site/DataInsightsIndexPage.tsx
+++ b/site/DataInsightsIndexPage.tsx
@@ -12,6 +12,7 @@ import {
     _OWID_DATA_INSIGHTS_INDEX_PAGE_DATA,
 } from "./DataInsightsIndexPageContent.js"
 import { DATA_INSIGHT_ATOM_FEED_PROPS } from "./gdocs/utils.js"
+import { DebugProvider } from "./gdocs/DebugContext.js"
 
 export interface DataInsightsIndexPageProps {
     dataInsights: OwidGdocDataInsightInterface[]
@@ -22,7 +23,7 @@ export interface DataInsightsIndexPageProps {
 }
 
 export const DataInsightsIndexPage = (props: DataInsightsIndexPageProps) => {
-    const { baseUrl } = props
+    const { baseUrl, isPreviewing } = props
     return (
         <html>
             <Head
@@ -39,7 +40,9 @@ export const DataInsightsIndexPage = (props: DataInsightsIndexPageProps) => {
                     id="data-insights-index-page-container"
                     className="data-insights-index-page grid grid-cols-12-full-width"
                 >
-                    <DataInsightsIndexPageContent {...props} />
+                    <DebugProvider debug={isPreviewing}>
+                        <DataInsightsIndexPageContent {...props} />
+                    </DebugProvider>
                 </main>
                 <SiteFooter
                     baseUrl={baseUrl}

--- a/site/DataInsightsIndexPageContent.tsx
+++ b/site/DataInsightsIndexPageContent.tsx
@@ -15,6 +15,7 @@ import { AttachmentsContext, DocumentContext } from "./gdocs/OwidGdoc.js"
 import { DataInsightsIndexPageProps } from "./DataInsightsIndexPage.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faArrowLeft, faArrowRight } from "@fortawesome/free-solid-svg-icons"
+import { DebugProvider } from "./gdocs/DebugContext.js"
 
 const Pagination = (props: { pageNumber: number; totalPageCount: number }) => {
     const { pageNumber, totalPageCount } = props
@@ -155,6 +156,11 @@ export function hydrateDataInsightsIndexPage() {
     )
 
     if (container && props) {
-        ReactDOM.hydrate(<DataInsightsIndexPageContent {...props} />, container)
+        ReactDOM.hydrate(
+            <DebugProvider>
+                <DataInsightsIndexPageContent {...props} />
+            </DebugProvider>,
+            container
+        )
     }
 }

--- a/site/gdocs/OwidGdocPage.tsx
+++ b/site/gdocs/OwidGdocPage.tsx
@@ -14,7 +14,7 @@ import {
 import { getCanonicalUrl, getPageTitle } from "@ourworldindata/components"
 import { DebugProvider } from "./DebugContext.js"
 import { match, P } from "ts-pattern"
-import { IMAGES_DIRECTORY } from "@ourworldindata/types"
+import { EnrichedBlockText, IMAGES_DIRECTORY } from "@ourworldindata/types"
 import { DATA_INSIGHT_ATOM_FEED_PROPS } from "./utils.js"
 
 declare global {
@@ -40,9 +40,14 @@ function getPageDesc(gdoc: OwidGdocUnionType): string | undefined {
                 return match.content.excerpt
             }
         )
-        .with({ content: { type: OwidGdocType.DataInsight } }, () => {
-            // TODO: what do we put here?
-            return undefined
+        .with({ content: { type: OwidGdocType.DataInsight } }, (match) => {
+            const firstParagraph = match.content.body.find(
+                (block) => block.type === "text"
+            ) as EnrichedBlockText | undefined
+            // different platforms truncate at different lengths, let's leave it up to them
+            return firstParagraph
+                ? spansToUnformattedPlainText(firstParagraph.value)
+                : undefined
         })
         .with({ content: { type: OwidGdocType.Homepage } }, () => {
             return "Research and data to make progress against the world’s largest problems"


### PR DESCRIPTION
Fixes an issue with the local preview for data insights, and adds a more informative `og:description`

![image](https://github.com/owid/owid-grapher/assets/11844404/4a981a09-0076-4086-a16c-8bac89cee397)
