### PR TITLE
🔨 (grapher) refactor modals and entity selector

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.scss
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.scss
@@ -46,9 +46,6 @@ nav.controlsRow .chart-controls .settings-menu {
     // chart-type label
     //
     .settings-menu-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
         background: white;
         padding: 9px $indent 3px $indent;
         position: sticky;

--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
@@ -9,7 +9,6 @@ import { SelectionArray } from "../selection/SelectionArray"
 import { ChartDimension } from "../chart/ChartDimension"
 import { makeSelectionArray } from "../chart/ChartUtils.js"
 import { AxisConfig } from "../axis/AxisConfig"
-import { CloseButton } from "../closeButton/CloseButton.js"
 
 import { AxisScaleToggle } from "./settings/AxisScaleToggle"
 import { AbsRelToggle, AbsRelToggleManager } from "./settings/AbsRelToggle"
@@ -30,6 +29,7 @@ import {
     TableFilterToggle,
     TableFilterToggleManager,
 } from "./settings/TableFilterToggle"
+import { OverlayHeader } from "../core/OverlayHeader"
 
 const {
     LineChart,
@@ -315,12 +315,11 @@ export class SettingsMenu extends React.Component<{
                         ...this.layout,
                     }}
                 >
-                    <div className="settings-menu-header">
-                        <div className="grapher_h5-black-caps grapher_light">
-                            {menuTitle}
-                        </div>
-                        <CloseButton onClick={() => this.toggleVisibility()} />
-                    </div>
+                    <OverlayHeader
+                        className="settings-menu-header"
+                        title={menuTitle}
+                        onDismiss={this.toggleVisibility}
+                    />
 
                     <div className="settings-menu-controls">
                         <SettingsGroup

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -9,7 +9,6 @@ import {
     reaction,
 } from "mobx"
 import { bind } from "decko"
-import a from "indefinite"
 import {
     uniqWith,
     isEqual,
@@ -2606,10 +2605,7 @@ export class Grapher
                 <div className="CaptionedChartAndSidePanel">
                     <CaptionedChart manager={this} />
                     {this.sidePanelBounds && (
-                        <SidePanel
-                            title={this.entitySelectorTitle}
-                            bounds={this.sidePanelBounds}
-                        >
+                        <SidePanel bounds={this.sidePanelBounds}>
                             <EntitySelector manager={this} />
                         </SidePanel>
                     )}
@@ -2625,7 +2621,6 @@ export class Grapher
 
                 {/* entity selector in a slide-in drawer */}
                 <SlideInDrawer
-                    title={this.entitySelectorTitle}
                     active={this.isEntitySelectorDrawerOpen}
                     toggle={() => {
                         this.isEntitySelectorModalOrDrawerOpen =
@@ -3113,14 +3108,6 @@ export class Grapher
         return isMobile()
             ? timeColumn.formatValueForMobile(value)
             : timeColumn.formatValue(value)
-    }
-
-    @computed get entitySelectorTitle(): string {
-        return this.canHighlightEntities
-            ? `Select ${this.entityTypePlural}`
-            : this.canChangeEntity
-              ? `Choose ${a(this.entityType)}`
-              : `Add/remove ${this.entityTypePlural}`
     }
 
     @computed get canSelectMultipleEntities(): boolean {

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -6,9 +6,8 @@ export const GRAPHER_EMBEDDED_FIGURE_CONFIG_ATTR = "data-grapher-config"
 export const GRAPHER_PAGE_BODY_CLASS = "StandaloneGrapherOrExplorerPage"
 export const GRAPHER_DRAWER_ID = "grapher-drawer"
 export const GRAPHER_IS_IN_IFRAME_CLASS = "IsInIframe"
-export const GRAPHER_SCROLLABLE_CONTAINER_CLASS = "scrollable-container"
 export const GRAPHER_TIMELINE_CLASS = "timeline-component"
-export const GRAPHER_ENTITY_SELECTOR_CLASS = "entity-selector"
+export const GRAPHER_SIDE_PANEL_CLASS = "side-panel"
 
 export const DEFAULT_GRAPHER_CONFIG_SCHEMA =
     "https://files.ourworldindata.org/schemas/grapher-schema.004.json"

--- a/packages/@ourworldindata/grapher/src/core/OverlayHeader.scss
+++ b/packages/@ourworldindata/grapher/src/core/OverlayHeader.scss
@@ -1,0 +1,12 @@
+.overlay-header {
+    --padding: var(--modal-padding, 16px);
+
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--padding) var(--padding) 16px;
+
+    button {
+        margin-left: 8px;
+    }
+}

--- a/packages/@ourworldindata/grapher/src/core/OverlayHeader.tsx
+++ b/packages/@ourworldindata/grapher/src/core/OverlayHeader.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import cx from "classnames"
+import { CloseButton } from "../closeButton/CloseButton.js"
+
+export function OverlayHeader({
+    title,
+    onDismiss,
+    className,
+}: {
+    title: string
+    onDismiss?: () => void
+    className?: string
+}): JSX.Element {
+    return (
+        <div className={cx("overlay-header", className)}>
+            <h2 className="grapher_h5-black-caps grapher_light">{title}</h2>
+            {onDismiss && <CloseButton onClick={onDismiss} />}
+        </div>
+    )
+}

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -89,6 +89,7 @@ $zindex-controls-drawer: 150;
 @import "../closeButton/CloseButton.scss";
 @import "../controls/RadioButton.scss";
 @import "../controls/Dropdown.scss";
+@import "../core/OverlayHeader.scss";
 
 .grapher_dark {
     color: $dark-text;

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
@@ -2,28 +2,110 @@
     .entity-selector {
         --padding: var(--modal-padding, 16px);
 
-        $row-border: 1px solid #f2f2f2;
+        color: $dark-text;
 
-        $footer-height: 48px;
+        // necessary for scrolling
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        > * {
+            flex-shrink: 0;
+        }
 
-        $zindex-header: 2;
-        $zindex-footer: 2;
-        $zindex-animated: 1;
+        .scrollable {
+            flex: 1 1 auto;
+            overflow-y: auto;
+            width: 100%;
+        }
 
         .entity-selector__search-bar {
-            position: sticky;
-            top: 0;
-            left: 0;
-            background-color: #fff;
-            z-index: $zindex-header;
             padding: 0 var(--padding) 8px var(--padding);
-            margin-bottom: 8px;
+
+            .search-input {
+                // search icon
+                $svg-margin: 8px;
+                $svg-size: 12px;
+
+                $placeholder: #a1a1a1;
+                $focus: 1px solid #a4b6ca;
+
+                position: relative;
+
+                .search-icon {
+                    position: absolute;
+                    top: 50%;
+                    left: $svg-margin;
+                    color: $light-text;
+                    transform: translateY(-50%);
+                    font-size: $svg-size;
+                }
+
+                .clear {
+                    margin: 0;
+                    padding: 0;
+                    background: none;
+                    border: none;
+                    position: absolute;
+                    top: 50%;
+                    right: $svg-margin;
+                    transform: translateY(-50%);
+                    font-size: $svg-size;
+                    color: $dark-text;
+                    cursor: pointer;
+                }
+
+                input[type="search"] {
+                    @include grapher_label-2-regular;
+                    width: 100%;
+                    height: 32px;
+                    border: 1px solid #e7e7e7;
+                    padding-left: $svg-margin + $svg-size + 4px;
+                    padding-right: $svg-margin + $svg-size + 4px;
+                    border-radius: 4px;
+                    background: #fff;
+
+                    // style placeholder text in search input
+                    &::placeholder {
+                        color: $placeholder;
+                        opacity: 1; /* Firefox */
+                    }
+                    &:-ms-input-placeholder {
+                        color: $placeholder;
+                    }
+                    &::-ms-input-placeholder {
+                        color: $placeholder;
+                    }
+
+                    // style focus state
+                    &:focus {
+                        outline: none;
+                        border: $focus;
+                    }
+                    &:focus:not(:focus-visible) {
+                        border: none;
+                    }
+                    &:focus-visible {
+                        border: $focus;
+                    }
+
+                    &::-webkit-search-cancel-button {
+                        -webkit-appearance: none;
+                    }
+                }
+
+                &.search-input--empty {
+                    input[type="search"] {
+                        padding-right: 8px;
+                    }
+                }
+            }
         }
 
         .entity-selector__sort-bar {
             padding: 0 var(--padding);
             display: flex;
             align-items: center;
+            margin-top: 8px;
             margin-bottom: 16px;
 
             .grapher-dropdown {
@@ -79,21 +161,102 @@
             }
         }
 
+        .entity-selector__content {
+            $row-border: 1px solid #f2f2f2;
+
+            margin: 0 var(--padding) 8px var(--padding);
+
+            .entity-section + .entity-section {
+                margin-top: 16px;
+            }
+
+            .entity-section__title {
+                letter-spacing: 0.01em;
+                margin-bottom: 8px;
+            }
+
+            .entity-search-results {
+                margin-top: 8px;
+            }
+
+            .selectable-entity {
+                padding: 9px 8px 9px 16px;
+                display: flex;
+                justify-content: space-between;
+                position: relative;
+                cursor: pointer;
+
+                .value {
+                    color: #a1a1a1;
+                    white-space: nowrap;
+                    margin-left: 8px;
+                }
+
+                .bar {
+                    position: absolute;
+                    top: 0;
+                    left: 0;
+                    height: 100%;
+                    background: #ebeef2;
+                    z-index: -1;
+                }
+
+                .label-with-location-icon {
+                    display: flex;
+                    align-items: center;
+
+                    svg {
+                        margin-left: 8px;
+                        font-size: 0.9em;
+                        color: #a1a1a1;
+
+                        // hide focus outline when clicked
+                        &:focus:not(:focus-visible) {
+                            outline: none;
+                        }
+                    }
+                }
+            }
+
+            .animated-entity {
+                position: relative;
+                z-index: 0;
+                background: #fff;
+
+                &.most-recently-selected {
+                    z-index: 1;
+                }
+            }
+
+            ul {
+                margin: 0;
+                padding: 0;
+                list-style-type: none;
+            }
+
+            li + li .selectable-entity {
+                border-top: $row-border;
+            }
+
+            li:first-of-type .selectable-entity {
+                border-top: $row-border;
+            }
+
+            li:last-of-type .selectable-entity {
+                border-bottom: $row-border;
+            }
+        }
+
         .entity-selector__footer {
-            position: absolute;
-            bottom: 0;
-            left: 0;
             background-color: #fff;
-            padding: 0 16px;
             width: 100%;
             border-radius: 4px;
-            z-index: $zindex-footer;
+            z-index: 2;
 
             display: flex;
             align-items: center;
             justify-content: space-between;
-            padding: 0 var(--padding);
-            height: $footer-height;
+            padding: 16px var(--padding);
             box-shadow: 0px -4px 8px 0px rgba(0, 0, 0, 0.04);
 
             .footer__selected {
@@ -102,15 +265,9 @@
                 letter-spacing: 0.06em;
                 text-transform: uppercase;
 
-                // small visual correction
-                top: 1px;
-                position: relative;
-
-                &--no-wrap {
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    white-space: nowrap;
-                }
+                display: flex;
+                flex-wrap: wrap;
+                column-gap: 4px;
             }
 
             button {
@@ -130,171 +287,6 @@
                     cursor: default;
                 }
             }
-        }
-
-        .entity-selector__content {
-            margin: 0 var(--padding) ($footer-height + 8px) var(--padding);
-        }
-
-        &.entity-selector--single {
-            .entity-selector__content {
-                margin-bottom: 16px;
-            }
-        }
-
-        .entity-section + .entity-section {
-            margin-top: 16px;
-        }
-
-        .entity-section__title {
-            letter-spacing: 0.01em;
-            margin-bottom: 8px;
-        }
-
-        .selectable-entity {
-            padding: 9px 8px 9px 16px;
-            display: flex;
-            justify-content: space-between;
-            position: relative;
-            cursor: pointer;
-
-            .value {
-                color: #a1a1a1;
-                white-space: nowrap;
-                margin-left: 8px;
-            }
-
-            .bar {
-                position: absolute;
-                top: 0;
-                left: 0;
-                height: 100%;
-                background: #ebeef2;
-                z-index: -1;
-            }
-
-            .label-with-location-icon {
-                display: flex;
-                align-items: center;
-
-                svg {
-                    margin-left: 8px;
-                    font-size: 0.9em;
-                    color: #a1a1a1;
-
-                    // hide focus outline when clicked
-                    &:focus:not(:focus-visible) {
-                        outline: none;
-                    }
-                }
-            }
-        }
-
-        .animated-entity {
-            position: relative;
-            z-index: 0;
-            background: #fff;
-
-            &.most-recently-selected {
-                z-index: $zindex-animated;
-            }
-        }
-
-        li + li .selectable-entity {
-            border-top: $row-border;
-        }
-
-        li:first-of-type .selectable-entity {
-            border-top: $row-border;
-        }
-
-        li:last-of-type .selectable-entity {
-            border-bottom: $row-border;
-        }
-
-        .search-input {
-            // search icon
-            $svg-margin: 8px;
-            $svg-size: 12px;
-
-            $placeholder: #a1a1a1;
-            $focus: 1px solid #a4b6ca;
-
-            position: relative;
-
-            .search-icon {
-                position: absolute;
-                top: 50%;
-                left: $svg-margin;
-                color: $light-text;
-                transform: translateY(-50%);
-                font-size: $svg-size;
-            }
-
-            .clear {
-                margin: 0;
-                padding: 0;
-                background: none;
-                border: none;
-                position: absolute;
-                top: 50%;
-                right: $svg-margin;
-                transform: translateY(-50%);
-                font-size: $svg-size;
-                color: $dark-text;
-                cursor: pointer;
-            }
-
-            input[type="search"] {
-                @include grapher_label-2-regular;
-                width: 100%;
-                height: 32px;
-                border: 1px solid #e7e7e7;
-                padding-left: $svg-margin + $svg-size + 4px;
-                padding-right: $svg-margin + $svg-size + 4px;
-                border-radius: 4px;
-                background: #fff;
-
-                // style placeholder text in search input
-                &::placeholder {
-                    color: $placeholder;
-                    opacity: 1; /* Firefox */
-                }
-                &:-ms-input-placeholder {
-                    color: $placeholder;
-                }
-                &::-ms-input-placeholder {
-                    color: $placeholder;
-                }
-
-                // style focus state
-                &:focus {
-                    outline: none;
-                    border: $focus;
-                }
-                &:focus:not(:focus-visible) {
-                    border: none;
-                }
-                &:focus-visible {
-                    border: $focus;
-                }
-
-                &::-webkit-search-cancel-button {
-                    -webkit-appearance: none;
-                }
-            }
-
-            &.search-input--empty {
-                input[type="search"] {
-                    padding-right: 8px;
-                }
-            }
-        }
-
-        ul {
-            margin: 0;
-            padding: 0;
-            list-style-type: none;
         }
     }
 }

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -1,8 +1,24 @@
 .download-modal-content {
     color: $dark-text;
-    padding: 0 var(--modal-padding) var(--modal-padding);
-    min-height: 45px;
-    position: relative;
+
+    // necessary for scrolling
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    > * {
+        flex-shrink: 0;
+    }
+
+    .scrollable {
+        flex: 1 1 auto;
+        overflow-y: auto;
+        padding: 0 var(--modal-padding) var(--modal-padding);
+        width: 100%;
+
+        // needed for the loading indicator
+        position: relative;
+        min-height: 45px;
+    }
 
     .grouped-menu-section {
         h3 {

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -20,6 +20,7 @@ import {
 } from "@ourworldindata/core-table"
 import { Modal } from "./Modal"
 import { GrapherExport } from "../captionedChart/StaticChartRasterizer.js"
+import { OverlayHeader } from "../core/OverlayHeader.js"
 
 export interface DownloadModalManager {
     displaySlug: string
@@ -362,17 +363,22 @@ export class DownloadModal extends React.Component<DownloadModalProps> {
 
     render(): JSX.Element {
         return (
-            <Modal
-                title="Download"
-                bounds={this.modalBounds}
-                onDismiss={this.onDismiss}
-            >
-                <div className="download-modal-content">
-                    {this.isReady ? (
-                        this.renderReady()
-                    ) : (
-                        <LoadingIndicator color="#000" />
-                    )}
+            <Modal bounds={this.modalBounds} onDismiss={this.onDismiss}>
+                <div
+                    className="download-modal-content"
+                    style={{ maxHeight: this.modalBounds.height }}
+                >
+                    <OverlayHeader
+                        title="Download"
+                        onDismiss={this.onDismiss}
+                    />
+                    <div className="scrollable">
+                        {this.isReady ? (
+                            this.renderReady()
+                        ) : (
+                            <LoadingIndicator color="#000" />
+                        )}
+                    </div>
                 </div>
             </Modal>
         )

--- a/packages/@ourworldindata/grapher/src/modal/EmbedModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/EmbedModal.scss
@@ -1,6 +1,20 @@
 .embed-modal-content {
     color: $dark-text;
-    margin: 0 var(--modal-padding) var(--modal-padding);
+
+    // necessary for scrolling
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    > * {
+        flex-shrink: 0;
+    }
+
+    .scrollable {
+        flex: 1 1 auto;
+        overflow-y: auto;
+        padding: 0 var(--modal-padding) var(--modal-padding);
+        width: 100%;
+    }
 
     p {
         margin-bottom: 16px;

--- a/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
@@ -4,6 +4,7 @@ import { computed, action } from "mobx"
 import { Bounds, DEFAULT_BOUNDS } from "@ourworldindata/utils"
 import { Modal } from "./Modal"
 import { CodeSnippet } from "@ourworldindata/components"
+import { OverlayHeader } from "../core/OverlayHeader.js"
 
 export interface EmbedModalManager {
     canonicalUrl?: string
@@ -45,17 +46,22 @@ export class EmbedModal extends React.Component<EmbedModalProps> {
     render(): JSX.Element {
         return (
             <Modal
-                title="Embed"
                 bounds={this.modalBounds}
                 alignVertical="bottom"
                 onDismiss={this.onDismiss}
             >
-                <div className="embed-modal-content">
-                    <p className="grapher_label-1-medium">
-                        Paste this into any HTML page:
-                    </p>
-                    <CodeSnippet code={this.codeSnippet} />
-                    {this.manager.embedDialogAdditionalElements}
+                <div
+                    className="embed-modal-content"
+                    style={{ maxHeight: this.modalBounds.height }}
+                >
+                    <OverlayHeader title="Embed" onDismiss={this.onDismiss} />
+                    <div className="scrollable">
+                        <p className="grapher_label-1-medium">
+                            Paste this into any HTML page:
+                        </p>
+                        <CodeSnippet code={this.codeSnippet} />
+                        {this.manager.embedDialogAdditionalElements}
+                    </div>
                 </div>
             </Modal>
         )

--- a/packages/@ourworldindata/grapher/src/modal/EntitySelectorModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/EntitySelectorModal.tsx
@@ -11,7 +11,6 @@ import {
 export interface EntitySelectorModalManager extends EntitySelectorManager {
     isEntitySelectorModalOrDrawerOpen?: boolean
     frameBounds?: Bounds
-    entitySelectorTitle?: string
 }
 
 @observer
@@ -39,7 +38,6 @@ export class EntitySelectorModal extends React.Component<{
     render(): JSX.Element {
         return (
             <Modal
-                title={this.manager.entitySelectorTitle}
                 onDismiss={this.onDismiss}
                 bounds={this.modalBounds}
                 isHeightFixed={true}

--- a/packages/@ourworldindata/grapher/src/modal/Modal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/Modal.scss
@@ -22,35 +22,6 @@
             background: #fff;
             box-shadow: 0px 4px 30px 0px rgba(0, 0, 0, 0.15);
             min-height: 150px;
-
-            // necessary to allow modal to scroll
-            display: flex;
-            flex-direction: column;
-
-            .close-button--top-right {
-                position: absolute;
-                top: 0;
-                right: 0;
-                margin: var(--modal-padding);
-            }
-
-            .modal-header {
-                flex-shrink: 0; // necessary to allow modal to scroll
-
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-                padding: var(--modal-padding) var(--modal-padding) 16px;
-
-                button {
-                    margin-left: 8px;
-                }
-            }
-
-            .modal-scrollable {
-                flex-grow: 1;
-                overflow-y: auto;
-            }
         }
     }
 }

--- a/packages/@ourworldindata/grapher/src/modal/Modal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/Modal.tsx
@@ -1,29 +1,20 @@
 import React from "react"
-import cx from "classnames"
 import { observer } from "mobx-react"
 import { action, computed } from "mobx"
 import { Bounds } from "@ourworldindata/utils"
-import { CloseButton } from "../closeButton/CloseButton.js"
-import { GRAPHER_SCROLLABLE_CONTAINER_CLASS } from "../core/GrapherConstants.js"
 
 @observer
 export class Modal extends React.Component<{
     bounds: Bounds
     onDismiss: () => void
-    title?: string
     children?: React.ReactNode
     isHeightFixed?: boolean // by default, the modal height is not fixed but fits to the content
     alignVertical?: "center" | "bottom"
-    showStickyHeader?: boolean
 }> {
     contentRef: React.RefObject<HTMLDivElement> = React.createRef()
 
     @computed private get bounds(): Bounds {
         return this.props.bounds
-    }
-
-    @computed private get title(): string | undefined {
-        return this.props.title
     }
 
     @computed private get isHeightFixed(): boolean {
@@ -32,10 +23,6 @@ export class Modal extends React.Component<{
 
     @computed private get alignVertical(): "center" | "bottom" {
         return this.props.alignVertical ?? "center"
-    }
-
-    @computed private get showStickyHeader(): boolean {
-        return this.props.showStickyHeader || !!this.title
     }
 
     @action.bound onDocumentClick(e: MouseEvent): void {
@@ -95,27 +82,7 @@ export class Modal extends React.Component<{
                         style={contentStyle}
                         ref={this.contentRef}
                     >
-                        {this.showStickyHeader ? (
-                            <div className="modal-header">
-                                <h2 className="grapher_h5-black-caps grapher_light">
-                                    {this.title}
-                                </h2>
-                                <CloseButton onClick={this.props.onDismiss} />
-                            </div>
-                        ) : (
-                            <CloseButton
-                                className="close-button--top-right"
-                                onClick={this.props.onDismiss}
-                            />
-                        )}
-                        <div
-                            className={cx(
-                                "modal-scrollable",
-                                GRAPHER_SCROLLABLE_CONTAINER_CLASS
-                            )}
-                        >
-                            {this.props.children}
-                        </div>
+                        {this.props.children}
                     </div>
                 </div>
             </div>

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.scss
@@ -7,12 +7,37 @@
 
     $border: #e7e7e7;
 
-    max-width: $max-content-width;
-    margin: 0 auto;
-    padding: 0 var(--modal-padding) var(--modal-padding);
+    // necessary for scrolling
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    > * {
+        flex-shrink: 0;
+    }
 
-    &.sources-modal-content--pad-top {
-        margin-top: var(--modal-padding);
+    .scrollable {
+        max-width: $max-content-width;
+        margin: 0 auto;
+        width: 100%;
+
+        flex: 1 1 auto;
+        overflow-y: auto;
+        padding: 0 var(--modal-padding) var(--modal-padding);
+
+        &--pad-top {
+            padding-top: var(--modal-padding);
+        }
+
+        // needed for the loading indicator
+        position: relative;
+        min-height: 45px;
+    }
+
+    .close-button--top-right {
+        position: absolute;
+        top: 0;
+        right: 0;
+        margin: var(--modal-padding);
     }
 
     .note-multiple-indicators {

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
@@ -36,8 +36,9 @@ import { SourcesDescriptions } from "./SourcesDescriptions"
 import { Tabs } from "../tabs/Tabs"
 import { ExpandableTabs } from "../tabs/ExpandableTabs"
 import { LoadingIndicator } from "../loadingIndicator/LoadingIndicator"
-import { CLOSE_BUTTON_WIDTH } from "../closeButton/CloseButton"
+import { CLOSE_BUTTON_WIDTH, CloseButton } from "../closeButton/CloseButton"
 import { isContinentsVariableId } from "../core/GrapherConstants"
+import { OverlayHeader } from "../core/OverlayHeader.js"
 
 // keep in sync with variables in SourcesModal.scss
 const MAX_CONTENT_WIDTH = 640
@@ -92,7 +93,7 @@ export class SourcesModal extends React.Component<
         return this.frameBounds.padHeight(15).padWidth(padWidth)
     }
 
-    @computed private get showStickyModalHeader(): boolean {
+    @computed private get showStickyHeader(): boolean {
         const modalWidth = this.modalBounds.width - 2 * this.modalPadding
         return (modalWidth - MAX_CONTENT_WIDTH) / 2 < CLOSE_BUTTON_WIDTH + 2
     }
@@ -262,19 +263,27 @@ export class SourcesModal extends React.Component<
                 bounds={this.modalBounds}
                 isHeightFixed={true}
                 onDismiss={this.onDismiss}
-                showStickyHeader={this.showStickyModalHeader}
             >
-                <div
-                    className={cx("sources-modal-content", {
-                        "sources-modal-content--pad-top":
-                            !this.showStickyModalHeader,
-                    })}
-                >
-                    {this.manager.isReady ? (
-                        this.renderModalContent()
+                <div className="sources-modal-content">
+                    {this.showStickyHeader ? (
+                        <OverlayHeader title="" onDismiss={this.onDismiss} />
                     ) : (
-                        <LoadingIndicator />
+                        <CloseButton
+                            className="close-button--top-right"
+                            onClick={this.onDismiss}
+                        />
                     )}
+                    <div
+                        className={cx("scrollable", {
+                            "scrollable--pad-top": !this.showStickyHeader,
+                        })}
+                    >
+                        {this.manager.isReady ? (
+                            this.renderModalContent()
+                        ) : (
+                            <LoadingIndicator />
+                        )}
+                    </div>
                 </div>
             </Modal>
         )

--- a/packages/@ourworldindata/grapher/src/sidePanel/SidePanel.scss
+++ b/packages/@ourworldindata/grapher/src/sidePanel/SidePanel.scss
@@ -3,19 +3,8 @@
     flex-shrink: 0;
     border-left: 1px solid $frame-color;
 
-    position: relative;
-
-    // necessary for scrolling
-    display: flex;
-    flex-direction: column;
-
-    .side-panel__header {
-        margin: 16px;
-        flex-shrink: 0; // necessary for scrolling
-    }
-
-    .side-panel__scrollable {
-        flex-grow: 1;
-        overflow-y: auto;
+    // don't show close button in the side panel header
+    .overlay-header .close-button {
+        display: none;
     }
 }

--- a/packages/@ourworldindata/grapher/src/sidePanel/SidePanel.tsx
+++ b/packages/@ourworldindata/grapher/src/sidePanel/SidePanel.tsx
@@ -1,14 +1,12 @@
 import React from "react"
-import cx from "classnames"
 import { observer } from "mobx-react"
 import { computed } from "mobx"
 import { Bounds } from "@ourworldindata/utils"
-import { GRAPHER_SCROLLABLE_CONTAINER_CLASS } from "../core/GrapherConstants"
+import { GRAPHER_SIDE_PANEL_CLASS } from "../core/GrapherConstants.js"
 
 @observer
 export class SidePanel extends React.Component<{
     bounds: Bounds
-    title: string
     children: React.ReactNode
 }> {
     @computed private get bounds(): Bounds {
@@ -18,23 +16,13 @@ export class SidePanel extends React.Component<{
     render(): JSX.Element {
         return (
             <div
-                className="side-panel"
+                className={GRAPHER_SIDE_PANEL_CLASS}
                 style={{
                     width: this.bounds.width,
                     height: this.bounds.height,
                 }}
             >
-                <h3 className="side-panel__header grapher_h5-black-caps grapher_light">
-                    {this.props.title}
-                </h3>
-                <div
-                    className={cx(
-                        "side-panel__scrollable",
-                        GRAPHER_SCROLLABLE_CONTAINER_CLASS
-                    )}
-                >
-                    {this.props.children}
-                </div>
+                {this.props.children}
             </div>
         )
     }

--- a/packages/@ourworldindata/grapher/src/slideInDrawer/SlideInDrawer.scss
+++ b/packages/@ourworldindata/grapher/src/slideInDrawer/SlideInDrawer.scss
@@ -16,35 +16,7 @@
             width: 300px;
             height: 100vh;
             z-index: $zindex-controls-drawer;
-            overflow-y: scroll;
             background: white;
-
-            // necessary for scrolling
-            display: flex;
-            flex-direction: column;
-
-            .grapher-drawer-header {
-                position: static;
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-                background: white;
-                padding: 16px;
-                position: sticky;
-                top: 0;
-                z-index: 1;
-
-                flex-shrink: 0; // necessary for scrolling
-
-                button {
-                    margin-left: 8px;
-                }
-            }
-
-            .grapher-drawer-scrollable {
-                overflow-y: auto;
-                flex-grow: 1;
-            }
         }
 
         .grapher-drawer-backdrop {

--- a/packages/@ourworldindata/grapher/src/slideInDrawer/SlideInDrawer.tsx
+++ b/packages/@ourworldindata/grapher/src/slideInDrawer/SlideInDrawer.tsx
@@ -1,17 +1,15 @@
 import React from "react"
-import cx from "classnames"
 import { createPortal } from "react-dom"
 import { computed, action, observable } from "mobx"
 import { observer } from "mobx-react"
-import {
-    GRAPHER_DRAWER_ID,
-    GRAPHER_SCROLLABLE_CONTAINER_CLASS,
-} from "../core/GrapherConstants"
-import { CloseButton } from "../closeButton/CloseButton.js"
+import { GRAPHER_DRAWER_ID } from "../core/GrapherConstants"
+
+export const DrawerContext = React.createContext<{
+    toggleDrawerVisibility?: () => void
+}>({})
 
 @observer
 export class SlideInDrawer extends React.Component<{
-    title: string
     active: boolean
     toggle: () => void
     children: React.ReactNode
@@ -87,21 +85,13 @@ export class SlideInDrawer extends React.Component<{
                         ...this.animationFor("grapher-drawer-contents"),
                     }}
                 >
-                    <div className="grapher-drawer-header">
-                        <div className="grapher_h5-black-caps grapher_light">
-                            {this.props.title}
-                        </div>
-                        <CloseButton onClick={() => this.toggleVisibility()} />
-                    </div>
-
-                    <div
-                        className={cx(
-                            "grapher-drawer-scrollable",
-                            GRAPHER_SCROLLABLE_CONTAINER_CLASS
-                        )}
+                    <DrawerContext.Provider
+                        value={{
+                            toggleDrawerVisibility: this.toggleVisibility,
+                        }}
                     >
                         {this.props.children}
-                    </div>
+                    </DrawerContext.Provider>
                 </div>
             </div>
         )

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -35,7 +35,7 @@ import {
     GRAPHER_FONT_SCALE_10_5,
     GRAPHER_FONT_SCALE_11_2,
     GRAPHER_TIMELINE_CLASS,
-    GRAPHER_ENTITY_SELECTOR_CLASS,
+    GRAPHER_SIDE_PANEL_CLASS,
 } from "../core/GrapherConstants"
 import {
     ScaleType,
@@ -536,7 +536,7 @@ export class SlopeChart
         const target = e.target as HTMLElement
 
         // check if the target is an interactive element or contained within one
-        const selector = `a, button, input, .${GRAPHER_TIMELINE_CLASS}, .${GRAPHER_ENTITY_SELECTOR_CLASS}`
+        const selector = `a, button, input, .${GRAPHER_TIMELINE_CLASS}, .${GRAPHER_SIDE_PANEL_CLASS}`
         const isTargetInteractive = target.closest(selector) !== null
 
         if (


### PR DESCRIPTION
[Cycle 2024.2: Entity selector](https://github.com/owid/owid-grapher/issues/3349) | [Designs](https://www.figma.com/file/X5mOEX8zULS6qyHocUYdmh/Grapher-UI?type=design&node-id=2523%3A6266&mode=design&t=7edFp79OOjz6RENz-1)

## Background

- Modals used to come with a sticky header with a title and a close button, making the content area scrollable by default.
- This was convenient when our modals were relatively simple but started breaking down first for the Sources modal (where we need a sticky header on smaller screens only) and then for the entity selector (where we have some more sticky content on the top and bottom)
- For the entity selector in particular, making the entity selector work with the current `<Modal />` implementation led to a number of bugs that were difficult to get rid of (1px of text surfacing above the search input, the scrollbar hidden behind the footer)

## Summary

- Makes the `<Modal />`, `<SlideInDrawer />` and `<SidePanel />` into unopinionated container components that render their children – and nothing else
- Content that is rendered into a modal/drawer/panel is then responsible for making itself scrollable (if necessary)

## SVG tester

The SVG tester fails due to the changes in #3373 