### PR TITLE
Fix `updatedAt` field initialization in `gdocs_posts`

### DIFF
--- a/db/model/Gdoc/GdocFactory.ts
+++ b/db/model/Gdoc/GdocFactory.ts
@@ -63,7 +63,7 @@ export function gdocFromJSON(
 
     json.createdAt = new Date(json.createdAt)
     json.publishedAt = json.publishedAt ? new Date(json.publishedAt) : null
-    json.updatedAt = new Date(json.updatedAt)
+    json.updatedAt = json.updatedAt ? new Date(json.updatedAt) : null
 
     return match(type)
         .with(

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -315,7 +315,7 @@ export const mapGdocsToWordpressPosts = (
         slug: gdoc.slug,
         type: gdoc.content.type,
         date: gdoc.publishedAt as Date,
-        modifiedDate: gdoc.updatedAt as Date,
+        modifiedDate: gdoc.updatedAt === null ? null : new Date(gdoc.updatedAt), // Pff0f
         authors: gdoc.content.authors,
         excerpt: gdoc.content["atom-excerpt"] || gdoc.content.excerpt,
         imageUrl: gdoc.content["featured-image"]


### PR DESCRIPTION
Fixes #3832

Fix the issue where `gdocs_posts.updatedAt` is often set to the Unix epoch instead of `NULL`.

* **db/model/Gdoc/GdocFactory.ts**
  - Replace `new Date(null)` with `null` in the `updatedAt` field initialization.
  - Ensure `updatedAt` is explicitly set to `NULL` if no updates have occurred post create.

* **db/model/Post.ts**
  - Replace `new Date(null)` with `null` in the `updatedAt` field initialization.
  - Ensure `updatedAt` is explicitly set to `NULL` if no updates have occurred post create.

## Todo

- [ ] Fix typechecks