### PR TITLE
🐛 (slope) format x-axis labels

### DIFF
--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -1312,21 +1312,21 @@ class LabelledSlopes
                 <line x1={x2} y1={y1} x2={x2} y2={y2} stroke="#999" />
                 <text
                     x={x1}
-                    y={y1 + BOTTOM_PADDING}
+                    y={y1 + BOTTOM_PADDING - 2}
                     textAnchor="middle"
                     fill={GRAPHER_DARK_TEXT}
                     fontSize={this.yAxis.tickFontSize}
                 >
-                    {xDomain[0].toString()}
+                    {this.yColumn.formatTime(xDomain[0])}
                 </text>
                 <text
                     x={x2}
-                    y={y1 + BOTTOM_PADDING}
+                    y={y1 + BOTTOM_PADDING - 2}
                     textAnchor="middle"
                     fill={GRAPHER_DARK_TEXT}
                     fontSize={this.yAxis.tickFontSize}
                 >
-                    {xDomain[1].toString()}
+                    {this.yColumn.formatTime(xDomain[1])}
                 </text>
                 <g className="slopes">
                     {this.renderGroups(this.backgroundGroups)}


### PR DESCRIPTION
Format x-axis labels for slope charts.

![Screenshot 2024-05-08 at 19 53 53](https://github.com/owid/owid-grapher/assets/12461810/5a3477b7-54bf-4a8c-936b-bd077efccccb)
