### PR TITLE
✨ (data page) use full width for chart on mobile

### DIFF
--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -96,7 +96,6 @@
         @include sm-up {
             margin-bottom: 40px;
         }
-        width: 100%;
         @include grid(12);
 
         figure[data-grapher-src] {

--- a/site/GrapherWithFallback.tsx
+++ b/site/GrapherWithFallback.tsx
@@ -20,7 +20,14 @@ export const GrapherWithFallback = ({
     id?: string
 }) => {
     return (
-        <div className={cx("GrapherWithFallback", className)} id={id}>
+        <div
+            className={cx(
+                "GrapherWithFallback",
+                "full-width-on-mobile",
+                className
+            )}
+            id={id}
+        >
             <>
                 {grapher ? (
                     <GrapherFigureView grapher={grapher} />


### PR DESCRIPTION
On smaller devices, use the full width for the main chart on a data page.
