### PR TITLE
🐛 fix ref commas appearing in gdoc articles when paragraph text is between them

### DIFF
--- a/site/gdocs/utils.tsx
+++ b/site/gdocs/utils.tsx
@@ -180,7 +180,7 @@ export function renderSpan(
 ): React.ReactElement {
     return match(span)
         .with({ spanType: "span-simple-text" }, (span) => (
-            <React.Fragment key={key}>{span.text}</React.Fragment>
+            <span key={key}>{span.text}</span>
         ))
         .with({ spanType: "span-link" }, (span) => (
             <LinkedA span={span} key={key} />
@@ -217,9 +217,7 @@ export function renderSpan(
             <q key={key}>{renderSpans(span.children)}</q>
         ))
         .with({ spanType: "span-fallback" }, (span) => (
-            <React.Fragment key={key}>
-                {renderSpans(span.children)}
-            </React.Fragment>
+            <span key={key}>{renderSpans(span.children)}</span>
         ))
         .exhaustive()
 }


### PR DESCRIPTION
the `innerText` separating these two footnote spans wasn't interrupting the sibling selector that I added in https://github.com/owid/owid-grapher/pull/3670

![image](https://github.com/owid/owid-grapher/assets/11844404/a5f47e70-98ca-4f53-bfae-c98527d6da83)

![image](https://github.com/owid/owid-grapher/assets/11844404/b01b5148-68c1-41e3-9058-c19f57c23c2b)


This PR puts all `span-simple-text` spans inside actual span elements to interrupt the CSS sibling selector.
![image](https://github.com/owid/owid-grapher/assets/11844404/09d10eea-48fa-4435-9c20-810d452dbe75)
![image](https://github.com/owid/owid-grapher/assets/11844404/b089f962-9cb7-4053-9566-a2519562ae1d)

I've checked Chrome, Firefox, and Safari, as well as Grapher and Grapher exports because they also use this renderer in the dod footnotes.