### PR TITLE
🎉 (stacked bar) add neg/pos color encoding / TAS-547

### DIFF
--- a/packages/@ourworldindata/grapher/src/chart/ChartInterface.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartInterface.ts
@@ -26,6 +26,7 @@ export interface ChartInterface {
     transformedTable: OwidTable // Points to the OwidTable after the chart has transformed the input table. The chart may add a relative transform, for example. Standardized as part of the interface as a development aid.
 
     colorScale?: ColorScale
+    shouldUseValueBasedColorScheme?: boolean // Opt-out of assigned colors and use a value-based color scheme instead
 
     seriesStrategy?: SeriesStrategy
     series: readonly ChartSeries[] // This points to the marks that the chart will render. They don't have to be placed yet. Standardized as part of the interface as a development aid.

--- a/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
@@ -50,6 +50,11 @@ export interface ChartManager {
     colorScaleColumnOverride?: CoreColumn
     // for passing colorScale to sparkline in map charts
     colorScaleOverride?: ColorScale
+    // If you want to use auto-assigned colors, but then have them preserved across selection and chart changes
+    seriesColorMap?: SeriesColorMap
+    // If you want to opt out of assigned colors and use a value-based color scheme instead
+    // (e.g. stacked bar charts coloring positive/negative values differently)
+    useValueBasedColorScheme?: boolean
 
     yAxisConfig?: Readonly<AxisConfigInterface>
     xAxisConfig?: Readonly<AxisConfigInterface>
@@ -64,9 +69,6 @@ export interface ChartManager {
 
     selection?: SelectionArray | EntityName[]
     entityType?: string
-
-    // If you want to use auto-assigned colors, but then have them preserved across selection and chart changes
-    seriesColorMap?: SeriesColorMap
 
     hidePoints?: boolean // for line options
     startHandleTimeBound?: TimeBound // for relative-to-first-year line chart

--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
@@ -344,6 +344,13 @@ export class FacetChart
     // Only made public for testing
     @computed get placedSeries(): PlacedFacetSeries[] {
         const { intermediateChartInstances } = this
+
+        // If one of the charts should use a value-based color scheme,
+        // switch them all over for consistency
+        const useValueBasedColorScheme = intermediateChartInstances.some(
+            (instance) => instance.shouldUseValueBasedColorScheme
+        )
+
         // Define the global axis config, shared between all facets
         const sharedAxesSizes: PositionMap<number> = {}
 
@@ -437,6 +444,7 @@ export class FacetChart
             // We need to preserve most config coming in.
             const manager = {
                 ...series.manager,
+                useValueBasedColorScheme,
                 externalLegendFocusBin: this.legendFocusBin,
                 xAxisConfig: {
                     hideAxis: shouldHideFacetAxis(

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -394,12 +394,13 @@ export class StackedBarChart
                     columns={[formatColumn]}
                     totals={[totalValue]}
                     rows={sortedHoverPoints.map(
-                        ({ point, seriesName: name, seriesColor: swatch }) => {
+                        ({ point, seriesName: name, seriesColor }) => {
                             const focused = hoverSeries?.seriesName === name
                             const blurred = point?.fake ?? true
                             const values = [
                                 point?.fake ? undefined : point?.value,
                             ]
+                            const swatch = point?.color ?? seriesColor
 
                             return { name, swatch, blurred, focused, values }
                         }
@@ -641,7 +642,7 @@ export class StackedBarChart
                                         <StackedBarSegment
                                             key={index}
                                             bar={bar}
-                                            color={series.color}
+                                            color={bar.color ?? series.color}
                                             xOffset={xPos}
                                             opacity={barOpacity}
                                             yAxis={verticalAxis}
@@ -691,6 +692,25 @@ export class StackedBarChart
     }
 
     defaultBaseColorScheme = ColorSchemeName.stackedAreaDefault
+
+    /**
+     * Colour positive and negative values differently if there is only one series
+     * (and that series has both positive and negative values)
+     */
+    @computed get shouldUseValueBasedColorScheme(): boolean {
+        return (
+            this.rawSeries.length === 1 &&
+            this.rawSeries[0].rows.some((row) => row.value < 0) &&
+            this.rawSeries[0].rows.some((row) => row.value > 0)
+        )
+    }
+
+    @computed get useValueBasedColorScheme(): boolean {
+        return (
+            this.manager.useValueBasedColorScheme ||
+            this.shouldUseValueBasedColorScheme
+        )
+    }
 
     @computed get series(): readonly StackedSeries<number>[] {
         // TODO: remove once monthly data is supported (https://github.com/owid/owid-grapher/issues/2007)

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedConstants.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedConstants.ts
@@ -13,6 +13,7 @@ export interface StackedPoint<PositionType extends StackedPointPositionType> {
     time: number
     interpolated?: boolean
     fake?: boolean
+    color?: string
 }
 
 export interface StackedSeries<PositionType extends StackedPointPositionType>

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.ts
@@ -96,6 +96,7 @@ export const withMissingValuesAsZeroes = <
                     valueOffset: 0,
                     interpolated: point?.interpolated,
                     fake: !point || !!point.interpolated,
+                    color: point?.color,
                 })
             }),
         }


### PR DESCRIPTION
Automatically colours positive and negative values differently (if a single series is plotted)

Implemented as part of an effort to create a set of climate charts, see draft charts on [this staging site](http://staging-site-stacked-bar/admin/charts)

## Summary

- Positive and negative values are coloured differently if a single series is currently plotted and that series actually has positive and negative values
- If one faceted chart uses pos/neg colouring, then we switch them all over for consistency
- The colours for positive and negative values are currently hard-coded, I don't want to add config for this; let's see how far we get with hard-coded values first

## Screenshot

Example on staging: http://staging-site-stacked-bar-colors/admin/charts/7905/edit

<img width="817" alt="Screenshot 2024-06-21 at 17 18 40" src="https://github.com/owid/owid-grapher/assets/12461810/cc9c0954-c794-4d8a-9603-27bcdb95d815">
