### PR TITLE
Switch to `docker compose` invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ up: require create-if-missing.env ../owid-content tmp-downloads/owid_metadata.sq
 	@echo '==> Starting dev environment'
 	@mkdir -p logs
 	tmux new-session -s grapher \
-		-n docker 'docker-compose -f docker-compose.grapher.yml up' \; \
+		-n docker 'docker compose -f docker-compose.grapher.yml up' \; \
 			set remain-on-exit on \; \
 		set-option -g default-shell $(SCRIPT_SHELL) \; \
 		new-window -n admin \
@@ -114,7 +114,7 @@ up.full: require create-if-missing.env.full ../owid-content wordpress/.env tmp-d
 
 	@echo '==> Starting dev environment'
 	tmux new-session -s grapher \
-		-n docker 'docker-compose -f docker-compose.full.yml up' \; \
+		-n docker 'docker compose -f docker-compose.full.yml up' \; \
 			set remain-on-exit on \; \
 		set-option -g default-shell $(SCRIPT_SHELL) \; \
 		new-window -n admin \
@@ -178,15 +178,15 @@ sync-images.preflight-check:
 
 down:
 	@echo '==> Stopping services'
-	docker-compose -f docker-compose.grapher.yml down
+	docker compose -f docker-compose.grapher.yml down
 
 down.full:
 	@echo '==> Stopping services'
-	docker-compose -f docker-compose.full.yml down
+	docker compose -f docker-compose.full.yml down
 
 require:
 	@echo '==> Checking your local environment has the necessary commands...'
-	@which docker-compose >/dev/null 2>&1 || (echo "ERROR: docker-compose is required."; exit 1)
+	@which docker >/dev/null 2>&1 || (echo "ERROR: docker compose is required."; exit 1)
 	@which yarn >/dev/null 2>&1 || (echo "ERROR: yarn is required."; exit 1)
 	@which tmux >/dev/null 2>&1 || (echo "ERROR: tmux is required."; exit 1)
 	@which finger >/dev/null 2>&1 || (echo "ERROR: finger is required."; exit 1)

--- a/db/tests/run-db-tests.sh
+++ b/db/tests/run-db-tests.sh
@@ -13,7 +13,7 @@ set -o nounset
 
 echo '==> Starting & initializing Mysql instance for testing'
 
-docker-compose -f docker-compose.dbtests.yml up -d
+docker compose -f docker-compose.dbtests.yml up -d
 
 ./devTools/docker/wait-for-tests-mysql.sh
 
@@ -26,11 +26,11 @@ if ! yarn run jest --config=jest.db.config.js --runInBand # runInBand runs multi
 then
     echo '💀 Tests failed'
     ./devTools/docker/mark-test-mysql-dirty.sh
-    docker-compose -f docker-compose.dbtests.yml stop
+    docker compose -f docker-compose.dbtests.yml stop
     exit 23
 else
     echo '✅ DB tests succeeded'
     ./devTools/docker/mark-test-mysql-dirty.sh
-    docker-compose -f docker-compose.dbtests.yml stop
+    docker compose -f docker-compose.dbtests.yml stop
     exit 0
 fi

--- a/docs/devcontainer-setup.md
+++ b/docs/devcontainer-setup.md
@@ -90,7 +90,7 @@ An important note first: when using the VS Code Devcontainers extension, there i
 To check the status, make sure you run the following commands in a terminal **outside** your devcontainer, in the working directory root of this repository:
 
 ```bash
-docker-compose -f docker-compose.devcontainer.yml logs -f
+docker compose -f docker-compose.devcontainer.yml logs -f
 ```
 
 This will follow all log entries (i.e. it will print log statements while they happen) of all three containers: the app-1 container (your devcontainer with node, yarn etc), the db-1 container (MySQL), and the db-load-data container (that loads the data and then stops). On the first run of the devcontainer setup, this last container will download two gz files into the tmp-downloads folder and then ingest them into the MySQL database. This whole process can take between 5 and 20 minutes. When it is done you should see this message:


### PR DESCRIPTION
We used to still use the old `docker-compose` in a few places and it seems that this was deprecated now on the GA runner image. This PR switches to the modern `docker compose` invocation everywhere.