### PR TITLE
garden: improvements to dev admin chart list

### DIFF
--- a/adminSiteClient/ChartList.tsx
+++ b/adminSiteClient/ChartList.tsx
@@ -105,7 +105,6 @@ export class ChartList extends React.Component<{
             <table className="table table-bordered">
                 <thead>
                     <tr>
-                        <th></th>
                         <th>Chart</th>
                         <th>Id</th>
                         <th>Type</th>

--- a/adminSiteClient/ChartRow.tsx
+++ b/adminSiteClient/ChartRow.tsx
@@ -46,12 +46,14 @@ export class ChartRow extends React.Component<{
 
         return (
             <tr>
-                <td style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    width: "400px",
-                }}>
-                    <div style={{ marginBottom: '16px' }}>
+                <td
+                    style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        width: "400px",
+                    }}
+                >
+                    <div style={{ marginBottom: "16px" }}>
                         {chart.isPublished ? (
                             <a href={`${BAKED_GRAPHER_URL}/${chart.slug}`}>
                                 {highlight(chart.title ?? "")}
@@ -73,7 +75,7 @@ export class ChartRow extends React.Component<{
                             </div>
                         )}
                     </div>
-                    <div style={{ marginBottom: '16px' }}>
+                    <div style={{ marginBottom: "16px" }}>
                         {chart.isPublished && (
                             <a href={`${BAKED_GRAPHER_URL}/${chart.slug}`}>
                                 <img
@@ -85,7 +87,9 @@ export class ChartRow extends React.Component<{
                     </div>
                 </td>
                 <td style={{ minWidth: "60px" }}>
-                    <a href={`/admin/test/embeds?ids=${chart.id}&comparisonUrl=https%3A%2F%2Fourworldindata.org`}>
+                    <a
+                        href={`/admin/test/embeds?ids=${chart.id}&comparisonUrl=https%3A%2F%2Fourworldindata.org`}
+                    >
                         {chart.id}
                     </a>
                 </td>

--- a/adminSiteClient/ChartRow.tsx
+++ b/adminSiteClient/ChartRow.tsx
@@ -46,45 +46,51 @@ export class ChartRow extends React.Component<{
 
         return (
             <tr>
-                <td style={{ minWidth: "240px", width: "12.5%" }}>
-                    {chart.isPublished && (
-                        <a href={`${BAKED_GRAPHER_URL}/${chart.slug}`}>
-                            <img
-                                src={`${BAKED_GRAPHER_EXPORTS_BASE_URL}/${chart.slug}.svg`}
-                                className="chartPreview"
-                            />
-                        </a>
-                    )}
-                </td>
-                <td style={{ minWidth: "140px" }}>
-                    {chart.isPublished ? (
-                        <a href={`${BAKED_GRAPHER_URL}/${chart.slug}`}>
-                            {highlight(chart.title ?? "")}
-                        </a>
-                    ) : (
-                        <span>
-                            <span style={{ color: "red" }}>Draft: </span>{" "}
-                            {highlight(chart.title ?? "")}
-                        </span>
-                    )}{" "}
-                    {chart.variantName ? (
-                        <span style={{ color: "#aaa" }}>
-                            ({highlight(chart.variantName)})
-                        </span>
-                    ) : undefined}
-                    {chart.internalNotes && (
-                        <div className="internalNotes">
-                            {highlight(chart.internalNotes)}
-                        </div>
-                    )}
+                <td style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    width: "400px",
+                }}>
+                    <div style={{ marginBottom: '16px' }}>
+                        {chart.isPublished ? (
+                            <a href={`${BAKED_GRAPHER_URL}/${chart.slug}`}>
+                                {highlight(chart.title ?? "")}
+                            </a>
+                        ) : (
+                            <span>
+                                <span style={{ color: "red" }}>Draft: </span>{" "}
+                                {highlight(chart.title ?? "")}
+                            </span>
+                        )}{" "}
+                        {chart.variantName ? (
+                            <span style={{ color: "#aaa" }}>
+                                ({highlight(chart.variantName)})
+                            </span>
+                        ) : undefined}
+                        {chart.internalNotes && (
+                            <div className="internalNotes">
+                                {highlight(chart.internalNotes)}
+                            </div>
+                        )}
+                    </div>
+                    <div style={{ marginBottom: '16px' }}>
+                        {chart.isPublished && (
+                            <a href={`${BAKED_GRAPHER_URL}/${chart.slug}`}>
+                                <img
+                                    src={`${BAKED_GRAPHER_EXPORTS_BASE_URL}/${chart.slug}.svg`}
+                                    className="chartPreview"
+                                />
+                            </a>
+                        )}
+                    </div>
                 </td>
                 <td style={{ minWidth: "60px" }}>
                     <a href={`/admin/test/embeds?ids=${chart.id}&comparisonUrl=https%3A%2F%2Fourworldindata.org`}>
                         {chart.id}
                     </a>
                 </td>
-                <td style={{ minWidth: "100px" }}>{showChartType(chart)}</td>
-                <td style={{ minWidth: "340px" }}>
+                <td style={{ minWidth: "200px" }}>{showChartType(chart)}</td>
+                <td style={{ minWidth: "240px" }}>
                     <EditableTags
                         tags={chart.tags}
                         suggestions={availableTags}

--- a/adminSiteClient/ChartRow.tsx
+++ b/adminSiteClient/ChartRow.tsx
@@ -46,7 +46,7 @@ export class ChartRow extends React.Component<{
 
         return (
             <tr>
-                <td style={{ minWidth: "140px", width: "12.5%" }}>
+                <td style={{ minWidth: "240px", width: "12.5%" }}>
                     {chart.isPublished && (
                         <a href={`${BAKED_GRAPHER_URL}/${chart.slug}`}>
                             <img
@@ -56,7 +56,7 @@ export class ChartRow extends React.Component<{
                         </a>
                     )}
                 </td>
-                <td style={{ minWidth: "180px" }}>
+                <td style={{ minWidth: "140px" }}>
                     {chart.isPublished ? (
                         <a href={`${BAKED_GRAPHER_URL}/${chart.slug}`}>
                             {highlight(chart.title ?? "")}
@@ -78,7 +78,9 @@ export class ChartRow extends React.Component<{
                         </div>
                     )}
                 </td>
-                <td style={{ minWidth: "100px" }}>{chart.id}</td>
+                <td style={{ minWidth: "60px" }}>
+                        {chart.id}
+                </td>
                 <td style={{ minWidth: "100px" }}>{showChartType(chart)}</td>
                 <td style={{ minWidth: "340px" }}>
                     <EditableTags

--- a/adminSiteClient/ChartRow.tsx
+++ b/adminSiteClient/ChartRow.tsx
@@ -79,7 +79,9 @@ export class ChartRow extends React.Component<{
                     )}
                 </td>
                 <td style={{ minWidth: "60px" }}>
+                    <a href={`/admin/test/embeds?ids=${chart.id}&comparisonUrl=https%3A%2F%2Fourworldindata.org`}>
                         {chart.id}
+                    </a>
                 </td>
                 <td style={{ minWidth: "100px" }}>{showChartType(chart)}</td>
                 <td style={{ minWidth: "340px" }}>

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2629,6 +2629,7 @@ export class Grapher
                 ref={this.base}
                 className={containerClasses}
                 style={containerStyle}
+                data-grapher-id={this.id}
                 data-grapher-url={this.canonicalUrl}
             >
                 {this.commandPalette}


### PR DESCRIPTION
**Note** no rush with this one, if it got as far as merge conflicts, I'd deal with them myself.

This improves things for me and therefore possibly also for folk who dev in the same way as me.

There was an issue, I think it has been edited, where  "World" blocks the search and removing that word yielded the one needed chart.

But that has no link to the embed screen which is really useful, so I made the ID output in the table into a link that goes straight through to the embed screen. Having the side by side comparison with the live site is really useful, at least for me eg: [this Marimekko labelling fix](https://github.com/owid/owid-grapher/pull/3581) of mine a couple of months ago. In fact it provided the proof and screen-shots of it.

I also changed the widths a bit, made the chart a bit bigger because it's visual, and narrowed the name and ID columns.

(I'm working on a MacBook Air.)

Here's the overall result:

<img width="1521" alt="image" src="https://github.com/user-attachments/assets/d8d3b68a-0410-48e8-9984-ef70db1e1781">

### Final commit

I did this quick POC, it stacks the title and chart because both benefit from the wider space - easy to roll back

<img width="1494" alt="Screenshot 2024-07-20 at 04 35 45" src="https://github.com/user-attachments/assets/e59878af-d17d-49b0-8274-8ef0f10a82ba">


