### PR TITLE
:bug: Fix analytics logging of search event parameters

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
@@ -41,7 +41,7 @@ type countrySelectorEvent =
 interface GAEvent {
     event: EventCategory
     eventAction?: string
-    eventContext?: string | Record<string, string>
+    eventContext?: string
     eventTarget?: string
     grapherPath?: string
 }

--- a/site/SiteAnalytics.ts
+++ b/site/SiteAnalytics.ts
@@ -41,7 +41,12 @@ export class SiteAnalytics extends GrapherAnalytics {
         this.logToGA({
             event: EventCategory.SiteSearchClick,
             eventAction: "click",
-            eventContext: { query, position, positionInSection, filter },
+            eventContext: JSON.stringify({
+                query,
+                position,
+                positionInSection,
+                filter,
+            }),
             eventTarget: url,
         })
     }
@@ -58,7 +63,7 @@ export class SiteAnalytics extends GrapherAnalytics {
         this.logToGA({
             event: EventCategory.SiteInstantSearchClick,
             eventAction: "click",
-            eventContext: { query, position },
+            eventContext: JSON.stringify({ query, position }),
             eventTarget: url,
         })
     }


### PR DESCRIPTION
Currently BigQuery is receiving `[object Object]` instead of the JSON
parameters. Here we stringify them first so that they get passed
through.
