### PR TITLE
✨ (line labels) increase height of the line legend / TAS-507

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -706,6 +706,13 @@ export class LineChart
         return this.bounds.right - (this.lineLegendDimensions?.width || 0)
     }
 
+    @computed get lineLegendY(): [number, number] {
+        return [
+            this.boundsWithoutColorLegend.top,
+            this.boundsWithoutColorLegend.bottom,
+        ]
+    }
+
     @computed get clipPathBounds(): Bounds {
         const { dualAxis, boundsWithoutColorLegend } = this
         return boundsWithoutColorLegend

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -624,6 +624,10 @@ export class StackedAreaChart
             : 0
     }
 
+    @computed get lineLegendY(): [number, number] {
+        return [this.bounds.top, this.bounds.bottom]
+    }
+
     @computed get series(): readonly StackedSeries<number>[] {
         return stackSeries(withMissingValuesAsZeroes(this.unstackedSeries))
     }


### PR DESCRIPTION
Increases the height of the line legend to both sides. The line legend used to be as tall as the y-axis. Now the line legend uses the full extent of the chart. On smaller screens, a larger height can give us an additional label, see below 👇🏻 

| Before  | After  |
| ------- | ------ |
| <img width="317" alt="334457762-5f2cf38c-1419-47af-a4b8-085e39c718e6" src="https://github.com/owid/owid-grapher/assets/12461810/e9d1a047-992f-4865-be2c-10f4b69db8c4">  | <img width="317" alt="Screenshot 2024-05-28 at 16 15 55" src="https://github.com/owid/owid-grapher/assets/12461810/51f06dbb-8724-40e4-9386-b9aa93c7db09"> |