### PR TITLE
✨ (legend) small visual & hover improvements

### DIFF
--- a/packages/@ourworldindata/components/src/TextWrap/TextWrap.tsx
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrap.tsx
@@ -237,6 +237,23 @@ export class TextWrap {
         )
     }
 
+    getPositionForSvgRendering(x: number, y: number): [number, number] {
+        const { lines, fontSize, lineHeight } = this
+
+        // Magic number set through experimentation.
+        // The HTML and SVG renderers need to position lines identically.
+        // This number was tweaked until the overlaid HTML and SVG outputs
+        // overlap (see storybook of this component).
+        const HEIGHT_CORRECTION_FACTOR = 0.74
+
+        const textHeight = (lines[0].height ?? 0) * HEIGHT_CORRECTION_FACTOR
+        const containerHeight = lineHeight * fontSize
+        const yOffset =
+            y + (containerHeight - (containerHeight - textHeight) / 2)
+
+        return [x, yOffset]
+    }
+
     render(
         x: number,
         y: number,
@@ -246,22 +263,14 @@ export class TextWrap {
 
         if (lines.length === 0) return null
 
-        // Magic number set through experimentation.
-        // The HTML and SVG renderers need to position lines identically.
-        // This number was tweaked until the overlaid HTML and SVG outputs
-        // overlap (see storybook of this component).
-        const HEIGHT_CORRECTION_FACTOR = 0.74
+        const [correctedX, correctedY] = this.getPositionForSvgRendering(x, y)
 
-        const textHeight = lines[0].height * HEIGHT_CORRECTION_FACTOR
-        const containerHeight = lineHeight * fontSize
-        const yOffset =
-            y + (containerHeight - (containerHeight - textHeight) / 2)
         return (
             <text
                 fontSize={fontSize.toFixed(2)}
                 fontWeight={fontWeight}
-                x={x.toFixed(1)}
-                y={yOffset.toFixed(1)}
+                x={correctedX.toFixed(1)}
+                y={correctedY.toFixed(1)}
                 {...textProps}
             >
                 {lines.map((line, i) => {
@@ -269,8 +278,8 @@ export class TextWrap {
                         return (
                             <tspan
                                 key={i}
-                                x={x}
-                                y={yOffset + lineHeight * fontSize * i}
+                                x={correctedX}
+                                y={correctedY + lineHeight * fontSize * i}
                                 dangerouslySetInnerHTML={{ __html: line.text }}
                             />
                         )
@@ -278,9 +287,9 @@ export class TextWrap {
                         return (
                             <tspan
                                 key={i}
-                                x={x}
+                                x={correctedX}
                                 y={
-                                    yOffset +
+                                    correctedY +
                                     (i === 0 ? 0 : lineHeight * fontSize * i)
                                 }
                             >

--- a/packages/@ourworldindata/grapher/src/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/packages/@ourworldindata/grapher/src/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -49,6 +49,7 @@ interface CategoricalMark {
     x: number
     y: number
     rectSize: number
+    width: number
     label: {
         text: string
         bounds: Bounds
@@ -730,6 +731,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
             marks.push({
                 x: markX,
                 y: markY,
+                width: markWidth,
                 rectSize,
                 label,
                 bin,
@@ -822,9 +824,8 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
                                     y={this.categoryLegendY + mark.y}
                                     height={mark.rectSize}
                                     width={
-                                        mark.label.bounds.width +
-                                        mark.label.bounds.x -
-                                        mark.x
+                                        mark.width +
+                                        SPACE_BETWEEN_CATEGORICAL_BINS
                                     }
                                     fill="#fff"
                                     opacity={0}

--- a/packages/@ourworldindata/grapher/src/verticalColorLegend/VerticalColorLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/verticalColorLegend/VerticalColorLegend.tsx
@@ -160,6 +160,15 @@ export class VerticalColorLegend extends React.Component<{
                             ? (): void => onLegendClick(series.color)
                             : undefined
 
+                        const textX = x + rectSize + rectPadding
+                        const textY = y + markOffset
+
+                        const renderedTextPosition =
+                            series.textWrap.getPositionForSvgRendering(
+                                textX,
+                                textY
+                            )
+
                         const result = (
                             <g
                                 key={index}
@@ -179,18 +188,14 @@ export class VerticalColorLegend extends React.Component<{
                                 />
                                 <rect
                                     x={x}
-                                    y={
-                                        y +
-                                        markOffset +
-                                        (series.height - rectSize) / 2
-                                    }
+                                    y={renderedTextPosition[1] - rectSize}
                                     width={rectSize}
                                     height={rectSize}
                                     fill={isActive ? series.color : undefined}
                                 />
                                 {series.textWrap.render(
-                                    x + rectSize + rectPadding,
-                                    y + markOffset,
+                                    textX,
+                                    textY,
                                     isFocus
                                         ? {
                                               textProps: {


### PR DESCRIPTION
Two small legend improvements:
- For horizontal legends: Improves hover interaction such that the hover is not lost when moving from one item to the next.
- For vertical legends: The color indicator and the text label are aligned at the top. This makes it easier to read when labels are long and broken into multiple lines.

| Before  | After  |
| ------- | ------ |
| <img width="326" alt="Screenshot 2024-05-24 at 11 55 13" src="https://github.com/owid/owid-grapher/assets/12461810/8703a3fb-56ba-4f7f-abf2-71037a1a2daa">  | <img width="326" alt="Screenshot 2024-05-24 at 11 55 01" src="https://github.com/owid/owid-grapher/assets/12461810/22223fdd-e980-4b42-8416-ddf7c0e355a3"> |