### PR TITLE
3147: Remove `indexViewsSeparately` and gardened away some WordPress

### DIFF
--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -781,17 +781,6 @@ export const renderExplorerPage = async (
             return mergePartialGrapherConfigs(etlConfig, adminConfig)
         })
 
-    const wpContent = transformedProgram.wpBlockId
-        ? await renderReusableBlock(
-              await getBlockContentFromSnapshot(
-                  knex,
-                  transformedProgram.wpBlockId
-              ),
-              transformedProgram.wpBlockId,
-              knex
-          )
-        : undefined
-
     return (
         `<!doctype html>` +
         ReactDOMServer.renderToStaticMarkup(
@@ -799,7 +788,6 @@ export const renderExplorerPage = async (
                 grapherConfigs={grapherConfigs}
                 partialGrapherConfigs={partialGrapherConfigs}
                 program={transformedProgram}
-                wpContent={wpContent}
                 baseUrl={BAKED_BASE_URL}
                 urlMigrationSpec={opts?.urlMigrationSpec}
                 isPreviewing={opts?.isPreviewing}

--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -38,27 +38,17 @@ const xmlify = (url: SitemapUrl) => {
 }
 
 const explorerToSitemapUrl = (program: ExplorerProgram): SitemapUrl[] => {
-    const baseUrl = `${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${program.slug}`
+    const loc = `${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${program.slug}`
     const lastmod = program.lastCommit?.date
         ? dayjs(program.lastCommit.date).format("YYYY-MM-DD")
         : undefined
 
-    if (program.indexViewsSeparately) {
-        // return an array containing the URLs to each view of the explorer
-        return program.decisionMatrix
-            .allDecisionsAsQueryParams()
-            .map((params) => ({
-                loc: baseUrl + queryParamsToStr(params),
-                lastmod,
-            }))
-    } else {
         return [
             {
-                loc: baseUrl,
+                loc,
                 lastmod,
             },
         ]
-    }
 }
 
 // TODO: this transaction is only RW because somewhere inside it we fetch images

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -305,7 +305,6 @@ export class Explorer
         if (
             this.props.isInStandalonePage &&
             this.grapher &&
-            this.explorerProgram.indexViewsSeparately &&
             document.location.search
         ) {
             document.title = `${this.grapher.displayTitle} - Our World in Data`
@@ -802,12 +801,7 @@ export class Explorer
     }
 
     @computed get canonicalUrlForGoogle(): string {
-        // we want the canonical URL to match what's in the sitemap, so it's different depending on indexViewsSeparately
-        if (this.explorerProgram.indexViewsSeparately)
-            return Url.fromURL(this.baseUrl).setQueryParams(
-                this.currentChoiceParams
-            ).fullUrl
-        else return this.baseUrl
+        return this.baseUrl
     }
 
     private bindToWindow() {

--- a/explorer/ExplorerGrammar.ts
+++ b/explorer/ExplorerGrammar.ts
@@ -99,12 +99,6 @@ export const ExplorerGrammar: Grammar = {
         keyword: "isPublished",
         description: "Set to true to make this Explorer public.",
     },
-    indexViewsSeparately: {
-        ...BooleanCellDef,
-        keyword: "indexViewsSeparately",
-        description:
-            "Set to true to make Google index every view of this explorer, rather than only indexing the default view.",
-    },
     wpBlockId: {
         ...IntegerCellDef,
         keyword: "wpBlockId",

--- a/explorer/ExplorerGrammar.ts
+++ b/explorer/ExplorerGrammar.ts
@@ -99,12 +99,6 @@ export const ExplorerGrammar: Grammar = {
         keyword: "isPublished",
         description: "Set to true to make this Explorer public.",
     },
-    wpBlockId: {
-        ...IntegerCellDef,
-        keyword: "wpBlockId",
-        description:
-            "If present will show the matching Wordpress block ID beneath the Explorer.",
-    },
     hideControls: {
         ...BooleanCellDef,
         keyword: "hideControls",

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -198,13 +198,6 @@ export class ExplorerProgram extends GridProgram {
         )
     }
 
-    get indexViewsSeparately() {
-        return (
-            this.getLineValue(ExplorerGrammar.indexViewsSeparately.keyword) ===
-            GridBoolean.true
-        )
-    }
-
     get wpBlockId() {
         const blockIdString = this.getLineValue(
             ExplorerGrammar.wpBlockId.keyword

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -198,13 +198,6 @@ export class ExplorerProgram extends GridProgram {
         )
     }
 
-    get wpBlockId() {
-        const blockIdString = this.getLineValue(
-            ExplorerGrammar.wpBlockId.keyword
-        )
-        return blockIdString ? parseInt(blockIdString, 10) : undefined
-    }
-
     get decisionMatrixCode() {
         const keywordIndex = this.getKeywordIndex(
             ExplorerGrammar.graphers.keyword

--- a/site/ExplorerPage.tsx
+++ b/site/ExplorerPage.tsx
@@ -25,7 +25,6 @@ import { SiteSubnavigation } from "../site/SiteSubnavigation.js"
 
 interface ExplorerPageSettings {
     program: ExplorerProgram
-    wpContent?: string
     grapherConfigs: GrapherInterface[]
     partialGrapherConfigs: GrapherInterface[]
     baseUrl: string
@@ -56,7 +55,6 @@ const ExplorerContent = ({ content }: { content: string }) => {
 
 export const ExplorerPage = (props: ExplorerPageSettings) => {
     const {
-        wpContent,
         program,
         grapherConfigs,
         partialGrapherConfigs,
@@ -117,7 +115,6 @@ window.Explorer.renderSingleExplorerOnExplorerPage(explorerProgram, grapherConfi
                 <main id={ExplorerContainerId}>
                     <LoadingIndicator />
                 </main>
-                {wpContent && <ExplorerContent content={wpContent} />}
                 <SiteFooter
                     baseUrl={baseUrl}
                     context={SiteFooterContext.explorerPage}


### PR DESCRIPTION
## Actual issue - remove indexViewsSeparately experiment

* removed conditional that handled this independently of other views
* removed condition in Explorer that used this variable to set a title
* removed some grammar related code that also related to this

Fixes #3147 

## Weedpress gardening efforts

Code that was passed through from the siteRenderer to the Explorer page was removed based on the keys: `wpBlockId` coincidentally next to one I removed; and `wpContent` which that ID led to, it just seems to be used Explorer code and non-existence was already well protected agaist.

## Problem

Locally I see this on the population growth screen, it's pushed into one column, I checked my latest forked master against the live site and can see the difference, so I concluded it's not my changes

### Live
<img width="1589" alt="Screenshot 2024-07-12 at 00 29 41" src="https://github.com/user-attachments/assets/02ffb15f-06f1-4b5d-a979-ce2b8f6d17db">

### Local
<img width="1450" alt="Screenshot 2024-07-12 at 00 29 25" src="https://github.com/user-attachments/assets/ca84ad66-832a-4209-b48b-3b7085c7a6d0">

`