### PR TITLE
✨ (grapher) left-align external facet legend

### DIFF
--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
@@ -629,7 +629,7 @@ export class FacetChart
     }
 
     @computed get legendAlign(): HorizontalAlign {
-        return HorizontalAlign.center
+        return HorizontalAlign.left
     }
 
     @computed get legendTitle(): string | undefined {


### PR DESCRIPTION
The external facet legend is the only one that is center-aligned. Left-align for consistency.
