### PR TITLE
✨ (scatter) space savings on mobile

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -805,6 +805,7 @@ export class LineChart
                             key={index}
                             dualAxis={dualAxis}
                             comparisonLine={line}
+                            baseFontSize={this.fontSize}
                         />
                     ))}
                     {showLegend && <LineLegend manager={this} />}

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ComparisonLine.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ComparisonLine.tsx
@@ -12,11 +12,13 @@ import { DualAxis } from "../axis/Axis"
 import { generateComparisonLinePoints } from "./ComparisonLineGenerator"
 import { getElementWithHalo } from "./Halos"
 import { ComparisonLineConfig } from "@ourworldindata/types"
+import { GRAPHER_FONT_SCALE_10_5 } from "../core/GrapherConstants"
 
 @observer
 export class ComparisonLine extends React.Component<{
     dualAxis: DualAxis
     comparisonLine: ComparisonLineConfig
+    baseFontSize: number
 }> {
     private renderUid = guid()
 
@@ -111,7 +113,9 @@ export class ComparisonLine extends React.Component<{
                 {placedLabel && (
                     <text
                         style={{
-                            fontSize: "80%",
+                            fontSize:
+                                GRAPHER_FONT_SCALE_10_5 *
+                                this.props.baseFontSize,
                             opacity: 0.9,
                             textAnchor: "end",
                             fill: "#999",


### PR DESCRIPTION
Small improvements for scatter plots on smaller screens:
- Smaller gap between axis and axis label
- Smaller font size of comparison line label
- Smaller in-place label font sizes
- Smaller dots

Doesn't make a big difference to be honest but looks a bit more proportional at least.

| Before  | After  |
| ------- | ------ |
| <img width="326" alt="Screenshot 2024-05-27 at 18 32 58" src="https://github.com/owid/owid-grapher/assets/12461810/6459f986-29d1-441a-8c30-9f8419b719b7">  | <img width="326" alt="Screenshot 2024-05-27 at 18 32 47" src="https://github.com/owid/owid-grapher/assets/12461810/b24cc616-8557-412a-9ba0-ab466a933d78"> |