### PR TITLE
🎉 (stacked bar) share x-axis across facets / TAS-549

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -520,6 +520,10 @@ export class HorizontalAxis extends AbstractAxis {
         return this.rangeSize
     }
 
+    // note that we intentionally don't take `hideAxisLabels` into account here.
+    // tick labels might be hidden in faceted charts. when faceted, it's important
+    // the axis size doesn't change as a result of hiding the axis labels, or else
+    // we might end up with misaligned axes.
     @computed get height(): number {
         if (this.hideAxis) return 0
         const { labelOffset, labelPadding } = this
@@ -635,6 +639,10 @@ export class VerticalAxis extends AbstractAxis {
             : 0
     }
 
+    // note that we intentionally don't take `hideAxisLabels` into account here.
+    // tick labels might be hidden in faceted charts. when faceted, it's important
+    // the axis size doesn't change as a result of hiding the axis labels, or else
+    // we might end up with misaligned axes.
     @computed get width(): number {
         if (this.hideAxis) return 0
         const { labelOffset, labelPadding } = this

--- a/packages/@ourworldindata/grapher/src/axis/AxisConfig.ts
+++ b/packages/@ourworldindata/grapher/src/axis/AxisConfig.ts
@@ -31,6 +31,7 @@ class AxisConfigDefaults implements AxisConfigInterface {
     @observable.ref minSize?: number = undefined
     @observable.ref hideAxis?: boolean = undefined
     @observable.ref hideGridlines?: boolean = undefined
+    @observable.ref hideTickLabels?: boolean = undefined
     @observable.ref labelPadding?: number = undefined
     @observable.ref nice?: boolean = undefined
     @observable.ref maxTicks?: number = undefined
@@ -70,6 +71,7 @@ export class AxisConfig
             minSize: this.minSize,
             hideAxis: this.hideAxis,
             hideGridlines: this.hideGridlines,
+            hideTickLabels: this.hideTickLabels,
             labelPadding: this.labelPadding,
             nice: this.nice,
             maxTicks: this.maxTicks,

--- a/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
+++ b/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
@@ -260,7 +260,7 @@ export class VerticalAxisComponent extends React.Component<{
             detailsMarker,
             showTickMarks,
         } = this.props
-        const { tickLabels, labelTextWrap } = verticalAxis
+        const { tickLabels, labelTextWrap, config } = verticalAxis
 
         return (
             <g
@@ -299,34 +299,38 @@ export class VerticalAxisComponent extends React.Component<{
                         ))}
                     </g>
                 )}
-                <g id={makeIdForHumanConsumption("tick-labels")}>
-                    {tickLabels.map((label, i) => {
-                        const { y, xAlign, yAlign, formattedValue } = label
-                        return (
-                            <text
-                                key={i}
-                                id={makeIdForHumanConsumption(
-                                    "tick-label",
-                                    formattedValue
-                                )}
-                                x={(
-                                    bounds.left +
-                                    verticalAxis.width -
-                                    verticalAxis.labelPadding
-                                ).toFixed(2)}
-                                y={y}
-                                dy={dyFromAlign(yAlign ?? VerticalAlign.middle)}
-                                textAnchor={textAnchorFromAlign(
-                                    xAlign ?? HorizontalAlign.right
-                                )}
-                                fill={tickColor || GRAPHER_DARK_TEXT}
-                                fontSize={verticalAxis.tickFontSize}
-                            >
-                                {formattedValue}
-                            </text>
-                        )
-                    })}
-                </g>
+                {!config.hideTickLabels && (
+                    <g id={makeIdForHumanConsumption("tick-labels")}>
+                        {tickLabels.map((label, i) => {
+                            const { y, xAlign, yAlign, formattedValue } = label
+                            return (
+                                <text
+                                    key={i}
+                                    id={makeIdForHumanConsumption(
+                                        "tick-label",
+                                        formattedValue
+                                    )}
+                                    x={(
+                                        bounds.left +
+                                        verticalAxis.width -
+                                        verticalAxis.labelPadding
+                                    ).toFixed(2)}
+                                    y={y}
+                                    dy={dyFromAlign(
+                                        yAlign ?? VerticalAlign.middle
+                                    )}
+                                    textAnchor={textAnchorFromAlign(
+                                        xAlign ?? HorizontalAlign.right
+                                    )}
+                                    fill={tickColor || GRAPHER_DARK_TEXT}
+                                    fontSize={verticalAxis.tickFontSize}
+                                >
+                                    {formattedValue}
+                                </text>
+                            )
+                        })}
+                    </g>
+                )}
             </g>
         )
     }
@@ -384,6 +388,8 @@ export class HorizontalAxisComponent extends React.Component<{
             ? bounds.top + labelOffset + 10
             : bounds.bottom - labelOffset
 
+        const showTickLabels = !axis.config.hideTickLabels
+
         return (
             <g
                 id={makeIdForHumanConsumption("horizontal-axis")}
@@ -398,40 +404,46 @@ export class HorizontalAxisComponent extends React.Component<{
                         },
                         detailsMarker,
                     })}
-                {tickLabels.map((label) => {
-                    const { x, xAlign, formattedValue } = label
-                    return (
-                        <g
-                            id={makeIdForHumanConsumption(
-                                "tick",
-                                formattedValue
-                            )}
-                            key={formattedValue}
-                        >
-                            {showTickMarks && (
-                                <line
-                                    x1={axis.place(label.value)}
-                                    y1={tickMarksYPosition - tickMarkWidth / 2}
-                                    x2={axis.place(label.value)}
-                                    y2={tickMarksYPosition + tickSize}
-                                    stroke={SOLID_TICK_COLOR}
-                                    strokeWidth={tickMarkWidth}
-                                />
-                            )}
-                            <text
-                                x={x}
-                                y={tickLabelYPlacement}
-                                fill={tickColor || GRAPHER_DARK_TEXT}
-                                textAnchor={textAnchorFromAlign(
-                                    xAlign ?? HorizontalAlign.center
+                {(showTickMarks || showTickLabels) &&
+                    tickLabels.map((label) => {
+                        const { x, xAlign, formattedValue } = label
+                        return (
+                            <g
+                                id={makeIdForHumanConsumption(
+                                    "tick",
+                                    formattedValue
                                 )}
-                                fontSize={axis.tickFontSize}
+                                key={formattedValue}
                             >
-                                {formattedValue}
-                            </text>
-                        </g>
-                    )
-                })}
+                                {showTickMarks && (
+                                    <line
+                                        x1={axis.place(label.value)}
+                                        y1={
+                                            tickMarksYPosition -
+                                            tickMarkWidth / 2
+                                        }
+                                        x2={axis.place(label.value)}
+                                        y2={tickMarksYPosition + tickSize}
+                                        stroke={SOLID_TICK_COLOR}
+                                        strokeWidth={tickMarkWidth}
+                                    />
+                                )}
+                                {showTickLabels && (
+                                    <text
+                                        x={x}
+                                        y={tickLabelYPlacement}
+                                        fill={tickColor || GRAPHER_DARK_TEXT}
+                                        textAnchor={textAnchorFromAlign(
+                                            xAlign ?? HorizontalAlign.center
+                                        )}
+                                        fontSize={axis.tickFontSize}
+                                    >
+                                        {formattedValue}
+                                    </text>
+                                )}
+                            </g>
+                        )
+                    })}
             </g>
         )
     }

--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChartUtils.tsx
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChartUtils.tsx
@@ -17,14 +17,24 @@ export const getFontSize = (
 export const getLabelPadding = (baseFontSize: number): number =>
     0.5 * baseFontSize
 
-export const getChartPadding = (
+export const getChartPadding = ({
+    baseFontSize,
+    isSharedXAxis,
+}: {
     baseFontSize: number
-): { rowPadding: number; columnPadding: number; outerPadding: number } => {
+    isSharedXAxis: boolean
+}): { rowPadding: number; columnPadding: number; outerPadding: number } => {
     const labelHeight = baseFontSize
     const labelPadding = getLabelPadding(baseFontSize)
+
+    const rowPadding = isSharedXAxis ? 0 : 1
+    const columnPadding = 1
+
     return {
-        rowPadding: Math.round(labelHeight + labelPadding + baseFontSize),
-        columnPadding: Math.round(baseFontSize),
+        rowPadding: Math.round(
+            labelHeight + labelPadding + rowPadding * baseFontSize
+        ),
+        columnPadding: Math.round(columnPadding * baseFontSize),
         outerPadding: 0,
     }
 }

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -192,7 +192,11 @@ export class StackedBarChart
     }
 
     @computed protected get paddingForLegendRight(): number {
-        return this.showHorizontalLegend ? 0 : this.sidebarWidth + 20
+        return this.showHorizontalLegend
+            ? 0
+            : this.sidebarWidth > 0
+              ? this.sidebarWidth + 20
+              : 0
     }
 
     @computed protected get paddingForLegendTop(): number {

--- a/packages/@ourworldindata/types/src/domainTypes/Layout.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Layout.ts
@@ -30,4 +30,5 @@ export enum AxisAlign {
 export interface GridParameters {
     rows: number
     columns: number
+    count: number
 }

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -226,6 +226,7 @@ export interface AxisConfigInterface {
     canChangeScaleType?: boolean
     removePointsOutsideDomain?: boolean
     hideAxis?: boolean
+    hideTickLabels?: boolean
 
     /** Hide the faint lines that are shown inside the plot (axis ticks may still be visible). */
     hideGridlines?: boolean

--- a/packages/@ourworldindata/utils/src/Bounds.test.ts
+++ b/packages/@ourworldindata/utils/src/Bounds.test.ts
@@ -10,7 +10,7 @@ it("can report the center", () => {
 
 it("can split a bounds into correct number of pieces", () => {
     const bounds = new Bounds(0, 0, 100, 100)
-    const quads = bounds.grid({ rows: 2, columns: 2 })
+    const quads = bounds.grid({ rows: 2, columns: 2, count: 4 })
     expect(quads.length).toEqual(4)
     const first = quads[0]
     const second = quads[1]
@@ -22,24 +22,58 @@ it("can split a bounds into correct number of pieces", () => {
     expect(third.bounds.x).toEqual(0)
     expect(fourth.bounds.height).toEqual(50)
 
-    expect(Array.from(first.edges.values())).toEqual(
+    expect(Array.from(first.cellEdges.values())).toEqual(
         expect.arrayContaining([Position.left, Position.top])
     )
-    expect(Array.from(second.edges.values())).toEqual(
+    expect(Array.from(second.cellEdges.values())).toEqual(
         expect.arrayContaining([Position.top, Position.right])
     )
-    expect(Array.from(third.edges.values())).toEqual(
+    expect(Array.from(third.cellEdges.values())).toEqual(
         expect.arrayContaining([Position.left, Position.bottom])
     )
-    expect(Array.from(fourth.edges.values())).toEqual(
+    expect(Array.from(fourth.cellEdges.values())).toEqual(
         expect.arrayContaining([Position.bottom, Position.right])
+    )
+})
+
+it("can split a bounds into an arbitrary number of pieces", () => {
+    const bounds = new Bounds(0, 0, 100, 100)
+    const grid = bounds.grid({ rows: 2, columns: 4, count: 5 })
+    expect(grid.length).toEqual(5)
+    const first = grid[0]
+    const second = grid[1]
+    const third = grid[2]
+    const fourth = grid[3]
+    const fifth = grid[4]
+
+    expect(second.bounds.x).toEqual(25)
+    expect(third.bounds.y).toEqual(0)
+    expect(third.bounds.x).toEqual(50)
+    expect(fourth.bounds.height).toEqual(50)
+    expect(fifth.bounds.x).toEqual(0)
+    expect(fifth.bounds.y).toEqual(50)
+
+    expect(Array.from(first.cellEdges.values())).toEqual(
+        expect.arrayContaining([Position.left, Position.top])
+    )
+    expect(Array.from(second.cellEdges.values())).toEqual(
+        expect.arrayContaining([Position.top, Position.bottom])
+    )
+    expect(Array.from(third.cellEdges.values())).toEqual(
+        expect.arrayContaining([Position.top, Position.bottom])
+    )
+    expect(Array.from(fourth.cellEdges.values())).toEqual(
+        expect.arrayContaining([Position.top, Position.right, Position.bottom])
+    )
+    expect(Array.from(fifth.cellEdges.values())).toEqual(
+        expect.arrayContaining([Position.right, Position.bottom, Position.left])
     )
 })
 
 it("can split with padding between charts", () => {
     const bounds = new Bounds(10, 10, 100, 100)
     const quads = bounds.grid(
-        { rows: 2, columns: 2 },
+        { rows: 2, columns: 2, count: 4 },
         { rowPadding: 20, columnPadding: 20 }
     )
     expect(quads.length).toEqual(4)

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -652,7 +652,7 @@ export const getIdealGridParams = ({
     const ratio = containerAspectRatio / idealAspectRatio
     // Prefer vertical grid for count=2.
     if (count === 2 && containerAspectRatio < 2.8)
-        return { rows: 2, columns: 1 }
+        return { rows: 2, columns: 1, count }
     // Otherwise, optimize for closest to the ideal aspect ratio.
     const initialColumns = Math.min(Math.round(Math.sqrt(count * ratio)), count)
     const rows = Math.ceil(count / initialColumns)
@@ -662,6 +662,7 @@ export const getIdealGridParams = ({
     return {
         rows,
         columns,
+        count,
     }
 }
 


### PR DESCRIPTION
Shares the x-axis across faceted StackedBar charts

Implemented as part of an effort to create a set of climate charts, see draft charts on [this staging site](http://staging-site-stacked-bar/admin/charts)

### Summary

- Hiding axis labels of inner facets declutters the chart if there are many facets
    - For charts with many facets, the x-axes are relatively close to each other, so it's easy to parse, even if there is only one axis on the bottom
    - For charts with few facets, the x-axes are relatively far from each other. If then some axis labels are missing, it can be difficult to figure out the x-axis value of a bar
- I ended up with a threshold of 12 facets (partly because we want this for the climate charts that we're working on and they have 12 facets) 

### Future work

- We might want to enable this for line charts and stacked area charts as well

### Known bugs

Suffers from [this bug](https://github.com/owid/owid-grapher/issues/2127) where axes are missing if one of the bottom facets doesn't have any data (fixed in the [next PR](https://github.com/owid/owid-grapher/pull/3735))

<details><summary>Screenshot</summary>
<p>

<img width="967" alt="Screenshot 2024-06-21 at 13 50 01" src="https://github.com/owid/owid-grapher/assets/12461810/e72ab179-bf10-44e7-90f2-4f7f10814d3a">

</p>
</details> 