### PR TITLE
Format chart and topic counts on homepage

### DIFF
--- a/site/gdocs/components/HomepageSearch.tsx
+++ b/site/gdocs/components/HomepageSearch.tsx
@@ -6,15 +6,17 @@ export function HomepageSearch(props: { className?: string }) {
     const { homepageMetadata } = useContext(AttachmentsContext)
     const chartCount = homepageMetadata?.chartCount
     const topicCount = homepageMetadata?.topicCount
+    const formatter = new Intl.NumberFormat("en-GB")
     const message =
         chartCount && topicCount ? (
             <>
-                <a href="/charts">{chartCount} charts</a> across{" "}
+                <a href="/charts">{formatter.format(chartCount)} charts</a>{" "}
+                across{" "}
                 <a
                     href="#all-topics"
                     className="homepage-search__all-topics-link"
                 >
-                    {topicCount} topics
+                    {formatter.format(topicCount)} topics
                 </a>
                 <span className="homepage-search__open-source-notice">
                     All free: open access and open source


### PR DESCRIPTION
This effectively adds a thousand separator to the charts count:

<img width="652" alt="image" src="https://github.com/owid/owid-grapher/assets/6129025/b60ff3b7-a053-462e-a80d-94f1e6d9ed16">
