### PR TITLE
refactor(bake): remove WP topic page handling from data page baking

### DIFF
--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -25,7 +25,6 @@ import * as db from "../db/db.js"
 import { glob } from "glob"
 import { isPathRedirectedToExplorer } from "../explorerAdminServer/ExplorerRedirects.js"
 import {
-    getPostEnrichedBySlug,
     getPostIdFromSlug,
     getPostRelatedCharts,
     getRelatedArticles,
@@ -258,20 +257,6 @@ export async function renderDataPageV2(
             datapageData.primaryTopic = {
                 topicTag: firstTopicTag,
                 citation,
-            }
-        } else {
-            const post = await getPostEnrichedBySlug(knex, slug)
-            if (post) {
-                const authors = post.authors
-                const citation = getShortPageCitation(
-                    authors ?? [],
-                    post.title,
-                    post.published_at
-                )
-                datapageData.primaryTopic = {
-                    topicTag: firstTopicTag,
-                    citation,
-                }
             }
         }
     }


### PR DESCRIPTION
I'm pretty sure this is good to go now, now that there are no more WP-based topic pages.

Would be great if someone can actually confirm this :)