### PR TITLE
🐛 (grapher) don't show full-screen button when not useful

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
@@ -26,6 +26,7 @@ export interface ActionButtonsManager extends ShareMenuManager {
     canonicalUrl?: string
     isInFullScreenMode?: boolean
     isDownloadModalOpen?: boolean
+    hideFullScreenButton?: boolean
 }
 
 // keep in sync with sass variables in ActionButtons.scss
@@ -206,7 +207,7 @@ export class ActionButtons extends React.Component<{
     }
 
     @computed private get hasFullScreenButton(): boolean {
-        return !this.manager.isInIFrame
+        return !this.manager.hideFullScreenButton && !this.manager.isInIFrame
     }
 
     @computed private get hasExploreTheDataButton(): boolean {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2121,6 +2121,12 @@ export class Grapher
         return windowInnerWidth < 940 ? 0 : 40
     }
 
+    @computed get hideFullScreenButton(): boolean {
+        const { windowInnerHeight } = this
+        if (!windowInnerHeight) return true
+        return this.windowInnerHeight! < this.frameBounds.height
+    }
+
     @computed private get availableWidth(): number {
         const {
             externalBounds,


### PR DESCRIPTION
Resolves #2887 

Hides the full-screen button if you'd end up with a smaller grapher frame in full-screen mode (this is the case for landscape mode on mobile, for example)