### PR TITLE
🎉 (entity selector) highlight user location

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -2,7 +2,7 @@
     "files": [
         {
             "path": "./dist/assets/owid.mjs",
-            "maxSize": "2.4MB"
+            "maxSize": "2.6MB"
         },
         {
             "path": "./dist/assets/owid.css",

--- a/packages/@ourworldindata/grapher/src/controls/LabeledSwitch.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/LabeledSwitch.tsx
@@ -31,9 +31,8 @@ export class LabeledSwitch extends React.Component<{
                     {tooltip && (
                         <Tippy
                             content={tooltip}
-                            theme="settings"
+                            theme="grapher-explanation"
                             placement="top"
-                            // arrow={false}
                             maxWidth={338}
                         >
                             <FontAwesomeIcon icon={faInfoCircle} />

--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.scss
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.scss
@@ -112,21 +112,6 @@ nav.controlsRow .chart-controls .settings-menu {
                     height: 13px;
                     padding: 0 0.333em;
                 }
-
-                // the tooltip triggered by hovering the circle-i
-                @at-root .tippy-box[data-theme="settings"] {
-                    background: white;
-                    color: $dark-text;
-                    font: 400 14px/1.5 $sans-serif-font-stack;
-                    box-shadow: 0px 4px 40px 0px rgba(0, 0, 0, 0.15);
-
-                    .tippy-content {
-                        padding: $indent;
-                    }
-                    .tippy-arrow {
-                        color: white;
-                    }
-                }
             }
 
             .labeled-switch .labeled-switch-subtitle,

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -204,6 +204,25 @@ $zindex-controls-drawer: 150;
     z-index: $zindex-Tooltip;
 }
 
+// white background tooltip for longer explanations
+// (the `--short` version has a little less padding)
+.tippy-box[data-theme="grapher-explanation"],
+.tippy-box[data-theme="grapher-explanation--short"] {
+    background: white;
+    color: $dark-text;
+    font: 400 14px/1.5 $sans-serif-font-stack;
+    box-shadow: 0px 4px 40px 0px rgba(0, 0, 0, 0.15);
+
+    .tippy-arrow {
+        color: white;
+    }
+}
+.tippy-box[data-theme="grapher-explanation"] {
+    .tippy-content {
+        padding: 15px;
+    }
+}
+
 .markdown-text-wrap__line {
     display: block;
 }

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
@@ -172,6 +172,22 @@
                 background: #ebeef2;
                 z-index: -1;
             }
+
+            .label-with-location-icon {
+                display: flex;
+                align-items: center;
+
+                svg {
+                    margin-left: 8px;
+                    font-size: 0.9em;
+                    color: #a1a1a1;
+
+                    // hide focus outline when clicked
+                    &:focus:not(:focus-visible) {
+                        outline: none;
+                    }
+                }
+            }
         }
 
         .animated-entity {


### PR DESCRIPTION
[Cycle 2024.2: Entity selector](https://github.com/owid/owid-grapher/issues/3349) | [Designs](https://www.figma.com/file/X5mOEX8zULS6qyHocUYdmh/Grapher-UI?type=design&node-id=2523%3A6266&mode=design&t=7edFp79OOjz6RENz-1)

## Summary

Detects the user's location and displays it at the top of the list. Also shows a little icon next to the user's country/region with a tooltip rendered on hover.

## Details

- The user's location is displayed at the top if it's not currently selected (if it's already selected, then I don't think there is a need to move it to the top)

## SVG tester

The SVG tester fails due to the changes in #3373 