### PR TITLE
Make image description optional

### DIFF
--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -708,7 +708,7 @@ export class GdocBase implements OwidGdocBaseInterface {
                     errors.push({
                         property: "imageMetadata",
                         message: `${filename} is missing a default alt text`,
-                        type: OwidGdocErrorMessageType.Error,
+                        type: OwidGdocErrorMessageType.Warning,
                     })
                 }
                 return errors


### PR DESCRIPTION
Joe suggested not requiring `alt` on featured images at all, but not sure if: 

* it's worth the added complexity
* they are always only presentational

Long term, we might switch to auto-generating the description as you suggested before, but that is a much bigger project we didn't scope out, yet.

Fixes #3201