### PR TITLE
feat(search): surface explorer views in search results

### DIFF
--- a/site/SiteAnalytics.ts
+++ b/site/SiteAnalytics.ts
@@ -30,11 +30,15 @@ export class SiteAnalytics extends GrapherAnalytics {
         position,
         url,
         positionInSection,
+        cardPosition,
+        positionWithinCard,
         filter,
     }: {
         query: string
         position: string
         positionInSection: string
+        cardPosition?: string
+        positionWithinCard?: string
         url: string
         filter: SearchCategoryFilter
     }) {
@@ -45,6 +49,8 @@ export class SiteAnalytics extends GrapherAnalytics {
                 query,
                 position,
                 positionInSection,
+                cardPosition,
+                positionWithinCard,
                 filter,
             }),
             eventTarget: url,

--- a/site/search/Autocomplete.scss
+++ b/site/search/Autocomplete.scss
@@ -215,9 +215,14 @@ section[data-autocomplete-source-id="recentSearchesPlugin"]
     }
 }
 
-section[data-autocomplete-source-id="autocomplete"]
+section[data-autocomplete-source-id="autocomplete"] {
+    .aa-ItemWrapper {
+        text-wrap: pretty;
+    }
+
     .aa-ItemWrapper__contentType {
-    color: $blue-50;
+        color: $blue-50;
+    }
 }
 
 section[data-autocomplete-source-id="runSearch"] {

--- a/site/search/Autocomplete.tsx
+++ b/site/search/Autocomplete.tsx
@@ -76,7 +76,12 @@ const getItemUrl: AutocompleteSource<BaseItem>["getItemUrl"] = ({ item }) =>
 const prependSubdirectoryToAlgoliaItemUrl = (item: BaseItem): string => {
     const indexName = parseIndexName(item.__autocomplete_indexName as string)
     const subdirectory = indexNameToSubdirectoryMap[indexName]
-    return `${subdirectory}/${item.slug}`
+    switch (indexName) {
+        case SearchIndexName.ExplorerViews:
+            return `${subdirectory}/${item.explorerSlug}${item.viewQueryParams}`
+        default:
+            return `${subdirectory}/${item.slug}`
+    }
 }
 
 const FeaturedSearchesSource: AutocompleteSource<BaseItem> = {
@@ -142,6 +147,14 @@ const AlgoliaSource: AutocompleteSource<BaseItem> = {
                     },
                 },
                 {
+                    indexName: getIndexName(SearchIndexName.ExplorerViews),
+                    query,
+                    params: {
+                        hitsPerPage: 1,
+                        distinct: true,
+                    },
+                },
+                {
                     indexName: getIndexName(SearchIndexName.Explorers),
                     query,
                     params: {
@@ -160,11 +173,20 @@ const AlgoliaSource: AutocompleteSource<BaseItem> = {
                 item.__autocomplete_indexName as string
             )
             const indexLabel =
-                index === SearchIndexName.Charts
-                    ? "Chart"
-                    : index === SearchIndexName.Explorers
-                      ? "Explorer"
-                      : pageTypeDisplayNames[item.type as PageType]
+                index === SearchIndexName.Charts ? (
+                    "Chart"
+                ) : index === SearchIndexName.Explorers ? (
+                    "Explorer"
+                ) : index === SearchIndexName.ExplorerViews ? (
+                    <>
+                        in <em>{item.explorerTitle} Data Explorer</em>
+                    </>
+                ) : (
+                    pageTypeDisplayNames[item.type as PageType]
+                )
+
+            const mainAttribute =
+                index === SearchIndexName.ExplorerViews ? "viewTitle" : "title"
 
             return (
                 <div
@@ -175,7 +197,7 @@ const AlgoliaSource: AutocompleteSource<BaseItem> = {
                     <span>
                         <components.Highlight
                             hit={item}
-                            attribute="title"
+                            attribute={mainAttribute}
                             tagName="strong"
                         />
                     </span>

--- a/site/search/Autocomplete.tsx
+++ b/site/search/Autocomplete.tsx
@@ -154,14 +154,6 @@ const AlgoliaSource: AutocompleteSource<BaseItem> = {
                         distinct: true,
                     },
                 },
-                {
-                    indexName: getIndexName(SearchIndexName.Explorers),
-                    query,
-                    params: {
-                        hitsPerPage: 1,
-                        distinct: true,
-                    },
-                },
             ],
         })
     },
@@ -175,8 +167,6 @@ const AlgoliaSource: AutocompleteSource<BaseItem> = {
             const indexLabel =
                 index === SearchIndexName.Charts ? (
                     "Chart"
-                ) : index === SearchIndexName.Explorers ? (
-                    "Explorer"
                 ) : index === SearchIndexName.ExplorerViews ? (
                     <>
                         in <em>{item.explorerTitle} Data Explorer</em>

--- a/site/search/Autocomplete.tsx
+++ b/site/search/Autocomplete.tsx
@@ -165,15 +165,11 @@ const AlgoliaSource: AutocompleteSource<BaseItem> = {
                 item.__autocomplete_indexName as string
             )
             const indexLabel =
-                index === SearchIndexName.Charts ? (
-                    "Chart"
-                ) : index === SearchIndexName.ExplorerViews ? (
-                    <>
-                        in <em>{item.explorerTitle} Data Explorer</em>
-                    </>
-                ) : (
-                    pageTypeDisplayNames[item.type as PageType]
-                )
+                index === SearchIndexName.Charts
+                    ? "Chart"
+                    : index === SearchIndexName.ExplorerViews
+                      ? "Explorer"
+                      : pageTypeDisplayNames[item.type as PageType]
 
             const mainAttribute =
                 index === SearchIndexName.ExplorerViews ? "viewTitle" : "title"

--- a/site/search/Search.scss
+++ b/site/search/Search.scss
@@ -416,10 +416,10 @@
             width: 100%;
         }
 
-        // On the "All" tab, limit to the first 4 pages, 4 charts, and 1 explorer view
+        // On the "All" tab, limit to the first 4 pages, 4 charts, and 2 explorer views
         .search-results__page-hit:nth-child(n + 5),
         .search-results__chart-hit:nth-child(n + 5),
-        .search-results__explorer-hit:nth-child(n + 2) {
+        .search-results__explorer-hit:nth-child(n + 3) {
             display: none;
         }
     }

--- a/site/search/Search.scss
+++ b/site/search/Search.scss
@@ -404,54 +404,35 @@
     display: none;
 }
 
-.search-results[data-active-filter="all"] {
-    .search-results__pages,
-    .search-results__explorers,
-    .search-results__charts {
-        // both needed for .search-results__show-more-container absolute-positioning
-        display: inline-block;
-        position: relative;
-        width: 100%;
+// Show results depending on active tab
+.search-results {
+    &[data-active-filter="all"] {
+        .search-results__pages,
+        .search-results__explorers,
+        .search-results__charts {
+            // both needed for .search-results__show-more-container absolute-positioning
+            display: inline-block;
+            position: relative;
+            width: 100%;
+        }
+
+        // On the "All" tab, limit to the first 4 pages, 4 charts, and 1 explorer view
+        .search-results__page-hit:nth-child(n + 5),
+        .search-results__chart-hit:nth-child(n + 5),
+        .search-results__explorer-hit:nth-child(n + 2) {
+            display: none;
+        }
     }
-}
 
-.search-results__page-hit {
-    display: none;
-}
-
-.search-results__page-hit {
-    &:nth-child(-n + 4) {
+    &[data-active-filter="pages"] .search-results__pages {
         display: inline;
     }
-}
 
-.search-results[data-active-filter="pages"] .search-results__pages {
-    display: inline;
-
-    .search-results__page-hit {
+    &[data-active-filter="charts"] .search-results__charts {
         display: inline;
     }
-}
 
-.search-results[data-active-filter="charts"] .search-results__charts {
-    display: inline;
-
-    .search-results__chart-hit {
-        display: inline;
-    }
-}
-
-.search-results__explorer-hit {
-    display: none;
-
-    &:nth-child(-n + 1) {
-        display: inline;
-    }
-}
-
-.search-results[data-active-filter="explorer-views"] {
-    .search-results__explorers,
-    .search-results__explorer-hit {
+    &[data-active-filter="explorer-views"] .search-results__explorers {
         display: inline;
     }
 }

--- a/site/search/Search.scss
+++ b/site/search/Search.scss
@@ -243,6 +243,12 @@
         font-weight: 400;
     }
 
+    .search-results__explorer-hit-link-mobile {
+        @include owid-link-60;
+        margin-top: 16px;
+        display: block;
+    }
+
     .search-results__explorer-hit-header {
         display: flex;
         justify-content: space-between;
@@ -266,6 +272,7 @@
 
         .search-results__explorer-hit-link {
             @include owid-link-60;
+            margin-top: 0;
             flex: 1 0 auto;
             text-align: right;
         }
@@ -275,7 +282,7 @@
         margin-left: 20px;
         margin-top: 5px;
         list-style: none;
-        gap: 10px 16px;
+        gap: 16px;
 
         .search-results__explorer-view {
             overflow: hidden;

--- a/site/search/Search.scss
+++ b/site/search/Search.scss
@@ -299,7 +299,8 @@
             }
 
             .search-results__explorer-view-subtitle {
-                margin-top: 0px;
+                margin-top: 0;
+                margin-bottom: 0;
                 text-overflow: ellipsis;
                 white-space: nowrap;
                 overflow: hidden;

--- a/site/search/Search.scss
+++ b/site/search/Search.scss
@@ -232,18 +232,6 @@
     height: 100%;
     padding: 24px;
     display: block;
-    transition: background-color 0.1s;
-
-    @supports (grid-template-rows: subgrid) {
-        display: grid;
-        grid-template-rows: subgrid;
-        grid-row: span 4;
-        gap: 0;
-    }
-
-    &:hover {
-        background-color: $blue-20;
-    }
 
     h4 {
         margin: 0;
@@ -251,49 +239,57 @@
     }
 
     p {
-        color: $blue-60;
+        color: $blue-50;
+        font-weight: 400;
     }
 
-    .search-results__explorer-hit-title {
-        display: inline;
-        color: $blue-90;
-        margin: 0 8px 0 0;
-    }
+    .search-results__explorer-hit-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
 
-    .search-results__explorer-hit-subtitle {
-        margin: 0 8px 0 0;
+        .search-results__explorer-hit-title {
+            display: inline;
+            color: $blue-90;
+            margin: 0 8px 0 0;
+        }
+
+        .search-results__explorer-hit-subtitle {
+            margin: 0 8px 0 0;
+        }
+
+        .search-results__explorer-hit-link {
+            @include owid-link-60;
+        }
     }
 
     .search-results__explorer-views-list {
         margin-left: 20px;
         margin-top: 5px;
         list-style: none;
+        gap: 10px 16px;
 
-        .search-results__explorer-view-title-container {
-            display: flex;
-            align-items: center;
-            gap: 4px;
-            color: $blue-90;
-            text-decoration: underline;
-            @include owid-link-90;
+        .search-results__explorer-view {
+            overflow: hidden;
 
-            svg {
-                font-size: 0.8em;
+            .search-results__explorer-view-title-container {
+                color: $blue-90;
+                text-decoration: underline;
+                @include owid-link-90;
+
+                svg {
+                    font-size: 0.75em;
+                    margin-left: 6px;
+                }
+            }
+
+            .search-results__explorer-view-subtitle {
+                margin-top: 0px;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+                overflow: hidden;
             }
         }
-
-        .search-results__explorer-view-subtitle {
-            color: $blue-60;
-            margin-top: 0px;
-            // text-overflow: ellipsis;
-            // white-space: nowrap;
-            // overflow: hidden;
-            // max-width: 100%;
-        }
-    }
-
-    .search-results__explorer-hit-link {
-        @include owid-link-60;
     }
 }
 
@@ -374,14 +370,14 @@
 **/
 
 .search-results__pages,
-.search-results__explorer-views,
+.search-results__explorers,
 .search-results__charts {
     display: none;
 }
 
 .search-results[data-active-filter="all"] {
     .search-results__pages,
-    .search-results__explorer-views,
+    .search-results__explorers,
     .search-results__charts {
         // both needed for .search-results__show-more-container absolute-positioning
         display: inline-block;
@@ -416,17 +412,17 @@
     }
 }
 
-.search-results__explorer-view-hit {
+.search-results__explorer-hit {
     display: none;
 
-    &:nth-child(-n + 4) {
+    &:nth-child(-n + 1) {
         display: inline;
     }
 }
 
 .search-results[data-active-filter="explorer-views"] {
-    .search-results__explorer-views,
-    .search-results__explorer-view-hit {
+    .search-results__explorers,
+    .search-results__explorer-hit {
         display: inline;
     }
 }

--- a/site/search/Search.scss
+++ b/site/search/Search.scss
@@ -246,7 +246,10 @@
     .search-results__explorer-hit-header {
         display: flex;
         justify-content: space-between;
-        align-items: center;
+
+        .search-results__explorer-hit-title-container {
+            min-width: 0;
+        }
 
         .search-results__explorer-hit-title {
             display: inline;
@@ -256,10 +259,15 @@
 
         .search-results__explorer-hit-subtitle {
             margin: 0 8px 0 0;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            overflow: hidden;
         }
 
         .search-results__explorer-hit-link {
             @include owid-link-60;
+            flex: 1 0 auto;
+            text-align: right;
         }
     }
 
@@ -288,6 +296,19 @@
                 text-overflow: ellipsis;
                 white-space: nowrap;
                 overflow: hidden;
+            }
+
+            @include sm-only {
+                // *If on "All" tab on small screens*, only show the first two views on mobile, and hide view subtitles
+                @at-root .search-results[data-active-filter="all"] & {
+                    &:nth-child(n + 3) {
+                        display: none;
+                    }
+
+                    .search-results__explorer-view-subtitle {
+                        display: none;
+                    }
+                }
             }
         }
     }

--- a/site/search/Search.scss
+++ b/site/search/Search.scss
@@ -192,7 +192,6 @@
 }
 
 .search-results__pages-list,
-.search-results__explorers-list,
 .search-results__explorer-views-list,
 .search-results__charts-list {
     gap: var(--grid-gap);
@@ -228,7 +227,6 @@
     display: block;
 }
 
-.search-results__explorer-hit a,
 .search-results__explorer-view-hit a {
     background-color: $blue-10;
     height: 100%;
@@ -327,7 +325,6 @@
 **/
 
 .search-results__pages,
-.search-results__explorers,
 .search-results__explorer-views,
 .search-results__charts {
     display: none;
@@ -335,7 +332,6 @@
 
 .search-results[data-active-filter="all"] {
     .search-results__pages,
-    .search-results__explorers,
     .search-results__explorer-views,
     .search-results__charts {
         // both needed for .search-results__show-more-container absolute-positioning
@@ -371,16 +367,6 @@
     }
 }
 
-.search-results__explorer-hit {
-    display: none;
-}
-
-.search-results__explorer-hit {
-    &:nth-child(-n + 2) {
-        display: inline;
-    }
-}
-
 .search-results__explorer-view-hit {
     display: none;
 
@@ -389,12 +375,8 @@
     }
 }
 
-.search-results[data-active-filter="explorers"] .search-results__explorers,
-.search-results[data-active-filter="explorers"]
-    .search-results__explorer-views {
-    display: inline;
-
-    .search-results__explorer-hit,
+.search-results[data-active-filter="explorer-views"] {
+    .search-results__explorer-views,
     .search-results__explorer-view-hit {
         display: inline;
     }

--- a/site/search/Search.scss
+++ b/site/search/Search.scss
@@ -193,6 +193,7 @@
 
 .search-results__pages-list,
 .search-results__explorers-list,
+.search-results__explorer-views-list,
 .search-results__charts-list {
     gap: var(--grid-gap);
     @include sm-only {
@@ -227,7 +228,8 @@
     display: block;
 }
 
-.search-results__explorer-hit a {
+.search-results__explorer-hit a,
+.search-results__explorer-view-hit a {
     background-color: $blue-10;
     height: 100%;
     padding: 24px;
@@ -326,6 +328,7 @@
 
 .search-results__pages,
 .search-results__explorers,
+.search-results__explorer-views,
 .search-results__charts {
     display: none;
 }
@@ -333,6 +336,7 @@
 .search-results[data-active-filter="all"] {
     .search-results__pages,
     .search-results__explorers,
+    .search-results__explorer-views,
     .search-results__charts {
         // both needed for .search-results__show-more-container absolute-positioning
         display: inline-block;
@@ -377,10 +381,21 @@
     }
 }
 
-.search-results[data-active-filter="explorers"] .search-results__explorers {
+.search-results__explorer-view-hit {
+    display: none;
+
+    &:nth-child(-n + 4) {
+        display: inline;
+    }
+}
+
+.search-results[data-active-filter="explorers"] .search-results__explorers,
+.search-results[data-active-filter="explorers"]
+    .search-results__explorer-views {
     display: inline;
 
-    .search-results__explorer-hit {
+    .search-results__explorer-hit,
+    .search-results__explorer-view-hit {
         display: inline;
     }
 }

--- a/site/search/Search.scss
+++ b/site/search/Search.scss
@@ -234,6 +234,13 @@
     display: block;
     transition: background-color 0.1s;
 
+    @supports (grid-template-rows: subgrid) {
+        display: grid;
+        grid-template-rows: subgrid;
+        grid-row: span 4;
+        gap: 0;
+    }
+
     &:hover {
         background-color: $blue-20;
     }
@@ -262,9 +269,17 @@
         margin-top: 5px;
         list-style: none;
 
-        .search-results__explorer-view-title {
+        .search-results__explorer-view-title-container {
+            display: flex;
+            align-items: center;
+            gap: 4px;
             color: $blue-90;
             text-decoration: underline;
+            @include owid-link-90;
+
+            svg {
+                font-size: 0.8em;
+            }
         }
 
         .search-results__explorer-view-subtitle {

--- a/site/search/Search.scss
+++ b/site/search/Search.scss
@@ -192,7 +192,7 @@
 }
 
 .search-results__pages-list,
-.search-results__explorer-views-list,
+.search-results__explorer-list,
 .search-results__charts-list {
     gap: var(--grid-gap);
     @include sm-only {
@@ -227,7 +227,7 @@
     display: block;
 }
 
-.search-results__explorer-view-hit a {
+.search-results__explorer-hit {
     background-color: $blue-10;
     height: 100%;
     padding: 24px;
@@ -245,6 +245,40 @@
 
     p {
         color: $blue-60;
+    }
+
+    .search-results__explorer-hit-title {
+        display: inline;
+        color: $blue-90;
+        margin: 0 8px 0 0;
+    }
+
+    .search-results__explorer-hit-subtitle {
+        margin: 0 8px 0 0;
+    }
+
+    .search-results__explorer-views-list {
+        margin-left: 20px;
+        margin-top: 5px;
+        list-style: none;
+
+        .search-results__explorer-view-title {
+            color: $blue-90;
+            text-decoration: underline;
+        }
+
+        .search-results__explorer-view-subtitle {
+            color: $blue-60;
+            margin-top: 0px;
+            // text-overflow: ellipsis;
+            // white-space: nowrap;
+            // overflow: hidden;
+            // max-width: 100%;
+        }
+    }
+
+    .search-results__explorer-hit-link {
+        @include owid-link-60;
     }
 }
 

--- a/site/search/SearchPanel.tsx
+++ b/site/search/SearchPanel.tsx
@@ -196,7 +196,7 @@ function ExplorerHit({ groupedHit }: { groupedHit: GroupedExplorerViews }) {
 
                 <a
                     href={`${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${groupedHit.explorerSlug}`}
-                    className="search-results__explorer-hit-link"
+                    className="search-results__explorer-hit-link hide-sm-only"
                 >
                     Explore all {groupedHit.numViewsWithinExplorer} indicators
                 </a>
@@ -230,6 +230,12 @@ function ExplorerHit({ groupedHit }: { groupedHit: GroupedExplorerViews }) {
                     </li>
                 ))}
             </ul>
+            <a
+                href={`${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${groupedHit.explorerSlug}`}
+                className="search-results__explorer-hit-link-mobile hide-sm-up"
+            >
+                Explore all {groupedHit.numViewsWithinExplorer} indicators
+            </a>
         </div>
     )
 }

--- a/site/search/SearchPanel.tsx
+++ b/site/search/SearchPanel.tsx
@@ -169,7 +169,7 @@ function ExplorerViewHits() {
 
     return (
         <div className="search-results__list-container">
-            <div className="search-results__explorer-list grid grid-cols-2 grid-sm-cols-1">
+            <div className="search-results__explorer-list grid grid-cols-1">
                 {groupedHits.map((group) => (
                     <ExplorerHit groupedHit={group} key={group.explorerSlug} />
                 ))}
@@ -184,13 +184,24 @@ function ExplorerHit({ groupedHit }: { groupedHit: GroupedExplorerViews }) {
             key={groupedHit.explorerSlug}
             className="search-results__explorer-hit"
         >
-            <h3 className="h3-bold search-results__explorer-hit-title">
-                {groupedHit.explorerTitle}
-            </h3>
-            <p className="body-3-medium-italic search-results__explorer-hit-subtitle">
-                {groupedHit.explorerSubtitle}
-            </p>
-            <ul className="search-results__explorer-views-list">
+            <div className="search-results__explorer-hit-header">
+                <div>
+                    <h3 className="h3-bold search-results__explorer-hit-title">
+                        {groupedHit.explorerTitle}
+                    </h3>
+                    <p className="body-3-medium-italic search-results__explorer-hit-subtitle">
+                        {groupedHit.explorerSubtitle}
+                    </p>
+                </div>
+
+                <a
+                    href={`${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${groupedHit.explorerSlug}`}
+                    className="search-results__explorer-hit-link"
+                >
+                    Explore all {groupedHit.numViewsWithinExplorer} indicators
+                </a>
+            </div>
+            <ul className="search-results__explorer-views-list grid grid-cols-2">
                 {groupedHit.views.map((view) => (
                     <li
                         key={view.objectID}
@@ -219,12 +230,6 @@ function ExplorerHit({ groupedHit }: { groupedHit: GroupedExplorerViews }) {
                     </li>
                 ))}
             </ul>
-            <a
-                href={`${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${groupedHit.explorerSlug}`}
-                className="search-results__explorer-hit-link"
-            >
-                Explore all {groupedHit.numViewsWithinExplorer} indicators
-            </a>
         </div>
     )
 }
@@ -506,14 +511,14 @@ const SearchResults = (props: SearchResultsProps) => {
                     } /* Hack: This is the only way to _not_ send `restrictSearchableAttributes` along for this index */
                 />
                 <NoResultsBoundary>
-                    <section className="search-results__explorer-views">
+                    <section className="search-results__explorers">
                         <header className="search-results__header">
                             <h2 className="h2-bold search-results__section-title">
                                 Data Explorers
                             </h2>
                             <ShowMore
                                 category={SearchIndexName.ExplorerViews}
-                                cutoffNumber={2}
+                                cutoffNumber={1}
                                 activeCategoryFilter={activeCategoryFilter}
                                 handleCategoryFilterClick={
                                     handleCategoryFilterClick

--- a/site/search/SearchPanel.tsx
+++ b/site/search/SearchPanel.tsx
@@ -131,77 +131,91 @@ function ChartHit({ hit }: { hit: IChartHit }) {
     )
 }
 
-function ExplorerViewHits() {
-    const { hits, results, sendEvent } = useHits<IExplorerViewHit>()
+interface GroupedExplorerViews {
+    explorerSlug: string
+    explorerTitle: string
+    explorerSubtitle: string
+    numViewsWithinExplorer: number
+    views: IExplorerViewHit[]
+}
 
-    const groupedBySlug = groupBy(hits, "explorerSlug")
-    const grouped = Object.values(groupedBySlug).map((explorerViews) => {
-        const firstView = explorerViews[0]
-        return {
-            explorerSlug: firstView.explorerSlug,
-            explorerTitle: firstView.explorerTitle,
-            explorerSubtitle: firstView.explorerSubtitle,
-            numViewsWithinExplorer: firstView.numViewsWithinExplorer,
-            views: uniqBy(explorerViews, "viewTitle"),
-        }
-    })
+function ExplorerViewHits() {
+    const { hits } = useHits<IExplorerViewHit>()
+
+    const groupedHits = useMemo(() => {
+        const groupedBySlug = groupBy(hits, "explorerSlug")
+        return Object.values(groupedBySlug).map((explorerViews) => {
+            const firstView = explorerViews[0]
+            return {
+                explorerSlug: firstView.explorerSlug,
+                explorerTitle: firstView.explorerTitle,
+                explorerSubtitle: firstView.explorerSubtitle,
+                numViewsWithinExplorer: firstView.numViewsWithinExplorer,
+
+                // Run uniq, so if we end up in a situation where multiple views with the same title
+                // are returned, we only show the first of them
+                views: uniqBy(explorerViews, "viewTitle"),
+            }
+        })
+    }, [hits])
 
     return (
         <div className="search-results__list-container">
-            <ol className="search-results__explorer-list grid grid-cols-2 grid-sm-cols-1">
-                {grouped.map((group) => (
-                    <div
-                        key={group.explorerSlug}
-                        className="search-results__explorer-hit"
-                    >
-                        <h3 className="h3-bold search-results__explorer-hit-title">
-                            {group.explorerTitle}
-                        </h3>
-                        <p className="body-3-medium-italic search-results__explorer-hit-subtitle">
-                            {group.explorerSubtitle}
-                        </p>
-                        <ul className="search-results__explorer-views-list">
-                            {group.views.map((hit) => (
-                                <li
-                                    key={hit.objectID}
-                                    className="search-results__explorer-view"
-                                >
-                                    <ExplorerViewHit hit={hit} />
-                                </li>
-                            ))}
-                        </ul>
-                        <a
-                            href={`${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${group.explorerSlug}`}
-                            className="search-results__explorer-hit-link"
-                        >
-                            Explore all {group.numViewsWithinExplorer}{" "}
-                            indicators
-                        </a>
-                    </div>
+            <div className="search-results__explorer-list grid grid-cols-2 grid-sm-cols-1">
+                {groupedHits.map((group) => (
+                    <ExplorerHit groupedHit={group} key={group.explorerSlug} />
                 ))}
-            </ol>
+            </div>
         </div>
     )
 }
 
-function ExplorerViewHit({ hit }: { hit: IExplorerViewHit }) {
+function ExplorerHit({ groupedHit }: { groupedHit: GroupedExplorerViews }) {
     return (
-        <a
-            data-algolia-index={getIndexName(SearchIndexName.ExplorerViews)}
-            data-algolia-object-id={hit.objectID}
-            data-algolia-position={hit.__position}
-            href={`${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${hit.explorerSlug}${hit.viewQueryParams}`}
+        <div
+            key={groupedHit.explorerSlug}
+            className="search-results__explorer-hit"
         >
-            <Highlight
-                attribute="viewTitle"
-                hit={hit}
-                highlightedTagName="strong"
-                className="search-results__explorer-view-title"
-            />
-            <p className="body-3-medium-italic search-results__explorer-view-subtitle">
-                {hit.viewSubtitle}
+            <h3 className="h3-bold search-results__explorer-hit-title">
+                {groupedHit.explorerTitle}
+            </h3>
+            <p className="body-3-medium-italic search-results__explorer-hit-subtitle">
+                {groupedHit.explorerSubtitle}
             </p>
-        </a>
+            <ul className="search-results__explorer-views-list">
+                {groupedHit.views.map((view) => (
+                    <li
+                        key={view.objectID}
+                        className="search-results__explorer-view"
+                    >
+                        <a
+                            data-algolia-index={getIndexName(
+                                SearchIndexName.ExplorerViews
+                            )}
+                            data-algolia-object-id={view.objectID}
+                            data-algolia-position={view.__position}
+                            href={`${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${view.explorerSlug}${view.viewQueryParams}`}
+                        >
+                            <Highlight
+                                attribute="viewTitle"
+                                hit={view}
+                                highlightedTagName="strong"
+                                className="search-results__explorer-view-title"
+                            />
+                            <p className="body-3-medium-italic search-results__explorer-view-subtitle">
+                                {view.viewSubtitle}
+                            </p>
+                        </a>
+                    </li>
+                ))}
+            </ul>
+            <a
+                href={`${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${groupedHit.explorerSlug}`}
+                className="search-results__explorer-hit-link"
+            >
+                Explore all {groupedHit.numViewsWithinExplorer} indicators
+            </a>
+        </div>
     )
 }
 

--- a/site/search/SearchPanel.tsx
+++ b/site/search/SearchPanel.tsx
@@ -185,7 +185,7 @@ function ExplorerHit({ groupedHit }: { groupedHit: GroupedExplorerViews }) {
             className="search-results__explorer-hit"
         >
             <div className="search-results__explorer-hit-header">
-                <div>
+                <div className="search-results__explorer-hit-title-container">
                     <h3 className="h3-bold search-results__explorer-hit-title">
                         {groupedHit.explorerTitle}
                     </h3>
@@ -201,7 +201,7 @@ function ExplorerHit({ groupedHit }: { groupedHit: GroupedExplorerViews }) {
                     Explore all {groupedHit.numViewsWithinExplorer} indicators
                 </a>
             </div>
-            <ul className="search-results__explorer-views-list grid grid-cols-2">
+            <ul className="search-results__explorer-views-list grid grid-cols-2 grid-sm-cols-1">
                 {groupedHit.views.map((view) => (
                     <li
                         key={view.objectID}

--- a/site/search/SearchPanel.tsx
+++ b/site/search/SearchPanel.tsx
@@ -507,6 +507,41 @@ const SearchResults = (props: SearchResultsProps) => {
                     />
                 </section>
             </NoResultsBoundary>
+            <Index indexName={getIndexName(SearchIndexName.Charts)}>
+                <Configure
+                    hitsPerPage={40}
+                    distinct
+                    clickAnalytics={hasClickAnalyticsConsent}
+                    restrictSearchableAttributes={
+                        "" as any
+                    } /* Hack: This is the only way to _not_ send `restrictSearchableAttributes` along for this index */
+                />
+                <NoResultsBoundary>
+                    <section className="search-results__charts">
+                        <header className="search-results__header">
+                            <h2 className="h2-bold search-results__section-title">
+                                Charts
+                            </h2>
+                            <ShowMore
+                                category={SearchIndexName.Charts}
+                                cutoffNumber={4}
+                                activeCategoryFilter={activeCategoryFilter}
+                                handleCategoryFilterClick={
+                                    handleCategoryFilterClick
+                                }
+                            />
+                        </header>
+                        <Hits
+                            classNames={{
+                                root: "search-results__list-container",
+                                list: "search-results__charts-list grid grid-cols-4 grid-sm-cols-2",
+                                item: "search-results__chart-hit span-md-cols-2",
+                            }}
+                            hitComponent={ChartHit}
+                        />
+                    </section>
+                </NoResultsBoundary>
+            </Index>
             <Index indexName={getIndexName(SearchIndexName.ExplorerViews)}>
                 <Configure
                     hitsPerPage={20}
@@ -535,41 +570,6 @@ const SearchResults = (props: SearchResultsProps) => {
                             />
                         </header>
                         <ExplorerViewHits />
-                    </section>
-                </NoResultsBoundary>
-            </Index>
-            <Index indexName={getIndexName(SearchIndexName.Charts)}>
-                <Configure
-                    hitsPerPage={40}
-                    distinct
-                    clickAnalytics={hasClickAnalyticsConsent}
-                    restrictSearchableAttributes={
-                        "" as any
-                    } /* Hack: This is the only way to _not_ send `restrictSearchableAttributes` along for this index */
-                />
-                <NoResultsBoundary>
-                    <section className="search-results__charts">
-                        <header className="search-results__header">
-                            <h2 className="h2-bold search-results__section-title">
-                                Charts
-                            </h2>
-                            <ShowMore
-                                category={SearchIndexName.Charts}
-                                cutoffNumber={40}
-                                activeCategoryFilter={activeCategoryFilter}
-                                handleCategoryFilterClick={
-                                    handleCategoryFilterClick
-                                }
-                            />
-                        </header>
-                        <Hits
-                            classNames={{
-                                root: "search-results__list-container",
-                                list: "search-results__charts-list grid grid-cols-4 grid-sm-cols-2",
-                                item: "search-results__chart-hit span-md-cols-2",
-                            }}
-                            hitComponent={ChartHit}
-                        />
                     </section>
                 </NoResultsBoundary>
             </Index>

--- a/site/search/SearchPanel.tsx
+++ b/site/search/SearchPanel.tsx
@@ -30,7 +30,6 @@ import {
 import { action, observable } from "mobx"
 import { observer } from "mobx-react"
 import {
-    IExplorerHit,
     IChartHit,
     SearchCategoryFilter,
     SearchIndexName,
@@ -146,20 +145,6 @@ function ExplorerViewHit({ hit }: { hit: IExplorerViewHit }) {
     )
 }
 
-function ExplorerHit({ hit }: { hit: IExplorerHit }) {
-    return (
-        <a
-            data-algolia-index={getIndexName(SearchIndexName.Explorers)}
-            data-algolia-object-id={hit.objectID}
-            data-algolia-position={hit.__position}
-            href={`${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${hit.slug}`}
-        >
-            <h4 className="h3-bold">{hit.title}</h4>
-            {/* Explorer subtitles are mostly useless at the moment, so we're only showing titles */}
-        </a>
-    )
-}
-
 function ShowMore({
     category,
     cutoffNumber,
@@ -223,10 +208,6 @@ function Filters({
     hitsLengthByIndexName[getIndexName("all")] = Object.values(
         hitsLengthByIndexName
     ).reduce((a: number, b: number) => a + b, 0)
-
-    hitsLengthByIndexName[getIndexName(SearchIndexName.Explorers)] =
-        hitsLengthByIndexName[getIndexName(SearchIndexName.Explorers)] +
-        hitsLengthByIndexName[getIndexName(SearchIndexName.ExplorerViews)]
 
     return (
         <div className="search-filters">
@@ -464,7 +445,7 @@ const SearchResults = (props: SearchResultsProps) => {
                     <section className="search-results__explorer-views">
                         <header className="search-results__header">
                             <h2 className="h2-bold search-results__section-title">
-                                Data Explorer views
+                                Data Explorers
                             </h2>
                             <ShowMore
                                 category={SearchIndexName.ExplorerViews}

--- a/site/search/SearchPanel.tsx
+++ b/site/search/SearchPanel.tsx
@@ -559,7 +559,7 @@ const SearchResults = (props: SearchResultsProps) => {
                             </h2>
                             <ShowMore
                                 category={SearchIndexName.ExplorerViews}
-                                cutoffNumber={1}
+                                cutoffNumber={2}
                                 activeCategoryFilter={activeCategoryFilter}
                                 handleCategoryFilterClick={
                                     handleCategoryFilterClick

--- a/site/search/SearchPanel.tsx
+++ b/site/search/SearchPanel.tsx
@@ -208,6 +208,17 @@ function ExplorerHit({
     cardPosition: number
 }) {
     const firstHit = groupedHit.views[0]
+
+    const exploreAllProps = {
+        href: `${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${groupedHit.explorerSlug}`,
+        "data-algolia-index": getIndexName(SearchIndexName.ExplorerViews),
+        "data-algolia-object-id": firstHit.objectID,
+        "data-algolia-position": firstHit.hitPositionOverall,
+        "data-algolia-card-position": cardPosition,
+        "data-algolia-position-within-card": 0,
+        "data-algolia-event-name": "click_explorer",
+    }
+
     return (
         <div
             key={groupedHit.explorerSlug}
@@ -224,16 +235,8 @@ function ExplorerHit({
                 </div>
 
                 <a
-                    href={`${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${groupedHit.explorerSlug}`}
                     className="search-results__explorer-hit-link hide-sm-only"
-                    data-algolia-index={getIndexName(
-                        SearchIndexName.ExplorerViews
-                    )}
-                    data-algolia-object-id={firstHit.objectID}
-                    data-algolia-position={firstHit.hitPositionOverall}
-                    data-algolia-card-position={cardPosition}
-                    data-algolia-position-within-card={0}
-                    data-algolia-event-name="click_explorer"
+                    {...exploreAllProps}
                 >
                     Explore all {groupedHit.numViewsWithinExplorer} indicators
                 </a>
@@ -273,8 +276,8 @@ function ExplorerHit({
                 ))}
             </ul>
             <a
-                href={`${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${groupedHit.explorerSlug}`}
                 className="search-results__explorer-hit-link-mobile hide-sm-up"
+                {...exploreAllProps}
             >
                 Explore all {groupedHit.numViewsWithinExplorer} indicators
             </a>

--- a/site/search/SearchPanel.tsx
+++ b/site/search/SearchPanel.tsx
@@ -37,6 +37,7 @@ import {
     searchCategoryFilters,
     IPageHit,
     pageTypeDisplayNames,
+    IExplorerViewHit,
     PageRecord,
 } from "./searchTypes.js"
 import { EXPLORERS_ROUTE_FOLDER } from "../../explorer/ExplorerConstants.js"
@@ -128,6 +129,23 @@ function ChartHit({ hit }: { hit: IChartHit }) {
     )
 }
 
+function ExplorerViewHit({ hit }: { hit: IExplorerViewHit }) {
+    return (
+        <a
+            data-algolia-index={getIndexName(SearchIndexName.ExplorerViews)}
+            data-algolia-object-id={hit.objectID}
+            data-algolia-position={hit.__position}
+            href={`${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${hit.explorerSlug}${hit.viewQueryParams}`}
+        >
+            <h4 className="h3-bold">{hit.viewTitle}</h4>
+            <span>
+                in <em>{hit.explorerTitle} Data Explorer</em>
+            </span>
+            {/* Explorer subtitles are mostly useless at the moment, so we're only showing titles */}
+        </a>
+    )
+}
+
 function ExplorerHit({ hit }: { hit: IExplorerHit }) {
     return (
         <a
@@ -201,9 +219,14 @@ function Filters({
     const hitsLengthByIndexName = mapValues(resultsByIndexName, (results) =>
         get(results, ["results", "hits", "length"], 0)
     )
+
     hitsLengthByIndexName[getIndexName("all")] = Object.values(
         hitsLengthByIndexName
     ).reduce((a: number, b: number) => a + b, 0)
+
+    hitsLengthByIndexName[getIndexName(SearchIndexName.Explorers)] =
+        hitsLengthByIndexName[getIndexName(SearchIndexName.Explorers)] +
+        hitsLengthByIndexName[getIndexName(SearchIndexName.ExplorerViews)]
 
     return (
         <div className="search-filters">
@@ -427,6 +450,38 @@ const SearchResults = (props: SearchResultsProps) => {
                                 item: "search-results__explorer-hit",
                             }}
                             hitComponent={ExplorerHit}
+                        />
+                    </section>
+                </NoResultsBoundary>
+            </Index>
+            <Index indexName={getIndexName(SearchIndexName.ExplorerViews)}>
+                <Configure
+                    hitsPerPage={10}
+                    distinct
+                    clickAnalytics={hasClickAnalyticsConsent}
+                />
+                <NoResultsBoundary>
+                    <section className="search-results__explorer-views">
+                        <header className="search-results__header">
+                            <h2 className="h2-bold search-results__section-title">
+                                Data Explorer views
+                            </h2>
+                            <ShowMore
+                                category={SearchIndexName.ExplorerViews}
+                                cutoffNumber={4}
+                                activeCategoryFilter={activeCategoryFilter}
+                                handleCategoryFilterClick={
+                                    handleCategoryFilterClick
+                                }
+                            />
+                        </header>
+                        <Hits
+                            classNames={{
+                                root: "search-results__list-container",
+                                list: "search-results__explorer-views-list grid grid-cols-2 grid-sm-cols-1",
+                                item: "search-results__explorer-view-hit",
+                            }}
+                            hitComponent={ExplorerViewHit}
                         />
                     </section>
                 </NoResultsBoundary>

--- a/site/search/SearchPanel.tsx
+++ b/site/search/SearchPanel.tsx
@@ -44,7 +44,11 @@ import {
 } from "./searchTypes.js"
 import { EXPLORERS_ROUTE_FOLDER } from "../../explorer/ExplorerConstants.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
-import { faHeartBroken, faSearch } from "@fortawesome/free-solid-svg-icons"
+import {
+    faArrowRight,
+    faHeartBroken,
+    faSearch,
+} from "@fortawesome/free-solid-svg-icons"
 import {
     DEFAULT_SEARCH_PLACEHOLDER,
     getIndexName,
@@ -195,6 +199,7 @@ function ExplorerHit({ groupedHit }: { groupedHit: GroupedExplorerViews }) {
                             data-algolia-object-id={view.objectID}
                             data-algolia-position={view.__position}
                             href={`${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${view.explorerSlug}${view.viewQueryParams}`}
+                            className="search-results__explorer-view-title-container"
                         >
                             <Highlight
                                 attribute="viewTitle"
@@ -202,10 +207,11 @@ function ExplorerHit({ groupedHit }: { groupedHit: GroupedExplorerViews }) {
                                 highlightedTagName="strong"
                                 className="search-results__explorer-view-title"
                             />
-                            <p className="body-3-medium-italic search-results__explorer-view-subtitle">
-                                {view.viewSubtitle}
-                            </p>
+                            <FontAwesomeIcon icon={faArrowRight} />
                         </a>
+                        <p className="body-3-medium-italic search-results__explorer-view-subtitle">
+                            {view.viewSubtitle}
+                        </p>
                     </li>
                 ))}
             </ul>

--- a/site/search/searchClient.ts
+++ b/site/search/searchClient.ts
@@ -42,10 +42,13 @@ export const parseIndexName = (index: string): SearchIndexName => {
 }
 
 export const logSiteSearchClickToAlgoliaInsights = (
-    event: Omit<InsightsSearchClickEvent, "eventName">
+    event: Omit<InsightsSearchClickEvent, "eventName"> & { eventName?: string }
 ) => {
     const client = getInsightsClient()
-    client("clickedObjectIDsAfterSearch", { ...event, eventName: "click" })
+    client("clickedObjectIDsAfterSearch", {
+        ...event,
+        eventName: event.eventName ?? "click",
+    })
 }
 
 export const DEFAULT_SEARCH_PLACEHOLDER =

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -42,6 +42,7 @@ export type IExplorerViewHit = Hit<BaseHit> & {
     // Explorer-wide fields
     explorerSlug: string
     explorerTitle: string
+    explorerSubtitle: string
     numViewsWithinExplorer: number
 
     // View-specific fields

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -94,8 +94,8 @@ export type SearchCategoryFilter = SearchIndexName | "all"
 export const searchCategoryFilters: [string, SearchCategoryFilter][] = [
     ["All", "all"],
     ["Research & Writing", SearchIndexName.Pages],
-    ["Data Explorers", SearchIndexName.ExplorerViews],
     ["Charts", SearchIndexName.Charts],
+    ["Data Explorers", SearchIndexName.ExplorerViews],
 ]
 
 export const indexNameToSubdirectoryMap: Record<SearchIndexName, string> = {

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -36,6 +36,14 @@ export interface PageRecord {
 
 export type IPageHit = PageRecord & Hit<BaseHit>
 
+export type IExplorerViewHit = Hit<BaseHit> & {
+    objectID: string
+    explorerSlug: string
+    viewTitle: string
+    explorerTitle: string
+    viewQueryParams: string
+}
+
 export type IExplorerHit = Hit<BaseHit> & {
     objectID: string
     slug: string

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -38,10 +38,17 @@ export type IPageHit = PageRecord & Hit<BaseHit>
 
 export type IExplorerViewHit = Hit<BaseHit> & {
     objectID: string
+
+    // Explorer-wide fields
     explorerSlug: string
-    viewTitle: string
     explorerTitle: string
+    numViewsWithinExplorer: number
+
+    // View-specific fields
+    viewTitle: string
+    viewSubtitle: string
     viewQueryParams: string
+    viewTitleIndexWithinExplorer: number
 }
 
 export type IExplorerHit = Hit<BaseHit> & {
@@ -86,7 +93,7 @@ export type SearchCategoryFilter = SearchIndexName | "all"
 export const searchCategoryFilters: [string, SearchCategoryFilter][] = [
     ["All", "all"],
     ["Research & Writing", SearchIndexName.Pages],
-    ["Data Explorers", SearchIndexName.Explorers],
+    ["Data Explorers", SearchIndexName.ExplorerViews],
     ["Charts", SearchIndexName.Charts],
 ]
 


### PR DESCRIPTION
## TODOs

- [x] Implement card-based design
- [x] Do grouping by `explorerSlug`
- [x] Do client-side deduplication based on `[viewTitle, explorerSlug]`
- [x] Add click tracking
- [ ] ~_maybe_ do country name removal (`optionalWords`)~
- [ ] ~_probably_ sort explorer cards with more view items higher up~
- [x] cleanup:
	- [x] remove display of `explorers` index
	- [x] remove `SearchIndexName.explorers` and all uses (#3472)
	- [x] remove all references, styles etc.
	- [x] css styles