### PR TITLE
🐝 (db) rename charts.is_indexable -> isIndexable

### DIFF
--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -135,7 +135,7 @@ const getChartsRecords = async (
                      LEFT JOIN charts_x_entities ce ON c.id = ce.chartId
                      LEFT JOIN entities e ON ce.entityId = e.id
             WHERE config ->> "$.isPublished" = 'true'
-              AND is_indexable IS TRUE
+              AND isIndexable IS TRUE
             GROUP BY c.id
         )
         SELECT c.id,

--- a/baker/countryProfiles.tsx
+++ b/baker/countryProfiles.tsx
@@ -49,7 +49,7 @@ const countryIndicatorGraphers = async (
             await trx
                 .table("charts")
                 .whereRaw(
-                    "publishedAt is not null and config->>'$.isPublished' = 'true' and is_indexable is true"
+                    "publishedAt is not null and config->>'$.isPublished' = 'true' and isIndexable is true"
                 )
         ).map((c: any) => JSON.parse(c.config)) as GrapherInterface[]
 

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -112,7 +112,7 @@ export const renderChartsPage = async (
             config->>"$.variantName" AS variantName
         FROM charts
         WHERE
-            is_indexable IS TRUE
+            isIndexable IS TRUE
             AND publishedAt IS NOT NULL
             AND config->>"$.isPublished" = "true"
     `

--- a/db/migration/1720173993285-RenameIsIndexableColumn.ts
+++ b/db/migration/1720173993285-RenameIsIndexableColumn.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class RenameIsIndexableColumn1720173993285
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE charts
+            RENAME COLUMN is_indexable TO isIndexable
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE charts
+            RENAME COLUMN isIndexable TO is_indexable
+        `)
+    }
+}

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -229,7 +229,7 @@ export async function setChartTags(
     const isIndexable = tags.some((t) => t.name === "Unlisted")
         ? false
         : parentIds.some((t) => PUBLIC_TAG_PARENT_IDS.includes(t.parentId))
-    await db.knexRaw(knex, "update charts set is_indexable = ? where id = ?", [
+    await db.knexRaw(knex, "update charts set isIndexable = ? where id = ?", [
         isIndexable,
         chartId,
     ])

--- a/db/tests/basic.test.ts
+++ b/db/tests/basic.test.ts
@@ -72,7 +72,7 @@ test("timestamps are automatically created and updated", async () => {
                 config: "{}",
                 lastEditedAt: new Date(),
                 lastEditedByUserId: user.id,
-                is_indexable: 0,
+                isIndexable: 0,
             }
             const res = await trx.table(ChartsTableName).insert(chart)
             const chartId = res[0]
@@ -89,7 +89,7 @@ test("timestamps are automatically created and updated", async () => {
                 await trx
                     .table(ChartsTableName)
                     .where({ id: chartId })
-                    .update({ is_indexable: 1 })
+                    .update({ isIndexable: 1 })
                 const updated = await knexRawFirst<DbRawChart>(
                     trx,
                     "select * from charts where id = ?",

--- a/packages/@ourworldindata/types/src/dbTypes/Charts.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Charts.ts
@@ -6,7 +6,7 @@ export interface DbInsertChart {
     config: JsonString
     createdAt?: Date
     id?: number
-    is_indexable?: number
+    isIndexable?: number
     lastEditedAt: Date
     lastEditedByUserId: number
     publishedAt?: Date | null


### PR DESCRIPTION
Rename `charts.is_indexable` to `isIndexable` in the database (https://github.com/owid/etl/pull/2938 does the same in the ETL)

Should the ETL-PR of this PR be merged first?