### PR TITLE
:bug: Adding Corruption to topic lists on homepage

### DIFF
--- a/site/SiteNavigation.tsx
+++ b/site/SiteNavigation.tsx
@@ -997,6 +997,10 @@ export const SiteNavigationStatic: { categories: CategoryWithEntries[] } = {
                     title: "LGBT+ Rights",
                 },
                 {
+                    slug: "corruption",
+                    title: "Corruption",
+                },
+                {
                     slug: "economic-inequality-by-gender",
                     title: "Economic Inequality by Gender",
                 },


### PR DESCRIPTION
The 'Corruption' topic is missing from the “Browse by topic” and “All our topics” on the landing page - [full Slack message here](https://owid.slack.com/archives/C03NV9Z3YSV/p1719504484565099).