### PR TITLE
🐝 add no-constant-binary-expression eslint rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -59,6 +59,7 @@ module.exports = {
         "react/no-unescaped-entities": ["warn", { forbid: [">", "}"] }],
         "react/prop-types": "warn",
         "@typescript-eslint/no-floating-promises": "error",
+        "no-constant-binary-expression": "error"
     },
     settings: {
         "import/resolver": {

--- a/adminSiteClient/GrapherConfigGridEditorTypesAndUtils.tsx
+++ b/adminSiteClient/GrapherConfigGridEditorTypesAndUtils.tsx
@@ -138,7 +138,7 @@ export function fetchVariablesParametersFromQueryString(
         offset: Number.parseInt(params.offset ?? "0"),
         filterQuery: filterQuery ?? filterExpressionNoFilter,
         sortByColumn: params.sortByColumn ?? "id",
-        sortByAscending: params.sortByAscending === "true" ?? false,
+        sortByAscending: params.sortByAscending === "true",
     }
 }
 

--- a/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
+++ b/adminSiteClient/SuggestedChartRevisionApproverPage.tsx
@@ -301,7 +301,7 @@ export class SuggestedChartRevisionApproverPage extends React.Component<{
                 this.currentSuggestedChartRevision.suggestedConfig.subtitle =
                     subtitle
                 this.gptNumDisp = this.gptNum + 1
-                this.gptNum = this.gptNumDisp % suggestions?.length ?? 1
+                this.gptNum = this.gptNumDisp % suggestions?.length || 1
                 this.usingGPT = true
             }
         }

--- a/packages/@ourworldindata/grapher/src/controls/ShareMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ShareMenu.tsx
@@ -203,7 +203,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
                     title="Tweet a link"
                     data-track-note="chart_share_twitter"
                     href={twitterHref}
-                    rel="noopener"
+                    rel="noreferrer noopener"
                 >
                     <span className="icon">
                         <FontAwesomeIcon icon={faXTwitter} />
@@ -215,7 +215,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
                     title="Share on Facebook"
                     data-track-note="chart_share_facebook"
                     href={facebookHref}
-                    rel="noopener"
+                    rel="noreferrer noopener"
                 >
                     <span className="icon">
                         <FontAwesomeIcon icon={faFacebook} />
@@ -262,7 +262,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
                         target="_blank"
                         title="Edit chart"
                         href={editUrl}
-                        rel="noopener"
+                        rel="noreferrer noopener"
                     >
                         <span className="icon">
                             <FontAwesomeIcon icon={faEdit} />

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -816,12 +816,12 @@ export class Grapher
     }
 
     private get isStaging(): boolean {
-        if (typeof location === undefined) return false
+        if (typeof location === "undefined") return false
         return location.host.includes("staging")
     }
 
     private get isLocalhost(): boolean {
-        if (typeof location === undefined) return false
+        if (typeof location === "undefined") return false
         return location.host.includes("localhost")
     }
 

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -61,7 +61,7 @@ export const GOOGLE_TAG_MANAGER_ID: string =
     process.env.GOOGLE_TAG_MANAGER_ID ?? ""
 
 export const TOPICS_CONTENT_GRAPH: boolean =
-    process.env.TOPICS_CONTENT_GRAPH === "true" ?? false
+    process.env.TOPICS_CONTENT_GRAPH === "true"
 
 export const GDOCS_CLIENT_EMAIL: string = process.env.GDOCS_CLIENT_EMAIL ?? ""
 export const GDOCS_BASIC_ARTICLE_TEMPLATE_URL: string =

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -27,8 +27,7 @@ export const DATA_API_FOR_ADMIN_UI: string | undefined =
     serverSettings.DATA_API_FOR_ADMIN_UI
 export const BAKED_BASE_URL: string = clientSettings.BAKED_BASE_URL
 
-export const VITE_PREVIEW: boolean =
-    serverSettings.VITE_PREVIEW === "true" ?? false
+export const VITE_PREVIEW: boolean = serverSettings.VITE_PREVIEW === "true"
 
 export const ADMIN_BASE_URL: string = clientSettings.ADMIN_BASE_URL
 
@@ -36,7 +35,7 @@ export const BAKED_GRAPHER_URL: string =
     serverSettings.BAKED_GRAPHER_URL ?? `${BAKED_BASE_URL}/grapher`
 
 export const OPTIMIZE_SVG_EXPORTS: boolean =
-    serverSettings.OPTIMIZE_SVG_EXPORTS === "true" ?? false
+    serverSettings.OPTIMIZE_SVG_EXPORTS === "true"
 
 export const GITHUB_USERNAME: string =
     serverSettings.GITHUB_USERNAME ?? "owid-test"
@@ -85,10 +84,10 @@ export const SESSION_COOKIE_AGE: number =
 export const ALGOLIA_SECRET_KEY: string =
     serverSettings.ALGOLIA_SECRET_KEY ?? ""
 export const ALGOLIA_INDEXING: boolean =
-    serverSettings.ALGOLIA_INDEXING === "true" ?? false
+    serverSettings.ALGOLIA_INDEXING === "true"
 
 // Wordpress target setting
-export const HTTPS_ONLY: boolean = serverSettings.HTTPS_ONLY !== "false" ?? true
+export const HTTPS_ONLY: boolean = serverSettings.HTTPS_ONLY !== "false"
 
 export const GIT_DATASETS_DIR: string =
     serverSettings.GIT_DATASETS_DIR ?? `${BASE_DIR}/datasetsExport` //  Where the git exports go
@@ -97,8 +96,7 @@ export const UNCATEGORIZED_TAG_ID: number =
     parseIntOrUndefined(serverSettings.UNCATEGORIZED_TAG_ID) ?? 375
 
 // Should the static site output be baked when relevant database items change
-export const BAKE_ON_CHANGE: boolean =
-    serverSettings.BAKE_ON_CHANGE === "true" ?? false
+export const BAKE_ON_CHANGE: boolean = serverSettings.BAKE_ON_CHANGE === "true"
 export const DEPLOY_QUEUE_FILE_PATH: string =
     serverSettings.DEPLOY_QUEUE_FILE_PATH ?? `${BASE_DIR}/.queue`
 export const DEPLOY_PENDING_FILE_PATH: string =


### PR DESCRIPTION
Adds a `no-constant-binary-expression` lint rule. I sometimes run [Oxlint](https://oxc-project.github.io/docs/guide/usage/linter.html) on our project where this is enabled by default, and I think it makes sense to have it enabled in general.

This PR also fixes a couple of other things that Oxlint complains about, without adding more rules to eslint.