### PR TITLE
🐛 (timeline) show current time point correctly

### DIFF
--- a/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
@@ -6,7 +6,6 @@ import {
     isMobile,
     debounce,
     Bounds,
-    timeFromTimebounds,
     DEFAULT_BOUNDS,
 } from "@ourworldindata/utils"
 import { observable, computed, action } from "mobx"
@@ -317,18 +316,19 @@ export class TimelineComponent extends React.Component<{
 
     render(): JSX.Element {
         const { manager, controller } = this
-        const { startTimeProgress, endTimeProgress, minTime, maxTime } =
-            controller
-        const { startHandleTimeBound, endHandleTimeBound } = manager
+        const {
+            startTimeProgress,
+            endTimeProgress,
+            minTime,
+            maxTime,
+            startTime,
+            endTime,
+        } = controller
 
         const formattedMinTime = this.formatTime(minTime)
         const formattedMaxTime = this.formatTime(maxTime)
-        const formattedStartTime = this.formatTime(
-            timeFromTimebounds(startHandleTimeBound, minTime, maxTime)
-        )
-        const formattedEndTime = this.formatTime(
-            timeFromTimebounds(endHandleTimeBound, minTime, maxTime)
-        )
+        const formattedStartTime = this.formatTime(startTime)
+        const formattedEndTime = this.formatTime(endTime)
 
         return (
             <div

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineController.ts
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineController.ts
@@ -33,14 +33,14 @@ export class TimelineController {
         return this.manager.times
     }
 
-    private get startTime(): number {
+    get startTime(): number {
         return findClosestTime(
             this.timesAsc,
             this.manager.startHandleTimeBound
         )!
     }
 
-    private get endTime(): number {
+    get endTime(): number {
         return findClosestTime(this.timesAsc, this.manager.endHandleTimeBound)!
     }
 


### PR DESCRIPTION
- Fixes an issue where the current start or end point wasn't in sync with the timeline handle
- To reproduce:
    - Go to https://ourworldindata.org/grapher/life-expectancy-at-different-ages
    - Go to the table tab and move the start timeline handle a bit to the right
    - Go back to the chart tab and hover over the timeline's start handle
    - Note that the current time displayed in the tooltip isn't the actual time that is used for plotting (see screenshot)

<img width="811" alt="Screenshot 2024-04-15 at 14 21 13" src="https://github.com/owid/owid-grapher/assets/12461810/b082aa76-4567-426c-88bf-f70e1f685ac9">

