### PR TITLE
✨ (grapher) make title wider on smaller screens / TAS-517

### DIFF
--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -100,10 +100,16 @@ export class Header<
     }
 
     @computed get title(): TextWrap {
+        const logoPadding = this.manager.isNarrow
+            ? 12
+            : this.manager.isSmall
+              ? 16
+              : 24
+
         const makeTitle = (fontSize: number): TextWrap =>
             new TextWrap({
                 text: this.titleText,
-                maxWidth: this.maxWidth - this.logoWidth - 24,
+                maxWidth: this.maxWidth - this.logoWidth - logoPadding,
                 fontWeight: this.titleFontWeight,
                 lineHeight: this.titleLineHeight,
                 fontSize,


### PR DESCRIPTION
Reduces the title-logo padding on smaller screens.

Examples:
- http://staging-site-mobile-title/grapher/deaths-by-age-group-stacked
- http://staging-site-mobile-title/grapher/deaths-from-natural-disasters-by-type