### PR TITLE
Don't fetch image metadata during Algolia sync (with tags)

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -135,7 +135,7 @@ import {
     getGdocBaseObjectById,
     setLinksForGdoc,
     setTagsForGdoc,
-    syncImagesAndAddToContentGraph,
+    addImagesToContentGraph,
     updateGdocContentOnly,
     upsertGdoc,
 } from "../db/model/Gdoc/GdocFactory.js"
@@ -2276,6 +2276,7 @@ getRouteNonIdempotentWithRWTransaction(
             | undefined
 
         try {
+            // Beware: if contentSource=gdocs this will update images in the DB+S3 even if the gdoc is published
             const gdoc = await getAndLoadGdocById(trx, id, contentSource)
 
             if (!gdoc.published) {
@@ -2367,7 +2368,7 @@ putRouteWithRWTransaction(apiRouter, "/gdocs/:id", async (req, res, trx) => {
     const nextGdoc = gdocFromJSON(req.body)
     await nextGdoc.loadState(trx)
 
-    await syncImagesAndAddToContentGraph(trx, nextGdoc)
+    await addImagesToContentGraph(trx, nextGdoc)
 
     await setLinksForGdoc(
         trx,

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -328,7 +328,8 @@ export class SiteBaker {
                     keyBy(images, "filename")
                 )
 
-            // This step usually runs so quickly that the progress bar doesn't log, but the step is still counted
+            // This step runs so quickly that the progress bar doesn't log, so we add a small delay
+            await new Promise((resolve) => setTimeout(resolve, 10))
             this.progressBar.tick({
                 name: `✅ Prefetched ${Object.values(imageMetadataDictionary).length} images`,
             })
@@ -386,13 +387,7 @@ export class SiteBaker {
             const publishedChartsWithIndicatorIds = publishedCharts.filter(
                 (chart) => chart.indicatorId
             )
-            console.log(
-                "publishedChartsWithIndicatorIds.length",
-                publishedChartsWithIndicatorIds.length
-            )
-            const datapageIndicators: LinkedIndicator[] = []
-
-            await Promise.all(
+            const datapageIndicators: LinkedIndicator[] = await Promise.all(
                 publishedChartsWithIndicatorIds.map(async (linkedChart) => {
                     const indicatorId = linkedChart.indicatorId as number
                     const metadata = await getVariableMetadata(indicatorId)

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -1,7 +1,7 @@
 import fs from "fs-extra"
 import path from "path"
 import { glob } from "glob"
-import { keyBy, without, uniq, mapValues, pick } from "lodash"
+import { keyBy, without, uniq, mapValues, pick, chunk } from "lodash"
 import ProgressBar from "progress"
 import * as wpdb from "../db/wpdb.js"
 import * as db from "../db/db.js"
@@ -100,7 +100,10 @@ import {
     getVariableMetadata,
     getVariableOfDatapageIfApplicable,
 } from "../db/model/Variable.js"
-import { getAllMinimalGdocBaseObjects } from "../db/model/Gdoc/GdocFactory.js"
+import {
+    gdocFromJSON,
+    getAllMinimalGdocBaseObjects,
+} from "../db/model/Gdoc/GdocFactory.js"
 import { getBakePath } from "@ourworldindata/components"
 import { GdocAuthor } from "../db/model/Gdoc/GdocAuthor.js"
 import { DATA_INSIGHTS_ATOM_FEED_NAME } from "../site/gdocs/utils.js"
@@ -304,6 +307,7 @@ export class SiteBaker {
         picks?: [string[], string[], string[], string[]]
     ): Promise<PrefetchedAttachments> {
         if (!this._prefetchedAttachmentsCache) {
+            console.log("Prefetching attachments")
             const publishedGdocs = await getAllMinimalGdocBaseObjects(knex)
             const publishedGdocsDictionary = keyBy(publishedGdocs, "id")
 
@@ -328,23 +332,31 @@ export class SiteBaker {
 
             // Includes redirects
             const publishedChartsRaw = await mapSlugsToConfigs(knex)
-            const publishedCharts: LinkedChart[] = await Promise.all(
-                publishedChartsRaw.map(async (chart) => {
-                    const tab = chart.config.tab ?? GrapherTabOption.chart
-                    const datapageIndicator =
-                        await getVariableOfDatapageIfApplicable(chart.config)
-                    return {
-                        originalSlug: chart.slug,
-                        resolvedUrl: `${BAKED_GRAPHER_URL}/${chart.config.slug}`,
-                        tab,
-                        queryString: "",
-                        title: chart.config.title || "",
-                        thumbnail: `${BAKED_GRAPHER_EXPORTS_BASE_URL}/${chart.config.slug}.svg`,
-                        indicatorId: datapageIndicator?.id,
-                        tags: [],
-                    }
-                })
-            )
+            const publishedCharts: LinkedChart[] = []
+
+            for (const publishedChartsRawChunk of chunk(
+                publishedChartsRaw,
+                20
+            )) {
+                await Promise.all(
+                    publishedChartsRawChunk.map(async (chart) => {
+                        const tab = chart.config.tab ?? GrapherTabOption.chart
+                        const datapageIndicator =
+                            await getVariableOfDatapageIfApplicable(
+                                chart.config
+                            )
+                        publishedCharts.push({
+                            originalSlug: chart.slug,
+                            resolvedUrl: `${BAKED_GRAPHER_URL}/${chart.config.slug}`,
+                            tab,
+                            title: chart.config.title || "",
+                            thumbnail: `${BAKED_GRAPHER_EXPORTS_BASE_URL}/${chart.config.slug}.svg`,
+                            indicatorId: datapageIndicator?.id,
+                            tags: [],
+                        })
+                    })
+                )
+            }
             const publishedChartsBySlug = keyBy(publishedCharts, "originalSlug")
 
             const publishedChartsWithIndicatorIds = publishedCharts.filter(
@@ -486,7 +498,10 @@ export class SiteBaker {
     // TODO: this transaction is only RW because somewhere inside it we fetch images
     async bakeGDocPosts(knex: db.KnexReadWriteTransaction, slugs?: string[]) {
         if (!this.bakeSteps.has("gdocPosts")) return
-        const publishedGdocs = await GdocPost.getPublishedGdocPosts(knex)
+        // We don't need to load these as we prefetch all attachments
+        const publishedGdocs = await db
+            .getPublishedGdocPosts(knex)
+            .then((gdocs) => gdocs.map(gdocFromJSON))
 
         const gdocsToBake =
             slugs !== undefined
@@ -519,7 +534,9 @@ export class SiteBaker {
             publishedGdoc.linkedIndicators = attachments.linkedIndicators
 
             // this is a no-op if the gdoc doesn't have an all-chart block
-            await publishedGdoc.loadRelatedCharts(knex)
+            if ("loadRelatedCharts" in publishedGdoc) {
+                await publishedGdoc.loadRelatedCharts(knex)
+            }
 
             await publishedGdoc.validate(knex)
             if (

--- a/baker/algolia/algoliaUtils.tsx
+++ b/baker/algolia/algoliaUtils.tsx
@@ -211,7 +211,7 @@ function generateGdocRecords(
 export const getPagesRecords = async (knex: db.KnexReadWriteTransaction) => {
     const pageviews = await getAnalyticsPageviewsByUrlObj(knex)
     const gdocs = await db
-        .getPublishedGdocPosts(knex)
+        .getPublishedGdocPostsWithTags(knex)
         .then((gdocs) => gdocs.map(gdocFromJSON) as OwidGdocPostInterface[])
 
     const publishedGdocsBySlug = keyBy(gdocs, "slug")

--- a/baker/algolia/algoliaUtils.tsx
+++ b/baker/algolia/algoliaUtils.tsx
@@ -23,7 +23,6 @@ import {
     SearchIndexName,
 } from "../../site/search/searchTypes.js"
 import { getAnalyticsPageviewsByUrlObj } from "../../db/model/Pageview.js"
-import { GdocPost } from "../../db/model/Gdoc/GdocPost.js"
 import { ArticleBlocks } from "../../site/gdocs/components/ArticleBlocks.js"
 import React from "react"
 import {
@@ -34,6 +33,8 @@ import {
 import { getIndexName } from "../../site/search/searchClient.js"
 import { ObjectWithObjectID } from "@algolia/client-search"
 import { SearchIndex } from "algoliasearch"
+import { match, P } from "ts-pattern"
+import { gdocFromJSON } from "../../db/model/Gdoc/GdocFactory.js"
 
 interface TypeAndImportance {
     type: PageType
@@ -146,20 +147,27 @@ function generateGdocRecords(
     const getPostTypeAndImportance = (
         gdoc: OwidGdocPostInterface
     ): TypeAndImportance => {
-        switch (gdoc.content.type) {
-            case OwidGdocType.TopicPage:
-                return { type: "topic", importance: 3 }
-            case OwidGdocType.LinearTopicPage:
-                return { type: "topic", importance: 3 }
-            case OwidGdocType.Fragment:
-                // this should not happen because we filter out fragments; but we want to have an exhaustive switch/case so we include it
-                return { type: "other", importance: 0 }
-            case OwidGdocType.AboutPage:
-                return { type: "about", importance: 0 }
-            case OwidGdocType.Article:
-            case undefined:
-                return { type: "article", importance: 0 }
-        }
+        return match(gdoc.content.type)
+            .with(OwidGdocType.Article, () => ({
+                type: "article" as const,
+                importance: 0,
+            }))
+            .with(OwidGdocType.AboutPage, () => ({
+                type: "about" as const,
+                importance: 1,
+            }))
+            .with(
+                P.union(OwidGdocType.TopicPage, OwidGdocType.LinearTopicPage),
+                () => ({
+                    type: "topic" as const,
+                    importance: 3,
+                })
+            )
+            .with(P.union(OwidGdocType.Fragment, undefined), () => ({
+                type: "other" as const,
+                importance: 0,
+            }))
+            .exhaustive()
     }
 
     const records: PageRecord[] = []
@@ -202,9 +210,11 @@ function generateGdocRecords(
 // Generate records for countries, WP posts (not including posts that have been succeeded by Gdocs equivalents), and Gdocs
 export const getPagesRecords = async (knex: db.KnexReadWriteTransaction) => {
     const pageviews = await getAnalyticsPageviewsByUrlObj(knex)
-    const gdocs = await GdocPost.getPublishedGdocPosts(knex)
+    const gdocs = await db
+        .getPublishedGdocPosts(knex)
+        .then((gdocs) => gdocs.map(gdocFromJSON) as OwidGdocPostInterface[])
+
     const publishedGdocsBySlug = keyBy(gdocs, "slug")
-    // TODO: the knex instance should be handed down as a parameter
     const slugsWithPublishedGdocsSuccessors =
         await db.getSlugsWithPublishedGdocsSuccessors(knex)
     const postsApi = await getPostsFromSnapshots(knex, undefined, (post) => {

--- a/baker/algolia/indexToAlgolia.tsx
+++ b/baker/algolia/indexToAlgolia.tsx
@@ -25,6 +25,8 @@ const indexToAlgolia = async () => {
     await index.replaceAllObjects(records)
 
     await wpdb.singleton.end()
+
+    process.exit(0)
 }
 
 process.on("unhandledRejection", (e) => {

--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -15,7 +15,6 @@ import { countryProfileSpecs } from "../site/countryProfileProjects.js"
 import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer.js"
 import { EXPLORERS_ROUTE_FOLDER } from "../explorer/ExplorerConstants.js"
 import { ExplorerProgram } from "../explorer/ExplorerProgram.js"
-import { GdocPost } from "../db/model/Gdoc/GdocPost.js"
 import { getPostsFromSnapshots } from "../db/model/Post.js"
 import { calculateDataInsightIndexPageCount } from "../db/model/Gdoc/gdocUtils.js"
 
@@ -74,7 +73,7 @@ export const makeSitemap = async (
         undefined,
         (postrow) => !alreadyPublishedViaGdocsSlugsSet.has(postrow.slug)
     )
-    const gdocPosts = await GdocPost.getPublishedGdocPosts(knex)
+    const gdocPosts = await db.getPublishedGdocPosts(knex)
 
     const publishedDataInsights = await db.getPublishedDataInsights(knex)
     const dataInsightFeedPageCount = calculateDataInsightIndexPageCount(

--- a/db/db.ts
+++ b/db/db.ts
@@ -396,17 +396,17 @@ export const getPublishedGdocPostsWithTags = async (
         g.revisionId,
         g.slug,
         g.updatedAt,
-        JSON_ARRAYAGG(
-          JSON_OBJECT(
-            'id', t.id,
-            'name', t.name,
-            'slug', t.slug
-        )) AS tags
+        if( COUNT(t.id) = 0, JSON_ARRAY(), JSON_ARRAYAGG(
+            JSON_OBJECT(
+              'id', t.id,
+              'name', t.name,
+              'slug', t.slug
+          ))) AS tags
     FROM
         posts_gdocs g
-    JOIN posts_gdocs_x_tags gxt ON
+    LEFT JOIN posts_gdocs_x_tags gxt ON
         g.id = gxt.gdocId 
-    JOIN tags t ON
+    LEFT JOIN tags t ON
         gxt.tagId = t.id
     WHERE
         g.published = 1

--- a/db/db.ts
+++ b/db/db.ts
@@ -10,8 +10,12 @@ import { registerExitHandler } from "./cleanup.js"
 import { keyBy } from "@ourworldindata/utils"
 import {
     DbChartTagJoin,
+    DbEnrichedPostGdoc,
+    DbRawPostGdoc,
+    ImageMetadata,
     MinimalDataInsightInterface,
     OwidGdocType,
+    parsePostsGdocsRow,
 } from "@ourworldindata/types"
 
 // Return the first match from a mysql query
@@ -309,4 +313,51 @@ export const getHomepageId = (
             content->>'$.type' = '${OwidGdocType.Homepage}'
             AND published = TRUE`
     ).then((result) => result?.id)
+}
+
+export const getImageMetadataByFilenames = async (
+    knex: KnexReadonlyTransaction,
+    filenames: string[]
+): Promise<Record<string, ImageMetadata & { id: number }>> => {
+    if (filenames.length === 0) return {}
+    const rows = await knexRaw<ImageMetadata & { id: number }>(
+        knex,
+        `-- sql
+        SELECT
+            id,
+            googleId,
+            filename,
+            defaultAlt,
+            updatedAt,
+            originalWidth,
+            originalHeight
+        FROM
+            images
+        WHERE filename IN (?)`,
+        [filenames]
+    )
+    return keyBy(rows, "filename")
+}
+
+export const getPublishedGdocPosts = async (
+    knex: KnexReadonlyTransaction
+): Promise<DbEnrichedPostGdoc[]> => {
+    return knexRaw<DbRawPostGdoc>(
+        knex,
+        `-- sql
+            SELECT *
+            FROM posts_gdocs
+            WHERE published = 1
+            AND content ->> '$.type' IN (:types)
+            AND publishedAt <= NOW()
+            ORDER BY publishedAt DESC`,
+        {
+            types: [
+                OwidGdocType.Article,
+                OwidGdocType.LinearTopicPage,
+                OwidGdocType.TopicPage,
+                OwidGdocType.AboutPage,
+            ],
+        }
+    ).then((rows) => rows.map(parsePostsGdocsRow))
 }

--- a/db/model/Gdoc/GdocAuthor.ts
+++ b/db/model/Gdoc/GdocAuthor.ts
@@ -43,16 +43,14 @@ export class GdocAuthor extends GdocBase implements OwidGdocAuthorInterface {
         return blocks
     }
 
-    // TODO: this transaction is only RW because somewhere inside it we fetch images
     _loadSubclassAttachments = (
-        knex: db.KnexReadWriteTransaction
+        knex: db.KnexReadonlyTransaction
     ): Promise<void> => {
         return this.loadLatestWorkImages(knex)
     }
 
-    // TODO: this transaction is only RW because somewhere inside it we fetch images
     loadLatestWorkImages = async (
-        knex: db.KnexReadWriteTransaction
+        knex: db.KnexReadonlyTransaction
     ): Promise<void> => {
         if (!this.content.title) return
 
@@ -77,7 +75,7 @@ export class GdocAuthor extends GdocBase implements OwidGdocAuthorInterface {
         // Load the image metadata for the latest work images, including the
         // default featured image which is used as a fallback in the entire
         // research and writing block
-        return super.loadImageMetadata(knex, [
+        return super.loadImageMetadataFromDB(knex, [
             ...latestWorkImageFilenames,
             DEFAULT_GDOC_FEATURED_IMAGE,
         ])

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -5,7 +5,6 @@ import {
     LinkedIndicator,
     keyBy,
     ImageMetadata,
-    excludeUndefined,
     OwidGdocErrorMessage,
     OwidGdocErrorMessageType,
     excludeNullish,
@@ -32,7 +31,6 @@ import { BAKED_GRAPHER_URL } from "../../../settings/serverSettings.js"
 import { google } from "googleapis"
 import { gdocToArchie } from "./gdocToArchie.js"
 import { archieToEnriched } from "./archieToEnriched.js"
-import { imageStore } from "../Image.js"
 import { getChartConfigById, mapSlugsToIds } from "../Chart.js"
 import {
     BAKED_BASE_URL,
@@ -86,9 +84,8 @@ export class GdocBase implements OwidGdocBaseInterface {
     ) => Promise<OwidGdocErrorMessage[]> = async () => []
     _omittableFields: string[] = []
 
-    // TODO: this transaction is only RW because somewhere inside it we fetch images
     _loadSubclassAttachments: (
-        knex: db.KnexReadWriteTransaction
+        knex: db.KnexReadonlyTransaction
     ) => Promise<void> = async () => undefined
 
     constructor(id?: string) {
@@ -562,29 +559,27 @@ export class GdocBase implements OwidGdocBaseInterface {
         const slugToIdMap = await mapSlugsToIds(knex)
         // TODO: rewrite this as a single query instead of N queries
         const linkedGrapherCharts = await Promise.all(
-            [...this.linkedChartSlugs.grapher.values()].map(
-                async (originalSlug) => {
-                    const chartId = slugToIdMap[originalSlug]
-                    if (!chartId) return
-                    const chart = await getChartConfigById(knex, chartId)
-                    if (!chart) return
-                    const resolvedSlug = chart.config.slug ?? ""
-                    const resolvedTitle = chart.config.title ?? ""
-                    const tab = chart.config.tab ?? GrapherTabOption.chart
-                    const datapageIndicator =
-                        await getVariableOfDatapageIfApplicable(chart.config)
-                    const linkedChart: LinkedChart = {
-                        originalSlug,
-                        title: resolvedTitle,
-                        tab,
-                        resolvedUrl: `${BAKED_GRAPHER_URL}/${resolvedSlug}`,
-                        thumbnail: `${BAKED_GRAPHER_EXPORTS_BASE_URL}/${resolvedSlug}.svg`,
-                        tags: [],
-                        indicatorId: datapageIndicator?.id,
-                    }
-                    return linkedChart
+            this.linkedChartSlugs.grapher.map(async (originalSlug) => {
+                const chartId = slugToIdMap[originalSlug]
+                if (!chartId) return
+                const chart = await getChartConfigById(knex, chartId)
+                if (!chart) return
+                const resolvedSlug = chart.config.slug ?? ""
+                const resolvedTitle = chart.config.title ?? ""
+                const tab = chart.config.tab ?? GrapherTabOption.chart
+                const datapageIndicator =
+                    await getVariableOfDatapageIfApplicable(chart.config)
+                const linkedChart: LinkedChart = {
+                    originalSlug,
+                    title: resolvedTitle,
+                    tab,
+                    resolvedUrl: `${BAKED_GRAPHER_URL}/${resolvedSlug}`,
+                    thumbnail: `${BAKED_GRAPHER_EXPORTS_BASE_URL}/${resolvedSlug}.svg`,
+                    tags: [],
+                    indicatorId: datapageIndicator?.id,
                 }
-            )
+                return linkedChart
+            })
         ).then(excludeNullish)
 
         const publishedExplorersBySlug =
@@ -641,26 +636,25 @@ export class GdocBase implements OwidGdocBaseInterface {
         this.linkedDocuments = keyBy(linkedDocuments, "id")
     }
 
-    // TODO: this transaction is only RW because somewhere inside it we fetch images
-    async loadImageMetadata(
-        knex: db.KnexReadWriteTransaction,
+    /**
+     * Load image metadata from the database. Does not check Google Drive or sync to S3
+     */
+    async loadImageMetadataFromDB(
+        knex: db.KnexReadonlyTransaction,
         filenames?: string[]
     ): Promise<void> {
         const imagesFilenames = filenames ?? this.linkedImageFilenames
 
         if (!imagesFilenames.length) return
 
-        await imageStore.fetchImageMetadata(imagesFilenames)
-        const images = await imageStore
-            .syncImagesToS3(knex)
-            .then(excludeUndefined)
+        const imageMetadata = await db.getImageMetadataByFilenames(
+            knex,
+            imagesFilenames
+        )
 
-        // Merge the new image metadata with the existing image metadata. This
-        // is used by GdocAuthor to load additional image metadata from the
-        // latest work section.
         this.imageMetadata = {
             ...this.imageMetadata,
-            ...keyBy(images, "filename"),
+            ...keyBy(imageMetadata, "filename"),
         }
     }
 
@@ -784,10 +778,9 @@ export class GdocBase implements OwidGdocBaseInterface {
         ]
     }
 
-    // TODO: this transaction is only RW because somewhere inside it we fetch images
-    async loadState(knex: db.KnexReadWriteTransaction): Promise<void> {
+    async loadState(knex: db.KnexReadonlyTransaction): Promise<void> {
         await this.loadLinkedDocuments(knex)
-        await this.loadImageMetadata(knex)
+        await this.loadImageMetadataFromDB(knex)
         await this.loadLinkedCharts(knex)
         await this.loadLinkedIndicators() // depends on linked charts
         await this._loadSubclassAttachments(knex)

--- a/db/model/Gdoc/GdocFactory.ts
+++ b/db/model/Gdoc/GdocFactory.ts
@@ -58,10 +58,7 @@ export function gdocFromJSON(
     json.createdAt = new Date(json.createdAt)
     json.publishedAt = json.publishedAt ? new Date(json.publishedAt) : null
     json.updatedAt = new Date(json.updatedAt)
-
-    // `tags` ordinarily gets populated via a join table in .load(), for our purposes we don't need it here
-    // except for the fact that loadRelatedCharts() assumes the array exists
-    json.tags = json.tags
+    json.tags = json.tags ? JSON.parse(json.tags) : []
 
     return match(type)
         .with(

--- a/db/model/Gdoc/GdocPost.ts
+++ b/db/model/Gdoc/GdocPost.ts
@@ -23,15 +23,8 @@ import { ADMIN_BASE_URL } from "../../../settings/clientSettings.js"
 import { parseDetails, parseFaqs } from "./rawToEnriched.js"
 import { htmlToEnrichedTextBlock } from "./htmlToEnriched.js"
 import { GdocBase } from "./GdocBase.js"
-import {
-    KnexReadWriteTransaction,
-    KnexReadonlyTransaction,
-    knexRaw,
-} from "../../db.js"
-import {
-    getGdocBaseObjectById,
-    getAndLoadPublishedGdocPosts,
-} from "./GdocFactory.js"
+import { KnexReadonlyTransaction, knexRaw } from "../../db.js"
+import { getGdocBaseObjectById } from "./GdocFactory.js"
 
 export class GdocPost extends GdocBase implements OwidGdocPostInterface {
     content!: OwidGdocPostContent
@@ -234,24 +227,5 @@ export class GdocPost extends GdocBase implements OwidGdocPostInterface {
         }
 
         return parseDetails(gdoc.content.details)
-    }
-
-    // TODO: this transaction is only RW because somewhere inside it we fetch images
-    static async getPublishedGdocPosts(
-        knex: KnexReadWriteTransaction
-    ): Promise<GdocPost[]> {
-        // #gdocsvalidation this cast means that we trust the admin code and
-        // workflow to provide published articles that have all the required content
-        // fields (see #gdocsvalidationclient and pending #gdocsvalidationserver).
-        // It also means that if a required field is added after the publication of
-        // an article, there won't currently be any checks preventing the then
-        // incomplete article to be republished (short of an error being raised down
-        // the line). A migration should then be added to update current articles
-        // with a sensible default for the new required content field. An
-        // alternative would be to encapsulate that default in
-        // mapGdocsToWordpressPosts(). This would make the Gdoc entity coming from
-        // the database dependent on the mapping function, which is more practical
-        // but also makes it less of a source of truth when considered in isolation.
-        return getAndLoadPublishedGdocPosts(knex)
     }
 }

--- a/db/model/Image.ts
+++ b/db/model/Image.ts
@@ -317,9 +317,8 @@ export async function fetchImagesFromDriveAndSyncToS3(
     if (!filenames.length) return []
 
     try {
-        const imageMetadata = await imageStore.fetchImageMetadata(filenames)
-
-        const metadataArray = Object.values(imageMetadata) as ImageMetadata[]
+        const metadataObject = await imageStore.fetchImageMetadata(filenames)
+        const metadataArray = Object.values(metadataObject) as ImageMetadata[]
 
         return Promise.all(
             metadataArray.map((metadata) => Image.syncImage(knex, metadata))

--- a/devTools/updateImageHeights/update-image-heights.ts
+++ b/devTools/updateImageHeights/update-image-heights.ts
@@ -15,10 +15,10 @@ async function updateImageHeights() {
         .then((rows) => rows.map((row) => row.filename))
 
     console.log("Fetching image metadata...")
-    await imageStore.fetchImageMetadata([])
+    const images = await imageStore.fetchImageMetadata([])
     console.log("Fetching image metadata...done")
 
-    if (!imageStore.images) {
+    if (!images) {
         throw new Error("No images found")
     }
 
@@ -28,7 +28,7 @@ async function updateImageHeights() {
         for (const batch of lodash.chunk(filenames, 20)) {
             const promises = []
             for (const filename of batch) {
-                const image = imageStore.images[filename]
+                const image = images[filename]
                 if (image && image.originalHeight) {
                     promises.push(
                         db.knexRaw(

--- a/packages/@ourworldindata/types/src/dbTypes/PostsGdocs.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/PostsGdocs.ts
@@ -4,6 +4,7 @@ import {
     OwidGdocContent,
     OwidGdocPublicationContext,
 } from "../gdocTypes/Gdoc.js"
+import { MinimalTag } from "./Tags.js"
 
 export const PostsGdocsTableName = "posts_gdocs"
 export interface DbInsertPostGdoc {
@@ -27,6 +28,14 @@ export type DbEnrichedPostGdoc = Omit<
     content: OwidGdocContent
     breadcrumbs: BreadcrumbItem[] | null
     published: boolean
+}
+
+export type DBRawPostGdocWithTags = DbRawPostGdoc & {
+    tags: MinimalTag[]
+}
+
+export type DBEnrichedPostGdocWithTags = DbEnrichedPostGdoc & {
+    tags: MinimalTag[]
 }
 
 export function parsePostGdocContent(content: JsonString): OwidGdocContent {
@@ -55,6 +64,15 @@ export function parsePostsGdocsRow(row: DbRawPostGdoc): DbEnrichedPostGdoc {
         content: parsePostGdocContent(row.content),
         breadcrumbs: parsePostsGdocsBreadcrumbs(row.breadcrumbs),
         published: !!row.published,
+    }
+}
+
+export function parsePostsGdocsWithTagsRow(
+    row: DBRawPostGdocWithTags
+): DBEnrichedPostGdocWithTags {
+    return {
+        ...parsePostsGdocsRow(row),
+        tags: row.tags,
     }
 }
 

--- a/packages/@ourworldindata/types/src/dbTypes/Tags.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Tags.ts
@@ -11,3 +11,6 @@ export interface DbInsertTag {
     updatedAt?: Date | null
 }
 export type DbPlainTag = Required<DbInsertTag>
+
+// For now, this is all the metadata we need for tags in the frontend
+export type MinimalTag = Pick<DbPlainTag, "id" | "name" | "slug">

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -12,7 +12,7 @@ import {
     RefDictionary,
 } from "./ArchieMlComponents.js"
 import { DbChartTagJoin } from "../dbTypes/ChartTags.js"
-import { DbPlainTag } from "../dbTypes/Tags.js"
+import { MinimalTag } from "../dbTypes/Tags.js"
 import { DbEnrichedLatestWork } from "../domainTypes/Author.js"
 
 export enum OwidGdocPublicationContext {
@@ -72,7 +72,7 @@ export interface OwidGdocBaseInterface {
     linkedIndicators?: Record<number, LinkedIndicator>
     imageMetadata?: Record<string, ImageMetadata>
     relatedCharts?: RelatedChart[]
-    tags?: DbPlainTag[] | null
+    tags?: MinimalTag[] | null
     errors?: OwidGdocErrorMessage[]
     markdown: string | null
 }

--- a/packages/@ourworldindata/types/src/gdocTypes/Image.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Image.ts
@@ -1,3 +1,5 @@
+import { DbEnrichedImage } from "../dbTypes/Images.js"
+
 // This is the JSON we get from Google's API before remapping the keys to be consistent with the rest of our interfaces
 export interface GDriveImageMetadata {
     name: string // -> filename
@@ -10,13 +12,14 @@ export interface GDriveImageMetadata {
     }
 }
 
-export interface ImageMetadata {
-    googleId: string
-    filename: string
-    defaultAlt: string
-    // MySQL Date objects round to the nearest second, whereas Google includes milliseconds
-    // so we store as an epoch to avoid any conversion issues
-    updatedAt: number | null
-    originalWidth?: number | null
-    originalHeight?: number | null
-}
+// All the data we use in the client to render images
+// everything except the ID, effectively
+export type ImageMetadata = Pick<
+    DbEnrichedImage,
+    | "defaultAlt"
+    | "filename"
+    | "googleId"
+    | "originalHeight"
+    | "originalWidth"
+    | "updatedAt"
+>

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -541,13 +541,16 @@ export {
 export {
     type DbInsertPostGdoc,
     type DbRawPostGdoc,
+    type DBRawPostGdocWithTags,
     type DbEnrichedPostGdoc,
+    type DBEnrichedPostGdocWithTags,
     PostsGdocsTableName,
     parsePostGdocContent,
     serializePostGdocContent,
     parsePostsGdocsBreadcrumbs,
     serializePostsGdocsBreadcrumbs,
     parsePostsGdocsRow,
+    parsePostsGdocsWithTagsRow,
     serializePostsGdocsRow,
 } from "./dbTypes/PostsGdocs.js"
 export {
@@ -609,6 +612,7 @@ export {
 export {
     type DbInsertTag,
     type DbPlainTag,
+    type MinimalTag,
     TagsTableName,
 } from "./dbTypes/Tags.js"
 export {

--- a/site/gdocs/pages/DataInsight.tsx
+++ b/site/gdocs/pages/DataInsight.tsx
@@ -12,7 +12,7 @@ import {
     MinimalDataInsightInterface,
     formatDate,
     copyToClipboard,
-    DbPlainTag,
+    MinimalTag,
 } from "@ourworldindata/utils"
 import React, { useContext } from "react"
 import { ArticleBlocks } from "../components/ArticleBlocks.js"
@@ -79,7 +79,7 @@ const RelatedTopicsList = ({
     tags,
     className,
 }: {
-    tags?: DbPlainTag[]
+    tags?: MinimalTag[]
     className?: string
 }) => {
     if (!tags?.length) return null


### PR DESCRIPTION
https://github.com/owid/owid-grapher/pull/3496 was reverted because I forgot to select tags in the new version of `getPublishedGdocPosts`. This broke topic pages' all-charts blocks, data pages related research & writing sections, and algolia indexing of tags.

This PR is a re-application of that PR, plus a new function called `getPublishedGdocPostsWithTags` which selects published posts plus `{ tags: MinimalTag[] }`

`MinimalTag` follows the `Minimal-` suffix that I've used elsewhere to designate subtypes of our DB rows with only the attributes that we need for rendering on the frontend.

`getPublishedGdocPostsWithTags` is now correctly called in the SiteBaker, and in the Algolia indexing script.

I also added some additional logging to the SiteBaker for prefetching attachments, related to this issue we should follow up on soon: https://github.com/owid/owid-grapher/issues/3514