### PR TITLE
fix(socials): harmonize logos widths

### DIFF
--- a/site/gdocs/pages/Author.scss
+++ b/site/gdocs/pages/Author.scss
@@ -64,6 +64,7 @@
     svg {
         margin-right: 8px;
         color: $blue-50;
+        width: 1em;
     }
 }
 


### PR DESCRIPTION
see [slack](https://owid.slack.com/archives/C5BDCB2R3/p1717144683552119)

### Before
![cleanshot_2024-05-31_at_10.36.39_360.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0SFFiIjKuUK6UPYHVe6u/b66dafb4-8fb6-4915-ba27-75ccd6291836.png)

### After

![Screenshot 2024-05-31 at 15.21.53.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0SFFiIjKuUK6UPYHVe6u/12b8bd7b-3f79-400d-b13e-9a220812762b.png)

