### PR TITLE
✨ (stacked bar) hide single-item legends

### DIFF
--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -791,7 +791,7 @@ export class DiscreteBarChart
     }
 
     @computed get showColorLegend(): boolean {
-        return this.hasColorLegend && !this.manager.hideLegend
+        return this.hasColorLegend && !!this.manager.showLegend
     }
 
     @computed get legendX(): number {
@@ -857,7 +857,7 @@ export class DiscreteBarChart
     legendTickSize = 1
 
     @computed get numericLegend(): HorizontalNumericColorLegend | undefined {
-        return this.hasColorScale && !this.manager.hideLegend
+        return this.hasColorScale && this.manager.showLegend
             ? new HorizontalNumericColorLegend({ manager: this })
             : undefined
     }

--- a/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
@@ -37,7 +37,7 @@ export interface ChartManager {
     isExportingToSvgOrPng?: boolean
     isRelativeMode?: boolean
     comparisonLines?: ComparisonLineConfig[]
-    hideLegend?: boolean
+    showLegend?: boolean
     tooltips?: TooltipManager["tooltips"]
     baseColorScheme?: ColorSchemeName
     invertColorScheme?: boolean

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -684,6 +684,25 @@ export class Grapher
         return this.xAxis.toObject()
     }
 
+    @computed get showLegend(): boolean {
+        // hide the legend for stacked bar charts
+        // if the legend only ever shows a single entity
+        if (this.isStackedBar) {
+            const seriesStrategy =
+                this.chartInstance.seriesStrategy ||
+                autoDetectSeriesStrategy(this, true)
+            const hasSingleEntity =
+                this.selection.selectedEntityNames.length === 1 &&
+                (this.hideEntityControls || !this.canAddEntities)
+            const hideLegend =
+                this.hideLegend ||
+                (seriesStrategy === SeriesStrategy.entity && hasSingleEntity)
+            return !hideLegend
+        }
+
+        return !this.hideLegend
+    }
+
     // table that is used for display in the table tab
     @computed get tableForDisplay(): OwidTable {
         const table = this.table
@@ -1371,7 +1390,7 @@ export class Grapher
         return !!(
             !this.forceHideAnnotationFieldsInTitle?.entity &&
             this.tab === GrapherTabOption.chart &&
-            (seriesStrategy !== SeriesStrategy.entity || this.hideLegend) &&
+            (seriesStrategy !== SeriesStrategy.entity || !this.showLegend) &&
             selectedEntityNames.length === 1 &&
             (showEntityAnnotation ||
                 this.canChangeEntity ||

--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChart.test.ts
@@ -193,7 +193,7 @@ describe("config overrides", () => {
     })
 
     it("entity legend is hidden for single-metric facets by entity", () => {
-        expect(chart.placedSeries[0].manager.hideLegend).toEqual(true)
+        expect(chart.placedSeries[0].manager.showLegend).toEqual(false)
     })
 })
 

--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
@@ -286,7 +286,7 @@ export class FacetChart
 
         return series.map((series, index) => {
             const { bounds } = gridBoundsArr[index]
-            const hideLegend = this.hideFacetLegends
+            const showLegend = !this.hideFacetLegends
             const hidePoints = true
 
             // NOTE: The order of overrides is important!
@@ -294,7 +294,7 @@ export class FacetChart
             const manager: ChartManager = {
                 table,
                 fontSize,
-                hideLegend,
+                showLegend,
                 hidePoints,
                 yColumnSlug,
                 xColumnSlug,

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.test.ts
@@ -291,14 +291,14 @@ describe("externalLegendBins", () => {
 
     it("doesn't expose externalLegendBins when legend is shown", () => {
         const chart = new LineChart({
-            manager: { ...baseManager },
+            manager: { ...baseManager, showLegend: true },
         })
         expect(chart["externalLegend"]).toBeUndefined()
     })
 
     it("exposes externalLegendBins when legend is hidden", () => {
         const chart = new LineChart({
-            manager: { ...baseManager, hideLegend: true },
+            manager: { ...baseManager, showLegend: false },
         })
         expect(chart["externalLegend"]?.categoricalLegendData?.length).toEqual(
             2

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -730,7 +730,7 @@ export class LineChart
     }
 
     @computed private get lineLegendDimensions(): LineLegend | undefined {
-        return this.manager.hideLegend
+        return !this.manager.showLegend
             ? undefined
             : new LineLegend({ manager: this })
     }
@@ -763,8 +763,6 @@ export class LineChart
             this
 
         const comparisonLines = manager.comparisonLines || []
-
-        const showLegend = !manager.hideLegend
 
         // The tiny bit of extra space in the clippath is to ensure circles centered on the very edge are still fully visible
         return (
@@ -808,7 +806,7 @@ export class LineChart
                             baseFontSize={this.fontSize}
                         />
                     ))}
-                    {showLegend && <LineLegend manager={this} />}
+                    {manager.showLegend && <LineLegend manager={this} />}
                     <Lines
                         dualAxis={dualAxis}
                         placedSeries={this.placedSeries}
@@ -898,7 +896,7 @@ export class LineChart
     // Color legend props
 
     @computed private get hasColorLegend(): boolean {
-        return this.hasColorScale && !this.manager.hideLegend
+        return this.hasColorScale && !!this.manager.showLegend
     }
 
     @computed get legendX(): number {
@@ -934,7 +932,7 @@ export class LineChart
     legendTickSize = 1
 
     @computed get numericLegend(): HorizontalNumericColorLegend | undefined {
-        return this.hasColorScale && !this.manager.hideLegend
+        return this.hasColorScale && this.manager.showLegend
             ? new HorizontalNumericColorLegend({ manager: this })
             : undefined
     }
@@ -1157,7 +1155,7 @@ export class LineChart
                 color,
                 seriesName,
                 // E.g. https://ourworldindata.org/grapher/size-poverty-gap-world
-                label: this.manager.hideLegend ? "" : `${seriesName}`,
+                label: !this.manager.showLegend ? "" : `${seriesName}`,
                 annotation: this.getAnnotationsForSeries(seriesName),
                 yValue: lastValue,
             }
@@ -1242,7 +1240,7 @@ export class LineChart
     }
 
     @computed get externalLegend(): HorizontalColorLegendManager | undefined {
-        if (this.manager.hideLegend) {
+        if (!this.manager.showLegend) {
             const numericLegendData = this.hasColorScale
                 ? this.numericLegendData
                 : []

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
@@ -135,7 +135,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
             colorColumnSlug: this.mapColumnSlug,
             selection: [this.entityName],
             colorScaleOverride: this.lineColorScale,
-            hideLegend: true,
+            showLegend: false,
             hidePoints: true,
             fontSize: 11,
             disableIntroAnimation: true,

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -403,7 +403,7 @@ export class AbstractStackedChart
     }
 
     @computed get externalLegend(): HorizontalColorLegendManager | undefined {
-        if (this.manager.hideLegend) {
+        if (!this.manager.showLegend) {
             const categoricalLegendData = this.series
                 .map(
                     (series, index) =>

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.test.ts
@@ -223,14 +223,14 @@ describe("externalLegendBins", () => {
 
     it("doesn't expose externalLegendBins when legend is shown", () => {
         const chart = new StackedAreaChart({
-            manager: { ...baseManager },
+            manager: { ...baseManager, showLegend: true },
         })
         expect(chart["externalLegend"]).toBeUndefined()
     })
 
     it("exposes externalLegendBins when legend is hidden", () => {
         const chart = new StackedAreaChart({
-            manager: { ...baseManager, hideLegend: true },
+            manager: { ...baseManager, showLegend: false },
         })
         expect(chart["externalLegend"]?.categoricalLegendData?.length).toEqual(
             2

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -295,7 +295,7 @@ export class StackedAreaChart
     }
 
     @computed get legendDimensions(): LineLegend | undefined {
-        if (this.manager.hideLegend) return undefined
+        if (!this.manager.showLegend) return undefined
         return new LineLegend({ manager: this })
     }
 
@@ -515,7 +515,7 @@ export class StackedAreaChart
         const { manager, bounds, dualAxis, renderUid, series } = this
         const { target } = this.tooltipState
 
-        const showLegend = !this.manager.hideLegend
+        const showLegend = this.manager.showLegend
 
         const clipPath = makeClipPath(renderUid, {
             ...bounds,

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -229,7 +229,7 @@ export class StackedBarChart
         return 100
     }
     @computed get sidebarWidth(): number {
-        if (this.manager.hideLegend) return 0
+        if (!this.manager.showLegend) return 0
         const { sidebarMinWidth, sidebarMaxWidth, legendDimensions } = this
         return Math.max(
             Math.min(legendDimensions.width, sidebarMaxWidth),
@@ -549,7 +549,7 @@ export class StackedBarChart
                     })}
                 </g>
 
-                {!this.manager.hideLegend && (
+                {this.manager.showLegend && (
                     <VerticalColorLegend manager={this} />
                 )}
                 {tooltip}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.test.ts
@@ -149,6 +149,7 @@ describe("columns as series", () => {
         table,
         selection: table.sampleEntityName(5),
         yColumnSlugs: [SampleColumnSlugs.Fruit, SampleColumnSlugs.Vegetables],
+        showLegend: true,
     }
     const chart = new StackedDiscreteBarChart({ manager })
 
@@ -300,7 +301,7 @@ describe("sorting", () => {
     })
 })
 
-describe("hideLegend", () => {
+describe("showLegend", () => {
     const table = SynthesizeFruitTable({
         timeRange: [2000, 2001],
         entityCount: 5,
@@ -311,18 +312,18 @@ describe("hideLegend", () => {
         yColumnSlugs: [SampleColumnSlugs.Fruit, SampleColumnSlugs.Vegetables],
     }
 
-    it("renders internal legend when hideLegend is false", () => {
+    it("renders internal legend when showLegend is true", () => {
         const chart = new StackedDiscreteBarChart({
-            manager: { ...baseManager },
+            manager: { ...baseManager, showLegend: true },
         })
         expect(chart["legend"].height).toBeGreaterThan(0)
         expect(chart["categoricalLegendData"].length).toBeGreaterThan(0)
         expect(chart["externalLegend"]).toBeUndefined()
     })
 
-    it("exposes externalLegendBins when hideLegend is true", () => {
+    it("exposes externalLegendBins when showLegend is false", () => {
         const chart = new StackedDiscreteBarChart({
-            manager: { ...baseManager, hideLegend: true },
+            manager: { ...baseManager, showLegend: false },
         })
         expect(chart["legend"].height).toEqual(0)
         expect(chart["categoricalLegendData"].length).toEqual(0)

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -174,7 +174,7 @@ export class StackedDiscreteBarChart
     }
 
     @computed private get showLegend(): boolean {
-        return !this.manager.hideLegend
+        return !!this.manager.showLegend
     }
 
     @computed private get barCount(): number {


### PR DESCRIPTION
Hide single-item legends for stacked bar charts. This is space-saving for mobile especially.

For stacked area charts with a "Change entity" button, the currently selected entity is shown in the title.

| Before  | After  |
| ------- | ------ |
|https://ourworldindata.org/grapher/ace-north-atlantic-hurricanes|http://staging-site-stacked-bar-hide-legend/grapher/ace-north-atlantic-hurricanes|
| <img width="379" alt="Screenshot 2024-05-21 at 16 37 08" src="https://github.com/owid/owid-grapher/assets/12461810/2a77d007-b5f5-4bf6-a6b3-84b84fadcf0f">  | <img width="379" alt="Screenshot 2024-05-21 at 16 36 57" src="https://github.com/owid/owid-grapher/assets/12461810/05cad141-88d3-429a-9d0f-6c9cf9cb1d73"> |
|https://ourworldindata.org/grapher/tsunami-deaths|http://staging-site-stacked-bar-hide-legend/grapher/tsunami-deaths|
|<img width="334" alt="Screenshot 2024-05-22 at 10 49 45" src="https://github.com/owid/owid-grapher/assets/12461810/9a49b3a5-da06-4f10-9cfd-422f7df96966">|<img width="334" alt="Screenshot 2024-05-22 at 10 49 58" src="https://github.com/owid/owid-grapher/assets/12461810/61ed2271-a965-4473-b62c-2d782798ef21">|
