### PR TITLE
🐛 (key indicator) fix broken animation / TAS-535

### DIFF
--- a/site/gdocs/components/KeyIndicatorCollection.tsx
+++ b/site/gdocs/components/KeyIndicatorCollection.tsx
@@ -189,9 +189,16 @@ function AccordionItem({
                                     })
                                 }
 
-                                if (contentRef.current) {
-                                    contentRef.current.focus()
-                                }
+                                // focus on content after the scroll-into-view
+                                // animation has finished (fixes a bug in Safari
+                                // where focus is lost after an accordion item
+                                // is opened and the focus unexpectedly jumps
+                                // to the top of the page on further interactions)
+                                setTimeout(() => {
+                                    if (contentRef.current) {
+                                        contentRef.current.focus()
+                                    }
+                                }, 600)
                             }, HEIGHT_ANIMATION_DURATION_IN_SECONDS * 1000)
                         }
                     }}


### PR DESCRIPTION
#3527 attempted to fix a bug where - after opening an accordion item using the keyboard - the focus unexpectedly jumped to the top of the page. This was fixed by programmatically focusing the content area after opening an accordion. Unfortunately, this breaks the scroll-into-view animation. To avoid interrupting the scroll-into-view animation, we wait a few hundred ms to focus the content area. But we don't really know how much time the animation needs, so the timeout time is set through experimentation. If you're extremely quick to continue navigating, you'll still jump to the top page and then back. This only happens in Safari though – I can't repro the original bug in Chrome or Firefox. 

Not really happy with this fix, but can't think of another way...