### PR TITLE
Author page alternate template (topics-focused)

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -2552,7 +2552,13 @@ deleteRouteWithRWTransaction(
 // using the alternate template, which highlights topics rather than articles.
 getRouteWithROTransaction(apiRouter, "/all-work", async (req, res, trx) => {
     type WordpressPageRecord = Record<
-        "slug" | "title" | "type" | "thumbnail" | "authors" | "publishedAt",
+        | "slug"
+        | "title"
+        | "subtitle"
+        | "type"
+        | "thumbnail"
+        | "authors"
+        | "publishedAt",
         string
     >
     type GdocRecord = Pick<DbRawPostGdoc, "id" | "publishedAt"> &
@@ -2577,6 +2583,7 @@ getRouteWithROTransaction(apiRouter, "/all-work", async (req, res, trx) => {
         SELECT
             wpApiSnapshot->>"$.slug" as slug,
             wpApiSnapshot->>"$.title.rendered" as title,
+            wpApiSnapshot->>"$.excerpt.rendered" as subtitle,
             wpApiSnapshot->>"$.type" as type,
             wpApiSnapshot->>"$.authors_name" as authors,
             wpApiSnapshot->>"$.featured_media_paths.medium_large" as thumbnail,
@@ -2619,6 +2626,7 @@ getRouteWithROTransaction(apiRouter, "/all-work", async (req, res, trx) => {
             if (isWordpressPage(post)) {
                 yield* generateProperty("url", post.slug)
                 yield* generateProperty("title", post.title)
+                yield* generateProperty("subtitle", post.subtitle)
                 yield* generateProperty(
                     "authors",
                     JSON.parse(post.authors).join(", ")

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -2624,7 +2624,10 @@ getRouteWithROTransaction(apiRouter, "/all-work", async (req, res, trx) => {
             sortByDateDesc
         )) {
             if (isWordpressPage(post)) {
-                yield* generateProperty("url", post.slug)
+                yield* generateProperty(
+                    "url",
+                    `https://ourworldindata.org/${post.slug}`
+                )
                 yield* generateProperty("title", post.title)
                 yield* generateProperty("subtitle", post.subtitle)
                 yield* generateProperty(

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -2565,7 +2565,7 @@ getRouteWithROTransaction(apiRouter, "/all-work", async (req, res, trx) => {
             SELECT id, content->>'$.title' as title, content->>'$.type'
             FROM posts_gdocs
             WHERE JSON_CONTAINS(content->'$.authors', '"${author}"')
-            AND type NOT IN ("data-insight", "article", "fragment")
+            AND type NOT IN ("data-insight", "fragment")
             AND published = 1
             ORDER BY publishedAt DESC
     `

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -1636,40 +1636,6 @@ function parseExpandableParagraph(
 function parseResearchAndWritingBlock(
     raw: RawBlockResearchAndWriting
 ): EnrichedBlockResearchAndWriting {
-    const createError = (
-        error: ParseError,
-        heading = "",
-        hideAuthors = false,
-        primary = [
-            {
-                value: { url: "" },
-            },
-        ],
-        secondary = [
-            {
-                value: { url: "" },
-            },
-        ],
-        more: EnrichedBlockResearchAndWritingRow = {
-            heading: "",
-            articles: [],
-        },
-        latest: EnrichedBlockResearchAndWritingRow = {
-            heading: "",
-            articles: [],
-        },
-        rows: EnrichedBlockResearchAndWritingRow[] = []
-    ): EnrichedBlockResearchAndWriting => ({
-        type: "research-and-writing",
-        heading,
-        "hide-authors": hideAuthors,
-        primary,
-        secondary,
-        more,
-        latest,
-        rows,
-        parseErrors: [error],
-    })
     const parseErrors: ParseError[] = []
 
     function enrichLink(
@@ -1729,12 +1695,10 @@ function parseResearchAndWritingBlock(
         })
     }
 
-    if (!raw.value.primary)
-        return createError({ message: "Missing primary link" })
     const primary: EnrichedBlockResearchAndWritingLink[] = []
     if (isArray(raw.value.primary)) {
         primary.push(...raw.value.primary.map((link) => enrichLink(link)))
-    } else {
+    } else if (raw.value.primary) {
         primary.push(enrichLink(raw.value.primary))
     }
 

--- a/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
@@ -852,8 +852,8 @@ export enum SocialLinkType {
 }
 
 export type RawSocialLink = {
-    text: string
-    url: string
+    text?: string
+    url?: string
     type?: SocialLinkType
 }
 
@@ -862,7 +862,11 @@ export type RawBlockSocials = {
     value: RawSocialLink[] | ArchieMLUnexpectedNonObjectValue
 }
 
-export type EnrichedSocialLink = RawSocialLink
+export type EnrichedSocialLink = {
+    text: string
+    url: string
+    type?: SocialLinkType
+}
 
 export type EnrichedBlockSocials = {
     type: "socials"

--- a/packages/@ourworldindata/utils/src/image.ts
+++ b/packages/@ourworldindata/utils/src/image.ts
@@ -48,7 +48,7 @@ export function getFilenameWithoutExtension(
 export function getFilenameExtension(
     filename: ImageMetadata["filename"]
 ): string {
-    return filename.slice(filename.indexOf(".") + 1)
+    return filename.slice(filename.lastIndexOf(".") + 1)
 }
 
 export function getFilenameAsPng(filename: ImageMetadata["filename"]): string {


### PR DESCRIPTION
Added a route to get an ArchieML output of all work produced by an author from both gdoc articles and wordpress pages.

- Example route: http://staging-site-author-page-alt/admin/api/all-work?author=Esteban%20Ortiz-Ospina 
- Example page: http://staging-site-author-page-alt/admin/gdocs/1pU8nVBchpI_LYZmNOo4Dag9lHvQkzG-r8JD_57_-1rw/preview

### Why make this change?

To provide a way to manually populate the secondary section of research and writing blocks on author pages with topics rather than articles. This is relevant for a handful of authors who mostly work on topic pages, as well as data managers.

![Screenshot 2024-05-07 at 14.31.06.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0SFFiIjKuUK6UPYHVe6u/16ed5a76-2cef-4b0e-aa0e-8dcbea95ac73.png)