### PR TITLE
🥽 make sure that "make migrate" deletes itsJustJavascript for safety

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ up.full: require create-if-missing.env.full ../owid-content wordpress/.env tmp-d
 
 migrate:
 	@echo '==> Running DB migrations'
-	yarn && yarn buildTsc && yarn runDbMigrations
+	rm -rf itsJustJavascript && yarn && yarn buildLerna && yarn buildTsc && yarn runDbMigrations
 
 refresh.full: refresh refresh.wp sync-images
 


### PR DESCRIPTION
Our yarn buildTsc script does an incremental build that doesn not delete old files. When we run yarn runDbMigrations, this can lead to problems.

This PR makes sure that we delete the itsJustJavascript directory when we run the make migrate command
