### PR TITLE
enhance(noscript): better handling of JS-disabled-or-not-working states

### DIFF
--- a/docs/browser-support.md
+++ b/docs/browser-support.md
@@ -46,11 +46,11 @@ For (1) and (2), we can get by with using `<noscript>` elements, containing HTML
 
 -   Our static renders all start out with `<html class="js-disabled">`, via [Html.tsx](../site/Html.tsx).
     -   Addresses (1) and (2), where no further scripts are ever executed.
--   An inline script in [Head.tsx](../site/Head.tsx) that is executed early checks if `<script type="module">` is supported, and then replaces `js-disabled` with `js-enabled`. It is executed synchronously before any rendering is performed, meaning that CSS styles targeting `js-disabled` are never evaluated, and e.g. fallback images are not downloaded if not needed.
+-   An inline script called [`<NoJSDetector>`](../site/NoJSDetector.tsx) (contained in `<Head>`) that is executed early checks if `<script type="module">` is supported, and then replaces `js-disabled` with `js-enabled`. It is executed synchronously before any rendering is performed, meaning that CSS styles targeting `js-disabled` are never evaluated, and e.g. fallback images are not downloaded if not needed.
     -   Addresses (3).
 -   This same inline script also sets up a global `window.onerror` event handler. If that one catches a global `SyntaxError` _under our own domain_, then we go back to replacing `js-enabled` with `js-disabled`. The domain check disregards failures coming from other scripts (e.g. Google Tag Manager) or browser extensions.
     -   Addresses (4).
--   Another inline script in [SiteFooter.tsx](../site/SiteFooter.tsx) sets up a `<script onerror="...">` handler for our core JS assets, which we mark using a `data-attach-owid-error-handler` attribute. If the handler fires (meaning the script couldn't be loaded), we again replace `js-enabled` with `js-disabled`.
+-   Another inline script called [`<ScriptLoadErrorDetector>`](../site/NoJSDetector.tsx) (contained in `<SiteFooter>`) sets up a `<script onerror="...">` handler for our core JS assets, which we mark using a `data-attach-owid-error-handler` attribute. If the handler fires (meaning the script couldn't be loaded), we again replace `js-enabled` with `js-disabled`.
     -   Addresses (5).
 -   If `owid.mjs` executes successfully, it will additionally add a `js-loaded` class to the `<html>` element.
 

--- a/docs/browser-support.md
+++ b/docs/browser-support.md
@@ -29,3 +29,42 @@ We use https://cdnjs.cloudflare.com/polyfill (see `site/SiteConstants.ts`), so u
 We have to be careful in increasing the `vite.config.ts` field `build.target`.
 
 Dropping support for older browsers is fine, but it should be a conscious decision.
+
+## Detecting disabled/non-functioning JS
+
+We try our very best to detect when the browser JS is disabled or non-functioning in any way.
+There are many such ways:
+
+-   (1) JS is disabled at the browser level.
+-   (2) JS is disabled via an extension like Ghostery or NoScript.
+-   (3) JS is enabled, but the browser doesn't support `<script type="module">`.
+-   (4) JS is enabled, but the browser is old and loading our code results in a `SyntaxError` (because of "relatively modern" syntax features like `await`, `import`, `var?.attr` etc.).
+-   (5) One of our core JS assets (e.g. `owid.mjs`) cannot be loaded, either because of networking issues, an extension, or something else.
+-   (6) There is a runtime error early on in script execution (e.g. in `runSiteFooterScripts`), e.g. calling an undefined function <-- **_this one we don't handle!_**
+
+For (1) and (2), we can get by with using `<noscript>` elements, containing HTML that is only ever parsed if scripting is disabled. However, to detect the other failure cases, we need more sophisticated error handling, as such:
+
+-   Our static renders all start out with `<html class="js-disabled">`, via [Html.tsx](../site/Html.tsx).
+    -   Addresses (1) and (2), where no further scripts are ever executed.
+-   An inline script in [Head.tsx](../site/Head.tsx) that is executed early checks if `<script type="module">` is supported, and then replaces `js-disabled` with `js-enabled`. It is executed synchronously before any rendering is performed, meaning that CSS styles targeting `js-disabled` are never evaluated, and e.g. fallback images are not downloaded if not needed.
+    -   Addresses (3).
+-   This same inline script also sets up a global `window.onerror` event handler. If that one catches a global `SyntaxError` _under our own domain_, then we go back to replacing `js-enabled` with `js-disabled`. The domain check disregards failures coming from other scripts (e.g. Google Tag Manager) or browser extensions.
+    -   Addresses (4).
+-   Another inline script in [SiteFooter.tsx](../site/SiteFooter.tsx) sets up a `<script onerror="...">` handler for our core JS assets, which we mark using a `data-attach-owid-error-handler` attribute. If the handler fires (meaning the script couldn't be loaded), we again replace `js-enabled` with `js-disabled`.
+    -   Addresses (5).
+-   If `owid.mjs` executes successfully, it will additionally add a `js-loaded` class to the `<html>` element.
+
+### CSS classes
+
+This all gives access to the following CSS classes:
+
+-   `js-disabled` and `js-enabled`, mutually exclusive and hopefully self-explanatory.
+    -   Note that there can be cases where we temporarily are at `js-enabled` and then go back to `js-disabled`, e.g. if we encounter a syntax error.
+-   `js-loaded`, which is applied a bit after `js-enabled` and is more technical.
+-   `js--hide-if-js-disabled` and `.js--hide-if-js-enabled`, defined in [noscript.scss](../site/css/noscript.scss) can be used as global utility classes.
+-   Likewise, `js--show-warning-block-if-js-disabled` can show a big warning block if necessary.
+
+### Handling runtime errors (6)
+
+We could totally do a better job of handling global runtime errors, and falling back to no-JS is probably a good idea in that case, too.
+However, we would need to do a good job communicating the difference to the user - in this case the messaging shouldn't be "You need to enable JavaScript and that's why this isn't interactive", but rather "We screwed up and that's why this isn't interactive".

--- a/site/BlogIndexPage.tsx
+++ b/site/BlogIndexPage.tsx
@@ -4,6 +4,7 @@ import { SiteHeader } from "./SiteHeader.js"
 import { SiteFooter } from "./SiteFooter.js"
 import { range, IndexPost } from "@ourworldindata/utils"
 import PostCard from "./PostCard/PostCard.js"
+import { Html } from "./Html.js"
 
 export const BlogIndexPage = (props: {
     posts: IndexPost[]
@@ -16,7 +17,7 @@ export const BlogIndexPage = (props: {
     const pageTitle = "Latest"
 
     return (
-        <html>
+        <Html>
             <Head
                 canonicalUrl={
                     `${baseUrl}/latest` +
@@ -72,6 +73,6 @@ export const BlogIndexPage = (props: {
                 </main>
                 <SiteFooter baseUrl={baseUrl} />
             </body>
-        </html>
+        </Html>
     )
 }

--- a/site/ChartsIndexPage.tsx
+++ b/site/ChartsIndexPage.tsx
@@ -9,6 +9,7 @@ import { slugify } from "@ourworldindata/utils"
 import { ExplorerProgram } from "../explorer/ExplorerProgram.js"
 import { BAKED_BASE_URL } from "../settings/serverSettings.js"
 import { EXPLORERS_ROUTE_FOLDER } from "../explorer/ExplorerConstants.js"
+import { Html } from "./Html.js"
 
 export interface ChartIndexItem {
     id: number
@@ -81,7 +82,7 @@ export const ChartsIndexPage = (props: {
     )
 
     return (
-        <html>
+        <Html>
             <Head
                 canonicalUrl={`${baseUrl}/charts`}
                 pageTitle="Charts"
@@ -167,6 +168,6 @@ export const ChartsIndexPage = (props: {
                     }}
                 />
             </body>
-        </html>
+        </Html>
     )
 }

--- a/site/CountriesIndexPage.tsx
+++ b/site/CountriesIndexPage.tsx
@@ -3,6 +3,7 @@ import { Head } from "./Head.js"
 import { SiteHeader } from "./SiteHeader.js"
 import { SiteFooter } from "./SiteFooter.js"
 import { Country, sortBy } from "@ourworldindata/utils"
+import { Html } from "./Html.js"
 
 export const CountriesIndexPage = (props: {
     countries: Country[]
@@ -13,7 +14,7 @@ export const CountriesIndexPage = (props: {
     const sortedCountries = sortBy(countries, (country) => country.name)
 
     return (
-        <html>
+        <Html>
             <Head
                 canonicalUrl={`${baseUrl}/countries`}
                 pageTitle="Countries"
@@ -42,6 +43,6 @@ export const CountriesIndexPage = (props: {
                 <SiteFooter baseUrl={baseUrl} />
                 {/* <script>{`window.runChartsIndexPage()`}</script> */}
             </body>
-        </html>
+        </Html>
     )
 }

--- a/site/CountryProfilePage.tsx
+++ b/site/CountryProfilePage.tsx
@@ -4,6 +4,7 @@ import { SiteHeader } from "./SiteHeader.js"
 import { SiteFooter } from "./SiteFooter.js"
 import urljoin from "url-join"
 import { Country } from "@ourworldindata/utils"
+import { Html } from "./Html.js"
 
 export interface CountryProfileIndicator {
     name: string
@@ -35,7 +36,7 @@ export const CountryProfilePage = (props: CountryProfilePageProps) => {
     const script = `window.runCountryProfilePage()`
 
     return (
-        <html>
+        <Html>
             <Head
                 canonicalUrl={`${baseUrl}/country/${country.slug}`}
                 pageTitle={`${country.name}`}
@@ -101,6 +102,6 @@ export const CountryProfilePage = (props: CountryProfilePageProps) => {
                     dangerouslySetInnerHTML={{ __html: script }}
                 />
             </body>
-        </html>
+        </Html>
     )
 }

--- a/site/DataInsightsIndexPage.tsx
+++ b/site/DataInsightsIndexPage.tsx
@@ -13,6 +13,7 @@ import {
 } from "./DataInsightsIndexPageContent.js"
 import { DATA_INSIGHT_ATOM_FEED_PROPS } from "./gdocs/utils.js"
 import { DebugProvider } from "./gdocs/DebugContext.js"
+import { Html } from "./Html.js"
 
 export interface DataInsightsIndexPageProps {
     dataInsights: OwidGdocDataInsightInterface[]
@@ -25,7 +26,7 @@ export interface DataInsightsIndexPageProps {
 export const DataInsightsIndexPage = (props: DataInsightsIndexPageProps) => {
     const { baseUrl, isPreviewing } = props
     return (
-        <html>
+        <Html>
             <Head
                 canonicalUrl={`${baseUrl}/data-insights`}
                 pageTitle="Daily Data Insights"
@@ -56,6 +57,6 @@ export const DataInsightsIndexPage = (props: DataInsightsIndexPageProps) => {
                     }}
                 />
             </body>
-        </html>
+        </Html>
     )
 }

--- a/site/DataPageV2.tsx
+++ b/site/DataPageV2.tsx
@@ -33,6 +33,7 @@ import { SiteFooter } from "./SiteFooter.js"
 import { SiteHeader } from "./SiteHeader.js"
 import { IFrameDetector } from "./IframeDetector.js"
 import { DebugProvider } from "./gdocs/DebugContext.js"
+import { Html } from "./Html.js"
 
 export const DataPageV2 = (props: {
     grapher: GrapherInterface | undefined
@@ -109,7 +110,7 @@ export const DataPageV2 = (props: {
     )
 
     return (
-        <html>
+        <Html>
             <Head
                 canonicalUrl={canonicalUrl}
                 pageTitle={pageTitle}
@@ -186,6 +187,6 @@ export const DataPageV2 = (props: {
                     }}
                 />
             </body>
-        </html>
+        </Html>
     )
 }

--- a/site/DonatePage.tsx
+++ b/site/DonatePage.tsx
@@ -6,13 +6,14 @@ import { IMAGES_DIRECTORY, OwidGdocPostInterface } from "@ourworldindata/utils"
 import { ArticleBlocks } from "./gdocs/components/ArticleBlocks.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faArrowDown } from "@fortawesome/free-solid-svg-icons"
+import { Html } from "./Html.js"
 
 export const DonatePage = (props: {
     baseUrl: string
     faqsGdoc: OwidGdocPostInterface
     recaptchaKey: string
 }) => (
-    <html>
+    <Html>
         <Head
             canonicalUrl={`${props.baseUrl}/donate`}
             pageTitle="Donate"
@@ -97,5 +98,5 @@ export const DonatePage = (props: {
                 }}
             />
         </body>
-    </html>
+    </Html>
 )

--- a/site/ExplorerPage.tsx
+++ b/site/ExplorerPage.tsx
@@ -116,6 +116,7 @@ window.Explorer.renderSingleExplorerOnExplorerPage(explorerProgram, grapherConfi
                 />
                 {subNav}
                 <main id={ExplorerContainerId}>
+                    <div className="js--show-warning-block-if-js-disabled" />
                     <LoadingIndicator />
                 </main>
                 {wpContent && <ExplorerContent content={wpContent} />}

--- a/site/ExplorerPage.tsx
+++ b/site/ExplorerPage.tsx
@@ -22,6 +22,7 @@ import { IFrameDetector } from "../site/IframeDetector.js"
 import { SiteFooter } from "../site/SiteFooter.js"
 import { SiteHeader } from "../site/SiteHeader.js"
 import { SiteSubnavigation } from "../site/SiteSubnavigation.js"
+import { Html } from "./Html.js"
 
 interface ExplorerPageSettings {
     program: ExplorerProgram
@@ -97,7 +98,7 @@ const urlMigrationSpec = ${
 window.Explorer.renderSingleExplorerOnExplorerPage(explorerProgram, grapherConfigs, partialGrapherConfigs, urlMigrationSpec);`
 
     return (
-        <html>
+        <Html>
             <Head
                 canonicalUrl={`${baseUrl}/${EXPLORERS_ROUTE_FOLDER}/${slug}`}
                 hideCanonicalUrl // explorers set their canonical url dynamically
@@ -127,6 +128,6 @@ window.Explorer.renderSingleExplorerOnExplorerPage(explorerProgram, grapherConfi
                     dangerouslySetInnerHTML={{ __html: inlineJs }}
                 />
             </body>
-        </html>
+        </Html>
     )
 }

--- a/site/FeedbackPage.tsx
+++ b/site/FeedbackPage.tsx
@@ -3,12 +3,13 @@ import { Head } from "./Head.js"
 import { SiteHeader } from "./SiteHeader.js"
 import { SiteFooter } from "./SiteFooter.js"
 import { FeedbackForm } from "../site/Feedback.js"
+import { Html } from "./Html.js"
 
 export class FeedbackPage extends React.Component<{ baseUrl: string }> {
     render() {
         const { baseUrl } = this.props
         return (
-            <html>
+            <Html>
                 <Head
                     canonicalUrl={`${baseUrl}/feedback`}
                     pageTitle="Feedback"
@@ -23,7 +24,7 @@ export class FeedbackPage extends React.Component<{ baseUrl: string }> {
                     <SiteFooter hideDonate={true} baseUrl={baseUrl} />
                 </body>
                 <script type="module">{`window.runFeedbackPage()`}</script>
-            </html>
+            </Html>
         )
     }
 }

--- a/site/GrapherPage.tsx
+++ b/site/GrapherPage.tsx
@@ -86,11 +86,6 @@ window.Grapher.renderSingleGrapherOnGrapherPage(jsonConfig)`
                 <meta property="og:image:width" content={imageWidth} />
                 <meta property="og:image:height" content={imageHeight} />
                 <IFrameDetector />
-                <noscript>
-                    <style>{`
-                    figure { display: none !important; }
-                `}</style>
-                </noscript>
                 <link rel="preconnect" href={dataApiOrigin} />
                 {variableIds.flatMap((variableId) =>
                     [
@@ -117,10 +112,13 @@ window.Grapher.renderSingleGrapherOnGrapherPage(jsonConfig)`
             <body className={GRAPHER_PAGE_BODY_CLASS}>
                 <SiteHeader baseUrl={baseUrl} />
                 <main>
-                    <figure data-grapher-src={`/grapher/${grapher.slug}`}>
+                    <figure
+                        className="js--hide-if-js-disabled"
+                        data-grapher-src={`/grapher/${grapher.slug}`}
+                    >
                         <LoadingIndicator />
                     </figure>
-                    <noscript id="fallback">
+                    <div className="js--hide-if-js-enabled" id="fallback">
                         {grapher.slug && (
                             <GrapherImage
                                 slug={grapher.slug}
@@ -128,7 +126,7 @@ window.Grapher.renderSingleGrapherOnGrapherPage(jsonConfig)`
                             />
                         )}
                         <p>Interactive visualization requires JavaScript</p>
-                    </noscript>
+                    </div>
 
                     {((relatedArticles && relatedArticles.length !== 0) ||
                         (relatedCharts && relatedCharts.length !== 0)) && (

--- a/site/GrapherPage.tsx
+++ b/site/GrapherPage.tsx
@@ -28,6 +28,7 @@ import { RelatedArticles } from "./RelatedArticles/RelatedArticles.js"
 import { SiteFooter } from "./SiteFooter.js"
 import { SiteHeader } from "./SiteHeader.js"
 import GrapherImage from "./GrapherImage.js"
+import { Html } from "./Html.js"
 
 export const GrapherPage = (props: {
     grapher: GrapherInterface
@@ -74,7 +75,7 @@ window.Grapher.renderSingleGrapherOnGrapherPage(jsonConfig)`
     const variableIds = uniq(grapher.dimensions!.map((d) => d.variableId))
 
     return (
-        <html>
+        <Html>
             <Head
                 canonicalUrl={canonicalUrl}
                 pageTitle={pageTitle}
@@ -170,6 +171,6 @@ window.Grapher.renderSingleGrapherOnGrapherPage(jsonConfig)`
                     dangerouslySetInnerHTML={{ __html: script }}
                 />
             </body>
-        </html>
+        </Html>
     )
 }

--- a/site/Head.tsx
+++ b/site/Head.tsx
@@ -99,6 +99,38 @@ export const Head = (props: {
             <meta name="twitter:image" content={encodeURI(imageUrl)} />
             {stylesheets}
             {props.children}
+            <script
+                // Handle any SyntaxErrors, which are likely to occur in old browsers.
+                // We're adding a class "js-disabled" to the <html> element to allow for CSS overrides.
+                // We only handle errors that occur on scripts from our domain, not ones from third-party scripts or extensions.
+                // Checking for <script nomodule> support is a quickfire way to detect old browsers immediately.
+                dangerouslySetInnerHTML={{
+                    __html: `
+function setJSEnabled(enabled) {
+    var elem = window.document.documentElement;
+    if (enabled) {
+        elem.classList.remove("js-disabled");
+        elem.classList.add("js-enabled");
+    } else {
+        elem.classList.remove("js-enabled");
+        elem.classList.add("js-disabled");
+    }
+}
+if ("noModule" in HTMLScriptElement.prototype) {
+    setJSEnabled(true);
+} else {
+    setJSEnabled(false);
+}
+window.onerror = function (err, url) {
+    var isOurSyntaxError = typeof err === "string" && err.indexOf("SyntaxError") > -1 && url.indexOf("${baseUrl}") > -1;
+    if (isOurSyntaxError) {
+        console.error("Caught global syntax error", err, url);
+        setJSEnabled(false);
+    }
+}`,
+                }}
+            ></script>
+            {/* <script dangerouslySetInnerHTML={{ __html: `{` }} /> */}
             <GTMScriptTags gtmId={GOOGLE_TAG_MANAGER_ID} />
         </head>
     )

--- a/site/Head.tsx
+++ b/site/Head.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { viteAssetsForSite } from "./viteUtils.js"
 import { GOOGLE_TAG_MANAGER_ID } from "../settings/clientSettings.js"
+import { NoJSDetector } from "./NoJSDetector.js"
 
 export const GTMScriptTags = ({ gtmId }: { gtmId: string }) => {
     if (!gtmId || /["']/.test(gtmId)) return null
@@ -99,38 +100,7 @@ export const Head = (props: {
             <meta name="twitter:image" content={encodeURI(imageUrl)} />
             {stylesheets}
             {props.children}
-            <script
-                // Handle any SyntaxErrors, which are likely to occur in old browsers.
-                // We're adding a class "js-disabled" to the <html> element to allow for CSS overrides.
-                // We only handle errors that occur on scripts from our domain, not ones from third-party scripts or extensions.
-                // Checking for <script nomodule> support is a quickfire way to detect old browsers immediately.
-                dangerouslySetInnerHTML={{
-                    __html: `
-function setJSEnabled(enabled) {
-    var elem = window.document.documentElement;
-    if (enabled) {
-        elem.classList.remove("js-disabled");
-        elem.classList.add("js-enabled");
-    } else {
-        elem.classList.remove("js-enabled");
-        elem.classList.add("js-disabled");
-    }
-}
-if ("noModule" in HTMLScriptElement.prototype) {
-    setJSEnabled(true);
-} else {
-    setJSEnabled(false);
-}
-window.onerror = function (err, url) {
-    var isOurSyntaxError = typeof err === "string" && err.indexOf("SyntaxError") > -1 && url.indexOf("${baseUrl}") > -1;
-    if (isOurSyntaxError) {
-        console.error("Caught global syntax error", err, url);
-        setJSEnabled(false);
-    }
-}`,
-                }}
-            ></script>
-            {/* <script dangerouslySetInnerHTML={{ __html: `{` }} /> */}
+            <NoJSDetector baseUrl={baseUrl} />
             <GTMScriptTags gtmId={GOOGLE_TAG_MANAGER_ID} />
         </head>
     )

--- a/site/Html.tsx
+++ b/site/Html.tsx
@@ -1,0 +1,11 @@
+import cx from "classnames"
+import React, { HtmlHTMLAttributes } from "react"
+
+/**
+ * Renders a <html> element with the class "js-disabled" to indicate that JavaScript is disabled.
+ * This is then removed *synchronously* by the client-side JavaScript, once we detect that JavaScript is enabled.
+ * See the <script> tag in Head.tsx for the client-side JavaScript that removes this class.
+ */
+export const Html = (props: HtmlHTMLAttributes<Element>) => {
+    return <html {...props} className={cx("js-disabled", props.className)} />
+}

--- a/site/LongFormPage.tsx
+++ b/site/LongFormPage.tsx
@@ -18,6 +18,7 @@ import { BackToTopic } from "./BackToTopic.js"
 import StickyNav from "./blocks/StickyNav.js"
 import { CodeSnippet } from "@ourworldindata/components"
 import { formatAuthors } from "./clientFormatting.js"
+import { Html } from "./Html.js"
 
 export interface PageOverrides {
     pageTitle?: string
@@ -109,7 +110,7 @@ export const LongFormPage = (props: {
     note = {${citationCanonicalUrl}}
 }`
     return (
-        <html>
+        <Html>
             <Head
                 pageTitle={pageTitleSEO}
                 pageDesc={pageDesc}
@@ -426,6 +427,6 @@ export const LongFormPage = (props: {
                     }}
                 />
             </body>
-        </html>
+        </Html>
     )
 }

--- a/site/NoJSDetector.tsx
+++ b/site/NoJSDetector.tsx
@@ -1,0 +1,56 @@
+import React from "react"
+
+/**
+ * For more details about these components, see `browser-support.md`.
+ */
+
+// Detect if JavaScript is enabled and set a class on the HTML element.
+// Also detect if the browser doesn't support `<script type="module">`, or if there's a parsing error
+// happening in old browsers because "relatively new" syntax is being used.
+// Sets the `js-enabled` class if JavaScript is enabled, and `js-disabled` if not or if an error ocurred.
+export const NoJSDetector = ({ baseUrl }: { baseUrl: string }) => (
+    <script
+        dangerouslySetInnerHTML={{
+            __html: `
+function setJSEnabled(enabled) {
+    var elem = window.document.documentElement;
+    if (enabled) {
+        elem.classList.remove("js-disabled");
+        elem.classList.add("js-enabled");
+    } else {
+        elem.classList.remove("js-enabled");
+        elem.classList.add("js-disabled");
+    }
+}
+if ("noModule" in HTMLScriptElement.prototype) {
+    setJSEnabled(true);
+} else {
+    setJSEnabled(false);
+}
+window.onerror = function (err, url) {
+    var isOurSyntaxError = typeof err === "string" && err.indexOf("SyntaxError") > -1 && url.indexOf("${baseUrl}") > -1;
+    if (isOurSyntaxError) {
+        console.error("Caught global syntax error", err, url);
+        setJSEnabled(false);
+    }
+}`,
+        }}
+    ></script>
+)
+
+// Attaches `onerror` event listeners to all scripts with a `data-attach-owid-error-handler` attribute.
+// If they fail to load, it will set the `js-disabled` class on the HTML element.
+export const ScriptLoadErrorDetector = () => (
+    <script
+        dangerouslySetInnerHTML={{
+            __html: `
+document.querySelectorAll("script[data-attach-owid-error-handler]").forEach(script => {
+    script.onerror = () => {
+        console.log(new Error("Failed to load script: ", script.src));
+        document.documentElement.classList.add("js-disabled");
+        document.documentElement.classList.remove("js-enabled");
+    }
+})`,
+        }}
+    />
+)

--- a/site/NoJSDetector.tsx
+++ b/site/NoJSDetector.tsx
@@ -8,6 +8,14 @@ import React from "react"
 // Also detect if the browser doesn't support `<script type="module">`, or if there's a parsing error
 // happening in old browsers because "relatively new" syntax is being used.
 // Sets the `js-enabled` class if JavaScript is enabled, and `js-disabled` if not or if an error ocurred.
+
+// The `"noModule" in HTMLScriptElement` check serves as a good proxy to disregard
+// any browsers that will _definitely_ throw a SyntaxError early:
+// See https://caniuse.com/mdn-api_htmlscriptelement_nomodule:
+// - Chrome/Edge <61
+// - Safari <11
+// - Firefox <60
+// - All Internet Explorer
 export const NoJSDetector = ({ baseUrl }: { baseUrl: string }) => (
     <script
         dangerouslySetInnerHTML={{

--- a/site/NotFoundPage.tsx
+++ b/site/NotFoundPage.tsx
@@ -4,10 +4,11 @@ import { SiteHeader } from "./SiteHeader.js"
 import { SiteFooter } from "./SiteFooter.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faSearch } from "@fortawesome/free-solid-svg-icons"
+import { Html } from "./Html.js"
 
 export const NotFoundPage = (props: { baseUrl: string }) => {
     return (
-        <html>
+        <Html>
             <Head
                 canonicalUrl={`${props.baseUrl}/search`}
                 pageTitle="404 Not Found"
@@ -51,6 +52,6 @@ export const NotFoundPage = (props: { baseUrl: string }) => {
                     }}
                 />
             </body>
-        </html>
+        </Html>
     )
 }

--- a/site/SiteFooter.tsx
+++ b/site/SiteFooter.tsx
@@ -302,6 +302,18 @@ export const SiteFooter = (props: SiteFooterProps) => (
             <div className="site-tools" />
             {viteAssetsForSite().forFooter}
             <script
+                dangerouslySetInnerHTML={{
+                    __html: `
+document.querySelectorAll("script[data-attach-owid-error-handler]").forEach(script => {
+    script.onerror = () => {
+        console.log(new Error("Failed to load script: ", script.src));
+        document.documentElement.classList.add("js-disabled");
+        document.documentElement.classList.remove("js-enabled");
+    }
+})`,
+                }}
+            />
+            <script
                 type="module"
                 dangerouslySetInnerHTML={{
                     __html: `window.runSiteFooterScripts(${JSON.stringify({

--- a/site/SiteFooter.tsx
+++ b/site/SiteFooter.tsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faAngleRight } from "@fortawesome/free-solid-svg-icons"
 import { SiteFooterContext } from "@ourworldindata/utils"
 import { viteAssetsForSite } from "./viteUtils.js"
+import { ScriptLoadErrorDetector } from "./NoJSDetector.js"
 
 interface SiteFooterProps {
     hideDonate?: boolean
@@ -301,18 +302,7 @@ export const SiteFooter = (props: SiteFooterProps) => (
             </div>
             <div className="site-tools" />
             {viteAssetsForSite().forFooter}
-            <script
-                dangerouslySetInnerHTML={{
-                    __html: `
-document.querySelectorAll("script[data-attach-owid-error-handler]").forEach(script => {
-    script.onerror = () => {
-        console.log(new Error("Failed to load script: ", script.src));
-        document.documentElement.classList.add("js-disabled");
-        document.documentElement.classList.remove("js-enabled");
-    }
-})`,
-                }}
-            />
+            <ScriptLoadErrorDetector />
             <script
                 type="module"
                 dangerouslySetInnerHTML={{

--- a/site/ThankYouPage.tsx
+++ b/site/ThankYouPage.tsx
@@ -5,13 +5,14 @@ import { SiteFooter } from "./SiteFooter.js"
 import { IMAGES_DIRECTORY } from "@ourworldindata/utils"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faFacebook, faXTwitter } from "@fortawesome/free-brands-svg-icons"
+import { Html } from "./Html.js"
 
 const shareMessage =
     "I’m proud to be a supporter of Our World in Data! Their team builds a public resource, free for everyone, that makes the research and data on the world’s largest problems easier to access and understand. You can donate here:"
 const donateLink = "https://ourworldindata.org/donate"
 
 export const ThankYouPage = (props: { baseUrl: string }) => (
-    <html>
+    <Html>
         <Head
             canonicalUrl={`${props.baseUrl}/thank-you`}
             pageTitle="Thank you"
@@ -101,5 +102,5 @@ export const ThankYouPage = (props: { baseUrl: string }) => (
 
             <SiteFooter hideDonate={true} baseUrl={props.baseUrl} />
         </body>
-    </html>
+    </Html>
 )

--- a/site/blocks/RelatedCharts.tsx
+++ b/site/blocks/RelatedCharts.tsx
@@ -53,14 +53,14 @@ export const RelatedCharts = ({
             key={activeChartSlug}
             data-grapher-src={grapherUrl}
         >
-            <noscript>
+            <div className="js--hide-if-js-enabled">
                 <a href={grapherUrl}>
                     <GrapherImage
                         slug={activeChartSlug}
                         alt={activeChart?.title}
                     />
                 </a>
-            </noscript>
+            </div>
         </figure>
     )
 

--- a/site/collections/DynamicCollectionPage.tsx
+++ b/site/collections/DynamicCollectionPage.tsx
@@ -10,6 +10,7 @@ import {
 import { DynamicCollection } from "./DynamicCollection.js"
 import { ObservableMap } from "mobx"
 import { Grapher } from "@ourworldindata/grapher"
+import { Html } from "../Html.js"
 
 type OriginalSlug = string
 
@@ -40,7 +41,7 @@ export const DynamicCollectionPage = (props: { baseUrl: string }) => {
     const { baseUrl } = props
 
     return (
-        <html>
+        <Html>
             <Head
                 canonicalUrl={`${baseUrl}/collection/custom`}
                 pageTitle="Chart Collection"
@@ -76,6 +77,6 @@ export const DynamicCollectionPage = (props: { baseUrl: string }) => {
                     context={SiteFooterContext.dynamicCollectionPage}
                 />
             </body>
-        </html>
+        </Html>
     )
 }

--- a/site/collections/StaticCollectionPage.tsx
+++ b/site/collections/StaticCollectionPage.tsx
@@ -6,6 +6,7 @@ import { SiteHeader } from "../SiteHeader.js"
 import { SiteFooter } from "../SiteFooter.js"
 import InteractionNotice from "../InteractionNotice.js"
 import GrapherImage from "../GrapherImage.js"
+import { Html } from "../Html.js"
 
 export interface StaticCollectionPageProps {
     title: string
@@ -19,7 +20,7 @@ export const StaticCollectionPage = (
     const { baseUrl, title, charts, introduction } = props
 
     return (
-        <html>
+        <Html>
             <Head
                 canonicalUrl={`${baseUrl}/shared-collection/top-charts`}
                 pageTitle={title}
@@ -66,6 +67,6 @@ export const StaticCollectionPage = (
                 </main>
                 <SiteFooter hideDonate={true} baseUrl={baseUrl} />
             </body>
-        </html>
+        </Html>
     )
 }

--- a/site/css/noscript.scss
+++ b/site/css/noscript.scss
@@ -9,3 +9,33 @@
         display: none;
     }
 }
+
+.js--show-warning-block-if-js-disabled {
+    @at-root html.js-disabled & {
+        display: block;
+        background: repeating-linear-gradient(
+            45deg,
+            $amber-10,
+            $amber-10 10px,
+            transparent 10px,
+            transparent 20px
+        );
+        // Fill the entire parent container
+        height: 100%;
+        min-height: inherit;
+        max-height: inherit;
+        width: 100%;
+
+        padding: 10px;
+        text-align: center;
+
+        &::after {
+            white-space: pre-wrap;
+            content: "⚠️ JavaScript needs to be enabled to view this content.\A Either enable JavaScript in your browser or switch to a modern browser that supports it.";
+        }
+    }
+
+    @at-root html.js-enabled & {
+        display: none;
+    }
+}

--- a/site/css/noscript.scss
+++ b/site/css/noscript.scss
@@ -1,12 +1,12 @@
 .js--hide-if-js-disabled {
     @at-root html.js-disabled & {
-        display: none;
+        display: none !important;
     }
 }
 
 .js--hide-if-js-enabled {
     @at-root html.js-enabled & {
-        display: none;
+        display: none !important;
     }
 }
 

--- a/site/css/noscript.scss
+++ b/site/css/noscript.scss
@@ -1,0 +1,11 @@
+.js--hide-if-js-disabled {
+    @at-root html.js-disabled & {
+        display: none;
+    }
+}
+
+.js--hide-if-js-enabled {
+    @at-root html.js-enabled & {
+        display: none;
+    }
+}

--- a/site/gdocs/OwidGdocPage.tsx
+++ b/site/gdocs/OwidGdocPage.tsx
@@ -16,6 +16,7 @@ import { DebugProvider } from "./DebugContext.js"
 import { match, P } from "ts-pattern"
 import { EnrichedBlockText, IMAGES_DIRECTORY } from "@ourworldindata/types"
 import { DATA_INSIGHT_ATOM_FEED_PROPS } from "./utils.js"
+import { Html } from "../Html.js"
 
 declare global {
     interface Window {
@@ -89,7 +90,7 @@ export default function OwidGdocPage({
     const isAuthor = gdoc.content.type === OwidGdocType.Author
 
     return (
-        <html>
+        <Html>
             <Head
                 pageTitle={pageTitle}
                 pageDesc={pageDesc}
@@ -137,6 +138,6 @@ export default function OwidGdocPage({
                     isPreviewing={isPreviewing}
                 />
             </body>
-        </html>
+        </Html>
     )
 }

--- a/site/gdocs/components/Chart.tsx
+++ b/site/gdocs/components/Chart.tsx
@@ -114,11 +114,7 @@ export default function Chart({
                 }}
             >
                 {isExplorer ? (
-                    <div className="js--hide-if-js-enabled">
-                        <p className="align-center">
-                            Interactive visualization requires JavaScript.
-                        </p>
-                    </div>
+                    <div className="js--show-warning-block-if-js-disabled" />
                 ) : (
                     resolvedSlug && (
                         <a href={resolvedUrl} target="_blank" rel="noopener">

--- a/site/gdocs/components/Chart.tsx
+++ b/site/gdocs/components/Chart.tsx
@@ -114,11 +114,11 @@ export default function Chart({
                 }}
             >
                 {isExplorer ? (
-                    <noscript>
+                    <div className="js--hide-if-js-enabled">
                         <p className="align-center">
                             Interactive visualization requires JavaScript.
                         </p>
-                    </noscript>
+                    </div>
                 ) : (
                     resolvedSlug && (
                         <a href={resolvedUrl} target="_blank" rel="noopener">

--- a/site/gdocs/components/KeyIndicatorCollection.scss
+++ b/site/gdocs/components/KeyIndicatorCollection.scss
@@ -1,3 +1,14 @@
+// These styles apply on the sm-only breakpoint (i.e. on mobile), or when JavaScript is not enabled.
+// This is because the mobile version is friendly to JS being disabled, and the desktop version is not very functional without JS.
+@mixin sm-only-or-no-js {
+    @include sm-only {
+        @content;
+    }
+    @at-root html.js-disabled & {
+        @content;
+    }
+}
+
 .key-indicator-collection {
     $duration: 0.4s; // keep in sync with HEIGHT_ANIMATION_DURATION_IN_SECONDS in KeyIndicatorCollection.tsx
 
@@ -6,7 +17,7 @@
 
     margin: 24px 0;
 
-    @include sm-only {
+    @include sm-only-or-no-js {
         margin: 8px -16px;
     }
 
@@ -16,7 +27,7 @@
 
     .accordion-item .accordion-item__heading {
         margin: 0;
-        @include sm-only {
+        @include sm-only-or-no-js {
             display: none;
         }
     }
@@ -32,14 +43,14 @@
         background-color: $blue-5;
         padding: 16px var(--padding);
 
-        @include sm-only {
+        @include sm-only-or-no-js {
             padding-bottom: 0;
         }
     }
 
     // on desktop, show a clickable header that opens the accordion
     .accordion-item--closed .accordion-item__button {
-        @include sm-only {
+        @include sm-only-or-no-js {
             display: none;
         }
     }
@@ -48,16 +59,17 @@
     .accordion-item__link-mobile {
         padding: 12px 0;
         line-height: 1.2;
+        display: none;
 
-        @include sm-up {
-            display: none;
+        @include sm-only-or-no-js {
+            display: block;
         }
     }
 
     .accordion-item--open .accordion-item__button {
         background-color: $blue-20;
 
-        @include sm-only {
+        @include sm-only-or-no-js {
             background-color: $blue-5;
         }
     }
@@ -77,7 +89,7 @@
             color: $blue-90;
             margin: 0;
 
-            @include sm-only {
+            @include sm-only-or-no-js {
                 font-size: 1.5rem;
                 margin-bottom: 4px;
             }
@@ -88,7 +100,7 @@
             margin: 0;
         }
 
-        @include sm-only {
+        @include sm-only-or-no-js {
             padding: 16px 16px 0 16px;
             margin-bottom: 0;
         }
@@ -100,7 +112,7 @@
         align-self: center;
         justify-self: end;
 
-        @include sm-only {
+        @include sm-only-or-no-js {
             margin: 24px 16px;
             justify-self: unset;
             text-align: center;
@@ -131,13 +143,13 @@
         color: $blue-90;
         margin-right: 8px;
 
-        @include sm-only {
+        @include sm-only-or-no-js {
             line-height: 1.2;
         }
     }
 
     .accordion-item--closed .key-indicator-header__title {
-        @include sm-only {
+        @include sm-only-or-no-js {
             margin-left: 0;
         }
     }
@@ -155,7 +167,7 @@
     }
 
     .accordion-item--closed .key-indicator-header__source {
-        @include sm-only {
+        @include sm-only-or-no-js {
             display: block;
             margin-top: 2px;
         }
@@ -166,22 +178,23 @@
         font-size: 0.875rem;
         font-weight: 900;
 
-        @include sm-only {
+        @include sm-only-or-no-js {
             font-size: 0.75rem;
         }
     }
 
     // hidden on mobile
     .key-indicator-header__icon[data-icon="plus"] {
-        @include sm-only {
+        @include sm-only-or-no-js {
             display: none;
         }
     }
 
     // hidden on desktop
     .key-indicator-header__icon[data-icon="arrow-right"] {
-        @include sm-up {
-            display: none;
+        display: none;
+        @include sm-only-or-no-js {
+            display: inline-block;
         }
     }
 
@@ -196,7 +209,7 @@
         cursor: default;
     }
 
-    @include sm-only {
+    @include sm-only-or-no-js {
         --border: #{$blue-10};
 
         .accordion-item:first-of-type::after {

--- a/site/gdocs/components/LatestDataInsights.scss
+++ b/site/gdocs/components/LatestDataInsights.scss
@@ -17,7 +17,7 @@
     margin: -24px 0 -24px -24px;
 }
 
-html:not(.js) .latest-data-insights__viewport {
+html:not(.js-enabled) .latest-data-insights__viewport {
     overflow: auto;
 }
 
@@ -41,7 +41,7 @@ html:not(.js) .latest-data-insights__viewport {
     }
 }
 
-html:not(.js) .latest-data-insights__card,
+html:not(.js-enabled) .latest-data-insights__card,
 .latest-data-insights__card.is-snapped {
     opacity: 1;
 }

--- a/site/multiembedder/MultiEmbedderTestPage.tsx
+++ b/site/multiembedder/MultiEmbedderTestPage.tsx
@@ -7,6 +7,7 @@ import { EXPLORER_EMBEDDED_FIGURE_SELECTOR } from "../../explorer/ExplorerConsta
 import { Head } from "../../site/Head.js"
 import { SiteFooter } from "../../site/SiteFooter.js"
 import { SiteHeader } from "../../site/SiteHeader.js"
+import { Html } from "../Html.js"
 
 export const MultiEmbedderTestPage = (
     globalEntitySelector = false,
@@ -24,7 +25,7 @@ export const MultiEmbedderTestPage = (
         height: "600px",
     }
     return (
-        <html>
+        <Html>
             <Head canonicalUrl={slug} pageTitle={title} baseUrl="/" />
             <body>
                 <SiteHeader baseUrl={""} />
@@ -121,6 +122,6 @@ Chart embedded on
                 </main>
                 <SiteFooter baseUrl={""} />
             </body>
-        </html>
+        </Html>
     )
 }

--- a/site/owid.entry.ts
+++ b/site/owid.entry.ts
@@ -86,7 +86,7 @@ if (BUGSNAG_API_KEY) {
 
 const analytics = new SiteAnalytics(ENV)
 
-document.querySelector("html")?.classList.add("js")
+document.documentElement?.classList.add("js-loaded")
 
 try {
     // Cookie access can be restricted by iframe sandboxing, in which case the below code will throw an error

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -36,6 +36,7 @@
 @import "css/grid.scss";
 @import "css/layout.scss";
 @import "css/general.scss";
+@import "css/noscript.scss";
 @import "./collections/CollectionsPage.scss";
 @import "./SiteSearchNavigation.scss";
 @import "./site/search/Autocomplete.scss";

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -685,12 +685,6 @@ a.ref sup {
     display: none !important;
 }
 
-html:not(.js) {
-    .js-only {
-        display: none;
-    }
-}
-
 @media print {
     .site-header,
     .alert-banner,

--- a/site/search/SearchPage.tsx
+++ b/site/search/SearchPage.tsx
@@ -2,11 +2,12 @@ import React from "react"
 import { Head } from "../Head.js"
 import { SiteHeader } from "../SiteHeader.js"
 import { SiteFooter } from "../SiteFooter.js"
+import { Html } from "../Html.js"
 
 export const SearchPage = (props: { baseUrl: string }) => {
     const { baseUrl } = props
     return (
-        <html>
+        <Html>
             <Head
                 canonicalUrl={`${baseUrl}/search`}
                 pageTitle="Search"
@@ -35,6 +36,6 @@ export const SearchPage = (props: { baseUrl: string }) => {
                 <SiteFooter hideDonate={true} baseUrl={baseUrl} />
                 <script type="module">{`window.runSearchPage()`}</script>
             </body>
-        </html>
+        </Html>
     )
 }

--- a/site/viteUtils.test.ts
+++ b/site/viteUtils.test.ts
@@ -66,7 +66,7 @@ describe(createTagsForManifestEntry, () => {
 
         expect(assetsForFooter.length).toEqual(1)
         expect(assetsForFooter).toEqual([
-            '<script type="module" src="BASE/assets/owid.mjs"></script>',
+            '<script type="module" src="BASE/assets/owid.mjs" data-attach-owid-error-handler="true"></script>',
         ])
     })
 })

--- a/site/viteUtils.tsx
+++ b/site/viteUtils.tsx
@@ -121,7 +121,12 @@ export const createTagsForManifestEntry = (
             if (manifestEntry?.isEntry) {
                 assets = [
                     ...assets,
-                    <script key={entry} type="module" src={assetUrl} />,
+                    <script
+                        key={entry}
+                        type="module"
+                        src={assetUrl}
+                        data-attach-owid-error-handler
+                    />,
                 ]
             }
 


### PR DESCRIPTION
This PR resolves most of the cases where we weren't handling a browser with JS not enabled _or_ not working properly (e.g. old browser) nicely.

There are still a few cases that could see improvements, but we have a good foundation now, mostly based on the mutually-exclusive `js-enabled`/`js-disabled` classes on the `<html>` element.

This all is way more involved than you'd think: See https://github.com/owid/owid-grapher/blob/noscript/docs/browser-support.md#detecting-disablednon-functioning-js for all the details of this.

There's also a long companion video on Slack: https://owid.slack.com/archives/CQQUA2C2U/p1722965563740379

## One before/after example

(styles can be improved 😁)
![CleanShot 2024-08-06 at 18 30 15](https://github.com/user-attachments/assets/81fa8e3e-8e27-450e-b4df-74f160750ebf)
