### PR TITLE
Explorer data page experiment

### DIFF
--- a/adminSiteClient/AdminApp.tsx
+++ b/adminSiteClient/AdminApp.tsx
@@ -163,8 +163,6 @@ export class AdminApp extends React.Component<{
                                     <AdminLayout title="Preview Explorer data page">
                                         <ExplorerDataPage
                                             slug={match.params.slug}
-                                            gitCmsBranchName={gitCmsBranchName}
-                                            manager={admin}
                                         />
                                     </AdminLayout>
                                 )}

--- a/adminSiteClient/AdminApp.tsx
+++ b/adminSiteClient/AdminApp.tsx
@@ -36,6 +36,7 @@ import { AdminAppContext } from "./AdminAppContext.js"
 import { Base64 } from "js-base64"
 import { ExplorerCreatePage } from "../explorerAdminClient/ExplorerCreatePage.js"
 import { ExplorersIndexPage } from "../explorerAdminClient/ExplorersListPage.js"
+import { ExplorerDataPage } from "../explorerAdminClient/ExplorerDataPage.js"
 import { EXPLORERS_ROUTE_FOLDER } from "../explorer/ExplorerConstants.js"
 import { AdminLayout } from "./AdminLayout.js"
 import { BulkGrapherConfigEditorPage } from "./BulkGrapherConfigEditor.js"
@@ -154,6 +155,19 @@ export class AdminApp extends React.Component<{
                                 exact
                                 path="/charts"
                                 component={ChartIndexPage}
+                            />
+                            <Route
+                                exact
+                                path={`/${EXPLORERS_ROUTE_FOLDER}/datapage/:slug`}
+                                render={({ match }) => (
+                                    <AdminLayout title="Preview Explorer data page">
+                                        <ExplorerDataPage
+                                            slug={match.params.slug}
+                                            gitCmsBranchName={gitCmsBranchName}
+                                            manager={admin}
+                                        />
+                                    </AdminLayout>
+                                )}
                             />
                             <Route
                                 exact

--- a/adminSiteClient/admin.entry.ts
+++ b/adminSiteClient/admin.entry.ts
@@ -1,4 +1,5 @@
 import "./admin.scss"
+import "../site/owid.scss"
 import "@ourworldindata/grapher/src/core/grapher.scss"
 import "../explorerAdminClient/ExplorerCreatePage.scss"
 import "handsontable/dist/handsontable.full.css"

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -13,14 +13,6 @@
 
 @import "./GdocsIndexPage.scss";
 
-@import "../packages/@ourworldindata/components/src/styles/variables.scss";
-@import "../packages/@ourworldindata/components/src/styles/colors.scss";
-@import "../packages/@ourworldindata/components/src/styles/typography.scss";
-@import "../packages/@ourworldindata/components/src/styles/util.scss";
-@import "../packages/@ourworldindata/components/src/styles/mixins.scss";
-
-@import "../site/DataPageContent.scss";
-
 html {
     font-size: 14px;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -13,6 +13,14 @@
 
 @import "./GdocsIndexPage.scss";
 
+@import "../packages/@ourworldindata/components/src/styles/variables.scss";
+@import "../packages/@ourworldindata/components/src/styles/colors.scss";
+@import "../packages/@ourworldindata/components/src/styles/typography.scss";
+@import "../packages/@ourworldindata/components/src/styles/util.scss";
+@import "../packages/@ourworldindata/components/src/styles/mixins.scss";
+
+@import "../site/DataPageContent.scss";
+
 html {
     font-size: 14px;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -150,7 +150,7 @@ import { match } from "ts-pattern"
 import { GdocDataInsight } from "../db/model/Gdoc/GdocDataInsight.js"
 import { GdocHomepage } from "../db/model/Gdoc/GdocHomepage.js"
 import { GdocAuthor } from "../db/model/Gdoc/GdocAuthor.js"
-import { fetchDataPageV2Data } from "../baker/GrapherBaker.js"
+import { fetchDataPageV2Data } from "../baker/DatapageTools.js"
 
 const apiRouter = new FunctionalRouter()
 

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -27,6 +27,7 @@ import {
     fetchS3MetadataByPath,
     fetchS3DataValuesByPath,
     searchVariables,
+    getVariableMetadata,
 } from "../db/model/Variable.js"
 import {
     applyPatch,
@@ -149,6 +150,7 @@ import { match } from "ts-pattern"
 import { GdocDataInsight } from "../db/model/Gdoc/GdocDataInsight.js"
 import { GdocHomepage } from "../db/model/Gdoc/GdocHomepage.js"
 import { GdocAuthor } from "../db/model/Gdoc/GdocAuthor.js"
+import { fetchDataPageV2Data } from "../baker/GrapherBaker.js"
 
 const apiRouter = new FunctionalRouter()
 
@@ -2544,6 +2546,26 @@ deleteRouteWithRWTransaction(
         const { slug } = req.params
         await trx.table("explorer_tags").where({ explorerSlug: slug }).delete()
         return { success: true }
+    }
+)
+
+getRouteNonIdempotentWithRWTransaction(
+    apiRouter,
+    "/explorer/datapagepreview/:indicatorId.json",
+    async (req, res, trx) => {
+        const indicatorId = expectInt(req.params.indicatorId)
+        const variableMetadata = await getVariableMetadata(indicatorId)
+        const datapageDataFull = await fetchDataPageV2Data(
+            indicatorId,
+            variableMetadata,
+            true,
+            true,
+            undefined,
+            undefined,
+            trx
+        )
+
+        return { datapageDataFull, success: true }
     }
 )
 

--- a/baker/DatapageTools.ts
+++ b/baker/DatapageTools.ts
@@ -1,0 +1,217 @@
+import {
+    OwidVariableWithSource,
+    GrapherInterface,
+    FullDatapageData,
+    FaqDictionary,
+    EnrichedFaq,
+    JsonError,
+    FaqEntryData,
+    OwidChartDimensionInterface,
+    DimensionProperty,
+    OwidGdocBaseInterface,
+    ImageMetadata,
+    DataPageRelatedResearch,
+} from "@ourworldindata/types"
+import { mergePartialGrapherConfigs } from "@ourworldindata/utils"
+import lodash, { compact, uniq, partition } from "lodash"
+import { getRelatedChartsForVariable } from "../db/model/Chart.js"
+import { getGdocBaseObjectBySlug } from "../db/model/Gdoc/GdocFactory.js"
+import { parseFaqs } from "../db/model/Gdoc/rawToEnriched.js"
+import {
+    getPostEnrichedBySlug,
+    getRelatedResearchAndWritingForVariable,
+} from "../db/model/Post.js"
+import { getMergedGrapherConfigForVariable } from "../db/model/Variable.js"
+import { logErrorAndMaybeSendToBugsnag } from "../serverUtils/errorLog.js"
+import {
+    BAKED_BASE_URL,
+    BAKED_GRAPHER_URL,
+} from "../settings/clientSettings.js"
+import { getShortPageCitation } from "../site/gdocs/utils.js"
+import { getDatapageGdoc, getDatapageDataV2 } from "./DatapageHelpers.js"
+import { getSlugForTopicTag, getTagToSlugMap } from "./GrapherBakingUtils.js"
+import { renderToHtmlPage } from "./siteRenderers.js"
+import { KnexReadWriteTransaction } from "../db/db.js"
+
+type EnrichedFaqLookupError = {
+    type: "error"
+    error: string
+}
+
+type EnrichedFaqLookupSuccess = {
+    type: "success"
+    enrichedFaq: EnrichedFaq
+}
+
+type EnrichedFaqLookupResult = EnrichedFaqLookupError | EnrichedFaqLookupSuccess
+
+export async function fetchDataPageV2Data(
+    variableId: number,
+    variableMetadata: OwidVariableWithSource,
+    isPreviewing: boolean,
+    useIndicatorGrapherConfigs: boolean,
+    pageGrapher: GrapherInterface | undefined,
+    imageMetadataDictionary = {},
+    knex: KnexReadWriteTransaction
+): Promise<FullDatapageData> {
+    const grapherConfigForVariable = await getMergedGrapherConfigForVariable(
+        variableId,
+        knex
+    )
+    // Only merge the grapher config on the indicator if the caller tells us to do so -
+    // this is true for preview pages for datapages on the indicator level but false
+    // if we are on Grapher pages. Once we have a good way in the grapher admin for how
+    // to use indicator level defaults, we should reconsider how this works here.
+    const grapher = useIndicatorGrapherConfigs
+        ? mergePartialGrapherConfigs(grapherConfigForVariable, pageGrapher)
+        : pageGrapher ?? {}
+
+    const faqDocs = compact(
+        uniq(variableMetadata.presentation?.faqs?.map((faq) => faq.gdocId))
+    )
+    const gdocFetchPromises = faqDocs.map((gdocId) =>
+        getDatapageGdoc(knex, gdocId, isPreviewing)
+    )
+    const gdocs = await Promise.all(gdocFetchPromises)
+    const gdocIdToFragmentIdToBlock: Record<string, FaqDictionary> = {}
+    gdocs.forEach((gdoc) => {
+        if (!gdoc) return
+        const faqs = parseFaqs(
+            ("faqs" in gdoc.content && gdoc.content?.faqs) ?? [],
+            gdoc.id
+        )
+        gdocIdToFragmentIdToBlock[gdoc.id] = faqs.faqs
+    })
+
+    const resolvedFaqsResults: EnrichedFaqLookupResult[] = variableMetadata
+        .presentation?.faqs
+        ? variableMetadata.presentation.faqs.map((faq) => {
+              const enrichedFaq = gdocIdToFragmentIdToBlock[faq.gdocId]?.[
+                  faq.fragmentId
+              ] as EnrichedFaq | undefined
+              if (!enrichedFaq)
+                  return {
+                      type: "error",
+                      error: `Could not find fragment ${faq.fragmentId} in gdoc ${faq.gdocId}`,
+                  }
+              return {
+                  type: "success",
+                  enrichedFaq,
+              }
+          })
+        : []
+
+    const [resolvedFaqs, faqResolveErrors] = partition(
+        resolvedFaqsResults,
+        (result) => result.type === "success"
+    ) as [EnrichedFaqLookupSuccess[], EnrichedFaqLookupError[]]
+
+    if (faqResolveErrors.length > 0) {
+        for (const error of faqResolveErrors) {
+            await logErrorAndMaybeSendToBugsnag(
+                new JsonError(
+                    `Data page error in finding FAQs for variable ${variableId}: ${error.error}`
+                )
+            )
+        }
+    }
+
+    const faqEntries: FaqEntryData = {
+        faqs: resolvedFaqs?.flatMap((faq) => faq.enrichedFaq.content) ?? [],
+    }
+
+    // If we are rendering this in the context of an indicator page preview or similar,
+    // then the chart config might be entirely empty. Make sure that dimensions is
+    // set to the variableId as a Y variable in theses cases.
+    if (
+        !grapher.dimensions ||
+        (grapher.dimensions as OwidChartDimensionInterface[]).length === 0
+    ) {
+        const dimensions: OwidChartDimensionInterface[] = [
+            {
+                variableId: variableId,
+                property: DimensionProperty.y,
+                display: variableMetadata.display,
+            },
+        ]
+        grapher.dimensions = dimensions
+    }
+    const datapageData = await getDatapageDataV2(
+        variableMetadata,
+        grapher ?? {}
+    )
+
+    const firstTopicTag = datapageData.topicTagsLinks?.[0]
+
+    let slug = ""
+    if (firstTopicTag) {
+        try {
+            slug = await getSlugForTopicTag(knex, firstTopicTag)
+        } catch (error) {
+            await logErrorAndMaybeSendToBugsnag(
+                `Datapage with variableId "${variableId}" and title "${datapageData.title.title}" is using "${firstTopicTag}" as its primary tag, which we are unable to resolve to a tag in the grapher DB`
+            )
+        }
+        let gdoc: OwidGdocBaseInterface | undefined = undefined
+        if (slug) {
+            gdoc = await getGdocBaseObjectBySlug(knex, slug, true)
+        }
+        if (gdoc) {
+            const citation = getShortPageCitation(
+                gdoc.content.authors,
+                gdoc.content.title ?? "",
+                gdoc?.publishedAt
+            )
+            datapageData.primaryTopic = {
+                topicTag: firstTopicTag,
+                citation,
+            }
+        } else {
+            const post = await getPostEnrichedBySlug(knex, slug)
+            if (post) {
+                const authors = post.authors
+                const citation = getShortPageCitation(
+                    authors ?? [],
+                    post.title,
+                    post.published_at
+                )
+                datapageData.primaryTopic = {
+                    topicTag: firstTopicTag,
+                    citation,
+                }
+            }
+        }
+    }
+
+    // Get the charts this variable is being used in (aka "related charts")
+    // and exclude the current chart to avoid duplicates
+    datapageData.allCharts = await getRelatedChartsForVariable(
+        knex,
+        variableId,
+        grapher && "id" in grapher ? [grapher.id as number] : []
+    )
+
+    datapageData.relatedResearch =
+        (await getRelatedResearchAndWritingForVariable(
+            knex,
+            variableId
+        )) as DataPageRelatedResearch[]
+
+    const relatedResearchFilenames = datapageData.relatedResearch
+        .map((r) => r.imageUrl)
+        .filter((f): f is string => !!f)
+
+    const imageMetadata = lodash.pick(
+        imageMetadataDictionary,
+        uniq(relatedResearchFilenames)
+    )
+
+    const tagToSlugMap = await getTagToSlugMap(knex)
+    return {
+        grapher,
+        datapageData,
+        imageMetadata,
+        faqEntries,
+        tagToSlugMap,
+    }
+}

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -61,6 +61,7 @@ import { knexRaw } from "../db/db.js"
 import { getRelatedChartsForVariable } from "../db/model/Chart.js"
 import pMap from "p-map"
 import { getGdocBaseObjectBySlug } from "../db/model/Gdoc/GdocFactory.js"
+import { fetchDataPageV2Data } from "./DatapageTools.js"
 
 const renderDatapageIfApplicable = async (
     grapher: GrapherInterface,
@@ -115,185 +116,6 @@ export const renderDataPageOrGrapherPage = async (
     return renderGrapherPage(grapher, knex)
 }
 
-type EnrichedFaqLookupError = {
-    type: "error"
-    error: string
-}
-
-type EnrichedFaqLookupSuccess = {
-    type: "success"
-    enrichedFaq: EnrichedFaq
-}
-
-type EnrichedFaqLookupResult = EnrichedFaqLookupError | EnrichedFaqLookupSuccess
-
-export async function fetchDataPageV2Data(
-    variableId: number,
-    variableMetadata: OwidVariableWithSource,
-    isPreviewing: boolean,
-    useIndicatorGrapherConfigs: boolean,
-    pageGrapher: GrapherInterface | undefined,
-    imageMetadataDictionary = {},
-    knex: db.KnexReadWriteTransaction
-): Promise<FullDatapageData> {
-    const grapherConfigForVariable = await getMergedGrapherConfigForVariable(
-        variableId,
-        knex
-    )
-    // Only merge the grapher config on the indicator if the caller tells us to do so -
-    // this is true for preview pages for datapages on the indicator level but false
-    // if we are on Grapher pages. Once we have a good way in the grapher admin for how
-    // to use indicator level defaults, we should reconsider how this works here.
-    const grapher = useIndicatorGrapherConfigs
-        ? mergePartialGrapherConfigs(grapherConfigForVariable, pageGrapher)
-        : pageGrapher ?? {}
-
-    const faqDocs = compact(
-        uniq(variableMetadata.presentation?.faqs?.map((faq) => faq.gdocId))
-    )
-    const gdocFetchPromises = faqDocs.map((gdocId) =>
-        getDatapageGdoc(knex, gdocId, isPreviewing)
-    )
-    const gdocs = await Promise.all(gdocFetchPromises)
-    const gdocIdToFragmentIdToBlock: Record<string, FaqDictionary> = {}
-    gdocs.forEach((gdoc) => {
-        if (!gdoc) return
-        const faqs = parseFaqs(
-            ("faqs" in gdoc.content && gdoc.content?.faqs) ?? [],
-            gdoc.id
-        )
-        gdocIdToFragmentIdToBlock[gdoc.id] = faqs.faqs
-    })
-
-    const resolvedFaqsResults: EnrichedFaqLookupResult[] = variableMetadata
-        .presentation?.faqs
-        ? variableMetadata.presentation.faqs.map((faq) => {
-              const enrichedFaq = gdocIdToFragmentIdToBlock[faq.gdocId]?.[
-                  faq.fragmentId
-              ] as EnrichedFaq | undefined
-              if (!enrichedFaq)
-                  return {
-                      type: "error",
-                      error: `Could not find fragment ${faq.fragmentId} in gdoc ${faq.gdocId}`,
-                  }
-              return {
-                  type: "success",
-                  enrichedFaq,
-              }
-          })
-        : []
-
-    const [resolvedFaqs, faqResolveErrors] = partition(
-        resolvedFaqsResults,
-        (result) => result.type === "success"
-    ) as [EnrichedFaqLookupSuccess[], EnrichedFaqLookupError[]]
-
-    if (faqResolveErrors.length > 0) {
-        for (const error of faqResolveErrors) {
-            await logErrorAndMaybeSendToBugsnag(
-                new JsonError(
-                    `Data page error in finding FAQs for variable ${variableId}: ${error.error}`
-                )
-            )
-        }
-    }
-
-    const faqEntries: FaqEntryData = {
-        faqs: resolvedFaqs?.flatMap((faq) => faq.enrichedFaq.content) ?? [],
-    }
-
-    // If we are rendering this in the context of an indicator page preview or similar,
-    // then the chart config might be entirely empty. Make sure that dimensions is
-    // set to the variableId as a Y variable in theses cases.
-    if (
-        !grapher.dimensions ||
-        (grapher.dimensions as OwidChartDimensionInterface[]).length === 0
-    ) {
-        const dimensions: OwidChartDimensionInterface[] = [
-            {
-                variableId: variableId,
-                property: DimensionProperty.y,
-                display: variableMetadata.display,
-            },
-        ]
-        grapher.dimensions = dimensions
-    }
-    const datapageData = await getDatapageDataV2(
-        variableMetadata,
-        grapher ?? {}
-    )
-
-    const firstTopicTag = datapageData.topicTagsLinks?.[0]
-
-    let slug = ""
-    if (firstTopicTag) {
-        try {
-            slug = await getSlugForTopicTag(knex, firstTopicTag)
-        } catch (error) {
-            await logErrorAndMaybeSendToBugsnag(
-                `Datapage with variableId "${variableId}" and title "${datapageData.title.title}" is using "${firstTopicTag}" as its primary tag, which we are unable to resolve to a tag in the grapher DB`
-            )
-        }
-        let gdoc: OwidGdocBaseInterface | undefined = undefined
-        if (slug) {
-            gdoc = await getGdocBaseObjectBySlug(knex, slug, true)
-        }
-        if (gdoc) {
-            const citation = getShortPageCitation(
-                gdoc.content.authors,
-                gdoc.content.title ?? "",
-                gdoc?.publishedAt
-            )
-            datapageData.primaryTopic = {
-                topicTag: firstTopicTag,
-                citation,
-            }
-        } else {
-            const post = await getPostEnrichedBySlug(knex, slug)
-            if (post) {
-                const authors = post.authors
-                const citation = getShortPageCitation(
-                    authors ?? [],
-                    post.title,
-                    post.published_at
-                )
-                datapageData.primaryTopic = {
-                    topicTag: firstTopicTag,
-                    citation,
-                }
-            }
-        }
-    }
-
-    // Get the charts this variable is being used in (aka "related charts")
-    // and exclude the current chart to avoid duplicates
-    datapageData.allCharts = await getRelatedChartsForVariable(
-        knex,
-        variableId,
-        grapher && "id" in grapher ? [grapher.id as number] : []
-    )
-
-    datapageData.relatedResearch =
-        await getRelatedResearchAndWritingForVariable(knex, variableId)
-
-    const relatedResearchFilenames = datapageData.relatedResearch
-        .map((r) => r.imageUrl)
-        .filter((f): f is string => !!f)
-
-    const imageMetadata = lodash.pick(
-        imageMetadataDictionary,
-        uniq(relatedResearchFilenames)
-    )
-
-    const tagToSlugMap = await getTagToSlugMap(knex)
-    return {
-        grapher,
-        datapageData,
-        imageMetadata,
-        faqEntries,
-        tagToSlugMap,
-    }
-}
 export async function renderDataPageV2(
     {
         variableId,
@@ -337,7 +159,6 @@ export async function renderDataPageV2(
         />
     )
 }
-
 /**
  *
  * Similar to renderDataPageOrGrapherPage(), but for admin previews

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -117,6 +117,10 @@ export class ExplorerProgram extends GridProgram {
             : row + this.decisionMatrix.selectedRowIndex + 2
     }
 
+    get currentlySelectedGrapherRowContent() {
+        return this.decisionMatrix.selectedRow
+    }
+
     static fromMatrix(slug: string, matrix: CoreMatrix) {
         const str = matrix
             .map((row) =>

--- a/explorerAdminClient/ExplorerDataPage.tsx
+++ b/explorerAdminClient/ExplorerDataPage.tsx
@@ -1,7 +1,10 @@
 import React from "react"
 import { ExplorerProgram, makeFullPath } from "../explorer/ExplorerProgram.js"
 import { GitCmsClient } from "../gitCms/GitCmsClient.js"
-import { ExplorerControlPanel } from "../explorer/ExplorerControls.js"
+import {
+    ExplorerControlBar,
+    ExplorerControlPanel,
+} from "../explorer/ExplorerControls.js"
 import { GIT_CMS_BASE_ROUTE } from "../gitCms/GitCmsConstants.js"
 import { observer } from "mobx-react"
 import { action, computed, observable, reaction } from "mobx"
@@ -118,7 +121,7 @@ export class ExplorerDataPage extends React.Component<ExplorerDataPageProps> {
 
     render() {
         const { explorer, datapageDataFull, grapherConfig } = this
-        const panel = explorer
+        const panels = explorer
             ? explorer.decisionMatrix.choicesWithAvailability.map((choice) => (
                   <ExplorerControlPanel
                       key={choice.title}
@@ -135,7 +138,10 @@ export class ExplorerDataPage extends React.Component<ExplorerDataPageProps> {
             : null
         return (
             <>
-                {panel}
+                <ExplorerControlBar isMobile={false} showControls={false}>
+                    {panels}
+                </ExplorerControlBar>
+
                 <DebugProvider debug={true}>
                     {datapageDataFull && (
                         <DataPageV2Body

--- a/explorerAdminClient/ExplorerDataPage.tsx
+++ b/explorerAdminClient/ExplorerDataPage.tsx
@@ -8,7 +8,12 @@ import { observer } from "mobx-react"
 import { action, computed, observable, reaction } from "mobx"
 import { DebugProvider } from "../site/gdocs/DebugContext.js"
 import { DataPageV2Content } from "../site/DataPageV2Content.js"
-import { FullDatapageData } from "@ourworldindata/types"
+import { DataPageV2 } from "../site/DataPageV2.js"
+import {
+    DimensionProperty,
+    FullDatapageData,
+    GrapherInterface,
+} from "@ourworldindata/types"
 
 export interface ExplorerDataPageProps {
     slug: string
@@ -74,8 +79,22 @@ export class ExplorerDataPage extends React.Component<ExplorerDataPageProps> {
         )
     }
 
+    @computed private get grapherConfig(): GrapherInterface | null {
+        const { datapageDataFull, currentlySelectedYIndicatorId } = this
+        if (!datapageDataFull || !currentlySelectedYIndicatorId) return null
+        return {
+            ...datapageDataFull.grapher,
+            dimensions: [
+                {
+                    property: DimensionProperty.y,
+                    variableId: currentlySelectedYIndicatorId,
+                },
+            ],
+        }
+    }
+
     render() {
-        const { explorer, datapageDataFull } = this
+        const { explorer, datapageDataFull, grapherConfig } = this
         const panel = explorer
             ? explorer.decisionMatrix.choicesWithAvailability.map((choice) => (
                   <ExplorerControlPanel
@@ -96,13 +115,14 @@ export class ExplorerDataPage extends React.Component<ExplorerDataPageProps> {
                 {panel}
                 <DebugProvider debug={true}>
                     {datapageDataFull && (
-                        <DataPageV2Content
+                        <DataPageV2
                             datapageData={datapageDataFull.datapageData}
-                            grapherConfig={{}}
+                            grapher={grapherConfig ?? undefined}
                             imageMetadata={datapageDataFull.imageMetadata}
                             isPreviewing={true}
                             faqEntries={datapageDataFull.faqEntries}
-                            canonicalUrl={"/"}
+                            baseGrapherUrl="/grapher/"
+                            baseUrl="/"
                             tagToSlugMap={datapageDataFull.tagToSlugMap}
                         />
                     )}

--- a/explorerAdminClient/ExplorerDataPage.tsx
+++ b/explorerAdminClient/ExplorerDataPage.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from "react"
+import { ExplorerProgram, makeFullPath } from "../explorer/ExplorerProgram.js"
+import { AdminManager } from "./AdminManager.js"
+import { GitCmsClient } from "../gitCms/GitCmsClient.js"
+import { ExplorerControlPanel } from "../explorer/ExplorerControls.js"
+import { GIT_CMS_BASE_ROUTE } from "../gitCms/GitCmsConstants.js"
+
+export interface ExplorerDataPageProps {
+    slug: string
+    gitCmsBranchName: string
+    manager?: AdminManager
+}
+
+export const ExplorerDataPage = ({
+    slug,
+    gitCmsBranchName,
+    manager,
+}: ExplorerDataPageProps) => {
+    const [explorer, setExplorer] = useState<ExplorerProgram | undefined>(
+        undefined
+    )
+    useEffect(() => {
+        let ignore = false
+        const fetchData = async () => {
+            const gitCmsClient = new GitCmsClient(GIT_CMS_BASE_ROUTE)
+            return gitCmsClient.readRemoteFile({
+                filepath: makeFullPath(slug),
+            })
+        }
+        void fetchData().then((gitCmsData) => {
+            if (!ignore)
+                setExplorer(new ExplorerProgram(slug, gitCmsData.content))
+        })
+        return () => {
+            ignore = true
+        }
+    }, [slug, setExplorer])
+    const panel = explorer
+        ? explorer.decisionMatrix.choicesWithAvailability.map((choice) => (
+              <ExplorerControlPanel
+                  key={choice.title}
+                  choice={choice}
+                  isMobile={false}
+              />
+          ))
+        : null
+    return <>{panel}</>
+}

--- a/explorerAdminClient/ExplorerDataPage.tsx
+++ b/explorerAdminClient/ExplorerDataPage.tsx
@@ -4,45 +4,90 @@ import { AdminManager } from "./AdminManager.js"
 import { GitCmsClient } from "../gitCms/GitCmsClient.js"
 import { ExplorerControlPanel } from "../explorer/ExplorerControls.js"
 import { GIT_CMS_BASE_ROUTE } from "../gitCms/GitCmsConstants.js"
+import { observer } from "mobx-react"
+import { action, computed, observable } from "mobx"
 
 export interface ExplorerDataPageProps {
     slug: string
-    gitCmsBranchName: string
-    manager?: AdminManager
 }
 
-export const ExplorerDataPage = ({
-    slug,
-    gitCmsBranchName,
-    manager,
-}: ExplorerDataPageProps) => {
-    const [explorer, setExplorer] = useState<ExplorerProgram | undefined>(
-        undefined
-    )
-    useEffect(() => {
-        let ignore = false
-        const fetchData = async () => {
-            const gitCmsClient = new GitCmsClient(GIT_CMS_BASE_ROUTE)
-            return gitCmsClient.readRemoteFile({
-                filepath: makeFullPath(slug),
-            })
-        }
-        void fetchData().then((gitCmsData) => {
-            if (!ignore)
-                setExplorer(new ExplorerProgram(slug, gitCmsData.content))
+@observer
+export class ExplorerDataPage extends React.Component<ExplorerDataPageProps> {
+    @observable private explorer: ExplorerProgram | null = null
+
+    iframeRef = React.createRef<HTMLIFrameElement>()
+
+    @computed private get slug() {
+        return this.props.slug
+    }
+
+    // @computed private get currentChoice(): string | null {
+    //     const { explorer } = this
+    //     if (!explorer) return null
+    //     return Object.entries(explorer.decisionMatrix.currentParams)
+    //         .map(([key, value]) => `${key}=${value}`)
+    //         .join("-")
+    // }
+
+    @computed private get currentlySelectedYIndicatorIds(): number[] {
+        const { explorer } = this
+        if (!explorer) return []
+        if (!("yVariableIds" in explorer.currentlySelectedGrapherRowContent))
+            return []
+        const yVariableIds =
+            explorer.currentlySelectedGrapherRowContent.yVariableIds
+                .split(" ")
+                .map((str: string) => parseInt(str))
+        return yVariableIds
+    }
+
+    @computed private get currentlySelectedYIndicatorId(): number | null {
+        const { currentlySelectedYIndicatorIds } = this
+        return currentlySelectedYIndicatorIds.length > 0
+            ? currentlySelectedYIndicatorIds[0]
+            : null
+    }
+
+    @action.bound private async fetchData() {
+        const { slug } = this
+        const gitCmsClient = new GitCmsClient(GIT_CMS_BASE_ROUTE)
+        const explorerContent = await gitCmsClient.readRemoteFile({
+            filepath: makeFullPath(slug),
         })
-        return () => {
-            ignore = true
-        }
-    }, [slug, setExplorer])
-    const panel = explorer
-        ? explorer.decisionMatrix.choicesWithAvailability.map((choice) => (
-              <ExplorerControlPanel
-                  key={choice.title}
-                  choice={choice}
-                  isMobile={false}
-              />
-          ))
-        : null
-    return <>{panel}</>
+        this.explorer = new ExplorerProgram(slug, explorerContent.content)
+    }
+    componentDidMount() {
+        void this.fetchData()
+    }
+
+    render() {
+        const { explorer, currentlySelectedYIndicatorId, iframeRef } = this
+        const panel = explorer
+            ? explorer.decisionMatrix.choicesWithAvailability.map((choice) => (
+                  <ExplorerControlPanel
+                      key={choice.title}
+                      choice={choice}
+                      isMobile={false}
+                      onChange={(val) =>
+                          explorer.decisionMatrix.setValueCommand(
+                              choice.title,
+                              val
+                          )
+                      }
+                  />
+              ))
+            : null
+        return (
+            <>
+                {panel}
+                <iframe
+                    ref={iframeRef}
+                    src={`/admin/datapage-preview/${currentlySelectedYIndicatorId}?country=~OWID_WRL`}
+                    style={{ width: "100%", border: "none", height: "100%" }}
+                    // use `updatedAt` as a proxy for when database-level settings such as breadcrumbs have changed
+                    key={currentlySelectedYIndicatorId}
+                />
+            </>
+        )
+    }
 }

--- a/explorerAdminClient/ExplorerDataPage.tsx
+++ b/explorerAdminClient/ExplorerDataPage.tsx
@@ -139,7 +139,6 @@ export class ExplorerDataPage extends React.Component<ExplorerDataPageProps> {
                 <DebugProvider debug={true}>
                     {datapageDataFull && (
                         <DataPageV2Body
-                            key={this.currentlySelectedYIndicatorId}
                             datapageData={datapageDataFull.datapageData}
                             grapher={grapherConfig ?? undefined}
                             imageMetadata={datapageDataFull.imageMetadata}
@@ -149,6 +148,9 @@ export class ExplorerDataPage extends React.Component<ExplorerDataPageProps> {
                             baseUrl="/"
                             canonicalUrl="/"
                             tagToSlugMap={datapageDataFull.tagToSlugMap}
+                            grapherKey={this.currentlySelectedYIndicatorIds
+                                .map((i) => i.toString())
+                                .join("-")}
                         />
                         // <></>
                     )}

--- a/explorerAdminClient/ExplorersListPage.tsx
+++ b/explorerAdminClient/ExplorersListPage.tsx
@@ -93,6 +93,10 @@ class ExplorerRow extends React.Component<{
                     <a href={`/admin/${EXPLORERS_PREVIEW_ROUTE}/${slug}`}>
                         Preview
                     </a>
+                    {" - "}
+                    <a href={`/admin/explorers/datapage/${slug}`}>
+                        Datapage preview
+                    </a>
                 </td>
                 <td>
                     {searchHighlight

--- a/explorerAdminClient/tsconfig.json
+++ b/explorerAdminClient/tsconfig.json
@@ -5,8 +5,17 @@
         "rootDir": "."
     },
     "references": [
-        { "path": "../explorer" },
-        { "path": "../gridLang" },
-        { "path": "../gitCms" }
+        {
+            "path": "../explorer"
+        },
+        {
+            "path": "../gridLang"
+        },
+        {
+            "path": "../gitCms"
+        },
+        {
+            "path": "../site"
+        }
     ]
 }

--- a/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
@@ -5,7 +5,7 @@ import {
     IndicatorTitleWithFragments,
     OwidProcessingLevel,
 } from "../OwidVariable.js"
-import { RelatedChart } from "../grapherTypes/GrapherTypes.js"
+import { GrapherInterface, RelatedChart } from "../grapherTypes/GrapherTypes.js"
 import { Static, Type } from "@sinclair/typebox"
 import { OwidEnrichedGdocBlock } from "./ArchieMlComponents.js"
 import { ImageMetadata } from "./Image.js"
@@ -165,4 +165,12 @@ export interface DisplaySource {
     retrievedOn?: string
     retrievedFrom?: string
     citation?: string
+}
+
+export interface FullDatapageData {
+    grapher: GrapherInterface
+    datapageData: DataPageDataV2
+    imageMetadata: Record<string, ImageMetadata>
+    faqEntries: FaqEntryData
+    tagToSlugMap: Record<string, string>
 }

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -319,6 +319,7 @@ export {
     type FaqLink,
     type FaqEntryData,
     type DisplaySource,
+    type FullDatapageData,
 } from "./gdocTypes/Datapage.js"
 
 export {

--- a/site/DataPageV2Body.tsx
+++ b/site/DataPageV2Body.tsx
@@ -1,0 +1,127 @@
+import {
+    GrapherProgrammaticInterface,
+    GRAPHER_SETTINGS_DRAWER_ID,
+} from "@ourworldindata/grapher"
+import {
+    GrapherInterface,
+    DataPageDataV2,
+    FaqEntryData,
+    ImageMetadata,
+    SiteFooterContext,
+} from "@ourworldindata/types"
+import {
+    mergePartialGrapherConfigs,
+    serializeJSONForHTML,
+} from "@ourworldindata/utils"
+import { pick } from "lodash"
+import React from "react"
+import {
+    BAKED_GRAPHER_URL,
+    ADMIN_BASE_URL,
+    DATA_API_URL,
+} from "../settings/clientSettings.js"
+import {
+    OWID_DATAPAGE_CONTENT_ROOT_ID,
+    DataPageV2Content,
+} from "./DataPageV2Content.js"
+// import { SiteFooter } from "./SiteFooter.js"
+import { SiteHeader } from "./SiteHeader.js"
+import { DebugProvider } from "./gdocs/DebugContext.js"
+
+export const DataPageV2Body = (props: {
+    grapher: GrapherInterface | undefined
+    datapageData: DataPageDataV2
+    baseUrl: string
+    baseGrapherUrl: string
+    isPreviewing: boolean
+    faqEntries?: FaqEntryData
+    imageMetadata: Record<string, ImageMetadata>
+    tagToSlugMap: Record<string | number, string>
+    canonicalUrl: string
+}) => {
+    const {
+        grapher,
+        datapageData,
+        baseGrapherUrl,
+        baseUrl,
+        isPreviewing,
+        faqEntries,
+        tagToSlugMap,
+        imageMetadata,
+        canonicalUrl,
+    } = props
+    const mergedGrapherConfig = mergePartialGrapherConfigs(
+        datapageData.chartConfig as GrapherInterface,
+        grapher
+    )
+
+    // Note that we cannot set `bindUrlToWindow` and `isEmbeddedInADataPage` here,
+    // because this would then get serialized into the EMBEDDED_JSON object,
+    // and MultiEmbedder would then pick it up for other charts on the page
+    // _aside_ from the main one (e.g. the related charts block),
+    // which we don't want to happen.
+    const grapherConfig: GrapherProgrammaticInterface = {
+        ...mergedGrapherConfig,
+        bakedGrapherURL: BAKED_GRAPHER_URL,
+        adminBaseUrl: ADMIN_BASE_URL,
+        dataApiUrl: DATA_API_URL,
+    }
+
+    // Only embed the tags that are actually used by the datapage, instead of the complete JSON object with ~240 properties
+    const minimalTagToSlugMap = pick(
+        tagToSlugMap,
+        datapageData.topicTagsLinks || []
+    )
+    return (
+        <body className="DataPage">
+            <SiteHeader baseUrl={baseUrl} />
+            <main>
+                <>
+                    <nav id={GRAPHER_SETTINGS_DRAWER_ID}></nav>
+                    <script
+                        dangerouslySetInnerHTML={{
+                            __html: `window._OWID_DATAPAGEV2_PROPS = ${JSON.stringify(
+                                {
+                                    datapageData,
+                                    faqEntries,
+                                    canonicalUrl,
+                                    tagToSlugMap: minimalTagToSlugMap,
+                                    imageMetadata,
+                                }
+                            )}`,
+                        }}
+                    />
+                    <div id={OWID_DATAPAGE_CONTENT_ROOT_ID}>
+                        <DebugProvider debug={isPreviewing}>
+                            <DataPageV2Content
+                                datapageData={datapageData}
+                                grapherConfig={grapherConfig}
+                                imageMetadata={imageMetadata}
+                                isPreviewing={isPreviewing}
+                                faqEntries={faqEntries}
+                                canonicalUrl={canonicalUrl}
+                                tagToSlugMap={tagToSlugMap}
+                            />
+                        </DebugProvider>
+                    </div>
+                </>
+            </main>
+
+            {/* TODO: This screws up how data pages are rendered but
+                  if we include it the viteUtils are pulled in and then
+                  that includes fs-extra and then the admin breaks...
+                <SiteFooter
+                baseUrl={baseUrl}
+                context={SiteFooterContext.dataPageV2}
+                isPreviewing={isPreviewing}
+            /> */}
+            <script
+                dangerouslySetInnerHTML={{
+                    __html: `window._OWID_GRAPHER_CONFIG = ${serializeJSONForHTML(
+                        grapherConfig
+                    )}`,
+                }}
+            />
+        </body>
+    )
+}

--- a/site/DataPageV2Body.tsx
+++ b/site/DataPageV2Body.tsx
@@ -38,6 +38,7 @@ export const DataPageV2Body = (props: {
     imageMetadata: Record<string, ImageMetadata>
     tagToSlugMap: Record<string | number, string>
     canonicalUrl: string
+    grapherKey?: string
 }) => {
     const {
         grapher,
@@ -49,6 +50,7 @@ export const DataPageV2Body = (props: {
         tagToSlugMap,
         imageMetadata,
         canonicalUrl,
+        grapherKey,
     } = props
     const mergedGrapherConfig = mergePartialGrapherConfigs(
         datapageData.chartConfig as GrapherInterface,
@@ -94,6 +96,7 @@ export const DataPageV2Body = (props: {
                     <div id={OWID_DATAPAGE_CONTENT_ROOT_ID}>
                         <DebugProvider debug={isPreviewing}>
                             <DataPageV2Content
+                                key={grapherKey}
                                 datapageData={datapageData}
                                 grapherConfig={grapherConfig}
                                 imageMetadata={imageMetadata}

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -39,6 +39,7 @@ import {
     getCitationLong,
     joinTitleFragments,
     ImageMetadata,
+    grapherKeysToSerialize,
 } from "@ourworldindata/utils"
 import { AttachmentsContext, DocumentContext } from "./gdocs/OwidGdoc.js"
 import StickyNav from "./blocks/StickyNav.js"


### PR DESCRIPTION
This PR is a first rough, exploratory prototype to see what the combination of an explorer and a data page could look like. From the explorer we take here mostly only the top control bar, the rest (including the chart) is taken from the indicator data page.

For this PR the datapage is rendered client side to make switching faster.