### PR TITLE
fix(author): fail on create due to functions as enumerable properties overridden in Object.assign

### DIFF
--- a/db/model/Gdoc/GdocAuthor.ts
+++ b/db/model/Gdoc/GdocAuthor.ts
@@ -27,6 +27,28 @@ export class GdocAuthor extends GdocBase implements OwidGdocAuthorInterface {
 
     static create(obj: OwidGdocBaseInterface): GdocAuthor {
         const gdoc = new GdocAuthor()
+        // We need to prevent obj methods from overriding GdocAuthor methods.
+        // This happens when createGdocAndInsertIntoDb() passes a GdocBase
+        // instance to loadGdocFromGdocBase(), instead of a simple object. In
+        // this case, simply assigning obj to gdoc would override GdocAuthor
+        // methods with GdocBase methods, in particular the
+        // _enrichedSubclassContent. When creating a new author,
+        // _enrichedSubclassContent would run from the base GdocBase class
+        // instead of the GdocAuthor subclass, and the socials block would not
+        // be shaped as an ArchieML block, thus throwing an error.
+
+        // A first approach to avoid this would be to use Object.assign(), while
+        // omitting functions:
+        // Object.assign(gdoc, omitBy(obj, isFunction))
+
+        // A better approach is to avoid registering these functions as
+        // enumerable properties in the first place, so they are not listed by
+        // Object.assign(). The simplest way to do this is to define them as
+        // class methods, which are not enumerable, and instead attached to the
+        // class prototype. When we call Object.assign(gdoc, obj), these methods
+        // are ignored. Even after the assign, gdoc._enrichedSubclassContent()
+        // will then still accurately target the GdocAuthor method, and not the
+        // GdocBase method.
         Object.assign(gdoc, obj)
         return gdoc
     }

--- a/db/model/Gdoc/GdocAuthor.ts
+++ b/db/model/Gdoc/GdocAuthor.ts
@@ -49,6 +49,11 @@ export class GdocAuthor extends GdocBase implements OwidGdocAuthorInterface {
         // are ignored. Even after the assign, gdoc._enrichedSubclassContent()
         // will then still accurately target the GdocAuthor method, and not the
         // GdocBase method.
+
+        // see
+        // https://github.com/owid/owid-grapher/pull/3600#issuecomment-2116990248
+        // for a more detailed presentation on this topic
+
         Object.assign(gdoc, obj)
         return gdoc
     }

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -13,7 +13,6 @@ import {
     Span,
     traverseEnrichedSpan,
     uniq,
-    identity,
     OwidGdocBaseInterface,
     OwidGdocPublicationContext,
     BreadcrumbItem,
@@ -74,24 +73,38 @@ export class GdocBase implements OwidGdocBaseInterface {
     linkedIndicators: Record<number, LinkedIndicator> = {}
     linkedDocuments: Record<string, OwidGdocMinimalPostInterface> = {}
     latestDataInsights: MinimalDataInsightInterface[] = []
-
-    _getSubclassEnrichedBlocks: (gdoc: typeof this) => OwidEnrichedGdocBlock[] =
-        () => []
-    _enrichSubclassContent: (content: Record<string, any>) => void = identity
-    _validateSubclass: (
-        knex: db.KnexReadonlyTransaction,
-        gdoc: typeof this
-    ) => Promise<OwidGdocErrorMessage[]> = async () => []
     _omittableFields: string[] = []
-
-    _loadSubclassAttachments: (
-        knex: db.KnexReadonlyTransaction
-    ) => Promise<void> = async () => undefined
 
     constructor(id?: string) {
         if (id) {
             this.id = id
         }
+    }
+
+    /******************************************************************
+     * !! Use methods instead of functions as enumerable properties   *
+     * (see GdocAuthor.ts for rationale)                              *
+     ******************************************************************/
+
+    _getSubclassEnrichedBlocks(_gdoc: typeof this): OwidEnrichedGdocBlock[] {
+        return []
+    }
+
+    _enrichSubclassContent(_content: Record<string, any>): void {
+        return
+    }
+
+    async _validateSubclass(
+        _knex: db.KnexReadonlyTransaction,
+        _gdoc: typeof this
+    ): Promise<OwidGdocErrorMessage[]> {
+        return []
+    }
+
+    async _loadSubclassAttachments(
+        _knex: db.KnexReadonlyTransaction
+    ): Promise<void> {
+        return
     }
 
     protected typeSpecificFilenames(): string[] {

--- a/db/model/Gdoc/GdocDataInsight.ts
+++ b/db/model/Gdoc/GdocDataInsight.ts
@@ -19,10 +19,7 @@ export class GdocDataInsight
     content!: OwidGdocDataInsightContent
 
     constructor(id?: string) {
-        super()
-        if (id) {
-            this.id = id
-        }
+        super(id)
     }
 
     static create(obj: OwidGdocBaseInterface): GdocDataInsight {

--- a/db/model/Gdoc/GdocFactory.ts
+++ b/db/model/Gdoc/GdocFactory.ts
@@ -111,7 +111,7 @@ export async function createGdocAndInsertIntoDb(
     // enrichments are not present on the Gdoc subclass when loading from the DB
     // (GdocsContentSource.Internal), since subclass enrichements are only done
     // while fetching the live gdocs (GdocsContentSource.Gdocs) in
-    // loadFromGdocBase().
+    // loadGdocFromGdocBase().
     await upsertGdoc(knex, gdoc)
 
     return gdoc

--- a/db/model/Gdoc/GdocHomepage.ts
+++ b/db/model/Gdoc/GdocHomepage.ts
@@ -20,10 +20,7 @@ export class GdocHomepage
     content!: OwidGdocHomepageContent
 
     constructor(id?: string) {
-        super()
-        if (id) {
-            this.id = id
-        }
+        super(id)
     }
 
     static create(obj: OwidGdocBaseInterface): GdocHomepage {


### PR DESCRIPTION
*alternate solution to #3578, which had to be reverted because [this.content in GdocPost](https://github.com/owid/owid-grapher/blob/3691a52abfa41b34d7853df84df3329d80a9a187/db/model/Gdoc/GdocPost.ts#L34-L36) would  be honored by _.defaults as a property not to override, but would result in the `content` property not respecting `OwidGdocContent` at run time.*

### What changed?

This PR promotes GdocBase instance-level functions (e.g. `_enrichSubclassContent` as class methods.

### Why make this change?

GdocAuthor (but also GdocPost, GdocHomepage and Gdoc DataInsight) are created from a GdocBase instance (only when inserting a new Gdoc) using `Object.assign(gdocAuthor, gdocBase)`. This call lists all enumerable properties on GdocBase, including instance-level functions such as `_enrichSubclassContent`, and overrides the subclass version.

This leads to the subclass enrichment not being performed, and in the case of author creation, an error.

## Follow-up

Promoting instance-level functions to class methods on `GdocBase` is enough to solve this issue, but we should consider whether to apply the same treatment to the GdocBase subclasses too.