### PR TITLE
🐛 (grapher) remove extra space on bottom

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/EntitySelectionToggle.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/EntitySelectionToggle.tsx
@@ -17,6 +17,7 @@ export interface EntitySelectionManager {
     entityTypePlural?: string
     isEntitySelectorModalOrDrawerOpen?: boolean
     isOnChartTab?: boolean
+    hideEntityControls?: boolean
 }
 
 interface EntitySelectionLabel {
@@ -35,7 +36,8 @@ export class EntitySelectionToggle extends React.Component<{
     }
 
     @computed get showToggle(): boolean {
-        const { isOnChartTab } = this.props.manager
+        const { isOnChartTab, hideEntityControls } = this.props.manager
+        if (hideEntityControls) return false
         return !!(isOnChartTab && this.label)
     }
 

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -175,6 +175,7 @@ $zindex-controls-drawer: 150;
 
     .CaptionedChartAndSidePanel {
         display: flex;
+        height: 100%;
     }
 
     // customize css of the <CodeSnippet> component


### PR DESCRIPTION
Fixes a small issue where narrative charts had too much space on the bottom:

<img width="635" alt="Screenshot 2024-05-20 at 10 51 15" src="https://github.com/owid/owid-grapher/assets/12461810/8bf7ea6f-3d6b-47de-8fd5-f91610b25e84">
