### PR TITLE
🐛 fix research-and-writing links still rendering on bake even when content is invalid

### DIFF
--- a/site/gdocs/components/ResearchAndWriting.tsx
+++ b/site/gdocs/components/ResearchAndWriting.tsx
@@ -50,13 +50,21 @@ function ResearchAndWritingLink(
     const { linkedDocument, errorMessage } = useLinkedDocument(url)
     const { isPreviewing } = useContext(DocumentContext)
 
-    if (isPreviewing && errorMessage) {
-        return (
-            <div className={cx(className, "research-and-writing-link--error")}>
-                <p>{errorMessage}</p>
-                <p>This block won't render during baking</p>
-            </div>
-        )
+    if (errorMessage) {
+        if (isPreviewing) {
+            return (
+                <div
+                    className={cx(
+                        className,
+                        "research-and-writing-link--error"
+                    )}
+                >
+                    <p>{errorMessage}</p>
+                    <p>This block won't render during baking</p>
+                </div>
+            )
+        }
+        return null
     }
 
     if (linkedDocument) {


### PR DESCRIPTION
The research and writing block had an incorrectly implemented fallback for when linked documents were invalid. 

If there's an error and we're previewing, we show a red warning block. If we're not previewing (i.e. baking), we should return null.

This was noticed because an unpublished gdoc that was being linked to in the [CO₂ topic page](https://ourworldindata.org/co2-and-greenhouse-gas-emissions#research-writing) was showing up as an empty tile.

<img width="750" alt="error" src="https://github.com/owid/owid-grapher/assets/11844404/f6a6c9d1-79fe-40f3-8231-55b8d7528ec3">
