### PR TITLE
fix 3312: remove min-height

### DIFF
--- a/site/owid.scss
+++ b/site/owid.scss
@@ -186,10 +186,6 @@ h1.entry-title > a:hover {
     background: #f04848;
 }
 
-main {
-    min-height: 500px;
-}
-
 .deep-link {
     display: inline-block;
     width: 28px;


### PR DESCRIPTION
**NOTE** it would be really useful to have to actual chart IDs to find them [in this tool](http://localhost:3030/admin/test/embeds) - it's such a useful way to see "have I fixed it" or "nope, I broke it even worse". Even if they were just stuck on the chart as a `data-chart-id` property (might be already). Just to close to the loop a bit for fixing stuff.

* was forcing a scroll where one wasn't needed - note this has not been QAd in all 19 places, but the example given in the ticket was checked

Fixes #3312 

### Before
<img width="1643" alt="Screenshot 2024-07-12 at 01 31 47" src="https://github.com/user-attachments/assets/758fd138-069b-4f85-b77d-e3aca8abe4c6">

### After
<img width="1642" alt="Screenshot 2024-07-12 at 01 32 25" src="https://github.com/user-attachments/assets/4f003f67-f3a9-4aa5-a7d5-978491ce7318">
