### PR TITLE
feat(search): pre-select explorer entities if they appear in search query

### DIFF
--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -9,7 +9,7 @@ import {
     ALGOLIA_INDEXING,
     ALGOLIA_SECRET_KEY,
 } from "../../settings/serverSettings.js"
-import { countries } from "@ourworldindata/utils"
+import { countries, regions } from "@ourworldindata/utils"
 import { SearchIndexName } from "../../site/search/searchTypes.js"
 import { getIndexName } from "../../site/search/searchClient.js"
 
@@ -24,6 +24,11 @@ export const getAlgoliaClient = (): SearchClient | undefined => {
     const client = algoliasearch(ALGOLIA_ID, ALGOLIA_SECRET_KEY)
     return client
 }
+
+const allCountryNamesAndVariants = regions.flatMap((region) => [
+    region.name,
+    ...(("variantNames" in region && region.variantNames) || []),
+])
 
 // This function initializes and applies settings to the Algolia search indices
 // Algolia settings should be configured here rather than in the Algolia dashboard UI, as then
@@ -164,6 +169,7 @@ export const configureAlgolia = async () => {
         attributeForDistinct: "explorerSlug",
         distinct: 4,
         minWordSizefor1Typo: 6,
+        optionalWords: allCountryNamesAndVariants,
     })
 
     const synonyms = [


### PR DESCRIPTION
Once we detect a country/region name in the search query string, we now add it as a query param to the explorer link.
We do this *even though we don't know for sure that data for this country will be available in the explorer*. This is an accepted tradeoff, since we believe that it'll be worth it for the 80-90% of cases where this just works (most of our explorers have countries as entities, and most of them include a lot of different entities).
And then, if no data is available for that entity, then the user will be presented with an empty explorer - which is not great, but also not the end of the world.