### PR TITLE
migrate: Unpublish WP articles which are redirected

### DIFF
--- a/db/migration/1712742455229-UnpublishWPRedirectedArticles.ts
+++ b/db/migration/1712742455229-UnpublishWPRedirectedArticles.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class UnpublishRedirectedWPArticles1712742455229
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+        UPDATE posts p
+        INNER JOIN redirects r ON r.source = CONCAT("/", p.slug)
+        SET status        = "private",
+            wpApiSnapshot = JSON_SET(wpApiSnapshot, "$.status", "private")
+        WHERE p.status = "publish"
+          AND p.content != ""`)
+    }
+
+    public async down(): Promise<void> {
+        // empty
+    }
+}


### PR DESCRIPTION
This migration unpublishes [all (currently 36) articles](http://datasette-private/owid?sql=SELECT+p.id+AS+postId%2C+p.title%2C+p.updated_at_in_wordpress%2C+r.source%2C+r.target%2C+r.createdAt%0D%0AFROM+redirects+r%0D%0AJOIN+posts+p+ON+r.source+%3D+%22%2F%22+%7C%7C+p.slug%0D%0AWHERE+p.status+%3D+%22publish%22%0D%0AAND+p.content+%21%3D+%22%22%0D%0AORDER+BY+p.updated_at_in_wordpress) which are being redirected.
The main benefit is that they will no longer appear as search results, [see discussion here](https://owid.slack.com/archives/C06JNSC90UE/p1712739957398759).

Is there anything we need to keep in mind when unpublishing? At least for WP, it should be enough to just mark them as private, right?