### PR TITLE
Add admin page for site redirects

### DIFF
--- a/adminSiteClient/AdminApp.tsx
+++ b/adminSiteClient/AdminApp.tsx
@@ -13,6 +13,7 @@ import { DatasetEditPage } from "./DatasetEditPage.js"
 import { VariablesAnnotationPage } from "./VariablesAnnotationPage.js"
 import { SourceEditPage } from "./SourceEditPage.js"
 import { RedirectsIndexPage } from "./RedirectsIndexPage.js"
+import SiteRedirectsIndexPage from "./SiteRedirectsIndexPage"
 import { TagEditPage } from "./TagEditPage.js"
 import { TagsIndexPage } from "./TagsIndexPage.js"
 import { PostsIndexPage } from "./PostsIndexPage.js"
@@ -247,6 +248,11 @@ export class AdminApp extends React.Component<{
                                 exact
                                 path="/redirects"
                                 component={RedirectsIndexPage}
+                            />
+                            <Route
+                                exact
+                                path="/site-redirects"
+                                component={SiteRedirectsIndexPage}
                             />
                             <Route
                                 exact

--- a/adminSiteClient/AdminSidebar.tsx
+++ b/adminSiteClient/AdminSidebar.tsx
@@ -114,7 +114,12 @@ export const AdminSidebar = (): JSX.Element => (
             </li>
             <li>
                 <Link to="/redirects">
-                    <FontAwesomeIcon icon={faArrowRight} /> Redirects
+                    <FontAwesomeIcon icon={faArrowRight} /> Chart Redirects
+                </Link>
+            </li>
+            <li>
+                <Link to="/site-redirects">
+                    <FontAwesomeIcon icon={faArrowRight} /> Site Redirects
                 </Link>
             </li>
             <li>

--- a/adminSiteClient/RedirectsIndexPage.tsx
+++ b/adminSiteClient/RedirectsIndexPage.tsx
@@ -77,7 +77,7 @@ export class RedirectsIndexPage extends React.Component {
         const { redirects } = this
 
         return (
-            <AdminLayout title="Redirects">
+            <AdminLayout title="Chart Redirects">
                 <main className="RedirectsIndexPage">
                     <FieldsRow>
                         <span>Showing {redirects.length} redirects</span>

--- a/adminSiteClient/SiteRedirectsIndexPage.tsx
+++ b/adminSiteClient/SiteRedirectsIndexPage.tsx
@@ -1,0 +1,184 @@
+import cx from "classnames"
+import React, { useContext, useEffect, useState } from "react"
+import { useForm } from "react-hook-form"
+
+import { AdminAppContext } from "./AdminAppContext.js"
+import { AdminLayout } from "./AdminLayout.js"
+
+const VALID_PATTERN = /^\/$|^.*[^\/]+$/
+const INVALID_PATTERN_MESSAGE =
+    "URL cannot end with a slash unless it's the root."
+
+type Redirect = {
+    id: number
+    source: string
+    target: string
+}
+
+function RedirectRow({
+    redirect,
+    onDelete,
+}: {
+    redirect: Redirect
+    onDelete: (redirect: Redirect) => void
+}) {
+    return (
+        <tr>
+            <td className="text-break">{redirect.source}</td>
+            <td className="text-break">
+                <a href={redirect.target} target="_blank" rel="noopener">
+                    {redirect.target}
+                </a>
+            </td>
+            <td>
+                <button
+                    className="btn btn-danger"
+                    onClick={() => onDelete(redirect)}
+                >
+                    Delete
+                </button>
+            </td>
+        </tr>
+    )
+}
+
+type FormData = {
+    source: string
+    target: string
+}
+
+export default function SiteRedirectsIndexPage() {
+    const { admin } = useContext(AdminAppContext)
+    const [redirects, setRedirects] = useState<Redirect[]>([])
+    const [error, setError] = useState<string | null>(null)
+    const {
+        register,
+        formState: { errors, isSubmitting },
+        handleSubmit,
+        watch,
+    } = useForm<FormData>()
+    const source = watch("source")
+
+    useEffect(() => {
+        admin
+            .getJSON("/api/site-redirects.json")
+            .then((json) => {
+                setRedirects(json.redirects)
+            })
+            .catch(() => {
+                setError("Error loading redirects.")
+            })
+    }, [admin])
+
+    function validateTarget(value: string) {
+        if (value === source) {
+            return "Source and target cannot be the same."
+        }
+        return undefined
+    }
+
+    async function onSubmit(data: FormData) {
+        setError(null)
+        const json = await admin.requestJSON(
+            "/api/site-redirects/new",
+            data,
+            "POST"
+        )
+        if (json.success) {
+            setRedirects([json.redirect, ...redirects])
+        } else {
+            setError("Error creating a redirect.")
+        }
+    }
+
+    async function handleDelete(redirect: Redirect) {
+        if (!window.confirm(`Delete the redirect from ${redirect.source}?`))
+            return
+        setError(null)
+        const json = await admin.requestJSON(
+            `/api/site-redirects/${redirect.id}`,
+            {},
+            "DELETE"
+        )
+        if (json.success) {
+            setRedirects(redirects.filter((r) => r.id !== redirect.id))
+        } else {
+            setError("Error deleting the redirect.")
+        }
+    }
+
+    return (
+        <AdminLayout title="Site Redirects">
+            <main>
+                <form onSubmit={handleSubmit(onSubmit)}>
+                    <div className="form-row">
+                        <div className="form-group col-12 col-md-4">
+                            <label>Source</label>
+                            <input
+                                className={cx("form-control", {
+                                    "is-invalid": errors.source,
+                                })}
+                                {...register("source", {
+                                    required: "Please provide a source.",
+                                    pattern: {
+                                        value: VALID_PATTERN,
+                                        message: INVALID_PATTERN_MESSAGE,
+                                    },
+                                })}
+                            />
+                            <div className="invalid-feedback">
+                                {errors.source?.message}
+                            </div>
+                        </div>
+                        <div className="form-group col-12 col-md-4">
+                            <label>Target</label>
+                            <input
+                                className={cx("form-control", {
+                                    "is-invalid": errors.target,
+                                })}
+                                {...register("target", {
+                                    required: "Please provide a target.",
+                                    pattern: {
+                                        value: VALID_PATTERN,
+                                        message: INVALID_PATTERN_MESSAGE,
+                                    },
+                                    validate: validateTarget,
+                                })}
+                            />
+                            <div className="invalid-feedback">
+                                {errors.target?.message}
+                            </div>
+                        </div>
+                    </div>
+                    <button
+                        className="btn btn-primary mb-3"
+                        type="submit"
+                        disabled={isSubmitting}
+                    >
+                        Create
+                    </button>
+                    {error && <div className="text-danger mb-3">{error}</div>}
+                </form>
+                <p>Showing {redirects.length} redirects</p>
+                <table className="table table-bordered">
+                    <thead>
+                        <tr>
+                            <th>Source</th>
+                            <th>Target</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {redirects.map((redirect) => (
+                            <RedirectRow
+                                key={redirect.id}
+                                redirect={redirect}
+                                onDelete={handleDelete}
+                            />
+                        ))}
+                    </tbody>
+                </table>
+            </main>
+        </AdminLayout>
+    )
+}

--- a/adminSiteClient/SiteRedirectsIndexPage.tsx
+++ b/adminSiteClient/SiteRedirectsIndexPage.tsx
@@ -4,6 +4,7 @@ import { useForm } from "react-hook-form"
 
 import { AdminAppContext } from "./AdminAppContext.js"
 import { AdminLayout } from "./AdminLayout.js"
+import { Link } from "./Link.js"
 
 const SOURCE_PATTERN = /^\/$|^\/.*[^\/]+$/
 const INVALID_SOURCE_MESSAGE =
@@ -124,7 +125,7 @@ export default function SiteRedirectsIndexPage() {
                             This page is used to create and delete redirects for
                             the site. Don't use this page to create redirects
                             for charts, use the{" "}
-                            <a href="/admin/redirects">chart redirects page</a>{" "}
+                            <Link to="/redirects">chart redirects page</Link>{" "}
                             instead.
                         </p>
                         <p>

--- a/adminSiteClient/SiteRedirectsIndexPage.tsx
+++ b/adminSiteClient/SiteRedirectsIndexPage.tsx
@@ -121,10 +121,27 @@ export default function SiteRedirectsIndexPage() {
                 <div className="row">
                     <div className="col-12 col-md-8">
                         <p>
-                            Source has to start with a slash and any query
-                            parameters (?a=b) or fragments (#c) will be
-                            stripped, if present. The target can contain a full
-                            URL or a relative URL starting with a slash and both
+                            This page is used to create and delete redirects for
+                            the site. Don't use this page to create redirects
+                            for charts, use the{" "}
+                            <a href="/admin/redirects">chart redirects page</a>{" "}
+                            instead.
+                        </p>
+                        <p>
+                            The source has to start with a slash and any query
+                            parameters (/war-and-peace
+                            <span className="redirect-emphasis">
+                                ?insight=insightid
+                            </span>
+                            ) or fragments (/war-and-peace
+                            <span className="redirect-emphasis">
+                                #all-charts
+                            </span>
+                            ) will be stripped, if present.
+                        </p>
+                        <p>
+                            The target can point to a full URL at another domain
+                            or a relative URL starting with a slash and both
                             query parameters and fragments are allowed.
                         </p>
                         <p>
@@ -141,6 +158,7 @@ export default function SiteRedirectsIndexPage() {
                                 className={cx("form-control", {
                                     "is-invalid": errors.source,
                                 })}
+                                placeholder="/fertility-can-decline-extremely-fast"
                                 {...register("source", {
                                     required: "Please provide a source.",
                                     pattern: {
@@ -159,6 +177,7 @@ export default function SiteRedirectsIndexPage() {
                                 className={cx("form-control", {
                                     "is-invalid": errors.target,
                                 })}
+                                placeholder="/fertility-rate"
                                 {...register("target", {
                                     required: "Please provide a target.",
                                     pattern: {

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -926,6 +926,14 @@ main:not(.ChartEditorPage):not(.GdocsEditPage) {
     text-decoration: none;
 }
 
+.redirect-emphasis {
+    // font-weight: 600;
+    // color: #0066aa;
+    // make the text underlined the underline color gray
+    text-decoration: underline;
+    text-decoration-color: #ccc;
+}
+
 .add-redirect-form {
     display: flex;
     flex-direction: row;

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -927,9 +927,6 @@ main:not(.ChartEditorPage):not(.GdocsEditPage) {
 }
 
 .redirect-emphasis {
-    // font-weight: 600;
-    // color: #0066aa;
-    // make the text underlined the underline color gray
     text-decoration: underline;
     text-decoration-color: #ccc;
 }

--- a/db/migration/1713447826006-UniqueRedirectSource.ts
+++ b/db/migration/1713447826006-UniqueRedirectSource.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class UniqueRedirectSource1713447826006 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE redirects ADD CONSTRAINT source_unique UNIQUE (source(255))`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE redirects DROP CONSTRAINT source_unique`
+        )
+    }
+}

--- a/db/model/Redirect.ts
+++ b/db/model/Redirect.ts
@@ -3,13 +3,68 @@ import * as db from "../db"
 
 export const getRedirectsFromDb = async (
     knex: db.KnexReadonlyTransaction
-): Promise<DbPlainRedirect[]> => {
-    const redirectsFromDb: DbPlainRedirect[] = await db.knexRaw(
-        knex,
-        `
-        SELECT source, target, code FROM redirects
-        `
-    )
+): Promise<Pick<DbPlainRedirect, "source" | "target" | "code">[]> => {
+    return await db.knexRaw(knex, `SELECT source, target, code FROM redirects`)
+}
 
-    return redirectsFromDb
+export async function getRedirects(
+    knex: db.KnexReadonlyTransaction
+): Promise<Pick<DbPlainRedirect, "id" | "source" | "target">[]> {
+    return await db.knexRaw(
+        knex,
+        `SELECT id, source, target FROM redirects ORDER BY id DESC`
+    )
+}
+
+export async function getRedirectById(
+    knex: db.KnexReadonlyTransaction,
+    id: number
+): Promise<Pick<DbPlainRedirect, "id" | "source" | "target"> | undefined> {
+    return await db.knexRawFirst(
+        knex,
+        `SELECT id, source, target FROM redirects WHERE id = ?`,
+        [id]
+    )
+}
+
+export async function redirectWithSourceExists(
+    knex: db.KnexReadonlyTransaction,
+    source: string
+): Promise<boolean> {
+    const result = await db.knexRawFirst(
+        knex,
+        `SELECT 1 FROM redirects WHERE source = ?`,
+        [source]
+    )
+    return Boolean(result)
+}
+
+export async function wouldCreateRedirectCycle(
+    knex: db.KnexReadonlyTransaction,
+    source: string,
+    target: string
+): Promise<boolean> {
+    const result: { cycleExists: number } | undefined = await db.knexRawFirst(
+        knex,
+        `WITH RECURSIVE redirect_chain AS (
+            -- Base case: Start with the target of the proposed new redirect.
+            SELECT source, target
+            FROM redirects
+            WHERE source = ?
+
+            UNION ALL
+
+            -- Recursive step: Follow the chain of redirects.
+            SELECT r.source, r.target
+            FROM redirects r
+            INNER JOIN redirect_chain rc ON rc.target = r.source
+        )
+         -- Check if the new source appears in the redirect chain starting from
+         -- the new target.
+         SELECT COUNT(*) > 0 AS cycleExists
+         FROM redirect_chain
+         WHERE source = ? OR target = ?`,
+        [target, source, source]
+    )
+    return Boolean(result?.cycleExists)
 }

--- a/db/model/Redirect.ts
+++ b/db/model/Redirect.ts
@@ -39,32 +39,14 @@ export async function redirectWithSourceExists(
     return Boolean(result)
 }
 
-export async function wouldCreateRedirectCycle(
+export async function getChainedRedirect(
     knex: db.KnexReadonlyTransaction,
     source: string,
     target: string
-): Promise<boolean> {
-    const result: { cycleExists: number } | undefined = await db.knexRawFirst(
+): Promise<Pick<DbPlainRedirect, "source" | "target"> | undefined> {
+    return await db.knexRawFirst(
         knex,
-        `WITH RECURSIVE redirect_chain AS (
-            -- Base case: Start with the target of the proposed new redirect.
-            SELECT source, target
-            FROM redirects
-            WHERE source = ?
-
-            UNION ALL
-
-            -- Recursive step: Follow the chain of redirects.
-            SELECT r.source, r.target
-            FROM redirects r
-            INNER JOIN redirect_chain rc ON rc.target = r.source
-        )
-         -- Check if the new source appears in the redirect chain starting from
-         -- the new target.
-         SELECT COUNT(*) > 0 AS cycleExists
-         FROM redirect_chain
-         WHERE source = ? OR target = ?`,
-        [target, source, source]
+        `SELECT source, target FROM redirects WHERE source = ? OR target = ?`,
+        [target, source]
     )
-    return Boolean(result?.cycleExists)
 }

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
         "react-dom": "^17.0.2",
         "react-error-boundary": "^4.0.10",
         "react-flip-toolkit": "^7.0.9",
+        "react-hook-form": "^7.51.3",
         "react-horizontal-scrolling-menu": "^4.0.3",
         "react-instantsearch": "^7.7.1",
         "react-intersection-observer": "^9.4.0",

--- a/packages/@ourworldindata/types/src/dbTypes/Redirects.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Redirects.ts
@@ -3,8 +3,13 @@ export enum RedirectCode {
     FOUND = 302,
 }
 
-export interface DbPlainRedirect {
+export interface DbInsertRedirect {
+    id: number
     source: string
     target: string
     code: RedirectCode
+    createdAt?: Date | null
+    updatedAt?: Date | null
 }
+
+export type DbPlainRedirect = Required<DbInsertRedirect>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11195,6 +11195,7 @@ __metadata:
     react-dom: "npm:^17.0.2"
     react-error-boundary: "npm:^4.0.10"
     react-flip-toolkit: "npm:^7.0.9"
+    react-hook-form: "npm:^7.51.3"
     react-horizontal-scrolling-menu: "npm:^4.0.3"
     react-instantsearch: "npm:^7.7.1"
     react-intersection-observer: "npm:^9.4.0"
@@ -17500,6 +17501,15 @@ __metadata:
     react: 16.x
     react-dom: ">= 16.x"
   checksum: 10/2229e48ad0e67839222489b28aa9413ff49d7affcba78bee5b328f9c2cbc3ba99b5669a029a2aba8b732ed5cac8a8b11ccef78b5809ca96a1b39b5aa6308ffb5
+  languageName: node
+  linkType: hard
+
+"react-hook-form@npm:^7.51.3":
+  version: 7.51.3
+  resolution: "react-hook-form@npm:7.51.3"
+  peerDependencies:
+    react: ^16.8.0 || ^17 || ^18
+  checksum: 10/37f5d681b0f9d6a64b56e38c6ea98941c78d2634e175e7722e66a6bd72b4b22a73a5b912ada8cc010b5ec9e1019b8e2d4a6b0f38e87280600f8e921dee96aaca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I got heavily inspired by `RedirectsIndexPage.tsx`. I used `react-hook-form` since I had good experience with it before, and it makes the form handling nice.

Server validation error leads to a generic error popup on the frontend, which is bad UX, but it seems this is what we do also elsewhere. Let me know if there is a good way to avoid that.