### PR TITLE
🐝 (svg tester) prepare for move to foundation

### DIFF
--- a/.github/workflows/svg-compare-all-views.yml
+++ b/.github/workflows/svg-compare-all-views.yml
@@ -61,27 +61,6 @@ jobs:
                   RM_ON_ERROR: ${{ env.ORIGINAL_BRANCH_NAME == 'master' && '' || '--rm-on-error' }}
               run: node --enable-source-maps itsJustJavascript/devTools/svgTester/verify-graphs.js -i owid-grapher-svgs/configs -o owid-grapher-svgs/all-views/svg -r owid-grapher-svgs/all-views/svg --ids-from-file owid-grapher-svgs/most-viewed-charts.txt --all-views $RM_ON_ERROR > compare-result
 
-            # If the last step failed we want to commit all changed svgs and push them to the new branch on the owid-grapher-svgs repo
-            - uses: stefanzweifel/git-auto-commit-action@v5
-              if: ${{ steps.run-verify-graphs.outcome == 'failure' }}
-              with:
-                  repository: ./owid-grapher-svgs/
-                  branch: ${{ env.PUSH_BRANCH_NAME }}
-                  push_options: "--force"
-                  commit_message: Automated commit with svg differences (all views) triggered by commit https://github.com/owid/owid-grapher/commit/${{github.sha}}
-
-            # Merge differences into owid-grapher-svgs master if we are on master in owid-grapher
-            - name: Merge into owid-grapher-svgs master
-              if: ${{ steps.run-verify-graphs.outcome == 'failure' && env.ORIGINAL_BRANCH_NAME == 'master' }}
-              working-directory: owid-grapher-svgs
-              run: |
-                  git config user.name "${GITHUB_ACTOR}"
-                  git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-                  git checkout master
-                  git pull origin master
-                  git merge -s ort -X theirs -m 'Automated merge commit with svg differences (all views) triggered by commit https://github.com/owid/owid-grapher/commit/${{github.sha}}' ${{ env.PUSH_BRANCH_NAME }}
-                  git push --force origin master
-
             # The action fails if there were any errors.
             - name: Fail with error message if we had errors
               if: ${{ steps.run-verify-graphs.outputs.num_errors > 0 }}

--- a/.github/workflows/svg-compare.yml
+++ b/.github/workflows/svg-compare.yml
@@ -60,27 +60,6 @@ jobs:
                   RM_ON_ERROR: ${{ env.ORIGINAL_BRANCH_NAME == 'master' && '' || '--rm-on-error' }}
               run: node --enable-source-maps itsJustJavascript/devTools/svgTester/verify-graphs.js -i owid-grapher-svgs/configs -o owid-grapher-svgs/svg -r owid-grapher-svgs/svg $RM_ON_ERROR > compare-result
 
-            # If the last step failed we want to commit all changed svgs and push them to the new branch on the owid-grapher-svgs repo
-            - uses: stefanzweifel/git-auto-commit-action@v4
-              if: ${{ steps.run-verify-graphs.outcome == 'failure' }}
-              with:
-                  repository: ./owid-grapher-svgs/
-                  branch: ${{ env.PUSH_BRANCH_NAME }}
-                  push_options: "--force"
-                  commit_message: Automated commit with svg differences triggered by commit https://github.com/owid/owid-grapher/commit/${{github.sha}}
-
-            # Merge differences into owid-grapher-svgs master if we are on master in owid-grapher
-            - name: Merge into owid-grapher-svgs master
-              if: ${{ steps.run-verify-graphs.outcome == 'failure' && env.ORIGINAL_BRANCH_NAME == 'master' }}
-              working-directory: owid-grapher-svgs
-              run: |
-                  git config user.name "${GITHUB_ACTOR}"
-                  git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-                  git checkout master
-                  git pull origin master
-                  git merge -s ort -X theirs -m 'Automated merge commit with svg differences triggered by commit https://github.com/owid/owid-grapher/commit/${{github.sha}}' ${{ env.PUSH_BRANCH_NAME }}
-                  git push --force origin master
-
             # The action fails if there were any errors.
             - name: Fail with error message if we had errors
               if: ${{ steps.run-verify-graphs.outputs.num_errors > 0 }}

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -18,10 +18,6 @@ import { getVariableData } from "../../db/model/Variable.js"
 import { GrapherInterface } from "@ourworldindata/types"
 import _ from "lodash"
 import util from "util"
-import {
-    BAKED_GRAPHER_URL,
-    BAKED_BASE_URL,
-} from "../../settings/serverSettings.js"
 import { getHeapStatistics } from "v8"
 import { queryStringsByChartType } from "./chart-configurations.js"
 import * as d3 from "d3"
@@ -400,8 +396,8 @@ export async function renderSvg(
     const grapher = initGrapherForSvgExport(
         {
             ...configAndData.config,
-            adminBaseUrl: BAKED_BASE_URL,
-            bakedGrapherURL: BAKED_GRAPHER_URL,
+            adminBaseUrl: "https://ourworldindata.org",
+            bakedGrapherURL: "https://ourworldindata.org/grapher",
         },
         queryStr
     )


### PR DESCRIPTION
Small tweaks to prepare the SVG tester for move to foundation. In particular,

- the base URL is hard-coded to point to prod (this used to depend on the environment, i.e. was `localhost` for reference charts since they're usually exported locally and `staging-site-x` on staging, which then made every chart fail)
- keep the SVG tester GitHub actions for now since it's convenient that they're setup to fail when differences were detected (the Buildkite jobs currently don't give any indication of success/failure) but remove the steps that commit/push to `owid-grapher-svgs` (in the future we want the Buildkite job to post a comment on a PR with a summary; if we have that, we can drop the GitHub actions)