### PR TITLE
🐛 (grapher) don't validate dods

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1273,12 +1273,7 @@ export class Grapher
             ...noteDetails,
         ])
 
-        const validDetails = uniqueDetails.filter((detailId: string) => {
-            const detail = window.details?.[detailId]
-            return detail !== undefined
-        })
-
-        return validDetails
+        return uniqueDetails
     }
 
     @computed get detailsMarkerInSvg(): DetailsMarker {

--- a/site/Head.tsx
+++ b/site/Head.tsx
@@ -1,9 +1,6 @@
 import React from "react"
 import { viteAssetsForSite } from "./viteUtils.js"
-import {
-    GOOGLE_TAG_MANAGER_ID,
-    BAKED_BASE_URL,
-} from "../settings/clientSettings.js"
+import { GOOGLE_TAG_MANAGER_ID } from "../settings/clientSettings.js"
 
 export const GTMScriptTags = ({ gtmId }: { gtmId: string }) => {
     if (!gtmId || /["']/.test(gtmId)) return null
@@ -101,29 +98,8 @@ export const Head = (props: {
             <meta name="twitter:description" content={pageDesc} />
             <meta name="twitter:image" content={encodeURI(imageUrl)} />
             {stylesheets}
-            <ScriptTagLoadingDetails />
             {props.children}
             <GTMScriptTags gtmId={GOOGLE_TAG_MANAGER_ID} />
         </head>
-    )
-}
-
-function ScriptTagLoadingDetails() {
-    return (
-        <script
-            dangerouslySetInnerHTML={{
-                __html: `fetch("${BAKED_BASE_URL}/dods.json", {
-                    method: "GET",
-                    credentials: "same-origin",
-                    headers: {
-                        Accept: "application/json",
-                    },
-                })
-                    .then((res) => res.json())
-                    .then((details) => {
-                        window.details = details
-                    })`,
-            }}
-        />
     )
 }

--- a/site/detailsOnDemand.tsx
+++ b/site/detailsOnDemand.tsx
@@ -17,20 +17,13 @@ declare global {
 }
 
 export async function runDetailsOnDemand() {
-    if (!window.details) {
-        const details: DetailDictionary = await fetch(
-            `${BAKED_BASE_URL}/dods.json`,
-            {
-                method: "GET",
-                credentials: "same-origin",
-                headers: {
-                    Accept: "application/json",
-                },
-            }
-        ).then((res) => res.json())
-
-        window.details = details
-    }
+    window.details = await fetch(`${BAKED_BASE_URL}/dods.json`, {
+        method: "GET",
+        credentials: "same-origin",
+        headers: {
+            Accept: "application/json",
+        },
+    }).then((res) => res.json())
 
     document.addEventListener("mouseover", handleEvent, { passive: true })
     document.addEventListener("touchstart", handleEvent, { passive: true })


### PR DESCRIPTION
- Fixes #3439
- We recently started validating DoDs in Grapher
- We need validation when we automatically check for DoDs with a specific prefix, like `grapher_indicator_my-indicator-title` (we never shipped automatic DoD checking though)
- `window.details` must be populated before Grapher loads for validation to work (if it's not there, Grapher can't validate and assumes all given details are invalid)
- Since we never shipped automatic DoD checking, we also don't currently need validation and can just remove the code around it
- Let's just do so for now and figure out how to do bug-free details validation in Grapher when we really need it
- This is "tested" by refreshing a Grapher page a number of times and verifying that the DoD checkbox in the Download modal is present