### PR TITLE
🐛 make key indicator collection more accessible

### DIFF
--- a/site/gdocs/components/KeyIndicatorCollection.tsx
+++ b/site/gdocs/components/KeyIndicatorCollection.tsx
@@ -152,6 +152,12 @@ function AccordionItem({
     const headerId = `${id}_header`
     const contentId = `${id}_content`
 
+    // remove content from the tab sequence if it's not visible
+    useEffect(() => {
+        if (!contentRef.current) return
+        contentRef.current.inert = !isOpen
+    }, [isOpen, contentRef])
+
     return (
         <div
             ref={ref}
@@ -182,6 +188,10 @@ function AccordionItem({
                                         behavior: "smooth",
                                     })
                                 }
+
+                                if (contentRef.current) {
+                                    contentRef.current.focus()
+                                }
                             }, HEIGHT_ANIMATION_DURATION_IN_SECONDS * 1000)
                         }
                     }}
@@ -204,7 +214,13 @@ function AccordionItem({
                 role="region"
                 aria-labelledby={headerId}
             >
-                <div ref={contentRef}>{children}</div>
+                <div
+                    ref={contentRef}
+                    tabIndex={isOpen ? 0 : -1}
+                    aria-hidden={!isOpen}
+                >
+                    {children}
+                </div>
             </div>
         </div>
     )


### PR DESCRIPTION
I dropped the ball on the accordion's accessibility, so here I am making amends 😇

This PR makes the `key-indicator-collection` component more accessible to keyboard and screen reader users.

In particular,
- Hidden content (i.e. closed accordion items) is removed from the tab sequence and the accessibility tree (uses the [inert attribute](https://web.dev/articles/inert) to do so)
- Fixes a bug where "clicking" on an accordion item by tabbing to it and then pressing Enter made the focus jump back to the first focusable element on the screen (the OWID logo in the header)