### PR TITLE
chore: initialize some module-scope variables lazily

### DIFF
--- a/db/model/Gdoc/GdocHomepage.ts
+++ b/db/model/Gdoc/GdocHomepage.ts
@@ -12,7 +12,7 @@ import {
     OwidGdocBaseInterface,
     OwidGdocHomepageMetadata,
 } from "@ourworldindata/types"
-import { UNIQUE_TOPIC_COUNT } from "../../../site/SiteNavigation.js"
+import { getUniqueTopicCount } from "../../../site/SiteNavigation.js"
 export class GdocHomepage
     extends GdocBase
     implements OwidGdocHomepageInterface
@@ -67,7 +67,7 @@ export class GdocHomepage
 
         this.homepageMetadata = {
             chartCount: grapherCount + nonGrapherExplorerViewCount,
-            topicCount: UNIQUE_TOPIC_COUNT,
+            topicCount: getUniqueTopicCount(),
         }
 
         this.latestDataInsights = await db.getPublishedDataInsights(knex, 4)

--- a/packages/@ourworldindata/grapher/src/color/ColorBrewerSchemes.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorBrewerSchemes.ts
@@ -63,6 +63,7 @@ const ColorBrewerSchemeIndex: {
 
 const brewerKeys = Object.keys(colorbrewer) as ColorSchemeName[]
 
+// TODO: Make this into a lazy initialization
 export const ColorBrewerSchemes: ColorSchemeInterface[] = brewerKeys
     .filter((brewerName) => ColorBrewerSchemeIndex[brewerName])
     .map((brewerName) => {

--- a/packages/@ourworldindata/grapher/src/color/ColorSchemes.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorSchemes.ts
@@ -107,6 +107,7 @@ const initAllSchemes = (): { [key in ColorSchemeName]: ColorScheme } => {
     return colorSchemes as { [key in ColorSchemeName]: ColorScheme }
 }
 
+// TODO: Init lazily
 export const ColorSchemes = initAllSchemes()
 
 export function getColorSchemeForChartType(type: ChartTypeName): {

--- a/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
+++ b/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
@@ -1,6 +1,7 @@
 import { omit, invert, lazy } from "@ourworldindata/utils"
 import { ColorSchemeInterface, ColorSchemeName } from "@ourworldindata/types"
 
+// TODO: Initialize CustomColorSchemes lazily
 export const CustomColorSchemes: ColorSchemeInterface[] = []
 
 // Create some of our own!
@@ -54,6 +55,7 @@ const darkerColorReplacementsHexToReplacementColorName = {
     [OwidDistinctColors.Lime]: DarkerOwidDistinctColors.LimeDarker,
 } as Record<string, string>
 
+// TODO: Make this into a lazy initialization
 export const OwidDistinctLinesColors = {
     ...omit(OwidDistinctColors, Object.keys(DarkerOwidDistinctColors)),
     ...DarkerOwidDistinctColors,

--- a/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
+++ b/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
@@ -1,4 +1,4 @@
-import { omit, invert } from "@ourworldindata/utils"
+import { omit, invert, lazy } from "@ourworldindata/utils"
 import { ColorSchemeInterface, ColorSchemeName } from "@ourworldindata/types"
 
 export const CustomColorSchemes: ColorSchemeInterface[] = []
@@ -32,7 +32,7 @@ export const OwidDistinctColors = {
     Coral: "#D73C50",
 } as const
 
-const OwidDistinctColorsNames = invert(OwidDistinctColors)
+const OwidDistinctColorsNames = lazy(() => invert(OwidDistinctColors))
 
 // These are variations of some of the colors above where the original color would have too little
 // contrast against a white background for thin lines or text elements
@@ -60,7 +60,7 @@ export const OwidDistinctLinesColors = {
 }
 
 // Used for looking up names from color hex values
-const OwidDistinctLinesColorNames = invert(OwidDistinctLinesColors)
+const OwidDistinctLinesColorNames = lazy(() => invert(OwidDistinctLinesColors))
 
 // Below are 5 variations of the same colors in different permutations
 export const CategoricalColorsPaletteA = [
@@ -253,7 +253,7 @@ export const EnergyColors = {
 }
 
 // Used for looking up color names from hex values
-const EnergyColorsNames = invert(EnergyColors)
+const EnergyColorsNames = lazy(() => invert(EnergyColors))
 
 const EnergyColorPalette = [
     EnergyColors.Coal,
@@ -289,7 +289,9 @@ function getModifiedLinesNames(
     )
 }
 
-const EnergyColorsLinesNames = getModifiedLinesNames(EnergyColorsNames)
+const EnergyColorsLinesNames = lazy(() =>
+    getModifiedLinesNames(EnergyColorsNames())
+)
 
 export const OwidEnergyLines = getModifiedLinesColorScheme(OwidEnergy)
 CustomColorSchemes.push(OwidEnergyLines)
@@ -332,7 +334,7 @@ export const ContinentColors = {
 } as const
 
 // Used for looking up color names from hex values
-const ContinentColorsNames = invert(ContinentColors)
+const ContinentColorsNames = lazy(() => invert(ContinentColors))
 
 const ContinentColorPalette = [
     ContinentColors.Africa,
@@ -383,7 +385,9 @@ function getModifiedLinesColorScheme(
     }
 }
 
-const ContinentColorsLinesNames = getModifiedLinesNames(ContinentColorsNames)
+const ContinentColorsLinesNames = lazy(() =>
+    getModifiedLinesNames(ContinentColorsNames())
+)
 
 export const ContinentColorsLinesColorScheme = getModifiedLinesColorScheme(
     ContinentColorsColorScheme
@@ -625,9 +629,9 @@ export function getColorNameOwidDistinctAndSemanticPalettes(
 ): string[] {
     return getColorNameAndSemanticPalettes(
         color,
-        OwidDistinctColorsNames,
-        ContinentColorsNames,
-        EnergyColorsNames
+        OwidDistinctColorsNames(),
+        ContinentColorsNames(),
+        EnergyColorsNames()
     )
 }
 
@@ -636,9 +640,9 @@ export function getColorNameOwidDistinctLinesAndSemanticPalettes(
 ): string[] {
     return getColorNameAndSemanticPalettes(
         color,
-        OwidDistinctLinesColorNames,
-        ContinentColorsLinesNames,
-        EnergyColorsLinesNames
+        OwidDistinctLinesColorNames(),
+        ContinentColorsLinesNames(),
+        EnergyColorsLinesNames()
     )
 }
 

--- a/packages/@ourworldindata/grapher/src/controls/globalEntitySelector/GlobalEntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/globalEntitySelector/GlobalEntitySelector.tsx
@@ -45,7 +45,7 @@ interface DropdownEntity {
     value: string
 }
 
-const allEntities = lazy(() =>
+const getAllEntitiesSortedWithWorld = lazy(() =>
     sortBy(countries, (c) => c.name)
         // Add 'World'
         .concat([
@@ -192,7 +192,7 @@ export class GlobalEntitySelector extends React.Component<{
             const localCountryCode = await getUserCountryInformation()
             if (!localCountryCode) return
 
-            const country = allEntities().find(
+            const country = getAllEntitiesSortedWithWorld().find(
                 (entity): boolean => entity.code === localCountryCode.code
             )
             if (country) this.localEntityName = country.name
@@ -228,7 +228,7 @@ export class GlobalEntitySelector extends React.Component<{
         optionGroups = optionGroups.concat([
             {
                 label: "All countries",
-                options: allEntities()
+                options: getAllEntitiesSortedWithWorld()
                     .map((entity) => entity.name)
                     .map(entityNameToOption),
             },

--- a/packages/@ourworldindata/grapher/src/controls/globalEntitySelector/GlobalEntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/globalEntitySelector/GlobalEntitySelector.tsx
@@ -20,6 +20,7 @@ import {
     sortBy,
     getWindowUrl,
     setWindowUrl,
+    lazy,
 } from "@ourworldindata/utils"
 import { GrapherAnalytics } from "../../core/GrapherAnalytics"
 import { WorldEntityName } from "../../core/GrapherConstants"
@@ -44,16 +45,18 @@ interface DropdownEntity {
     value: string
 }
 
-const allEntities = sortBy(countries, (c) => c.name)
-    // Add 'World'
-    .concat([
-        {
-            name: WorldEntityName,
-            code: "OWID_WRL",
-            slug: "world",
-            regionType: "other",
-        },
-    ])
+const allEntities = lazy(() =>
+    sortBy(countries, (c) => c.name)
+        // Add 'World'
+        .concat([
+            {
+                name: WorldEntityName,
+                code: "OWID_WRL",
+                slug: "world",
+                regionType: "other",
+            },
+        ])
+)
 
 const Option = (
     props: OptionProps<DropdownEntity, true, any>
@@ -189,7 +192,7 @@ export class GlobalEntitySelector extends React.Component<{
             const localCountryCode = await getUserCountryInformation()
             if (!localCountryCode) return
 
-            const country = allEntities.find(
+            const country = allEntities().find(
                 (entity): boolean => entity.code === localCountryCode.code
             )
             if (country) this.localEntityName = country.name
@@ -225,7 +228,7 @@ export class GlobalEntitySelector extends React.Component<{
         optionGroups = optionGroups.concat([
             {
                 label: "All countries",
-                options: allEntities
+                options: allEntities()
                     .map((entity) => entity.name)
                     .map(entityNameToOption),
             },

--- a/packages/@ourworldindata/grapher/src/core/EntityCodes.ts
+++ b/packages/@ourworldindata/grapher/src/core/EntityCodes.ts
@@ -1,16 +1,18 @@
 import { invert, lazy, regions } from "@ourworldindata/utils"
 import { EntityName } from "@ourworldindata/types"
 
-const entityCodesToEntityNames: () => Record<string, string> = lazy(() =>
+const getEntityCodesToEntityNames: () => Record<string, string> = lazy(() =>
     Object.fromEntries(regions.map(({ code, name }) => [code, name]))
 )
 
-const entityNamesToEntityCodes = lazy(() => invert(entityCodesToEntityNames()))
+const getEntityNamesToEntityCodes = lazy(() =>
+    invert(getEntityCodesToEntityNames())
+)
 
 export const codeToEntityName = (codeOrEntityName: string): EntityName => {
-    return entityCodesToEntityNames()[codeOrEntityName] ?? codeOrEntityName
+    return getEntityCodesToEntityNames()[codeOrEntityName] ?? codeOrEntityName
 }
 
 export const entityNameToCode = (entityName: EntityName): string => {
-    return entityNamesToEntityCodes()[entityName] ?? entityName
+    return getEntityNamesToEntityCodes()[entityName] ?? entityName
 }

--- a/packages/@ourworldindata/grapher/src/core/EntityCodes.ts
+++ b/packages/@ourworldindata/grapher/src/core/EntityCodes.ts
@@ -1,15 +1,16 @@
-import { invert, regions } from "@ourworldindata/utils"
+import { invert, lazy, regions } from "@ourworldindata/utils"
 import { EntityName } from "@ourworldindata/types"
 
-export const entityCodesToEntityNames: Record<string, string> =
+const entityCodesToEntityNames: () => Record<string, string> = lazy(() =>
     Object.fromEntries(regions.map(({ code, name }) => [code, name]))
+)
 
-export const entityNamesToEntityCodes = invert(entityCodesToEntityNames)
+const entityNamesToEntityCodes = lazy(() => invert(entityCodesToEntityNames()))
 
 export const codeToEntityName = (codeOrEntityName: string): EntityName => {
-    return entityCodesToEntityNames[codeOrEntityName] ?? codeOrEntityName
+    return entityCodesToEntityNames()[codeOrEntityName] ?? codeOrEntityName
 }
 
 export const entityNameToCode = (entityName: EntityName): string => {
-    return entityNamesToEntityCodes[entityName] ?? entityName
+    return entityNamesToEntityCodes()[entityName] ?? entityName
 }

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -51,7 +51,7 @@ import {
 } from "../color/ColorScaleBin"
 import * as topojson from "topojson-client"
 import { MapTopology } from "./MapTopology"
-import { getCountryToProjectionMap } from "./WorldRegionsToProjection"
+import { getCountriesByProjection } from "./WorldRegionsToProjection"
 import {
     ColorSchemeName,
     MapProjectionName,
@@ -756,9 +756,11 @@ class ChoroplethMap extends React.Component<{
         const features = renderFeaturesFor(projection)
         if (projection === MapProjectionName.World) return features
 
-        return features.filter(
-            (feature) =>
-                projection === getCountryToProjectionMap().get(feature.id)
+        const countriesByProjection = getCountriesByProjection(projection)
+        if (countriesByProjection === undefined) return []
+
+        return features.filter((feature) =>
+            countriesByProjection.has(feature.id)
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -51,10 +51,7 @@ import {
 } from "../color/ColorScaleBin"
 import * as topojson from "topojson-client"
 import { MapTopology } from "./MapTopology"
-import {
-    WorldRegionName,
-    WorldRegionToProjection,
-} from "./WorldRegionsToProjection"
+import { getCountryToProjectionMap } from "./WorldRegionsToProjection"
 import {
     ColorSchemeName,
     MapProjectionName,
@@ -761,10 +758,7 @@ class ChoroplethMap extends React.Component<{
 
         return features.filter(
             (feature) =>
-                projection ===
-                (WorldRegionToProjection()[
-                    feature.id as WorldRegionName
-                ] as any as MapProjectionName)
+                projection === getCountryToProjectionMap().get(feature.id)
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -762,7 +762,7 @@ class ChoroplethMap extends React.Component<{
         return features.filter(
             (feature) =>
                 projection ===
-                (WorldRegionToProjection[
+                (WorldRegionToProjection()[
                     feature.id as WorldRegionName
                 ] as any as MapProjectionName)
         )

--- a/packages/@ourworldindata/grapher/src/mapCharts/WorldRegionsToProjection.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/WorldRegionsToProjection.ts
@@ -1,9 +1,9 @@
-import { regions, continents } from "@ourworldindata/utils"
+import { regions, continents, lazy, Continent } from "@ourworldindata/utils"
 import { MapProjectionName } from "@ourworldindata/types"
 
-export const WorldRegionToProjection: Map<string, MapProjectionName> =
+export const WorldRegionToProjection = lazy(() =>
     Object.fromEntries(
-        continents.flatMap(({ name, members }) =>
+        continents().flatMap(({ name, members }) =>
             members
                 .map((code) => [
                     regions.find((c) => c.code === code)?.name,
@@ -12,5 +12,6 @@ export const WorldRegionToProjection: Map<string, MapProjectionName> =
                 .filter(([name, _projection]) => !!name)
         )
     )
+)
 
-export type WorldRegionName = keyof typeof WorldRegionToProjection
+export type WorldRegionName = Continent["name"]

--- a/packages/@ourworldindata/grapher/src/mapCharts/WorldRegionsToProjection.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/WorldRegionsToProjection.ts
@@ -1,29 +1,29 @@
-import { regions, getContinents, lazy, Continent } from "@ourworldindata/utils"
+import { regions, getContinents, lazy } from "@ourworldindata/utils"
 import { MapProjectionName } from "@ourworldindata/types"
 
-// Returns a map of the form:
-// - Spain: Europe
-// - United States: NorthAmerica
-
-export const getCountryToProjectionMap = lazy(
+// A map of the form:
+// - Africa: [Algeria, Angola, ...]
+// - NorthAmerica: [Canada, United States, ...]
+const countriesByProjectionMap = lazy(
     () =>
-        new Map<string, MapProjectionName>(
-            getContinents().flatMap(({ name: continentName, members }) => {
+        new Map(
+            getContinents().map(({ name: continentName, members }) => {
                 const continentNameNoSpace = continentName.replace(
                     / /,
                     ""
                 ) as MapProjectionName
-
-                return members
-                    .map((code) => [
-                        regions.find((c) => c.code === code)?.name,
-                        continentNameNoSpace,
-                    ])
-                    .filter(
-                        ([regionName, _projection]) => regionName !== undefined
-                    ) as [string, MapProjectionName][]
+                return [
+                    continentNameNoSpace,
+                    new Set(
+                        members
+                            .map((code) => regions.find((c) => c.code === code))
+                            .filter((region) => region !== undefined)
+                            .map((region) => region.name)
+                    ),
+                ]
             })
         )
 )
 
-export type WorldRegionName = Continent["name"]
+export const getCountriesByProjection = (projection: MapProjectionName) =>
+    countriesByProjectionMap().get(projection)

--- a/packages/@ourworldindata/grapher/src/mapCharts/WorldRegionsToProjection.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/WorldRegionsToProjection.ts
@@ -25,5 +25,6 @@ const countriesByProjectionMap = lazy(
         )
 )
 
-export const getCountriesByProjection = (projection: MapProjectionName) =>
-    countriesByProjectionMap().get(projection)
+export const getCountriesByProjection = (
+    projection: MapProjectionName
+): Set<string> | undefined => countriesByProjectionMap().get(projection)

--- a/packages/@ourworldindata/grapher/src/mapCharts/WorldRegionsToProjection.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/WorldRegionsToProjection.ts
@@ -1,17 +1,29 @@
-import { regions, continents, lazy, Continent } from "@ourworldindata/utils"
+import { regions, getContinents, lazy, Continent } from "@ourworldindata/utils"
 import { MapProjectionName } from "@ourworldindata/types"
 
-export const WorldRegionToProjection = lazy(() =>
-    Object.fromEntries(
-        continents().flatMap(({ name, members }) =>
-            members
-                .map((code) => [
-                    regions.find((c) => c.code === code)?.name,
-                    name.replace(/ /, "") as MapProjectionName,
-                ])
-                .filter(([name, _projection]) => !!name)
+// Returns a map of the form:
+// - Spain: Europe
+// - United States: NorthAmerica
+
+export const getCountryToProjectionMap = lazy(
+    () =>
+        new Map<string, MapProjectionName>(
+            getContinents().flatMap(({ name: continentName, members }) => {
+                const continentNameNoSpace = continentName.replace(
+                    / /,
+                    ""
+                ) as MapProjectionName
+
+                return members
+                    .map((code) => [
+                        regions.find((c) => c.code === code)?.name,
+                        continentNameNoSpace,
+                    ])
+                    .filter(
+                        ([regionName, _projection]) => regionName !== undefined
+                    ) as [string, MapProjectionName][]
+            })
         )
-    )
 )
 
 export type WorldRegionName = Continent["name"]

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1846,12 +1846,12 @@ export function roundDownToNearestHundred(value: number): number {
     return Math.floor(value / 100) * 100
 }
 
-const commafyFormatter = new Intl.NumberFormat("en-US")
+const commafyFormatter = lazy(() => new Intl.NumberFormat("en-US"))
 /**
  * Example: 12000 -> "12,000"
  */
 export function commafyNumber(value: number): string {
-    return commafyFormatter.format(value)
+    return commafyFormatter().format(value)
 }
 
 export function isFiniteWithGuard(value: unknown): value is number {

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1903,3 +1903,22 @@ export function formatInlineList(
     if (array.length === 1) return `${array[0]}`
     return `${array.slice(0, -1).join(", ")} ${connector} ${last(array)}`
 }
+
+// The below comment marks this function as side-effect free, meaning that the bundler
+// can safely remove it if it is not used.
+// This is useful for e.g. constants that are only used in some parts of the codebase.
+// See https://rollupjs.org/configuration-options/#no-side-effects
+// @__NO_SIDE_EFFECTS__
+// Other than that, this function is like lodash's once, in that it'll run fn at most once
+// and then save the result for future calls.
+export function lazy<T>(fn: () => T): () => T {
+    let hasRun = false
+    let _value: T
+    return () => {
+        if (!hasRun) {
+            _value = fn()
+            hasRun = true
+        }
+        return _value
+    }
+}

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -123,6 +123,7 @@ export {
     isFiniteWithGuard,
     createTagGraph,
     formatInlineList,
+    lazy,
 } from "./Util.js"
 
 export {

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -249,11 +249,11 @@ export {
     getCountryByName,
     getRegionByNameOrVariantName,
     isCountryName,
-    continents,
+    getContinents,
     type Continent,
-    aggregates,
+    getAggregates,
     type Aggregate,
-    others,
+    getOthers,
 } from "./regions.js"
 
 export { getStylesForTargetHeight } from "./react-select.js"

--- a/packages/@ourworldindata/utils/src/regions.ts
+++ b/packages/@ourworldindata/utils/src/regions.ts
@@ -52,19 +52,19 @@ export const countries: Country[] = regions.filter(
         !entity.isHistorical
 ) as Country[]
 
-export const others = lazy(
+export const getOthers = lazy(
     () =>
         entities.filter((entity) => entity.regionType === "other") as Country[]
 )
 
-export const aggregates = lazy(
+export const getAggregates = lazy(
     () =>
         entities.filter(
             (entity) => entity.regionType === "aggregate"
         ) as Aggregate[]
 )
 
-export const continents = lazy(
+export const getContinents = lazy(
     () =>
         entities.filter(
             (entity) => entity.regionType === "continent"
@@ -79,16 +79,21 @@ const countriesBySlug = lazy(() =>
     Object.fromEntries(countries.map((country) => [country.slug, country]))
 )
 
-const regionsByNameOrVariantNameLowercase: Map<string, Region> = new Map(
-    regions.flatMap((region) => {
-        const names = [region.name.toLowerCase()]
-        if ("variantNames" in region && region.variantNames) {
-            names.push(
-                ...region.variantNames.map((variant) => variant.toLowerCase())
-            )
-        }
-        return names.map((name) => [name, region])
-    })
+const regionsByNameOrVariantNameLowercase = lazy(
+    () =>
+        new Map(
+            regions.flatMap((region) => {
+                const names = [region.name.toLowerCase()]
+                if ("variantNames" in region && region.variantNames) {
+                    names.push(
+                        ...region.variantNames.map((variant) =>
+                            variant.toLowerCase()
+                        )
+                    )
+                }
+                return names.map((name) => [name, region])
+            })
+        )
 )
 
 const currentAndHistoricalCountryNames = lazy(() =>
@@ -109,4 +114,4 @@ export const getCountryBySlug = (slug: string): Country | undefined =>
 export const getRegionByNameOrVariantName = (
     nameOrVariantName: string
 ): Region | undefined =>
-    regionsByNameOrVariantNameLowercase.get(nameOrVariantName.toLowerCase())
+    regionsByNameOrVariantNameLowercase().get(nameOrVariantName.toLowerCase())

--- a/packages/@ourworldindata/utils/src/regions.ts
+++ b/packages/@ourworldindata/utils/src/regions.ts
@@ -1,4 +1,5 @@
 import entities from "./regions.json"
+import { lazy } from "./Util.js"
 
 export enum RegionType {
     Country = "country",
@@ -51,24 +52,31 @@ export const countries: Country[] = regions.filter(
         !entity.isHistorical
 ) as Country[]
 
-export const others: Country[] = entities.filter(
-    (entity) => entity.regionType === "other"
-) as Country[]
-
-export const aggregates: Aggregate[] = entities.filter(
-    (entity) => entity.regionType === "aggregate"
-) as Aggregate[]
-
-export const continents: Continent[] = entities.filter(
-    (entity) => entity.regionType === "continent"
-) as Continent[]
-
-const countriesByName: Record<string, Country> = Object.fromEntries(
-    countries.map((country) => [country.name, country])
+export const others = lazy(
+    () =>
+        entities.filter((entity) => entity.regionType === "other") as Country[]
 )
 
-const countriesBySlug: Record<string, Country> = Object.fromEntries(
-    countries.map((country) => [country.slug, country])
+export const aggregates = lazy(
+    () =>
+        entities.filter(
+            (entity) => entity.regionType === "aggregate"
+        ) as Aggregate[]
+)
+
+export const continents = lazy(
+    () =>
+        entities.filter(
+            (entity) => entity.regionType === "continent"
+        ) as Continent[]
+)
+
+const countriesByName = lazy(() =>
+    Object.fromEntries(countries.map((country) => [country.name, country]))
+)
+
+const countriesBySlug = lazy(() =>
+    Object.fromEntries(countries.map((country) => [country.slug, country]))
 )
 
 const regionsByNameOrVariantNameLowercase: Map<string, Region> = new Map(
@@ -83,18 +91,20 @@ const regionsByNameOrVariantNameLowercase: Map<string, Region> = new Map(
     })
 )
 
-const currentAndHistoricalCountryNames = regions
-    .filter(({ regionType }) => regionType === "country")
-    .map(({ name }) => name.toLowerCase())
+const currentAndHistoricalCountryNames = lazy(() =>
+    regions
+        .filter(({ regionType }) => regionType === "country")
+        .map(({ name }) => name.toLowerCase())
+)
 
 export const isCountryName = (name: string): boolean =>
-    currentAndHistoricalCountryNames.includes(name.toLowerCase())
+    currentAndHistoricalCountryNames().includes(name.toLowerCase())
 
 export const getCountryByName = (name: string): Country | undefined =>
-    countriesByName[name]
+    countriesByName()[name]
 
 export const getCountryBySlug = (slug: string): Country | undefined =>
-    countriesBySlug[slug]
+    countriesBySlug()[slug]
 
 export const getRegionByNameOrVariantName = (
     nameOrVariantName: string

--- a/site/SiteNavigation.tsx
+++ b/site/SiteNavigation.tsx
@@ -1057,13 +1057,14 @@ export const SiteNavigationStatic: { categories: CategoryWithEntries[] } = {
     ],
 }
 
-export const UNIQUE_TOPIC_COUNT = SiteNavigationStatic.categories
-    .flatMap((category) => {
-        const subcategoryEntries =
-            category?.subcategories?.flatMap(
-                (subcategory) => subcategory.entries || []
-            ) || []
-        return [...category.entries, ...subcategoryEntries]
-    })
-    .map((entry) => entry.slug)
-    .filter((value, index, array) => array.indexOf(value) === index).length
+export const getUniqueTopicCount = () =>
+    SiteNavigationStatic.categories
+        .flatMap((category) => {
+            const subcategoryEntries =
+                category?.subcategories?.flatMap(
+                    (subcategory) => subcategory.entries || []
+                ) || []
+            return [...category.entries, ...subcategoryEntries]
+        })
+        .map((entry) => entry.slug)
+        .filter((value, index, array) => array.indexOf(value) === index).length

--- a/site/search/SearchUtils.tsx
+++ b/site/search/SearchUtils.tsx
@@ -6,6 +6,7 @@ import {
     regions,
     escapeRegExp,
     removeTrailingParenthetical,
+    lazy,
 } from "@ourworldindata/utils"
 
 /**
@@ -30,19 +31,23 @@ import {
  * -- @marcelgerber, 2024-06-18
  */
 
-const allCountryNamesAndVariants = regions.flatMap((c) => [
-    c.name,
-    ...(("variantNames" in c && c.variantNames) || []),
-])
+const regionNameRegex = lazy(() => {
+    const allCountryNamesAndVariants = lazy(() =>
+        regions.flatMap((c) => [
+            c.name,
+            ...(("variantNames" in c && c.variantNames) || []),
+        ])
+    )
 
-// A RegExp that matches any country, region and variant name. Case-independent.
-const regionNameRegex = new RegExp(
-    `\\b(${allCountryNamesAndVariants.map(escapeRegExp).join("|")})\\b`,
-    "gi"
-)
+    // A RegExp that matches any country, region and variant name. Case-independent.
+    return new RegExp(
+        `\\b(${allCountryNamesAndVariants().map(escapeRegExp).join("|")})\\b`,
+        "gi"
+    )
+})
 
 export const extractRegionNamesFromSearchQuery = (query: string) => {
-    const matches = query.matchAll(regionNameRegex)
+    const matches = query.matchAll(regionNameRegex())
     const regionNames = Array.from(matches, (match) => match[0])
     if (regionNames.length === 0) return null
     return regionNames.map(getRegionByNameOrVariantName) as Region[]

--- a/site/search/SearchUtils.tsx
+++ b/site/search/SearchUtils.tsx
@@ -31,7 +31,7 @@ import {
  * -- @marcelgerber, 2024-06-18
  */
 
-const regionNameRegex = lazy(() => {
+const getRegionNameRegex = lazy(() => {
     const allCountryNamesAndVariants = lazy(() =>
         regions.flatMap((c) => [
             c.name,
@@ -47,7 +47,7 @@ const regionNameRegex = lazy(() => {
 })
 
 export const extractRegionNamesFromSearchQuery = (query: string) => {
-    const matches = query.matchAll(regionNameRegex())
+    const matches = query.matchAll(getRegionNameRegex())
     const regionNames = Array.from(matches, (match) => match[0])
     if (regionNames.length === 0) return null
     return regionNames.map(getRegionByNameOrVariantName) as Region[]


### PR DESCRIPTION
I noticed a bunch of module-scope function calls; these get executed every time the corresponding module (and thereby `owid.mjs`) is loaded.

Many of these values are not needed at all, and some are only needed in "rare" cases.
There are probably more such things, I didn't do a full-on search of everything. A _rough_ regex to find those is `^(export )?(const|let) [\w_.]+ = [^(]*\w\(` (although that won't find multiline ones like `entities [newline] .filter(...)`).

I also discovered that the result of some of these, especially the ones in `CustomSchemes`, are never accessed at all.
By marking them with `@__NO_SIDE_EFFECTS__`, Rollup can eliminate (i.e. tree-shake) the call entirely from the bundle.

---

I think there is no way to do "proper" lazy properties, i.e. ones that are not a function call, without wrapping them in a class. Am I right? I would love to be proven otherwise :)