### PR TITLE
✨ (grapher) prevent controls from overflowing

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -27,15 +27,6 @@ import { LoadingIndicator } from "../loadingIndicator/LoadingIndicator"
 import { FacetChart } from "../facetChart/FacetChart"
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
-import {
-    EntitySelectionToggle,
-    EntitySelectionManager,
-} from "../controls/EntitySelectionToggle"
-import {
-    MapProjectionMenu,
-    MapProjectionMenuManager,
-} from "../controls/MapProjectionMenu"
-import { SettingsMenu, SettingsMenuManager } from "../controls/SettingsMenu"
 import { FooterManager } from "../footer/FooterManager"
 import { HeaderManager } from "../header/HeaderManager"
 import { SelectionArray } from "../selection/SelectionArray"
@@ -48,14 +39,14 @@ import {
 } from "@ourworldindata/types"
 import { DataTable, DataTableManager } from "../dataTable/DataTable"
 import {
-    ContentSwitchers,
-    ContentSwitchersManager,
-} from "../controls/ContentSwitchers"
-import {
     TimelineComponent,
     TIMELINE_HEIGHT,
 } from "../timeline/TimelineComponent"
 import { TimelineController } from "../timeline/TimelineController"
+import {
+    ControlsRow,
+    ControlsRowManager,
+} from "../controls/controlsRow/ControlsRow"
 
 export interface CaptionedChartManager
     extends ChartManager,
@@ -63,10 +54,7 @@ export interface CaptionedChartManager
         FooterManager,
         HeaderManager,
         DataTableManager,
-        ContentSwitchersManager,
-        EntitySelectionManager,
-        MapProjectionMenuManager,
-        SettingsMenuManager {
+        ControlsRowManager {
     containerElement?: HTMLDivElement
     bakedGrapherURL?: string
     isReady?: boolean
@@ -207,22 +195,6 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         return !this.manager.isOnMapTab && hasStrategy
     }
 
-    @computed get showContentSwitchers(): boolean {
-        return (this.manager.availableTabs?.length ?? 0) > 1
-    }
-
-    @computed get showControls(): boolean {
-        return (
-            SettingsMenu.shouldShow(this.manager) ||
-            EntitySelectionToggle.shouldShow(this.manager) ||
-            MapProjectionMenu.shouldShow(this.manager)
-        )
-    }
-
-    @computed get showControlsRow(): boolean {
-        return this.showContentSwitchers || this.showControls
-    }
-
     @computed get chartTypeName(): ChartTypeName {
         const { manager } = this
         return this.manager.isOnMapTab
@@ -274,44 +246,23 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         return this.manager.isMedium ? 24 : 28
     }
 
-    @computed private get sidePanelWidth(): number {
-        return this.manager.sidePanelBounds?.width ?? 0
+    @computed private get showControlsRow(): boolean {
+        return ControlsRow.shouldShow(this.manager)
     }
 
     private renderControlsRow(): React.ReactElement {
-        const { showEntitySelectionToggle } = this.manager
         return (
-            <nav
-                className="controlsRow"
-                style={{ padding: `0 ${this.framePaddingHorizontal}px` }}
-            >
-                <div>
-                    {this.showContentSwitchers && (
-                        <ContentSwitchers manager={this.manager} />
-                    )}
-                </div>
-                <div className="chart-controls">
-                    {showEntitySelectionToggle && (
-                        <EntitySelectionToggle manager={this.manager} />
-                    )}
-
-                    <SettingsMenu
-                        manager={this.manager}
-                        top={
-                            this.framePaddingVertical +
-                            this.header.height +
-                            this.verticalPadding +
-                            CONTROLS_ROW_HEIGHT +
-                            4 // margin between button and menu
-                        }
-                        bottom={this.framePaddingVertical}
-                        right={
-                            this.sidePanelWidth + this.framePaddingHorizontal
-                        }
-                    />
-                    <MapProjectionMenu manager={this.manager} />
-                </div>
-            </nav>
+            <ControlsRow
+                manager={this.manager}
+                maxWidth={this.maxWidth}
+                settingsMenuTop={
+                    this.framePaddingVertical +
+                    this.header.height +
+                    this.verticalPadding +
+                    CONTROLS_ROW_HEIGHT +
+                    4 // margin between button and menu
+                }
+            />
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
@@ -1,4 +1,10 @@
 .ContentSwitchers {
+    // keep in sync with variables in ContentSwitchers.tsx
+    $font-size: 13px;
+    $icon-width: 13px;
+    $icon-padding: 6px;
+    --outer-padding: 16px;
+
     $light-stroke: #e7e7e7;
 
     $hover-fill: #f2f2f2;
@@ -30,12 +36,12 @@
         display: block;
         text-transform: capitalize;
         color: $light-text;
-        font-size: 13px;
+        font-size: $font-size;
         font-weight: 500;
         height: $height;
         line-height: $height;
         border-radius: $border-radius - $visual-gap;
-        padding: 0 16px;
+        padding: 0 var(--outer-padding);
         cursor: default;
         letter-spacing: 0.01em;
         white-space: nowrap;
@@ -47,14 +53,14 @@
         }
 
         .label {
-            margin-left: 6px;
+            margin-left: $icon-padding;
         }
 
         svg {
             color: $info-icon;
 
             &.custom-icon {
-                --size: 13px;
+                --size: $icon-width;
 
                 display: inline-block;
                 height: var(--size);
@@ -106,6 +112,6 @@
 
 &.GrapherComponentMedium {
     .ContentSwitchers:not(.iconOnly) li > button {
-        padding: 0 8px;
+        --outer-padding: 8px;
     }
 }

--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
@@ -6,19 +6,36 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faTable, faEarthAmericas } from "@fortawesome/free-solid-svg-icons"
 import { ChartTypeName, GrapherTabOption } from "@ourworldindata/types"
 import { chartIcons } from "./ChartIcons"
+import { Bounds, capitalize } from "@ourworldindata/utils"
 
 export interface ContentSwitchersManager {
     availableTabs?: GrapherTabOption[]
     tab?: GrapherTabOption
     isNarrow?: boolean
-    type?: ChartTypeName
+    isMedium?: boolean
+    type: ChartTypeName
     isLineChartThatTurnedIntoDiscreteBar?: boolean
 }
+
+// keep in sync with ContentSwitcher.scss
+const TAB_FONT_SIZE = 13
+const ICON_WIDTH = 13
+const ICON_PADDING = 6
 
 @observer
 export class ContentSwitchers extends React.Component<{
     manager: ContentSwitchersManager
 }> {
+    static shouldShow(manager: ContentSwitchersManager): boolean {
+        const test = new ContentSwitchers({ manager })
+        return test.showTabs
+    }
+
+    static width(manager: ContentSwitchersManager): number {
+        const test = new ContentSwitchers({ manager })
+        return test.width
+    }
+
     @computed private get manager(): ContentSwitchersManager {
         return this.props.manager
     }
@@ -27,12 +44,35 @@ export class ContentSwitchers extends React.Component<{
         return this.manager.availableTabs || []
     }
 
+    @computed private get showTabs(): boolean {
+        return this.availableTabs.length > 1
+    }
+
     @computed private get showTabLabels(): boolean {
         return !this.manager.isNarrow
     }
 
     @computed private get chartType(): ChartTypeName {
         return this.manager.type ?? ChartTypeName.LineChart
+    }
+
+    @computed get width(): number {
+        return this.availableTabs.reduce((totalWidth, tab) => {
+            // keep in sync with ContentSwitcher.scss
+            const outerPadding =
+                this.showTabLabels && this.manager.isMedium ? 8 : 16
+
+            let tabWidth = 2 * outerPadding + ICON_WIDTH
+
+            if (this.showTabLabels) {
+                const labelWidth = Bounds.forText(capitalize(tab), {
+                    fontSize: TAB_FONT_SIZE,
+                }).width
+                tabWidth += labelWidth + ICON_PADDING
+            }
+
+            return totalWidth + tabWidth
+        }, 0)
     }
 
     private tabIcon(tab: GrapherTabOption): React.ReactElement {

--- a/packages/@ourworldindata/grapher/src/controls/LabeledSwitch.scss
+++ b/packages/@ourworldindata/grapher/src/controls/LabeledSwitch.scss
@@ -13,6 +13,9 @@ $lato: $sans-serif-font-stack;
     .settings-menu-contents {
         // on/off switch with label written to the right
         .labeled-switch {
+            // keep in sync with TableFilterToggle.tsx
+            // where the width of a labeled switch is calculated
+
             display: flex;
             color: $light-text;
             font: $medium 13px/16px $lato;

--- a/packages/@ourworldindata/grapher/src/controls/MapProjectionMenu.scss
+++ b/packages/@ourworldindata/grapher/src/controls/MapProjectionMenu.scss
@@ -1,6 +1,9 @@
 .map-projection-menu {
-    .control {
+    width: 150px;
+
+    .menu {
         min-width: 150px;
+        right: 0;
     }
 
     .menu:before {

--- a/packages/@ourworldindata/grapher/src/controls/MapProjectionMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/MapProjectionMenu.tsx
@@ -5,6 +5,7 @@ import { MapConfig } from "../mapCharts/MapConfig"
 import { MapProjectionName } from "@ourworldindata/types"
 import { MapProjectionLabels } from "../mapCharts/MapProjections"
 import { Dropdown } from "./Dropdown"
+import { DEFAULT_BOUNDS } from "@ourworldindata/utils"
 
 export { AbsRelToggle } from "./settings/AbsRelToggle"
 export { FacetStrategySelector } from "./settings/FacetStrategySelector"
@@ -27,6 +28,7 @@ interface MapProjectionMenuItem {
 @observer
 export class MapProjectionMenu extends React.Component<{
     manager: MapProjectionMenuManager
+    maxWidth?: number
 }> {
     static shouldShow(manager: MapProjectionMenuManager): boolean {
         const menu = new MapProjectionMenu({ manager })
@@ -38,6 +40,10 @@ export class MapProjectionMenu extends React.Component<{
                 this.props.manager,
             { projection } = mapConfig ?? {}
         return !hideMapProjectionMenu && !!(isOnMapTab && projection)
+    }
+
+    @computed private get maxWidth(): number {
+        return this.props.maxWidth ?? DEFAULT_BOUNDS.width
     }
 
     @action.bound onChange(selected: unknown): void {
@@ -62,7 +68,10 @@ export class MapProjectionMenu extends React.Component<{
 
     render(): React.ReactElement | null {
         return this.showMenu ? (
-            <div className="map-projection-menu">
+            <div
+                className="map-projection-menu"
+                style={{ maxWidth: this.maxWidth }}
+            >
                 <Dropdown
                     options={this.options}
                     onChange={this.onChange}

--- a/packages/@ourworldindata/grapher/src/controls/controlsRow/ControlsRow.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/controlsRow/ControlsRow.tsx
@@ -1,0 +1,117 @@
+import React from "react"
+import { computed } from "mobx"
+import { observer } from "mobx-react"
+
+import { Bounds, DEFAULT_BOUNDS, GrapherTabOption } from "@ourworldindata/utils"
+
+import { ContentSwitchers, ContentSwitchersManager } from "../ContentSwitchers"
+import {
+    EntitySelectionToggle,
+    EntitySelectionManager,
+} from "../EntitySelectionToggle"
+import {
+    MapProjectionMenu,
+    MapProjectionMenuManager,
+} from "../MapProjectionMenu"
+import { SettingsMenu, SettingsMenuManager } from "../SettingsMenu"
+import { DEFAULT_GRAPHER_FRAME_PADDING } from "../../core/GrapherConstants"
+
+export interface ControlsRowManager
+    extends ContentSwitchersManager,
+        EntitySelectionManager,
+        MapProjectionMenuManager,
+        SettingsMenuManager {
+    sidePanelBounds?: Bounds
+    availableTabs?: GrapherTabOption[]
+    showEntitySelectionToggle?: boolean
+    framePaddingHorizontal?: number
+    framePaddingVertical?: number
+}
+
+@observer
+export class ControlsRow extends React.Component<{
+    manager: ControlsRowManager
+    maxWidth?: number
+    settingsMenuTop?: number
+}> {
+    static shouldShow(manager: ControlsRowManager): boolean {
+        const test = new ControlsRow({ manager })
+        return test.showControlsRow
+    }
+
+    @computed private get manager(): ControlsRowManager {
+        return this.props.manager
+    }
+
+    @computed private get maxWidth(): number {
+        return this.props.maxWidth ?? DEFAULT_BOUNDS.width
+    }
+
+    @computed private get framePaddingHorizontal(): number {
+        return (
+            this.manager.framePaddingHorizontal ?? DEFAULT_GRAPHER_FRAME_PADDING
+        )
+    }
+
+    @computed private get framePaddingVertical(): number {
+        return (
+            this.manager.framePaddingVertical ?? DEFAULT_GRAPHER_FRAME_PADDING
+        )
+    }
+
+    @computed private get sidePanelWidth(): number {
+        return this.manager.sidePanelBounds?.width ?? 0
+    }
+
+    @computed private get contentSwitchersWidth(): number {
+        return ContentSwitchers.width(this.manager)
+    }
+
+    @computed private get availableWidth(): number {
+        return this.maxWidth - this.contentSwitchersWidth - 16
+    }
+
+    @computed private get showControlsRow(): boolean {
+        return (
+            SettingsMenu.shouldShow(this.manager) ||
+            EntitySelectionToggle.shouldShow(this.manager) ||
+            MapProjectionMenu.shouldShow(this.manager) ||
+            ContentSwitchers.shouldShow(this.manager)
+        )
+    }
+
+    render(): JSX.Element {
+        const { showEntitySelectionToggle } = this.manager
+        return (
+            <nav
+                className="controlsRow"
+                style={{
+                    padding: `0 ${this.framePaddingHorizontal}px`,
+                }}
+            >
+                <div>
+                    <ContentSwitchers manager={this.manager} />
+                </div>
+                <div className="chart-controls">
+                    {showEntitySelectionToggle && (
+                        <EntitySelectionToggle manager={this.manager} />
+                    )}
+
+                    <SettingsMenu
+                        manager={this.manager}
+                        maxWidth={this.availableWidth}
+                        top={this.props.settingsMenuTop ?? 0}
+                        bottom={this.framePaddingVertical}
+                        right={
+                            this.sidePanelWidth + this.framePaddingHorizontal
+                        }
+                    />
+                    <MapProjectionMenu
+                        manager={this.manager}
+                        maxWidth={this.availableWidth}
+                    />
+                </div>
+            </nav>
+        )
+    }
+}

--- a/packages/@ourworldindata/grapher/src/controls/settings/TableFilterToggle.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/settings/TableFilterToggle.tsx
@@ -1,8 +1,9 @@
 import React from "react"
-import { action } from "mobx"
+import { action, computed } from "mobx"
 import { observer } from "mobx-react"
 import { DEFAULT_GRAPHER_ENTITY_TYPE_PLURAL } from "../../core/GrapherConstants"
 import { LabeledSwitch } from "../LabeledSwitch"
+import { Bounds } from "@ourworldindata/utils"
 
 export interface TableFilterToggleManager {
     showSelectionOnlyInDataTable?: boolean
@@ -12,7 +13,22 @@ export interface TableFilterToggleManager {
 @observer
 export class TableFilterToggle extends React.Component<{
     manager: TableFilterToggleManager
+    showTooltip?: boolean
 }> {
+    static width(manager: TableFilterToggleManager): number {
+        return new TableFilterToggle({ manager }).width
+    }
+
+    private label = "Show selection only"
+
+    // keep in sync with CSS
+    @computed get width(): number {
+        const toggleWidth = 30
+        const infoIconWidth = 22
+        const labelWidth = Bounds.forText(this.label, { fontSize: 13 }).width
+        return labelWidth + toggleWidth + infoIconWidth + 4
+    }
+
     @action.bound onToggle(): void {
         const { manager } = this.props
         manager.showSelectionOnlyInDataTable =
@@ -28,7 +44,7 @@ export class TableFilterToggle extends React.Component<{
         return (
             <LabeledSwitch
                 label="Show selection only"
-                tooltip={tooltip}
+                tooltip={this.props.showTooltip ? tooltip : undefined}
                 value={this.props.manager.showSelectionOnlyInDataTable}
                 onToggle={this.onToggle}
                 tracking="chart_filter_table_rows"


### PR DESCRIPTION
Keeps controls from overflowing on smaller screens. See screenshots 👇🏻 

The "Show selection only" toggle on the table tab is moved into the settings drawer. The rest are just CSS touchups.

We compute the widths of the content switchers and the toggle to determine if there is enough space for the table toggle. I could have implemented this in a simpler way using breakpoints, but I wanted to make sure that we only hide the table toggle if absolutely necessary.

| Before  | After  |
| ------- | ------ |
| <img width="319" alt="Screenshot 2024-05-23 at 18 36 23" src="https://github.com/owid/owid-grapher/assets/12461810/7b4904bb-726b-4a4d-afe4-164b3d3bce81">  | <img width="319" alt="Screenshot 2024-05-23 at 18 36 02" src="https://github.com/owid/owid-grapher/assets/12461810/a9a94e2e-a154-4538-87fd-4aebcbc23333"> |
| <img width="319" alt="Screenshot 2024-05-23 at 18 35 18" src="https://github.com/owid/owid-grapher/assets/12461810/96b56772-3f9f-4def-a953-a6daaae0ad53"> | <img width="319" alt="Screenshot 2024-05-23 at 18 35 02" src="https://github.com/owid/owid-grapher/assets/12461810/84bda382-f801-428b-93a1-c0c258b0a583"> |
| <img width="319" alt="Screenshot 2024-05-23 at 18 35 27" src="https://github.com/owid/owid-grapher/assets/12461810/24b69518-5e5e-4443-97a8-adf48596fc64"> | <img width="319" alt="Screenshot 2024-05-23 at 18 35 51" src="https://github.com/owid/owid-grapher/assets/12461810/d5f8683a-6833-4c25-b932-9e41f8670fdb"> |