### PR TITLE
Revert "Fix too many files generated for CF pages (#3818)"

### DIFF
--- a/packages/@ourworldindata/utils/src/image.ts
+++ b/packages/@ourworldindata/utils/src/image.ts
@@ -6,6 +6,7 @@ import { traverseEnrichedBlock } from "./Util.js"
 import { OwidGdoc, OwidGdocType, ImageMetadata } from "@ourworldindata/types"
 import { match, P } from "ts-pattern"
 
+export const AUTHOR_BYLINE_WIDTH = 48
 export const THUMBNAIL_WIDTH = 100
 export const LARGE_THUMBNAIL_WIDTH = 350
 
@@ -14,7 +15,7 @@ export function getSizes(
 ): number[] {
     if (!originalWidth) return []
     // ensure a thumbnail and author byline is generated
-    const widths = [THUMBNAIL_WIDTH]
+    const widths = [AUTHOR_BYLINE_WIDTH, THUMBNAIL_WIDTH]
     // start at large thumbnail and go up by 500 to a max of 1350 before we just show the original image
     let width = LARGE_THUMBNAIL_WIDTH
     while (width < originalWidth && width <= 1350) {

--- a/site/gdocs/components/Image.tsx
+++ b/site/gdocs/components/Image.tsx
@@ -53,7 +53,7 @@ const containerSizes: Record<ImageParentContainer, string> = {
     ["datapage"]: gridSpan6,
     ["full-width"]: "100vw",
     ["key-insight"]: gridSpan5,
-    ["author-byline"]: "100px",
+    ["author-byline"]: "48px",
     ["author-header"]: gridSpan2,
     ["span-5"]: gridSpan5,
     ["span-6"]: gridSpan6,


### PR DESCRIPTION
This reverts commit 267045989055623a58977f263e02b864c4ea1b2e.