### PR TITLE
Fix outdated "how to use" links

### DIFF
--- a/site/LongFormPage.tsx
+++ b/site/LongFormPage.tsx
@@ -388,7 +388,7 @@ export const LongFormPage = (props: {
                                                         </p>
                                                         <p>
                                                             All of{" "}
-                                                            <a href="/how-to-use-our-world-in-data#how-to-embed-interactive-charts-in-your-article">
+                                                            <a href="/faqs#how-can-i-embed-one-of-your-interactive-charts-in-my-website">
                                                                 our charts can
                                                                 be embedded
                                                             </a>{" "}

--- a/site/SiteFooter.tsx
+++ b/site/SiteFooter.tsx
@@ -89,10 +89,10 @@ export const SiteFooter = (props: SiteFooterProps) => (
                             </li>
                             <li>
                                 <a
-                                    href="/about/how-to-use-our-world-in-data"
+                                    href="/faqs"
                                     data-track-note="footer_navigation"
                                 >
-                                    How to use
+                                    FAQs
                                 </a>
                             </li>
                             <li>


### PR DESCRIPTION
These are the only places I found that referenced that old page(s?).

Fixes #2013.