### PR TITLE
✨ (grapher) fixed tooltip position on mobile / TAS-520

### DIFF
--- a/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
@@ -39,6 +39,7 @@ export interface ChartManager {
     comparisonLines?: ComparisonLineConfig[]
     showLegend?: boolean
     tooltips?: TooltipManager["tooltips"]
+    activeTooltipId?: TooltipManager["activeTooltipId"]
     baseColorScheme?: ColorSchemeName
     invertColorScheme?: boolean
     compareEndPointsOnly?: boolean

--- a/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
@@ -95,6 +95,7 @@ export interface ChartManager {
     isSemiNarrow?: boolean
     isStaticAndSmall?: boolean
     secondaryColorInStaticCharts?: string
+    isTooltipFixedToBottom?: boolean
 
     detailsOrderedByReference?: string[]
     detailsMarkerInSvg?: DetailsMarker

--- a/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
@@ -38,8 +38,7 @@ export interface ChartManager {
     isRelativeMode?: boolean
     comparisonLines?: ComparisonLineConfig[]
     showLegend?: boolean
-    tooltips?: TooltipManager["tooltips"]
-    activeTooltipId?: TooltipManager["activeTooltipId"]
+    tooltip?: TooltipManager["tooltip"]
     baseColorScheme?: ColorSchemeName
     invertColorScheme?: boolean
     compareEndPointsOnly?: boolean

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -823,9 +823,7 @@ export class Grapher
     @observable.ref renderToStatic = false
     @observable.ref isExportingToSvgOrPng = false
 
-    tooltips?: TooltipManager["tooltips"] = observable.map({}, { deep: false })
-    activeTooltipId?: TooltipManager["activeTooltipId"] =
-        observable.box(undefined)
+    @observable.ref tooltip?: TooltipManager["tooltip"] = undefined
 
     @observable isPlaying = false
 
@@ -2734,9 +2732,7 @@ export class Grapher
                         if (entry.isIntersecting) {
                             this.hasBeenVisible = true
                         } else {
-                            this.tooltips?.forEach((tooltip) => {
-                                tooltip.dismiss?.()
-                            })
+                            this.tooltip?.dismiss?.()
                         }
                     })
                 },

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -823,7 +823,8 @@ export class Grapher
     @observable.ref renderToStatic = false
     @observable.ref isExportingToSvgOrPng = false
 
-    @observable.ref tooltip?: TooltipManager["tooltip"] = undefined
+    @observable.ref tooltip?: TooltipManager["tooltip"] =
+        observable.box(undefined)
 
     @observable isPlaying = false
 
@@ -2732,7 +2733,7 @@ export class Grapher
                         if (entry.isIntersecting) {
                             this.hasBeenVisible = true
                         } else {
-                            this.tooltip?.dismiss?.()
+                            this.tooltip?.get()?.dismiss?.()
                         }
                     })
                 },

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -824,6 +824,9 @@ export class Grapher
     @observable.ref isExportingToSvgOrPng = false
 
     tooltips?: TooltipManager["tooltips"] = observable.map({}, { deep: false })
+    activeTooltipId?: TooltipManager["activeTooltipId"] =
+        observable.box(undefined)
+
     @observable isPlaying = false
 
     @observable.ref isEntitySelectorModalOrDrawerOpen = false

--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
@@ -457,6 +457,8 @@ export class FacetChart
                     ...axes.y.config,
                 },
                 tooltips: this.manager.tooltips,
+                activeTooltipId: this.manager.activeTooltipId,
+                isTooltipFixedToBottom: this.manager.isTooltipFixedToBottom,
                 base: this.manager.base,
             }
             const contentBounds = getContentBounds(

--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
@@ -456,8 +456,7 @@ export class FacetChart
                     ...series.manager.yAxisConfig,
                     ...axes.y.config,
                 },
-                tooltips: this.manager.tooltips,
-                activeTooltipId: this.manager.activeTooltipId,
+                tooltip: this.manager.tooltip,
                 isTooltipFixedToBottom: this.manager.isTooltipFixedToBottom,
                 base: this.manager.base,
             }

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -524,7 +524,7 @@ export class LineChart
     }
 
     @computed private get isTooltipActive(): boolean {
-        return this.manager.tooltip?.id === this.tooltipId
+        return this.manager.tooltip?.get()?.id === this.tooltipId
     }
 
     @computed private get tooltip(): React.ReactElement | undefined {
@@ -623,10 +623,10 @@ export class LineChart
                                 )
                               : series.color
 
-                        const values = [
+                        const values = excludeUndefined([
                             point?.y,
                             point?.colorValue as undefined | number,
-                        ]
+                        ])
 
                         return {
                             name,

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -519,6 +519,14 @@ export class LineChart
         )
     }
 
+    @computed private get tooltipId(): number {
+        return this.renderUid
+    }
+
+    @computed private get isTooltipActive(): boolean {
+        return this.manager.activeTooltipId?.get() === this.tooltipId
+    }
+
     @computed private get tooltip(): React.ReactElement | undefined {
         const { formatColumn, colorColumn, hasColorScale } = this
         const { target, position, fading } = this.tooltipState
@@ -576,7 +584,7 @@ export class LineChart
 
         return (
             <Tooltip
-                id={this.renderUid}
+                id={this.tooltipId}
                 tooltipManager={this.manager}
                 x={position.x}
                 y={position.y}
@@ -885,7 +893,7 @@ export class LineChart
                         markerRadius={this.markerRadius}
                     />
                 </g>
-                {activeXVerticalLine}
+                {this.isTooltipActive && activeXVerticalLine}
 
                 {tooltip}
             </g>

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -524,7 +524,7 @@ export class LineChart
     }
 
     @computed private get isTooltipActive(): boolean {
-        return this.manager.activeTooltipId?.get() === this.tooltipId
+        return this.manager.tooltip?.id === this.tooltipId
     }
 
     @computed private get tooltip(): React.ReactElement | undefined {

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -357,8 +357,14 @@ export class LineChart
         return table
     }
 
-    @action.bound private onCursorLeave(): void {
+    @action.bound private dismissTooltip(): void {
         this.tooltipState.target = null
+    }
+
+    @action.bound private onCursorLeave(): void {
+        if (!this.manager.isTooltipFixedToBottom) {
+            this.dismissTooltip()
+        }
         this.clearHighlightedSeries()
     }
 
@@ -584,6 +590,8 @@ export class LineChart
                 footer={footer}
                 footerFormat="stripes"
                 dissolve={fading}
+                dismiss={this.dismissTooltip}
+                dismissOnDocumentClick={true}
             >
                 <TooltipTable
                     columns={columns}

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.scss
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.scss
@@ -1,46 +1,48 @@
-.sparkline {
-    padding-bottom: 4px;
+@at-root {
+    .sparkline {
+        padding-bottom: 4px;
 
-    .HorizontalAxis text {
-        fill: #787878;
-        font-weight: 700;
-        font-size: 10px;
-        transform: translate(2px, 2px);
+        .HorizontalAxis text {
+            fill: #787878;
+            font-weight: 700;
+            font-size: 10px;
+            transform: translate(2px, 2px);
 
-        &:last-child {
-            transform: translate(-2px, 2px);
+            &:last-child {
+                transform: translate(-2px, 2px);
+            }
         }
-    }
 
-    // min-line + zero-line
-    .AxisGridLines.horizontalLines {
-        line {
-            stroke-dasharray: 0;
+        // min-line + zero-line
+        .AxisGridLines.horizontalLines {
+            line {
+                stroke-dasharray: 0;
+                stroke-linecap: square;
+                stroke: #dadada;
+            }
+
+            // the zero line
+            line:nth-child(2) {
+                stroke: #787878;
+            }
+        }
+
+        line.max-line {
             stroke-linecap: square;
             stroke: #dadada;
         }
 
-        // the zero line
-        line:nth-child(2) {
-            stroke: #787878;
-        }
-    }
-
-    line.max-line {
-        stroke-linecap: square;
-        stroke: #dadada;
-    }
-
-    .axis-label {
-        text {
-            font: 400 10px Lato;
-            letter-spacing: 0.01em;
-            font-style: italic;
-            text-anchor: end;
-            fill: #787878;
-            &.outline {
-                stroke: rgba(255, 255, 255, 0.85);
-                stroke-width: 2px;
+        .axis-label {
+            text {
+                font: 400 10px Lato;
+                letter-spacing: 0.01em;
+                font-style: italic;
+                text-anchor: end;
+                fill: #787878;
+                &.outline {
+                    stroke: rgba(255, 255, 255, 0.85);
+                    stroke-width: 2px;
+                }
             }
         }
     }

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
@@ -29,10 +29,13 @@ interface MapTooltipProps {
     formatValue: (d: PrimitiveType) => string
     timeSeriesTable: OwidTable
     targetTime?: Time
+    sparklineWidth?: number
+    sparklineHeight?: number
 }
 
-const SPARKLINE_WIDTH = 250
-const SPARKLINE_HEIGHT = 87
+const DEFAULT_SPARKLINE_WIDTH = 250
+const DEFAULT_SPARKLINE_HEIGHT = 87
+
 const SPARKLINE_PADDING = 15
 const SPARKLINE_NUDGE = 3 // step away from the axis
 
@@ -179,10 +182,18 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
         }
     }
 
+    @computed private get sparklineWidth(): number {
+        return this.props.sparklineWidth ?? DEFAULT_SPARKLINE_WIDTH
+    }
+
+    @computed private get sparklineHeight(): number {
+        return this.props.sparklineHeight ?? DEFAULT_SPARKLINE_HEIGHT
+    }
+
     @computed private get sparklineBounds(): Bounds {
         // Add padding so that the edges of the plot doesn't get clipped.
         // The plot can go out of boundaries due to line stroke thickness & labels.
-        return new Bounds(0, 0, SPARKLINE_WIDTH, SPARKLINE_HEIGHT).pad({
+        return new Bounds(0, 0, this.sparklineWidth, this.sparklineHeight).pad({
             top: 9,
             left: SPARKLINE_PADDING,
             right: SPARKLINE_PADDING,
@@ -261,6 +272,7 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                 footer={notice}
                 footerFormat="notice"
                 dissolve={fading}
+                dismiss={() => (this.props.tooltipState.target = null)}
             >
                 <TooltipValue
                     column={yColumn}
@@ -275,8 +287,8 @@ export class MapTooltip extends React.Component<MapTooltipProps> {
                     >
                         <svg
                             className="plot"
-                            width={SPARKLINE_WIDTH}
-                            height={SPARKLINE_HEIGHT}
+                            width={this.sparklineWidth}
+                            height={this.sparklineHeight}
                         >
                             <line
                                 className="max-line"

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -985,6 +985,7 @@ export class ScatterPlotChart
                 dissolve={fading}
                 footer={targetNotice}
                 footerFormat="notice"
+                dismiss={() => (this.tooltipState.target = null)}
             >
                 <TooltipValueRange
                     column={xColumn}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -1029,6 +1029,7 @@ export class MarimekkoChart
                         footer={notice}
                         footerFormat="notice"
                         dissolve={fading}
+                        dismiss={() => (this.tooltipState.target = null)}
                     >
                         {yValues.map(({ name, value, notice }) => (
                             <TooltipValue

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -567,7 +567,7 @@ export class StackedAreaChart
     }
 
     @computed private get isTooltipActive(): boolean {
-        return this.manager.activeTooltipId?.get() === this.tooltipId
+        return this.manager.tooltip?.id === this.tooltipId
     }
 
     @computed private get tooltip(): React.ReactElement | undefined {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -562,6 +562,14 @@ export class StackedAreaChart
         )
     }
 
+    @computed private get tooltipId(): number {
+        return this.renderUid
+    }
+
+    @computed private get isTooltipActive(): boolean {
+        return this.manager.activeTooltipId?.get() === this.tooltipId
+    }
+
     @computed private get tooltip(): React.ReactElement | undefined {
         const { target, position, fading } = this.tooltipState
         if (!target) return undefined
@@ -580,7 +588,7 @@ export class StackedAreaChart
 
         return (
             <Tooltip
-                id={this.renderUid}
+                id={this.tooltipId}
                 tooltipManager={this.props.manager}
                 x={position.x}
                 y={position.y}
@@ -677,7 +685,7 @@ export class StackedAreaChart
                         onAreaMouseLeave={this.onAreaMouseLeave}
                     />
                 </g>
-                {this.activeXVerticalLine}
+                {this.isTooltipActive && this.activeXVerticalLine}
                 {this.tooltip}
             </g>
         )

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -446,9 +446,15 @@ export class StackedAreaChart
                   }
     }
 
-    @action.bound private onCursorLeave(): void {
-        this.hoverSeriesName = undefined
+    @action.bound private dismissTooltip(): void {
         this.tooltipState.target = null
+    }
+
+    @action.bound private onCursorLeave(): void {
+        if (!this.manager.isTooltipFixedToBottom) {
+            this.dismissTooltip()
+        }
+        this.hoverSeriesName = undefined
     }
 
     componentDidMount(): void {
@@ -586,6 +592,8 @@ export class StackedAreaChart
                 subtitle={unit !== shortUnit ? unit : undefined}
                 subtitleFormat="unit"
                 dissolve={fading}
+                dismiss={this.dismissTooltip}
+                dismissOnDocumentClick={true}
             >
                 <TooltipTable
                     columns={[yColumn]}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -567,7 +567,7 @@ export class StackedAreaChart
     }
 
     @computed private get isTooltipActive(): boolean {
-        return this.manager.tooltip?.id === this.tooltipId
+        return this.manager.tooltip?.get()?.id === this.tooltipId
     }
 
     @computed private get tooltip(): React.ReactElement | undefined {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -334,6 +334,7 @@ export class StackedBarChart
                 subtitle={unit !== shortUnit ? unit : undefined}
                 subtitleFormat="unit"
                 dissolve={fading}
+                dismiss={() => (this.tooltipState.target = null)}
             >
                 <TooltipTable
                     columns={[yColumn]}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -789,6 +789,7 @@ export class StackedDiscreteBarChart
                     footer={notice}
                     footerFormat="notice"
                     dissolve={fading}
+                    dismiss={() => (this.tooltipState.target = null)}
                 >
                     <TooltipTable
                         columns={[this.formatColumn]}

--- a/packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss
+++ b/packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss
@@ -1,426 +1,455 @@
-.tooltip-container > .Tooltip {
-    $background-fill: #f0f0f0;
-    $background-stroke: #e7e7e7;
-    $dark-grey: #2d2d2d;
-    $light-grey: #dadada;
-    $grey: #787878;
-    $red: #cc3b55;
-    $green: #2c8465;
-    $fade-time: 200ms;
-    $fade-delay: 200ms;
-    $medium: 400;
-    $bold: 700;
+@at-root {
+    .tooltip-container {
+        $background-fill: #f0f0f0;
+        $background-stroke: #e7e7e7;
+        $dark-grey: #2d2d2d;
+        $light-grey: #dadada;
+        $grey: #787878;
+        $red: #cc3b55;
+        $green: #2c8465;
+        $fade-time: 200ms;
+        $fade-delay: 200ms;
+        $medium: 400;
+        $bold: 700;
 
-    border-radius: 4px;
-    border: 1px solid $background-stroke;
-    box-shadow: 0px 4px 40px rgba(0, 0, 0, 0.2);
-    background: white;
-    text-align: left;
-    position: absolute;
-    pointer-events: none;
-    font-family: $sans-serif-font-stack;
-    font-size: 16px;
+        &.fixed-bottom {
+            position: fixed;
+            left: 4px;
+            bottom: 4px;
+            width: calc(100% - 8px);
+            z-index: $zindex-tooltip;
 
-    @mixin diagonal-background($background, $color) {
-        background: repeating-linear-gradient(
-            -45deg,
-            $background,
-            $background 16%,
-            $color 16%,
-            $color 25%
-        );
-    }
+            > .Tooltip {
+                pointer-events: auto;
 
-    .frontmatter {
-        background: $background-fill;
-        color: black;
-        padding: 8px 12px;
-        border-radius: 3px 3px 0 0;
-
-        .title,
-        .subtitle {
-            margin: 0;
-            padding: 0;
-            line-height: 1.125em;
-        }
-
-        .title {
-            font-size: 14px;
-            font-weight: $bold;
-            letter-spacing: 0;
-        }
-        .subtitle {
-            margin: 4px 0 2px 0;
-            font-size: 12px;
-            font-weight: $medium;
-            letter-spacing: 0.01em;
-
-            svg.fa-circle-info {
-                color: $grey;
-                margin-right: 0.5em;
-            }
-        }
-    }
-
-    &.plain header {
-        border-radius: 3px;
-        background: white;
-    }
-
-    .content {
-        padding: 8px 12px;
-
-        > p {
-            margin: 0;
-            padding: 0;
-        }
-
-        .variable {
-            .definition {
-                color: #858585;
-                font-size: 12px;
-                line-height: 15px;
-                letter-spacing: 0.01em;
-                font-weight: $bold;
-
-                .name {
-                    margin-right: 0.25em;
-                }
-
-                .unit {
-                    font-weight: $medium;
-                    font-style: normal;
-
-                    &::before {
-                        content: "(";
-                    }
-
-                    &::after {
-                        content: ")";
-                    }
+                .content {
+                    max-height: 25vh;
+                    overflow-y: auto;
+                    overflow-x: hidden;
                 }
             }
+        }
 
-            .values {
-                display: flex;
-                align-items: baseline;
-                justify-content: space-between;
-                color: $dark-grey;
-                padding: 2px 0;
-                line-height: 21px;
-                font-size: 18px;
-                font-weight: $bold;
+        > .Tooltip {
+            border-radius: 4px;
+            border: 1px solid $background-stroke;
+            box-shadow: 0px 4px 40px rgba(0, 0, 0, 0.2);
+            background: white;
+            text-align: left;
+            pointer-events: none;
+            font-family: $sans-serif-font-stack;
+            font-size: 16px;
 
-                .range {
-                    display: flex;
-                    flex-wrap: wrap;
-                    align-items: baseline;
-                    column-gap: 0.2em;
-                    flex-grow: 1;
+            @mixin diagonal-background($background, $color) {
+                background: repeating-linear-gradient(
+                    -45deg,
+                    $background,
+                    $background 16%,
+                    $color 16%,
+                    $color 25%
+                );
+            }
 
-                    .term {
-                        overflow-wrap: anywhere;
-                    }
+            .frontmatter {
+                background: $background-fill;
+                color: black;
+                padding: 8px 12px;
+                border-radius: 3px 3px 0 0;
 
-                    svg.arrow {
-                        height: 14px;
-                        padding-right: 0.15em;
-                        &.up path {
-                            fill: $green;
-                        }
-                        &.down path {
-                            fill: $red;
-                        }
-                        &.right path {
-                            fill: $grey;
-                        }
-                    }
+                .title,
+                .subtitle {
+                    margin: 0;
+                    padding: 0;
+                    line-height: 1.125em;
                 }
 
-                .time-notice {
-                    position: relative;
-                    font-weight: $medium;
+                .title {
                     font-size: 14px;
-                    line-height: 21px;
-                    padding-left: 20px;
-                    svg.fa-circle-info {
-                        position: absolute;
-                        top: 3px;
-                        left: 0;
-                    }
-                    color: $grey;
+                    font-weight: $bold;
+                    letter-spacing: 0;
                 }
-            }
-        }
-
-        .variable + .variable {
-            margin-top: 4px;
-            padding-top: 8px;
-            border-top: 1px solid $light-grey;
-        }
-
-        table.series-list {
-            color: $dark-grey;
-            font-size: 14px;
-            line-height: 22px;
-            font-weight: $medium;
-            white-space: normal;
-            border-collapse: collapse;
-            width: 100%;
-
-            // only used if rows have ≥2 values
-            thead {
-                font-size: 12px;
-                letter-spacing: 0.01em;
-
-                tr td.series-value {
+                .subtitle {
+                    margin: 4px 0 2px 0;
+                    font-size: 12px;
                     font-weight: $medium;
+                    letter-spacing: 0.01em;
+
+                    svg.fa-circle-info {
+                        color: $grey;
+                        margin-right: 0.5em;
+                    }
                 }
             }
 
-            // -- standard columns --
-            td {
-                vertical-align: baseline;
+            &.plain header {
+                border-radius: 3px;
+                background: white;
             }
 
-            td.series-color {
-                padding-left: 0;
-                .swatch {
+            .content {
+                padding: 8px 12px;
+
+                > p {
+                    margin: 0;
+                    padding: 0;
+                }
+
+                .variable {
+                    .definition {
+                        color: #858585;
+                        font-size: 12px;
+                        line-height: 15px;
+                        letter-spacing: 0.01em;
+                        font-weight: $bold;
+
+                        .name {
+                            margin-right: 0.25em;
+                        }
+
+                        .unit {
+                            font-weight: $medium;
+                            font-style: normal;
+
+                            &::before {
+                                content: "(";
+                            }
+
+                            &::after {
+                                content: ")";
+                            }
+                        }
+                    }
+
+                    .values {
+                        display: flex;
+                        align-items: baseline;
+                        justify-content: space-between;
+                        color: $dark-grey;
+                        padding: 2px 0;
+                        line-height: 21px;
+                        font-size: 18px;
+                        font-weight: $bold;
+
+                        .range {
+                            display: flex;
+                            flex-wrap: wrap;
+                            align-items: baseline;
+                            column-gap: 0.2em;
+                            flex-grow: 1;
+
+                            .term {
+                                overflow-wrap: anywhere;
+                            }
+
+                            svg.arrow {
+                                height: 14px;
+                                padding-right: 0.15em;
+                                &.up path {
+                                    fill: $green;
+                                }
+                                &.down path {
+                                    fill: $red;
+                                }
+                                &.right path {
+                                    fill: $grey;
+                                }
+                            }
+                        }
+
+                        .time-notice {
+                            position: relative;
+                            font-weight: $medium;
+                            font-size: 14px;
+                            line-height: 21px;
+                            padding-left: 20px;
+                            svg.fa-circle-info {
+                                position: absolute;
+                                top: 3px;
+                                left: 0;
+                            }
+                            color: $grey;
+                        }
+                    }
+                }
+
+                .variable + .variable {
+                    margin-top: 4px;
+                    padding-top: 8px;
+                    border-top: 1px solid $light-grey;
+                }
+
+                table.series-list {
+                    color: $dark-grey;
+                    font-size: 14px;
+                    line-height: 22px;
+                    font-weight: $medium;
+                    white-space: normal;
+                    border-collapse: collapse;
+                    width: 100%;
+
+                    // only used if rows have ≥2 values
+                    thead {
+                        font-size: 12px;
+                        letter-spacing: 0.01em;
+
+                        tr td.series-value {
+                            font-weight: $medium;
+                        }
+                    }
+
+                    // -- standard columns --
+                    td {
+                        vertical-align: baseline;
+                    }
+
+                    td.series-color {
+                        padding-left: 0;
+                        .swatch {
+                            width: 12px;
+                            height: 12px;
+                            display: inline-block;
+                            margin-right: 0.3em;
+                            text-align: left;
+                            position: relative;
+                        }
+                    }
+
+                    td.series-name {
+                        padding-right: 0.9em;
+                        line-height: 16px;
+                        width: 100%;
+                        .parenthetical {
+                            color: $grey;
+                        }
+
+                        .annotation {
+                            display: block;
+                            color: $grey;
+                            font-size: 12px;
+                            letter-spacing: 0.01em;
+                        }
+                    }
+
+                    td.series-value {
+                        font-weight: $bold;
+                        text-align: right;
+                        white-space: nowrap;
+
+                        &.missing::before {
+                            content: "No data";
+                            color: $light-grey;
+                        }
+
+                        & + .series-value {
+                            padding-left: 0.5em;
+                        }
+                    }
+
+                    td.time-notice {
+                        font-weight: $medium;
+                        text-indent: 20px;
+                        text-align: right;
+                        padding-right: 0;
+                        color: $grey;
+                    }
+
+                    // -- special row types --
+
+                    tr.blurred {
+                        color: $light-grey;
+                        .series-color .swatch {
+                            opacity: 0.25;
+                        }
+                        .series-name span {
+                            color: inherit;
+                        }
+                    }
+
+                    tr.spacer {
+                        line-height: 2px;
+                        font-size: 2px;
+                        &::before {
+                            content: "\00a0";
+                        }
+                    }
+
+                    tr.total {
+                        td {
+                            line-height: 14px;
+                        }
+                        td:nth-child(2),
+                        td:nth-child(3) {
+                            border-top: 1px solid $background-stroke;
+                            vertical-align: bottom;
+                        }
+                        td:last-child::before {
+                            content: "\200a";
+                            height: 5px;
+                            display: block;
+                        }
+                    }
+
+                    tr.total--top {
+                        td:nth-child(2),
+                        td:nth-child(3) {
+                            border-bottom: 1px solid $background-stroke;
+                            vertical-align: top;
+                        }
+                    }
+
+                    // highlight hovered row
+                    &.focal {
+                        tr:not(.focused, .total) td {
+                            opacity: 0.6;
+                        }
+
+                        td.series-value {
+                            font-weight: $medium;
+                        }
+
+                        tr.focused td {
+                            font-weight: $bold;
+
+                            .parenthetical {
+                                font-weight: $medium;
+                            }
+                            &.time-notice {
+                                font-weight: $medium;
+                            }
+                        }
+                    }
+
+                    // hide unused color swatch column
+                    &:not(.swatched) {
+                        td.series-color {
+                            display: none;
+                        }
+                    }
+
+                    // overlay a diagonal line pattern on striped swatches
+                    tr.striped .series-color .swatch::before {
+                        content: " ";
+                        position: absolute;
+                        width: 100%;
+                        height: 100%;
+                        @include diagonal-background(transparent, white);
+                    }
+
+                    tr.striped.blurred .series-color .swatch::before {
+                        @include diagonal-background($grey, white);
+                    }
+                }
+
+                .hoverIndicator circle {
+                    stroke-width: 1;
+                    r: 5px;
+                }
+            }
+
+            // tolerance captions w/ circle-i icon or projection warning with striped swatch
+            .endmatter {
+                position: relative;
+                color: $grey;
+                padding: 8px 12px;
+                border-radius: 0 0 3px 3px;
+                border-top: 1px solid $light-grey;
+
+                .icon {
+                    position: absolute;
                     width: 12px;
-                    height: 12px;
-                    display: inline-block;
-                    margin-right: 0.3em;
-                    text-align: left;
-                    position: relative;
-                }
-            }
 
-            td.series-name {
-                padding-right: 0.9em;
-                line-height: 16px;
-                width: 100%;
-                .parenthetical {
-                    color: $grey;
+                    &.stripes {
+                        content: " ";
+                        height: 12px;
+                        @include diagonal-background($grey, white);
+                    }
                 }
 
-                .annotation {
-                    display: block;
-                    color: $grey;
+                p {
                     font-size: 12px;
                     letter-spacing: 0.01em;
-                }
-            }
-
-            td.series-value {
-                font-weight: $bold;
-                text-align: right;
-                white-space: nowrap;
-
-                &.missing::before {
-                    content: "No data";
-                    color: $light-grey;
+                    line-height: 15px;
+                    margin: 0;
+                    max-width: 260px;
                 }
 
-                & + .series-value {
-                    padding-left: 0.5em;
-                }
-            }
-
-            td.time-notice {
-                font-weight: $medium;
-                text-indent: 20px;
-                text-align: right;
-                padding-right: 0;
-                color: $grey;
-            }
-
-            // -- special row types --
-
-            tr.blurred {
-                color: $light-grey;
-                .series-color .swatch {
-                    opacity: 0.25;
-                }
-                .series-name span {
-                    color: inherit;
-                }
-            }
-
-            tr.spacer {
-                line-height: 2px;
-                font-size: 2px;
-                &::before {
-                    content: "\00a0";
-                }
-            }
-
-            tr.total {
-                td {
-                    line-height: 14px;
-                }
-                td:nth-child(2),
-                td:nth-child(3) {
-                    border-top: 1px solid $background-stroke;
-                    vertical-align: bottom;
-                }
-                td:last-child::before {
-                    content: "\200a";
-                    height: 5px;
-                    display: block;
-                }
-            }
-
-            // highlight hovered row
-            &.focal {
-                tr:not(.focused, .total) td {
-                    opacity: 0.6;
-                }
-
-                td.series-value {
-                    font-weight: $medium;
-                }
-
-                tr.focused td {
-                    font-weight: $bold;
-
-                    .parenthetical {
-                        font-weight: $medium;
+                // add boilerplate around time value for tolerance notices
+                p.tolerance {
+                    &::before {
+                        content: "Data not available for ";
                     }
-                    &.time-notice {
-                        font-weight: $medium;
-                    }
-                }
-            }
-
-            // hide unused color swatch column
-            &:not(.swatched) {
-                td.series-color {
-                    display: none;
-                }
-            }
-
-            // overlay a diagonal line pattern on striped swatches
-            tr.striped .series-color .swatch::before {
-                content: " ";
-                position: absolute;
-                width: 100%;
-                height: 100%;
-                @include diagonal-background(transparent, white);
-            }
-
-            tr.striped.blurred .series-color .swatch::before {
-                @include diagonal-background($grey, white);
-            }
-        }
-
-        .hoverIndicator circle {
-            stroke-width: 1;
-            r: 5px;
-        }
-    }
-
-    // tolerance captions w/ circle-i icon or projection warning with striped swatch
-    .endmatter {
-        position: relative;
-        color: $grey;
-        padding: 8px 12px;
-        border-radius: 0 0 3px 3px;
-        border-top: 1px solid $light-grey;
-
-        .icon {
-            position: absolute;
-            width: 12px;
-
-            &.stripes {
-                content: " ";
-                height: 12px;
-                @include diagonal-background($grey, white);
-            }
-        }
-
-        p {
-            font-size: 12px;
-            letter-spacing: 0.01em;
-            line-height: 15px;
-            margin: 0;
-            max-width: 260px;
-        }
-
-        // add boilerplate around time value for tolerance notices
-        p.tolerance {
-            &::before {
-                content: "Data not available for ";
-            }
-            &::after {
-                content: ". Showing closest available data point instead";
-            }
-        }
-
-        .icon ~ p {
-            padding-left: 19px;
-        }
-    }
-
-    // class names passed to the `dissolve` prop control fade-out timing
-    &.dissolve {
-        opacity: 0;
-        transition: opacity $fade-time $fade-delay;
-        &.immediate {
-            transition: opacity $fade-time;
-        }
-    }
-
-    //
-    // ‘TEMPORARY’ FIX:
-    // Until the map variable displayNames can be copy-edited, hide the variable name entirely
-    // and use just the unit (if present) as a label
-    //
-    &#mapTooltip {
-        .variable .definition {
-            .name {
-                display: none;
-            }
-
-            .unit::after,
-            .unit::before {
-                content: none;
-            }
-        }
-    }
-}
-
-// adapt to smaller display areas
-@container grapher (max-width:900px) {
-    .Tooltip {
-        .content {
-            padding: 4px 12px;
-            .variable .values {
-                font-size: 16px;
-                line-height: 18px;
-                svg.arrow {
-                    height: 12px;
-                    padding-right: 2px;
-                }
-            }
-
-            .variable + .variable {
-                padding-top: 4px;
-            }
-
-            table.series-list {
-                font-size: 12px;
-                line-height: 18px;
-                letter-spacing: 0.01em;
-
-                tr.total {
-                    td:last-child::before {
-                        height: 4px;
+                    &::after {
+                        content: ". Showing closest available data point instead";
                     }
                 }
 
-                td.series-name .annotation {
-                    font-size: 10px;
-                    line-height: 12px;
+                .icon ~ p {
+                    padding-left: 19px;
+                }
+            }
+
+            // class names passed to the `dissolve` prop control fade-out timing
+            &.dissolve {
+                opacity: 0;
+                transition: opacity $fade-time $fade-delay;
+                &.immediate {
+                    transition: opacity $fade-time;
+                }
+            }
+
+            //
+            // ‘TEMPORARY’ FIX:
+            // Until the map variable displayNames can be copy-edited, hide the variable name entirely
+            // and use just the unit (if present) as a label
+            //
+            &#mapTooltip {
+                .variable .definition {
+                    .name {
+                        display: none;
+                    }
+
+                    .unit::after,
+                    .unit::before {
+                        content: none;
+                    }
+                }
+            }
+        }
+
+        // adapt to smaller display areas
+        @container grapher (max-width:900px) {
+            .Tooltip {
+                .content {
+                    padding: 4px 12px;
+                    .variable .values {
+                        font-size: 16px;
+                        line-height: 18px;
+                        svg.arrow {
+                            height: 12px;
+                            padding-right: 2px;
+                        }
+                    }
+
+                    .variable + .variable {
+                        padding-top: 4px;
+                    }
+
+                    table.series-list {
+                        font-size: 12px;
+                        line-height: 18px;
+                        letter-spacing: 0.01em;
+
+                        tr.total {
+                            td:last-child::before {
+                                height: 4px;
+                            }
+                        }
+
+                        td.series-name .annotation {
+                            font-size: 10px;
+                            line-height: 12px;
+                        }
+                    }
                 }
             }
         }

--- a/packages/@ourworldindata/grapher/src/tooltip/Tooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/tooltip/Tooltip.tsx
@@ -206,7 +206,8 @@ export class TooltipContainer extends React.Component<{
     containerHeight?: number // only relevant for tooltips anchored to the mouse
 }> {
     @action.bound private onDocumentClick(e: MouseEvent): void {
-        const { tooltip } = this.props.tooltipProvider
+        const { tooltip: tooltipBox } = this.props.tooltipProvider
+        const tooltip = tooltipBox?.get()
         if (!tooltip) return
         if (tooltip.dismissOnDocumentClick) tooltip.dismiss?.()
         e.stopPropagation()
@@ -229,7 +230,8 @@ export class TooltipContainer extends React.Component<{
     }
 
     @computed private get rendered(): React.ReactElement | null {
-        const { tooltip } = this.props.tooltipProvider
+        const { tooltip: tooltipBox } = this.props.tooltipProvider
+        const tooltip = tooltipBox?.get()
         if (!tooltip) return null
         return (
             <TooltipContext.Provider
@@ -265,11 +267,11 @@ export class Tooltip extends React.Component<TooltipProps> {
     }
 
     @action.bound private connectTooltipToContainer(): void {
-        this.props.tooltipManager.tooltip = this.props
+        this.props.tooltipManager.tooltip?.set(this.props)
     }
 
     @action.bound private removeToolTipFromContainer(): void {
-        this.props.tooltipManager.tooltip = undefined
+        this.props.tooltipManager.tooltip?.set(undefined)
     }
 
     componentDidUpdate(): void {

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipProps.ts
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipProps.ts
@@ -1,6 +1,10 @@
+import React from "react"
 import { ObservableMap } from "mobx"
 import { CoreColumn } from "@ourworldindata/core-table"
-import { TickFormattingOptions } from "@ourworldindata/utils"
+import {
+    GrapherTooltipAnchor,
+    TickFormattingOptions,
+} from "@ourworldindata/utils"
 
 // We can't pass the property directly because we need it to be observable.
 export interface TooltipManager {
@@ -26,6 +30,8 @@ export interface TooltipProps {
     dissolve?: TooltipFadeMode // flag that the tooltip should begin fading out
     tooltipManager: TooltipManager
     children?: React.ReactNode
+    dismiss?: () => void
+    dismissOnDocumentClick?: boolean
 }
 
 export interface TooltipValueProps {
@@ -64,3 +70,7 @@ export interface TooltipTableData {
     value: number
     fake?: boolean
 }
+
+export const TooltipContext = React.createContext<{
+    anchor?: GrapherTooltipAnchor
+}>({})

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipProps.ts
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipProps.ts
@@ -4,10 +4,11 @@ import {
     GrapherTooltipAnchor,
     TickFormattingOptions,
 } from "@ourworldindata/utils"
+import { IObservableValue } from "mobx"
 
 // We can't pass the property directly because we need it to be observable.
 export interface TooltipManager {
-    tooltip?: TooltipProps
+    tooltip?: IObservableValue<TooltipProps | undefined>
 }
 
 export interface TooltipOptions {

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipProps.ts
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipProps.ts
@@ -1,5 +1,4 @@
 import React from "react"
-import { ObservableMap, IObservableValue } from "mobx"
 import { CoreColumn } from "@ourworldindata/core-table"
 import {
     GrapherTooltipAnchor,
@@ -8,8 +7,7 @@ import {
 
 // We can't pass the property directly because we need it to be observable.
 export interface TooltipManager {
-    tooltips?: ObservableMap<TooltipProps["id"], TooltipProps>
-    activeTooltipId?: IObservableValue<TooltipProps["id"] | undefined>
+    tooltip?: TooltipProps
 }
 
 export interface TooltipOptions {

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipProps.ts
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipProps.ts
@@ -1,5 +1,5 @@
 import React from "react"
-import { ObservableMap } from "mobx"
+import { ObservableMap, IObservableValue } from "mobx"
 import { CoreColumn } from "@ourworldindata/core-table"
 import {
     GrapherTooltipAnchor,
@@ -9,6 +9,11 @@ import {
 // We can't pass the property directly because we need it to be observable.
 export interface TooltipManager {
     tooltips?: ObservableMap<TooltipProps["id"], TooltipProps>
+    activeTooltipId?: IObservableValue<TooltipProps["id"] | undefined>
+}
+
+export interface TooltipOptions {
+    allowMultiple?: boolean
 }
 
 export type TooltipFadeMode = "delayed" | "immediate" | "none"

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -190,6 +190,13 @@ export enum ScatterPointLabelStrategy {
     y = "y",
 }
 
+export enum GrapherTooltipAnchor {
+    // the tooltip is positioned relative to the mouse cursor
+    mouse = "mouse",
+    // the tooltip is fixed to the bottom of the screen
+    bottom = "bottom",
+}
+
 export interface AnnotationFieldsInTitle {
     entity?: boolean
     time?: boolean

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -111,6 +111,7 @@ export {
     type ChartRedirect,
     type DetailsMarker,
     GrapherWindowType,
+    GrapherTooltipAnchor,
 } from "./grapherTypes/GrapherTypes.js"
 
 export {


### PR DESCRIPTION
Makes it so that mobile tooltips stick to the bottom (see screenshot below).

Notes:
- If the tooltip content is taller than the allowed max-width, then the tooltip becomes scrollable (that's why the tooltip stays on screen even after an interaction has ended; the tooltip can be dismissed by clicking anywhere on the screen)
- For tooltips that have a "total" row (e.g. stacked area charts), the total row is moved to the top for mobile tooltips (so that it's visible by default, even if the tooltip is scrollable)
- Tooltips are automatically dismissed when the Grapher is scrolled out of view
    - This works by utilizing Grapher's intersection observer. There was a weird bug on iOS Safari where the intersection observer simply didn't fire when Grapher was out of view. For some reason, that doesn't happen if the threshold is set to some small number (instead of 0, which is the default)
    - Ideally, I would want to dismiss tooltips a bit earlier, but I didn't want to set up a second intersection observer just for that...
    - Note that previously, after scrolling a Grapher into view, we would disconnect the intersection observer. Now, we keep it around – I don't think this should be a problem, but wanted to mention it.

To do:
- Map tooltips are broken

<img width="382" alt="Screenshot 2024-06-05 at 14 54 46" src="https://github.com/owid/owid-grapher/assets/12461810/9c946bfc-7346-43de-b6ed-74a59ac56316">
