### PR TITLE
🔨 add migration to add chart_diff_conflicts table

### DIFF
--- a/db/migration/1719334981843-chart-diff-conflicts.ts
+++ b/db/migration/1719334981843-chart-diff-conflicts.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class ChartDiffConflicts1719334981843 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            CREATE TABLE chart_diff_conflicts (
+                id integer NOT NULL AUTO_INCREMENT,
+                chartId integer NOT NULL,
+                targetUpdatedAt datetime DEFAULT NULL,
+                conflict varchar(255) NOT NULL,
+                FOREIGN KEY (chartId) REFERENCES charts (id) ON DELETE CASCADE ON UPDATE CASCADE,
+                PRIMARY KEY (id),
+                INDEX (chartId)
+            )
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE chart_diff_conflicts`)
+    }
+}

--- a/db/migration/1719338980266-AddChartDiffConflictsTable.ts
+++ b/db/migration/1719338980266-AddChartDiffConflictsTable.ts
@@ -7,6 +7,7 @@ export class ChartDiffConflicts1719334981843 implements MigrationInterface {
                 id integer NOT NULL AUTO_INCREMENT,
                 chartId integer NOT NULL,
                 targetUpdatedAt datetime DEFAULT NULL,
+                updatedAt datetime NOT NULL,
                 conflict varchar(255) NOT NULL,
                 FOREIGN KEY (chartId) REFERENCES charts (id) ON DELETE CASCADE ON UPDATE CASCADE,
                 PRIMARY KEY (id),


### PR DESCRIPTION
In our new workflow, we need some way to track chart conflicts* between PROD and staging servers.

Currently, we define a conflict if the `updatedAt` field of a chart is greater in PROD than in STAGING.

If we take a look at the diagram below, we observe that the current method only captures scenario 1.

![image](https://github.com/owid/owid-grapher/assets/18101289/2d710148-ca45-4754-b0f5-6fa01871d5cb)

To capture scenario 2, we need to be smarter. I've been thinking of a logical expression, but I believe there is none. Therefore, the idea now is to track in a table if a conflict was resolved. A conflict will be identified by the chart ID and timestamp of edit in PROD.

*A chart conflict happens when one user edits a chart in PROD and another in STAGING, after branching out. Similar to git-conflict.

Related: https://github.com/owid/owid-grapher/pull/3584