### PR TITLE
✨ (stacked bar) align x-axis of facets / TAS-548

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/AxisConfig.ts
+++ b/packages/@ourworldindata/grapher/src/axis/AxisConfig.ts
@@ -40,6 +40,7 @@ class AxisConfigDefaults implements AxisConfigInterface {
     @observable.ref ticks?: Tickmark[] = undefined
     @observable.ref singleValueAxisPointAlign?: AxisAlign = undefined
     @observable.ref label: string = ""
+    @observable.ref domainValues?: number[] = undefined
 }
 
 export class AxisConfig
@@ -78,6 +79,7 @@ export class AxisConfig
             facetDomain: this.facetDomain,
             ticks: this.ticks,
             singleValueAxisPointAlign: this.singleValueAxisPointAlign,
+            domainValues: this.domainValues,
         })
 
         deleteRuntimeAndUnchangedProps(obj, new AxisConfigDefaults())

--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
@@ -18,6 +18,7 @@ import {
     PositionMap,
     HorizontalAlign,
     Color,
+    uniq,
 } from "@ourworldindata/utils"
 import { shortenForTargetWidth } from "@ourworldindata/components"
 import { action, computed, observable } from "mobx"
@@ -393,14 +394,27 @@ export class FacetChart
                 (axis) => axis?.size
             )
             if (uniform) {
-                // If the axes are uniform, we want to find the full domain extent across all facets
-                const domains = excludeUndefined(
-                    intermediateChartInstances
-                        .map(axisAccessor)
-                        .map((axis) => axis?.domain)
+                const axes = excludeUndefined(
+                    intermediateChartInstances.map(axisAccessor)
                 )
+
+                // If the axes are uniform, we want to find the full domain extent across all facets
+                const domains = axes.map((axis) => axis.domain)
                 config.min = min(domains.map((d) => d[0]))
                 config.max = max(domains.map((d) => d[1]))
+
+                // Find domain values across all facets
+                const domainValues = uniq(
+                    axes.flatMap((axis) => axis.config.domainValues ?? [])
+                )
+                if (domainValues.length > 0) config.domainValues = domainValues
+
+                // Find ticks across all facets
+                const ticks = uniq(
+                    axes.flatMap((axis) => axis.config.ticks ?? [])
+                )
+                if (ticks.length > 0) config.ticks = ticks
+
                 // If there was at least one chart with a non-undefined axis,
                 // this variable will be populated
                 if (axisWithMaxSize) {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -205,22 +205,22 @@ export class AbstractStackedChart
         return autoDetectSeriesStrategy(this.manager)
     }
 
-    @computed protected get dualAxis(): DualAxis {
-        const {
-            bounds,
-            horizontalAxisPart,
-            verticalAxisPart,
-            paddingForLegendRight,
-            paddingForLegendTop,
-        } = this
-        return new DualAxis({
-            bounds: bounds
-                .padTop(paddingForLegendTop)
-                .padRight(paddingForLegendRight)
+    @computed get innerBounds(): Bounds {
+        return (
+            this.bounds
+                .padTop(this.paddingForLegendTop)
+                .padRight(this.paddingForLegendRight)
                 // top padding leaves room for tick labels
                 .padTop(6)
                 // bottom padding avoids axis labels to be cut off at some resolutions
-                .padBottom(2),
+                .padBottom(2)
+        )
+    }
+
+    @computed protected get dualAxis(): DualAxis {
+        const { horizontalAxisPart, verticalAxisPart } = this
+        return new DualAxis({
+            bounds: this.innerBounds,
             horizontalAxis: horizontalAxisPart,
             verticalAxis: verticalAxisPart,
         })
@@ -234,14 +234,9 @@ export class AbstractStackedChart
         return this.dualAxis.horizontalAxis
     }
 
-    @computed private get xAxisConfig(): AxisConfig {
-        return new AxisConfig(
-            {
-                hideGridlines: true,
-                ...this.manager.xAxisConfig,
-            },
-            this
-        )
+    // implemented in subclasses
+    @computed protected get xAxisConfig(): AxisConfig {
+        return new AxisConfig()
     }
 
     @computed private get horizontalAxisPart(): HorizontalAxis {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -54,6 +54,7 @@ import {
 import { stackSeries, withMissingValuesAsZeroes } from "./StackedUtils"
 import { makeClipPath } from "../chart/ChartUtils"
 import { bind } from "decko"
+import { AxisConfig } from "../axis/AxisConfig.js"
 
 interface AreasProps extends React.SVGAttributes<SVGGElement> {
     dualAxis: DualAxis
@@ -277,6 +278,16 @@ export class StackedAreaChart
             (point) => point.value + point.valueOffset
         )
         return [0, max(yValues) ?? 0]
+    }
+
+    @computed protected get xAxisConfig(): AxisConfig {
+        return new AxisConfig(
+            {
+                hideGridlines: true,
+                ...this.manager.xAxisConfig,
+            },
+            this
+        )
     }
 
     @computed get midpoints(): number[] {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -9,18 +9,12 @@ import {
     sum,
     getRelativeMouse,
     colorScaleConfigDefaults,
-    dyFromAlign,
-    makeIdForHumanConsumption,
     excludeUndefined,
     min,
     max,
     partition,
 } from "@ourworldindata/utils"
-import {
-    VerticalAxisComponent,
-    HorizontalAxisTickMark,
-    VerticalAxisGridLines,
-} from "../axis/AxisViews"
+import { DualAxisComponent } from "../axis/AxisViews"
 import { NoDataModal } from "../noDataModal/NoDataModal"
 import {
     VerticalColorLegend,
@@ -37,7 +31,6 @@ import {
 import {
     BASE_FONT_SIZE,
     GRAPHER_AREA_OPACITY_DEFAULT,
-    GRAPHER_DARK_TEXT,
     GRAPHER_AXIS_LINE_WIDTH_DEFAULT,
     GRAPHER_AXIS_LINE_WIDTH_THICK,
     GRAPHER_FONT_SCALE_12,
@@ -49,11 +42,7 @@ import {
 } from "./AbstractStackedChart"
 import { StackedPoint, StackedSeries } from "./StackedConstants"
 import { VerticalAxis } from "../axis/Axis"
-import {
-    ColorSchemeName,
-    HorizontalAlign,
-    VerticalAlign,
-} from "@ourworldindata/types"
+import { ColorSchemeName, HorizontalAlign } from "@ourworldindata/types"
 import {
     stackSeriesInBothDirections,
     withMissingValuesAsZeroes,
@@ -63,6 +52,7 @@ import { ColorScaleConfigDefaults } from "../color/ColorScaleConfig"
 import { ColumnTypeMap } from "@ourworldindata/core-table"
 import { HorizontalCategoricalColorLegend } from "../horizontalColorLegend/HorizontalColorLegends"
 import { CategoricalBin, ColorScaleBin } from "../color/ColorScaleBin"
+import { AxisConfig } from "../axis/AxisConfig.js"
 
 interface StackedBarSegmentProps extends React.SVGAttributes<SVGGElement> {
     bar: StackedPoint<Time>
@@ -170,6 +160,18 @@ export class StackedBarChart
         return GRAPHER_FONT_SCALE_12 * this.baseFontSize
     }
 
+    @computed protected get xAxisConfig(): AxisConfig {
+        return new AxisConfig(
+            {
+                hideGridlines: true,
+                domainValues: this.xValues,
+                ticks: this.xValues.map((value) => ({ value, priority: 2 })),
+                ...this.manager.xAxisConfig,
+            },
+            this
+        )
+    }
+
     @computed protected get yAxisDomain(): [number, number] {
         const yValues = this.allStackedPoints.map(
             (point) => point.value + point.valueOffset
@@ -178,16 +180,7 @@ export class StackedBarChart
     }
 
     @computed get barWidth(): number {
-        const { dualAxis } = this
-
-        return (0.8 * dualAxis.innerBounds.width) / this.xValues.length
-    }
-
-    @computed get barSpacing(): number {
-        return (
-            this.dualAxis.innerBounds.width / this.xValues.length -
-            this.barWidth
-        )
+        return (this.dualAxis.horizontalAxis.bandWidth ?? 0) * 0.8
     }
 
     @computed private get showHorizontalLegend(): boolean {
@@ -410,63 +403,6 @@ export class StackedBarChart
         )
     }
 
-    @computed get mapXValueToOffset(): Map<number, number> {
-        const { dualAxis, barWidth, barSpacing } = this
-
-        const xValueToOffset = new Map<number, number>()
-        let xOffset = dualAxis.innerBounds.left + barSpacing
-
-        for (const xValue of this.xValues) {
-            xValueToOffset.set(xValue, xOffset)
-            xOffset += barWidth + barSpacing
-        }
-        return xValueToOffset
-    }
-
-    // Place ticks centered beneath the bars, before doing overlap detection
-    @computed private get tickPlacements(): TickmarkPlacement[] {
-        const { mapXValueToOffset, barWidth, dualAxis } = this
-        const { xValues } = this
-        const { horizontalAxis } = dualAxis
-
-        return xValues.map((x) => {
-            const text = horizontalAxis.formatTick(x)
-            const xPos = mapXValueToOffset.get(x) as number
-
-            const bounds = Bounds.forText(text, { fontSize: this.tickFontSize })
-            return {
-                time: x,
-                text,
-                bounds: bounds.set({
-                    x: xPos + barWidth / 2 - bounds.width / 2,
-                    y: dualAxis.innerBounds.bottom + 5,
-                }),
-                isHidden: false,
-            }
-        })
-    }
-
-    @computed get ticks(): TickmarkPlacement[] {
-        const { tickPlacements } = this
-
-        for (let i = 0; i < tickPlacements.length; i++) {
-            for (let j = 1; j < tickPlacements.length; j++) {
-                const t1 = tickPlacements[i],
-                    t2 = tickPlacements[j]
-
-                if (t1 === t2 || t1.isHidden || t2.isHidden) continue
-
-                if (t1.bounds.intersects(t2.bounds.padWidth(-5))) {
-                    if (i === 0) t2.isHidden = true
-                    else if (j === tickPlacements.length - 1) t1.isHidden = true
-                    else t2.isHidden = true
-                }
-            }
-        }
-
-        return tickPlacements.filter((t) => !t.isHidden)
-    }
-
     // Both legend managers accept a `onLegendMouseOver` property, but define different signatures.
     // The <HorizontalCategoricalColorLegend /> component expects a string,
     // the <VerticalColorLegend /> component expects a ColorScaleBin.
@@ -522,18 +458,12 @@ export class StackedBarChart
             bounds,
             tooltip,
             barWidth,
-            mapXValueToOffset,
-            ticks,
             tooltipState: { target },
         } = this
         const { series } = this
-        const { innerBounds, verticalAxis } = dualAxis
+        const { innerBounds, verticalAxis, horizontalAxis } = dualAxis
 
         const clipPath = makeClipPath(renderUid, innerBounds)
-
-        const axisLineWidth = manager.isStaticAndSmall
-            ? GRAPHER_AXIS_LINE_WIDTH_THICK
-            : GRAPHER_AXIS_LINE_WIDTH_DEFAULT
 
         const legend = this.showHorizontalLegend ? (
             <HorizontalCategoricalColorLegend manager={this} />
@@ -558,60 +488,18 @@ export class StackedBarChart
                     opacity={0}
                     fill="rgba(255,255,255,0)"
                 />
-                {!verticalAxis.hideAxis && (
-                    <VerticalAxisComponent
-                        bounds={bounds}
-                        verticalAxis={verticalAxis}
-                        labelColor={manager.secondaryColorInStaticCharts}
-                        detailsMarker={manager.detailsMarkerInSvg}
-                    />
-                )}
-                <VerticalAxisGridLines
-                    verticalAxis={verticalAxis}
-                    bounds={innerBounds}
-                    strokeWidth={axisLineWidth}
+
+                <DualAxisComponent
+                    dualAxis={dualAxis}
+                    showTickMarks={true}
+                    labelColor={manager.secondaryColorInStaticCharts}
+                    lineWidth={
+                        manager.isStaticAndSmall
+                            ? GRAPHER_AXIS_LINE_WIDTH_THICK
+                            : GRAPHER_AXIS_LINE_WIDTH_DEFAULT
+                    }
+                    detailsMarker={manager.detailsMarkerInSvg}
                 />
-
-                <g id={makeIdForHumanConsumption("tick-marks")}>
-                    {ticks.map((tick, i) => (
-                        <HorizontalAxisTickMark
-                            key={i}
-                            id={makeIdForHumanConsumption(
-                                "tick-mark",
-                                tick.text
-                            )}
-                            tickMarkTopPosition={innerBounds.bottom}
-                            tickMarkXPosition={tick.bounds.centerX}
-                            color="#666"
-                            width={axisLineWidth}
-                        />
-                    ))}
-                </g>
-
-                <g id={makeIdForHumanConsumption("tick-labels")}>
-                    {ticks.map((tick, i) => {
-                        return (
-                            <text
-                                key={i}
-                                id={makeIdForHumanConsumption(
-                                    "tick__label",
-                                    tick.text
-                                )}
-                                x={tick.bounds.x}
-                                y={tick.bounds.y + 1}
-                                fill={GRAPHER_DARK_TEXT}
-                                fontSize={this.tickFontSize}
-                                onMouseOver={(): void => {
-                                    this.onLabelMouseOver(tick)
-                                }}
-                                onMouseLeave={this.onLabelMouseLeave}
-                                dy={dyFromAlign(VerticalAlign.bottom)}
-                            >
-                                {tick.text}
-                            </text>
-                        )
-                    })}
-                </g>
 
                 <g clipPath={clipPath.id}>
                     {series.map((series, index) => {
@@ -632,9 +520,9 @@ export class StackedBarChart
                                 }
                             >
                                 {series.points.map((bar, index) => {
-                                    const xPos = mapXValueToOffset.get(
-                                        bar.position
-                                    ) as number
+                                    const xPos =
+                                        horizontalAxis.place(bar.position) -
+                                        this.barWidth / 2
                                     const barOpacity =
                                         bar === target?.bar ? 1 : opacity
 
@@ -680,10 +568,6 @@ export class StackedBarChart
             : this.bounds.right - this.sidebarWidth
     }
 
-    @computed private get xValues(): number[] {
-        return uniq(this.allStackedPoints.map((bar) => bar.position))
-    }
-
     @computed get colorScaleConfig(): ColorScaleConfigDefaults | undefined {
         return {
             ...colorScaleConfigDefaults,
@@ -712,16 +596,30 @@ export class StackedBarChart
         )
     }
 
-    @computed get series(): readonly StackedSeries<number>[] {
+    @computed
+    private get unstackedSeriesWithMissingValuesAsZeroes(): StackedSeries<number>[] {
         // TODO: remove once monthly data is supported (https://github.com/owid/owid-grapher/issues/2007)
         const enforceUniformSpacing = !(
             this.transformedTable.timeColumn instanceof ColumnTypeMap.Day
         )
 
+        return withMissingValuesAsZeroes(this.unstackedSeries, {
+            enforceUniformSpacing,
+        })
+    }
+
+    @computed private get xValues(): number[] {
+        return uniq(
+            this.unstackedSeriesWithMissingValuesAsZeroes.flatMap((s) =>
+                s.points.map((p) => p.position)
+            )
+        )
+    }
+
+    @computed
+    get series(): readonly StackedSeries<number>[] {
         return stackSeriesInBothDirections(
-            withMissingValuesAsZeroes(this.unstackedSeries, {
-                enforceUniformSpacing,
-            })
+            this.unstackedSeriesWithMissingValuesAsZeroes
         )
     }
 }

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -285,6 +285,13 @@ export interface AxisConfigInterface {
      * Should the point be placed at the start, middle or end of the axis?
      */
     singleValueAxisPointAlign?: AxisAlign
+
+    /**
+     * If given, think of the axis scale as a band scale, where each domain value
+     * occupies a fixed width. The axis is padded on both sides to reserve space
+     * for the outermost values.
+     */
+    domainValues?: number[]
 }
 
 export interface ComparisonLineConfig {


### PR DESCRIPTION
Aligns x-axes of faceted StackedBar charts, resolves #2160

Implemented as part of an effort to create a set of climate charts, see draft charts on [this staging site](http://staging-site-stacked-bar/admin/charts)

## Summary

- Replaces the StackedBar chart's custom x-axis implementation with `DualAxisComponent`
- This works by passing a list of `domainValues` to the axis – it's then the axis' job (i) to figure out how much space is available for a single domain value (called the `bandWidth`) and (ii) to adjust the scale in such a way that we have sufficient padding on both sides for the outer bars to fit
- We also pass custom x-ticks to the axis, based on the actual x-values in the chart
- The `domainValues` and the `ticks` are shared across all facets, so that we end up with the same x-axis for all facets

## Screenshots

| Before  | After  |
| ------- | ------ |
| <img width="965" alt="Screenshot 2024-06-21 at 17 30 05" src="https://github.com/owid/owid-grapher/assets/12461810/1c231224-f4c2-483d-9e73-24054cafe4c6">  | <img width="965" alt="Screenshot 2024-06-21 at 17 30 40" src="https://github.com/owid/owid-grapher/assets/12461810/560274d0-c784-475f-b8c3-37b565e184a8"> |

Link: http://staging-site-stacked-bar-dual-axis/grapher/natural-disasters-by-type?facet=entity&uniformYAxis=0&country=Wildfire~Glacial+lake+outburst+flood~Dry+mass+movement~Extreme+temperature