### PR TITLE
Include charts' parent tags in the algolia index

### DIFF
--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -11,6 +11,7 @@ import {
     countries,
     orderBy,
     removeTrailingParenthetical,
+    uniq,
 } from "@ourworldindata/utils"
 import { MarkdownTextWrap } from "@ourworldindata/components"
 import { getAnalyticsPageviewsByUrlObj } from "../../db/model/Pageview.js"
@@ -161,6 +162,8 @@ const getChartsRecords = async (
 
     const pageviews = await getAnalyticsPageviewsByUrlObj(knex)
 
+    const parentTagsByChildName = await db.getParentTagsByChildName(knex)
+
     const records: ChartRecord[] = []
     for (const c of parsedRows) {
         // Our search currently cannot render explorers, so don't index them because
@@ -181,6 +184,11 @@ const getChartsRecords = async (
                   fontSize: 10, // doesn't matter, but is a mandatory field
               }).plaintext
 
+        const parentTags = c.tags.flatMap(
+            // a chart can be tagged with a tag that isn't in the tag graph
+            (tag) => parentTagsByChildName[tag] || []
+        )
+
         const record = {
             objectID: c.id.toString(),
             chartId: c.id,
@@ -192,7 +200,7 @@ const getChartsRecords = async (
             numDimensions: parseInt(c.numDimensions),
             publishedAt: c.publishedAt,
             updatedAt: c.updatedAt,
-            tags: c.tags as any as string[],
+            tags: uniq([...c.tags, ...parentTags]),
             keyChartForTags: c.keyChartForTags as string[],
             titleLength: c.title.length,
             // Number of references to this chart in all our posts and pages

--- a/db/db.ts
+++ b/db/db.ts
@@ -536,11 +536,9 @@ export async function getParentTagsByChildName(
     const { __rootId, ...flatTagGraph } = await getFlatTagGraph(trx)
     const tagGraph = createTagGraph(flatTagGraph, __rootId)
 
-    const tagsById = await knexRaw<Pick<DbPlainTag, "id" | "name">>(
-        trx,
-        `-- sql
-        SELECT id, name FROM tags`
-    ).then((tags) => keyBy(tags, "id"))
+    const tagsById = await trx("tags")
+        .select("id", "name")
+        .then((tags) => keyBy(tags, "id"))
 
     const parentTagsByChildName: Record<
         DbPlainTag["name"],


### PR DESCRIPTION
Part of https://github.com/owid/owid-grapher/issues/3781

Adds a new function that finds all ancestors of a given tag and includes them in a chart's record when we index to Algolia.

**Examples**
- A chart record that used to have a `tag` value of `["Cardiovascular Diseases"]` will now have `["Cardiovascular Diseases", "Health"]` 
- A chart record that used to have a `tag` value of `["Indoor Air Pollution", "CO2 & Greenhouse Gas Emissions"]` will now have `["Indoor Air Pollution", "CO2 & Greenhouse Gas Emissions", "Air Pollution", "Health", "Energy and Environment"]`

[Example output of `getParentTagsByChildName`](https://github.com/user-attachments/files/16199640/tagGraphByChildren.json)
