### PR TITLE
fix 3701 style error

### DIFF
--- a/site/gdocs/components/KeyIndicator.scss
+++ b/site/gdocs/components/KeyIndicator.scss
@@ -75,7 +75,6 @@
 
     .description {
         @include body-3-medium;
-        color: $blue-60;
         margin-top: 0;
         margin-bottom: 16px;
     }


### PR DESCRIPTION
## Details
The blue "key-indicator" panel which displayed information and graph in a feature article has a "learn more" link and here there was a text style which did not match the common styling of these boxes.

## Screen-shots
### Before
<img width="700" alt="Screenshot 2024-06-30 at 04 52 22" src="https://github.com/owid/owid-grapher/assets/10499070/31564422-8d0f-411b-a513-18d8e4a965b5">

### After
<img width="700" alt="Screenshot 2024-06-30 at 04 52 37" src="https://github.com/owid/owid-grapher/assets/10499070/136dd8be-fac3-487e-99ae-70779c82cc20">

### Standard
<img width="700" alt="Screenshot 2024-06-30 at 04 53 03" src="https://github.com/owid/owid-grapher/assets/10499070/f426b706-4284-45a0-b0f4-4ade7cac5b5c">

## Notes

Looks at git blame it can be seen that this was recently added. The description class was added three months ago. [Before](https://github.com/owid/owid-grapher/blame/5b071a1b8cb57ee5f2dfef6c4c8d82485381964d/site/gdocs/components/KeyIndicator.scss) and [after](https://github.com/owid/owid-grapher/blame/master/site/gdocs/components/KeyIndicator.scss#L76). That seems to be part of a much larger piece of work with no obvious link to design in the PRs, so I ddin't dig too deep and concluded it was most likely a style oversight.