### PR TITLE
(marimekko) fix 3456 missing labels

### DIFF
--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -79,6 +79,7 @@ import {
 
 const MARKER_MARGIN: number = 4
 const MARKER_AREA_HEIGHT: number = 25
+const MAX_LABEL_COUNT: number = 20
 
 function MarimekkoBar({
     bar,
@@ -1341,7 +1342,7 @@ export class MarimekkoChart
         const labelHeight = labelCandidates[0].bounds.height
 
         const numLabelsToAdd = Math.floor(
-            Math.min(availablePixels / (labelHeight + paddingInPixels) / 3, 20) // factor 3 is arbitrary to taste
+            Math.min(availablePixels / (labelHeight + paddingInPixels) / 3, MAX_LABEL_COUNT) // factor 3 is arbitrary to taste
         )
         const chunks = MarimekkoChart.splitIntoEqualDomainSizeChunks(
             items,

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -1224,17 +1224,17 @@ export class MarimekkoChart
         candidates: LabelCandidate[],
         numChunks: number
     ): LabelCandidate[][] {
-        // we'll use this to validate a candidate against it's chart appearance validity
-        const validItemNames: String[] = items.map(({ entityName }) => entityName)
+        // candidates contains all valid entites across a set of N selectable charts (ie. years)
+        // items is just the valid entities for the currently selected member of the set
+        // validItemNames will enable us to filter correctly
+        const validItemNames = items.map(({ entityName }) => entityName)
 
-        // reduce the list of candidates down to just those that match the valid entities
+        // filter the list to remove invalid candidates given validItemNames
         // all further calculations are then done only with validCandidates
-        let validCandidates: LabelCandidate[] = []
-        for (const candidate of candidates) {
-            if (validItemNames.includes(candidate.item.entityName)) {
-                validCandidates.push(candidate)
-            }
-        }
+        const validCandidates = candidates.filter((candidate) =>
+            validItemNames.includes(candidate.item.entityName)
+        )
+
         const chunks: LabelCandidate[][] = []
         let currentChunk: LabelCandidate[] = []
         let domainSizeOfChunk = 0


### PR DESCRIPTION
## Explanation

Filtered the label candidates which are a full list of nations using the `items` value provided by the chart code to reduce that set to just valid candidates, before performing label code; therefore, no candidate can get in just because it's in the list, it also has to a value that makes it valid, logic which is performed to create the chart `items` property.

This is a [more detailed description of my working out](https://github.com/owid/owid-grapher/issues/3456#issuecomment-2049376383) if you're interested.

Fixes: #3456

On the way I made something a constant and this seemed like gardening, so I left that in.

## Questions

~1. I stuck with `for(const candidate ...` in the loop in order to keep your style consistent, but would br curious to know whether `let candidate` once, then re-used by both loops in the function would be better for memory?~ [edit: invalid after PR review]
2. I wasn't able to access `this.items` from inside the function, and it wasn't super-clear why (large file, getter/class style I know of but haven't used much, etc.) so I had to pass it in as a variable. While it probably doesn't impact much on a macro scale, I'd like to know why so I can learn more (the whole thing with this being built differently makes me want to learn for the sake of it tbh).

## Notes

1. It seems that code deliberately measures labels and ensures they don't clash resulting in there being fewer than the full set shown in many cases, so while my fix shows labels it doesn't show them all and that is reasonable from my current understanding of the code

## Screen shots

All taken from the rather useful [/admin/test dev tool ](http://localhost:3030/admin/test/embeds?ids=7216&comparisonUrl=https%3A%2F%2Fourworldindata.org) <- hoping that URL just opens the chart directly for others to test.

### Problem in issue is fixed

![Screenshot 2024-05-06 at 17 47 47](https://github.com/owid/owid-grapher/assets/10499070/81cacfd9-5e99-41f5-961c-03478a169c0c)

### Another broken year is too

![Screenshot 2024-05-06 at 17 47 33](https://github.com/owid/owid-grapher/assets/10499070/94a5573b-5874-451e-bcaf-ca931bcaae22)

### Really early example with just 1 is fixed too

![Screenshot 2024-05-06 at 17 48 03](https://github.com/owid/owid-grapher/assets/10499070/9fdd53bc-6f6f-4fa7-b998-d1821b8b9992)

### Modern data with 100s hasn't changed

![Screenshot 2024-05-06 at 17 47 12](https://github.com/owid/owid-grapher/assets/10499070/15b95a01-3125-45d1-b3d2-672b2ab273c6)

