### PR TITLE
fix 3234 add overlay to menu

### DIFF
--- a/packages/@ourworldindata/components/src/styles/variables.scss
+++ b/packages/@ourworldindata/components/src/styles/variables.scss
@@ -153,8 +153,7 @@ $zindex-popover: 100;
 $zindex-search-overlay: 100;
 $zindex-cookie-notice: 110;
 $zindex-site-header: 120;
-// $zindex-extended-header ensures search overlays topic-page headers and ToC does not
-$zindex-extended-header: $zindex-site-header - 1;
+$zindex-extended-header: $zindex-site-header - 1; // $zindex-extended-header ensures search overlays topic-page headers and ToC does not
 $zindex-tooltip: 1070;
 $zindex-lightbox: 99998;
 $zindex-adminbar: 99999;

--- a/packages/@ourworldindata/components/src/styles/variables.scss
+++ b/packages/@ourworldindata/components/src/styles/variables.scss
@@ -153,8 +153,8 @@ $zindex-popover: 100;
 $zindex-search-overlay: 100;
 $zindex-cookie-notice: 110;
 $zindex-site-header: 120;
-// $zindex-article-header ensures search overlays topic-page headers and ToC does not
-$zindex-topic-page-header: $zindex-site-header - 1;
+// $zindex-extended-header ensures search overlays topic-page headers and ToC does not
+$zindex-extended-header: $zindex-site-header - 1;
 $zindex-tooltip: 1070;
 $zindex-lightbox: 99998;
 $zindex-adminbar: 99999;

--- a/packages/@ourworldindata/components/src/styles/variables.scss
+++ b/packages/@ourworldindata/components/src/styles/variables.scss
@@ -153,7 +153,7 @@ $zindex-popover: 100;
 $zindex-search-overlay: 100;
 $zindex-cookie-notice: 110;
 $zindex-site-header: 120;
-$zindex-extended-header: $zindex-site-header - 1; // $zindex-extended-header ensures search overlays topic-page headers and ToC does not
+$zindex-extended-header: $zindex-site-header - 1; // ensures search overlays topic-page headers and ToC does not
 $zindex-tooltip: 1070;
 $zindex-lightbox: 99998;
 $zindex-adminbar: 99999;

--- a/packages/@ourworldindata/components/src/styles/variables.scss
+++ b/packages/@ourworldindata/components/src/styles/variables.scss
@@ -153,8 +153,8 @@ $zindex-popover: 100;
 $zindex-search-overlay: 100;
 $zindex-cookie-notice: 110;
 $zindex-site-header: 120;
-// $zindex-article-header ensures search overlays article headers and ToC does not
-$zindex-article-header: $zindex-site-header - 1;
+// $zindex-article-header ensures search overlays topic-page headers and ToC does not
+$zindex-topic-page-header: $zindex-site-header - 1;
 $zindex-tooltip: 1070;
 $zindex-lightbox: 99998;
 $zindex-adminbar: 99999;

--- a/packages/@ourworldindata/components/src/styles/variables.scss
+++ b/packages/@ourworldindata/components/src/styles/variables.scss
@@ -153,6 +153,8 @@ $zindex-popover: 100;
 $zindex-search-overlay: 100;
 $zindex-cookie-notice: 110;
 $zindex-site-header: 120;
+// $zindex-article-header ensures search overlays article headers and ToC does not
+$zindex-article-header: $zindex-site-header - 1;
 $zindex-tooltip: 1070;
 $zindex-lightbox: 99998;
 $zindex-adminbar: 99999;

--- a/site/TableOfContents.tsx
+++ b/site/TableOfContents.tsx
@@ -153,6 +153,11 @@ export const TableOfContents = ({
 
     return (
         <div className={TOC_WRAPPER_CLASSNAME}>
+            <div
+                className={classNames({
+                    "entry-sidebar__overlay": isOpen,
+                })}
+            />
             <aside
                 className={classNames("entry-sidebar", {
                     "entry-sidebar--is-open": isOpen,

--- a/site/TableOfContents.tsx
+++ b/site/TableOfContents.tsx
@@ -63,11 +63,6 @@ export const TableOfContents = ({
 
     useTriggerWhenClickOutside(tocRef, isOpen, setIsOpen)
 
-    // Open the sidebar on desktop by default when mounting
-    useEffect(() => {
-        setIsOpen(window.innerWidth >= 1536)
-    }, [])
-
     useEffect(() => {
         if ("IntersectionObserver" in window) {
             const previousHeadings = headings.map((heading, i) => ({

--- a/site/css/page.scss
+++ b/site/css/page.scss
@@ -111,8 +111,14 @@
     }
 
     &.large-banner {
+        .offset-subnavigation {
+            position: relative;
+            z-index: $zindex-extended-header;
+        }
         .offset-header {
             background-color: $blue-10;
+            position: relative;
+            z-index: $zindex-extended-header;
         }
 
         .article-header {

--- a/site/css/sidebar.scss
+++ b/site/css/sidebar.scss
@@ -12,6 +12,11 @@
     @include xxlg-up {
         height: 100%;
     }
+
+    .entry-sidebar__overlay {
+        @include overlay;
+        z-index: $zindex-sidebar - 1;
+    }
 }
 
 .entry-sidebar {

--- a/site/css/sidebar.scss
+++ b/site/css/sidebar.scss
@@ -15,7 +15,6 @@
 
     .entry-sidebar__overlay {
         @include overlay;
-        z-index: $zindex-sidebar - 1;
     }
 }
 

--- a/site/gdocs/components/topic-page.scss
+++ b/site/gdocs/components/topic-page.scss
@@ -7,6 +7,7 @@
     background-color: $blue-10;
     color: $blue-90;
     margin-bottom: 48px;
+    z-index: $zindex-article-header;
 
     h1 {
         margin-bottom: 0;

--- a/site/gdocs/components/topic-page.scss
+++ b/site/gdocs/components/topic-page.scss
@@ -7,7 +7,7 @@
     background-color: $blue-10;
     color: $blue-90;
     margin-bottom: 48px;
-    z-index: $zindex-article-header;
+    z-index: $zindex-topic-page-header;
 
     h1 {
         margin-bottom: 0;

--- a/site/gdocs/components/topic-page.scss
+++ b/site/gdocs/components/topic-page.scss
@@ -7,7 +7,7 @@
     background-color: $blue-10;
     color: $blue-90;
     margin-bottom: 48px;
-    z-index: $zindex-topic-page-header;
+    z-index: $zindex-extended-header;
 
     h1 {
         margin-bottom: 0;


### PR DESCRIPTION
## Intro

As stated in my comment I have brought this up once the style is applied. A few images to look at.

Some further requirements to come as issue discussions raised three pages and states they should all function with the same style and behaviour: 

http://localhost:3030/age-structure
http://localhost:3030/charts
http://localhost:3030/entries-by-year

## Issue

https://github.com/owid/owid-grapher/issues/3234

## Applying overlay

* ensure article header is still visible on article pages using a new z-index variable
* that z-index is calced from the site-header value
* this ensures the search box overlay still works as it does currently, covering the artcile header
* overlay is on ToC click and tested as click-away in both contexts: with and without an article header
* the "open on load" ToC at larger screen sizes logic is removed

## Suggestion

Move the close button to the left of the menu.

This means the menu can be toggled open and close without moving the mouse and puts it within easier left thumb range for standard use of a hand-held device (and the thumb doesn't need to move either). The edge of the clickable area can also touch the edge of the screen, making the click target easier to hit, some part of [Fitt's Law](https://www.interaction-design.org/literature/topics/fitts-law). 

## Consistency

For consistent styling I had to get this page too, it's pushed up, but wasn't originally asked for.

So over to you as technically this breaks [the Contr. Guide](https://github.com/owid/owid-grapher/blob/master/CONTRIBUTING.md#contributing-to-the-our-world-in-data-site). The [commit is isolated](https://github.com/owid/owid-grapher/pull/3597/commits/790aed4495400db89e2ca07b3ac0e25ffd5e025b).

But it also makes me wonder where else the consistency might be broken, fairly complex site, bits I've never seen etc. put me at a disadvantage answering this. It's more likely a "type of header" list than page list.

![Screenshot 2024-05-10 at 06 18 15](https://github.com/owid/owid-grapher/assets/10499070/8360e3ff-b0f0-448e-9a17-19aae975b20d)

## Screen shots

![Screenshot 2024-05-09 at 18 59 49](https://github.com/owid/owid-grapher/assets/10499070/87860a66-4a83-4997-91f4-bb6f96fdf276)

![Screenshot 2024-05-09 at 18 57 24](https://github.com/owid/owid-grapher/assets/10499070/f6605966-2151-469e-a31b-26c17ea3c1b1)

![Screenshot 2024-05-09 at 18 56 57](https://github.com/owid/owid-grapher/assets/10499070/d330f6aa-58e4-4773-8446-7063b566d4be)

![Screenshot 2024-05-09 at 19 02 28](https://github.com/owid/owid-grapher/assets/10499070/27036229-12c2-46eb-b465-291a97d92f60)
