### PR TITLE
chore: remove `$.data.availableEntities` from configs and schema

### DIFF
--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -223,11 +223,6 @@ export class ChartEditor {
         if (!currentGrapherObject.slug)
             currentGrapherObject.slug = grapher.displaySlug
 
-        // We need to save availableEntities for Algolia search. Todo: remove.
-        const availableEntities = grapher.table.availableEntityNames
-        if (availableEntities.length)
-            (currentGrapherObject as any).data = { availableEntities }
-
         const targetUrl = isNewGrapher
             ? "/api/charts"
             : `/api/charts/${grapher.id}`

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -1089,7 +1089,7 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
 
     async getFieldDefinitions() {
         const json = await fetch(
-            "https://files.ourworldindata.org/schemas/grapher-schema.003.json"
+            "https://files.ourworldindata.org/schemas/grapher-schema.004.json"
         ).then((response) => response.json())
         const fieldDescriptions = extractFieldDescriptionsFromSchema(json)
         runInAction(() => {

--- a/db/migration/1711580214803-RemoveAvailableEntitiesFromChartConfigs.ts
+++ b/db/migration/1711580214803-RemoveAvailableEntitiesFromChartConfigs.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class RemoveAvailableEntitiesFromChartConfigs1711580214803
+    implements MigrationInterface
+{
+    // Removes `$.data.availableEntities` from chart configs
+    // In doing that, we can also remove the whole `$.data` object, because it is not used anymore
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const configColumns = [
+            { table: "charts", column: "config" },
+            { table: "chart_revisions", column: "config" },
+            { table: "suggested_chart_revisions", column: "suggestedConfig" },
+            { table: "variables", column: "grapherConfigAdmin" },
+            { table: "variables", column: "grapherConfigETL" },
+        ]
+
+        for (const { table, column } of configColumns) {
+            await queryRunner.query(
+                `-- sql
+                UPDATE ??
+                SET ?? = JSON_REMOVE(??, "$.data")
+                WHERE JSON_CONTAINS_PATH(??, "one", "$.data")
+            `,
+                [table, column, column, column]
+            )
+
+            // Update schema version to 004
+            await queryRunner.query(
+                `-- sql
+                UPDATE ??
+                SET ?? = JSON_SET(??, "$.$schema", "https://files.ourworldindata.org/schemas/grapher-schema.004.json")`,
+                [table, column, column]
+            )
+        }
+    }
+
+    public async down(): Promise<void> {
+        return
+    }
+}

--- a/devTools/schemaProcessor/columns.json
+++ b/devTools/schemaProcessor/columns.json
@@ -260,11 +260,6 @@
         "editor": "checkbox"
     },
     {
-        "type": "array",
-        "pointer": "/data/availableEntities",
-        "editor": "primitiveListEditor"
-    },
-    {
         "type": "boolean",
         "pointer": "/hideLegend",
         "default": false,

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -9,7 +9,7 @@ export const GRAPHER_SETTINGS_DRAWER_ID = "grapher-settings-drawer"
 export const GRAPHER_IS_IN_IFRAME_CLASS = "IsInIframe"
 
 export const DEFAULT_GRAPHER_CONFIG_SCHEMA =
-    "https://files.ourworldindata.org/schemas/grapher-schema.003.json"
+    "https://files.ourworldindata.org/schemas/grapher-schema.004.json"
 
 export const DEFAULT_GRAPHER_ENTITY_TYPE = "country or region"
 export const DEFAULT_GRAPHER_ENTITY_TYPE_PLURAL = "countries and regions"

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.004.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.004.yaml
@@ -1,5 +1,5 @@
 $schema: "http://json-schema.org/draft-07/schema#"
-$id: "https://files.ourworldindata.org/schemas/grapher-schema.003.json"
+$id: "https://files.ourworldindata.org/schemas/grapher-schema.004.json"
 $defs:
     axis:
         type: object
@@ -201,7 +201,7 @@ properties:
         type: string
         description: Url of the concrete schema version to use to validate this document
         format: uri
-        default: "https://files.ourworldindata.org/schemas/grapher-schema.003.json"
+        default: "https://files.ourworldindata.org/schemas/grapher-schema.004.json"
     id:
         type: integer
         description: Internal DB id. Useful internally for OWID but not required if just using grapher directly.
@@ -305,16 +305,6 @@ properties:
         type: boolean
         default: true
         description: Whether to show the (non-map) chart tab
-    data:
-        type: object
-        description: Obsolete name - used only to store the available entities
-        properties:
-            availableEntities:
-                type: array
-                description: List of available entities
-                items:
-                    type: string
-        additionalProperties: false
     hideLegend:
         type: boolean
         default: false


### PR DESCRIPTION
Follow-up work to #3418.

Drops the `$.data` property from all our configs. It was only used for `$.data.availableEntities`, which we won't need any longer.