### PR TITLE
✨ article byline `/team` page fallback if no author present

### DIFF
--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -496,7 +496,8 @@ getPlainRouteNonIdempotentWithRWTransaction(
     mockSiteRouter,
     "/*",
     async (req, res, trx) => {
-        const slug = req.path.replace(/^\//, "")
+        // Remove leading and trailing slashes
+        const slug = req.path.replace(/^\/|\/$/g, "")
 
         try {
             const page = await renderGdocsPageBySlug(trx, slug)

--- a/site/gdocs/components/LinkedAuthor.tsx
+++ b/site/gdocs/components/LinkedAuthor.tsx
@@ -25,22 +25,9 @@ export default function LinkedAuthor({
             />
         ) : undefined
 
-    // Somehow, using a fragment here messes up the hydration process and causes
-    // some links to be applied to the wrong authors, but only if the first
-    // author is unlinked (which probably gets tangled with the "By: " text
-    // above). Additional markup, here in the form of a span, works more
-    // reliably.
-    if (!author.slug) {
-        return (
-            <span className={className}>
-                {image}
-                {author.name}
-            </span>
-        )
-    }
-
     const path = getCanonicalUrl("", {
-        slug: author.slug,
+        // If there's no author slug, this will link to /team/
+        slug: author.slug || "",
         content: { type: OwidGdocType.Author },
     })
     return (


### PR DESCRIPTION

https://github.com/user-attachments/assets/c3df8307-a5b8-4168-96d9-ef4c55c6081f

