### PR TITLE
🐛 (marimekko) drop entities without data

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -701,7 +701,7 @@ export class Grapher
         // different; e.g. for scatterplots, the entity needs to (1) not be excluded and
         // (2) needs to have data for the x and y dimension.
         let table =
-            this.isScatter || this.isSlopeChart
+            this.isScatter || this.isMarimekko || this.isSlopeChart
                 ? this.tableAfterAuthorTimelineAndActiveChartTransform
                 : this.inputTable
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -310,11 +310,14 @@ export class MarimekkoChart
                 table = table.dropRowsWithErrorValuesForColumn(colorColumnSlug)
             }
         }
-        if (!manager.showNoDataArea)
+
+        const hideNoDataArea = !manager.showNoDataArea || !xColumnSlug
+        if (hideNoDataArea)
             table = table.dropRowsWithErrorValuesForAllColumns(yColumnSlugs)
 
         if (xColumnSlug)
             table = table.dropRowsWithErrorValuesForColumn(xColumnSlug)
+
         if (manager.isRelativeMode) {
             // TODO: this should not be necessary but we sometimes get NoMatchingValuesAfterJoin if both relative and showNoDataArea are set
             table = table.dropRowsWithErrorValuesForColumn(


### PR DESCRIPTION
- Fixes a bug where Marimekko charts offered entities for selection that are not included in the chart
- Example: [this chart](https://ourworldindata.org/grapher/share-of-people-who-say-that-looking-after-the-environment-is-important-to-them?time=latest&country=~OWID_GFR) offers "West Germany" for selection but we don't have any data for West Germany for any of the years
- Solution:
    - Marimekko charts should use the transformed table for the entity selector (they're similar to scatter plots and slope charts in that regard, as all entities are on screen for a selected year)
    - There was a small bug in the `transformTable` function: We also don't show a "No data" area if we don't have a x-dimension

### SVG tester

- After making this change, it becomes apparent that tolerance is applied twice, and some entities are displayed for years when they shouldn't be
- For example: `United Arab Emirates` show up on [staging](http://staging-site-marimekko-missing-data/grapher/daily-income-or-consumption-of-the-richest-10-marimekko?time=latest&country=~ARE) but not on [live](https://ourworldindata.org/grapher/daily-income-or-consumption-of-the-richest-10-marimekko?time=latest&country=~ARE)
    - `United Arab Emirates` has data for a single year (2013), and the indicator's tolerance is set to 5
    - In production, `United Arab Emirates` shows up for the years 2008-2018 (correct), but on staging shows up for 2003-2022 (10 years to both sides instead of 5)
    - I think this happens because tolerance is applied in the `transformTable` function and then again when filtering for the currently displayed year (see next PR)