### PR TITLE
✨ switch population variable identification from variable id to version agnostic ETL path

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -125,7 +125,7 @@ import {
     GRAPHER_LIGHT_TEXT,
     GRAPHER_LOADED_EVENT_NAME,
     isContinentsVariableId,
-    isPopulationVariableId,
+    isPopulationVariableETLPath,
 } from "../core/GrapherConstants"
 import { loadVariableDataAndMetadata } from "./loadVariable"
 import Cookies from "js-cookie"
@@ -1626,17 +1626,23 @@ export class Grapher
             columnSlugs.push(colorColumnSlug)
 
         if (xColumnSlug !== undefined) {
+            const xColumn = this.inputTable.get(xColumnSlug)
+                .def as OwidColumnDef
             // exclude population variable if it's used as the x dimension in a marimekko
-            if (!isMarimekko || !isPopulationVariableId(xColumnSlug))
+            if (
+                !isMarimekko ||
+                !isPopulationVariableETLPath(xColumn?.catalogPath ?? "")
+            )
                 columnSlugs.push(xColumnSlug)
         }
 
         // exclude population variable if it's used as the size dimension in a scatter plot
-        if (
-            sizeColumnSlug !== undefined &&
-            !isPopulationVariableId(sizeColumnSlug)
-        )
-            columnSlugs.push(sizeColumnSlug)
+        if (sizeColumnSlug !== undefined) {
+            const sizeColumn = this.inputTable.get(sizeColumnSlug)
+                .def as OwidColumnDef
+            if (!isPopulationVariableETLPath(sizeColumn?.catalogPath ?? ""))
+                columnSlugs.push(sizeColumnSlug)
+        }
         return columnSlugs
     }
 

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -58,14 +58,11 @@ export const GDP_PER_CAPITA_INDICATOR_ID_USED_IN_ENTITY_SELECTOR = 735665 // "Wo
 export const isContinentsVariableId = (id: string | number): boolean =>
     id.toString() === CONTINENTS_INDICATOR_ID.toString()
 
-export const isPopulationVariableId = (id: string | number): boolean => {
-    const idString = id.toString()
-    return (
-        idString === "525709" || // "Population (historical + projections), Gapminder, HYDE & UN"
-        idString === "525711" || // "Population (historical estimates), Gapminder, HYDE & UN"
-        idString === "597929" || // "Population (various sources, 2023.1)"
-        idString === "597930" // "Population (various sources, 2023.1)"
-    )
+const population_regex =
+    /^grapher\/demography\/[\d-]+\/population\/population#population(_historical)?$/
+
+export const isPopulationVariableETLPath = (path: string): boolean => {
+    return population_regex.test(path)
 }
 
 export enum Patterns {

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -58,6 +58,10 @@ export const GDP_PER_CAPITA_INDICATOR_ID_USED_IN_ENTITY_SELECTOR = 735665 // "Wo
 export const isContinentsVariableId = (id: string | number): boolean =>
     id.toString() === CONTINENTS_INDICATOR_ID.toString()
 
+// ETL paths are composed of channel/namespace/version/dataset/table#columnname
+// We want to identify the any version of these two columns (added whitespaces for readability):
+// grapher / demography / ANY VERSION / population # population
+// grapher / demography / ANY VERSION / population # population_historical
 const population_regex =
     /^grapher\/demography\/[\d-]+\/population\/population#population(_historical)?$/
 

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -101,7 +101,7 @@ const EXTERNAL_SORT_INDICATORS = [
         indicatorId: POPULATION_INDICATOR_ID_USED_IN_ENTITY_SELECTOR,
         isMatch: (column: CoreColumn): boolean =>
             isPopulationVariableETLPath(
-                (column as OwidColumnDef)?.catalogPath ?? ""
+                (column.def as OwidColumnDef)?.catalogPath ?? ""
             ),
     },
     {

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -38,13 +38,13 @@ import {
     DEFAULT_GRAPHER_ENTITY_TYPE_PLURAL,
     POPULATION_INDICATOR_ID_USED_IN_ENTITY_SELECTOR,
     GDP_PER_CAPITA_INDICATOR_ID_USED_IN_ENTITY_SELECTOR,
-    isPopulationVariableId,
+    isPopulationVariableETLPath,
 } from "../core/GrapherConstants"
 import { CoreColumn, OwidTable } from "@ourworldindata/core-table"
 import { SortIcon } from "../controls/SortIcon"
 import { Dropdown } from "../controls/Dropdown"
 import { scaleLinear, type ScaleLinear } from "d3-scale"
-import { ColumnSlug } from "@ourworldindata/types"
+import { ColumnSlug, OwidColumnDef } from "@ourworldindata/types"
 import { buildVariableTable } from "../core/LegacyToOwidTable"
 import { loadVariableDataAndMetadata } from "../core/loadVariable"
 import { OverlayHeader } from "../core/OverlayHeader.js"
@@ -100,7 +100,9 @@ const EXTERNAL_SORT_INDICATORS = [
         label: "Population",
         indicatorId: POPULATION_INDICATOR_ID_USED_IN_ENTITY_SELECTOR,
         isMatch: (column: CoreColumn): boolean =>
-            isPopulationVariableId(column.slug),
+            isPopulationVariableETLPath(
+                (column as OwidColumnDef)?.catalogPath ?? ""
+            ),
     },
     {
         key: "gdpPerCapita",


### PR DESCRIPTION
This PR changes how we recognize our population indicators in Grapher. This identification is mainly done so that we can hide population in the short citation note that is visible in grapher when it is only used to size bubbles in scatter plots or similar.