### PR TITLE
🐛 Exclude fragments from normal baking and showing up in algolia

### DIFF
--- a/db/model/Gdoc/GdocFactory.ts
+++ b/db/model/Gdoc/GdocFactory.ts
@@ -392,7 +392,6 @@ export async function getAndLoadPublishedGdocPosts(
                 OwidGdocType.Article,
                 OwidGdocType.LinearTopicPage,
                 OwidGdocType.TopicPage,
-                OwidGdocType.Fragment,
                 OwidGdocType.AboutPage,
             ],
         }


### PR DESCRIPTION
GDoc documents of type Fragment were accidentally included in queries for published gdocs. This made them appear in the sitemap and algolia results.