### PR TITLE
Make the make migrate script safer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,8 @@ up.full: require create-if-missing.env.full ../owid-content wordpress/.env tmp-d
 
 migrate:
 	@echo '==> Running DB migrations'
-	yarn && yarn buildTsc && yarn runDbMigrations
+    rm -rf itsJustJavascript
+	yarn && yarn buildLerna && yarn buildTsc && yarn runDbMigrations
 
 refresh.full: refresh refresh.wp sync-images
 

--- a/db/model/Gdoc/GdocFactory.ts
+++ b/db/model/Gdoc/GdocFactory.ts
@@ -494,9 +494,7 @@ export async function setTagsForGdoc(
     await knex.table(PostsGdocsXTagsTableName).where({ gdocId }).delete()
     const tagIdsForInsert = tagIds.map(({ id: tagId }) => ({ gdocId, tagId }))
     if (tagIdsForInsert.length)
-        await knex
-            .table(PostsGdocsXTagsTableName)
-            .insert(tagIdsForInsert)
+        await knex.table(PostsGdocsXTagsTableName).insert(tagIdsForInsert)
 }
 
 export enum GdocLinkUpdateMode {

--- a/site/DataInsightsIndexPageContent.tsx
+++ b/site/DataInsightsIndexPageContent.tsx
@@ -116,7 +116,7 @@ export const DataInsightsIndexPageContent = (
             >
                 <header className="data-insights-index-page__header grid grid-cols-12-full-width span-cols-14">
                     <h2 className="span-cols-8 col-start-4 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12 display-2-semibold ">
-                        Data insights
+                        Data Insights
                     </h2>
                     <p className="span-cols-8 col-start-4 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12 body-1-regular">
                         Bite-sized insights on how the world is changing,


### PR DESCRIPTION
Our `yarn buildTsc` script does an incremental build that doesn not delete old files. When we run `yarn runDbMigrations`, this can lead to problems.

This PR makes sure that we delete the `itsJustJavascript` directory when we run the `make migrate` command