### PR TITLE
✨ widen author featured image column at medium breakpoint

### DIFF
--- a/site/gdocs/pages/Author.tsx
+++ b/site/gdocs/pages/Author.tsx
@@ -55,11 +55,9 @@ const AuthorHeader = (gdoc: OwidGdocAuthorInterface) => {
                 )}
             </section>
             <section className="author-header__md grid grid-cols-12-full-width span-cols-14">
-                <div className="grid grid-cols-8 span-cols-8 col-start-2 span-md-cols-7 col-md-start-2">
-                    <h1 className="author-header__name span-cols-8">{title}</h1>
-                    <div className="author-header__role span-cols-8">
-                        {role}
-                    </div>
+                <div className="span-cols-8 col-start-2 span-md-cols-7 col-md-start-2">
+                    <h1 className="author-header__name">{title}</h1>
+                    <div className="author-header__role">{role}</div>
                     {bio?.length && (
                         <ArticleBlocks
                             blocks={bio}

--- a/site/gdocs/pages/Author.tsx
+++ b/site/gdocs/pages/Author.tsx
@@ -55,7 +55,7 @@ const AuthorHeader = (gdoc: OwidGdocAuthorInterface) => {
                 )}
             </section>
             <section className="author-header__md grid grid-cols-12-full-width span-cols-14">
-                <div className="grid grid-cols-8 span-cols-8 col-start-2">
+                <div className="grid grid-cols-8 span-cols-8 col-start-2 span-md-cols-7 col-md-start-2">
                     <h1 className="author-header__name span-cols-8">{title}</h1>
                     <div className="author-header__role span-cols-8">
                         {role}
@@ -67,7 +67,7 @@ const AuthorHeader = (gdoc: OwidGdocAuthorInterface) => {
                         />
                     )}
                 </div>
-                <div className="grid grid-cols-3 col-start-11 span-cols-3">
+                <div className="grid grid-cols-3 col-start-11 span-cols-3 span-md-cols-4 col-md-start-10">
                     {featuredImage && (
                         <Image
                             filename={featuredImage}


### PR DESCRIPTION
Adds an extra column's width to the featured image column on our medium breakpoint to prevent the social media links from wrapping

I saw the comment about keeping the two headers in sync but I'm pretty sure it doesn't apply in this case?

https://github.com/owid/owid-grapher/assets/11844404/73dc839b-09d1-4cd7-a8bd-2a75bad883e5

