### PR TITLE
Maintain latest data insights image ratio

### DIFF
--- a/site/gdocs/components/LatestDataInsights.scss
+++ b/site/gdocs/components/LatestDataInsights.scss
@@ -85,22 +85,24 @@ html:not(.js) .latest-data-insights__card,
 
 .latest-data-insights__card-left {
     display: flex;
-    flex: 1 1 410px;
+    height: 100%;
 
-    @include md-down {
-        flex: initial;
+    img {
+        height: 100%;
+        width: auto;
+        max-width: initial;
+
+        @include md-down {
+            max-width: 100%;
+        }
     }
 }
 
 .latest-data-insights__card-right {
     display: flex;
     flex-direction: column;
-    flex: 1 0 379px;
-
-    @include md-down {
-        flex: 1 1 0;
-        min-height: 0;
-    }
+    height: 100%;
+    min-height: 0;
 }
 
 .latest-data-insights__card-body {


### PR DESCRIPTION
Not all images used for data insights have the same aspect ratio, which I didn't know when I initially implemented it. Now the ratio should be preserved.

Before:
![image](https://github.com/user-attachments/assets/ae8ee2cc-0f62-4403-a08a-c9b1f31fe8c0)

After:
![image](https://github.com/user-attachments/assets/29eb1d1a-145f-4c0e-9b99-6b3602dd5992)

