### PR TITLE
🐛 remove obsolete rebuild table that results in undefined variable

### DIFF
--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -162,7 +162,7 @@ class DimensionSlotView extends React.Component<{
             dimensions: grapher.dimensions.map((dim) => dim.toObject()),
         })
         grapher.seriesColorMap?.clear()
-        this.grapher.rebuildInputOwidTable()
+        //this.grapher.rebuildInputOwidTable()
     }
 
     @action.bound private onDragEnd(result: DropResult) {


### PR DESCRIPTION
While debugging the chart issue that turned out to be an OOM problem I realized that the admin calls rebuildInputOwidTable explicitly at a point when the data for the newly added indicators isn't yet available. It is called again later, I think throuh a reaction.

This PR thus removes what I think is a redudant and semantically misplaced call.