### PR TITLE
perf(table): optimize `tableForSelection` calls

### DIFF
--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -23,6 +23,7 @@ import {
     ColumnSlug,
     imemo,
     ToleranceStrategy,
+    differenceOfSets,
 } from "@ourworldindata/utils"
 import {
     Integer,
@@ -312,15 +313,19 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
             }
         }
 
-        // const entityNamesToDrop = differenceOfSets([
-        //     this.availableEntityNameSet,
-        //     entityNamesToKeep,
-        // ])
+        const entityNamesToDrop = differenceOfSets([
+            this.availableEntityNameSet,
+            entityNamesToKeep,
+        ])
+        const droppedEntitiesStr =
+            entityNamesToDrop.size > 0
+                ? [...entityNamesToDrop].join(", ")
+                : "(None)"
 
         return this.columnFilter(
             this.entityNameSlug,
             (rowEntityName) => entityNamesToKeep.has(rowEntityName as string),
-            `Drop entities that have no data in some column: ${columnSlugs.join(", ")}`
+            `Drop entities that have no data in some column: ${columnSlugs.join(", ")}.\nDropped entities: ${droppedEntitiesStr}`
         )
     }
 

--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -279,6 +279,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         )
     }
 
+    // Drop _all rows_ for an entity if there is any column that has no valid values for that entity.
     dropEntitiesThatHaveNoDataInSomeColumn(columnSlugs: ColumnSlug[]): this {
         const indexesByEntityName = this.rowIndicesByEntityName
 

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -72,7 +72,6 @@ import {
     OwidTable,
     CoreColumn,
     isNotErrorValue,
-    BlankOwidTable,
 } from "@ourworldindata/core-table"
 import {
     autoDetectSeriesStrategy,
@@ -312,13 +311,9 @@ export class LineChart
                 this.yColumnSlugs
             )
 
-            const groupedByEntity = table
-                .groupBy(table.entityNameColumn.slug)
-                .filter((t) => !t.hasAnyColumnNoValidValue(this.yColumnSlugs))
-
-            if (groupedByEntity.length === 0) return BlankOwidTable()
-
-            table = groupedByEntity[0].concat(groupedByEntity.slice(1))
+            table = table.dropEntitiesThatHaveNoDataInSomeColumn(
+                this.yColumnSlugs
+            )
         }
 
         return table

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -27,7 +27,6 @@ import {
 import {
     OwidTable,
     CoreColumn,
-    BlankOwidTable,
     isNotErrorValueOrEmptyCell,
 } from "@ourworldindata/core-table"
 import {
@@ -103,15 +102,7 @@ export class AbstractStackedChart
                 })
             }
 
-            const groupedByEntity = table
-                .groupBy(table.entityNameColumn.slug)
-                .map((t: OwidTable) =>
-                    t.dropRowsWithErrorValuesForAnyColumn(this.yColumnSlugs)
-                )
-
-            if (groupedByEntity.length === 0) return BlankOwidTable()
-
-            table = groupedByEntity[0].concat(groupedByEntity.slice(1))
+            table = table.dropRowsWithErrorValuesForAnyColumn(this.yColumnSlugs)
         }
 
         return table


### PR DESCRIPTION
I noticed some performance problems with the `tableForSelection` call, and specifically the `transformTableForSelection` method in chart instances, while reviewing #3447.

So, I got at it and could quite improve these 🚀 
- For https://ourworldindata.org/grapher/excess-deaths-cumulative-economist-single-entity, we're now down from 3 seconds per call to 100ms
- Similar for https://ourworldindata.org/grapher/daily-new-estimated-covid-19-infections-icl-model

---

What I did to check that this is correct:
I just loaded up 10-or-so different charts with `missingDataStrategy = 'hide'`, ran `grapher.tableForSelection.dump()`, and compared stats like `numRows`, `numValidCells`, and `numErrorValues` across live and localhost.
They are all the same everywhere.