### PR TITLE
experiment: cloudflare images

### DIFF
--- a/_routes.json
+++ b/_routes.json
@@ -1,5 +1,5 @@
 {
     "version": 1,
-    "include": ["/grapher/*", "/donation/*"],
+    "include": ["/grapher/*", "/donation/*", "images-worker/*"],
     "exclude": ["/grapher/_grapherRedirects.json"]
 }

--- a/functions/images-worker/[[filepath]].ts
+++ b/functions/images-worker/[[filepath]].ts
@@ -1,0 +1,54 @@
+import { RequestInit, RequestInitCfProperties } from "@cloudflare/workers-types"
+
+export const onRequestGet: PagesFunction = async (context) => {
+    const imageFilepath = context.params.filepath
+    return handleRequest(context.request, imageFilepath)
+}
+
+/**
+ * Fetch and log a request
+ * @param {Request} request
+ */
+async function handleRequest(request: Request, filepath: string[]) {
+    // Parse request URL to get access to query string
+    const url = new URL(request.url)
+
+    const fileExtension = filepath.at(-1).split(".").pop()
+
+    // Cloudflare-specific options are in the cf object.
+    const options: RequestInit<RequestInitCfProperties> = { cf: { image: {} } }
+
+    // Copy parameters from query string to request options.
+    // You can implement various different parameters here.
+    if (url.searchParams.has("fit"))
+        options.cf.image.fit = url.searchParams.get("fit") as any
+    if (url.searchParams.has("width"))
+        options.cf.image.width = url.searchParams.get("width") as any
+    if (url.searchParams.has("height"))
+        options.cf.image.height = url.searchParams.get("height") as any
+    if (url.searchParams.has("quality"))
+        options.cf.image.quality = url.searchParams.get("quality") as any
+
+    // Your Worker is responsible for automatic format negotiation. Check the Accept header.
+    // const accept = request.headers.get("Accept")
+    // if (/image\/avif/.test(accept)) {
+    //     options.cf.image.format = "avif"
+    // } else if (/image\/webp/.test(accept)) {
+    //     options.cf.image.format = "webp"
+    // }
+
+    options.cf.image.format = fileExtension as any
+
+    // Get URL of the original (full size) image to resize.
+    // You could adjust the URL here, e.g., prefix it with a fixed address of your server,
+    // so that user-visible URLs are shorter and cleaner.
+    const imageURL = new URL(`/${filepath.join("/")}`, url)
+
+    // Build a request that passes through request headers
+    const imageRequest = new Request(imageURL, {
+        headers: request.headers,
+    })
+
+    // Returning fetch() with resizing options will pass through response with the resized image.
+    return fetch(imageRequest, options)
+}

--- a/packages/@ourworldindata/utils/src/image.ts
+++ b/packages/@ourworldindata/utils/src/image.ts
@@ -28,9 +28,9 @@ export function generateSrcSet(
 ): string {
     return sizes
         .map((size) => {
-            const path = `/images/published/${getFilenameWithoutExtension(
-                encodeURIComponent(filename)
-            )}_${size}.png`
+            const path = `https://images-test.owid.io/images/published/${encodeURIComponent(
+                filename
+            )}?width=${size}`
             return `${path} ${size}w`
         })
         .join(", ")
@@ -68,6 +68,7 @@ export function getFilenameMIMEType(filename: string): string | undefined {
 export type SourceProps = {
     media: string | undefined
     srcSet: string
+    highResFilename?: string
 }
 
 /**
@@ -86,12 +87,14 @@ export function generateSourceProps(
         props.push({
             media: "(max-width: 768px)",
             srcSet: generateSrcSet(smallSizes, smallImage.filename),
+            highResFilename: encodeURIComponent(smallImage.filename),
         })
     }
     const regularSizes = getSizes(regularImage.originalWidth)
     props.push({
         media: undefined,
         srcSet: generateSrcSet(regularSizes, regularImage.filename),
+        highResFilename: encodeURIComponent(regularImage.filename),
     })
     return props
 }

--- a/site/Lightbox.tsx
+++ b/site/Lightbox.tsx
@@ -25,6 +25,9 @@ function getActiveSourceImgUrl(img: HTMLImageElement): string | undefined {
         const activeSource = Array.from(sources).find((s) =>
             s.media ? window.matchMedia(s.media).matches : true
         )
+        const highResSrc = activeSource?.getAttribute("data-high-res-src")
+        if (highResSrc) return highResSrc
+
         const sourceSrcset = activeSource?.getAttribute("srcset")
         // split sourceSrcset into [src, width] pairs
         const srcsetPairs = sourceSrcset

--- a/site/formatting.tsx
+++ b/site/formatting.tsx
@@ -50,6 +50,14 @@ export const formatUrls = (html: string) => {
         ),
         BAKED_WORDPRESS_UPLOADS_URL
     )
+
+    formatted = formatted.replace(
+        new RegExp(
+            `${lodash.escapeRegExp(BAKED_WORDPRESS_UPLOADS_URL)}/(\\S+?)-(\\d+)x(\\d+)\\.(\\w+)`,
+            "g"
+        ),
+        "https://images-test.owid.io/uploads/$1.$4?width=$2&height=$3"
+    )
     return formatted
 }
 

--- a/site/gdocs/components/Image.tsx
+++ b/site/gdocs/components/Image.tsx
@@ -162,10 +162,16 @@ export default function Image(props: {
             {sourceProps.map((props, i) => (
                 <source
                     key={i}
-                    {...props}
+                    media={props.media}
+                    srcSet={props.srcSet}
                     type="image/png"
                     sizes={
                         containerSizes[containerType] ?? containerSizes.default
+                    }
+                    data-high-res-src={
+                        props.highResFilename
+                            ? `${IMAGES_DIRECTORY}${props.highResFilename}`
+                            : undefined
                     }
                 />
             ))}


### PR DESCRIPTION
This serves all our images which are currently being served via either `/images/published` or via `assets.ourworldindata.org` via cloudflare workers, using an experimental worker set up at `images-test.owid.io` - see https://github.com/owid/cloudflare-workers/pull/20 for that part.

The caveats of CF Images apply: Cloudflare is not always happy to churn out pngs, and will often times produce jpegs instead, without us having much control over that. But otherwise, this all is pretty straightforward.

As an experiment, I also added some hacky code that also serves WP uploads via Cloudflare images.
We don't want to actually do this, because we already have resized variants available for all of these, and no new WP images are being uploaded.