### PR TITLE
Fix deleted assets staying in Cloudflare cache

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -34,7 +34,6 @@ import {
     BulkGrapherConfigResponse,
     camelCaseProperties,
     chartBulkUpdateAllowedColumnNamesAndTypes,
-    dayjs,
     GdocsContentSource,
     GrapherConfigPatch,
     isEmpty,
@@ -2473,11 +2472,11 @@ deleteRouteWithRWTransaction(apiRouter, "/gdocs/:id", async (req, res, trx) => {
     // Assets have TTL of one week in Cloudflare. Add a redirect to make sure
     // the page is no longer accessible.
     // https://developers.cloudflare.com/pages/configuration/serving-pages/#asset-retention
-    const ttl = dayjs().add(8, "days").toDate()
     await db.knexRawInsert(
         trx,
-        `INSERT INTO redirects (source, target, ttl) VALUES (?, ?, ?)`,
-        [getCanonicalUrl("", gdoc), "/", ttl]
+        `INSERT INTO redirects (source, target, ttl)
+         VALUES (?, ?, DATE_ADD(NOW(), INTERVAL 8 DAY))`,
+        [getCanonicalUrl("", gdoc), "/"]
     )
     await triggerStaticBuild(res.locals.user, `Deleting ${gdoc.slug}`)
     return {}

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -1014,7 +1014,7 @@ export class SiteBaker {
         this.progressBar.tick({ name: "✅ baked assets" })
     }
 
-    async bakeRedirects(knex: db.KnexReadonlyTransaction) {
+    async bakeRedirects(knex: db.KnexReadWriteTransaction) {
         if (!this.bakeSteps.has("redirects")) return
         const redirects = await getRedirects(knex)
         this.progressBar.tick({ name: "✅ got redirects" })
@@ -1032,7 +1032,8 @@ export class SiteBaker {
         this.progressBar.tick({ name: "✅ baked redirects" })
     }
 
-    // TODO: this transaction is only RW because somewhere inside it we fetch images
+    // TODO: This transaction is RW because we delete expired redirects and
+    //       somewhere inside it we fetch images.
     async bakeWordpressPages(knex: db.KnexReadWriteTransaction) {
         await this.bakeRedirects(knex)
         await this.bakeEmbeds(knex)

--- a/db/migration/1718295383278-AddRedirectsTtl.ts
+++ b/db/migration/1718295383278-AddRedirectsTtl.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddRedirectsTtl1718295383278 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE redirects
+            ADD COLUMN ttl TIMESTAMP DEFAULT NULL
+        `)
+        await queryRunner.query(
+            "CREATE INDEX idx_redirects_ttl ON redirects (ttl)"
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query("DROP INDEX idx_redirects_ttl ON redirects")
+        await queryRunner.query("ALTER TABLE redirects DROP COLUMN ttl")
+    }
+}

--- a/db/model/Redirect.ts
+++ b/db/model/Redirect.ts
@@ -50,3 +50,9 @@ export async function getChainedRedirect(
         [target, source]
     )
 }
+
+export async function deleteExpiredRedirects(
+    knex: db.KnexReadWriteTransaction
+): Promise<void> {
+    await db.knexRaw(knex, "DELETE FROM redirects WHERE ttl < NOW()")
+}

--- a/packages/@ourworldindata/types/src/dbTypes/Redirects.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Redirects.ts
@@ -10,6 +10,7 @@ export interface DbInsertRedirect {
     code: RedirectCode
     createdAt?: Date | null
     updatedAt?: Date | null
+    ttl?: Date | null
 }
 
 export type DbPlainRedirect = Required<DbInsertRedirect>


### PR DESCRIPTION
When we delete a post it no longer gets baked and is thus not present in the next CF Pages deployment. However, assets can stay in the CF Pages cache for up to a week and we want them to be inaccessible right away, e.g. for job postings.

I verified that this works both locally and on staging, including deployment to staging Pages.

Fixes #2896