### PR TITLE
✨ Render thumbnails for graphers by uuid

### DIFF
--- a/.env.example-full
+++ b/.env.example-full
@@ -36,7 +36,7 @@ GRAPHER_CONFIG_R2_BUCKET_PATH= # optional - for local dev set it to "devs/YOURNA
 
 OPENAI_API_KEY=
 
-GRAPHER_DYNAMIC_THUMBNAIL_URL=  # optional; can set this to https://ourworldindata.org/grapher/thumbnail to use the live thumbnail worker
+GRAPHER_DYNAMIC_THUMBNAIL_URL=  # optional; can set this to https://ourworldindata.org/grapher to use the live thumbnail worker
 
 # enable search (readonly)
 ALGOLIA_ID=   # optional

--- a/functions/_common/grapherRenderer.ts
+++ b/functions/_common/grapherRenderer.ts
@@ -23,6 +23,8 @@ declare global {
     var window: any
 }
 
+export type Etag = string
+
 const grapherBaseUrl = "https://ourworldindata.org/grapher"
 
 // Lots of defaults; these are mostly the same as they are in owid-grapher.
@@ -166,17 +168,17 @@ interface FetchGrapherConfigResult {
     etag: string | undefined
 }
 
-interface GrapherSlug {
+export interface GrapherSlug {
     type: "slug"
     id: string
 }
 
-interface GrapherUuid {
+export interface GrapherUuid {
     type: "uuid"
     id: string
 }
 
-type GrapherIdentifier = GrapherSlug | GrapherUuid
+export type GrapherIdentifier = GrapherSlug | GrapherUuid
 
 export async function fetchUnparsedGrapherConfig(
     identifier: GrapherIdentifier,
@@ -267,17 +269,14 @@ export async function fetchGrapherConfig(
 }
 
 async function fetchAndRenderGrapherToSvg(
-    slug: string,
+    id: GrapherIdentifier,
     options: ImageOptions,
     searchParams: URLSearchParams,
     env: Env
 ): Promise<string> {
     const grapherLogger = new TimeLogger("grapher")
 
-    const grapherConfigResponse = await fetchGrapherConfig(
-        { type: "slug", id: slug },
-        env
-    )
+    const grapherConfigResponse = await fetchGrapherConfig(id, env)
 
     if (grapherConfigResponse.status === 404) {
         // we throw 404 errors instad of returning a 404 response so that the router
@@ -320,20 +319,15 @@ async function fetchAndRenderGrapherToSvg(
 }
 
 export const fetchAndRenderGrapher = async (
-    slug: string,
+    id: GrapherIdentifier,
     searchParams: URLSearchParams,
     outType: "png" | "svg",
     env: Env
 ) => {
     const options = extractOptions(searchParams)
 
-    console.log("Rendering", slug, outType, options)
-    const svg = await fetchAndRenderGrapherToSvg(
-        slug,
-        options,
-        searchParams,
-        env
-    )
+    console.log("Rendering", id.id, outType, options)
+    const svg = await fetchAndRenderGrapherToSvg(id, options, searchParams, env)
     console.log("fetched svg")
 
     switch (outType) {

--- a/functions/_common/reusableHandlers.ts
+++ b/functions/_common/reusableHandlers.ts
@@ -1,0 +1,37 @@
+import { Env } from "./env.js"
+import {
+    Etag,
+    GrapherIdentifier,
+    fetchAndRenderGrapher,
+} from "./grapherRenderer.js"
+
+export async function handleThumbnailRequest(
+    id: GrapherIdentifier,
+    searchParams: URLSearchParams,
+    env: Env,
+    _etag: Etag,
+    ctx: EventContext<unknown, any, Record<string, unknown>>,
+    extension: "png" | "svg"
+) {
+    const url = new URL(env.url)
+    const shouldCache = !url.searchParams.has("nocache")
+
+    const cache = caches.default
+    console.log("Handling", env.url, ctx.request.headers.get("User-Agent"))
+    if (shouldCache) {
+        console.log("Checking cache")
+        const maybeCached = await cache.match(ctx.request)
+        console.log("Cache check result", maybeCached ? "hit" : "miss")
+        if (maybeCached) return maybeCached
+    }
+    const resp = await fetchAndRenderGrapher(id, searchParams, extension, env)
+    if (shouldCache) {
+        resp.headers.set("Cache-Control", "public, s-maxage=3600, max-age=3600")
+        ctx.waitUntil(caches.default.put(ctx.request, resp.clone()))
+    } else
+        resp.headers.set(
+            "Cache-Control",
+            "public, s-maxage=0, max-age=0, must-revalidate"
+        )
+    return resp
+}

--- a/functions/grapher/thumbnail/[slug].ts
+++ b/functions/grapher/thumbnail/[slug].ts
@@ -2,22 +2,39 @@ import { Env } from "../../_common/env.js"
 import { fetchAndRenderGrapher } from "../../_common/grapherRenderer.js"
 import { IRequestStrict, Router, error } from "itty-router"
 
+// TODO: remove the /grapher/thumbnail route two weeks or so after the change to use /grapher/:slug.png is deployed
+// We keep this around for another two weeks so that cached html pages etc can still fetch the correct thumbnail
 const router = Router<IRequestStrict, [URL, Env, ExecutionContext]>()
 router
     .get(
         "/grapher/thumbnail/:slug.png",
         async ({ params: { slug } }, { searchParams }, env) =>
-            fetchAndRenderGrapher(slug, searchParams, "png", env)
+            fetchAndRenderGrapher(
+                { type: "slug", id: slug },
+                searchParams,
+                "png",
+                env
+            )
     )
     .get(
         "/grapher/thumbnail/:slug.svg",
         async ({ params: { slug } }, { searchParams }, env) =>
-            fetchAndRenderGrapher(slug, searchParams, "svg", env)
+            fetchAndRenderGrapher(
+                { type: "slug", id: slug },
+                searchParams,
+                "svg",
+                env
+            )
     )
     .get(
         "/grapher/thumbnail/:slug",
         async ({ params: { slug } }, { searchParams }, env) =>
-            fetchAndRenderGrapher(slug, searchParams, "svg", env)
+            fetchAndRenderGrapher(
+                { type: "slug", id: slug },
+                searchParams,
+                "svg",
+                env
+            )
     )
     .all("*", () => error(404, "Route not defined"))
 

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -35,8 +35,7 @@ export const BAKED_SITE_EXPORTS_BASE_URL: string =
     process.env.BAKED_SITE_EXPORTS_BASE_URL ?? `${BAKED_BASE_URL}/exports`
 
 export const GRAPHER_DYNAMIC_THUMBNAIL_URL: string =
-    process.env.GRAPHER_DYNAMIC_THUMBNAIL_URL ??
-    `${BAKED_GRAPHER_URL}/thumbnail`
+    process.env.GRAPHER_DYNAMIC_THUMBNAIL_URL ?? `${BAKED_GRAPHER_URL}`
 
 export const ADMIN_BASE_URL: string =
     process.env.ADMIN_BASE_URL ??

--- a/site/search/SearchPanel.tsx
+++ b/site/search/SearchPanel.tsx
@@ -159,7 +159,7 @@ function ChartHit({
     )
     const queryStr = useMemo(() => getEntityQueryStr(entities), [entities])
     const previewUrl = queryStr
-        ? `${GRAPHER_DYNAMIC_THUMBNAIL_URL}/${hit.slug}${queryStr}`
+        ? `${GRAPHER_DYNAMIC_THUMBNAIL_URL}/${hit.slug}.svg${queryStr}`
         : `${BAKED_GRAPHER_EXPORTS_BASE_URL}/${hit.slug}.svg`
 
     useEffect(() => {


### PR DESCRIPTION
This PR duplicates the thumbnail rendering logic into the top level so that we can render pngs at `/grapher/SLUG.png` and svgs at `/grapher/SLUG.svg`. It also adds thumbnail rendering at `/grapher/by-uuid/UUID.png` and `.svg`. 

The HTML rewriting (of og images) is changed to point to the new `/grapher/SLUG.png` route. 

The old thumbnail rendering at `/grapher/thumbnail/SLUG` is kept for now so that existing fetches will still work until the various cached versions of the HTML have expired.