### PR TITLE
garden: remove unneeded DB column

### DIFF
--- a/db/migration/1720038601815-RemoveEntitiesDisplayName.ts
+++ b/db/migration/1720038601815-RemoveEntitiesDisplayName.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class RemoveEntitiesDisplayName1720038601815 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        "ALTER TABLE entites DROP COLUMN displayName"
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        "ALTER TABLE entites ADD COLUMN displayName"
+    }
+}

--- a/db/migration/1720038601815-RemoveEntitiesDisplayName.ts
+++ b/db/migration/1720038601815-RemoveEntitiesDisplayName.ts
@@ -3,10 +3,18 @@ import { MigrationInterface, QueryRunner } from "typeorm";
 export class RemoveEntitiesDisplayName1720038601815 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        "ALTER TABLE entites DROP COLUMN displayName"
+        await queryRunner.query(`
+            ALTER TABLE entities
+                DROP COLUMN
+                displayName`
+        )
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        "ALTER TABLE entites ADD COLUMN displayName"
+        await queryRunner.query(`
+            ALTER TABLE entities
+                ADD COLUMN
+                displayName`
+        )
     }
 }

--- a/db/migration/1720038601815-RemoveEntitiesDisplayName.ts
+++ b/db/migration/1720038601815-RemoveEntitiesDisplayName.ts
@@ -14,7 +14,7 @@ export class RemoveEntitiesDisplayName1720038601815 implements MigrationInterfac
         await queryRunner.query(`
             ALTER TABLE entities
                 ADD COLUMN
-                displayName`
+                displayName varchar(255) COLLATE utf8mb4_0900_as_cs NOT NULL`
         )
     }
 }


### PR DESCRIPTION
Fixes #3169 

By dropping the column, any data is lost and won't be retrieved by the `down` side of the migration. If the column was truly never used then fair enough, but users find ways of doing usefuly stuff with what they find so I wanted to check that before merging

- [ ] impact of column drop on live users passed "not an impact" - preferably in the production DB, with this being 10 years of work, better be safe than in a mess with DBs.

I have checked this table locally and it's not got anything in it, **and now it's gone**

Bit of a "gotcha" having to run `yarn runDbMigrations` - I'm sure you all know, but it doesn't hurt to remind

<img width="1063" alt="image" src="https://github.com/owid/owid-grapher/assets/10499070/e31278f1-f999-436f-b642-6e463783e69e">
