### PR TITLE
correct population historical path

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -60,10 +60,10 @@ export const isContinentsVariableId = (id: string | number): boolean =>
 
 // ETL paths are composed of channel/namespace/version/dataset/table#columnname
 // We want to identify the any version of these two columns (added whitespaces for readability):
-// grapher / demography / ANY VERSION / population # population
-// grapher / demography / ANY VERSION / population # population_historical
+// grapher / demography / ANY VERSION / population / population # population
+// grapher / demography / ANY VERSION / population / historical # population_historical
 const population_regex =
-    /^grapher\/demography\/[\d-]+\/population\/population#population(_historical)?$/
+    /^grapher\/demography\/[\d-]+\/population\/(population#population|historical#population_historical)$/
 
 export const isPopulationVariableETLPath = (path: string): boolean => {
     return population_regex.test(path)


### PR DESCRIPTION
I recently changed the ETL path of the historical OMM.

This has affected the indicator-detection by regex. As a consequence, scatterplots using population historical are showing the complete population source, as reported by Pablo [here](https://owid.slack.com/archives/C46U9LXRR/p1721899309662919).


Work on this was previously done in https://github.com/owid/owid-grapher/pull/3794/ and discussed in [slack](ttps://owid.slack.com/archives/CQQUA2C2U/p1721825347861559?thread_ts=1721123937.512529&cid=CQQUA2C2U)

(Asked for two revisions, but just aiming at one revision (first one). Thanks!)