### PR TITLE
chore(mysql): change mysql auth mode to new default (`caching_sha2_password`)

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,7 +18,7 @@ tasks:
     # this is run in the prebuild state and should be ready when launching a new workspace
     - init: |
           gp await-port 3306 && ./db/downloadAndCreateDatabase.sh
-          mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '';"
+          mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH caching_sha2_password BY '';"
           nvm install
           npm install -g yarn
           git clone https://github.com/owid/owid-content

--- a/docker-compose.dbtests.yml
+++ b/docker-compose.dbtests.yml
@@ -2,7 +2,7 @@ services:
     # Stock mysql database. Root password is hardcoded for now
     db:
         image: mysql/mysql-server:latest
-        command: --default-authentication-plugin=mysql_native_password --log-bin-trust-function-creators=ON
+        command: --log-bin-trust-function-creators=ON
         restart: always
         volumes:
             - mysql_data_testing:/var/lib/mysql

--- a/docker-compose.devcontainer.yml
+++ b/docker-compose.devcontainer.yml
@@ -43,7 +43,6 @@ services:
     # Stock mysql database. Used for grapher database. Root password is hardcoded for now
     db:
         image: mysql/mysql-server:latest
-        command: --default-authentication-plugin=mysql_native_password
         restart: always
         volumes:
             - mysql_data:/var/lib/mysql

--- a/docker-compose.grapher.yml
+++ b/docker-compose.grapher.yml
@@ -28,7 +28,6 @@ services:
     # Stock mysql database. Root password is hardcoded for now
     db:
         image: mysql/mysql-server:latest
-        command: --default-authentication-plugin=mysql_native_password
         restart: always
         volumes:
             - ./devTools/docker/my.cnf:/etc/my.cnf:ro

--- a/docs/local-database-setup.md
+++ b/docs/local-database-setup.md
@@ -7,7 +7,7 @@ If you want to develop on your local system without any Docker containers then y
 Remove the password for root by opening the MySQL shell with `mysql` and running:
 
 ```sql
-ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '';
+ALTER USER 'root'@'localhost' IDENTIFIED WITH caching_sha2_password BY '';
 ```
 
 We do this for convenience so we can run `mysql` commands without providing a password each time. You can also set a password, just make sure you include it in your `.env` file later.


### PR DESCRIPTION
The MySQL 9 client, which came out last week, [removes the deprecated `mysql_native_password` auth mode](https://dev.mysql.com/doc/refman/9.0/en/mysql-nutshell.html#mysql-nutshell-removals).

This means that you can't log into the server if the server uses that mode as its auth mode, which for us was the case.
Or, more specifically, the `Waiting for MySQL to come up...` check will never succeed.

This PR makes it so we are using the default auth mode (`caching_sha2_password`).

## Notes

The actual change will only take place once the database is rebuilt, or you manually run an `ALTER USER` command.
I tested it out, and existing databases will remain in full working order even if these command line args are not present - they'll just continue using `mysql_native_password` as the auth mode.

## Recreate DB

To re-create a DB from scratch, it's easiest to run `docker volume rm owid-grapher_mysql_data_public` and then `make up` to have it recreated.
This will delete all tables and databases that exist in this mysql instance. If that's not an option, there are also other options available.