### PR TITLE
✨ (grapher) allow line breaks after hyphens / TAS-524

### DIFF
--- a/packages/@ourworldindata/components/src/TextWrap/TextWrapUtils.test.ts
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrapUtils.test.ts
@@ -1,0 +1,43 @@
+#! /usr/bin/env jest
+
+import { joinFragments, splitIntoFragments } from "./TextWrapUtils"
+
+it("splits text correctly into fragments", () => {
+    expect(splitIntoFragments("")).toEqual([])
+    expect(splitIntoFragments("word")).toEqual([
+        { text: "word", separator: "" },
+    ])
+    expect(splitIntoFragments("an example line")).toEqual([
+        { text: "an", separator: " " },
+        { text: "example", separator: " " },
+        { text: "line", separator: "" },
+    ])
+    expect(splitIntoFragments("high-income countries")).toEqual([
+        { text: "high-income", separator: " " },
+        { text: "countries", separator: "" },
+    ])
+    expect(splitIntoFragments("high-income countries", [" ", "-"])).toEqual([
+        { text: "high", separator: "-" },
+        { text: "income", separator: " " },
+        { text: "countries", separator: "" },
+    ])
+})
+
+it("splits and joins text correctly into fragments", () => {
+    const examples = [
+        "",
+        "word",
+        "an example line",
+        "an example    spaced   out text",
+        "an example-with-hyphens",
+        "an example - with - a - differennt - kind-of - hyphen",
+        "hyphen at the end -",
+        "a mixed-bag - ok",
+    ]
+    for (const text of examples) {
+        expect(joinFragments(splitIntoFragments(text))).toEqual(text)
+        expect(joinFragments(splitIntoFragments(text, [" ", "-"]))).toEqual(
+            text
+        )
+    }
+})

--- a/packages/@ourworldindata/components/src/TextWrap/TextWrapUtils.ts
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrapUtils.ts
@@ -1,0 +1,32 @@
+import { isEmpty } from "@ourworldindata/utils"
+
+export type Fragment = {
+    text: string
+    separator: string
+}
+
+export function splitIntoFragments(
+    text: string,
+    separators = [" "]
+): Fragment[] {
+    if (isEmpty(text)) return []
+    const fragments: Fragment[] = []
+    let currText = ""
+    for (const char of text) {
+        if (separators.includes(char)) {
+            fragments.push({ text: currText, separator: char })
+            currText = ""
+        } else {
+            currText += char
+        }
+    }
+    fragments.push({ text: currText, separator: "" })
+    return fragments
+}
+
+export function joinFragments(fragments: Fragment[]): string {
+    return fragments
+        .map(({ text, separator }) => text + separator)
+        .join("")
+        .trim()
+}

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -925,6 +925,7 @@ class LabelledSlopes
                 ...valueLabelProps,
                 maxWidth,
                 fontWeight: 700,
+                separators: [" ", "-"],
             }
             const leftEntityLabel = new TextWrap({
                 text,


### PR DESCRIPTION
### Summary

Adds the ability to break after hyphens (`-`) to `TextWrap`. This is then used for slope labels to reduce the space we need for the labels on both sides.

I considered making this the default but decided against it because many labels looked worse / less balanced with additional line breaks after hyphens.

### SVG tester

Some charts come back with a difference, but they're visually the same. The new code trims whitespace from each side:

```
Svg was different for 2649. The difference starts at character 15152.
Reference: 5" y="465.895">home) </tspan></text></g>
Current  : 5" y="465.895">home)</tspan></text></g><
```

```
Svg was different for 3552. The difference starts at character 11307.
Reference: "4.995000000000001"> Lower respiratory i
Current  : "4.995000000000001">Lower respiratory in
```

```
Svg was different for 5215. The difference starts at character 8953.
Reference: urement policies and </tspan><tspan x="1
Current  : urement policies and</tspan><tspan x="16
```

### Screenshots

| Before  | After  |
| ------- | ------ |
| <img width="326" alt="Screenshot 2024-06-05 at 16 46 18" src="https://github.com/owid/owid-grapher/assets/12461810/5da4072f-c8ec-4993-a1d0-74d74e01169b">  | <img width="326" alt="Screenshot 2024-06-05 at 16 46 12" src="https://github.com/owid/owid-grapher/assets/12461810/27f4a626-769c-4f84-a865-c334633599e3"> |

Example chart: https://ourworldindata.org/grapher/maternal-mortality-slope-chart?country=High-income+countries~Lower-middle-income+countries
