### PR TITLE
🎉 (entity selector) sort by name or value

### DIFF
--- a/packages/@ourworldindata/components/src/Checkbox.scss
+++ b/packages/@ourworldindata/components/src/Checkbox.scss
@@ -3,7 +3,7 @@
 
     $light-stroke: #dadada;
     $hover-stroke: #a4b6ca;
-    $active-fill: #dbe5f0;
+    $active-fill: #a4b6ca;
 
     position: relative;
 
@@ -27,7 +27,7 @@
         pointer-events: none;
         border-radius: 2px;
         border: 1px solid $light-stroke;
-        color: $dark-text;
+        color: #fff;
 
         display: flex;
         align-items: center;
@@ -36,7 +36,6 @@
         svg {
             font-size: 10px;
             padding-left: 0.75px;
-            color: $active-text;
         }
     }
 

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -76,6 +76,10 @@ export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
         return this instanceof MissingColumn
     }
 
+    @imemo get hasNumberFormatting(): boolean {
+        return this instanceof AbstractColumnWithNumberFormatting
+    }
+
     get sum(): number | undefined {
         return this.summary.sum
     }

--- a/packages/@ourworldindata/grapher/src/controls/Dropdown.scss
+++ b/packages/@ourworldindata/grapher/src/controls/Dropdown.scss
@@ -1,0 +1,92 @@
+.grapher-dropdown {
+    $option-checkmark: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iOSIgdmlld0JveD0iMCAwIDEyIDkiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0xMS4wMTU2IDAuOTg0Mzc1QzExLjMyMDMgMS4yNjU2MiAxMS4zMjAzIDEuNzU3ODEgMTEuMDE1NiAyLjAzOTA2TDUuMDE1NjIgOC4wMzkwNkM0LjczNDM4IDguMzQzNzUgNC4yNDIxOSA4LjM0Mzc1IDMuOTYwOTQgOC4wMzkwNkwwLjk2MDkzOCA1LjAzOTA2QzAuNjU2MjUgNC43NTc4MSAwLjY1NjI1IDQuMjY1NjIgMC45NjA5MzggMy45ODQzOEMxLjI0MjE5IDMuNjc5NjkgMS43MzQzOCAzLjY3OTY5IDIuMDE1NjIgMy45ODQzOEw0LjQ3NjU2IDYuNDQ1MzFMOS45NjA5NCAwLjk4NDM3NUMxMC4yNDIyIDAuNjc5Njg4IDEwLjczNDQgMC42Nzk2ODggMTEuMDE1NiAwLjk4NDM3NVoiIGZpbGw9IiMxRDNENjMiLz4KPC9zdmc+";
+    $menu-caret-up: "data:image/svg+xml;base64, PHN2ZyB3aWR0aD0iOCIgaGVpZ2h0PSI1IiB2aWV3Qm94PSIwIDAgOCA1IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBkPSJNMC40NjA5MzggMy43MzQzOEwzLjQzNzUgMC43MzQzNzVDMy42MDE1NiAwLjU5Mzc1IDMuNzg5MDYgMC41IDQgMC41QzQuMTg3NSAwLjUgNC4zNzUgMC41OTM3NSA0LjUxNTYyIDAuNzM0Mzc1TDcuNDkyMTkgMy43MzQzOEM3LjcwMzEyIDMuOTQ1MzEgNy43NzM0NCA0LjI3MzQ0IDcuNjU2MjUgNC41NTQ2OUM3LjUzOTA2IDQuODM1OTQgNy4yODEyNSA1IDYuOTc2NTYgNUgxQzAuNjk1MzEyIDUgMC40MTQwNjIgNC44MzU5NCAwLjI5Njg3NSA0LjU1NDY5QzAuMTc5Njg4IDQuMjczNDQgMC4yNSAzLjk0NTMxIDAuNDYwOTM4IDMuNzM0MzhaIiBmaWxsPSIjNUI1QjVCIi8+Cjwvc3ZnPg==";
+    $menu-caret-down: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iOCIgaGVpZ2h0PSI1IiB2aWV3Qm94PSIwIDAgOCA1IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBkPSJNNy41MTU2MiAxLjI4OTA2TDQuNTM5MDYgNC4yODkwNkM0LjM3NSA0LjQyOTY5IDQuMTg3NSA0LjUgNCA0LjVDMy43ODkwNiA0LjUgMy42MDE1NiA0LjQyOTY5IDMuNDYwOTQgNC4yODkwNkwwLjQ4NDM3NSAxLjI4OTA2QzAuMjUgMS4wNzgxMiAwLjE3OTY4OCAwLjc1IDAuMjk2ODc1IDAuNDY4NzVDMC40MTQwNjIgMC4xODc1IDAuNjk1MzEyIDAgMSAwSDYuOTc2NTZDNy4yODEyNSAwIDcuNTM5MDYgMC4xODc1IDcuNjU2MjUgMC40Njg3NUM3Ljc3MzQ0IDAuNzUgNy43MjY1NiAxLjA3ODEyIDcuNTE1NjIgMS4yODkwNloiIGZpbGw9IiM1QjVCNUIiLz4KPC9zdmc+Cg==";
+
+    $medium: 400;
+    $lato: $sans-serif-font-stack;
+
+    $light-stroke: #e7e7e7;
+    $active-stroke: #a4b6ca;
+
+    $active-fill: #dbe5f0;
+    $hover-fill: #f2f2f2;
+    $selected-fill: #c7ced7;
+
+    $light-text: #858585;
+
+    font: $medium 13px/16px $lato;
+
+    // fixes a bug in Firefox where long labels would cause the dropdown to resize,
+    // see https://github.com/JedWatson/react-select/issues/5170
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+
+    .control {
+        min-height: auto;
+        font: $medium 13px/16px $lato;
+        letter-spacing: 0.01em;
+        display: flex;
+        align-items: center;
+        border: 1px solid $light-stroke;
+        border-radius: 4px;
+        padding: 7px;
+        color: $dark-text;
+
+        &:hover {
+            background: $hover-fill;
+            cursor: pointer;
+        }
+
+        &:after {
+            content: " ";
+            background: url($menu-caret-down) no-repeat center;
+            width: 16px;
+            height: 16px;
+        }
+
+        &.active {
+            border-color: $active-stroke;
+            &:after {
+                background: url($menu-caret-up) no-repeat center;
+            }
+        }
+    }
+
+    .menu {
+        margin-top: 3px;
+        border-radius: 4px;
+        background: white;
+        box-shadow: 0px 4px 40px 0px rgba(0, 0, 0, 0.15);
+        z-index: $zindex-controls-popup;
+        color: $dark-text;
+
+        .option {
+            padding: 8px 18px;
+            &:hover {
+                cursor: pointer;
+                background: $hover-fill;
+            }
+            &:active,
+            &.active {
+                color: $active-text;
+                background: $active-fill;
+            }
+            &.active {
+                position: relative;
+                &:hover {
+                    background: $selected-fill;
+                }
+                &:after {
+                    content: " ";
+                    background: url($option-checkmark) no-repeat;
+                    width: 12px;
+                    height: 9px;
+                    position: absolute;
+                    right: 18px;
+                    bottom: 11px;
+                }
+            }
+        }
+    }
+}

--- a/packages/@ourworldindata/grapher/src/controls/Dropdown.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/Dropdown.tsx
@@ -1,0 +1,26 @@
+import React from "react"
+import Select, { Props } from "react-select"
+
+export function Dropdown(props: Props): React.JSX.Element {
+    return (
+        <Select
+            className="grapher-dropdown"
+            menuPlacement="bottom"
+            components={{
+                IndicatorSeparator: null,
+                DropdownIndicator: null,
+            }}
+            isSearchable={false}
+            unstyled={true}
+            isMulti={false}
+            classNames={{
+                control: (state) =>
+                    state.menuIsOpen ? "active control" : "control",
+                option: (state) =>
+                    state.isSelected ? "active option" : "option",
+                menu: () => "menu",
+            }}
+            {...props}
+        />
+    )
+}

--- a/packages/@ourworldindata/grapher/src/controls/MapProjectionMenu.scss
+++ b/packages/@ourworldindata/grapher/src/controls/MapProjectionMenu.scss
@@ -1,95 +1,13 @@
 .map-projection-menu {
-    $option-checkmark: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iOSIgdmlld0JveD0iMCAwIDEyIDkiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0xMS4wMTU2IDAuOTg0Mzc1QzExLjMyMDMgMS4yNjU2MiAxMS4zMjAzIDEuNzU3ODEgMTEuMDE1NiAyLjAzOTA2TDUuMDE1NjIgOC4wMzkwNkM0LjczNDM4IDguMzQzNzUgNC4yNDIxOSA4LjM0Mzc1IDMuOTYwOTQgOC4wMzkwNkwwLjk2MDkzOCA1LjAzOTA2QzAuNjU2MjUgNC43NTc4MSAwLjY1NjI1IDQuMjY1NjIgMC45NjA5MzggMy45ODQzOEMxLjI0MjE5IDMuNjc5NjkgMS43MzQzOCAzLjY3OTY5IDIuMDE1NjIgMy45ODQzOEw0LjQ3NjU2IDYuNDQ1MzFMOS45NjA5NCAwLjk4NDM3NUMxMC4yNDIyIDAuNjc5Njg4IDEwLjczNDQgMC42Nzk2ODggMTEuMDE1NiAwLjk4NDM3NVoiIGZpbGw9IiMxRDNENjMiLz4KPC9zdmc+";
-    $menu-caret-up: "data:image/svg+xml;base64, PHN2ZyB3aWR0aD0iOCIgaGVpZ2h0PSI1IiB2aWV3Qm94PSIwIDAgOCA1IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBkPSJNMC40NjA5MzggMy43MzQzOEwzLjQzNzUgMC43MzQzNzVDMy42MDE1NiAwLjU5Mzc1IDMuNzg5MDYgMC41IDQgMC41QzQuMTg3NSAwLjUgNC4zNzUgMC41OTM3NSA0LjUxNTYyIDAuNzM0Mzc1TDcuNDkyMTkgMy43MzQzOEM3LjcwMzEyIDMuOTQ1MzEgNy43NzM0NCA0LjI3MzQ0IDcuNjU2MjUgNC41NTQ2OUM3LjUzOTA2IDQuODM1OTQgNy4yODEyNSA1IDYuOTc2NTYgNUgxQzAuNjk1MzEyIDUgMC40MTQwNjIgNC44MzU5NCAwLjI5Njg3NSA0LjU1NDY5QzAuMTc5Njg4IDQuMjczNDQgMC4yNSAzLjk0NTMxIDAuNDYwOTM4IDMuNzM0MzhaIiBmaWxsPSIjNUI1QjVCIi8+Cjwvc3ZnPg==";
-    $menu-caret-down: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iOCIgaGVpZ2h0PSI1IiB2aWV3Qm94PSIwIDAgOCA1IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBkPSJNNy41MTU2MiAxLjI4OTA2TDQuNTM5MDYgNC4yODkwNkM0LjM3NSA0LjQyOTY5IDQuMTg3NSA0LjUgNCA0LjVDMy43ODkwNiA0LjUgMy42MDE1NiA0LjQyOTY5IDMuNDYwOTQgNC4yODkwNkwwLjQ4NDM3NSAxLjI4OTA2QzAuMjUgMS4wNzgxMiAwLjE3OTY4OCAwLjc1IDAuMjk2ODc1IDAuNDY4NzVDMC40MTQwNjIgMC4xODc1IDAuNjk1MzEyIDAgMSAwSDYuOTc2NTZDNy4yODEyNSAwIDcuNTM5MDYgMC4xODc1IDcuNjU2MjUgMC40Njg3NUM3Ljc3MzQ0IDAuNzUgNy43MjY1NiAxLjA3ODEyIDcuNTE1NjIgMS4yODkwNloiIGZpbGw9IiM1QjVCNUIiLz4KPC9zdmc+Cg==";
-
-    $medium: 400;
-    $lato: $sans-serif-font-stack;
-
-    $light-stroke: #e7e7e7;
-    $active-stroke: #a4b6ca;
-
-    $active-fill: #dbe5f0;
-    $hover-fill: #f2f2f2;
-    $selected-fill: #c7ced7;
-
-    $light-text: #858585;
-
-    font: $medium 13px/16px $lato;
-
     .control {
-        min-height: auto;
         min-width: 150px;
-        font: $medium 13px/16px $lato;
-        letter-spacing: 0.01em;
-        display: flex;
-        align-items: center;
-        border: 1px solid $light-stroke;
-        border-radius: 4px;
-        padding: 7px;
-        color: $dark-text;
-
-        &:hover {
-            background: $hover-fill;
-            cursor: pointer;
-        }
-
-        &:after {
-            content: " ";
-            background: url($menu-caret-down) no-repeat center;
-            width: 16px;
-            height: 16px;
-        }
-
-        &.active {
-            border-color: $active-stroke;
-            &:after {
-                background: url($menu-caret-up) no-repeat center;
-            }
-        }
     }
 
-    .menu {
-        margin-top: 3px;
-        border-radius: 4px;
-        background: white;
-        box-shadow: 0px 4px 40px 0px rgba(0, 0, 0, 0.15);
-        z-index: $zindex-controls-popup;
-
-        &:before {
-            display: inline-block;
-            content: "Zoom to selection";
-            font: 700 12px/16px $lato;
-            color: $light-text;
-            padding: 8px 18px;
-        }
-
-        .option {
-            padding: 8px 18px;
-            &:hover {
-                cursor: pointer;
-                background: $hover-fill;
-            }
-            &:active,
-            &.active {
-                color: $active-text;
-                background: $active-fill;
-            }
-            &.active {
-                position: relative;
-                &:hover {
-                    background: $selected-fill;
-                }
-                &:after {
-                    content: " ";
-                    background: url($option-checkmark) no-repeat;
-                    width: 12px;
-                    height: 9px;
-                    position: absolute;
-                    right: 18px;
-                    bottom: 11px;
-                }
-            }
-        }
+    .menu:before {
+        display: inline-block;
+        content: "Zoom to selection";
+        font: 700 12px/16px $lato;
+        color: $light-text;
+        padding: 8px 18px;
     }
 }

--- a/packages/@ourworldindata/grapher/src/controls/MapProjectionMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/MapProjectionMenu.tsx
@@ -1,10 +1,10 @@
 import React from "react"
-import Select from "react-select"
 import { computed, action } from "mobx"
 import { observer } from "mobx-react"
 import { MapConfig } from "../mapCharts/MapConfig"
 import { MapProjectionName } from "@ourworldindata/types"
 import { MapProjectionLabels } from "../mapCharts/MapProjections"
+import { Dropdown } from "./Dropdown"
 
 export { AbsRelToggle } from "./settings/AbsRelToggle"
 export { FacetStrategySelector } from "./settings/FacetStrategySelector"
@@ -40,9 +40,10 @@ export class MapProjectionMenu extends React.Component<{
         return !hideMapProjectionMenu && !!(isOnMapTab && projection)
     }
 
-    @action.bound onChange(selected: MapProjectionMenuItem | null): void {
+    @action.bound onChange(selected: unknown): void {
         const { mapConfig } = this.props.manager
-        if (selected && mapConfig) mapConfig.projection = selected.value
+        if (selected && mapConfig)
+            mapConfig.projection = (selected as MapProjectionMenuItem).value
     }
 
     @computed get options(): MapProjectionMenuItem[] {
@@ -62,25 +63,10 @@ export class MapProjectionMenu extends React.Component<{
     render(): JSX.Element | null {
         return this.showMenu ? (
             <div className="map-projection-menu">
-                <Select
+                <Dropdown
                     options={this.options}
                     onChange={this.onChange}
                     value={this.value}
-                    menuPlacement="bottom"
-                    components={{
-                        IndicatorSeparator: null,
-                        DropdownIndicator: null,
-                    }}
-                    isSearchable={false}
-                    unstyled={true}
-                    isMulti={false}
-                    classNames={{
-                        control: (state) =>
-                            state.menuIsOpen ? "active control" : "control",
-                        option: (state) =>
-                            state.isSelected ? "active option" : "option",
-                        menu: () => "menu",
-                    }}
                 />
             </div>
         ) : null

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -88,6 +88,7 @@ $zindex-controls-drawer: 150;
 @import "../../../components/src/Checkbox.scss";
 @import "../closeButton/CloseButton.scss";
 @import "../controls/RadioButton.scss";
+@import "../controls/Dropdown.scss";
 
 .grapher_dark {
     color: $dark-text;

--- a/packages/@ourworldindata/grapher/src/core/typography.scss
+++ b/packages/@ourworldindata/grapher/src/core/typography.scss
@@ -134,3 +134,12 @@
 .grapher_label-2-regular {
     @include grapher_label-2-regular;
 }
+
+@mixin grapher_label-2-medium {
+    @include grapher_label-2-regular;
+    font-weight: 500;
+}
+
+.grapher_label-2-medium {
+    @include grapher_label-2-medium;
+}

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
@@ -17,7 +17,66 @@
             background-color: #fff;
             z-index: $zindex-header;
             padding: 0 var(--padding) 8px var(--padding);
+            margin-bottom: 8px;
+        }
+
+        .entity-selector__sort-bar {
+            padding: 0 var(--padding);
+            display: flex;
+            align-items: center;
             margin-bottom: 16px;
+
+            .grapher-dropdown {
+                flex-grow: 1;
+            }
+
+            .label {
+                flex-shrink: 0;
+                margin-right: 8px;
+                color: $dark-text;
+            }
+
+            button.sort {
+                flex-shrink: 0;
+                margin-left: 16px;
+
+                $size: 32px;
+
+                display: flex;
+                align-items: center;
+                justify-content: center;
+
+                position: relative;
+                height: $size;
+                width: $size;
+                padding: 7px;
+
+                color: $dark-text;
+                background: #f2f2f2;
+                border: none;
+                border-radius: 4px;
+
+                svg {
+                    height: 14px;
+                    width: 14px;
+                }
+
+                &:hover:not(:disabled) {
+                    background: #e7e7e7;
+                    cursor: pointer;
+                }
+
+                &:active:not(:disabled) {
+                    color: #1d3d63;
+                    background: #dbe5f0;
+                    border: 1px solid #dbe5f0;
+                }
+
+                &:disabled {
+                    background: #f2f2f2;
+                    color: #a1a1a1;
+                }
+            }
         }
 
         .entity-selector__footer {
@@ -74,7 +133,7 @@
         }
 
         .entity-selector__content {
-            margin: -8px var(--padding) ($footer-height + 8px) var(--padding);
+            margin: 0 var(--padding) ($footer-height + 8px) var(--padding);
         }
 
         &.entity-selector--single {
@@ -83,19 +142,36 @@
             }
         }
 
-        .entity-search-results {
+        .entity-section + .entity-section {
             margin-top: 16px;
         }
 
-        .section-title {
+        .entity-section__title {
             letter-spacing: 0.01em;
-            margin-top: 16px;
             margin-bottom: 8px;
         }
 
         .selectable-entity {
             padding: 9px 8px 9px 16px;
+            display: flex;
+            justify-content: space-between;
+            position: relative;
             cursor: pointer;
+
+            .value {
+                color: #a1a1a1;
+                white-space: nowrap;
+                margin-left: 8px;
+            }
+
+            .bar {
+                position: absolute;
+                top: 0;
+                left: 0;
+                height: 100%;
+                background: #ebeef2;
+                z-index: -1;
+            }
         }
 
         .animated-entity {

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -5,9 +5,15 @@ import cx from "classnames"
 import a from "indefinite"
 import {
     isTouchDevice,
-    sortBy,
     partition,
     capitalize,
+    SortOrder,
+    orderBy,
+    keyBy,
+    isFiniteWithGuard,
+    CoreValueType,
+    clamp,
+    maxBy,
 } from "@ourworldindata/utils"
 import { Checkbox } from "@ourworldindata/components"
 import { FuzzySearch } from "../controls/FuzzySearch"
@@ -26,27 +32,46 @@ import {
     GRAPHER_ENTITY_SELECTOR_CLASS,
     GRAPHER_SCROLLABLE_CONTAINER_CLASS,
 } from "../core/GrapherConstants"
+import { CoreColumn, OwidTable } from "@ourworldindata/core-table"
+import { SortIcon } from "../controls/SortIcon"
+import { Dropdown } from "../controls/Dropdown"
+import { scaleLinear, type ScaleLinear } from "d3-scale"
+import { ColumnSlug } from "@ourworldindata/types"
 
 export interface EntitySelectorState {
     searchInput: string
+    sortConfig: SortConfig
     mostRecentlySelectedEntityName?: string
 }
 
 export interface EntitySelectorManager {
     entitySelectorState: Partial<EntitySelectorState>
+    tableForSelection: OwidTable
     selection: SelectionArray
     canChangeEntity: boolean
     entityType?: string
     entityTypePlural?: string
+    activeColumnSlugs?: string[]
 }
 
-interface SearchableEntity {
-    name: string
+interface SortConfig {
+    slug: ColumnSlug
+    order: SortOrder
 }
+
+type SearchableEntity = { name: string } & Record<
+    ColumnSlug,
+    CoreValueType | undefined
+>
 
 interface PartitionedEntities {
-    selected: string[]
-    unselected: string[]
+    selected: SearchableEntity[]
+    unselected: SearchableEntity[]
+}
+
+interface DropdownOption {
+    value: string
+    label: string
 }
 
 @observer
@@ -57,6 +82,11 @@ export class EntitySelector extends React.Component<{
 }> {
     container: React.RefObject<HTMLDivElement> = React.createRef()
     searchField: React.RefObject<HTMLInputElement> = React.createRef()
+
+    private defaultSortConfig = {
+        slug: this.table.entityNameSlug,
+        order: SortOrder.asc,
+    }
 
     componentDidMount(): void {
         if (this.props.autoFocus && !isTouchDevice())
@@ -75,15 +105,58 @@ export class EntitySelector extends React.Component<{
         )
     }
 
-    private set(state: Partial<EntitySelectorState>): void {
+    private set(newState: Partial<EntitySelectorState>): void {
+        const correctedState = { ...newState }
+
+        if (newState.sortConfig !== undefined) {
+            const correctedSortConfig = { ...newState.sortConfig }
+
+            const shouldBeSortedByName =
+                newState.sortConfig.slug === this.table.entityNameSlug
+
+            // sort names in ascending order by default
+            if (shouldBeSortedByName && !this.isSortedByName) {
+                correctedSortConfig.order = SortOrder.asc
+            }
+
+            // sort values in descending order by default
+            if (!shouldBeSortedByName && this.isSortedByName) {
+                correctedSortConfig.order = SortOrder.desc
+            }
+
+            correctedState.sortConfig = correctedSortConfig
+        }
+
         this.manager.entitySelectorState = {
             ...this.manager.entitySelectorState,
-            ...state,
+            ...correctedState,
         }
     }
 
     private clearSearchInput(): void {
         this.set({ searchInput: "" })
+    }
+
+    private updateSortSlug(newSlug: ColumnSlug) {
+        this.set({
+            sortConfig: {
+                slug: newSlug,
+                order: this.sortConfig.order,
+            },
+        })
+    }
+
+    private toggleSortOrder() {
+        const newOrder =
+            this.sortConfig.order === SortOrder.asc
+                ? SortOrder.desc
+                : SortOrder.asc
+        this.set({
+            sortConfig: {
+                slug: this.sortConfig.slug,
+                order: newOrder,
+            },
+        })
     }
 
     @computed private get manager(): EntitySelectorManager {
@@ -96,6 +169,65 @@ export class EntitySelector extends React.Component<{
 
     @computed private get mostRecentlySelectedEntityName(): string | undefined {
         return this.manager.entitySelectorState.mostRecentlySelectedEntityName
+    }
+
+    @computed private get sortConfig(): SortConfig {
+        return (
+            this.manager.entitySelectorState.sortConfig ??
+            this.defaultSortConfig
+        )
+    }
+
+    @computed private get table(): OwidTable {
+        return this.manager.tableForSelection
+    }
+
+    @computed private get sortColumns(): CoreColumn[] {
+        const activeSlugs = this.manager.activeColumnSlugs ?? []
+
+        const sortColumns = activeSlugs
+            .map((slug) => this.table.get(slug))
+            .filter(
+                (column) => column.hasNumberFormatting && !column.isProjection
+            )
+
+        return [this.table.entityNameColumn, ...sortColumns]
+    }
+
+    @computed private get sortColumnsBySlug(): Record<ColumnSlug, CoreColumn> {
+        return keyBy(this.sortColumns, (column: CoreColumn) => column.slug)
+    }
+
+    @computed get sortOptions(): DropdownOption[] {
+        const options: DropdownOption[] = []
+
+        const getDropdownLabel = (column: CoreColumn): string => {
+            if (column.slug === this.table.entityNameSlug) return "Name"
+            return column.titlePublicOrDisplayName.title
+        }
+
+        options.push(
+            ...this.sortColumns.map((column) => {
+                return {
+                    value: column.slug,
+                    label: getDropdownLabel(column),
+                }
+            })
+        )
+
+        return options
+    }
+
+    @computed get sortValue(): DropdownOption | null {
+        return (
+            this.sortOptions.find(
+                (option) => option.value === this.sortConfig.slug
+            ) ?? null
+        )
+    }
+
+    @computed private get isSortedByName(): boolean {
+        return this.sortConfig.slug === this.table.entityNameSlug
     }
 
     @computed private get entityType(): string {
@@ -112,12 +244,63 @@ export class EntitySelector extends React.Component<{
         return makeSelectionArray(this.manager.selection)
     }
 
-    @computed get sortedAvailableEntities(): string[] {
-        return sortBy(this.selectionArray.availableEntityNames)
+    @computed private get availableEntityNames(): string[] {
+        return this.table.availableEntityNames
     }
 
-    @computed private get searchableEntities(): SearchableEntity[] {
-        return this.sortedAvailableEntities.map((name) => ({ name }))
+    @computed private get availableEntities(): SearchableEntity[] {
+        return this.availableEntityNames.map((entityName) => {
+            const searchableEntity: SearchableEntity = { name: entityName }
+
+            for (const column of this.sortColumns) {
+                const rows = column.owidRowsByEntityName.get(entityName) ?? []
+                searchableEntity[column.slug] = maxBy(
+                    rows,
+                    (row) => row.time
+                )?.value
+            }
+
+            return searchableEntity
+        })
+    }
+
+    private sortEntities(entities: SearchableEntity[]): SearchableEntity[] {
+        const { sortConfig } = this
+
+        const shouldBeSortedByName =
+            sortConfig.slug === this.table.entityNameSlug
+
+        // sort by name
+        if (shouldBeSortedByName) {
+            return orderBy(
+                entities,
+                (entity: SearchableEntity) => entity.name,
+                sortConfig.order
+            )
+        }
+
+        // sort by number column, with missing values at the end
+        const [withValues, withoutValues] = partition(
+            entities,
+            (entity: SearchableEntity) =>
+                isFiniteWithGuard(entity[sortConfig.slug])
+        )
+        const sortedEntitiesWithValues = orderBy(
+            withValues,
+            (entity: SearchableEntity) => entity[sortConfig.slug],
+            sortConfig.order
+        )
+        const sortedEntitiesWithoutValues = orderBy(
+            withoutValues,
+            (entity: SearchableEntity) => entity.name,
+            SortOrder.asc
+        )
+
+        return [...sortedEntitiesWithValues, ...sortedEntitiesWithoutValues]
+    }
+
+    @computed private get sortedAvailableEntities(): SearchableEntity[] {
+        return this.sortEntities(this.availableEntities)
     }
 
     @computed get isMultiMode(): boolean {
@@ -125,13 +308,12 @@ export class EntitySelector extends React.Component<{
     }
 
     @computed get fuzzy(): FuzzySearch<SearchableEntity> {
-        return new FuzzySearch(this.searchableEntities, "name")
+        return new FuzzySearch(this.sortedAvailableEntities, "name")
     }
 
     @computed get searchResults(): SearchableEntity[] | undefined {
-        return this.searchInput
-            ? this.fuzzy.search(this.searchInput)
-            : undefined
+        if (!this.searchInput) return undefined
+        return this.fuzzy.search(this.searchInput)
     }
 
     @computed get partitionedSearchResults(): PartitionedEntities | undefined {
@@ -140,8 +322,8 @@ export class EntitySelector extends React.Component<{
         if (!searchResults) return undefined
 
         const [selected, unselected] = partition(
-            searchResults.map((entity) => entity.name),
-            (name) => this.isEntitySelected(name)
+            searchResults,
+            (entity: SearchableEntity) => this.isEntitySelected(entity)
         )
 
         return { selected, unselected }
@@ -150,10 +332,13 @@ export class EntitySelector extends React.Component<{
     @computed get partitionedAvailableEntities(): PartitionedEntities {
         const [selected, unselected] = partition(
             this.sortedAvailableEntities,
-            (name) => this.isEntitySelected(name)
+            (entity: SearchableEntity) => this.isEntitySelected(entity)
         )
 
-        return { selected, unselected }
+        return {
+            selected: this.sortEntities(selected),
+            unselected: this.sortEntities(unselected),
+        }
     }
 
     @computed get partitionedVisibleEntities(): PartitionedEntities {
@@ -184,12 +369,26 @@ export class EntitySelector extends React.Component<{
     }
 
     @action.bound onClear(): void {
-        const { partitionedSearchResults: searchResults } = this
+        const { partitionedSearchResults } = this
         if (this.searchInput) {
-            this.selectionArray.deselectEntities(searchResults?.selected ?? [])
+            const { selected = [] } = partitionedSearchResults ?? {}
+            this.selectionArray.deselectEntities(
+                selected.map((entity) => entity.name)
+            )
         } else {
             this.selectionArray.clearSelection()
         }
+    }
+
+    @action.bound onChangeSortSlug(selected: unknown): void {
+        if (selected) {
+            const selectedOption = selected as DropdownOption
+            this.updateSortSlug(selectedOption.value)
+        }
+    }
+
+    @action.bound onChangeSortOrder(): void {
+        this.toggleSortOrder()
     }
 
     private renderSearchBar(): JSX.Element {
@@ -230,6 +429,29 @@ export class EntitySelector extends React.Component<{
         )
     }
 
+    private renderSortBar(): JSX.Element {
+        return (
+            <div className="entity-selector__sort-bar">
+                <span className="label grapher_label-2-medium">Sort by</span>
+                <Dropdown
+                    options={this.sortOptions}
+                    onChange={this.onChangeSortSlug}
+                    value={this.sortValue}
+                />
+                <button
+                    type="button"
+                    className="sort"
+                    onClick={this.onChangeSortOrder}
+                >
+                    <SortIcon
+                        type={this.isSortedByName ? "text" : "numeric"}
+                        order={this.sortConfig.order}
+                    />
+                </button>
+            </div>
+        )
+    }
+
     private renderSearchResults(): JSX.Element {
         if (!this.searchResults || this.searchResults.length === 0) {
             return (
@@ -243,13 +465,14 @@ export class EntitySelector extends React.Component<{
 
         return (
             <ul className="entity-search-results">
-                {this.searchResults.map(({ name }) => (
-                    <li key={name}>
+                {this.searchResults.map((entity) => (
+                    <li key={entity.name}>
                         <SelectableEntity
-                            name={name}
+                            name={entity.name}
                             type={this.isMultiMode ? "checkbox" : "radio"}
-                            checked={this.isEntitySelected(name)}
-                            onChange={() => this.onChange(name)}
+                            checked={this.isEntitySelected(entity)}
+                            bar={this.getBarConfigForEntity(entity)}
+                            onChange={() => this.onChange(entity.name)}
                         />
                     </li>
                 ))}
@@ -260,13 +483,14 @@ export class EntitySelector extends React.Component<{
     private renderAllEntitiesInSingleMode(): JSX.Element {
         return (
             <ul>
-                {this.sortedAvailableEntities.map((name) => (
-                    <li key={name}>
+                {this.sortedAvailableEntities.map((entity) => (
+                    <li key={entity.name}>
                         <SelectableEntity
-                            name={name}
+                            name={entity.name}
                             type="radio"
-                            checked={this.isEntitySelected(name)}
-                            onChange={() => this.onChange(name)}
+                            checked={this.isEntitySelected(entity)}
+                            bar={this.getBarConfigForEntity(entity)}
+                            onChange={() => this.onChange(entity.name)}
                         />
                     </li>
                 ))}
@@ -274,8 +498,37 @@ export class EntitySelector extends React.Component<{
         )
     }
 
-    private isEntitySelected(name: string): boolean {
-        return this.selectionArray.selectedSet.has(name)
+    @computed private get displayColumn(): CoreColumn | undefined {
+        const { sortConfig } = this
+        if (this.isSortedByName) return undefined
+        return this.sortColumnsBySlug[sortConfig.slug]
+    }
+
+    @computed private get barScale(): ScaleLinear<number, number> {
+        return scaleLinear()
+            .domain([0, this.displayColumn?.maxValue ?? 1])
+            .range([0, 1])
+    }
+
+    private getBarConfigForEntity(
+        entity: SearchableEntity
+    ): BarConfig | undefined {
+        const { displayColumn, barScale } = this
+
+        if (!displayColumn) return undefined
+
+        const value = entity[displayColumn.slug]
+
+        if (!isFiniteWithGuard(value)) return { formattedValue: "No data" }
+
+        return {
+            formattedValue: displayColumn.formatValueShort(value),
+            width: clamp(barScale(value), 0, 1),
+        }
+    }
+
+    private isEntitySelected(entity: SearchableEntity): boolean {
+        return this.selectionArray.selectedSet.has(entity.name)
     }
 
     private renderAllEntitiesInMultiMode(): JSX.Element {
@@ -289,62 +542,84 @@ export class EntitySelector extends React.Component<{
                 }}
                 flipKey={this.selectionArray.selectedEntityNames.join(",")}
             >
-                {selected.length > 0 && (
-                    <Flipped flipId="__selection" translate opacity>
-                        <div className="section-title grapher_body-3-medium-italic">
-                            Selection
-                        </div>
-                    </Flipped>
-                )}
-                <ul>
-                    {selected.map((name) => (
-                        <Flipped key={name} flipId={name} translate opacity>
-                            <li
-                                className={cx("animated-entity", {
-                                    "most-recently-selected":
-                                        this.mostRecentlySelectedEntityName ===
-                                        name,
-                                })}
-                            >
-                                <SelectableEntity
-                                    name={name}
-                                    type="checkbox"
-                                    checked={true}
-                                    onChange={() => this.onChange(name)}
-                                />
-                            </li>
+                <div className="entity-section">
+                    {selected.length > 0 && (
+                        <Flipped flipId="__selection" translate opacity>
+                            <div className="entity-section__title grapher_body-3-medium-italic">
+                                Selection
+                            </div>
                         </Flipped>
-                    ))}
-                </ul>
-
-                {selected.length > 0 && unselected.length > 0 && (
-                    <Flipped flipId="__available" translate opacity>
-                        <div className="section-title grapher_body-3-medium-italic grapher_light">
-                            {capitalize(this.entityTypePlural)}
-                        </div>
-                    </Flipped>
-                )}
-
-                <ul>
-                    {unselected.map((name) => (
-                        <Flipped key={name} flipId={name} translate opacity>
-                            <li
-                                className={cx("animated-entity", {
-                                    "most-recently-selected":
-                                        this.mostRecentlySelectedEntityName ===
-                                        name,
-                                })}
+                    )}
+                    <ul>
+                        {selected.map((entity) => (
+                            <Flipped
+                                key={entity.name}
+                                flipId={entity.name}
+                                translate
+                                opacity
                             >
-                                <SelectableEntity
-                                    name={name}
-                                    type="checkbox"
-                                    checked={false}
-                                    onChange={() => this.onChange(name)}
-                                />
-                            </li>
+                                <li
+                                    className={cx("animated-entity", {
+                                        "most-recently-selected":
+                                            this
+                                                .mostRecentlySelectedEntityName ===
+                                            entity.name,
+                                    })}
+                                >
+                                    <SelectableEntity
+                                        name={entity.name}
+                                        type="checkbox"
+                                        checked={true}
+                                        bar={this.getBarConfigForEntity(entity)}
+                                        onChange={() =>
+                                            this.onChange(entity.name)
+                                        }
+                                    />
+                                </li>
+                            </Flipped>
+                        ))}
+                    </ul>
+                </div>
+
+                <div className="entity-section">
+                    {selected.length > 0 && unselected.length > 0 && (
+                        <Flipped flipId="__available" translate opacity>
+                            <div className="entity-section__title grapher_body-3-medium-italic grapher_light">
+                                {capitalize(this.entityTypePlural)}
+                            </div>
                         </Flipped>
-                    ))}
-                </ul>
+                    )}
+
+                    <ul>
+                        {unselected.map((entity) => (
+                            <Flipped
+                                key={entity.name}
+                                flipId={entity.name}
+                                translate
+                                opacity
+                            >
+                                <li
+                                    className={cx("animated-entity", {
+                                        "most-recently-selected":
+                                            this
+                                                .mostRecentlySelectedEntityName ===
+                                            entity.name,
+                                    })}
+                                >
+                                    <SelectableEntity
+                                        name={entity.name}
+                                        type="checkbox"
+                                        checked={false}
+                                        bar={this.getBarConfigForEntity(entity)}
+                                        onChange={() =>
+                                            this.onChange(entity.name)
+                                        }
+                                    />
+                                </li>
+                            </Flipped>
+                        ))}
+                    </ul>
+                </div>
             </Flipper>
         )
     }
@@ -391,6 +666,10 @@ export class EntitySelector extends React.Component<{
             >
                 {this.renderSearchBar()}
 
+                {!this.searchInput &&
+                    this.sortOptions.length > 1 &&
+                    this.renderSortBar()}
+
                 <div className="entity-selector__content">
                     {this.searchInput
                         ? this.renderSearchResults()
@@ -405,15 +684,19 @@ export class EntitySelector extends React.Component<{
     }
 }
 
+type BarConfig = { formattedValue: string; width?: number }
+
 function SelectableEntity({
     name,
     checked,
     type,
+    bar,
     onChange,
 }: {
     name: React.ReactNode
     checked: boolean
     type: "checkbox" | "radio"
+    bar?: BarConfig
     onChange: () => void
 }) {
     const Input = {
@@ -431,7 +714,15 @@ function SelectableEntity({
                 onChange()
             }}
         >
+            {bar && bar.width !== undefined && (
+                <div className="bar" style={{ width: `${bar.width * 100}%` }} />
+            )}
             <Input label={name} checked={checked} onChange={onChange} />
+            {bar && (
+                <span className="value grapher_label-1-medium">
+                    {bar.formattedValue}
+                </span>
+            )}
         </div>
     )
 }

--- a/packages/@ourworldindata/grapher/src/modal/ModalHeader.scss
+++ b/packages/@ourworldindata/grapher/src/modal/ModalHeader.scss
@@ -1,0 +1,12 @@
+.modal-header {
+    --padding: var(--modal-padding, 16px);
+
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--padding) var(--padding) 16px;
+
+    button {
+        margin-left: 8px;
+    }
+}

--- a/packages/@ourworldindata/grapher/src/modal/ModalHeader.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/ModalHeader.tsx
@@ -1,0 +1,17 @@
+import React from "react"
+import { CloseButton } from "../closeButton/CloseButton.js"
+
+export function ModalHeader({
+    title,
+    onDismiss,
+}: {
+    title: string
+    onDismiss?: () => void
+}) {
+    return (
+        <div className="modal-header">
+            <h2 className="grapher_h5-black-caps grapher_light">{title}</h2>
+            {onDismiss && <CloseButton onClick={onDismiss} />}
+        </div>
+    )
+}

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1847,6 +1847,7 @@ export function checkIsAuthor(x: unknown): x is OwidGdocAuthorInterface {
     const type = get(x, "content.type")
     return type === OwidGdocType.Author
 }
+
 /**
  * Returns the cartesian product of the given arrays.
  *
@@ -1880,4 +1881,8 @@ export function isElementHidden(element: Element | null): boolean {
 
 export function roundDownToNearestHundred(value: number): number {
     return Math.floor(value / 100) * 100
+}
+
+export function isFiniteWithGuard(value: unknown): value is number {
+    return isFinite(value as any)
 }

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -123,6 +123,7 @@ export {
     removeTrailingParenthetical,
     isElementHidden,
     roundDownToNearestHundred,
+    isFiniteWithGuard,
 } from "./Util.js"
 
 export {


### PR DESCRIPTION
[Cycle 2024.2: Entity selector](https://github.com/owid/owid-grapher/issues/3349) | [Designs](https://www.figma.com/file/X5mOEX8zULS6qyHocUYdmh/Grapher-UI?type=design&node-id=2523%3A6266&mode=design&t=7edFp79OOjz6RENz-1)

## Summary

Adds a dropdown menu to sort by name or indicator, as well as a button to toggle the sort order. Draws a simple bar chart when sorted by an indicator.

## Details

- Indicators considered for sorting are all indicators of the chart that can be formatted numerically (includes `NumberOrStringColumn`) and that are not projections
- Names are sorted asc by default, while numerical values are sorted desc by default
- If sorted by an indicator, then values without data are listed at the end (and are marked with a "No data" label)

## Caveats

- The (display) name of a column that is used as dropdown option is not always nice :( (but we surface it in other places already..)
- We can't draw a bar chart for negative values. For now, we opted to simply not draw anything in that case

## SVG tester

The SVG tester fails due to the changes in #3373 

## Data

- [x] Go through the top 50 charts and make sure all columns have appropriate display names