### PR TITLE
Fix comma in sql bug

### DIFF
--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -404,7 +404,7 @@ export const getGdocsPostReferencesByChartId = async (
                 AND pg.content ->> '$.type' NOT IN (
                     '${OwidGdocType.Fragment}',
                     '${OwidGdocType.AboutPage}',
-                    '${OwidGdocType.DataInsight}',
+                    '${OwidGdocType.DataInsight}'
                 )
                 AND pg.published = 1
             ORDER BY


### PR DESCRIPTION
A recent change to exclude data-insights from related posts on grapher page had a spurrious comma in the end which is not allowed in sql