### PR TITLE
🎉 Add NTDs & Wildfires topic pages to the menu

### DIFF
--- a/site/SiteNavigation.tsx
+++ b/site/SiteNavigation.tsx
@@ -422,6 +422,10 @@ export const SiteNavigationStatic: { categories: CategoryWithEntries[] } = {
                             slug: "smallpox",
                             title: "Smallpox",
                         },
+                        {
+                            slug: "neglected-tropical-diseases",
+                            title: "Neglected Tropical Diseases",
+                        },
                     ],
                 },
                 {

--- a/site/SiteNavigation.tsx
+++ b/site/SiteNavigation.tsx
@@ -604,6 +604,10 @@ export const SiteNavigationStatic: { categories: CategoryWithEntries[] } = {
                             title: "Natural Disasters",
                         },
                         {
+                            slug: "wildfires",
+                            title: "Wildfires",
+                        },
+                        {
                             slug: "biodiversity",
                             title: "Biodiversity",
                         },


### PR DESCRIPTION
On Monday, we'll launch a new topic page on Neglected Tropical Diseases, and recently, we launched another topic page on Wildfires. Both need to be added to our menu. 

@ikesau We shouldn't merge before Monday, but can you please confirm this is the right way to do this?

(cc @paarriagadap @pabloarosado @veronikasamborska1994 @spoonerf @lucasrodes — we should remember to do this now!)