### PR TITLE
Fix data pages embedding all image metadata

### DIFF
--- a/adminSiteClient/gdocsValidation.ts
+++ b/adminSiteClient/gdocsValidation.ts
@@ -5,7 +5,7 @@ import {
     OwidGdocErrorMessageType,
     OwidGdocType,
     checkIsOwidGdocType,
-    traverseEnrichedBlocks,
+    traverseEnrichedBlock,
     OwidGdocErrorMessageProperty,
     OwidGdoc,
     checkIsGdocPost,
@@ -58,7 +58,7 @@ function validateBody(gdoc: OwidGdoc, errors: OwidGdocErrorMessage[]) {
         errors.push(getMissingContentPropertyError("body"))
     } else {
         for (const block of gdoc.content.body) {
-            traverseEnrichedBlocks(block, (block) => {
+            traverseEnrichedBlock(block, (block) => {
                 errors.push(
                     ...block.parseErrors.map((parseError) => ({
                         message: parseError.message,
@@ -86,7 +86,7 @@ function validateRefs(
         if (gdoc.content.refs.definitions) {
             Object.values(gdoc.content.refs.definitions).map((definition) => {
                 definition.content.map((block) => {
-                    traverseEnrichedBlocks(block, (node) => {
+                    traverseEnrichedBlock(block, (node) => {
                         if (node.parseErrors.length) {
                             for (const parseError of node.parseErrors) {
                                 errors.push({

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -180,19 +180,6 @@ export async function renderDataPageV2(
         gdocIdToFragmentIdToBlock[gdoc.id] = faqs.faqs
     })
 
-    const linkedCharts: OwidGdocPostInterface["linkedCharts"] = merge(
-        {},
-        ...compact(gdocs.map((gdoc) => gdoc?.linkedCharts))
-    )
-    const linkedDocuments: Record<string, OwidGdocMinimalPostInterface> = merge(
-        {},
-        ...compact(gdocs.map((gdoc) => gdoc?.linkedDocuments))
-    )
-
-    const relatedCharts: OwidGdocPostInterface["relatedCharts"] = gdocs.flatMap(
-        (gdoc) => gdoc?.relatedCharts ?? []
-    )
-
     const resolvedFaqsResults: EnrichedFaqLookupResult[] = variableMetadata
         .presentation?.faqs
         ? variableMetadata.presentation.faqs.map((faq) => {
@@ -227,9 +214,6 @@ export async function renderDataPageV2(
     }
 
     const faqEntries: FaqEntryData = {
-        linkedCharts,
-        linkedDocuments,
-        relatedCharts,
         faqs: resolvedFaqs?.flatMap((faq) => faq.enrichedFaq.content) ?? [],
     }
 

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -176,11 +176,13 @@ export async function renderDataPageV2(
         {},
         ...compact(gdocs.map((gdoc) => gdoc?.linkedDocuments))
     )
+    // TODO: this is the place to select the right images, but only once the DB knex refactor has been merged
     const imageMetadata: OwidGdocPostInterface["imageMetadata"] = merge(
         {},
         imageMetadataDictionary,
         ...compact(gdocs.map((gdoc) => gdoc?.imageMetadata))
     )
+
     const relatedCharts: OwidGdocPostInterface["relatedCharts"] = gdocs.flatMap(
         (gdoc) => gdoc?.relatedCharts ?? []
     )

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -11,9 +11,7 @@ import {
     keyBy,
     mergePartialGrapherConfigs,
     compact,
-    merge,
     partition,
-    traverseEnrichedBlock,
 } from "@ourworldindata/utils"
 import fs from "fs-extra"
 import * as lodash from "lodash"
@@ -39,13 +37,11 @@ import {
     DimensionProperty,
     OwidVariableWithSource,
     OwidChartDimensionInterface,
-    OwidGdocPostInterface,
     EnrichedFaq,
     FaqEntryData,
     FaqDictionary,
     ImageMetadata,
     OwidGdocBaseInterface,
-    OwidGdocMinimalPostInterface,
 } from "@ourworldindata/types"
 import ProgressBar from "progress"
 import {
@@ -64,7 +60,6 @@ import { knexRaw } from "../db/db.js"
 import { getRelatedChartsForVariable } from "../db/model/Chart.js"
 import pMap from "p-map"
 import { getGdocBaseObjectBySlug } from "../db/model/Gdoc/GdocFactory.js"
-import { extractFilenamesFromBlock } from "../db/model/Gdoc/gdocUtils.js"
 
 const renderDatapageIfApplicable = async (
     grapher: GrapherInterface,
@@ -295,16 +290,9 @@ export async function renderDataPageV2(
         .map((r) => r.imageUrl)
         .filter((f): f is string => !!f)
 
-    const faqEntryFilenames: string[] = []
-    faqEntries.faqs.forEach((f) => {
-        traverseEnrichedBlock(f, (block) => {
-            faqEntryFilenames.push(...extractFilenamesFromBlock(block))
-        })
-    })
-
     const imageMetadata = lodash.pick(
         imageMetadataDictionary,
-        uniq([...relatedResearchFilenames, ...faqEntryFilenames])
+        uniq(relatedResearchFilenames)
     )
 
     const tagToSlugMap = await getTagToSlugMap(knex)

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -488,7 +488,6 @@ export const bakeAllChangedGrapherPagesVariablesPngSvgAndDeleteRemovedGraphers =
                 SELECT
                     id, config, config->>'$.slug' as slug
                 FROM charts WHERE JSON_EXTRACT(config, "$.isPublished")=true
-                AND slug = 'living-planet-index-by-region'
                 ORDER BY JSON_EXTRACT(config, "$.slug") ASC
                 `
             )

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -13,7 +13,7 @@ import {
     compact,
     merge,
     partition,
-    traverseEnrichedBlocks,
+    traverseEnrichedBlock,
 } from "@ourworldindata/utils"
 import fs from "fs-extra"
 import * as lodash from "lodash"
@@ -313,7 +313,7 @@ export async function renderDataPageV2(
 
     const faqEntryFilenames: string[] = []
     faqEntries.faqs.forEach((f) => {
-        traverseEnrichedBlocks(f, (block) => {
+        traverseEnrichedBlock(f, (block) => {
             faqEntryFilenames.push(...extractFilenamesFromBlock(block))
         })
     })

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -12,7 +12,6 @@ import {
     traverseEnrichedBlocks,
     OwidEnrichedGdocBlock,
     Span,
-    EnrichedBlockResearchAndWritingLink,
     traverseEnrichedSpan,
     uniq,
     identity,
@@ -42,6 +41,7 @@ import {
 import { EXPLORERS_ROUTE_FOLDER } from "../../../explorer/ExplorerConstants.js"
 import { match, P } from "ts-pattern"
 import {
+    extractFilenamesFromBlock,
     extractUrl,
     getAllLinksFromResearchAndWritingBlock,
     spansToSimpleString,
@@ -137,45 +137,7 @@ export class GdocBase implements OwidGdocBaseInterface {
 
         for (const enrichedBlockSource of this.enrichedBlockSources) {
             enrichedBlockSource.forEach((block) =>
-                traverseEnrichedBlocks(block, (item) => {
-                    if ("type" in item) {
-                        if ("filename" in item && item.filename) {
-                            filenames.add(item.filename)
-                        }
-                        if (item.type === "image" && item.smallFilename) {
-                            filenames.add(item.smallFilename)
-                        }
-                        if (item.type === "prominent-link" && item.thumbnail) {
-                            filenames.add(item.thumbnail)
-                        }
-                        if (item.type === "research-and-writing") {
-                            const allLinks =
-                                getAllLinksFromResearchAndWritingBlock(item)
-                            allLinks.forEach(
-                                (link: EnrichedBlockResearchAndWritingLink) => {
-                                    if (link.value.filename) {
-                                        filenames.add(link.value.filename)
-                                    }
-                                }
-                            )
-                        }
-                        if (item.type === "key-insights") {
-                            item.insights.forEach((insight) => {
-                                if (insight.filename) {
-                                    filenames.add(insight.filename)
-                                }
-                            })
-                        }
-                        if (item.type === "homepage-intro") {
-                            item.featuredWork.forEach((featuredWork) => {
-                                if (featuredWork.filename) {
-                                    filenames.add(featuredWork.filename)
-                                }
-                            })
-                        }
-                    }
-                    return item
-                })
+                traverseEnrichedBlocks(block, extractFilenamesFromBlock)
             )
         }
 

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -9,7 +9,7 @@ import {
     OwidGdocErrorMessage,
     OwidGdocErrorMessageType,
     excludeNullish,
-    traverseEnrichedBlocks,
+    traverseEnrichedBlock,
     OwidEnrichedGdocBlock,
     Span,
     traverseEnrichedSpan,
@@ -137,7 +137,7 @@ export class GdocBase implements OwidGdocBaseInterface {
 
         for (const enrichedBlockSource of this.enrichedBlockSources) {
             enrichedBlockSource.forEach((block) =>
-                traverseEnrichedBlocks(block, extractFilenamesFromBlock)
+                traverseEnrichedBlock(block, extractFilenamesFromBlock)
             )
         }
 
@@ -149,7 +149,7 @@ export class GdocBase implements OwidGdocBaseInterface {
 
         for (const enrichedBlockSource of this.enrichedBlockSources) {
             enrichedBlockSource.forEach((block) =>
-                traverseEnrichedBlocks(
+                traverseEnrichedBlock(
                     block,
                     (x) => x,
                     (span) => {
@@ -182,7 +182,7 @@ export class GdocBase implements OwidGdocBaseInterface {
 
         for (const enrichedBlockSource of this.enrichedBlockSources) {
             enrichedBlockSource.forEach((block) =>
-                traverseEnrichedBlocks(
+                traverseEnrichedBlock(
                     block,
                     (block) => {
                         const extractedLinks = this.extractLinksFromBlock(block)
@@ -223,7 +223,7 @@ export class GdocBase implements OwidGdocBaseInterface {
         const slugs = new Set<string>()
         for (const enrichedBlockSource of this.enrichedBlockSources) {
             for (const block of enrichedBlockSource) {
-                traverseEnrichedBlocks(block, (block) => {
+                traverseEnrichedBlock(block, (block) => {
                     if (block.type === "key-indicator") {
                         slugs.add(urlToSlug(block.datapageUrl))
                     }
@@ -257,7 +257,7 @@ export class GdocBase implements OwidGdocBaseInterface {
         for (const enrichedBlockSource of this.enrichedBlockSources) {
             for (const block of enrichedBlockSource) {
                 if (hasAllChartsBlock) break
-                traverseEnrichedBlocks(block, (block) => {
+                traverseEnrichedBlock(block, (block) => {
                     if (block.type === "all-charts") {
                         hasAllChartsBlock = true
                     }
@@ -400,7 +400,7 @@ export class GdocBase implements OwidGdocBaseInterface {
             .with({ type: "key-insights" }, (block) => {
                 const links: DbInsertPostGdocLink[] = []
 
-                // insights content is traversed by traverseEnrichedBlocks
+                // insights content is traversed by traverseEnrichedBlock
                 block.insights.forEach((insight) => {
                     if (insight.url) {
                         const insightLink = createLinkFromUrl({
@@ -497,7 +497,7 @@ export class GdocBase implements OwidGdocBaseInterface {
             .with(
                 {
                     // no urls directly on any of these blocks
-                    // their children may contain urls, but they'll be addressed by traverseEnrichedBlocks
+                    // their children may contain urls, but they'll be addressed by traverseEnrichedBlock
                     type: P.union(
                         "additional-charts",
                         "align",
@@ -755,7 +755,7 @@ export class GdocBase implements OwidGdocBaseInterface {
         const contentErrors: OwidGdocErrorMessage[] = []
         for (const enrichedBlockSource of this.enrichedBlockSources) {
             enrichedBlockSource.forEach((block) =>
-                traverseEnrichedBlocks(block, (block) => {
+                traverseEnrichedBlock(block, (block) => {
                     if (block.type === "key-indicator" && block.datapageUrl) {
                         const slug = urlToSlug(block.datapageUrl)
                         const linkedChart = this.linkedCharts?.[slug]

--- a/db/model/Gdoc/archieToEnriched.ts
+++ b/db/model/Gdoc/archieToEnriched.ts
@@ -12,7 +12,7 @@ import {
     EnrichedBlockSimpleText,
     lowercaseObjectKeys,
     OwidEnrichedGdocBlock,
-    traverseEnrichedBlocks,
+    traverseEnrichedBlock,
     ALL_CHARTS_ID,
     KEY_INSIGHTS_ID,
     ENDNOTES_ID,
@@ -137,7 +137,7 @@ export function generateToc(
     const toc: TocHeadingWithTitleSupertitle[] = []
 
     body.forEach((block) =>
-        traverseEnrichedBlocks(block, (child) => {
+        traverseEnrichedBlock(block, (child) => {
             if (child.type === "heading") {
                 const { level, text, supertitle } = child
                 const titleString = spansToSimpleString(text)

--- a/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
@@ -7,7 +7,6 @@ import {
 } from "../OwidVariable.js"
 import { RelatedChart } from "../grapherTypes/GrapherTypes.js"
 import { Static, Type } from "@sinclair/typebox"
-import { OwidGdocPostInterface } from "./Gdoc.js"
 import { OwidEnrichedGdocBlock } from "./ArchieMlComponents.js"
 import { ImageMetadata } from "./Image.js"
 

--- a/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
@@ -9,6 +9,7 @@ import { RelatedChart } from "../grapherTypes/GrapherTypes.js"
 import { Static, Type } from "@sinclair/typebox"
 import { OwidGdocPostInterface } from "./Gdoc.js"
 import { OwidEnrichedGdocBlock } from "./ArchieMlComponents.js"
+import { ImageMetadata } from "./Image.js"
 
 export interface FaqLink {
     gdocId: string
@@ -146,11 +147,7 @@ export type DataPageParseError = { message: string; path?: string }
 
 export type FaqEntryData = Pick<
     OwidGdocPostInterface,
-    | "linkedCharts"
-    | "linkedIndicators"
-    | "linkedDocuments"
-    | "relatedCharts"
-    | "imageMetadata"
+    "linkedCharts" | "linkedIndicators" | "linkedDocuments" | "relatedCharts"
 > & {
     faqs: OwidEnrichedGdocBlock[]
 }
@@ -162,6 +159,7 @@ export interface DataPageV2ContentFields {
     isPreviewing?: boolean
     canonicalUrl: string
     tagToSlugMap: Record<string, string>
+    imageMetadata: Record<string, ImageMetadata>
 }
 export interface DisplaySource {
     label: string

--- a/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
@@ -145,10 +145,8 @@ export type DataPageJson = Static<typeof DataPageJsonTypeObject>
 
 export type DataPageParseError = { message: string; path?: string }
 
-export type FaqEntryData = Pick<
-    OwidGdocPostInterface,
-    "linkedCharts" | "linkedIndicators" | "linkedDocuments" | "relatedCharts"
-> & {
+// TODO: https://github.com/owid/owid-grapher/issues/3426
+export type FaqEntryData = {
     faqs: OwidEnrichedGdocBlock[]
 }
 

--- a/packages/@ourworldindata/utils/src/Util.test.ts
+++ b/packages/@ourworldindata/utils/src/Util.test.ts
@@ -27,7 +27,7 @@ import {
     slugifySameCase,
     greatestCommonDivisor,
     findGreatestCommonDivisorOfArray,
-    traverseEnrichedBlocks,
+    traverseEnrichedBlock,
     cartesian,
 } from "./Util.js"
 import {
@@ -569,7 +569,7 @@ describe(findGreatestCommonDivisorOfArray, () => {
     })
 })
 
-describe(traverseEnrichedBlocks, () => {
+describe(traverseEnrichedBlock, () => {
     const enrichedBlocks: OwidEnrichedGdocBlock[] = [
         {
             type: "prominent-link",
@@ -689,7 +689,7 @@ describe(traverseEnrichedBlocks, () => {
         const seen: string[] = []
 
         enrichedBlocks.forEach((block) => {
-            traverseEnrichedBlocks(block, (block) => {
+            traverseEnrichedBlock(block, (block) => {
                 seen.push(block.type)
             })
         })
@@ -712,7 +712,7 @@ describe(traverseEnrichedBlocks, () => {
         const seen: string[] = []
 
         enrichedBlocks.forEach((block) => {
-            traverseEnrichedBlocks(
+            traverseEnrichedBlock(
                 block,
                 (block) => {
                     seen.push(block.type)

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1506,7 +1506,7 @@ export function traverseEnrichedSpan(
 // If your node has children that are Spans, the spanCallback will apply to them
 // If your node has children that aren't OwidEnrichedGdocBlocks or Spans, e.g. EnrichedBlockScroller & EnrichedScrollerItem
 // you'll have to handle those children yourself in your callback
-export function traverseEnrichedBlocks(
+export function traverseEnrichedBlock(
     node: OwidEnrichedGdocBlock,
     callback: (x: OwidEnrichedGdocBlock) => void,
     spanCallback?: (x: Span) => void
@@ -1517,24 +1517,24 @@ export function traverseEnrichedBlocks(
             (container) => {
                 callback(container)
                 container.left.forEach((leftNode) =>
-                    traverseEnrichedBlocks(leftNode, callback, spanCallback)
+                    traverseEnrichedBlock(leftNode, callback, spanCallback)
                 )
                 container.right.forEach((rightNode) =>
-                    traverseEnrichedBlocks(rightNode, callback, spanCallback)
+                    traverseEnrichedBlock(rightNode, callback, spanCallback)
                 )
             }
         )
         .with({ type: "gray-section" }, (graySection) => {
             callback(graySection)
             graySection.items.forEach((node) =>
-                traverseEnrichedBlocks(node, callback, spanCallback)
+                traverseEnrichedBlock(node, callback, spanCallback)
             )
         })
         .with({ type: "key-insights" }, (keyInsights) => {
             callback(keyInsights)
             keyInsights.insights.forEach((insight) =>
                 insight.content.forEach((node) =>
-                    traverseEnrichedBlocks(node, callback, spanCallback)
+                    traverseEnrichedBlock(node, callback, spanCallback)
                 )
             )
         })
@@ -1542,7 +1542,7 @@ export function traverseEnrichedBlocks(
             callback(callout)
             if (spanCallback) {
                 callout.text.forEach((textBlock) =>
-                    traverseEnrichedBlocks(textBlock, callback, spanCallback)
+                    traverseEnrichedBlock(textBlock, callback, spanCallback)
                 )
             }
         })
@@ -1558,7 +1558,7 @@ export function traverseEnrichedBlocks(
             callback(list)
             if (spanCallback) {
                 list.items.forEach((textBlock) =>
-                    traverseEnrichedBlocks(textBlock, callback, spanCallback)
+                    traverseEnrichedBlock(textBlock, callback, spanCallback)
                 )
             }
         })
@@ -1566,7 +1566,7 @@ export function traverseEnrichedBlocks(
             callback(numberedList)
             if (spanCallback) {
                 numberedList.items.forEach((textBlock) =>
-                    traverseEnrichedBlocks(textBlock, callback, spanCallback)
+                    traverseEnrichedBlock(textBlock, callback, spanCallback)
                 )
             }
         })
@@ -1604,13 +1604,13 @@ export function traverseEnrichedBlocks(
         .with({ type: "expandable-paragraph" }, (expandableParagraph) => {
             callback(expandableParagraph)
             expandableParagraph.items.forEach((textBlock) => {
-                traverseEnrichedBlocks(textBlock, callback, spanCallback)
+                traverseEnrichedBlock(textBlock, callback, spanCallback)
             })
         })
         .with({ type: "align" }, (align) => {
             callback(align)
             align.content.forEach((node) => {
-                traverseEnrichedBlocks(node, callback, spanCallback)
+                traverseEnrichedBlock(node, callback, spanCallback)
             })
         })
         .with({ type: "table" }, (table) => {
@@ -1618,7 +1618,7 @@ export function traverseEnrichedBlocks(
             table.rows.forEach((row) => {
                 row.cells.forEach((cell) => {
                     cell.content.forEach((node) => {
-                        traverseEnrichedBlocks(node, callback, spanCallback)
+                        traverseEnrichedBlock(node, callback, spanCallback)
                     })
                 })
             })
@@ -1626,7 +1626,7 @@ export function traverseEnrichedBlocks(
         .with({ type: "blockquote" }, (blockquote) => {
             callback(blockquote)
             blockquote.text.forEach((node) => {
-                traverseEnrichedBlocks(node, callback, spanCallback)
+                traverseEnrichedBlock(node, callback, spanCallback)
             })
         })
         .with(
@@ -1636,7 +1636,7 @@ export function traverseEnrichedBlocks(
             (keyIndicator) => {
                 callback(keyIndicator)
                 keyIndicator.text.forEach((node) => {
-                    traverseEnrichedBlocks(node, callback, spanCallback)
+                    traverseEnrichedBlock(node, callback, spanCallback)
                 })
             }
         )
@@ -1645,7 +1645,7 @@ export function traverseEnrichedBlocks(
             (keyIndicatorCollection) => {
                 callback(keyIndicatorCollection)
                 keyIndicatorCollection.blocks.forEach((node) =>
-                    traverseEnrichedBlocks(node, callback, spanCallback)
+                    traverseEnrichedBlock(node, callback, spanCallback)
                 )
             }
         )

--- a/packages/@ourworldindata/utils/src/image.ts
+++ b/packages/@ourworldindata/utils/src/image.ts
@@ -2,7 +2,7 @@
 Common utlities for deriving properties from image metadata.
 */
 
-import { traverseEnrichedBlocks } from "./Util.js"
+import { traverseEnrichedBlock } from "./Util.js"
 import { OwidGdoc, OwidGdocType, ImageMetadata } from "@ourworldindata/types"
 import { match, P } from "ts-pattern"
 
@@ -123,7 +123,7 @@ export function getFeaturedImageFilename(gdoc: OwidGdoc): string | undefined {
             // Use the first image in the document as the featured image
             let filename: string | undefined = undefined
             for (const block of gdoc.content.body) {
-                traverseEnrichedBlocks(block, (block) => {
+                traverseEnrichedBlock(block, (block) => {
                     if (!filename && block.type === "image") {
                         filename = block.smallFilename || block.filename
                     }

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -100,7 +100,7 @@ export {
     isPositiveInfinity,
     imemo,
     recursivelyMapArticleContent,
-    traverseEnrichedBlocks,
+    traverseEnrichedBlock,
     checkNodeIsSpan,
     checkNodeIsSpanLink,
     spansToUnformattedPlainText,

--- a/site/DataPageV2.tsx
+++ b/site/DataPageV2.tsx
@@ -14,6 +14,7 @@ import {
     FaqEntryData,
     pick,
     GrapherInterface,
+    ImageMetadata,
 } from "@ourworldindata/utils"
 import { MarkdownTextWrap } from "@ourworldindata/components"
 import React from "react"
@@ -40,6 +41,7 @@ export const DataPageV2 = (props: {
     baseGrapherUrl: string
     isPreviewing: boolean
     faqEntries?: FaqEntryData
+    imageMetadata: Record<string, ImageMetadata>
     tagToSlugMap: Record<string | number, string>
 }) => {
     const {
@@ -50,6 +52,7 @@ export const DataPageV2 = (props: {
         isPreviewing,
         faqEntries,
         tagToSlugMap,
+        imageMetadata,
     } = props
     const pageTitle = grapher?.title ?? datapageData.title.title
     const canonicalUrl = grapher?.slug
@@ -149,6 +152,7 @@ export const DataPageV2 = (props: {
                                         faqEntries,
                                         canonicalUrl,
                                         tagToSlugMap: minimalTagToSlugMap,
+                                        imageMetadata,
                                     }
                                 )}`,
                             }}
@@ -158,6 +162,7 @@ export const DataPageV2 = (props: {
                                 <DataPageV2Content
                                     datapageData={datapageData}
                                     grapherConfig={grapherConfig}
+                                    imageMetadata={imageMetadata}
                                     isPreviewing={isPreviewing}
                                     faqEntries={faqEntries}
                                     canonicalUrl={canonicalUrl}

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -186,13 +186,6 @@ export const DataPageV2Content = ({
         canonicalUrl
     )
 
-    const {
-        linkedDocuments = {},
-        linkedCharts = {},
-        linkedIndicators = {},
-        relatedCharts = [],
-    } = faqEntries ?? {}
-
     const adaptedFrom =
         producers.length > 0 ? producers.join(", ") : datapageData.source?.name
 
@@ -249,11 +242,11 @@ export const DataPageV2Content = ({
     return (
         <AttachmentsContext.Provider
             value={{
-                linkedDocuments,
+                linkedDocuments: {},
                 imageMetadata,
-                linkedCharts,
-                linkedIndicators,
-                relatedCharts,
+                linkedCharts: {},
+                linkedIndicators: {},
+                relatedCharts: [],
             }}
         >
             <DocumentContext.Provider value={{ isPreviewing }}>

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -31,8 +31,6 @@ import {
     formatAuthors,
     intersection,
     prepareSourcesForDisplay,
-    DataPageRelatedResearch,
-    isEmpty,
     excludeUndefined,
     OwidOrigin,
     DataPageDataV2,
@@ -40,16 +38,15 @@ import {
     GrapherInterface,
     getCitationLong,
     joinTitleFragments,
+    ImageMetadata,
 } from "@ourworldindata/utils"
 import { AttachmentsContext, DocumentContext } from "./gdocs/OwidGdoc.js"
 import StickyNav from "./blocks/StickyNav.js"
 import cx from "classnames"
 import { DebugProvider } from "./gdocs/DebugContext.js"
 import dayjs from "dayjs"
-import {
-    BAKED_BASE_URL,
-    IMAGE_HOSTING_R2_CDN_URL,
-} from "../settings/clientSettings.js"
+import { BAKED_BASE_URL } from "../settings/clientSettings.js"
+import Image from "./gdocs/components/Image.js"
 declare global {
     interface Window {
         _OWID_DATAPAGEV2_PROPS: DataPageV2ContentFields
@@ -58,6 +55,34 @@ declare global {
 }
 export const OWID_DATAPAGE_CONTENT_ROOT_ID = "owid-datapageJson-root"
 
+// We still have topic pages on WordPress, whose featured images are specified as absolute URLs which this component handles
+// Once we've migrated all WP topic pages to gdocs, we'll be able to remove this component and just use <Image />
+const DatapageResearchThumbnail = ({
+    urlOrFilename,
+}: {
+    urlOrFilename: string | undefined | null
+}) => {
+    if (!urlOrFilename) {
+        urlOrFilename = `${BAKED_BASE_URL}/default-thumbnail.jpg`
+    }
+    if (urlOrFilename.startsWith("http")) {
+        return (
+            <img
+                src={urlOrFilename}
+                className="span-lg-cols-2 span-sm-cols-3"
+            />
+        )
+    }
+    return (
+        <Image
+            filename={urlOrFilename}
+            shouldLightbox={false}
+            containerType="thumbnail"
+            className="span-lg-cols-2 span-sm-cols-3"
+        />
+    )
+}
+
 export const DataPageV2Content = ({
     datapageData,
     grapherConfig,
@@ -65,8 +90,10 @@ export const DataPageV2Content = ({
     faqEntries,
     canonicalUrl = "{URL}", // when we bake pages to their proper url this will be set correctly but on preview pages we leave this undefined
     tagToSlugMap,
+    imageMetadata,
 }: DataPageV2ContentFields & {
     grapherConfig: GrapherInterface
+    imageMetadata: Record<string, ImageMetadata>
 }) => {
     const [grapher, setGrapher] = React.useState<Grapher | undefined>(undefined)
 
@@ -161,7 +188,6 @@ export const DataPageV2Content = ({
 
     const {
         linkedDocuments = {},
-        imageMetadata = {},
         linkedCharts = {},
         linkedIndicators = {},
         relatedCharts = [],
@@ -185,16 +211,6 @@ export const DataPageV2Content = ({
         adaptedFrom ? `Data adapted from ${adaptedFrom}.` : undefined,
         `Retrieved from ${canonicalUrl} [online resource]`,
     ]).join(" ")
-
-    const getImageUrl = (research: DataPageRelatedResearch) => {
-        if (research.imageUrl && research.imageUrl.startsWith("http"))
-            return research.imageUrl
-        else if (!isEmpty(research.imageUrl))
-            return encodeURI(
-                `${IMAGE_HOSTING_R2_CDN_URL}/production/${research.imageUrl}`
-            )
-        return `${BAKED_BASE_URL}/default-thumbnail.jpg`
-    }
 
     const relatedResearchCandidates = datapageData.relatedResearch
     const relatedResearch =
@@ -421,24 +437,10 @@ export const DataPageV2Content = ({
                                             key={research.url}
                                             className="related-research__item grid grid-cols-4 grid-lg-cols-6 grid-sm-cols-12 span-cols-4 span-lg-cols-6 span-sm-cols-12"
                                         >
-                                            {/* <figure>
-                                                        <Image
-                                                            filename={
-                                                                research.imageUrl
-                                                            }
-                                                            shouldLightbox={
-                                                                false
-                                                            }
-                                                            containerType={
-                                                                "thumbnail"
-                                                            }
-                                                        />
-                                                    </figure> */}
-                                            {/* // TODO: switch this to use the Image component and put the required information for the thumbnails into hte attachment context or similar */}
-                                            <img
-                                                src={getImageUrl(research)}
-                                                alt=""
-                                                className="span-lg-cols-2 span-sm-cols-3"
+                                            <DatapageResearchThumbnail
+                                                urlOrFilename={
+                                                    research.imageUrl
+                                                }
                                             />
                                             <div className="span-cols-3 span-lg-cols-4 span-sm-cols-9">
                                                 <h3 className="related-article__title">


### PR DESCRIPTION
Fixes https://github.com/owid/owid-grapher/issues/3301

I remember taking a road trip that passed through a town with an odd bend in the highway as you exited. Apparently they'd started constructing the road from both ends, and only realized that they weren't aligned by the time they were in sight of each other.

![image](https://github.com/owid/owid-grapher/assets/11844404/9439dc72-3b4f-4939-b3bd-eb48f250077e)


This part of the datapage code feels a bit like that, except the two bits of road aren't even connected 😄 (All due respect to Daniel, who was under an enormous time crunch to get data pages implemented across the entire stack)

Changes:
- Removes the exhaustive `imageMetadataDicitionary` and other unused properties from FAQ documents that were being attached to the datapage's embedded JSON
- Attaches image metadata for the related research & writing's featured images (which are the only images we currently ned for datapages)
- renames `traverseEnrichedBlocks` → `traverseEnrichedBlock` (because it only takes a single block as an argument, even if that block contains multiple child blocks)

I decided not to refactor anything else to wait till https://github.com/owid/owid-grapher/issues/3426
