### PR TITLE
docs(fn): update deploy-content-preview

### DIFF
--- a/ops/buildkite/deploy-content-preview
+++ b/ops/buildkite/deploy-content-preview
@@ -10,9 +10,9 @@
 #  USAGE
 #
 #  - $ yarn deploy-content-preview (default, deploys to
-#    https://[YOUR_CURRENT_GIT_BRANCH].owid-staging.pages.dev)
+#    https://[YOUR_CURRENT_GIT_BRANCH].owid.pages.dev)
 #  - $ PREVIEW_BRANCH=[PREVIEW_BRANCH] yarn deploy-content-preview (deploys to
-#    https://[PREVIEW_BRANCH].owid-staging.pages.dev)
+#    https://[PREVIEW_BRANCH].owid.pages.dev)
 #
 #  This script is meant to be run manually and locally. It is not triggered
 #  automatically and run by an Buildkite agent, unlike its production
@@ -21,7 +21,7 @@
 #
 #  By default, running `yarn deploy-content-preview` will deploy to a preview
 #  URL prefixed with the current git branch name. For example, if you're on the
-#  `donate` branch, the preview URL will be https://donate.owid-staging.pages.dev. This
+#  `donate` branch, the preview URL will be https://donate.owid.pages.dev. This
 #  is mimicking the default Cloudflare Pages preview environment behavior, when
 #  production and preview deploys are triggered by a git push (as a side note,
 #  our setup doesn't use this git integration, and rather deploys manually
@@ -30,7 +30,7 @@
 #  Alternatively, you can pass a custom branch name to this script. This is
 #  useful for maintaining a stable review URL across time for a complex feature
 #  spread across multiple stacked PRs. For example, if you want to deploy to
-#  https://donate.owid-staging.pages.dev, while on the `donate-2` branch you can run:
+#  https://donate.owid.pages.dev, while on the `donate-2` branch you can run:
 #
 #  PREVIEW_BRANCH=donate yarn deploy-content-preview
 #
@@ -52,12 +52,12 @@
 #  http://staging-site-donate).
 #
 #  Before running this script, you need to rebake the content using the target
-#  preview BAKED_BASE_URL (e.g. https://donate.owid-staging.pages.dev) to avoid CORS
+#  preview BAKED_BASE_URL (e.g. https://donate.owid.pages.dev) to avoid CORS
 #  issues. This is done by running the following sequence on the staging server
 #  (not locally):
 #  - in ~/owid-grapher/.env, set BAKED_BASE_URL to
-#    https://[PREVIEW_BRANCH].owid-staging.pages.dev
-#  - `yarn buildLocalBake https://[PREVIEW_BRANCH].owid-staging.pages.dev /home/owid/live-data/bakedSite`
+#    https://[PREVIEW_BRANCH].owid.pages.dev
+#  - `yarn buildLocalBake https://[PREVIEW_BRANCH].owid.pages.dev /home/owid/live-data/bakedSite`
 #
 #  You don't need to continuously rebake the site to test iterative changes to
 #  functions code in the preview environment. Functions are not baked, they are
@@ -102,7 +102,7 @@ as_owid() {
 }
 
 # Cloudflare Pages settings
-PROJECT_NAME=owid-staging
+PROJECT_NAME=owid
 
 # Set PREVIEW_BRANCH to the current git branch name if not set
 PREVIEW_BRANCH=${PREVIEW_BRANCH:-$GIT_BRANCH}

--- a/ops/buildkite/deploy-content-preview
+++ b/ops/buildkite/deploy-content-preview
@@ -67,7 +67,7 @@
 #  rather merely copied as-is to the `dist` folder to be executed on the server.
 #  When git pushing functions code, the regular staging job will automatically
 #  update them on the staging server. You then just need to run `yarn
-#  deploy-content-preview` to deploy the updated functions code to the preview
+#  deployContentPreview` to deploy the updated functions code to the preview
 #  URL.
 #
 #  ## CREATING CLOUDFLARE PAGES API TOKEN (optional)

--- a/ops/buildkite/deploy-content-preview
+++ b/ops/buildkite/deploy-content-preview
@@ -111,6 +111,12 @@ PREVIEW_BRANCH=${PREVIEW_BRANCH:-$GIT_BRANCH}
 BAKED_BASE_URL="https://$PREVIEW_BRANCH.$PROJECT_NAME.pages.dev"
 
 deploy_site () {
+    # Do not deploy from branch "master"
+    if [ "$PREVIEW_BRANCH" = "master" ]; then
+        echo "Cannot deploy from branch 'master'"
+        exit 1
+    fi
+
     echo "--- Deploy site to $BAKED_BASE_URL from $HOST"
 
     create_dist

--- a/ops/buildkite/deploy-content-preview
+++ b/ops/buildkite/deploy-content-preview
@@ -57,10 +57,7 @@
 #  (not locally):
 #  - in ~/owid-grapher/.env, set BAKED_BASE_URL to
 #    https://[PREVIEW_BRANCH].owid-staging.pages.dev
-#  - `rm ~/.site-baked` (see ops > templates > lxc-manager > grapher-refresh)
-#  - locate the latest Buildkite job for your staging environment and click
-#    "Rebuild". This will run the full site baking sequence with the preview URL
-#    as BAKED_BASE_URL.
+#  - `yarn buildLocalBake https://[PREVIEW_BRANCH].owid-staging.pages.dev /home/owid/live-data/bakedSite`
 #
 #  You don't need to continuously rebake the site to test iterative changes to
 #  functions code in the preview environment. Functions are not baked, they are


### PR DESCRIPTION
- update `yarn deployContentPreview` docs
- revert to using preview deploys on the `owid` (production) app (see [slack](https://owid.slack.com/archives/CQQUA2C2U/p1716985481093269))

![Screenshot 2024-05-30 at 16.11.06.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0SFFiIjKuUK6UPYHVe6u/a6969bdf-cf55-4cf1-ae21-e6a125394d72.png)


- add failsafe in case script in run on the `master` branch by mistake