### PR TITLE
enhance(algolia): demote `proximity` ranking for charts index

### DIFF
--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -83,6 +83,7 @@ export const configureAlgolia = async () => {
             "unordered(tags)",
             "unordered(availableEntities)",
         ],
+        ranking: ["typo", "words", "exact", "attribute", "custom", "proximity"],
         customRanking: [
             "desc(score)",
             "desc(numRelatedArticles)",


### PR DESCRIPTION
- The `proximity` ranking criterion was causing subpar search results, _especially_ when multiple country names are contained in the query.
- I always believed that removing it as a criterion would make many queries much worse, but at first sight, this is not the case.

Certainly improves queries like:
- gdp per capita india china
- share extreme poverty
- co2 per capita
- ghg emissions

Triggered by this [Slack discussion](https://owid.slack.com/archives/C06UA61V85U/p1714762934458109).