### PR TITLE
feat(share): on mobile OSs, show system share sheet immediately

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
@@ -9,15 +9,14 @@ import {
     faDownload,
     faArrowRight,
     IconDefinition,
-    faArrowUpFromBracket,
 } from "@fortawesome/free-solid-svg-icons"
 import {
     ShareMenu,
     ShareMenuManager,
     shareUsingShareApi,
     shouldShareUsingShareApi,
-} from "./ShareMenu"
-import { DEFAULT_BOUNDS, Bounds, isIOS } from "@ourworldindata/utils"
+} from "./ShareMenu.js"
+import { DEFAULT_BOUNDS, Bounds } from "@ourworldindata/utils"
 
 export interface ActionButtonsManager extends ShareMenuManager {
     isShareMenuActive?: boolean
@@ -224,11 +223,6 @@ export class ActionButtons extends React.Component<{
         return count
     }
 
-    @computed private get shareButtonIcon(): IconDefinition {
-        if (isIOS()) return faArrowUpFromBracket
-        else return faShareNodes
-    }
-
     private renderShareMenu(): JSX.Element {
         // distance between the right edge of the share button and the inner border of the frame
         let right = 0
@@ -247,7 +241,7 @@ export class ActionButtons extends React.Component<{
     }
 
     render(): JSX.Element {
-        const { manager, shareButtonIcon } = this
+        const { manager } = this
         const { isShareMenuActive } = manager
 
         return (
@@ -277,7 +271,7 @@ export class ActionButtons extends React.Component<{
                                 label="Share"
                                 dataTrackNote="chart_click_share"
                                 showLabel={this.showButtonLabels}
-                                icon={shareButtonIcon}
+                                icon={faShareNodes}
                                 onClick={(e): void => {
                                     this.toggleShareMenu()
                                     e.stopPropagation()

--- a/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
@@ -9,6 +9,7 @@ import {
     faDownload,
     faArrowRight,
     IconDefinition,
+    faArrowUpFromBracket,
 } from "@fortawesome/free-solid-svg-icons"
 import {
     ShareMenu,
@@ -16,7 +17,7 @@ import {
     shareUsingShareApi,
     shouldShareUsingShareApi,
 } from "./ShareMenu"
-import { DEFAULT_BOUNDS, Bounds } from "@ourworldindata/utils"
+import { DEFAULT_BOUNDS, Bounds, isIOS } from "@ourworldindata/utils"
 
 export interface ActionButtonsManager extends ShareMenuManager {
     isShareMenuActive?: boolean
@@ -223,6 +224,11 @@ export class ActionButtons extends React.Component<{
         return count
     }
 
+    @computed private get shareButtonIcon(): IconDefinition {
+        if (isIOS()) return faArrowUpFromBracket
+        else return faShareNodes
+    }
+
     private renderShareMenu(): JSX.Element {
         // distance between the right edge of the share button and the inner border of the frame
         let right = 0
@@ -241,7 +247,7 @@ export class ActionButtons extends React.Component<{
     }
 
     render(): JSX.Element {
-        const { manager } = this
+        const { manager, shareButtonIcon } = this
         const { isShareMenuActive } = manager
 
         return (
@@ -271,7 +277,7 @@ export class ActionButtons extends React.Component<{
                                 label="Share"
                                 dataTrackNote="chart_click_share"
                                 showLabel={this.showButtonLabels}
-                                icon={faShareNodes}
+                                icon={shareButtonIcon}
                                 onClick={(e): void => {
                                     this.toggleShareMenu()
                                     e.stopPropagation()

--- a/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
@@ -186,7 +186,7 @@ export class ActionButtons extends React.Component<{
     }
 
     @action.bound toggleShareMenu(): void {
-        if (shouldShareUsingShareApi()) {
+        if (shouldShareUsingShareApi(this.manager)) {
             void shareUsingShareApi(this.manager)
             return
         }

--- a/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
@@ -10,7 +10,12 @@ import {
     faArrowRight,
     IconDefinition,
 } from "@fortawesome/free-solid-svg-icons"
-import { ShareMenu, ShareMenuManager } from "./ShareMenu"
+import {
+    ShareMenu,
+    ShareMenuManager,
+    shareUsingShareApi,
+    shouldShareUsingShareApi,
+} from "./ShareMenu"
 import { DEFAULT_BOUNDS, Bounds } from "@ourworldindata/utils"
 
 export interface ActionButtonsManager extends ShareMenuManager {
@@ -181,6 +186,10 @@ export class ActionButtons extends React.Component<{
     }
 
     @action.bound toggleShareMenu(): void {
+        if (shouldShareUsingShareApi()) {
+            void shareUsingShareApi(this.manager)
+            return
+        }
         this.manager.isShareMenuActive = !this.manager.isShareMenuActive
     }
 

--- a/packages/@ourworldindata/grapher/src/controls/ShareMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ShareMenu.tsx
@@ -32,10 +32,14 @@ interface ShareMenuState {
 
 type ShareApiManager = Pick<ShareMenuManager, "canonicalUrl" | "currentTitle">
 
-const getShareData = (manager: ShareApiManager): ShareData => ({
-    title: manager.currentTitle ?? "",
-    url: manager.canonicalUrl,
-})
+const getShareData = (manager: ShareApiManager): ShareData | undefined => {
+    if (!manager.canonicalUrl) return undefined
+
+    return {
+        title: manager.currentTitle ?? "",
+        url: manager.canonicalUrl,
+    }
+}
 
 // On mobile OSs, the system-level share API does a way better job of providing
 // relevant options to the user than our own <ShareMenu> does - for example,
@@ -47,6 +51,8 @@ const getShareData = (manager: ShareApiManager): ShareData => ({
 // -@marcelgerber, 2024-04-24
 export const shouldShareUsingShareApi = (manager: ShareApiManager): boolean => {
     const shareData = getShareData(manager)
+    if (!shareData) return false
+
     return (
         (isAndroid() || isIOS()) &&
         "share" in navigator &&
@@ -58,9 +64,10 @@ export const shouldShareUsingShareApi = (manager: ShareApiManager): boolean => {
 export const shareUsingShareApi = async (
     manager: ShareApiManager
 ): Promise<void> => {
-    if (!manager.canonicalUrl || !navigator.share) return
+    if (!navigator.share) return
 
     const shareData = getShareData(manager)
+    if (!shareData) return
 
     try {
         await navigator.share(shareData)

--- a/packages/@ourworldindata/utils/src/BrowserUtils.ts
+++ b/packages/@ourworldindata/utils/src/BrowserUtils.ts
@@ -1,0 +1,12 @@
+export const isAndroid = (): boolean => {
+    return /Android/i.test(navigator.userAgent)
+}
+
+export const isIOS = (): boolean => {
+    return (
+        /iPhone|iPad|iPod/.test(navigator.userAgent) ||
+        // iPadOS 13+ reports itself as Macintosh, see https://stackoverflow.com/a/9039885
+        (navigator.userAgent.includes("Intel Mac OS X") &&
+            navigator.maxTouchPoints > 1)
+    )
+}

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -400,3 +400,5 @@ export {
     MAX_DONATION_AMOUNT,
     PLEASE_TRY_AGAIN,
 } from "./DonateUtils.js"
+
+export { isAndroid, isIOS } from "./BrowserUtils.js"


### PR DESCRIPTION
Resolves #3446.

Demo page: https://mobile-share-api.owid-staging.pages.dev/grapher/child-mortality-rate-ihme

The below video shows the behavior on: iOS -> Android -> macOS.
Also notice how the icon used is different on iOS.

Sadly, this will not work out of the box on staging servers, since the Web Share API is only available on https connections.

https://github.com/owid/owid-grapher/assets/2641501/076812d1-a301-43fb-bbe2-f905df41d5c9


