### PR TITLE
🐛 (explorer) pass isEmbeddedInAnOwidPage to Grapher

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -928,6 +928,9 @@ export class Explorer
                         enableKeyboardShortcuts={true}
                         manager={this}
                         ref={this.grapherRef}
+                        isEmbeddedInAnOwidPage={
+                            this.props.isEmbeddedInAnOwidPage
+                        }
                     />
                 </div>
             </div>


### PR DESCRIPTION
Fixes a bug where embedded explorers (with hidden controls) scrolled to the "About this data" section instead of opening the sources modal when the "Learn about this data" link was clicked. This happened because Grapher was not aware that it was embedded since the explorer didn't pass that information on.