### PR TITLE
db: add index on `posts_gdocs.slug` column

### DIFF
--- a/db/migration/1718371124648-AddGdocsPostsSlugIndex.ts
+++ b/db/migration/1718371124648-AddGdocsPostsSlugIndex.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddGdocsPostsSlugIndex1718371124648 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE posts_gdocs ADD INDEX idx_posts_gdocs_slug (slug(100));
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            DROP INDEX idx_posts_gdocs_slug ON posts_gdocs;
+        `)
+    }
+}


### PR DESCRIPTION
Noticed that we don't have an index for that column yet, and it seems super sensible to have one 👀
