### PR TITLE
feat: implement `MissingDataStrategy` for `StackedDiscreteBar` chart

### DIFF
--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -110,7 +110,11 @@ export class EditorFeatures {
     @computed get canSpecifyMissingDataStrategy() {
         if (!this.grapher.hasMultipleYColumns) return false
 
-        if (this.grapher.isStackedArea || this.grapher.isStackedBar) {
+        if (
+            this.grapher.isStackedArea ||
+            this.grapher.isStackedBar ||
+            this.grapher.isStackedDiscreteBar
+        ) {
             return true
         }
 

--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -277,6 +277,20 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         )
     }
 
+    dropRowsWithAtLeastThisManyErrorValuesForColumns(
+        slugs: ColumnSlug[],
+        minErrorValues: number
+    ): this {
+        return this.rowFilter(
+            (row) =>
+                slugs.filter((slug) => !isNotErrorValue(row[slug])).length <
+                minErrorValues,
+            `Drop rows with at least ${minErrorValues} ErrorValues in every column: ${slugs.join(
+                ", "
+            )}`
+        )
+    }
+
     // Drop _all rows_ for an entity if there is any column that has no valid values for that entity.
     dropEntitiesThatHaveNoDataInSomeColumn(columnSlugs: ColumnSlug[]): this {
         const indexesByEntityName = this.rowIndicesByEntityName

--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -277,20 +277,6 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         )
     }
 
-    dropRowsWithAtLeastThisManyErrorValuesForColumns(
-        slugs: ColumnSlug[],
-        minErrorValues: number
-    ): this {
-        return this.rowFilter(
-            (row) =>
-                slugs.filter((slug) => !isNotErrorValue(row[slug])).length <
-                minErrorValues,
-            `Drop rows with at least ${minErrorValues} ErrorValues in every column: ${slugs.join(
-                ", "
-            )}`
-        )
-    }
-
     // Drop _all rows_ for an entity if there is any column that has no valid values for that entity.
     dropEntitiesThatHaveNoDataInSomeColumn(columnSlugs: ColumnSlug[]): this {
         const indexesByEntityName = this.rowIndicesByEntityName

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.test.ts
@@ -1,6 +1,11 @@
 #! /usr/bin/env jest
 
-import { SortOrder, SortBy, ColumnTypeNames } from "@ourworldindata/utils"
+import {
+    SortOrder,
+    SortBy,
+    ColumnTypeNames,
+    MissingDataStrategy,
+} from "@ourworldindata/utils"
 import {
     OwidTable,
     SampleColumnSlugs,
@@ -105,6 +110,10 @@ it("can display a chart with missing variable data for some entities", () => {
 
     // Check that our absolute values get properly transformed into percentages
     expect(chart.failMessage).toEqual("")
+    expect(
+        chart.transformTableForSelection(table).availableEntityNames
+    ).toEqual(["France", "Spain"])
+
     expect(chart.series.length).toEqual(2)
     expect(chart.series[0].points).toEqual([
         {
@@ -134,6 +143,52 @@ it("can display a chart with missing variable data for some entities", () => {
             position: "Spain",
             value: 14,
             valueOffset: 0,
+            time: 2000,
+            fake: false,
+        },
+    ])
+})
+
+it("can display a chart with missing variable data for some entities, while hiding missing data", () => {
+    const csv = `coal,gas,year,entityName
+    20,,2000,France
+    10,20,2000,Italy
+    ,14,2000,Spain`
+    const table = new OwidTable(csv, [
+        { slug: "coal", type: ColumnTypeNames.Numeric },
+        { slug: "gas", type: ColumnTypeNames.Numeric },
+        { slug: "year", type: ColumnTypeNames.Year },
+    ])
+
+    const manager: ChartManager = {
+        table,
+        selection: table.availableEntityNames,
+        yColumnSlugs: ["coal", "gas"],
+        missingDataStrategy: MissingDataStrategy.hide,
+    }
+    const chart = new StackedDiscreteBarChart({ manager })
+
+    // Check that our absolute values get properly transformed into percentages
+    expect(chart.failMessage).toEqual("")
+    expect(
+        chart.transformTableForSelection(table).availableEntityNames
+    ).toEqual(["Italy"])
+
+    expect(chart.series.length).toEqual(2)
+    expect(chart.series[0].points).toEqual([
+        {
+            position: "Italy",
+            value: 10,
+            valueOffset: 0,
+            time: 2000,
+            fake: false,
+        },
+    ])
+    expect(chart.series[1].points).toEqual([
+        {
+            position: "Italy",
+            value: 20,
+            valueOffset: 10,
             time: 2000,
             fake: false,
         },

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -130,15 +130,9 @@ export class StackedDiscreteBarChart
             // If MissingDataStrategy is explicitly set to hide, drop rows (= times) where one of
             // the y columns has no data
             return table.dropRowsWithErrorValuesForAnyColumn(this.yColumnSlugs)
-        } else if (this.missingDataStrategy === MissingDataStrategy.auto) {
-            // If MissingDataStrategy is set to auto, drop rows where there is only a single non-error value
-            if (this.yColumnSlugs.length > 1) {
-                return table.dropRowsWithAtLeastThisManyErrorValuesForColumns(
-                    this.yColumnSlugs,
-                    this.yColumnSlugs.length - 1
-                )
-            }
         }
+
+        // Otherwise, don't apply any special treatment
         return table
     }
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -144,9 +144,9 @@ export class StackedDiscreteBarChart
             table = table.interpolateColumnWithTolerance(slug)
         })
 
-        // If MissingDataStrategy is not explicitly set to show, drop rows (= times) where one of
+        // If MissingDataStrategy is explicitly set to hide, drop rows (= times) where one of
         // the y columns has no data
-        if (this.missingDataStrategy !== MissingDataStrategy.show) {
+        if (this.missingDataStrategy === MissingDataStrategy.hide) {
             table = table.dropRowsWithErrorValuesForAnyColumn(this.yColumnSlugs)
         }
 
@@ -165,7 +165,7 @@ export class StackedDiscreteBarChart
             .replaceNegativeCellsWithErrorValues(this.yColumnSlugs)
             .dropRowsWithErrorValuesForAllColumns(this.yColumnSlugs)
 
-        if (this.missingDataStrategy !== MissingDataStrategy.show) {
+        if (this.missingDataStrategy === MissingDataStrategy.hide) {
             table = table.dropRowsWithErrorValuesForAnyColumn(this.yColumnSlugs)
         }
 


### PR DESCRIPTION
[Slack discussion](https://owid.slack.com/archives/C04LNF8LBA8/p1722269332128619?thread_ts=1722256968.554819&cid=C04LNF8LBA8)

Currently having it as `auto` (default) will hide missing data.
I'll check with the SVG tester if that seems like a good default.

## Before / After

<table>
<tr><th>With `MissingDataStrategy.auto` <th> With `MissingDataStrategy.hide`
<tr>
<td> 

![image](https://github.com/user-attachments/assets/247e2788-addb-42ee-a8cc-3455699c650c)

<td>

![image](https://github.com/user-attachments/assets/b2434365-0d9b-4043-8825-90a1bd905fa1)

</table>
