### PR TITLE
Fix ESLint config when using Pycharm

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,5 @@
+const path = require('node:path');
+
 module.exports = {
     extends: [
         "plugin:react/recommended",
@@ -12,7 +14,7 @@ module.exports = {
         ecmaFeatures: {
             jsx: true,
         },
-        project: "./tsconfig.eslint.json",
+        project: path.join(__dirname, "tsconfig.eslint.json"),
         ecmaVersion: "latest",
     },
     overrides: [


### PR DESCRIPTION
Pycharm otherwise raises error about ESLint being unable to read the referenced file.