### PR TITLE
🐛 don't fallback to static export views of charts by default on mobile

### DIFF
--- a/site/GrapherImage.tsx
+++ b/site/GrapherImage.tsx
@@ -18,6 +18,8 @@ export default function GrapherImage({
     return (
         <img
             className="GrapherImage"
+            // TODO: use the CF worker to render these previews so that we can show non-default configurations of the chart
+            // https://github.com/owid/owid-grapher/issues/3661
             src={`${BAKED_GRAPHER_EXPORTS_BASE_URL}/${slug}.svg`}
             alt={alt}
             width={DEFAULT_GRAPHER_WIDTH}

--- a/site/multiembedder/MultiEmbedder.tsx
+++ b/site/multiembedder/MultiEmbedder.tsx
@@ -16,7 +16,6 @@ import {
     fetchText,
     getWindowUrl,
     isArray,
-    isMobile,
     isPresent,
     Url,
     GrapherTabOption,
@@ -53,13 +52,13 @@ const figuresFromDOM = (
 // Determine whether this device is powerful enough to handle
 // loading a bunch of inline interactive charts
 // 680px is also used in CSS – keep it in sync if you change this
-export const shouldProgressiveEmbed = () =>
-    !isMobile() ||
-    window.screen.width > 680 ||
-    pageContainsGlobalEntitySelector()
+export const shouldProgressiveEmbed = () => true
+// disabling this behaviour for now until we have a better way to detect low power devices
+// https://github.com/owid/owid-grapher/issues/3661
+// !isMobile() || window.screen.width > 680 || pageContainsGlobalEntitySelector()
 
-const pageContainsGlobalEntitySelector = () =>
-    globalEntitySelectorElement() !== null
+// const pageContainsGlobalEntitySelector = () =>
+//     globalEntitySelectorElement() !== null
 
 const globalEntitySelectorElement = () =>
     document.querySelector(GLOBAL_ENTITY_SELECTOR_ELEMENT)


### PR DESCRIPTION
A temporary fix for a flawed change we made to grapher behaviour on mobile, to be followed-up by https://github.com/owid/owid-grapher/issues/3661