### PR TITLE
🐛 (tooltip) fix missing display names

### DIFF
--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
@@ -179,7 +179,7 @@ export class TooltipTable extends React.Component<TooltipTableProps> {
                             swatch = "transparent",
                         } = row
                         const [_m, seriesName, seriesParenthetical] =
-                            name.match(/^(.*?)(\([^()]*\))?$/) ?? []
+                            name.trim().match(/^(.*?)(\([^()]*\))?$/) ?? []
 
                         return (
                             <tr


### PR DESCRIPTION
Fixes an issue where the tooltip doesn't show a variable's display name because it contains a new line character at the end (which throws off the regex)

Chart: https://ourworldindata.org/grapher/people-living-in-democracies-autocracies-simplified-lexical?stackMode=relative

![image](https://github.com/owid/owid-grapher/assets/12461810/f6b66dff-d97c-41be-9518-888e2784121b)
