### PR TITLE
🎉 add commas between sibling ref superscripts

### DIFF
--- a/site/gdocs/components/centered-article.scss
+++ b/site/gdocs/components/centered-article.scss
@@ -31,6 +31,21 @@
         }
     }
 
+    .ref + .ref {
+        margin-left: 4px;
+        position: relative;
+        ::before {
+            font-size: 0.75em;
+            position: absolute;
+            content: ",";
+            left: -0.25em;
+            top: -0.35em;
+            line-height: 1;
+            color: $blue-60;
+            pointer-events: none;
+        }
+    }
+
     .toc-wrapper {
         position: sticky;
         top: 0;


### PR DESCRIPTION
Different browsers render (slightly) differently but I think it's passable

Firefox:
![image](https://github.com/owid/owid-grapher/assets/11844404/992fb0f8-5b2d-4477-afd5-0a53dfdc5c95)

Chrome:
![image](https://github.com/owid/owid-grapher/assets/11844404/04e70ef1-384f-4ef1-bf05-85841167ecfc)

Safari:
![image](https://github.com/owid/owid-grapher/assets/11844404/06fbec0b-348b-4590-b1af-da319030fbb6)
