### PR TITLE
🐝 (baking) report explorers with missing variable IDs

### DIFF
--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -735,6 +735,18 @@ export const renderExplorerPage = async (
             `SELECT id, grapherConfigETL, grapherConfigAdmin FROM variables WHERE id IN (?)`,
             [requiredVariableIds]
         )
+
+        // check if all required variable IDs exist in the database
+        const missingIds = requiredVariableIds.filter(
+            (id) => !partialGrapherConfigRows.find((row) => row.id === id)
+        )
+        if (missingIds.length > 0) {
+            void logErrorAndMaybeSendToBugsnag(
+                new JsonError(
+                    `Referenced variable IDs do not exist in the database for explorer ${program.slug}: ${missingIds.join(", ")}.`
+                )
+            )
+        }
     }
 
     const parseGrapherConfigFromRow = (row: ChartRow): GrapherInterface => {


### PR DESCRIPTION
### Summary

Sends a report to Bugsnag when indicators that are referenced in an explorer do not exist. We bake the explorer in any case, though (some chart views not loading is better than a broken link, in my opinion).

Not really a complete solution for #2937 but a bit better than what we have now :)