### PR TITLE
Add author pages to sitemap

### DIFF
--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -17,6 +17,7 @@ import { EXPLORERS_ROUTE_FOLDER } from "../explorer/ExplorerConstants.js"
 import { ExplorerProgram } from "../explorer/ExplorerProgram.js"
 import { getPostsFromSnapshots } from "../db/model/Post.js"
 import { calculateDataInsightIndexPageCount } from "../db/model/Gdoc/gdocUtils.js"
+import { GdocAuthor } from "../db/model/Gdoc/GdocAuthor.js"
 
 interface SitemapUrl {
     loc: string
@@ -74,6 +75,7 @@ export const makeSitemap = async (
         (postrow) => !alreadyPublishedViaGdocsSlugsSet.has(postrow.slug)
     )
     const gdocPosts = await db.getPublishedGdocPosts(knex)
+    const authorPages = await GdocAuthor.getPublishedAuthors(knex)
 
     const publishedDataInsights = await db.getPublishedDataInsights(knex)
     const dataInsightFeedPageCount = calculateDataInsightIndexPageCount(
@@ -140,6 +142,12 @@ export const makeSitemap = async (
             }))
         )
         .concat(explorers.flatMap(explorerToSitemapUrl))
+        .concat(
+            authorPages.map((a) => ({
+                loc: urljoin(BAKED_BASE_URL, "team", a.slug),
+                lastmod: dayjs(a.updatedAt).format("YYYY-MM-DD"),
+            }))
+        )
 
     const sitemap = `<?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -17,7 +17,7 @@ import { EXPLORERS_ROUTE_FOLDER } from "../explorer/ExplorerConstants.js"
 import { ExplorerProgram } from "../explorer/ExplorerProgram.js"
 import { getPostsFromSnapshots } from "../db/model/Post.js"
 import { calculateDataInsightIndexPageCount } from "../db/model/Gdoc/gdocUtils.js"
-import { GdocAuthor } from "../db/model/Gdoc/GdocAuthor.js"
+import { GdocAuthor, getMinimalAuthors } from "../db/model/Gdoc/GdocAuthor.js"
 
 interface SitemapUrl {
     loc: string
@@ -75,7 +75,7 @@ export const makeSitemap = async (
         (postrow) => !alreadyPublishedViaGdocsSlugsSet.has(postrow.slug)
     )
     const gdocPosts = await db.getPublishedGdocPosts(knex)
-    const authorPages = await GdocAuthor.getPublishedAuthors(knex)
+    const authorPages = await getMinimalAuthors(knex)
 
     const publishedDataInsights = await db.getPublishedDataInsights(knex)
     const dataInsightFeedPageCount = calculateDataInsightIndexPageCount(

--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -17,7 +17,7 @@ import { EXPLORERS_ROUTE_FOLDER } from "../explorer/ExplorerConstants.js"
 import { ExplorerProgram } from "../explorer/ExplorerProgram.js"
 import { getPostsFromSnapshots } from "../db/model/Post.js"
 import { calculateDataInsightIndexPageCount } from "../db/model/Gdoc/gdocUtils.js"
-import { GdocAuthor, getMinimalAuthors } from "../db/model/Gdoc/GdocAuthor.js"
+import { getMinimalAuthors } from "../db/model/Gdoc/GdocAuthor.js"
 
 interface SitemapUrl {
     loc: string

--- a/db/model/Gdoc/GdocAuthor.ts
+++ b/db/model/Gdoc/GdocAuthor.ts
@@ -170,7 +170,8 @@ export async function getMinimalAuthors(
             SELECT
                 slug,
                 content->>'$.title' as name,
-                content->>'$."featured-image"' as featuredImage
+                content->>'$."featured-image"' as featuredImage,
+                updatedAt
             FROM posts_gdocs
             WHERE type = 'author'
             AND published = 1`

--- a/db/model/Gdoc/GdocAuthor.ts
+++ b/db/model/Gdoc/GdocAuthor.ts
@@ -171,7 +171,8 @@ export async function getMinimalAuthors(
                 slug,
                 content->>'$.title' as name,
                 content->>'$."featured-image"' as featuredImage,
-                updatedAt
+                -- updatedAt is often set to the unix epoch instead of null
+                COALESCE(NULLIF(updatedAt, '1970-01-01'), createdAt) updatedAt
             FROM posts_gdocs
             WHERE type = 'author'
             AND published = 1`

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -912,7 +912,8 @@ export async function getMinimalAuthorsByNames(
                slug,
                content->>'$.title' AS name,
                content->>'$."featured-image"' AS featuredImage,
-               updatedAt
+               -- updatedAt is often set to the unix epoch instead of null
+               COALESCE(NULLIF(updatedAt, '1970-01-01'), createdAt) updatedAt
            FROM posts_gdocs
            WHERE type = 'author'
            AND content->>'$.title' in (:names)

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -911,7 +911,8 @@ export async function getMinimalAuthorsByNames(
            SELECT
                slug,
                content->>'$.title' AS name,
-               content->>'$."featured-image"' AS featuredImage
+               content->>'$."featured-image"' AS featuredImage,
+               updatedAt
            FROM posts_gdocs
            WHERE type = 'author'
            AND content->>'$.title' in (:names)

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -32,6 +32,7 @@ export interface LinkedAuthor {
     name: string
     slug: string
     featuredImage: string | null
+    updatedAt: Date
 }
 
 // A minimal object containing metadata needed for rendering prominent links etc in the client


### PR DESCRIPTION
Fixes #3775

Include author pages in the sitemap.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/owid/owid-grapher/issues/3775?shareId=40cd30c1-26cd-4d29-982d-5d54377d693e).