### PR TITLE
fix: only update legacy entity-dimension pair if entity contains non-numeric character

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/EntityUrlBuilder.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/EntityUrlBuilder.test.ts
@@ -4,6 +4,7 @@ import { Url } from "@ourworldindata/utils"
 import {
     ENTITY_V2_DELIMITER,
     getSelectedEntityNamesParam,
+    migrateSelectedEntityNamesParam,
     setSelectedEntityNamesParam,
 } from "./EntityUrlBuilder"
 
@@ -74,7 +75,9 @@ encodeTests.forEach((testCase) => {
     it(`correctly decodes url strings`, () => {
         expect(
             getSelectedEntityNamesParam(
-                Url.fromQueryStr(testCase.inputQueryStr)
+                migrateSelectedEntityNamesParam(
+                    Url.fromQueryStr(testCase.inputQueryStr)
+                )
             )
         ).toEqual(testCase.entities)
     })
@@ -99,7 +102,11 @@ describe("legacyLinks", () => {
     legacyLinks.forEach((testCase) => {
         it(`correctly decodes legacy url strings`, () => {
             expect(
-                getSelectedEntityNamesParam(Url.fromQueryStr(testCase.queryStr))
+                getSelectedEntityNamesParam(
+                    migrateSelectedEntityNamesParam(
+                        Url.fromQueryStr(testCase.queryStr)
+                    )
+                )
             ).toEqual(testCase.entities)
         })
     })
@@ -133,7 +140,9 @@ describe("it can handle legacy urls with dimension in selection key", () => {
         ].join(ENTITY_V2_DELIMITER),
     })
 
-    const results = getSelectedEntityNamesParam(url)
+    const results = getSelectedEntityNamesParam(
+        migrateSelectedEntityNamesParam(url)
+    )
 
     expect(results).toEqual([
         "United States",

--- a/packages/@ourworldindata/grapher/src/core/EntityUrlBuilder.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/EntityUrlBuilder.test.ts
@@ -141,7 +141,6 @@ describe("it can handle legacy urls with dimension in selection key", () => {
         "GBR-0",
         "United Kingdom",
         "1980-1989",
-        "1980",
         "NotFound",
     ])
 })

--- a/packages/@ourworldindata/grapher/src/core/EntityUrlBuilder.ts
+++ b/packages/@ourworldindata/grapher/src/core/EntityUrlBuilder.ts
@@ -54,6 +54,7 @@ const entityNamesFromV2Param = (queryParam: string): EntityName[] => {
 
 const migrateV1Delimited: UrlMigration = (url) => {
     const { country } = url.encodedQueryParams
+
     if (country !== undefined && isV1Param(country)) {
         return url.updateQueryParams({
             country: entityNamesToV2Param(
@@ -87,7 +88,8 @@ const migrateV1Delimited: UrlMigration = (url) => {
  *
  */
 
-const LegacyDimensionRegex = /\-\d+$/
+// Pattern for a entity name - number pair, where the entity name contains at least one non-digit character.
+const LegacyDimensionRegex = /^(.*\D.*)\-\d+$/
 
 const injectEntityNamesInLegacyDimension = (
     entityNames: EntityName[]
@@ -100,7 +102,7 @@ const injectEntityNamesInLegacyDimension = (
         if (LegacyDimensionRegex.test(entityName)) {
             const nonDimensionName = entityName.replace(
                 LegacyDimensionRegex,
-                ""
+                "$1"
             )
             newNames.push(nonDimensionName)
         }

--- a/packages/@ourworldindata/grapher/src/core/EntityUrlBuilder.ts
+++ b/packages/@ourworldindata/grapher/src/core/EntityUrlBuilder.ts
@@ -146,7 +146,8 @@ export const migrateSelectedEntityNamesParam: UrlMigration = (
 export const getSelectedEntityNamesParam = (
     url: Url
 ): EntityName[] | undefined => {
-    const { country } = migrateSelectedEntityNamesParam(url).queryParams
+    // Expects an already-migrated URL as input
+    const { country } = url.queryParams
     return country !== undefined
         ? entityNamesFromV2Param(country).map(codeToEntityName)
         : undefined
@@ -156,7 +157,8 @@ export const setSelectedEntityNamesParam = (
     url: Url,
     entityNames: EntityName[] | undefined
 ): Url => {
-    return migrateSelectedEntityNamesParam(url).updateQueryParams({
+    // Expects an already-migrated URL as input
+    return url.updateQueryParams({
         country: entityNames
             ? entityNamesToV2Param(entityNames.map(entityNameToCode))
             : undefined,


### PR DESCRIPTION
Fixes #3704.