### PR TITLE
fix: don't animate initially-open key indicator height

### DIFF
--- a/site/gdocs/components/KeyIndicatorCollection.tsx
+++ b/site/gdocs/components/KeyIndicatorCollection.tsx
@@ -158,6 +158,8 @@ function AccordionItem({
         contentRef.current.inert = !isOpen
     }, [isOpen, contentRef])
 
+    const contentHeight = isOpen ? height : 0
+
     return (
         <div
             ref={ref}
@@ -216,7 +218,7 @@ function AccordionItem({
                 id={contentId}
                 className="accordion-item__content"
                 style={{
-                    height: isOpen ? `${height}px` : "0px",
+                    height: contentHeight,
                 }}
                 role="region"
                 aria-labelledby={headerId}
@@ -322,7 +324,7 @@ function KeyIndicatorLink({
 const useHeight = () => {
     const ref = useRef<HTMLDivElement>(null)
 
-    const [height, setHeight] = useState(0)
+    const [height, setHeight] = useState<number | undefined>(undefined)
 
     useEffect(() => {
         const element = ref.current as HTMLDivElement


### PR DESCRIPTION
Fixes #3863 by omitting the explicit `height: 0px` during server-side rendering.

This makes it so the first section of the collection is open by default, without a height animation.