### PR TITLE
🐛 (facet) hide legends with a single bin

### DIFF
--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
@@ -700,6 +700,8 @@ export class FacetChart
                     index,
                 })
         )
+        if (this.facetStrategy === FacetStrategy.metric && newBins.length <= 1)
+            return []
         return newBins
     }
 


### PR DESCRIPTION
Fixes https://github.com/owid/owid-grapher/issues/2594

Hides single-item legends for facetted charts (ok since the entity name is mentioned in the title).
