### PR TITLE
🔨 render thumbnails in CF workers using chart configs from R2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ dist/
 .nx/workspace-data
 .dev.vars
 **/tsup.config.bundled*.mjs
+cfstorage

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -85,6 +85,7 @@ import {
     DbInsertUser,
     FlatTagGraph,
     DbRawChartConfig,
+    R2GrapherConfigDirectory,
 } from "@ourworldindata/types"
 import { uuidv7 } from "uuidv7"
 import {
@@ -158,7 +159,6 @@ import path from "path"
 import {
     deleteGrapherConfigFromR2,
     deleteGrapherConfigFromR2ByUUID,
-    R2GrapherConfigDirectory,
     saveGrapherConfigToR2,
     saveGrapherConfigToR2ByUUID,
     getMd5HashBase64,

--- a/adminSiteServer/chartConfigR2Helpers.ts
+++ b/adminSiteServer/chartConfigR2Helpers.ts
@@ -14,6 +14,7 @@ import {
     S3Client,
 } from "@aws-sdk/client-s3"
 import { Base64String, JsonError } from "@ourworldindata/utils"
+import { R2GrapherConfigDirectory } from "@ourworldindata/types"
 import { logErrorAndMaybeSendToBugsnag } from "../serverUtils/errorLog.js"
 import { createHash } from "crypto"
 
@@ -24,10 +25,6 @@ export function getMd5HashBase64(data: string): Base64String {
     return createHash("md5")
         .update(data, "utf-8")
         .digest("base64") as Base64String
-}
-export enum R2GrapherConfigDirectory {
-    byUUID = "config/by-uuid",
-    publishedGrapherBySlug = "grapher/by-slug",
 }
 
 let s3Client: S3Client | undefined = undefined

--- a/devTools/syncGraphersToR2/syncGraphersToR2.ts
+++ b/devTools/syncGraphersToR2/syncGraphersToR2.ts
@@ -23,7 +23,6 @@ import {
     KnexReadonlyTransaction,
     knexReadonlyTransaction,
 } from "../../db/db.js"
-import { R2GrapherConfigDirectory } from "../../adminSiteServer/chartConfigR2Helpers.js"
 import {
     base64ToBytes,
     bytesToBase64,
@@ -32,6 +31,7 @@ import {
     excludeUndefined,
     HexString,
     hexToBytes,
+    R2GrapherConfigDirectory,
 } from "@ourworldindata/utils"
 import { string } from "ts-pattern/dist/patterns.js"
 import { chunk, take } from "lodash"

--- a/functions/_common/grapherRenderer.ts
+++ b/functions/_common/grapherRenderer.ts
@@ -150,11 +150,21 @@ async function fetchAndRenderGrapherToSvg({
 
     const url = new URL(`/grapher/${slug}`, env.url)
     const slugOnly = url.pathname.split("/").pop()
+
+    // The top level directory is either the bucket path (should be set in dev environments and production)
+    // or the branch name on preview staging environments
+    console.log("branch", env.CF_PAGES_BRANCH)
+    const topLevelDirectory = env.GRAPHER_CONFIG_R2_BUCKET_PATH
+        ? [env.GRAPHER_CONFIG_R2_BUCKET_PATH]
+        : ["by-branch", env.CF_PAGES_BRANCH]
+
     const key = excludeUndefined([
-        env.GRAPHER_CONFIG_R2_BUCKET_PATH,
+        ...topLevelDirectory,
         R2GrapherConfigDirectory.publishedGrapherBySlug,
         `${slugOnly}.json`,
     ]).join("/")
+
+    console.log("fetching grapher config from this key", key)
 
     // Fetch grapher config
     const fetchResponse = await env.r2ChartConfigs.get(key)
@@ -164,7 +174,7 @@ async function fetchAndRenderGrapherToSvg({
     }
 
     const grapherConfig: GrapherInterface = await fetchResponse.json()
-    console.log("grapher interface", grapherConfig)
+    console.log("grapher title", grapherConfig.title)
 
     const bounds = new Bounds(0, 0, options.svgWidth, options.svgHeight)
     const grapher = new Grapher({

--- a/functions/grapher/thumbnail/[slug].ts
+++ b/functions/grapher/thumbnail/[slug].ts
@@ -10,6 +10,7 @@ export interface Env {
     }
     url: URL
     GRAPHER_CONFIG_R2_BUCKET_PATH: string
+    CF_PAGES_BRANCH: string
     ENV: string
 }
 

--- a/functions/grapher/thumbnail/[slug].ts
+++ b/functions/grapher/thumbnail/[slug].ts
@@ -34,14 +34,6 @@ router
 
 export const onRequestGet: PagesFunction = async (ctx) => {
     const { request, env } = ctx
-    const test = await (ctx.env as any).r2ChartConfigs.get(
-        "devs/daniel/grapher/by-slug/life-expectancy.json"
-    )
-    const listed = await (ctx.env as any).r2ChartConfigs.list({ limit: 10 })
-    console.log("listed", listed)
-    console.log("bucket is null", (ctx.env as any).r2ChartConfigs === null)
-    console.log("has get get", "get" in (ctx.env as any).r2ChartConfigs)
-    console.log("r2", test)
 
     const url = new URL(request.url)
     const shouldCache = !url.searchParams.has("nocache")

--- a/functions/grapher/thumbnail/[slug].ts
+++ b/functions/grapher/thumbnail/[slug].ts
@@ -5,7 +5,11 @@ export interface Env {
     ASSETS: {
         fetch: typeof fetch
     }
+    r2ChartConfigs: {
+        get: (url: string) => Promise<R2ObjectBody>
+    }
     url: URL
+    GRAPHER_CONFIG_R2_BUCKET_PATH: string
     ENV: string
 }
 
@@ -30,6 +34,14 @@ router
 
 export const onRequestGet: PagesFunction = async (ctx) => {
     const { request, env } = ctx
+    const test = await (ctx.env as any).r2ChartConfigs.get(
+        "devs/daniel/grapher/by-slug/life-expectancy.json"
+    )
+    const listed = await (ctx.env as any).r2ChartConfigs.list({ limit: 10 })
+    console.log("listed", listed)
+    console.log("bucket is null", (ctx.env as any).r2ChartConfigs === null)
+    console.log("has get get", "get" in (ctx.env as any).r2ChartConfigs)
+    console.log("r2", test)
 
     const url = new URL(request.url)
     const shouldCache = !url.searchParams.has("nocache")

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "revertLastDbMigration": "tsx --tsconfig tsconfig.tsx.json node_modules/typeorm/cli.js migration:revert -d db/dataSource.ts",
         "startAdminServer": "node --enable-source-maps ./itsJustJavascript/adminSiteServer/app.js",
         "startAdminDevServer": "tsx watch --ignore '**.mjs' --tsconfig tsconfig.tsx.json adminSiteServer/app.tsx",
-        "startLocalCloudflareFunctions": "wrangler pages dev",
+        "startLocalCloudflareFunctions": "wrangler pages dev --local --persist-to ./cfstorage",
         "startDeployQueueServer": "node --enable-source-maps ./itsJustJavascript/baker/startDeployQueueServer.js",
         "startLernaWatcher": "lerna watch --scope '@ourworldindata/*' -- lerna run build --scope=\\$LERNA_PACKAGE_NAME --include-dependents",
         "startTmuxServer": "node_modules/tmex/tmex dev \"yarn startLernaWatcher\" \"yarn startAdminDevServer\" \"yarn startViteServer\"",

--- a/packages/@ourworldindata/types/src/domainTypes/Various.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Various.ts
@@ -65,3 +65,8 @@ export class JsonError extends Error {
 export interface QueryParams {
     [key: string]: string | undefined
 }
+
+export enum R2GrapherConfigDirectory {
+    byUUID = "config/by-uuid",
+    publishedGrapherBySlug = "grapher/by-slug",
+}

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -18,6 +18,7 @@ export {
     type RawPageview,
     type UserCountryInformation,
     type QueryParams,
+    type R2GrapherConfigDirectory,
 } from "./domainTypes/Various.js"
 export { type BreadcrumbItem, type KeyValueProps } from "./domainTypes/Site.js"
 export {

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -18,7 +18,7 @@ export {
     type RawPageview,
     type UserCountryInformation,
     type QueryParams,
-    type R2GrapherConfigDirectory,
+    R2GrapherConfigDirectory,
 } from "./domainTypes/Various.js"
 export { type BreadcrumbItem, type KeyValueProps } from "./domainTypes/Site.js"
 export {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -36,4 +36,3 @@ GRAPHER_CONFIG_R2_BUCKET_PATH = "v1"
 binding = "r2ChartConfigs"
 bucket_name = "owid-grapher-configs-staging"
 
-[env.preview.vars]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -17,7 +17,16 @@ ENV = "preview"
 [env.production]
 compatibility_date = "2024-04-29"
 
+[[env.production.r2_buckets]]
+binding = "r2ChartConfigs"
+bucket_name = "owid-grapher-configs"
+
 [env.production.vars]
 ENV = "production"
 MAILGUN_DOMAIN = "mg.ourworldindata.org"
 SLACK_ERROR_CHANNEL_ID = "C5JJW19PS"
+
+
+[[env.development.r2_buckets]]
+binding = "r2ChartConfigs"
+bucket_name = "owid-grapher-configs-staging"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,6 +13,10 @@ MAILGUN_DOMAIN = "mg.ourworldindata.org"
 SLACK_ERROR_CHANNEL_ID = "C016H0BNNB1"
 ENV = "preview"
 
+[[r2_buckets]]
+binding = "r2ChartConfigs"
+bucket_name = "owid-grapher-configs-staging"
+
 # Overrides for CF production deployment
 [env.production]
 compatibility_date = "2024-04-29"
@@ -25,8 +29,11 @@ bucket_name = "owid-grapher-configs"
 ENV = "production"
 MAILGUN_DOMAIN = "mg.ourworldindata.org"
 SLACK_ERROR_CHANNEL_ID = "C5JJW19PS"
+GRAPHER_CONFIG_R2_BUCKET_PATH = "v1"
 
 
-[[env.development.r2_buckets]]
+[[env.preview.r2_buckets]]
 binding = "r2ChartConfigs"
 bucket_name = "owid-grapher-configs-staging"
+
+[env.preview.vars]


### PR DESCRIPTION
This PR changes how the CF thumnail worker gets the config for a chart. It used to be the case that it would fetch the HTML file of the grapher page at the given slug and extract the config from that HTML. Now it looks up the grapher config json file in an R2 bucket.

This PR only changes this for published charts accessed by slug. A later PR will enable this also by UUID.

Cloudflare is a bit weird with the intersection of support of various features between CF workers/pages functions, R2 and local/remote dev support: 
- Initially I wanted to use bindings in CF functions. For local development, wrangler dev does not support using a remote R2 bucket which is annoying
- I then thought I'd switch to fetching data from R2 buckets via HTTPS instead of bindings, similar to what we do with our variable data/metadata.json files. I realized then though that this only works if the bucket itself is accessible publicly via HTTPS. I'd like to keep the R2 bucket internal and not expose it directly.
- My next approach was to try to use the S3 API in the CF pages function. This didn't work because the default AWS library doesn't work in CF functions and the simpler replacement libraries that I could find were very barebones and made you deal with XML manually
- So finally I decided to go back to bindings and accepting the somewhat annoying dev story

