### PR TITLE
garden: Improve TMux/make.up commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ up: require create-if-missing.env ../owid-content tmp-downloads/owid_metadata.sq
 
 	@echo '==> Starting dev environment'
 	@mkdir -p logs
+
+	@make kill-if-exists
 	tmux new-session -s grapher \
 		-n docker 'docker compose -f docker-compose.grapher.yml up' \; \
 			set remain-on-exit on \; \
@@ -77,6 +79,8 @@ up.devcontainer: create-if-missing.env.devcontainer tmp-downloads/owid_metadata.
 
 	@echo '==> Starting dev environment'
 	@mkdir -p logs
+
+	@make kill-if-exists
 	tmux new-session -s grapher \
 		-n admin \
 			'devTools/docker/wait-for-mysql.sh && yarn startAdminDevServer' \; \
@@ -100,6 +104,8 @@ up.full: require create-if-missing.env.full ../owid-content tmp-downloads/owid_m
 	yarn lerna run build
 
 	@echo '==> Starting dev environment'
+
+	@make kill-if-exists
 	tmux new-session -s grapher \
 		-n docker 'docker compose -f docker-compose.grapher.yml up' \; \
 			set remain-on-exit on \; \
@@ -119,6 +125,11 @@ up.full: require create-if-missing.env.full ../owid-content tmp-downloads/owid_m
 		bind Q kill-server \; \
 		set -g mouse on \
 		|| make down
+
+kill-if-exists:
+	@if tmux has-session; then \
+		tmux kill-session -t grapher; \
+	fi
 
 migrate: node_modules
 	@echo '==> Running DB migrations'

--- a/devTools/docker/wait-for-mysql.sh
+++ b/devTools/docker/wait-for-mysql.sh
@@ -15,8 +15,10 @@ fi
 : "${GRAPHER_DB_PORT:?Need to set GRAPHER_DB_PORT non-empty}"
 
 printf 'Waiting for MySQL to come up...'
-while ! mysql -u$GRAPHER_DB_USER -p$GRAPHER_DB_PASS -h $GRAPHER_DB_HOST --port=$GRAPHER_DB_PORT -e 'select 1' $GRAPHER_DB_NAME &>/dev/null; do
+while ! mysqlsh; do
     printf '.'
     sleep 1
+    if [ mysqlsh -u$GRAPHER_DB_USER -p$GRAPHER_DB_PASS -h $GRAPHER_DB_HOST --port=$GRAPHER_DB_PORT -e 'select 1' $GRAPHER_DB_NAME ]; then
+        break;
+    fi
 done
-printf 'ok\n'

--- a/devTools/docker/wait-for-tests-mysql.sh
+++ b/devTools/docker/wait-for-tests-mysql.sh
@@ -15,8 +15,10 @@ fi
 : "${GRAPHER_TEST_DB_PORT:?Need to set GRAPHER_TEST_DB_PORT non-empty}"
 
 printf 'Waiting for MySQL to come up...'
-while ! mysql -u$GRAPHER_TEST_DB_USER -p$GRAPHER_TEST_DB_PASS -h $GRAPHER_TEST_DB_HOST --port=$GRAPHER_TEST_DB_PORT -e 'select 1 from _test_db_ready' $GRAPHER_TEST_DB_NAME &>/dev/null; do
+while ! mysqlsh; do
     printf '.'
     sleep 1
+    if [ mysql -u$GRAPHER_TEST_DB_USER -p$GRAPHER_TEST_DB_PASS -h $GRAPHER_TEST_DB_HOST --port=$GRAPHER_TEST_DB_PORT -e 'select 1 from _test_db_ready' $GRAPHER_TEST_DB_NAME ]; then
+        break;
+    fi
 done
-printf 'ok\n'

--- a/docs/docker-compose-mysql.md
+++ b/docs/docker-compose-mysql.md
@@ -11,7 +11,7 @@ This option uses `make` to spin up all the services with a single command, but i
 -   [Docker](https://www.docker.com/get-started)
 -   [Node.js and Yarn](./local-typescript-setup.md)
 -   [tmux](https://github.com/tmux/tmux/wiki/Installing#binary-packages)
--   [MySQL client tools](https://dev.mysql.com/doc/refman/8.0/en/mysql.html) (install it e.g. via [this brew package](https://formulae.brew.sh/formula/mysql-client) on MacOS)
+-   [MySQL client tools](https://dev.mysql.com/downloads/shell/)
 
 If you're using Windows, we recommend you use the Windows Subsystem for Linux, where you'll require some additional utilities. Please also make sure to check out the [before you start on windows guide](before-you-start-on-windows.md). To install the additional tools, run the following in a WSL terminal:
 


### PR DESCRIPTION
* if the TMux window is closed in some other way than Ctrl+b, Q then `make up` will error, throwing duplicate session - this change checks for a session and removes the grapher session if it's found before going back to where the contributor was.
* This also happens if `master` is updated on a fork and `make up` is re-run to bring things up to date.

Thinking from the perspective of an open source contributor, perhaps with less experience, and wanting to make things like TMux/Docker pain free. Some input from those with better code knowledge might see issues with the change, maybe I missed an instruction or somesuch. I am also a Sublime Text user, as it happens, I note some instructions are VSCode-centric.

### Current master

The contributor gets stuck with a `duplicate session` error when things are broken by something (some error, closing and re-opening tab). DBeaver showing things are broken. They can fix things with some investigation or they could be time constrained/inexperienced/imposter syndrome/etc. and leave.

https://github.com/owid/owid-grapher/assets/10499070/be1e0055-3036-4047-a2a5-3a7a72542712

<img width="1678" alt="Screenshot 2024-05-23 at 00 24 41" src="https://github.com/owid/owid-grapher/assets/10499070/4feb762d-dfd0-4065-8de3-fbcda2be2418">

### With change

The user just needs to run `make up` twice rather than getting stuck with a duplicate session. DBeaver showing the DB. Things like errors in the UI about TS disappear, and UI refreshes.

https://github.com/owid/owid-grapher/assets/10499070/1e81f99f-9422-4b84-aef3-4ba065412f25

<img width="1680" alt="Screenshot 2024-05-23 at 00 40 18" src="https://github.com/owid/owid-grapher/assets/10499070/503fcf2b-af1b-4911-a831-7ca41209ac58">

### Closing TMux terminal window (likely) with PR change applied

https://github.com/owid/owid-grapher/assets/10499070/eec37dac-94e7-4bd6-b4a2-b6e843c47418

Also sees DB and UI refresh nicely.

### Finally, changes make the "waiting for MySQL" TMux screen give clearer output for new devs

<img width="853" alt="Screenshot 2024-06-18 at 09 49 18" src="https://github.com/owid/owid-grapher/assets/10499070/e356a89f-ba46-4d02-9d3f-37a781003aa1">





