### PR TITLE
enhance(embed): explicitly `allow` share features in iframe snippet

### DIFF
--- a/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
@@ -36,7 +36,7 @@ export class EmbedModal extends React.Component<EmbedModalProps> {
 
     @computed private get codeSnippet(): string {
         const url = this.manager.embedUrl
-        return `<iframe src="${url}" loading="lazy" style="width: 100%; height: 600px; border: 0px none;"></iframe>`
+        return `<iframe src="${url}" loading="lazy" style="width: 100%; height: 600px; border: 0px none;" allow="web-share; clipboard-write"></iframe>`
     }
 
     @action.bound private onDismiss(): void {


### PR DESCRIPTION
This explicitly requests the [`web-share`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy/web-share) and [`clipboard-write`](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API#security_considerations:~:text=The%20HTTP%20Permissions%2DPolicy%20permissions) permissions in our default iframe snippet.

If they are not set, two of our most-used Share menu interactions ("Share via OS share sheet" and "Copy URL to clipboard") will not work when in an iframe context.
Or, well, the `clipboard-write` permission is currently only required in Chromium browsers, but that's still a vast majority of users.

---

If these permissions are not granted, we now do a pretty nice feature & permission detection, and will not display the Share menu items which are not working.