### PR TITLE
fix(search): fix search highlighting of entities containing stop words

### DIFF
--- a/site/search/SearchPanel.tsx
+++ b/site/search/SearchPanel.tsx
@@ -74,6 +74,7 @@ import {
     extractRegionNamesFromSearchQuery,
     pickEntitiesForChartHit,
 } from "./SearchUtils.js"
+import { HitAttributeHighlightResult } from "instantsearch.js"
 
 const siteAnalytics = new SiteAnalytics()
 
@@ -131,14 +132,30 @@ const getEntityQueryStr = (
     }
 }
 
-function ChartHit({ hit }: { hit: IChartHit }) {
+function ChartHit({
+    hit,
+    searchQueryRegionsMatches,
+}: {
+    hit: IChartHit
+    searchQueryRegionsMatches?: Region[] | undefined
+}) {
     const [imgLoaded, setImgLoaded] = useState(false)
     const [imgError, setImgError] = useState(false)
 
     const entities = useMemo(
-        () => pickEntitiesForChartHit(hit),
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [hit._highlightResult?.availableEntities]
+        () =>
+            pickEntitiesForChartHit(
+                hit._highlightResult?.availableEntities as
+                    | HitAttributeHighlightResult[]
+                    | undefined,
+                hit.availableEntities,
+                searchQueryRegionsMatches
+            ),
+        [
+            hit._highlightResult?.availableEntities,
+            hit.availableEntities,
+            searchQueryRegionsMatches,
+        ]
     )
     const queryStr = useMemo(() => getEntityQueryStr(entities), [entities])
     const previewUrl = queryStr
@@ -702,13 +719,20 @@ const SearchResults = (props: SearchResultsProps) => {
                                 />
                             </div>
                         </header>
-                        <Hits
+                        <Hits<IChartHit>
                             classNames={{
                                 root: "search-results__list-container",
                                 list: "search-results__charts-list grid grid-cols-4 grid-sm-cols-2",
                                 item: "search-results__chart-hit span-md-cols-2",
                             }}
-                            hitComponent={ChartHit}
+                            hitComponent={(props) => (
+                                <ChartHit
+                                    {...props}
+                                    searchQueryRegionsMatches={
+                                        searchQueryRegionsMatches
+                                    }
+                                />
+                            )}
                         />
                     </section>
                 </NoResultsBoundary>

--- a/site/search/SearchUtils.tsx
+++ b/site/search/SearchUtils.tsx
@@ -8,6 +8,28 @@ import {
     removeTrailingParenthetical,
 } from "@ourworldindata/utils"
 
+/**
+ * The below code is used to search for entities we can highlight in charts and explorer results.
+ *
+ * There are two main functions here:
+ * - `extractRegionNamesFromSearchQuery` looks at the search query (e.g. "covid cases us china asia") and extracts anything
+ *   that looks like a country, region or variant name (e.g. "US"), case-insensitive.
+ *   It doesn't have any knowledge of what entities are actually available.
+ * - `pickEntitiesForChartHit` gets information about the entities available in a chart.
+ *    It also receives the result of `extractRegionNamesFromSearchQuery`, i.e. a list of regions that are mentioned in the search query.
+ *    This is useful because Algolia removes stop words like "the" and "and", which makes it difficult to match entities like
+ *    "Trinidad and Tobago".
+ *    - It then reduces this list to the entities that are actually available in the chart.
+ *    - Afterwards, it uses the highlighted entities from Algolia to pick any other entities that are fully contained in the
+ *      search query - this now adds any entities _not_ in the `regions` list, like "high-income countries" or "Salmon (farmed)".
+ *
+ * In practice, we use `pickEntitiesForChartHit` for explorers, since there we don't have any entity information available,
+ * and can only act based on the fact that most explorers are country-based and have data for most countries and regions.
+ * For charts, we use the more accurate `pickEntitiesForChartHit` function, since entity information is available.
+ *
+ * -- @marcelgerber, 2024-06-18
+ */
+
 const allCountryNamesAndVariants = regions.flatMap((c) => [
     c.name,
     ...(("variantNames" in c && c.variantNames) || []),


### PR DESCRIPTION
So, earlier today when we were talking about search, I assured Lars that "yes, we can now match all kinds of entities in search queries". I realized shortly thereafter that this wasn't the case.

The problem is that for countries like "Trinidad **_and_** Tobago" or "Saint Vincent **_and the_** Grenadines", Algolia would remove stop words from the highlighted results, and then the matching based on highlighted results wouldn't include them.

I now fixed this by _also_ running the "dumber" `extractRegionNamesFromSearchQuery`, for a first pass of matching country/region names that's purely based on the search query.
Only after that will it run the other matching logic (in order to also catch non-region matches, like `Salmon (farmed)` or also `Africa (UN)`).
This now means that non-country entities that contain a stop word will not be matched - something like `Salmon and tuna`, maybe - but I think this is very much acceptable.

There's a big code comment now explaining the rationale for all this logic, hope that one mostly clears it up!

## Before / After

![CleanShot 2024-06-18 at 18 04 41](https://github.com/owid/owid-grapher/assets/2641501/72a000e6-de9a-4e04-9c33-f114b288ffd9)

[Link](https://ourworldindata.org/search?q=saint%20vincent%20and%20the%20grenadines%2C%20trinidad%20and%20tobago%2C%20china%2C%20us)