### PR TITLE
Fix tmux session handling in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,12 @@ up: export DEBUG = 'knex:query'
 up: require create-if-missing.env ../owid-content tmp-downloads/owid_metadata.sql.gz node_modules
 	@make validate.env
 	@make check-port-3306
+
+	@if tmux has-session -t grapher 2>/dev/null; then \
+		echo '==> Killing existing tmux session'; \
+		tmux kill-session -t grapher; \
+	fi
+
 	@echo '==> Building grapher'
 	yarn lerna run build
 
@@ -96,6 +102,11 @@ up.full: export DEBUG = 'knex:query'
 up.full: require create-if-missing.env.full ../owid-content tmp-downloads/owid_metadata.sql.gz node_modules
 	@make validate.env.full
 	@make check-port-3306
+
+	@if tmux has-session -t grapher 2>/dev/null; then \
+		echo '==> Killing existing tmux session'; \
+		tmux kill-session -t grapher; \
+	fi
 
 	@echo '==> Building grapher'
 	yarn lerna run build


### PR DESCRIPTION
Fixes #3840

Modify the `Makefile` to check for an existing tmux session named `grapher` and kill it if it exists, during `make up` or `make up.full`.