### PR TITLE
🐛 (grapher) fix cut-off action label

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2666,6 +2666,7 @@ export class Grapher
 
                 {/* entity selector in a slide-in drawer */}
                 <SlideInDrawer
+                    grapherRef={this.base}
                     active={this.isEntitySelectorDrawerOpen}
                     toggle={() => {
                         this.isEntitySelectorModalOrDrawerOpen =

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -123,9 +123,6 @@ $zindex-controls-drawer: 150;
     border: 1px solid $frame-color;
     z-index: $zindex-chart;
 
-    // important for the slide-in drawer
-    overflow-x: clip;
-
     * {
         box-sizing: border-box;
     }

--- a/packages/@ourworldindata/grapher/src/slideInDrawer/SlideInDrawer.tsx
+++ b/packages/@ourworldindata/grapher/src/slideInDrawer/SlideInDrawer.tsx
@@ -12,6 +12,7 @@ export class SlideInDrawer extends React.Component<{
     active: boolean
     toggle: () => void
     children: React.ReactNode
+    grapherRef?: React.RefObject<HTMLDivElement>
 }> {
     @observable.ref visible: boolean = this.props.active // true while the drawer is active and during enter/exit transitions
     drawerRef: React.RefObject<HTMLDivElement> = React.createRef()
@@ -28,6 +29,14 @@ export class SlideInDrawer extends React.Component<{
         document.removeEventListener("click", this.onDocumentClick, {
             capture: true,
         })
+    }
+
+    componentDidUpdate(): void {
+        const grapherElement = this.props.grapherRef?.current
+        if (grapherElement) {
+            grapherElement.style.overflowX =
+                this.active || this.visible ? "clip" : "visible"
+        }
     }
 
     @action.bound onDocumentKeyDown(e: KeyboardEvent): void {


### PR DESCRIPTION
To make the slide-in drawer's animation work, `overflow-x: clip` was added to the grapher component. Since the drawer slides in and out, clipping content is needed to make sure that the entity selector isn't visible outside of the Grapher frame. But `overflow-x: clip` messes with the design in various places 👇🏻 

The "Enter full-screen" label is clipped:
<img width="905" alt="Screenshot 2024-05-27 at 10 23 15" src="https://github.com/owid/owid-grapher/assets/12461810/1d5ce119-ffb4-4686-8d84-5d859415ef7f">

Weird visual effect when in full-screen mode and a modal is open:
<img width="1915" alt="Screenshot 2024-05-27 at 10 23 33" src="https://github.com/owid/owid-grapher/assets/12461810/0628d405-a9d0-4e2b-9691-93d62f5ebfb3">

The tooltip's border is cut-off:
<img width="273" alt="Screenshot 2024-05-27 at 10 25 47" src="https://github.com/owid/owid-grapher/assets/12461810/0ac4579a-a172-4370-8de5-8936d7e38b4e">

