### PR TITLE
✨ (stacked bar) wrap long labels / TAS-504

### DIFF
--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartConstants.ts
@@ -2,12 +2,14 @@ import { ChartManager } from "../chart/ChartManager"
 import { CoreColumn } from "@ourworldindata/core-table"
 import { ChartSeries } from "../chart/ChartInterface"
 import { CoreValueType, Time } from "@ourworldindata/types"
+import { TextWrap } from "@ourworldindata/components"
 
 export interface DiscreteBarSeries extends ChartSeries {
     yColumn: CoreColumn
     value: number
     time: Time
     colorValue?: CoreValueType
+    label?: TextWrap
 }
 
 export interface DiscreteBarChartManager extends ChartManager {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -213,7 +213,7 @@ export class StackedDiscreteBarChart
 
     // Account for the width of the legend
     @computed private get labelWidth(): number {
-        return max(this.labelledItems.map((d) => d.label.width)) ?? 0
+        return max(this.sizedItems.map((d) => d.label.width)) ?? 0
     }
 
     @computed get showTotalValueLabel(): boolean {
@@ -228,7 +228,7 @@ export class StackedDiscreteBarChart
     @computed private get totalValueLabelWidth(): number {
         if (!this.showTotalValueLabel) return 0
 
-        const labels = this.labelledItems.map((d) =>
+        const labels = this.sizedItems.map((d) =>
             this.formatValueForLabel(d.totalValue)
         )
         const longestLabel = maxBy(labels, (l) => l.length)
@@ -327,16 +327,16 @@ export class StackedDiscreteBarChart
         return items
     }
 
-    @computed get labelledItems(): readonly Item[] {
+    @computed get sizedItems(): readonly Item[] {
+        // can't use `this.barHeight` due to a circular dependency
+        const barHeight = this.approximateBarHeight
+
         return this.items.map((item) => {
             let label = new TextWrap({
                 text: item.entityName,
                 maxWidth: this.boundsWithoutLegend.width * 0.3,
                 ...this.labelStyle,
             })
-
-            // can't use `this.barHeight` due to a circular dependency
-            const barHeight = this.approximateBarHeight
 
             // prevent labels from being taller than the bar
             while (label.height > barHeight && label.lines.length > 1) {
@@ -376,7 +376,7 @@ export class StackedDiscreteBarChart
                     return lastPoint.valueOffset + lastPoint.value
                 }
         }
-        const sortedItems = sortBy(this.labelledItems, sortByFunc)
+        const sortedItems = sortBy(this.sizedItems, sortByFunc)
         const sortOrder = this.sortConfig.sortOrder ?? SortOrder.desc
         if (sortOrder === SortOrder.desc) sortedItems.reverse()
 


### PR DESCRIPTION
Wrap long labels in stacked bar charts. Gives more room to bars, esp. on mobile.

| Before  | After  |
| ------- | ------ |
| <img width="326" alt="Screenshot 2024-05-28 at 10 02 30" src="https://github.com/owid/owid-grapher/assets/12461810/ab102a91-a219-461f-b650-e661359eac3a">  | <img width="326" alt="Screenshot 2024-05-28 at 10 02 42" src="https://github.com/owid/owid-grapher/assets/12461810/cb379ce5-9b7b-4ab5-b180-efa7d179ce8b"> |
