### PR TITLE
🐛 parse gdoc JSON tags in the correct place

### DIFF
--- a/db/model/Gdoc/GdocFactory.ts
+++ b/db/model/Gdoc/GdocFactory.ts
@@ -58,7 +58,6 @@ export function gdocFromJSON(
     json.createdAt = new Date(json.createdAt)
     json.publishedAt = json.publishedAt ? new Date(json.publishedAt) : null
     json.updatedAt = new Date(json.updatedAt)
-    json.tags = json.tags ? JSON.parse(json.tags) : []
 
     return match(type)
         .with(

--- a/packages/@ourworldindata/types/src/dbTypes/PostsGdocs.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/PostsGdocs.ts
@@ -31,7 +31,7 @@ export type DbEnrichedPostGdoc = Omit<
 }
 
 export type DBRawPostGdocWithTags = DbRawPostGdoc & {
-    tags: MinimalTag[]
+    tags: string
 }
 
 export type DBEnrichedPostGdocWithTags = DbEnrichedPostGdoc & {
@@ -72,7 +72,7 @@ export function parsePostsGdocsWithTagsRow(
 ): DBEnrichedPostGdocWithTags {
     return {
         ...parsePostsGdocsRow(row),
-        tags: row.tags,
+        tags: JSON.parse(row.tags),
     }
 }
 


### PR DESCRIPTION
`gdocFromJSON` gets called in a few different places that have already correctly parsed the JSON tags object.

This PR moves the JSON tags parsing for `DBRawPostGdocWithTags->DBEnrichedPostGdocWithTags` to the correct place so that there's no type error from calling `JSON.parse([ { id: 1, name: "some-tag" } ])`