### PR TITLE
✨ (grapher) use full width for the subtitle

### DIFF
--- a/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
+++ b/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
@@ -15,6 +15,7 @@ export interface HeaderManager {
     isNarrow?: boolean
     isSmall?: boolean
     isMedium?: boolean
+    isSemiNarrow?: boolean
     framePaddingHorizontal?: number
     framePaddingVertical?: number
     isOnCanonicalUrl?: boolean


### PR DESCRIPTION
Use the full width for the subtitle on smaller screens. This saves space on mobile if the title is short and the subtitle is long.

Alternatively, we could make it so that the subtitle wraps under the OWID logo. I'm sure there is a way to do it, but it would be more complex than the current solution, and I think the current solution is good enough.

Example chart: https://ourworldindata.org/grapher/fishing-pressure-by-taxa

| Before  | After  |
| ------- | ------ |
| <img width="319" alt="Screenshot 2024-05-23 at 10 15 50" src="https://github.com/owid/owid-grapher/assets/12461810/3d776ffa-e5b0-4a7d-a202-fc34ad12d559"> | <img width="319" alt="Screenshot 2024-05-23 at 10 15 55" src="https://github.com/owid/owid-grapher/assets/12461810/f14495e0-3896-4f11-8cc8-d3ea83dafda1"> |
