### PR TITLE
Persist search query in URL parameters

### DIFF
--- a/adminSiteClient/ChartIndexPage.tsx
+++ b/adminSiteClient/ChartIndexPage.tsx
@@ -60,6 +60,7 @@ export class ChartIndexPage extends React.Component {
 
     @action.bound onSearchInput(input: string) {
         this.searchInput = input
+        this.setSearchInputInUrl(input)
     }
 
     @action.bound onShowMore() {
@@ -115,6 +116,23 @@ export class ChartIndexPage extends React.Component {
     }
 
     componentDidMount() {
+        this.searchInput = this.getSearchInputFromUrl()
         void this.getData()
+    }
+
+    getSearchInputFromUrl(): string {
+        const params = new URLSearchParams(window.location.search)
+        return params.get("search") || ""
+    }
+
+    setSearchInputInUrl(searchInput: string) {
+        const params = new URLSearchParams(window.location.search)
+        if (searchInput) {
+            params.set("search", searchInput)
+        } else {
+            params.delete("search")
+        }
+        const newUrl = `${window.location.pathname}?${params.toString()}`
+        window.history.replaceState({}, "", newUrl)
     }
 }


### PR DESCRIPTION
Fixes #3803

Persist search queries in the admin across browser navigation.

* Update `onSearchInput` method to update the URL parameters with the search input state.
* Update `componentDidMount` method to initialize the search input state from the URL parameters.