### PR TITLE
Fix deprecation warning in SCSS for /

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/RadioButton.scss
+++ b/packages/@ourworldindata/grapher/src/controls/RadioButton.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .radio {
     $radio-size: 16px;
 
@@ -35,8 +37,8 @@
         justify-content: center;
 
         .inner {
-            width: $radio-size / 2;
-            height: $radio-size / 2;
+            width: math.div($radio-size, 2);
+            height: math.div($radio-size, 2);
             background-color: $active-fill;
             border-radius: 50%;
         }


### PR DESCRIPTION
We were getting a warning from Vite build.

Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0. See:

https://sass-lang.com/d/slash-div