### PR TITLE
:hammer: add command for deleting Algolia index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,6 +284,10 @@ reindex: itsJustJavascript
 	node --enable-source-maps itsJustJavascript/baker/algolia/indexChartsToAlgolia.js
 	node --enable-source-maps itsJustJavascript/baker/algolia/indexExplorerViewsToAlgolia.js
 
+delete-algolia-index: itsJustJavascript
+	@echo '==> Deleting Algolia index'
+	node --enable-source-maps itsJustJavascript/baker/algolia/deleteAlgoliaIndex.js
+
 bench.search: itsJustJavascript
 	@echo '==> Running search benchmarks'
 	@node --enable-source-maps itsJustJavascript/site/search/evaluateSearch.js

--- a/baker/algolia/deleteAlgoliaIndex.tsx
+++ b/baker/algolia/deleteAlgoliaIndex.tsx
@@ -1,0 +1,46 @@
+import { ALGOLIA_INDEXING } from "../../settings/serverSettings.js"
+import { ALGOLIA_INDEX_PREFIX } from "../../settings/clientSettings.js"
+import { getAlgoliaClient } from "./configureAlgolia.js"
+import { SearchIndexName } from "../../site/search/searchTypes.js"
+import { getIndexName } from "../../site/search/searchClient.js"
+
+const deleteAlgoliaIndex = async () => {
+    if (!ALGOLIA_INDEXING) return
+
+    if (ALGOLIA_INDEX_PREFIX === "") {
+        console.error(
+            "ALGOLIA_INDEX_PREFIX is not set, refusing to delete production indexes"
+        )
+        return
+    }
+
+    const client = getAlgoliaClient()
+    if (!client) {
+        console.error(`Failed to remove index (Algolia client not initialized)`)
+        return
+    }
+
+    for (const suffix of [
+        SearchIndexName.Pages,
+        SearchIndexName.Charts,
+        SearchIndexName.ExplorerViews,
+    ]) {
+        const indexName = getIndexName(suffix)
+        const index = client.initIndex(indexName)
+        try {
+            await index.delete()
+            console.log(`Index '${indexName}' removed successfully`)
+        } catch (error) {
+            console.error(`Error removing index '${indexName}':`, error)
+        }
+    }
+
+    process.exit(0)
+}
+
+process.on("unhandledRejection", (e) => {
+    console.error(e)
+    process.exit(1)
+})
+
+void deleteAlgoliaIndex()


### PR DESCRIPTION
Command for deleting all Algolia indexes (implements https://github.com/owid/owid-grapher/issues/3563). Ops part https://github.com/owid/ops/pull/201.