### PR TITLE
feat(algolia): index explorer views to Algolia

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -358,6 +358,7 @@ reindex: itsJustJavascript
 	node --enable-source-maps itsJustJavascript/baker/algolia/indexToAlgolia.js
 	node --enable-source-maps itsJustJavascript/baker/algolia/indexChartsToAlgolia.js
 	node --enable-source-maps itsJustJavascript/baker/algolia/indexExplorersToAlgolia.js
+	node --enable-source-maps itsJustJavascript/baker/algolia/indexExplorerViewsToAlgolia.js
 
 clean:
 	rm -rf node_modules itsJustJavascript

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -150,9 +150,9 @@ export const configureAlgolia = async () => {
     await explorerViewsIndex.setSettings({
         ...baseSettings,
         searchableAttributes: [
+            "unordered(explorerTitle)",
             "unordered(viewTitle)",
             "unordered(viewSettings)",
-            "unordered(explorerTitle)",
         ],
         customRanking: [
             // For multiple explorer views with the same title, we want to avoid surfacing duplicates.

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -152,10 +152,17 @@ export const configureAlgolia = async () => {
         searchableAttributes: [
             "unordered(viewTitle)",
             "unordered(viewSettings)",
+            "unordered(explorerTitle)",
         ],
-        customRanking: ["desc(score)", "asc(viewIndexWithinExplorer)"],
-        attributeForDistinct: "viewTitleAndExplorerSlug",
-        distinct: true,
+        customRanking: [
+            // For multiple explorer views with the same title, we want to avoid surfacing duplicates.
+            // So, rank a result with viewTitleIndexWithinExplorer=0 way more highly than one with 1, 2, etc.
+            "asc(viewTitleIndexWithinExplorer)",
+            "desc(score)",
+            "asc(viewIndexWithinExplorer)",
+        ],
+        attributeForDistinct: "explorerSlug",
+        distinct: 4,
         minWordSizefor1Typo: 6,
     })
 

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -330,6 +330,9 @@ export const configureAlgolia = async () => {
     await explorersIndex.saveSynonyms(algoliaSynonyms, {
         replaceExistingSynonyms: true,
     })
+    await explorerViewsIndex.saveSynonyms(algoliaSynonyms, {
+        replaceExistingSynonyms: true,
+    })
 
     if (TOPICS_CONTENT_GRAPH) {
         const graphIndex = client.initIndex(CONTENT_GRAPH_ALGOLIA_INDEX)

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -143,6 +143,22 @@ export const configureAlgolia = async () => {
         disableTypoToleranceOnAttributes: ["text"],
     })
 
+    const explorerViewsIndex = client.initIndex(
+        getIndexName(SearchIndexName.ExplorerViews)
+    )
+
+    await explorerViewsIndex.setSettings({
+        ...baseSettings,
+        searchableAttributes: [
+            "unordered(viewTitle)",
+            "unordered(viewSettings)",
+        ],
+        customRanking: ["desc(score)", "asc(viewIndexWithinExplorer)"],
+        attributeForDistinct: "viewTitleAndExplorerSlug",
+        distinct: true,
+        minWordSizefor1Typo: 6,
+    })
+
     const synonyms = [
         ["owid", "our world in data"],
         ["kids", "children"],

--- a/baker/algolia/indexExplorerViewsToAlgolia.ts
+++ b/baker/algolia/indexExplorerViewsToAlgolia.ts
@@ -1,0 +1,199 @@
+import * as db from "../../db/db.js"
+import { ExplorerBlockGraphers } from "./indexExplorersToAlgolia.js"
+import { DecisionMatrix } from "../../explorer/ExplorerDecisionMatrix.js"
+import { tsvFormat } from "d3-dsv"
+import {
+    ExplorerChoiceParams,
+    ExplorerControlType,
+} from "../../explorer/ExplorerConstants.js"
+import { GridBoolean } from "../../gridLang/GridLangConstants.js"
+import { getAnalyticsPageviewsByUrlObj } from "../../db/model/Pageview.js"
+import { ALGOLIA_INDEXING } from "../../settings/serverSettings.js"
+import { getAlgoliaClient } from "./configureAlgolia.js"
+import { getIndexName } from "../../site/search/searchClient.js"
+import { SearchIndexName } from "../../site/search/searchTypes.js"
+
+interface ExplorerViewEntry {
+    viewTitle: string
+    viewSubtitle: string
+    viewSettings: string[]
+    viewQueryParams: string
+
+    viewGrapherId?: number
+
+    // Potential ranking criteria
+    viewIndexWithinExplorer: number
+    titleLength: number
+    numNonDefaultSettings: number
+    // viewViews_7d: number
+}
+
+interface ExplorerViewEntryWithExplorerInfo extends ExplorerViewEntry {
+    explorerSlug: string
+    explorerTitle: string
+    explorerViews_7d: number
+    viewTitleAndExplorerSlug: string // used for deduplication: `viewTitle | explorerSlug`
+
+    score: number
+
+    objectID?: string
+}
+
+const explorerChoiceToViewSettings = (
+    choices: ExplorerChoiceParams,
+    decisionMatrix: DecisionMatrix
+): string[] => {
+    return Object.entries(choices).map(([choiceName, choiceValue]) => {
+        const choiceControlType =
+            decisionMatrix.choiceNameToControlTypeMap.get(choiceName)
+        if (choiceControlType === ExplorerControlType.Checkbox)
+            return choiceValue === GridBoolean.true ? choiceName : ""
+        else return choiceValue
+    })
+}
+
+const getExplorerViewRecordsForExplorerSlug = async (
+    trx: db.KnexReadonlyTransaction,
+    slug: string
+): Promise<ExplorerViewEntry[]> => {
+    const explorerConfig = await trx
+        .table("explorers")
+        .select("config")
+        .where({ slug })
+        .first()
+        .then((row) => JSON.parse(row.config) as any)
+
+    const explorerGrapherBlock: ExplorerBlockGraphers =
+        explorerConfig.blocks.filter(
+            (block: any) => block.type === "graphers"
+        )[0] as ExplorerBlockGraphers
+
+    if (explorerGrapherBlock === undefined)
+        throw new Error(`Explorer ${slug} has no grapher block`)
+
+    // TODO: Maybe make DecisionMatrix accept JSON directly
+    const tsv = tsvFormat(explorerGrapherBlock.block)
+    const explorerDecisionMatrix = new DecisionMatrix(tsv)
+
+    console.log(
+        `Processing explorer ${slug} (${explorerDecisionMatrix.numRows} rows)`
+    )
+
+    const defaultSettings = explorerDecisionMatrix.defaultSettings
+
+    const records = explorerDecisionMatrix
+        .allDecisionsAsQueryParams()
+        .map((choice, i) => {
+            explorerDecisionMatrix.setValuesFromChoiceParams(choice)
+
+            // Check which choices are non-default, i.e. are not the first available option in a dropdown/radio
+            const nonDefaultSettings = Object.entries(
+                explorerDecisionMatrix.availableChoiceOptions
+            ).filter(([choiceName, choiceOptions]) => {
+                // Keep only choices which are not the default, which is:
+                // - either the options marked as `default` in the decision matrix
+                // - or the first available option in the decision matrix
+                return (
+                    choiceOptions.length > 1 &&
+                    !(defaultSettings[choiceName] !== undefined
+                        ? defaultSettings[choiceName] === choice[choiceName]
+                        : choice[choiceName] === choiceOptions[0])
+                )
+            })
+
+            // TODO: Handle grapherId and fetch title/subtitle
+            // TODO: Handle indicator-based explorers
+
+            const record: ExplorerViewEntry = {
+                viewTitle: explorerDecisionMatrix.selectedRow.title,
+                viewSubtitle: explorerDecisionMatrix.selectedRow.subtitle,
+                viewSettings: explorerChoiceToViewSettings(
+                    choice,
+                    explorerDecisionMatrix
+                ),
+                viewGrapherId: explorerDecisionMatrix.selectedRow.grapherId,
+                viewQueryParams: explorerDecisionMatrix.toString(),
+
+                viewIndexWithinExplorer: i,
+                titleLength: explorerDecisionMatrix.selectedRow.title?.length,
+                numNonDefaultSettings: nonDefaultSettings.length,
+            }
+            return record
+        })
+
+    return records
+}
+
+const getExplorerViewRecords = async (
+    trx: db.KnexReadonlyTransaction
+): Promise<ExplorerViewEntryWithExplorerInfo[]> => {
+    const publishedExplorers = Object.values(
+        await db.getPublishedExplorersBySlug(trx)
+    )
+
+    const pageviews = await getAnalyticsPageviewsByUrlObj(trx)
+
+    let records = [] as ExplorerViewEntryWithExplorerInfo[]
+    for (const explorerInfo of publishedExplorers) {
+        const explorerViewRecords = await getExplorerViewRecordsForExplorerSlug(
+            trx,
+            explorerInfo.slug
+        )
+
+        const explorerPageviews =
+            pageviews[`/explorers/${explorerInfo.slug}`]?.views_7d ?? 0
+        records = records.concat(
+            explorerViewRecords.map(
+                (record, i): ExplorerViewEntryWithExplorerInfo => ({
+                    ...record,
+                    explorerSlug: explorerInfo.slug,
+                    explorerTitle: explorerInfo.title,
+                    explorerViews_7d: explorerPageviews,
+                    viewTitleAndExplorerSlug: `${record.viewTitle} | ${explorerInfo.slug}`,
+                    // Scoring function
+                    score:
+                        explorerPageviews * 10 -
+                        record.numNonDefaultSettings * 50 -
+                        record.titleLength,
+
+                    objectID: `${explorerInfo.slug}-${i}`,
+                })
+            )
+        )
+    }
+
+    return records
+}
+
+const indexExplorerViewsToAlgolia = async () => {
+    if (!ALGOLIA_INDEXING) return
+
+    const client = getAlgoliaClient()
+    if (!client) {
+        console.error(
+            `Failed indexing explorer views (Algolia client not initialized)`
+        )
+        return
+    }
+
+    try {
+        const index = client.initIndex(
+            getIndexName(SearchIndexName.ExplorerViews)
+        )
+
+        const records = await db.knexReadonlyTransaction(
+            getExplorerViewRecords,
+            db.TransactionCloseMode.Close
+        )
+        await index.replaceAllObjects(records)
+    } catch (e) {
+        console.log("Error indexing explorer views to Algolia:", e)
+    }
+}
+
+process.on("unhandledRejection", (e) => {
+    console.error(e)
+    process.exit(1)
+})
+
+void indexExplorerViewsToAlgolia()

--- a/baker/algolia/indexExplorerViewsToAlgolia.ts
+++ b/baker/algolia/indexExplorerViewsToAlgolia.ts
@@ -13,6 +13,7 @@ import { getAlgoliaClient } from "./configureAlgolia.js"
 import { getIndexName } from "../../site/search/searchClient.js"
 import { SearchIndexName } from "../../site/search/searchTypes.js"
 import { groupBy, keyBy, orderBy } from "lodash"
+import { MarkdownTextWrap } from "@ourworldindata/components"
 
 interface ExplorerViewEntry {
     viewTitle: string
@@ -177,6 +178,16 @@ const getExplorerViewRecordsForExplorerSlug = async (
             }
         }
     }
+
+    // Remove Markdown from viewSubtitle; do this after fetching grapher info above, as it might also contain Markdown
+    records.forEach((record) => {
+        if (record.viewSubtitle) {
+            record.viewSubtitle = new MarkdownTextWrap({
+                text: record.viewSubtitle,
+                fontSize: 10, // doesn't matter, but is a mandatory field
+            }).plaintext
+        }
+    })
 
     // Compute viewTitleIndexWithinExplorer:
     // First, sort by score descending (ignoring views_7d, which is not relevant _within_ an explorer).

--- a/baker/algolia/indexExplorerViewsToAlgolia.ts
+++ b/baker/algolia/indexExplorerViewsToAlgolia.ts
@@ -64,10 +64,13 @@ const explorerChoiceToViewSettings = (
     })
 }
 
-const computeScore = (record: Partial<ExplorerViewEntryWithExplorerInfo>) =>
+const computeScore = (
+    record: Omit<ExplorerViewEntry, "viewTitleIndexWithinExplorer"> &
+        Partial<ExplorerViewEntryWithExplorerInfo>
+) =>
     (record.explorerViews_7d ?? 0) * 10 -
-    (record.numNonDefaultSettings ?? 0) * 50 -
-    (record.titleLength ?? 0)
+    record.numNonDefaultSettings * 50 -
+    record.titleLength
 
 const getExplorerViewRecordsForExplorerSlug = async (
     trx: db.KnexReadonlyTransaction,

--- a/baker/algolia/indexExplorerViewsToAlgolia.ts
+++ b/baker/algolia/indexExplorerViewsToAlgolia.ts
@@ -39,6 +39,7 @@ interface ExplorerViewEntry {
 interface ExplorerViewEntryWithExplorerInfo extends ExplorerViewEntry {
     explorerSlug: string
     explorerTitle: string
+    explorerSubtitle: string
     explorerViews_7d: number
     viewTitleAndExplorerSlug: string // used for deduplication: `viewTitle | explorerSlug`
     numViewsWithinExplorer: number
@@ -224,6 +225,7 @@ const getExplorerViewRecords = async (
                 ...record,
                 explorerSlug: explorerInfo.slug,
                 explorerTitle: explorerInfo.title,
+                explorerSubtitle: explorerInfo.subtitle,
                 explorerViews_7d: explorerPageviews,
                 viewTitleAndExplorerSlug: `${record.viewTitle} | ${explorerInfo.slug}`,
                 numViewsWithinExplorer: explorerViewRecords.length,

--- a/baker/algolia/indexExplorersToAlgolia.ts
+++ b/baker/algolia/indexExplorersToAlgolia.ts
@@ -22,7 +22,7 @@ type ExplorerBlockColumns = {
     block: { name: string; additionalInfo?: string }[]
 }
 
-type ExplorerBlockGraphers = {
+export type ExplorerBlockGraphers = {
     type: "graphers"
     block: {
         title?: string

--- a/explorer/ExplorerDecisionMatrix.ts
+++ b/explorer/ExplorerDecisionMatrix.ts
@@ -86,7 +86,7 @@ export class DecisionMatrix {
     table: CoreTable
     @observable currentParams: ExplorerChoiceParams = {}
     constructor(delimited: string, hash = "") {
-        this.choices = makeChoicesMap(delimited)
+        this.choiceNameToControlTypeMap = makeChoicesMap(delimited)
         this.table = new CoreTable(parseDelimited(dropColumnTypes(delimited)), [
             // todo: remove col def?
             {
@@ -141,7 +141,7 @@ export class DecisionMatrix {
         )
     }
 
-    private choices: Map<ChoiceName, ExplorerControlType>
+    choiceNameToControlTypeMap: Map<ChoiceName, ExplorerControlType>
     hash: string
 
     toConstrainedOptions(): ExplorerChoiceParams {
@@ -243,7 +243,7 @@ export class DecisionMatrix {
     }
 
     @computed private get choiceNames(): ChoiceName[] {
-        return Array.from(this.choices.keys())
+        return Array.from(this.choiceNameToControlTypeMap.keys())
     }
 
     @computed private get allChoiceOptions(): ChoiceMap {
@@ -256,7 +256,7 @@ export class DecisionMatrix {
         return choiceMap
     }
 
-    @computed private get availableChoiceOptions(): ChoiceMap {
+    @computed get availableChoiceOptions(): ChoiceMap {
         const result: ChoiceMap = {}
         this.choiceNames.forEach((choiceName) => {
             result[choiceName] = this.allChoiceOptions[choiceName].filter(
@@ -317,7 +317,7 @@ export class DecisionMatrix {
     }
 
     // The first row with defaultView column value of "true" determines the default view to use
-    private get defaultSettings() {
+    get defaultSettings() {
         const hits = this.rowsWith({
             [GrapherGrammar.defaultView.keyword]: "true",
         })
@@ -373,7 +373,7 @@ export class DecisionMatrix {
                     constrainedOptions
                 )
             )
-            const type = this.choices.get(title)!
+            const type = this.choiceNameToControlTypeMap.get(title)!
 
             return {
                 title,

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -68,6 +68,7 @@ export type IChartHit = Hit<BaseHit> & ChartRecord
 
 export enum SearchIndexName {
     Explorers = "explorers",
+    ExplorerViews = "explorer-views",
     Charts = "charts",
     Pages = "pages",
 }
@@ -85,4 +86,5 @@ export const indexNameToSubdirectoryMap: Record<SearchIndexName, string> = {
     [SearchIndexName.Pages]: "",
     [SearchIndexName.Charts]: "/grapher",
     [SearchIndexName.Explorers]: "/explorers",
+    [SearchIndexName.ExplorerViews]: "/explorers",
 }


### PR DESCRIPTION
Resolves #3332.

## Staging environment

This PR doesn't have its own Algolia staging environment, but instead you can look at the ones for the upstack PR #3429: `search-explorer-indexing-algolia`

## Ranking

Ranking criteria being used:
- 7-day pageviews of the _whole_ explorer
- Number of explorer settings that differ from the default
- Length of title

These are then combined into the rather-arbitrary-but-seemingly-working-quite well
```
score = explorerPageviews * 10 - numNonDefaultSettings * 50 - titleLength
```

Note that `explorerPageviews` doesn't change between different views of the same explorers; so it's only used to discriminate results from different explorers.

## TODOs

- [x] Change `configureAlgolia`:
	- `distinct: 4` by `explorerSlug`
	- order by `viewTitleIndexWithinExplorer`
	- _maybe_ set [`removeWordsIfNoResults`](https://www.algolia.com/doc/api-reference/api-parameters/removeWordsIfNoResults/)
- [x] Compute and index `viewTitleIndexWithinExplorer`
- [x] Index `numViewsWithinExplorer`
- [x] Strip out Markdown syntax, like DoDs
- [ ] Get rid of `indexExplorersToAlgolia`, it's superseded (-> will do this in future cleanup PR)