### PR TITLE
🔨 (db) add chart_configs table / TAS-563

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -84,6 +84,7 @@ import {
     FlatTagGraph,
     DbRawChartConfig,
 } from "@ourworldindata/types"
+import { uuidv7 } from "uuidv7"
 import {
     getVariableDataRoute,
     getVariableMetadataRoute,
@@ -374,7 +375,7 @@ const saveGrapher = async (
             [now, user.id, chartId]
         )
     } else {
-        const configId = await db.getBinaryUUID(knex)
+        const configId = uuidv7()
         await db.knexRaw(
             knex,
             `-- sql

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -71,7 +71,7 @@ import {
     PostsTableName,
     DbRawPost,
     DbPlainChartSlugRedirect,
-    DbRawChart,
+    DbPlainChart,
     DbInsertChartRevision,
     serializeChartConfig,
     DbRawOrigin,
@@ -82,6 +82,7 @@ import {
     DbPlainDataset,
     DbInsertUser,
     FlatTagGraph,
+    DbRawChartConfig,
 } from "@ourworldindata/types"
 import {
     getVariableDataRoute,
@@ -288,9 +289,17 @@ const saveGrapher = async (
     }
 
     async function isSlugUsedInOtherGrapher() {
-        const rows = await db.knexRaw<Pick<DbRawChart, "id">>(
+        const rows = await db.knexRaw<Pick<DbPlainChart, "id">>(
             knex,
-            `SELECT id FROM charts WHERE id != ? AND config->>"$.isPublished" = "true" AND JSON_EXTRACT(config, "$.slug") = ?`,
+            `-- sql
+                SELECT c.id
+                FROM charts c
+                JOIN chart_configs cc ON cc.id = c.configId
+                WHERE
+                    c.id != ?
+                    AND cc.full ->> "$.isPublished" = "true"
+                    AND cc.slug = ?
+            `,
             // -1 is a placeholder ID that will never exist; but we cannot use NULL because
             // in that case we would always get back an empty resultset
             [existingConfig ? existingConfig.id : -1, newConfig.slug]
@@ -342,25 +351,61 @@ const saveGrapher = async (
     const now = new Date()
     let chartId = existingConfig && existingConfig.id
     const newJsonConfig = JSON.stringify(newConfig)
-    if (existingConfig)
+    if (existingConfig) {
         await db.knexRaw(
             knex,
-            `UPDATE charts SET config=?, updatedAt=?, lastEditedAt=?, lastEditedByUserId=? WHERE id = ?`,
-            [newJsonConfig, now, now, user.id, chartId]
+            `-- sql
+                UPDATE chart_configs cc
+                JOIN charts c ON c.configId = cc.id
+                SET
+                    cc.patch=?,
+                    cc.full=?
+                WHERE c.id = ?
+            `,
+            [newJsonConfig, newJsonConfig, chartId]
         )
-    else {
+        await db.knexRaw(
+            knex,
+            `-- sql
+                UPDATE charts
+                SET lastEditedAt=?, lastEditedByUserId=?
+                WHERE id = ?
+            `,
+            [now, user.id, chartId]
+        )
+    } else {
+        const configId = await db.getBinaryUUID(knex)
+        await db.knexRaw(
+            knex,
+            `-- sql
+                INSERT INTO chart_configs (id, patch, full)
+                VALUES (?, ?, ?)
+            `,
+            [configId, newJsonConfig, newJsonConfig]
+        )
         const result = await db.knexRawInsert(
             knex,
-            `INSERT INTO charts (config, createdAt, updatedAt, lastEditedAt, lastEditedByUserId) VALUES (?, ?, ?, ?, ?)`,
-            [newJsonConfig, now, now, now, user.id]
+            `-- sql
+                INSERT INTO charts (configId, lastEditedAt, lastEditedByUserId)
+                VALUES (?, ?, ?)
+            `,
+            [configId, now, user.id]
         )
         chartId = result.insertId
         // The chart config itself has an id field that should store the id of the chart - update the chart now so this is true
         newConfig.id = chartId
-        await db.knexRaw(knex, `UPDATE charts SET config=? WHERE id = ?`, [
-            JSON.stringify(newConfig),
-            chartId,
-        ])
+        await db.knexRaw(
+            knex,
+            `-- sql
+                UPDATE chart_configs cc
+                JOIN charts c ON c.configId = cc.id
+                SET
+                    cc.patch=JSON_SET(cc.patch, '$.id', ?),
+                    cc.full=JSON_SET(cc.full, '$.id', ?)
+                WHERE c.id = ?
+            `,
+            [chartId, chartId, chartId]
+        )
     }
 
     // Record this change in version history
@@ -441,11 +486,12 @@ getRouteWithROTransaction(apiRouter, "/charts.json", async (req, res, trx) => {
     const charts = await db.knexRaw<OldChartFieldList>(
         trx,
         `-- sql
-        SELECT ${oldChartFieldList} FROM charts
-        JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
-        LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
-        ORDER BY charts.lastEditedAt DESC LIMIT ?
-    `,
+            SELECT ${oldChartFieldList} FROM charts
+            JOIN chart_configs ON chart_configs.id = charts.configId
+            JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
+            LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
+            ORDER BY charts.lastEditedAt DESC LIMIT ?
+        `,
         [limit]
     )
 
@@ -461,36 +507,37 @@ getRouteWithROTransaction(apiRouter, "/charts.csv", async (req, res, trx) => {
     const charts = await db.knexRaw(
         trx,
         `-- sql
-        SELECT
-            charts.id,
-            charts.config->>"$.version" AS version,
-            CONCAT("${BAKED_BASE_URL}/grapher/", charts.config->>"$.slug") AS url,
-            CONCAT("${ADMIN_BASE_URL}", "/admin/charts/", charts.id, "/edit") AS editUrl,
-            charts.config->>"$.slug" AS slug,
-            charts.config->>"$.title" AS title,
-            charts.config->>"$.subtitle" AS subtitle,
-            charts.config->>"$.sourceDesc" AS sourceDesc,
-            charts.config->>"$.note" AS note,
-            charts.config->>"$.type" AS type,
-            charts.config->>"$.internalNotes" AS internalNotes,
-            charts.config->>"$.variantName" AS variantName,
-            charts.config->>"$.isPublished" AS isPublished,
-            charts.config->>"$.tab" AS tab,
-            JSON_EXTRACT(charts.config, "$.hasChartTab") = true AS hasChartTab,
-            JSON_EXTRACT(charts.config, "$.hasMapTab") = true AS hasMapTab,
-            charts.config->>"$.originUrl" AS originUrl,
-            charts.lastEditedAt,
-            charts.lastEditedByUserId,
-            lastEditedByUser.fullName AS lastEditedBy,
-            charts.publishedAt,
-            charts.publishedByUserId,
-            publishedByUser.fullName AS publishedBy
-        FROM charts
-        JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
-        LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
-        ORDER BY charts.lastEditedAt DESC
-        LIMIT ?
-    `,
+            SELECT
+                charts.id,
+                chart_configs.full->>"$.version" AS version,
+                CONCAT("${BAKED_BASE_URL}/grapher/", chart_configs.full->>"$.slug") AS url,
+                CONCAT("${ADMIN_BASE_URL}", "/admin/charts/", charts.id, "/edit") AS editUrl,
+                chart_configs.full->>"$.slug" AS slug,
+                chart_configs.full->>"$.title" AS title,
+                chart_configs.full->>"$.subtitle" AS subtitle,
+                chart_configs.full->>"$.sourceDesc" AS sourceDesc,
+                chart_configs.full->>"$.note" AS note,
+                chart_configs.full->>"$.type" AS type,
+                chart_configs.full->>"$.internalNotes" AS internalNotes,
+                chart_configs.full->>"$.variantName" AS variantName,
+                chart_configs.full->>"$.isPublished" AS isPublished,
+                chart_configs.full->>"$.tab" AS tab,
+                JSON_EXTRACT(chart_configs.full, "$.hasChartTab") = true AS hasChartTab,
+                JSON_EXTRACT(chart_configs.full, "$.hasMapTab") = true AS hasMapTab,
+                chart_configs.full->>"$.originUrl" AS originUrl,
+                charts.lastEditedAt,
+                charts.lastEditedByUserId,
+                lastEditedByUser.fullName AS lastEditedBy,
+                charts.publishedAt,
+                charts.publishedByUserId,
+                publishedByUser.fullName AS publishedBy
+            FROM charts
+            JOIN chart_configs ON chart_configs.id = charts.configId
+            JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
+            LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
+            ORDER BY charts.lastEditedAt DESC
+            LIMIT ?
+        `,
         [limit]
     )
     // note: retrieving references is VERY slow.
@@ -759,7 +806,18 @@ deleteRouteWithRWTransaction(
             `DELETE FROM chart_slug_redirects WHERE chart_id=?`,
             [chart.id]
         )
-        await db.knexRaw(trx, `DELETE FROM charts WHERE id=?`, [chart.id])
+
+        const row = await db.knexRawFirst<{ configId: number }>(
+            trx,
+            `SELECT configId FROM charts WHERE id = ?`,
+            [chart.id]
+        )
+        if (row) {
+            await db.knexRaw(trx, `DELETE FROM charts WHERE id=?`, [chart.id])
+            await db.knexRaw(trx, `DELETE FROM chart_configs WHERE id=?`, [
+                row.configId,
+            ])
+        }
 
         if (chart.isPublished)
             await triggerStaticBuild(
@@ -871,7 +929,7 @@ getRouteWithROTransaction(
         trx
     ): Promise<BulkGrapherConfigResponse<BulkChartEditResponseRow>> => {
         const context: OperationContext = {
-            grapherConfigFieldName: "config",
+            grapherConfigFieldName: "chart_configs.full",
             whitelistedColumnNamesAndTypes:
                 chartBulkUpdateAllowedColumnNamesAndTypes,
         }
@@ -889,21 +947,25 @@ getRouteWithROTransaction(
         const whereClause = filterSExpr?.toSql() ?? "true"
         const resultsWithStringGrapherConfigs = await db.knexRaw(
             trx,
-            `SELECT charts.id as id,
-            charts.config as config,
-            charts.createdAt as createdAt,
-            charts.updatedAt as updatedAt,
-            charts.lastEditedAt as lastEditedAt,
-            charts.publishedAt as publishedAt,
-            lastEditedByUser.fullName as lastEditedByUser,
-            publishedByUser.fullName as publishedByUser
-FROM charts
-LEFT JOIN users lastEditedByUser ON lastEditedByUser.id=charts.lastEditedByUserId
-LEFT JOIN users publishedByUser ON publishedByUser.id=charts.publishedByUserId
-WHERE ${whereClause}
-ORDER BY charts.id DESC
-LIMIT 50
-OFFSET ${offset.toString()}`
+            `-- sql
+                SELECT
+                    charts.id as id,
+                    chart_configs.full as config,
+                    charts.createdAt as createdAt,
+                    charts.updatedAt as updatedAt,
+                    charts.lastEditedAt as lastEditedAt,
+                    charts.publishedAt as publishedAt,
+                    lastEditedByUser.fullName as lastEditedByUser,
+                    publishedByUser.fullName as publishedByUser
+                FROM charts
+                LEFT JOIN chart_configs ON chart_configs.id = charts.configId
+                LEFT JOIN users lastEditedByUser ON lastEditedByUser.id=charts.lastEditedByUserId
+                LEFT JOIN users publishedByUser ON publishedByUser.id=charts.publishedByUserId
+                WHERE ${whereClause}
+                ORDER BY charts.id DESC
+                LIMIT 50
+                OFFSET ${offset.toString()}
+            `
         )
 
         const results = resultsWithStringGrapherConfigs.map((row: any) => ({
@@ -912,9 +974,12 @@ OFFSET ${offset.toString()}`
         }))
         const resultCount = await db.knexRaw<{ count: number }>(
             trx,
-            `SELECT count(*) as count
-FROM charts
-WHERE ${whereClause}`
+            `-- sql
+                SELECT count(*) as count
+                FROM charts
+                JOIN chart_configs ON chart_configs.id = charts.configId
+                WHERE ${whereClause}
+            `
         )
         return { rows: results, numTotalRows: resultCount[0].count }
     }
@@ -928,10 +993,17 @@ patchRouteWithRWTransaction(
         const chartIds = new Set(patchesList.map((patch) => patch.id))
 
         const configsAndIds = await db.knexRaw<
-            Pick<DbRawChart, "id" | "config">
-        >(trx, `SELECT id, config FROM charts where id IN (?)`, [
-            [...chartIds.values()],
-        ])
+            Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["full"] }
+        >(
+            trx,
+            `-- sql
+                SELECT c.id, cc.full as config
+                FROM charts c
+                JOIN chart_configs cc ON cc.id = c.configId
+                WHERE c.id IN (?)
+            `,
+            [[...chartIds.values()]]
+        )
         const configMap = new Map<number, GrapherInterface>(
             configsAndIds.map((item: any) => [
                 item.id,
@@ -1099,13 +1171,14 @@ getRouteWithROTransaction(
         const charts = await db.knexRaw<OldChartFieldList>(
             trx,
             `-- sql
-            SELECT ${oldChartFieldList}
-            FROM charts
-            JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
-            LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
-            JOIN chart_dimensions cd ON cd.chartId = charts.id
-            WHERE cd.variableId = ?
-            GROUP BY charts.id
+                SELECT ${oldChartFieldList}
+                FROM charts
+                JOIN chart_configs ON chart_configs.id = charts.configId
+                JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
+                LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
+                JOIN chart_dimensions cd ON cd.chartId = charts.id
+                WHERE cd.variableId = ?
+                GROUP BY charts.id
             `,
             [variableId]
         )
@@ -1325,15 +1398,16 @@ getRouteWithROTransaction(
         const charts = await db.knexRaw<OldChartFieldList>(
             trx,
             `-- sql
-        SELECT ${oldChartFieldList}
-        FROM charts
-        JOIN chart_dimensions AS cd ON cd.chartId = charts.id
-        JOIN variables AS v ON cd.variableId = v.id
-        JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
-        LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
-        WHERE v.datasetId = ?
-        GROUP BY charts.id
-    `,
+                SELECT ${oldChartFieldList}
+                FROM charts
+                JOIN chart_configs ON chart_configs.id = charts.configId
+                JOIN chart_dimensions AS cd ON cd.chartId = charts.id
+                JOIN variables AS v ON cd.variableId = v.id
+                JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
+                LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
+                WHERE v.datasetId = ?
+                GROUP BY charts.id
+            `,
             [datasetId]
         )
 
@@ -1506,16 +1580,18 @@ postRouteWithRWTransaction(
         if (req.body.republish) {
             await db.knexRaw(
                 trx,
-                `
-            UPDATE charts
-            SET config = JSON_SET(config, "$.version", config->"$.version" + 1)
-            WHERE id IN (
-                SELECT DISTINCT chart_dimensions.chartId
-                FROM chart_dimensions
-                JOIN variables ON variables.id = chart_dimensions.variableId
-                WHERE variables.datasetId = ?
-            )
-            `,
+                `-- sql
+                    UPDATE chart_configs cc
+                    JOIN charts c ON c.configId = cc.id
+                    SET
+                        cc.patch = JSON_SET(cc.patch, "$.version", cc.patch->"$.version" + 1),
+                        cc.full = JSON_SET(cc.full, "$.version", cc.full->"$.version" + 1)
+                    WHERE c.id IN (
+                        SELECT DISTINCT chart_dimensions.chartId
+                        FROM chart_dimensions
+                        JOIN variables ON variables.id = chart_dimensions.variableId
+                        WHERE variables.datasetId = ?
+                    )`,
                 [datasetId]
             )
         }
@@ -1537,9 +1613,16 @@ getRouteWithROTransaction(
         redirects: await db.knexRaw(
             trx,
             `-- sql
-        SELECT r.id, r.slug, r.chart_id as chartId, JSON_UNQUOTE(JSON_EXTRACT(charts.config, "$.slug")) AS chartSlug
-        FROM chart_slug_redirects AS r JOIN charts ON charts.id = r.chart_id
-        ORDER BY r.id DESC`
+                SELECT
+                    r.id,
+                    r.slug,
+                    r.chart_id as chartId,
+                    chart_configs.slug AS chartSlug
+                FROM chart_slug_redirects AS r
+                JOIN charts ON charts.id = r.chart_id
+                JOIN chart_configs ON chart_configs.id = charts.configId
+                ORDER BY r.id DESC
+            `
         ),
     })
 )
@@ -1714,14 +1797,15 @@ getRouteWithROTransaction(
         const charts = await db.knexRaw<OldChartFieldList>(
             trx,
             `-- sql
-        SELECT ${oldChartFieldList} FROM charts
-        LEFT JOIN chart_tags ct ON ct.chartId=charts.id
-        JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
-        LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
-        WHERE ct.tagId ${tagId === UNCATEGORIZED_TAG_ID ? "IS NULL" : "= ?"}
-        GROUP BY charts.id
-        ORDER BY charts.updatedAt DESC
-    `,
+                SELECT ${oldChartFieldList} FROM charts
+                JOIN chart_configs ON chart_configs.id = charts.configId
+                LEFT JOIN chart_tags ct ON ct.chartId=charts.id
+                JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
+                LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
+                WHERE ct.tagId ${tagId === UNCATEGORIZED_TAG_ID ? "IS NULL" : "= ?"}
+                GROUP BY charts.id
+                ORDER BY charts.updatedAt DESC
+            `,
             uncategorized ? [] : [tagId]
         )
         tag.charts = charts

--- a/baker/GrapherBakingUtils.ts
+++ b/baker/GrapherBakingUtils.ts
@@ -82,7 +82,12 @@ export const bakeGrapherUrls = async (
 
         const rows = await db.knexRaw<{ version: number }>(
             knex,
-            `SELECT charts.config->>"$.version" AS version FROM charts WHERE charts.id=?`,
+            `-- sql
+                SELECT cc.full->>"$.version" AS version
+                FROM charts c
+                JOIN chart_configs cc ON c.configId = cc.id
+                WHERE c.id=?
+            `,
             [chartId]
         )
         if (!rows.length) {

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -724,19 +724,21 @@ export class SiteBaker {
                 knex,
                 `-- sql
                 SELECT
-                    config ->> '$.slug' as slug,
-                    config ->> '$.subtitle' as subtitle,
-                    config ->> '$.note' as note
+                    cc.slug,
+                    cc.full ->> '$.subtitle' as subtitle,
+                    cc.full ->> '$.note' as note
                 FROM
-                    charts
+                    charts c
+                JOIN
+                    chart_configs cc ON c.configId = cc.id
                 WHERE
-                    JSON_EXTRACT(config, "$.isPublished") = true
+                    JSON_EXTRACT(cc.full, "$.isPublished") = true
                 AND (
-                    JSON_EXTRACT(config, "$.subtitle") LIKE "%#dod:%"
-                    OR JSON_EXTRACT(config, "$.note") LIKE "%#dod:%"
+                    JSON_EXTRACT(cc.full, "$.subtitle") LIKE "%#dod:%"
+                    OR JSON_EXTRACT(cc.full, "$.note") LIKE "%#dod:%"
                 )
                 ORDER BY
-                    JSON_EXTRACT(config, "$.slug") ASC
+                    cc.slug ASC
             `
             )
 

--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -123,19 +123,20 @@ const getChartsRecords = async (
         `-- sql
         WITH indexable_charts_with_entity_names AS (
             SELECT c.id,
-                   config ->> "$.slug"                    AS slug,
-                   config ->> "$.title"                   AS title,
-                   config ->> "$.variantName"             AS variantName,
-                   config ->> "$.subtitle"                AS subtitle,
-                   JSON_LENGTH(config ->> "$.dimensions") AS numDimensions,
+                   cc.slug,
+                   cc.full ->> "$.title"                   AS title,
+                   cc.full ->> "$.variantName"             AS variantName,
+                   cc.full ->> "$.subtitle"                AS subtitle,
+                   JSON_LENGTH(cc.full ->> "$.dimensions") AS numDimensions,
                    c.publishedAt,
                    c.updatedAt,
                    JSON_ARRAYAGG(e.name)                  AS entityNames
             FROM charts c
+                     LEFT JOIN chart_configs cc ON c.configId = cc.id
                      LEFT JOIN charts_x_entities ce ON c.id = ce.chartId
                      LEFT JOIN entities e ON ce.entityId = e.id
-            WHERE config ->> "$.isPublished" = 'true'
-              AND isIndexable IS TRUE
+            WHERE cc.full ->> "$.isPublished" = 'true'
+                AND c.isIndexable IS TRUE
             GROUP BY c.id
         )
         SELECT c.id,

--- a/baker/countryProfiles.tsx
+++ b/baker/countryProfiles.tsx
@@ -7,6 +7,8 @@ import {
     DbEnrichedVariable,
     VariablesTableName,
     parseVariablesRow,
+    DbRawChartConfig,
+    parseChartConfig,
 } from "@ourworldindata/types"
 import * as lodash from "lodash"
 import {
@@ -45,13 +47,20 @@ const countryIndicatorGraphers = async (
     trx: db.KnexReadonlyTransaction
 ): Promise<GrapherInterface[]> =>
     bakeCache(countryIndicatorGraphers, async () => {
-        const graphers = (
-            await trx
-                .table("charts")
-                .whereRaw(
-                    "publishedAt is not null and config->>'$.isPublished' = 'true' and isIndexable is true"
-                )
-        ).map((c: any) => JSON.parse(c.config)) as GrapherInterface[]
+        const configs = await db.knexRaw<{ config: DbRawChartConfig["full"] }>(
+            trx,
+            `-- sql
+                SELECT cc.full as config
+                FROM charts c
+                JOIN chart_configs cc ON cc.id = c.configId
+                WHERE
+                    c.publishedAt is not null
+                    AND cc.full->>'$.isPublished' = 'true'
+                    AND c.isIndexable is true
+            `
+        )
+
+        const graphers = configs.map((c: any) => parseChartConfig(c.config))
 
         return graphers.filter(checkShouldShowIndicator)
     })

--- a/baker/redirects.ts
+++ b/baker/redirects.ts
@@ -97,9 +97,11 @@ export const getGrapherRedirectsMap = async (
     }>(
         knex,
         `-- sql
-        SELECT chart_slug_redirects.slug as oldSlug, charts.config ->> "$.slug" as newSlug
-        FROM chart_slug_redirects INNER JOIN charts ON charts.id=chart_id
-    `
+            SELECT chart_slug_redirects.slug as oldSlug, chart_configs.slug as newSlug
+            FROM chart_slug_redirects
+            INNER JOIN charts ON charts.id=chart_id
+            INNER JOIN chart_configs ON chart_configs.id=charts.configId
+        `
     )) as Array<{ oldSlug: string; newSlug: string }>
 
     return new Map(

--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -7,7 +7,7 @@ import {
     dayjs,
     countries,
     queryParamsToStr,
-    ChartsTableName,
+    DbPlainChart,
 } from "@ourworldindata/utils"
 import * as db from "../db/db.js"
 import urljoin from "url-join"
@@ -82,13 +82,18 @@ export const makeSitemap = async (
         publishedDataInsights.length
     )
 
-    const charts = (await knex
-        .table(ChartsTableName)
-        .select(knex.raw(`updatedAt, config->>"$.slug" AS slug`))
-        .whereRaw('config->"$.isPublished" = true')) as {
-        updatedAt: Date
-        slug: string
-    }[]
+    const charts = await db.knexRaw<
+        Pick<DbPlainChart, "updatedAt"> & { slug: string }
+    >(
+        knex,
+        `-- sql
+            SELECT c.updatedAt, cc.slug
+            FROM charts c
+            JOIN chart_configs cc ON cc.id = c.configId
+            WHERE
+                cc.full->"$.isPublished" = true
+        `
+    )
 
     const explorers = await explorerAdminServer.getAllPublishedExplorers()
 

--- a/baker/updateChartEntities.ts
+++ b/baker/updateChartEntities.ts
@@ -6,13 +6,13 @@
 
 import { Grapher } from "@ourworldindata/grapher"
 import {
-    ChartsTableName,
     ChartsXEntitiesTableName,
-    DbRawChart,
+    DbPlainChart,
     GrapherInterface,
     GrapherTabOption,
     MultipleOwidVariableDataDimensionsMap,
     OwidVariableDataMetadataDimensions,
+    DbRawChartConfig,
 } from "@ourworldindata/types"
 import * as db from "../db/db.js"
 import pMap from "p-map"
@@ -41,13 +41,15 @@ const preFetchCommonVariables = async (
     const commonVariables = (await db.knexRaw(
         trx,
         `-- sql
-        SELECT variableId, COUNT(variableId) AS useCount
-        FROM chart_dimensions cd
-        JOIN charts c ON cd.chartId = c.id
-        WHERE config ->> "$.isPublished" = "true"
-        GROUP BY variableId
-        ORDER BY COUNT(variableId) DESC
-        LIMIT ??`,
+            SELECT variableId, COUNT(variableId) AS useCount
+            FROM chart_dimensions cd
+            JOIN charts c ON cd.chartId = c.id
+            JOIN chart_configs cc ON c.configId = cc.id
+            WHERE cc.full ->> "$.isPublished" = "true"
+            GROUP BY variableId
+            ORDER BY COUNT(variableId) DESC
+            LIMIT ??
+        `,
         [VARIABLES_TO_PREFETCH]
     )) as { variableId: number; useCount: number }[]
 
@@ -123,13 +125,17 @@ const obtainAvailableEntitiesForAllGraphers = async (
 ) => {
     const entityNameToIdMap = await mapEntityNamesToEntityIds(trx)
 
-    const allPublishedGraphers = (await trx
-        .select("id", "config")
-        .from(ChartsTableName)
-        .whereRaw("config ->> '$.isPublished' = 'true'")) as Pick<
-        DbRawChart,
-        "id" | "config"
-    >[]
+    const allPublishedGraphers = await db.knexRaw<
+        Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["full"] }
+    >(
+        trx,
+        `-- sql
+            SELECT c.id, cc.full as config
+            FROM charts c
+            JOIN chart_configs cc ON c.configId = cc.id
+            WHERE cc.full ->> "$.isPublished" = 'true'
+        `
+    )
 
     const availableEntitiesByChartId = new Map<number, number[]>()
     await pMap(

--- a/db/db.ts
+++ b/db/db.ts
@@ -304,10 +304,12 @@ export const getTotalNumberOfCharts = (
 ): Promise<number> => {
     return knexRawFirst<{ count: number }>(
         knex,
+        `-- sql
+            SELECT COUNT(*) AS count
+            FROM charts c
+            JOIN chart_configs cc ON c.configId = cc.id
+            WHERE cc.full ->> "$.isPublished" = "true"
         `
-        SELECT COUNT(*) AS count
-        FROM charts
-        WHERE config->"$.isPublished" = TRUE`
     ).then((res) => res?.count ?? 0)
 }
 
@@ -665,4 +667,14 @@ export async function getLinkedIndicatorSlugs({
         .then((gdocs) => gdocs.map((gdoc) => gdocFromJSON(gdoc)))
         .then((gdocs) => gdocs.flatMap((gdoc) => gdoc.linkedKeyIndicatorSlugs))
         .then((slugs) => new Set(slugs))
+}
+
+export const getBinaryUUID = async (
+    knex: KnexReadonlyTransaction
+): Promise<Buffer> => {
+    const { id } = (await knexRawFirst<{ id: Buffer }>(
+        knex,
+        `SELECT UUID_TO_BIN(UUID(), 1) AS id`
+    ))!
+    return id
 }

--- a/db/db.ts
+++ b/db/db.ts
@@ -668,13 +668,3 @@ export async function getLinkedIndicatorSlugs({
         .then((gdocs) => gdocs.flatMap((gdoc) => gdoc.linkedKeyIndicatorSlugs))
         .then((slugs) => new Set(slugs))
 }
-
-export const getBinaryUUID = async (
-    knex: KnexReadonlyTransaction
-): Promise<Buffer> => {
-    const { id } = (await knexRawFirst<{ id: Buffer }>(
-        knex,
-        `SELECT UUID_TO_BIN(UUID(), 1) AS id`
-    ))!
-    return id
-}

--- a/db/migration/1719842654592-AddChartConfigsTable.ts
+++ b/db/migration/1719842654592-AddChartConfigsTable.ts
@@ -1,0 +1,134 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddChartConfigsTable1719842654592 implements MigrationInterface {
+    private async createChartConfigsTable(
+        queryRunner: QueryRunner
+    ): Promise<void> {
+        await queryRunner.query(`-- sql
+            CREATE TABLE chart_configs (
+                id binary(16) NOT NULL DEFAULT (UUID_TO_BIN(UUID(), 1)) PRIMARY KEY,
+                uuid varchar(36) GENERATED ALWAYS AS (BIN_TO_UUID(id, 1)) VIRTUAL,
+                patch json NOT NULL,
+                full json NOT NULL,
+                slug varchar(255) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(full, '$.slug'))) STORED,
+                createdAt datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updatedAt datetime DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+                INDEX idx_chart_configs_slug (slug)
+            )
+        `)
+    }
+
+    private async createConfigIdColumnInChartsTable(
+        queryRunner: QueryRunner
+    ): Promise<void> {
+        // add a new `configId` column to the charts table
+        // that points to the `chart_configs` table
+        await queryRunner.query(`-- sql
+            ALTER TABLE charts
+            ADD COLUMN configId binary(16) UNIQUE AFTER type,
+            ADD CONSTRAINT charts_configId
+                FOREIGN KEY (configId)
+                REFERENCES chart_configs (id)
+                ON DELETE RESTRICT
+                ON UPDATE RESTRICT
+        `)
+    }
+
+    private async moveConfigsToChartConfigsTable(
+        queryRunner: QueryRunner
+    ): Promise<void> {
+        // make sure that the config's id matches the table's primary key
+        await queryRunner.query(`-- sql
+            UPDATE charts
+            SET config = JSON_REPLACE(config, '$.id', id)
+            WHERE id != config ->> "$.id";
+        `)
+
+        // insert all the configs into the `chart_configs` table
+        await queryRunner.query(`-- sql
+            INSERT INTO chart_configs (patch, full)
+            SELECT config, config FROM charts
+        `)
+
+        // update the `configId` column in the `charts` table
+        await queryRunner.query(`-- sql
+            UPDATE charts ca
+            JOIN chart_configs cc
+            ON ca.id = cc.full ->> '$.id'
+            SET ca.configId = cc.id
+        `)
+
+        // now that the `configId` column is filled, make it NOT NULL
+        await queryRunner.query(`-- sql
+            ALTER TABLE charts
+            MODIFY COLUMN configId binary(16) NOT NULL;
+        `)
+
+        // update `createdAt` and `updatedAt` of the chart_configs table
+        await queryRunner.query(`-- sql
+            UPDATE chart_configs cc
+            JOIN charts ca
+            ON cc.id = ca.configId
+            SET
+                cc.createdAt = ca.createdAt,
+                cc.updatedAt = ca.updatedAt
+        `)
+    }
+
+    private async dropConfigColumnFromChartsTable(
+        queryRunner: QueryRunner
+    ): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE charts
+            DROP COLUMN slug,
+            DROP COLUMN type,
+            DROP COLUMN config
+        `)
+    }
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await this.createChartConfigsTable(queryRunner)
+        await this.createConfigIdColumnInChartsTable(queryRunner)
+        await this.moveConfigsToChartConfigsTable(queryRunner)
+        await this.dropConfigColumnFromChartsTable(queryRunner)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // add back the config column and its virtual columns
+        await queryRunner.query(`-- sql
+            ALTER TABLE charts
+            ADD COLUMN config JSON AFTER configId,
+            ADD COLUMN slug VARCHAR(255) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(config, '$.slug'))) VIRTUAL AFTER config,
+            ADD COLUMN type VARCHAR(255) GENERATED ALWAYS AS (COALESCE(JSON_UNQUOTE(JSON_EXTRACT(config, '$.type')), 'LineChart')) VIRTUAL AFTER slug
+        `)
+
+        await queryRunner.query(`-- sql
+            CREATE INDEX idx_charts_slug ON charts (slug)
+        `)
+
+        // recover configs
+        await queryRunner.query(`-- sql
+            UPDATE charts c
+            JOIN chart_configs cc ON c.configId = cc.id
+            SET c.config = cc.full
+        `)
+
+        // make the config column NOT NULL
+        await queryRunner.query(`-- sql
+            ALTER TABLE charts
+            MODIFY COLUMN config JSON NOT NULL;
+        `)
+
+        // drop the `charts.configId` column
+        await queryRunner.query(`-- sql
+            ALTER TABLE charts
+            DROP FOREIGN KEY charts_configId,
+            DROP COLUMN configId
+        `)
+
+        // drop the `chart_configs` table
+        await queryRunner.query(`-- sql
+            DROP TABLE chart_configs
+        `)
+    }
+}

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -12,12 +12,12 @@ import {
     ChartTypeName,
     RelatedChart,
     DbPlainPostLink,
-    DbRawChart,
-    DbEnrichedChart,
-    parseChartsRow,
+    DbPlainChart,
     parseChartConfig,
     ChartRedirect,
     DbPlainTag,
+    DbRawChartConfig,
+    DbEnrichedChartConfig,
 } from "@ourworldindata/types"
 import { OpenAI } from "openai"
 import {
@@ -42,12 +42,11 @@ export async function mapSlugsToIds(
     const rows = await db.knexRaw<{ id: number; slug: string }>(
         knex,
         `-- sql
-    SELECT
-        id,
-        JSON_UNQUOTE(JSON_EXTRACT(config, "$.slug")) AS slug
-    FROM charts
-    WHERE config->>"$.isPublished" = "true"
-`
+            SELECT c.id, cc.slug
+            FROM charts c
+            JOIN chart_configs cc ON cc.id = c.configId
+            WHERE cc.full ->> "$.isPublished" = "true"
+        `
     )
 
     const slugToId: { [slug: string]: number } = {}
@@ -72,16 +71,17 @@ export async function mapSlugsToConfigs(
         .knexRaw<{ slug: string; config: string; id: number }>(
             knex,
             `-- sql
-SELECT csr.slug AS slug, c.config AS config, c.id AS id
-FROM chart_slug_redirects csr
-JOIN charts c
-ON csr.chart_id = c.id
-WHERE c.config -> "$.isPublished" = true
-UNION
-SELECT c.slug AS slug, c.config AS config, c.id AS id
-FROM charts c
-WHERE c.config -> "$.isPublished" = true
-`
+                SELECT csr.slug AS slug, cc.full AS config, c.id AS id
+                FROM chart_slug_redirects csr
+                JOIN charts c ON csr.chart_id = c.id
+                JOIN chart_configs cc ON cc.id = c.configId
+                WHERE cc.full ->> "$.isPublished" = "true"
+                UNION
+                SELECT cc.slug, cc.full AS config, c.id AS id
+                FROM charts c
+                JOIN chart_configs cc ON cc.id = c.configId
+                WHERE cc.full ->> "$.isPublished" = "true"
+            `
         )
         .then((results) =>
             results.map((result) => ({
@@ -94,31 +94,42 @@ WHERE c.config -> "$.isPublished" = true
 export async function getEnrichedChartBySlug(
     knex: db.KnexReadonlyTransaction,
     slug: string
-): Promise<DbEnrichedChart | null> {
-    let chart = await db.knexRawFirst<DbRawChart>(
+): Promise<(DbPlainChart & { config: DbEnrichedChartConfig["full"] }) | null> {
+    let chart = await db.knexRawFirst<
+        DbPlainChart & { config: DbRawChartConfig["full"] }
+    >(
         knex,
-        `SELECT * FROM charts WHERE config ->> '$.slug' = ?`,
+        `-- sql
+            SELECT c.*, cc.full as config
+            FROM charts c
+            JOIN chart_configs cc ON c.configId = cc.id
+            WHERE cc.slug = ?
+        `,
         [slug]
     )
 
     if (!chart) {
-        chart = await db.knexRawFirst<DbRawChart>(
+        chart = await db.knexRawFirst<
+            DbPlainChart & { config: DbRawChartConfig["full"] }
+        >(
             knex,
             `-- sql
-            SELECT
-                c.*
-            FROM
-                chart_slug_redirects csr
-                JOIN charts c ON csr.chart_id = c.id
-            WHERE
-                csr.slug = ?`,
+                SELECT
+                    c.*, cc.full as config
+                FROM
+                    chart_slug_redirects csr
+                    JOIN charts c ON csr.chart_id = c.id
+                    JOIN chart_configs cc ON c.configId = cc.id
+                WHERE
+                    csr.slug = ?
+            `,
             [slug]
         )
     }
 
     if (!chart) return null
 
-    const enrichedChart = parseChartsRow(chart)
+    const enrichedChart = { ...chart, config: parseChartConfig(chart.config) }
 
     return enrichedChart
 }
@@ -126,10 +137,17 @@ export async function getEnrichedChartBySlug(
 export async function getRawChartById(
     knex: db.KnexReadonlyTransaction,
     id: number
-): Promise<DbRawChart | null> {
-    const chart = await db.knexRawFirst<DbRawChart>(
+): Promise<(DbPlainChart & { config: DbRawChartConfig["full"] }) | null> {
+    const chart = await db.knexRawFirst<
+        DbPlainChart & { config: DbRawChartConfig["full"] }
+    >(
         knex,
-        `SELECT * FROM charts WHERE id = ?`,
+        `-- sql
+            SELECT c.*, cc.full AS config
+            FROM charts c
+            JOIN chart_configs cc ON c.configId = cc.id
+            WHERE id = ?
+        `,
         [id]
     )
     if (!chart) return null
@@ -139,19 +157,24 @@ export async function getRawChartById(
 export async function getEnrichedChartById(
     knex: db.KnexReadonlyTransaction,
     id: number
-): Promise<DbEnrichedChart | null> {
+): Promise<(DbPlainChart & { config: DbEnrichedChartConfig["full"] }) | null> {
     const rawChart = await getRawChartById(knex, id)
     if (!rawChart) return null
-    return parseChartsRow(rawChart)
+    return { ...rawChart, config: parseChartConfig(rawChart.config) }
 }
 
 export async function getChartSlugById(
     knex: db.KnexReadonlyTransaction,
     id: number
 ): Promise<string | null> {
-    const chart = await db.knexRawFirst<Pick<DbRawChart, "slug">>(
+    const chart = await db.knexRawFirst<{ slug: string }>(
         knex,
-        `SELECT config ->> '$.slug' AS slug FROM charts WHERE id = ?`,
+        `-- sql
+            SELECT slug
+            FROM chart_configs cc
+            JOIN charts c ON c.configId = cc.id
+            WHERE c.id = ?
+        `,
         [id]
     )
     if (!chart) return null
@@ -161,10 +184,20 @@ export async function getChartSlugById(
 export const getChartConfigById = async (
     knex: db.KnexReadonlyTransaction,
     grapherId: number
-): Promise<Pick<DbEnrichedChart, "id" | "config"> | undefined> => {
-    const grapher = await db.knexRawFirst<Pick<DbRawChart, "id" | "config">>(
+): Promise<
+    | (Pick<DbPlainChart, "id"> & { config: DbEnrichedChartConfig["full"] })
+    | undefined
+> => {
+    const grapher = await db.knexRawFirst<
+        Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["full"] }
+    >(
         knex,
-        `SELECT id, config FROM charts WHERE id=?`,
+        `-- sql
+            SELECT c.id, cc.full as config
+            FROM charts c
+            JOIN chart_configs cc ON c.configId = cc.id
+            WHERE c.id=?
+        `,
         [grapherId]
     )
 
@@ -179,16 +212,24 @@ export const getChartConfigById = async (
 export async function getChartConfigBySlug(
     knex: db.KnexReadonlyTransaction,
     slug: string
-): Promise<Pick<DbEnrichedChart, "id" | "config">> {
-    const row = await db.knexRawFirst<Pick<DbRawChart, "id" | "config">>(
+): Promise<
+    Pick<DbPlainChart, "id"> & { config: DbEnrichedChartConfig["full"] }
+> {
+    const row = await db.knexRawFirst<
+        Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["full"] }
+    >(
         knex,
-        `SELECT id, config FROM charts WHERE JSON_EXTRACT(config, "$.slug") = ?`,
+        `-- sql
+            SELECT c.id, cc.full as config
+            FROM charts c
+            JOIN chart_configs cc ON c.configId = cc.id
+            WHERE cc.slug = ?`,
         [slug]
     )
 
     if (!row) throw new JsonError(`No chart found for slug ${slug}`, 404)
 
-    return { id: row.id, config: JSON.parse(row.config) }
+    return { id: row.id, config: parseChartConfig(row.config) }
 }
 
 export async function setChartTags(
@@ -287,11 +328,16 @@ export async function getGptTopicSuggestions(
 ): Promise<Pick<DbPlainTag, "id" | "name">[]> {
     if (!OPENAI_API_KEY) throw new JsonError("No OPENAI_API_KEY env found", 500)
 
-    const chartConfigOnly: Pick<DbRawChart, "config"> | undefined = await knex
-        .table<DbRawChart>("charts")
-        .select("config")
-        .where({ id: chartId })
-        .first()
+    const chartConfigOnly = await db.knexRawFirst<{ config: string }>(
+        knex,
+        `-- sql
+            SELECT cc.full as config
+            FROM chart_configs cc
+            JOIN charts c ON c.configId = cc.id
+            WHERE c.id = ?
+        `,
+        [chartId]
+    )
     if (!chartConfigOnly)
         throw new JsonError(`No chart found for id ${chartId}`, 404)
     const enrichedChartConfig = parseChartConfig(chartConfigOnly.config)
@@ -389,15 +435,15 @@ export interface OldChartFieldList {
 
 export const oldChartFieldList = `
         charts.id,
-        charts.config->>"$.title" AS title,
-        charts.config->>"$.slug" AS slug,
-        charts.config->>"$.type" AS type,
-        charts.config->>"$.internalNotes" AS internalNotes,
-        charts.config->>"$.variantName" AS variantName,
-        charts.config->>"$.isPublished" AS isPublished,
-        charts.config->>"$.tab" AS tab,
-        JSON_EXTRACT(charts.config, "$.hasChartTab") = true AS hasChartTab,
-        JSON_EXTRACT(charts.config, "$.hasMapTab") = true AS hasMapTab,
+        chart_configs.full->>"$.title" AS title,
+        chart_configs.full->>"$.slug" AS slug,
+        chart_configs.full->>"$.type" AS type,
+        chart_configs.full->>"$.internalNotes" AS internalNotes,
+        chart_configs.full->>"$.variantName" AS variantName,
+        chart_configs.full->>"$.isPublished" AS isPublished,
+        chart_configs.full->>"$.tab" AS tab,
+        JSON_EXTRACT(chart_configs.full, "$.hasChartTab") = true AS hasChartTab,
+        JSON_EXTRACT(chart_configs.full, "$.hasMapTab") = true AS hasMapTab,
         charts.lastEditedAt,
         charts.lastEditedByUserId,
         lastEditedByUser.fullName AS lastEditedBy,
@@ -426,15 +472,18 @@ export const getMostViewedGrapherIdsByChartType = async (
 ): Promise<number[]> => {
     const ids = await db.knexRaw<{ id: number }>(
         knex,
-        `SELECT c.id
-        FROM analytics_pageviews a
-        JOIN charts c ON c.slug = SUBSTRING_INDEX(a.url, '/', -1)
-        WHERE a.url LIKE "https://ourworldindata.org/grapher/%"
-            AND c.type = ?
-            AND c.config ->> "$.isPublished" = "true"
-            and (c.config ->> "$.hasChartTab" = "true" or c.config ->> "$.hasChartTab" is null)
-        ORDER BY a.views_365d DESC
-        LIMIT ?`,
+        `-- sql
+            SELECT c.id
+            FROM analytics_pageviews a
+            JOIN chart_configs cc ON slug = SUBSTRING_INDEX(a.url, '/', -1)
+            JOIN charts c ON c.configId = cc.id
+            WHERE a.url LIKE "https://ourworldindata.org/grapher/%"
+                AND cc.full ->> "$.type" = ?
+                AND cc.full ->> "$.isPublished" = "true"
+                and (cc.full ->> "$.hasChartTab" = "true" or cc.full ->> "$.hasChartTab" is null)
+            ORDER BY a.views_365d DESC
+            LIMIT ?
+        `,
         [chartType, count]
     )
     return ids.map((row) => row.id)
@@ -453,19 +502,20 @@ export const getRelatedChartsForVariable = async (
     return db.knexRaw<RelatedChart>(
         knex,
         `-- sql
-                SELECT
-                    charts.config->>"$.slug" AS slug,
-                    charts.config->>"$.title" AS title,
-                    charts.config->>"$.variantName" AS variantName,
-                    MAX(chart_tags.keyChartLevel) as keyChartLevel
-                FROM charts
-                INNER JOIN chart_tags ON charts.id=chart_tags.chartId
-                WHERE JSON_CONTAINS(config->'$.dimensions', '{"variableId":${variableId}}')
-                AND charts.config->>"$.isPublished" = "true"
-                ${excludeChartIds}
-                GROUP BY charts.id
-                ORDER BY title ASC
-            `
+            SELECT
+                chart_configs.slug,
+                chart_configs.full->>"$.title" AS title,
+                chart_configs.full->>"$.variantName" AS variantName,
+                MAX(chart_tags.keyChartLevel) as keyChartLevel
+            FROM charts
+            JOIN chart_configs ON charts.configId=chart_configs.id
+            INNER JOIN chart_tags ON charts.id=chart_tags.chartId
+            WHERE JSON_CONTAINS(chart_configs.full->'$.dimensions', '{"variableId":${variableId}}')
+            AND chart_configs.full->>"$.isPublished" = "true"
+            ${excludeChartIds}
+            GROUP BY charts.id
+            ORDER BY title ASC
+        `
     )
 }
 

--- a/db/model/Gdoc/GdocPost.ts
+++ b/db/model/Gdoc/GdocPost.ts
@@ -179,17 +179,18 @@ export class GdocPost extends GdocBase implements OwidGdocPostInterface {
         }>(
             knex,
             `-- sql
-        SELECT DISTINCT
-        charts.config->>"$.slug" AS slug,
-        charts.config->>"$.title" AS title,
-        charts.config->>"$.variantName" AS variantName,
-        chart_tags.keyChartLevel
-        FROM charts
-        INNER JOIN chart_tags ON charts.id=chart_tags.chartId
-        WHERE chart_tags.tagId IN (?)
-        AND charts.config->>"$.isPublished" = "true"
-        ORDER BY title ASC
-        `,
+                SELECT DISTINCT
+                    chart_configs.slug,
+                    chart_configs.full->>"$.title" AS title,
+                    chart_configs.full->>"$.variantName" AS variantName,
+                    chart_tags.keyChartLevel
+                FROM charts
+                JOIN chart_configs ON charts.configId=chart_configs.id
+                INNER JOIN chart_tags ON charts.id=chart_tags.chartId
+                WHERE chart_tags.tagId IN (?)
+                    AND chart_configs.full->>"$.isPublished" = "true"
+                ORDER BY title ASC
+            `,
             [this.tags.map((tag) => tag.id)]
         )
 

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -233,15 +233,16 @@ export const getPostRelatedCharts = async (
         knex,
         `-- sql
         SELECT DISTINCT
-            charts.config->>"$.slug" AS slug,
-            charts.config->>"$.title" AS title,
-            charts.config->>"$.variantName" AS variantName,
+            chart_configs.slug,
+            chart_configs.full->>"$.title" AS title,
+            chart_configs.full->>"$.variantName" AS variantName,
             chart_tags.keyChartLevel
         FROM charts
+        JOIN chart_configs ON charts.configId=chart_configs.id
         INNER JOIN chart_tags ON charts.id=chart_tags.chartId
         INNER JOIN post_tags ON chart_tags.tagId=post_tags.tag_id
         WHERE post_tags.post_id=${postId}
-        AND charts.config->>"$.isPublished" = "true"
+        AND chart_configs.full->>"$.isPublished" = "true"
         ORDER BY title ASC
     `
     )
@@ -357,7 +358,8 @@ export const getWordpressPostReferencesByChartId = async (
             FROM
                 posts p
                 JOIN posts_links pl ON p.id = pl.sourceId
-                JOIN charts c ON pl.target = c.slug
+                JOIN chart_configs cc ON pl.target = cc.slug
+                JOIN charts c ON c.configId = cc.id
                 OR pl.target IN (
                     SELECT
                         cr.slug
@@ -405,7 +407,8 @@ export const getGdocsPostReferencesByChartId = async (
             FROM
                 posts_gdocs pg
                 JOIN posts_gdocs_links pgl ON pg.id = pgl.sourceId
-                JOIN charts c ON pgl.target = c.slug
+                JOIN chart_configs cc ON pgl.target = cc.slug
+                JOIN charts c ON c.configId = cc.id
                 OR pgl.target IN (
                     SELECT
                         cr.slug
@@ -490,7 +493,7 @@ export const getRelatedResearchAndWritingForVariable = async (
             SELECT DISTINCT
                 pl.target AS linkTargetSlug,
                 pl.componentType AS componentType,
-                COALESCE(csr.slug, c.slug) AS chartSlug,
+                COALESCE(csr.slug, cc.slug) AS chartSlug,
                 p.title AS title,
                 p.slug AS postSlug,
                 COALESCE(csr.chart_id, c.id) AS chartId,
@@ -510,7 +513,8 @@ export const getRelatedResearchAndWritingForVariable = async (
             FROM
                 posts_links pl
                 JOIN posts p ON pl.sourceId = p.id
-                LEFT JOIN charts c ON pl.target = c.slug
+                LEFT JOIN chart_configs cc on pl.target = cc.slug
+                LEFT JOIN charts c ON cc.id = c.configId
                 LEFT JOIN chart_slug_redirects csr ON pl.target = csr.slug
                 LEFT JOIN chart_dimensions cd ON cd.chartId = COALESCE(csr.chart_id, c.id)
                 LEFT JOIN analytics_pageviews pv ON pv.url = CONCAT('https://ourworldindata.org/', p.slug)
@@ -545,7 +549,7 @@ export const getRelatedResearchAndWritingForVariable = async (
         SELECT DISTINCT
             pl.target AS linkTargetSlug,
             pl.componentType AS componentType,
-            COALESCE(csr.slug, c.slug) AS chartSlug,
+            COALESCE(csr.slug, cc.slug) AS chartSlug,
             p.content ->> '$.title' AS title,
             p.slug AS postSlug,
             COALESCE(csr.chart_id, c.id) AS chartId,
@@ -565,7 +569,8 @@ export const getRelatedResearchAndWritingForVariable = async (
         FROM
             posts_gdocs_links pl
             JOIN posts_gdocs p ON pl.sourceId = p.id
-            LEFT JOIN charts c ON pl.target = c.slug
+            LEFT JOIN chart_configs cc ON pl.target = cc.slug
+            LEFT JOIN charts c ON c.configId = cc.id
             LEFT JOIN chart_slug_redirects csr ON pl.target = csr.slug
             JOIN chart_dimensions cd ON cd.chartId = COALESCE(csr.chart_id, c.id)
             LEFT JOIN analytics_pageviews pv ON pv.url = CONCAT('https://ourworldindata.org/', p.slug)

--- a/db/tests/basic.test.ts
+++ b/db/tests/basic.test.ts
@@ -9,9 +9,9 @@ import {
     knexRawFirst,
     knexReadonlyTransaction,
     TransactionCloseMode,
-    getBinaryUUID,
 } from "../db.js"
 import { deleteUser, insertUser, updateUser } from "../model/User.js"
+import { uuidv7 } from "uuidv7"
 import {
     ChartsTableName,
     ChartConfigsTableName,
@@ -71,7 +71,7 @@ test("timestamps are automatically created and updated", async () => {
                 .first<DbPlainUser>()
             expect(user).toBeTruthy()
             expect(user.email).toBe("admin@example.com")
-            const configId = await getBinaryUUID(trx)
+            const configId = uuidv7()
             const chartConfig: DbInsertChartConfig = {
                 id: configId,
                 patch: "{}",

--- a/db/tests/basic.test.ts
+++ b/db/tests/basic.test.ts
@@ -9,14 +9,17 @@ import {
     knexRawFirst,
     knexReadonlyTransaction,
     TransactionCloseMode,
+    getBinaryUUID,
 } from "../db.js"
 import { deleteUser, insertUser, updateUser } from "../model/User.js"
 import {
     ChartsTableName,
+    ChartConfigsTableName,
     DbInsertChart,
     DbPlainUser,
-    DbRawChart,
+    DbPlainChart,
     UsersTableName,
+    DbInsertChartConfig,
 } from "@ourworldindata/types"
 import { cleanTestDb, sleep } from "./testHelpers.js"
 
@@ -68,15 +71,22 @@ test("timestamps are automatically created and updated", async () => {
                 .first<DbPlainUser>()
             expect(user).toBeTruthy()
             expect(user.email).toBe("admin@example.com")
+            const configId = await getBinaryUUID(trx)
+            const chartConfig: DbInsertChartConfig = {
+                id: configId,
+                patch: "{}",
+                full: "{}",
+            }
             const chart: DbInsertChart = {
-                config: "{}",
+                configId,
                 lastEditedAt: new Date(),
                 lastEditedByUserId: user.id,
                 isIndexable: 0,
             }
+            await trx.table(ChartConfigsTableName).insert(chartConfig)
             const res = await trx.table(ChartsTableName).insert(chart)
             const chartId = res[0]
-            const created = await knexRawFirst<DbRawChart>(
+            const created = await knexRawFirst<DbPlainChart>(
                 trx,
                 "select * from charts where id = ?",
                 [chartId]
@@ -90,7 +100,7 @@ test("timestamps are automatically created and updated", async () => {
                     .table(ChartsTableName)
                     .where({ id: chartId })
                     .update({ isIndexable: 1 })
-                const updated = await knexRawFirst<DbRawChart>(
+                const updated = await knexRawFirst<DbPlainChart>(
                     trx,
                     "select * from charts where id = ?",
                     [chartId]

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
         "url-parse": "^1.5.10",
         "url-slug": "^3.0.2",
         "usehooks-ts": "^3.1.0",
+        "uuidv7": "^1.0.1",
         "webfontloader": "^1.6.28",
         "workerpool": "^6.2.0",
         "yaml": "^2.4.2"

--- a/packages/@ourworldindata/types/src/dbTypes/ChartConfigs.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/ChartConfigs.ts
@@ -1,0 +1,47 @@
+import { JsonString } from "../domainTypes/Various.js"
+import { GrapherInterface } from "../grapherTypes/GrapherTypes.js"
+
+export const ChartConfigsTableName = "chart_configs"
+export interface DbInsertChartConfig {
+    id: Buffer
+    uuid?: string
+    patch: JsonString
+    full: JsonString
+    slug?: string | null
+    createdAt?: Date
+    updatedAt?: Date | null
+}
+export type DbRawChartConfig = Required<DbInsertChartConfig>
+
+export type DbEnrichedChartConfig = Omit<DbRawChartConfig, "patch" | "full"> & {
+    patch: GrapherInterface
+    full: GrapherInterface
+}
+
+export function parseChartConfig(config: JsonString): GrapherInterface {
+    return JSON.parse(config)
+}
+
+export function serializeChartConfig(config: GrapherInterface): JsonString {
+    return JSON.stringify(config)
+}
+
+export function parseChartConfigsRow(
+    row: DbRawChartConfig
+): DbEnrichedChartConfig {
+    return {
+        ...row,
+        patch: parseChartConfig(row.patch),
+        full: parseChartConfig(row.full),
+    }
+}
+
+export function serializeChartsRow(
+    row: DbEnrichedChartConfig
+): DbRawChartConfig {
+    return {
+        ...row,
+        patch: serializeChartConfig(row.patch),
+        full: serializeChartConfig(row.full),
+    }
+}

--- a/packages/@ourworldindata/types/src/dbTypes/ChartConfigs.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/ChartConfigs.ts
@@ -3,8 +3,7 @@ import { GrapherInterface } from "../grapherTypes/GrapherTypes.js"
 
 export const ChartConfigsTableName = "chart_configs"
 export interface DbInsertChartConfig {
-    id: Buffer
-    uuid?: string
+    id: string
     patch: JsonString
     full: JsonString
     slug?: string | null

--- a/packages/@ourworldindata/types/src/dbTypes/ChartRevisions.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/ChartRevisions.ts
@@ -1,6 +1,6 @@
 import { JsonString } from "../domainTypes/Various.js"
 import { GrapherInterface } from "../grapherTypes/GrapherTypes.js"
-import { parseChartConfig, serializeChartConfig } from "./Charts.js"
+import { parseChartConfig, serializeChartConfig } from "./ChartConfigs.js"
 
 export const ChartRevisionsTableName = "chart_revisions"
 export interface DbInsertChartRevision {

--- a/packages/@ourworldindata/types/src/dbTypes/Charts.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Charts.ts
@@ -1,6 +1,6 @@
 export const ChartsTableName = "charts"
 export interface DbInsertChart {
-    configId: Buffer
+    configId: string
     createdAt?: Date
     id?: number
     isIndexable?: number

--- a/packages/@ourworldindata/types/src/dbTypes/Charts.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Charts.ts
@@ -1,9 +1,6 @@
-import { JsonString } from "../domainTypes/Various.js"
-import { GrapherInterface } from "../grapherTypes/GrapherTypes.js"
-
 export const ChartsTableName = "charts"
 export interface DbInsertChart {
-    config: JsonString
+    configId: Buffer
     createdAt?: Date
     id?: number
     isIndexable?: number
@@ -11,31 +8,6 @@ export interface DbInsertChart {
     lastEditedByUserId: number
     publishedAt?: Date | null
     publishedByUserId?: number | null
-    slug?: string | null
-    type?: string | null
     updatedAt?: Date | null
 }
-export type DbRawChart = Required<DbInsertChart>
-
-export type DbEnrichedChart = Omit<DbRawChart, "config"> & {
-    config: GrapherInterface
-}
-
-export function parseChartConfig(config: JsonString): GrapherInterface {
-    return JSON.parse(config)
-}
-
-export function serializeChartConfig(config: GrapherInterface): JsonString {
-    return JSON.stringify(config)
-}
-
-export function parseChartsRow(row: DbRawChart): DbEnrichedChart {
-    return { ...row, config: parseChartConfig(row.config) }
-}
-
-export function serializeChartsRow(row: DbEnrichedChart): DbRawChart {
-    return {
-        ...row,
-        config: serializeChartConfig(row.config),
-    }
-}
+export type DbPlainChart = Required<DbInsertChart>

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -414,6 +414,15 @@ export {
     AnalyticsPageviewsTableName,
 } from "./dbTypes/AnalyticsPageviews.js"
 export {
+    type DbInsertChartConfig,
+    type DbRawChartConfig,
+    type DbEnrichedChartConfig,
+    parseChartConfigsRow,
+    parseChartConfig,
+    serializeChartConfig,
+    ChartConfigsTableName,
+} from "./dbTypes/ChartConfigs.js"
+export {
     type DbPlainChartDimension,
     type DbInsertChartDimension,
     ChartDimensionsTableName,
@@ -428,13 +437,8 @@ export {
 } from "./dbTypes/ChartRevisions.js"
 export {
     type DbInsertChart,
-    type DbRawChart,
-    type DbEnrichedChart,
+    type DbPlainChart,
     ChartsTableName,
-    parseChartConfig,
-    serializeChartConfig,
-    parseChartsRow,
-    serializeChartsRow,
 } from "./dbTypes/Charts.js"
 export {
     type DbPlainChartSlugRedirect,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11067,6 +11067,7 @@ __metadata:
     url-parse: "npm:^1.5.10"
     url-slug: "npm:^3.0.2"
     usehooks-ts: "npm:^3.1.0"
+    uuidv7: "npm:^1.0.1"
     vite: "npm:^5.4.2"
     vite-plugin-checker: "npm:^0.7.2"
     webfontloader: "npm:^1.6.28"
@@ -19975,6 +19976,15 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 10/9d0b6adb72b736e36f2b1b53da0d559125ba3e39d913b6072f6f033e0c87835b414f0836b45bcfaf2bdf698f92297fea1c3cc19b0b258bc182c9c43cc0fab9f2
+  languageName: node
+  linkType: hard
+
+"uuidv7@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "uuidv7@npm:1.0.1"
+  bin:
+    uuidv7: cli.js
+  checksum: 10/24f835d067ee69ee46b1734b1da33e6f751f04ccfa5aa83703fc84693b8628d0ae0b4cd7f31c940ec933268971c338931bf5b57b09e882e14df47dfebba2b760
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds a `chart_configs` table to the database, adds a `configId` column to the `charts` table that points to a `chart_configs` row, and removes the `config` column.

Shouldn't result in any functionality change.

## Details

- All configs are copied from the `charts` table to the `chart_configs` table (for now, `patch config = full config` since inheritance hasn't been implemented yet)
- Configs have a UUID, but it's not yet used (the id of the chart is still the sequential primary key of the charts table) 

## Testing

- [x] Bakes locally
- [x] Bakes staging site

Site:
- [x] http://staging-site-db-chart-configs/
- [x] http://staging-site-db-chart-configs/grapher/life-expectancy
- [x] http://staging-site-db-chart-configs/explorers/coronavirus-data-explorer
- [x] http://staging-site-db-chart-configs/explorers/democracy
- [x] http://staging-site-db-chart-configs/explorers/conflict-data
- [x] http://staging-site-db-chart-configs/poverty
- [x] http://staging-site-db-chart-configs/financing-education
- [x] http://staging-site-db-chart-configs/part-two-how-many-people-die-from-extreme-temperatures-and-how-could-this-change-in-the-future
- [x] http://staging-site-db-chart-configs/covid-hospitalizations
- [x] http://staging-site-db-chart-configs/country/germany
- [x] http://staging-site-db-chart-configs/energy/country/india
- [x] http://staging-site-db-chart-configs/data-insights
- [x] http://staging-site-db-chart-configs/collection/top-charts
- [x] http://staging-site-db-chart-configs/sdgs
- [x] http://staging-site-db-chart-configs/sdgs/no-poverty

Admin:
- [x] Chart editor:
    - [x] Create new chart
    - [x] Save as new chart
    - [x] Update existing chart
    - [x] Publish chart
    - [x] Unpublish chart
    - [x] Delete chart
- [x] Bulk chart editor
- [x] Chart test page
- [x] Variable page (chart list)

## On the ETL side

Mojmir opened a PR for changes to the ETL: https://github.com/owid/etl/pull/2957

## To do

- [x] ~Is it safe to rewrite the config's id?~ I think it's okay
- [x] I don't understand why we manually insert `createdAt` and `updatedAt` since the db inserts values on insert/update?
- [x] Checklist for updating the db: https://www.notion.so/owid/Database-access-in-Grapher-d9db343c2bfb4ae0b14b3dec72f686c6?pvs=4#dd5b51bab6f84630839f4173b59feba2
- [x] Let Mojmir know so that he can update the ETL db schema (wait for the table structure to be signed off on)

## To do after merging

- [ ] ETL: https://github.com/owid/etl/pull/2957
- [ ] Datasette: https://github.com/owid/analytics/pull/138
- [ ] Schema validation: https://github.com/owid/automation/pull/12