### PR TITLE
Fix HMR with SSR in dev

### DIFF
--- a/adminSiteServer/app.test.tsx
+++ b/adminSiteServer/app.test.tsx
@@ -83,7 +83,12 @@ beforeAll(async () => {
 
     setKnexInstance(serverKnexInstance!)
 
-    app = new OwidAdminApp({ isDev: true, gitCmsDir: "", quiet: true })
+    app = new OwidAdminApp({
+        isDev: true,
+        isTest: true,
+        gitCmsDir: "",
+        quiet: true,
+    })
     await app.startListening(8765, "localhost")
     cookieId = (
         await logInAsUser({


### PR DESCRIPTION
When we changed a React component in dev, the HMR kicked in for the client code, but then the page would fail to load and we had to refresh it manually. Adding the Vite middleware fixes it.