### PR TITLE
✨ (marimekko) use country short names as labels / TAS-523

### DIFF
--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartConstants.ts
@@ -71,11 +71,13 @@ export interface PlacedItem extends Item {
 
 export interface EntityWithSize {
     entityName: string
+    shortEntityName?: string
     xValue: number
     ySortValue: number | undefined
 }
 export interface LabelCandidate {
     item: EntityWithSize
+    label: string
     bounds: Bounds
     isPicked: boolean
     isSelected: boolean

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -246,6 +246,7 @@ export {
     countries,
     type Country,
     getCountryBySlug,
+    getCountryByName,
     getRegionByNameOrVariantName,
     isCountryName,
     continents,

--- a/packages/@ourworldindata/utils/src/regions.ts
+++ b/packages/@ourworldindata/utils/src/regions.ts
@@ -63,6 +63,10 @@ export const continents: Continent[] = entities.filter(
     (entity) => entity.regionType === "continent"
 ) as Continent[]
 
+const countriesByName: Record<string, Country> = Object.fromEntries(
+    countries.map((country) => [country.name, country])
+)
+
 const countriesBySlug: Record<string, Country> = Object.fromEntries(
     countries.map((country) => [country.slug, country])
 )
@@ -85,6 +89,9 @@ const currentAndHistoricalCountryNames = regions
 
 export const isCountryName = (name: string): boolean =>
     currentAndHistoricalCountryNames.includes(name.toLowerCase())
+
+export const getCountryByName = (name: string): Country | undefined =>
+    countriesByName[name]
 
 export const getCountryBySlug = (slug: string): Country | undefined =>
     countriesBySlug[slug]


### PR DESCRIPTION
Improves #3683 

Uses a country's short name for Marimekko labels if the entity name is long. For now, we only have a single short name, `DR Congo`, but it's a good one.

We could also use the regions.json `variantNames`, but these are meant to be used as search aliases, so I don't think we should use them as label variants. But I hope that we add more short names in the future :)