### PR TITLE
🐛 use `utf8mb4` for knex connections

### DIFF
--- a/db/db.ts
+++ b/db/db.ts
@@ -35,6 +35,7 @@ export const knexInstance = (): Knex<any, any[]> => {
             password: GRAPHER_DB_PASS,
             database: GRAPHER_DB_NAME,
             port: GRAPHER_DB_PORT,
+            charset: "utf8mb4",
             typeCast: (field: any, next: any) => {
                 if (field.type === "TINY" && field.length === 1) {
                     return field.string() === "1" // 1 = true, 0 = false


### PR DESCRIPTION
The live grapher database's charset is `utf8mb4`, but the default connection charset for knex is `utf8mb3` (utf8, multibyte 3) which is [deprecated](https://dev.mysql.com/blog-archive/mysql-8-0-when-to-use-utf8mb3-over-utf8mb4/) and was causing the emoji in our dods to render as `?` characters.

This PR fixes that.

Further reading: [a great blog post on unicode](https://tonsky.me/blog/unicode/)